### PR TITLE
feat(reference): integrate preview1 reference-life development stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,134 @@
-# Alberta Framework — agent guide
+# ASI — agent guide
 
-JAX continual-learning research track for elizaOS
-([The Alberta Plan](https://arxiv.org/abs/2208.11173)). This tree is a
-**development fork** of `lalalune/alberta` (fork point `2ac3533`), not a
-lightly-patched vendor copy — see `VENDORING.md` for the divergence summary
-and the canonical upstream URL. The robot track imports the continual-RL
-subset in-process; keep `requires-python >= 3.12` and the `numpy >= 1.26`
-floor intact.
+ASI is elizaOS's JAX continual-learning research and hillclimbing project. Its
+north star is one end-to-end agent that keeps learning through an operational
+life, retains and reuses useful knowledge, adapts without whole-agent or
+task-by-task reinitialization, operates within explicit compute, memory, and
+latency budgets, and scales from research benchmarks to real work — especially
+robotics.
+State-of-the-art continual learning is the destination, not a current claim.
 
-**Current headline lane:** the IPMNIST screening/confirmation campaign,
-which is development-grade and permanently nonpromoting. Results move; read
-the `summary_*.json` files and `publication_runs/RESULTS.md` under
+[The Alberta Plan](https://arxiv.org/abs/2208.11173) is a foundational
+inspiration and a source of inherited mechanisms, vocabulary, and file names.
+It is not ASI's specification or outer boundary. Follow the evidence wherever
+it leads: improve Alberta-derived ideas, combine them with other continual-
+learning and reinforcement-learning methods, or replace them when stronger
+concepts win.
+
+This tree is a **development fork** of `lalalune/alberta` (fork point
+`2ac3533`), not a lightly-patched vendor copy — see `VENDORING.md` for the
+divergence summary and canonical upstream URL. ASI is the project identity;
+`alberta_framework`, the `alberta-framework` distribution, `alberta-*` CLIs,
+and historical schema IDs remain compatibility and provenance interfaces. Do
+not casually rename them. The robot track imports the continual-RL subset
+in-process; keep `requires-python >= 3.12`, the `numpy >= 1.26` floor, and the
+existing import surface intact.
+
+**Current program hillclimb:** run a permanently nonpromoting matched
+development scorecard across `SwitchingTwoStateMDP` and `RiverSwimMDP` with
+frozen/no-learning, random, finite-horizon privileged dynamic-programming, and
+strong SARSA-family controls plus explicit resource accounting. This is
+development selection only; it does not populate `reference-dev` or create
+performance or scientific evidence.
+
+The scorecard implementation is in
+`alberta_framework/{reference_life_controls.py,benchmarks/reference_life_scorecard.py}`
+and runs through `asi-reference-life-scorecard`. Its literal-frozen plan has
+12 consumed development seeds, 2 environments, and 6 arms (144 fresh-process
+shards); every shard binds its current source identity, and aggregation requires
+one matching current identity. The privileged normalization arm is an
+environment-bound finite-horizon dynamic-programming control and is excluded
+from candidate Pareto comparisons.
+All agent RNG roots use explicit Threefry keys. Records enforce the fixed reward
+lattice, complete counters, canonical initial/final numeric payload accounting
+(including static oracle policy bytes), and permanently nonpromoting policy.
+Timing remains telemetry-only until a separately qualified timing protocol
+exists. The implementation and validators do not constitute a completed run or
+performance result; consistency hashes are not authenticated execution proof.
+
+The unfrozen `preview1` transaction protocol, pure reducer/CAS ledger,
+primitive-only exact-dispatch Prototype bridge, and aggregate runner are in
+`alberta_framework/{reference_agent,prototype_reference_adapter,reference_life}.py`.
+One immutable aggregate owns agent, environment, transaction, dispatch, RNG
+cursor, metrics, counters, recovery state, transcript, and generations. Its
+process-local outer lock covers command issuance through execution, receipt,
+outcome, learning/metrics staging, and one aggregate commit; retained tests
+cover concurrency, horizon, strict execution validation, faults, and
+no-redispatch pending-outcome recovery. The primitive RiverSwim slice uses a
+distinct environment manifest/state discriminator and stationary metrics,
+rejects configurations outside `2 <= n_states <= 12` before its exponential
+oracle is constructed, passes the exact same runner-derived JAX key to
+execution and validation, and replays the keyed stochastic transition during
+strict validation.
+
+The development-only checkpoint codec in
+`alberta_framework/reference_life_checkpoint.py`, covered by
+`tests/test_reference_life_checkpoint.py` and
+`tests/test_reference_life_riverswim_checkpoint.py`, now implements the
+current-schema quiescent whole-life checkpoint and exact-resume gate for the
+primitive Prototype + SwitchingTwoState and Prototype + RiverSwim lives. A
+successful save uses Linux atomic no-replace publication for one immutable
+generation, advances commit/checkpoint generations, nests the complete
+Prototype v3 checkpoint, binds the aggregate state plus current
+source/runtime/dependency identities and consistency hashes, reconstructs fresh
+components from the environment discriminator, validates strict
+cross-component adoption, and produces exact original-versus-restored
+continuation from the same persisted barrier.
+
+This remains a `preview1` L0 mechanism, not a frozen or portable checkpoint
+contract, `reference-dev`, safety conformance, robotics readiness, RiverSwim
+learning or performance benefit, performance evidence, or scientific evidence.
+Checkpoints support only quiescent pre-completion state for the two implemented
+simulators and fail closed across current source/runtime/dependency drift; they
+do not restore in-flight, halted,
+pending-outcome, completed, or physical state. The hashes bind consistency but
+are not authenticated execution attestation. The ordinary-`Exception`
+at-most-once guard remains process-local and supplies no process-death,
+`BaseException`, durable/idempotent executor, hardware-delivery, or
+reconciled-resume guarantee. Independent safety/veto, options,
+replacement/rebinding, boundaries, wire/durable dispatch replay,
+additional/general environment support, Forager, and robot adapters remain
+open. In the monorepo, use
+`../robot/docs/asimov-1.md` and
+`../robot/docs/ALBERTA_PRODUCTION_READINESS.md` as the existing ASIMOV-1
+application interface and open-gate record; do not create a duplicate robotics
+ladder or treat its smoke plumbing as performance evidence.
+
+**Current measured subsystem campaign:** IPMNIST development screening and
+development confirmation is one plasticity/conditioning lane, not the
+definition of ASI. It is permanently nonpromoting. Results move; read the
+`summary_*.json` files and `publication_runs/RESULTS.md` under
 `outputs/ipmnist_screening/` instead of copying numbers into overview docs,
-and re-measure the selected baseline before any A/B. The theory snapshot is
+and re-measure the selected control before any A/B. The theory snapshot is
 `docs/research/ipmnist-theory.md`; raw records and audits live beside the
 outputs. Check `docs/evidence/negative-results.md` before retrying an idea.
+
+## Research operating loop
+
+- **Measure the live baseline.** Bind the current source, workload, seeds,
+  resources, and pre-update metric before comparing a change.
+- **Name the bottleneck and hypothesis.** State the predicted benefit, causal
+  mechanism, resource cost, ablation, and failure condition before a long run.
+- **Build an end-to-end slice.** Prefer changes that run through the existing
+  agent and environment interfaces over isolated surfaces with no consumer.
+- **Screen cheaply and honestly.** Development runs select and reject ideas;
+  use paired schedules and strong baselines, and never treat screening as
+  promotion.
+- **Test transfer, retention, and control.** A local score improvement is
+  provisional until it survives recurrence or distribution change, resource
+  accounting, and a downstream agent/control check.
+- **Advance development, then evaluate scientifically.** A matched development
+  win may enter the explicitly nonpromoting `reference-dev` configuration
+  after its regression panel passes. Freeze a separate protocol with fresh
+  seeds only when a claim warrants scientific evaluation.
+- **Integrate and remeasure.** Record negative results, keep resource-acceptable
+  wins in the appropriate reference channel, and rerun the whole-life
+  scorecard before the next hillclimb.
+
+Prioritize work that closes an integration gap or resolves a high-value
+uncertainty. More APIs, mechanisms, or tests are not progress by themselves.
+The durable strategy and application ladder live in
+`docs/research/asi-roadmap.md`.
 
 ## Layout
 
@@ -30,19 +144,37 @@ alberta_framework/
   benchmarks/  IPMNIST lanes (upgd_ipmnist, ipmnist_screening,
                upgd_label_emnist), Forager integrations
   utils/       multi-seed experiments, statistics, metrics, export
-  steps/       public Step 1–12 kernels: smoke CLIs for Steps 1–2,
+  steps/       inherited Alberta Step 1–12 kernels: smoke CLIs for Steps 1–2,
                pipeline.py consumes Steps 3–4, Steps 5–12 are
-               library-surface only (cited by docs/status.md)
+               library-surface only; this is not ASI's outer roadmap
 outputs/       evidence + campaign artifacts — see immutability rules below
 tests/         unit, integration, scientific, and replay checks
 ```
 
 Key documents:
 
+- Mission and hillclimb ladder: `docs/research/asi-roadmap.md`
+- Proposed reference-agent protocol: `docs/design/asi-reference-agent-protocol.md`
+- Implemented `preview1` transaction ledger, primitive Prototype bridge,
+  aggregate Switching/RiverSwim life runner, quiescent exact-resume gates, and
+  matched development-scorecard machinery:
+  `alberta_framework/reference_agent.py` ·
+  `alberta_framework/prototype_reference_adapter.py` ·
+  `alberta_framework/reference_life.py` ·
+  `alberta_framework/reference_life_checkpoint.py` ·
+  `alberta_framework/reference_life_controls.py` ·
+  `alberta_framework/benchmarks/reference_life_scorecard.py` ·
+  `tests/test_reference_life.py` ·
+  `tests/test_reference_life_checkpoint.py` ·
+  `tests/test_reference_life_riverswim.py` ·
+  `tests/test_reference_life_riverswim_checkpoint.py` ·
+  `tests/test_reference_life_controls.py` ·
+  `tests/test_reference_life_scorecard.py`
 - Status & evidence: `docs/status.md` (levels L0–L3, completion gates) ·
   `docs/evidence/methodology.md` (property-by-property map)
 - Active campaign: `docs/research/ipmnist-theory.md` ·
   `outputs/ipmnist_screening/{RUNBOOK,FINAL_REPORT,AUDIT,CEILING_ANALYSIS,SOTA_LANDSCAPE_2026}.md`
+- Current external comparison map: `docs/research/sota-landscape.md`
 - Durable records: `docs/archive/forager-comparator-audit.md` ·
   `docs/design/rtu-taylor-correction.md` ·
   `docs/evidence/negative-results.md`
@@ -66,7 +198,8 @@ Always use the project venv:
 ```
 
 See `[project.scripts]` in `pyproject.toml` for the current console-script
-inventory. The ones you'll reach for are `alberta-evidence-status`,
+inventory. The ones you'll reach for are `asi-reference-life-scorecard`,
+`alberta-evidence-status`,
 `alberta-forager-benchmark`, `alberta-foragax-open-screen`, and the
 `alberta-forager-matched-*` family. Benchmark executions happen through
 scripts/CLIs, never inside pytest — tests must stay CI-cheap unless
@@ -107,7 +240,8 @@ The fast runtime selector is `-m "not slow and not package"`.
 - **Registered source hashes are load-bearing.** Editing a registered source
   file invalidates persisted evidence until the frozen protocol is rerun; the
   registry reports `invalid` (exit 2) — that is working-as-designed, not a
-  bug to silence. Read `evaluation/evidence_manifest.py` for the current
+  bug to silence. Read `alberta_framework/evaluation/evidence_manifest.py`
+  for the current
   five-claim source inventory, and inspect each development lane's own source
   manifest before touching it. Counts in narrative docs are not authoritative.
 - Thresholds are calibrated empirically on development data with ≥2x margins,
@@ -135,8 +269,9 @@ recorded in the pinned artifacts are:
 | `recurring_multiagent_coadaptation` | accepted (narrow L2) | `outputs/continual_multiagent/evidence.json` | `alberta-multiagent-evidence` |
 | `continual_intelligence_amplification` | valid rejection (frozen 10% gate) | `outputs/continual_ia/evidence.json` | `alberta-ia-evidence` |
 
-No accepted claim is an Alberta Plan completion; keep README/status wording
-narrow and honest.
+No accepted claim establishes an integrated ASI agent, robotics readiness,
+state of the art, or Alberta Plan completion; keep README/status wording narrow
+and honest.
 
 ## Files that are load-bearing outside the docs
 
@@ -153,6 +288,8 @@ narrow and honest.
 
 - ruff line length 100; ESM/TS conventions do not apply here — this is a pure
   Python track.
+- Use **ASI** for the current project and research program. Preserve Alberta
+  names when referring to upstream history, Plan-specific mechanisms, the
+  compatibility package/CLI surface, or historical evidence identifiers.
 - `CLAUDE.md` and `AGENTS.md` are identical: author `CLAUDE.md`, copy to
   `AGENTS.md`.
-- No git commits unless explicitly asked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the unfrozen `preview1` reference-agent transaction ledger, primitive
+  Prototype adapter, aggregate SwitchingTwoState/RiverSwim life runner, and
+  development-only quiescent checkpoint codec. These L0 mechanisms enforce
+  exact dispatch ownership, immutable aggregate state, strict transition
+  validation, and exact continuation for the documented simulator/configuration
+  pairs; they are not `reference-dev`, safety, robotics, performance, or
+  scientific evidence.
+- Added the permanently nonpromoting reference-life development scorecard and
+  `asi-reference-life-scorecard` CLI. Its literal-frozen 144-shard plan compares
+  six arms across two environments and 12 consumed development seeds with
+  explicit source identity, Threefry roots, reward/counter validation, and
+  numeric-payload accounting. The machinery does not constitute a completed
+  run or result.
 - Added the code-only, permanently nonpromoting IPMNIST gate-ablation arm
   `rls_head_resid_l1_preset005_nogate`. It has no result artifact and does not authorize a
   benchmark run; execution remains gated by the issue's source receipt and owner-approved

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,20 +1,134 @@
-# Alberta Framework — agent guide
+# ASI — agent guide
 
-JAX continual-learning research track for elizaOS
-([The Alberta Plan](https://arxiv.org/abs/2208.11173)). This tree is a
-**development fork** of `lalalune/alberta` (fork point `2ac3533`), not a
-lightly-patched vendor copy — see `VENDORING.md` for the divergence summary
-and the canonical upstream URL. The robot track imports the continual-RL
-subset in-process; keep `requires-python >= 3.12` and the `numpy >= 1.26`
-floor intact.
+ASI is elizaOS's JAX continual-learning research and hillclimbing project. Its
+north star is one end-to-end agent that keeps learning through an operational
+life, retains and reuses useful knowledge, adapts without whole-agent or
+task-by-task reinitialization, operates within explicit compute, memory, and
+latency budgets, and scales from research benchmarks to real work — especially
+robotics.
+State-of-the-art continual learning is the destination, not a current claim.
 
-**Current headline lane:** the IPMNIST screening/confirmation campaign,
-which is development-grade and permanently nonpromoting. Results move; read
-the `summary_*.json` files and `publication_runs/RESULTS.md` under
+[The Alberta Plan](https://arxiv.org/abs/2208.11173) is a foundational
+inspiration and a source of inherited mechanisms, vocabulary, and file names.
+It is not ASI's specification or outer boundary. Follow the evidence wherever
+it leads: improve Alberta-derived ideas, combine them with other continual-
+learning and reinforcement-learning methods, or replace them when stronger
+concepts win.
+
+This tree is a **development fork** of `lalalune/alberta` (fork point
+`2ac3533`), not a lightly-patched vendor copy — see `VENDORING.md` for the
+divergence summary and canonical upstream URL. ASI is the project identity;
+`alberta_framework`, the `alberta-framework` distribution, `alberta-*` CLIs,
+and historical schema IDs remain compatibility and provenance interfaces. Do
+not casually rename them. The robot track imports the continual-RL subset
+in-process; keep `requires-python >= 3.12`, the `numpy >= 1.26` floor, and the
+existing import surface intact.
+
+**Current program hillclimb:** run a permanently nonpromoting matched
+development scorecard across `SwitchingTwoStateMDP` and `RiverSwimMDP` with
+frozen/no-learning, random, finite-horizon privileged dynamic-programming, and
+strong SARSA-family controls plus explicit resource accounting. This is
+development selection only; it does not populate `reference-dev` or create
+performance or scientific evidence.
+
+The scorecard implementation is in
+`alberta_framework/{reference_life_controls.py,benchmarks/reference_life_scorecard.py}`
+and runs through `asi-reference-life-scorecard`. Its literal-frozen plan has
+12 consumed development seeds, 2 environments, and 6 arms (144 fresh-process
+shards); every shard binds its current source identity, and aggregation requires
+one matching current identity. The privileged normalization arm is an
+environment-bound finite-horizon dynamic-programming control and is excluded
+from candidate Pareto comparisons.
+All agent RNG roots use explicit Threefry keys. Records enforce the fixed reward
+lattice, complete counters, canonical initial/final numeric payload accounting
+(including static oracle policy bytes), and permanently nonpromoting policy.
+Timing remains telemetry-only until a separately qualified timing protocol
+exists. The implementation and validators do not constitute a completed run or
+performance result; consistency hashes are not authenticated execution proof.
+
+The unfrozen `preview1` transaction protocol, pure reducer/CAS ledger,
+primitive-only exact-dispatch Prototype bridge, and aggregate runner are in
+`alberta_framework/{reference_agent,prototype_reference_adapter,reference_life}.py`.
+One immutable aggregate owns agent, environment, transaction, dispatch, RNG
+cursor, metrics, counters, recovery state, transcript, and generations. Its
+process-local outer lock covers command issuance through execution, receipt,
+outcome, learning/metrics staging, and one aggregate commit; retained tests
+cover concurrency, horizon, strict execution validation, faults, and
+no-redispatch pending-outcome recovery. The primitive RiverSwim slice uses a
+distinct environment manifest/state discriminator and stationary metrics,
+rejects configurations outside `2 <= n_states <= 12` before its exponential
+oracle is constructed, passes the exact same runner-derived JAX key to
+execution and validation, and replays the keyed stochastic transition during
+strict validation.
+
+The development-only checkpoint codec in
+`alberta_framework/reference_life_checkpoint.py`, covered by
+`tests/test_reference_life_checkpoint.py` and
+`tests/test_reference_life_riverswim_checkpoint.py`, now implements the
+current-schema quiescent whole-life checkpoint and exact-resume gate for the
+primitive Prototype + SwitchingTwoState and Prototype + RiverSwim lives. A
+successful save uses Linux atomic no-replace publication for one immutable
+generation, advances commit/checkpoint generations, nests the complete
+Prototype v3 checkpoint, binds the aggregate state plus current
+source/runtime/dependency identities and consistency hashes, reconstructs fresh
+components from the environment discriminator, validates strict
+cross-component adoption, and produces exact original-versus-restored
+continuation from the same persisted barrier.
+
+This remains a `preview1` L0 mechanism, not a frozen or portable checkpoint
+contract, `reference-dev`, safety conformance, robotics readiness, RiverSwim
+learning or performance benefit, performance evidence, or scientific evidence.
+Checkpoints support only quiescent pre-completion state for the two implemented
+simulators and fail closed across current source/runtime/dependency drift; they
+do not restore in-flight, halted,
+pending-outcome, completed, or physical state. The hashes bind consistency but
+are not authenticated execution attestation. The ordinary-`Exception`
+at-most-once guard remains process-local and supplies no process-death,
+`BaseException`, durable/idempotent executor, hardware-delivery, or
+reconciled-resume guarantee. Independent safety/veto, options,
+replacement/rebinding, boundaries, wire/durable dispatch replay,
+additional/general environment support, Forager, and robot adapters remain
+open. In the monorepo, use
+`../robot/docs/asimov-1.md` and
+`../robot/docs/ALBERTA_PRODUCTION_READINESS.md` as the existing ASIMOV-1
+application interface and open-gate record; do not create a duplicate robotics
+ladder or treat its smoke plumbing as performance evidence.
+
+**Current measured subsystem campaign:** IPMNIST development screening and
+development confirmation is one plasticity/conditioning lane, not the
+definition of ASI. It is permanently nonpromoting. Results move; read the
+`summary_*.json` files and `publication_runs/RESULTS.md` under
 `outputs/ipmnist_screening/` instead of copying numbers into overview docs,
-and re-measure the selected baseline before any A/B. The theory snapshot is
+and re-measure the selected control before any A/B. The theory snapshot is
 `docs/research/ipmnist-theory.md`; raw records and audits live beside the
 outputs. Check `docs/evidence/negative-results.md` before retrying an idea.
+
+## Research operating loop
+
+- **Measure the live baseline.** Bind the current source, workload, seeds,
+  resources, and pre-update metric before comparing a change.
+- **Name the bottleneck and hypothesis.** State the predicted benefit, causal
+  mechanism, resource cost, ablation, and failure condition before a long run.
+- **Build an end-to-end slice.** Prefer changes that run through the existing
+  agent and environment interfaces over isolated surfaces with no consumer.
+- **Screen cheaply and honestly.** Development runs select and reject ideas;
+  use paired schedules and strong baselines, and never treat screening as
+  promotion.
+- **Test transfer, retention, and control.** A local score improvement is
+  provisional until it survives recurrence or distribution change, resource
+  accounting, and a downstream agent/control check.
+- **Advance development, then evaluate scientifically.** A matched development
+  win may enter the explicitly nonpromoting `reference-dev` configuration
+  after its regression panel passes. Freeze a separate protocol with fresh
+  seeds only when a claim warrants scientific evaluation.
+- **Integrate and remeasure.** Record negative results, keep resource-acceptable
+  wins in the appropriate reference channel, and rerun the whole-life
+  scorecard before the next hillclimb.
+
+Prioritize work that closes an integration gap or resolves a high-value
+uncertainty. More APIs, mechanisms, or tests are not progress by themselves.
+The durable strategy and application ladder live in
+`docs/research/asi-roadmap.md`.
 
 ## Layout
 
@@ -30,19 +144,37 @@ alberta_framework/
   benchmarks/  IPMNIST lanes (upgd_ipmnist, ipmnist_screening,
                upgd_label_emnist), Forager integrations
   utils/       multi-seed experiments, statistics, metrics, export
-  steps/       public Step 1–12 kernels: smoke CLIs for Steps 1–2,
+  steps/       inherited Alberta Step 1–12 kernels: smoke CLIs for Steps 1–2,
                pipeline.py consumes Steps 3–4, Steps 5–12 are
-               library-surface only (cited by docs/status.md)
+               library-surface only; this is not ASI's outer roadmap
 outputs/       evidence + campaign artifacts — see immutability rules below
 tests/         unit, integration, scientific, and replay checks
 ```
 
 Key documents:
 
+- Mission and hillclimb ladder: `docs/research/asi-roadmap.md`
+- Proposed reference-agent protocol: `docs/design/asi-reference-agent-protocol.md`
+- Implemented `preview1` transaction ledger, primitive Prototype bridge,
+  aggregate Switching/RiverSwim life runner, quiescent exact-resume gates, and
+  matched development-scorecard machinery:
+  `alberta_framework/reference_agent.py` ·
+  `alberta_framework/prototype_reference_adapter.py` ·
+  `alberta_framework/reference_life.py` ·
+  `alberta_framework/reference_life_checkpoint.py` ·
+  `alberta_framework/reference_life_controls.py` ·
+  `alberta_framework/benchmarks/reference_life_scorecard.py` ·
+  `tests/test_reference_life.py` ·
+  `tests/test_reference_life_checkpoint.py` ·
+  `tests/test_reference_life_riverswim.py` ·
+  `tests/test_reference_life_riverswim_checkpoint.py` ·
+  `tests/test_reference_life_controls.py` ·
+  `tests/test_reference_life_scorecard.py`
 - Status & evidence: `docs/status.md` (levels L0–L3, completion gates) ·
   `docs/evidence/methodology.md` (property-by-property map)
 - Active campaign: `docs/research/ipmnist-theory.md` ·
   `outputs/ipmnist_screening/{RUNBOOK,FINAL_REPORT,AUDIT,CEILING_ANALYSIS,SOTA_LANDSCAPE_2026}.md`
+- Current external comparison map: `docs/research/sota-landscape.md`
 - Durable records: `docs/archive/forager-comparator-audit.md` ·
   `docs/design/rtu-taylor-correction.md` ·
   `docs/evidence/negative-results.md`
@@ -66,7 +198,8 @@ Always use the project venv:
 ```
 
 See `[project.scripts]` in `pyproject.toml` for the current console-script
-inventory. The ones you'll reach for are `alberta-evidence-status`,
+inventory. The ones you'll reach for are `asi-reference-life-scorecard`,
+`alberta-evidence-status`,
 `alberta-forager-benchmark`, `alberta-foragax-open-screen`, and the
 `alberta-forager-matched-*` family. Benchmark executions happen through
 scripts/CLIs, never inside pytest — tests must stay CI-cheap unless
@@ -107,7 +240,8 @@ The fast runtime selector is `-m "not slow and not package"`.
 - **Registered source hashes are load-bearing.** Editing a registered source
   file invalidates persisted evidence until the frozen protocol is rerun; the
   registry reports `invalid` (exit 2) — that is working-as-designed, not a
-  bug to silence. Read `evaluation/evidence_manifest.py` for the current
+  bug to silence. Read `alberta_framework/evaluation/evidence_manifest.py`
+  for the current
   five-claim source inventory, and inspect each development lane's own source
   manifest before touching it. Counts in narrative docs are not authoritative.
 - Thresholds are calibrated empirically on development data with ≥2x margins,
@@ -135,8 +269,9 @@ recorded in the pinned artifacts are:
 | `recurring_multiagent_coadaptation` | accepted (narrow L2) | `outputs/continual_multiagent/evidence.json` | `alberta-multiagent-evidence` |
 | `continual_intelligence_amplification` | valid rejection (frozen 10% gate) | `outputs/continual_ia/evidence.json` | `alberta-ia-evidence` |
 
-No accepted claim is an Alberta Plan completion; keep README/status wording
-narrow and honest.
+No accepted claim establishes an integrated ASI agent, robotics readiness,
+state of the art, or Alberta Plan completion; keep README/status wording narrow
+and honest.
 
 ## Files that are load-bearing outside the docs
 
@@ -153,6 +288,8 @@ narrow and honest.
 
 - ruff line length 100; ESM/TS conventions do not apply here — this is a pure
   Python track.
+- Use **ASI** for the current project and research program. Preserve Alberta
+  names when referring to upstream history, Plan-specific mechanisms, the
+  compatibility package/CLI surface, or historical evidence identifiers.
 - `CLAUDE.md` and `AGENTS.md` are identical: author `CLAUDE.md`, copy to
   `AGENTS.md`.
-- No git commits unless explicitly asked.

--- a/README.md
+++ b/README.md
@@ -1,50 +1,176 @@
-# Alberta Framework
+# ASI
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](pyproject.toml)
 
-Alberta Framework is a JAX research package for continual learning and continual
-reinforcement learning, guided by
-[The Alberta Plan for AI Research](https://arxiv.org/abs/2208.11173). It provides online
-learners, adaptive optimizers, prediction and control agents, learned-state mechanisms,
-planning and option components, non-stationary streams, benchmarks, and strict evidence
-validators.
+ASI is elizaOS's evidence-driven continual-learning research and hillclimbing project. We are
+building one end-to-end agent that can keep learning throughout its operational life: adapt to
+change, retain and reuse useful knowledge, build state and models, plan and act, and remain
+within explicit compute, memory, and latency budgets. The intended application envelope
+includes useful ongoing work and embodied systems such as robotics.
 
-This repository is a development fork of `lalalune/alberta` at fork point `2ac3533`.
-[VENDORING.md](VENDORING.md) records the relationship to upstream and the local divergence.
-The continual-RL subset is also imported in-process by the elizaOS robot track, so the
-package keeps Python 3.12 compatibility and a NumPy 1.26 floor.
+The goal is a state-of-the-art continual-learning application. That is an aspiration and a
+comparative research target, not a claim about the current checkout. ASI does not yet have a
+completed whole-agent L3 protocol or result, state-of-the-art application evidence, or
+robotics readiness.
 
-## Research status
+The repository provides a JAX package of online learners, adaptive optimizers, prediction and
+control agents, learned-state and memory mechanisms, world models, planning and option
+components, non-stationary streams, benchmarks, and strict evidence validators.
 
-The framework contains implementation surfaces related to all twelve steps of the Alberta
-Plan. That is not an integrated Alberta Plan completion claim. Individual mechanisms range
-from contract-tested kernels to narrow historical evidence packages; important end-to-end,
-retention, control-benefit, resource-matching, and integration gates remain open.
+## Research direction
+
+[The Alberta Plan for AI Research](https://arxiv.org/abs/2208.11173) is a foundational
+inspiration and a useful coverage lens. It is not ASI's specification, mandatory sequence, or
+scope boundary. ASI can reorder, combine, revise, reject, or replace Alberta-derived mechanisms
+and pursue ideas from the wider continual-learning and reinforcement-learning literature when
+measured results justify the move.
+
+The intended operating loop repeatedly remeasures the current lane-specific control, names a
+falsifiable bottleneck, runs a bounded paired development screen, retains or rejects the idea,
+checks transfer and system regressions, and issues a separate frozen held-out protocol only
+when a scientific claim is warranted. Once a canonical reference life exists, the same loop
+will remeasure its versioned whole-agent baseline. Improvements are judged across online
+utility, adaptation, retention, transfer, stability, compute, memory, latency, and downstream
+control — not one leaderboard number.
+
+The durable mission, application ladder, whole-life scorecard, and current program priorities
+are in the [ASI research roadmap](docs/research/asi-roadmap.md).
+The [continual-learning comparison landscape](docs/research/sota-landscape.md) separates current
+local development leaders from protocol-comparable external results and records what is still
+required before any state-of-the-art claim.
+
+## Identity and compatibility
+
+This repository is [`elizaOS/asi`](https://github.com/elizaOS/asi). It began from
+[`lalalune/alberta`](https://github.com/lalalune/alberta) at fork point `2ac3533` and is now a
+substantially divergent development line. [VENDORING.md](VENDORING.md) records that history.
+
+ASI is the project identity. The Python namespace `alberta_framework`, distribution name
+`alberta-framework`, `alberta-*` commands, Alberta-specific Step modules, and historical
+`alberta.*` schemas remain stable compatibility or provenance names. The elizaOS robot track
+imports part of that surface in-process, so this rebrand intentionally does not break it. The
+package keeps Python 3.12 compatibility and a NumPy 1.26 floor. The name labels the research
+program; it is not a claim about the current software's level of intelligence.
+
+## Current status
+
+Individual mechanisms range from contract-tested kernels to narrow historical evidence
+packages. The retained `PrototypeAgent` is a candidate composition surface, not a completed
+reference application. Important end-to-end, retention, control-benefit, resource-scaling,
+robustness, and robotics gates remain open.
+
+The selected architectural direction is a shared reference-agent protocol with adapters for the
+retained `PrototypeAgent` and the sibling robot controller. The
+[Proposed protocol ADR](docs/design/asi-reference-agent-protocol.md) specifies state ownership,
+dispatch lineage, an exact-resume acceptance gate, and its ordered implementation sequence. The
+[preview1 L0 transaction contract](alberta_framework/reference_agent.py) and its
+[retained contract tests](tests/test_reference_agent_protocol.py) now cover immutable typed
+payloads, separate authorization, learner settlement, pre-execution command,
+post-execution applied-action receipt, receipt-bound outcome records, and explicit
+bootstrap/reset observation IDs. A pure reducer owns semantic transitions; its process-local
+ledger wrapper uses a lock and current-object identity compare-and-swap to reject stale snapshots
+and repeated initialization inside one live ledger. A rejected event remains unconsumed and
+leaves that ledger halted with recovery required; the final uint64-indexed event is consumed
+before the ledger becomes exhausted.
+
+The development-only
+[Prototype reference adapter](alberta_framework/prototype_reference_adapter.py) and its
+[retained tests](tests/test_prototype_reference_adapter.py) implement a second L0 slice: a
+manifest-bound, primitive-only, exact-dispatch agent transaction bridge for continuing tasks.
+Its immutable envelope binds the Prototype state to the manifest/configuration and owns the
+host lifecycle, decision index, and observation identity. It supports neither options nor action
+replacement/rebinding and rejects boundary transactions.
+
+The development-only [aggregate reference-life runner](alberta_framework/reference_life.py), its
+[base retained tests](tests/test_reference_life.py), and its
+[RiverSwim tests](tests/test_reference_life_riverswim.py) implement primitive Prototype lives for
+SwitchingTwoState and RiverSwim. A canonical immutable life configuration binds the complete
+selected Prototype, environment, exact-dispatch, and metric configurations and rejects
+`max_accepted_events` above the smallest component capacity. One immutable aggregate state owns
+agent, environment, transaction, dispatch, RNG-cursor, metric, counter, pending-outcome, halt,
+commit-generation, and checkpoint-generation state. Under one process-local outer lock, the
+runner derives observation IDs and executes authority, settlement, command, functional
+environment execution, post-execution receipt, outcome, agent update, metrics, and one aggregate
+commit. It also covers horizon completion, phase/reward/oracle/regret metrics, transcript hashing,
+strict action validation, retained post-execution failures, and no-redispatch recovery from a
+complete pending outcome.
+
+The RiverSwim path has a distinct manifest/state discriminator and stationary metrics. It rejects
+configurations outside `2 <= n_states <= 12` before constructing the exponential exact oracle,
+passes the identical runner-derived JAX key to execution and validation, and has the validator
+replay the stochastic transition exactly rather than merely accept any possible next state.
+
+The development-only
+[whole-life checkpoint codec](alberta_framework/reference_life_checkpoint.py), its
+[Switching tests](tests/test_reference_life_checkpoint.py), and its
+[RiverSwim tests](tests/test_reference_life_riverswim_checkpoint.py) close the current-schema
+quiescent checkpoint/exact-resume L0 gate for both supported primitive lives. A successful save
+uses Linux atomic no-replace publication for one immutable generation, advances commit/checkpoint
+generations, nests the complete Prototype v3 checkpoint, binds canonical life state plus current
+source/runtime/dependency identities and consistency hashes, reconstructs fresh components from
+the environment discriminator, and validates exact original-versus-restored continuation from the
+same persisted barrier.
+
+All reference schemas remain unfrozen `preview1`. This is not a portable or migrating checkpoint
+contract, authenticated execution provenance, `reference-dev`, safety conformance, robotics
+readiness, RiverSwim learning or performance benefit, or evidence. Only quiescent pre-completion
+state for the two implemented simulators is supported; no in-flight, halted, pending-outcome,
+completed, or physical state is restored. Reward and discount remain finite scalars, there are no
+protocol sidecars or wire decoder, and the live owners cannot be pickled. The runner's static
+exact authority is not a safety policy. Its ordinary-`Exception` guard provides process-local
+at-most-once submission
+relative to stale snapshots within one live runner; it supplies no process-death,
+`BaseException`, durable/idempotent executor, hardware-delivery, or reconciled-resume guarantee.
+Options, replacement/rebinding, boundaries, wire/durable dispatch replay, independent safety,
+additional/general environments, Forager, and robot adapters remain open. The robot and Forager
+paths do not currently consume `PrototypeAgent`, and Forager still records an unresolved
+extended-action dispatch edge.
+
+The current reference-life hillclimb is implemented as a permanently nonpromoting matched
+development scorecard in
+[`reference_life_controls.py`](alberta_framework/reference_life_controls.py) and
+[`reference_life_scorecard.py`](alberta_framework/benchmarks/reference_life_scorecard.py), with
+retained [control](tests/test_reference_life_controls.py) and
+[artifact/CLI](tests/test_reference_life_scorecard.py) tests. The literal-frozen plan uses 12
+consumed development seeds across SwitchingTwoState and RiverSwim and compares Prototype,
+frozen/no-learning Prototype, uniform random, an environment-bound finite-horizon privileged
+dynamic-programming control, differential SARSA, and discounted SARSA in 144 fresh-process
+shards. Every shard binds its current source identity, and aggregation requires one matching
+current identity. Agent RNG roots use explicit Threefry keys. Records validate fixed reward
+lattices, complete counters, and canonical initial/final numeric payload accounting including
+static oracle policy bytes; timing is telemetry-only. Run it through
+`asi-reference-life-scorecard`. This
+machinery is L0 and permanently nonpromoting: implementation, a valid plan, or passing validators
+does not select `reference-dev`, attest execution, or constitute a completed run, performance
+result, or scientific evidence.
+
+The package also contains inherited surfaces related to all twelve steps of the Alberta Plan.
+That crosswalk is useful for finding gaps, but completing a checklist of Plan mechanisms would
+not by itself establish the ASI north star.
 
 Keep these boundaries in mind:
 
-- Development and screening runs are permanently nonpromoting unless a separate frozen
-  protocol explicitly says otherwise.
+- Development and screening records are permanently nonpromoting. A distinct run under a
+  separately frozen protocol with untouched seeds may test a newly scoped scientific claim.
 - A passing unit test, smoke run, replay, or benchmark does not promote a scientific claim.
 - Registered evidence claims are narrow. Acceptance of one does not certify the package or
-  establish Alberta Plan completion.
+  establish ASI's whole-agent target, robotics readiness, state of the art, or Alberta Plan
+  completion.
 - Pinned artifacts are immutable historical records. Source drift makes compatibility checks
   fail closed; it is not repaired by editing the artifact or loosening its validator.
 - Consumed development or evidence seeds cannot be reused as fresh promotion seeds.
 
-See [the research status](docs/status.md) for the current requirement-to-evidence map and
+See [the research status](docs/status.md) for the current capability and Alberta crosswalk and
 [the evidence methodology](docs/evidence/methodology.md) for promotion rules, artifact
 contracts, and validator semantics.
 
 ## Install
 
-Alberta Framework requires Python 3.12 or newer, JAX/JAXlib 0.7.1 or newer, and
-NumPy 1.26 or newer.
-
-This development fork is not published under a fork-controlled PyPI name. The
-existing `alberta-framework` project on PyPI is a different distribution and
-does not install this repository. Install from a checkout:
+ASI currently requires Python 3.12 or newer. The
+existing `alberta-framework` project on PyPI is a different distribution and does not track this
+fork's version, Python floor, or dependency extras.
+Install ASI from a checkout instead:
 
 ```bash
 git clone https://github.com/elizaOS/asi.git
@@ -53,22 +179,28 @@ python3.12 -m venv .venv
 .venv/bin/python -m pip install -e .
 ```
 
-Optional dependency groups are available for common workflows:
+Optional dependency groups are available from the same checkout:
 
 ```bash
 .venv/bin/python -m pip install -e '.[gymnasium]'  # Gymnasium adapters
 .venv/bin/python -m pip install -e '.[forager]'    # continual-foragax testbed
-.venv/bin/python -m pip install -e '.[research]'   # plotting, datasets, parallel helpers
+.venv/bin/python -m pip install -e '.[research]'   # plots, tables, and dataset loaders
 .venv/bin/python -m pip install -e '.[gpu]'        # JAX CUDA 12 build
-.venv/bin/python -m pip install -e '.[dev]'        # tests, lint, and type checking
+.venv/bin/python -m pip install -e '.[dev]'        # tests, lint, typing, and research tools
 ```
 
-For repository development, use that project virtual environment for every command.
+For repository development, install the development extra and use the project virtual
+environment for every command:
+
+```bash
+.venv/bin/python -m pip install -e '.[dev]'
+```
 
 ## Quick start
 
-This example runs an online linear predictor on a drifting synthetic stream. JAX keys are
-explicit, and the learning loop uses `jax.lax.scan`.
+This small example runs one online-learning primitive on a drifting synthetic stream. It is
+useful for checking the library surface, not a demonstration of the target end-to-end agent.
+JAX keys are explicit, and the learning loop uses `jax.lax.scan`.
 
 ```python
 import jax.random as jr
@@ -91,7 +223,7 @@ state, metrics = run_learning_loop(
 )
 ```
 
-The repository also exposes short Step 1 and Step 2 integration probes:
+The repository also exposes two inherited Alberta Step integration probes:
 
 ```bash
 .venv/bin/alberta-step1-smoke --steps 256 --seed 0
@@ -108,12 +240,11 @@ The console scripts are grouped by responsibility; every command supports `--hel
 | Commands | Purpose |
 |---|---|
 | `alberta-step1-smoke`, `alberta-step2-smoke` | Nonpromoting mechanism smoke checks |
+| `asi-reference-life-scorecard` | Run or validate the permanently nonpromoting reference-life development scorecard |
 | `alberta-evidence-status` | Validate the complete five-claim evidence registry |
 | `alberta-recurring-feature-evidence`, `alberta-scale-robust-evidence`, `alberta-ftl-evidence`, `alberta-multiagent-evidence`, `alberta-ia-evidence` | Validate or build one claim's versioned artifact under its strict protocol |
-| `alberta-forager-benchmark` | Run development Forager comparisons; its `historical` subcommand exposes reconstructed historical-family inspection |
-| `alberta-historical-forager` | Compatibility alias for the historical inspection subcommand |
-| `alberta-foragax-open-screen` | Operate the bounded open-screen workflow documented in the runbook |
-| `alberta-foragax-oci` | Prepare, archive, build, inspect, probe, emit, or qualify the attested OCI execution environment |
+| `alberta-forager-benchmark`, `alberta-historical-forager` | Run development Forager comparisons or inspect reconstructed historical families |
+| `alberta-foragax-open-screen`, `alberta-foragax-oci` | Operate the bounded open-screen and qualified OCI workflows |
 | `alberta-forager-matched-campaign`, `alberta-forager-matched-qualification`, `alberta-forager-matched-sealed-evaluation` | Operate the matched-comparison campaign stages |
 
 Benchmark commands are not shortcuts around the evidence rules. Read
@@ -131,7 +262,7 @@ alberta_framework/
   evaluation/   evidence schemas, strict validators, registries, and CLIs
   benchmarks/   IPMNIST and Forager integrations and campaign runners
   utils/        experiment, metric, statistics, and export helpers
-  steps/        public Step 1-12 mechanism kernels and smoke integration
+  steps/        inherited Alberta Step 1-12 mechanism kernels and smoke integration
 tests/          unit, integration, scientific, and replay tests
 outputs/        evidence and campaign artifacts; see the immutability rules
 ```
@@ -149,7 +280,7 @@ The major package surfaces include:
 | Control | SARSA, actor-critic, average-reward and off-policy variants |
 | Continual mechanisms | learned state, feature lifecycles, memory, world models |
 | Temporal abstraction | subtasks, STOMP, OaK, option models and bounded planning |
-| Composition | `PrototypeAgent` and explicit transition/decision ownership |
+| Composition | `PrototypeAgent` candidate surface and explicit transition/decision ownership |
 | Evaluation | versioned artifacts, strict validators, evidence registry |
 
 API presence means that a mechanism is available for research. It does not imply empirical
@@ -172,8 +303,8 @@ The exit-code contract is:
 | `2` | at least one artifact is invalid |
 
 The registry validates artifact schema, protocol metadata, and registered source hashes. It is
-an operational index of narrow claims, not a package-wide evidence score or completion
-certificate.
+an operational index of narrow claims, not a package-wide evidence score, hillclimb metric, or
+completion certificate.
 
 Wheels and source distributions intentionally exclude `outputs/`. Consequently, running the
 status command from a normal package installation reports missing artifacts. Use a checkout
@@ -183,23 +314,30 @@ Do not overwrite, repair, or regenerate a pinned artifact in place. A new run mu
 path and, when required by its contract, a new schema version. The full rules are in
 [the evidence methodology](docs/evidence/methodology.md).
 
-## Active development campaigns
+## Current measured subsystem campaign
 
-The current headline lane is IPMNIST screening and confirmation. It is development-grade and
-permanently nonpromoting. Results change as new shards are appended, so this README does not
-copy arm rankings, means, test counts, or seed counts.
+IPMNIST development screening and development confirmation is the current measured plasticity
+and conditioning lane. It generates and rejects mechanism hypotheses; it is not the end-to-end
+target or the top-level reference-life hillclimb. The lane is permanently nonpromoting. Results
+change as new shards are appended, so this README does not copy arm rankings, means, test
+counts, or seed counts.
 
-Use the primary records instead:
+Use the mutable campaign index to find the current record. The output documents are
+append-only chronological records, so their historical words such as "final" or "current"
+may have been superseded by a later summary.
 
+- [Current IPMNIST campaign index](docs/research/ipmnist-campaign-index.md)
 - [IPMNIST theory and forward hypotheses](docs/research/ipmnist-theory.md)
-- [Campaign runbook](outputs/ipmnist_screening/RUNBOOK.md)
-- [Stored development report](outputs/ipmnist_screening/FINAL_REPORT.md)
-- [Artifact and reproducibility audit](outputs/ipmnist_screening/AUDIT.md)
-- [Publication-run record](outputs/ipmnist_screening/publication_runs/RESULTS.md)
-- `outputs/ipmnist_screening/summary_*.json` for the latest stored summaries
+- `outputs/ipmnist_screening/summary_*.json` for stored measurement records
+- [Chronological campaign runbook](outputs/ipmnist_screening/RUNBOOK.md)
+- [Historical accumulated report](outputs/ipmnist_screening/FINAL_REPORT.md)
+- [Historical artifact and reproducibility audit](outputs/ipmnist_screening/AUDIT.md)
+- [Pre-RLS publication-run record](outputs/ipmnist_screening/publication_runs/RESULTS.md)
 
 Remeasure the intended baseline under the current development protocol before making an A/B
-comparison. Do not infer a scientific or state-of-the-art claim from the screening record.
+comparison. A survivor still needs complementary-stream, resource, and downstream-control
+checks before it is an integrated improvement. Do not infer an ASI, robotics, scientific, or
+state-of-the-art claim from the screening record.
 
 Forager integration and comparator details are in
 [FORAGER_BENCHMARK.md](FORAGER_BENCHMARK.md).
@@ -226,6 +364,8 @@ The repository uses these pytest markers:
 - `slow`: wall-clock-heavy tests excluded from the fast per-change lane
 - `package`: built-distribution and installed-entry-point contracts run only in the package lane
 
+The fast CI runtime selector is `-m "not slow and not package"`.
+
 Benchmark campaigns run through their scripts or console CLIs, never as ordinary pytest work.
 Keep tests CI-cheap unless the protocol is deliberately registered as scientific evidence.
 
@@ -233,11 +373,21 @@ Library changes should start with a failing test. Preserve immutable state, expl
 `jax.random` keys, Python 3.12 support, and the NumPy 1.26 minimum. Before editing evaluation
 or benchmark sources, check whether a stored artifact registers their hashes.
 
+Research changes should also start from a freshly measured control and a named integration
+path. Prefer a small falsifiable comparison that can remove an idea over a broad new mechanism
+surface with no whole-agent consumer. Use the process in the
+[ASI research roadmap](docs/research/asi-roadmap.md).
+
 Do not auto-promote results, retune a frozen threshold after seeing held-out data, reuse
 consumed seeds, or modify immutable `outputs/` records. See
 [the evidence methodology](docs/evidence/methodology.md) before changing any evidence lane.
 
 ## Documentation
+
+### Mission and strategy
+
+- [ASI research roadmap and whole-life scorecard](docs/research/asi-roadmap.md)
+- [Proposed ASI reference-agent protocol](docs/design/asi-reference-agent-protocol.md)
 
 ### Status and evidence
 
@@ -252,7 +402,9 @@ consumed seeds, or modify immutable `outputs/` records. See
 ### Research and historical audits
 
 - [IPMNIST theory](docs/research/ipmnist-theory.md)
+- [Current IPMNIST campaign index](docs/research/ipmnist-campaign-index.md)
 - [RTU Taylor-correction derivation](docs/design/rtu-taylor-correction.md)
+- [Dated repository anti-LARP audit](docs/audits/repository-larp-audit.md)
 - [Forager comparator audit](docs/archive/forager-comparator-audit.md)
 - [Historical Forager reconstruction](docs/archive/historical-forager-reconstruction.md)
 - [OPMNIST closure provenance](outputs/step2_canonical/step2_opmnist_solution_800task_3seed_PROVENANCE.md)
@@ -266,10 +418,10 @@ consumed seeds, or modify immutable `outputs/` records. See
 
 ## Citation
 
-Project citation metadata is provided in [CITATION.cff](CITATION.cff). Cite the original papers
+ASI citation metadata is provided in [CITATION.cff](CITATION.cff). Cite the original papers
 for algorithms and benchmarks used in a particular experiment, including the
 [Alberta Plan](https://arxiv.org/abs/2208.11173).
 
 ## License
 
-Alberta Framework is licensed under the [Apache License 2.0](LICENSE).
+ASI is licensed under the [Apache License 2.0](LICENSE).

--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -1,0 +1,3457 @@
+"""Matched, permanently nonpromoting reference-life development scorecard.
+
+The scorecard is a development-selection instrument, never scientific evidence
+and never a route to ``reference-dev``.  Its plan is intentionally fixed.  A
+different arm, seed, horizon, environment, or gate is a new schema, not a CLI
+override.
+
+Execution streams each accepted event into bounded summaries.  Full event
+objects are never retained by this module.  Wall-clock measurements are kept in
+a separately labelled telemetry block and are excluded from every score and
+gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import dataclasses
+import errno
+import functools
+import hashlib
+import json
+import math
+import os
+import stat
+import struct
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, NoReturn, cast
+
+import jax
+import numpy as np
+
+from alberta_framework.core.oak import OaKConfig
+from alberta_framework.core.options import STOMPConfig
+from alberta_framework.core.prototype_agent import PrototypeAgentConfig
+from alberta_framework.prototype_reference_adapter import PrototypeReferenceState
+from alberta_framework.reference_agent import (
+    REFERENCE_AGENT_API_VERSION,
+    AgentCapabilities,
+    AgentManifest,
+    ArrayValue,
+    ReferenceAgentUpdate,
+    SpaceSpec,
+    canonical_config_sha256,
+)
+from alberta_framework.reference_life import (
+    REFERENCE_LIFE_RNG_SCHEDULE,
+    ExactDispatchConfig,
+    LifePhase,
+    ReferenceEnvironmentManifest,
+    ReferenceLifeMetricsConfig,
+    ReferenceLifeRunner,
+    RiverSwimReferenceEnvironment,
+    SwitchingTwoStateReferenceEnvironment,
+    build_prototype_riverswim_life,
+    build_prototype_switching_life,
+)
+from alberta_framework.reference_life_checkpoint import (
+    _dependency_identity as _checkpoint_dependency_identity,
+)
+from alberta_framework.reference_life_checkpoint import (
+    _runtime_identity as _checkpoint_runtime_identity,
+)
+from alberta_framework.reference_life_checkpoint import (
+    _source_identity as _checkpoint_source_identity,
+)
+from alberta_framework.streams.closed_loop import (
+    RiverSwimConfig,
+    RiverSwimMDP,
+    SwitchingTwoStateConfig,
+    SwitchingTwoStateMDP,
+)
+
+# Importing ReferenceAgentUpdate above is deliberate: the runner/control seam is
+# the state-agnostic update contract, not PrototypeAdapterUpdate.
+_REFERENCE_UPDATE_TYPE = ReferenceAgentUpdate
+
+REFERENCE_LIFE_SCORECARD_PLAN_SCHEMA = "asi.reference_life_scorecard.plan.v1"
+REFERENCE_LIFE_SCORECARD_RUN_SCHEMA = "asi.reference_life_scorecard.run.v1"
+REFERENCE_LIFE_SCORECARD_ARTIFACT_SCHEMA = "asi.reference_life_scorecard.artifact.v1"
+REFERENCE_LIFE_SCORECARD_SUMMARY_SCHEMA = "asi.reference_life_scorecard.summary.v1"
+PROTOCOL_ID = "asi.reference_life_scorecard.matched_development.v1"
+
+ARM_ROSTER = (
+    "prototype",
+    "prototype_frozen",
+    "random",
+    "privileged_oracle",
+    "differential_sarsa",
+    "sarsa",
+)
+ENVIRONMENT_ROSTER = ("switching_two_state", "riverswim")
+SEED_ROSTER = tuple(range(70_000, 70_012))
+
+SWITCHING_HORIZON = 4_000
+SWITCHING_PHASE_LENGTH = 250
+SWITCHING_POST_SWITCH_WINDOW = 50
+RIVERSWIM_HORIZON = 20_000
+RIVERSWIM_N_STATES = 6
+RIVERSWIM_EARLY_WINDOW = 2_000
+RIVERSWIM_LATE_WINDOW = 2_000
+
+SWITCHING_PAYOFFS_A = ((0.0, 1.0), (1.0, 0.0))
+SWITCHING_PAYOFFS_B = ((1.0, 0.0), (0.0, 1.0))
+RIVERSWIM_P_RIGHT_UP = 0.35
+RIVERSWIM_P_RIGHT_DOWN = 0.05
+RIVERSWIM_REWARD_LEFT = 0.005
+RIVERSWIM_REWARD_RIGHT = 1.0
+RIVERSWIM_INITIAL_STATE = 0
+
+# Plan v1 pins its explicit literals and every shard records the fully resolved
+# live component configs plus source identity.  It does not claim that the plan
+# digest alone freezes defaults which are not explicit in this payload.
+REFERENCE_LIFE_SCORECARD_PLAN_V1_SHA256 = (
+    "4c4396848da3abebc53fb61c7b241866566ad2b44fa83ee3395a5a389a869b86"
+)
+
+# A complete 144-shard aggregate is comfortably below this limit.  Keeping
+# the cap explicit prevents validation inputs from becoming an unbounded read.
+MAX_SCORECARD_JSON_INPUT_BYTES = 64 * 1024 * 1024
+MAX_SCORECARD_AGGREGATE_INPUT_BYTES = 256 * 1024 * 1024
+
+CONTROL_GATE_T_CRITICAL = 2.201
+CONTROL_GATE_LCB_THRESHOLD = 0.10
+
+NONPROMOTING_POLICY: dict[str, object] = {
+    "evidence_class": "development_selection_scorecard",
+    "development_only": True,
+    "permanently_nonpromoting": True,
+    "scientific_promotion_allowed": False,
+    "reference_dev_population_allowed": False,
+}
+
+TELEMETRY_POLICY = {
+    "classification": "telemetry_only",
+    "used_for_selection": False,
+    "used_for_scoring": False,
+    "cross_machine_comparison_supported": False,
+}
+
+_SHA256_PATTERN_LENGTH = 64
+
+
+def _fail(message: str) -> NoReturn:
+    raise ValueError(message)
+
+
+def _validate_json_value(value: Any, *, path: str = "$", depth: int = 0) -> None:
+    if depth > 64:
+        _fail(f"{path}: JSON nesting exceeds 64 levels")
+    if value is None or type(value) in (str, bool, int):
+        return
+    if type(value) is float:
+        if not math.isfinite(value):
+            _fail(f"{path}: JSON numbers must be finite")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_json_value(item, path=f"{path}[{index}]", depth=depth + 1)
+        return
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                _fail(f"{path}: JSON object keys must be strings")
+            _validate_json_value(item, path=f"{path}.{key}", depth=depth + 1)
+        return
+    _fail(f"{path}: value is not canonical JSON")
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Encode finite JSON with the scorecard's hash canonicalization."""
+
+    _validate_json_value(value)
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError("value does not have a canonical JSON encoding") from exc
+
+
+def _sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _json_exact_equal(left: Any, right: Any) -> bool:
+    """Compare canonical JSON values without Python's bool/int coercions."""
+
+    if type(left) is not type(right):
+        return False
+    if type(left) is dict:
+        return set(left) == set(right) and all(
+            _json_exact_equal(left[key], right[key]) for key in left
+        )
+    if type(left) is list:
+        return len(left) == len(right) and all(
+            _json_exact_equal(a, b) for a, b in zip(left, right, strict=True)
+        )
+    if type(left) is float:
+        return struct.pack(">d", left) == struct.pack(">d", right)
+    return bool(left == right)
+
+
+def _digest_excluding(payload: Mapping[str, Any], field: str) -> str:
+    return _sha256_json({key: value for key, value in payload.items() if key != field})
+
+
+def _is_sha256(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == _SHA256_PATTERN_LENGTH
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _arm_definitions() -> list[dict[str, Any]]:
+    return [
+        {
+            "arm": "prototype",
+            "family": "prototype",
+            "role": "candidate",
+            "learning_expectation": "at_least_one_parameter_change",
+            "config": {
+                "base_step_size": 0.05,
+                "base_average_reward_step_size": 0.01,
+                "base_trace_decay": 0.0,
+                "epsilon_base": 0.1,
+                "primitive_only": True,
+            },
+        },
+        {
+            "arm": "prototype_frozen",
+            "family": "prototype",
+            "role": "frozen_no_learning_control",
+            "learning_expectation": "zero_parameter_changes",
+            "config": {
+                "base_step_size": 0.0,
+                "base_average_reward_step_size": 0.0,
+                "base_trace_decay": 0.0,
+                "epsilon_base": 0.1,
+                "primitive_only": True,
+            },
+        },
+        {
+            "arm": "random",
+            "family": "uniform_random",
+            "role": "random_control",
+            "learning_expectation": "zero_parameter_changes",
+            "config": {"action_distribution": "uniform", "n_actions": 2},
+        },
+        {
+            "arm": "privileged_oracle",
+            "family": "analytic_oracle",
+            "role": "privileged_upper_control",
+            "learning_expectation": "zero_parameter_changes",
+            "config": {
+                "finite_horizon_solver": (
+                    "finite_horizon_backward_dynamic_program.float64.tie_low.preview1"
+                ),
+                "horizon_binding": "environment_protocol_horizon",
+                "privileged_environment_model": True,
+                "tie_break": "lowest_action_index",
+            },
+        },
+        {
+            "arm": "differential_sarsa",
+            "family": "differential_sarsa",
+            "role": "strong_control_candidate",
+            "learning_expectation": "at_least_one_parameter_change",
+            "config": {
+                "q_step_size": 0.1,
+                "average_reward_step_size": 0.01,
+                "trace_decay": 0.0,
+                "epsilon_start": 0.5,
+                "epsilon_end": 0.02,
+                "epsilon_decay_steps": 2_500,
+                "use_bias": True,
+            },
+        },
+        {
+            "arm": "sarsa",
+            "family": "discounted_sarsa",
+            "role": "strong_control_candidate",
+            "learning_expectation": "at_least_one_parameter_change",
+            "config": {
+                "gamma": 0.9,
+                "epsilon_start": 0.5,
+                "epsilon_end": 0.02,
+                "epsilon_decay_steps": 2_500,
+                "hidden_sizes": [],
+                "step_size": 0.05,
+                "sparsity": 0.0,
+                "leaky_relu_slope": 0.01,
+                "use_layer_norm": False,
+                "lamda": 0.0,
+            },
+        },
+    ]
+
+
+def _rotated_arms(seed_index: int) -> tuple[str, ...]:
+    offset = seed_index % len(ARM_ROSTER)
+    return ARM_ROSTER[offset:] + ARM_ROSTER[:offset]
+
+
+def _fixed_plan_payload_without_digest() -> dict[str, Any]:
+    return {
+        "schema": REFERENCE_LIFE_SCORECARD_PLAN_SCHEMA,
+        "schema_version": 1,
+        "benchmark": "reference_life_matched_development_scorecard",
+        "protocol_id": PROTOCOL_ID,
+        "evidence_policy": dict(NONPROMOTING_POLICY),
+        "claim_limitations": [
+            "not scientific evidence",
+            "not performance evidence",
+            "not reference-dev promotion",
+            "not robotics readiness",
+        ],
+        "arm_roster": list(ARM_ROSTER),
+        "arm_definitions": _arm_definitions(),
+        "environment_roster": list(ENVIRONMENT_ROSTER),
+        "seed_roster": list(SEED_ROSTER),
+        "schedule": {
+            "environment_seed_contract": (
+                "each arm receives the identical uint32 life seed; environment keys are "
+                "jax split index 1 and execution keys fold in the same cursor"
+            ),
+            "environment_order": list(ENVIRONMENT_ROSTER),
+            "arm_order_policy": "left_cyclic_rotation_by_seed_roster_index",
+            "execution_isolation": (
+                "one_canonical_shard_per_fresh_python_process; aggregate only reads shards"
+            ),
+            "per_seed_arm_order": [
+                {"seed": seed, "arms": list(_rotated_arms(index))}
+                for index, seed in enumerate(SEED_ROSTER)
+            ],
+        },
+        "protocols": {
+            "switching_two_state": {
+                "horizon": SWITCHING_HORIZON,
+                "phase_length": SWITCHING_PHASE_LENGTH,
+                "segments": 16,
+                "post_switch_window": SWITCHING_POST_SWITCH_WINDOW,
+                "aba_windows": {
+                    "initial_a": [0, 50],
+                    "first_b": [250, 300],
+                    "return_a": [500, 550],
+                    "interval_semantics": "zero_based_half_open_accepted_event_indices",
+                },
+                "payoffs_a": [list(row) for row in SWITCHING_PAYOFFS_A],
+                "payoffs_b": [list(row) for row in SWITCHING_PAYOFFS_B],
+                "initial_state": "uniform_random_from_environment_root_key",
+                "continuing": True,
+            },
+            "riverswim": {
+                "horizon": RIVERSWIM_HORIZON,
+                "n_states": RIVERSWIM_N_STATES,
+                "p_right_up": RIVERSWIM_P_RIGHT_UP,
+                "p_right_down": RIVERSWIM_P_RIGHT_DOWN,
+                "reward_left": RIVERSWIM_REWARD_LEFT,
+                "reward_right": RIVERSWIM_REWARD_RIGHT,
+                "initial_state": RIVERSWIM_INITIAL_STATE,
+                "early_window": RIVERSWIM_EARLY_WINDOW,
+                "late_window": RIVERSWIM_LATE_WINDOW,
+                "high_end_visit_definition": (
+                    "post_transition_state_index_equals_n_states_minus_one"
+                ),
+                "continuing": True,
+            },
+        },
+        "summaries": {
+            "event_retention": "streaming_o1_no_full_event_list",
+            "normalization": (
+                "within_environment_seed_paired_(arm_return-random_return)/"
+                "mean(oracle_return-random_return)"
+            ),
+            "cross_environment_pooling": "forbidden",
+        },
+        "control_calibration_gate": {
+            "classification": "development_heuristic_not_scientific_inference",
+            "required_complete_seed_count": 12,
+            "scale": "mean_seed(oracle_return-random_return)",
+            "paired_sample": "(sarsa_return_i-random_return_i)/scale",
+            "lcb": "mean(sample)-2.201*sample_sd_ddof1/sqrt(12)",
+            "t_critical": CONTROL_GATE_T_CRITICAL,
+            "minimum_lcb_exclusive": CONTROL_GATE_LCB_THRESHOLD,
+            "environment_qualifies": (
+                "differential_sarsa_or_sarsa_has_lcb_strictly_above_threshold"
+            ),
+            "overall_failure_status": "valid_baseline_failure",
+        },
+        "candidate_development_gate": {
+            "classification": "development_heuristic_not_scientific_inference",
+            "prototype_vs_frozen_paired_lcb_minimum_inclusive": 0.05,
+            "prototype_vs_best_qualifying_sarsa_noninferiority_margin": -0.05,
+            "required_in_each_environment": True,
+            "pareto_utility_advantage": 0.05,
+            "pareto_resource_advantage_fraction": 0.20,
+            "resource_decision": "not_evaluated_while_latency_is_telemetry_only",
+        },
+        "timing_policy": dict(TELEMETRY_POLICY),
+        "resource_policy": {
+            "persistent_state": "numeric_jax_and_numpy_pytree_leaf_bytes",
+            "static_adapter_numeric_state": (
+                "finite_horizon_oracle_policy_bytes_else_zero"
+            ),
+            "trainable_scalars": (
+                "adapter_parameter_tree_when_available_else_floating_leaf_upper_bound"
+            ),
+            "estimates_are_not_hardware_memory_peaks": True,
+        },
+    }
+
+
+def _fixed_plan_payload() -> dict[str, Any]:
+    payload = _fixed_plan_payload_without_digest()
+    observed_digest = _sha256_json(payload)
+    if observed_digest != REFERENCE_LIFE_SCORECARD_PLAN_V1_SHA256:
+        raise RuntimeError(
+            "reference-life scorecard plan v1 literals no longer match the pinned digest"
+        )
+    payload["plan_sha256"] = REFERENCE_LIFE_SCORECARD_PLAN_V1_SHA256
+    return payload
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceLifeDevelopmentPlan:
+    """Deeply immutable wrapper around the one accepted development plan."""
+
+    schema: str
+    plan_sha256: str
+    _canonical_json: str = dataclasses.field(repr=False)
+
+    def __post_init__(self) -> None:
+        if self.schema != REFERENCE_LIFE_SCORECARD_PLAN_SCHEMA:
+            raise ValueError("unsupported reference-life development-plan schema")
+        if not _is_sha256(self.plan_sha256):
+            raise ValueError("plan_sha256 must be a lowercase SHA-256 digest")
+        try:
+            payload = json.loads(self._canonical_json)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ValueError("development plan is not canonical JSON") from exc
+        if canonical_json_bytes(payload).decode("utf-8") != self._canonical_json:
+            raise ValueError("development plan JSON is not canonical")
+        if not _json_exact_equal(payload, _fixed_plan_payload()):
+            raise ValueError("payload is not the canonical fixed development plan")
+        if payload["plan_sha256"] != self.plan_sha256:
+            raise ValueError("development plan digest is inconsistent")
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> ReferenceLifeDevelopmentPlan:
+        try:
+            copied = json.loads(canonical_json_bytes(payload).decode("utf-8"))
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise ValueError("payload is not the canonical fixed development plan") from exc
+        if not _json_exact_equal(copied, _fixed_plan_payload()):
+            raise ValueError("payload is not the canonical fixed development plan")
+        return cls(
+            schema=REFERENCE_LIFE_SCORECARD_PLAN_SCHEMA,
+            plan_sha256=cast(str, copied["plan_sha256"]),
+            _canonical_json=canonical_json_bytes(copied).decode("utf-8"),
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        payload = json.loads(self._canonical_json)
+        assert isinstance(payload, dict)
+        return payload
+
+    @property
+    def seeds(self) -> tuple[int, ...]:
+        return SEED_ROSTER
+
+    @property
+    def arms(self) -> tuple[str, ...]:
+        return ARM_ROSTER
+
+    @property
+    def environments(self) -> tuple[str, ...]:
+        return ENVIRONMENT_ROSTER
+
+    def arm_order(self, seed: int) -> tuple[str, ...]:
+        if type(seed) is not int or seed not in SEED_ROSTER:
+            raise ValueError("seed is not in the fixed scorecard roster")
+        return _rotated_arms(SEED_ROSTER.index(seed))
+
+    def arm_definition(self, arm: str) -> dict[str, Any]:
+        if arm not in ARM_ROSTER:
+            raise ValueError(f"unsupported scorecard arm {arm!r}")
+        definitions = self.to_payload()["arm_definitions"]
+        assert isinstance(definitions, list)
+        for definition in definitions:
+            if definition["arm"] == arm:
+                return cast(dict[str, Any], definition)
+        raise AssertionError("canonical arm definition is missing")
+
+    def protocol(self, environment_kind: str) -> dict[str, Any]:
+        if environment_kind not in ENVIRONMENT_ROSTER:
+            raise ValueError(f"unsupported environment {environment_kind!r}")
+        protocol = self.to_payload()["protocols"][environment_kind]
+        assert isinstance(protocol, dict)
+        return protocol
+
+
+def build_development_plan() -> ReferenceLifeDevelopmentPlan:
+    """Return the only scorecard plan accepted by this schema."""
+
+    return ReferenceLifeDevelopmentPlan.from_payload(_fixed_plan_payload())
+
+
+@dataclasses.dataclass(slots=True)
+class _Window:
+    start: int
+    stop: int
+    event_count: int = 0
+    reward_sum: float = 0.0
+    regret_sum: float = 0.0
+
+    def observe(self, index: int, reward: float, oracle_reward: float) -> None:
+        if self.start <= index < self.stop:
+            self.event_count += 1
+            self.reward_sum += reward
+            self.regret_sum += oracle_reward - reward
+
+    def payload(self) -> dict[str, int | float]:
+        if self.event_count <= 0:
+            raise ValueError("metric window did not receive its fixed event count")
+        return {
+            "event_count": self.event_count,
+            "reward_sum": self.reward_sum,
+            "mean_reward": self.reward_sum / self.event_count,
+            "mean_oracle_regret": self.regret_sum / self.event_count,
+        }
+
+
+class StreamingRunSummary:
+    """O(1)-space online reducer for one fixed-horizon life.
+
+    The object owns only scalar counters and at most three fixed windows.  It
+    intentionally has no event collection and cannot reconstruct a transcript.
+    The authoritative runner's transcript digest is recorded separately.
+    """
+
+    __slots__ = (
+        "_accepted_events",
+        "_early",
+        "_environment_kind",
+        "_high_end_visit_count",
+        "_horizon",
+        "_late",
+        "_n_states",
+        "_oracle_reward_sum",
+        "_parameter_change_events",
+        "_phase_event_counts",
+        "_phase_length",
+        "_phase_reward_sums",
+        "_reward_sum",
+        "_switching_windows",
+    )
+
+    def __init__(
+        self,
+        *,
+        environment_kind: str,
+        horizon: int,
+        phase_length: int | None,
+        n_states: int | None,
+        early_window: int | None,
+        late_window: int | None,
+        post_switch_window: int | None,
+    ) -> None:
+        if environment_kind not in ENVIRONMENT_ROSTER:
+            raise ValueError("unsupported streaming-summary environment")
+        if type(horizon) is not int or horizon <= 0:
+            raise ValueError("horizon must be a positive integer")
+        self._environment_kind = environment_kind
+        self._horizon = horizon
+        self._accepted_events = 0
+        self._reward_sum = 0.0
+        self._oracle_reward_sum = 0.0
+        self._parameter_change_events = 0
+        self._phase_event_counts = [0, 0]
+        self._phase_reward_sums = [0.0, 0.0]
+        self._high_end_visit_count = 0
+        self._phase_length = phase_length
+        self._n_states = n_states
+        self._switching_windows: dict[str, _Window] = {}
+        self._early: _Window | None = None
+        self._late: _Window | None = None
+
+        if environment_kind == "switching_two_state":
+            if type(phase_length) is not int or phase_length <= 0:
+                raise ValueError("switching phase_length must be positive")
+            if type(post_switch_window) is not int or post_switch_window <= 0:
+                raise ValueError("switching post_switch_window must be positive")
+            if 2 * phase_length + post_switch_window > horizon:
+                raise ValueError("switching horizon does not contain the A/B/A windows")
+            self._switching_windows = {
+                "initial_a": _Window(0, post_switch_window),
+                "first_b": _Window(phase_length, phase_length + post_switch_window),
+                "return_a": _Window(
+                    2 * phase_length,
+                    2 * phase_length + post_switch_window,
+                ),
+            }
+        else:
+            if type(n_states) is not int or n_states < 2:
+                raise ValueError("RiverSwim n_states must be at least two")
+            if type(early_window) is not int or not 0 < early_window <= horizon:
+                raise ValueError("RiverSwim early window is outside the horizon")
+            if type(late_window) is not int or not 0 < late_window <= horizon:
+                raise ValueError("RiverSwim late window is outside the horizon")
+            self._early = _Window(0, early_window)
+            self._late = _Window(horizon - late_window, horizon)
+
+    @classmethod
+    def for_switching(
+        cls,
+        *,
+        horizon: int,
+        phase_length: int,
+        post_switch_window: int,
+    ) -> StreamingRunSummary:
+        return cls(
+            environment_kind="switching_two_state",
+            horizon=horizon,
+            phase_length=phase_length,
+            n_states=None,
+            early_window=None,
+            late_window=None,
+            post_switch_window=post_switch_window,
+        )
+
+    @classmethod
+    def for_riverswim(
+        cls,
+        *,
+        horizon: int,
+        early_window: int,
+        late_window: int,
+        n_states: int,
+    ) -> StreamingRunSummary:
+        return cls(
+            environment_kind="riverswim",
+            horizon=horizon,
+            phase_length=None,
+            n_states=n_states,
+            early_window=early_window,
+            late_window=late_window,
+            post_switch_window=None,
+        )
+
+    @property
+    def accepted_events(self) -> int:
+        return self._accepted_events
+
+    def observe(
+        self,
+        *,
+        reward: float,
+        oracle_reward: float,
+        regime_id: int,
+        parameters_changed: bool,
+        next_state_index: int,
+    ) -> None:
+        if self._accepted_events >= self._horizon:
+            raise ValueError("streaming summary already reached its horizon")
+        if isinstance(reward, bool) or not isinstance(reward, (int, float)):
+            raise ValueError("reward must be a finite number")
+        if isinstance(oracle_reward, bool) or not isinstance(oracle_reward, (int, float)):
+            raise ValueError("oracle_reward must be a finite number")
+        reward_value = float(reward)
+        oracle_value = float(oracle_reward)
+        if not math.isfinite(reward_value) or not math.isfinite(oracle_value):
+            raise ValueError("streaming metric inputs must be finite")
+        if not isinstance(parameters_changed, bool):
+            raise ValueError("parameters_changed must be boolean")
+        if type(next_state_index) is not int:
+            raise ValueError("next_state_index must be an integer")
+
+        index = self._accepted_events
+        if self._environment_kind == "switching_two_state":
+            assert self._phase_length is not None
+            expected_regime = (index // self._phase_length) % 2
+            if regime_id != expected_regime:
+                raise ValueError("switching regime does not match the fixed schedule")
+            if next_state_index not in (0, 1):
+                raise ValueError("switching next state is outside {0, 1}")
+            for window in self._switching_windows.values():
+                window.observe(index, reward_value, oracle_value)
+        else:
+            if regime_id != 0:
+                raise ValueError("RiverSwim must remain in stationary regime zero")
+            assert self._n_states is not None
+            if next_state_index < 0 or next_state_index >= self._n_states:
+                raise ValueError("RiverSwim next state is outside its chain")
+            assert self._early is not None and self._late is not None
+            self._early.observe(index, reward_value, oracle_value)
+            self._late.observe(index, reward_value, oracle_value)
+            self._high_end_visit_count += int(next_state_index == self._n_states - 1)
+
+        self._accepted_events += 1
+        self._reward_sum += reward_value
+        self._oracle_reward_sum += oracle_value
+        self._parameter_change_events += int(parameters_changed)
+        self._phase_event_counts[regime_id] += 1
+        self._phase_reward_sums[regime_id] += reward_value
+
+    def _payload(self, *, require_complete: bool) -> dict[str, Any]:
+        if require_complete and self._accepted_events != self._horizon:
+            raise ValueError(
+                "cannot finalize streaming summary before the configured horizon"
+            )
+        payload: dict[str, Any] = {
+            "summary_mode": "streaming_o1_no_retained_events",
+            "configured_horizon": self._horizon,
+            "accepted_events": self._accepted_events,
+            "reward_sum": self._reward_sum,
+            "mean_reward": (
+                None
+                if self._accepted_events == 0
+                else self._reward_sum / self._accepted_events
+            ),
+            "oracle_reward_sum": self._oracle_reward_sum,
+            "regret_sum": self._oracle_reward_sum - self._reward_sum,
+            "parameter_change_events": self._parameter_change_events,
+            "phase_event_counts": list(self._phase_event_counts),
+            "phase_reward_sums": list(self._phase_reward_sums),
+        }
+        if self._environment_kind == "switching_two_state":
+            windows: dict[str, Any]
+            if require_complete:
+                windows = {
+                    name: window.payload()
+                    for name, window in self._switching_windows.items()
+                }
+            else:
+                windows = {
+                    name: (
+                        None if window.event_count == 0 else window.payload()
+                    )
+                    for name, window in self._switching_windows.items()
+                }
+            payload["windows"] = windows
+            payload["high_end_visit_count"] = None
+            payload["high_end_visit_rate"] = None
+        else:
+            assert self._early is not None and self._late is not None
+            payload["windows"] = {
+                "early": (
+                    self._early.payload()
+                    if self._early.event_count > 0
+                    else None
+                ),
+                "late": (
+                    self._late.payload()
+                    if self._late.event_count > 0
+                    else None
+                ),
+            }
+            payload["high_end_visit_count"] = self._high_end_visit_count
+            payload["high_end_visit_rate"] = (
+                None
+                if self._accepted_events == 0
+                else self._high_end_visit_count / self._accepted_events
+            )
+        return payload
+
+    def finalize(self) -> dict[str, Any]:
+        return self._payload(require_complete=True)
+
+    def partial(self) -> dict[str, Any]:
+        """Return bounded diagnostics for a failed incomplete life."""
+
+        return self._payload(require_complete=False)
+
+
+def _iter_array_leaves(value: Any) -> Any:
+    if isinstance(value, ArrayValue):
+        # ArrayValue is a dataclass whose numeric storage is intentionally an
+        # immutable bytes payload.  Treat that payload as the numeric leaf it
+        # represents instead of losing cached observations/actions while
+        # recursively walking only Python containers.
+        yield value.to_numpy()
+        return
+    if isinstance(value, (jax.Array, np.ndarray)):
+        yield value
+        return
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        for field in dataclasses.fields(value):
+            yield from _iter_array_leaves(getattr(value, field.name))
+        return
+    if isinstance(value, Mapping):
+        for item in value.values():
+            yield from _iter_array_leaves(item)
+        return
+    if isinstance(value, (tuple, list)):
+        for item in value:
+            yield from _iter_array_leaves(item)
+
+
+def _array_leaf_facts(tree: Any) -> tuple[int, int, int, int]:
+    array_leaves = 0
+    elements = 0
+    byte_count = 0
+    floating_elements = 0
+    for leaf in _iter_array_leaves(tree):
+        array_leaves += 1
+        leaf_size = int(getattr(leaf, "size", 0))
+        elements += leaf_size
+        byte_count += int(getattr(leaf, "nbytes", 0))
+        try:
+            dtype = np.dtype(leaf.dtype)
+        except TypeError:
+            # Typed JAX PRNG keys are persistent arrays but are not trainable.
+            continue
+        if dtype.kind in {"f", "c"}:
+            floating_elements += leaf_size
+    return array_leaves, elements, byte_count, floating_elements
+
+
+def estimate_jax_resources(state: Any) -> dict[str, Any]:
+    """Return a transparent generic persistent-state/resource estimate.
+
+    The fallback trainable count is explicitly an upper bound: floating
+    optimizer statistics, traces, and caches may be included.  Execution uses
+    narrower adapter-specific parameter trees where this module knows them.
+    """
+
+    leaves, elements, byte_count, floating_elements = _array_leaf_facts(state)
+    return {
+        "persistent_jax_array_leaves": leaves,
+        "persistent_jax_array_scalar_count": elements,
+        "persistent_jax_array_bytes": byte_count,
+        "persistent_state_measurement": "numeric_jax_and_numpy_pytree_leaves",
+        "trainable_scalar_count_estimate": floating_elements,
+        "trainable_scalar_count_method": "floating_jax_pytree_leaves_upper_bound",
+        "hardware_peak_memory_measured": False,
+    }
+
+
+def _prototype_parameter_tree(state: Any) -> Any | None:
+    if not isinstance(state, PrototypeReferenceState):
+        return None
+    oak_state = state.agent_state.oak_state
+    stomp_state = getattr(oak_state, "stomp_state", None)
+    base = getattr(stomp_state, "base_learner_state", None)
+    if base is None:
+        return None
+    return (
+        getattr(base, "trunk_params", ()),
+        getattr(base, "head_params", ()),
+        getattr(stomp_state, "base_average_reward", ()),
+    )
+
+
+def _known_control_parameter_tree(state: Any) -> Any | None:
+    """Extract known control parameters without treating traces as trainable."""
+
+    inner = getattr(state, "agent_state", state)
+    if all(hasattr(inner, name) for name in ("q_weights", "average_reward")):
+        return (
+            inner.q_weights,
+            getattr(inner, "q_bias", ()),
+            inner.average_reward,
+        )
+    learner_state = getattr(inner, "learner_state", None)
+    if learner_state is not None and all(
+        hasattr(learner_state, name) for name in ("trunk_params", "head_params")
+    ):
+        return learner_state.trunk_params, learner_state.head_params
+    return None
+
+
+def _agent_resource_payload(adapter: Any, state: Any) -> dict[str, Any]:
+    resource = estimate_jax_resources(state)
+    static_bytes = getattr(adapter, "static_numeric_bytes", 0)
+    if type(static_bytes) is not int or static_bytes < 0:
+        raise ValueError("adapter static_numeric_bytes must be a nonnegative integer")
+    resource["persistent_static_numeric_bytes"] = static_bytes
+    resource["persistent_numeric_bytes_total"] = (
+        resource["persistent_jax_array_bytes"] + static_bytes
+    )
+    parameter_tree: Any | None = None
+    method = "floating_jax_pytree_leaves_upper_bound"
+    adapter_tree = getattr(adapter, "trainable_parameter_tree", None)
+    if callable(adapter_tree):
+        parameter_tree = adapter_tree(state)
+        method = "adapter_declared_parameter_tree"
+    if parameter_tree is None:
+        parameter_tree = _prototype_parameter_tree(state)
+        if parameter_tree is not None:
+            method = "prototype_control_parameter_tree"
+    if parameter_tree is None:
+        parameter_tree = _known_control_parameter_tree(state)
+        if parameter_tree is not None:
+            method = "known_sarsa_parameter_fields"
+    if parameter_tree is not None:
+        _, parameter_elements, _, floating_elements = _array_leaf_facts(parameter_tree)
+        resource["trainable_scalar_count_estimate"] = floating_elements
+        resource["trainable_parameter_tree_scalar_count"] = parameter_elements
+        resource["trainable_scalar_count_method"] = method
+    return resource
+
+
+@functools.lru_cache(maxsize=len(ENVIRONMENT_ROSTER) * len(ARM_ROSTER))
+def _canonical_initial_resource_payload(
+    environment_kind: str,
+    arm: str,
+) -> dict[str, Any]:
+    """Measure the fixed-shape canonical initial state once per arm/environment."""
+
+    plan = build_development_plan()
+    spec = next(
+        item
+        for item in iter_run_specs(plan)
+        if item.environment_kind == environment_kind
+        and item.arm == arm
+        and item.seed == SEED_ROSTER[0]
+    )
+    runner = build_scorecard_runner(plan, spec)
+    state = runner.init()
+    return _agent_resource_payload(runner.agent_adapter, state.agent_state)
+
+
+def parameter_change_check(arm: str, parameter_change_events: int) -> dict[str, Any]:
+    """Apply the fixed candidate/frozen/control learning-side-effect check."""
+
+    if arm not in ARM_ROSTER:
+        raise ValueError(f"unsupported scorecard arm {arm!r}")
+    if type(parameter_change_events) is not int or parameter_change_events < 0:
+        raise ValueError("parameter_change_events must be nonnegative")
+    must_change = arm in ("prototype", "differential_sarsa", "sarsa")
+    passed = parameter_change_events > 0 if must_change else parameter_change_events == 0
+    return {
+        "expectation": (
+            "at_least_one_parameter_change" if must_change else "zero_parameter_changes"
+        ),
+        "observed_parameter_change_events": parameter_change_events,
+        "passed": passed,
+    }
+
+
+def _mean(values: Sequence[float]) -> float:
+    if not values:
+        raise ValueError("mean requires at least one value")
+    return math.fsum(values) / len(values)
+
+
+def _sample_sd(values: Sequence[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    average = _mean(values)
+    return math.sqrt(math.fsum((value - average) ** 2 for value in values) / (len(values) - 1))
+
+
+def _stderr(values: Sequence[float]) -> float:
+    return _sample_sd(values) / math.sqrt(len(values)) if values else 0.0
+
+
+def _paired_lcb(values: Sequence[float]) -> float | None:
+    if len(values) != len(SEED_ROSTER):
+        return None
+    return _mean(values) - CONTROL_GATE_T_CRITICAL * _sample_sd(values) / math.sqrt(
+        len(values)
+    )
+
+
+def _record_identity(record: Mapping[str, Any]) -> tuple[str, str, int]:
+    environment = record.get("environment_kind")
+    arm = record.get("arm")
+    seed = record.get("seed")
+    if environment not in ENVIRONMENT_ROSTER:
+        raise ValueError("run record has an unsupported environment")
+    if arm not in ARM_ROSTER:
+        raise ValueError("run record has an unsupported arm")
+    if type(seed) is not int or seed not in SEED_ROSTER:
+        raise ValueError("run record has a seed outside the fixed roster")
+    return cast(str, environment), cast(str, arm), seed
+
+
+def _reward_sum(record: Mapping[str, Any]) -> float:
+    outcome = record.get("outcome")
+    if not isinstance(outcome, Mapping):
+        raise ValueError("completed run record lacks an outcome")
+    value = outcome.get("reward_sum")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("completed run reward_sum must be finite")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError("completed run reward_sum must be finite")
+    return result
+
+
+def _summarize_validated_run_records(
+    plan: ReferenceLifeDevelopmentPlan,
+    records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Reduce a complete set after every record passed strict validation."""
+
+    if not isinstance(plan, ReferenceLifeDevelopmentPlan):
+        raise TypeError("plan must be a ReferenceLifeDevelopmentPlan")
+    expected = {
+        (environment, arm, seed)
+        for environment in ENVIRONMENT_ROSTER
+        for arm in ARM_ROSTER
+        for seed in SEED_ROSTER
+    }
+    indexed: dict[tuple[str, str, int], Mapping[str, Any]] = {}
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise ValueError("every run record must be an object")
+        identity = _record_identity(record)
+        if identity in indexed:
+            raise ValueError(f"duplicate run identity {identity!r}")
+        status = record.get("status")
+        if status not in ("completed", "failed"):
+            raise ValueError("run status must be completed or failed")
+        if status == "completed":
+            _reward_sum(record)
+        indexed[identity] = record
+    if set(indexed) != expected:
+        missing = sorted(expected - set(indexed))
+        extra = sorted(set(indexed) - expected)
+        raise ValueError(
+            f"run records do not cover the fixed matched schedule; missing={missing[:3]}, "
+            f"extra={extra[:3]}"
+        )
+
+    failures = []
+    parameter_failures = []
+    for identity in sorted(
+        indexed,
+        key=lambda item: (
+            ENVIRONMENT_ROSTER.index(item[0]),
+            ARM_ROSTER.index(item[1]),
+            SEED_ROSTER.index(item[2]),
+        ),
+    ):
+        record = indexed[identity]
+        if record["status"] == "failed":
+            failures.append(
+                {
+                    "environment_kind": identity[0],
+                    "arm": identity[1],
+                    "seed": identity[2],
+                    "failure": record.get("failure"),
+                }
+            )
+        outcome = record.get("outcome")
+        if isinstance(outcome, Mapping):
+            check = outcome.get("parameter_change_check")
+            if isinstance(check, Mapping) and check.get("passed") is not True:
+                parameter_failures.append(
+                    {
+                        "environment_kind": identity[0],
+                        "arm": identity[1],
+                        "seed": identity[2],
+                        "parameter_change_check": dict(check),
+                    }
+                )
+    execution_or_learning_failed = bool(failures or parameter_failures)
+
+    environment_summaries: dict[str, Any] = {}
+    environments_qualified = not execution_or_learning_failed
+    candidate_utility_qualified = not execution_or_learning_failed
+    for environment in ENVIRONMENT_ROSTER:
+        returns: dict[str, dict[int, float]] = {}
+        for arm in ARM_ROSTER:
+            returns[arm] = {
+                seed: _reward_sum(indexed[(environment, arm, seed)])
+                for seed in SEED_ROSTER
+                if indexed[(environment, arm, seed)]["status"] == "completed"
+            }
+
+        paired_baseline_seeds = tuple(
+            seed
+            for seed in SEED_ROSTER
+            if seed in returns["random"] and seed in returns["privileged_oracle"]
+        )
+        baseline_differences = [
+            returns["privileged_oracle"][seed] - returns["random"][seed]
+            for seed in paired_baseline_seeds
+        ]
+        scale = (
+            _mean(baseline_differences)
+            if len(paired_baseline_seeds) == len(SEED_ROSTER)
+            else None
+        )
+        scale_valid = scale is not None and math.isfinite(scale) and scale > 0.0
+
+        arm_summaries: dict[str, Any] = {}
+        for arm in ARM_ROSTER:
+            arm_values = [returns[arm][seed] for seed in SEED_ROSTER if seed in returns[arm]]
+            paired_seeds = tuple(
+                seed
+                for seed in SEED_ROSTER
+                if seed in returns[arm] and seed in returns["random"]
+            )
+            normalized: list[float] | None = None
+            if scale_valid and len(paired_seeds) == len(SEED_ROSTER):
+                assert scale is not None
+                normalized = [
+                    (returns[arm][seed] - returns["random"][seed]) / scale
+                    for seed in paired_seeds
+                ]
+            if normalized is None:
+                normalized_mean = None
+                normalized_sd = None
+                lcb = None
+            else:
+                normalized_mean = _mean(normalized)
+                normalized_sd = _sample_sd(normalized)
+                lcb = normalized_mean - (
+                    CONTROL_GATE_T_CRITICAL
+                    * normalized_sd
+                    / math.sqrt(len(normalized))
+                )
+            arm_summaries[arm] = {
+                "completed_seed_count": len(arm_values),
+                "failed_seed_count": len(SEED_ROSTER) - len(arm_values),
+                "reward_sum_mean": None if not arm_values else _mean(arm_values),
+                "reward_sum_stderr": None if not arm_values else _stderr(arm_values),
+                "paired_seed_count": len(paired_seeds),
+                "normalized_score_mean": normalized_mean,
+                "normalized_score_sample_sd": normalized_sd,
+                "paired_t_lcb_95": lcb,
+                "normalized_samples_by_seed": (
+                    None
+                    if normalized is None
+                    else [
+                        {"seed": seed, "score": score}
+                        for seed, score in zip(paired_seeds, normalized, strict=True)
+                    ]
+                ),
+            }
+
+        statistically_qualified_arms = [
+            arm
+            for arm in ("differential_sarsa", "sarsa")
+            if arm_summaries[arm]["paired_seed_count"] == len(SEED_ROSTER)
+            and arm_summaries[arm]["paired_t_lcb_95"] is not None
+            and arm_summaries[arm]["paired_t_lcb_95"] > CONTROL_GATE_LCB_THRESHOLD
+        ]
+        qualified_arms = (
+            [] if execution_or_learning_failed else statistically_qualified_arms
+        )
+        environment_qualified = (
+            not execution_or_learning_failed and scale_valid and bool(qualified_arms)
+        )
+        environments_qualified = environments_qualified and environment_qualified
+
+        prototype_frozen_samples: list[float] | None = None
+        if scale_valid and all(
+            seed in returns["prototype"] and seed in returns["prototype_frozen"]
+            for seed in SEED_ROSTER
+        ):
+            assert scale is not None
+            prototype_frozen_samples = [
+                (
+                    returns["prototype"][seed]
+                    - returns["prototype_frozen"][seed]
+                )
+                / scale
+                for seed in SEED_ROSTER
+            ]
+        prototype_frozen_lcb = (
+            None
+            if prototype_frozen_samples is None
+            else _paired_lcb(prototype_frozen_samples)
+        )
+        beats_frozen = not execution_or_learning_failed and (
+            prototype_frozen_lcb is not None and prototype_frozen_lcb >= 0.05
+        )
+
+        best_sarsa: str | None = None
+        if qualified_arms:
+            best_sarsa = max(
+                qualified_arms,
+                key=lambda arm: (
+                    cast(float, arm_summaries[arm]["normalized_score_mean"]),
+                    -ARM_ROSTER.index(arm),
+                ),
+            )
+        prototype_sarsa_samples: list[float] | None = None
+        if (
+            scale_valid
+            and best_sarsa is not None
+            and all(
+                seed in returns["prototype"] and seed in returns[best_sarsa]
+                for seed in SEED_ROSTER
+            )
+        ):
+            assert scale is not None
+            prototype_sarsa_samples = [
+                (returns["prototype"][seed] - returns[best_sarsa][seed]) / scale
+                for seed in SEED_ROSTER
+            ]
+        prototype_sarsa_lcb = (
+            None
+            if prototype_sarsa_samples is None
+            else _paired_lcb(prototype_sarsa_samples)
+        )
+        sarsa_noninferior = not execution_or_learning_failed and (
+            prototype_sarsa_lcb is not None and prototype_sarsa_lcb >= -0.05
+        )
+        environment_candidate_qualified = (
+            environment_qualified and beats_frozen and sarsa_noninferior
+        )
+        candidate_utility_qualified = (
+            candidate_utility_qualified and environment_candidate_qualified
+        )
+        environment_summaries[environment] = {
+            "normalization": {
+                "scope": "within_environment_only",
+                "paired_baseline_seed_count": len(paired_baseline_seeds),
+                "scale": scale,
+                "scale_valid_finite_positive": scale_valid,
+                "definition": (
+                    "(arm_reward_sum-random_reward_sum)/"
+                    "mean_seed(oracle_reward_sum-random_reward_sum)"
+                ),
+            },
+            "arms": arm_summaries,
+            "control_calibration": {
+                "classification": "development_heuristic_not_scientific_inference",
+                "qualified": environment_qualified,
+                "qualified_sarsa_arms": qualified_arms,
+                "minimum_lcb_exclusive": CONTROL_GATE_LCB_THRESHOLD,
+                "t_critical": CONTROL_GATE_T_CRITICAL,
+            },
+            "candidate_development_checks": {
+                "classification": "development_heuristic_not_scientific_inference",
+                "prototype_vs_frozen_paired_lcb_95": prototype_frozen_lcb,
+                "prototype_vs_frozen_minimum_inclusive": 0.05,
+                "prototype_vs_frozen_passed": beats_frozen,
+                "best_qualifying_sarsa_arm": best_sarsa,
+                "prototype_vs_best_sarsa_paired_lcb_95": prototype_sarsa_lcb,
+                "sarsa_noninferiority_margin_inclusive": -0.05,
+                "sarsa_noninferiority_passed": sarsa_noninferior,
+                "utility_gate_passed": environment_candidate_qualified,
+            },
+        }
+
+    if failures:
+        status = "valid_execution_failure"
+    elif parameter_failures:
+        status = "valid_parameter_change_failure"
+    elif not environments_qualified:
+        status = "valid_baseline_failure"
+    else:
+        status = "development_scorecard_complete"
+    if failures:
+        candidate_selection_status = "not_evaluated_execution_failure"
+    elif parameter_failures:
+        candidate_selection_status = "not_evaluated_parameter_change_failure"
+    elif not environments_qualified:
+        candidate_selection_status = "not_evaluated_baseline_failure"
+    elif not candidate_utility_qualified:
+        candidate_selection_status = "rejected_development_utility_gate"
+    else:
+        candidate_selection_status = "not_evaluated_resource_telemetry_only"
+    return {
+        "schema": REFERENCE_LIFE_SCORECARD_SUMMARY_SCHEMA,
+        "plan_sha256": plan.plan_sha256,
+        "evidence_policy": dict(NONPROMOTING_POLICY),
+        "status": status,
+        "status_is_promotion": False,
+        "run_count": len(records),
+        "failure_count": len(failures),
+        "failures": failures,
+        "parameter_change_failure_count": len(parameter_failures),
+        "parameter_change_failures": parameter_failures,
+        "environments": environment_summaries,
+        "cross_environment_pooled_score": None,
+        "cross_environment_pooling_forbidden": True,
+        "control_calibration_gate_passed": environments_qualified,
+        "candidate_utility_gate_passed": candidate_utility_qualified,
+        "candidate_selection_status": candidate_selection_status,
+        "pareto_resource_decision": {
+            "status": "not_evaluated_resource_telemetry_only",
+            "reason": (
+                "cold/warmed latency is telemetry-only and cannot be used in selection"
+            ),
+            "future_gate_if_latency_is_qualified_under_a_new_protocol": {
+                "requires_no_qualifying_sarsa_utility_noninferior_on_both_environments": True,
+                "candidate_utility_advantage": 0.05,
+                "candidate_resource_advantage_fraction": 0.20,
+                "requires_no_more_persistent_bytes": True,
+                "requires_no_more_p95_latency": True,
+            },
+        },
+    }
+
+
+def summarize_run_records(
+    plan: ReferenceLifeDevelopmentPlan,
+    records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Strictly validate a complete matrix, then recompute its development gates."""
+
+    if not isinstance(plan, ReferenceLifeDevelopmentPlan):
+        raise TypeError("plan must be a ReferenceLifeDevelopmentPlan")
+    specs = iter_run_specs(plan)
+    if len(records) != len(specs):
+        raise ValueError("run records must contain exactly the fixed 144-shard matrix")
+    by_identity: dict[tuple[str, str, int], Mapping[str, Any]] = {}
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise ValueError("every run record must be an object")
+        identity = _record_identity(record)
+        if identity in by_identity:
+            raise ValueError(f"duplicate run identity {identity!r}")
+        by_identity[identity] = record
+    identities = _current_consistency_identities()
+    ordered: list[Mapping[str, Any]] = []
+    for spec in specs:
+        identity = (spec.environment_kind, spec.arm, spec.seed)
+        scheduled_record = by_identity.get(identity)
+        if scheduled_record is None:
+            raise ValueError(f"run records are missing scheduled identity {identity!r}")
+        _validate_run_record(
+            plan,
+            scheduled_record,
+            spec,
+            path=f"$.runs[{spec.schedule_index}]",
+            consistency_identities=identities,
+        )
+        ordered.append(scheduled_record)
+    return _summarize_validated_run_records(plan, ordered)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ScorecardRunSpec:
+    schedule_index: int
+    environment_kind: str
+    arm: str
+    seed: int
+    lifecycle_id: str
+
+
+def iter_run_specs(plan: ReferenceLifeDevelopmentPlan) -> tuple[ScorecardRunSpec, ...]:
+    """Expand the fixed cyclic schedule into immutable run identities."""
+
+    if not isinstance(plan, ReferenceLifeDevelopmentPlan):
+        raise TypeError("plan must be a ReferenceLifeDevelopmentPlan")
+    specs: list[ScorecardRunSpec] = []
+    for seed in plan.seeds:
+        for environment in plan.environments:
+            for arm in plan.arm_order(seed):
+                schedule_index = len(specs)
+                identity = f"{plan.plan_sha256}:{environment}:{arm}:{seed}"
+                lifecycle_hex = hashlib.sha256(identity.encode("ascii")).hexdigest()[:16]
+                specs.append(
+                    ScorecardRunSpec(
+                        schedule_index=schedule_index,
+                        environment_kind=environment,
+                        arm=arm,
+                        seed=seed,
+                        lifecycle_id=f"prototype.{lifecycle_hex}",
+                    )
+                )
+    return tuple(specs)
+
+
+def preflight_new_output(path: Path) -> Path:
+    """Reject an occupied output before any expensive scorecard execution."""
+
+    destination, parent_fd = _open_output_parent(Path(path), create=True)
+    try:
+        try:
+            os.stat(destination.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return destination
+        raise FileExistsError(f"refusing to overwrite immutable output: {destination}")
+    finally:
+        os.close(parent_fd)
+
+
+def _open_output_parent(path: Path, *, create: bool) -> tuple[Path, int]:
+    """Open an absolute parent through no-follow directory descriptors."""
+
+    destination = Path(os.path.abspath(os.fspath(path)))
+    parent = destination.parent
+    descriptor = os.open(
+        os.path.sep,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC,
+    )
+    try:
+        for component in parent.parts[1:]:
+            if component in ("", ".", ".."):
+                raise ValueError("output path contains an unsafe directory component")
+            if create:
+                try:
+                    os.mkdir(component, mode=0o755, dir_fd=descriptor)
+                except FileExistsError:
+                    pass
+            next_descriptor = os.open(
+                component,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                dir_fd=descriptor,
+            )
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return destination, descriptor
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _link_unnamed_file(file_fd: int, parent_fd: int, name: str) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    linkat = libc.linkat
+    linkat.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+    )
+    linkat.restype = ctypes.c_int
+    if linkat(file_fd, b"", parent_fd, os.fsencode(name), 0x1000) != 0:
+        error = ctypes.get_errno()
+        if error == errno.EEXIST:
+            raise FileExistsError(error, os.strerror(error), name)
+        raise OSError(error, os.strerror(error), name)
+
+
+def write_new_json(path: Path, value: Any) -> Path:
+    """Atomically publish deterministic JSON without replacing existing bytes."""
+
+    destination, parent_fd = _open_output_parent(Path(path), create=True)
+    _validate_json_value(value)
+    encoded = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        indent=2,
+        sort_keys=True,
+    ).encode("utf-8") + b"\n"
+    file_fd: int | None = None
+    try:
+        try:
+            os.stat(destination.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(
+                f"refusing to overwrite immutable output: {destination}"
+            )
+        if not hasattr(os, "O_TMPFILE"):
+            raise OSError("immutable publication requires Linux O_TMPFILE support")
+        file_fd = os.open(
+            ".",
+            os.O_WRONLY | os.O_CLOEXEC | os.O_TMPFILE,
+            0o600,
+            dir_fd=parent_fd,
+        )
+        view = memoryview(encoded)
+        written = 0
+        while written < len(view):
+            written += os.write(file_fd, view[written:])
+        os.fsync(file_fd)
+        os.fchmod(file_fd, 0o444)
+        try:
+            _link_unnamed_file(file_fd, parent_fd, destination.name)
+        except FileExistsError as exc:
+            raise FileExistsError(
+                f"refusing to overwrite immutable output: {destination}"
+            ) from exc
+        return destination
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        os.close(parent_fd)
+
+
+def _load_json_strict_with_metadata(
+    path: Path,
+    *,
+    max_bytes: int = MAX_SCORECARD_JSON_INPUT_BYTES,
+) -> tuple[dict[str, Any], os.stat_result]:
+    """Load JSON and return metadata from the descriptor that supplied its bytes."""
+
+    if type(max_bytes) is not int or not 0 <= max_bytes <= MAX_SCORECARD_JSON_INPUT_BYTES:
+        raise ValueError("strict JSON byte limit is invalid")
+
+    def pairs_hook(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key {key!r}")
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> NoReturn:
+        raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise ValueError("strict JSON loading requires no-follow file support")
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            Path(path),
+            os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK,
+        )
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError(f"{path}: strict JSON input must be a regular file")
+        if metadata.st_size > max_bytes:
+            raise ValueError(
+                f"{path}: strict JSON input exceeds {max_bytes} bytes"
+            )
+        chunks: list[bytes] = []
+        remaining = max_bytes + 1
+        while remaining > 0:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        encoded = b"".join(chunks)
+        if len(encoded) > max_bytes:
+            raise ValueError(
+                f"{path}: strict JSON input exceeds {max_bytes} bytes"
+            )
+        final_metadata = os.fstat(descriptor)
+        stable_fields = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+        if len(encoded) != metadata.st_size or any(
+            getattr(metadata, field) != getattr(final_metadata, field)
+            for field in stable_fields
+        ):
+            raise ValueError(f"{path}: strict JSON input changed while being read")
+        try:
+            source = encoded.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"{path}: strict JSON input is not UTF-8") from exc
+        payload = json.loads(
+            source,
+            object_pairs_hook=pairs_hook,
+            parse_constant=reject_constant,
+        )
+    except ValueError:
+        raise
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot load strict JSON from {path}: {exc}") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: top-level JSON value must be an object")
+    _validate_json_value(payload)
+    return payload, final_metadata
+
+
+def load_json_strict(path: Path) -> dict[str, Any]:
+    """Load one bounded regular-file JSON object without following a symlink."""
+
+    payload, _ = _load_json_strict_with_metadata(path)
+    return payload
+
+
+def _record_with_digest(payload: Mapping[str, Any]) -> dict[str, Any]:
+    result = dict(payload)
+    if "record_sha256" in result:
+        raise ValueError("unfinalized record unexpectedly contains record_sha256")
+    result["record_sha256"] = _sha256_json(result)
+    return result
+
+
+def _current_consistency_identities() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    return (
+        _checkpoint_source_identity(),
+        _checkpoint_runtime_identity(),
+        _checkpoint_dependency_identity(),
+    )
+
+
+def build_scorecard_artifact(
+    plan: ReferenceLifeDevelopmentPlan,
+    records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Assemble one immutable aggregate and bind its deterministic summary."""
+
+    ordered_records = sorted(records, key=lambda record: int(record["schedule_index"]))
+    summary = summarize_run_records(plan, ordered_records)
+    run_order = [
+        {
+            "schedule_index": spec.schedule_index,
+            "environment_kind": spec.environment_kind,
+            "arm": spec.arm,
+            "seed": spec.seed,
+            "lifecycle_id": spec.lifecycle_id,
+        }
+        for spec in iter_run_specs(plan)
+    ]
+    source_identity, runtime_identity, dependency_identity = (
+        _current_consistency_identities()
+    )
+    payload: dict[str, Any] = {
+        "schema": REFERENCE_LIFE_SCORECARD_ARTIFACT_SCHEMA,
+        "schema_version": 1,
+        "benchmark": "reference_life_matched_development_scorecard",
+        "plan": plan.to_payload(),
+        "plan_sha256": plan.plan_sha256,
+        "evidence_policy": dict(NONPROMOTING_POLICY),
+        "source_identity": source_identity,
+        "runtime_identity": runtime_identity,
+        "dependency_identity": dependency_identity,
+        "identity_scope_note": (
+            "consistency binding only; not authenticated execution attestation"
+        ),
+        "run_order": run_order,
+        "runs": [dict(record) for record in ordered_records],
+        "summary": summary,
+    }
+    payload["artifact_sha256"] = _sha256_json(payload)
+    return payload
+
+
+def _require_finite_nonnegative(value: Any, *, path: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{path} must be a finite nonnegative number")
+    result = float(value)
+    if not math.isfinite(result) or result < 0.0:
+        raise ValueError(f"{path} must be a finite nonnegative number")
+    return result
+
+
+def _require_nonnegative_int(value: Any, *, path: str) -> int:
+    if type(value) is not int or value < 0:
+        raise ValueError(f"{path} must be a nonnegative integer")
+    return value
+
+
+def _require_finite_number(value: Any, *, path: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{path} must be a finite number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{path} must be a finite number")
+    return result
+
+
+def _numerically_equal(left: float, right: float) -> bool:
+    return math.isclose(left, right, rel_tol=1e-12, abs_tol=1e-12)
+
+
+def _validate_agent_manifest_descriptor(value: Any, *, path: str) -> None:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{path} must be a complete agent manifest")
+    required = {
+        "api_version",
+        "schema",
+        "implementation_id",
+        "state_schema",
+        "config_sha256",
+        "manifest_id",
+        "config",
+        "observation_spec",
+        "action_spec",
+        "capabilities",
+    }
+    if set(value) != required:
+        raise ValueError(f"{path} fields do not match the agent-manifest contract")
+    if value["api_version"] != REFERENCE_AGENT_API_VERSION:
+        raise ValueError(f"{path} API version is unsupported")
+    config = value["config"]
+    if not isinstance(config, Mapping):
+        raise ValueError(f"{path}.config must be an object")
+    if canonical_config_sha256(config) != value["config_sha256"]:
+        raise ValueError(f"{path} config digest mismatch")
+    if not _is_sha256(value["manifest_id"]):
+        raise ValueError(f"{path}.manifest_id must be a SHA-256 digest")
+    observation_spec = _space_from_descriptor(
+        value["observation_spec"], path=f"{path}.observation_spec"
+    )
+    action_spec = _space_from_descriptor(
+        value["action_spec"], path=f"{path}.action_spec"
+    )
+    capabilities = value["capabilities"]
+    if not isinstance(capabilities, Mapping) or set(capabilities) != {
+        "dispatch_rebinding"
+    }:
+        raise ValueError(f"{path}.capabilities fields are invalid")
+    reconstructed = AgentManifest.from_config(
+        schema=cast(str, value["schema"]),
+        implementation_id=cast(str, value["implementation_id"]),
+        state_schema=cast(str, value["state_schema"]),
+        config=config,
+        observation_spec=observation_spec,
+        action_spec=action_spec,
+        capabilities=AgentCapabilities(
+            dispatch_rebinding=capabilities["dispatch_rebinding"]
+        ),
+    )
+    if _agent_manifest_descriptor(reconstructed) != dict(value):
+        raise ValueError(f"{path} manifest identity does not recompute")
+
+
+def _space_from_descriptor(value: Any, *, path: str) -> SpaceSpec:
+    if not isinstance(value, Mapping) or set(value) != {
+        "kind",
+        "shape",
+        "dtype",
+        "semantic_id",
+        "cardinality",
+        "low",
+        "high",
+    }:
+        raise ValueError(f"{path} fields do not match a space descriptor")
+    shape = value["shape"]
+    if not isinstance(shape, list) or any(type(item) is not int for item in shape):
+        raise ValueError(f"{path}.shape must be an integer list")
+    if value["kind"] == "discrete":
+        if value["low"] is not None or value["high"] is not None:
+            raise ValueError(f"{path} discrete descriptor cannot carry bounds")
+        return SpaceSpec.discrete(
+            cardinality=value["cardinality"],
+            dtype=value["dtype"],
+            semantic_id=value["semantic_id"],
+        )
+    if value["kind"] == "box":
+        low = value["low"]
+        high = value["high"]
+        if low is not None and not isinstance(low, list):
+            raise ValueError(f"{path}.low must be null or a list")
+        if high is not None and not isinstance(high, list):
+            raise ValueError(f"{path}.high must be null or a list")
+        return SpaceSpec.box(
+            shape=tuple(shape),
+            dtype=value["dtype"],
+            low=low,
+            high=high,
+            semantic_id=value["semantic_id"],
+        )
+    raise ValueError(f"{path}.kind is unsupported")
+
+
+def _validate_environment_manifest_descriptor(value: Any, *, path: str) -> None:
+    if not isinstance(value, Mapping) or set(value) != {
+        "schema",
+        "implementation_id",
+        "state_schema",
+        "config_sha256",
+        "manifest_id",
+        "config",
+        "observation_spec",
+        "action_spec",
+        "max_executions",
+    }:
+        raise ValueError(f"{path} fields do not match an environment manifest")
+    config = value["config"]
+    if not isinstance(config, Mapping):
+        raise ValueError(f"{path}.config must be an object")
+    reconstructed = ReferenceEnvironmentManifest.from_config(
+        implementation_id=cast(str, value["implementation_id"]),
+        state_schema=cast(str, value["state_schema"]),
+        config=config,
+        observation_spec=_space_from_descriptor(
+            value["observation_spec"], path=f"{path}.observation_spec"
+        ),
+        action_spec=_space_from_descriptor(
+            value["action_spec"], path=f"{path}.action_spec"
+        ),
+        max_executions=cast(int, value["max_executions"]),
+    )
+    if reconstructed.descriptor() != dict(value):
+        raise ValueError(f"{path} manifest identity does not recompute")
+
+
+def _validate_resolved_components(
+    resolved: Mapping[str, Any],
+    *,
+    plan: ReferenceLifeDevelopmentPlan,
+    spec: ScorecardRunSpec,
+    path: str,
+) -> None:
+    agent_manifest = resolved["agent_manifest"]
+    _validate_agent_manifest_descriptor(
+        agent_manifest, path=f"{path}.agent_manifest"
+    )
+    environment_manifest = resolved["environment_manifest"]
+    _validate_environment_manifest_descriptor(
+        environment_manifest, path=f"{path}.environment_manifest"
+    )
+    assert isinstance(agent_manifest, Mapping)
+    assert isinstance(environment_manifest, Mapping)
+    environment_config = environment_manifest["config"]
+    assert isinstance(environment_config, Mapping)
+    if environment_config.get("environment_kind") != spec.environment_kind:
+        raise ValueError(f"{path} environment kind differs from the schedule")
+    if agent_manifest["observation_spec"] != environment_manifest["observation_spec"]:
+        raise ValueError(f"{path} agent/environment observation specs differ")
+    if agent_manifest["action_spec"] != environment_manifest["action_spec"]:
+        raise ValueError(f"{path} agent/environment action specs differ")
+
+    life_config = resolved["life_config"]
+    if not isinstance(life_config, Mapping):
+        raise ValueError(f"{path} lacks a complete life config")
+    if _sha256_json(life_config) != resolved["life_config_sha256"]:
+        raise ValueError(f"{path} life config digest mismatch")
+    protocol = plan.protocol(spec.environment_kind)
+    expected_scalars = {
+        "lifecycle_id": spec.lifecycle_id,
+        "seed": spec.seed,
+        "max_accepted_events": protocol["horizon"],
+        "rng_schedule": REFERENCE_LIFE_RNG_SCHEDULE,
+    }
+    for field, expected in expected_scalars.items():
+        if life_config.get(field) != expected:
+            raise ValueError(f"{path}.life_config.{field} differs from the schedule")
+    life_agent = life_config.get("agent")
+    life_environment = life_config.get("environment")
+    if not isinstance(life_agent, Mapping) or not isinstance(life_environment, Mapping):
+        raise ValueError(f"{path}.life_config lacks complete component bindings")
+    if life_agent.get("manifest_id") != agent_manifest["manifest_id"]:
+        raise ValueError(f"{path}.life_config binds another agent manifest")
+    if life_environment.get("manifest_id") != environment_manifest["manifest_id"]:
+        raise ValueError(f"{path}.life_config binds another environment manifest")
+
+    canonical_runner = build_scorecard_runner(plan, spec)
+    canonical_resolved = _resolved_components(plan, spec, canonical_runner)
+    if not _json_exact_equal(dict(resolved), canonical_resolved):
+        raise ValueError(
+            f"{path} does not match the canonical resolved components for the "
+            "scheduled arm and exact environment definition"
+        )
+
+
+def _validate_resource_payload(resource: Any, *, arm: str, path: str) -> None:
+    if not isinstance(resource, Mapping):
+        raise ValueError(f"{path} must be an object")
+    expected_method = (
+        "prototype_control_parameter_tree"
+        if arm in ("prototype", "prototype_frozen")
+        else (
+            "known_sarsa_parameter_fields"
+            if arm in ("differential_sarsa", "sarsa")
+            else "floating_jax_pytree_leaves_upper_bound"
+        )
+    )
+    required = {
+        "persistent_jax_array_leaves",
+        "persistent_jax_array_scalar_count",
+        "persistent_jax_array_bytes",
+        "persistent_static_numeric_bytes",
+        "persistent_numeric_bytes_total",
+        "persistent_state_measurement",
+        "trainable_scalar_count_estimate",
+        "trainable_scalar_count_method",
+        "hardware_peak_memory_measured",
+    }
+    if expected_method != "floating_jax_pytree_leaves_upper_bound":
+        required.add("trainable_parameter_tree_scalar_count")
+    if set(resource) != required:
+        raise ValueError(f"{path} fields do not match the resource contract")
+    if resource["persistent_state_measurement"] != (
+        "numeric_jax_and_numpy_pytree_leaves"
+    ):
+        raise ValueError(f"{path}.persistent_state_measurement is unsupported")
+    if resource["trainable_scalar_count_method"] != expected_method:
+        raise ValueError(f"{path}.trainable_scalar_count_method differs from the arm")
+    if resource["hardware_peak_memory_measured"] is not False:
+        raise ValueError(f"{path} must not claim a hardware peak measurement")
+    leaves = _require_nonnegative_int(
+        resource["persistent_jax_array_leaves"],
+        path=f"{path}.persistent_jax_array_leaves",
+    )
+    elements = _require_nonnegative_int(
+        resource["persistent_jax_array_scalar_count"],
+        path=f"{path}.persistent_jax_array_scalar_count",
+    )
+    byte_count = _require_nonnegative_int(
+        resource["persistent_jax_array_bytes"],
+        path=f"{path}.persistent_jax_array_bytes",
+    )
+    static_bytes = _require_nonnegative_int(
+        resource["persistent_static_numeric_bytes"],
+        path=f"{path}.persistent_static_numeric_bytes",
+    )
+    total_bytes = _require_nonnegative_int(
+        resource["persistent_numeric_bytes_total"],
+        path=f"{path}.persistent_numeric_bytes_total",
+    )
+    if total_bytes != byte_count + static_bytes:
+        raise ValueError(f"{path} persistent numeric byte total is inconsistent")
+    trainable = _require_nonnegative_int(
+        resource["trainable_scalar_count_estimate"],
+        path=f"{path}.trainable_scalar_count_estimate",
+    )
+    if leaves == 0 and (elements != 0 or byte_count != 0):
+        raise ValueError(f"{path} reports numeric storage without an array leaf")
+    if (elements == 0) != (byte_count == 0):
+        raise ValueError(f"{path} scalar and byte counts disagree about empty storage")
+    if elements > 0 and byte_count < elements:
+        raise ValueError(f"{path} byte count is smaller than its numeric scalar count")
+    if trainable > elements:
+        raise ValueError(f"{path} trainable estimate exceeds persistent numeric state")
+    if expected_method != "floating_jax_pytree_leaves_upper_bound":
+        parameter_elements = _require_nonnegative_int(
+            resource["trainable_parameter_tree_scalar_count"],
+            path=f"{path}.trainable_parameter_tree_scalar_count",
+        )
+        if parameter_elements > elements or trainable > parameter_elements:
+            raise ValueError(f"{path} parameter-tree counts exceed persistent state")
+
+
+def _reward_lattice_matches(
+    total: float,
+    *,
+    event_count: int,
+    reward_values: Sequence[float],
+) -> bool:
+    """Return whether a total is reachable from the selected discrete rewards."""
+
+    values = sorted({float(np.float32(value)) for value in reward_values})
+    if any(not math.isfinite(value) or value < 0.0 for value in values):
+        return False
+    positive = [value for value in values if value > 0.0]
+    tolerance = float(
+        max(1e-12, event_count * float(np.spacing(max(1.0, abs(total)))) * 4.0)
+    )
+    if not positive:
+        return abs(total) <= tolerance
+    if len(positive) == 1:
+        count = round(total / positive[0])
+        return 0 <= count <= event_count and math.isclose(
+            total,
+            count * positive[0],
+            rel_tol=0.0,
+            abs_tol=tolerance,
+        )
+    if len(positive) == 2:
+        low, high = positive
+        maximum_high = min(event_count, max(0, int(math.floor(total / high)) + 1))
+        for high_count in range(maximum_high + 1):
+            residual = total - high_count * high
+            low_count = round(residual / low)
+            if (
+                0 <= low_count <= event_count - high_count
+                and math.isclose(
+                    total,
+                    high_count * high + low_count * low,
+                    rel_tol=0.0,
+                    abs_tol=tolerance,
+                )
+            ):
+                return True
+    return False
+
+
+def _validate_metric_window(
+    window: Any,
+    *,
+    event_count: int,
+    oracle_reward: float,
+    minimum_reward: float,
+    maximum_reward: float,
+    reward_values: Sequence[float],
+    path: str,
+) -> float:
+    required = {"event_count", "reward_sum", "mean_reward", "mean_oracle_regret"}
+    if not isinstance(window, Mapping) or set(window) != required:
+        raise ValueError(f"{path} fields do not match the metric-window contract")
+    if window["event_count"] != event_count or type(window["event_count"]) is not int:
+        raise ValueError(f"{path}.event_count differs from the fixed window")
+    reward_sum = _require_finite_number(window["reward_sum"], path=f"{path}.reward_sum")
+    mean_reward = _require_finite_number(
+        window["mean_reward"], path=f"{path}.mean_reward"
+    )
+    mean_regret = _require_finite_number(
+        window["mean_oracle_regret"], path=f"{path}.mean_oracle_regret"
+    )
+    if not _numerically_equal(mean_reward, reward_sum / event_count):
+        raise ValueError(f"{path}.mean_reward is inconsistent")
+    if not _numerically_equal(mean_regret, oracle_reward - mean_reward):
+        raise ValueError(f"{path}.mean_oracle_regret is inconsistent")
+    tolerance = 1e-9 * max(1.0, abs(reward_sum))
+    if not (
+        minimum_reward * event_count - tolerance
+        <= reward_sum
+        <= maximum_reward * event_count + tolerance
+    ):
+        raise ValueError(f"{path}.reward_sum is outside the exact environment range")
+    if not _reward_lattice_matches(
+        reward_sum,
+        event_count=event_count,
+        reward_values=reward_values,
+    ):
+        raise ValueError(f"{path}.reward_sum is outside the exact reward lattice")
+    return reward_sum
+
+
+def _validate_completed_outcome(
+    outcome: Any,
+    *,
+    environment: str,
+    arm: str,
+    protocol: Mapping[str, Any],
+    expected_initial_resource: Mapping[str, Any],
+    path: str,
+) -> None:
+    if not isinstance(outcome, Mapping):
+        raise ValueError(f"{path} must be an object")
+    required = {
+        "summary_mode",
+        "configured_horizon",
+        "accepted_events",
+        "reward_sum",
+        "mean_reward",
+        "oracle_reward_sum",
+        "regret_sum",
+        "parameter_change_events",
+        "phase_event_counts",
+        "phase_reward_sums",
+        "windows",
+        "high_end_visit_count",
+        "high_end_visit_rate",
+        "environment_rng_cursor",
+        "transcript_sha256",
+        "resources",
+        "parameter_change_check",
+    }
+    if set(outcome) != required:
+        raise ValueError(f"{path} fields do not match the completed-outcome contract")
+    horizon = protocol["horizon"]
+    if (
+        type(outcome["configured_horizon"]) is not int
+        or type(outcome["accepted_events"]) is not int
+        or outcome["configured_horizon"] != horizon
+        or outcome["accepted_events"] != horizon
+    ):
+        raise ValueError(f"{path} does not reach the fixed horizon")
+    if (
+        type(outcome["environment_rng_cursor"]) is not int
+        or outcome["environment_rng_cursor"] != horizon
+    ):
+        raise ValueError(f"{path} environment RNG cursor is not matched to the horizon")
+    if outcome["summary_mode"] != "streaming_o1_no_retained_events":
+        raise ValueError(f"{path} did not use the streaming summary")
+    reward_sum = _require_finite_number(
+        outcome["reward_sum"], path=f"{path}.reward_sum"
+    )
+    oracle_reward_sum = _require_finite_number(
+        outcome["oracle_reward_sum"], path=f"{path}.oracle_reward_sum"
+    )
+    mean_reward = _require_finite_number(
+        outcome["mean_reward"], path=f"{path}.mean_reward"
+    )
+    regret_sum = _require_finite_number(
+        outcome["regret_sum"], path=f"{path}.regret_sum"
+    )
+    if not _numerically_equal(mean_reward, reward_sum / horizon):
+        raise ValueError(f"{path}.mean_reward is inconsistent")
+    if not _numerically_equal(regret_sum, oracle_reward_sum - reward_sum):
+        raise ValueError(f"{path}.regret_sum is inconsistent")
+    changes = outcome["parameter_change_events"]
+    if type(changes) is not int or not 0 <= changes <= horizon:
+        raise ValueError(f"{path}.parameter_change_events is invalid")
+    if outcome["parameter_change_check"] != parameter_change_check(arm, changes):
+        raise ValueError(f"{path} parameter-change check is inconsistent")
+    if not _is_sha256(outcome["transcript_sha256"]):
+        raise ValueError(f"{path}.transcript_sha256 must be a digest")
+    resources = outcome["resources"]
+    if not isinstance(resources, Mapping) or set(resources) != {"initial", "final"}:
+        raise ValueError(f"{path}.resources must bind initial and final state")
+    for label in ("initial", "final"):
+        _validate_resource_payload(
+            resources[label], arm=arm, path=f"{path}.resources.{label}"
+        )
+    if not _json_exact_equal(dict(resources["initial"]), dict(expected_initial_resource)):
+        raise ValueError(f"{path}.resources.initial differs from the canonical agent state")
+    if not _json_exact_equal(dict(resources["final"]), dict(resources["initial"])):
+        raise ValueError(f"{path}.resources reports persistent-state growth or shrinkage")
+
+    windows = outcome["windows"]
+    if not isinstance(windows, Mapping):
+        raise ValueError(f"{path}.windows must be an object")
+    phase_counts = outcome["phase_event_counts"]
+    phase_rewards = outcome["phase_reward_sums"]
+    if (
+        not isinstance(phase_counts, list)
+        or len(phase_counts) != 2
+        or any(type(value) is not int or value < 0 for value in phase_counts)
+        or sum(phase_counts) != horizon
+    ):
+        raise ValueError(f"{path}.phase_event_counts is inconsistent")
+    if not isinstance(phase_rewards, list) or len(phase_rewards) != 2:
+        raise ValueError(f"{path}.phase_reward_sums is inconsistent")
+    phase_reward_values = [
+        _require_finite_number(value, path=f"{path}.phase_reward_sums[{index}]")
+        for index, value in enumerate(phase_rewards)
+    ]
+    if not math.isclose(
+        math.fsum(phase_reward_values),
+        reward_sum,
+        rel_tol=0.0,
+        abs_tol=1e-9,
+    ):
+        raise ValueError(f"{path}.phase_reward_sums is inconsistent")
+
+    window_reward_sums: list[float] = []
+    if environment == "switching_two_state":
+        if set(windows) != {"initial_a", "first_b", "return_a"}:
+            raise ValueError(f"{path} lacks the fixed A/B/A windows")
+        phase_length = protocol["phase_length"]
+        expected_phase_counts = [
+            sum(
+                min(phase_length, horizon - start)
+                for start in range(0, horizon, phase_length)
+                if (start // phase_length) % 2 == phase
+            )
+            for phase in (0, 1)
+        ]
+        if phase_counts != expected_phase_counts:
+            raise ValueError(f"{path}.phase_event_counts violates the switching schedule")
+        switching_config = SwitchingTwoStateConfig(  # type: ignore[call-arg]
+            phase_length=phase_length,
+            payoffs_a=tuple(tuple(row) for row in protocol["payoffs_a"]),
+            payoffs_b=tuple(tuple(row) for row in protocol["payoffs_b"]),
+        )
+        switching = SwitchingTwoStateMDP(switching_config)
+        oracle_rewards = [switching.optimal_average_reward(phase) for phase in (0, 1)]
+        phase_payoffs = (protocol["payoffs_a"], protocol["payoffs_b"])
+        for phase in (0, 1):
+            flattened = [float(value) for row in phase_payoffs[phase] for value in row]
+            tolerance = 1e-9 * max(1.0, abs(phase_reward_values[phase]))
+            if not (
+                min(flattened) * phase_counts[phase] - tolerance
+                <= phase_reward_values[phase]
+                <= max(flattened) * phase_counts[phase] + tolerance
+            ):
+                raise ValueError(
+                    f"{path}.phase_reward_sums[{phase}] is outside the payoff range"
+                )
+            if not _reward_lattice_matches(
+                phase_reward_values[phase],
+                event_count=phase_counts[phase],
+                reward_values=flattened,
+            ):
+                raise ValueError(
+                    f"{path}.phase_reward_sums[{phase}] is outside the reward lattice"
+                )
+        for name, phase in (("initial_a", 0), ("first_b", 1), ("return_a", 0)):
+            flattened = [float(value) for row in phase_payoffs[phase] for value in row]
+            window_reward_sums.append(
+                _validate_metric_window(
+                    windows[name],
+                    event_count=protocol["post_switch_window"],
+                    oracle_reward=oracle_rewards[phase],
+                    minimum_reward=min(flattened),
+                    maximum_reward=max(flattened),
+                    reward_values=flattened,
+                    path=f"{path}.windows.{name}",
+                )
+            )
+        if (
+            window_reward_sums[0] + window_reward_sums[2]
+            > phase_reward_values[0] + 1e-9
+            or window_reward_sums[1] > phase_reward_values[1] + 1e-9
+        ):
+            raise ValueError(f"{path}.windows exceed their switching-phase rewards")
+        if outcome["high_end_visit_count"] is not None or outcome[
+            "high_end_visit_rate"
+        ] is not None:
+            raise ValueError(f"{path} switching run must not claim RiverSwim visits")
+    elif environment == "riverswim":
+        if set(windows) != {"early", "late"}:
+            raise ValueError(f"{path} lacks the fixed RiverSwim windows")
+        if phase_counts != [horizon, 0]:
+            raise ValueError(f"{path}.phase_event_counts violates stationary semantics")
+        river_config = RiverSwimConfig(  # type: ignore[call-arg]
+            n_states=protocol["n_states"],
+            p_right_up=protocol["p_right_up"],
+            p_right_down=protocol["p_right_down"],
+            reward_left=protocol["reward_left"],
+            reward_right=protocol["reward_right"],
+            initial_state=protocol["initial_state"],
+        )
+        river = RiverSwimMDP(river_config)
+        oracle_rewards = [river.optimal_average_reward(), 0.0]
+        possible_rewards = (0.0, protocol["reward_left"], protocol["reward_right"])
+        minimum_reward = min(possible_rewards)
+        maximum_reward = max(possible_rewards)
+        tolerance = 1e-9 * max(1.0, abs(phase_reward_values[0]))
+        if not (
+            minimum_reward * horizon - tolerance
+            <= phase_reward_values[0]
+            <= maximum_reward * horizon + tolerance
+        ) or phase_reward_values[1] != 0.0:
+            raise ValueError(f"{path}.phase_reward_sums violates stationary rewards")
+        if not _reward_lattice_matches(
+            phase_reward_values[0],
+            event_count=horizon,
+            reward_values=possible_rewards,
+        ):
+            raise ValueError(f"{path}.phase_reward_sums violates the reward lattice")
+        for name, expected_count in (
+            ("early", protocol["early_window"]),
+            ("late", protocol["late_window"]),
+        ):
+            window_reward_sums.append(
+                _validate_metric_window(
+                    windows[name],
+                    event_count=expected_count,
+                    oracle_reward=oracle_rewards[0],
+                    minimum_reward=minimum_reward,
+                    maximum_reward=maximum_reward,
+                    reward_values=possible_rewards,
+                    path=f"{path}.windows.{name}",
+                )
+            )
+        if math.fsum(window_reward_sums) > phase_reward_values[0] + 1e-9:
+            raise ValueError(f"{path}.windows exceed the stationary reward sum")
+        visits = outcome["high_end_visit_count"]
+        if type(visits) is not int or not 0 <= visits <= horizon:
+            raise ValueError(f"{path}.high_end_visit_count is invalid")
+        rate = _require_finite_number(
+            outcome["high_end_visit_rate"], path=f"{path}.high_end_visit_rate"
+        )
+        if not _numerically_equal(rate, visits / horizon):
+            raise ValueError(f"{path}.high_end_visit_rate is inconsistent")
+    else:
+        raise ValueError(f"{path} has an unsupported environment")
+
+    expected_oracle_sum = math.fsum(
+        count * oracle for count, oracle in zip(phase_counts, oracle_rewards, strict=True)
+    )
+    if not _numerically_equal(oracle_reward_sum, expected_oracle_sum):
+        raise ValueError(f"{path}.oracle_reward_sum differs from the exact environment")
+    all_reward_values = (
+        [
+            float(value)
+            for matrix in (protocol["payoffs_a"], protocol["payoffs_b"])
+            for row in matrix
+            for value in row
+        ]
+        if environment == "switching_two_state"
+        else [0.0, protocol["reward_left"], protocol["reward_right"]]
+    )
+    if not _reward_lattice_matches(
+        reward_sum,
+        event_count=horizon,
+        reward_values=all_reward_values,
+    ):
+        raise ValueError(f"{path}.reward_sum is outside the exact reward lattice")
+
+
+def _partial_window_count(start: int, stop: int, accepted: int) -> int:
+    return max(0, min(stop, accepted) - start)
+
+
+def _validate_partial_outcome(
+    partial: Any,
+    *,
+    accepted: int,
+    environment: str,
+    protocol: Mapping[str, Any],
+    path: str,
+) -> None:
+    required = {
+        "summary_mode",
+        "configured_horizon",
+        "accepted_events",
+        "reward_sum",
+        "mean_reward",
+        "oracle_reward_sum",
+        "regret_sum",
+        "parameter_change_events",
+        "phase_event_counts",
+        "phase_reward_sums",
+        "windows",
+        "high_end_visit_count",
+        "high_end_visit_rate",
+    }
+    if not isinstance(partial, Mapping) or set(partial) != required:
+        raise ValueError(f"{path} fields do not match the partial-outcome contract")
+    horizon = protocol["horizon"]
+    if (
+        partial["summary_mode"] != "streaming_o1_no_retained_events"
+        or type(partial["configured_horizon"]) is not int
+        or partial["configured_horizon"] != horizon
+        or type(partial["accepted_events"]) is not int
+        or partial["accepted_events"] != accepted
+    ):
+        raise ValueError(f"{path} counters do not match the failed shard")
+    reward_sum = _require_finite_number(partial["reward_sum"], path=f"{path}.reward_sum")
+    oracle_sum = _require_finite_number(
+        partial["oracle_reward_sum"], path=f"{path}.oracle_reward_sum"
+    )
+    regret_sum = _require_finite_number(
+        partial["regret_sum"], path=f"{path}.regret_sum"
+    )
+    mean = partial["mean_reward"]
+    if accepted == 0:
+        if mean is not None or any(value != 0.0 for value in (reward_sum, oracle_sum, regret_sum)):
+            raise ValueError(f"{path} zero-event arithmetic is inconsistent")
+    else:
+        mean_value = _require_finite_number(mean, path=f"{path}.mean_reward")
+        if not _numerically_equal(mean_value, reward_sum / accepted):
+            raise ValueError(f"{path}.mean_reward is inconsistent")
+    if not _numerically_equal(regret_sum, oracle_sum - reward_sum):
+        raise ValueError(f"{path}.regret_sum is inconsistent")
+    changes = partial["parameter_change_events"]
+    if type(changes) is not int or not 0 <= changes <= accepted:
+        raise ValueError(f"{path}.parameter_change_events is invalid")
+
+    phase_counts = partial["phase_event_counts"]
+    phase_rewards = partial["phase_reward_sums"]
+    if (
+        not isinstance(phase_counts, list)
+        or len(phase_counts) != 2
+        or any(type(value) is not int or value < 0 for value in phase_counts)
+        or sum(phase_counts) != accepted
+        or not isinstance(phase_rewards, list)
+        or len(phase_rewards) != 2
+    ):
+        raise ValueError(f"{path} phase summaries are malformed")
+    phase_reward_values = [
+        _require_finite_number(value, path=f"{path}.phase_reward_sums[{index}]")
+        for index, value in enumerate(phase_rewards)
+    ]
+    if not _numerically_equal(math.fsum(phase_reward_values), reward_sum):
+        raise ValueError(f"{path}.phase_reward_sums do not sum to reward_sum")
+    windows = partial["windows"]
+    if not isinstance(windows, Mapping):
+        raise ValueError(f"{path}.windows must be an object")
+
+    if environment == "switching_two_state":
+        phase_length = protocol["phase_length"]
+        cycles, remainder = divmod(accepted, 2 * phase_length)
+        expected_counts = [
+            cycles * phase_length + min(remainder, phase_length),
+            cycles * phase_length + max(0, remainder - phase_length),
+        ]
+        if phase_counts != expected_counts:
+            raise ValueError(f"{path}.phase_event_counts violates the switching schedule")
+        kernel = SwitchingTwoStateMDP(
+            SwitchingTwoStateConfig(  # type: ignore[call-arg]
+                phase_length=phase_length,
+                payoffs_a=tuple(tuple(row) for row in protocol["payoffs_a"]),
+                payoffs_b=tuple(tuple(row) for row in protocol["payoffs_b"]),
+            )
+        )
+        payoffs = (protocol["payoffs_a"], protocol["payoffs_b"])
+        oracle_rewards = [kernel.optimal_average_reward(phase) for phase in (0, 1)]
+        for phase in (0, 1):
+            rewards = [float(value) for row in payoffs[phase] for value in row]
+            if not _reward_lattice_matches(
+                phase_reward_values[phase],
+                event_count=phase_counts[phase],
+                reward_values=rewards,
+            ):
+                raise ValueError(f"{path}.phase_reward_sums[{phase}] violates rewards")
+        if set(windows) != {"initial_a", "first_b", "return_a"}:
+            raise ValueError(f"{path}.windows does not match the A/B/A contract")
+        window = protocol["post_switch_window"]
+        for name, start, phase in (
+            ("initial_a", 0, 0),
+            ("first_b", phase_length, 1),
+            ("return_a", 2 * phase_length, 0),
+        ):
+            expected_count = _partial_window_count(start, start + window, accepted)
+            value = windows[name]
+            if expected_count == 0:
+                if value is not None:
+                    raise ValueError(f"{path}.windows.{name} must be empty")
+            else:
+                rewards = [float(item) for row in payoffs[phase] for item in row]
+                _validate_metric_window(
+                    value,
+                    event_count=expected_count,
+                    oracle_reward=oracle_rewards[phase],
+                    minimum_reward=min(rewards),
+                    maximum_reward=max(rewards),
+                    reward_values=rewards,
+                    path=f"{path}.windows.{name}",
+                )
+        if partial["high_end_visit_count"] is not None or partial[
+            "high_end_visit_rate"
+        ] is not None:
+            raise ValueError(f"{path} switching partial cannot claim RiverSwim visits")
+    elif environment == "riverswim":
+        if phase_counts != [accepted, 0] or phase_reward_values[1] != 0.0:
+            raise ValueError(f"{path} violates stationary RiverSwim semantics")
+        river = RiverSwimMDP(
+            RiverSwimConfig(  # type: ignore[call-arg]
+                n_states=protocol["n_states"],
+                p_right_up=protocol["p_right_up"],
+                p_right_down=protocol["p_right_down"],
+                reward_left=protocol["reward_left"],
+                reward_right=protocol["reward_right"],
+                initial_state=protocol["initial_state"],
+            )
+        )
+        oracle_rewards = [river.optimal_average_reward(), 0.0]
+        river_rewards = (0.0, protocol["reward_left"], protocol["reward_right"])
+        if not _reward_lattice_matches(
+            phase_reward_values[0], event_count=accepted, reward_values=river_rewards
+        ):
+            raise ValueError(f"{path}.phase_reward_sums violates RiverSwim rewards")
+        if set(windows) != {"early", "late"}:
+            raise ValueError(f"{path}.windows does not match the RiverSwim contract")
+        for name, start, stop in (
+            ("early", 0, protocol["early_window"]),
+            ("late", horizon - protocol["late_window"], horizon),
+        ):
+            expected_count = _partial_window_count(start, stop, accepted)
+            value = windows[name]
+            if expected_count == 0:
+                if value is not None:
+                    raise ValueError(f"{path}.windows.{name} must be empty")
+            else:
+                _validate_metric_window(
+                    value,
+                    event_count=expected_count,
+                    oracle_reward=oracle_rewards[0],
+                    minimum_reward=min(river_rewards),
+                    maximum_reward=max(river_rewards),
+                    reward_values=river_rewards,
+                    path=f"{path}.windows.{name}",
+                )
+        visits = partial["high_end_visit_count"]
+        if type(visits) is not int or not 0 <= visits <= accepted:
+            raise ValueError(f"{path}.high_end_visit_count is invalid")
+        rate = partial["high_end_visit_rate"]
+        if accepted == 0:
+            if rate is not None:
+                raise ValueError(f"{path}.high_end_visit_rate must be empty")
+        else:
+            rate_value = _require_finite_number(rate, path=f"{path}.high_end_visit_rate")
+            if not _numerically_equal(rate_value, visits / accepted):
+                raise ValueError(f"{path}.high_end_visit_rate is inconsistent")
+    else:
+        raise ValueError(f"{path} has an unsupported environment")
+    expected_oracle = math.fsum(
+        count * oracle
+        for count, oracle in zip(phase_counts, oracle_rewards, strict=True)
+    )
+    if not _numerically_equal(oracle_sum, expected_oracle):
+        raise ValueError(f"{path}.oracle_reward_sum is inconsistent")
+
+
+def _validate_run_record(
+    plan: ReferenceLifeDevelopmentPlan,
+    record: Any,
+    expected_spec: ScorecardRunSpec,
+    *,
+    path: str,
+    consistency_identities: tuple[dict[str, Any], dict[str, Any], dict[str, Any]],
+) -> None:
+    if not isinstance(record, Mapping):
+        raise ValueError(f"{path} must be an object")
+    required = {
+        "schema",
+        "plan_sha256",
+        "schedule_index",
+        "environment_kind",
+        "arm",
+        "seed",
+        "lifecycle_id",
+        "evidence_policy",
+        "source_identity",
+        "runtime_identity",
+        "dependency_identity",
+        "status",
+        "failure",
+        "resolved",
+        "outcome",
+        "partial_outcome",
+        "telemetry",
+        "record_sha256",
+    }
+    if set(record) != required:
+        raise ValueError(f"{path} fields do not match the run-record contract")
+    expected_identity = (
+        expected_spec.schedule_index,
+        expected_spec.environment_kind,
+        expected_spec.arm,
+        expected_spec.seed,
+        expected_spec.lifecycle_id,
+    )
+    observed_identity = (
+        record["schedule_index"],
+        record["environment_kind"],
+        record["arm"],
+        record["seed"],
+        record["lifecycle_id"],
+    )
+    if (
+        type(record["schedule_index"]) is not int
+        or type(record["seed"]) is not int
+        or type(record["environment_kind"]) is not str
+        or type(record["arm"]) is not str
+        or type(record["lifecycle_id"]) is not str
+        or observed_identity != expected_identity
+    ):
+        raise ValueError(f"{path} is outside the canonical cyclic schedule")
+    if record["schema"] != REFERENCE_LIFE_SCORECARD_RUN_SCHEMA:
+        raise ValueError(f"{path} has an unsupported schema")
+    if record["plan_sha256"] != plan.plan_sha256:
+        raise ValueError(f"{path} belongs to another plan")
+    if not _json_exact_equal(record["evidence_policy"], NONPROMOTING_POLICY):
+        raise ValueError(f"{path} must remain permanently nonpromoting")
+    source_identity, runtime_identity, dependency_identity = consistency_identities
+    if not _json_exact_equal(record["source_identity"], source_identity):
+        raise ValueError(f"{path} source identity differs from the current source tree")
+    if not _json_exact_equal(record["runtime_identity"], runtime_identity):
+        raise ValueError(f"{path} runtime identity differs from the current runtime")
+    if not _json_exact_equal(record["dependency_identity"], dependency_identity):
+        raise ValueError(f"{path} dependency identity differs from current dependencies")
+    if record["record_sha256"] != _digest_excluding(record, "record_sha256"):
+        raise ValueError(f"{path} content digest mismatch")
+
+    telemetry = record["telemetry"]
+    telemetry_fields = {
+        "policy",
+        "setup_seconds",
+        "cold_step_seconds",
+        "warmed_step_seconds_total",
+        "warmed_step_count",
+        "warmed_step_seconds_mean",
+        "total_seconds",
+    }
+    if not isinstance(telemetry, Mapping) or set(telemetry) != telemetry_fields:
+        raise ValueError(f"{path}.telemetry fields do not match the telemetry contract")
+    if not _json_exact_equal(telemetry["policy"], TELEMETRY_POLICY):
+        raise ValueError(f"{path}.telemetry is not clearly telemetry-only")
+    optional_durations: dict[str, float | None] = {}
+    for field in ("setup_seconds", "cold_step_seconds"):
+        value = telemetry[field]
+        optional_durations[field] = (
+            None
+            if value is None
+            else _require_finite_nonnegative(
+                value, path=f"{path}.telemetry.{field}"
+            )
+        )
+    warmed_total = _require_finite_nonnegative(
+        telemetry["warmed_step_seconds_total"],
+        path=f"{path}.telemetry.warmed_step_seconds_total",
+    )
+    total_seconds = _require_finite_nonnegative(
+        telemetry["total_seconds"], path=f"{path}.telemetry.total_seconds"
+    )
+    warmed_count = _require_nonnegative_int(
+        telemetry["warmed_step_count"], path=f"{path}.telemetry.warmed_step_count"
+    )
+    warmed_mean_value = telemetry["warmed_step_seconds_mean"]
+    if warmed_count == 0:
+        if warmed_total != 0.0 or warmed_mean_value is not None:
+            raise ValueError(f"{path}.telemetry warmed timing is inconsistent")
+    else:
+        warmed_mean = _require_finite_nonnegative(
+            warmed_mean_value, path=f"{path}.telemetry.warmed_step_seconds_mean"
+        )
+        if not _numerically_equal(warmed_mean, warmed_total / warmed_count):
+            raise ValueError(f"{path}.telemetry warmed timing is inconsistent")
+    timed_components = warmed_total + math.fsum(
+        value for value in optional_durations.values() if value is not None
+    )
+    if total_seconds + 1e-12 < timed_components:
+        raise ValueError(f"{path}.telemetry.total_seconds is smaller than timed work")
+
+    resolved = record["resolved"]
+    if not isinstance(resolved, Mapping):
+        raise ValueError(f"{path}.resolved must be an object")
+    expected_resolved_fields = {
+        "arm_definition",
+        "agent_manifest",
+        "environment_manifest",
+        "life_config",
+        "life_config_sha256",
+    }
+    if set(resolved) != expected_resolved_fields:
+        raise ValueError(f"{path}.resolved fields are incomplete")
+    if not _json_exact_equal(
+        resolved["arm_definition"], plan.arm_definition(expected_spec.arm)
+    ):
+        raise ValueError(f"{path} arm definition differs from the plan")
+
+    status = record["status"]
+    if status == "completed":
+        if record["failure"] is not None or record["partial_outcome"] is not None:
+            raise ValueError(f"{path} completed record carries failure data")
+        horizon = plan.protocol(expected_spec.environment_kind)["horizon"]
+        if (
+            optional_durations["setup_seconds"] is None
+            or optional_durations["cold_step_seconds"] is None
+            or warmed_count != horizon - 1
+        ):
+            raise ValueError(f"{path}.telemetry does not cover every completed step")
+        _validate_resolved_components(
+            resolved,
+            plan=plan,
+            spec=expected_spec,
+            path=f"{path}.resolved",
+        )
+        _validate_completed_outcome(
+            record["outcome"],
+            environment=expected_spec.environment_kind,
+            arm=expected_spec.arm,
+            protocol=plan.protocol(expected_spec.environment_kind),
+            expected_initial_resource=_canonical_initial_resource_payload(
+                expected_spec.environment_kind,
+                expected_spec.arm,
+            ),
+            path=f"{path}.outcome",
+        )
+    elif status == "failed":
+        if record["outcome"] is not None:
+            raise ValueError(f"{path} failed record cannot carry a completed outcome")
+        failure = record["failure"]
+        if not isinstance(failure, Mapping) or set(failure) != {
+            "stage",
+            "type",
+            "message",
+            "accepted_events",
+        }:
+            raise ValueError(f"{path} failure record is incomplete")
+        if failure["stage"] not in {"build", "init", "step"}:
+            raise ValueError(f"{path} failure stage is unsupported")
+        if not isinstance(failure["type"], str) or not failure["type"]:
+            raise ValueError(f"{path} failure type must be nonempty")
+        if not isinstance(failure["message"], str) or not failure["message"]:
+            raise ValueError(f"{path} failure message must be nonempty")
+        if type(failure["accepted_events"]) is not int or failure["accepted_events"] < 0:
+            raise ValueError(f"{path} failure accepted-event count is invalid")
+        horizon = plan.protocol(expected_spec.environment_kind)["horizon"]
+        if failure["accepted_events"] > horizon:
+            raise ValueError(f"{path} failure accepted-event count exceeds the horizon")
+        partial = record["partial_outcome"]
+        _validate_partial_outcome(
+            partial,
+            accepted=failure["accepted_events"],
+            environment=expected_spec.environment_kind,
+            protocol=plan.protocol(expected_spec.environment_kind),
+            path=f"{path}.partial_outcome",
+        )
+        if failure["stage"] in {"build", "init"} and failure["accepted_events"] != 0:
+            raise ValueError(f"{path} pre-step failure cannot claim accepted events")
+        if failure["stage"] == "build":
+            if any(
+                resolved[field] is not None
+                for field in (
+                    "agent_manifest",
+                    "environment_manifest",
+                    "life_config",
+                    "life_config_sha256",
+                )
+            ):
+                raise ValueError(f"{path} build failure carries partial live bindings")
+        else:
+            _validate_resolved_components(
+                resolved,
+                plan=plan,
+                spec=expected_spec,
+                path=f"{path}.resolved",
+            )
+    else:
+        raise ValueError(f"{path} status must be completed or failed")
+
+
+def validate_scorecard_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Strictly validate and recompute one scorecard aggregate."""
+
+    required = {
+        "schema",
+        "schema_version",
+        "benchmark",
+        "plan",
+        "plan_sha256",
+        "evidence_policy",
+        "source_identity",
+        "runtime_identity",
+        "dependency_identity",
+        "identity_scope_note",
+        "run_order",
+        "runs",
+        "summary",
+        "artifact_sha256",
+    }
+    if set(payload) != required:
+        raise ValueError("artifact fields do not match the scorecard schema")
+    if (
+        payload["schema"] != REFERENCE_LIFE_SCORECARD_ARTIFACT_SCHEMA
+        or type(payload["schema_version"]) is not int
+        or payload["schema_version"] != 1
+        or payload["benchmark"] != "reference_life_matched_development_scorecard"
+    ):
+        raise ValueError("artifact schema identity is unsupported")
+    if not _json_exact_equal(payload["evidence_policy"], NONPROMOTING_POLICY):
+        raise ValueError("artifact must remain permanently nonpromoting")
+    consistency_identities = _current_consistency_identities()
+    source_identity, runtime_identity, dependency_identity = consistency_identities
+    if not _json_exact_equal(payload["source_identity"], source_identity):
+        raise ValueError("artifact source identity differs from the current source tree")
+    if not _json_exact_equal(payload["runtime_identity"], runtime_identity):
+        raise ValueError("artifact runtime identity differs from the current runtime")
+    if not _json_exact_equal(payload["dependency_identity"], dependency_identity):
+        raise ValueError("artifact dependency identity differs from current dependencies")
+    if payload["identity_scope_note"] != (
+        "consistency binding only; not authenticated execution attestation"
+    ):
+        raise ValueError("artifact identity scope note is misleading")
+    plan_value = payload["plan"]
+    if not isinstance(plan_value, Mapping):
+        raise ValueError("artifact plan must be an object")
+    plan = ReferenceLifeDevelopmentPlan.from_payload(plan_value)
+    if payload["plan_sha256"] != plan.plan_sha256:
+        raise ValueError("artifact plan digest mismatch")
+    specs = iter_run_specs(plan)
+    expected_order = [
+        {
+            "schedule_index": spec.schedule_index,
+            "environment_kind": spec.environment_kind,
+            "arm": spec.arm,
+            "seed": spec.seed,
+            "lifecycle_id": spec.lifecycle_id,
+        }
+        for spec in specs
+    ]
+    if not _json_exact_equal(payload["run_order"], expected_order):
+        raise ValueError("artifact run order is not the fixed cyclic schedule")
+    runs = payload["runs"]
+    if not isinstance(runs, list) or len(runs) != len(specs):
+        raise ValueError("artifact must retain exactly one record per scheduled run")
+    for index, (record, spec) in enumerate(zip(runs, specs, strict=True)):
+        _validate_run_record(
+            plan,
+            record,
+            spec,
+            path=f"$.runs[{index}]",
+            consistency_identities=consistency_identities,
+        )
+    recomputed_summary = _summarize_validated_run_records(
+        plan,
+        cast(list[Mapping[str, Any]], runs),
+    )
+    if not _json_exact_equal(payload["summary"], recomputed_summary):
+        raise ValueError("artifact summary does not recompute from retained run records")
+    if payload["artifact_sha256"] != _digest_excluding(payload, "artifact_sha256"):
+        raise ValueError("artifact content digest mismatch")
+    return {
+        "valid": True,
+        "schema": REFERENCE_LIFE_SCORECARD_ARTIFACT_SCHEMA,
+        "plan_sha256": plan.plan_sha256,
+        "status": recomputed_summary["status"],
+        "permanently_nonpromoting": True,
+    }
+
+
+def _space_descriptor(spec: SpaceSpec) -> dict[str, Any]:
+    return {
+        "kind": spec.kind,
+        "shape": list(spec.shape),
+        "dtype": spec.dtype,
+        "semantic_id": spec.semantic_id,
+        "cardinality": spec.cardinality,
+        "low": None if spec.low is None else list(spec.low),
+        "high": None if spec.high is None else list(spec.high),
+    }
+
+
+def _agent_manifest_descriptor(manifest: AgentManifest) -> dict[str, Any]:
+    return {
+        "api_version": REFERENCE_AGENT_API_VERSION,
+        "schema": manifest.schema,
+        "implementation_id": manifest.implementation_id,
+        "state_schema": manifest.state_schema,
+        "config_sha256": manifest.config_sha256,
+        "manifest_id": manifest.manifest_id,
+        "config": manifest.config,
+        "observation_spec": _space_descriptor(manifest.observation_spec),
+        "action_spec": _space_descriptor(manifest.action_spec),
+        "capabilities": {
+            "dispatch_rebinding": manifest.capabilities.dispatch_rebinding,
+        },
+    }
+
+
+def _switching_environment_config(plan: ReferenceLifeDevelopmentPlan) -> SwitchingTwoStateConfig:
+    protocol = plan.protocol("switching_two_state")
+    return SwitchingTwoStateConfig(  # type: ignore[call-arg]
+        phase_length=protocol["phase_length"],
+        payoffs_a=tuple(tuple(row) for row in protocol["payoffs_a"]),
+        payoffs_b=tuple(tuple(row) for row in protocol["payoffs_b"]),
+    )
+
+
+def _river_environment_config(plan: ReferenceLifeDevelopmentPlan) -> RiverSwimConfig:
+    protocol = plan.protocol("riverswim")
+    return RiverSwimConfig(  # type: ignore[call-arg]
+        n_states=protocol["n_states"],
+        p_right_up=protocol["p_right_up"],
+        p_right_down=protocol["p_right_down"],
+        reward_left=protocol["reward_left"],
+        reward_right=protocol["reward_right"],
+        initial_state=protocol["initial_state"],
+    )
+
+
+def _prototype_agent_config(
+    plan: ReferenceLifeDevelopmentPlan,
+    *,
+    environment_kind: str,
+    arm: str,
+) -> PrototypeAgentConfig:
+    definition = plan.arm_definition(arm)
+    config = definition["config"]
+    observation_dim = (
+        2
+        if environment_kind == "switching_two_state"
+        else cast(int, plan.protocol("riverswim")["n_states"])
+    )
+    return PrototypeAgentConfig(
+        oak=OaKConfig(
+            stomp=STOMPConfig(
+                subtask_specs=(),
+                observation_dim=observation_dim,
+                n_primitive_actions=2,
+                base_step_size=config["base_step_size"],
+                base_avg_reward_step_size=config["base_average_reward_step_size"],
+                base_trace_decay=config["base_trace_decay"],
+                epsilon_base=config["epsilon_base"],
+            )
+        )
+    )
+
+
+def _control_adapter(
+    *,
+    arm: str,
+    arm_definition: Mapping[str, Any],
+    environment_kind: str,
+    switching_config: SwitchingTwoStateConfig | None,
+    river_config: RiverSwimConfig | None,
+    horizon: int,
+) -> Any:
+    # Lazy import keeps plan/validation tooling usable while the optional run
+    # surface is being installed, while still using the exact named adapters.
+    from alberta_framework.reference_life_controls import (
+        AnalyticOracleReferenceAdapter,
+        AnalyticOracleReferenceConfig,
+        DifferentialSARSAReferenceAdapter,
+        DifferentialSARSAReferenceConfig,
+        DiscountedSARSAReferenceAdapter,
+        DiscountedSARSAReferenceConfig,
+        UniformRandomReferenceAdapter,
+        UniformRandomReferenceConfig,
+    )
+
+    if environment_kind == "switching_two_state":
+        if switching_config is None:
+            raise ValueError("switching control construction lacks its environment config")
+        factory_argument: SwitchingTwoStateConfig | RiverSwimConfig = switching_config
+    elif environment_kind == "riverswim":
+        if river_config is None:
+            raise ValueError("RiverSwim control construction lacks its environment config")
+        factory_argument = river_config
+    else:
+        raise ValueError(f"unsupported environment {environment_kind!r}")
+
+    if arm_definition != build_development_plan().arm_definition(arm):
+        raise ValueError("control arm definition is not the pinned plan-v1 definition")
+    definition_config = arm_definition.get("config")
+    if not isinstance(definition_config, Mapping):
+        raise ValueError("control arm definition lacks its exact config")
+    config = dict(definition_config)
+
+    if arm == "random":
+        if config != {"action_distribution": "uniform", "n_actions": 2}:
+            raise ValueError("random control config is outside the pinned plan")
+        random_config = (
+            UniformRandomReferenceConfig.for_switching(factory_argument)
+            if isinstance(factory_argument, SwitchingTwoStateConfig)
+            else UniformRandomReferenceConfig.for_riverswim(factory_argument)
+        )
+        random_payload = random_config.to_config()
+        if (
+            random_payload["n_actions"] != config["n_actions"]
+            or random_payload["action_distribution"] != config["action_distribution"]
+        ):
+            raise ValueError("random control did not resolve the planned semantics")
+        return UniformRandomReferenceAdapter(random_config)
+    if arm == "privileged_oracle":
+        if not _json_exact_equal(config, {
+            "finite_horizon_solver": (
+                "finite_horizon_backward_dynamic_program.float64.tie_low.preview1"
+            ),
+            "horizon_binding": "environment_protocol_horizon",
+            "privileged_environment_model": True,
+            "tie_break": "lowest_action_index",
+        }):
+            raise ValueError("oracle control config is outside the pinned plan")
+        oracle_config = (
+            AnalyticOracleReferenceConfig.for_switching(
+                factory_argument,
+                horizon=horizon,
+            )
+            if isinstance(factory_argument, SwitchingTwoStateConfig)
+            else AnalyticOracleReferenceConfig.for_riverswim(
+                factory_argument,
+                horizon=horizon,
+            )
+        )
+        oracle_payload = oracle_config.to_config()
+        if (
+            oracle_payload["privileged_environment_model"]
+            != config["privileged_environment_model"]
+            or oracle_payload["tie_break"] != config["tie_break"]
+        ):
+            raise ValueError("oracle control did not resolve the planned semantics")
+        return AnalyticOracleReferenceAdapter(oracle_config)
+    if arm == "differential_sarsa":
+        differential_config = (
+            DifferentialSARSAReferenceConfig.for_switching(factory_argument, **config)
+            if isinstance(factory_argument, SwitchingTwoStateConfig)
+            else DifferentialSARSAReferenceConfig.for_riverswim(
+                factory_argument, **config
+            )
+        )
+        return DifferentialSARSAReferenceAdapter(differential_config)
+    if arm == "sarsa":
+        discounted_config = (
+            DiscountedSARSAReferenceConfig.for_switching(factory_argument, **config)
+            if isinstance(factory_argument, SwitchingTwoStateConfig)
+            else DiscountedSARSAReferenceConfig.for_riverswim(
+                factory_argument, **config
+            )
+        )
+        return DiscountedSARSAReferenceAdapter(discounted_config)
+    raise ValueError(f"arm {arm!r} is not a control adapter")
+
+
+def build_scorecard_runner(
+    plan: ReferenceLifeDevelopmentPlan,
+    spec: ScorecardRunSpec,
+) -> ReferenceLifeRunner:
+    """Build but do not initialize one canonical matched life."""
+
+    expected = iter_run_specs(plan)[spec.schedule_index]
+    if spec != expected:
+        raise ValueError("run spec is not at its canonical cyclic schedule position")
+    protocol = plan.protocol(spec.environment_kind)
+    horizon = cast(int, protocol["horizon"])
+    switching_config = (
+        _switching_environment_config(plan)
+        if spec.environment_kind == "switching_two_state"
+        else None
+    )
+    river_config = (
+        _river_environment_config(plan) if spec.environment_kind == "riverswim" else None
+    )
+
+    if spec.arm in ("prototype", "prototype_frozen"):
+        agent_config = _prototype_agent_config(
+            plan,
+            environment_kind=spec.environment_kind,
+            arm=spec.arm,
+        )
+        if switching_config is not None:
+            return build_prototype_switching_life(
+                agent_config=agent_config,
+                environment_config=switching_config,
+                lifecycle_id=spec.lifecycle_id,
+                seed=spec.seed,
+                max_accepted_events=horizon,
+            )
+        assert river_config is not None
+        return build_prototype_riverswim_life(
+            agent_config=agent_config,
+            environment_config=river_config,
+            lifecycle_id=spec.lifecycle_id,
+            seed=spec.seed,
+            max_accepted_events=horizon,
+        )
+
+    adapter = _control_adapter(
+        arm=spec.arm,
+        arm_definition=plan.arm_definition(spec.arm),
+        environment_kind=spec.environment_kind,
+        switching_config=switching_config,
+        river_config=river_config,
+        horizon=horizon,
+    )
+    environment: Any
+    if switching_config is not None:
+        dispatch_config = ExactDispatchConfig()
+        metrics_config = ReferenceLifeMetricsConfig(mode="switching_two_phase")
+        environment = SwitchingTwoStateReferenceEnvironment(
+            switching_config,
+            observation_spec=adapter.manifest.observation_spec,
+            action_spec=adapter.manifest.action_spec,
+            executor_id=dispatch_config.executor_id,
+            executor_epoch=dispatch_config.executor_epoch,
+        )
+    else:
+        assert river_config is not None
+        dispatch_config = ExactDispatchConfig(
+            executor_id="asi.riverswim.executor",
+            executor_epoch="asi.riverswim.executor_epoch.1",
+        )
+        metrics_config = ReferenceLifeMetricsConfig(mode="stationary")
+        environment = RiverSwimReferenceEnvironment(
+            river_config,
+            observation_spec=adapter.manifest.observation_spec,
+            action_spec=adapter.manifest.action_spec,
+            executor_id=dispatch_config.executor_id,
+            executor_epoch=dispatch_config.executor_epoch,
+        )
+    return ReferenceLifeRunner.create(
+        agent_adapter=adapter,
+        environment_adapter=environment,
+        lifecycle_id=spec.lifecycle_id,
+        seed=spec.seed,
+        max_accepted_events=horizon,
+        dispatch_config=dispatch_config,
+        metrics_config=metrics_config,
+    )
+
+
+def _streaming_summary_for_spec(
+    plan: ReferenceLifeDevelopmentPlan,
+    spec: ScorecardRunSpec,
+) -> StreamingRunSummary:
+    protocol = plan.protocol(spec.environment_kind)
+    if spec.environment_kind == "switching_two_state":
+        return StreamingRunSummary.for_switching(
+            horizon=protocol["horizon"],
+            phase_length=protocol["phase_length"],
+            post_switch_window=protocol["post_switch_window"],
+        )
+    return StreamingRunSummary.for_riverswim(
+        horizon=protocol["horizon"],
+        early_window=protocol["early_window"],
+        late_window=protocol["late_window"],
+        n_states=protocol["n_states"],
+    )
+
+
+def _block_agent_state(state: Any) -> None:
+    for leaf in _iter_array_leaves(state):
+        if isinstance(leaf, jax.Array):
+            leaf.block_until_ready()
+
+
+def _resolved_components(
+    plan: ReferenceLifeDevelopmentPlan,
+    spec: ScorecardRunSpec,
+    runner: ReferenceLifeRunner | None,
+) -> dict[str, Any]:
+    if runner is None:
+        return {
+            "arm_definition": plan.arm_definition(spec.arm),
+            "agent_manifest": None,
+            "environment_manifest": None,
+            "life_config": None,
+            "life_config_sha256": None,
+        }
+    return {
+        "arm_definition": plan.arm_definition(spec.arm),
+        "agent_manifest": _agent_manifest_descriptor(runner.agent_adapter.manifest),
+        "environment_manifest": runner.environment_adapter.manifest.descriptor(),
+        "life_config": runner.config.config,
+        "life_config_sha256": runner.config.config_sha256,
+    }
+
+
+def _telemetry_payload(
+    *,
+    setup_seconds: float | None,
+    cold_step_seconds: float | None,
+    warmed_step_seconds_total: float,
+    warmed_step_count: int,
+    total_seconds: float,
+) -> dict[str, Any]:
+    return {
+        "policy": dict(TELEMETRY_POLICY),
+        "setup_seconds": setup_seconds,
+        "cold_step_seconds": cold_step_seconds,
+        "warmed_step_seconds_total": warmed_step_seconds_total,
+        "warmed_step_count": warmed_step_count,
+        "warmed_step_seconds_mean": (
+            None
+            if warmed_step_count == 0
+            else warmed_step_seconds_total / warmed_step_count
+        ),
+        "total_seconds": total_seconds,
+    }
+
+
+def run_scorecard_shard(
+    plan: ReferenceLifeDevelopmentPlan,
+    spec: ScorecardRunSpec,
+) -> dict[str, Any]:
+    """Execute one fresh-process shard and retain success or ordinary failure."""
+
+    expected = iter_run_specs(plan)[spec.schedule_index]
+    if spec != expected:
+        raise ValueError("run spec is not at its canonical schedule position")
+    source_identity, runtime_identity, dependency_identity = (
+        _current_consistency_identities()
+    )
+    started = time.monotonic()
+    stage = "build"
+    runner: ReferenceLifeRunner | None = None
+    state: Any | None = None
+    streaming = _streaming_summary_for_spec(plan, spec)
+    setup_seconds: float | None = None
+    cold_step_seconds: float | None = None
+    warmed_step_seconds_total = 0.0
+    warmed_step_count = 0
+    initial_resources: dict[str, Any] | None = None
+
+    try:
+        setup_started = time.monotonic()
+        runner = build_scorecard_runner(plan, spec)
+        stage = "init"
+        state = runner.init()
+        _block_agent_state(state.agent_state)
+        setup_seconds = time.monotonic() - setup_started
+        initial_resources = _agent_resource_payload(runner.agent_adapter, state.agent_state)
+        stage = "step"
+        while state.phase is LifePhase.QUIESCENT:
+            step_started = time.monotonic()
+            step = runner.step(state)
+            _block_agent_state(step.state.agent_state)
+            step_seconds = time.monotonic() - step_started
+            if cold_step_seconds is None:
+                cold_step_seconds = step_seconds
+            else:
+                warmed_step_seconds_total += step_seconds
+                warmed_step_count += 1
+            if step.accepted:
+                if step.event is None:
+                    raise RuntimeError("accepted runner step did not expose its event")
+                observation = step.event.transaction.next_decision_observation
+                if observation is None:
+                    raise RuntimeError("continuing scorecard event lacks its next observation")
+                observation_array = observation.to_numpy()
+                if observation_array.ndim != 1:
+                    raise RuntimeError("scorecard observation is not a one-hot vector")
+                next_state_index = int(np.argmax(observation_array))
+                streaming.observe(
+                    reward=step.event.transaction.reward,
+                    oracle_reward=step.event.oracle_reward,
+                    regime_id=step.event.regime_id,
+                    parameters_changed=step.event.step_result.parameters_changed,
+                    next_state_index=next_state_index,
+                )
+            state = step.state
+            if not step.accepted:
+                reason = step.rejection_reason or "reference life rejected a step"
+                raise RuntimeError(reason)
+        if state.phase is not LifePhase.COMPLETED:
+            reason = (
+                "reference life left quiescent execution without reaching completed phase"
+                if state.halt is None
+                else state.halt.reason
+            )
+            raise RuntimeError(reason)
+        outcome = streaming.finalize()
+        if state.accepted_events != outcome["accepted_events"]:
+            raise RuntimeError("runner and streaming accepted-event counts disagree")
+        if state.environment_rng_cursor != state.accepted_events:
+            raise RuntimeError("runner environment cursor is not matched to accepted events")
+        if initial_resources is None:
+            raise RuntimeError("initial resource accounting is unavailable")
+        final_resources = _agent_resource_payload(runner.agent_adapter, state.agent_state)
+        outcome.update(
+            {
+                "environment_rng_cursor": state.environment_rng_cursor,
+                "transcript_sha256": state.transcript_sha256,
+                "resources": {
+                    "initial": initial_resources,
+                    "final": final_resources,
+                },
+                "parameter_change_check": parameter_change_check(
+                    spec.arm, state.metrics.parameter_change_events
+                ),
+            }
+        )
+        record = {
+            "schema": REFERENCE_LIFE_SCORECARD_RUN_SCHEMA,
+            "plan_sha256": plan.plan_sha256,
+            "schedule_index": spec.schedule_index,
+            "environment_kind": spec.environment_kind,
+            "arm": spec.arm,
+            "seed": spec.seed,
+            "lifecycle_id": spec.lifecycle_id,
+            "evidence_policy": dict(NONPROMOTING_POLICY),
+            "source_identity": source_identity,
+            "runtime_identity": runtime_identity,
+            "dependency_identity": dependency_identity,
+            "status": "completed",
+            "failure": None,
+            "resolved": _resolved_components(plan, spec, runner),
+            "outcome": outcome,
+            "partial_outcome": None,
+            "telemetry": _telemetry_payload(
+                setup_seconds=setup_seconds,
+                cold_step_seconds=cold_step_seconds,
+                warmed_step_seconds_total=warmed_step_seconds_total,
+                warmed_step_count=warmed_step_count,
+                total_seconds=time.monotonic() - started,
+            ),
+        }
+        return _record_with_digest(record)
+    except Exception as exc:
+        accepted_events = (
+            streaming.accepted_events
+            if state is None
+            else int(getattr(state, "accepted_events", streaming.accepted_events))
+        )
+        message = str(exc).strip() or repr(exc)
+        failure_record = {
+            "schema": REFERENCE_LIFE_SCORECARD_RUN_SCHEMA,
+            "plan_sha256": plan.plan_sha256,
+            "schedule_index": spec.schedule_index,
+            "environment_kind": spec.environment_kind,
+            "arm": spec.arm,
+            "seed": spec.seed,
+            "lifecycle_id": spec.lifecycle_id,
+            "evidence_policy": dict(NONPROMOTING_POLICY),
+            "source_identity": source_identity,
+            "runtime_identity": runtime_identity,
+            "dependency_identity": dependency_identity,
+            "status": "failed",
+            "failure": {
+                "stage": stage,
+                "type": type(exc).__qualname__,
+                "message": message,
+                "accepted_events": accepted_events,
+            },
+            "resolved": _resolved_components(plan, spec, runner),
+            "outcome": None,
+            "partial_outcome": streaming.partial(),
+            "telemetry": _telemetry_payload(
+                setup_seconds=setup_seconds,
+                cold_step_seconds=cold_step_seconds,
+                warmed_step_seconds_total=warmed_step_seconds_total,
+                warmed_step_count=warmed_step_count,
+                total_seconds=time.monotonic() - started,
+            ),
+        }
+        return _record_with_digest(failure_record)
+
+
+def _spec_for_identity(
+    plan: ReferenceLifeDevelopmentPlan,
+    *,
+    environment_kind: str,
+    arm: str,
+    seed: int,
+) -> ScorecardRunSpec:
+    matches = [
+        spec
+        for spec in iter_run_specs(plan)
+        if spec.environment_kind == environment_kind and spec.arm == arm and spec.seed == seed
+    ]
+    if len(matches) != 1:
+        raise ValueError("requested run identity is outside the fixed plan")
+    return matches[0]
+
+
+def validate_scorecard_run_record(
+    payload: Mapping[str, Any],
+    *,
+    plan: ReferenceLifeDevelopmentPlan | None = None,
+    _consistency_identities: (
+        tuple[dict[str, Any], dict[str, Any], dict[str, Any]] | None
+    ) = None,
+) -> dict[str, Any]:
+    """Validate one shard against its canonical schedule identity."""
+
+    effective_plan = build_development_plan() if plan is None else plan
+    environment = payload.get("environment_kind")
+    arm = payload.get("arm")
+    seed = payload.get("seed")
+    if not isinstance(environment, str) or not isinstance(arm, str) or type(seed) is not int:
+        raise ValueError("run shard identity is malformed")
+    spec = _spec_for_identity(
+        effective_plan,
+        environment_kind=environment,
+        arm=arm,
+        seed=seed,
+    )
+    identities = (
+        _current_consistency_identities()
+        if _consistency_identities is None
+        else _consistency_identities
+    )
+    _validate_run_record(
+        effective_plan,
+        payload,
+        spec,
+        path="$",
+        consistency_identities=identities,
+    )
+    return {
+        "valid": True,
+        "schema": REFERENCE_LIFE_SCORECARD_RUN_SCHEMA,
+        "plan_sha256": effective_plan.plan_sha256,
+        "schedule_index": spec.schedule_index,
+        "status": payload["status"],
+        "permanently_nonpromoting": True,
+    }
+
+
+def summarize_shard_files(
+    paths: Sequence[Path],
+    *,
+    plan: ReferenceLifeDevelopmentPlan | None = None,
+) -> dict[str, Any]:
+    """Strictly load all 144 fresh-process shards and build the aggregate."""
+
+    effective_plan = build_development_plan() if plan is None else plan
+    expected_count = len(iter_run_specs(effective_plan))
+    if len(paths) != expected_count:
+        raise ValueError(f"aggregate requires exactly {expected_count} shard paths")
+    records: list[dict[str, Any]] = []
+    seen_files: set[tuple[int, int]] = set()
+    total_bytes = 0
+    consistency_identities = _current_consistency_identities()
+    for path in paths:
+        remaining_budget = MAX_SCORECARD_AGGREGATE_INPUT_BYTES - total_bytes
+        payload, metadata = _load_json_strict_with_metadata(
+            Path(path),
+            max_bytes=min(MAX_SCORECARD_JSON_INPUT_BYTES, remaining_budget),
+        )
+        identity = (metadata.st_dev, metadata.st_ino)
+        if identity in seen_files:
+            raise ValueError("aggregate shard paths must name unique regular files")
+        seen_files.add(identity)
+        total_bytes += metadata.st_size
+        validate_scorecard_run_record(
+            payload,
+            plan=effective_plan,
+            _consistency_identities=consistency_identities,
+        )
+        records.append(payload)
+    artifact = build_scorecard_artifact(effective_plan, records)
+    validate_scorecard_artifact(artifact)
+    return artifact
+
+
+def _load_plan(path: Path | None) -> ReferenceLifeDevelopmentPlan:
+    if path is None:
+        return build_development_plan()
+    return ReferenceLifeDevelopmentPlan.from_payload(load_json_strict(path))
+
+
+def _print_json(value: Any) -> None:
+    print(
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "PERMANENTLY NONPROMOTING matched reference-life development scorecard"
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan_parser = subparsers.add_parser("plan", help="write the immutable canonical plan")
+    plan_parser.add_argument("--output", type=Path, required=True)
+
+    shard_parser = subparsers.add_parser(
+        "run-shard",
+        help="run exactly one canonical shard in this fresh Python process",
+    )
+    shard_parser.add_argument("--plan", type=Path)
+    shard_parser.add_argument("--environment", choices=ENVIRONMENT_ROSTER, required=True)
+    shard_parser.add_argument("--arm", choices=ARM_ROSTER, required=True)
+    shard_parser.add_argument("--seed", type=int, choices=SEED_ROSTER, required=True)
+    shard_parser.add_argument("--output", type=Path, required=True)
+
+    summarize_parser = subparsers.add_parser(
+        "summarize", help="strictly combine all canonical fresh-process shards"
+    )
+    summarize_parser.add_argument("--plan", type=Path)
+    summarize_parser.add_argument("--output", type=Path, required=True)
+    summarize_parser.add_argument("shards", type=Path, nargs="+")
+
+    validate_parser = subparsers.add_parser(
+        "validate", help="validate one shard or one aggregate"
+    )
+    validate_parser.add_argument("input", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint for the immutable nonpromoting development workflow."""
+
+    args = _parser().parse_args(argv)
+    if args.command == "plan":
+        plan = build_development_plan()
+        write_new_json(args.output, plan.to_payload())
+        return 0
+    if args.command == "run-shard":
+        # Fail before source hashing, JAX setup, or life construction.
+        preflight_new_output(args.output)
+        plan = _load_plan(args.plan)
+        spec = _spec_for_identity(
+            plan,
+            environment_kind=args.environment,
+            arm=args.arm,
+            seed=args.seed,
+        )
+        record = run_scorecard_shard(plan, spec)
+        validate_scorecard_run_record(record, plan=plan)
+        write_new_json(args.output, record)
+        return 0 if record["status"] == "completed" else 1
+    if args.command == "summarize":
+        preflight_new_output(args.output)
+        plan = _load_plan(args.plan)
+        artifact = summarize_shard_files(args.shards, plan=plan)
+        write_new_json(args.output, artifact)
+        return 0
+    if args.command == "validate":
+        payload = load_json_strict(args.input)
+        if payload.get("schema") == REFERENCE_LIFE_SCORECARD_PLAN_SCHEMA:
+            plan = ReferenceLifeDevelopmentPlan.from_payload(payload)
+            result = {
+                "valid": True,
+                "schema": REFERENCE_LIFE_SCORECARD_PLAN_SCHEMA,
+                "plan_sha256": plan.plan_sha256,
+                "evidence_policy": NONPROMOTING_POLICY,
+            }
+        elif payload.get("schema") == REFERENCE_LIFE_SCORECARD_RUN_SCHEMA:
+            result = validate_scorecard_run_record(payload)
+        elif payload.get("schema") == REFERENCE_LIFE_SCORECARD_ARTIFACT_SCHEMA:
+            result = validate_scorecard_artifact(payload)
+        else:
+            raise ValueError("input is neither a scorecard plan, shard, nor aggregate")
+        _print_json(result)
+        return 0
+    raise AssertionError("argparse returned an unknown command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -38,6 +38,9 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
 
+import jax
+import jax.numpy as jnp
+import numpy as np
 import orbax.checkpoint as ocp
 
 # Stamped into checkpoint metadata on save, but deliberately NOT validated on
@@ -49,6 +52,38 @@ _FORMAT_VERSION = 2
 
 # Internal metadata key — stripped from user-facing metadata
 _VERSION_KEY = "_format_version"
+
+
+def _is_empty_array(value: object) -> bool:
+    return isinstance(value, (jax.Array, np.ndarray)) and value.size == 0
+
+
+def _orbax_compatible_tree(tree: Any) -> Any:
+    """Represent empty leaves with typed sentinels Orbax can serialize.
+
+    Empty arrays contain no payload bytes. Their exact shapes and dtypes come
+    from the caller's restore template, so a one-element sentinel carries only
+    the leaf type through Orbax without weakening structural restoration.
+    """
+
+    def compatible(leaf: Any) -> Any:
+        if not _is_empty_array(leaf):
+            return leaf
+        if isinstance(leaf, jax.Array):
+            return jnp.zeros((1,), dtype=leaf.dtype)
+        return np.zeros((1,), dtype=leaf.dtype)
+
+    return jax.tree.map(compatible, tree)
+
+
+def _restore_empty_arrays(template: Any, restored: Any) -> Any:
+    """Reinstate exact empty leaves from the structurally matched template."""
+
+    return jax.tree.map(
+        lambda expected, actual: expected if _is_empty_array(expected) else actual,
+        template,
+        restored,
+    )
 
 
 def _copy_mapping(payload: object, *, name: str) -> dict[str, Any]:
@@ -110,7 +145,7 @@ def save_checkpoint(
         ckptr.save(
             str(path),
             args=ocp.args.Composite(
-                state=ocp.args.StandardSave(state),
+                state=ocp.args.StandardSave(_orbax_compatible_tree(state)),
                 metadata=ocp.args.JsonSave(meta_to_save),
             ),
         )
@@ -146,11 +181,12 @@ def load_checkpoint(
         raise FileNotFoundError(f"Checkpoint not found: {path}")
 
     try:
+        compatible_template = _orbax_compatible_tree(state_template)
         with ocp.Checkpointer(ocp.CompositeCheckpointHandler()) as ckptr:
             loaded = ckptr.restore(
                 str(path),
                 args=ocp.args.Composite(
-                    state=ocp.args.StandardRestore(state_template),
+                    state=ocp.args.StandardRestore(compatible_template),
                     metadata=ocp.args.JsonRestore(),
                 ),
             )
@@ -165,7 +201,7 @@ def load_checkpoint(
     user_metadata = _copy_mapping(raw_metadata, name="checkpoint metadata")
     user_metadata.pop(_VERSION_KEY, None)
     _require_json_safe_metadata(user_metadata)
-    return loaded.state, user_metadata
+    return _restore_empty_arrays(state_template, loaded.state), user_metadata
 
 
 def load_checkpoint_metadata(path: str | Path) -> dict[str, Any]:

--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -177,6 +177,8 @@ from alberta_framework.core.world_model_ensemble import (
 PROTOTYPE_CHECKPOINT_SCHEMA = "alberta.prototype_agent.v3"
 _PROTOTYPE_CHECKPOINT_SCHEMA_V2 = "alberta.prototype_agent.v2"
 _PROTOTYPE_CHECKPOINT_SCHEMA_V1 = "alberta.prototype_agent.v1"
+_PROTOTYPE_EMPTY_ARRAY_CODEC = "alberta.prototype_agent.empty_array_projection.v1"
+_PROTOTYPE_SUPPORTED_PRNG_IMPLS = frozenset({"threefry2x32", "rbg"})
 _DREAM_NEXT_OBSERVATION_STREAM_TAG = 0x44524D4F
 _PROTOTYPE_V2_REPLAY_MIGRATION_TAG = 0x50525632
 _PROTOTYPE_FEATURE_LIFECYCLE_KEY_TAG = 0x50464C43
@@ -5429,8 +5431,7 @@ class PrototypeAgent:
             carry: tuple[OaKState, Array], dream_index: Array
         ) -> tuple[tuple[OaKState, Array], Float[Array, ""]]:
             oak_s, k = carry
-            # Keep this legacy split unchanged so raw and sampled-one-hot
-            # ablations share identical anchor/action key streams.
+            # Both observation ablations use identical anchor/action key streams.
             k, sample_key, action_key = jr.split(k, 3)
             anchor_obs, _ = self._buffer.sample(buf_state, sample_key)
             action = jr.randint(action_key, (), 0, n_prim, dtype=jnp.int32)
@@ -6100,6 +6101,7 @@ class PrototypeAgent:
             transition_diagnostics=diagnostics,
         )
 
+    @functools.partial(jax.jit, static_argnums=(0,))
     def _update_transition_impl(
         self,
         state: PrototypeAgentState,
@@ -6119,7 +6121,7 @@ class PrototypeAgent:
         ),
         partner_policy_fusion_feedback_supplied: Array,
     ) -> PrototypeUpdateResult:
-        """Atomically apply a valid transition or return an exact no-op."""
+        """Atomically apply one normalized transition at a reusable JAX boundary."""
 
         def valid_branch(_: None) -> PrototypeUpdateResult:
             result = self._apply_valid_transition_impl(
@@ -7910,6 +7912,25 @@ def _prototype_config_digest(config: dict[str, Any]) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
+def _prototype_state_prng_impl(state: PrototypeAgentState) -> str:
+    """Return the one supported typed-key implementation used by the state."""
+
+    implementations: set[str] = set()
+    for leaf in jax.tree_util.tree_leaves(state):
+        dtype = getattr(leaf, "dtype", None)
+        if dtype is None or not jax.dtypes.issubdtype(dtype, jax.dtypes.prng_key):
+            continue
+        implementations.add(str(jr.key_impl(leaf)))
+    if len(implementations) != 1:
+        raise ValueError("prototype state must use one typed PRNG implementation")
+    implementation = next(iter(implementations))
+    if implementation not in _PROTOTYPE_SUPPORTED_PRNG_IMPLS:
+        raise ValueError(
+            f"prototype state uses unsupported PRNG implementation {implementation!r}"
+        )
+    return implementation
+
+
 def save_prototype_checkpoint(
     agent: PrototypeAgent,
     state: PrototypeAgentState,
@@ -7926,6 +7947,7 @@ def save_prototype_checkpoint(
         raise ValueError("cannot save an inconsistent PrototypeAgent state")
 
     config = agent.to_config()
+    prng_impl = _prototype_state_prng_impl(state)
     save_checkpoint(
         state,
         path,
@@ -7933,6 +7955,8 @@ def save_prototype_checkpoint(
             "schema": PROTOTYPE_CHECKPOINT_SCHEMA,
             "agent_config": config,
             "config_sha256": _prototype_config_digest(config),
+            "empty_array_codec": _PROTOTYPE_EMPTY_ARRAY_CODEC,
+            "prng_impl": prng_impl,
         },
     )
 
@@ -7966,6 +7990,20 @@ def load_prototype_checkpoint(
         raise ValueError(
             "checkpoint is not an Alberta PrototypeAgent v1/v2/v3 checkpoint"
         )
+    empty_array_codec = metadata.get("empty_array_codec")
+    if empty_array_codec is not None and empty_array_codec != _PROTOTYPE_EMPTY_ARRAY_CODEC:
+        raise ValueError("prototype checkpoint uses an unknown empty-array codec")
+    checkpoint_prng_impl = metadata.get("prng_impl")
+    if checkpoint_prng_impl is not None and checkpoint_prng_impl not in (
+        _PROTOTYPE_SUPPORTED_PRNG_IMPLS
+    ):
+        raise ValueError("prototype checkpoint uses an unsupported PRNG implementation")
+    if empty_array_codec is not None and schema != PROTOTYPE_CHECKPOINT_SCHEMA:
+        raise ValueError("prototype empty-array codec is valid only for v3 checkpoints")
+    if checkpoint_prng_impl is not None and schema != PROTOTYPE_CHECKPOINT_SCHEMA:
+        raise ValueError("prototype PRNG metadata is valid only for v3 checkpoints")
+    if empty_array_codec is not None and checkpoint_prng_impl is None:
+        raise ValueError("prototype checkpoint is missing PRNG implementation metadata")
     config = metadata.get("agent_config")
     if not isinstance(config, dict):
         raise ValueError("prototype checkpoint is missing agent_config")
@@ -7986,7 +8024,16 @@ def load_prototype_checkpoint(
             "prototype_feature_lifecycle is unsupported by legacy v1/v2 "
             "PrototypeAgent checkpoints"
         )
-    key = jr.key(0) if template_key is None else template_key
+    if checkpoint_prng_impl is None:
+        key = jr.key(0) if template_key is None else template_key
+    elif template_key is None:
+        key = jr.key(0, impl=checkpoint_prng_impl)
+    else:
+        if str(jr.key_impl(template_key)) != checkpoint_prng_impl:
+            raise ValueError(
+                "template_key PRNG implementation does not match checkpoint metadata"
+            )
+        key = template_key
     template = agent.init(key)
     if schema == PROTOTYPE_CHECKPOINT_SCHEMA:
         restored, restored_metadata = load_checkpoint(template, path)

--- a/alberta_framework/prototype_reference_adapter.py
+++ b/alberta_framework/prototype_reference_adapter.py
@@ -38,6 +38,7 @@ from alberta_framework.reference_agent import (
     DecisionOwnershipError,
     DispatchAuthorization,
     DispatchStatus,
+    ReferenceAgentUpdate,
     SpaceSpec,
     Transaction,
 )
@@ -47,6 +48,7 @@ PROTOTYPE_REFERENCE_IMPLEMENTATION_ID = "asi.prototype_exact_adapter.preview1"
 PROTOTYPE_REFERENCE_STATE_SCHEMA = "asi.prototype_reference_state.preview1"
 PROTOTYPE_OBSERVATION_SEMANTIC_ID = "asi.prototype_raw_observation.preview1"
 PROTOTYPE_ACTION_SEMANTIC_ID = "asi.prototype_primitive_action.preview1"
+PROTOTYPE_REFERENCE_MAX_ACCEPTED_EVENTS = 2**31 - 4
 
 _LIFECYCLE_CODEC = "prototype_uint32x2_hex.preview1"
 _SCALAR_CODEC = "finite_float32_round_to_nearest.preview1"
@@ -116,32 +118,14 @@ class PrototypeReferenceState:
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
-class PrototypeAdapterUpdate:
+class PrototypeAdapterUpdate(ReferenceAgentUpdate):
     """Staged functional result for a host runner to accept or reject."""
 
     state: PrototypeReferenceState
-    next_decision: Decision | None
-    accepted: bool
-    parameters_changed: bool
-    rejection_reason: str | None
-
     def __post_init__(self) -> None:
         if not isinstance(self.state, PrototypeReferenceState):
             raise ValueError("state must be a PrototypeReferenceState")
-        if not isinstance(self.accepted, bool):
-            raise ValueError("accepted must be boolean")
-        if not isinstance(self.parameters_changed, bool):
-            raise ValueError("parameters_changed must be boolean")
-        if self.accepted:
-            if self.rejection_reason is not None:
-                raise ValueError("an accepted update cannot carry a rejection reason")
-        else:
-            if self.parameters_changed:
-                raise ValueError("a rejected update cannot change parameters")
-            if self.next_decision is not None:
-                raise ValueError("a rejected update cannot arm a next decision")
-            if not isinstance(self.rejection_reason, str) or not self.rejection_reason.strip():
-                raise ValueError("a rejected update requires a nonempty reason")
+        ReferenceAgentUpdate.__post_init__(self)
 
 
 def _lifecycle_words(lifecycle_id: str) -> Array:
@@ -331,6 +315,12 @@ class PrototypeReferenceAdapter:
     def config(self) -> PrototypeAgentConfig:
         return self._config
 
+    @property
+    def max_accepted_events(self) -> int:
+        """Maximum continuing events that retain an armed next decision."""
+
+        return PROTOTYPE_REFERENCE_MAX_ACCEPTED_EVENTS
+
     def __reduce__(self) -> Any:
         raise TypeError(
             "Prototype reference adapter is process-local and cannot be serialized; "
@@ -433,6 +423,34 @@ class PrototypeReferenceAdapter:
             proposed_action=prototype_decision.action,
             armed=True,
         )
+
+    def validate_state(self, state: PrototypeReferenceState) -> None:
+        """Validate one adapter-owned state and its currently armed decision."""
+
+        self.current_decision(state)
+
+    def adopt_checkpoint_state(
+        self,
+        *,
+        agent_state: PrototypeAgentState,
+        lifecycle_id: str,
+        decision_index: int,
+        current_observation_id: str,
+    ) -> PrototypeReferenceState:
+        """Bind a validated functional checkpoint state to this fresh adapter."""
+
+        candidate = PrototypeReferenceState(
+            schema=PROTOTYPE_REFERENCE_STATE_SCHEMA,
+            manifest_id=self.manifest.manifest_id,
+            config_sha256=self.manifest.config_sha256,
+            agent_state=agent_state,
+            lifecycle_id=lifecycle_id,
+            decision_index=decision_index,
+            current_observation_id=current_observation_id,
+            _owner_token=self._state_owner_token,
+        )
+        self.validate_state(candidate)
+        return candidate
 
     def _require_current_host_decision(
         self,
@@ -619,6 +637,7 @@ __all__ = [
     "PROTOTYPE_OBSERVATION_SEMANTIC_ID",
     "PROTOTYPE_REFERENCE_ADAPTER_SCHEMA",
     "PROTOTYPE_REFERENCE_IMPLEMENTATION_ID",
+    "PROTOTYPE_REFERENCE_MAX_ACCEPTED_EVENTS",
     "PROTOTYPE_REFERENCE_STATE_SCHEMA",
     "PrototypeAdapterUpdate",
     "PrototypeReferenceAdapter",

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -3,7 +3,8 @@
 This module provides immutable records and an in-process, single-writer
 ownership ledger. It is an L0 interoperability preview only: it does not select
 reference-dev, prove learning benefit, certify safety or robotics readiness, or
-establish exact whole-life checkpoint resume.
+provide standalone checkpointing. The separate reference-life checkpoint codec
+supports its documented quiescent aggregate configurations.
 """
 
 from __future__ import annotations
@@ -684,6 +685,7 @@ class TransactionPhase(enum.Enum):
     ARMED = "armed"
     AUTHORIZED = "authorized"
     SETTLED = "settled"
+    ISSUED = "issued"
     DISPATCHED = "dispatched"
     OUTCOME = "outcome"
     EXHAUSTED = "exhausted"
@@ -790,22 +792,24 @@ class DispatchAck:
         return self.decision.decision_id
 
 @dataclasses.dataclass(frozen=True, slots=True)
-class DispatchReceipt:
-    """Host record of an executor acknowledgement for one settled action."""
+class DispatchCommand:
+    """Pre-execution command binding a settlement to one executor epoch."""
 
     dispatch: DispatchAck
-    receipt_id: str
+    command_id: str
     executor_id: str
+    executor_epoch: str
 
     def __post_init__(self) -> None:
         if not isinstance(self.dispatch, DispatchAck):
-            raise ValueError("receipt requires a DispatchAck")
-        _require_safe_id(self.receipt_id, name="receipt_id")
+            raise ValueError("dispatch command requires a DispatchAck")
+        _require_safe_id(self.command_id, name="command_id")
         _require_safe_id(self.executor_id, name="executor_id")
-        expected_id = f"{self.decision.decision_id}:receipt"
-        if self.receipt_id != expected_id:
+        _require_safe_id(self.executor_epoch, name="executor_epoch")
+        expected_id = f"{self.decision_id}:command"
+        if self.command_id != expected_id:
             host_expected = _require_exact_str("expected_id", expected_id)
-            raise ValueError(f"receipt_id must use canonical value '{host_expected}'")
+            raise ValueError(f"command_id must use canonical value '{host_expected}'")
 
     @property
     def effective_action(self) -> ArrayValue:
@@ -814,6 +818,91 @@ class DispatchReceipt:
     @property
     def decision(self) -> Decision:
         return self.dispatch.decision
+
+    @property
+    def lifecycle_id(self) -> str:
+        return self.decision.lifecycle_id
+
+    @property
+    def decision_id(self) -> str:
+        return self.decision.decision_id
+
+
+@dataclasses.dataclass(frozen=True, slots=True, init=False)
+class DispatchReceipt:
+    """Post-execution acknowledgement of the action an executor applied.
+
+    The legacy ``dispatch``/``executor_id`` constructor remains available for
+    preview compatibility and creates an explicit legacy executor command.
+    New integrations must pass the command and independently reported action.
+    """
+
+    command: DispatchCommand
+    applied_action: ArrayValue
+    receipt_id: str
+
+    def __init__(
+        self,
+        *,
+        receipt_id: str,
+        command: DispatchCommand | None = None,
+        applied_action: ArrayValue | None = None,
+        dispatch: DispatchAck | None = None,
+        executor_id: str | None = None,
+    ) -> None:
+        if command is None:
+            if not isinstance(dispatch, DispatchAck) or executor_id is None:
+                raise ValueError(
+                    "receipt requires command/applied_action or legacy dispatch/executor_id"
+                )
+            command = DispatchCommand(
+                dispatch=dispatch,
+                command_id=f"{dispatch.decision_id}:command",
+                executor_id=executor_id,
+                executor_epoch="legacy.preview1",
+            )
+            applied_action = dispatch.effective_action
+        elif dispatch is not None:
+            if executor_id is not None:
+                raise ValueError("receipt constructors cannot mix executor_id with command")
+            command = dataclasses.replace(command, dispatch=dispatch)
+        elif executor_id is not None:
+            raise ValueError("receipt constructors cannot mix executor_id with command")
+        if not isinstance(command, DispatchCommand):
+            raise ValueError("receipt requires a DispatchCommand")
+        if not isinstance(applied_action, ArrayValue):
+            raise ValueError("receipt applied_action must be an ArrayValue")
+        object.__setattr__(self, "command", command)
+        object.__setattr__(self, "applied_action", applied_action)
+        object.__setattr__(self, "receipt_id", receipt_id)
+        self.__post_init__()
+
+    def __post_init__(self) -> None:
+        _require_safe_id(self.receipt_id, name="receipt_id")
+        expected_id = f"{self.decision.decision_id}:receipt"
+        if self.receipt_id != expected_id:
+            host_expected = _require_exact_str("expected_id", expected_id)
+            raise ValueError(f"receipt_id must use canonical value '{host_expected}'")
+
+    @property
+    def effective_action(self) -> ArrayValue:
+        return self.applied_action
+
+    @property
+    def dispatch(self) -> DispatchAck:
+        return self.command.dispatch
+
+    @property
+    def executor_id(self) -> str:
+        return self.command.executor_id
+
+    @property
+    def executor_epoch(self) -> str:
+        return self.command.executor_epoch
+
+    @property
+    def decision(self) -> Decision:
+        return self.command.decision
 
 
 def _finite_scalar(value: Any, *, name: str) -> float:
@@ -929,6 +1018,33 @@ class Transaction:
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceAgentUpdate:
+    """State-agnostic staged result returned by a reference-agent adapter."""
+
+    state: Any
+    next_decision: Decision | None
+    accepted: bool
+    parameters_changed: bool
+    rejection_reason: str | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.accepted, bool):
+            raise ValueError("accepted must be boolean")
+        if not isinstance(self.parameters_changed, bool):
+            raise ValueError("parameters_changed must be boolean")
+        if self.accepted:
+            if self.rejection_reason is not None:
+                raise ValueError("an accepted update cannot carry a rejection reason")
+        else:
+            if self.parameters_changed:
+                raise ValueError("a rejected update cannot change parameters")
+            if self.next_decision is not None:
+                raise ValueError("a rejected update cannot arm a next decision")
+            if not isinstance(self.rejection_reason, str) or not self.rejection_reason.strip():
+                raise ValueError("a rejected update requires a nonempty reason")
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
 class StepResult:
     """Outcome acceptance or fail-closed recovery result."""
 
@@ -1010,6 +1126,7 @@ class ReferenceTransactionState:
     decision: Decision | None = None
     authorization: DispatchAuthorization | None = None
     dispatch: DispatchAck | None = None
+    command: DispatchCommand | None = None
     receipt: DispatchReceipt | None = None
     transaction: Transaction | None = None
     halt_reason: str | None = None
@@ -1042,24 +1159,26 @@ class ReferenceTransactionState:
             self.decision,
             self.authorization,
             self.dispatch,
+            self.command,
             self.receipt,
             self.transaction,
         )
         presence = tuple(record is not None for record in records)
         exact_presence = {
-            TransactionPhase.READY: (False, False, False, False, False),
-            TransactionPhase.ARMED: (True, False, False, False, False),
-            TransactionPhase.AUTHORIZED: (True, True, False, False, False),
-            TransactionPhase.SETTLED: (True, True, True, False, False),
-            TransactionPhase.DISPATCHED: (True, True, True, True, False),
-            TransactionPhase.OUTCOME: (True, True, True, True, True),
-            TransactionPhase.EXHAUSTED: (False, False, False, False, False),
+            TransactionPhase.READY: (False, False, False, False, False, False),
+            TransactionPhase.ARMED: (True, False, False, False, False, False),
+            TransactionPhase.AUTHORIZED: (True, True, False, False, False, False),
+            TransactionPhase.SETTLED: (True, True, True, False, False, False),
+            TransactionPhase.ISSUED: (True, True, True, True, False, False),
+            TransactionPhase.DISPATCHED: (True, True, True, True, True, False),
+            TransactionPhase.OUTCOME: (True, True, True, True, True, True),
+            TransactionPhase.EXHAUSTED: (False, False, False, False, False, False),
         }
         if self.phase in exact_presence and presence != exact_presence[self.phase]:
             raise ValueError(f"{self.phase.value} phase carries inconsistent transaction records")
         if self.phase is TransactionPhase.HALTED:
             depth = sum(presence)
-            if depth == 0 or presence != tuple(index < depth for index in range(5)):
+            if depth == 0 or presence != tuple(index < depth for index in range(6)):
                 raise ValueError("halted phase requires one contiguous transaction record prefix")
 
         if self.phase is TransactionPhase.READY:
@@ -1084,8 +1203,17 @@ class ReferenceTransactionState:
             raise ValueError("authorization decision violates the ownership chain")
         if self.dispatch is not None and self.dispatch.authorization != self.authorization:
             raise ValueError("dispatch authorization violates the ownership chain")
-        if self.receipt is not None and self.receipt.dispatch != self.dispatch:
-            raise ValueError("receipt dispatch violates the ownership chain")
+        if self.command is not None and self.command.dispatch != self.dispatch:
+            raise ValueError("command dispatch violates the ownership chain")
+        if self.receipt is not None and self.receipt.command != self.command:
+            raise ValueError("receipt command violates the ownership chain")
+        if (
+            self.receipt is not None
+            and self.command is not None
+            and self.phase is not TransactionPhase.HALTED
+            and self.receipt.applied_action != self.command.effective_action
+        ):
+            raise ValueError("a non-halted receipt applied action must equal the command")
         if self.transaction is not None and self.transaction.receipt != self.receipt:
             raise ValueError("outcome receipt violates the ownership chain")
         if (
@@ -1094,6 +1222,298 @@ class ReferenceTransactionState:
             and self.phase is not TransactionPhase.HALTED
         ):
             raise ValueError("vetoed authorization is valid only in a halted state")
+
+
+class ReferenceTransactionReducer:
+    """Pure semantic transitions for one manifest-bound transaction state.
+
+    Aggregate runners use this reducer under their own outer commit. The live
+    ledger remains the process-local compatibility/CAS owner.
+    """
+
+    __slots__ = ("_manifest",)
+
+    def __init__(self, manifest: AgentManifest) -> None:
+        if not isinstance(manifest, AgentManifest):
+            raise ValueError("manifest must be an AgentManifest")
+        self._manifest = manifest
+
+    @property
+    def manifest(self) -> AgentManifest:
+        return self._manifest
+
+    def init(self) -> ReferenceTransactionState:
+        return ReferenceTransactionState(
+            schema=REFERENCE_TRANSACTION_STATE_SCHEMA,
+            manifest_id=self.manifest.manifest_id,
+            phase=TransactionPhase.READY,
+            lifecycle_id=None,
+            next_decision_index=0,
+        )
+
+    def _ledger(self, state: ReferenceTransactionState) -> ReferenceTransactionLedger:
+        ledger = ReferenceTransactionLedger(self.manifest)
+        ledger._current_state = state
+        return ledger
+
+    def _validate_state(
+        self,
+        state: ReferenceTransactionState,
+        *,
+        require_current: bool = False,
+    ) -> None:
+        del require_current
+        self._ledger(state)._validate_state(state)
+
+    def validate_state(self, state: ReferenceTransactionState) -> None:
+        self._validate_state(state)
+
+    def _commit(
+        self,
+        previous: ReferenceTransactionState,
+        next_state: ReferenceTransactionState,
+    ) -> ReferenceTransactionState:
+        self._validate_state(previous)
+        self._validate_state(next_state)
+        return next_state
+
+    def _require_phase(
+        self,
+        state: ReferenceTransactionState,
+        expected: TransactionPhase,
+    ) -> None:
+        self._validate_state(state)
+        if state.phase is not expected:
+            raise DecisionOwnershipError(
+                f"transaction phase must be {expected.value}, got {state.phase.value}"
+            )
+
+    def _halt(
+        self,
+        state: ReferenceTransactionState,
+        *,
+        reason: str,
+    ) -> ReferenceTransactionState:
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("halt reason must be nonempty")
+        return self._commit(
+            state,
+            dataclasses.replace(
+                state,
+                phase=TransactionPhase.HALTED,
+                halt_reason=reason,
+            ),
+        )
+
+    def halt(
+        self,
+        state: ReferenceTransactionState,
+        *,
+        reason: str,
+    ) -> ReferenceTransactionState:
+        self._validate_state(state)
+        if state.phase in (TransactionPhase.HALTED, TransactionPhase.EXHAUSTED):
+            raise DecisionOwnershipError(
+                f"cannot halt a transaction already in phase {state.phase.value}"
+            )
+        return self._halt(state, reason=reason)
+
+    def arm(
+        self,
+        state: ReferenceTransactionState,
+        decision: Decision,
+    ) -> ReferenceTransactionState:
+        return self._ledger(state).arm(state, decision)
+
+    def authorize(
+        self,
+        state: ReferenceTransactionState,
+        decision: Decision,
+        *,
+        authorized_action: Any | None,
+        authority_id: str,
+        policy_version: str,
+        authorization_id: str,
+        veto_reason: str | None = None,
+    ) -> tuple[ReferenceTransactionState, DispatchAuthorization]:
+        return self._ledger(state).authorize(
+            state,
+            decision,
+            authorized_action=authorized_action,
+            authority_id=authority_id,
+            policy_version=policy_version,
+            authorization_id=authorization_id,
+            veto_reason=veto_reason,
+        )
+
+    def settle_dispatch(
+        self,
+        state: ReferenceTransactionState,
+        authorization: DispatchAuthorization,
+        *,
+        rebinding_applied: bool,
+        settlement_id: str,
+    ) -> tuple[ReferenceTransactionState, DispatchAck | None]:
+        return self._ledger(state).settle_dispatch(
+            state,
+            authorization,
+            rebinding_applied=rebinding_applied,
+            settlement_id=settlement_id,
+        )
+
+    def issue_dispatch(
+        self,
+        state: ReferenceTransactionState,
+        dispatch: DispatchAck,
+        *,
+        command_id: str,
+        executor_id: str,
+        executor_epoch: str,
+    ) -> tuple[ReferenceTransactionState, DispatchCommand]:
+        self._require_phase(state, TransactionPhase.SETTLED)
+        if state.dispatch != dispatch:
+            raise DecisionOwnershipError("dispatch command does not own the settlement")
+        command = DispatchCommand(
+            dispatch=dispatch,
+            command_id=command_id,
+            executor_id=executor_id,
+            executor_epoch=executor_epoch,
+        )
+        return (
+            self._commit(
+                state,
+                dataclasses.replace(
+                    state,
+                    phase=TransactionPhase.ISSUED,
+                    command=command,
+                ),
+            ),
+            command,
+        )
+
+    def record_dispatch(
+        self,
+        state: ReferenceTransactionState,
+        receipt: DispatchReceipt,
+    ) -> tuple[ReferenceTransactionState, DispatchReceipt]:
+        self._require_phase(state, TransactionPhase.ISSUED)
+        if not isinstance(receipt, DispatchReceipt):
+            raise DecisionOwnershipError("dispatch acknowledgement must be a DispatchReceipt")
+        if state.command != receipt.command:
+            raise DecisionOwnershipError("dispatch receipt does not own the issued command")
+        try:
+            applied_action = self.manifest.action_spec.encode(receipt.applied_action)
+        except (TypeError, ValueError) as exc:
+            return self._halt(
+                state,
+                reason=f"executor applied action violates the manifest codec: {exc}",
+            ), receipt
+        assert state.command is not None
+        if applied_action != state.command.effective_action:
+            return (
+                self._commit(
+                    state,
+                    dataclasses.replace(
+                        state,
+                        phase=TransactionPhase.HALTED,
+                        receipt=receipt,
+                        halt_reason="executor applied action differs from the settled command",
+                    ),
+                ),
+                receipt,
+            )
+        return (
+            self._commit(
+                state,
+                dataclasses.replace(
+                    state,
+                    phase=TransactionPhase.DISPATCHED,
+                    receipt=receipt,
+                ),
+            ),
+            receipt,
+        )
+
+    def halt_after_execution(
+        self,
+        state: ReferenceTransactionState,
+        receipt: DispatchReceipt,
+        *,
+        reason: str,
+    ) -> ReferenceTransactionState:
+        self._require_phase(state, TransactionPhase.ISSUED)
+        if not isinstance(receipt, DispatchReceipt) or state.command != receipt.command:
+            raise DecisionOwnershipError(
+                "post-execution halt receipt does not own the issued command"
+            )
+        try:
+            self.manifest.action_spec.encode(receipt.applied_action)
+        except (TypeError, ValueError) as exc:
+            return self._halt(
+                state,
+                reason=f"{reason}; executor receipt could not be retained: {exc}",
+            )
+        return self._commit(
+            state,
+            dataclasses.replace(
+                state,
+                phase=TransactionPhase.HALTED,
+                receipt=receipt,
+                halt_reason=reason,
+            ),
+        )
+
+    def record_outcome(
+        self,
+        state: ReferenceTransactionState,
+        receipt: DispatchReceipt,
+        **kwargs: Any,
+    ) -> tuple[ReferenceTransactionState, Transaction]:
+        return self._ledger(state).record_outcome(state, receipt, **kwargs)
+
+    def accept(
+        self,
+        state: ReferenceTransactionState,
+        *,
+        next_decision: Decision | None,
+        parameters_changed: bool,
+    ) -> tuple[ReferenceTransactionState, StepResult]:
+        return self._ledger(state).accept(
+            state,
+            next_decision=next_decision,
+            parameters_changed=parameters_changed,
+        )
+
+    def reject(
+        self,
+        state: ReferenceTransactionState,
+        *,
+        reason: str,
+    ) -> tuple[ReferenceTransactionState, StepResult]:
+        return self._ledger(state).reject(state, reason=reason)
+
+    def recover_accept(
+        self,
+        state: ReferenceTransactionState,
+        *,
+        next_decision: Decision | None,
+        parameters_changed: bool,
+    ) -> tuple[ReferenceTransactionState, StepResult]:
+        self._validate_state(state)
+        if state.phase is not TransactionPhase.HALTED or state.transaction is None:
+            raise DecisionOwnershipError(
+                "recovery requires a halted state retaining a complete outcome"
+            )
+        outcome = dataclasses.replace(
+            state,
+            phase=TransactionPhase.OUTCOME,
+            halt_reason=None,
+        )
+        return self.accept(
+            outcome,
+            next_decision=next_decision,
+            parameters_changed=parameters_changed,
+        )
 
 
 class ReferenceTransactionLedger:
@@ -1137,7 +1557,8 @@ class ReferenceTransactionLedger:
     def __reduce__(self) -> Any:
         raise TypeError(
             "live reference transaction ledger cannot be serialized; "
-            "whole-life checkpoint/resume is not implemented"
+            "checkpoint the supported quiescent aggregate through "
+            "reference_life_checkpoint"
         )
 
     def _validate_state(
@@ -1173,6 +1594,10 @@ class ReferenceTransactionLedger:
                 raise DecisionOwnershipError(
                     "rebound settlement is not declared by the agent manifest"
                 )
+        if state.command is not None:
+            self.manifest.action_spec.encode(state.command.effective_action)
+        if state.receipt is not None:
+            self.manifest.action_spec.encode(state.receipt.applied_action)
         if state.transaction is not None:
             self.manifest.observation_spec.encode(state.transaction.bootstrap_observation)
             if state.transaction.next_decision_observation is not None:
@@ -1241,6 +1666,7 @@ class ReferenceTransactionLedger:
             decision=decision,
             authorization=None,
             dispatch=None,
+            command=None,
             receipt=None,
             transaction=None,
             halt_reason=None,
@@ -1370,6 +1796,7 @@ class ReferenceTransactionLedger:
         next_state = dataclasses.replace(
             state,
             phase=TransactionPhase.DISPATCHED,
+            command=receipt.command,
             receipt=receipt,
         )
         return self._commit(state, next_state), receipt
@@ -1448,6 +1875,7 @@ class ReferenceTransactionLedger:
                 decision=None,
                 authorization=None,
                 dispatch=None,
+                command=None,
                 receipt=None,
                 transaction=None,
             )
@@ -1460,6 +1888,7 @@ class ReferenceTransactionLedger:
                 decision=None,
                 authorization=None,
                 dispatch=None,
+                command=None,
                 receipt=None,
                 transaction=None,
             )
@@ -1472,6 +1901,7 @@ class ReferenceTransactionLedger:
                 decision=next_decision,
                 authorization=None,
                 dispatch=None,
+                command=None,
                 receipt=None,
                 transaction=None,
             )
@@ -1509,9 +1939,12 @@ __all__ = [
     "DecisionOwnershipError",
     "DispatchAck",
     "DispatchAuthorization",
+    "DispatchCommand",
     "DispatchReceipt",
     "DispatchStatus",
+    "ReferenceAgentUpdate",
     "ReferenceTransactionLedger",
+    "ReferenceTransactionReducer",
     "ReferenceTransactionState",
     "SpaceSpec",
     "StepResult",

--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -1,0 +1,3375 @@
+"""Development-only aggregate runner for primitive Prototype reference lives.
+
+The module owns synchronous, functional slices across the host transaction
+reducer, a primitive-only :class:`PrototypeReferenceAdapter`, and the selected
+SwitchingTwoState/RiverSwim environments.  It is an L0 integration mechanism;
+the separate current-schema checkpoint module covers only supported quiescent
+states.  Neither module establishes ``reference-dev``, learning benefit,
+portable recovery, robotics readiness, or scientific evidence.  The declared
+in-process authority is only a static identity for the exact-action lane, not
+an independent safety policy or evidence of veto conformance. The synchronous
+fault boundary covers ordinary :class:`Exception` failures, not process death
+or :class:`BaseException` cancellation.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import hashlib
+import json
+import math
+import re
+import struct
+import threading
+from collections.abc import Callable, Mapping
+from typing import Any, Protocol, TypeVar
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+from jax import Array
+
+from alberta_framework.core.prototype_agent import PrototypeAgentConfig
+from alberta_framework.prototype_reference_adapter import (
+    PrototypeReferenceAdapter,
+    PrototypeReferenceState,
+)
+from alberta_framework.reference_agent import (
+    MAX_DECISION_INDEX,
+    AgentManifest,
+    ArrayValue,
+    AuthorizationStatus,
+    Decision,
+    DecisionOwnershipError,
+    DispatchAuthorization,
+    DispatchCommand,
+    DispatchReceipt,
+    ReferenceAgentUpdate,
+    ReferenceTransactionReducer,
+    ReferenceTransactionState,
+    SpaceSpec,
+    StepResult,
+    Transaction,
+    TransactionPhase,
+)
+from alberta_framework.streams.closed_loop import (
+    RiverSwimConfig,
+    RiverSwimMDP,
+    RiverSwimState,
+    SwitchingTwoStateConfig,
+    SwitchingTwoStateMDP,
+    SwitchingTwoStateState,
+)
+
+REFERENCE_LIFE_CONFIG_SCHEMA = "asi.reference_life_config.preview1"
+REFERENCE_LIFE_STATE_SCHEMA = "asi.reference_life_state.preview1"
+REFERENCE_LIFE_METRICS_SCHEMA = "asi.reference_life_metrics.preview1"
+REFERENCE_ENVIRONMENT_MANIFEST_SCHEMA = "asi.reference_environment_manifest.preview1"
+SWITCHING_ENVIRONMENT_IMPLEMENTATION_ID = "asi.switching_two_state_environment.preview1"
+SWITCHING_ENVIRONMENT_STATE_SCHEMA = "asi.switching_two_state_state.preview1"
+RIVERSWIM_ENVIRONMENT_IMPLEMENTATION_ID = "asi.riverswim_environment.preview1"
+RIVERSWIM_ENVIRONMENT_STATE_SCHEMA = "asi.riverswim_state.preview1"
+EXACT_DISPATCH_SCHEMA = "asi.exact_dispatch.preview1"
+EXACT_DISPATCH_STATE_SCHEMA = "asi.exact_dispatch_state.preview1"
+REFERENCE_METRICS_CONFIG_SCHEMA = "asi.reference_life_metrics_config.preview1"
+REFERENCE_LIFE_PRNG_IMPLEMENTATION = "threefry2x32"
+REFERENCE_LIFE_RNG_SCHEDULE = "jax_threefry2x32_fold_in_environment_cursor.preview1"
+
+_SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9._:-]*$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_PROTOTYPE_LIFECYCLE = re.compile(r"^prototype\.[0-9a-f]{16}$")
+_MAX_ID_LENGTH = 256
+_MAX_SWITCHING_EXECUTIONS = int(np.iinfo(np.int32).max)
+RIVERSWIM_REFERENCE_MAX_STATES = 12
+_CheckpointPublishResult = TypeVar("_CheckpointPublishResult")
+
+
+def _require_id(value: str, *, name: str) -> None:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > _MAX_ID_LENGTH
+        or _SAFE_ID.fullmatch(value) is None
+    ):
+        raise ValueError(f"{name} must be a lowercase safe identifier")
+
+
+def _require_digest(value: str, *, name: str) -> None:
+    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+def _require_prototype_lifecycle_id(value: str) -> None:
+    if not isinstance(value, str) or _PROTOTYPE_LIFECYCLE.fullmatch(value) is None:
+        raise ValueError(
+            "lifecycle_id must use the Prototype lifecycle codec "
+            "'prototype.' followed by 16 lowercase hexadecimal digits"
+        )
+
+
+def _canonical_json(value: Mapping[str, Any]) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("reference-life configuration must be canonical finite JSON") from exc
+    decoded = json.loads(encoded)
+    if not isinstance(decoded, dict):
+        raise ValueError("reference-life configuration must be a JSON object")
+    return encoded
+
+
+def _digest_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _space_descriptor(spec: SpaceSpec) -> dict[str, Any]:
+    return {
+        "kind": spec.kind,
+        "shape": list(spec.shape),
+        "dtype": spec.dtype,
+        "semantic_id": spec.semantic_id,
+        "cardinality": spec.cardinality,
+        "low": None if spec.low is None else list(spec.low),
+        "high": None if spec.high is None else list(spec.high),
+    }
+
+
+def _array_descriptor(value: ArrayValue) -> dict[str, Any]:
+    return {
+        "semantic_id": value.semantic_id,
+        "dtype": value.dtype,
+        "shape": list(value.shape),
+        "payload_sha256": hashlib.sha256(value.payload).hexdigest(),
+    }
+
+
+def _replace_tuple_value(
+    values: tuple[Any, Any],
+    index: int,
+    value: Any,
+) -> tuple[Any, Any]:
+    return (value, values[1]) if index == 0 else (values[0], value)
+
+
+def _switching_metric_schedule(
+    accepted_events: int,
+    phase_length: int,
+) -> tuple[tuple[int, int], int, int, int]:
+    """Return the deterministic phase counters in constant time."""
+
+    if accepted_events < 0 or phase_length <= 0:
+        raise ValueError("switching metric schedule requires nonnegative events and a phase")
+    full_segments, remainder = divmod(accepted_events, phase_length)
+    phase_zero = ((full_segments + 1) // 2) * phase_length
+    phase_one = (full_segments // 2) * phase_length
+    if full_segments % 2 == 0:
+        phase_zero += remainder
+    else:
+        phase_one += remainder
+    current_phase = 0 if accepted_events == 0 else ((accepted_events - 1) // phase_length) % 2
+    phase_switches = 0 if accepted_events == 0 else (accepted_events - 1) // phase_length
+    segment_events = 0 if accepted_events == 0 else ((accepted_events - 1) % phase_length) + 1
+    return (
+        (phase_zero, phase_one),
+        current_phase,
+        phase_switches,
+        segment_events,
+    )
+
+
+class LifePhase(enum.Enum):
+    QUIESCENT = "quiescent"
+    HALTED = "halted"
+    COMPLETED = "completed"
+    ABORTED = "aborted"
+
+
+class HaltStage(enum.Enum):
+    PRE_DISPATCH = "pre_dispatch"
+    OUTCOME_PENDING = "outcome_pending"
+    DISPATCH_UNCERTAIN = "dispatch_uncertain"
+    POST_EXECUTION_DIVERGENCE = "post_execution_divergence"
+
+
+class RecoveryMode(enum.Enum):
+    RETRY_OUTCOME = "retry_outcome"
+    RECONCILE_ONLY = "reconcile_only"
+    ABORT_ONLY = "abort_only"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceEnvironmentManifest:
+    """Canonical declaration for one functional environment adapter."""
+
+    schema: str
+    implementation_id: str
+    state_schema: str
+    config_sha256: str
+    manifest_id: str
+    observation_spec: SpaceSpec
+    action_spec: SpaceSpec
+    max_executions: int
+    _config_json: str = dataclasses.field(repr=False)
+
+    def __post_init__(self) -> None:
+        if self.schema != REFERENCE_ENVIRONMENT_MANIFEST_SCHEMA:
+            raise ValueError("unsupported environment manifest schema")
+        _require_id(self.implementation_id, name="implementation_id")
+        _require_id(self.state_schema, name="state_schema")
+        _require_digest(self.config_sha256, name="config_sha256")
+        _require_digest(self.manifest_id, name="manifest_id")
+        if not isinstance(self.observation_spec, SpaceSpec):
+            raise ValueError("observation_spec must be a SpaceSpec")
+        if not isinstance(self.action_spec, SpaceSpec):
+            raise ValueError("action_spec must be a SpaceSpec")
+        if (
+            isinstance(self.max_executions, bool)
+            or not isinstance(self.max_executions, int)
+            or self.max_executions <= 0
+        ):
+            raise ValueError("max_executions must be a positive integer")
+        config = self.config
+        if _canonical_json(config) != self._config_json:
+            raise ValueError("environment config is not canonical JSON")
+        if _digest_json(config) != self.config_sha256:
+            raise ValueError("environment config digest mismatch")
+        if _digest_json(self._manifest_payload()) != self.manifest_id:
+            raise ValueError("environment manifest digest mismatch")
+
+    @classmethod
+    def from_config(
+        cls,
+        *,
+        implementation_id: str,
+        state_schema: str,
+        config: Mapping[str, Any],
+        observation_spec: SpaceSpec,
+        action_spec: SpaceSpec,
+        max_executions: int,
+    ) -> ReferenceEnvironmentManifest:
+        config_json = _canonical_json(config)
+        config_sha256 = hashlib.sha256(config_json.encode("utf-8")).hexdigest()
+        provisional = {
+            "schema": REFERENCE_ENVIRONMENT_MANIFEST_SCHEMA,
+            "implementation_id": implementation_id,
+            "state_schema": state_schema,
+            "config_sha256": config_sha256,
+            "config": json.loads(config_json),
+            "observation_spec": _space_descriptor(observation_spec),
+            "action_spec": _space_descriptor(action_spec),
+            "max_executions": max_executions,
+        }
+        return cls(
+            schema=REFERENCE_ENVIRONMENT_MANIFEST_SCHEMA,
+            implementation_id=implementation_id,
+            state_schema=state_schema,
+            config_sha256=config_sha256,
+            manifest_id=_digest_json(provisional),
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            max_executions=max_executions,
+            _config_json=config_json,
+        )
+
+    @property
+    def config(self) -> dict[str, Any]:
+        value = json.loads(self._config_json)
+        assert isinstance(value, dict)
+        return value
+
+    def _manifest_payload(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "implementation_id": self.implementation_id,
+            "state_schema": self.state_schema,
+            "config_sha256": self.config_sha256,
+            "config": self.config,
+            "observation_spec": _space_descriptor(self.observation_spec),
+            "action_spec": _space_descriptor(self.action_spec),
+            "max_executions": self.max_executions,
+        }
+
+    def descriptor(self) -> dict[str, Any]:
+        return {**self._manifest_payload(), "manifest_id": self.manifest_id}
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ExactDispatchConfig:
+    """Declared static authority and executor identity for the exact lane."""
+
+    authority_id: str = "asi.reference_life.authority"
+    policy_version: str = "asi.reference_life.exact_policy.1"
+    executor_id: str = "asi.switching_two_state.executor"
+    executor_epoch: str = "asi.switching_two_state.executor_epoch.1"
+    mode: str = "exact_only"
+    schema: str = EXACT_DISPATCH_SCHEMA
+    config_sha256: str = dataclasses.field(init=False)
+    manifest_id: str = dataclasses.field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.schema != EXACT_DISPATCH_SCHEMA or self.mode != "exact_only":
+            raise ValueError("the development runner supports exact dispatch only")
+        for name in ("authority_id", "policy_version", "executor_id", "executor_epoch"):
+            _require_id(getattr(self, name), name=name)
+        config_sha256 = _digest_json(self.config)
+        object.__setattr__(self, "config_sha256", config_sha256)
+        object.__setattr__(
+            self,
+            "manifest_id",
+            _digest_json(
+                {
+                    "schema": self.schema,
+                    "config_sha256": config_sha256,
+                    "config": self.config,
+                    "max_dispatches": MAX_DECISION_INDEX + 1,
+                }
+            ),
+        )
+
+    @property
+    def config(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "authority_role": "declared_static_identity",
+            "safety_policy": "unimplemented",
+            "veto_conformance": False,
+            "authority_id": self.authority_id,
+            "policy_version": self.policy_version,
+            "executor_id": self.executor_id,
+            "executor_epoch": self.executor_epoch,
+        }
+
+    def descriptor(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "config_sha256": self.config_sha256,
+            "manifest_id": self.manifest_id,
+            "config": self.config,
+            "max_dispatches": MAX_DECISION_INDEX + 1,
+        }
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ExactDispatchState:
+    schema: str
+    manifest_id: str
+    authorizations: int
+    commands_issued: int
+    receipts_recorded: int
+    last_command_id: str | None
+
+    def __post_init__(self) -> None:
+        if self.schema != EXACT_DISPATCH_STATE_SCHEMA:
+            raise ValueError("unsupported exact-dispatch state schema")
+        _require_digest(self.manifest_id, name="manifest_id")
+        for name in ("authorizations", "commands_issued", "receipts_recorded"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a nonnegative integer")
+        if not (self.receipts_recorded <= self.commands_issued <= self.authorizations):
+            raise ValueError("dispatch counters are out of order")
+        if self.last_command_id is not None:
+            _require_id(self.last_command_id, name="last_command_id")
+
+
+class ExactDispatchAdapter:
+    """Stateless-policy adapter whose counters live entirely in its state."""
+
+    __slots__ = ("_config",)
+
+    def __init__(self, config: ExactDispatchConfig | None = None) -> None:
+        self._config = ExactDispatchConfig() if config is None else config
+
+    @property
+    def config(self) -> ExactDispatchConfig:
+        return self._config
+
+    @property
+    def max_dispatches(self) -> int:
+        return MAX_DECISION_INDEX + 1
+
+    def init(self) -> ExactDispatchState:
+        return ExactDispatchState(
+            schema=EXACT_DISPATCH_STATE_SCHEMA,
+            manifest_id=self.config.manifest_id,
+            authorizations=0,
+            commands_issued=0,
+            receipts_recorded=0,
+            last_command_id=None,
+        )
+
+    def authorized(self, state: ExactDispatchState) -> ExactDispatchState:
+        self._validate(state)
+        return dataclasses.replace(state, authorizations=state.authorizations + 1)
+
+    def issued(
+        self,
+        state: ExactDispatchState,
+        command: DispatchCommand,
+    ) -> ExactDispatchState:
+        self._validate(state)
+        return dataclasses.replace(
+            state,
+            commands_issued=state.commands_issued + 1,
+            last_command_id=command.command_id,
+        )
+
+    def receipted(
+        self,
+        state: ExactDispatchState,
+        receipt: DispatchReceipt,
+    ) -> ExactDispatchState:
+        self._validate(state)
+        if state.last_command_id != receipt.command.command_id:
+            raise DecisionOwnershipError("receipt does not own the last issued command")
+        return dataclasses.replace(
+            state,
+            receipts_recorded=state.receipts_recorded + 1,
+        )
+
+    def _validate(self, state: ExactDispatchState) -> None:
+        if not isinstance(state, ExactDispatchState):
+            raise DecisionOwnershipError("dispatch state has the wrong type")
+        if state.manifest_id != self.config.manifest_id:
+            raise DecisionOwnershipError("dispatch state manifest mismatch")
+
+    def validate_state(self, state: ExactDispatchState) -> None:
+        """Validate a candidate before it becomes an aggregate trust root."""
+
+        self._validate(state)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceLifeMetricsConfig:
+    schema: str = REFERENCE_METRICS_CONFIG_SCHEMA
+    oracle_regret: bool = True
+    mode: str = "switching_two_phase"
+    config_sha256: str = dataclasses.field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.schema != REFERENCE_METRICS_CONFIG_SCHEMA:
+            raise ValueError("unsupported metrics config schema")
+        if not isinstance(self.oracle_regret, bool) or not self.oracle_regret:
+            raise ValueError("the development metric requires oracle regret")
+        if self.mode not in ("switching_two_phase", "stationary"):
+            raise ValueError("metrics mode must be switching_two_phase or stationary")
+        object.__setattr__(self, "config_sha256", _digest_json(self.config))
+
+    @property
+    def config(self) -> dict[str, Any]:
+        return {"mode": self.mode, "oracle_regret": self.oracle_regret}
+
+    def descriptor(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "config_sha256": self.config_sha256,
+            "config": self.config,
+        }
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceLifeMetricsState:
+    """Bounded deterministic online metrics; wall-clock telemetry is excluded."""
+
+    schema: str
+    config_sha256: str
+    accepted_events: int
+    parameter_change_events: int
+    reward_sum: float
+    oracle_reward_sum: float
+    regret_sum: float
+    phase_event_counts: tuple[int, int]
+    phase_reward_sums: tuple[float, float]
+    phase_regret_sums: tuple[float, float]
+    phase_switches: int
+    current_phase: int
+    current_segment_events: int
+    current_segment_reward: float
+    current_segment_regret: float
+    first_completed_segment_reward: tuple[float | None, float | None]
+    latest_completed_segment_reward: tuple[float | None, float | None]
+
+    def __post_init__(self) -> None:
+        if self.schema != REFERENCE_LIFE_METRICS_SCHEMA:
+            raise ValueError("unsupported reference-life metrics schema")
+        _require_digest(self.config_sha256, name="config_sha256")
+        for name in (
+            "accepted_events",
+            "parameter_change_events",
+            "phase_switches",
+            "current_segment_events",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a nonnegative integer")
+        if self.current_phase not in (0, 1):
+            raise ValueError("current_phase must be 0 or 1")
+        pairs = (
+            self.phase_event_counts,
+            self.phase_reward_sums,
+            self.phase_regret_sums,
+            self.first_completed_segment_reward,
+            self.latest_completed_segment_reward,
+        )
+        if any(len(values) != 2 for values in pairs):
+            raise ValueError("phase and segment metric tuples must have length two")
+        if any(value < 0 for value in self.phase_event_counts):
+            raise ValueError("phase event counts must be nonnegative")
+        if self.parameter_change_events > self.accepted_events:
+            raise ValueError("parameter changes cannot exceed accepted events")
+        if sum(self.phase_event_counts) != self.accepted_events:
+            raise ValueError("phase event counts must sum to accepted events")
+        if self.phase_switches > self.accepted_events:
+            raise ValueError("phase switches cannot exceed accepted events")
+        if self.current_segment_events > self.phase_event_counts[self.current_phase]:
+            raise ValueError("current segment cannot exceed its phase event count")
+        optional = (
+            *self.first_completed_segment_reward,
+            *self.latest_completed_segment_reward,
+        )
+        if any(value is not None and not math.isfinite(value) for value in optional):
+            raise ValueError("optional segment metrics must be finite when present")
+        numeric = (
+            self.reward_sum,
+            self.oracle_reward_sum,
+            self.regret_sum,
+            *self.phase_reward_sums,
+            *self.phase_regret_sums,
+            self.current_segment_reward,
+            self.current_segment_regret,
+        )
+        if not all(math.isfinite(value) for value in numeric):
+            raise ValueError("metric accumulators must be finite")
+
+
+class ReferenceLifeMetricsAdapter:
+    __slots__ = ("_config",)
+
+    def __init__(self, config: ReferenceLifeMetricsConfig | None = None) -> None:
+        self._config = ReferenceLifeMetricsConfig() if config is None else config
+
+    @property
+    def config(self) -> ReferenceLifeMetricsConfig:
+        return self._config
+
+    def init(self, *, initial_phase: int) -> ReferenceLifeMetricsState:
+        if initial_phase not in (0, 1):
+            raise ValueError("initial_phase must be 0 or 1")
+        if self.config.mode == "stationary" and initial_phase != 0:
+            raise ValueError("stationary metrics require regime zero")
+        return ReferenceLifeMetricsState(
+            schema=REFERENCE_LIFE_METRICS_SCHEMA,
+            config_sha256=self.config.config_sha256,
+            accepted_events=0,
+            parameter_change_events=0,
+            reward_sum=0.0,
+            oracle_reward_sum=0.0,
+            regret_sum=0.0,
+            phase_event_counts=(0, 0),
+            phase_reward_sums=(0.0, 0.0),
+            phase_regret_sums=(0.0, 0.0),
+            phase_switches=0,
+            current_phase=initial_phase,
+            current_segment_events=0,
+            current_segment_reward=0.0,
+            current_segment_regret=0.0,
+            first_completed_segment_reward=(None, None),
+            latest_completed_segment_reward=(None, None),
+        )
+
+    def observe(
+        self,
+        state: ReferenceLifeMetricsState,
+        *,
+        phase: int,
+        reward: float,
+        oracle_reward: float,
+        parameters_changed: bool,
+    ) -> ReferenceLifeMetricsState:
+        if state.config_sha256 != self.config.config_sha256:
+            raise DecisionOwnershipError("metrics state config mismatch")
+        if phase not in (0, 1):
+            raise ValueError("phase must be 0 or 1")
+        if self.config.mode == "stationary" and phase != 0:
+            raise ValueError("stationary metrics require regime zero")
+        reward = float(reward)
+        oracle_reward = float(oracle_reward)
+        regret = oracle_reward - reward
+        if not all(math.isfinite(value) for value in (reward, oracle_reward, regret)):
+            raise ValueError("metric inputs must be finite")
+
+        first = state.first_completed_segment_reward
+        latest = state.latest_completed_segment_reward
+        switches = state.phase_switches
+        segment_events = state.current_segment_events
+        segment_reward = state.current_segment_reward
+        segment_regret = state.current_segment_regret
+        if phase != state.current_phase:
+            previous = state.current_phase
+            if first[previous] is None:
+                first = _replace_tuple_value(first, previous, segment_reward)
+            latest = _replace_tuple_value(latest, previous, segment_reward)
+            switches += 1
+            segment_events = 0
+            segment_reward = 0.0
+            segment_regret = 0.0
+
+        phase_counts = _replace_tuple_value(
+            state.phase_event_counts,
+            phase,
+            state.phase_event_counts[phase] + 1,
+        )
+        phase_rewards = _replace_tuple_value(
+            state.phase_reward_sums,
+            phase,
+            state.phase_reward_sums[phase] + reward,
+        )
+        phase_regrets = _replace_tuple_value(
+            state.phase_regret_sums,
+            phase,
+            state.phase_regret_sums[phase] + regret,
+        )
+        oracle_reward_sum = (
+            float(state.accepted_events + 1) * oracle_reward
+            if self.config.mode == "stationary"
+            else state.oracle_reward_sum + oracle_reward
+        )
+        return ReferenceLifeMetricsState(
+            schema=state.schema,
+            config_sha256=state.config_sha256,
+            accepted_events=state.accepted_events + 1,
+            parameter_change_events=(state.parameter_change_events + int(parameters_changed)),
+            reward_sum=state.reward_sum + reward,
+            oracle_reward_sum=oracle_reward_sum,
+            regret_sum=state.regret_sum + regret,
+            phase_event_counts=phase_counts,
+            phase_reward_sums=phase_rewards,
+            phase_regret_sums=phase_regrets,
+            phase_switches=switches,
+            current_phase=phase,
+            current_segment_events=segment_events + 1,
+            current_segment_reward=segment_reward + reward,
+            current_segment_regret=segment_regret + regret,
+            first_completed_segment_reward=first,
+            latest_completed_segment_reward=latest,
+        )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceEnvironmentStart:
+    """Generic functional environment initialization result."""
+
+    state: Any
+    observation: ArrayValue
+    regime_id: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.observation, ArrayValue):
+            raise ValueError("environment start observation must be an ArrayValue")
+        if self.regime_id not in (0, 1):
+            raise ValueError("environment start regime_id must be 0 or 1")
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceEnvironmentExecution:
+    """Generic post-command result from one functional environment executor."""
+
+    command: DispatchCommand
+    state: Any
+    applied_action: ArrayValue
+    next_observation: ArrayValue
+    reward: float
+    discount: float
+    terminated: bool
+    truncated: bool
+    autoreset: bool
+    regime_id: int
+    oracle_reward: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.command, DispatchCommand):
+            raise ValueError("environment execution requires a DispatchCommand")
+        if not isinstance(self.applied_action, ArrayValue):
+            raise ValueError("applied_action must be an ArrayValue")
+        if not isinstance(self.next_observation, ArrayValue):
+            raise ValueError("next_observation must be an ArrayValue")
+        for name in ("reward", "discount", "oracle_reward"):
+            if not math.isfinite(float(getattr(self, name))):
+                raise ValueError(f"{name} must be finite")
+        if self.discount < 0.0 or self.discount > 1.0:
+            raise ValueError("discount must be in [0, 1]")
+        if any(
+            not isinstance(getattr(self, name), bool)
+            for name in ("terminated", "truncated", "autoreset")
+        ):
+            raise ValueError("environment boundary flags must be boolean")
+        if self.regime_id not in (0, 1):
+            raise ValueError("regime_id must be 0 or 1")
+
+
+# Compatibility names retained for the original deterministic slice.
+SwitchingEnvironmentStart = ReferenceEnvironmentStart
+SwitchingEnvironmentExecution = ReferenceEnvironmentExecution
+
+
+class ReferenceAgentAdapter(Protocol):
+    @property
+    def manifest(self) -> AgentManifest: ...
+
+    @property
+    def max_accepted_events(self) -> int: ...
+
+    def init(self, key: Array, *, lifecycle_id: str) -> Any: ...
+
+    def start(
+        self,
+        state: Any,
+        *,
+        observation_id: str,
+        observation: Any,
+    ) -> tuple[Any, Decision]: ...
+
+    def settle_dispatch(
+        self,
+        state: Any,
+        authorization: DispatchAuthorization,
+    ) -> tuple[Any, bool]: ...
+
+    def apply_outcome(self, state: Any, transaction: Transaction) -> ReferenceAgentUpdate: ...
+
+    def current_decision(self, state: Any) -> Decision: ...
+
+    def validate_state(self, state: Any) -> None: ...
+
+
+class ReferenceEnvironmentAdapter(Protocol):
+    @property
+    def manifest(self) -> ReferenceEnvironmentManifest: ...
+
+    @property
+    def max_executions(self) -> int: ...
+
+    def init(self, key: Array) -> ReferenceEnvironmentStart: ...
+
+    def execute(
+        self,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Array,
+    ) -> ReferenceEnvironmentExecution: ...
+
+    def validate_execution(
+        self,
+        previous_state: Any,
+        command: DispatchCommand,
+        execution: ReferenceEnvironmentExecution,
+        *,
+        key: Array,
+    ) -> None: ...
+
+    def current_observation(self, state: Any) -> ArrayValue: ...
+
+    def validate_state(self, state: Any) -> None: ...
+
+
+class _ImmutableSwitchingTwoStateMDP(SwitchingTwoStateMDP):
+    """Switching kernel whose behavior-defining fields cannot drift in-process."""
+
+    __slots__ = ("_reference_life_frozen",)
+
+    def __init__(self, config: SwitchingTwoStateConfig) -> None:
+        object.__setattr__(self, "_reference_life_frozen", False)
+        super().__init__(config)
+        payoff_bytes = np.ascontiguousarray(self._payoffs_np, dtype="<f4").tobytes()
+        immutable_payoffs = np.frombuffer(payoff_bytes, dtype="<f4").reshape((2, 2, 2))
+        object.__setattr__(self, "_payoffs_np", immutable_payoffs)
+        object.__setattr__(self, "_payoffs", jnp.asarray(immutable_payoffs))
+        object.__setattr__(self, "_reference_life_frozen", True)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if getattr(self, "_reference_life_frozen", False):
+            raise AttributeError("reference-life switching environment is immutable")
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        if getattr(self, "_reference_life_frozen", False):
+            raise AttributeError("reference-life switching environment is immutable")
+        object.__delattr__(self, name)
+
+
+class SwitchingTwoStateReferenceEnvironment:
+    """Strict codec wrapper around the otherwise clipping switching MDP."""
+
+    __slots__ = ("_environment", "_frozen", "_manifest")
+
+    def __init__(
+        self,
+        config: SwitchingTwoStateConfig,
+        *,
+        observation_spec: SpaceSpec,
+        action_spec: SpaceSpec,
+        executor_id: str = "asi.switching_two_state.executor",
+        executor_epoch: str = "asi.switching_two_state.executor_epoch.1",
+    ) -> None:
+        object.__setattr__(self, "_frozen", False)
+        _require_id(executor_id, name="executor_id")
+        _require_id(executor_epoch, name="executor_epoch")
+        phase_length = config.phase_length
+        if (
+            isinstance(phase_length, bool)
+            or not isinstance(phase_length, int)
+            or phase_length <= 0
+            or phase_length > _MAX_SWITCHING_EXECUTIONS
+        ):
+            raise ValueError(
+                "phase_length must be an integer within signed-int32 capacity "
+                f"[1, {_MAX_SWITCHING_EXECUTIONS}]"
+            )
+        if (
+            observation_spec.kind != "box"
+            or observation_spec.shape != (2,)
+            or observation_spec.dtype != "float32"
+        ):
+            raise ValueError(
+                "switching environment requires a float32 box observation of shape (2,)"
+            )
+        if (
+            action_spec.kind != "discrete"
+            or action_spec.shape != ()
+            or action_spec.dtype != "int32"
+            or action_spec.cardinality != 2
+        ):
+            raise ValueError(
+                "switching environment requires a scalar int32 action of cardinality 2"
+            )
+        try:
+            payoffs_a = np.asarray(config.payoffs_a, dtype=np.float32)
+            payoffs_b = np.asarray(config.payoffs_b, dtype=np.float32)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("switching payoffs must be numeric 2x2 matrices") from exc
+        if payoffs_a.shape != (2, 2) or payoffs_b.shape != (2, 2):
+            raise ValueError("switching payoffs must be 2x2 (state x action) matrices")
+        if not np.all(np.isfinite(payoffs_a)) or not np.all(np.isfinite(payoffs_b)):
+            raise ValueError("switching payoffs must be finite")
+        canonical_config = SwitchingTwoStateConfig(  # type: ignore[call-arg]
+            phase_length=phase_length,
+            payoffs_a=tuple(tuple(float(value) for value in row) for row in payoffs_a),
+            payoffs_b=tuple(tuple(float(value) for value in row) for row in payoffs_b),
+        )
+        environment = _ImmutableSwitchingTwoStateMDP(canonical_config)
+        self._environment = environment
+        self._manifest = ReferenceEnvironmentManifest.from_config(
+            implementation_id=SWITCHING_ENVIRONMENT_IMPLEMENTATION_ID,
+            state_schema=SWITCHING_ENVIRONMENT_STATE_SCHEMA,
+            config={
+                "environment_kind": "switching_two_state",
+                "metrics_mode": "switching_two_phase",
+                "phase_length": phase_length,
+                "payoffs_a": [list(row) for row in canonical_config.payoffs_a],
+                "payoffs_b": [list(row) for row in canonical_config.payoffs_b],
+                "executor_id": executor_id,
+                "executor_epoch": executor_epoch,
+                "dynamics": "next_state_equals_action",
+                "rng_mode": "key_schedule_bound_but_dynamics_deterministic",
+                "boundary_mode": "continuing_only",
+            },
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            max_executions=_MAX_SWITCHING_EXECUTIONS,
+        )
+        object.__setattr__(self, "_frozen", True)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if getattr(self, "_frozen", False):
+            raise AttributeError("reference-life switching environment is immutable")
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        if getattr(self, "_frozen", False):
+            raise AttributeError("reference-life switching environment is immutable")
+        object.__delattr__(self, name)
+
+    @property
+    def manifest(self) -> ReferenceEnvironmentManifest:
+        return self._manifest
+
+    @property
+    def max_executions(self) -> int:
+        return self.manifest.max_executions
+
+    @property
+    def executor_id(self) -> str:
+        value = self.manifest.config["executor_id"]
+        assert isinstance(value, str)
+        return value
+
+    @property
+    def executor_epoch(self) -> str:
+        value = self.manifest.config["executor_epoch"]
+        assert isinstance(value, str)
+        return value
+
+    def _validate_state(
+        self,
+        state: SwitchingTwoStateState,
+        *,
+        require_capacity: bool,
+    ) -> None:
+        if not isinstance(state, SwitchingTwoStateState):
+            raise DecisionOwnershipError("environment state has the wrong type")
+        state_index = np.asarray(state.state_index)
+        step_count = np.asarray(state.step_count)
+        if state_index.shape != () or state_index.dtype != np.dtype(np.int32):
+            raise DecisionOwnershipError("environment state_index must be scalar int32")
+        if step_count.shape != () or step_count.dtype != np.dtype(np.int32):
+            raise DecisionOwnershipError("environment step_count must be scalar int32")
+        if int(state_index) not in (0, 1):
+            raise DecisionOwnershipError("environment state_index is outside {0, 1}")
+        if int(step_count) < 0 or (require_capacity and int(step_count) >= self.max_executions):
+            raise DecisionOwnershipError("environment step counter capacity is exhausted")
+
+    def validate_state(self, state: SwitchingTwoStateState) -> None:
+        """Validate a restorable environment state at a quiescent boundary."""
+
+        self._validate_state(state, require_capacity=True)
+
+    def current_observation(self, state: SwitchingTwoStateState) -> ArrayValue:
+        """Encode the observation owned by one validated environment state."""
+
+        self.validate_state(state)
+        return self.manifest.observation_spec.encode(
+            np.asarray(self._environment.observe(state), dtype=np.float32)
+        )
+
+    def init(self, key: Array) -> SwitchingEnvironmentStart:
+        state = self._environment.init(key)
+        self._validate_state(state, require_capacity=True)
+        observation = self.manifest.observation_spec.encode(
+            np.asarray(self._environment.observe(state), dtype=np.float32)
+        )
+        return SwitchingEnvironmentStart(
+            state=state,
+            observation=observation,
+            regime_id=int(self._environment.phase_id(state)),
+        )
+
+    def execute(
+        self,
+        state: SwitchingTwoStateState,
+        command: DispatchCommand,
+        *,
+        key: Array,
+    ) -> SwitchingEnvironmentExecution:
+        """Execute only an already-valid exact int32 command, never a coerced action."""
+
+        self._validate_state(state, require_capacity=True)
+        if not isinstance(command, DispatchCommand):
+            raise DecisionOwnershipError("environment execute requires a DispatchCommand")
+        if command.executor_id != self.executor_id or command.executor_epoch != self.executor_epoch:
+            raise DecisionOwnershipError("command targets another executor identity or epoch")
+        # This validation occurs before the underlying environment, whose
+        # public step method deliberately clips/casts for its legacy API.
+        action = self.manifest.action_spec.encode(command.effective_action)
+        action_array = action.to_numpy()
+        if action_array.shape != () or action_array.dtype != np.dtype(np.int32):
+            raise ValueError("executor action must remain a scalar int32")
+        action_index = int(action_array)
+        if action_index < 0 or action_index >= 2:
+            raise ValueError("executor action is outside the discrete cardinality range")
+
+        phase = int(self._environment.phase_id(state))
+        next_observation, reward, next_state = self._environment.step(
+            state,
+            jnp.asarray(action_array, dtype=jnp.int32),
+            key,
+        )
+        self._validate_state(next_state, require_capacity=False)
+        encoded_observation = self.manifest.observation_spec.encode(
+            np.asarray(next_observation, dtype=np.float32)
+        )
+        reward_value = float(np.asarray(reward, dtype=np.float32))
+        return SwitchingEnvironmentExecution(
+            command=command,
+            state=next_state,
+            applied_action=action,
+            next_observation=encoded_observation,
+            reward=reward_value,
+            discount=1.0,
+            terminated=False,
+            truncated=False,
+            autoreset=False,
+            regime_id=phase,
+            oracle_reward=self._environment.optimal_average_reward(phase),
+        )
+
+    def validate_execution(
+        self,
+        previous_state: SwitchingTwoStateState,
+        command: DispatchCommand,
+        execution: ReferenceEnvironmentExecution,
+        *,
+        key: Array,
+    ) -> None:
+        """Recompute every deterministic result field before it reaches learning."""
+
+        del key
+        self._validate_state(previous_state, require_capacity=True)
+        self._validate_state(execution.state, require_capacity=False)
+        if execution.command != command:
+            raise DecisionOwnershipError("execution result belongs to another command")
+        previous_step = int(np.asarray(previous_state.step_count))
+        next_step = int(np.asarray(execution.state.step_count))
+        if next_step != previous_step + 1:
+            raise DecisionOwnershipError("execution step counter did not advance exactly once")
+        applied = self.manifest.action_spec.encode(execution.applied_action)
+        applied_value = applied.to_python()
+        if not isinstance(applied_value, int):
+            raise DecisionOwnershipError("execution applied action is not a scalar integer")
+        next_state_index = int(np.asarray(execution.state.state_index))
+        if next_state_index != applied_value:
+            raise DecisionOwnershipError(
+                "execution state does not equal the deterministic applied action"
+            )
+        expected_observation = self.manifest.observation_spec.encode(
+            np.asarray(self._environment.observe(execution.state), dtype=np.float32)
+        )
+        if execution.next_observation != expected_observation:
+            raise DecisionOwnershipError("execution observation does not describe its state")
+        phase = int(self._environment.phase_id(previous_state))
+        if execution.regime_id != phase:
+            raise DecisionOwnershipError("execution regime does not match the previous state")
+        payoff_config = (
+            self._environment.config.payoffs_a if phase == 0 else self._environment.config.payoffs_b
+        )
+        expected_reward = float(
+            np.asarray(
+                payoff_config[int(np.asarray(previous_state.state_index))][applied_value],
+                dtype=np.float32,
+            )
+        )
+        if execution.reward != expected_reward:
+            raise DecisionOwnershipError("execution reward does not match switching dynamics")
+        expected_oracle = self._environment.optimal_average_reward(phase)
+        if execution.oracle_reward != expected_oracle:
+            raise DecisionOwnershipError("execution oracle reward does not match its regime")
+        if (
+            execution.discount != 1.0
+            or execution.terminated
+            or execution.truncated
+            or execution.autoreset
+        ):
+            raise DecisionOwnershipError(
+                "switching execution must retain continuing-task boundary semantics"
+            )
+
+
+class _ImmutableRiverSwimMDP(RiverSwimMDP):
+    """RiverSwim kernel whose behavior-defining fields cannot drift in-process."""
+
+    __slots__ = ("_reference_life_frozen",)
+
+    def __init__(self, config: RiverSwimConfig) -> None:
+        object.__setattr__(self, "_reference_life_frozen", False)
+        super().__init__(config)
+        transition_shape = (2, config.n_states, config.n_states)
+        transition_bytes = np.ascontiguousarray(self._transitions_np, dtype="<f4").tobytes()
+        immutable_transitions = np.frombuffer(transition_bytes, dtype="<f4").reshape(
+            transition_shape
+        )
+        reward_bytes = np.ascontiguousarray(self._rewards_np, dtype="<f4").tobytes()
+        immutable_rewards = np.frombuffer(reward_bytes, dtype="<f4").reshape(
+            (config.n_states, 2)
+        )
+        object.__setattr__(self, "_transitions_np", immutable_transitions)
+        object.__setattr__(self, "_rewards_np", immutable_rewards)
+        object.__setattr__(
+            self,
+            "_transition_logits",
+            jnp.where(
+                jnp.asarray(immutable_transitions) > 0.0,
+                jnp.log(jnp.clip(jnp.asarray(immutable_transitions), 1e-30, 1.0)),
+                -jnp.inf,
+            ),
+        )
+        object.__setattr__(self, "_rewards", jnp.asarray(immutable_rewards))
+        object.__setattr__(self, "_reference_life_frozen", True)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if getattr(self, "_reference_life_frozen", False):
+            raise AttributeError("reference-life RiverSwim environment is immutable")
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        if getattr(self, "_reference_life_frozen", False):
+            raise AttributeError("reference-life RiverSwim environment is immutable")
+        object.__delattr__(self, name)
+
+
+class RiverSwimReferenceEnvironment:
+    """Strict keyed codec/executor wrapper for the stochastic RiverSwim MDP."""
+
+    __slots__ = ("_environment", "_frozen", "_manifest", "_oracle_reward")
+
+    def __init__(
+        self,
+        config: RiverSwimConfig,
+        *,
+        observation_spec: SpaceSpec,
+        action_spec: SpaceSpec,
+        executor_id: str = "asi.riverswim.executor",
+        executor_epoch: str = "asi.riverswim.executor_epoch.1",
+    ) -> None:
+        object.__setattr__(self, "_frozen", False)
+        _require_id(executor_id, name="executor_id")
+        _require_id(executor_epoch, name="executor_epoch")
+        if not isinstance(config, RiverSwimConfig):
+            raise ValueError("RiverSwim config has the wrong type")
+        n_states = config.n_states
+        if (
+            isinstance(n_states, bool)
+            or not isinstance(n_states, int)
+            or n_states < 2
+            or n_states > RIVERSWIM_REFERENCE_MAX_STATES
+        ):
+            raise ValueError(
+                "RiverSwim n_states must be an integer in "
+                f"[2, {RIVERSWIM_REFERENCE_MAX_STATES}] before exact 2**n oracle enumeration"
+            )
+        initial_state = config.initial_state
+        if (
+            isinstance(initial_state, bool)
+            or not isinstance(initial_state, int)
+            or initial_state < 0
+            or initial_state >= n_states
+        ):
+            raise ValueError("RiverSwim initial_state is outside the configured chain")
+
+        def canonical_float32(value: Any, *, name: str) -> float:
+            if isinstance(value, bool):
+                raise ValueError(f"RiverSwim {name} must be a finite float32 value")
+            try:
+                raw = float(value)
+                cast = float(np.asarray(raw, dtype=np.float32))
+            except (TypeError, ValueError, OverflowError) as exc:
+                raise ValueError(f"RiverSwim {name} must be a finite float32 value") from exc
+            if not math.isfinite(raw) or not math.isfinite(cast):
+                raise ValueError(f"RiverSwim {name} must be a finite float32 value")
+            return cast
+
+        p_right_up = canonical_float32(config.p_right_up, name="p_right_up")
+        p_right_down = canonical_float32(config.p_right_down, name="p_right_down")
+        reward_left = canonical_float32(config.reward_left, name="reward_left")
+        reward_right = canonical_float32(config.reward_right, name="reward_right")
+        if p_right_up <= 0.0 or p_right_down <= 0.0:
+            raise ValueError("RiverSwim right-transition probabilities must be positive")
+        if p_right_up + p_right_down > 1.0:
+            raise ValueError("RiverSwim right-transition probabilities must sum to at most one")
+        if (
+            observation_spec.kind != "box"
+            or observation_spec.shape != (n_states,)
+            or observation_spec.dtype != "float32"
+        ):
+            raise ValueError(
+                f"RiverSwim requires a float32 box observation of shape ({n_states},)"
+            )
+        if (
+            action_spec.kind != "discrete"
+            or action_spec.shape != ()
+            or action_spec.dtype != "int32"
+            or action_spec.cardinality != 2
+        ):
+            raise ValueError("RiverSwim requires a scalar int32 action of cardinality 2")
+
+        canonical_config = RiverSwimConfig(  # type: ignore[call-arg]
+            n_states=n_states,
+            p_right_up=p_right_up,
+            p_right_down=p_right_down,
+            reward_left=reward_left,
+            reward_right=reward_right,
+            initial_state=initial_state,
+        )
+        environment = _ImmutableRiverSwimMDP(canonical_config)
+        oracle_reward = environment.optimal_average_reward()
+        if not math.isfinite(oracle_reward):
+            raise ValueError("RiverSwim exact stationary oracle must be finite")
+        self._environment = environment
+        self._oracle_reward = oracle_reward
+        self._manifest = ReferenceEnvironmentManifest.from_config(
+            implementation_id=RIVERSWIM_ENVIRONMENT_IMPLEMENTATION_ID,
+            state_schema=RIVERSWIM_ENVIRONMENT_STATE_SCHEMA,
+            config={
+                "environment_kind": "riverswim",
+                "metrics_mode": "stationary",
+                "n_states": n_states,
+                "p_right_up": p_right_up,
+                "p_right_down": p_right_down,
+                "reward_left": reward_left,
+                "reward_right": reward_right,
+                "initial_state": initial_state,
+                "oracle_average_reward": oracle_reward,
+                "executor_id": executor_id,
+                "executor_epoch": executor_epoch,
+                "dynamics": "riverswim_stochastic_chain",
+                "rng_mode": "exact_jax_key_replay",
+                "boundary_mode": "continuing_only",
+            },
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            max_executions=_MAX_SWITCHING_EXECUTIONS,
+        )
+        object.__setattr__(self, "_frozen", True)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if getattr(self, "_frozen", False):
+            raise AttributeError("reference-life RiverSwim environment is immutable")
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        if getattr(self, "_frozen", False):
+            raise AttributeError("reference-life RiverSwim environment is immutable")
+        object.__delattr__(self, name)
+
+    @property
+    def manifest(self) -> ReferenceEnvironmentManifest:
+        return self._manifest
+
+    @property
+    def max_executions(self) -> int:
+        return self.manifest.max_executions
+
+    @property
+    def executor_id(self) -> str:
+        value = self.manifest.config["executor_id"]
+        assert isinstance(value, str)
+        return value
+
+    @property
+    def executor_epoch(self) -> str:
+        value = self.manifest.config["executor_epoch"]
+        assert isinstance(value, str)
+        return value
+
+    def _validate_state(self, state: RiverSwimState, *, require_capacity: bool) -> None:
+        if not isinstance(state, RiverSwimState):
+            raise DecisionOwnershipError("RiverSwim state has the wrong type")
+        state_index = np.asarray(state.state_index)
+        step_count = np.asarray(state.step_count)
+        if state_index.shape != () or state_index.dtype != np.dtype(np.int32):
+            raise DecisionOwnershipError("RiverSwim state_index must be scalar int32")
+        if step_count.shape != () or step_count.dtype != np.dtype(np.int32):
+            raise DecisionOwnershipError("RiverSwim step_count must be scalar int32")
+        if int(state_index) < 0 or int(state_index) >= self._environment.n_states:
+            raise DecisionOwnershipError("RiverSwim state_index is outside the chain")
+        if int(step_count) < 0 or (require_capacity and int(step_count) >= self.max_executions):
+            raise DecisionOwnershipError("RiverSwim step counter capacity is exhausted")
+
+    def validate_state(self, state: RiverSwimState) -> None:
+        self._validate_state(state, require_capacity=True)
+
+    def current_observation(self, state: RiverSwimState) -> ArrayValue:
+        self.validate_state(state)
+        return self.manifest.observation_spec.encode(
+            np.asarray(self._environment.observe(state), dtype=np.float32)
+        )
+
+    def init(self, key: Array) -> ReferenceEnvironmentStart:
+        state = self._environment.init(key)
+        self._validate_state(state, require_capacity=True)
+        observation = self.manifest.observation_spec.encode(
+            np.asarray(self._environment.observe(state), dtype=np.float32)
+        )
+        return ReferenceEnvironmentStart(state=state, observation=observation, regime_id=0)
+
+    def execute(
+        self,
+        state: RiverSwimState,
+        command: DispatchCommand,
+        *,
+        key: Array,
+    ) -> ReferenceEnvironmentExecution:
+        self._validate_state(state, require_capacity=True)
+        if not isinstance(command, DispatchCommand):
+            raise DecisionOwnershipError("RiverSwim execute requires a DispatchCommand")
+        if command.executor_id != self.executor_id or command.executor_epoch != self.executor_epoch:
+            raise DecisionOwnershipError("command targets another RiverSwim executor")
+        action = self.manifest.action_spec.encode(command.effective_action)
+        action_array = action.to_numpy()
+        if action_array.shape != () or action_array.dtype != np.dtype(np.int32):
+            raise ValueError("RiverSwim executor action must remain scalar int32")
+        action_index = int(action_array)
+        if action_index < 0 or action_index >= 2:
+            raise ValueError("RiverSwim executor action is outside cardinality range")
+        next_observation, reward, next_state = self._environment.step(
+            state,
+            jnp.asarray(action_array, dtype=jnp.int32),
+            key,
+        )
+        self._validate_state(next_state, require_capacity=False)
+        return ReferenceEnvironmentExecution(
+            command=command,
+            state=next_state,
+            applied_action=action,
+            next_observation=self.manifest.observation_spec.encode(
+                np.asarray(next_observation, dtype=np.float32)
+            ),
+            reward=float(np.asarray(reward, dtype=np.float32)),
+            discount=1.0,
+            terminated=False,
+            truncated=False,
+            autoreset=False,
+            regime_id=0,
+            oracle_reward=self._oracle_reward,
+        )
+
+    def validate_execution(
+        self,
+        previous_state: RiverSwimState,
+        command: DispatchCommand,
+        execution: ReferenceEnvironmentExecution,
+        *,
+        key: Array,
+    ) -> None:
+        """Replay the stochastic transition with the exact scheduled key."""
+
+        self._validate_state(previous_state, require_capacity=True)
+        self._validate_state(execution.state, require_capacity=False)
+        if execution.command != command:
+            raise DecisionOwnershipError("RiverSwim execution belongs to another command")
+        applied = self.manifest.action_spec.encode(execution.applied_action)
+        applied_value = applied.to_python()
+        if not isinstance(applied_value, int):
+            raise DecisionOwnershipError("RiverSwim applied action is not scalar int32")
+        try:
+            expected_observation, expected_reward_array, expected_state = self._environment.step(
+                previous_state,
+                jnp.asarray(applied_value, dtype=jnp.int32),
+                key,
+            )
+        except Exception as exc:
+            raise DecisionOwnershipError("RiverSwim stochastic key replay failed") from exc
+        expected_state_index = np.asarray(expected_state.state_index)
+        actual_state_index = np.asarray(execution.state.state_index)
+        expected_step_count = np.asarray(expected_state.step_count)
+        actual_step_count = np.asarray(execution.state.step_count)
+        if (
+            expected_state_index.dtype != actual_state_index.dtype
+            or expected_state_index.tobytes() != actual_state_index.tobytes()
+            or expected_step_count.dtype != actual_step_count.dtype
+            or expected_step_count.tobytes() != actual_step_count.tobytes()
+        ):
+            raise DecisionOwnershipError(
+                "RiverSwim stochastic transition does not match exact key replay"
+            )
+        expected_encoded_observation = self.manifest.observation_spec.encode(
+            np.asarray(expected_observation, dtype=np.float32)
+        )
+        if execution.next_observation != expected_encoded_observation:
+            raise DecisionOwnershipError("RiverSwim observation does not match key replay")
+        expected_reward = float(np.asarray(expected_reward_array, dtype=np.float32))
+        if struct.pack(">d", execution.reward) != struct.pack(">d", expected_reward):
+            raise DecisionOwnershipError("RiverSwim reward does not match key replay")
+        if execution.regime_id != 0:
+            raise DecisionOwnershipError("RiverSwim stationary regime must be zero")
+        if struct.pack(">d", execution.oracle_reward) != struct.pack(">d", self._oracle_reward):
+            raise DecisionOwnershipError("RiverSwim stationary oracle reward is inconsistent")
+        if (
+            execution.discount != 1.0
+            or execution.terminated
+            or execution.truncated
+            or execution.autoreset
+        ):
+            raise DecisionOwnershipError(
+                "RiverSwim execution must retain continuing-task boundary semantics"
+            )
+
+
+def _agent_descriptor(
+    manifest: AgentManifest,
+    *,
+    max_accepted_events: int,
+) -> dict[str, Any]:
+    return {
+        "schema": manifest.schema,
+        "implementation_id": manifest.implementation_id,
+        "state_schema": manifest.state_schema,
+        "config_sha256": manifest.config_sha256,
+        "manifest_id": manifest.manifest_id,
+        "config": manifest.config,
+        "observation_spec": _space_descriptor(manifest.observation_spec),
+        "action_spec": _space_descriptor(manifest.action_spec),
+        "capabilities": {
+            "dispatch_rebinding": manifest.capabilities.dispatch_rebinding,
+        },
+        "max_accepted_events": max_accepted_events,
+    }
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceLifeConfig:
+    """Deeply immutable canonical binding for one development life."""
+
+    schema: str
+    lifecycle_id: str
+    seed: int
+    max_accepted_events: int
+    agent_manifest_id: str
+    environment_manifest_id: str
+    dispatch_manifest_id: str
+    metrics_config_sha256: str
+    config_sha256: str
+    _config_json: str = dataclasses.field(repr=False)
+
+    def __post_init__(self) -> None:
+        if self.schema != REFERENCE_LIFE_CONFIG_SCHEMA:
+            raise ValueError("unsupported reference-life config schema")
+        _require_id(self.lifecycle_id, name="lifecycle_id")
+        if (
+            isinstance(self.seed, bool)
+            or not isinstance(self.seed, int)
+            or self.seed < 0
+            or self.seed > int(np.iinfo(np.uint32).max)
+        ):
+            raise ValueError("seed must be a uint32 integer")
+        if (
+            isinstance(self.max_accepted_events, bool)
+            or not isinstance(self.max_accepted_events, int)
+            or self.max_accepted_events <= 0
+            or self.max_accepted_events > MAX_DECISION_INDEX + 1
+        ):
+            raise ValueError("max_accepted_events must be a positive host-capacity count")
+        for name in (
+            "agent_manifest_id",
+            "environment_manifest_id",
+            "dispatch_manifest_id",
+            "metrics_config_sha256",
+            "config_sha256",
+        ):
+            _require_digest(getattr(self, name), name=name)
+        payload = self.config
+        if _canonical_json(payload) != self._config_json:
+            raise ValueError("life configuration is not canonical JSON")
+        if _digest_json(payload) != self.config_sha256:
+            raise ValueError("life configuration digest mismatch")
+        expected = {
+            "lifecycle_id": self.lifecycle_id,
+            "seed": self.seed,
+            "max_accepted_events": self.max_accepted_events,
+        }
+        for key, value in expected.items():
+            if payload.get(key) != value:
+                raise ValueError(f"life configuration field {key!r} is not bound")
+        if payload.get("agent", {}).get("manifest_id") != self.agent_manifest_id:
+            raise ValueError("agent manifest identity is not bound")
+        if payload.get("environment", {}).get("manifest_id") != self.environment_manifest_id:
+            raise ValueError("environment manifest identity is not bound")
+        if payload.get("dispatch", {}).get("manifest_id") != self.dispatch_manifest_id:
+            raise ValueError("dispatch manifest identity is not bound")
+        if payload.get("metrics", {}).get("config_sha256") != self.metrics_config_sha256:
+            raise ValueError("metrics configuration identity is not bound")
+
+    @classmethod
+    def from_components(
+        cls,
+        *,
+        lifecycle_id: str,
+        seed: int,
+        max_accepted_events: int,
+        agent_manifest: AgentManifest,
+        agent_capacity: int,
+        environment_manifest: ReferenceEnvironmentManifest,
+        dispatch_config: ExactDispatchConfig,
+        metrics_config: ReferenceLifeMetricsConfig,
+    ) -> ReferenceLifeConfig:
+        payload = {
+            "schema": REFERENCE_LIFE_CONFIG_SCHEMA,
+            "lifecycle_id": lifecycle_id,
+            "seed": seed,
+            "max_accepted_events": max_accepted_events,
+            "rng_schedule": REFERENCE_LIFE_RNG_SCHEDULE,
+            "observation_id_schedule": "lifecycle_observation_index.preview1",
+            "checkpoint_policy": "atomic_quiescent_bundle.preview1",
+            "agent": _agent_descriptor(
+                agent_manifest,
+                max_accepted_events=agent_capacity,
+            ),
+            "environment": environment_manifest.descriptor(),
+            "dispatch": dispatch_config.descriptor(),
+            "metrics": metrics_config.descriptor(),
+        }
+        config_json = _canonical_json(payload)
+        return cls(
+            schema=REFERENCE_LIFE_CONFIG_SCHEMA,
+            lifecycle_id=lifecycle_id,
+            seed=seed,
+            max_accepted_events=max_accepted_events,
+            agent_manifest_id=agent_manifest.manifest_id,
+            environment_manifest_id=environment_manifest.manifest_id,
+            dispatch_manifest_id=dispatch_config.manifest_id,
+            metrics_config_sha256=metrics_config.config_sha256,
+            config_sha256=hashlib.sha256(config_json.encode("utf-8")).hexdigest(),
+            _config_json=config_json,
+        )
+
+    @property
+    def config(self) -> dict[str, Any]:
+        value = json.loads(self._config_json)
+        assert isinstance(value, dict)
+        return value
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class LifeHalt:
+    stage: HaltStage
+    recovery_mode: RecoveryMode
+    reason: str
+    recovery_attempts: int = 0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.stage, HaltStage):
+            raise ValueError("halt stage must be a HaltStage")
+        if not isinstance(self.recovery_mode, RecoveryMode):
+            raise ValueError("recovery_mode must be a RecoveryMode")
+        if not isinstance(self.reason, str) or not self.reason.strip():
+            raise ValueError("halt reason must be nonempty")
+        if (
+            isinstance(self.recovery_attempts, bool)
+            or not isinstance(self.recovery_attempts, int)
+            or self.recovery_attempts < 0
+        ):
+            raise ValueError("recovery_attempts must be nonnegative")
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PendingOutcome:
+    transaction: Transaction
+    regime_id: int
+    oracle_reward: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.transaction, Transaction):
+            raise ValueError("pending outcome requires a Transaction")
+        if self.regime_id not in (0, 1):
+            raise ValueError("pending outcome regime_id must be 0 or 1")
+        if not math.isfinite(self.oracle_reward):
+            raise ValueError("pending outcome oracle reward must be finite")
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceLifeState:
+    """One immutable aggregate owning every mutable development-life component."""
+
+    schema: str
+    config_sha256: str
+    lifecycle_id: str
+    phase: LifePhase
+    accepted_events: int
+    dispatch_attempts: int
+    executed_events: int
+    environment_rng_cursor: int
+    commit_generation: int
+    checkpoint_generation: int
+    agent_state: Any
+    environment_state: Any
+    transaction_state: ReferenceTransactionState
+    dispatch_state: ExactDispatchState
+    metrics: ReferenceLifeMetricsState
+    pending_outcome: PendingOutcome | None
+    halt: LifeHalt | None
+    transcript_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.schema != REFERENCE_LIFE_STATE_SCHEMA:
+            raise ValueError("unsupported reference-life state schema")
+        _require_digest(self.config_sha256, name="config_sha256")
+        _require_id(self.lifecycle_id, name="lifecycle_id")
+        _require_digest(self.transcript_sha256, name="transcript_sha256")
+        if not isinstance(self.phase, LifePhase):
+            raise ValueError("phase must be a LifePhase")
+        for name in (
+            "accepted_events",
+            "dispatch_attempts",
+            "executed_events",
+            "environment_rng_cursor",
+            "commit_generation",
+            "checkpoint_generation",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a nonnegative integer")
+        if not (self.accepted_events <= self.executed_events <= self.dispatch_attempts):
+            raise ValueError("life counters violate accepted <= outcomes <= dispatches")
+        if self.environment_rng_cursor != self.dispatch_attempts:
+            raise ValueError("environment RNG cursor must count dispatch attempts")
+        if not isinstance(self.transaction_state, ReferenceTransactionState):
+            raise ValueError("transaction_state has the wrong type")
+        if not isinstance(self.dispatch_state, ExactDispatchState):
+            raise ValueError("dispatch_state has the wrong type")
+        if not isinstance(self.metrics, ReferenceLifeMetricsState):
+            raise ValueError("metrics has the wrong type")
+        if self.metrics.accepted_events != self.accepted_events:
+            raise ValueError("metrics and runner accepted-event counters disagree")
+
+        if self.phase in (LifePhase.QUIESCENT, LifePhase.COMPLETED):
+            if self.pending_outcome is not None or self.halt is not None:
+                raise ValueError("quiescent/completed life cannot retain a halt")
+            if not (self.accepted_events == self.executed_events == self.dispatch_attempts):
+                raise ValueError("quiescent/completed life counters must align")
+            if self.transaction_state.phase not in (
+                TransactionPhase.ARMED,
+                TransactionPhase.EXHAUSTED,
+            ):
+                raise ValueError("quiescent/completed life must own an armed/exhausted transaction")
+        elif self.phase is LifePhase.HALTED:
+            if self.halt is None:
+                raise ValueError("halted life requires halt metadata")
+            if self.halt.stage is HaltStage.OUTCOME_PENDING:
+                if self.pending_outcome is None:
+                    raise ValueError("outcome-pending halt requires the retained outcome")
+                if self.transaction_state.transaction != self.pending_outcome.transaction:
+                    raise ValueError("pending outcome does not match transaction state")
+            elif self.pending_outcome is not None:
+                raise ValueError("only an outcome-pending halt may retain a transaction")
+        elif self.phase is LifePhase.ABORTED and self.halt is None:
+            raise ValueError("aborted life requires terminal halt metadata")
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceLifeEvent:
+    command: DispatchCommand
+    receipt: DispatchReceipt
+    transaction: Transaction
+    step_result: StepResult
+    regime_id: int
+    oracle_reward: float
+    transcript_sha256: str
+    recovered: bool
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceLifeStep:
+    state: ReferenceLifeState
+    event: ReferenceLifeEvent | None
+    accepted: bool
+    rejection_reason: str | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.accepted, bool):
+            raise ValueError("accepted must be boolean")
+        if self.accepted and self.rejection_reason is not None:
+            raise ValueError("accepted life step cannot carry a rejection reason")
+        if not self.accepted and (
+            not isinstance(self.rejection_reason, str) or not self.rejection_reason.strip()
+        ):
+            raise ValueError("rejected life step requires a reason")
+
+    @property
+    def recovery_required(self) -> bool:
+        return not self.accepted and self.state.phase is LifePhase.HALTED
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceLifeRun:
+    state: ReferenceLifeState
+    events: tuple[ReferenceLifeEvent, ...]
+
+
+@dataclasses.dataclass(slots=True)
+class _PostIssueContext:
+    """Ephemeral deepest-valid prefix for the post-issue emergency CAS."""
+
+    transaction_state: ReferenceTransactionState
+    dispatch_state: ExactDispatchState
+    issued_state: ReferenceTransactionState | None = None
+    command: DispatchCommand | None = None
+    execution: ReferenceEnvironmentExecution | None = None
+    receipt: DispatchReceipt | None = None
+    transcript_sha256: str | None = None
+
+
+def _initial_transcript(
+    config: ReferenceLifeConfig,
+    observation: ArrayValue,
+) -> str:
+    return _digest_json(
+        {
+            "schema": "asi.reference_life_transcript_init.preview1",
+            "config_sha256": config.config_sha256,
+            "lifecycle_id": config.lifecycle_id,
+            "observation": _array_descriptor(observation),
+        }
+    )
+
+
+def _advance_transcript(
+    previous_digest: str,
+    *,
+    execution: ReferenceEnvironmentExecution,
+    receipt: DispatchReceipt,
+    next_observation_id: str,
+) -> str:
+    command = receipt.command
+    payload = {
+        "schema": "asi.reference_life_transcript_event.preview1",
+        "previous_sha256": previous_digest,
+        "decision_id": command.decision_id,
+        "observation_id": command.decision.observation_id,
+        "command_id": command.command_id,
+        "executor_result_command_id": execution.command.command_id,
+        "receipt_id": receipt.receipt_id,
+        "proposed_action": _array_descriptor(command.decision.proposed_action)
+        if command.decision.proposed_action is not None
+        else None,
+        "settled_action": _array_descriptor(command.effective_action),
+        "applied_action": _array_descriptor(receipt.applied_action),
+        "reward_hex": float(execution.reward).hex(),
+        "discount_hex": float(execution.discount).hex(),
+        "terminated": execution.terminated,
+        "truncated": execution.truncated,
+        "autoreset": execution.autoreset,
+        "next_observation_id": next_observation_id,
+        "next_observation": _array_descriptor(execution.next_observation),
+        "regime_id": execution.regime_id,
+        "oracle_reward_hex": float(execution.oracle_reward).hex(),
+    }
+    return _digest_json(payload)
+
+
+class ReferenceLifeRunner:
+    """Single-writer synchronous owner for one aggregate development life."""
+
+    __slots__ = (
+        "_agent_adapter",
+        "_config",
+        "_current_state",
+        "_dispatch_adapter",
+        "_environment_adapter",
+        "_lock",
+        "_metrics_adapter",
+        "_reducer",
+    )
+
+    def __init__(
+        self,
+        *,
+        config: ReferenceLifeConfig,
+        agent_adapter: ReferenceAgentAdapter,
+        environment_adapter: ReferenceEnvironmentAdapter,
+        dispatch_adapter: ExactDispatchAdapter,
+        metrics_adapter: ReferenceLifeMetricsAdapter,
+    ) -> None:
+        if (
+            agent_adapter.manifest.config.get("lifecycle_codec")
+            == "prototype_uint32x2_hex.preview1"
+        ):
+            _require_prototype_lifecycle_id(config.lifecycle_id)
+        canonical_config = ReferenceLifeConfig.from_components(
+            lifecycle_id=config.lifecycle_id,
+            seed=config.seed,
+            max_accepted_events=config.max_accepted_events,
+            agent_manifest=agent_adapter.manifest,
+            agent_capacity=agent_adapter.max_accepted_events,
+            environment_manifest=environment_adapter.manifest,
+            dispatch_config=dispatch_adapter.config,
+            metrics_config=metrics_adapter.config,
+        )
+        if config != canonical_config:
+            raise ValueError(
+                "life configuration must exactly equal the canonical live-component binding"
+            )
+        if config.agent_manifest_id != agent_adapter.manifest.manifest_id:
+            raise ValueError("life config agent manifest mismatch")
+        if config.environment_manifest_id != environment_adapter.manifest.manifest_id:
+            raise ValueError("life config environment manifest mismatch")
+        if config.dispatch_manifest_id != dispatch_adapter.config.manifest_id:
+            raise ValueError("life config dispatch manifest mismatch")
+        if config.metrics_config_sha256 != metrics_adapter.config.config_sha256:
+            raise ValueError("life config metrics mismatch")
+        environment_config = environment_adapter.manifest.config
+        agent_config = agent_adapter.manifest.config
+        if environment_config.get("executor_id") != dispatch_adapter.config.executor_id:
+            raise ValueError("dispatch and environment executor IDs differ")
+        if environment_config.get("executor_epoch") != dispatch_adapter.config.executor_epoch:
+            raise ValueError("dispatch and environment executor epochs differ")
+        if environment_config.get("metrics_mode") != metrics_adapter.config.mode:
+            raise ValueError("metrics and environment modes differ")
+        agent_environment_kind = agent_config.get("environment_kind")
+        if (
+            agent_environment_kind is not None
+            and agent_environment_kind != environment_config.get("environment_kind")
+        ):
+            raise ValueError("agent and environment kinds differ")
+        bound_environment = agent_config.get("environment_config")
+        if bound_environment is not None:
+            environment_kind = environment_config.get("environment_kind")
+            if environment_kind == "switching_two_state":
+                expected_bound_environment = {
+                    "phase_length": environment_config.get("phase_length"),
+                    "payoffs_a": environment_config.get("payoffs_a"),
+                    "payoffs_b": environment_config.get("payoffs_b"),
+                }
+            elif environment_kind == "riverswim":
+                expected_bound_environment = {
+                    "n_states": environment_config.get("n_states"),
+                    "p_right_up": environment_config.get("p_right_up"),
+                    "p_right_down": environment_config.get("p_right_down"),
+                    "reward_left": environment_config.get("reward_left"),
+                    "reward_right": environment_config.get("reward_right"),
+                    "initial_state": environment_config.get("initial_state"),
+                }
+            else:
+                raise ValueError("environment-bound agent selected an unsupported environment")
+            if bound_environment != expected_bound_environment:
+                raise ValueError("agent's bound environment differs from the live environment")
+        if agent_adapter.manifest.observation_spec != environment_adapter.manifest.observation_spec:
+            raise ValueError("agent and environment observation codecs must match exactly")
+        if agent_adapter.manifest.action_spec != environment_adapter.manifest.action_spec:
+            raise ValueError("agent and environment action codecs must match exactly")
+        capacities = {
+            "agent": agent_adapter.max_accepted_events,
+            "environment": environment_adapter.max_executions,
+            "dispatch": dispatch_adapter.max_dispatches,
+            "host": MAX_DECISION_INDEX + 1,
+        }
+        invalid_capacity = [
+            name for name, capacity in capacities.items() if config.max_accepted_events > capacity
+        ]
+        if invalid_capacity:
+            detail = ", ".join(f"{name}={capacities[name]}" for name in sorted(invalid_capacity))
+            raise ValueError("max_accepted_events exceeds selected component capacity: " + detail)
+        self._config = config
+        self._agent_adapter = agent_adapter
+        self._environment_adapter = environment_adapter
+        self._dispatch_adapter = dispatch_adapter
+        self._metrics_adapter = metrics_adapter
+        self._reducer = ReferenceTransactionReducer(agent_adapter.manifest)
+        self._current_state: ReferenceLifeState | None = None
+        self._lock = threading.RLock()
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        agent_adapter: ReferenceAgentAdapter,
+        environment_adapter: ReferenceEnvironmentAdapter,
+        lifecycle_id: str,
+        seed: int,
+        max_accepted_events: int,
+        dispatch_config: ExactDispatchConfig | None = None,
+        metrics_config: ReferenceLifeMetricsConfig | None = None,
+    ) -> ReferenceLifeRunner:
+        dispatch_adapter = ExactDispatchAdapter(dispatch_config)
+        metrics_adapter = ReferenceLifeMetricsAdapter(metrics_config)
+        environment_config = environment_adapter.manifest.config
+        if environment_config.get("executor_id") != dispatch_adapter.config.executor_id:
+            raise ValueError("dispatch and environment executor IDs differ")
+        if environment_config.get("executor_epoch") != dispatch_adapter.config.executor_epoch:
+            raise ValueError("dispatch and environment executor epochs differ")
+        config = ReferenceLifeConfig.from_components(
+            lifecycle_id=lifecycle_id,
+            seed=seed,
+            max_accepted_events=max_accepted_events,
+            agent_manifest=agent_adapter.manifest,
+            agent_capacity=agent_adapter.max_accepted_events,
+            environment_manifest=environment_adapter.manifest,
+            dispatch_config=dispatch_adapter.config,
+            metrics_config=metrics_adapter.config,
+        )
+        return cls(
+            config=config,
+            agent_adapter=agent_adapter,
+            environment_adapter=environment_adapter,
+            dispatch_adapter=dispatch_adapter,
+            metrics_adapter=metrics_adapter,
+        )
+
+    @property
+    def config(self) -> ReferenceLifeConfig:
+        return self._config
+
+    @property
+    def agent_adapter(self) -> ReferenceAgentAdapter:
+        return self._agent_adapter
+
+    @property
+    def environment_adapter(self) -> ReferenceEnvironmentAdapter:
+        return self._environment_adapter
+
+    @property
+    def current_state(self) -> ReferenceLifeState | None:
+        with self._lock:
+            return self._current_state
+
+    def __reduce__(self) -> Any:
+        raise TypeError(
+            "live reference-life runner cannot be serialized; use the quiescent "
+            "whole-life checkpoint API"
+        )
+
+    def _require_current_locked(self, state: ReferenceLifeState) -> None:
+        if not isinstance(state, ReferenceLifeState):
+            raise DecisionOwnershipError("state must be a ReferenceLifeState")
+        if state.config_sha256 != self.config.config_sha256:
+            raise DecisionOwnershipError("life state configuration mismatch")
+        if state.lifecycle_id != self.config.lifecycle_id:
+            raise DecisionOwnershipError("life state lifecycle mismatch")
+        if self._current_state is None:
+            raise DecisionOwnershipError("life runner must be initialized before use")
+        if state is not self._current_state:
+            raise DecisionOwnershipError("life state is stale, replayed, or not current")
+        self._reducer.validate_state(state.transaction_state)
+
+    def _commit_locked(
+        self,
+        previous: ReferenceLifeState,
+        candidate: ReferenceLifeState,
+    ) -> ReferenceLifeState:
+        if self._current_state is not previous:
+            raise DecisionOwnershipError("life state changed before aggregate commit")
+        if candidate.config_sha256 != self.config.config_sha256:
+            raise DecisionOwnershipError("candidate life configuration mismatch")
+        self._reducer.validate_state(candidate.transaction_state)
+        self._current_state = candidate
+        return candidate
+
+    @staticmethod
+    def _int32_scalar(value: Any, *, name: str) -> int:
+        array = np.asarray(value)
+        if array.shape != () or array.dtype != np.dtype(np.int32):
+            raise DecisionOwnershipError(f"{name} must be a scalar int32")
+        return int(array)
+
+    def validate_checkpoint_state(self, state: ReferenceLifeState) -> None:
+        """Validate the exact cross-component quiescent checkpoint boundary."""
+
+        if not isinstance(state, ReferenceLifeState):
+            raise DecisionOwnershipError("checkpoint state must be a ReferenceLifeState")
+        if not isinstance(self._agent_adapter, PrototypeReferenceAdapter):
+            raise DecisionOwnershipError("checkpoint runner must use the Prototype adapter")
+        if state.config_sha256 != self.config.config_sha256:
+            raise DecisionOwnershipError("checkpoint life configuration mismatch")
+        if state.lifecycle_id != self.config.lifecycle_id:
+            raise DecisionOwnershipError("checkpoint lifecycle mismatch")
+        if state.phase is not LifePhase.QUIESCENT:
+            raise DecisionOwnershipError("checkpoint state must be quiescent")
+        if state.transaction_state.phase is not TransactionPhase.ARMED:
+            raise DecisionOwnershipError("checkpoint transaction must be armed")
+        if state.pending_outcome is not None or state.halt is not None:
+            raise DecisionOwnershipError("checkpoint state cannot retain recovery state")
+        if state.accepted_events >= self.config.max_accepted_events:
+            raise DecisionOwnershipError("checkpoint state must precede life completion")
+        if state.checkpoint_generation > state.commit_generation:
+            raise DecisionOwnershipError("checkpoint generation exceeds commit generation")
+        if state.commit_generation < (state.accepted_events + state.checkpoint_generation):
+            raise DecisionOwnershipError("checkpoint generation history predates accepted events")
+
+        self._reducer.validate_state(state.transaction_state)
+        self._dispatch_adapter.validate_state(state.dispatch_state)
+        self._environment_adapter.validate_state(state.environment_state)
+        self._agent_adapter.validate_state(state.agent_state)
+        if state.metrics.config_sha256 != self._metrics_adapter.config.config_sha256:
+            raise DecisionOwnershipError("checkpoint metrics configuration mismatch")
+
+        accepted = state.accepted_events
+        if not (
+            state.dispatch_attempts
+            == state.executed_events
+            == state.environment_rng_cursor
+            == state.metrics.accepted_events
+            == accepted
+        ):
+            raise DecisionOwnershipError("checkpoint event counters do not align")
+        if not (
+            state.dispatch_state.authorizations
+            == state.dispatch_state.commands_issued
+            == state.dispatch_state.receipts_recorded
+            == accepted
+        ):
+            raise DecisionOwnershipError("checkpoint dispatch counters do not align")
+        expected_last_command = (
+            None if accepted == 0 else f"{state.lifecycle_id}:{accepted - 1}:command"
+        )
+        if state.dispatch_state.last_command_id != expected_last_command:
+            raise DecisionOwnershipError("checkpoint last command identity is inconsistent")
+
+        if not isinstance(state.agent_state, PrototypeReferenceState):
+            raise DecisionOwnershipError("checkpoint agent wrapper has the wrong type")
+        agent_state = state.agent_state
+        if (
+            agent_state.manifest_id != self._agent_adapter.manifest.manifest_id
+            or agent_state.config_sha256 != self._agent_adapter.manifest.config_sha256
+            or agent_state.lifecycle_id != state.lifecycle_id
+            or agent_state.decision_index != accepted
+        ):
+            raise DecisionOwnershipError("checkpoint agent wrapper identity is inconsistent")
+        expected_observation_id = f"{state.lifecycle_id}:observation:{accepted}"
+        if agent_state.current_observation_id != expected_observation_id:
+            raise DecisionOwnershipError("checkpoint observation identity is inconsistent")
+
+        prototype_step = self._int32_scalar(
+            agent_state.agent_state.step_count,
+            name="Prototype step_count",
+        )
+        prototype_observations = self._int32_scalar(
+            agent_state.agent_state.observation_event_count,
+            name="Prototype observation_event_count",
+        )
+        environment_step = self._int32_scalar(
+            state.environment_state.step_count,
+            name="environment step_count",
+        )
+        if prototype_step != accepted or environment_step != accepted:
+            raise DecisionOwnershipError("checkpoint component step counters do not align")
+        if prototype_observations != accepted + 1:
+            raise DecisionOwnershipError("checkpoint observation counter is inconsistent")
+
+        transaction = state.transaction_state
+        if transaction.next_decision_index != accepted or transaction.decision is None:
+            raise DecisionOwnershipError("checkpoint ledger decision index is inconsistent")
+        decision = self._agent_adapter.current_decision(agent_state)
+        if transaction.decision != decision:
+            raise DecisionOwnershipError("checkpoint current decision lineage is inconsistent")
+        if decision.observation_id != expected_observation_id:
+            raise DecisionOwnershipError("checkpoint decision observation identity is inconsistent")
+        environment_observation = self._environment_adapter.current_observation(
+            state.environment_state
+        )
+        if decision.observation != environment_observation:
+            raise DecisionOwnershipError("checkpoint decision does not observe environment state")
+
+        metrics = state.metrics
+        environment_config = self._environment_adapter.manifest.config
+        environment_kind = environment_config.get("environment_kind")
+        metrics_mode = environment_config.get("metrics_mode")
+        if metrics_mode != self._metrics_adapter.config.mode:
+            raise DecisionOwnershipError("checkpoint environment/metrics modes differ")
+        positive_float64_zero = b"\x00" * 8
+        oracle_reward_must_match_bitwise = False
+        if environment_kind == "switching_two_state":
+            if metrics_mode != "switching_two_phase":
+                raise DecisionOwnershipError("checkpoint switching metrics mode is invalid")
+            phase_length = environment_config.get("phase_length")
+            if isinstance(phase_length, bool) or not isinstance(phase_length, int):
+                raise DecisionOwnershipError("checkpoint environment phase schedule is invalid")
+            if phase_length <= 0:
+                raise DecisionOwnershipError("checkpoint environment phase schedule is invalid")
+            payoff_matrices = (
+                np.asarray(environment_config.get("payoffs_a"), dtype=np.float32),
+                np.asarray(environment_config.get("payoffs_b"), dtype=np.float32),
+            )
+            if any(payoff.shape != (2, 2) for payoff in payoff_matrices):
+                raise DecisionOwnershipError("checkpoint environment payoff schedule is invalid")
+            oracle_rewards = tuple(
+                max(
+                    float(payoff[0, 0]),
+                    float(payoff[1, 1]),
+                    0.5 * float(payoff[0, 1] + payoff[1, 0]),
+                )
+                for payoff in payoff_matrices
+            )
+            (
+                expected_phase_counts,
+                expected_current_phase,
+                expected_phase_switches,
+                expected_segment_events,
+            ) = _switching_metric_schedule(accepted, phase_length)
+            expected_oracle_reward = (
+                expected_phase_counts[0] * oracle_rewards[0]
+                + expected_phase_counts[1] * oracle_rewards[1]
+            )
+        elif environment_kind == "riverswim":
+            if metrics_mode != "stationary":
+                raise DecisionOwnershipError("checkpoint RiverSwim metrics mode is invalid")
+            oracle_value = environment_config.get("oracle_average_reward")
+            if isinstance(oracle_value, bool) or not isinstance(oracle_value, (int, float)):
+                raise DecisionOwnershipError("checkpoint RiverSwim oracle is invalid")
+            oracle_reward = float(oracle_value)
+            if not math.isfinite(oracle_reward):
+                raise DecisionOwnershipError("checkpoint RiverSwim oracle is invalid")
+            expected_phase_counts = (accepted, 0)
+            expected_current_phase = 0
+            expected_phase_switches = 0
+            expected_segment_events = accepted
+            expected_oracle_reward = accepted * oracle_reward
+            oracle_reward_must_match_bitwise = True
+            stationary_exact_pairs = (
+                (metrics.current_segment_reward, metrics.reward_sum),
+                (metrics.current_segment_regret, metrics.regret_sum),
+                (metrics.phase_reward_sums[0], metrics.reward_sum),
+                (metrics.phase_regret_sums[0], metrics.regret_sum),
+            )
+            if (
+                metrics.first_completed_segment_reward != (None, None)
+                or metrics.latest_completed_segment_reward != (None, None)
+                or any(
+                    type(left) is not float
+                    or type(right) is not float
+                    or struct.pack(">d", left) != struct.pack(">d", right)
+                    for left, right in stationary_exact_pairs
+                )
+            ):
+                raise DecisionOwnershipError(
+                    "checkpoint stationary reward/regret accumulators are not bit-exact"
+                )
+        else:
+            raise DecisionOwnershipError("checkpoint environment kind is unsupported")
+
+        for phase, count in enumerate(expected_phase_counts):
+            if count != 0:
+                continue
+            reward_sum = metrics.phase_reward_sums[phase]
+            regret_sum = metrics.phase_regret_sums[phase]
+            if (
+                type(reward_sum) is not float
+                or struct.pack(">d", reward_sum) != positive_float64_zero
+                or type(regret_sum) is not float
+                or struct.pack(">d", regret_sum) != positive_float64_zero
+                or metrics.first_completed_segment_reward[phase] is not None
+                or metrics.latest_completed_segment_reward[phase] is not None
+            ):
+                raise DecisionOwnershipError(
+                    "checkpoint zero-event phase metrics must be exact positive zero "
+                    "with no completed-segment values"
+                )
+        oracle_reward_matches = (
+            struct.pack(">d", metrics.oracle_reward_sum)
+            == struct.pack(">d", expected_oracle_reward)
+            if oracle_reward_must_match_bitwise
+            else math.isclose(
+                metrics.oracle_reward_sum,
+                expected_oracle_reward,
+                rel_tol=1.0e-12,
+                abs_tol=1.0e-12,
+            )
+        )
+        if (
+            metrics.phase_event_counts != expected_phase_counts
+            or metrics.current_phase != expected_current_phase
+            or metrics.phase_switches != expected_phase_switches
+            or metrics.current_segment_events != expected_segment_events
+            or not oracle_reward_matches
+        ):
+            raise DecisionOwnershipError("checkpoint metrics do not match the environment schedule")
+        # Reward/regret history is preserved exactly by the recursively hashed
+        # semantic bundle, but without a retained event log it is integrity-bound,
+        # not independently authenticated or reconstructable. Validate only the
+        # algebra and deterministic schedule fields derivable from current state.
+        if not math.isclose(
+            sum(metrics.phase_reward_sums),
+            metrics.reward_sum,
+            rel_tol=1.0e-12,
+            abs_tol=1.0e-12,
+        ) or not math.isclose(
+            sum(metrics.phase_regret_sums),
+            metrics.regret_sum,
+            rel_tol=1.0e-12,
+            abs_tol=1.0e-12,
+        ):
+            raise DecisionOwnershipError("checkpoint metric phase totals are inconsistent")
+        if not math.isclose(
+            metrics.oracle_reward_sum - metrics.reward_sum,
+            metrics.regret_sum,
+            rel_tol=1.0e-12,
+            abs_tol=1.0e-12,
+        ):
+            raise DecisionOwnershipError("checkpoint metric regret algebra is inconsistent")
+
+    def checkpoint_barrier(
+        self,
+        state: ReferenceLifeState,
+        publisher: Callable[
+            [ReferenceLifeState, Callable[[], None]],
+            _CheckpointPublishResult,
+        ],
+    ) -> tuple[ReferenceLifeState, _CheckpointPublishResult]:
+        """Publish one immutable checkpoint generation under the runner lock."""
+
+        if not callable(publisher):
+            raise TypeError("checkpoint publisher must be callable")
+        with self._lock:
+            self._require_current_locked(state)
+            self.validate_checkpoint_state(state)
+            candidate = dataclasses.replace(
+                state,
+                commit_generation=state.commit_generation + 1,
+                checkpoint_generation=state.checkpoint_generation + 1,
+            )
+            self.validate_checkpoint_state(candidate)
+            installed = False
+
+            def install_committed_candidate() -> None:
+                nonlocal installed
+                if installed or self._current_state is not state:
+                    raise DecisionOwnershipError(
+                        "checkpoint candidate installation is stale or repeated"
+                    )
+                self._current_state = candidate
+                installed = True
+
+            published = publisher(candidate, install_committed_candidate)
+            if not installed:
+                raise RuntimeError("checkpoint publisher did not install its committed state")
+            return candidate, published
+
+    def adopt_checkpoint_state(self, state: ReferenceLifeState) -> ReferenceLifeState:
+        """Install one fully validated checkpoint into a fresh runner owner."""
+
+        with self._lock:
+            if self._current_state is not None:
+                raise DecisionOwnershipError("checkpoint adoption requires a fresh runner")
+            if state.checkpoint_generation <= 0:
+                raise DecisionOwnershipError("restored checkpoint generation must be positive")
+            self.validate_checkpoint_state(state)
+            self._current_state = state
+            return state
+
+    def _environment_key(self, cursor: int) -> Array:
+        root = jr.fold_in(
+            jr.key(self.config.seed, impl=REFERENCE_LIFE_PRNG_IMPLEMENTATION),
+            0x415349,
+        )
+        return jr.fold_in(root, cursor)
+
+    def _validate_accepted_agent_update(
+        self,
+        update: ReferenceAgentUpdate,
+        *,
+        previous_agent_state: Any,
+        transaction: Transaction,
+    ) -> None:
+        """Cross-check staged agent state before metrics or ledger acceptance."""
+
+        if not isinstance(update, ReferenceAgentUpdate) or not update.accepted:
+            raise DecisionOwnershipError("agent update is not an accepted reference-agent update")
+        if update.state is previous_agent_state:
+            raise DecisionOwnershipError("accepted agent update retained the stale input state")
+        self._agent_adapter.validate_state(update.state)
+        current_decision = self._agent_adapter.current_decision(update.state)
+        if update.next_decision != current_decision:
+            raise DecisionOwnershipError(
+                "accepted update next_decision does not match its agent state"
+            )
+        if transaction.decision.decision_index >= MAX_DECISION_INDEX:
+            raise DecisionOwnershipError(
+                "selected reference life cannot accept the final uint64 decision"
+            )
+        expected_index = transaction.decision.decision_index + 1
+        if (
+            current_decision.lifecycle_id != transaction.decision.lifecycle_id
+            or current_decision.decision_index != expected_index
+            or current_decision.observation_id != transaction.next_decision_observation_id
+            or current_decision.observation != transaction.next_decision_observation
+        ):
+            raise DecisionOwnershipError(
+                "accepted agent state does not advance the retained outcome exactly once"
+            )
+
+    def init(self) -> ReferenceLifeState:
+        """Initialize every state owner exactly once and arm decision zero."""
+
+        with self._lock:
+            if self._current_state is not None:
+                raise DecisionOwnershipError("life runner is already initialized")
+            root_key = jr.key(
+                self.config.seed,
+                impl=REFERENCE_LIFE_PRNG_IMPLEMENTATION,
+            )
+            agent_key, environment_key = jr.split(root_key, 2)
+            environment_start = self.environment_adapter.init(environment_key)
+            initial_observation_id = f"{self.config.lifecycle_id}:observation:0"
+            agent_state = self.agent_adapter.init(
+                agent_key,
+                lifecycle_id=self.config.lifecycle_id,
+            )
+            agent_state, decision = self.agent_adapter.start(
+                agent_state,
+                observation_id=initial_observation_id,
+                observation=environment_start.observation,
+            )
+            transaction_state = self._reducer.arm(self._reducer.init(), decision)
+            state = ReferenceLifeState(
+                schema=REFERENCE_LIFE_STATE_SCHEMA,
+                config_sha256=self.config.config_sha256,
+                lifecycle_id=self.config.lifecycle_id,
+                phase=LifePhase.QUIESCENT,
+                accepted_events=0,
+                dispatch_attempts=0,
+                executed_events=0,
+                environment_rng_cursor=0,
+                commit_generation=0,
+                checkpoint_generation=0,
+                agent_state=agent_state,
+                environment_state=environment_start.state,
+                transaction_state=transaction_state,
+                dispatch_state=self._dispatch_adapter.init(),
+                metrics=self._metrics_adapter.init(initial_phase=environment_start.regime_id),
+                pending_outcome=None,
+                halt=None,
+                transcript_sha256=_initial_transcript(
+                    self.config,
+                    environment_start.observation,
+                ),
+            )
+            self._current_state = state
+            return state
+
+    def _halt_before_execution_locked(
+        self,
+        previous: ReferenceLifeState,
+        transaction_state: ReferenceTransactionState,
+        dispatch_state: ExactDispatchState,
+        *,
+        reason: str,
+    ) -> ReferenceLifeStep:
+        if transaction_state.phase is not TransactionPhase.HALTED:
+            transaction_state = self._reducer.halt(
+                transaction_state,
+                reason=reason,
+            )
+        candidate = dataclasses.replace(
+            previous,
+            phase=LifePhase.HALTED,
+            transaction_state=transaction_state,
+            dispatch_state=dispatch_state,
+            commit_generation=previous.commit_generation + 1,
+            halt=LifeHalt(
+                stage=HaltStage.PRE_DISPATCH,
+                recovery_mode=RecoveryMode.ABORT_ONLY,
+                reason=reason,
+            ),
+        )
+        return ReferenceLifeStep(
+            state=self._commit_locked(previous, candidate),
+            event=None,
+            accepted=False,
+            rejection_reason=reason,
+        )
+
+    def _halt_uncertain_locked(
+        self,
+        previous: ReferenceLifeState,
+        transaction_state: ReferenceTransactionState,
+        dispatch_state: ExactDispatchState,
+        *,
+        reason: str,
+    ) -> ReferenceLifeStep:
+        if transaction_state.phase is not TransactionPhase.HALTED:
+            transaction_state = self._reducer.halt(
+                transaction_state,
+                reason=reason,
+            )
+        candidate = dataclasses.replace(
+            previous,
+            phase=LifePhase.HALTED,
+            transaction_state=transaction_state,
+            dispatch_state=dispatch_state,
+            dispatch_attempts=previous.dispatch_attempts + 1,
+            environment_rng_cursor=previous.environment_rng_cursor + 1,
+            commit_generation=previous.commit_generation + 1,
+            halt=LifeHalt(
+                stage=HaltStage.DISPATCH_UNCERTAIN,
+                recovery_mode=RecoveryMode.RECONCILE_ONLY,
+                reason=reason,
+            ),
+        )
+        return ReferenceLifeStep(
+            state=self._commit_locked(previous, candidate),
+            event=None,
+            accepted=False,
+            rejection_reason=reason,
+        )
+
+    def _halt_after_execution_locked(
+        self,
+        previous: ReferenceLifeState,
+        transaction_state: ReferenceTransactionState,
+        dispatch_state: ExactDispatchState,
+        execution: ReferenceEnvironmentExecution,
+        receipt: DispatchReceipt | None,
+        *,
+        transcript_sha256: str,
+        reason: str,
+    ) -> ReferenceLifeStep:
+        """Commit a known execution while discarding all staged learning."""
+
+        if transaction_state.phase is TransactionPhase.ISSUED and receipt is not None:
+            transaction_state = self._reducer.halt_after_execution(
+                transaction_state,
+                receipt,
+                reason=reason,
+            )
+        elif transaction_state.phase is not TransactionPhase.HALTED:
+            transaction_state = self._reducer.halt(
+                transaction_state,
+                reason=reason,
+            )
+        candidate = dataclasses.replace(
+            previous,
+            phase=LifePhase.HALTED,
+            environment_state=execution.state,
+            transaction_state=transaction_state,
+            dispatch_state=dispatch_state,
+            dispatch_attempts=previous.dispatch_attempts + 1,
+            executed_events=previous.executed_events + 1,
+            environment_rng_cursor=previous.environment_rng_cursor + 1,
+            commit_generation=previous.commit_generation + 1,
+            pending_outcome=None,
+            halt=LifeHalt(
+                stage=HaltStage.POST_EXECUTION_DIVERGENCE,
+                recovery_mode=RecoveryMode.RECONCILE_ONLY,
+                reason=reason,
+            ),
+            transcript_sha256=transcript_sha256,
+        )
+        return ReferenceLifeStep(
+            state=self._commit_locked(previous, candidate),
+            event=None,
+            accepted=False,
+            rejection_reason=reason,
+        )
+
+    def _halt_pending_outcome_locked(
+        self,
+        previous: ReferenceLifeState,
+        transaction_state: ReferenceTransactionState,
+        dispatch_state: ExactDispatchState,
+        execution: ReferenceEnvironmentExecution,
+        transaction: Transaction,
+        *,
+        transcript_sha256: str,
+        reason: str,
+    ) -> ReferenceLifeStep:
+        transaction_state, result = self._reducer.reject(
+            transaction_state,
+            reason=reason,
+        )
+        event = ReferenceLifeEvent(
+            command=transaction.receipt.command,
+            receipt=transaction.receipt,
+            transaction=transaction,
+            step_result=result,
+            regime_id=execution.regime_id,
+            oracle_reward=execution.oracle_reward,
+            transcript_sha256=transcript_sha256,
+            recovered=False,
+        )
+        candidate = dataclasses.replace(
+            previous,
+            phase=LifePhase.HALTED,
+            environment_state=execution.state,
+            transaction_state=transaction_state,
+            dispatch_state=dispatch_state,
+            dispatch_attempts=previous.dispatch_attempts + 1,
+            executed_events=previous.executed_events + 1,
+            environment_rng_cursor=previous.environment_rng_cursor + 1,
+            commit_generation=previous.commit_generation + 1,
+            pending_outcome=PendingOutcome(
+                transaction=transaction,
+                regime_id=execution.regime_id,
+                oracle_reward=execution.oracle_reward,
+            ),
+            halt=LifeHalt(
+                stage=HaltStage.OUTCOME_PENDING,
+                recovery_mode=RecoveryMode.RETRY_OUTCOME,
+                reason=reason,
+            ),
+            transcript_sha256=transcript_sha256,
+        )
+        return ReferenceLifeStep(
+            state=self._commit_locked(previous, candidate),
+            event=event,
+            accepted=False,
+            rejection_reason=reason,
+        )
+
+    def _emergency_halt_locked(
+        self,
+        previous: ReferenceLifeState,
+        context: _PostIssueContext,
+        *,
+        cause: Exception,
+    ) -> ReferenceLifeStep:
+        """Last-resort CAS that does not invoke a possibly failing reducer method."""
+
+        if self._current_state is not previous:
+            raise cause
+        reason = f"post-issue emergency halt after {type(cause).__name__}: {cause}"
+        deepest = context.transaction_state
+        try:
+            if deepest.phase is TransactionPhase.HALTED:
+                halted_transaction = deepest
+            elif deepest.phase is TransactionPhase.ISSUED and context.receipt is not None:
+                halted_transaction = dataclasses.replace(
+                    deepest,
+                    phase=TransactionPhase.HALTED,
+                    receipt=context.receipt,
+                    halt_reason=reason,
+                )
+            else:
+                halted_transaction = dataclasses.replace(
+                    deepest,
+                    phase=TransactionPhase.HALTED,
+                    halt_reason=reason,
+                )
+        except Exception:
+            issued = context.issued_state
+            if issued is None:
+                raise cause
+            halted_transaction = dataclasses.replace(
+                issued,
+                phase=TransactionPhase.HALTED,
+                halt_reason=reason,
+            )
+
+        execution = context.execution
+        execution_known = execution is not None
+        candidate = dataclasses.replace(
+            previous,
+            phase=LifePhase.HALTED,
+            environment_state=(
+                execution.state if execution is not None else previous.environment_state
+            ),
+            transaction_state=halted_transaction,
+            dispatch_state=context.dispatch_state,
+            dispatch_attempts=previous.dispatch_attempts + 1,
+            executed_events=previous.executed_events + int(execution_known),
+            environment_rng_cursor=previous.environment_rng_cursor + 1,
+            commit_generation=previous.commit_generation + 1,
+            pending_outcome=None,
+            halt=LifeHalt(
+                stage=(
+                    HaltStage.POST_EXECUTION_DIVERGENCE
+                    if execution_known
+                    else HaltStage.DISPATCH_UNCERTAIN
+                ),
+                recovery_mode=RecoveryMode.RECONCILE_ONLY,
+                reason=reason,
+            ),
+            transcript_sha256=(
+                context.transcript_sha256
+                if execution_known and context.transcript_sha256 is not None
+                else previous.transcript_sha256
+            ),
+        )
+        if self._current_state is not previous:
+            raise cause
+        self._current_state = candidate
+        return ReferenceLifeStep(
+            state=candidate,
+            event=None,
+            accepted=False,
+            rejection_reason=reason,
+        )
+
+    def step(self, state: ReferenceLifeState) -> ReferenceLifeStep:
+        """Run one event under a post-issue emergency fault boundary."""
+
+        context = _PostIssueContext(
+            transaction_state=state.transaction_state,
+            dispatch_state=state.dispatch_state,
+            transcript_sha256=state.transcript_sha256,
+        )
+        with self._lock:
+            try:
+                return self._step_locked(state, context)
+            except Exception as exc:
+                if self._current_state is not state or context.command is None:
+                    raise
+                return self._emergency_halt_locked(
+                    state,
+                    context,
+                    cause=exc,
+                )
+
+    def _step_locked(
+        self,
+        state: ReferenceLifeState,
+        context: _PostIssueContext,
+    ) -> ReferenceLifeStep:
+        """Execute, learn from, measure, and commit one synchronous event."""
+
+        # The lock deliberately spans validation through executor invocation
+        # and aggregate commit. Two callers holding the same immutable snapshot
+        # therefore cannot both dispatch before one loses a final CAS.
+        with self._lock:
+            self._require_current_locked(state)
+            if state.phase is LifePhase.COMPLETED:
+                raise DecisionOwnershipError("life is completed; no further dispatch is valid")
+            if state.phase is LifePhase.ABORTED:
+                raise DecisionOwnershipError("life is aborted; no further dispatch is valid")
+            if state.phase is LifePhase.HALTED:
+                raise DecisionOwnershipError("life is halted and requires explicit recovery/abort")
+            if state.accepted_events >= self.config.max_accepted_events:
+                raise DecisionOwnershipError("configured life horizon is completed")
+            decision = state.transaction_state.decision
+            if decision is None:
+                raise DecisionOwnershipError("quiescent life lacks an armed decision")
+
+            transaction_state = state.transaction_state
+            dispatch_state = state.dispatch_state
+            settled_agent_state = state.agent_state
+            try:
+                candidate_transaction_state, authorization = self._reducer.authorize(
+                    transaction_state,
+                    decision,
+                    authorized_action=None,
+                    authority_id=self._dispatch_adapter.config.authority_id,
+                    policy_version=self._dispatch_adapter.config.policy_version,
+                    authorization_id=f"{decision.decision_id}:authorization",
+                )
+                self._reducer.validate_state(candidate_transaction_state)
+                if (
+                    candidate_transaction_state.phase
+                    not in (TransactionPhase.AUTHORIZED, TransactionPhase.HALTED)
+                    or candidate_transaction_state.authorization != authorization
+                ):
+                    raise DecisionOwnershipError(
+                        "authorization returned an invalid transaction prefix"
+                    )
+                transaction_state = candidate_transaction_state
+                candidate_dispatch_state = self._dispatch_adapter.authorized(dispatch_state)
+                self._dispatch_adapter.validate_state(candidate_dispatch_state)
+                dispatch_state = candidate_dispatch_state
+                context.dispatch_state = dispatch_state
+                if authorization.status is AuthorizationStatus.VETOED:
+                    reason = transaction_state.halt_reason or "dispatch authorization vetoed"
+                    return self._halt_before_execution_locked(
+                        state,
+                        transaction_state,
+                        dispatch_state,
+                        reason=reason,
+                    )
+                settled_agent_state, rebinding_applied = self.agent_adapter.settle_dispatch(
+                    state.agent_state,
+                    authorization,
+                )
+                candidate_transaction_state, dispatch = self._reducer.settle_dispatch(
+                    transaction_state,
+                    authorization,
+                    rebinding_applied=rebinding_applied,
+                    settlement_id=f"{decision.decision_id}:settlement",
+                )
+                self._reducer.validate_state(candidate_transaction_state)
+                if dispatch is None:
+                    if candidate_transaction_state.phase is not TransactionPhase.HALTED:
+                        raise DecisionOwnershipError(
+                            "empty settlement did not return a halted transaction"
+                        )
+                elif (
+                    candidate_transaction_state.phase is not TransactionPhase.SETTLED
+                    or candidate_transaction_state.dispatch != dispatch
+                ):
+                    raise DecisionOwnershipError(
+                        "settlement returned an invalid transaction prefix"
+                    )
+                transaction_state = candidate_transaction_state
+                if dispatch is None:
+                    reason = transaction_state.halt_reason or "dispatch settlement halted"
+                    return self._halt_before_execution_locked(
+                        state,
+                        transaction_state,
+                        dispatch_state,
+                        reason=reason,
+                    )
+                candidate_transaction_state, command = self._reducer.issue_dispatch(
+                    transaction_state,
+                    dispatch,
+                    command_id=f"{decision.decision_id}:command",
+                    executor_id=self._dispatch_adapter.config.executor_id,
+                    executor_epoch=self._dispatch_adapter.config.executor_epoch,
+                )
+                self._reducer.validate_state(candidate_transaction_state)
+                if (
+                    candidate_transaction_state.phase is not TransactionPhase.ISSUED
+                    or candidate_transaction_state.command != command
+                ):
+                    raise DecisionOwnershipError(
+                        "command issuance returned an invalid transaction prefix"
+                    )
+                transaction_state = candidate_transaction_state
+                context.transaction_state = transaction_state
+                context.issued_state = transaction_state
+                context.command = command
+                candidate_dispatch_state = self._dispatch_adapter.issued(
+                    dispatch_state,
+                    command,
+                )
+                self._dispatch_adapter.validate_state(candidate_dispatch_state)
+                dispatch_state = candidate_dispatch_state
+                context.dispatch_state = dispatch_state
+            except Exception as exc:
+                if context.command is not None:
+                    raise
+                return self._halt_before_execution_locked(
+                    state,
+                    transaction_state,
+                    dispatch_state,
+                    reason=f"pre-dispatch failure: {exc}",
+                )
+
+            environment_key = self._environment_key(state.environment_rng_cursor)
+            try:
+                execution = self.environment_adapter.execute(
+                    state.environment_state,
+                    command,
+                    key=environment_key,
+                )
+            except Exception as exc:
+                return self._halt_uncertain_locked(
+                    state,
+                    transaction_state,
+                    dispatch_state,
+                    reason=f"executor completion is uncertain: {exc}",
+                )
+
+            if not isinstance(execution, ReferenceEnvironmentExecution):
+                return self._halt_uncertain_locked(
+                    state,
+                    transaction_state,
+                    dispatch_state,
+                    reason="executor returned no trustworthy execution result",
+                )
+            if execution.command != command:
+                return self._halt_uncertain_locked(
+                    state,
+                    transaction_state,
+                    dispatch_state,
+                    reason="executor result belongs to another issued command",
+                )
+            try:
+                self.environment_adapter.validate_execution(
+                    state.environment_state,
+                    command,
+                    execution,
+                    key=environment_key,
+                )
+            except Exception as exc:
+                return self._halt_uncertain_locked(
+                    state,
+                    transaction_state,
+                    dispatch_state,
+                    reason=f"executor result failed semantic validation: {exc}",
+                )
+            context.execution = execution
+            next_executed_events = state.executed_events + 1
+            next_observation_id = f"{self.config.lifecycle_id}:observation:{next_executed_events}"
+            receipt: DispatchReceipt | None = None
+            transcript_sha256 = state.transcript_sha256
+            try:
+                receipt = DispatchReceipt(
+                    command=command,
+                    applied_action=execution.applied_action,
+                    receipt_id=f"{decision.decision_id}:receipt",
+                )
+                context.receipt = receipt
+                transcript_sha256 = _advance_transcript(
+                    state.transcript_sha256,
+                    execution=execution,
+                    receipt=receipt,
+                    next_observation_id=next_observation_id,
+                )
+                context.transcript_sha256 = transcript_sha256
+            except Exception as exc:
+                return self._halt_after_execution_locked(
+                    state,
+                    transaction_state,
+                    dispatch_state,
+                    execution,
+                    receipt,
+                    transcript_sha256=transcript_sha256,
+                    reason=f"post-execution receipt staging failed: {exc}",
+                )
+            try:
+                candidate_transaction_state, recorded_receipt = self._reducer.record_dispatch(
+                    transaction_state,
+                    receipt,
+                )
+                self._reducer.validate_state(candidate_transaction_state)
+                if (
+                    candidate_transaction_state.phase
+                    not in (TransactionPhase.DISPATCHED, TransactionPhase.HALTED)
+                    or candidate_transaction_state.receipt != recorded_receipt
+                ):
+                    raise DecisionOwnershipError(
+                        "receipt recording returned an invalid transaction prefix"
+                    )
+                transaction_state = candidate_transaction_state
+                receipt = recorded_receipt
+                context.transaction_state = transaction_state
+                context.receipt = receipt
+                candidate_dispatch_state = self._dispatch_adapter.receipted(
+                    dispatch_state,
+                    receipt,
+                )
+                self._dispatch_adapter.validate_state(candidate_dispatch_state)
+                dispatch_state = candidate_dispatch_state
+                context.dispatch_state = dispatch_state
+            except Exception as exc:
+                return self._halt_after_execution_locked(
+                    state,
+                    transaction_state,
+                    dispatch_state,
+                    execution,
+                    receipt,
+                    transcript_sha256=transcript_sha256,
+                    reason=f"post-execution receipt recording failed: {exc}",
+                )
+            if transaction_state.phase is TransactionPhase.HALTED:
+                reason = transaction_state.halt_reason or (
+                    "executor applied action differs from issued command"
+                )
+                return self._halt_after_execution_locked(
+                    state,
+                    transaction_state,
+                    dispatch_state,
+                    execution,
+                    receipt,
+                    transcript_sha256=transcript_sha256,
+                    reason=reason,
+                )
+
+            try:
+                candidate_transaction_state, transaction = self._reducer.record_outcome(
+                    transaction_state,
+                    receipt,
+                    reward=execution.reward,
+                    discount=execution.discount,
+                    terminated=execution.terminated,
+                    truncated=execution.truncated,
+                    autoreset=execution.autoreset,
+                    bootstrap_observation_id=next_observation_id,
+                    bootstrap_observation=execution.next_observation,
+                    next_decision_observation_id=next_observation_id,
+                    next_decision_observation=execution.next_observation,
+                )
+                self._reducer.validate_state(candidate_transaction_state)
+                if (
+                    candidate_transaction_state.phase is not TransactionPhase.OUTCOME
+                    or candidate_transaction_state.transaction != transaction
+                ):
+                    raise DecisionOwnershipError(
+                        "outcome recording returned an invalid transaction prefix"
+                    )
+                transaction_state = candidate_transaction_state
+                context.transaction_state = transaction_state
+            except Exception as exc:
+                return self._halt_after_execution_locked(
+                    state,
+                    transaction_state,
+                    dispatch_state,
+                    execution,
+                    receipt,
+                    transcript_sha256=transcript_sha256,
+                    reason=f"post-execution outcome recording failed: {exc}",
+                )
+
+            update: ReferenceAgentUpdate
+            try:
+                update = self.agent_adapter.apply_outcome(
+                    settled_agent_state,
+                    transaction,
+                )
+            except Exception as exc:
+                update = ReferenceAgentUpdate(
+                    state=settled_agent_state,
+                    next_decision=None,
+                    accepted=False,
+                    parameters_changed=False,
+                    rejection_reason=f"agent update raised: {exc}",
+                )
+            if not isinstance(update, ReferenceAgentUpdate):
+                update = ReferenceAgentUpdate(
+                    state=settled_agent_state,
+                    next_decision=None,
+                    accepted=False,
+                    parameters_changed=False,
+                    rejection_reason="agent returned a malformed update",
+                )
+            if not update.accepted:
+                reason = update.rejection_reason or "agent rejected the retained outcome"
+                try:
+                    return self._halt_pending_outcome_locked(
+                        state,
+                        transaction_state,
+                        dispatch_state,
+                        execution,
+                        transaction,
+                        transcript_sha256=transcript_sha256,
+                        reason=reason,
+                    )
+                except Exception as exc:
+                    return self._halt_after_execution_locked(
+                        state,
+                        transaction_state,
+                        dispatch_state,
+                        execution,
+                        receipt,
+                        transcript_sha256=transcript_sha256,
+                        reason=f"post-execution rejection staging failed: {exc}",
+                    )
+
+            try:
+                self._validate_accepted_agent_update(
+                    update,
+                    previous_agent_state=settled_agent_state,
+                    transaction=transaction,
+                )
+            except Exception as exc:
+                reason = f"accepted agent update failed validation: {exc}"
+                try:
+                    return self._halt_pending_outcome_locked(
+                        state,
+                        transaction_state,
+                        dispatch_state,
+                        execution,
+                        transaction,
+                        transcript_sha256=transcript_sha256,
+                        reason=reason,
+                    )
+                except Exception as rejection_exc:
+                    return self._halt_after_execution_locked(
+                        state,
+                        transaction_state,
+                        dispatch_state,
+                        execution,
+                        receipt,
+                        transcript_sha256=transcript_sha256,
+                        reason=(
+                            "post-execution invalid-agent rejection staging failed: "
+                            f"{rejection_exc}"
+                        ),
+                    )
+
+            try:
+                metrics = self._metrics_adapter.observe(
+                    state.metrics,
+                    phase=execution.regime_id,
+                    reward=transaction.reward,
+                    oracle_reward=execution.oracle_reward,
+                    parameters_changed=update.parameters_changed,
+                )
+            except Exception as exc:
+                reason = f"metric update rejected retained outcome: {exc}"
+                try:
+                    return self._halt_pending_outcome_locked(
+                        state,
+                        transaction_state,
+                        dispatch_state,
+                        execution,
+                        transaction,
+                        transcript_sha256=transcript_sha256,
+                        reason=reason,
+                    )
+                except Exception as rejection_exc:
+                    return self._halt_after_execution_locked(
+                        state,
+                        transaction_state,
+                        dispatch_state,
+                        execution,
+                        receipt,
+                        transcript_sha256=transcript_sha256,
+                        reason=(f"post-execution metric rejection staging failed: {rejection_exc}"),
+                    )
+
+            try:
+                accepted_transaction_state, result = self._reducer.accept(
+                    transaction_state,
+                    next_decision=update.next_decision,
+                    parameters_changed=update.parameters_changed,
+                )
+                self._reducer.validate_state(accepted_transaction_state)
+                if accepted_transaction_state.phase not in (
+                    TransactionPhase.ARMED,
+                    TransactionPhase.READY,
+                    TransactionPhase.EXHAUSTED,
+                ):
+                    raise DecisionOwnershipError("acceptance returned an invalid transaction phase")
+            except Exception as exc:
+                return self._halt_after_execution_locked(
+                    state,
+                    transaction_state,
+                    dispatch_state,
+                    execution,
+                    receipt,
+                    transcript_sha256=transcript_sha256,
+                    reason=f"post-execution transaction acceptance failed: {exc}",
+                )
+            next_accepted_events = state.accepted_events + 1
+            phase = (
+                LifePhase.COMPLETED
+                if next_accepted_events == self.config.max_accepted_events
+                else LifePhase.QUIESCENT
+            )
+            candidate = dataclasses.replace(
+                state,
+                phase=phase,
+                accepted_events=next_accepted_events,
+                dispatch_attempts=state.dispatch_attempts + 1,
+                executed_events=next_executed_events,
+                environment_rng_cursor=state.environment_rng_cursor + 1,
+                commit_generation=state.commit_generation + 1,
+                agent_state=update.state,
+                environment_state=execution.state,
+                transaction_state=accepted_transaction_state,
+                dispatch_state=dispatch_state,
+                metrics=metrics,
+                transcript_sha256=transcript_sha256,
+            )
+            event = ReferenceLifeEvent(
+                command=command,
+                receipt=receipt,
+                transaction=transaction,
+                step_result=result,
+                regime_id=execution.regime_id,
+                oracle_reward=execution.oracle_reward,
+                transcript_sha256=transcript_sha256,
+                recovered=False,
+            )
+            return ReferenceLifeStep(
+                state=self._commit_locked(state, candidate),
+                event=event,
+                accepted=True,
+                rejection_reason=None,
+            )
+
+    def _retain_pending_recovery_locked(
+        self,
+        state: ReferenceLifeState,
+        pending: PendingOutcome,
+        *,
+        reason: str,
+    ) -> ReferenceLifeStep:
+        """Record one failed staging retry without consuming its retained outcome."""
+
+        if state.halt is None:
+            raise DecisionOwnershipError("pending-outcome recovery lacks halt metadata")
+        transaction = pending.transaction
+        halt = dataclasses.replace(
+            state.halt,
+            reason=reason,
+            recovery_attempts=state.halt.recovery_attempts + 1,
+        )
+        candidate = dataclasses.replace(
+            state,
+            commit_generation=state.commit_generation + 1,
+            halt=halt,
+        )
+        result = StepResult(
+            transaction=transaction,
+            next_decision=None,
+            transaction_accepted=False,
+            parameters_changed=False,
+            rejection_reason=reason,
+        )
+        event = ReferenceLifeEvent(
+            command=transaction.receipt.command,
+            receipt=transaction.receipt,
+            transaction=transaction,
+            step_result=result,
+            regime_id=pending.regime_id,
+            oracle_reward=pending.oracle_reward,
+            transcript_sha256=state.transcript_sha256,
+            recovered=True,
+        )
+        return ReferenceLifeStep(
+            state=self._commit_locked(state, candidate),
+            event=event,
+            accepted=False,
+            rejection_reason=reason,
+        )
+
+    def recover_pending_outcome(
+        self,
+        state: ReferenceLifeState,
+    ) -> ReferenceLifeStep:
+        """Retry only agent/metric staging for one already-executed event."""
+
+        with self._lock:
+            self._require_current_locked(state)
+            if (
+                state.phase is not LifePhase.HALTED
+                or state.halt is None
+                or state.halt.stage is not HaltStage.OUTCOME_PENDING
+                or state.halt.recovery_mode is not RecoveryMode.RETRY_OUTCOME
+                or state.pending_outcome is None
+            ):
+                raise DecisionOwnershipError(
+                    "recovery requires the current complete outcome-pending halt"
+                )
+            pending = state.pending_outcome
+            transaction = pending.transaction
+            command = transaction.receipt.command
+            receipt = transaction.receipt
+            try:
+                update = self.agent_adapter.apply_outcome(
+                    state.agent_state,
+                    transaction,
+                )
+            except Exception as exc:
+                update = ReferenceAgentUpdate(
+                    state=state.agent_state,
+                    next_decision=None,
+                    accepted=False,
+                    parameters_changed=False,
+                    rejection_reason=f"agent recovery update raised: {exc}",
+                )
+            if not isinstance(update, ReferenceAgentUpdate):
+                update = ReferenceAgentUpdate(
+                    state=state.agent_state,
+                    next_decision=None,
+                    accepted=False,
+                    parameters_changed=False,
+                    rejection_reason="agent recovery returned a malformed update",
+                )
+            if not update.accepted:
+                reason = update.rejection_reason or "agent recovery rejected outcome"
+                return self._retain_pending_recovery_locked(
+                    state,
+                    pending,
+                    reason=reason,
+                )
+
+            try:
+                self._validate_accepted_agent_update(
+                    update,
+                    previous_agent_state=state.agent_state,
+                    transaction=transaction,
+                )
+            except Exception as exc:
+                return self._retain_pending_recovery_locked(
+                    state,
+                    pending,
+                    reason=f"accepted agent update failed recovery validation: {exc}",
+                )
+
+            try:
+                metrics = self._metrics_adapter.observe(
+                    state.metrics,
+                    phase=pending.regime_id,
+                    reward=transaction.reward,
+                    oracle_reward=pending.oracle_reward,
+                    parameters_changed=update.parameters_changed,
+                )
+            except (DecisionOwnershipError, RuntimeError, TypeError, ValueError) as exc:
+                reason = f"metric recovery rejected retained outcome: {exc}"
+                return self._retain_pending_recovery_locked(
+                    state,
+                    pending,
+                    reason=reason,
+                )
+
+            transaction_state, result = self._reducer.recover_accept(
+                state.transaction_state,
+                next_decision=update.next_decision,
+                parameters_changed=update.parameters_changed,
+            )
+            next_accepted_events = state.accepted_events + 1
+            phase = (
+                LifePhase.COMPLETED
+                if next_accepted_events == self.config.max_accepted_events
+                else LifePhase.QUIESCENT
+            )
+            candidate = dataclasses.replace(
+                state,
+                phase=phase,
+                accepted_events=next_accepted_events,
+                commit_generation=state.commit_generation + 1,
+                agent_state=update.state,
+                transaction_state=transaction_state,
+                metrics=metrics,
+                pending_outcome=None,
+                halt=None,
+            )
+            event = ReferenceLifeEvent(
+                command=command,
+                receipt=receipt,
+                transaction=transaction,
+                step_result=result,
+                regime_id=pending.regime_id,
+                oracle_reward=pending.oracle_reward,
+                transcript_sha256=state.transcript_sha256,
+                recovered=True,
+            )
+            return ReferenceLifeStep(
+                state=self._commit_locked(state, candidate),
+                event=event,
+                accepted=True,
+                rejection_reason=None,
+            )
+
+    def abort(
+        self,
+        state: ReferenceLifeState,
+        *,
+        reason: str,
+    ) -> ReferenceLifeState:
+        """Terminate the current life without relabelling an unconsumed event."""
+
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("abort reason must be nonempty")
+        with self._lock:
+            self._require_current_locked(state)
+            if state.phase is LifePhase.ABORTED:
+                raise DecisionOwnershipError("life is already aborted")
+            if state.phase is LifePhase.COMPLETED:
+                raise DecisionOwnershipError("completed life cannot be aborted")
+            stage = state.halt.stage if state.halt is not None else HaltStage.PRE_DISPATCH
+            candidate = dataclasses.replace(
+                state,
+                phase=LifePhase.ABORTED,
+                commit_generation=state.commit_generation + 1,
+                halt=LifeHalt(
+                    stage=stage,
+                    recovery_mode=RecoveryMode.ABORT_ONLY,
+                    reason=reason,
+                    recovery_attempts=(0 if state.halt is None else state.halt.recovery_attempts),
+                ),
+            )
+            return self._commit_locked(state, candidate)
+
+    def run_to_completion(self, state: ReferenceLifeState) -> ReferenceLifeRun:
+        """Drive the configured small development horizon until complete/halted."""
+
+        events: list[ReferenceLifeEvent] = []
+        current = state
+        while current.phase is LifePhase.QUIESCENT:
+            step = self.step(current)
+            if step.event is not None:
+                events.append(step.event)
+            current = step.state
+        return ReferenceLifeRun(state=current, events=tuple(events))
+
+
+def build_prototype_switching_life(
+    *,
+    agent_config: PrototypeAgentConfig,
+    environment_config: SwitchingTwoStateConfig,
+    lifecycle_id: str,
+    seed: int,
+    max_accepted_events: int,
+    dispatch_config: ExactDispatchConfig | None = None,
+    metrics_config: ReferenceLifeMetricsConfig | None = None,
+) -> ReferenceLifeRunner:
+    """Build, but do not initialize, the canonical primitive switching slice."""
+
+    _require_prototype_lifecycle_id(lifecycle_id)
+    agent_adapter = PrototypeReferenceAdapter.from_config(agent_config)
+    effective_dispatch = ExactDispatchConfig() if dispatch_config is None else dispatch_config
+    effective_metrics = (
+        ReferenceLifeMetricsConfig(mode="switching_two_phase")
+        if metrics_config is None
+        else metrics_config
+    )
+    if effective_metrics.mode != "switching_two_phase":
+        raise ValueError("Switching life requires switching_two_phase metrics")
+    environment_adapter = SwitchingTwoStateReferenceEnvironment(
+        environment_config,
+        observation_spec=agent_adapter.manifest.observation_spec,
+        action_spec=agent_adapter.manifest.action_spec,
+        executor_id=effective_dispatch.executor_id,
+        executor_epoch=effective_dispatch.executor_epoch,
+    )
+    return ReferenceLifeRunner.create(
+        agent_adapter=agent_adapter,
+        environment_adapter=environment_adapter,
+        lifecycle_id=lifecycle_id,
+        seed=seed,
+        max_accepted_events=max_accepted_events,
+        dispatch_config=effective_dispatch,
+        metrics_config=effective_metrics,
+    )
+
+
+def build_prototype_riverswim_life(
+    *,
+    agent_config: PrototypeAgentConfig,
+    environment_config: RiverSwimConfig,
+    lifecycle_id: str,
+    seed: int,
+    max_accepted_events: int,
+    dispatch_config: ExactDispatchConfig | None = None,
+    metrics_config: ReferenceLifeMetricsConfig | None = None,
+) -> ReferenceLifeRunner:
+    """Build, but do not initialize, the canonical stochastic RiverSwim slice."""
+
+    _require_prototype_lifecycle_id(lifecycle_id)
+    agent_adapter = PrototypeReferenceAdapter.from_config(agent_config)
+    effective_dispatch = (
+        ExactDispatchConfig(
+            executor_id="asi.riverswim.executor",
+            executor_epoch="asi.riverswim.executor_epoch.1",
+        )
+        if dispatch_config is None
+        else dispatch_config
+    )
+    effective_metrics = (
+        ReferenceLifeMetricsConfig(mode="stationary")
+        if metrics_config is None
+        else metrics_config
+    )
+    if effective_metrics.mode != "stationary":
+        raise ValueError("RiverSwim life requires stationary metrics")
+    environment_adapter = RiverSwimReferenceEnvironment(
+        environment_config,
+        observation_spec=agent_adapter.manifest.observation_spec,
+        action_spec=agent_adapter.manifest.action_spec,
+        executor_id=effective_dispatch.executor_id,
+        executor_epoch=effective_dispatch.executor_epoch,
+    )
+    return ReferenceLifeRunner.create(
+        agent_adapter=agent_adapter,
+        environment_adapter=environment_adapter,
+        lifecycle_id=lifecycle_id,
+        seed=seed,
+        max_accepted_events=max_accepted_events,
+        dispatch_config=effective_dispatch,
+        metrics_config=effective_metrics,
+    )
+
+
+__all__ = [
+    "EXACT_DISPATCH_SCHEMA",
+    "EXACT_DISPATCH_STATE_SCHEMA",
+    "REFERENCE_ENVIRONMENT_MANIFEST_SCHEMA",
+    "REFERENCE_LIFE_CONFIG_SCHEMA",
+    "REFERENCE_LIFE_METRICS_SCHEMA",
+    "REFERENCE_LIFE_STATE_SCHEMA",
+    "RIVERSWIM_ENVIRONMENT_IMPLEMENTATION_ID",
+    "RIVERSWIM_ENVIRONMENT_STATE_SCHEMA",
+    "RIVERSWIM_REFERENCE_MAX_STATES",
+    "ExactDispatchAdapter",
+    "ExactDispatchConfig",
+    "ExactDispatchState",
+    "HaltStage",
+    "LifeHalt",
+    "LifePhase",
+    "PendingOutcome",
+    "RecoveryMode",
+    "ReferenceAgentAdapter",
+    "ReferenceEnvironmentAdapter",
+    "ReferenceEnvironmentExecution",
+    "ReferenceEnvironmentManifest",
+    "ReferenceEnvironmentStart",
+    "ReferenceLifeConfig",
+    "ReferenceLifeEvent",
+    "ReferenceLifeMetricsAdapter",
+    "ReferenceLifeMetricsConfig",
+    "ReferenceLifeMetricsState",
+    "ReferenceLifeRun",
+    "ReferenceLifeRunner",
+    "ReferenceLifeState",
+    "ReferenceLifeStep",
+    "RiverSwimReferenceEnvironment",
+    "SwitchingEnvironmentExecution",
+    "SwitchingEnvironmentStart",
+    "SwitchingTwoStateReferenceEnvironment",
+    "build_prototype_riverswim_life",
+    "build_prototype_switching_life",
+]

--- a/alberta_framework/reference_life_checkpoint.py
+++ b/alberta_framework/reference_life_checkpoint.py
@@ -1,0 +1,2026 @@
+"""Canonical whole-life checkpoints for the development-only reference runner.
+
+Only the primitive Prototype + SwitchingTwoState/RiverSwim reference slices
+are supported. Checkpoints are taken between transactions; this module makes
+no process-crash or durable physical-dispatch claim.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import fcntl
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import shutil
+import stat as stat_module
+import struct
+import sys
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, NoReturn, cast
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from alberta_framework.core.checkpoints import load_checkpoint_metadata
+from alberta_framework.core.prototype_agent import (
+    PROTOTYPE_CHECKPOINT_SCHEMA,
+    PrototypeAgent,
+    PrototypeAgentConfig,
+    PrototypeAgentState,
+    load_prototype_checkpoint,
+    save_prototype_checkpoint,
+)
+from alberta_framework.prototype_reference_adapter import (
+    PrototypeReferenceAdapter,
+    PrototypeReferenceState,
+)
+from alberta_framework.reference_agent import (
+    ArrayValue,
+    Decision,
+    ReferenceTransactionState,
+    TransactionPhase,
+)
+from alberta_framework.reference_life import (
+    REFERENCE_LIFE_CONFIG_SCHEMA,
+    REFERENCE_LIFE_RNG_SCHEDULE,
+    REFERENCE_LIFE_STATE_SCHEMA,
+    RIVERSWIM_ENVIRONMENT_IMPLEMENTATION_ID,
+    RIVERSWIM_ENVIRONMENT_STATE_SCHEMA,
+    RIVERSWIM_REFERENCE_MAX_STATES,
+    SWITCHING_ENVIRONMENT_IMPLEMENTATION_ID,
+    SWITCHING_ENVIRONMENT_STATE_SCHEMA,
+    ExactDispatchConfig,
+    ExactDispatchState,
+    LifePhase,
+    ReferenceLifeMetricsConfig,
+    ReferenceLifeMetricsState,
+    ReferenceLifeRunner,
+    ReferenceLifeState,
+    build_prototype_riverswim_life,
+    build_prototype_switching_life,
+)
+from alberta_framework.streams.closed_loop import (
+    RiverSwimConfig,
+    RiverSwimState,
+    SwitchingTwoStateConfig,
+    SwitchingTwoStateState,
+)
+
+REFERENCE_LIFE_CHECKPOINT_SCHEMA = "asi.reference_life_checkpoint.preview1"
+REFERENCE_LIFE_CHECKPOINT_STATE_SCHEMA = "asi.reference_life_checkpoint_state.preview1"
+REFERENCE_LIFE_CHECKPOINT_SOURCE_SCHEMA = "asi.reference_life_checkpoint_source.preview1"
+REFERENCE_LIFE_CHECKPOINT_RUNTIME_SCHEMA = "asi.reference_life_checkpoint_runtime.preview1"
+REFERENCE_LIFE_CHECKPOINT_DEPENDENCIES_SCHEMA = (
+    "asi.reference_life_checkpoint_dependencies.preview1"
+)
+REFERENCE_LIFE_CHECKPOINT_HASHES_SCHEMA = "asi.reference_life_checkpoint_hashes.preview1"
+
+_MANIFEST_NAME = "manifest.json"
+_STATE_NAME = "life_state.json"
+_PROTOTYPE_NAME = "prototype"
+_COMMITTED_NAME = "COMMITTED"
+_SOURCE_SCOPE = "checkpoint_time_compatibility_only.preview1"
+_GENERATION_WIDTH = 20
+_SHA256_LENGTH = 64
+_DEPENDENCIES = ("chex", "jax", "jaxlib", "numpy", "orbax-checkpoint")
+_MAX_JSON_BYTES = 16 * 1024 * 1024
+_MAX_INVENTORY_FILES = 8192
+_MAX_PATH_BYTES = 1024
+_MAX_ARRAY_RANK = 16
+_MAX_ARRAY_ELEMENTS = 1 << 24
+_MAX_ARRAY_BYTES = 64 * 1024 * 1024
+_MAX_TREE_DEPTH = 32
+_MAX_CHILD_FILE_BYTES = 128 * 1024 * 1024
+_MAX_CHILD_TOTAL_BYTES = 512 * 1024 * 1024
+_PROTOTYPE_EMPTY_ARRAY_CODEC = "alberta.prototype_agent.empty_array_projection.v1"
+_PROTOTYPE_SUPPORTED_PRNG_IMPLS = frozenset({"threefry2x32", "rbg"})
+
+
+def _fail(message: str) -> NoReturn:
+    raise ValueError(message)
+
+
+def _require_keys(value: Any, expected: set[str], *, path: str) -> dict[str, Any]:
+    if type(value) is not dict:
+        _fail(f"{path} must be a JSON object")
+    mapping = cast(dict[str, Any], value)
+    if set(mapping) != expected:
+        _fail(f"{path} fields do not match the checkpoint schema")
+    return mapping
+
+
+def _require_str(value: Any, *, path: str) -> str:
+    if type(value) is not str:
+        _fail(f"{path} must be a string")
+    return value
+
+
+def _require_int(value: Any, *, path: str, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        _fail(f"{path} must be an integer >= {minimum}")
+    return value
+
+
+def _require_bool(value: Any, *, path: str) -> bool:
+    if type(value) is not bool:
+        _fail(f"{path} must be boolean")
+    return value
+
+
+def _require_float(value: Any, *, path: str) -> float:
+    if type(value) not in (int, float) or isinstance(value, bool):
+        _fail(f"{path} must be a finite JSON number")
+    result = float(value)
+    if not np.isfinite(result):
+        _fail(f"{path} must be finite")
+    return result
+
+
+def _require_digest(value: Any, *, path: str) -> str:
+    digest = _require_str(value, path=path)
+    if len(digest) != _SHA256_LENGTH or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        _fail(f"{path} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            _fail(f"checkpoint JSON contains duplicate key {key!r}")
+        result[key] = value
+    return result
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    try:
+        return (
+            json.dumps(
+                value,
+                allow_nan=False,
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("ascii")
+            + b"\n"
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("checkpoint value is not canonical finite JSON") from exc
+
+
+def _read_bounded_json_file(path: Path) -> bytes:
+    """Read one bounded regular JSON file through a no-follow descriptor."""
+
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat_module.S_ISREG(metadata.st_mode):
+            raise ValueError(f"{path.name} must be a regular file")
+        if metadata.st_size <= 0 or metadata.st_size > _MAX_JSON_BYTES:
+            raise ValueError(f"{path.name} exceeds the canonical JSON size limit")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            raw = stream.read(_MAX_JSON_BYTES + 1)
+        if len(raw) != metadata.st_size or len(raw) > _MAX_JSON_BYTES:
+            raise ValueError(f"{path.name} changed or exceeds the JSON size limit")
+    finally:
+        os.close(descriptor)
+    return raw
+
+
+def _load_canonical_json(path: Path) -> dict[str, Any]:
+    raw = _read_bounded_json_file(path)
+    try:
+        value = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{path.name} is not canonical JSON") from exc
+    if type(value) is not dict or raw != _canonical_json_bytes(value):
+        raise ValueError(f"{path.name} is not canonically encoded")
+    return cast(dict[str, Any], value)
+
+
+def _sha256_file(
+    path: Path,
+    *,
+    max_bytes: int = _MAX_CHILD_FILE_BYTES,
+) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat_module.S_ISREG(metadata.st_mode) or metadata.st_size > max_bytes:
+            raise ValueError(f"checkpoint file exceeds its byte limit: {path}")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            while chunk := stream.read(min(1024 * 1024, max_bytes - size + 1)):
+                digest.update(chunk)
+                size += len(chunk)
+                if size > max_bytes:
+                    raise ValueError(f"checkpoint file exceeds its byte limit: {path}")
+        if size != metadata.st_size:
+            raise ValueError(f"checkpoint file changed while hashing: {path}")
+    finally:
+        os.close(descriptor)
+    return digest.hexdigest(), size
+
+
+def _repository_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _source_identity() -> dict[str, Any]:
+    root = _repository_root()
+    paths = [
+        *sorted((root / "alberta_framework").rglob("*.py")),
+        root / "pyproject.toml",
+        root / "uv.lock",
+    ]
+    if len(paths) > _MAX_INVENTORY_FILES:
+        raise ValueError("checkpoint source inventory exceeds its file-count limit")
+    files: dict[str, Any] = {}
+    for path in paths:
+        if not path.is_file() or path.is_symlink():
+            raise ValueError(f"checkpoint source inventory entry is unavailable: {path}")
+        digest, size = _sha256_file(path, max_bytes=_MAX_JSON_BYTES)
+        relative = path.relative_to(root).as_posix()
+        if len(relative.encode("utf-8")) > _MAX_PATH_BYTES:
+            raise ValueError("checkpoint source inventory path is too long")
+        files[relative] = {"sha256": digest, "size": size}
+    return {
+        "schema": REFERENCE_LIFE_CHECKPOINT_SOURCE_SCHEMA,
+        "scope": _SOURCE_SCOPE,
+        "files": files,
+    }
+
+
+def _runtime_identity() -> dict[str, Any]:
+    devices = sorted(
+        (
+            {
+                "id": int(device.id),
+                "process_index": int(device.process_index),
+                "platform": str(device.platform),
+                "device_kind": str(device.device_kind),
+            }
+            for device in jax.devices()
+        ),
+        key=lambda value: (
+            value["process_index"],
+            value["id"],
+            value["platform"],
+            value["device_kind"],
+        ),
+    )
+    environment_names = (
+        "JAX_PLATFORMS",
+        "JAX_PLATFORM_NAME",
+        "JAX_ENABLE_X64",
+        "JAX_DEFAULT_PRNG_IMPL",
+        "JAX_DEFAULT_MATMUL_PRECISION",
+        "JAX_RANDOM_SEED_OFFSET",
+        "JAX_NUM_CPU_DEVICES",
+        "XLA_FLAGS",
+    )
+    return {
+        "schema": REFERENCE_LIFE_CHECKPOINT_RUNTIME_SCHEMA,
+        "python_implementation": platform.python_implementation(),
+        "python_version": list(sys.version_info[:3]),
+        "byteorder": sys.byteorder,
+        "platform": sys.platform,
+        "machine": platform.machine(),
+        "default_backend": jax.default_backend(),
+        "device_count": jax.device_count(),
+        "local_device_count": jax.local_device_count(),
+        "devices": devices,
+        "jax_enable_x64": bool(jax.config.jax_enable_x64),
+        "jax_default_prng_impl": str(jax.config.jax_default_prng_impl),
+        "jax_default_matmul_precision": str(jax.config.jax_default_matmul_precision),
+        "jax_random_seed_offset": int(jax.config.jax_random_seed_offset),
+        "jax_threefry_partitionable": bool(jax.config.jax_threefry_partitionable),
+        "jax_numpy_dtype_promotion": str(jax.config.jax_numpy_dtype_promotion),
+        "jax_numpy_rank_promotion": str(jax.config.jax_numpy_rank_promotion),
+        "environment": {name: os.environ.get(name) for name in environment_names},
+    }
+
+
+def _dependency_identity() -> dict[str, Any]:
+    versions = {name: importlib.metadata.version(name) for name in _DEPENDENCIES}
+    return {
+        "schema": REFERENCE_LIFE_CHECKPOINT_DEPENDENCIES_SCHEMA,
+        "versions": versions,
+    }
+
+
+def _encode_float(value: float) -> str:
+    number = float(value)
+    if not np.isfinite(number):
+        raise ValueError("checkpoint floats must be finite")
+    return struct.pack(">d", number).hex()
+
+
+def _decode_float(value: Any, *, path: str) -> float:
+    encoded = _require_str(value, path=path)
+    if len(encoded) != 16 or any(c not in "0123456789abcdef" for c in encoded):
+        _fail(f"{path} must be one canonical binary64 value")
+    result = cast(float, struct.unpack(">d", bytes.fromhex(encoded))[0])
+    if not np.isfinite(result):
+        _fail(f"{path} must be finite")
+    return result
+
+
+def _encode_array_value(value: ArrayValue) -> dict[str, Any]:
+    if not isinstance(value, ArrayValue):
+        raise ValueError("checkpoint protocol value must be an ArrayValue")
+    return {
+        "semantic_id": value.semantic_id,
+        "dtype": value.dtype,
+        "shape": list(value.shape),
+        "payload_hex": value.payload.hex(),
+    }
+
+
+def _decode_array_value(value: Any, *, path: str) -> ArrayValue:
+    data = _require_keys(
+        value,
+        {"semantic_id", "dtype", "shape", "payload_hex"},
+        path=path,
+    )
+    shape_raw = data["shape"]
+    if type(shape_raw) is not list:
+        _fail(f"{path}.shape must be a JSON array")
+    if len(shape_raw) > _MAX_ARRAY_RANK:
+        _fail(f"{path}.shape exceeds the rank limit")
+    shape = tuple(
+        _require_int(dimension, path=f"{path}.shape[{index}]", minimum=1)
+        for index, dimension in enumerate(shape_raw)
+    )
+    payload_hex = _require_str(data["payload_hex"], path=f"{path}.payload_hex")
+    if len(payload_hex) > 2 * _MAX_ARRAY_BYTES:
+        _fail(f"{path}.payload_hex exceeds the byte limit")
+    if len(payload_hex) % 2 or any(c not in "0123456789abcdef" for c in payload_hex):
+        _fail(f"{path}.payload_hex must be lowercase hexadecimal")
+    return ArrayValue(
+        semantic_id=_require_str(data["semantic_id"], path=f"{path}.semantic_id"),
+        dtype=_require_str(data["dtype"], path=f"{path}.dtype"),
+        shape=shape,
+        payload=bytes.fromhex(payload_hex),
+    )
+
+
+def _encode_decision(value: Decision) -> dict[str, Any]:
+    if not isinstance(value, Decision):
+        raise ValueError("checkpoint ledger must own a Decision")
+    return {
+        "manifest_id": value.manifest_id,
+        "lifecycle_id": value.lifecycle_id,
+        "decision_index": value.decision_index,
+        "decision_id": value.decision_id,
+        "observation_id": value.observation_id,
+        "observation": _encode_array_value(value.observation),
+        "proposed_action": (
+            None if value.proposed_action is None else _encode_array_value(value.proposed_action)
+        ),
+        "armed": value.armed,
+    }
+
+
+def _decode_decision(value: Any, *, path: str) -> Decision:
+    data = _require_keys(
+        value,
+        {
+            "manifest_id",
+            "lifecycle_id",
+            "decision_index",
+            "decision_id",
+            "observation_id",
+            "observation",
+            "proposed_action",
+            "armed",
+        },
+        path=path,
+    )
+    proposed_raw = data["proposed_action"]
+    return Decision(
+        manifest_id=_require_digest(data["manifest_id"], path=f"{path}.manifest_id"),
+        lifecycle_id=_require_str(data["lifecycle_id"], path=f"{path}.lifecycle_id"),
+        decision_index=_require_int(data["decision_index"], path=f"{path}.decision_index"),
+        decision_id=_require_str(data["decision_id"], path=f"{path}.decision_id"),
+        observation_id=_require_str(data["observation_id"], path=f"{path}.observation_id"),
+        observation=_decode_array_value(data["observation"], path=f"{path}.observation"),
+        proposed_action=(
+            None
+            if proposed_raw is None
+            else _decode_array_value(proposed_raw, path=f"{path}.proposed_action")
+        ),
+        armed=_require_bool(data["armed"], path=f"{path}.armed"),
+    )
+
+
+def _encode_jax_array(value: Any, *, path: str) -> dict[str, Any]:
+    if not isinstance(value, jax.Array):
+        raise ValueError(f"{path} must be a concrete JAX array")
+    if jax.dtypes.issubdtype(  # type: ignore[attr-defined]
+        value.dtype, jax.dtypes.prng_key
+    ):
+        raise ValueError(f"{path} must not be a typed PRNG key")
+    array = np.asarray(value)
+    dtype = np.dtype(array.dtype)
+    if dtype.byteorder not in ("=", "|"):
+        raise ValueError(f"{path} must use native byte order")
+    storage = array.astype(dtype.newbyteorder("<"), copy=False)
+    return {
+        "dtype": dtype.name,
+        "shape": list(array.shape),
+        "payload_hex": storage.tobytes(order="C").hex(),
+    }
+
+
+def _decode_jax_array(value: Any, *, path: str) -> jax.Array:
+    data = _require_keys(value, {"dtype", "shape", "payload_hex"}, path=path)
+    dtype_name = _require_str(data["dtype"], path=f"{path}.dtype")
+    try:
+        dtype = np.dtype(dtype_name)
+    except TypeError as exc:
+        raise ValueError(f"{path}.dtype is unsupported") from exc
+    if dtype.name != dtype_name or dtype.kind not in {"b", "f", "i", "u"}:
+        _fail(f"{path}.dtype is not a canonical numeric dtype")
+    shape_raw = data["shape"]
+    if type(shape_raw) is not list:
+        _fail(f"{path}.shape must be a JSON array")
+    if len(shape_raw) > _MAX_ARRAY_RANK:
+        _fail(f"{path}.shape exceeds the rank limit")
+    shape = tuple(
+        _require_int(dimension, path=f"{path}.shape[{index}]", minimum=0)
+        for index, dimension in enumerate(shape_raw)
+    )
+    payload_hex = _require_str(data["payload_hex"], path=f"{path}.payload_hex")
+    if len(payload_hex) > 2 * _MAX_ARRAY_BYTES:
+        _fail(f"{path}.payload_hex exceeds the byte limit")
+    if len(payload_hex) % 2 or any(c not in "0123456789abcdef" for c in payload_hex):
+        _fail(f"{path}.payload_hex must be lowercase hexadecimal")
+    raw = bytes.fromhex(payload_hex)
+    elements = 1
+    for dimension in shape:
+        elements *= dimension
+        if elements > _MAX_ARRAY_ELEMENTS:
+            _fail(f"{path}.shape exceeds the element limit")
+    if elements * dtype.itemsize > _MAX_ARRAY_BYTES:
+        _fail(f"{path} exceeds the byte limit")
+    if len(raw) != elements * dtype.itemsize:
+        _fail(f"{path}.payload_hex length does not match shape and dtype")
+    storage_dtype = dtype.newbyteorder("<")
+    array = np.frombuffer(raw, dtype=storage_dtype).astype(dtype, copy=True).reshape(shape)
+    result = jnp.asarray(array)
+    if result.shape != shape or np.dtype(result.dtype) != dtype:
+        _fail(f"{path} cannot preserve its encoded shape and dtype in this runtime")
+    return result
+
+
+def _encode_metrics(metrics: ReferenceLifeMetricsState) -> dict[str, Any]:
+    return {
+        "schema": metrics.schema,
+        "config_sha256": metrics.config_sha256,
+        "accepted_events": metrics.accepted_events,
+        "parameter_change_events": metrics.parameter_change_events,
+        "reward_sum": _encode_float(metrics.reward_sum),
+        "oracle_reward_sum": _encode_float(metrics.oracle_reward_sum),
+        "regret_sum": _encode_float(metrics.regret_sum),
+        "phase_event_counts": list(metrics.phase_event_counts),
+        "phase_reward_sums": [_encode_float(value) for value in metrics.phase_reward_sums],
+        "phase_regret_sums": [_encode_float(value) for value in metrics.phase_regret_sums],
+        "phase_switches": metrics.phase_switches,
+        "current_phase": metrics.current_phase,
+        "current_segment_events": metrics.current_segment_events,
+        "current_segment_reward": _encode_float(metrics.current_segment_reward),
+        "current_segment_regret": _encode_float(metrics.current_segment_regret),
+        "first_completed_segment_reward": [
+            None if value is None else _encode_float(value)
+            for value in metrics.first_completed_segment_reward
+        ],
+        "latest_completed_segment_reward": [
+            None if value is None else _encode_float(value)
+            for value in metrics.latest_completed_segment_reward
+        ],
+    }
+
+
+_METRICS_KEYS = {
+    "schema",
+    "config_sha256",
+    "accepted_events",
+    "parameter_change_events",
+    "reward_sum",
+    "oracle_reward_sum",
+    "regret_sum",
+    "phase_event_counts",
+    "phase_reward_sums",
+    "phase_regret_sums",
+    "phase_switches",
+    "current_phase",
+    "current_segment_events",
+    "current_segment_reward",
+    "current_segment_regret",
+    "first_completed_segment_reward",
+    "latest_completed_segment_reward",
+}
+
+
+def _decode_pair(
+    value: Any,
+    *,
+    path: str,
+    decode: Any,
+) -> tuple[Any, Any]:
+    if type(value) is not list or len(value) != 2:
+        _fail(f"{path} must be a two-element JSON array")
+    return decode(value[0], path=f"{path}[0]"), decode(value[1], path=f"{path}[1]")
+
+
+def _decode_metrics(value: Any, *, path: str) -> ReferenceLifeMetricsState:
+    data = _require_keys(value, _METRICS_KEYS, path=path)
+
+    def decode_int(item: Any, *, path: str) -> int:
+        return _require_int(item, path=path)
+
+    def decode_optional(item: Any, *, path: str) -> float | None:
+        return None if item is None else _decode_float(item, path=path)
+
+    return ReferenceLifeMetricsState(
+        schema=_require_str(data["schema"], path=f"{path}.schema"),
+        config_sha256=_require_digest(data["config_sha256"], path=f"{path}.config_sha256"),
+        accepted_events=_require_int(data["accepted_events"], path=f"{path}.accepted_events"),
+        parameter_change_events=_require_int(
+            data["parameter_change_events"], path=f"{path}.parameter_change_events"
+        ),
+        reward_sum=_decode_float(data["reward_sum"], path=f"{path}.reward_sum"),
+        oracle_reward_sum=_decode_float(
+            data["oracle_reward_sum"], path=f"{path}.oracle_reward_sum"
+        ),
+        regret_sum=_decode_float(data["regret_sum"], path=f"{path}.regret_sum"),
+        phase_event_counts=cast(
+            tuple[int, int],
+            _decode_pair(
+                data["phase_event_counts"], path=f"{path}.phase_event_counts", decode=decode_int
+            ),
+        ),
+        phase_reward_sums=cast(
+            tuple[float, float],
+            _decode_pair(
+                data["phase_reward_sums"], path=f"{path}.phase_reward_sums", decode=_decode_float
+            ),
+        ),
+        phase_regret_sums=cast(
+            tuple[float, float],
+            _decode_pair(
+                data["phase_regret_sums"], path=f"{path}.phase_regret_sums", decode=_decode_float
+            ),
+        ),
+        phase_switches=_require_int(data["phase_switches"], path=f"{path}.phase_switches"),
+        current_phase=_require_int(data["current_phase"], path=f"{path}.current_phase"),
+        current_segment_events=_require_int(
+            data["current_segment_events"], path=f"{path}.current_segment_events"
+        ),
+        current_segment_reward=_decode_float(
+            data["current_segment_reward"], path=f"{path}.current_segment_reward"
+        ),
+        current_segment_regret=_decode_float(
+            data["current_segment_regret"], path=f"{path}.current_segment_regret"
+        ),
+        first_completed_segment_reward=cast(
+            tuple[float | None, float | None],
+            _decode_pair(
+                data["first_completed_segment_reward"],
+                path=f"{path}.first_completed_segment_reward",
+                decode=decode_optional,
+            ),
+        ),
+        latest_completed_segment_reward=cast(
+            tuple[float | None, float | None],
+            _decode_pair(
+                data["latest_completed_segment_reward"],
+                path=f"{path}.latest_completed_segment_reward",
+                decode=decode_optional,
+            ),
+        ),
+    )
+
+
+def _encode_transaction(state: ReferenceTransactionState) -> dict[str, Any]:
+    if state.phase is not TransactionPhase.ARMED or state.decision is None:
+        raise ValueError("whole-life checkpoints require one armed transaction")
+    return {
+        "schema": state.schema,
+        "manifest_id": state.manifest_id,
+        "phase": state.phase.value,
+        "lifecycle_id": state.lifecycle_id,
+        "next_decision_index": state.next_decision_index,
+        "decision": _encode_decision(state.decision),
+        "authorization": None,
+        "dispatch": None,
+        "command": None,
+        "receipt": None,
+        "transaction": None,
+        "halt_reason": None,
+    }
+
+
+def _decode_transaction(value: Any, *, path: str) -> ReferenceTransactionState:
+    data = _require_keys(
+        value,
+        {
+            "schema",
+            "manifest_id",
+            "phase",
+            "lifecycle_id",
+            "next_decision_index",
+            "decision",
+            "authorization",
+            "dispatch",
+            "command",
+            "receipt",
+            "transaction",
+            "halt_reason",
+        },
+        path=path,
+    )
+    phase = _require_str(data["phase"], path=f"{path}.phase")
+    if phase != TransactionPhase.ARMED.value:
+        _fail(f"{path}.phase must be {TransactionPhase.ARMED.value!r}")
+    for name in (
+        "authorization",
+        "dispatch",
+        "command",
+        "receipt",
+        "transaction",
+        "halt_reason",
+    ):
+        if data[name] is not None:
+            _fail(f"{path}.{name} must be null at an armed checkpoint boundary")
+    lifecycle_id = data["lifecycle_id"]
+    if lifecycle_id is None:
+        _fail(f"{path}.lifecycle_id cannot be null")
+    return ReferenceTransactionState(
+        schema=_require_str(data["schema"], path=f"{path}.schema"),
+        manifest_id=_require_digest(data["manifest_id"], path=f"{path}.manifest_id"),
+        phase=TransactionPhase.ARMED,
+        lifecycle_id=_require_str(lifecycle_id, path=f"{path}.lifecycle_id"),
+        next_decision_index=_require_int(
+            data["next_decision_index"], path=f"{path}.next_decision_index"
+        ),
+        decision=_decode_decision(data["decision"], path=f"{path}.decision"),
+    )
+
+
+def _encode_environment_state(state: Any) -> dict[str, Any]:
+    if isinstance(state, SwitchingTwoStateState):
+        implementation_id = SWITCHING_ENVIRONMENT_IMPLEMENTATION_ID
+        state_schema = SWITCHING_ENVIRONMENT_STATE_SCHEMA
+    elif isinstance(state, RiverSwimState):
+        implementation_id = RIVERSWIM_ENVIRONMENT_IMPLEMENTATION_ID
+        state_schema = RIVERSWIM_ENVIRONMENT_STATE_SCHEMA
+    else:
+        raise ValueError("whole-life checkpoint environment state is unsupported")
+    return {
+        "implementation_id": implementation_id,
+        "schema": state_schema,
+        "state_index": _encode_jax_array(
+            state.state_index,
+            path="environment.state_index",
+        ),
+        "step_count": _encode_jax_array(
+            state.step_count,
+            path="environment.step_count",
+        ),
+    }
+
+
+def _encode_state(state: ReferenceLifeState) -> dict[str, Any]:
+    if state.phase is not LifePhase.QUIESCENT:
+        raise ValueError("whole-life checkpoints require quiescent state")
+    if not isinstance(state.agent_state, PrototypeReferenceState):
+        raise ValueError("whole-life checkpoint agent wrapper is unsupported")
+    wrapper = state.agent_state
+    dispatch = state.dispatch_state
+    return {
+        "schema": REFERENCE_LIFE_CHECKPOINT_STATE_SCHEMA,
+        "life_state_schema": state.schema,
+        "config_sha256": state.config_sha256,
+        "lifecycle_id": state.lifecycle_id,
+        "phase": state.phase.value,
+        "runner": {
+            "accepted_events": state.accepted_events,
+            "dispatch_attempts": state.dispatch_attempts,
+            "executed_events": state.executed_events,
+            "environment_rng_cursor": state.environment_rng_cursor,
+            "commit_generation": state.commit_generation,
+            "checkpoint_generation": state.checkpoint_generation,
+            "transcript_sha256": state.transcript_sha256,
+        },
+        "agent": {
+            "schema": wrapper.schema,
+            "manifest_id": wrapper.manifest_id,
+            "config_sha256": wrapper.config_sha256,
+            "lifecycle_id": wrapper.lifecycle_id,
+            "decision_index": wrapper.decision_index,
+            "current_observation_id": wrapper.current_observation_id,
+        },
+        "environment": _encode_environment_state(state.environment_state),
+        "transaction": _encode_transaction(state.transaction_state),
+        "dispatch": {
+            "schema": dispatch.schema,
+            "manifest_id": dispatch.manifest_id,
+            "authorizations": dispatch.authorizations,
+            "commands_issued": dispatch.commands_issued,
+            "receipts_recorded": dispatch.receipts_recorded,
+            "last_command_id": dispatch.last_command_id,
+        },
+        "metrics": _encode_metrics(state.metrics),
+        "pending_outcome": None,
+        "halt": None,
+    }
+
+
+_STATE_KEYS = {
+    "schema",
+    "life_state_schema",
+    "config_sha256",
+    "lifecycle_id",
+    "phase",
+    "runner",
+    "agent",
+    "environment",
+    "transaction",
+    "dispatch",
+    "metrics",
+    "pending_outcome",
+    "halt",
+}
+
+
+def _decode_state(
+    value: Any,
+    *,
+    runner: ReferenceLifeRunner,
+    prototype_state: PrototypeAgentState,
+) -> ReferenceLifeState:
+    data = _require_keys(value, _STATE_KEYS, path="life_state")
+    if _require_str(data["schema"], path="life_state.schema") != (
+        REFERENCE_LIFE_CHECKPOINT_STATE_SCHEMA
+    ):
+        _fail("life_state.schema is unsupported")
+    if _require_str(data["life_state_schema"], path="life_state.life_state_schema") != (
+        REFERENCE_LIFE_STATE_SCHEMA
+    ):
+        _fail("life_state.life_state_schema is unsupported")
+    if _require_str(data["phase"], path="life_state.phase") != LifePhase.QUIESCENT.value:
+        _fail("life_state.phase must be quiescent")
+    if data["pending_outcome"] is not None or data["halt"] is not None:
+        _fail("quiescent checkpoint state cannot carry recovery data")
+
+    runner_data = _require_keys(
+        data["runner"],
+        {
+            "accepted_events",
+            "dispatch_attempts",
+            "executed_events",
+            "environment_rng_cursor",
+            "commit_generation",
+            "checkpoint_generation",
+            "transcript_sha256",
+        },
+        path="life_state.runner",
+    )
+    wrapper_data = _require_keys(
+        data["agent"],
+        {
+            "schema",
+            "manifest_id",
+            "config_sha256",
+            "lifecycle_id",
+            "decision_index",
+            "current_observation_id",
+        },
+        path="life_state.agent",
+    )
+    environment_data = _require_keys(
+        data["environment"],
+        {"implementation_id", "schema", "state_index", "step_count"},
+        path="life_state.environment",
+    )
+    environment_implementation_id = _require_str(
+        environment_data["implementation_id"],
+        path="life_state.environment.implementation_id",
+    )
+    environment_state_schema = _require_str(
+        environment_data["schema"], path="life_state.environment.schema"
+    )
+    live_environment_manifest = runner.environment_adapter.manifest
+    if (
+        environment_implementation_id != live_environment_manifest.implementation_id
+        or environment_state_schema != live_environment_manifest.state_schema
+    ):
+        _fail("life_state environment discriminator differs from the live manifest")
+    state_index = _decode_jax_array(
+        environment_data["state_index"], path="life_state.environment.state_index"
+    )
+    step_count = _decode_jax_array(
+        environment_data["step_count"], path="life_state.environment.step_count"
+    )
+    if (
+        environment_implementation_id == SWITCHING_ENVIRONMENT_IMPLEMENTATION_ID
+        and environment_state_schema == SWITCHING_ENVIRONMENT_STATE_SCHEMA
+    ):
+        environment_state: Any = SwitchingTwoStateState(
+            state_index=state_index,
+            step_count=step_count,
+        )  # type: ignore[call-arg]
+    elif (
+        environment_implementation_id == RIVERSWIM_ENVIRONMENT_IMPLEMENTATION_ID
+        and environment_state_schema == RIVERSWIM_ENVIRONMENT_STATE_SCHEMA
+    ):
+        environment_state = RiverSwimState(
+            state_index=state_index,
+            step_count=step_count,
+        )  # type: ignore[call-arg]
+    else:
+        _fail("life_state environment discriminator is unsupported or crossed")
+
+    dispatch_data = _require_keys(
+        data["dispatch"],
+        {
+            "schema",
+            "manifest_id",
+            "authorizations",
+            "commands_issued",
+            "receipts_recorded",
+            "last_command_id",
+        },
+        path="life_state.dispatch",
+    )
+    last_command = dispatch_data["last_command_id"]
+    dispatch_state = ExactDispatchState(
+        schema=_require_str(dispatch_data["schema"], path="life_state.dispatch.schema"),
+        manifest_id=_require_digest(
+            dispatch_data["manifest_id"], path="life_state.dispatch.manifest_id"
+        ),
+        authorizations=_require_int(
+            dispatch_data["authorizations"], path="life_state.dispatch.authorizations"
+        ),
+        commands_issued=_require_int(
+            dispatch_data["commands_issued"], path="life_state.dispatch.commands_issued"
+        ),
+        receipts_recorded=_require_int(
+            dispatch_data["receipts_recorded"], path="life_state.dispatch.receipts_recorded"
+        ),
+        last_command_id=(
+            None
+            if last_command is None
+            else _require_str(last_command, path="life_state.dispatch.last_command_id")
+        ),
+    )
+
+    current_observation = wrapper_data["current_observation_id"]
+    if current_observation is None:
+        _fail("life_state.agent.current_observation_id cannot be null")
+    adapter = runner.agent_adapter
+    if not isinstance(adapter, PrototypeReferenceAdapter):
+        _fail("restored life does not use the Prototype adapter")
+    wrapper_state = adapter.adopt_checkpoint_state(
+        agent_state=prototype_state,
+        lifecycle_id=_require_str(
+            wrapper_data["lifecycle_id"], path="life_state.agent.lifecycle_id"
+        ),
+        decision_index=_require_int(
+            wrapper_data["decision_index"], path="life_state.agent.decision_index"
+        ),
+        current_observation_id=_require_str(
+            current_observation,
+            path="life_state.agent.current_observation_id",
+        ),
+    )
+    if (
+        wrapper_state.schema != _require_str(wrapper_data["schema"], path="life_state.agent.schema")
+        or wrapper_state.manifest_id
+        != _require_digest(wrapper_data["manifest_id"], path="life_state.agent.manifest_id")
+        or wrapper_state.config_sha256
+        != _require_digest(wrapper_data["config_sha256"], path="life_state.agent.config_sha256")
+    ):
+        _fail("restored Prototype wrapper identity is inconsistent")
+
+    result = ReferenceLifeState(
+        schema=REFERENCE_LIFE_STATE_SCHEMA,
+        config_sha256=_require_digest(data["config_sha256"], path="life_state.config_sha256"),
+        lifecycle_id=_require_str(data["lifecycle_id"], path="life_state.lifecycle_id"),
+        phase=LifePhase.QUIESCENT,
+        accepted_events=_require_int(
+            runner_data["accepted_events"], path="life_state.runner.accepted_events"
+        ),
+        dispatch_attempts=_require_int(
+            runner_data["dispatch_attempts"], path="life_state.runner.dispatch_attempts"
+        ),
+        executed_events=_require_int(
+            runner_data["executed_events"], path="life_state.runner.executed_events"
+        ),
+        environment_rng_cursor=_require_int(
+            runner_data["environment_rng_cursor"],
+            path="life_state.runner.environment_rng_cursor",
+        ),
+        commit_generation=_require_int(
+            runner_data["commit_generation"], path="life_state.runner.commit_generation"
+        ),
+        checkpoint_generation=_require_int(
+            runner_data["checkpoint_generation"],
+            path="life_state.runner.checkpoint_generation",
+        ),
+        agent_state=wrapper_state,
+        environment_state=environment_state,
+        transaction_state=_decode_transaction(data["transaction"], path="life_state.transaction"),
+        dispatch_state=dispatch_state,
+        metrics=_decode_metrics(data["metrics"], path="life_state.metrics"),
+        pending_outcome=None,
+        halt=None,
+        transcript_sha256=_require_digest(
+            runner_data["transcript_sha256"], path="life_state.runner.transcript_sha256"
+        ),
+    )
+    runner.validate_checkpoint_state(result)
+    return result
+
+
+_LIFE_CONFIG_KEYS = {
+    "schema",
+    "lifecycle_id",
+    "seed",
+    "max_accepted_events",
+    "rng_schedule",
+    "observation_id_schedule",
+    "checkpoint_policy",
+    "agent",
+    "environment",
+    "dispatch",
+    "metrics",
+}
+
+
+def _build_runner(config_value: Any) -> tuple[ReferenceLifeRunner, dict[str, Any]]:
+    config = _require_keys(config_value, _LIFE_CONFIG_KEYS, path="manifest.life_config")
+    if _require_str(config["schema"], path="manifest.life_config.schema") != (
+        REFERENCE_LIFE_CONFIG_SCHEMA
+    ):
+        _fail("manifest.life_config.schema is unsupported")
+    schedules = {
+        "rng_schedule": REFERENCE_LIFE_RNG_SCHEDULE,
+        "observation_id_schedule": "lifecycle_observation_index.preview1",
+        "checkpoint_policy": "atomic_quiescent_bundle.preview1",
+    }
+    for name, expected in schedules.items():
+        if _require_str(config[name], path=f"manifest.life_config.{name}") != expected:
+            _fail(f"manifest.life_config.{name} is unsupported")
+
+    agent_descriptor = _require_keys(
+        config["agent"],
+        {
+            "schema",
+            "implementation_id",
+            "state_schema",
+            "config_sha256",
+            "manifest_id",
+            "config",
+            "observation_spec",
+            "action_spec",
+            "capabilities",
+            "max_accepted_events",
+        },
+        path="manifest.life_config.agent",
+    )
+    agent_binding = _require_keys(
+        agent_descriptor["config"],
+        {
+            "adapter_schema",
+            "dispatch_mode",
+            "environment_mode",
+            "lifecycle_codec",
+            "prototype_agent",
+            "prototype_state_schema",
+            "reward_discount_codec",
+        },
+        path="manifest.life_config.agent.config",
+    )
+    prototype_config_raw = agent_binding["prototype_agent"]
+    if type(prototype_config_raw) is not dict:
+        _fail("manifest.life_config.agent.config.prototype_agent must be an object")
+    prototype_config = PrototypeAgentConfig.from_config(cast(dict[str, Any], prototype_config_raw))
+
+    environment_descriptor = _require_keys(
+        config["environment"],
+        {
+            "schema",
+            "implementation_id",
+            "state_schema",
+            "config_sha256",
+            "manifest_id",
+            "config",
+            "observation_spec",
+            "action_spec",
+            "max_executions",
+        },
+        path="manifest.life_config.environment",
+    )
+    environment_implementation_id = _require_str(
+        environment_descriptor["implementation_id"],
+        path="manifest.life_config.environment.implementation_id",
+    )
+    environment_state_schema = _require_str(
+        environment_descriptor["state_schema"],
+        path="manifest.life_config.environment.state_schema",
+    )
+    environment_discriminator = (
+        environment_implementation_id,
+        environment_state_schema,
+    )
+    switching_discriminator = (
+        SWITCHING_ENVIRONMENT_IMPLEMENTATION_ID,
+        SWITCHING_ENVIRONMENT_STATE_SCHEMA,
+    )
+    riverswim_discriminator = (
+        RIVERSWIM_ENVIRONMENT_IMPLEMENTATION_ID,
+        RIVERSWIM_ENVIRONMENT_STATE_SCHEMA,
+    )
+    if environment_discriminator not in {
+        switching_discriminator,
+        riverswim_discriminator,
+    }:
+        _fail("manifest environment implementation/state discriminator is unsupported or crossed")
+
+    def payoff_matrix(value: Any, *, path: str) -> tuple[tuple[float, float], ...]:
+        if type(value) is not list or len(value) != 2:
+            _fail(f"{path} must be a two-by-two array")
+        rows: list[tuple[float, float]] = []
+        for index, row in enumerate(value):
+            if type(row) is not list or len(row) != 2:
+                _fail(f"{path}[{index}] must contain two values")
+            rows.append(
+                (
+                    _require_float(row[0], path=f"{path}[{index}][0]"),
+                    _require_float(row[1], path=f"{path}[{index}][1]"),
+                )
+            )
+        return tuple(rows)
+
+    environment_path = "manifest.life_config.environment.config"
+    environment_raw = environment_descriptor["config"]
+    if environment_discriminator == switching_discriminator:
+        environment = _require_keys(
+            environment_raw,
+            {
+                "environment_kind",
+                "metrics_mode",
+                "phase_length",
+                "payoffs_a",
+                "payoffs_b",
+                "executor_id",
+                "executor_epoch",
+                "dynamics",
+                "rng_mode",
+                "boundary_mode",
+            },
+            path=environment_path,
+        )
+        expected_strings = {
+            "environment_kind": "switching_two_state",
+            "metrics_mode": "switching_two_phase",
+            "dynamics": "next_state_equals_action",
+            "rng_mode": "key_schedule_bound_but_dynamics_deterministic",
+            "boundary_mode": "continuing_only",
+        }
+        for name, expected in expected_strings.items():
+            if _require_str(environment[name], path=f"{environment_path}.{name}") != expected:
+                _fail(f"{environment_path}.{name} is unsupported")
+        environment_config: SwitchingTwoStateConfig | RiverSwimConfig = (
+            SwitchingTwoStateConfig(
+                phase_length=_require_int(
+                    environment["phase_length"],
+                    path=f"{environment_path}.phase_length",
+                    minimum=1,
+                ),
+                payoffs_a=payoff_matrix(
+                    environment["payoffs_a"],
+                    path=f"{environment_path}.payoffs_a",
+                ),
+                payoffs_b=payoff_matrix(
+                    environment["payoffs_b"],
+                    path=f"{environment_path}.payoffs_b",
+                ),
+            )  # type: ignore[call-arg]
+        )
+        environment_metrics_mode = "switching_two_phase"
+    else:
+        environment = _require_keys(
+            environment_raw,
+            {
+                "environment_kind",
+                "metrics_mode",
+                "n_states",
+                "p_right_up",
+                "p_right_down",
+                "reward_left",
+                "reward_right",
+                "initial_state",
+                "oracle_average_reward",
+                "executor_id",
+                "executor_epoch",
+                "dynamics",
+                "rng_mode",
+                "boundary_mode",
+            },
+            path=environment_path,
+        )
+        expected_strings = {
+            "environment_kind": "riverswim",
+            "metrics_mode": "stationary",
+            "dynamics": "riverswim_stochastic_chain",
+            "rng_mode": "exact_jax_key_replay",
+            "boundary_mode": "continuing_only",
+        }
+        for name, expected in expected_strings.items():
+            if _require_str(environment[name], path=f"{environment_path}.{name}") != expected:
+                _fail(f"{environment_path}.{name} is unsupported")
+        n_states = _require_int(
+            environment["n_states"],
+            path=f"{environment_path}.n_states",
+            minimum=2,
+        )
+        if n_states > RIVERSWIM_REFERENCE_MAX_STATES:
+            _fail(
+                f"{environment_path}.n_states exceeds the RiverSwim reference bound"
+            )
+        initial_state = _require_int(
+            environment["initial_state"],
+            path=f"{environment_path}.initial_state",
+        )
+        if initial_state >= n_states:
+            _fail(f"{environment_path}.initial_state is outside the state space")
+        _require_float(
+            environment["oracle_average_reward"],
+            path=f"{environment_path}.oracle_average_reward",
+        )
+        environment_config = RiverSwimConfig(
+            n_states=n_states,
+            p_right_up=_require_float(
+                environment["p_right_up"], path=f"{environment_path}.p_right_up"
+            ),
+            p_right_down=_require_float(
+                environment["p_right_down"], path=f"{environment_path}.p_right_down"
+            ),
+            reward_left=_require_float(
+                environment["reward_left"], path=f"{environment_path}.reward_left"
+            ),
+            reward_right=_require_float(
+                environment["reward_right"], path=f"{environment_path}.reward_right"
+            ),
+            initial_state=initial_state,
+        )  # type: ignore[call-arg]
+        environment_metrics_mode = "stationary"
+
+    _require_str(
+        environment["executor_id"],
+        path=f"{environment_path}.executor_id",
+    )
+    _require_str(
+        environment["executor_epoch"],
+        path=f"{environment_path}.executor_epoch",
+    )
+
+    dispatch_descriptor = _require_keys(
+        config["dispatch"],
+        {"schema", "config_sha256", "manifest_id", "config", "max_dispatches"},
+        path="manifest.life_config.dispatch",
+    )
+    dispatch = _require_keys(
+        dispatch_descriptor["config"],
+        {
+            "mode",
+            "authority_role",
+            "safety_policy",
+            "veto_conformance",
+            "authority_id",
+            "policy_version",
+            "executor_id",
+            "executor_epoch",
+        },
+        path="manifest.life_config.dispatch.config",
+    )
+    dispatch_config = ExactDispatchConfig(
+        authority_id=_require_str(
+            dispatch["authority_id"],
+            path="manifest.life_config.dispatch.config.authority_id",
+        ),
+        policy_version=_require_str(
+            dispatch["policy_version"],
+            path="manifest.life_config.dispatch.config.policy_version",
+        ),
+        executor_id=_require_str(
+            dispatch["executor_id"],
+            path="manifest.life_config.dispatch.config.executor_id",
+        ),
+        executor_epoch=_require_str(
+            dispatch["executor_epoch"],
+            path="manifest.life_config.dispatch.config.executor_epoch",
+        ),
+        mode=_require_str(dispatch["mode"], path="manifest.life_config.dispatch.config.mode"),
+    )
+
+    metrics_descriptor = _require_keys(
+        config["metrics"],
+        {"schema", "config_sha256", "config"},
+        path="manifest.life_config.metrics",
+    )
+    metrics = _require_keys(
+        metrics_descriptor["config"],
+        {"mode", "oracle_regret"},
+        path="manifest.life_config.metrics.config",
+    )
+    metrics_mode = _require_str(
+        metrics["mode"],
+        path="manifest.life_config.metrics.config.mode",
+    )
+    if metrics_mode != environment_metrics_mode:
+        _fail("manifest metrics mode does not match the environment")
+    metrics_config = ReferenceLifeMetricsConfig(
+        mode=metrics_mode,
+        oracle_regret=_require_bool(
+            metrics["oracle_regret"],
+            path="manifest.life_config.metrics.config.oracle_regret",
+        )
+    )
+
+    lifecycle_id = _require_str(
+        config["lifecycle_id"], path="manifest.life_config.lifecycle_id"
+    )
+    seed = _require_int(config["seed"], path="manifest.life_config.seed")
+    max_accepted_events = _require_int(
+        config["max_accepted_events"],
+        path="manifest.life_config.max_accepted_events",
+        minimum=1,
+    )
+    if environment_discriminator == switching_discriminator:
+        runner = build_prototype_switching_life(
+            agent_config=prototype_config,
+            environment_config=cast(SwitchingTwoStateConfig, environment_config),
+            lifecycle_id=lifecycle_id,
+            seed=seed,
+            max_accepted_events=max_accepted_events,
+            dispatch_config=dispatch_config,
+            metrics_config=metrics_config,
+        )
+    else:
+        runner = build_prototype_riverswim_life(
+            agent_config=prototype_config,
+            environment_config=cast(RiverSwimConfig, environment_config),
+            lifecycle_id=lifecycle_id,
+            seed=seed,
+            max_accepted_events=max_accepted_events,
+            dispatch_config=dispatch_config,
+            metrics_config=metrics_config,
+        )
+    if _canonical_json_bytes(runner.config.config) != _canonical_json_bytes(config):
+        _fail("manifest.life_config is not the canonical reconstructed configuration")
+    return runner, cast(dict[str, Any], prototype_config_raw)
+
+
+def _write_new(path: Path, payload: bytes) -> None:
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        with os.fdopen(descriptor, "wb", closefd=False) as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+    finally:
+        os.close(descriptor)
+
+
+def _walk_regular_files(root: Path) -> dict[str, Path]:
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError(f"checkpoint directory is unavailable: {root}")
+    files: dict[str, Path] = {}
+    entries_seen = 0
+    total_bytes = 0
+
+    def visit(directory: Path, *, depth: int) -> None:
+        nonlocal entries_seen, total_bytes
+        if depth > _MAX_TREE_DEPTH:
+            raise ValueError("checkpoint directory tree exceeds its depth limit")
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                entries_seen += 1
+                if entries_seen > _MAX_INVENTORY_FILES:
+                    raise ValueError("checkpoint directory tree exceeds its entry limit")
+                path = Path(entry.path)
+                relative = path.relative_to(root).as_posix()
+                if len(relative.encode("utf-8")) > _MAX_PATH_BYTES:
+                    raise ValueError("checkpoint directory tree contains an overlong path")
+                if entry.is_symlink():
+                    raise ValueError(f"checkpoint cannot contain symlink {relative!r}")
+                if entry.is_dir(follow_symlinks=False):
+                    visit(path, depth=depth + 1)
+                elif entry.is_file(follow_symlinks=False):
+                    size = entry.stat(follow_symlinks=False).st_size
+                    if size > _MAX_CHILD_FILE_BYTES:
+                        raise ValueError(
+                            f"checkpoint child exceeds its per-file byte limit: {relative}"
+                        )
+                    total_bytes += size
+                    if total_bytes > _MAX_CHILD_TOTAL_BYTES:
+                        raise ValueError("checkpoint children exceed their total byte limit")
+                    files[relative] = path
+                else:
+                    raise ValueError(f"checkpoint cannot contain non-regular entry {relative!r}")
+
+    visit(root, depth=0)
+    return files
+
+
+def _child_hashes(root: Path) -> dict[str, Any]:
+    files = _walk_regular_files(root)
+    selected = {
+        name: path
+        for name, path in files.items()
+        if name == _STATE_NAME or name.startswith(f"{_PROTOTYPE_NAME}/")
+    }
+    if _STATE_NAME not in selected or not any(
+        name.startswith(f"{_PROTOTYPE_NAME}/") for name in selected
+    ):
+        raise ValueError("checkpoint is missing a required semantic child")
+    encoded: dict[str, dict[str, Any]] = {}
+    for name, path in sorted(selected.items()):
+        digest, size = _sha256_file(path)
+        encoded[name] = {"sha256": digest, "size": size}
+    return {
+        "schema": REFERENCE_LIFE_CHECKPOINT_HASHES_SCHEMA,
+        "files": encoded,
+    }
+
+
+def _verify_child_hashes(root: Path, value: Any) -> None:
+    data = _require_keys(value, {"schema", "files"}, path="manifest.children")
+    if _require_str(data["schema"], path="manifest.children.schema") != (
+        REFERENCE_LIFE_CHECKPOINT_HASHES_SCHEMA
+    ):
+        _fail("manifest.children.schema is unsupported")
+    files_raw = data["files"]
+    if type(files_raw) is not dict:
+        _fail("manifest.children.files must be an object")
+    if len(files_raw) > _MAX_INVENTORY_FILES:
+        _fail("manifest.children.files exceeds the inventory limit")
+    declared: dict[str, tuple[str, int]] = {}
+    for name, raw in cast(dict[str, Any], files_raw).items():
+        if (
+            type(name) is not str
+            or not name
+            or name.startswith("/")
+            or ".." in Path(name).parts
+            or name == _MANIFEST_NAME
+            or name == _COMMITTED_NAME
+        ):
+            _fail("manifest.children contains an unsafe path")
+        if len(name.encode("utf-8")) > _MAX_PATH_BYTES:
+            _fail("manifest.children contains an overlong path")
+        entry = _require_keys(raw, {"sha256", "size"}, path=f"manifest.children.files.{name}")
+        declared[name] = (
+            _require_digest(entry["sha256"], path=f"manifest.children.files.{name}.sha256"),
+            _require_int(entry["size"], path=f"manifest.children.files.{name}.size"),
+        )
+    actual = _child_hashes(root)["files"]
+    actual_pairs = {
+        name: (entry["sha256"], entry["size"])
+        for name, entry in cast(dict[str, dict[str, Any]], actual).items()
+    }
+    if declared != actual_pairs:
+        _fail("checkpoint child inventory or content hash does not match")
+
+
+def _fsync_tree(root: Path) -> None:
+    files = _walk_regular_files(root)
+    for path in files.values():
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    directories = [root, *(path for path in root.rglob("*") if path.is_dir())]
+    for directory in sorted(directories, key=lambda item: len(item.parts), reverse=True):
+        descriptor = os.open(
+            directory,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+_MANIFEST_PAYLOAD_KEYS = {
+    "schema",
+    "state_schema",
+    "prototype_schema",
+    "checkpoint_generation",
+    "config_sha256",
+    "life_config",
+    "source_identity",
+    "runtime_identity",
+    "dependency_identity",
+    "children",
+}
+_MANIFEST_KEYS = {*_MANIFEST_PAYLOAD_KEYS, "bundle_id"}
+_PROTOTYPE_METADATA_KEYS = {
+    "schema",
+    "agent_config",
+    "config_sha256",
+    "empty_array_codec",
+    "prng_impl",
+}
+_PROTOTYPE_RAW_METADATA_KEYS = {*_PROTOTYPE_METADATA_KEYS, "_format_version"}
+
+
+def _load_raw_prototype_metadata(path: Path) -> dict[str, Any]:
+    """Strictly parse Orbax JSON without requiring its incidental formatting."""
+
+    raw = _read_bounded_json_file(path)
+    try:
+        value = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("nested Prototype metadata is not valid bounded JSON") from exc
+    data = _require_keys(
+        value,
+        _PROTOTYPE_RAW_METADATA_KEYS,
+        path="prototype.metadata",
+    )
+    if (
+        _require_int(
+            data["_format_version"],
+            path="prototype.metadata._format_version",
+        )
+        != 2
+    ):
+        _fail("nested Prototype metadata format version is unsupported")
+    if _require_str(data["schema"], path="prototype.metadata.schema") != (
+        PROTOTYPE_CHECKPOINT_SCHEMA
+    ):
+        _fail("nested Prototype checkpoint is not exact current v3")
+    agent_config = data["agent_config"]
+    if type(agent_config) is not dict:
+        _fail("prototype.metadata.agent_config must be an object")
+    expected_config_digest = hashlib.sha256(
+        json.dumps(
+            agent_config,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    if (
+        _require_digest(
+            data["config_sha256"],
+            path="prototype.metadata.config_sha256",
+        )
+        != expected_config_digest
+    ):
+        _fail("nested Prototype metadata config digest does not match")
+    if (
+        _require_str(
+            data["empty_array_codec"],
+            path="prototype.metadata.empty_array_codec",
+        )
+        != _PROTOTYPE_EMPTY_ARRAY_CODEC
+    ):
+        _fail("nested Prototype metadata uses an unknown empty-array codec")
+    if _require_str(data["prng_impl"], path="prototype.metadata.prng_impl") not in (
+        _PROTOTYPE_SUPPORTED_PRNG_IMPLS
+    ):
+        _fail("nested Prototype metadata uses an unsupported PRNG implementation")
+    return {name: data[name] for name in _PROTOTYPE_METADATA_KEYS}
+
+
+def _bundle_id(payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+def _manifest_payload(
+    *,
+    runner: ReferenceLifeRunner,
+    state: ReferenceLifeState,
+    root: Path,
+) -> dict[str, Any]:
+    return {
+        "schema": REFERENCE_LIFE_CHECKPOINT_SCHEMA,
+        "state_schema": REFERENCE_LIFE_CHECKPOINT_STATE_SCHEMA,
+        "prototype_schema": PROTOTYPE_CHECKPOINT_SCHEMA,
+        "checkpoint_generation": state.checkpoint_generation,
+        "config_sha256": runner.config.config_sha256,
+        "life_config": runner.config.config,
+        "source_identity": _source_identity(),
+        "runtime_identity": _runtime_identity(),
+        "dependency_identity": _dependency_identity(),
+        "children": _child_hashes(root),
+    }
+
+
+def _validate_identity(value: Any, expected: dict[str, Any], *, path: str) -> None:
+    if type(value) is not dict:
+        _fail(f"{path} must be an object")
+    if path == "manifest.source_identity":
+        source = _require_keys(value, {"schema", "scope", "files"}, path=path)
+        files = source["files"]
+        if type(files) is not dict or len(files) > _MAX_INVENTORY_FILES:
+            _fail(f"{path}.files exceeds the inventory limit")
+        for name in cast(dict[str, Any], files):
+            if len(name.encode("utf-8")) > _MAX_PATH_BYTES:
+                _fail(f"{path}.files contains an overlong path")
+    if value != expected:
+        _fail(f"{path} does not match the current checkpoint-time identity")
+
+
+def _validate_root(root: Path) -> None:
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError("checkpoint root must be a real directory, not a symlink")
+    expected = {_MANIFEST_NAME, _STATE_NAME, _PROTOTYPE_NAME, _COMMITTED_NAME}
+    with os.scandir(root) as entries:
+        actual = {entry.name for entry in entries}
+    if actual != expected:
+        raise ValueError("checkpoint root entries do not match the bundle schema")
+    for name in (_MANIFEST_NAME, _STATE_NAME, _COMMITTED_NAME):
+        path = root / name
+        if path.is_symlink() or not path.is_file():
+            raise ValueError(f"checkpoint {name} must be a regular file")
+    prototype = root / _PROTOTYPE_NAME
+    if prototype.is_symlink() or not prototype.is_dir():
+        raise ValueError("checkpoint prototype child must be a real directory")
+    _walk_regular_files(root)
+
+
+def _trees_exact(left: Any, right: Any) -> bool:
+    left_leaves, left_structure = jax.tree_util.tree_flatten(left)
+    right_leaves, right_structure = jax.tree_util.tree_flatten(right)
+    if cast(Any, left_structure) != right_structure or len(left_leaves) != len(right_leaves):
+        return False
+    for left_leaf, right_leaf in zip(left_leaves, right_leaves, strict=True):
+        if not isinstance(left_leaf, jax.Array) or not isinstance(right_leaf, jax.Array):
+            return False
+        if left_leaf.shape != right_leaf.shape or left_leaf.dtype != right_leaf.dtype:
+            return False
+        if jax.dtypes.issubdtype(  # type: ignore[attr-defined]
+            left_leaf.dtype, jax.dtypes.prng_key
+        ):
+            if str(jax.random.key_impl(left_leaf)) != str(jax.random.key_impl(right_leaf)):
+                return False
+            left_array = np.asarray(jax.random.key_data(left_leaf))
+            right_array = np.asarray(jax.random.key_data(right_leaf))
+            if (
+                left_array.dtype != right_array.dtype
+                or left_array.shape != right_array.shape
+                or left_array.tobytes(order="C") != right_array.tobytes(order="C")
+            ):
+                return False
+        else:
+            left_array = np.asarray(left_leaf)
+            right_array = np.asarray(right_leaf)
+            if left_array.tobytes(order="C") != right_array.tobytes(order="C"):
+                return False
+    return True
+
+
+def _rename_noreplace(source: Path, target: Path) -> None:
+    """Atomically publish one directory without replacing any existing entry."""
+
+    if sys.platform != "linux":
+        raise OSError(errno.ENOTSUP, "atomic no-replace rename requires Linux renameat2")
+    library = ctypes.CDLL(None, use_errno=True)
+    try:
+        renameat2 = library.renameat2
+    except AttributeError as exc:
+        raise OSError(errno.ENOTSUP, "libc does not expose renameat2") from exc
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    result = renameat2(
+        -100,
+        os.fsencode(source),
+        -100,
+        os.fsencode(target),
+        1,
+    )
+    if result != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error), target)
+
+
+def _semantic_states_exact(left: ReferenceLifeState, right: ReferenceLifeState) -> bool:
+    if _encode_state(left) != _encode_state(right):
+        return False
+    left_wrapper = cast(PrototypeReferenceState, left.agent_state)
+    right_wrapper = cast(PrototypeReferenceState, right.agent_state)
+    return _trees_exact(left_wrapper.agent_state, right_wrapper.agent_state)
+
+
+def _snapshot_checkpoint(source: Path) -> Path:
+    """Copy an untrusted bundle into one bounded, private, stable directory."""
+
+    snapshot = Path(tempfile.mkdtemp(prefix=".reference-life-restore-"))
+    source_descriptor = -1
+    destination_descriptor = -1
+    entries_seen = 0
+    total_bytes = 0
+    try:
+        source_descriptor = os.open(
+            source,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        destination_descriptor = os.open(
+            snapshot,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+
+        def copy_directory(
+            source_fd: int,
+            destination_fd: int,
+            *,
+            relative: str,
+            depth: int,
+        ) -> None:
+            nonlocal entries_seen, total_bytes
+            if depth > _MAX_TREE_DEPTH:
+                raise ValueError("checkpoint directory tree exceeds its depth limit")
+            with os.scandir(source_fd) as entries:
+                for entry in entries:
+                    entries_seen += 1
+                    if entries_seen > _MAX_INVENTORY_FILES:
+                        raise ValueError("checkpoint directory tree exceeds its entry limit")
+                    name = entry.name
+                    child_relative = f"{relative}/{name}" if relative else name
+                    if len(child_relative.encode("utf-8")) > _MAX_PATH_BYTES:
+                        raise ValueError("checkpoint directory tree contains an overlong path")
+                    if entry.is_symlink():
+                        raise ValueError(f"checkpoint cannot contain symlink {child_relative!r}")
+                    if entry.is_dir(follow_symlinks=False):
+                        child_source = os.open(
+                            name,
+                            os.O_RDONLY
+                            | getattr(os, "O_DIRECTORY", 0)
+                            | getattr(os, "O_NOFOLLOW", 0),
+                            dir_fd=source_fd,
+                        )
+                        os.mkdir(name, mode=0o700, dir_fd=destination_fd)
+                        child_destination = os.open(
+                            name,
+                            os.O_RDONLY
+                            | getattr(os, "O_DIRECTORY", 0)
+                            | getattr(os, "O_NOFOLLOW", 0),
+                            dir_fd=destination_fd,
+                        )
+                        try:
+                            copy_directory(
+                                child_source,
+                                child_destination,
+                                relative=child_relative,
+                                depth=depth + 1,
+                            )
+                        finally:
+                            os.close(child_source)
+                            os.close(child_destination)
+                        continue
+                    if not entry.is_file(follow_symlinks=False):
+                        raise ValueError(
+                            f"checkpoint contains non-regular entry {child_relative!r}"
+                        )
+                    child_source = os.open(
+                        name,
+                        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                        dir_fd=source_fd,
+                    )
+                    try:
+                        metadata = os.fstat(child_source)
+                        if not stat_module.S_ISREG(metadata.st_mode):
+                            raise ValueError(
+                                f"checkpoint contains non-regular entry {child_relative!r}"
+                            )
+                        if metadata.st_size > _MAX_CHILD_FILE_BYTES:
+                            raise ValueError(
+                                f"checkpoint child exceeds its byte limit: {child_relative}"
+                            )
+                        total_bytes += metadata.st_size
+                        if total_bytes > _MAX_CHILD_TOTAL_BYTES:
+                            raise ValueError("checkpoint children exceed their total byte limit")
+                        child_destination = os.open(
+                            name,
+                            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+                            0o600,
+                            dir_fd=destination_fd,
+                        )
+                        copied = 0
+                        try:
+                            while True:
+                                chunk = os.read(
+                                    child_source,
+                                    min(
+                                        1024 * 1024,
+                                        _MAX_CHILD_FILE_BYTES - copied + 1,
+                                    ),
+                                )
+                                if not chunk:
+                                    break
+                                copied += len(chunk)
+                                if copied > _MAX_CHILD_FILE_BYTES:
+                                    raise ValueError("checkpoint child grew beyond its byte limit")
+                                view = memoryview(chunk)
+                                while view:
+                                    written = os.write(child_destination, view)
+                                    view = view[written:]
+                            if copied != metadata.st_size:
+                                raise ValueError(
+                                    f"checkpoint child changed while copied: {child_relative}"
+                                )
+                            os.fsync(child_destination)
+                        finally:
+                            os.close(child_destination)
+                    finally:
+                        os.close(child_source)
+
+        copy_directory(
+            source_descriptor,
+            destination_descriptor,
+            relative="",
+            depth=0,
+        )
+        os.fsync(destination_descriptor)
+        return snapshot
+    except Exception:
+        shutil.rmtree(snapshot, ignore_errors=True)
+        raise
+    finally:
+        if source_descriptor >= 0:
+            os.close(source_descriptor)
+        if destination_descriptor >= 0:
+            os.close(destination_descriptor)
+
+
+def _restore_owned_bundle(root: Path) -> tuple[ReferenceLifeRunner, ReferenceLifeState]:
+    _validate_root(root)
+    manifest = _load_canonical_json(root / _MANIFEST_NAME)
+    manifest_data = _require_keys(manifest, _MANIFEST_KEYS, path="manifest")
+    if _require_str(manifest_data["schema"], path="manifest.schema") != (
+        REFERENCE_LIFE_CHECKPOINT_SCHEMA
+    ):
+        _fail("manifest.schema is unsupported")
+    if _require_str(manifest_data["state_schema"], path="manifest.state_schema") != (
+        REFERENCE_LIFE_CHECKPOINT_STATE_SCHEMA
+    ):
+        _fail("manifest.state_schema is unsupported")
+    if (
+        _require_str(manifest_data["prototype_schema"], path="manifest.prototype_schema")
+        != PROTOTYPE_CHECKPOINT_SCHEMA
+    ):
+        _fail("manifest.prototype_schema must be the exact current Prototype v3 schema")
+    bundle_id = _require_digest(manifest_data["bundle_id"], path="manifest.bundle_id")
+    payload = {name: manifest_data[name] for name in _MANIFEST_PAYLOAD_KEYS}
+    if bundle_id != _bundle_id(payload):
+        _fail("manifest bundle_id does not match its canonical payload")
+    marker = (root / _COMMITTED_NAME).read_bytes()
+    if marker != f"{bundle_id}\n".encode("ascii"):
+        _fail("checkpoint COMMITTED marker is missing or inconsistent")
+
+    _validate_identity(
+        manifest_data["source_identity"],
+        _source_identity(),
+        path="manifest.source_identity",
+    )
+    _validate_identity(
+        manifest_data["runtime_identity"],
+        _runtime_identity(),
+        path="manifest.runtime_identity",
+    )
+    _validate_identity(
+        manifest_data["dependency_identity"],
+        _dependency_identity(),
+        path="manifest.dependency_identity",
+    )
+    _verify_child_hashes(root, manifest_data["children"])
+
+    runner, prototype_config = _build_runner(manifest_data["life_config"])
+    config_sha256 = _require_digest(manifest_data["config_sha256"], path="manifest.config_sha256")
+    if runner.config.config_sha256 != config_sha256:
+        _fail("manifest configuration digest is inconsistent")
+    generation = _require_int(
+        manifest_data["checkpoint_generation"],
+        path="manifest.checkpoint_generation",
+        minimum=1,
+    )
+
+    prototype_path = root / _PROTOTYPE_NAME
+    raw_prototype_metadata = _load_raw_prototype_metadata(prototype_path / "metadata" / "metadata")
+    if raw_prototype_metadata["agent_config"] != prototype_config:
+        _fail("nested Prototype configuration differs from the life binding")
+    prototype_metadata = load_checkpoint_metadata(prototype_path)
+    if set(prototype_metadata) != _PROTOTYPE_METADATA_KEYS:
+        _fail("nested Prototype checkpoint metadata fields are not exact current v3")
+    if prototype_metadata != raw_prototype_metadata:
+        _fail("Orbax did not preserve the exact nested Prototype metadata object")
+    if prototype_metadata.get("schema") != PROTOTYPE_CHECKPOINT_SCHEMA:
+        _fail("nested Prototype checkpoint is not exact current v3")
+    if prototype_metadata.get("agent_config") != prototype_config:
+        _fail("nested Prototype configuration differs from the life binding")
+    prototype_agent, prototype_state = load_prototype_checkpoint(prototype_path)
+    if prototype_agent.to_config() != prototype_config:
+        _fail("restored Prototype configuration differs from the life binding")
+    state_json = _load_canonical_json(root / _STATE_NAME)
+    state = _decode_state(state_json, runner=runner, prototype_state=prototype_state)
+    if state.config_sha256 != config_sha256:
+        _fail("life state configuration digest differs from the manifest")
+    if state.checkpoint_generation != generation:
+        _fail("life state checkpoint generation differs from the manifest")
+    # The source was copied into an owned mode-0700 snapshot before reaching
+    # this function. Rechecking every child after all semantic reads nevertheless
+    # detects an accidental same-process mutation during nested Orbax/state load.
+    _verify_child_hashes(root, manifest_data["children"])
+    runner.adopt_checkpoint_state(state)
+    return runner, state
+
+
+def save_reference_life_checkpoint(
+    runner: ReferenceLifeRunner,
+    state: ReferenceLifeState,
+    parent: str | Path,
+) -> tuple[ReferenceLifeState, Path]:
+    """Atomically publish a new immutable quiescent whole-life generation."""
+
+    if not isinstance(runner, ReferenceLifeRunner):
+        raise TypeError("runner must be a ReferenceLifeRunner")
+    parent_path = Path(parent).absolute()
+    markers = (_MANIFEST_NAME, _STATE_NAME, _PROTOTYPE_NAME, _COMMITTED_NAME)
+
+    def reject_bundle_destination() -> None:
+        try:
+            resolved_parent = parent_path.resolve(strict=False)
+        except (OSError, RuntimeError) as exc:
+            raise ValueError("checkpoint parent path cannot be resolved safely") from exc
+        candidates = (parent_path, resolved_parent)
+        for candidate in candidates:
+            proposed_markers = tuple(os.path.lexists(candidate / marker) for marker in markers)
+            if any(proposed_markers):
+                raise ValueError("checkpoint parent cannot be an existing bundle root")
+            for ancestor in candidate.parents:
+                if all(os.path.lexists(ancestor / marker) for marker in markers):
+                    raise ValueError("checkpoint parent cannot be inside an existing bundle root")
+
+    def publish(
+        candidate: ReferenceLifeState,
+        install_committed_candidate: Any,
+    ) -> Path:
+        # checkpoint_barrier invokes this callback while holding the runner lock,
+        # after current-state and quiescence validation. Keep every filesystem
+        # mutation inside that same transaction so a racing step cannot stale the
+        # candidate after a separate preflight has already created store entries.
+        reject_bundle_destination()
+        if os.path.lexists(parent_path):
+            if parent_path.is_symlink() or not parent_path.is_dir():
+                raise ValueError("checkpoint parent must be a real directory")
+        else:
+            parent_path.mkdir(parents=True, exist_ok=False)
+        if parent_path.is_symlink() or not parent_path.is_dir():
+            raise ValueError("checkpoint parent must be a real directory")
+        reject_bundle_destination()
+
+        lock_path = parent_path / ".reference-life-checkpoint.lock"
+        lock_descriptor = -1
+        parent_descriptor = -1
+        try:
+            lock_descriptor = os.open(
+                lock_path,
+                os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+            )
+            if not stat_module.S_ISREG(os.fstat(lock_descriptor).st_mode):
+                raise ValueError("checkpoint lock must be a regular file")
+            parent_descriptor = os.open(
+                parent_path,
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+            )
+            fcntl.flock(lock_descriptor, fcntl.LOCK_EX)
+            reject_bundle_destination()
+            generation_name = f"generation-{candidate.checkpoint_generation:0{_GENERATION_WIDTH}d}"
+            target = parent_path / generation_name
+            if os.path.lexists(target):
+                raise FileExistsError(f"checkpoint generation already exists: {target}")
+            staging = Path(tempfile.mkdtemp(prefix=f".{generation_name}.staging-", dir=parent_path))
+            renamed = False
+            try:
+                wrapper = candidate.agent_state
+                if not isinstance(wrapper, PrototypeReferenceState):
+                    raise ValueError("checkpoint candidate lacks Prototype wrapper state")
+                adapter = runner.agent_adapter
+                if not isinstance(adapter, PrototypeReferenceAdapter):
+                    raise ValueError("checkpoint runner does not use Prototype adapter")
+                save_prototype_checkpoint(
+                    PrototypeAgent(adapter.config),
+                    wrapper.agent_state,
+                    staging / _PROTOTYPE_NAME,
+                )
+                encoded_state = _encode_state(candidate)
+                encoded_environment = cast(
+                    dict[str, Any], encoded_state["environment"]
+                )
+                live_environment_manifest = runner.environment_adapter.manifest
+                if (
+                    encoded_environment["implementation_id"]
+                    != live_environment_manifest.implementation_id
+                    or encoded_environment["schema"]
+                    != live_environment_manifest.state_schema
+                ):
+                    raise ValueError(
+                        "checkpoint environment state discriminator differs from live manifest"
+                    )
+                _write_new(
+                    staging / _STATE_NAME,
+                    _canonical_json_bytes(encoded_state),
+                )
+                payload = _manifest_payload(runner=runner, state=candidate, root=staging)
+                bundle_id = _bundle_id(payload)
+                manifest = {**payload, "bundle_id": bundle_id}
+                _write_new(staging / _MANIFEST_NAME, _canonical_json_bytes(manifest))
+                _write_new(staging / _COMMITTED_NAME, f"{bundle_id}\n".encode("ascii"))
+                _fsync_tree(staging)
+
+                restored_runner, restored_state = _restore_owned_bundle(staging)
+                if restored_runner.config != runner.config or not _semantic_states_exact(
+                    restored_state, candidate
+                ):
+                    raise ValueError("staged checkpoint failed exact semantic self-validation")
+                if os.path.lexists(target):
+                    raise FileExistsError(f"checkpoint generation already exists: {target}")
+                _rename_noreplace(staging, target)
+                install_committed_candidate()
+                renamed = True
+                # The rename already made the generation visible and the runner now
+                # owns its barrier state. A parent-directory fsync error cannot be
+                # reported as an uncommitted save after that atomic visibility point.
+                try:
+                    os.fsync(parent_descriptor)
+                except OSError:
+                    pass
+                return target
+            finally:
+                if not renamed:
+                    shutil.rmtree(staging, ignore_errors=True)
+        finally:
+            if lock_descriptor >= 0:
+                try:
+                    fcntl.flock(lock_descriptor, fcntl.LOCK_UN)
+                except OSError:
+                    pass
+                try:
+                    os.close(lock_descriptor)
+                except OSError:
+                    pass
+            if parent_descriptor >= 0:
+                try:
+                    os.close(parent_descriptor)
+                except OSError:
+                    pass
+
+    return runner.checkpoint_barrier(state, publish)
+
+
+def load_reference_life_checkpoint(
+    path: str | Path,
+) -> tuple[ReferenceLifeRunner, ReferenceLifeState]:
+    """Validate and adopt one exact current-schema whole-life generation."""
+
+    snapshot = _snapshot_checkpoint(Path(path).absolute())
+    try:
+        return _restore_owned_bundle(snapshot)
+    finally:
+        shutil.rmtree(snapshot, ignore_errors=True)
+
+
+__all__ = [
+    "REFERENCE_LIFE_CHECKPOINT_SCHEMA",
+    "REFERENCE_LIFE_CHECKPOINT_STATE_SCHEMA",
+    "load_reference_life_checkpoint",
+    "save_reference_life_checkpoint",
+]

--- a/alberta_framework/reference_life_controls.py
+++ b/alberta_framework/reference_life_controls.py
@@ -1,0 +1,2155 @@
+"""Development-only exact-dispatch controls for the reference-life runner.
+
+These adapters are matched development controls, not ``reference-dev``, a
+checkpoint surface, or scientific evidence.  They intentionally support only
+the primitive continuing one-hot/discrete slices used by
+``SwitchingTwoStateMDP`` and ``RiverSwimMDP``.  Every live state is immutable
+and bound to one process-local adapter owner.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import math
+import re
+from numbers import Real
+from typing import Any, Literal, cast
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+from jax import Array
+
+from alberta_framework.core.average_reward import (
+    DifferentialSARSAAgent,
+    DifferentialSARSAConfig,
+    DifferentialSARSAState,
+)
+from alberta_framework.core.sarsa import SARSAAgent, SARSAConfig, SARSAState
+from alberta_framework.core.types import LMSState
+from alberta_framework.reference_agent import (
+    MAX_DECISION_INDEX,
+    REFERENCE_AGENT_MANIFEST_SCHEMA,
+    AgentCapabilities,
+    AgentManifest,
+    ArrayValue,
+    AuthorizationStatus,
+    Decision,
+    DecisionOwnershipError,
+    DispatchAuthorization,
+    DispatchStatus,
+    ReferenceAgentUpdate,
+    SpaceSpec,
+    Transaction,
+    canonical_config_sha256,
+)
+from alberta_framework.reference_life import REFERENCE_LIFE_PRNG_IMPLEMENTATION
+from alberta_framework.streams.closed_loop import (
+    RiverSwimConfig,
+    RiverSwimMDP,
+    SwitchingTwoStateConfig,
+    SwitchingTwoStateMDP,
+)
+
+# All selected simulators use signed-int32 transition counters.  An accepted
+# event at this capacity leaves decision ``int32.max`` armed, but no selected
+# life may request another transition.
+REFERENCE_CONTROL_MAX_ACCEPTED_EVENTS = int(np.iinfo(np.int32).max)
+REFERENCE_CONTROL_CONFIG_SCHEMA = "asi.reference_life_control_config.preview1"
+REFERENCE_CONTROL_OBSERVATION_SEMANTIC_ID = (
+    "asi.reference_life_control.one_hot_observation.preview1"
+)
+REFERENCE_CONTROL_ACTION_SEMANTIC_ID = (
+    "asi.reference_life_control.primitive_action.preview1"
+)
+
+UNIFORM_RANDOM_IMPLEMENTATION_ID = "asi.uniform_random_exact_control.preview1"
+UNIFORM_RANDOM_STATE_SCHEMA = "asi.uniform_random_exact_control_state.preview1"
+ANALYTIC_ORACLE_IMPLEMENTATION_ID = "asi.analytic_oracle_exact_control.preview1"
+ANALYTIC_ORACLE_STATE_SCHEMA = "asi.analytic_oracle_exact_control_state.preview1"
+DIFFERENTIAL_SARSA_IMPLEMENTATION_ID = "asi.differential_sarsa_exact_control.preview1"
+DIFFERENTIAL_SARSA_STATE_SCHEMA = "asi.differential_sarsa_exact_control_state.preview1"
+DISCOUNTED_SARSA_IMPLEMENTATION_ID = "asi.discounted_sarsa_exact_control.preview1"
+DISCOUNTED_SARSA_STATE_SCHEMA = "asi.discounted_sarsa_exact_control_state.preview1"
+
+_RIVERSWIM_REFERENCE_MAX_STATES = 12
+_INT32_MAX = int(np.iinfo(np.int32).max)
+_FLOAT32_MAX = float(np.finfo(np.float32).max)
+_MAX_HIDDEN_LAYERS = 32
+_MAX_HIDDEN_WIDTH = 4096
+_MAX_NETWORK_PARAMETERS = 1 << 20
+_MAX_ORACLE_HORIZON = 100_000
+_THREEFRY_IMPLEMENTATION = REFERENCE_LIFE_PRNG_IMPLEMENTATION
+_SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9._:-]*$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_MAX_ID_LENGTH = 256
+_RANDOM_DOMAIN = 0x4354524C
+
+EnvironmentKind = Literal["switching_two_state", "riverswim"]
+
+
+def _require_environment_shape(
+    environment_kind: EnvironmentKind,
+    observation_dim: int,
+    n_actions: int,
+) -> None:
+    if environment_kind not in ("switching_two_state", "riverswim"):
+        raise ValueError("environment_kind must be switching_two_state or riverswim")
+    if (
+        isinstance(observation_dim, bool)
+        or not isinstance(observation_dim, int)
+        or observation_dim < 2
+    ):
+        raise ValueError("observation_dim must be an integer of at least two")
+    if environment_kind == "switching_two_state" and observation_dim != 2:
+        raise ValueError("SwitchingTwoState controls require observation_dim == 2")
+    if environment_kind == "riverswim" and observation_dim > _RIVERSWIM_REFERENCE_MAX_STATES:
+        raise ValueError(
+            "RiverSwim controls require observation_dim <= "
+            f"{_RIVERSWIM_REFERENCE_MAX_STATES}"
+        )
+    if isinstance(n_actions, bool) or not isinstance(n_actions, int) or n_actions != 2:
+        raise ValueError("selected reference controls require exactly two actions")
+
+
+def _nonnegative_int(value: Any, *, name: str, maximum: int = _INT32_MAX) -> int:
+    if type(value) is not int or value < 0 or value > maximum:
+        raise ValueError(f"{name} must be a nonnegative integer within int32 capacity")
+    return value
+
+
+def _canonical_float32(
+    value: Any,
+    *,
+    name: str,
+    minimum: float = -_FLOAT32_MAX,
+    maximum: float = _FLOAT32_MAX,
+    minimum_inclusive: bool = True,
+    maximum_inclusive: bool = True,
+) -> float:
+    """Return the actual executed float32 value after checking both domains."""
+
+    if not isinstance(value, Real) or isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a real non-boolean float32 scalar")
+    try:
+        raw = float(value)
+        with np.errstate(over="ignore", invalid="ignore", under="ignore"):
+            converted = float(np.float32(raw))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite float32 value") from exc
+    if not math.isfinite(raw) or not math.isfinite(converted):
+        raise ValueError(f"{name} must be a finite float32 value")
+
+    def in_bounds(candidate: float) -> bool:
+        lower_ok = candidate >= minimum if minimum_inclusive else candidate > minimum
+        upper_ok = candidate <= maximum if maximum_inclusive else candidate < maximum
+        return lower_ok and upper_ok
+
+    if not in_bounds(raw):
+        left = "[" if minimum_inclusive else "("
+        right = "]" if maximum_inclusive else ")"
+        raise ValueError(
+            f"{name} must remain in {left}{minimum}, {maximum}{right} as float32"
+        )
+    if not minimum_inclusive and raw > minimum and converted == minimum:
+        raise ValueError(f"{name} must not collapse to its strict float32 lower bound")
+    if not maximum_inclusive and raw < maximum and converted == maximum:
+        raise ValueError(f"{name} must not round to its strict float32 upper bound")
+    if not in_bounds(converted):
+        left = "[" if minimum_inclusive else "("
+        right = "]" if maximum_inclusive else ")"
+        raise ValueError(
+            f"{name} must remain in {left}{minimum}, {maximum}{right} as float32"
+        )
+    # Canonicalize both spellings of zero to the same manifest/config value.
+    return 0.0 if converted == 0.0 else converted
+
+
+def _canonical_payoff_matrix(value: Any, *, name: str) -> np.ndarray[Any, Any]:
+    try:
+        source = np.asarray(value, dtype=object)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("switching payoffs must be numeric 2x2 matrices") from exc
+    if source.shape != (2, 2):
+        raise ValueError("switching payoffs must be 2x2 matrices")
+    result = np.empty((2, 2), dtype=np.float32)
+    for index in np.ndindex(source.shape):
+        result[index] = _canonical_float32(source[index], name=f"{name}{index}")
+    return result
+
+
+def _canonical_hidden_sizes(
+    value: Any,
+    *,
+    observation_dim: int,
+    n_actions: int,
+) -> tuple[int, ...]:
+    if not isinstance(value, (tuple, list)):
+        raise ValueError("hidden_sizes must be a bounded tuple or list")
+    if len(value) > _MAX_HIDDEN_LAYERS:
+        raise ValueError(f"hidden_sizes must contain at most {_MAX_HIDDEN_LAYERS} layers")
+    hidden_sizes = tuple(value)
+    if any(
+        type(size) is not int or size <= 0 or size > min(_INT32_MAX, _MAX_HIDDEN_WIDTH)
+        for size in hidden_sizes
+    ):
+        raise ValueError(
+            "hidden_sizes must contain positive int32 widths no greater than "
+            f"{_MAX_HIDDEN_WIDTH}"
+        )
+    layer_inputs = (observation_dim, *hidden_sizes[:-1]) if hidden_sizes else ()
+    parameter_count = sum(
+        fan_in * fan_out + fan_out
+        for fan_in, fan_out in zip(layer_inputs, hidden_sizes, strict=True)
+    )
+    final_width = hidden_sizes[-1] if hidden_sizes else observation_dim
+    parameter_count += n_actions * (final_width + 1)
+    if parameter_count > _MAX_NETWORK_PARAMETERS:
+        raise ValueError(
+            "discounted-SARSA network parameter resource bound exceeded: "
+            f"{parameter_count} > {_MAX_NETWORK_PARAMETERS}"
+        )
+    return hidden_sizes
+
+
+def _canonical_json(value: dict[str, Any]) -> str:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _canonical_switching_environment(
+    config: SwitchingTwoStateConfig,
+) -> tuple[dict[str, Any], int]:
+    if not isinstance(config, SwitchingTwoStateConfig):
+        raise ValueError("switching environment config has the wrong type")
+    phase_length = config.phase_length
+    if (
+        isinstance(phase_length, bool)
+        or not isinstance(phase_length, int)
+        or phase_length <= 0
+        or phase_length > REFERENCE_CONTROL_MAX_ACCEPTED_EVENTS
+    ):
+        raise ValueError("phase_length must lie within signed-int32 capacity")
+    payoffs_a = _canonical_payoff_matrix(config.payoffs_a, name="payoffs_a")
+    payoffs_b = _canonical_payoff_matrix(config.payoffs_b, name="payoffs_b")
+    canonical = SwitchingTwoStateConfig(  # type: ignore[call-arg]
+        phase_length=phase_length,
+        payoffs_a=tuple(tuple(float(value) for value in row) for row in payoffs_a),
+        payoffs_b=tuple(tuple(float(value) for value in row) for row in payoffs_b),
+    )
+    # Retain the kernel validation as part of the same config gate.
+    SwitchingTwoStateMDP(canonical)
+    payload = {
+        "phase_length": phase_length,
+        "payoffs_a": [list(row) for row in canonical.payoffs_a],
+        "payoffs_b": [list(row) for row in canonical.payoffs_b],
+    }
+    return payload, phase_length
+
+
+def _canonical_riverswim_environment(
+    config: RiverSwimConfig,
+) -> dict[str, Any]:
+    if not isinstance(config, RiverSwimConfig):
+        raise ValueError("RiverSwim environment config has the wrong type")
+    n_states = config.n_states
+    if (
+        isinstance(n_states, bool)
+        or not isinstance(n_states, int)
+        or n_states < 2
+        or n_states > _RIVERSWIM_REFERENCE_MAX_STATES
+    ):
+        raise ValueError(
+            "RiverSwim n_states must lie in "
+            f"[2, {_RIVERSWIM_REFERENCE_MAX_STATES}]"
+        )
+    initial_state = config.initial_state
+    if (
+        isinstance(initial_state, bool)
+        or not isinstance(initial_state, int)
+        or initial_state < 0
+        or initial_state >= n_states
+    ):
+        raise ValueError("RiverSwim initial_state is outside the configured chain")
+    p_right_up = _canonical_float32(
+        config.p_right_up,
+        name="p_right_up",
+        minimum=0.0,
+        maximum=1.0,
+        minimum_inclusive=False,
+    )
+    p_right_down = _canonical_float32(
+        config.p_right_down,
+        name="p_right_down",
+        minimum=0.0,
+        maximum=1.0,
+        minimum_inclusive=False,
+    )
+    reward_left = _canonical_float32(config.reward_left, name="reward_left")
+    reward_right = _canonical_float32(config.reward_right, name="reward_right")
+    if p_right_up + p_right_down > 1.0:
+        raise ValueError("RiverSwim right-transition probabilities must sum to at most one")
+    canonical = RiverSwimConfig(  # type: ignore[call-arg]
+        n_states=n_states,
+        p_right_up=p_right_up,
+        p_right_down=p_right_down,
+        reward_left=reward_left,
+        reward_right=reward_right,
+        initial_state=initial_state,
+    )
+    RiverSwimMDP(canonical)
+    payload = {
+        "n_states": n_states,
+        "p_right_up": p_right_up,
+        "p_right_down": p_right_down,
+        "reward_left": reward_left,
+        "reward_right": reward_right,
+        "initial_state": initial_state,
+    }
+    return payload
+
+
+def _canonical_oracle_horizon(value: Any) -> int:
+    if type(value) is not int or not 1 <= value <= _MAX_ORACLE_HORIZON:
+        raise ValueError(
+            f"analytic-oracle horizon must lie in [1, {_MAX_ORACLE_HORIZON}]"
+        )
+    return value
+
+
+def _finite_horizon_oracle_policy(
+    *,
+    environment_kind: EnvironmentKind,
+    environment_config: dict[str, Any],
+    horizon: int,
+) -> np.ndarray[Any, np.dtype[np.int32]]:
+    """Solve the exact selected finite-horizon control problem backwards.
+
+    Values are accumulated in float64 from the simulator's canonical float32
+    rewards and transition tensor. ``np.argmax`` supplies the declared
+    lowest-action tie break.  The resulting policy is indexed by accepted
+    decision index and observed state.
+    """
+
+    horizon = _canonical_oracle_horizon(horizon)
+    if environment_kind == "switching_two_state":
+        phase_length = cast(int, environment_config["phase_length"])
+        payoffs = np.asarray(
+            (
+                environment_config["payoffs_a"],
+                environment_config["payoffs_b"],
+            ),
+            dtype=np.float32,
+        ).astype(np.float64)
+        value = np.zeros(2, dtype=np.float64)
+        policy = np.zeros((horizon + 1, 2), dtype=np.int32)
+        for index in range(horizon - 1, -1, -1):
+            phase = (index // phase_length) % 2
+            action_values = payoffs[phase] + value[np.newaxis, :]
+            actions = np.argmax(action_values, axis=1).astype(np.int32)
+            policy[index] = actions
+            value = action_values[np.arange(2), actions]
+    elif environment_kind == "riverswim":
+        canonical = RiverSwimConfig(  # type: ignore[call-arg]
+            n_states=environment_config["n_states"],
+            p_right_up=environment_config["p_right_up"],
+            p_right_down=environment_config["p_right_down"],
+            reward_left=environment_config["reward_left"],
+            reward_right=environment_config["reward_right"],
+            initial_state=environment_config["initial_state"],
+        )
+        kernel = RiverSwimMDP(canonical)
+        transitions = kernel.transition_tensor.astype(np.float64)
+        rewards = kernel.reward_tensor.astype(np.float64)
+        value = np.zeros(kernel.n_states, dtype=np.float64)
+        policy = np.zeros((horizon + 1, kernel.n_states), dtype=np.int32)
+        for index in range(horizon - 1, -1, -1):
+            continuation = np.einsum("asn,n->sa", transitions, value)
+            action_values = rewards + continuation
+            actions = np.argmax(action_values, axis=1).astype(np.int32)
+            policy[index] = actions
+            value = action_values[np.arange(kernel.n_states), actions]
+    else:
+        raise ValueError("unsupported analytic-oracle environment")
+    if not bool(np.all(np.isfinite(value))):
+        raise ValueError("analytic-oracle dynamic program became non-finite")
+    return policy
+
+
+def _oracle_policy_sha256(policy: np.ndarray[Any, Any]) -> str:
+    canonical = np.asarray(policy, dtype="<i4", order="C")
+    header = f"int32le:{canonical.shape[0]}:{canonical.shape[1]}:".encode("ascii")
+    return hashlib.sha256(header + canonical.tobytes(order="C")).hexdigest()
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class UniformRandomReferenceConfig:
+    """Canonical uniform-random control configuration."""
+
+    environment_kind: EnvironmentKind
+    observation_dim: int
+    n_actions: int = 2
+
+    def __post_init__(self) -> None:
+        _require_environment_shape(
+            self.environment_kind,
+            self.observation_dim,
+            self.n_actions,
+        )
+
+    @classmethod
+    def for_switching(
+        cls,
+        environment_config: SwitchingTwoStateConfig,
+    ) -> UniformRandomReferenceConfig:
+        _canonical_switching_environment(environment_config)
+        return cls(
+            environment_kind="switching_two_state",
+            observation_dim=2,
+        )
+
+    @classmethod
+    def for_riverswim(
+        cls,
+        environment_config: RiverSwimConfig,
+    ) -> UniformRandomReferenceConfig:
+        payload = _canonical_riverswim_environment(environment_config)
+        return cls(
+            environment_kind="riverswim",
+            observation_dim=cast(int, payload["n_states"]),
+        )
+
+    def to_config(self) -> dict[str, Any]:
+        return {
+            "schema": REFERENCE_CONTROL_CONFIG_SCHEMA,
+            "algorithm": "uniform_random",
+            "environment_kind": self.environment_kind,
+            "observation_dim": self.observation_dim,
+            "n_actions": self.n_actions,
+            "action_distribution": "uniform",
+            "rng_schedule": "jax_fold_in_uint64_decision_index.preview1",
+            "rng_implementation": _THREEFRY_IMPLEMENTATION,
+            "initial_key_contract": "scalar_threefry2x32_typed_or_legacy.preview1",
+            "boundary_mode": "continuing_unit_discount_only",
+        }
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class DifferentialSARSAReferenceConfig:
+    """Canonical linear differential-SARSA control configuration."""
+
+    environment_kind: EnvironmentKind
+    observation_dim: int
+    n_actions: int = 2
+    q_step_size: float = 0.1
+    average_reward_step_size: float = 0.01
+    trace_decay: float = 0.0
+    epsilon_start: float = 0.5
+    epsilon_end: float = 0.02
+    epsilon_decay_steps: int = 2500
+    use_bias: bool = True
+
+    def __post_init__(self) -> None:
+        _require_environment_shape(
+            self.environment_kind,
+            self.observation_dim,
+            self.n_actions,
+        )
+        object.__setattr__(
+            self,
+            "q_step_size",
+            _canonical_float32(
+                self.q_step_size,
+                name="q_step_size",
+                minimum=0.0,
+                maximum=_FLOAT32_MAX,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "average_reward_step_size",
+            _canonical_float32(
+                self.average_reward_step_size,
+                name="average_reward_step_size",
+                minimum=0.0,
+                maximum=_FLOAT32_MAX,
+            ),
+        )
+        for name in ("trace_decay", "epsilon_start", "epsilon_end"):
+            object.__setattr__(
+                self,
+                name,
+                _canonical_float32(
+                    getattr(self, name),
+                    name=name,
+                    minimum=0.0,
+                    maximum=1.0,
+                ),
+            )
+        object.__setattr__(
+            self,
+            "epsilon_decay_steps",
+            _nonnegative_int(self.epsilon_decay_steps, name="epsilon_decay_steps"),
+        )
+        if self.epsilon_end > self.epsilon_start:
+            raise ValueError("epsilon_end must not exceed epsilon_start")
+        if not isinstance(self.use_bias, bool):
+            raise ValueError("use_bias must be boolean")
+
+    @classmethod
+    def for_switching(
+        cls,
+        environment_config: SwitchingTwoStateConfig,
+        **overrides: Any,
+    ) -> DifferentialSARSAReferenceConfig:
+        _canonical_switching_environment(environment_config)
+        return cls(
+            environment_kind="switching_two_state",
+            observation_dim=2,
+            **overrides,
+        )
+
+    @classmethod
+    def for_riverswim(
+        cls,
+        environment_config: RiverSwimConfig,
+        **overrides: Any,
+    ) -> DifferentialSARSAReferenceConfig:
+        payload = _canonical_riverswim_environment(environment_config)
+        return cls(
+            environment_kind="riverswim",
+            observation_dim=cast(int, payload["n_states"]),
+            **overrides,
+        )
+
+    def core_config(self) -> DifferentialSARSAConfig:
+        return DifferentialSARSAConfig(
+            n_actions=self.n_actions,
+            q_step_size=self.q_step_size,
+            average_reward_step_size=self.average_reward_step_size,
+            trace_decay=self.trace_decay,
+            epsilon_start=self.epsilon_start,
+            epsilon_end=self.epsilon_end,
+            epsilon_decay_steps=self.epsilon_decay_steps,
+            use_bias=self.use_bias,
+        )
+
+    def to_config(self) -> dict[str, Any]:
+        return {
+            "schema": REFERENCE_CONTROL_CONFIG_SCHEMA,
+            "algorithm": "differential_sarsa",
+            "environment_kind": self.environment_kind,
+            "observation_dim": self.observation_dim,
+            "n_actions": self.n_actions,
+            "q_step_size": self.q_step_size,
+            "average_reward_step_size": self.average_reward_step_size,
+            "trace_decay": self.trace_decay,
+            "epsilon_start": self.epsilon_start,
+            "epsilon_end": self.epsilon_end,
+            "epsilon_decay_steps": self.epsilon_decay_steps,
+            "use_bias": self.use_bias,
+            "rng_schedule": "owned_differential_sarsa_key.preview1",
+            "rng_implementation": _THREEFRY_IMPLEMENTATION,
+            "initial_key_contract": "scalar_threefry2x32_typed_or_legacy.preview1",
+            "boundary_mode": "continuing_unit_discount_only",
+        }
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class DiscountedSARSAReferenceConfig:
+    """Canonical discounted continuing-SARSA control configuration."""
+
+    environment_kind: EnvironmentKind
+    observation_dim: int
+    n_actions: int = 2
+    gamma: float = 0.9
+    epsilon_start: float = 0.5
+    epsilon_end: float = 0.02
+    epsilon_decay_steps: int = 2500
+    hidden_sizes: tuple[int, ...] = ()
+    step_size: float = 0.05
+    sparsity: float = 0.0
+    leaky_relu_slope: float = 0.01
+    use_layer_norm: bool = False
+    lamda: float = 0.0
+
+    def __post_init__(self) -> None:
+        _require_environment_shape(
+            self.environment_kind,
+            self.observation_dim,
+            self.n_actions,
+        )
+        gamma = _canonical_float32(
+            self.gamma,
+            name="gamma",
+            minimum=0.0,
+            maximum=1.0,
+            maximum_inclusive=False,
+        )
+        object.__setattr__(self, "gamma", gamma)
+        for name in ("epsilon_start", "epsilon_end", "lamda"):
+            object.__setattr__(
+                self,
+                name,
+                _canonical_float32(
+                    getattr(self, name),
+                    name=name,
+                    minimum=0.0,
+                    maximum=1.0,
+                ),
+            )
+        object.__setattr__(
+            self,
+            "sparsity",
+            _canonical_float32(
+                self.sparsity,
+                name="sparsity",
+                minimum=0.0,
+                maximum=1.0,
+                maximum_inclusive=False,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "step_size",
+            _canonical_float32(
+                self.step_size,
+                name="step_size",
+                minimum=0.0,
+                maximum=_FLOAT32_MAX,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "leaky_relu_slope",
+            _canonical_float32(
+                self.leaky_relu_slope,
+                name="leaky_relu_slope",
+                minimum=0.0,
+                maximum=_FLOAT32_MAX,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "epsilon_decay_steps",
+            _nonnegative_int(self.epsilon_decay_steps, name="epsilon_decay_steps"),
+        )
+        if self.epsilon_end > self.epsilon_start:
+            raise ValueError("epsilon_end must not exceed epsilon_start")
+        object.__setattr__(
+            self,
+            "hidden_sizes",
+            _canonical_hidden_sizes(
+                self.hidden_sizes,
+                observation_dim=self.observation_dim,
+                n_actions=self.n_actions,
+            ),
+        )
+        if not isinstance(self.use_layer_norm, bool):
+            raise ValueError("use_layer_norm must be boolean")
+
+    @classmethod
+    def for_switching(
+        cls,
+        environment_config: SwitchingTwoStateConfig,
+        **overrides: Any,
+    ) -> DiscountedSARSAReferenceConfig:
+        _canonical_switching_environment(environment_config)
+        return cls(
+            environment_kind="switching_two_state",
+            observation_dim=2,
+            **overrides,
+        )
+
+    @classmethod
+    def for_riverswim(
+        cls,
+        environment_config: RiverSwimConfig,
+        **overrides: Any,
+    ) -> DiscountedSARSAReferenceConfig:
+        payload = _canonical_riverswim_environment(environment_config)
+        return cls(
+            environment_kind="riverswim",
+            observation_dim=cast(int, payload["n_states"]),
+            **overrides,
+        )
+
+    def core_config(self) -> SARSAConfig:
+        return SARSAConfig(  # type: ignore[call-arg]
+            n_actions=self.n_actions,
+            gamma=self.gamma,
+            epsilon_start=self.epsilon_start,
+            epsilon_end=self.epsilon_end,
+            epsilon_decay_steps=self.epsilon_decay_steps,
+        )
+
+    def to_config(self) -> dict[str, Any]:
+        return {
+            "schema": REFERENCE_CONTROL_CONFIG_SCHEMA,
+            "algorithm": "discounted_sarsa",
+            "environment_kind": self.environment_kind,
+            "observation_dim": self.observation_dim,
+            "n_actions": self.n_actions,
+            "gamma": self.gamma,
+            "epsilon_start": self.epsilon_start,
+            "epsilon_end": self.epsilon_end,
+            "epsilon_decay_steps": self.epsilon_decay_steps,
+            "hidden_sizes": list(self.hidden_sizes),
+            "step_size": self.step_size,
+            "sparsity": self.sparsity,
+            "leaky_relu_slope": self.leaky_relu_slope,
+            "use_layer_norm": self.use_layer_norm,
+            "lamda": self.lamda,
+            "rng_schedule": "owned_sarsa_key.preview1",
+            "rng_implementation": _THREEFRY_IMPLEMENTATION,
+            "initial_key_contract": "scalar_threefry2x32_typed_or_legacy.preview1",
+            "boundary_mode": "continuing_unit_discount_only",
+        }
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AnalyticOracleReferenceConfig:
+    """Exact environment-bound finite-horizon privileged control."""
+
+    environment_kind: EnvironmentKind
+    observation_dim: int
+    n_actions: int
+    horizon: int
+    policy_sha256: str
+    environment_config_json: str = dataclasses.field(repr=False)
+
+    def __post_init__(self) -> None:
+        _require_environment_shape(
+            self.environment_kind,
+            self.observation_dim,
+            self.n_actions,
+        )
+        horizon = _canonical_oracle_horizon(self.horizon)
+        if not isinstance(self.policy_sha256, str) or _SHA256.fullmatch(
+            self.policy_sha256
+        ) is None:
+            raise ValueError("oracle policy_sha256 must be a lowercase SHA-256 digest")
+        try:
+            decoded = json.loads(self.environment_config_json)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ValueError("oracle environment config must be canonical JSON") from exc
+        if (
+            not isinstance(decoded, dict)
+            or _canonical_json(decoded) != self.environment_config_json
+        ):
+            raise ValueError("oracle environment config must use canonical JSON")
+        if self.environment_kind == "switching_two_state":
+            try:
+                switching_source = SwitchingTwoStateConfig(  # type: ignore[call-arg]
+                    phase_length=decoded["phase_length"],
+                    payoffs_a=tuple(tuple(row) for row in decoded["payoffs_a"]),
+                    payoffs_b=tuple(tuple(row) for row in decoded["payoffs_b"]),
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ValueError("oracle switching config is malformed") from exc
+            expected, _ = _canonical_switching_environment(
+                switching_source
+            )
+            if set(decoded) != {"phase_length", "payoffs_a", "payoffs_b"}:
+                raise ValueError("oracle switching config has unknown fields")
+            if decoded != expected:
+                raise ValueError("oracle switching config is not canonical")
+        else:
+            try:
+                river_source = RiverSwimConfig(  # type: ignore[call-arg]
+                    n_states=decoded["n_states"],
+                    p_right_up=decoded["p_right_up"],
+                    p_right_down=decoded["p_right_down"],
+                    reward_left=decoded["reward_left"],
+                    reward_right=decoded["reward_right"],
+                    initial_state=decoded["initial_state"],
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ValueError("oracle RiverSwim config is malformed") from exc
+            expected = _canonical_riverswim_environment(river_source)
+            if set(decoded) != {
+                "n_states",
+                "p_right_up",
+                "p_right_down",
+                "reward_left",
+                "reward_right",
+                "initial_state",
+            }:
+                raise ValueError("oracle RiverSwim config has unknown fields")
+            if decoded != expected:
+                raise ValueError("oracle RiverSwim config is not canonical")
+        policy = _finite_horizon_oracle_policy(
+            environment_kind=self.environment_kind,
+            environment_config=expected,
+            horizon=horizon,
+        )
+        if policy.shape != (horizon + 1, self.observation_dim):
+            raise ValueError("oracle policy has an invalid shape")
+        if _oracle_policy_sha256(policy) != self.policy_sha256:
+            raise ValueError("oracle policy digest does not match the exact dynamic program")
+
+    @classmethod
+    def for_switching(
+        cls,
+        environment_config: SwitchingTwoStateConfig,
+        *,
+        horizon: int,
+    ) -> AnalyticOracleReferenceConfig:
+        payload, _ = _canonical_switching_environment(environment_config)
+        canonical_horizon = _canonical_oracle_horizon(horizon)
+        policy = _finite_horizon_oracle_policy(
+            environment_kind="switching_two_state",
+            environment_config=payload,
+            horizon=canonical_horizon,
+        )
+        return cls(
+            environment_kind="switching_two_state",
+            observation_dim=2,
+            n_actions=2,
+            horizon=canonical_horizon,
+            policy_sha256=_oracle_policy_sha256(policy),
+            environment_config_json=_canonical_json(payload),
+        )
+
+    @classmethod
+    def for_riverswim(
+        cls,
+        environment_config: RiverSwimConfig,
+        *,
+        horizon: int,
+    ) -> AnalyticOracleReferenceConfig:
+        payload = _canonical_riverswim_environment(environment_config)
+        canonical_horizon = _canonical_oracle_horizon(horizon)
+        policy = _finite_horizon_oracle_policy(
+            environment_kind="riverswim",
+            environment_config=payload,
+            horizon=canonical_horizon,
+        )
+        return cls(
+            environment_kind="riverswim",
+            observation_dim=cast(int, payload["n_states"]),
+            n_actions=2,
+            horizon=canonical_horizon,
+            policy_sha256=_oracle_policy_sha256(policy),
+            environment_config_json=_canonical_json(payload),
+        )
+
+    @property
+    def environment_config(self) -> dict[str, Any]:
+        decoded = json.loads(self.environment_config_json)
+        assert isinstance(decoded, dict)
+        return decoded
+
+    @property
+    def environment_config_sha256(self) -> str:
+        return canonical_config_sha256(self.environment_config)
+
+    def to_config(self) -> dict[str, Any]:
+        return {
+            "schema": REFERENCE_CONTROL_CONFIG_SCHEMA,
+            "algorithm": "analytic_oracle",
+            "environment_kind": self.environment_kind,
+            "observation_dim": self.observation_dim,
+            "n_actions": self.n_actions,
+            "horizon": self.horizon,
+            "policy_shape": [self.horizon + 1, self.observation_dim],
+            "post_horizon_decision": "unused_lowest_action_sentinel_for_final_accept",
+            "policy_sha256": self.policy_sha256,
+            "solver": "finite_horizon_backward_dynamic_program.float64.tie_low.preview1",
+            "environment_config": self.environment_config,
+            "environment_config_sha256": self.environment_config_sha256,
+            "privileged": True,
+            "privileged_environment_model": True,
+            "privileged_inputs": (
+                ["environment_dynamics", "phase_schedule"]
+                if self.environment_kind == "switching_two_state"
+                else ["environment_dynamics"]
+            ),
+            "tie_break": "lowest_action_index",
+            "rng_schedule": "none_deterministic",
+            "rng_implementation": None,
+            "initial_key_contract": "scalar_jax_key_ignored.preview1",
+            "boundary_mode": "continuing_unit_discount_only",
+        }
+
+
+ControlConfig = (
+    UniformRandomReferenceConfig
+    | AnalyticOracleReferenceConfig
+    | DifferentialSARSAReferenceConfig
+    | DiscountedSARSAReferenceConfig
+)
+ControlAgentState = DifferentialSARSAState | SARSAState | None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceLifeControlState:
+    """Immutable process-local envelope shared by the four control adapters."""
+
+    schema: str
+    manifest_id: str
+    config_sha256: str
+    lifecycle_id: str
+    decision_index: int
+    current_observation_id: str | None
+    current_observation: ArrayValue | None
+    current_action: ArrayValue | None
+    random_key: Array | None
+    agent_state: ControlAgentState
+    _owner_token: object = dataclasses.field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.schema, str) or _SAFE_ID.fullmatch(self.schema) is None:
+            raise ValueError("control state schema must be a safe identifier")
+        if not isinstance(self.manifest_id, str) or _SHA256.fullmatch(self.manifest_id) is None:
+            raise ValueError("control state manifest_id must be a SHA-256 digest")
+        if (
+            not isinstance(self.config_sha256, str)
+            or _SHA256.fullmatch(self.config_sha256) is None
+        ):
+            raise ValueError("control state config_sha256 must be a SHA-256 digest")
+        if (
+            not isinstance(self.lifecycle_id, str)
+            or len(self.lifecycle_id) > _MAX_ID_LENGTH
+            or _SAFE_ID.fullmatch(self.lifecycle_id) is None
+        ):
+            raise ValueError("control state lifecycle_id must be a safe identifier")
+        if (
+            isinstance(self.decision_index, bool)
+            or not isinstance(self.decision_index, int)
+            or self.decision_index < 0
+            or self.decision_index > MAX_DECISION_INDEX
+        ):
+            raise ValueError("control state decision_index must be uint64")
+        armed_fields = (
+            self.current_observation_id,
+            self.current_observation,
+            self.current_action,
+        )
+        if any(value is None for value in armed_fields) and not all(
+            value is None for value in armed_fields
+        ):
+            raise ValueError("control state decision cache must be wholly fresh or armed")
+        if self.current_observation_id is not None and (
+            not isinstance(self.current_observation_id, str)
+            or _SAFE_ID.fullmatch(self.current_observation_id) is None
+        ):
+            raise ValueError("current_observation_id must be a safe identifier")
+        if self.current_observation is not None and not isinstance(
+            self.current_observation, ArrayValue
+        ):
+            raise ValueError("current_observation must be an ArrayValue")
+        if self.current_action is not None and not isinstance(self.current_action, ArrayValue):
+            raise ValueError("current_action must be an ArrayValue")
+
+    def __reduce__(self) -> Any:
+        raise TypeError(
+            "reference-life control state is process-local and has no checkpoint codec"
+        )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferenceControlResourceUsage:
+    """Primitive resource counts for one in-memory control state."""
+
+    array_leaves: int
+    array_elements: int
+    persistent_bytes: int
+    floating_array_leaves: int
+
+
+def control_state_resource_usage(
+    state: ReferenceLifeControlState,
+) -> ReferenceControlResourceUsage:
+    """Count numeric state leaves without making a checkpoint claim."""
+
+    if not isinstance(state, ReferenceLifeControlState):
+        raise ValueError("state must be a ReferenceLifeControlState")
+    arrays: list[np.ndarray[Any, Any]] = []
+    for encoded in (state.current_observation, state.current_action):
+        if encoded is not None:
+            arrays.append(encoded.to_numpy())
+    roots: tuple[Any, ...] = (state.random_key, state.agent_state)
+    for root in roots:
+        if root is None:
+            continue
+        for leaf in jax.tree.leaves(root):
+            try:
+                dtype = getattr(leaf, "dtype", None)
+                typed_key = dtype is not None and bool(
+                    jax.dtypes.issubdtype(  # type: ignore[attr-defined]
+                        dtype,
+                        jax.dtypes.prng_key,
+                    )
+                )
+                value = (
+                    np.asarray(jr.key_data(leaf))
+                    if typed_key
+                    else np.asarray(leaf)
+                )
+            except (TypeError, ValueError):
+                continue
+            if value.dtype.kind in {"b", "f", "i", "u", "c"}:
+                arrays.append(value)
+    return ReferenceControlResourceUsage(
+        array_leaves=len(arrays),
+        array_elements=sum(int(value.size) for value in arrays),
+        persistent_bytes=sum(int(value.nbytes) for value in arrays),
+        floating_array_leaves=sum(value.dtype.kind in {"f", "c"} for value in arrays),
+    )
+
+
+def _observation_spec(observation_dim: int) -> SpaceSpec:
+    return SpaceSpec.box(
+        shape=(observation_dim,),
+        dtype="float32",
+        low=(0.0,) * observation_dim,
+        high=(1.0,) * observation_dim,
+        semantic_id=REFERENCE_CONTROL_OBSERVATION_SEMANTIC_ID,
+    )
+
+
+def _action_spec(n_actions: int) -> SpaceSpec:
+    return SpaceSpec.discrete(
+        cardinality=n_actions,
+        dtype="int32",
+        semantic_id=REFERENCE_CONTROL_ACTION_SEMANTIC_ID,
+    )
+
+
+def _require_prng_key(
+    key: Any,
+    *,
+    name: str,
+    implementation: str | None = None,
+) -> str:
+    """Validate one scalar typed or legacy key and return its named PRNG impl."""
+
+    try:
+        key_shape = tuple(key.shape)
+        words = np.asarray(jr.key_data(key))
+        key_implementation = str(jr.key_impl(key))
+        dtype = key.dtype
+        typed = bool(
+            jax.dtypes.issubdtype(  # type: ignore[attr-defined]
+                dtype,
+                jax.dtypes.prng_key,
+            )
+        )
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise DecisionOwnershipError(f"{name} must be a scalar JAX PRNG key") from exc
+    if (
+        words.ndim != 1
+        or words.dtype != np.dtype(np.uint32)
+        or (typed and key_shape != ())
+        or (not typed and key_shape != words.shape)
+    ):
+        raise DecisionOwnershipError(f"{name} must be a scalar JAX PRNG key")
+    if implementation is not None and key_implementation != implementation:
+        raise DecisionOwnershipError(
+            f"{name} must use explicit {implementation}, got {key_implementation}"
+        )
+    if implementation == _THREEFRY_IMPLEMENTATION and words.shape != (2,):
+        raise DecisionOwnershipError(f"{name} must use a scalar threefry2x32 key")
+    return key_implementation
+
+
+def _explicit_threefry_key(key: Any, *, name: str) -> Array:
+    _require_prng_key(key, name=name, implementation=_THREEFRY_IMPLEMENTATION)
+    words = jnp.asarray(jr.key_data(key), dtype=jnp.uint32)
+    return cast(Array, jr.wrap_key_data(words, impl=_THREEFRY_IMPLEMENTATION))
+
+
+def _float32_scalar(value: Any, *, name: str) -> np.float32:
+    try:
+        with np.errstate(over="ignore", invalid="ignore", under="ignore"):
+            converted = np.asarray(value, dtype=np.float32)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise DecisionOwnershipError(f"{name} must be a finite float32 scalar") from exc
+    if converted.shape != () or not bool(np.isfinite(converted)):
+        raise DecisionOwnershipError(f"{name} must be a finite float32 scalar")
+    return np.float32(converted)
+
+
+def _tree_exactly_equal(left: Any, right: Any) -> bool:
+    left_leaves, left_structure = jax.tree.flatten(left)
+    right_leaves, right_structure = jax.tree.flatten(right)
+    if cast(Any, left_structure) != right_structure or len(left_leaves) != len(
+        right_leaves
+    ):
+        return False
+    return all(
+        np.asarray(left_leaf).dtype == np.asarray(right_leaf).dtype
+        and np.asarray(left_leaf).shape == np.asarray(right_leaf).shape
+        and np.array_equal(np.asarray(left_leaf), np.asarray(right_leaf))
+        for left_leaf, right_leaf in zip(left_leaves, right_leaves, strict=True)
+    )
+
+
+def _tree_finite(tree: Any) -> bool:
+    for leaf in jax.tree.leaves(tree):
+        try:
+            array = np.asarray(leaf)
+        except (TypeError, ValueError):
+            continue
+        if array.dtype.kind in {"f", "c"} and not bool(np.all(np.isfinite(array))):
+            return False
+    return True
+
+
+def _require_float32_array(value: Any, *, name: str, shape: tuple[int, ...]) -> None:
+    try:
+        array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise DecisionOwnershipError(f"{name} violates its float32 array contract") from exc
+    if array.shape != shape or array.dtype != np.dtype(np.float32):
+        raise DecisionOwnershipError(
+            f"{name} must have shape {shape} and dtype float32"
+        )
+    if not bool(np.all(np.isfinite(array))):
+        raise DecisionOwnershipError(f"{name} must contain only finite float32 values")
+
+
+def _require_float32_tree(
+    value: Any,
+    *,
+    name: str,
+    expected_shapes: tuple[tuple[int, ...], ...],
+) -> None:
+    leaves = jax.tree.leaves(value)
+    if len(leaves) != len(expected_shapes):
+        raise DecisionOwnershipError(f"{name} violates its array-tree structure contract")
+    for index, (leaf, shape) in enumerate(zip(leaves, expected_shapes, strict=True)):
+        _require_float32_array(leaf, name=f"{name}[{index}]", shape=shape)
+
+
+def _require_lms_optimizer_tree(
+    value: Any,
+    *,
+    name: str,
+    group_count: int,
+    step_size: float,
+) -> None:
+    if type(value) is not tuple or len(value) != group_count:
+        raise DecisionOwnershipError(f"{name} violates its LMS group structure")
+    expected_step = np.asarray(step_size, dtype=np.float32)
+    for group_index, group in enumerate(value):
+        if type(group) is not tuple or len(group) != 2:
+            raise DecisionOwnershipError(
+                f"{name}[{group_index}] must contain weight and bias LMS states"
+            )
+        for state_index, optimizer_state in enumerate(group):
+            if not isinstance(optimizer_state, LMSState):
+                raise DecisionOwnershipError(
+                    f"{name}[{group_index}][{state_index}] must be an LMSState"
+                )
+            observed = np.asarray(optimizer_state.step_size)
+            if (
+                observed.shape != ()
+                or observed.dtype != np.dtype(np.float32)
+                or not np.array_equal(observed, expected_step)
+            ):
+                raise DecisionOwnershipError(
+                    f"{name}[{group_index}][{state_index}] step size differs from config"
+                )
+
+
+def _counter_words(index: int) -> np.ndarray[Any, np.dtype[np.uint32]]:
+    return np.asarray(((index >> 32) & 0xFFFFFFFF, index & 0xFFFFFFFF), dtype=np.uint32)
+
+
+class _BaseReferenceControlAdapter:
+    """Shared exact-dispatch ownership and continuing-outcome machinery."""
+
+    _agent: DifferentialSARSAAgent | SARSAAgent | None
+    _agent_config_json: str | None
+    _config: ControlConfig
+    _frozen: bool
+    _manifest: AgentManifest
+    _owner_token: object
+    _state_schema: str
+
+    __slots__ = (
+        "_agent",
+        "_agent_config_json",
+        "_config",
+        "_frozen",
+        "_manifest",
+        "_owner_token",
+        "_state_schema",
+    )
+
+    def __init__(
+        self,
+        config: ControlConfig,
+        *,
+        implementation_id: str,
+        state_schema: str,
+        agent: DifferentialSARSAAgent | SARSAAgent | None,
+    ) -> None:
+        object.__setattr__(self, "_frozen", False)
+        object.__setattr__(self, "_config", config)
+        object.__setattr__(self, "_state_schema", state_schema)
+        object.__setattr__(self, "_agent", agent)
+        object.__setattr__(
+            self,
+            "_agent_config_json",
+            None if agent is None else _canonical_json(agent.to_config()),
+        )
+        object.__setattr__(self, "_owner_token", object())
+        object.__setattr__(
+            self,
+            "_manifest",
+            AgentManifest.from_config(
+                schema=REFERENCE_AGENT_MANIFEST_SCHEMA,
+                implementation_id=implementation_id,
+                state_schema=state_schema,
+                config=config.to_config(),
+                observation_spec=_observation_spec(config.observation_dim),
+                action_spec=_action_spec(config.n_actions),
+                capabilities=AgentCapabilities(dispatch_rebinding=False),
+            ),
+        )
+        object.__setattr__(self, "_frozen", True)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if getattr(self, "_frozen", False):
+            raise AttributeError("reference-life control adapter is immutable")
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        if getattr(self, "_frozen", False):
+            raise AttributeError("reference-life control adapter is immutable")
+        object.__delattr__(self, name)
+
+    def __reduce__(self) -> Any:
+        raise TypeError("reference-life control adapter is process-local")
+
+    @property
+    def manifest(self) -> AgentManifest:
+        return self._manifest
+
+    @property
+    def config(self) -> ControlConfig:
+        return self._config
+
+    @property
+    def max_accepted_events(self) -> int:
+        return REFERENCE_CONTROL_MAX_ACCEPTED_EVENTS
+
+    @property
+    def static_numeric_bytes(self) -> int:
+        return 0
+
+    def _base_state(
+        self,
+        *,
+        lifecycle_id: str,
+        random_key: Array | None,
+        agent_state: ControlAgentState,
+    ) -> ReferenceLifeControlState:
+        return ReferenceLifeControlState(
+            schema=self._state_schema,
+            manifest_id=self.manifest.manifest_id,
+            config_sha256=self.manifest.config_sha256,
+            lifecycle_id=lifecycle_id,
+            decision_index=0,
+            current_observation_id=None,
+            current_observation=None,
+            current_action=None,
+            random_key=random_key,
+            agent_state=agent_state,
+            _owner_token=self._owner_token,
+        )
+
+    def _require_bound_state(self, state: ReferenceLifeControlState) -> None:
+        if not isinstance(state, ReferenceLifeControlState):
+            raise DecisionOwnershipError("state must be a ReferenceLifeControlState")
+        if state._owner_token is not self._owner_token:
+            raise DecisionOwnershipError("control state belongs to another adapter owner")
+        if state.schema != self._state_schema:
+            raise DecisionOwnershipError("control state has another algorithm schema")
+        if state.manifest_id != self.manifest.manifest_id:
+            raise DecisionOwnershipError("control state belongs to another manifest")
+        if state.config_sha256 != self.manifest.config_sha256:
+            raise DecisionOwnershipError("control state belongs to another configuration")
+        if state.decision_index > self.max_accepted_events:
+            raise DecisionOwnershipError("control state exceeds adapter capacity")
+
+    def _one_hot(self, value: Any) -> np.ndarray[Any, np.dtype[np.float32]]:
+        try:
+            encoded = self.manifest.observation_spec.encode(value)
+        except (TypeError, ValueError) as exc:
+            raise DecisionOwnershipError(
+                "observation does not match the control codec"
+            ) from exc
+        observation = encoded.to_numpy()
+        if (
+            observation.dtype != np.dtype(np.float32)
+            or observation.shape != (self.config.observation_dim,)
+            or not np.all((observation == 0.0) | (observation == 1.0))
+            or int(np.count_nonzero(observation)) != 1
+        ):
+            raise DecisionOwnershipError("control observation must be exact float32 one-hot")
+        return observation
+
+    def _action_index(self, value: Any) -> int:
+        try:
+            encoded = self.manifest.action_spec.encode(value)
+        except (TypeError, ValueError) as exc:
+            raise DecisionOwnershipError("action does not match the control codec") from exc
+        action = encoded.to_numpy()
+        if action.shape != () or action.dtype != np.dtype(np.int32):
+            raise DecisionOwnershipError("control action must be scalar int32")
+        return int(action)
+
+    def _initial_payload(
+        self,
+        key: Array,
+    ) -> tuple[Array | None, ControlAgentState]:
+        raise NotImplementedError
+
+    def _start_payload(
+        self,
+        state: ReferenceLifeControlState,
+        observation: np.ndarray[Any, np.dtype[np.float32]],
+    ) -> tuple[Array | None, ControlAgentState, int]:
+        raise NotImplementedError
+
+    def _validate_payload(
+        self,
+        state: ReferenceLifeControlState,
+        observation: np.ndarray[Any, np.dtype[np.float32]],
+        action: int,
+    ) -> None:
+        raise NotImplementedError
+
+    def _advance_payload(
+        self,
+        state: ReferenceLifeControlState,
+        *,
+        reward: np.float32,
+        discount: np.float32,
+        next_observation: np.ndarray[Any, np.dtype[np.float32]],
+        next_index: int,
+    ) -> tuple[Array | None, ControlAgentState, int, bool]:
+        raise NotImplementedError
+
+    def init(self, key: Array, *, lifecycle_id: str) -> ReferenceLifeControlState:
+        _require_prng_key(key, name="initial control key")
+        if (
+            not isinstance(lifecycle_id, str)
+            or len(lifecycle_id) > _MAX_ID_LENGTH
+            or _SAFE_ID.fullmatch(lifecycle_id) is None
+        ):
+            raise ValueError("lifecycle_id must be a safe identifier")
+        random_key, agent_state = self._initial_payload(key)
+        return self._base_state(
+            lifecycle_id=lifecycle_id,
+            random_key=random_key,
+            agent_state=agent_state,
+        )
+
+    def start(
+        self,
+        state: ReferenceLifeControlState,
+        *,
+        observation_id: str,
+        observation: Any,
+    ) -> tuple[ReferenceLifeControlState, Decision]:
+        self._require_bound_state(state)
+        if (
+            state.decision_index != 0
+            or state.current_observation_id is not None
+            or state.current_observation is not None
+            or state.current_action is not None
+        ):
+            raise DecisionOwnershipError("start requires a fresh control state")
+        encoded_observation = self.manifest.observation_spec.encode(observation)
+        one_hot = self._one_hot(encoded_observation)
+        random_key, agent_state, action = self._start_payload(state, one_hot)
+        encoded_action = self.manifest.action_spec.encode(np.asarray(action, dtype=np.int32))
+        started = dataclasses.replace(
+            state,
+            current_observation_id=observation_id,
+            current_observation=encoded_observation,
+            current_action=encoded_action,
+            random_key=random_key,
+            agent_state=agent_state,
+        )
+        decision = self.current_decision(started)
+        return started, decision
+
+    def current_decision(self, state: ReferenceLifeControlState) -> Decision:
+        self._require_bound_state(state)
+        if (
+            state.current_observation_id is None
+            or state.current_observation is None
+            or state.current_action is None
+        ):
+            raise DecisionOwnershipError("fresh control state has no armed decision")
+        observation = self._one_hot(state.current_observation)
+        action = self._action_index(state.current_action)
+        self._validate_payload(state, observation, action)
+        return self.manifest.make_decision(
+            lifecycle_id=state.lifecycle_id,
+            decision_index=state.decision_index,
+            observation_id=state.current_observation_id,
+            observation=state.current_observation,
+            proposed_action=state.current_action,
+            armed=True,
+        )
+
+    def validate_state(self, state: ReferenceLifeControlState) -> None:
+        self.current_decision(state)
+
+    def settle_dispatch(
+        self,
+        state: ReferenceLifeControlState,
+        authorization: DispatchAuthorization,
+    ) -> tuple[ReferenceLifeControlState, Literal[False]]:
+        if not isinstance(authorization, DispatchAuthorization):
+            raise DecisionOwnershipError("settlement requires a DispatchAuthorization")
+        current = self.current_decision(state)
+        if authorization.decision != current:
+            raise DecisionOwnershipError(
+                "authorization decision does not match the current control cache"
+            )
+        if authorization.status is not AuthorizationStatus.EXACT:
+            raise DecisionOwnershipError("control adapters allow exact authorization only")
+        if authorization.authorized_action != current.proposed_action:
+            raise DecisionOwnershipError("authorized action does not match the control action")
+        return state, False
+
+    @staticmethod
+    def _rejected(state: Any, reason: str) -> ReferenceAgentUpdate:
+        return ReferenceAgentUpdate(
+            state=state,
+            next_decision=None,
+            accepted=False,
+            parameters_changed=False,
+            rejection_reason=reason,
+        )
+
+    def _require_current_transaction(
+        self,
+        state: ReferenceLifeControlState,
+        transaction: Transaction,
+    ) -> tuple[np.float32, np.float32, np.ndarray[Any, np.dtype[np.float32]]]:
+        if not isinstance(transaction, Transaction):
+            raise DecisionOwnershipError("outcome must be a Transaction")
+        current = self.current_decision(state)
+        if transaction.decision != current:
+            raise DecisionOwnershipError("outcome does not own the current control decision")
+        authorization = transaction.receipt.dispatch.authorization
+        if (
+            authorization.status is not AuthorizationStatus.EXACT
+            or transaction.receipt.dispatch.status is not DispatchStatus.EXACT
+            or transaction.receipt.applied_action != current.proposed_action
+        ):
+            raise DecisionOwnershipError("outcome does not preserve exact action ownership")
+        if transaction.is_boundary or transaction.autoreset:
+            raise DecisionOwnershipError("control adapters support continuing outcomes only")
+        if transaction.discount != 1.0:
+            raise DecisionOwnershipError(
+                "selected continuing controls require unit environment discount"
+            )
+        if (
+            transaction.next_decision_observation_id is None
+            or transaction.next_decision_observation is None
+        ):
+            raise DecisionOwnershipError("continuing outcome lacks a next observation")
+        if state.decision_index >= self.max_accepted_events:
+            raise DecisionOwnershipError("control adapter capacity is exhausted")
+        reward = _float32_scalar(transaction.reward, name="reward")
+        discount = _float32_scalar(transaction.discount, name="discount")
+        next_observation = self._one_hot(transaction.next_decision_observation)
+        return reward, discount, next_observation
+
+    def apply_outcome(
+        self,
+        state: Any,
+        transaction: Transaction,
+    ) -> ReferenceAgentUpdate:
+        """Stage one update, preserving the exact input state on every failure."""
+
+        if not isinstance(state, ReferenceLifeControlState):
+            return self._rejected(state, "state must be a ReferenceLifeControlState")
+        try:
+            reward, discount, next_observation = self._require_current_transaction(
+                state,
+                transaction,
+            )
+            assert transaction.next_decision_observation_id is not None
+            assert transaction.next_decision_observation is not None
+            next_index = state.decision_index + 1
+            random_key, agent_state, action, parameters_changed = self._advance_payload(
+                state,
+                reward=reward,
+                discount=discount,
+                next_observation=next_observation,
+                next_index=next_index,
+            )
+            candidate = dataclasses.replace(
+                state,
+                decision_index=next_index,
+                current_observation_id=transaction.next_decision_observation_id,
+                current_observation=transaction.next_decision_observation,
+                current_action=self.manifest.action_spec.encode(
+                    np.asarray(action, dtype=np.int32)
+                ),
+                random_key=random_key,
+                agent_state=agent_state,
+            )
+            decision = self.current_decision(candidate)
+        except Exception as exc:
+            return self._rejected(state, f"control transition rejected: {exc}")
+        return ReferenceAgentUpdate(
+            state=candidate,
+            next_decision=decision,
+            accepted=True,
+            parameters_changed=parameters_changed,
+            rejection_reason=None,
+        )
+
+
+class UniformRandomReferenceAdapter(_BaseReferenceControlAdapter):
+    """Owner-bound uniform random primitive-action control."""
+
+    __slots__ = ()
+
+    def __init__(self, config: UniformRandomReferenceConfig) -> None:
+        if not isinstance(config, UniformRandomReferenceConfig):
+            raise ValueError("uniform-random adapter config has the wrong type")
+        super().__init__(
+            config,
+            implementation_id=UNIFORM_RANDOM_IMPLEMENTATION_ID,
+            state_schema=UNIFORM_RANDOM_STATE_SCHEMA,
+            agent=None,
+        )
+
+    @property
+    def config(self) -> UniformRandomReferenceConfig:
+        return cast(UniformRandomReferenceConfig, super().config)
+
+    def _random_action(self, key: Array, decision_index: int) -> int:
+        _require_prng_key(
+            key,
+            name="uniform-random root key",
+            implementation=_THREEFRY_IMPLEMENTATION,
+        )
+        scheduled = jr.fold_in(key, _RANDOM_DOMAIN)
+        scheduled = jr.fold_in(scheduled, (decision_index >> 32) & 0xFFFFFFFF)
+        scheduled = jr.fold_in(scheduled, decision_index & 0xFFFFFFFF)
+        return int(jr.randint(scheduled, (), 0, self.config.n_actions, dtype=jnp.int32))
+
+    def _initial_payload(
+        self,
+        key: Array,
+    ) -> tuple[Array | None, ControlAgentState]:
+        return _explicit_threefry_key(key, name="uniform-random initial key"), None
+
+    def _start_payload(
+        self,
+        state: ReferenceLifeControlState,
+        observation: np.ndarray[Any, np.dtype[np.float32]],
+    ) -> tuple[Array | None, ControlAgentState, int]:
+        del observation
+        if state.random_key is None or state.agent_state is not None:
+            raise DecisionOwnershipError("uniform-random fresh state is inconsistent")
+        return state.random_key, None, self._random_action(state.random_key, 0)
+
+    def _validate_payload(
+        self,
+        state: ReferenceLifeControlState,
+        observation: np.ndarray[Any, np.dtype[np.float32]],
+        action: int,
+    ) -> None:
+        del observation
+        if state.random_key is None or state.agent_state is not None:
+            raise DecisionOwnershipError("uniform-random state payload is inconsistent")
+        expected = self._random_action(state.random_key, state.decision_index)
+        if action != expected:
+            raise DecisionOwnershipError("uniform-random action cache does not match its key")
+
+    def _advance_payload(
+        self,
+        state: ReferenceLifeControlState,
+        *,
+        reward: np.float32,
+        discount: np.float32,
+        next_observation: np.ndarray[Any, np.dtype[np.float32]],
+        next_index: int,
+    ) -> tuple[Array | None, ControlAgentState, int, bool]:
+        del reward, discount, next_observation
+        assert state.random_key is not None
+        return state.random_key, None, self._random_action(state.random_key, next_index), False
+
+
+class AnalyticOracleReferenceAdapter(_BaseReferenceControlAdapter):
+    """Privileged finite-horizon dynamic-programming control."""
+
+    _oracle_policy_bytes: bytes
+    __slots__ = ("_oracle_policy_bytes",)
+
+    def __init__(self, config: AnalyticOracleReferenceConfig) -> None:
+        if not isinstance(config, AnalyticOracleReferenceConfig):
+            raise ValueError("analytic-oracle adapter config has the wrong type")
+        policy = _finite_horizon_oracle_policy(
+            environment_kind=config.environment_kind,
+            environment_config=config.environment_config,
+            horizon=config.horizon,
+        )
+        object.__setattr__(
+            self,
+            "_oracle_policy_bytes",
+            np.asarray(policy, dtype="<i4", order="C").tobytes(order="C"),
+        )
+        super().__init__(
+            config,
+            implementation_id=ANALYTIC_ORACLE_IMPLEMENTATION_ID,
+            state_schema=ANALYTIC_ORACLE_STATE_SCHEMA,
+            agent=None,
+        )
+
+    @property
+    def config(self) -> AnalyticOracleReferenceConfig:
+        return cast(AnalyticOracleReferenceConfig, super().config)
+
+    @property
+    def max_accepted_events(self) -> int:
+        return self.config.horizon
+
+    @property
+    def static_numeric_bytes(self) -> int:
+        return len(self._oracle_policy_bytes)
+
+    def _oracle_action(
+        self,
+        observation: np.ndarray[Any, np.dtype[np.float32]],
+        decision_index: int,
+    ) -> int:
+        if decision_index < 0 or decision_index > self.config.horizon:
+            raise DecisionOwnershipError("analytic-oracle decision exceeds its horizon")
+        state_index = int(np.argmax(observation))
+        policy = np.frombuffer(self._oracle_policy_bytes, dtype="<i4").reshape(
+            self.config.horizon + 1,
+            self.config.observation_dim,
+        )
+        return int(policy[decision_index, state_index])
+
+    def _initial_payload(
+        self,
+        key: Array,
+    ) -> tuple[Array | None, ControlAgentState]:
+        del key
+        return None, None
+
+    def _start_payload(
+        self,
+        state: ReferenceLifeControlState,
+        observation: np.ndarray[Any, np.dtype[np.float32]],
+    ) -> tuple[Array | None, ControlAgentState, int]:
+        if state.random_key is not None or state.agent_state is not None:
+            raise DecisionOwnershipError("analytic-oracle fresh state is inconsistent")
+        return None, None, self._oracle_action(observation, 0)
+
+    def _validate_payload(
+        self,
+        state: ReferenceLifeControlState,
+        observation: np.ndarray[Any, np.dtype[np.float32]],
+        action: int,
+    ) -> None:
+        if state.random_key is not None or state.agent_state is not None:
+            raise DecisionOwnershipError("analytic-oracle state payload is inconsistent")
+        if action != self._oracle_action(observation, state.decision_index):
+            raise DecisionOwnershipError("analytic-oracle action cache is inconsistent")
+
+    def _advance_payload(
+        self,
+        state: ReferenceLifeControlState,
+        *,
+        reward: np.float32,
+        discount: np.float32,
+        next_observation: np.ndarray[Any, np.dtype[np.float32]],
+        next_index: int,
+    ) -> tuple[Array | None, ControlAgentState, int, bool]:
+        del state, reward, discount
+        return None, None, self._oracle_action(next_observation, next_index), False
+
+
+class DifferentialSARSAReferenceAdapter(_BaseReferenceControlAdapter):
+    """Exact-dispatch wrapper for the linear differential-SARSA control."""
+
+    __slots__ = ()
+
+    def __init__(self, config: DifferentialSARSAReferenceConfig) -> None:
+        if not isinstance(config, DifferentialSARSAReferenceConfig):
+            raise ValueError("differential-SARSA adapter config has the wrong type")
+        agent = DifferentialSARSAAgent(config.core_config())
+        super().__init__(
+            config,
+            implementation_id=DIFFERENTIAL_SARSA_IMPLEMENTATION_ID,
+            state_schema=DIFFERENTIAL_SARSA_STATE_SCHEMA,
+            agent=agent,
+        )
+
+    @property
+    def config(self) -> DifferentialSARSAReferenceConfig:
+        return cast(DifferentialSARSAReferenceConfig, super().config)
+
+    @property
+    def _differential_agent(self) -> DifferentialSARSAAgent:
+        agent = self._agent
+        if (
+            not isinstance(agent, DifferentialSARSAAgent)
+            or self._agent_config_json is None
+            or _canonical_json(agent.to_config()) != self._agent_config_json
+        ):
+            raise DecisionOwnershipError(
+                "differential-SARSA core configuration was mutated"
+            )
+        return agent
+
+    def _initial_payload(
+        self,
+        key: Array,
+    ) -> tuple[Array | None, ControlAgentState]:
+        explicit_key = _explicit_threefry_key(
+            key,
+            name="differential-SARSA initial key",
+        )
+        return None, self._differential_agent.init(self.config.observation_dim, explicit_key)
+
+    def _start_payload(
+        self,
+        state: ReferenceLifeControlState,
+        observation: np.ndarray[Any, np.dtype[np.float32]],
+    ) -> tuple[Array | None, ControlAgentState, int]:
+        if (
+            not isinstance(state.agent_state, DifferentialSARSAState)
+            or state.random_key is not None
+        ):
+            raise DecisionOwnershipError("differential-SARSA fresh state is inconsistent")
+        started, action = self._differential_agent.start(
+            state.agent_state,
+            jnp.asarray(observation, dtype=jnp.float32),
+        )
+        return None, started, int(action)
+
+    def _validate_payload(
+        self,
+        state: ReferenceLifeControlState,
+        observation: np.ndarray[Any, np.dtype[np.float32]],
+        action: int,
+    ) -> None:
+        learner = state.agent_state
+        if not isinstance(learner, DifferentialSARSAState) or state.random_key is not None:
+            raise DecisionOwnershipError("differential-SARSA state payload is inconsistent")
+        expected_float_shapes = (
+            ("q_weights", learner.q_weights, (self.config.n_actions, self.config.observation_dim)),
+            ("q_bias", learner.q_bias, (self.config.n_actions,)),
+            (
+                "q_trace_weights",
+                learner.q_trace_weights,
+                (self.config.n_actions, self.config.observation_dim),
+            ),
+            ("q_trace_bias", learner.q_trace_bias, (self.config.n_actions,)),
+            ("average_reward", learner.average_reward, ()),
+            ("last_observation", learner.last_observation, (self.config.observation_dim,)),
+            ("epsilon", learner.epsilon, ()),
+        )
+        for name, value, shape in expected_float_shapes:
+            array = np.asarray(value)
+            if array.shape != shape or array.dtype != np.dtype(np.float32):
+                raise DecisionOwnershipError(
+                    f"differential-SARSA {name} violates shape/dtype contract"
+                )
+        for name, value in (
+            ("last_action", learner.last_action),
+            ("step_count", learner.step_count),
+        ):
+            array = np.asarray(value)
+            if array.shape != () or array.dtype != np.dtype(np.int32):
+                raise DecisionOwnershipError(
+                    f"differential-SARSA {name} must be scalar int32"
+                )
+        step_words = np.asarray(learner.step_words)
+        if step_words.shape != (2,) or step_words.dtype != np.dtype(np.uint32):
+            raise DecisionOwnershipError(
+                "differential-SARSA step_words must have shape (2,) and dtype uint32"
+            )
+        _require_prng_key(
+            learner.rng_key,
+            name="differential-SARSA key",
+            implementation=_THREEFRY_IMPLEMENTATION,
+        )
+        if not _tree_finite(learner):
+            raise DecisionOwnershipError("differential-SARSA state must be finite")
+        if int(learner.step_count) != state.decision_index:
+            raise DecisionOwnershipError("differential-SARSA counter does not match decision")
+        if not np.array_equal(step_words, _counter_words(state.decision_index)):
+            raise DecisionOwnershipError("differential-SARSA exact counter is inconsistent")
+        if not np.array_equal(np.asarray(learner.last_observation), observation):
+            raise DecisionOwnershipError("differential-SARSA observation cache is inconsistent")
+        if int(learner.last_action) != action:
+            raise DecisionOwnershipError("differential-SARSA action cache is inconsistent")
+        epsilon = float(learner.epsilon)
+        if not 0.0 <= epsilon <= 1.0:
+            raise DecisionOwnershipError("differential-SARSA epsilon is invalid")
+
+    def _advance_payload(
+        self,
+        state: ReferenceLifeControlState,
+        *,
+        reward: np.float32,
+        discount: np.float32,
+        next_observation: np.ndarray[Any, np.dtype[np.float32]],
+        next_index: int,
+    ) -> tuple[Array | None, ControlAgentState, int, bool]:
+        del next_index
+        learner = state.agent_state
+        assert isinstance(learner, DifferentialSARSAState)
+        result = self._differential_agent.update(
+            learner,
+            jnp.asarray(reward, dtype=jnp.float32),
+            jnp.asarray(next_observation, dtype=jnp.float32),
+            discount=jnp.asarray(discount, dtype=jnp.float32),
+        )
+        if not bool(np.asarray(result.update_applied)):
+            raise DecisionOwnershipError("differential-SARSA functional update was unavailable")
+        old_parameters = (learner.q_weights, learner.q_bias, learner.average_reward)
+        new_parameters = (
+            result.state.q_weights,
+            result.state.q_bias,
+            result.state.average_reward,
+        )
+        return (
+            None,
+            result.state,
+            int(result.action),
+            not _tree_exactly_equal(old_parameters, new_parameters),
+        )
+
+
+class DiscountedSARSAReferenceAdapter(_BaseReferenceControlAdapter):
+    """Exact-dispatch wrapper for discounted SARSA on continuing outcomes."""
+
+    __slots__ = ()
+
+    def __init__(self, config: DiscountedSARSAReferenceConfig) -> None:
+        if not isinstance(config, DiscountedSARSAReferenceConfig):
+            raise ValueError("discounted-SARSA adapter config has the wrong type")
+        agent = SARSAAgent(
+            sarsa_config=config.core_config(),
+            hidden_sizes=config.hidden_sizes,
+            step_size=config.step_size,
+            sparsity=config.sparsity,
+            leaky_relu_slope=config.leaky_relu_slope,
+            use_layer_norm=config.use_layer_norm,
+            lamda=config.lamda,
+        )
+        super().__init__(
+            config,
+            implementation_id=DISCOUNTED_SARSA_IMPLEMENTATION_ID,
+            state_schema=DISCOUNTED_SARSA_STATE_SCHEMA,
+            agent=agent,
+        )
+
+    @property
+    def config(self) -> DiscountedSARSAReferenceConfig:
+        return cast(DiscountedSARSAReferenceConfig, super().config)
+
+    @property
+    def _sarsa_agent(self) -> SARSAAgent:
+        agent = self._agent
+        if (
+            not isinstance(agent, SARSAAgent)
+            or self._agent_config_json is None
+            or _canonical_json(agent.to_config()) != self._agent_config_json
+        ):
+            raise DecisionOwnershipError("discounted-SARSA core configuration was mutated")
+        return agent
+
+    def _initial_payload(
+        self,
+        key: Array,
+    ) -> tuple[Array | None, ControlAgentState]:
+        explicit_key = _explicit_threefry_key(
+            key,
+            name="discounted-SARSA initial key",
+        )
+        learner = self._sarsa_agent.init(self.config.observation_dim, explicit_key)
+        # The core learner exposes host-side lifecycle timers for its timed loop
+        # helpers.  This exact-dispatch adapter never uses those helpers, and a
+        # JIT update otherwise promotes both Python floats into persistent JAX
+        # leaves on the first transition.  Canonical scalar arrays keep the
+        # whole-life state shape fixed and exclude wall-clock time from state.
+        inner = learner.learner_state.replace(  # type: ignore[attr-defined]
+            birth_timestamp=jnp.asarray(0.0, dtype=jnp.float32),
+            uptime_s=jnp.asarray(0.0, dtype=jnp.float32),
+        )
+        return None, learner.replace(learner_state=inner)  # type: ignore[attr-defined]
+
+    def _start_payload(
+        self,
+        state: ReferenceLifeControlState,
+        observation: np.ndarray[Any, np.dtype[np.float32]],
+    ) -> tuple[Array | None, ControlAgentState, int]:
+        if not isinstance(state.agent_state, SARSAState) or state.random_key is not None:
+            raise DecisionOwnershipError("discounted-SARSA fresh state is inconsistent")
+        observation_array = jnp.asarray(observation, dtype=jnp.float32)
+        action, key = self._sarsa_agent.select_action(
+            state.agent_state,
+            observation_array,
+        )
+        started = state.agent_state.replace(  # type: ignore[attr-defined]
+            last_action=action,
+            last_observation=observation_array,
+            rng_key=key,
+        )
+        return None, started, int(action)
+
+    def _validate_inner_learner_contract(self, learner: SARSAState) -> None:
+        inner = learner.learner_state
+        hidden_sizes = self.config.hidden_sizes
+        input_widths = (
+            (self.config.observation_dim, *hidden_sizes[:-1]) if hidden_sizes else ()
+        )
+        trunk_weights = inner.trunk_params.weights
+        trunk_biases = inner.trunk_params.biases
+        if (
+            type(trunk_weights) is not tuple
+            or type(trunk_biases) is not tuple
+            or len(trunk_weights) != len(hidden_sizes)
+            or len(trunk_biases) != len(hidden_sizes)
+        ):
+            raise DecisionOwnershipError(
+                "discounted-SARSA trunk parameter structure violates its contract"
+            )
+        trunk_shapes: list[tuple[int, ...]] = []
+        for index, (fan_in, fan_out) in enumerate(
+            zip(input_widths, hidden_sizes, strict=True)
+        ):
+            weight_shape = (fan_out, fan_in)
+            bias_shape = (fan_out,)
+            _require_float32_array(
+                trunk_weights[index],
+                name=f"discounted-SARSA trunk weight {index}",
+                shape=weight_shape,
+            )
+            _require_float32_array(
+                trunk_biases[index],
+                name=f"discounted-SARSA trunk bias {index}",
+                shape=bias_shape,
+            )
+            trunk_shapes.extend((weight_shape, bias_shape))
+
+        final_width = hidden_sizes[-1] if hidden_sizes else self.config.observation_dim
+        head_weights = inner.head_params.weights
+        head_biases = inner.head_params.biases
+        if (
+            type(head_weights) is not tuple
+            or type(head_biases) is not tuple
+            or len(head_weights) != self.config.n_actions
+            or len(head_biases) != self.config.n_actions
+        ):
+            raise DecisionOwnershipError(
+                "discounted-SARSA head parameter structure violates its contract"
+            )
+        for index in range(self.config.n_actions):
+            _require_float32_array(
+                head_weights[index],
+                name=f"discounted-SARSA head weight {index}",
+                shape=(1, final_width),
+            )
+            _require_float32_array(
+                head_biases[index],
+                name=f"discounted-SARSA head bias {index}",
+                shape=(1,),
+            )
+
+        _require_lms_optimizer_tree(
+            inner.trunk_optimizer_states,
+            name="discounted-SARSA trunk optimizer state",
+            group_count=len(hidden_sizes),
+            step_size=self.config.step_size,
+        )
+        _require_lms_optimizer_tree(
+            inner.head_optimizer_states,
+            name="discounted-SARSA head optimizer state",
+            group_count=self.config.n_actions,
+            step_size=self.config.step_size,
+        )
+        _require_float32_tree(
+            inner.trunk_traces,
+            name="discounted-SARSA trunk traces",
+            expected_shapes=tuple(trunk_shapes),
+        )
+        _require_float32_tree(
+            inner.head_traces,
+            name="discounted-SARSA head traces",
+            expected_shapes=tuple(
+                shape
+                for _ in range(self.config.n_actions)
+                for shape in ((1, final_width), (1,))
+            ),
+        )
+        _require_float32_tree(
+            inner.hidden_unit_utilities,
+            name="discounted-SARSA hidden-unit utilities",
+            expected_shapes=tuple((width,) for width in hidden_sizes),
+        )
+        if inner.normalizer_state is not None:
+            raise DecisionOwnershipError(
+                "discounted-SARSA state must not contain an undeclared normalizer"
+            )
+        for name in ("birth_timestamp", "uptime_s"):
+            _require_float32_array(
+                getattr(inner, name),
+                name=f"discounted-SARSA {name}",
+                shape=(),
+            )
+
+    def _validate_payload(
+        self,
+        state: ReferenceLifeControlState,
+        observation: np.ndarray[Any, np.dtype[np.float32]],
+        action: int,
+    ) -> None:
+        learner = state.agent_state
+        if not isinstance(learner, SARSAState) or state.random_key is not None:
+            raise DecisionOwnershipError("discounted-SARSA state payload is inconsistent")
+        self._validate_inner_learner_contract(learner)
+        last_observation = np.asarray(learner.last_observation)
+        last_action = np.asarray(learner.last_action)
+        step_count = np.asarray(learner.step_count)
+        epsilon = np.asarray(learner.epsilon)
+        if (
+            last_observation.shape != (self.config.observation_dim,)
+            or last_observation.dtype != np.dtype(np.float32)
+        ):
+            raise DecisionOwnershipError("discounted-SARSA observation cache is malformed")
+        if last_action.shape != () or last_action.dtype != np.dtype(np.int32):
+            raise DecisionOwnershipError("discounted-SARSA action cache is malformed")
+        if step_count.shape != () or step_count.dtype != np.dtype(np.int32):
+            raise DecisionOwnershipError("discounted-SARSA step_count must be scalar int32")
+        if epsilon.shape != () or epsilon.dtype != np.dtype(np.float32):
+            raise DecisionOwnershipError("discounted-SARSA epsilon must be scalar float32")
+        _require_prng_key(
+            learner.rng_key,
+            name="discounted-SARSA key",
+            implementation=_THREEFRY_IMPLEMENTATION,
+        )
+        if not _tree_finite(learner):
+            raise DecisionOwnershipError("discounted-SARSA state must be finite")
+        if int(step_count) != state.decision_index:
+            raise DecisionOwnershipError("discounted-SARSA counter does not match decision")
+        inner_count = np.asarray(learner.learner_state.step_count)
+        inner_words = np.asarray(learner.learner_state.step_words)
+        if inner_words.shape != (2,) or inner_words.dtype != np.dtype(np.uint32):
+            raise DecisionOwnershipError(
+                "discounted-SARSA step_words must have shape (2,) and dtype uint32"
+            )
+        if (
+            inner_count.shape != ()
+            or inner_count.dtype != np.dtype(np.int32)
+            or int(inner_count) != state.decision_index
+            or not np.array_equal(inner_words, _counter_words(state.decision_index))
+        ):
+            raise DecisionOwnershipError("discounted-SARSA learner counter is inconsistent")
+        if not np.array_equal(last_observation, observation):
+            raise DecisionOwnershipError("discounted-SARSA observation cache is inconsistent")
+        if int(last_action) != action:
+            raise DecisionOwnershipError("discounted-SARSA action cache is inconsistent")
+        if not 0.0 <= float(epsilon) <= 1.0:
+            raise DecisionOwnershipError("discounted-SARSA epsilon is invalid")
+        try:
+            q_values = np.asarray(
+                self._sarsa_agent.horde.predict(
+                    learner.learner_state,
+                    jnp.asarray(observation, dtype=jnp.float32),
+                )[: self.config.n_actions]
+            )
+        except Exception as exc:
+            raise DecisionOwnershipError(
+                "discounted-SARSA learner structure is invalid"
+            ) from exc
+        if (
+            q_values.shape != (self.config.n_actions,)
+            or q_values.dtype != np.dtype(np.float32)
+            or not np.all(np.isfinite(q_values))
+        ):
+            raise DecisionOwnershipError("discounted-SARSA action values are invalid")
+
+    def _advance_payload(
+        self,
+        state: ReferenceLifeControlState,
+        *,
+        reward: np.float32,
+        discount: np.float32,
+        next_observation: np.ndarray[Any, np.dtype[np.float32]],
+        next_index: int,
+    ) -> tuple[Array | None, ControlAgentState, int, bool]:
+        del discount, next_index
+        learner = state.agent_state
+        assert isinstance(learner, SARSAState)
+        observation_array = jnp.asarray(next_observation, dtype=jnp.float32)
+        next_action, key = self._sarsa_agent.select_action(learner, observation_array)
+        selected = learner.replace(rng_key=key)  # type: ignore[attr-defined]
+        result = self._sarsa_agent.update(
+            selected,
+            jnp.asarray(reward, dtype=jnp.float32),
+            observation_array,
+            jnp.asarray(False, dtype=jnp.bool_),
+            next_action,
+        )
+        old_parameters = (
+            learner.learner_state.trunk_params,
+            learner.learner_state.head_params,
+        )
+        new_parameters = (
+            result.state.learner_state.trunk_params,
+            result.state.learner_state.head_params,
+        )
+        return (
+            None,
+            result.state,
+            int(result.action),
+            not _tree_exactly_equal(old_parameters, new_parameters),
+        )
+
+
+__all__ = [
+    "ANALYTIC_ORACLE_IMPLEMENTATION_ID",
+    "ANALYTIC_ORACLE_STATE_SCHEMA",
+    "DIFFERENTIAL_SARSA_IMPLEMENTATION_ID",
+    "DIFFERENTIAL_SARSA_STATE_SCHEMA",
+    "DISCOUNTED_SARSA_IMPLEMENTATION_ID",
+    "DISCOUNTED_SARSA_STATE_SCHEMA",
+    "REFERENCE_CONTROL_ACTION_SEMANTIC_ID",
+    "REFERENCE_CONTROL_CONFIG_SCHEMA",
+    "REFERENCE_CONTROL_MAX_ACCEPTED_EVENTS",
+    "REFERENCE_CONTROL_OBSERVATION_SEMANTIC_ID",
+    "UNIFORM_RANDOM_IMPLEMENTATION_ID",
+    "UNIFORM_RANDOM_STATE_SCHEMA",
+    "AnalyticOracleReferenceAdapter",
+    "AnalyticOracleReferenceConfig",
+    "DifferentialSARSAReferenceAdapter",
+    "DifferentialSARSAReferenceConfig",
+    "DiscountedSARSAReferenceAdapter",
+    "DiscountedSARSAReferenceConfig",
+    "ReferenceControlResourceUsage",
+    "ReferenceLifeControlState",
+    "UniformRandomReferenceAdapter",
+    "UniformRandomReferenceConfig",
+    "control_state_resource_usage",
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,69 @@
+# Documentation
+
+This directory holds ASI's research, design, evidence, runbook, and archive documents.
+The package overview and development entry points are in
+[`README.md`](../README.md).
+
+## Current references
+
+- [`research/asi-roadmap.md`](research/asi-roadmap.md) — ASI's mission, hillclimb loop,
+  application ladder, whole-life scorecard, and current program priorities.
+- [`design/asi-reference-agent-protocol.md`](design/asi-reference-agent-protocol.md) — Proposed
+  shared reference-life protocol, state ownership, dispatch invariants, adapter boundaries, and
+  exact-resume acceptance gate. Implemented narrow L0 slices include the
+  unfrozen [`preview1` transaction ledger](../alberta_framework/reference_agent.py),
+  the [primitive Prototype bridge](../alberta_framework/prototype_reference_adapter.py),
+  the [aggregate Switching/RiverSwim runner](../alberta_framework/reference_life.py),
+  the [quiescent checkpoint codec](../alberta_framework/reference_life_checkpoint.py),
+  [matched control adapters](../alberta_framework/reference_life_controls.py), and the
+  [development scorecard](../alberta_framework/benchmarks/reference_life_scorecard.py),
+  covered by
+  [transaction](../tests/test_reference_agent_protocol.py),
+  [bridge](../tests/test_prototype_reference_adapter.py),
+  [runner](../tests/test_reference_life.py),
+  [Switching checkpoint](../tests/test_reference_life_checkpoint.py),
+  [RiverSwim runner](../tests/test_reference_life_riverswim.py),
+  [RiverSwim checkpoint](../tests/test_reference_life_riverswim_checkpoint.py),
+  [control](../tests/test_reference_life_controls.py), and
+  [scorecard](../tests/test_reference_life_scorecard.py)
+  tests. RiverSwim has a distinct manifest/state discriminator and stationary
+  metrics, an exact `2 <= n_states <= 12` resource bound, identical derived JAX
+  keys at execution and replay validation, and exact original/restored
+  continuation from the same quiescent barrier. This is not a frozen/portable
+  checkpoint contract, safety/options/boundary/Forager/robot conformance,
+  broader environment support, `reference-dev`, RiverSwim
+  learning/performance benefit, or scientific evidence. The current hillclimb
+  machinery freezes a permanently nonpromoting 144-shard SwitchingTwoState +
+  RiverSwim development scorecard over 12 consumed seeds and six arms. It has
+  not produced a completed result or selected `reference-dev`.
+- [`status.md`](status.md) — requirement-to-evidence status and completion gates.
+- [`evidence/methodology.md`](evidence/methodology.md) — evidence levels, artifact rules,
+  validators, and the property map.
+- [`evidence/negative-results.md`](evidence/negative-results.md) — concluded negative and
+  bounded results. Check this before opening a new experimental lane.
+- [`audits/repository-larp-audit.md`](audits/repository-larp-audit.md) — dated cleanup audit of
+  unsupported surface, evidence state, and metadata drift. It is a historical snapshot, not
+  the current status authority.
+- [`research/ipmnist-theory.md`](research/ipmnist-theory.md) — mechanistic interpretation of
+  the development-only IPMNIST campaign.
+- [`research/ipmnist-campaign-index.md`](research/ipmnist-campaign-index.md) — mutable pointer
+  to the current IPMNIST summary and the supersession status of append-only records.
+- [`research/sota-landscape.md`](research/sota-landscape.md) — current protocol-aware external
+  comparison map for IPMNIST, Forager, and the other ASI lanes.
+- [`design/rtu-taylor-correction.md`](design/rtu-taylor-correction.md) — derivation and limits
+  of the optional RTU approximation.
+
+## Runbooks
+
+- [`runbooks/foragax-open-screen.md`](runbooks/foragax-open-screen.md)
+
+Runbooks retain their stated issuance and promotion boundaries. An unissued or
+development-only runbook does not authorize a scientific result.
+
+## Archive
+
+- [`archive/forager-comparator-audit.md`](archive/forager-comparator-audit.md)
+- [`archive/historical-forager-reconstruction.md`](archive/historical-forager-reconstruction.md)
+
+Archived documents are dated records, not current status pages. Current campaign artifacts
+live under `outputs/`; immutable or append-only rules in the agent guide still apply.

--- a/docs/design/asi-reference-agent-protocol.md
+++ b/docs/design/asi-reference-agent-protocol.md
@@ -1,0 +1,462 @@
+# ASI reference-agent protocol
+
+Status: **Proposed**
+
+This ADR selects a shared reference-life protocol with implementation-specific
+adapters as ASI's architectural direction. It does not select a current agent
+configuration, populate `reference-dev`, establish a whole-life result, or make
+a robotics-readiness or state-of-the-art claim.
+
+## Context
+
+ASI needs one runnable agent identity that can learn throughout an operational
+life and move from controlled continual-learning environments toward robotics.
+The repository currently has two relevant but incompatible composition paths:
+
+- `alberta_framework.core.prototype_agent.PrototypeAgent` has a strict,
+  functional discrete-action transition contract, decision ownership, and a
+  complete agent-state checkpoint wrapper. Development-only primitive
+  SwitchingTwoState and RiverSwim runners plus quiescent whole-life checkpoints
+  now consume it and pass same-runtime exact-continuation gates. Broader
+  environment generality and the OaK/STOMP extended-action ownership edge
+  remain open.
+- The sibling robot track has continuous-action controllers, Gymnasium/MuJoCo
+  loops, checkpoint manifests, and safety/bridge plumbing. It does not consume
+  `PrototypeAgent`, and its ordinary parameter snapshots are not an exact
+  checkpoint of every learner, runner, environment, and in-flight state.
+
+Making either implementation the universal interface would force the other
+action domain into the wrong abstraction. Maintaining unrelated lifecycle
+contracts would prevent one exact-resume gate and one whole-life scorecard from
+governing both paths.
+
+## Decision
+
+ASI defines one semantic reference-agent protocol and will implement adapters
+for concrete agents and environments. The protocol owns lifecycle, dispatch,
+transition, checkpoint, and measurement semantics; it does not prescribe a
+particular learner, observation encoding, or action tensor shape.
+
+A conforming implementation requires one authoritative life runner. Agent,
+environment, dispatch/safety, and metric adapters expose all mutable state to
+that runner. They may use functional or object-oriented internals, but no
+protocol implementation may hide mutable state that affects a future
+observation, action, update, metric, or replay decision.
+
+The selected direction is therefore the shared-protocol path. It remains
+Proposed while broader conformance is open. The current-schema quiescent
+checkpoint/exact-resume gate now passes for the primitive Prototype +
+SwitchingTwoState and Prototype + RiverSwim constructions; those narrow L0
+results neither freeze the protocol nor establish RiverSwim learning or
+performance benefit nor select `reference-dev`. A separate record must name the
+first `reference-dev` configuration after the remaining gates; this document
+cannot do so by assertion.
+
+### Implemented `preview1` L0 transaction slice
+
+The [host transaction module](../../alberta_framework/reference_agent.py)
+and its [retained contract tests](../../tests/test_reference_agent_protocol.py)
+implement the first acceptance slice:
+
+- `asi.reference_agent.preview1`, `asi.reference_agent_manifest.preview1`, and
+  `asi.reference_transaction_state.preview1` identify a versioned preview, not a
+  frozen v1 contract;
+- canonical configuration and manifest identities plus fixed, exact-dtype
+  observation/action spaces;
+- deeply immutable typed payloads and manifest-bound, lifecycle-scoped decisions;
+- separate independent authorization, learner settlement, pre-execution command,
+  post-execution executor receipt, and receipt-bound outcome records;
+- explicit bootstrap and post-reset observation IDs at episode boundaries;
+- a process-local, single-writer live ledger whose lock-protected current-object
+  identity compare-and-swap rejects stale snapshots, phase/chain forgery, and
+  repeated `init()` within that ledger object;
+- rejection semantics that leave the event unconsumed, retain its transaction in
+  `halted`, arm no next decision, and require recovery; and
+- a bounded uint64 decision index whose final accepted event is consumed before
+  the ledger clears the transaction and enters `exhausted` without wrapping.
+
+This is an L0 host transaction contract, not an agent, environment, safety, or
+metrics adapter. The host transaction module alone does not implement the
+canonical life configuration, aggregate life state, authoritative runner,
+whole-life checkpoint, exact resume, or `reference-dev`. The live ledger
+deliberately refuses pickling and supplies
+no durable replay protection, restore path, wire decoder, checkpoint format, or
+cross-process exact-resume claim. The preview accepts only finite scalar reward
+and discount values and defines no extension sidecars.
+
+For an authorized action replacement, the ledger checks that the manifest
+declares rebinding and that the adapter asserts `rebinding_applied=True`. It
+cannot prove that a concrete adapter updated every credit owner and action-bound
+cache; that remains an adapter conformance gate. Its `DispatchReceipt` is a typed
+executor acknowledgement, not proof of physical dispatch. The host now issues a
+distinct `DispatchCommand`, bound to the settlement and the declared executor ID
+and epoch, before execution. Only after execution may it record a receipt carrying
+the independently encoded applied action. An applied-action mismatch retains the
+receipt, halts before an outcome can be recorded, and cannot reach learning.
+
+### Implemented Prototype L0 agent transaction bridge
+
+The development-only
+[Prototype reference adapter](../../alberta_framework/prototype_reference_adapter.py)
+and its [retained tests](../../tests/test_prototype_reference_adapter.py) implement a
+manifest-bound, primitive-only, exact-dispatch bridge from the preview records to a
+sidecar-free `PrototypeAgent` configuration on continuing transactions. Its immutable state
+envelope binds the underlying agent state to the manifest and configuration and owns the host
+lifecycle, decision index, and observation identity. It stages functional updates, preserves
+the supplied state on rejection, and advances only an exact receipt-bound transaction.
+
+This is an L0 agent transaction bridge, not by itself an environment or executor adapter. It
+neither proves that the acknowledged action reached an environment nor supplies a whole-life
+checkpoint, durable replay/restore, or exact resume. Options, action replacement/rebinding, and
+episode-boundary semantics are deliberately unsupported; the bridge is not `reference-dev` or
+scientific evidence.
+
+### Implemented development-only aggregate L0 life slices
+
+The [aggregate reference-life module](../../alberta_framework/reference_life.py)
+and its [base retained tests](../../tests/test_reference_life.py) plus
+[RiverSwim tests](../../tests/test_reference_life_riverswim.py) implement the
+authoritative process-local runner through the primitive `PrototypeAgent` +
+`SwitchingTwoStateMDP` and `PrototypeAgent` + `RiverSwimMDP` paths:
+
+- a canonical immutable life configuration binds the complete agent, environment,
+  declared-static exact-dispatch, and metric configurations and digests, plus a
+  `max_accepted_events` bounded by the smallest selected component capacity;
+- one immutable aggregate state owns agent, environment, transaction, dispatch,
+  environment-RNG cursor, metrics, event counters, pending outcome, halt,
+  transcript, commit generation, and checkpoint generation;
+- a pure transaction reducer lets the aggregate runner own the only live CAS,
+  while the standalone ledger retains its process-local lock/current-object
+  behavior;
+- runner-derived observation IDs and one outer lock cover authority,
+  settlement, command issuance, strict action validation, functional
+  environment execution, post-execution receipt, outcome, agent/metric staging,
+  and one aggregate commit;
+- each concrete environment adapter recomputes state progression, observation,
+  reward, regime, oracle reward, and continuing-boundary semantics before a
+  result reaches learning;
+- RiverSwim has a distinct manifest/state discriminator, requires stationary
+  metrics, and rejects `n_states` outside `[2, 12]` before constructing its
+  exponential exact oracle;
+- RiverSwim execution and validation receive the identical runner-derived JAX
+  key, and validation replays the stochastic transition exactly;
+- phase/reward/oracle/regret metrics, horizon completion, transcript hashing,
+  abort, known post-execution divergence, and complete-outcome recovery without
+  redispatch are retained; and
+- an ordinary-`Exception` post-issue guard commits a process-local emergency
+  CAS halt so the original immutable snapshot becomes stale.
+
+This runner remains a `preview1` L0 development mechanism. Its declared static
+exact authority is not an independent safety policy, and its synthetic veto
+test is not safety conformance. Its at-most-once property is relative to stale
+snapshots within one live process; it is not a durable executor guarantee and
+excludes process death, `BaseException`, hardware delivery, and reconciliation.
+Options, rebinding, boundaries, wire decoding, additional/general environments,
+robot and Forager adapters, `reference-dev`, learning/performance benefit, and
+evidence remain open.
+
+### Implemented quiescent checkpoints and exact resume
+
+The development-only
+[checkpoint module](../../alberta_framework/reference_life_checkpoint.py) and
+its [Switching tests](../../tests/test_reference_life_checkpoint.py) and
+[RiverSwim tests](../../tests/test_reference_life_riverswim_checkpoint.py)
+implement a canonical current-schema bundle for both supported primitive lives.
+Save is permitted only at an armed, quiescent, pre-completion boundary. On Linux
+it atomically publishes one immutable no-replace generation, nests the complete
+Prototype v3 checkpoint, encodes every aggregate owner, binds current selected
+source/runtime/dependency identities and child consistency hashes, reconstructs
+fresh components from the distinct environment implementation/state
+discriminator, and requires strict cross-component adoption before
+continuation.
+
+The retained gate checkpoints after `N` events, continues the original runner
+for `M` events from the committed barrier, restores that same barrier into a
+fresh runner, and requires exact continuation steps, events, and aggregate
+state, including exact keyed stochastic RiverSwim continuation. These are L0
+simulation results, not a frozen or portable migration contract, authenticated
+execution attestation, durable dispatch replay, process-crash guarantee, safety
+result, RiverSwim learning or performance result, `reference-dev`, or evidence.
+In-flight, recovery, completed, unimplemented-environment, and physical-state
+restore are unsupported.
+
+## Protocol records
+
+Exact Python names and packaging may be refined during implementation, but the
+following semantic records are required and versioned.
+
+### Life configuration
+
+The canonical, JSON-compatible life configuration binds:
+
+- protocol and configuration schema versions;
+- agent adapter type and complete agent configuration;
+- environment adapter type and complete environment configuration;
+- observation and action codec versions;
+- dispatch and independent safety-authority configuration;
+- agent, environment, and adapter seed schedules;
+- task/regime schedule and all exposed boundary signals;
+- canonical `max_accepted_events`, bounded by the smallest non-wrapping counter
+  capacity declared by every selected agent, environment, dispatch, metrics, and
+  runner component;
+- checkpoint cadence and transaction-boundary policy;
+- metric definitions, resource ceilings, and latency deadlines; and
+- source, dependency, and runtime identity required by the declared lane.
+
+Defaults that affect behavior are materialized before hashing. Unknown fields,
+noncanonical encodings, incompatible adapter combinations, and event horizons
+above any selected component's capacity fail closed before initialization.
+
+### Life state
+
+The life runner is the sole owner of one aggregate state containing:
+
+| State | Required owner and contents |
+|---|---|
+| Agent | Agent adapter; all parameters, optimizer/traces, learned state, caches, counters, and RNGs |
+| Environment | Environment adapter; complete simulation state, reset state, RNGs, and task/regime position |
+| Dispatch | Dispatch adapter; proposed and authorized action lineage, safety/watchdog state, and any pending command or receipt |
+| Runner | Life runner; lifecycle ID, generation/event counters, phase, checkpoint generation, and seed derivation state |
+| Metrics | Metric adapter; online accumulators and enough state to continue the scorecard exactly |
+| Provenance | Canonical configuration digest plus declared source, dependency, environment, and runtime identities |
+
+Adapter objects may retain immutable compiled functions or static configuration.
+All mutable values belong in the aggregate state. There is no second informal
+owner and no parameter-only checkpoint exception.
+
+### Decision, authorization, and outcome
+
+Every decision has a manifest identity, lifecycle-scoped non-reusable decision
+ID and index, the observation identity from which it was produced, an immutable
+typed proposed action carrying its codec semantic ID, and an armed/disarmed
+status.
+
+Before an action reaches an environment, an independent dispatch/safety adapter
+returns an authorization record bound to that decision ID. It contains the
+authorized action, whether it differs from the proposal, the authority and
+policy version that made the decision, and an authorization ID. The agent
+adapter then returns a distinct settlement record binding learner credit to the
+authorized action. A configuration that cannot safely settle a changed action
+must halt rather than learn from a counterfactual proposal. The host next issues
+a distinct command that binds the settlement to a canonical command ID and the
+configured executor ID and epoch. After the executor reports execution, a
+distinct receipt binds that command, receipt ID, and independently encoded
+applied action. If the applied action differs from the settled command, the
+ledger halts before recording an outcome or applying learning.
+
+An outcome is bound to the exact dispatch receipt and therefore to its
+lifecycle and decision. In `preview1` it contains one finite scalar reward and
+one finite scalar continuation discount, termination and truncation flags, the
+final observation and identity used for bootstrapping, and the potentially
+distinct post-reset observation and identity used for the next decision.
+Additional learning-signal sidecars require a future protocol version.
+
+## Lifecycle
+
+One life follows this order:
+
+1. Canonicalize and validate the complete life configuration.
+2. Create a fresh lifecycle ID and initialize every state owner exactly once.
+3. Initialize or restore the environment and obtain the first observation.
+4. Start the agent once and arm one decision.
+5. Authorize and settle that decision.
+6. Issue one executor-bound dispatch command.
+7. Dispatch the commanded action exactly once.
+8. Record the executor's matching post-execution receipt and applied action.
+9. Record the matching outcome exactly once.
+10. Apply one atomic agent update, advance metrics and runner counters, and arm
+   the next decision.
+11. At a declared quiescent boundary, optionally write a whole-life checkpoint.
+12. Continue across task and episode boundaries without reinitializing learned
+    agent state. Only explicitly declared episodic state may reset.
+
+The implemented checkpoint API writes only after an accepted outcome and before
+the next command. A successful publication advances commit and checkpoint
+generations and persists that exact barrier; restore/adoption advances neither.
+In-flight and physical actions remain outside the exact-resume gate until a
+later protocol defines durable idempotent dispatch and reconciliation.
+
+In the preview ledger, rejecting an outcome leaves its event unconsumed and
+retains the transaction in `halted`. The aggregate runner can retry agent and
+metric staging only from a complete retained outcome, without command issuance
+or environment execution; vetoes, incomplete/uncertain results, known
+post-execution divergence, and stale snapshots cannot use that recovery path.
+This recovery is process-local and is not durable replay/restore. Accepting the
+event at the maximum uint64 decision index consumes that final event and moves
+the ledger to `exhausted`; it never wraps the counter.
+
+## Dispatch and transition invariants
+
+Conforming implementations must enforce all of the following:
+
+- A decision is used at most once and only within its lifecycle.
+- The observation, decision ID, authorized action, command, post-execution receipt,
+  applied action, and outcome form one
+  ownership chain. Stale, replayed, cross-life, out-of-order, or mismatched
+  records fail closed without a partial learning update.
+- Learning credits the action actually dispatched. Safety clipping, action
+  substitution, skill selection, residual blending, or actuator projection may
+  not be hidden behind the proposed action.
+- A command exists before execution and a receipt only afterward. A receipt must
+  report the independently encoded applied action; a mismatch with the settled
+  command halts before outcome recording or learning.
+- Extended or hierarchical action identity remains available while the
+  environment receives its primitive action. Rebinding a primitive must update
+  the correct base or intra-option owner without erasing the extended owner.
+- The final and next-decision observation identities are distinct at an
+  autoreset boundary, identical on a continuing transition, and the next
+  observation is absent until an explicit arm after a non-autoreset boundary.
+- Termination, truncation, and discount semantics are explicit and validated.
+- One accepted environment event causes one atomic learner transaction. A
+  rejected event remains unconsumed and halts the runner for recovery. Concrete
+  adapter conformance must prove that every agent state and RNG remains
+  synchronized with that event.
+- Independent safety authority may veto or replace an action and may halt the
+  runner. The learner cannot weaken, train through, or relabel that authority.
+- The final uint64-indexed event is consumed before counter exhaustion disarms
+  the life; the state becomes `exhausted` and the counter never wraps.
+
+## Exact-resume gate
+
+An agent checkpoint alone is not a life checkpoint. A conforming whole-life
+checkpoint binds the canonical configuration and every state in the ownership
+table, including environment and runner RNGs, metric accumulators, current
+decision lineage, and the quiescent transaction phase.
+
+For the implemented current-schema simulator gates, including keyed stochastic
+RiverSwim:
+
+1. Run `N` events and atomically publish quiescent barrier `B`.
+2. Continue the original runner from `B` for `M` events.
+3. Reconstruct fresh components, restore the same persisted `B`, and run `M`
+   events.
+4. Require exact equality of every continuation step and event and the full
+   aggregate state, including decisions/actions, observations/outcomes, agent
+   and environment state, metrics, transcript, counters, generations, and RNGs.
+
+A checkpoint-free control intentionally lacks the barrier's commit/checkpoint
+generation increments and is not the full-state oracle. Floating tolerances do
+not satisfy this gate. Serialized checkpoint directory bytes need not match;
+restored semantic state must.
+
+A physical environment generally cannot be restored exactly. Hardware restart
+must use a separately named reconciled-resume mode that re-establishes sensor,
+safety, and actuator state under independent authority. Reconciled resume is an
+important application gate, but it does not count as passing exact resume.
+
+## Prototype adapter
+
+The implemented primitive-only L0 bridge maps the agent transaction subset as follows:
+
+- `PrototypeAgent.init(..., lifecycle_id=...)` initializes agent state.
+- `start` arms the initial decision; the adapter derives the primitive action
+  and all host decision identity from its manifest-bound state envelope.
+- The adapter constructs the explicit `PrototypeTransition` and calls
+  `update_transition`; the legacy `update` path is not conforming.
+- Only exact primitive dispatch is accepted; veto and replacement are rejected
+  without mutating the supplied functional state.
+
+The current bridge does not support the host ledger's full uint64 horizon:
+Prototype decision/cache validity may disarm at its int32 telemetry or
+observation capacity before the host reaches its final decision index. The
+aggregate runner now binds
+`PROTOTYPE_REFERENCE_MAX_ACCEPTED_EVENTS = 2**31 - 4` into
+`max_accepted_events` and rejects an oversized life before component
+initialization. This is capacity enforcement, not a long-horizon stability or
+resource result.
+
+The implemented quiescent whole-life checkpoint nests the existing v3
+Prototype checkpoint as its agent portion rather than treating it as the entire
+bundle. A future rebinding-capable adapter must expose a public, decision-bound
+settlement path that either preserves or atomically rebinds OaK/STOMP
+base-versus-option credit when authorization changes the primitive action, and
+it must update every action-bound cache. Direct runner mutation of Prototype
+internals is forbidden.
+
+The concrete runner and checkpoint paths use `SwitchingTwoStateMDP` and
+`RiverSwimMDP` in `alberta_framework.streams.closed_loop`. RiverSwim is bounded
+to at most 12 states in this reference slice because its exact stationary oracle
+enumerates `2**n` policies; this is a resource guard, not a scaling or
+performance result. Before the adapter may enter Forager or be called
+conforming, a retained test must exercise an active option through real runner
+dispatch and prove that the primitive is credited to the correct intra-option
+owner while extended-action identity survives.
+
+## Robot adapter
+
+The robot adapter will retain the sibling track's continuous action space,
+environment/task interfaces, and independent bridge safety authority. It will
+map the controller's start/observe behavior into the shared decision,
+authorization, outcome, and boundary records rather than coercing continuous
+actuator vectors into Prototype primitives.
+
+To conform, the adapter must externalize the controller's complete mutable
+state: learned parameters, optimizer and eligibility traces, normalizer and
+feature state, last observation and actual action, task routing, counters, RNGs,
+dispatch/safety state, and any curriculum or environment state affecting future
+behavior. A parameter-only `state_dict` is insufficient. Clipping, residual
+composition, gait/skill priors, and bridge substitutions must be represented as
+authorization/settlement operations so learning is bound to the delivered
+action.
+
+The first robot conformance target is deterministic embodied simulation. The
+existing ASIMOV-1 task sequence and readiness documents remain the application
+ladder; this ADR does not duplicate them or turn existing smoke artifacts into
+performance evidence.
+
+## Non-goals
+
+This ADR does not:
+
+- choose a learner, `PrototypeAgent` configuration, robot controller, task
+  schedule, benchmark winner, or `reference-dev` contents;
+- make discrete and continuous action policies share one learner implementation;
+- require every retained ASI mechanism to coexist in one configuration;
+- establish RiverSwim or broader learning/performance benefit, state of the
+  art, scientific promotion, Alberta Plan completion, robotics readiness, or
+  guarded hardware authorization;
+- replace benchmark-specific frozen protocols or evidence validators;
+- rename the `alberta_framework` compatibility namespace or historical schemas;
+- claim exact restoration of the physical world; or
+- authorize edits to immutable or append-only `outputs/` artifacts.
+
+## Acceptance sequence
+
+The proposal advances only in this order:
+
+1. **Host transaction preview — implemented at L0.** The versioned-but-unfrozen
+   `preview1` manifest and transaction-state schemas, immutable typed payloads,
+   distinct authorization, settlement, command, receipt, and outcome records, explicit
+   bootstrap/reset observation IDs, process-local current-object ledger, and
+   retained validation/ownership tests implement the host transaction slice.
+   This is structural and nonpromoting; it is not a frozen compatibility version.
+2. **Primitive aggregate lives — implemented at L0.** Process-local Prototype +
+   SwitchingTwoState and Prototype + RiverSwim paths own the full aggregate and
+   cover synchronous dispatch, learning updates, metrics, faults, and
+   no-redispatch recovery. RiverSwim uses a distinct discriminator, stationary
+   metrics, exact keyed stochastic validation, and a strict 12-state cap.
+3. **Quiescent exact resume — implemented at L0.** The current-schema bundle,
+   strict restored-state adoption, and exact barrier-fork continuation gate pass
+   for both supported constructions, including keyed stochastic RiverSwim.
+4. **Matched development scorecard — implemented at L0 and permanently
+   nonpromoting.** The scorecard module freezes 12 consumed development seeds,
+   two environments, six fresh-process arms, explicit Threefry roots, an
+   environment-bound finite-horizon privileged dynamic-programming control,
+   fixed reward-lattice checks, and canonical numeric-payload accounting. Its
+   validator is a consistency gate, not authenticated execution attestation.
+   Issuing or validating the plan does not select `reference-dev` or create a
+   completed performance or scientific result.
+5. **Broader conformance — open.** Exercise active-option ownership,
+   replacement/rebinding, real veto authority, boundaries, extension/wire
+   policy, numerical stability, and resource ceilings.
+6. **Forager bridge — open.** Add the ordinary-observation adapter only after
+   extended-action ownership survives real runner dispatch.
+7. **Robot simulation adapter — open.** Externalize complete controller state,
+   bind continuous action after safety/residual transforms, and pass
+   deterministic simulation, fault, and latency gates.
+8. **`reference-dev` decision — open.** Only a separate permanently
+   nonpromoting decision after the full regression panel may select a concrete
+   `reference-dev` configuration and rollback policy.
+
+Until the final step is recorded, ASI has a selected proposed architecture but
+no canonical reference agent or `reference-dev` baseline.

--- a/docs/research/asi-roadmap.md
+++ b/docs/research/asi-roadmap.md
@@ -1,0 +1,305 @@
+# ASI research roadmap
+
+Status: living strategy. This document defines the direction of the project; it
+does not certify current capability or scientific evidence. Current
+implementation and evidence are tracked in [the status map](../status.md), and
+promotion rules live in [the evidence methodology](../evidence/methodology.md).
+
+## Mission
+
+ASI is an evidence-driven continual-learning hillclimbing project. The goal is
+an end-to-end agent that keeps learning throughout one operational life:
+adapting to change, retaining and reusing useful knowledge, discovering useful
+state and predictions, planning and acting, and doing so within bounded compute,
+memory, and latency. The intended application envelope includes useful ongoing
+work and embodied systems such as robotics.
+
+The target is state-of-the-art continual learning in an application, not a
+collection of state-of-the-art component scores. ASI does not currently claim
+that target; no whole-agent L3 protocol or result has been completed, and the
+project is not robotics-ready.
+
+[The Alberta Plan](https://arxiv.org/abs/2208.11173) is a major source of ideas
+and a valuable coverage lens. It is not a binding sequence, architecture, or
+scope boundary. ASI may reorder, combine, revise, reject, or replace its
+mechanisms and pursue ideas from continual learning, reinforcement learning,
+streaming optimization, representation learning, memory, world models,
+exploration, control, and other relevant research.
+
+## What the target means
+
+"State of the art" is comparative and time-dependent. It must be established
+against strong contemporaneous baselines under a frozen, matched protocol; it
+cannot be inferred from an internal record or a dated literature table. An ASI
+application is successful only when all of the following are true together:
+
+1. **Continual adaptation.** The agent improves from an ongoing stream without
+   benchmark-only reinitialization. Any replay, task cue, boundary signal, or
+   offline work is explicit and charged to the resource budget.
+2. **Retention and reuse.** It preserves, reacquires, and transfers useful
+   knowledge while remaining plastic enough to learn genuinely new behavior.
+3. **End-to-end benefit.** Learned state, prediction, memory, planning, and
+   control are judged by downstream lifetime behavior, not merely by isolated
+   component diagnostics.
+4. **Strong comparisons.** It beats or meaningfully extends competitive
+   continual and non-continual baselines without hiding losses on retention,
+   robustness, or cost.
+5. **Bounded operation.** Compute per event, memory growth, latency, checkpoint
+   behavior, and long-horizon numerical stability are measured and compatible
+   with the target application.
+6. **Application transfer.** Gains survive a ladder from controlled streams to
+   continual control, embodied simulation, and guarded real-world workloads.
+   A benchmark-only win is a subsystem result.
+7. **Reproducible evidence.** Claims survive preregistered held-out evaluation,
+   causal ablation, source and environment binding, and independent scrutiny.
+
+Every SOTA statement must be scoped to a named benchmark and version, task
+distribution, resource envelope, primary statistic and uncertainty/test,
+multiple-comparison rule, and baseline roster with an as-of date. The broader
+application target is a bundle of separately passed capability and operational
+gates, not one global SOTA label.
+
+No single metric can prove this target. A method that improves accuracy while
+destroying adaptation speed, lifetime return, latency, or safety has not moved
+the whole application uphill.
+
+## One reference agent
+
+Research should converge on one runnable reference composition rather than a
+growing set of disconnected mechanisms. The retained `PrototypeAgent` and the
+robot-imported continual-RL modules are candidate integration surfaces, not a
+completed application. They may be simplified, extended, or replaced when an
+explicit migration is justified by evidence.
+
+The architectural direction is selected in the
+[Proposed reference-agent protocol ADR](../design/asi-reference-agent-protocol.md):
+one semantic lifecycle, dispatch, state-ownership, and exact-resume contract with
+adapters for `PrototypeAgent` and the sibling robot controller. The
+[unfrozen `preview1` L0 transaction ledger](../../alberta_framework/reference_agent.py)
+and its [retained contract tests](../../tests/test_reference_agent_protocol.py)
+use versioned preview schemas, not frozen v1, and cover immutable typed payloads, distinct
+authorization/settlement/receipt/outcome records, explicit bootstrap/reset
+observation IDs, and a process-local single-writer/current-object ledger. Its
+lock/CAS rejects stale snapshots and repeated initialization inside one live
+object. Rejection leaves the event unconsumed and the ledger halted for recovery;
+the final uint64-indexed event is consumed before the state becomes exhausted.
+This resolves the initial host transaction slice, not completion of the
+implementation or baseline selection.
+The development-only
+[Prototype reference adapter](../../alberta_framework/prototype_reference_adapter.py)
+and its [retained tests](../../tests/test_prototype_reference_adapter.py) add a
+manifest-bound, primitive-only, exact-dispatch L0 agent transaction bridge for
+continuing tasks. It owns host decision identity around functional Prototype state
+and rejects foreign-configuration state, replacement or vetoed authorization,
+and boundaries.
+The development-only
+[aggregate reference-life runner](../../alberta_framework/reference_life.py)
+and its [base retained tests](../../tests/test_reference_life.py), plus its
+[RiverSwim tests](../../tests/test_reference_life_riverswim.py) add a canonical
+immutable life configuration, immutable aggregate state, pure transaction
+reducer, strict SwitchingTwoState and RiverSwim environment adapters,
+phase/stationary metrics, capacity preflight, and process-local outer-lock/CAS
+runner. Primitive Prototype lives for both environments execute authority,
+settlement, command, functional environment step, post-execution receipt,
+outcome, agent/metric staging, and aggregate commit. The tests cover
+concurrency, horizon completion, failure retention, semantic result validation,
+and complete-outcome recovery without redispatch. RiverSwim uses a distinct
+manifest/state discriminator and stationary metrics, is capped at
+`2 <= n_states <= 12` before its exponential exact oracle is constructed, sends
+the identical runner-derived JAX key through execution and validation, and
+replays the keyed stochastic transition during strict validation.
+
+The development-only
+[checkpoint codec](../../alberta_framework/reference_life_checkpoint.py), its
+[Switching tests](../../tests/test_reference_life_checkpoint.py), and its
+[RiverSwim tests](../../tests/test_reference_life_riverswim_checkpoint.py) now
+close the current-schema quiescent exact-resume gate for both primitive lives.
+On Linux a successful save atomically publishes an immutable no-replace
+generation, nests complete Prototype v3 state, binds the aggregate plus current
+source/runtime/dependency identities, reconstructs fresh components from the
+environment discriminator, validates cross-component adoption, and matches
+exact original-versus-restored continuation from the same persisted barrier.
+
+This is still an unfrozen `preview1` L0 construction. It establishes neither
+RiverSwim learning/performance benefit nor a portable checkpoint standard.
+Only quiescent pre-completion state for these two simulators is restored, and
+compatibility fails closed across current source/runtime/dependency drift. The
+hashes bind consistency but are not authenticated execution attestation. There is no
+in-flight dispatch replay, process-death or `BaseException` guarantee, durable
+executor, independent safety authority, additional/general environment adapter,
+option/rebinding/boundary conformance, robot or Forager adapter, selected
+`reference-dev`, or evidence. The Forager path still excludes
+Prototype because extended-action credit ownership has not survived real runner
+dispatch. These closed loops and checkpoint gates remain L0 development slices,
+not a canonical reference baseline.
+
+Every proposed subsystem should answer four questions:
+
+- Which observation-to-action path consumes it?
+- Which owner updates and checkpoints its state?
+- Which whole-life metric should improve, and what is the matched control?
+- What are its incremental compute, memory, latency, and failure costs?
+
+An implementation with no credible consumer belongs in a research note or
+branch, not the reference agent. An integrated change remains provisional until
+the system-level regression panel passes.
+
+ASI separates three channels:
+
+- **`reference-dev`** is the designation that will hold the current integrated
+  development baseline. It is unpopulated until the Proposed protocol's
+  conformance, exact-resume, adapter, and whole-life regression gates pass and a
+  separate decision names a concrete configuration. Once established, it may
+  advance after a matched development comparison and the complete regression
+  panel, but it and its source data remain permanently nonpromoting.
+- **A future release reference** advances only through a versioned,
+  predeclared engineering acceptance and rollback policy. Passing that policy
+  does not create a scientific claim.
+- **Scientific claims** use separately frozen protocols, untouched held-out
+  data, and their own acceptance authority. They never retroactively promote
+  `reference-dev` or release-acceptance runs.
+
+## Hillclimb loop
+
+Each research cycle follows the same loop:
+
+1. **Reproduce the starting point.** Measure the selected baseline with the
+   current source, data, environment, seeds, and resource accounting. Historical
+   means are context, not a live control.
+2. **Localize a bottleneck.** Use traces, ablations, failures, and scaling curves
+   to identify the limiting behavior. Write a falsifiable mechanism hypothesis
+   and a stop condition.
+3. **Choose the smallest coherent intervention.** Prefer a change that exercises
+   the real learning and decision path. Declare expected benefit, integration
+   surface, comparison arm, and cost before the expensive run.
+4. **Run a bounded development screen.** Use paired schedules, multiple seeds,
+   strong baselines, and enough horizon to expose recurrence or instability.
+   Development data may select ideas but can never promote them.
+5. **Retain or reject.** Keep an idea only when the predicted mechanism and
+   practical effect survive the planned controls. Record negative, bounded, and
+   superseded outcomes in the durable ledger.
+6. **Test generality.** Move a surviving idea to a complementary stream and then
+   a downstream control or agent setting. Measure the complete scorecard and
+   reject benchmark-specific regressions unless the scope is intentionally
+   narrow.
+7. **Advance `reference-dev`.** A resource-acceptable development winner may
+   become the next development baseline after its full regression panel passes.
+   Record the decision and keep its nonpromotion status explicit.
+8. **Evaluate scientifically when warranted.** Freeze a new protocol, untouched
+   held-out seeds, artifact schema, source closure, thresholds, and validator
+   before observing a claim-bearing result. This is not required for every
+   exploratory hillclimb and does not relabel earlier runs.
+9. **Rebaseline.** Rerun earlier panels against the selected reference channel
+   and begin the next cycle from that measured state.
+
+The project optimizes for information gain and end-to-end leverage, not the
+number of modules, experiments, or passing tests. High-risk ideas are welcome
+when the screen is cheap and the failure teaches something durable.
+
+## Application ladder
+
+The `R0`–`R5` stages route work toward an application. They are orthogonal to
+the L0–L3 evidence-strength levels and to promotion class. For example, an R2
+subsystem screen can remain development-only, while a narrow L2 scientific
+claim need not advance the whole application beyond R1 or R2.
+
+| Stage | Purpose | Typical evidence | What it cannot establish |
+|---|---|---|---|
+| R0. Contracts | Numerical, state, ownership, serialization, and API correctness | Unit and integration tests | Learning benefit |
+| R1. Diagnostics | Isolate plasticity, retention, scale, recurrence, and causal mechanisms | Short controlled streams and ablations | Application value |
+| R2. Subsystems | Compare learners and representations over meaningful continual horizons | IPMNIST, label-permutation, recurrence, and related paired campaigns | End-to-end control or robotics |
+| R3. Continual control | Measure lifetime return, recovery, learned state, and planning under matched budgets | Continuing-control suites and Forager-class environments | Embodied reliability |
+| R4. Embodied simulation | Exercise perception-to-action adaptation, disturbances, latency, and recovery | Reproducible robot task sequences and fault panels | Physical readiness by itself |
+| R5. Guarded application | Validate useful behavior under real interfaces and operational constraints | Staged canaries with independent safety and rollback authority | Unbounded generality |
+
+A candidate advances only when its lower-stage benefit remains visible at the
+next relevant stage. R0–R1 stay cheap enough for routine development;
+campaign and application execution happens through explicit runners, not by
+turning pytest into a benchmark scheduler.
+
+## Whole-life scorecard
+
+Every integrated comparison declares the relevant metrics before execution.
+At minimum, the scorecard considers:
+
+| Dimension | Questions to answer |
+|---|---|
+| Online utility | What reward, accuracy, or task success is achieved before each learning update? |
+| Adaptation | How much utility is lost after change, and how quickly is it recovered? |
+| Retention | What remains when a condition recurs, and is reacquisition faster than first learning? |
+| Transfer | Does prior learning help or obstruct new tasks, contexts, morphologies, or partners? |
+| Stability | Are learning state, predictions, and actions finite and reliable over the full horizon? |
+| Resources | What are per-event compute, peak and growing memory, latency, model queries, and stored experience? |
+| Autonomy | Which task IDs, boundaries, labels, demonstrations, resets, or oracle features are supplied? |
+| Robustness | What happens under scale shifts, observation faults, delayed feedback, and changed dynamics? |
+| Application fit | Can the same agent interface checkpoint, resume, respect safety authority, and meet the target control rate? |
+
+Exact metrics and thresholds belong to each protocol. The scorecard prevents a
+single favorable mean from concealing a system-level regression.
+
+Every comparison also freezes an acceptance policy. Safety, numerical
+stability, resource ceilings, and other application-critical dimensions are
+hard guardrails with declared noninferiority margins. Among candidates that
+pass them, advancement requires either a preregistered primary-metric
+improvement or a preregistered Pareto/utility rule over the remaining
+dimensions. Post-hoc tradeoff weights cannot turn a regression into a win.
+
+## Current program priorities
+
+1. **Execute the implemented Switching + RiverSwim development scorecard.** The
+   literal-frozen L0 plan defines 144 fresh-process shards over 12 consumed
+   development seeds, two environments, and Prototype, frozen/no-learning,
+   random, finite-horizon privileged dynamic-programming, differential-SARSA,
+   and discounted-SARSA arms. Each shard binds its current source identity, and
+   aggregation requires one matching current identity. It binds explicit Threefry roots, complete
+   counters, reward lattices, and canonical numeric-payload accounting. The
+   frozen acceptance rule requires a qualifying SARSA-family control on each
+   environment, candidate improvement over frozen on both, candidate
+   noninferiority to the best qualifying SARSA control on both, and no post-hoc
+   scalar. Timing is telemetry-only, so resource Pareto selection remains open
+   until separately qualified. Every result is permanently nonpromoting; the
+   scorecard does not populate `reference-dev` or constitute scientific
+   evidence.
+2. **Turn plasticity gains into agent gains.** Use the development-only IPMNIST
+   campaign to generate mechanisms, then remeasure controls and test survivors
+   on recurrence, a complementary stream, and continual control. Do not promote
+   or directly ship an inspected campaign winner.
+3. **Broaden reference-life conformance after the scorecard.** Add no
+   environment or mechanism without a named gate. Options/rebinding,
+   boundaries, independent safety, Forager, robot adapters, and general
+   environment support remain separate open integration work.
+4. **Close the robotics path.** Adopt the sibling robot track's existing
+   ASIMOV-1 sequence (`stand_up`, `walk_forward`, `walk_backward`,
+   `sidestep_left`, `sidestep_right`, `turn_left`, and `turn_right`) and its
+   checkpoint/bridge validation interface as the first concrete R4–R5 target,
+   or document why it cannot serve. Its smoke and integration plumbing are not
+   a matched continual-learning result. Full-budget comparisons, adaptation/
+   retention metrics, control-rate budgets, fault/safety panels, and guarded
+   hardware evidence remain required.
+5. **Scale deliberately.** Increase horizon, task diversity, observation size,
+   action complexity, and number of learned predictions while measuring how
+   performance and resource use scale.
+6. **Keep the search open.** Regularly compare the current bottleneck with ideas
+   inside and outside the Alberta Plan. Prefer causal experiments and portable
+   mechanisms over allegiance to an existing component.
+
+The [IPMNIST theory](ipmnist-theory.md) owns its current mechanism hypotheses.
+The [negative-results ledger](../evidence/negative-results.md) prevents closed
+ideas from being silently recycled. The [status map](../status.md) records what
+is actually implemented and evidenced; neither this roadmap nor a future plan
+can upgrade that status by assertion.
+
+## Naming and provenance
+
+ASI is the current project and repository identity. The Python import namespace
+`alberta_framework`, distribution name `alberta-framework`, `alberta-*` console
+commands, Alberta-specific Step modules, and historical `alberta.*` artifact
+schemas remain stable compatibility or provenance names. A future software
+namespace migration must be explicit, versioned, and tested across robot
+consumers, packaging, CLIs, validators, and stored evidence. Immutable output
+records are never rewritten to apply the new brand.
+
+Genuinely new ASI-native protocol and artifact families should use versioned
+`asi.*` schema IDs and may add `asi-*` CLI aliases. A new version that extends a
+frozen Alberta-family schema retains its `alberta.*` lineage and compatible
+loader. New aliases are additive; historical IDs are never renamed.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,12 +1,13 @@
-# Alberta Plan research status
+# ASI research status
+This document is the compact, human-readable status map for ASI. It separates
+available mechanisms, stored scientific outcomes, whole-agent capabilities,
+and the evidence still required for a continual-learning application.
 
-This document is the compact, human-readable status map for the Alberta
-Framework. It separates available mechanisms, stored scientific outcomes, and
-the evidence still required for a complete continual agent.
-
-**Verdict: in progress.** The package exposes research surfaces related to all
-twelve steps of the Alberta Plan, but no step satisfies this repository's full
-completion rule. There is no accepted end-to-end Alberta Plan completion claim.
+**Verdict: in progress.** No whole-agent L3 protocol or result has been
+completed, and there is no state-of-the-art application or robotics-readiness
+result. The package also exposes research surfaces related to all twelve steps
+of the Alberta Plan, but no Step satisfies this repository's full completion
+rule. The Plan is an inspiration and crosswalk, not ASI's binding roadmap.
 
 This page deliberately does not record a dated live evidence-registry result,
 module count, test count, campaign ranking, or session chronology. Those facts
@@ -16,14 +17,16 @@ change. Run the relevant command or read the primary artifact instead.
 
 Use each record only for the question it owns:
 
-- This page records the stable evidence levels, current Step 1–12 gaps, and
-  completion gates.
+- The [ASI research roadmap](research/asi-roadmap.md) owns the mission,
+  hillclimb loop, application ladder, and whole-life scorecard.
+- This page records the stable capability gaps, evidence levels, Alberta Step
+  1–12 crosswalk, and completion gates.
 - [Evidence methodology](evidence/methodology.md) owns promotion rules,
   property-level evidence, artifact contracts, and scientific limitations.
 - The [negative-results ledger](evidence/negative-results.md) owns rejected,
   bounded, consumed, and closed development results.
 - [`evidence_manifest.py`](../alberta_framework/evaluation/evidence_manifest.py)
-  owns the live five-claim registry, its exact source closures, and exit-code
+  owns the live five-claim registry, its exact registered source sets, and exit-code
   semantics.
 - Versioned JSON artifacts own frozen scientific outcomes. Validators, not
   narrative summaries, decide whether those artifacts match current sources.
@@ -36,41 +39,135 @@ evidence are different kinds of progress. A public class or passing test proves
 that a mechanism exists; it does not by itself prove benefit, retention,
 resource parity, or integration.
 
-## Evidence interpretation
+## Evidence levels
 
-The stable evidence scale is L0 for mechanism contracts, L1 for learning in a
-controlled toy problem, L2 for preregistered matched-resource comparison, and
-L3 for integration across one uninterrupted agent life. The
-[evidence methodology](evidence/methodology.md) defines these levels,
-promotion rules, artifact contracts, registered frozen outcomes, and the two
-narrow historical compatibility routes in detail.
+- **L0 — mechanism:** API, shape, finite-value, serialization, ownership, or
+  local-update contracts pass.
+- **L1 — learning:** a component learns in a controlled toy problem.
+- **L2 — comparison:** a preregistered, multi-seed, matched-resource benchmark
+  establishes the frozen claim against strong baselines.
+- **L3 — integration:** one uninterrupted agent life demonstrates the required
+  interactions, retention, recovery, bounded resources, and causal ablations.
 
 For this repository, a Step is complete only when its defining outcome reaches
 L2 and its required links to earlier Steps are exercised at L3. Missing
-promoting evidence must fail closed; it must not be treated as a skipped test
-or inferred from adjacent results. All twelve public Step modules contain
-mechanism or smoke surfaces. Only the Step 1 and Step 2 smoke probes are
-console scripts; smoke execution is L0 and structurally nonpromoting.
+promoted evidence must fail closed; it must not be treated as a skipped test or
+inferred from adjacent results.
 
-## Live evidence registry
+All twelve public Step modules contain mechanism or smoke surfaces. Only the
+Step 1 and Step 2 smoke probes are console scripts. Smoke execution is L0 and
+is structurally nonpromoting.
 
-The registry is intentionally limited to five narrow claims. Its exact claim
-inventory, source closures, and exit-code semantics live in
-[`evidence_manifest.py`](../alberta_framework/evaluation/evidence_manifest.py),
-while versioned artifacts and their strict validators own frozen outcomes. Run
-the live check from a repository checkout:
+## ASI capability map
+
+This map is primary for the end-to-end application. The Alberta Plan crosswalk
+below supplies a second view over the inherited research program.
+
+| Capability | Current surface | Open application gate |
+|---|---|---|
+| Online adaptation and plasticity | Online learners, adaptive optimizers, normalization, UPGD/CBP mechanisms, and development campaigns | No completed multi-domain comparison establishes sustained plasticity without hidden retention or resource regressions |
+| Learned state and representation | Feature construction, utility, routing, lifecycle, temporal-context, and recurrent-state mechanisms | No autonomous representation lifecycle has a whole-life downstream control result |
+| Prediction, memory, and world modeling | Horde/GVF learners, working and experiential memory, one-step/latent/recurrent models, and dreaming | No reference agent shows that these components causally improve retained control under one owner and budget |
+| Continual control and planning | SARSA, actor-critic, average-reward/off-policy control, options, STOMP/OaK, and bounded planning | No promoted matched-resource continual-control result closes adaptation, retention, and planning-benefit gates |
+| Agent composition | The unfrozen [`preview1` transaction/reducer/CAS ledger](../alberta_framework/reference_agent.py), [primitive exact-dispatch Prototype bridge](../alberta_framework/prototype_reference_adapter.py), aggregate [Prototype + SwitchingTwoState/RiverSwim runner](../alberta_framework/reference_life.py), current-schema [quiescent checkpoint codec](../alberta_framework/reference_life_checkpoint.py), [matched control adapters](../alberta_framework/reference_life_controls.py), and [development scorecard](../alberta_framework/benchmarks/reference_life_scorecard.py) are covered by retained L0 tests. The scorecard plan defines a 144-shard fresh-process schedule over 12 consumed development seeds, two environments, six arms, explicit Threefry roots, finite-horizon privileged normalization, fixed reward lattices, and numeric-payload accounting | No completed scorecard result, frozen/portable checkpoint contract, authenticated execution provenance, qualified timing/resource Pareto gate, in-flight or physical replay, process-death/`BaseException`/durable executor guarantee, independent safety, additional/general environment support, options/rebinding/boundary conformance, robot or Forager adapter, selected `reference-dev`, RiverSwim learning/performance benefit, evidence result, or uninterrupted L3 life exists |
+| Multi-agent learning | Recurring coadaptation surfaces, partner-policy fusion, and an IA intervention protocol | A frozen historical coadaptation outcome is not causal amplification; the frozen historical IA outcome is a valid rejection, while live validity must be checked separately |
+| Scale and operations | Fixed-shape JAX state, artifact tooling, robot-compatible imports, and bounded same-runtime exact checkpoint/recovery gates for one deterministic and one keyed stochastic simulator | Long-horizon compute, memory, latency, numerical stability, checkpoint migration, broader environment recovery, and workload scaling are not jointly established |
+| Robotics and real work | The sibling robot track consumes a continual-RL subset and defines an ASIMOV-1 task sequence plus checkpoint, bridge, and validation plumbing | No ASI reference-life binding or matched full-budget adaptation/retention result closes the control-rate, fault/safety, and guarded-hardware gates |
+
+Implementation presence in the middle column is not a benefit claim. Each open
+gate needs its own matched protocol, and the integrated target needs the
+whole-life dimensions to pass together.
+
+The current primitive Prototype runners bind
+`PROTOTYPE_REFERENCE_MAX_ACCEPTED_EVENTS = 2**31 - 4` and reject a larger
+`max_accepted_events` during construction. That preflight does not establish
+uint64-long-horizon stability, learning, or resource behavior. Every future
+adapter must declare its own non-wrapping capacity and remain part of the
+canonical minimum. The RiverSwim path separately rejects `n_states` outside
+`[2, 12]` before constructing its exponential exact stationary oracle. This is
+a strict resource guard, not a RiverSwim scale or performance result.
+
+The current reference-life hillclimb has implemented a literal-frozen L0 scorecard
+machinery for SwitchingTwoState and RiverSwim. Its 144 fresh-process shards use
+12 consumed development seeds and six controls: Prototype, frozen/no-learning,
+random, finite-horizon privileged dynamic programming, differential SARSA, and
+discounted SARSA. Shards bind their current source identity, and aggregation requires one
+matching current identity. It has not yet established a completed scorecard result. All
+records are permanently nonpromoting; they do not populate `reference-dev` or
+create performance or scientific evidence.
+
+## Registered evidence
+
+The five-claim registry is intentionally narrow. Even an `accepted` overall
+registry result would mean only that every listed narrow gate passed. It would
+not certify the package, complete a Step, or establish Alberta Plan completion.
+
+The immutable stored artifacts record these frozen outcomes:
+
+| Claim ID | Frozen scope | Artifact | Frozen outcome |
+|---|---|---|---|
+| `recurring_pair_features` | Retention and active-bank allocation of supplied pair-product features in a Gaussian/L2 recurring probe | [`evidence.v1.json`](../outputs/recurring_feature/evidence.v1.json) | Accepted, narrow L2 |
+| `scale_robust_pair_features` | Scale-robust selection and structural retention of relevant pair products in a visibly cued regression gauntlet | [`evidence.v2.json`](../outputs/scale_robust_feature/evidence.v2.json) | Accepted, narrow L2 |
+| `ftl_world_model_decision_fidelity` | Low menu regret for a sparse online transition model in one deterministic A–B–A decision-fidelity protocol | [`evidence.v1.json`](../outputs/ftl_decision/evidence.v1.json) | Accepted historical L2 |
+| `recurring_multiagent_coadaptation` | Fixed-memory coadaptation and retention in one visibly cued two-agent A–B–A sanity benchmark | [`evidence.json`](../outputs/continual_multiagent/evidence.json) | Accepted, narrow L2 |
+| `continual_intelligence_amplification` | Causal recommendation-channel uplift in one deterministic hidden-phase micro-MDP | [`evidence.json`](../outputs/continual_ia/evidence.json) | Valid rejection at the frozen L2 gate |
+
+The IA artifact remains a scientifically useful rejection. Its reward uplift
+and augmentation-control checks do not override the failed frozen
+action-changing-intervention gate. The threshold must not be lowered after the
+result.
+
+### Live validation semantics
+
+Run the registry from a repository checkout:
 
 ```bash
 .venv/bin/alberta-evidence-status
 ```
 
-An accepted registry does not certify the package, complete a Step, or
-establish Alberta Plan completion. Source mismatches and invalid artifacts fail
-closed; pinned artifacts must not be edited or repaired. Normal wheel and
-sdist installations exclude `outputs/`, so their registry checks ordinarily
-report artifacts as missing.
+The operational statuses are:
 
-## Alberta Steps 1–12
+- `accepted`: a valid promoting L2/L3 artifact passed its frozen gate;
+- `valid-rejection`: a valid promoting artifact failed at least one gate;
+- `not-run`: a required artifact is absent;
+- `invalid`: schema, provenance, source, integrity, reconstruction, or
+  contract validation failed; and
+- `verified-nonpromoting`: a valid unit or smoke record that cannot promote.
+
+The command exits `0` only when all registered promoting claims are accepted,
+`1` for a missing artifact, valid rejection, or nonpromoting-only result, and
+`2` when any claim is invalid.
+
+Validation hashes each claim's exact registered source paths. Those manually
+enumerated sets are load-bearing, but they are not complete recursive import
+closures. A clean worktree is not required. Changes outside a claim's registered
+source set are recorded as operational provenance but are not independently
+disqualifying. A change to a registered source is a source mismatch and normally
+makes the persisted artifact invalid until a newly authorized frozen protocol
+writes a new artifact that passes its strict validator.
+
+Two historical compatibility routes are deliberately narrower than a general
+source-drift waiver:
+
+- The FTL route is eligible only for its exact v1 contract and prescribed
+  builder-only drift. It reconstructs the historical acceptance and checks an
+  already-consumed-seed replay against unchanged invariant sources. That replay
+  is compatibility evidence, never fresh promotion evidence.
+- The IA route is eligible only for its exact v1 historical-rejection chain.
+  Its archived source snapshot and consumed-seed replay can preserve the
+  original rejection classification, never turn it into current-source
+  acceptance.
+
+Any additional source drift, artifact mutation, schema mismatch, or failed
+reconstruction remains invalid. Pinned artifacts must not be edited, repaired,
+or overwritten. New work writes a new path and, when the contract requires it,
+a new schema version with untouched preregistered seeds.
+
+Normal package installations do not include `outputs/`, so registry execution
+from an installed wheel or sdist normally reports artifacts as missing. Use a
+checkout to inspect the stored evidence chain.
+
+## Alberta Plan crosswalk: Steps 1–12
 
 ### Step 1 — Nonstationary prediction
 
@@ -90,9 +187,11 @@ the later learned-state/control agent satisfy the completion rule.
 utility, and replace features within a fixed budget while retaining recurring
 critical structure.
 
-**Available evidence.** Pair construction, bounded feature banks, utility and
-lifecycle mechanisms exist. The recurring-pair and scale-robust-pair artifacts
-record two accepted but deliberately narrow L2 outcomes.
+**Frozen historical evidence.** Pair construction, bounded feature banks,
+utility and lifecycle mechanisms exist. The recurring-pair and
+scale-robust-pair artifacts record two historically accepted but deliberately
+narrow L2 outcomes. They certify the current tree only when live validation is
+valid.
 
 **Open gate.** The stored protocols begin from constrained pair-product
 families and do not establish autonomous question discovery, general
@@ -168,14 +267,15 @@ under changing dynamics and representations.
 **Required outcome.** Close the perception → world model → feature ranking →
 feature replacement → model-feedback loop.
 
-**Available evidence.** One-step, action-conditioned, shallow, ensemble,
-recurrent, and latent model components exist. The FTL artifact records a
-narrow historical L2 decision-fidelity acceptance for one fixed-shape model
-and protocol.
+**Frozen historical evidence.** One-step, action-conditioned, sparse
+fixed-shape, ensemble, recurrent, and latent model components exist. The FTL
+artifact records a narrow historical L2 decision-fidelity acceptance for one
+fixed-shape model and protocol; live validity is separate.
 
-**Open gate.** The accepted FTL scope does not establish a calibrated general
-world model, learned-target quality, retained planning benefit, partner
-modeling, or the complete feedback loop under one owner and lifetime.
+**Open gate.** That historically accepted FTL scope does not establish a
+calibrated general world model, learned-target quality, retained planning
+benefit, partner modeling, or the complete feedback loop under one owner and
+lifetime.
 
 ### Step 9 — Exploration and search control
 
@@ -219,40 +319,47 @@ Mechanism-level lifecycle receipts do not grant deployment or promotion.
 **Required outcome.** Measurably increase another learning agent's capability
 through a closed, continuing interaction loop.
 
-**Available evidence.** Prediction augmentation, recommendation protocols,
-partner/world models, and two-agent streams exist. The recurring-multiagent
-artifact records one narrow accepted L2 coadaptation result. The frozen IA
-artifact is a valid rejection.
+**Frozen historical evidence.** Prediction augmentation, recommendation
+protocols, partner-policy fusion, generic world models, and two-agent streams
+exist. The recurring-multiagent artifact records one narrow historically
+accepted L2 coadaptation outcome. The frozen IA artifact records a historical
+valid rejection. Neither statement substitutes for live validation.
 
 **Open gate.** Coadaptation is not the same as causal amplification. The IA
 intervention gate remains failed, and there is no L3 partner-benefit result
 under changing reliability, communication cost, retained skills, and bounded
 resources.
 
-No Step currently satisfies the repository completion rule.
+No Step currently satisfies the repository completion rule. Even completing
+all twelve Step gates would be evidence about the Alberta-derived program, not
+automatic proof of ASI's broader application target.
 
 ## Active development campaigns
 
-### IPMNIST screening and confirmation
+### IPMNIST development screening and development confirmation
 
-IPMNIST is the headline optimization/plasticity lane, but it is
-**development-grade and permanently nonpromoting**. Screening, confirmation,
-and publication-run records may support descriptive development conclusions;
-they do not become scientific evidence through replication, more seeds, or
-better performance.
+IPMNIST is the current measured optimization/plasticity subsystem campaign,
+not ASI's top-level reference-life hillclimb. It is
+**development-grade and permanently nonpromoting**. Development-screening,
+development-confirmation, and publication-run records may support descriptive
+development conclusions; they do not become scientific evidence through
+replication, more seeds, or better performance.
 
-Use the primary records rather than copying rankings or means here:
+Use the mutable index to identify the current record rather than copying
+rankings or means here. Output documents are append-only chronological records;
+their historical superlatives and run-status language may have been superseded.
 
+- [current campaign index](research/ipmnist-campaign-index.md);
 - [theory and forward hypotheses](research/ipmnist-theory.md);
-- [campaign runbook](../outputs/ipmnist_screening/RUNBOOK.md);
-- [stored development report](../outputs/ipmnist_screening/FINAL_REPORT.md);
-- [artifact and reproducibility audit](../outputs/ipmnist_screening/AUDIT.md);
-- [publication-run record](../outputs/ipmnist_screening/publication_runs/RESULTS.md);
+- `outputs/ipmnist_screening/summary_*.json` for stored measurement records;
+- [chronological campaign runbook](../outputs/ipmnist_screening/RUNBOOK.md);
+- [historical accumulated report](../outputs/ipmnist_screening/FINAL_REPORT.md);
+- [historical artifact and reproducibility audit](../outputs/ipmnist_screening/AUDIT.md);
   and
-- `outputs/ipmnist_screening/summary_*.json` for the latest stored summaries.
+- [pre-RLS publication-run record](../outputs/ipmnist_screening/publication_runs/RESULTS.md).
 
 Remeasure the intended baseline under the current development protocol before
 any A/B comparison. Do not infer registry acceptance, a promoted
-state-of-the-art claim, or an Alberta Step completion from this lane. Seeds
-used for development or selection cannot later serve as untouched promotion
-seeds.
+state-of-the-art claim, ASI progress at the whole-agent level, robotics
+readiness, or an Alberta Step completion from this lane. Seeds used for
+development or selection cannot later serve as untouched promotion seeds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ Issues = "https://github.com/elizaOS/asi/issues"
 Upstream = "https://github.com/lalalune/alberta"
 
 [project.scripts]
+asi-reference-life-scorecard = "alberta_framework.benchmarks.reference_life_scorecard:main"
 alberta-step1-smoke = "alberta_framework.cli:step1_smoke_main"
 alberta-step2-smoke = "alberta_framework.cli:step2_smoke_main"
 alberta-evidence-status = "alberta_framework.evaluation.evidence_manifest_cli:main"

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -23,6 +23,20 @@ from alberta_framework import (
 class TestSaveLoadRoundTrip:
     """Round-trip save/load for different learner state types."""
 
+    def test_zero_sized_array_leaf_round_trips_from_template(self, tmp_path):
+        state = {
+            "empty": jnp.zeros((0, 3), dtype=jnp.float32),
+            "payload": jnp.arange(4, dtype=jnp.int32),
+        }
+
+        save_checkpoint(state, tmp_path / "empty_leaf")
+        loaded, metadata = load_checkpoint(state, tmp_path / "empty_leaf")
+
+        assert loaded["empty"].shape == (0, 3)
+        assert loaded["empty"].dtype == jnp.float32
+        chex.assert_trees_all_equal(loaded["payload"], state["payload"])
+        assert metadata == {}
+
     def test_linear_learner_state(self, tmp_path):
         """LinearLearner state should round-trip correctly."""
         learner = LinearLearner()

--- a/tests/test_console_entrypoints.py
+++ b/tests/test_console_entrypoints.py
@@ -20,6 +20,43 @@ _LAZY_SCRIPTS = {
     "alberta-historical-forager": ("alberta_framework.console_entrypoints:historical_forager_main"),
     "alberta-foragax-oci": ("alberta_framework.console_entrypoints:official_foragax_oci_main"),
 }
+_ASI_SCRIPTS = {
+    "asi-reference-life-scorecard": (
+        "alberta_framework.benchmarks.reference_life_scorecard:main"
+    ),
+}
+
+
+def test_package_import_does_not_require_optional_gymnasium() -> None:
+    probe = (
+        "import sys; "
+        "sys.modules['gymnasium'] = None; "
+        "import alberta_framework; "
+        "from alberta_framework.streams import GymnasiumStream"
+    )
+    completed = subprocess.run(
+        (sys.executable, "-c", probe),
+        cwd=_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_package_exports_pipeline_and_dependency_lazy_gymnasium_api() -> None:
+    """Internal import failures must not silently remove advertised APIs."""
+    package = importlib.import_module("alberta_framework")
+    expected = {
+        "AlbertaPipeline",
+        "make_alberta_pipeline",
+        "GymnasiumStream",
+        "make_gymnasium_stream",
+    }
+
+    assert expected <= set(package.__all__)
+    assert all(hasattr(package, name) for name in expected)
 
 
 def test_hard_link_sensitive_scripts_use_lazy_entrypoints() -> None:
@@ -28,6 +65,7 @@ def test_hard_link_sensitive_scripts_use_lazy_entrypoints() -> None:
     scripts = project["project"]["scripts"]
 
     assert {name: scripts[name] for name in _LAZY_SCRIPTS} == _LAZY_SCRIPTS
+    assert {name: scripts[name] for name in _ASI_SCRIPTS} == _ASI_SCRIPTS
 
 
 def test_importing_lazy_entrypoints_does_not_import_scientific_implementations() -> None:

--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -46,6 +46,7 @@ _WHEEL_FILES = tuple(
     and (path.suffix == ".py" or path.name == "py.typed")
 )
 _EXPECTED_SCRIPT_NAMES = {
+    "asi-reference-life-scorecard",
     "alberta-evidence-status",
     "alberta-forager-benchmark",
     "alberta-forager-matched-campaign",

--- a/tests/test_reference_life.py
+++ b/tests/test_reference_life.py
@@ -1,0 +1,1497 @@
+"""Failing-first contracts for the development-only aggregate reference life."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.oak import OaKConfig
+from alberta_framework.core.options import STOMPConfig
+from alberta_framework.core.prototype_agent import PrototypeAgentConfig
+from alberta_framework.prototype_reference_adapter import (
+    PROTOTYPE_REFERENCE_MAX_ACCEPTED_EVENTS,
+    PrototypeAdapterUpdate,
+    PrototypeReferenceAdapter,
+)
+from alberta_framework.reference_agent import (
+    AuthorizationStatus,
+    DecisionOwnershipError,
+    DispatchAck,
+    DispatchAuthorization,
+    DispatchCommand,
+    DispatchStatus,
+    ReferenceAgentUpdate,
+    ReferenceTransactionLedger,
+    ReferenceTransactionReducer,
+    TransactionPhase,
+)
+from alberta_framework.reference_life import (
+    ExactDispatchAdapter,
+    HaltStage,
+    LifePhase,
+    RecoveryMode,
+    ReferenceLifeConfig,
+    ReferenceLifeMetricsAdapter,
+    ReferenceLifeRunner,
+    SwitchingEnvironmentExecution,
+    SwitchingTwoStateReferenceEnvironment,
+    build_prototype_switching_life,
+)
+from alberta_framework.streams.closed_loop import (
+    PHASE_A,
+    PHASE_B,
+    SwitchingTwoStateConfig,
+    SwitchingTwoStateMDP,
+)
+
+pytestmark = pytest.mark.unit
+
+_LIFECYCLE_ID = "prototype.0000000100000002"
+
+
+def _agent_config() -> PrototypeAgentConfig:
+    return PrototypeAgentConfig(
+        oak=OaKConfig(
+            stomp=STOMPConfig(
+                subtask_specs=(),
+                observation_dim=2,
+                n_primitive_actions=2,
+                base_step_size=0.05,
+                epsilon_base=0.0,
+            )
+        )
+    )
+
+
+def _runner(
+    *,
+    horizon: int = 3,
+    phase_length: int = 2,
+) -> ReferenceLifeRunner:
+    return build_prototype_switching_life(
+        agent_config=_agent_config(),
+        environment_config=SwitchingTwoStateConfig(  # type: ignore[call-arg]
+            phase_length=phase_length
+        ),
+        lifecycle_id=_LIFECYCLE_ID,
+        seed=7,
+        max_accepted_events=horizon,
+    )
+
+
+def _corrupt_accepted_update(
+    update: PrototypeAdapterUpdate,
+    *,
+    prior_state: Any,
+    adapter: PrototypeReferenceAdapter,
+    defect: str,
+) -> PrototypeAdapterUpdate:
+    assert update.accepted
+    assert update.next_decision is not None
+    if defect == "stale_state":
+        return dataclasses.replace(update, state=prior_state)
+    if defect == "mismatched_decision":
+        action = update.next_decision.proposed_action
+        assert action is not None
+        action_value = action.to_python()
+        assert isinstance(action_value, int)
+        mismatched_action = adapter.manifest.action_spec.encode(
+            np.asarray(1 - action_value, dtype=np.int32)
+        )
+        return dataclasses.replace(
+            update,
+            next_decision=dataclasses.replace(
+                update.next_decision,
+                proposed_action=mismatched_action,
+            ),
+        )
+    raise AssertionError(f"unknown test defect: {defect}")
+
+
+def test_pure_transaction_reducer_has_no_hidden_current_state() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_agent_config())
+    agent_state = adapter.init(jr.key(7), lifecycle_id=_LIFECYCLE_ID)
+    agent_state, decision = adapter.start(
+        agent_state,
+        observation_id=f"{_LIFECYCLE_ID}:observation:0",
+        observation=np.asarray([1.0, 0.0], dtype=np.float32),
+    )
+    reducer = ReferenceTransactionReducer(adapter.manifest)
+
+    ready = reducer.init()
+    first = reducer.arm(ready, decision)
+    second = reducer.arm(ready, decision)
+
+    assert ready.phase is TransactionPhase.READY
+    assert first == second
+    assert first is not second
+    assert first.phase is TransactionPhase.ARMED
+
+    ledger = ReferenceTransactionLedger(adapter.manifest)
+    live_ready = ledger.init()
+    ledger.arm(live_ready, decision)
+    with pytest.raises(DecisionOwnershipError, match="stale|replayed|current"):
+        ledger.arm(live_ready, decision)
+
+
+def test_life_config_is_canonical_and_binds_complete_components() -> None:
+    runner = _runner()
+    config = runner.config
+    payload = config.config
+
+    assert payload["agent"]["manifest_id"] == runner.agent_adapter.manifest.manifest_id
+    assert payload["agent"]["config"] == runner.agent_adapter.manifest.config
+    assert payload["environment"]["config"]["phase_length"] == 2
+    assert payload["dispatch"]["config"]["mode"] == "exact_only"
+    assert payload["dispatch"]["config"]["authority_role"] == "declared_static_identity"
+    assert payload["dispatch"]["config"]["safety_policy"] == "unimplemented"
+    assert payload["dispatch"]["config"]["veto_conformance"] is False
+    assert payload["metrics"]["config"]["oracle_regret"] is True
+    assert payload["max_accepted_events"] == 3
+    assert len(config.config_sha256) == 64
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        config.max_accepted_events = 4  # type: ignore[misc]
+
+
+def test_runner_rejects_rehashed_nested_environment_descriptor_tamper() -> None:
+    runner = _runner()
+    payload = runner.config.config
+    payload["environment"]["config"]["phase_length"] = 999
+    encoded = json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    tampered = dataclasses.replace(
+        runner.config,
+        config_sha256=hashlib.sha256(encoded.encode("utf-8")).hexdigest(),
+        _config_json=encoded,
+    )
+    assert isinstance(tampered, ReferenceLifeConfig)
+
+    with pytest.raises(ValueError, match="canonical|component|configuration"):
+        ReferenceLifeRunner(
+            config=tampered,
+            agent_adapter=runner.agent_adapter,
+            environment_adapter=runner.environment_adapter,
+            dispatch_adapter=runner._dispatch_adapter,
+            metrics_adapter=runner._metrics_adapter,
+        )
+
+
+def test_direct_runner_constructor_rejects_executor_identity_mismatch() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_agent_config())
+    environment = SwitchingTwoStateReferenceEnvironment(
+        SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        observation_spec=adapter.manifest.observation_spec,
+        action_spec=adapter.manifest.action_spec,
+        executor_id="asi.switching_two_state.other_executor",
+    )
+    dispatch = ExactDispatchAdapter()
+    metrics = ReferenceLifeMetricsAdapter()
+    config = ReferenceLifeConfig.from_components(
+        lifecycle_id=_LIFECYCLE_ID,
+        seed=7,
+        max_accepted_events=1,
+        agent_manifest=adapter.manifest,
+        agent_capacity=adapter.max_accepted_events,
+        environment_manifest=environment.manifest,
+        dispatch_config=dispatch.config,
+        metrics_config=metrics.config,
+    )
+
+    with pytest.raises(ValueError, match="executor IDs"):
+        ReferenceLifeRunner(
+            config=config,
+            agent_adapter=adapter,
+            environment_adapter=environment,
+            dispatch_adapter=dispatch,
+            metrics_adapter=metrics,
+        )
+
+
+def test_current_state_must_match_configured_lifecycle() -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    forged = dataclasses.replace(
+        initial,
+        lifecycle_id="prototype.0000000100000003",
+    )
+    runner._current_state = forged
+
+    with pytest.raises(DecisionOwnershipError, match="lifecycle"):
+        runner.step(forged)
+
+
+def test_runner_rejects_oversized_life_before_component_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initialized = False
+
+    def forbidden_init(self: PrototypeReferenceAdapter, *args: Any, **kwargs: Any) -> Any:
+        del self, args, kwargs
+        nonlocal initialized
+        initialized = True
+        raise AssertionError("agent init must not run")
+
+    monkeypatch.setattr(PrototypeReferenceAdapter, "init", forbidden_init)
+    at_capacity = build_prototype_switching_life(
+        agent_config=_agent_config(),
+        environment_config=SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        lifecycle_id=_LIFECYCLE_ID,
+        seed=7,
+        max_accepted_events=PROTOTYPE_REFERENCE_MAX_ACCEPTED_EVENTS,
+    )
+    assert (
+        at_capacity.config.max_accepted_events
+        == PROTOTYPE_REFERENCE_MAX_ACCEPTED_EVENTS
+    )
+    with pytest.raises(ValueError, match="max_accepted_events|capacity"):
+        build_prototype_switching_life(
+            agent_config=_agent_config(),
+            environment_config=SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+            lifecycle_id=_LIFECYCLE_ID,
+            seed=7,
+            max_accepted_events=PROTOTYPE_REFERENCE_MAX_ACCEPTED_EVENTS + 1,
+        )
+    assert initialized is False
+
+
+@pytest.mark.parametrize(
+    "lifecycle_id",
+    (
+        "other.0000000100000002",
+        "prototype.000000010000000g",
+    ),
+)
+def test_concrete_life_rejects_invalid_prototype_lifecycle_before_init(
+    lifecycle_id: str,
+) -> None:
+    with pytest.raises(ValueError, match="Prototype lifecycle|lifecycle codec"):
+        build_prototype_switching_life(
+            agent_config=_agent_config(),
+            environment_config=SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+            lifecycle_id=lifecycle_id,
+            seed=7,
+            max_accepted_events=1,
+        )
+
+
+def test_switching_phase_length_cannot_exceed_signed_int32_capacity() -> None:
+    with pytest.raises(
+        ValueError,
+        match="phase_length.*(?:signed-int32|capacity|positive integer)",
+    ):
+        build_prototype_switching_life(
+            agent_config=_agent_config(),
+            environment_config=SwitchingTwoStateConfig(  # type: ignore[call-arg]
+                phase_length=int(np.iinfo(np.int32).max) + 1
+            ),
+            lifecycle_id=_LIFECYCLE_ID,
+            seed=7,
+            max_accepted_events=1,
+        )
+
+
+def test_switching_reference_environment_behavior_is_immutable() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_agent_config())
+    caller_payoffs: Any = [[0.0, 1.0], [1.0, 0.0]]
+    environment = SwitchingTwoStateReferenceEnvironment(
+        SwitchingTwoStateConfig(  # type: ignore[call-arg]
+            phase_length=2,
+            payoffs_a=caller_payoffs,
+        ),
+        observation_spec=adapter.manifest.observation_spec,
+        action_spec=adapter.manifest.action_spec,
+    )
+    kernel = environment._environment
+    oracle = kernel.optimal_average_reward(PHASE_A)
+
+    caller_payoffs[0][0] = 999.0
+
+    with pytest.raises(AttributeError, match="immutable"):
+        environment._environment = SwitchingTwoStateMDP()  # type: ignore[misc]
+    with pytest.raises(AttributeError, match="immutable"):
+        kernel._phase_length = 999  # type: ignore[misc]
+    with pytest.raises(AttributeError, match="immutable"):
+        kernel._payoffs_np = np.zeros((2, 2, 2), dtype=np.float32)  # type: ignore[misc]
+    with pytest.raises(ValueError, match="read-only"):
+        kernel._payoffs_np[PHASE_A, 0, 0] = 999.0
+    with pytest.raises((AttributeError, dataclasses.FrozenInstanceError)):
+        kernel.config.payoffs_a = ((999.0, 999.0), (999.0, 999.0))  # type: ignore[misc]
+
+    assert kernel.optimal_average_reward(PHASE_A) == oracle
+    assert kernel.config.payoffs_a[0][0] == 0.0
+    assert environment.manifest.config["phase_length"] == 2
+
+
+@pytest.mark.integration
+def test_authoritative_life_crosses_phase_and_completes_at_horizon() -> None:
+    runner = _runner(horizon=3, phase_length=2)
+    state = runner.init()
+    initial_digest = state.transcript_sha256
+    phases: list[int] = []
+
+    for expected_count in range(1, 4):
+        step = runner.step(state)
+        assert step.accepted, step.rejection_reason
+        assert step.event is not None
+        phases.append(step.event.regime_id)
+        assert step.event.receipt.command == step.event.command
+        assert step.event.receipt.applied_action == step.event.command.effective_action
+        state = step.state
+        assert state.accepted_events == expected_count
+        assert state.dispatch_attempts == expected_count
+        assert state.executed_events == expected_count
+        assert state.environment_rng_cursor == expected_count
+        assert int(state.environment_state.step_count) == expected_count
+        assert int(state.agent_state.agent_state.step_count) == expected_count
+        assert state.transaction_state.next_decision_index == expected_count
+        assert state.agent_state.current_observation_id == (
+            f"{_LIFECYCLE_ID}:observation:{expected_count}"
+        )
+
+    assert phases == [PHASE_A, PHASE_A, PHASE_B]
+    assert state.phase is LifePhase.COMPLETED
+    assert state.pending_outcome is None
+    assert state.halt is None
+    assert state.transcript_sha256 != initial_digest
+    assert state.metrics.accepted_events == 3
+    assert state.metrics.phase_event_counts == (2, 1)
+    assert state.metrics.oracle_reward_sum == pytest.approx(3.0)
+    assert state.metrics.regret_sum == pytest.approx(
+        state.metrics.oracle_reward_sum - state.metrics.reward_sum
+    )
+    with pytest.raises(DecisionOwnershipError, match="completed"):
+        runner.step(state)
+
+
+def test_environment_rejects_bad_action_before_clipping_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    state = runner.init()
+    assert state.transaction_state.decision is not None
+    decision = state.transaction_state.decision
+    assert decision.proposed_action is not None
+    bad_action = dataclasses.replace(
+        decision.proposed_action,
+        payload=np.asarray(2, dtype=np.int32).tobytes(),
+    )
+    forged_decision = dataclasses.replace(decision, proposed_action=bad_action)
+    authorization = DispatchAuthorization(
+        decision=forged_decision,
+        status=AuthorizationStatus.EXACT,
+        authorized_action=bad_action,
+        authority_id="tests.authority",
+        policy_version="tests.policy.v1",
+        authorization_id=f"{decision.decision_id}:authorization",
+    )
+    dispatch = DispatchAck(
+        authorization=authorization,
+        status=DispatchStatus.EXACT,
+        effective_action=bad_action,
+        settlement_id=f"{decision.decision_id}:settlement",
+    )
+    command = DispatchCommand(
+        dispatch=dispatch,
+        command_id=f"{decision.decision_id}:command",
+        executor_id="asi.switching_two_state.executor",
+        executor_epoch="asi.switching_two_state.executor_epoch.1",
+    )
+    called = False
+
+    def forbidden_step(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        nonlocal called
+        called = True
+        raise AssertionError("clipping environment must not receive invalid action")
+
+    monkeypatch.setattr(SwitchingTwoStateMDP, "step", forbidden_step)
+    with pytest.raises(ValueError, match="cardinality|outside|range"):
+        runner.environment_adapter.execute(
+            state.environment_state,
+            command,
+            key=jnp.asarray([0, 1], dtype=jnp.uint32),
+        )
+    assert called is False
+
+
+def test_post_execution_agent_rejection_halts_then_recovers_without_redispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_apply = PrototypeReferenceAdapter.apply_outcome
+    original_execute = SwitchingTwoStateReferenceEnvironment.execute
+    apply_calls = 0
+    execute_calls = 0
+
+    def reject_once(
+        self: PrototypeReferenceAdapter,
+        state: Any,
+        transaction: Any,
+    ) -> PrototypeAdapterUpdate:
+        nonlocal apply_calls
+        apply_calls += 1
+        if apply_calls == 1:
+            return PrototypeAdapterUpdate(
+                state=state,
+                next_decision=None,
+                accepted=False,
+                parameters_changed=False,
+                rejection_reason="synthetic post-execution rejection",
+            )
+        return original_apply(self, state, transaction)
+
+    def count_execute(
+        self: SwitchingTwoStateReferenceEnvironment,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        nonlocal execute_calls
+        execute_calls += 1
+        return original_execute(self, state, command, key=key)
+
+    monkeypatch.setattr(PrototypeReferenceAdapter, "apply_outcome", reject_once)
+    monkeypatch.setattr(SwitchingTwoStateReferenceEnvironment, "execute", count_execute)
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.phase is LifePhase.HALTED
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.OUTCOME_PENDING
+    assert halted.halt.recovery_mode is RecoveryMode.RETRY_OUTCOME
+    assert halted.pending_outcome is not None
+    assert halted.accepted_events == 0
+    assert halted.dispatch_attempts == 1
+    assert halted.executed_events == 1
+    assert int(halted.environment_state.step_count) == 1
+    assert int(halted.agent_state.agent_state.step_count) == 0
+    assert halted.metrics.accepted_events == 0
+    assert execute_calls == 1
+
+    recovered = runner.recover_pending_outcome(halted)
+    assert recovered.accepted, recovered.rejection_reason
+    assert recovered.state.phase is LifePhase.COMPLETED
+    assert recovered.state.accepted_events == 1
+    assert int(recovered.state.agent_state.agent_state.step_count) == 1
+    assert recovered.state.metrics.accepted_events == 1
+    assert recovered.state.pending_outcome is None
+    assert execute_calls == 1
+    assert apply_calls == 2
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.recover_pending_outcome(halted)
+
+
+@pytest.mark.parametrize("recover", (False, True))
+def test_runner_accepts_generic_agent_updates_in_step_and_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+    recover: bool,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_apply = PrototypeReferenceAdapter.apply_outcome
+    apply_calls = 0
+
+    def generic_update(
+        self: PrototypeReferenceAdapter,
+        state: Any,
+        transaction: Any,
+    ) -> ReferenceAgentUpdate:
+        nonlocal apply_calls
+        apply_calls += 1
+        if recover and apply_calls == 1:
+            return ReferenceAgentUpdate(
+                state=state,
+                next_decision=None,
+                accepted=False,
+                parameters_changed=False,
+                rejection_reason="synthetic generic rejection",
+            )
+        update = original_apply(self, state, transaction)
+        return ReferenceAgentUpdate(
+            state=update.state,
+            next_decision=update.next_decision,
+            accepted=update.accepted,
+            parameters_changed=update.parameters_changed,
+            rejection_reason=update.rejection_reason,
+        )
+
+    monkeypatch.setattr(PrototypeReferenceAdapter, "apply_outcome", generic_update)
+
+    first = runner.step(initial)
+    if recover:
+        assert not first.accepted
+        assert first.state.pending_outcome is not None
+        result = runner.recover_pending_outcome(first.state)
+    else:
+        result = first
+
+    assert result.accepted, result.rejection_reason
+    assert result.state.phase is LifePhase.COMPLETED
+    assert result.state.accepted_events == 1
+    assert int(result.state.agent_state.agent_state.step_count) == 1
+    assert apply_calls == (2 if recover else 1)
+
+
+def test_generic_agent_update_does_not_bypass_concrete_adapter_state_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_apply = PrototypeReferenceAdapter.apply_outcome
+    metric_calls = 0
+
+    def foreign_state_update(
+        self: PrototypeReferenceAdapter,
+        state: Any,
+        transaction: Any,
+    ) -> ReferenceAgentUpdate:
+        update = original_apply(self, state, transaction)
+        assert update.accepted
+        return ReferenceAgentUpdate(
+            state=object(),
+            next_decision=update.next_decision,
+            accepted=True,
+            parameters_changed=update.parameters_changed,
+            rejection_reason=None,
+        )
+
+    def forbidden_metric(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        nonlocal metric_calls
+        metric_calls += 1
+        raise AssertionError("foreign generic state must not reach metrics")
+
+    monkeypatch.setattr(PrototypeReferenceAdapter, "apply_outcome", foreign_state_update)
+    monkeypatch.setattr(ReferenceLifeMetricsAdapter, "observe", forbidden_metric)
+
+    rejected = runner.step(initial)
+
+    assert not rejected.accepted
+    assert rejected.state.phase is LifePhase.HALTED
+    assert rejected.state.pending_outcome is not None
+    assert rejected.state.agent_state is initial.agent_state
+    assert rejected.state.halt is not None
+    assert "PrototypeReferenceState" in rejected.state.halt.reason
+    assert metric_calls == 0
+
+
+def test_generic_agent_adapter_cannot_enter_prototype_checkpoint_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    monkeypatch.setattr(runner, "_agent_adapter", object())
+
+    with pytest.raises(DecisionOwnershipError, match="Prototype adapter"):
+        runner.validate_checkpoint_state(initial)
+
+
+@pytest.mark.parametrize("defect", ("stale_state", "mismatched_decision"))
+def test_invalid_accepted_agent_update_retains_outcome_before_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    defect: str,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_apply = PrototypeReferenceAdapter.apply_outcome
+    metric_calls = 0
+
+    def corrupt_update(
+        self: PrototypeReferenceAdapter,
+        state: Any,
+        transaction: Any,
+    ) -> PrototypeAdapterUpdate:
+        update = original_apply(self, state, transaction)
+        return _corrupt_accepted_update(
+            update,
+            prior_state=state,
+            adapter=self,
+            defect=defect,
+        )
+
+    def forbidden_metric(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        nonlocal metric_calls
+        metric_calls += 1
+        raise AssertionError("invalid accepted agent state must not reach metrics")
+
+    monkeypatch.setattr(PrototypeReferenceAdapter, "apply_outcome", corrupt_update)
+    monkeypatch.setattr(ReferenceLifeMetricsAdapter, "observe", forbidden_metric)
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.phase is LifePhase.HALTED
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.OUTCOME_PENDING
+    assert halted.halt.recovery_mode is RecoveryMode.RETRY_OUTCOME
+    assert "accepted agent update" in halted.halt.reason
+    assert halted.pending_outcome is not None
+    assert halted.accepted_events == 0
+    assert halted.executed_events == 1
+    assert halted.agent_state is initial.agent_state
+    assert halted.metrics is initial.metrics
+    assert metric_calls == 0
+
+
+@pytest.mark.parametrize("defect", ("stale_state", "mismatched_decision"))
+def test_invalid_accepted_agent_recovery_retains_pending_outcome_before_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    defect: str,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_apply = PrototypeReferenceAdapter.apply_outcome
+    apply_calls = 0
+    metric_calls = 0
+
+    def reject_then_corrupt(
+        self: PrototypeReferenceAdapter,
+        state: Any,
+        transaction: Any,
+    ) -> PrototypeAdapterUpdate:
+        nonlocal apply_calls
+        apply_calls += 1
+        if apply_calls == 1:
+            return PrototypeAdapterUpdate(
+                state=state,
+                next_decision=None,
+                accepted=False,
+                parameters_changed=False,
+                rejection_reason="synthetic initial rejection",
+            )
+        update = original_apply(self, state, transaction)
+        return _corrupt_accepted_update(
+            update,
+            prior_state=state,
+            adapter=self,
+            defect=defect,
+        )
+
+    def forbidden_metric(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        nonlocal metric_calls
+        metric_calls += 1
+        raise AssertionError("invalid recovered agent state must not reach metrics")
+
+    monkeypatch.setattr(PrototypeReferenceAdapter, "apply_outcome", reject_then_corrupt)
+    monkeypatch.setattr(ReferenceLifeMetricsAdapter, "observe", forbidden_metric)
+
+    first = runner.step(initial)
+    pending = first.state
+    assert pending.halt is not None
+    assert pending.halt.stage is HaltStage.OUTCOME_PENDING
+    assert pending.pending_outcome is not None
+
+    rejected = runner.recover_pending_outcome(pending)
+    retained = rejected.state
+    assert not rejected.accepted
+    assert retained.phase is LifePhase.HALTED
+    assert retained.halt is not None
+    assert retained.halt.stage is HaltStage.OUTCOME_PENDING
+    assert retained.halt.recovery_mode is RecoveryMode.RETRY_OUTCOME
+    assert retained.halt.recovery_attempts == pending.halt.recovery_attempts + 1
+    assert "accepted agent update" in retained.halt.reason
+    assert retained.pending_outcome == pending.pending_outcome
+    assert retained.accepted_events == 0
+    assert retained.executed_events == 1
+    assert retained.agent_state is pending.agent_state
+    assert retained.metrics is pending.metrics
+    assert apply_calls == 2
+    assert metric_calls == 0
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.recover_pending_outcome(pending)
+
+
+def test_metric_staging_failure_recovers_without_rolling_back_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_observe = ReferenceLifeMetricsAdapter.observe
+    original_execute = SwitchingTwoStateReferenceEnvironment.execute
+    observe_calls = 0
+    execute_calls = 0
+
+    def reject_metric_once(
+        self: ReferenceLifeMetricsAdapter,
+        state: Any,
+        **kwargs: Any,
+    ) -> Any:
+        nonlocal observe_calls
+        observe_calls += 1
+        if observe_calls == 1:
+            raise ValueError("synthetic metric staging failure")
+        return original_observe(self, state, **kwargs)
+
+    def count_execute(
+        self: SwitchingTwoStateReferenceEnvironment,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        nonlocal execute_calls
+        execute_calls += 1
+        return original_execute(self, state, command, key=key)
+
+    monkeypatch.setattr(ReferenceLifeMetricsAdapter, "observe", reject_metric_once)
+    monkeypatch.setattr(SwitchingTwoStateReferenceEnvironment, "execute", count_execute)
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.OUTCOME_PENDING
+    assert halted.pending_outcome is not None
+    assert "metric update" in halted.halt.reason
+    assert halted.accepted_events == 0
+    assert halted.executed_events == 1
+    assert int(halted.environment_state.step_count) == 1
+    assert int(halted.agent_state.agent_state.step_count) == 0
+    assert halted.metrics.accepted_events == 0
+
+    recovered = runner.recover_pending_outcome(halted)
+    assert recovered.accepted
+    assert recovered.state.phase is LifePhase.COMPLETED
+    assert int(recovered.state.agent_state.agent_state.step_count) == 1
+    assert recovered.state.metrics.accepted_events == 1
+    assert execute_calls == 1
+    assert observe_calls == 2
+
+
+def test_applied_action_mismatch_halts_without_learning() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_agent_config())
+    environment = _MismatchingEnvironment(
+        SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        observation_spec=adapter.manifest.observation_spec,
+        action_spec=adapter.manifest.action_spec,
+    )
+    runner = ReferenceLifeRunner.create(
+        agent_adapter=adapter,
+        environment_adapter=environment,
+        lifecycle_id=_LIFECYCLE_ID,
+        seed=7,
+        max_accepted_events=1,
+    )
+    initial = runner.init()
+
+    rejected = runner.step(initial)
+
+    assert not rejected.accepted
+    assert rejected.state.phase is LifePhase.HALTED
+    assert rejected.state.halt is not None
+    assert rejected.state.halt.stage is HaltStage.POST_EXECUTION_DIVERGENCE
+    assert rejected.state.halt.recovery_mode is RecoveryMode.RECONCILE_ONLY
+    assert rejected.state.accepted_events == 0
+    assert rejected.state.executed_events == 1
+    assert int(rejected.state.environment_state.step_count) == 1
+    assert int(rejected.state.agent_state.agent_state.step_count) == 0
+    assert rejected.state.metrics.accepted_events == 0
+    assert rejected.state.transaction_state.receipt is not None
+    command = rejected.state.transaction_state.command
+    assert command is not None
+    assert rejected.state.transaction_state.receipt.applied_action != command.effective_action
+    with pytest.raises(DecisionOwnershipError, match="complete outcome-pending"):
+        runner.recover_pending_outcome(rejected.state)
+
+
+class _MismatchingEnvironment(SwitchingTwoStateReferenceEnvironment):
+    def execute(
+        self,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        commanded_value = command.effective_action.to_python()
+        assert isinstance(commanded_value, int)
+        applied_value = 1 - commanded_value
+        phase = int(self._environment.phase_id(state))
+        next_observation, reward, next_state = self._environment.step(
+            state,
+            jnp.asarray(applied_value, dtype=jnp.int32),
+            key,
+        )
+        replacement = self.manifest.action_spec.encode(
+            np.asarray(applied_value, dtype=np.int32)
+        )
+        return SwitchingEnvironmentExecution(
+            command=command,
+            state=next_state,
+            applied_action=replacement,
+            next_observation=self.manifest.observation_spec.encode(
+                np.asarray(next_observation, dtype=np.float32)
+            ),
+            reward=float(np.asarray(reward, dtype=np.float32)),
+            discount=1.0,
+            terminated=False,
+            truncated=False,
+            autoreset=False,
+            regime_id=phase,
+            oracle_reward=self._environment.optimal_average_reward(phase),
+        )
+
+
+def test_timeout_after_executor_submission_commits_uncertain_halt_and_stales_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_execute = SwitchingTwoStateReferenceEnvironment.execute
+    execute_calls = 0
+
+    def execute_then_timeout(
+        self: SwitchingTwoStateReferenceEnvironment,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        nonlocal execute_calls
+        execute_calls += 1
+        original_execute(self, state, command, key=key)
+        raise TimeoutError("synthetic lost executor response")
+
+    monkeypatch.setattr(
+        SwitchingTwoStateReferenceEnvironment,
+        "execute",
+        execute_then_timeout,
+    )
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.DISPATCH_UNCERTAIN
+    assert halted.halt.recovery_mode is RecoveryMode.RECONCILE_ONLY
+    assert halted.dispatch_attempts == 1
+    assert halted.executed_events == 0
+    assert int(halted.environment_state.step_count) == 0
+    assert halted.transaction_state.command is not None
+    assert halted.transaction_state.receipt is None
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+    assert execute_calls == 1
+
+
+def test_post_execution_receipt_record_failure_retains_execution_and_stales_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    execute_calls = 0
+    original_execute = SwitchingTwoStateReferenceEnvironment.execute
+
+    def count_execute(
+        self: SwitchingTwoStateReferenceEnvironment,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        nonlocal execute_calls
+        execute_calls += 1
+        return original_execute(self, state, command, key=key)
+
+    def fail_record_dispatch(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise OSError("synthetic receipt persistence failure")
+
+    monkeypatch.setattr(SwitchingTwoStateReferenceEnvironment, "execute", count_execute)
+    monkeypatch.setattr(
+        ReferenceTransactionReducer,
+        "record_dispatch",
+        fail_record_dispatch,
+    )
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.POST_EXECUTION_DIVERGENCE
+    assert halted.halt.recovery_mode is RecoveryMode.RECONCILE_ONLY
+    assert halted.dispatch_attempts == 1
+    assert halted.executed_events == 1
+    assert int(halted.environment_state.step_count) == 1
+    assert int(halted.agent_state.agent_state.step_count) == 0
+    assert halted.metrics.accepted_events == 0
+    assert halted.transaction_state.receipt is not None
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+    assert execute_calls == 1
+
+
+def test_outcome_record_failure_halts_with_advanced_environment_and_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+
+    def fail_record_outcome(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise ValueError("synthetic outcome record failure")
+
+    monkeypatch.setattr(
+        ReferenceTransactionReducer,
+        "record_outcome",
+        fail_record_outcome,
+    )
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.POST_EXECUTION_DIVERGENCE
+    assert halted.executed_events == 1
+    assert int(halted.environment_state.step_count) == 1
+    assert halted.transaction_state.receipt is not None
+    assert halted.transaction_state.transaction is None
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+
+
+def test_post_execution_accept_failure_discards_staged_learning_and_never_redispatches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_execute = SwitchingTwoStateReferenceEnvironment.execute
+    execute_calls = 0
+
+    def count_execute(
+        self: SwitchingTwoStateReferenceEnvironment,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        nonlocal execute_calls
+        execute_calls += 1
+        return original_execute(self, state, command, key=key)
+
+    def fail_accept(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise OSError("synthetic transaction acceptance failure")
+
+    monkeypatch.setattr(SwitchingTwoStateReferenceEnvironment, "execute", count_execute)
+    monkeypatch.setattr(ReferenceTransactionReducer, "accept", fail_accept)
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.POST_EXECUTION_DIVERGENCE
+    assert halted.executed_events == 1
+    assert int(halted.environment_state.step_count) == 1
+    assert int(halted.agent_state.agent_state.step_count) == 0
+    assert halted.metrics.accepted_events == 0
+    assert halted.transaction_state.transaction is not None
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+    assert execute_calls == 1
+
+
+def test_post_accept_candidate_failure_halts_from_retained_outcome_and_stales_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_execute = SwitchingTwoStateReferenceEnvironment.execute
+    execute_calls = 0
+
+    def count_execute(
+        self: SwitchingTwoStateReferenceEnvironment,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        nonlocal execute_calls
+        execute_calls += 1
+        return original_execute(self, state, command, key=key)
+
+    def unchanged_metrics(
+        self: ReferenceLifeMetricsAdapter,
+        state: Any,
+        **kwargs: Any,
+    ) -> Any:
+        del self, kwargs
+        return state
+
+    monkeypatch.setattr(SwitchingTwoStateReferenceEnvironment, "execute", count_execute)
+    monkeypatch.setattr(ReferenceLifeMetricsAdapter, "observe", unchanged_metrics)
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.POST_EXECUTION_DIVERGENCE
+    assert halted.transaction_state.transaction is not None
+    assert halted.executed_events == 1
+    assert int(halted.environment_state.step_count) == 1
+    assert int(halted.agent_state.agent_state.step_count) == 0
+    assert halted.metrics.accepted_events == 0
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+    assert execute_calls == 1
+
+
+def test_double_fault_in_receipt_record_and_normal_halt_uses_emergency_cas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_execute = SwitchingTwoStateReferenceEnvironment.execute
+    execute_calls = 0
+
+    def count_execute(
+        self: SwitchingTwoStateReferenceEnvironment,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        nonlocal execute_calls
+        execute_calls += 1
+        return original_execute(self, state, command, key=key)
+
+    def fail(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise OSError("synthetic double fault")
+
+    monkeypatch.setattr(SwitchingTwoStateReferenceEnvironment, "execute", count_execute)
+    monkeypatch.setattr(ReferenceTransactionReducer, "record_dispatch", fail)
+    monkeypatch.setattr(ReferenceTransactionReducer, "halt_after_execution", fail)
+
+    rejected = runner.step(initial)
+    assert not rejected.accepted
+    assert rejected.state.phase is LifePhase.HALTED
+    assert rejected.state.executed_events == 1
+    assert int(rejected.state.environment_state.step_count) == 1
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+    assert execute_calls == 1
+
+
+def test_malformed_dispatch_issued_state_halts_before_environment_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    execute_calls = 0
+
+    def malformed_issued(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        return object()
+
+    def forbidden_execute(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        nonlocal execute_calls
+        execute_calls += 1
+        raise AssertionError("malformed dispatch state must prevent execution")
+
+    monkeypatch.setattr(ExactDispatchAdapter, "issued", malformed_issued)
+    monkeypatch.setattr(
+        SwitchingTwoStateReferenceEnvironment,
+        "execute",
+        forbidden_execute,
+    )
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.phase is LifePhase.HALTED
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.DISPATCH_UNCERTAIN
+    assert halted.executed_events == 0
+    assert int(halted.environment_state.step_count) == 0
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+    assert execute_calls == 0
+
+
+def test_malformed_transaction_issued_state_halts_before_environment_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_issue = ReferenceTransactionReducer.issue_dispatch
+    execute_calls = 0
+
+    def malformed_issue(
+        self: ReferenceTransactionReducer,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        _, command = original_issue(self, *args, **kwargs)
+        return object(), command
+
+    def forbidden_execute(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        nonlocal execute_calls
+        execute_calls += 1
+        raise AssertionError("malformed issued transaction must prevent execution")
+
+    monkeypatch.setattr(ReferenceTransactionReducer, "issue_dispatch", malformed_issue)
+    monkeypatch.setattr(
+        SwitchingTwoStateReferenceEnvironment,
+        "execute",
+        forbidden_execute,
+    )
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.phase is LifePhase.HALTED
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.PRE_DISPATCH
+    assert halted.dispatch_attempts == 0
+    assert halted.executed_events == 0
+    assert int(halted.environment_state.step_count) == 0
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+    assert execute_calls == 0
+
+
+def test_malformed_dispatch_receipted_state_retains_one_execution_and_stales_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_execute = SwitchingTwoStateReferenceEnvironment.execute
+    execute_calls = 0
+
+    def count_execute(
+        self: SwitchingTwoStateReferenceEnvironment,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        nonlocal execute_calls
+        execute_calls += 1
+        return original_execute(self, state, command, key=key)
+
+    def malformed_receipted(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        return object()
+
+    monkeypatch.setattr(SwitchingTwoStateReferenceEnvironment, "execute", count_execute)
+    monkeypatch.setattr(ExactDispatchAdapter, "receipted", malformed_receipted)
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.phase is LifePhase.HALTED
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.POST_EXECUTION_DIVERGENCE
+    assert halted.executed_events == 1
+    assert int(halted.environment_state.step_count) == 1
+    assert halted.dispatch_state.commands_issued == 1
+    assert halted.dispatch_state.receipts_recorded == 0
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+    assert execute_calls == 1
+
+
+class _ForeignCommandEnvironment(SwitchingTwoStateReferenceEnvironment):
+    def execute(
+        self,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        result = super().execute(state, command, key=key)
+        foreign = dataclasses.replace(
+            command,
+            executor_epoch="asi.switching_two_state.executor_epoch.2",
+        )
+        return dataclasses.replace(result, command=foreign)
+
+
+def test_foreign_command_result_cannot_acknowledge_or_advance_local_execution() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_agent_config())
+    environment = _ForeignCommandEnvironment(
+        SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        observation_spec=adapter.manifest.observation_spec,
+        action_spec=adapter.manifest.action_spec,
+    )
+    runner = ReferenceLifeRunner.create(
+        agent_adapter=adapter,
+        environment_adapter=environment,
+        lifecycle_id=_LIFECYCLE_ID,
+        seed=7,
+        max_accepted_events=1,
+    )
+    initial = runner.init()
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.DISPATCH_UNCERTAIN
+    assert halted.executed_events == 0
+    assert int(halted.environment_state.step_count) == 0
+    assert halted.transaction_state.receipt is None
+    assert halted.transcript_sha256 == initial.transcript_sha256
+
+
+class _FalseObservationEnvironment(SwitchingTwoStateReferenceEnvironment):
+    def execute(
+        self,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        result = super().execute(state, command, key=key)
+        observation = result.next_observation.to_numpy()[::-1].copy()
+        forged = self.manifest.observation_spec.encode(observation)
+        return dataclasses.replace(result, next_observation=forged)
+
+
+def test_semantically_inconsistent_execution_result_never_reaches_learning() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_agent_config())
+    environment = _FalseObservationEnvironment(
+        SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        observation_spec=adapter.manifest.observation_spec,
+        action_spec=adapter.manifest.action_spec,
+    )
+    runner = ReferenceLifeRunner.create(
+        agent_adapter=adapter,
+        environment_adapter=environment,
+        lifecycle_id=_LIFECYCLE_ID,
+        seed=7,
+        max_accepted_events=1,
+    )
+    initial = runner.init()
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.DISPATCH_UNCERTAIN
+    assert halted.executed_events == 0
+    assert int(halted.environment_state.step_count) == 0
+    assert int(halted.agent_state.agent_state.step_count) == 0
+    assert halted.metrics.accepted_events == 0
+    assert halted.transcript_sha256 == initial.transcript_sha256
+
+
+def test_malformed_executor_result_commits_uncertain_halt_and_never_redispatches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    execute_calls = 0
+
+    def malformed_result(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        nonlocal execute_calls
+        execute_calls += 1
+        return object()
+
+    monkeypatch.setattr(
+        SwitchingTwoStateReferenceEnvironment,
+        "execute",
+        malformed_result,
+    )
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.DISPATCH_UNCERTAIN
+    assert halted.executed_events == 0
+    assert int(halted.environment_state.step_count) == 0
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+    assert execute_calls == 1
+
+
+def test_synthetic_safety_veto_executes_no_command_and_cannot_recover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_authorize = ReferenceTransactionReducer.authorize
+    execute_calls = 0
+
+    def veto(
+        self: ReferenceTransactionReducer,
+        state: Any,
+        decision: Any,
+        *,
+        authorized_action: Any,
+        authority_id: str,
+        policy_version: str,
+        authorization_id: str,
+        veto_reason: str | None = None,
+    ) -> Any:
+        del authorized_action, veto_reason
+        return original_authorize(
+            self,
+            state,
+            decision,
+            authorized_action=None,
+            authority_id=authority_id,
+            policy_version=policy_version,
+            authorization_id=authorization_id,
+            veto_reason="synthetic safety veto",
+        )
+
+    def forbidden_execute(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        nonlocal execute_calls
+        execute_calls += 1
+        raise AssertionError("a vetoed decision must not execute")
+
+    monkeypatch.setattr(ReferenceTransactionReducer, "authorize", veto)
+    monkeypatch.setattr(
+        SwitchingTwoStateReferenceEnvironment,
+        "execute",
+        forbidden_execute,
+    )
+
+    rejected = runner.step(initial)
+    halted = rejected.state
+    assert not rejected.accepted
+    assert halted.halt is not None
+    assert halted.halt.stage is HaltStage.PRE_DISPATCH
+    assert halted.accepted_events == 0
+    assert halted.executed_events == 0
+    assert halted.dispatch_attempts == 0
+    assert halted.transaction_state.authorization is not None
+    assert halted.transaction_state.authorization.status is AuthorizationStatus.VETOED
+    assert execute_calls == 0
+    with pytest.raises(DecisionOwnershipError, match="complete outcome-pending"):
+        runner.recover_pending_outcome(halted)
+
+
+def test_recovery_refuses_incomplete_current_state() -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+
+    with pytest.raises(DecisionOwnershipError, match="complete outcome-pending"):
+        runner.recover_pending_outcome(initial)
+
+
+def test_command_precedes_execution_and_receipt_and_horizon_has_no_extra_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    initial = runner.init()
+    original_issue = ReferenceTransactionReducer.issue_dispatch
+    original_record = ReferenceTransactionReducer.record_dispatch
+    original_execute = SwitchingTwoStateReferenceEnvironment.execute
+    order: list[str] = []
+    execute_calls = 0
+
+    def issue(self: ReferenceTransactionReducer, *args: Any, **kwargs: Any) -> Any:
+        result = original_issue(self, *args, **kwargs)
+        order.append("command")
+        return result
+
+    def execute(
+        self: SwitchingTwoStateReferenceEnvironment,
+        *args: Any,
+        **kwargs: Any,
+    ) -> SwitchingEnvironmentExecution:
+        nonlocal execute_calls
+        assert order == ["command"]
+        order.append("execute")
+        execute_calls += 1
+        return original_execute(self, *args, **kwargs)
+
+    def record(self: ReferenceTransactionReducer, *args: Any, **kwargs: Any) -> Any:
+        assert order == ["command", "execute"]
+        order.append("receipt")
+        return original_record(self, *args, **kwargs)
+
+    monkeypatch.setattr(ReferenceTransactionReducer, "issue_dispatch", issue)
+    monkeypatch.setattr(SwitchingTwoStateReferenceEnvironment, "execute", execute)
+    monkeypatch.setattr(ReferenceTransactionReducer, "record_dispatch", record)
+
+    completed = runner.step(initial).state
+    assert completed.phase is LifePhase.COMPLETED
+    assert order == ["command", "execute", "receipt"]
+    with pytest.raises(DecisionOwnershipError, match="completed"):
+        runner.step(completed)
+    assert execute_calls == 1
+
+
+def test_outer_runner_cas_prevents_concurrent_double_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=2)
+    initial = runner.init()
+    barrier = threading.Barrier(2)
+    original_execute = SwitchingTwoStateReferenceEnvironment.execute
+    calls_lock = threading.Lock()
+    execute_calls = 0
+
+    def count_execute(
+        self: SwitchingTwoStateReferenceEnvironment,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        nonlocal execute_calls
+        with calls_lock:
+            execute_calls += 1
+        return original_execute(self, state, command, key=key)
+
+    monkeypatch.setattr(SwitchingTwoStateReferenceEnvironment, "execute", count_execute)
+
+    def race() -> Any:
+        barrier.wait()
+        return runner.step(initial)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(race) for _ in range(2)]
+        successes = []
+        failures = []
+        for future in futures:
+            try:
+                successes.append(future.result())
+            except DecisionOwnershipError as exc:
+                failures.append(exc)
+
+    assert len(successes) == 1
+    assert len(failures) == 1
+    assert successes[0].state.dispatch_attempts == 1
+    assert int(successes[0].state.environment_state.step_count) == 1
+    assert execute_calls == 1
+
+
+def test_abort_is_terminal_and_preserves_pending_execution() -> None:
+    runner = _runner(horizon=1)
+    state = runner.init()
+    aborted = runner.abort(state, reason="operator stop")
+
+    assert aborted.phase is LifePhase.ABORTED
+    assert aborted.accepted_events == 0
+    assert aborted.halt is not None
+    assert aborted.halt.recovery_mode is RecoveryMode.ABORT_ONLY
+    with pytest.raises(DecisionOwnershipError, match="aborted"):
+        runner.step(aborted)

--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -1,0 +1,575 @@
+"""Exact-resume contracts for the development-only reference life."""
+
+from __future__ import annotations
+
+import dataclasses
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import struct
+import threading
+from pathlib import Path
+from typing import Any
+
+import jax
+import numpy as np
+import pytest
+
+import alberta_framework.reference_life_checkpoint as checkpoint_module
+from alberta_framework.core.oak import OaKConfig
+from alberta_framework.core.options import STOMPConfig
+from alberta_framework.core.prototype_agent import PrototypeAgentConfig
+from alberta_framework.reference_life import (
+    LifePhase,
+    ReferenceLifeRunner,
+    ReferenceLifeState,
+    ReferenceLifeStep,
+    _switching_metric_schedule,
+    build_prototype_switching_life,
+)
+from alberta_framework.reference_life_checkpoint import (
+    load_reference_life_checkpoint,
+    save_reference_life_checkpoint,
+)
+from alberta_framework.streams.closed_loop import SwitchingTwoStateConfig
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+LIFECYCLE_ID = "prototype.0000001100000012"
+
+
+def test_switching_metric_schedule_is_constant_time_at_counter_horizon() -> None:
+    maximum_events = 2**31 - 4
+    assert _switching_metric_schedule(maximum_events, 2) == (
+        (1_073_741_822, 1_073_741_822),
+        1,
+        1_073_741_821,
+        2,
+    )
+    with pytest.raises(ValueError, match="requires nonnegative"):
+        _switching_metric_schedule(-1, 2)
+    with pytest.raises(ValueError, match="requires nonnegative"):
+        _switching_metric_schedule(1, 0)
+
+
+def test_checkpoint_validator_rejects_generation_and_zero_event_metric_forgery() -> None:
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+
+    impossible_generation = dataclasses.replace(
+        state,
+        commit_generation=state.accepted_events + state.checkpoint_generation - 1,
+    )
+    with pytest.raises(ValueError, match="generation history"):
+        runner.validate_checkpoint_state(impossible_generation)
+
+    metrics = state.metrics
+    nonzero_empty_phase = dataclasses.replace(
+        metrics,
+        reward_sum=metrics.reward_sum + 1.0,
+        regret_sum=metrics.regret_sum - 1.0,
+        phase_reward_sums=(metrics.phase_reward_sums[0], 1.0),
+        phase_regret_sums=(metrics.phase_regret_sums[0], -1.0),
+    )
+    negative_zero_empty_phase = dataclasses.replace(
+        metrics,
+        phase_reward_sums=(metrics.phase_reward_sums[0], -0.0),
+    )
+    completed_empty_phase = dataclasses.replace(
+        metrics,
+        first_completed_segment_reward=(metrics.first_completed_segment_reward[0], 0.0),
+        latest_completed_segment_reward=(metrics.latest_completed_segment_reward[0], 0.0),
+    )
+    for forged_metrics in (
+        nonzero_empty_phase,
+        negative_zero_empty_phase,
+        completed_empty_phase,
+    ):
+        forged = dataclasses.replace(state, metrics=forged_metrics)
+        with pytest.raises(ValueError, match="zero-event phase"):
+            runner.validate_checkpoint_state(forged)
+
+
+def _agent_config() -> PrototypeAgentConfig:
+    return PrototypeAgentConfig(
+        oak=OaKConfig(
+            stomp=STOMPConfig(
+                subtask_specs=(),
+                observation_dim=2,
+                n_primitive_actions=2,
+                base_step_size=0.05,
+                epsilon_base=0.25,
+            )
+        )
+    )
+
+
+def _runner(*, horizon: int = 6) -> ReferenceLifeRunner:
+    return build_prototype_switching_life(
+        agent_config=_agent_config(),
+        environment_config=SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        lifecycle_id=LIFECYCLE_ID,
+        seed=29,
+        max_accepted_events=horizon,
+    )
+
+
+def _advance(
+    runner: ReferenceLifeRunner,
+    state: ReferenceLifeState,
+    count: int,
+) -> tuple[ReferenceLifeState, tuple[ReferenceLifeStep, ...]]:
+    steps: list[ReferenceLifeStep] = []
+    for _ in range(count):
+        step = runner.step(state)
+        assert step.accepted, step.rejection_reason
+        assert step.event is not None
+        steps.append(step)
+        state = step.state
+    return state, tuple(steps)
+
+
+def _assert_semantic_state_exact(
+    left: ReferenceLifeState,
+    right: ReferenceLifeState,
+) -> None:
+    _assert_typed_exact(left, right)
+
+
+def _assert_typed_exact(left: object, right: object, *, path: str = "state") -> None:
+    if isinstance(left, jax.Array) or isinstance(right, jax.Array):
+        assert isinstance(left, jax.Array) and isinstance(right, jax.Array), path
+        assert left.shape == right.shape and left.dtype == right.dtype, path
+        if jax.dtypes.issubdtype(  # type: ignore[attr-defined]
+            left.dtype, jax.dtypes.prng_key
+        ):
+            assert str(jax.random.key_impl(left)) == str(jax.random.key_impl(right)), path
+            left = jax.random.key_data(left)
+            right = jax.random.key_data(right)
+        assert np.asarray(left).tobytes(order="C") == np.asarray(right).tobytes(order="C"), path
+        return
+    if dataclasses.is_dataclass(left) or dataclasses.is_dataclass(right):
+        assert type(left) is type(right) and dataclasses.is_dataclass(left), path
+        for field in dataclasses.fields(left):
+            if field.name == "_owner_token":
+                continue
+            _assert_typed_exact(
+                getattr(left, field.name),
+                getattr(right, field.name),
+                path=f"{path}.{field.name}",
+            )
+        return
+    if isinstance(left, float) or isinstance(right, float):
+        assert type(left) is type(right), path
+        assert struct.pack(">d", left) == struct.pack(">d", right), path
+        return
+    if isinstance(left, np.generic) or isinstance(right, np.generic):
+        assert isinstance(left, np.generic) and isinstance(right, np.generic), path
+        assert left.dtype == right.dtype and left.tobytes() == right.tobytes(), path
+        return
+    if isinstance(left, tuple) or isinstance(right, tuple):
+        assert isinstance(left, tuple) and isinstance(right, tuple), path
+        assert type(left) is type(right) and len(left) == len(right), path
+        for index, (left_item, right_item) in enumerate(zip(left, right, strict=True)):
+            _assert_typed_exact(left_item, right_item, path=f"{path}[{index}]")
+        return
+    if isinstance(left, dict) or isinstance(right, dict):
+        assert isinstance(left, dict) and isinstance(right, dict), path
+        assert type(left) is type(right) and left.keys() == right.keys(), path
+        for key in left:
+            _assert_typed_exact(left[key], right[key], path=f"{path}.{key}")
+        return
+    assert type(left) is type(right) and left == right, path
+
+
+@pytest.fixture(scope="module")
+def saved_case(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path]:
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+    assert state.phase is LifePhase.QUIESCENT
+    barrier_state, checkpoint = save_reference_life_checkpoint(
+        runner,
+        state,
+        tmp_path_factory.mktemp("reference-life-checkpoints"),
+    )
+    return runner, state, barrier_state, checkpoint
+
+
+def test_quiescent_checkpoint_restores_exact_continuation(
+    saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
+) -> None:
+    runner, state, barrier_state, checkpoint = saved_case
+    assert barrier_state.commit_generation == state.commit_generation + 1
+    assert barrier_state.checkpoint_generation == state.checkpoint_generation + 1
+
+    uninterrupted_state, uninterrupted_steps = _advance(runner, barrier_state, 4)
+    restored_runner, restored_state = load_reference_life_checkpoint(checkpoint)
+    assert restored_runner is not runner
+    assert restored_runner.agent_adapter is not runner.agent_adapter
+    assert restored_state.agent_state._owner_token is not barrier_state.agent_state._owner_token
+    restored_runner.agent_adapter.current_decision(restored_state.agent_state)
+    with pytest.raises(ValueError, match="owner is another"):
+        runner.agent_adapter.current_decision(restored_state.agent_state)
+    _assert_semantic_state_exact(restored_state, barrier_state)
+    restored_final, restored_steps = _advance(restored_runner, restored_state, 4)
+
+    _assert_typed_exact(restored_runner.config, runner.config, path="config")
+    _assert_typed_exact(restored_steps, uninterrupted_steps, path="steps")
+    assert uninterrupted_state.phase is LifePhase.COMPLETED
+    _assert_semantic_state_exact(restored_final, uninterrupted_state)
+    assert restored_final.transcript_sha256 == uninterrupted_state.transcript_sha256
+    assert restored_final.environment_rng_cursor == uninterrupted_state.environment_rng_cursor
+    assert restored_final.checkpoint_generation == 1
+
+
+def _write_canonical_json(path: Path, value: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(value, allow_nan=False, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+        + "\n",
+        encoding="ascii",
+    )
+
+
+def _rehash_bundle(path: Path) -> None:
+    manifest_path = path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="ascii"))
+    for relative, child in manifest["children"]["files"].items():
+        payload = (path / relative).read_bytes()
+        child["sha256"] = hashlib.sha256(payload).hexdigest()
+        child["size"] = len(payload)
+    payload = {key: value for key, value in manifest.items() if key != "bundle_id"}
+    bundle_id = hashlib.sha256(
+        json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("ascii")
+        + b"\n"
+    ).hexdigest()
+    manifest["bundle_id"] = bundle_id
+    _write_canonical_json(manifest_path, manifest)
+    (path / "COMMITTED").write_text(f"{bundle_id}\n", encoding="ascii")
+
+
+def test_restore_rejects_incomplete_tampered_unknown_and_symlink_bundles(
+    saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
+    tmp_path: Path,
+) -> None:
+    _, _, _, checkpoint = saved_case
+
+    incomplete = tmp_path / "incomplete"
+    shutil.copytree(checkpoint, incomplete)
+    (incomplete / "COMMITTED").unlink()
+    with pytest.raises(ValueError, match="root entries"):
+        load_reference_life_checkpoint(incomplete)
+
+    tampered = tmp_path / "tampered"
+    shutil.copytree(checkpoint, tampered)
+    state_payload = json.loads((tampered / "life_state.json").read_text(encoding="ascii"))
+    state_payload["runner"]["transcript_sha256"] = "0" * 64
+    _write_canonical_json(tampered / "life_state.json", state_payload)
+    with pytest.raises(ValueError, match="content hash"):
+        load_reference_life_checkpoint(tampered)
+
+    semantic = tmp_path / "semantic"
+    shutil.copytree(checkpoint, semantic)
+    semantic_state = json.loads((semantic / "life_state.json").read_text(encoding="ascii"))
+    semantic_state["metrics"]["phase_event_counts"] = [1, 1]
+    semantic_state["metrics"]["current_phase"] = 1
+    semantic_state["metrics"]["current_segment_events"] = 1
+    _write_canonical_json(semantic / "life_state.json", semantic_state)
+    _rehash_bundle(semantic)
+    with pytest.raises(ValueError, match="environment schedule|phase schedule"):
+        load_reference_life_checkpoint(semantic)
+
+    impossible_generation = tmp_path / "impossible-generation"
+    shutil.copytree(checkpoint, impossible_generation)
+    generation_state = json.loads(
+        (impossible_generation / "life_state.json").read_text(encoding="ascii")
+    )
+    generation_state["runner"]["commit_generation"] = 2
+    _write_canonical_json(impossible_generation / "life_state.json", generation_state)
+    _rehash_bundle(impossible_generation)
+    with pytest.raises(ValueError, match="generation history"):
+        load_reference_life_checkpoint(impossible_generation)
+
+    coerced_environment = tmp_path / "coerced-environment"
+    shutil.copytree(checkpoint, coerced_environment)
+    coerced_state = json.loads(
+        (coerced_environment / "life_state.json").read_text(encoding="ascii")
+    )
+    encoded_step = coerced_state["environment"]["step_count"]
+    step_value = int.from_bytes(
+        bytes.fromhex(encoded_step["payload_hex"]),
+        byteorder="little",
+        signed=True,
+    )
+    encoded_step["dtype"] = "int64"
+    encoded_step["payload_hex"] = step_value.to_bytes(8, "little", signed=True).hex()
+    _write_canonical_json(coerced_environment / "life_state.json", coerced_state)
+    _rehash_bundle(coerced_environment)
+    with pytest.raises(ValueError, match="cannot preserve its encoded shape and dtype"):
+        load_reference_life_checkpoint(coerced_environment)
+
+    unknown = tmp_path / "unknown"
+    shutil.copytree(checkpoint, unknown)
+    manifest = json.loads((unknown / "manifest.json").read_text(encoding="ascii"))
+    manifest["schema"] = "asi.reference_life_checkpoint.unknown"
+    _write_canonical_json(unknown / "manifest.json", manifest)
+    with pytest.raises(ValueError, match="manifest.schema is unsupported"):
+        load_reference_life_checkpoint(unknown)
+
+    prototype_unknown = tmp_path / "prototype-unknown"
+    shutil.copytree(checkpoint, prototype_unknown)
+    metadata_path = prototype_unknown / "prototype" / "metadata" / "metadata"
+    prototype_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    prototype_metadata["schema"] = "alberta.prototype_agent.unknown"
+    metadata_path.write_text(json.dumps(prototype_metadata), encoding="utf-8")
+    _rehash_bundle(prototype_unknown)
+    with pytest.raises(ValueError, match="nested Prototype checkpoint is not exact"):
+        load_reference_life_checkpoint(prototype_unknown)
+
+    symlinked = tmp_path / "symlinked"
+    shutil.copytree(checkpoint, symlinked)
+    (symlinked / "life_state.json").unlink()
+    (symlinked / "life_state.json").symlink_to(checkpoint / "life_state.json")
+    with pytest.raises(ValueError, match="symlink"):
+        load_reference_life_checkpoint(symlinked)
+
+
+def test_restore_rejects_rehashed_duplicate_prototype_metadata_key(
+    saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
+    tmp_path: Path,
+) -> None:
+    _, _, _, checkpoint = saved_case
+    duplicate = tmp_path / "duplicate-prototype-metadata"
+    shutil.copytree(checkpoint, duplicate)
+    metadata_path = duplicate / "prototype" / "metadata" / "metadata"
+    raw = metadata_path.read_text(encoding="utf-8")
+    assert raw.startswith("{")
+    metadata_path.write_text(
+        '{"schema":"alberta.prototype_agent.v3",' + raw[1:],
+        encoding="utf-8",
+    )
+    _rehash_bundle(duplicate)
+
+    with pytest.raises(ValueError, match="duplicate key 'schema'"):
+        load_reference_life_checkpoint(duplicate)
+
+
+def test_publish_failure_and_existing_generation_leave_runner_unchanged(
+    saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, _, existing_checkpoint = saved_case
+    duplicate_runner = _runner()
+    duplicate_state, _ = _advance(duplicate_runner, duplicate_runner.init(), 2)
+    with pytest.raises(FileExistsError, match="already exists"):
+        save_reference_life_checkpoint(
+            duplicate_runner,
+            duplicate_state,
+            existing_checkpoint.parent,
+        )
+    assert duplicate_runner.current_state is duplicate_state
+
+    failed_runner = _runner()
+    failed_state, _ = _advance(failed_runner, failed_runner.init(), 2)
+
+    def fail_save(*args: object, **kwargs: object) -> None:
+        raise OSError("injected Prototype child failure")
+
+    monkeypatch.setattr(checkpoint_module, "save_prototype_checkpoint", fail_save)
+    parent = tmp_path / "failed-publish"
+    with pytest.raises(OSError, match="injected Prototype child failure"):
+        save_reference_life_checkpoint(failed_runner, failed_state, parent)
+    assert failed_runner.current_state is failed_state
+    assert not tuple(parent.glob("generation-*"))
+    assert not tuple(parent.glob(".*.staging-*"))
+
+
+def test_post_commit_lock_cleanup_failure_returns_committed_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+    real_flock = fcntl.flock
+
+    def fail_cleanup(descriptor: int, operation: int) -> None:
+        if operation == fcntl.LOCK_UN:
+            os.close(descriptor)
+            raise OSError("injected unlock and close failure")
+        real_flock(descriptor, operation)
+
+    monkeypatch.setattr(fcntl, "flock", fail_cleanup)
+    barrier, checkpoint = save_reference_life_checkpoint(
+        runner,
+        state,
+        tmp_path / "cleanup-failure",
+    )
+    assert runner.current_state is barrier
+    assert checkpoint.is_dir()
+    restored_runner, restored_state = load_reference_life_checkpoint(checkpoint)
+    _assert_semantic_state_exact(restored_state, barrier)
+    assert restored_runner.current_state is restored_state
+
+
+def _bundle_bytes(path: Path) -> dict[str, bytes | None]:
+    return {
+        entry.relative_to(path).as_posix(): None if entry.is_dir() else entry.read_bytes()
+        for entry in sorted(path.rglob("*"))
+    }
+
+
+@pytest.mark.parametrize("stale", [False, True], ids=["current", "stale"])
+def test_save_to_existing_generation_is_rejected_without_mutation(
+    saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
+    tmp_path: Path,
+    stale: bool,
+) -> None:
+    _, _, barrier_state, checkpoint = saved_case
+    generation = tmp_path / "existing-generation"
+    shutil.copytree(checkpoint, generation)
+    before = _bundle_bytes(generation)
+
+    runner = _runner()
+    initial = runner.init()
+    if stale:
+        current = runner.step(initial).state
+        state = initial
+        expected = "stale"
+    else:
+        state, _ = _advance(runner, initial, 2)
+        current = state
+        expected = "bundle root"
+    with pytest.raises(ValueError, match=expected):
+        save_reference_life_checkpoint(runner, state, generation)
+
+    assert runner.current_state is current
+    assert _bundle_bytes(generation) == before
+    restored_runner, restored_state = load_reference_life_checkpoint(generation)
+    _assert_semantic_state_exact(restored_state, barrier_state)
+    assert restored_runner.current_state is restored_state
+
+
+def test_save_inside_existing_generation_is_rejected_without_mutation(
+    saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
+    tmp_path: Path,
+) -> None:
+    _, _, barrier_state, checkpoint = saved_case
+    generation = tmp_path / "existing-generation"
+    shutil.copytree(checkpoint, generation)
+    before = _bundle_bytes(generation)
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+
+    with pytest.raises(ValueError, match="inside an existing bundle root"):
+        save_reference_life_checkpoint(runner, state, generation / "prototype")
+
+    assert runner.current_state is state
+    assert _bundle_bytes(generation) == before
+    restored_runner, restored_state = load_reference_life_checkpoint(generation)
+    _assert_semantic_state_exact(restored_state, barrier_state)
+    assert restored_runner.current_state is restored_state
+
+
+def test_save_through_ancestor_symlink_into_generation_is_rejected(
+    saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
+    tmp_path: Path,
+) -> None:
+    _, _, barrier_state, checkpoint = saved_case
+    generation = tmp_path / "existing-generation"
+    shutil.copytree(checkpoint, generation)
+    before = _bundle_bytes(generation)
+    alias = tmp_path / "generation-alias"
+    alias.symlink_to(generation, target_is_directory=True)
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+
+    with pytest.raises(ValueError, match="inside an existing bundle root"):
+        save_reference_life_checkpoint(runner, state, alias / "prototype")
+
+    assert runner.current_state is state
+    assert _bundle_bytes(generation) == before
+    restored_runner, restored_state = load_reference_life_checkpoint(generation)
+    _assert_semantic_state_exact(restored_state, barrier_state)
+    assert restored_runner.current_state is restored_state
+
+
+def test_checkpoint_filesystem_publication_stays_inside_runner_barrier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+    parent = (tmp_path / "barrier-store").absolute()
+    first_marker = parent / "manifest.json"
+    entered_filesystem = threading.Event()
+    release_filesystem = threading.Event()
+    step_started = threading.Event()
+    step_finished = threading.Event()
+    gate_lock = threading.Lock()
+    gate_used = False
+    real_lexists = os.path.lexists
+
+    def gated_lexists(path: os.PathLike[str] | str) -> bool:
+        nonlocal gate_used
+        should_gate = False
+        with gate_lock:
+            if not gate_used and Path(path) == first_marker:
+                gate_used = True
+                should_gate = True
+        if should_gate:
+            entered_filesystem.set()
+            assert release_filesystem.wait(timeout=10.0)
+        return real_lexists(path)
+
+    monkeypatch.setattr(os.path, "lexists", gated_lexists)
+    save_results: list[tuple[ReferenceLifeState, Path]] = []
+    save_errors: list[BaseException] = []
+    step_errors: list[BaseException] = []
+
+    def save() -> None:
+        try:
+            save_results.append(save_reference_life_checkpoint(runner, state, parent))
+        except BaseException as exc:
+            save_errors.append(exc)
+
+    def race_step() -> None:
+        step_started.set()
+        try:
+            runner.step(state)
+        except BaseException as exc:
+            step_errors.append(exc)
+        finally:
+            step_finished.set()
+
+    save_thread = threading.Thread(target=save)
+    save_thread.start()
+    assert entered_filesystem.wait(timeout=10.0)
+    step_thread = threading.Thread(target=race_step)
+    step_thread.start()
+    assert step_started.wait(timeout=10.0)
+    assert not step_finished.wait(timeout=0.1)
+    release_filesystem.set()
+    save_thread.join(timeout=30.0)
+    step_thread.join(timeout=30.0)
+
+    assert not save_thread.is_alive() and not step_thread.is_alive()
+    assert not save_errors
+    assert len(save_results) == 1
+    barrier, checkpoint = save_results[0]
+    assert runner.current_state is barrier
+    assert len(step_errors) == 1
+    assert isinstance(step_errors[0], ValueError)
+    assert "stale" in str(step_errors[0])
+    restored_runner, restored_state = load_reference_life_checkpoint(checkpoint)
+    _assert_semantic_state_exact(restored_state, barrier)
+    assert restored_runner.current_state is restored_state

--- a/tests/test_reference_life_controls.py
+++ b/tests/test_reference_life_controls.py
@@ -1,0 +1,1013 @@
+"""Development contracts for exact-dispatch reference-life control adapters."""
+
+from __future__ import annotations
+
+import dataclasses
+import itertools
+import math
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.average_reward import DifferentialSARSAState
+from alberta_framework.core.sarsa import SARSAState
+from alberta_framework.core.types import LMSState
+from alberta_framework.reference_agent import (
+    AuthorizationStatus,
+    DecisionOwnershipError,
+    DispatchAuthorization,
+)
+from alberta_framework.reference_life import (
+    ExactDispatchConfig,
+    LifePhase,
+    ReferenceLifeMetricsConfig,
+    ReferenceLifeRunner,
+    RiverSwimReferenceEnvironment,
+    SwitchingTwoStateReferenceEnvironment,
+)
+from alberta_framework.reference_life_controls import (
+    REFERENCE_CONTROL_MAX_ACCEPTED_EVENTS,
+    AnalyticOracleReferenceAdapter,
+    AnalyticOracleReferenceConfig,
+    DifferentialSARSAReferenceAdapter,
+    DifferentialSARSAReferenceConfig,
+    DiscountedSARSAReferenceAdapter,
+    DiscountedSARSAReferenceConfig,
+    ReferenceLifeControlState,
+    UniformRandomReferenceAdapter,
+    UniformRandomReferenceConfig,
+    control_state_resource_usage,
+)
+from alberta_framework.streams.closed_loop import (
+    RiverSwimConfig,
+    RiverSwimMDP,
+    SwitchingTwoStateConfig,
+)
+
+
+def _switching_runner(
+    adapter: object,
+    environment_config: SwitchingTwoStateConfig,
+    *,
+    lifecycle_id: str,
+    seed: int = 17,
+    horizon: int = 4,
+) -> ReferenceLifeRunner:
+    manifest = adapter.manifest  # type: ignore[attr-defined]
+    environment = SwitchingTwoStateReferenceEnvironment(
+        environment_config,
+        observation_spec=manifest.observation_spec,
+        action_spec=manifest.action_spec,
+    )
+    return ReferenceLifeRunner.create(
+        agent_adapter=adapter,  # type: ignore[arg-type]
+        environment_adapter=environment,
+        lifecycle_id=lifecycle_id,
+        seed=seed,
+        max_accepted_events=horizon,
+        metrics_config=ReferenceLifeMetricsConfig(mode="switching_two_phase"),
+    )
+
+
+def _river_runner(
+    adapter: object,
+    environment_config: RiverSwimConfig,
+    *,
+    lifecycle_id: str,
+    seed: int = 17,
+    horizon: int = 4,
+) -> ReferenceLifeRunner:
+    manifest = adapter.manifest  # type: ignore[attr-defined]
+    dispatch = ExactDispatchConfig(
+        executor_id="asi.riverswim.executor",
+        executor_epoch="asi.riverswim.executor_epoch.1",
+    )
+    environment = RiverSwimReferenceEnvironment(
+        environment_config,
+        observation_spec=manifest.observation_spec,
+        action_spec=manifest.action_spec,
+        executor_id=dispatch.executor_id,
+        executor_epoch=dispatch.executor_epoch,
+    )
+    return ReferenceLifeRunner.create(
+        agent_adapter=adapter,  # type: ignore[arg-type]
+        environment_adapter=environment,
+        lifecycle_id=lifecycle_id,
+        seed=seed,
+        max_accepted_events=horizon,
+        dispatch_config=dispatch,
+        metrics_config=ReferenceLifeMetricsConfig(mode="stationary"),
+    )
+
+
+def _uniform_switching() -> UniformRandomReferenceAdapter:
+    environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    return UniformRandomReferenceAdapter(
+        UniformRandomReferenceConfig.for_switching(environment)
+    )
+
+
+def _differential_switching() -> DifferentialSARSAReferenceAdapter:
+    environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    return DifferentialSARSAReferenceAdapter(
+        DifferentialSARSAReferenceConfig.for_switching(
+            environment,
+            q_step_size=0.1,
+            average_reward_step_size=0.01,
+            epsilon_start=0.25,
+            epsilon_end=0.25,
+        )
+    )
+
+
+def _discounted_switching() -> DiscountedSARSAReferenceAdapter:
+    environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    return DiscountedSARSAReferenceAdapter(
+        DiscountedSARSAReferenceConfig.for_switching(
+            environment,
+            gamma=0.9,
+            epsilon_start=0.25,
+            epsilon_end=0.25,
+            hidden_sizes=(),
+            step_size=0.05,
+        )
+    )
+
+
+def _control_for_environment(
+    algorithm: str,
+    environment_kind: str,
+) -> tuple[object, SwitchingTwoStateConfig | RiverSwimConfig]:
+    if environment_kind == "switching_two_state":
+        switching_environment = SwitchingTwoStateConfig(  # type: ignore[call-arg]
+            phase_length=2
+        )
+        if algorithm == "uniform_random":
+            config = UniformRandomReferenceConfig.for_switching(switching_environment)
+            return UniformRandomReferenceAdapter(config), switching_environment
+        if algorithm == "analytic_oracle":
+            oracle_config = AnalyticOracleReferenceConfig.for_switching(
+                switching_environment,
+                horizon=4,
+            )
+            return AnalyticOracleReferenceAdapter(oracle_config), switching_environment
+        if algorithm == "differential_sarsa":
+            differential_config = DifferentialSARSAReferenceConfig.for_switching(
+                switching_environment,
+                epsilon_start=0.25,
+                epsilon_end=0.25,
+            )
+            return (
+                DifferentialSARSAReferenceAdapter(differential_config),
+                switching_environment,
+            )
+        if algorithm == "discounted_sarsa":
+            discounted_config = DiscountedSARSAReferenceConfig.for_switching(
+                switching_environment,
+                epsilon_start=0.25,
+                epsilon_end=0.25,
+                hidden_sizes=(),
+            )
+            return (
+                DiscountedSARSAReferenceAdapter(discounted_config),
+                switching_environment,
+            )
+    elif environment_kind == "riverswim":
+        river_environment = RiverSwimConfig(n_states=3)  # type: ignore[call-arg]
+        if algorithm == "uniform_random":
+            config = UniformRandomReferenceConfig.for_riverswim(river_environment)
+            return UniformRandomReferenceAdapter(config), river_environment
+        if algorithm == "analytic_oracle":
+            oracle_config = AnalyticOracleReferenceConfig.for_riverswim(
+                river_environment,
+                horizon=4,
+            )
+            return AnalyticOracleReferenceAdapter(oracle_config), river_environment
+        if algorithm == "differential_sarsa":
+            differential_config = DifferentialSARSAReferenceConfig.for_riverswim(
+                river_environment,
+                epsilon_start=0.25,
+                epsilon_end=0.25,
+            )
+            return DifferentialSARSAReferenceAdapter(differential_config), river_environment
+        if algorithm == "discounted_sarsa":
+            discounted_config = DiscountedSARSAReferenceConfig.for_riverswim(
+                river_environment,
+                epsilon_start=0.25,
+                epsilon_end=0.25,
+                hidden_sizes=(),
+            )
+            return DiscountedSARSAReferenceAdapter(discounted_config), river_environment
+    raise AssertionError(f"unsupported test control {algorithm}/{environment_kind}")
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "algorithm",
+    (
+        "uniform_random",
+        "analytic_oracle",
+        "differential_sarsa",
+        "discounted_sarsa",
+    ),
+)
+@pytest.mark.parametrize("environment_kind", ("switching_two_state", "riverswim"))
+def test_every_control_runs_one_complete_life_in_each_environment(
+    algorithm: str,
+    environment_kind: str,
+) -> None:
+    adapter, environment = _control_for_environment(algorithm, environment_kind)
+    if isinstance(environment, RiverSwimConfig):
+        runner = _river_runner(
+            adapter,
+            environment,
+            lifecycle_id=f"control.{algorithm}.riverswim.life",
+            horizon=3,
+        )
+    else:
+        runner = _switching_runner(
+            adapter,
+            environment,
+            lifecycle_id=f"control.{algorithm}.switching.life",
+            horizon=3,
+        )
+
+    run = runner.run_to_completion(runner.init())
+
+    assert run.state.phase is LifePhase.COMPLETED
+    assert run.state.accepted_events == 3
+    assert len(run.events) == 3
+    assert all(event.step_result.transaction_accepted for event in run.events)
+    assert all(event.transaction.decision.proposed_action is not None for event in run.events)
+
+
+def test_executed_control_scalars_are_canonical_actual_float32_values() -> None:
+    environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    differential_values = {
+        "q_step_size": 0.123456789,
+        "average_reward_step_size": 0.234567891,
+        "trace_decay": 0.345678912,
+        "epsilon_start": 0.456789123,
+        "epsilon_end": 0.123456789,
+    }
+    differential = DifferentialSARSAReferenceConfig.for_switching(
+        environment,
+        **differential_values,
+    )
+    discounted_values = {
+        "gamma": 0.912345678,
+        "epsilon_start": 0.456789123,
+        "epsilon_end": 0.123456789,
+        "step_size": 0.234567891,
+        "sparsity": 0.345678912,
+        "leaky_relu_slope": 0.0123456789,
+        "lamda": 0.567891234,
+    }
+    discounted = DiscountedSARSAReferenceConfig.for_switching(
+        environment,
+        hidden_sizes=(),
+        **discounted_values,
+    )
+
+    for name, raw in differential_values.items():
+        assert getattr(differential, name) == float(np.float32(raw))
+    for name, raw in discounted_values.items():
+        assert getattr(discounted, name) == float(np.float32(raw))
+    assert differential.core_config().q_step_size == differential.q_step_size
+    assert discounted.core_config().gamma == discounted.gamma
+
+
+def test_oracle_environment_scalars_bind_the_executed_float32_values() -> None:
+    switching_raw = 0.123456789
+    switching = AnalyticOracleReferenceConfig.for_switching(
+        SwitchingTwoStateConfig(  # type: ignore[call-arg]
+            phase_length=2,
+            payoffs_a=((switching_raw, 0.0), (0.0, switching_raw)),
+        ),
+        horizon=4,
+    )
+    assert switching.environment_config["payoffs_a"] == [
+        [float(np.float32(switching_raw)), 0.0],
+        [0.0, float(np.float32(switching_raw))],
+    ]
+
+    river_values = {
+        "p_right_up": 0.345678912,
+        "p_right_down": 0.123456789,
+        "reward_left": 0.0123456789,
+        "reward_right": 0.987654321,
+    }
+    river = AnalyticOracleReferenceConfig.for_riverswim(
+        RiverSwimConfig(  # type: ignore[call-arg]
+            n_states=3,
+            **river_values,
+        ),
+        horizon=4,
+    )
+    for name, raw in river_values.items():
+        assert river.environment_config[name] == float(np.float32(raw))
+
+
+def test_control_scalar_validation_uses_post_narrowing_float32_bounds() -> None:
+    environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    overflow = float(np.finfo(np.float32).max) * 2.0
+    for field in ("q_step_size", "average_reward_step_size"):
+        with pytest.raises(ValueError, match="float32"):
+            DifferentialSARSAReferenceConfig.for_switching(
+                environment,
+                **{field: overflow},
+            )
+    for field in ("step_size", "leaky_relu_slope"):
+        with pytest.raises(ValueError, match="float32"):
+            DiscountedSARSAReferenceConfig.for_switching(
+                environment,
+                hidden_sizes=(),
+                **{field: overflow},
+            )
+
+    rounds_to_one = math.nextafter(1.0, 0.0)
+    with pytest.raises(ValueError, match="gamma|less than one|float32"):
+        DiscountedSARSAReferenceConfig.for_switching(
+            environment,
+            gamma=rounds_to_one,
+            hidden_sizes=(),
+        )
+    with pytest.raises(ValueError, match="sparsity|less than one|float32"):
+        DiscountedSARSAReferenceConfig.for_switching(
+            environment,
+            sparsity=rounds_to_one,
+            hidden_sizes=(),
+        )
+
+
+def test_environment_scalar_gate_rejects_non_real_overflow_and_positive_collapse() -> None:
+    overflow = float(np.finfo(np.float32).max) * 2.0
+    with pytest.raises(ValueError, match="float32|numeric"):
+        UniformRandomReferenceConfig.for_switching(
+            SwitchingTwoStateConfig(  # type: ignore[call-arg]
+                phase_length=2,
+                payoffs_a=((overflow, 0.0), (0.0, 0.0)),
+            )
+        )
+    with pytest.raises(ValueError, match="real|float32|numeric"):
+        UniformRandomReferenceConfig.for_switching(
+            SwitchingTwoStateConfig(  # type: ignore[call-arg]
+                phase_length=2,
+                payoffs_a=(("0.5", 0.0), (0.0, 0.0)),
+            )
+        )
+    with pytest.raises(ValueError, match="positive|float32"):
+        UniformRandomReferenceConfig.for_riverswim(
+            RiverSwimConfig(  # type: ignore[call-arg]
+                n_states=3,
+                p_right_up=math.nextafter(0.0, 1.0),
+            )
+        )
+
+
+def test_decay_counts_and_discounted_network_shapes_are_resource_bounded() -> None:
+    environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    int32_max = int(np.iinfo(np.int32).max)
+    DifferentialSARSAReferenceConfig.for_switching(
+        environment,
+        epsilon_decay_steps=int32_max,
+    )
+    DiscountedSARSAReferenceConfig.for_switching(
+        environment,
+        epsilon_decay_steps=int32_max,
+        hidden_sizes=(),
+    )
+    for config_type in (
+        DifferentialSARSAReferenceConfig,
+        DiscountedSARSAReferenceConfig,
+    ):
+        with pytest.raises(ValueError, match="epsilon_decay_steps|int32|capacity"):
+            config_type(
+                environment_kind="switching_two_state",
+                observation_dim=2,
+                epsilon_decay_steps=int32_max + 1,
+            )
+
+    with pytest.raises(ValueError, match="hidden|layer|resource"):
+        DiscountedSARSAReferenceConfig.for_switching(
+            environment,
+            hidden_sizes=(1,) * 33,
+        )
+    with pytest.raises(ValueError, match="hidden|int32|resource"):
+        DiscountedSARSAReferenceConfig.for_switching(
+            environment,
+            hidden_sizes=(int32_max + 1,),
+        )
+    with pytest.raises(ValueError, match="network|parameter|resource"):
+        DiscountedSARSAReferenceConfig.for_switching(
+            environment,
+            hidden_sizes=(4096, 4096),
+        )
+
+
+def test_stochastic_controls_bind_explicit_threefry_roots_across_global_defaults() -> None:
+    environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    adapter = UniformRandomReferenceAdapter(
+        UniformRandomReferenceConfig.for_switching(environment)
+    )
+    assert adapter.manifest.config["rng_implementation"] == "threefry2x32"
+
+    explicit_key = jr.key(91, impl="threefry2x32")
+    baseline_state = adapter.init(explicit_key, lifecycle_id="control.rng.baseline")
+    baseline_started, baseline_decision = adapter.start(
+        baseline_state,
+        observation_id="observation.0",
+        observation=np.asarray((1.0, 0.0), dtype=np.float32),
+    )
+    assert baseline_decision.proposed_action is not None
+    assert baseline_started.random_key is not None
+    assert str(jr.key_impl(baseline_started.random_key)) == "threefry2x32"
+
+    with jax.default_prng_impl("rbg"):
+        alternate_state = adapter.init(
+            explicit_key,
+            lifecycle_id="control.rng.alternate_global",
+        )
+        _, alternate_decision = adapter.start(
+            alternate_state,
+            observation_id="observation.0",
+            observation=np.asarray((1.0, 0.0), dtype=np.float32),
+        )
+        assert alternate_decision.proposed_action == baseline_decision.proposed_action
+        with pytest.raises(DecisionOwnershipError, match="threefry2x32"):
+            adapter.init(
+                jr.key(91),
+                lifecycle_id="control.rng.rbg_root",
+            )
+
+
+def test_control_resource_usage_includes_both_array_value_caches() -> None:
+    adapter = _uniform_switching()
+    fresh = adapter.init(
+        jr.key(7, impl="threefry2x32"),
+        lifecycle_id="control.resources.cache",
+    )
+    fresh_usage = control_state_resource_usage(fresh)
+    started, _ = adapter.start(
+        fresh,
+        observation_id="observation.0",
+        observation=np.asarray((1.0, 0.0), dtype=np.float32),
+    )
+    armed_usage = control_state_resource_usage(started)
+
+    assert armed_usage.array_leaves == fresh_usage.array_leaves + 2
+    assert armed_usage.array_elements == fresh_usage.array_elements + 3
+    assert armed_usage.persistent_bytes == fresh_usage.persistent_bytes + 12
+    assert armed_usage.floating_array_leaves == fresh_usage.floating_array_leaves + 1
+
+
+def test_uniform_random_schedule_is_seed_deterministic_and_owner_bound() -> None:
+    environment = SwitchingTwoStateConfig(phase_length=3)  # type: ignore[call-arg]
+    config = UniformRandomReferenceConfig.for_switching(environment)
+    first = UniformRandomReferenceAdapter(config)
+    second = UniformRandomReferenceAdapter(config)
+    first_runner = _switching_runner(
+        first,
+        environment,
+        lifecycle_id="control.random.determinism",
+        seed=123,
+        horizon=24,
+    )
+    second_runner = _switching_runner(
+        second,
+        environment,
+        lifecycle_id="control.random.determinism",
+        seed=123,
+        horizon=24,
+    )
+
+    first_run = first_runner.run_to_completion(first_runner.init())
+    second_run = second_runner.run_to_completion(second_runner.init())
+    first_actions = tuple(
+        event.transaction.decision.proposed_action.to_python()  # type: ignore[union-attr]
+        for event in first_run.events
+    )
+    second_actions = tuple(
+        event.transaction.decision.proposed_action.to_python()  # type: ignore[union-attr]
+        for event in second_run.events
+    )
+
+    assert first_actions == second_actions
+    assert first_run.state.transcript_sha256 == second_run.state.transcript_sha256
+    with pytest.raises(DecisionOwnershipError, match="owner|another adapter"):
+        second.validate_state(first_run.state.agent_state)
+
+
+def test_oracle_uses_exact_finite_horizon_dynamic_program() -> None:
+    switching = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    switching_horizon = 6
+    switching_config = AnalyticOracleReferenceConfig.for_switching(
+        switching,
+        horizon=switching_horizon,
+    )
+    switching_runner = _switching_runner(
+        AnalyticOracleReferenceAdapter(switching_config),
+        switching,
+        lifecycle_id="control.oracle.switching.valid",
+        horizon=switching_horizon,
+    )
+    valid_switching_run = switching_runner.run_to_completion(switching_runner.init())
+    switching_payoffs = np.asarray(
+        (switching.payoffs_a, switching.payoffs_b), dtype=np.float64
+    )
+    switching_values = np.zeros(2, dtype=np.float64)
+    expected_switching = np.empty((switching_horizon, 2), dtype=np.int32)
+    for index in range(switching_horizon - 1, -1, -1):
+        phase = (index // switching.phase_length) % 2
+        q_values = switching_payoffs[phase] + switching_values[np.newaxis, :]
+        expected_switching[index] = np.argmax(q_values, axis=1)
+        switching_values = q_values[np.arange(2), expected_switching[index]]
+    for event in valid_switching_run.events:
+        decision = event.transaction.decision
+        observation = np.asarray(decision.observation.to_python())
+        state_index = int(np.argmax(observation))
+        assert decision.proposed_action is not None
+        assert decision.proposed_action.to_python() == int(
+            expected_switching[decision.decision_index, state_index]
+        )
+
+    river = RiverSwimConfig(n_states=4)  # type: ignore[call-arg]
+    river_kernel = RiverSwimMDP(river)
+    river_horizon = 8
+    river_config = AnalyticOracleReferenceConfig.for_riverswim(
+        river,
+        horizon=river_horizon,
+    )
+    river_adapter = AnalyticOracleReferenceAdapter(river_config)
+    river_runner = _river_runner(
+        river_adapter,
+        river,
+        lifecycle_id="control.oracle.river",
+        horizon=river_horizon,
+    )
+    river_run = river_runner.run_to_completion(river_runner.init())
+    transitions = river_kernel.transition_tensor.astype(np.float64)
+    rewards = river_kernel.reward_tensor.astype(np.float64)
+    river_values = np.zeros(river.n_states, dtype=np.float64)
+    expected_river = np.empty((river_horizon, river.n_states), dtype=np.int32)
+    for index in range(river_horizon - 1, -1, -1):
+        q_values = rewards + np.einsum("asn,n->sa", transitions, river_values)
+        expected_river[index] = np.argmax(q_values, axis=1)
+        river_values = q_values[np.arange(river.n_states), expected_river[index]]
+    for event in river_run.events:
+        decision = event.transaction.decision
+        state_index = int(np.argmax(np.asarray(decision.observation.to_python())))
+        assert decision.proposed_action is not None
+        assert decision.proposed_action.to_python() == int(
+            expected_river[decision.decision_index, state_index]
+        )
+
+    manifest_config = river_adapter.manifest.config
+    assert manifest_config["privileged"] is True
+    assert manifest_config["environment_config_sha256"] == river_config.environment_config_sha256
+
+
+def test_stale_cross_config_and_cached_action_corruption_are_failure_atomic() -> None:
+    environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    adapter = UniformRandomReferenceAdapter(
+        UniformRandomReferenceConfig.for_switching(environment)
+    )
+    runner = _switching_runner(
+        adapter,
+        environment,
+        lifecycle_id="control.random.ownership",
+        horizon=2,
+    )
+    initial = runner.init()
+    state = initial.agent_state
+    assert isinstance(state, ReferenceLifeControlState)
+    decision = adapter.current_decision(state)
+    assert decision.proposed_action is not None
+    proposed_action = decision.proposed_action.to_python()
+    assert isinstance(proposed_action, int)
+    other_action = adapter.manifest.action_spec.encode(
+        np.asarray(1 - proposed_action, dtype=np.int32)
+    )
+    substituted_decision = dataclasses.replace(decision, proposed_action=other_action)
+    substituted_authorization = DispatchAuthorization(
+        decision=substituted_decision,
+        status=AuthorizationStatus.EXACT,
+        authorized_action=other_action,
+        authority_id="control.test.authority",
+        policy_version="control.test.policy.1",
+        authorization_id=f"{substituted_decision.decision_id}:authorization",
+    )
+    with pytest.raises(DecisionOwnershipError, match="decision|action|cache"):
+        adapter.settle_dispatch(state, substituted_authorization)
+
+    corrupted = dataclasses.replace(state, current_action=other_action)
+    with pytest.raises(DecisionOwnershipError, match="action|random"):
+        adapter.validate_state(corrupted)
+
+    different_config = UniformRandomReferenceAdapter(
+        UniformRandomReferenceConfig.for_riverswim(
+            RiverSwimConfig(n_states=3)  # type: ignore[call-arg]
+        )
+    )
+    with pytest.raises(DecisionOwnershipError, match="owner|manifest|config"):
+        different_config.validate_state(state)
+    relabeled_config = dataclasses.replace(
+        state,
+        config_sha256=different_config.manifest.config_sha256,
+    )
+    with pytest.raises(DecisionOwnershipError, match="configuration"):
+        adapter.validate_state(relabeled_config)
+
+    first_step = runner.step(initial)
+    assert first_step.event is not None
+    stale_state = first_step.state.agent_state
+    rejected = adapter.apply_outcome(stale_state, first_step.event.transaction)
+    assert not rejected.accepted
+    assert rejected.state is stale_state
+    assert rejected.next_decision is None
+    assert rejected.parameters_changed is False
+
+
+def test_differential_sarsa_applies_hand_computed_first_update() -> None:
+    rewarding = SwitchingTwoStateConfig(  # type: ignore[call-arg]
+        phase_length=10,
+        payoffs_a=((1.0, 1.0), (1.0, 1.0)),
+        payoffs_b=((1.0, 1.0), (1.0, 1.0)),
+    )
+    adapter = DifferentialSARSAReferenceAdapter(
+        DifferentialSARSAReferenceConfig.for_switching(
+            rewarding,
+            q_step_size=0.5,
+            average_reward_step_size=0.25,
+            epsilon_start=0.0,
+            epsilon_end=0.0,
+            use_bias=False,
+        )
+    )
+    runner = _switching_runner(
+        adapter,
+        rewarding,
+        lifecycle_id="control.differential.update",
+        horizon=1,
+    )
+    initial = runner.init()
+    initial_control = initial.agent_state
+    assert isinstance(initial_control, ReferenceLifeControlState)
+    initial_learning = initial_control.agent_state
+    assert isinstance(initial_learning, DifferentialSARSAState)
+    initial_decision = adapter.current_decision(initial_control)
+    initial_state_index = int(np.argmax(initial_decision.observation.to_numpy()))
+    assert initial_decision.proposed_action is not None
+    initial_action = initial_decision.proposed_action.to_python()
+    assert isinstance(initial_action, int)
+
+    step = runner.step(initial)
+
+    assert step.accepted
+    final_control = step.state.agent_state
+    assert isinstance(final_control, ReferenceLifeControlState)
+    final_learning = final_control.agent_state
+    assert isinstance(final_learning, DifferentialSARSAState)
+    expected_weights = np.zeros((2, 2), dtype=np.float32)
+    expected_weights[initial_action, initial_state_index] = 0.5
+    np.testing.assert_array_equal(np.asarray(final_learning.q_weights), expected_weights)
+    np.testing.assert_array_equal(np.asarray(final_learning.q_bias), np.zeros(2, dtype=np.float32))
+    assert float(final_learning.average_reward) == pytest.approx(0.25)
+    assert int(final_learning.step_count) == 1
+    assert step.event is not None
+    assert step.event.step_result.parameters_changed
+
+
+def test_discounted_sarsa_updates_on_continuing_unit_discount_outcome() -> None:
+    rewarding = SwitchingTwoStateConfig(  # type: ignore[call-arg]
+        phase_length=10,
+        payoffs_a=((1.0, 1.0), (1.0, 1.0)),
+        payoffs_b=((1.0, 1.0), (1.0, 1.0)),
+    )
+    adapter = DiscountedSARSAReferenceAdapter(
+        DiscountedSARSAReferenceConfig.for_switching(
+            rewarding,
+            gamma=0.5,
+            epsilon_start=0.0,
+            epsilon_end=0.0,
+            hidden_sizes=(),
+            step_size=0.25,
+            sparsity=0.0,
+            use_layer_norm=False,
+        )
+    )
+    runner = _switching_runner(
+        adapter,
+        rewarding,
+        lifecycle_id="control.discounted.update",
+        horizon=2,
+    )
+    initial = runner.init()
+    run = runner.run_to_completion(initial)
+
+    assert run.state.phase is LifePhase.COMPLETED
+    final_control = run.state.agent_state
+    assert isinstance(final_control, ReferenceLifeControlState)
+    final_learning = final_control.agent_state
+    assert isinstance(final_learning, SARSAState)
+    assert int(final_learning.step_count) == 2
+    assert int(final_learning.learner_state.step_count) == 2
+    assert all(not event.transaction.is_boundary for event in run.events)
+    assert all(event.transaction.discount == 1.0 for event in run.events)
+    assert any(event.step_result.parameters_changed for event in run.events)
+    assert adapter.manifest.config["gamma"] == 0.5
+
+    resources = control_state_resource_usage(final_control)
+    assert resources.array_leaves > 0
+    assert resources.array_elements > 0
+    assert resources.persistent_bytes > 0
+    assert resources.floating_array_leaves > 0
+
+
+def test_learning_control_state_validation_requires_exact_persistent_dtypes() -> None:
+    differential = _differential_switching()
+    differential_runner = _switching_runner(
+        differential,
+        SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        lifecycle_id="control.differential.dtype",
+        horizon=1,
+    )
+    differential_state = differential_runner.init().agent_state
+    assert isinstance(differential_state, ReferenceLifeControlState)
+    differential_learner = differential_state.agent_state
+    assert isinstance(differential_learner, DifferentialSARSAState)
+    bad_differential_words = differential_learner.replace(  # type: ignore[attr-defined]
+        step_words=jnp.asarray((0, 0), dtype=jnp.int32)
+    )
+    with pytest.raises(DecisionOwnershipError, match="step_words|uint32|dtype"):
+        differential.validate_state(
+            dataclasses.replace(
+                differential_state,
+                agent_state=bad_differential_words,
+            )
+        )
+
+    discounted = _discounted_switching()
+    discounted_runner = _switching_runner(
+        discounted,
+        SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        lifecycle_id="control.discounted.dtype",
+        horizon=1,
+    )
+    discounted_state = discounted_runner.init().agent_state
+    assert isinstance(discounted_state, ReferenceLifeControlState)
+    discounted_learner = discounted_state.agent_state
+    assert isinstance(discounted_learner, SARSAState)
+    inner = discounted_learner.learner_state
+    bad_inner_words = inner.replace(  # type: ignore[attr-defined]
+        step_words=jnp.asarray((0, 0), dtype=jnp.int32)
+    )
+    with pytest.raises(DecisionOwnershipError, match="step_words|uint32|dtype"):
+        discounted.validate_state(
+            dataclasses.replace(
+                discounted_state,
+                agent_state=discounted_learner.replace(  # type: ignore[attr-defined]
+                    learner_state=bad_inner_words
+                ),
+            )
+        )
+
+    head_weights = inner.head_params.weights
+    bad_head_params = inner.head_params.replace(  # type: ignore[attr-defined]
+        weights=(head_weights[0].astype(jnp.float16), *head_weights[1:])
+    )
+    bad_float_tree = inner.replace(  # type: ignore[attr-defined]
+        head_params=bad_head_params
+    )
+    with pytest.raises(DecisionOwnershipError, match="float32|dtype|contract"):
+        discounted.validate_state(
+            dataclasses.replace(
+                discounted_state,
+                agent_state=discounted_learner.replace(  # type: ignore[attr-defined]
+                    learner_state=bad_float_tree
+                ),
+            )
+        )
+
+
+def test_all_control_adapters_declare_the_exact_signed_int32_capacity() -> None:
+    adapters = (
+        _uniform_switching(),
+        AnalyticOracleReferenceAdapter(
+            AnalyticOracleReferenceConfig.for_switching(
+                SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+                horizon=2,
+            )
+        ),
+        _differential_switching(),
+        _discounted_switching(),
+    )
+    assert REFERENCE_CONTROL_MAX_ACCEPTED_EVENTS == int(np.iinfo(np.int32).max)
+    assert adapters[1].max_accepted_events == 2
+    assert all(
+        adapter.max_accepted_events == REFERENCE_CONTROL_MAX_ACCEPTED_EVENTS
+        for adapter in (adapters[0], adapters[2], adapters[3])
+    )
+
+
+def test_control_configs_and_states_are_immutable() -> None:
+    config = UniformRandomReferenceConfig.for_switching(
+        SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        config.observation_dim = 3  # type: ignore[misc]
+
+    adapter = UniformRandomReferenceAdapter(config)
+    runner = _switching_runner(
+        adapter,
+        SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        lifecycle_id="control.random.immutable",
+        horizon=1,
+    )
+    state = runner.init().agent_state
+    assert isinstance(state, ReferenceLifeControlState)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        state.decision_index = 3  # type: ignore[misc]
+
+
+def test_runner_binds_control_environment_kind_and_oracle_model() -> None:
+    switching = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    uniform = UniformRandomReferenceAdapter(
+        UniformRandomReferenceConfig.for_switching(switching)
+    )
+    with pytest.raises(ValueError, match="kinds differ"):
+        _river_runner(
+            uniform,
+            RiverSwimConfig(n_states=2),  # type: ignore[call-arg]
+            lifecycle_id="control.cross-kind",
+            horizon=2,
+        )
+
+    oracle = AnalyticOracleReferenceAdapter(
+        AnalyticOracleReferenceConfig.for_switching(switching, horizon=3)
+    )
+    mismatched = SwitchingTwoStateConfig(phase_length=3)  # type: ignore[call-arg]
+    with pytest.raises(ValueError, match="bound environment differs"):
+        _switching_runner(
+            oracle,
+            mismatched,
+            lifecycle_id="control.oracle.cross-environment",
+            horizon=3,
+        )
+
+
+def test_runner_uses_explicit_threefry_under_an_rbg_global_default() -> None:
+    environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+
+    def action_trace() -> tuple[tuple[int, ...], str]:
+        adapter = UniformRandomReferenceAdapter(
+            UniformRandomReferenceConfig.for_switching(environment)
+        )
+        runner = _switching_runner(
+            adapter,
+            environment,
+            lifecycle_id="control.explicit-threefry",
+            seed=123,
+            horizon=12,
+        )
+        result = runner.run_to_completion(runner.init())
+        actions = tuple(
+            int(event.transaction.decision.proposed_action.to_python())
+            for event in result.events
+            if event.transaction.decision.proposed_action is not None
+        )
+        return actions, result.state.transcript_sha256
+
+    expected = action_trace()
+    with jax.default_prng_impl("rbg"):
+        observed = action_trace()
+    assert observed == expected
+
+
+def test_nested_core_agent_has_stable_jit_identity_and_mutation_fails_closed() -> None:
+    environment = SwitchingTwoStateConfig(  # type: ignore[call-arg]
+        phase_length=4,
+        payoffs_a=((1.0, 1.0), (1.0, 1.0)),
+        payoffs_b=((1.0, 1.0), (1.0, 1.0)),
+    )
+    config = DifferentialSARSAReferenceConfig.for_switching(
+        environment,
+        q_step_size=0.5,
+        average_reward_step_size=0.25,
+        epsilon_start=0.0,
+        epsilon_end=0.0,
+    )
+    adapter = DifferentialSARSAReferenceAdapter(config)
+    stable = adapter._differential_agent
+    assert adapter._differential_agent is stable
+    stable._config = dataclasses.replace(  # type: ignore[attr-defined]
+        stable.config,
+        q_step_size=0.0,
+        average_reward_step_size=0.0,
+    )
+    with pytest.raises(DecisionOwnershipError, match="configuration|mutat"):
+        _ = adapter._differential_agent
+
+
+def test_switching_oracle_is_finite_horizon_optimal_across_phase_boundaries() -> None:
+    environment = SwitchingTwoStateConfig(  # type: ignore[call-arg]
+        phase_length=1,
+        payoffs_a=((10.0, 0.0), (0.0, 9.0)),
+        payoffs_b=((9.0, 0.0), (0.0, 10.0)),
+    )
+    horizon = 6
+    adapter = AnalyticOracleReferenceAdapter(
+        AnalyticOracleReferenceConfig.for_switching(environment, horizon=horizon)
+    )
+    runner = _switching_runner(
+        adapter,
+        environment,
+        lifecycle_id="control.oracle.periodic-optimal",
+        seed=11,
+        horizon=horizon,
+    )
+    result = runner.run_to_completion(runner.init())
+    first_observation = result.events[0].transaction.decision.observation.to_numpy()
+    initial_state = int(np.argmax(first_observation))
+
+    def sequence_return(actions: tuple[int, ...]) -> float:
+        state = initial_state
+        total = 0.0
+        for index, action in enumerate(actions):
+            payoffs = environment.payoffs_a if index % 2 == 0 else environment.payoffs_b
+            total += float(payoffs[state][action])
+            state = action
+        return total
+
+    best = max(sequence_return(actions) for actions in itertools.product((0, 1), repeat=horizon))
+    assert result.state.metrics.reward_sum == best
+
+
+def test_riverswim_oracle_uses_stable_finite_horizon_expectations() -> None:
+    environment = RiverSwimConfig(  # type: ignore[call-arg]
+        n_states=2,
+        p_right_up=1e-20,
+        p_right_down=0.1,
+        reward_left=1.0,
+        reward_right=1e22,
+        initial_state=0,
+    )
+    adapter = AnalyticOracleReferenceAdapter(
+        AnalyticOracleReferenceConfig.for_riverswim(environment, horizon=2)
+    )
+    runner = _river_runner(
+        adapter,
+        environment,
+        lifecycle_id="control.oracle.conditioned-river",
+        seed=5,
+        horizon=2,
+    )
+    initial = runner.init()
+    decision = adapter.current_decision(initial.agent_state)
+    assert decision.proposed_action is not None
+    assert decision.proposed_action.to_python() == 1
+
+
+def test_discounted_sarsa_rejects_relabeled_lms_optimizer_state() -> None:
+    adapter = _discounted_switching()
+    runner = _switching_runner(
+        adapter,
+        SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        lifecycle_id="control.discounted.optimizer-binding",
+        horizon=1,
+    )
+    state = runner.init().agent_state
+    assert isinstance(state, ReferenceLifeControlState)
+    learner = state.agent_state
+    assert isinstance(learner, SARSAState)
+    inner = learner.learner_state
+    first_group = inner.head_optimizer_states[0]
+    altered_group = (
+        LMSState(step_size=jnp.asarray(0.0, dtype=jnp.float32)),
+        first_group[1],
+    )
+    altered_inner = inner.replace(  # type: ignore[attr-defined]
+        head_optimizer_states=(altered_group, *inner.head_optimizer_states[1:])
+    )
+    altered = dataclasses.replace(
+        state,
+        agent_state=learner.replace(learner_state=altered_inner),  # type: ignore[attr-defined]
+    )
+    with pytest.raises(DecisionOwnershipError, match="step size differs"):
+        adapter.validate_state(altered)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    (DifferentialSARSAReferenceConfig.for_switching, DiscountedSARSAReferenceConfig.for_switching),
+)
+def test_learning_controls_reject_increasing_epsilon_schedules(factory: object) -> None:
+    with pytest.raises(ValueError, match="epsilon_end must not exceed"):
+        factory(  # type: ignore[operator]
+            SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+            epsilon_start=0.1,
+            epsilon_end=0.2,
+        )

--- a/tests/test_reference_life_riverswim.py
+++ b/tests/test_reference_life_riverswim.py
@@ -1,0 +1,357 @@
+"""Failing-first contracts for the stochastic RiverSwim reference life."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.oak import OaKConfig
+from alberta_framework.core.options import STOMPConfig
+from alberta_framework.core.prototype_agent import PrototypeAgentConfig
+from alberta_framework.reference_agent import (
+    AuthorizationStatus,
+    DecisionOwnershipError,
+    DispatchAck,
+    DispatchAuthorization,
+    DispatchCommand,
+    DispatchStatus,
+)
+from alberta_framework.reference_life import (
+    RIVERSWIM_REFERENCE_MAX_STATES,
+    HaltStage,
+    LifePhase,
+    ReferenceEnvironmentExecution,
+    RiverSwimReferenceEnvironment,
+    build_prototype_riverswim_life,
+)
+from alberta_framework.streams.closed_loop import RiverSwimConfig, RiverSwimMDP
+
+pytestmark = pytest.mark.unit
+
+_LIFECYCLE_ID = "prototype.0000002100000022"
+
+
+def _agent_config(*, epsilon: float = 0.25, observation_dim: int = 3) -> PrototypeAgentConfig:
+    return PrototypeAgentConfig(
+        oak=OaKConfig(
+            stomp=STOMPConfig(
+                subtask_specs=(),
+                observation_dim=observation_dim,
+                n_primitive_actions=2,
+                base_step_size=0.05,
+                epsilon_base=epsilon,
+            )
+        )
+    )
+
+
+def _runner(*, horizon: int = 5, seed: int = 41) -> Any:
+    return build_prototype_riverswim_life(
+        agent_config=_agent_config(),
+        environment_config=RiverSwimConfig(  # type: ignore[call-arg]
+            n_states=3,
+            p_right_up=0.5,
+            p_right_down=0.25,
+            reward_left=0.01,
+            reward_right=1.0,
+            initial_state=0,
+        ),
+        lifecycle_id=_LIFECYCLE_ID,
+        seed=seed,
+        max_accepted_events=horizon,
+    )
+
+
+def _right_command(runner: Any, state: Any) -> DispatchCommand:
+    decision = state.transaction_state.decision
+    assert decision is not None
+    right = runner.agent_adapter.manifest.action_spec.encode(np.asarray(1, dtype=np.int32))
+    decision = dataclasses.replace(decision, proposed_action=right)
+    authorization = DispatchAuthorization(
+        decision=decision,
+        status=AuthorizationStatus.EXACT,
+        authorized_action=right,
+        authority_id="tests.riverswim.authority",
+        policy_version="tests.riverswim.policy.v1",
+        authorization_id=f"{decision.decision_id}:authorization",
+    )
+    dispatch = DispatchAck(
+        authorization=authorization,
+        status=DispatchStatus.EXACT,
+        effective_action=right,
+        settlement_id=f"{decision.decision_id}:settlement",
+    )
+    return DispatchCommand(
+        dispatch=dispatch,
+        command_id=f"{decision.decision_id}:command",
+        executor_id=runner.environment_adapter.executor_id,
+        executor_epoch=runner.environment_adapter.executor_epoch,
+    )
+
+
+def test_riverswim_execute_and_validation_receive_the_identical_derived_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1)
+    state = runner.init()
+    observed: dict[str, tuple[str, bytes]] = {}
+    original_execute = RiverSwimReferenceEnvironment.execute
+    original_validate = RiverSwimReferenceEnvironment.validate_execution
+
+    def key_bytes(key: Any) -> tuple[str, bytes]:
+        return str(jr.key_impl(key)), np.asarray(jr.key_data(key)).tobytes(order="C")
+
+    def execute(
+        self: RiverSwimReferenceEnvironment,
+        environment_state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> ReferenceEnvironmentExecution:
+        observed["execute"] = key_bytes(key)
+        return original_execute(self, environment_state, command, key=key)
+
+    def validate(
+        self: RiverSwimReferenceEnvironment,
+        previous_state: Any,
+        command: DispatchCommand,
+        execution: ReferenceEnvironmentExecution,
+        *,
+        key: Any,
+    ) -> None:
+        observed["validate"] = key_bytes(key)
+        original_validate(self, previous_state, command, execution, key=key)
+
+    monkeypatch.setattr(RiverSwimReferenceEnvironment, "execute", execute)
+    monkeypatch.setattr(RiverSwimReferenceEnvironment, "validate_execution", validate)
+
+    step = runner.step(state)
+    assert step.accepted, step.rejection_reason
+    assert observed["execute"] == observed["validate"]
+    assert observed["execute"] == key_bytes(runner._environment_key(0))
+
+
+def test_riverswim_state_cap_rejects_before_exponential_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oracle_called = False
+
+    def forbidden_oracle(self: RiverSwimMDP) -> float:
+        del self
+        nonlocal oracle_called
+        oracle_called = True
+        raise AssertionError("oversized chain must not enter 2**n oracle enumeration")
+
+    monkeypatch.setattr(RiverSwimMDP, "optimal_average_reward", forbidden_oracle)
+    with pytest.raises(ValueError, match=r"n_states|2\*\*n|oracle"):
+        build_prototype_riverswim_life(
+            agent_config=_agent_config(
+                observation_dim=RIVERSWIM_REFERENCE_MAX_STATES + 1
+            ),
+            environment_config=RiverSwimConfig(  # type: ignore[call-arg]
+                n_states=RIVERSWIM_REFERENCE_MAX_STATES + 1
+            ),
+            lifecycle_id=_LIFECYCLE_ID,
+            seed=41,
+            max_accepted_events=1,
+        )
+    assert oracle_called is False
+
+
+def test_riverswim_reference_environment_behavior_is_immutable() -> None:
+    runner = _runner(horizon=1)
+    environment = runner.environment_adapter
+    assert isinstance(environment, RiverSwimReferenceEnvironment)
+    kernel = environment._environment
+    oracle = kernel.optimal_average_reward()
+
+    with pytest.raises(AttributeError, match="immutable"):
+        setattr(environment, "_environment", RiverSwimMDP())
+    with pytest.raises(AttributeError, match="immutable"):
+        setattr(kernel, "_transitions_np", np.zeros((2, 3, 3), dtype=np.float32))
+    with pytest.raises(AttributeError, match="immutable"):
+        setattr(kernel, "_rewards_np", np.zeros((3, 2), dtype=np.float32))
+    with pytest.raises(ValueError, match="read-only"):
+        kernel._transitions_np[1, 0, 1] = 1.0
+    with pytest.raises(ValueError, match="read-only"):
+        kernel._rewards_np[0, 0] = 999.0
+
+    assert kernel.optimal_average_reward() == oracle
+
+
+def test_riverswim_validator_rejects_an_alternate_possible_wrong_key_transition() -> None:
+    runner = _runner(horizon=1)
+    state = runner.init()
+    command = _right_command(runner, state)
+    correct_key = runner._environment_key(0)
+    expected = runner.environment_adapter.execute(
+        state.environment_state,
+        command,
+        key=correct_key,
+    )
+
+    forged = None
+    for offset in range(1, 128):
+        wrong_key = jr.fold_in(correct_key, offset)
+        candidate = runner.environment_adapter.execute(
+            state.environment_state,
+            command,
+            key=wrong_key,
+        )
+        if np.asarray(candidate.state.state_index).tobytes() != np.asarray(
+            expected.state.state_index
+        ).tobytes():
+            forged = candidate
+            break
+    assert forged is not None, "test keys must include a different possible transition"
+
+    with pytest.raises(DecisionOwnershipError, match="key|replay|stochastic|transition"):
+        runner.environment_adapter.validate_execution(
+            state.environment_state,
+            command,
+            forged,
+            key=correct_key,
+        )
+
+
+def test_riverswim_wrong_key_result_commits_uncertain_halt_without_redispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1, seed=2)
+    initial = runner.init()
+    assert initial.transaction_state.decision is not None
+    assert initial.transaction_state.decision.proposed_action is not None
+    assert initial.transaction_state.decision.proposed_action.to_python() == 1
+    original_execute = RiverSwimReferenceEnvironment.execute
+    execute_calls = 0
+
+    def wrong_key_execute(
+        self: RiverSwimReferenceEnvironment,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> ReferenceEnvironmentExecution:
+        nonlocal execute_calls
+        execute_calls += 1
+        expected = original_execute(self, state, command, key=key)
+        for offset in range(1, 128):
+            candidate = original_execute(self, state, command, key=jr.fold_in(key, offset))
+            if np.asarray(candidate.state.state_index).tobytes() != np.asarray(
+                expected.state.state_index
+            ).tobytes():
+                return candidate
+        raise AssertionError("test keys must include a different possible transition")
+
+    monkeypatch.setattr(RiverSwimReferenceEnvironment, "execute", wrong_key_execute)
+    rejected = runner.step(initial)
+
+    assert not rejected.accepted
+    assert rejected.state.phase is LifePhase.HALTED
+    assert rejected.state.halt is not None
+    assert rejected.state.halt.stage is HaltStage.DISPATCH_UNCERTAIN
+    assert rejected.state.dispatch_attempts == 1
+    assert rejected.state.environment_rng_cursor == 1
+    assert rejected.state.executed_events == 0
+    assert rejected.state.accepted_events == 0
+    assert int(rejected.state.environment_state.step_count) == 0
+    assert int(rejected.state.agent_state.agent_state.step_count) == 0
+    assert rejected.state.metrics.accepted_events == 0
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+    assert execute_calls == 1
+
+
+def test_riverswim_applied_action_substitution_is_retained_without_learning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner(horizon=1, seed=2)
+    initial = runner.init()
+    original_execute = RiverSwimReferenceEnvironment.execute
+    execute_calls = 0
+
+    def substituted_execute(
+        self: RiverSwimReferenceEnvironment,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> ReferenceEnvironmentExecution:
+        nonlocal execute_calls
+        execute_calls += 1
+        reference = original_execute(self, state, command, key=key)
+        commanded = command.effective_action.to_python()
+        assert isinstance(commanded, int) and not isinstance(commanded, bool)
+        substituted = self.manifest.action_spec.encode(
+            np.asarray(1 - commanded, dtype=np.int32)
+        )
+        observation, reward, next_state = self._environment.step(
+            state,
+            jnp.asarray(substituted.to_numpy(), dtype=jnp.int32),
+            key,
+        )
+        return dataclasses.replace(
+            reference,
+            state=next_state,
+            applied_action=substituted,
+            next_observation=self.manifest.observation_spec.encode(
+                np.asarray(observation, dtype=np.float32)
+            ),
+            reward=float(np.asarray(reward, dtype=np.float32)),
+        )
+
+    monkeypatch.setattr(RiverSwimReferenceEnvironment, "execute", substituted_execute)
+    rejected = runner.step(initial)
+
+    assert not rejected.accepted
+    assert rejected.state.phase is LifePhase.HALTED
+    assert rejected.state.halt is not None
+    assert rejected.state.halt.stage is HaltStage.POST_EXECUTION_DIVERGENCE
+    assert rejected.state.dispatch_attempts == 1
+    assert rejected.state.environment_rng_cursor == 1
+    assert rejected.state.executed_events == 1
+    assert rejected.state.accepted_events == 0
+    assert int(rejected.state.environment_state.step_count) == 1
+    assert int(rejected.state.agent_state.agent_state.step_count) == 0
+    assert rejected.state.metrics.accepted_events == 0
+    assert rejected.state.pending_outcome is None
+    with pytest.raises(DecisionOwnershipError, match="stale|current"):
+        runner.step(initial)
+    assert execute_calls == 1
+
+
+@pytest.mark.integration
+def test_riverswim_reference_life_runs_five_keyed_events_without_extra_dispatch() -> None:
+    runner = _runner(horizon=5)
+    state = runner.init()
+    events = []
+    while state.phase is LifePhase.QUIESCENT:
+        step = runner.step(state)
+        assert step.accepted, step.rejection_reason
+        assert step.event is not None
+        events.append(step.event)
+        state = step.state
+
+    assert state.phase is LifePhase.COMPLETED
+    assert len(events) == 5
+    assert state.accepted_events == state.executed_events == state.dispatch_attempts == 5
+    assert state.environment_rng_cursor == 5
+    assert int(state.environment_state.step_count) == 5
+    assert int(state.agent_state.agent_state.step_count) == 5
+    assert state.metrics.accepted_events == 5
+    assert runner.config.config["metrics"]["config"]["mode"] == "stationary"
+    assert state.metrics.phase_event_counts == (5, 0)
+    assert state.metrics.phase_switches == 0
+    assert state.metrics.current_phase == 0
+    assert state.metrics.current_segment_events == 5
+    assert np.isclose(
+        state.metrics.oracle_reward_sum - state.metrics.reward_sum,
+        state.metrics.regret_sum,
+    )
+    with pytest.raises(DecisionOwnershipError, match="completed"):
+        runner.step(state)

--- a/tests/test_reference_life_riverswim_checkpoint.py
+++ b/tests/test_reference_life_riverswim_checkpoint.py
@@ -1,0 +1,307 @@
+"""Exact-resume gate for the stochastic RiverSwim reference life."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import shutil
+import struct
+from pathlib import Path
+from typing import Any
+
+import jax
+import numpy as np
+import pytest
+
+import alberta_framework.reference_life_checkpoint as checkpoint_module
+from alberta_framework.core.oak import OaKConfig
+from alberta_framework.core.options import STOMPConfig
+from alberta_framework.core.prototype_agent import PrototypeAgentConfig
+from alberta_framework.reference_life import (
+    SWITCHING_ENVIRONMENT_IMPLEMENTATION_ID,
+    SWITCHING_ENVIRONMENT_STATE_SCHEMA,
+    ReferenceLifeState,
+    RiverSwimReferenceEnvironment,
+    build_prototype_riverswim_life,
+)
+from alberta_framework.reference_life_checkpoint import (
+    load_reference_life_checkpoint,
+    save_reference_life_checkpoint,
+)
+from alberta_framework.streams.closed_loop import RiverSwimConfig, RiverSwimMDP
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+_LIFECYCLE_ID = "prototype.0000003100000032"
+
+
+def test_runtime_identity_binds_jax_random_seed_offset() -> None:
+    seed_offset = int(jax.config.jax_random_seed_offset)
+    baseline = checkpoint_module._runtime_identity()
+    jax.config.update(  # type: ignore[no-untyped-call]
+        "jax_random_seed_offset", seed_offset + 1
+    )
+    try:
+        changed = checkpoint_module._runtime_identity()
+    finally:
+        jax.config.update(  # type: ignore[no-untyped-call]
+            "jax_random_seed_offset", seed_offset
+        )
+
+    assert baseline != changed
+    assert baseline["jax_random_seed_offset"] == seed_offset
+    assert changed["jax_random_seed_offset"] == seed_offset + 1
+
+
+def _runner() -> Any:
+    agent_config = PrototypeAgentConfig(
+        oak=OaKConfig(
+            stomp=STOMPConfig(
+                subtask_specs=(),
+                observation_dim=3,
+                n_primitive_actions=2,
+                base_step_size=0.05,
+                epsilon_base=1.0,
+            )
+        )
+    )
+    return build_prototype_riverswim_life(
+        agent_config=agent_config,
+        environment_config=RiverSwimConfig(  # type: ignore[call-arg]
+            n_states=3,
+            p_right_up=0.5,
+            p_right_down=0.25,
+            reward_left=0.01,
+            reward_right=1.0,
+            initial_state=0,
+        ),
+        lifecycle_id=_LIFECYCLE_ID,
+        seed=53,
+        max_accepted_events=6,
+    )
+
+
+def _advance(runner: Any, state: Any, count: int) -> tuple[Any, tuple[Any, ...]]:
+    steps = []
+    for _ in range(count):
+        step = runner.step(state)
+        assert step.accepted, step.rejection_reason
+        assert step.event is not None
+        steps.append(step)
+        state = step.state
+    return state, tuple(steps)
+
+
+def test_riverswim_checkpoint_validator_rejects_sub_tolerance_metric_forgery() -> None:
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+    delta = 5.0e-13
+    forged_metrics = dataclasses.replace(
+        state.metrics,
+        reward_sum=state.metrics.reward_sum + delta,
+        regret_sum=state.metrics.regret_sum - delta,
+    )
+    forged: ReferenceLifeState = dataclasses.replace(state, metrics=forged_metrics)
+
+    with pytest.raises(ValueError, match="stationary|phase totals|regret algebra"):
+        runner.validate_checkpoint_state(forged)
+
+    forged_oracle: ReferenceLifeState = dataclasses.replace(
+        state,
+        metrics=dataclasses.replace(
+            state.metrics,
+            oracle_reward_sum=state.metrics.oracle_reward_sum + delta,
+        ),
+    )
+    with pytest.raises(ValueError, match="stationary|schedule|regret algebra"):
+        runner.validate_checkpoint_state(forged_oracle)
+
+
+def _assert_typed_exact(left: object, right: object, *, path: str = "value") -> None:
+    if isinstance(left, jax.Array) or isinstance(right, jax.Array):
+        assert isinstance(left, jax.Array) and isinstance(right, jax.Array), path
+        assert left.shape == right.shape and left.dtype == right.dtype, path
+        if jax.dtypes.issubdtype(left.dtype, jax.dtypes.prng_key):  # type: ignore[attr-defined]
+            assert str(jax.random.key_impl(left)) == str(jax.random.key_impl(right)), path
+            left = jax.random.key_data(left)
+            right = jax.random.key_data(right)
+        assert np.asarray(left).tobytes(order="C") == np.asarray(right).tobytes(order="C"), path
+        return
+    if dataclasses.is_dataclass(left) or dataclasses.is_dataclass(right):
+        assert type(left) is type(right) and dataclasses.is_dataclass(left), path
+        for field in dataclasses.fields(left):
+            if field.name == "_owner_token":
+                continue
+            _assert_typed_exact(
+                getattr(left, field.name),
+                getattr(right, field.name),
+                path=f"{path}.{field.name}",
+            )
+        return
+    if isinstance(left, float) or isinstance(right, float):
+        assert type(left) is type(right), path
+        assert struct.pack(">d", left) == struct.pack(">d", right), path
+        return
+    if isinstance(left, tuple) or isinstance(right, tuple):
+        assert isinstance(left, tuple) and isinstance(right, tuple), path
+        assert type(left) is type(right) and len(left) == len(right), path
+        for index, (left_item, right_item) in enumerate(zip(left, right, strict=True)):
+            _assert_typed_exact(left_item, right_item, path=f"{path}[{index}]")
+        return
+    if isinstance(left, dict) or isinstance(right, dict):
+        assert isinstance(left, dict) and isinstance(right, dict), path
+        assert type(left) is type(right) and left.keys() == right.keys(), path
+        for key in left:
+            _assert_typed_exact(left[key], right[key], path=f"{path}.{key}")
+        return
+    assert type(left) is type(right) and left == right, path
+
+
+def _write_canonical_json(path: Path, value: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(value, allow_nan=False, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+        + "\n",
+        encoding="ascii",
+    )
+
+
+def _rehash_bundle(path: Path) -> None:
+    manifest_path = path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="ascii"))
+    for relative, child in manifest["children"]["files"].items():
+        payload = (path / relative).read_bytes()
+        child["sha256"] = hashlib.sha256(payload).hexdigest()
+        child["size"] = len(payload)
+    payload = {key: value for key, value in manifest.items() if key != "bundle_id"}
+    bundle_id = hashlib.sha256(
+        json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("ascii")
+        + b"\n"
+    ).hexdigest()
+    manifest["bundle_id"] = bundle_id
+    _write_canonical_json(manifest_path, manifest)
+    (path / "COMMITTED").write_text(f"{bundle_id}\n", encoding="ascii")
+
+
+def test_riverswim_quiescent_checkpoint_restores_exact_stochastic_continuation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+    barrier, checkpoint = save_reference_life_checkpoint(runner, state, tmp_path)
+    original_final, original_steps = _advance(runner, barrier, 4)
+
+    seed_offset = int(jax.config.jax_random_seed_offset)
+    jax.config.update(  # type: ignore[no-untyped-call]
+        "jax_random_seed_offset", seed_offset + 1
+    )
+    try:
+        with pytest.raises(ValueError, match="runtime_identity"):
+            load_reference_life_checkpoint(checkpoint)
+    finally:
+        jax.config.update(  # type: ignore[no-untyped-call]
+            "jax_random_seed_offset", seed_offset
+        )
+
+    restored_runner, restored = load_reference_life_checkpoint(checkpoint)
+    restored_environment = restored_runner.environment_adapter
+    original_environment = runner.environment_adapter
+    assert isinstance(restored_environment, RiverSwimReferenceEnvironment)
+    assert isinstance(original_environment, RiverSwimReferenceEnvironment)
+    assert restored_environment is not original_environment
+    assert restored_environment._environment is not original_environment._environment
+    with pytest.raises(AttributeError, match="immutable"):
+        setattr(restored_environment, "_environment", RiverSwimMDP())
+    _assert_typed_exact(restored, barrier, path="barrier")
+    restored_final, restored_steps = _advance(restored_runner, restored, 4)
+
+    _assert_typed_exact(restored_runner.config, runner.config, path="config")
+    _assert_typed_exact(restored_steps, original_steps, path="steps")
+    _assert_typed_exact(restored_final, original_final, path="final")
+    assert any(
+        int(step.event.command.effective_action.to_python()) == 1
+        for step in original_steps
+        if step.event is not None
+    ), "post-checkpoint branch must exercise RiverSwim's stochastic RIGHT action"
+
+    for name, implementation_id, state_schema in (
+        (
+            "unknown-environment",
+            "asi.unknown_environment.preview1",
+            "asi.unknown_environment_state.preview1",
+        ),
+        (
+            "crossed-environment",
+            SWITCHING_ENVIRONMENT_IMPLEMENTATION_ID,
+            None,
+        ),
+    ):
+        forged = tmp_path / name
+        shutil.copytree(checkpoint, forged)
+        manifest = json.loads((forged / "manifest.json").read_text(encoding="ascii"))
+        manifest["life_config"]["environment"]["implementation_id"] = implementation_id
+        if state_schema is not None:
+            manifest["life_config"]["environment"]["state_schema"] = state_schema
+        _write_canonical_json(forged / "manifest.json", manifest)
+        _rehash_bundle(forged)
+        with pytest.raises(ValueError, match="unsupported or crossed"):
+            load_reference_life_checkpoint(forged)
+
+    crossed_state = tmp_path / "crossed-environment-state"
+    shutil.copytree(checkpoint, crossed_state)
+    state_payload = json.loads(
+        (crossed_state / "life_state.json").read_text(encoding="ascii")
+    )
+    state_payload["environment"]["schema"] = SWITCHING_ENVIRONMENT_STATE_SCHEMA
+    _write_canonical_json(crossed_state / "life_state.json", state_payload)
+    _rehash_bundle(crossed_state)
+    with pytest.raises(ValueError, match="discriminator differs from the live manifest"):
+        load_reference_life_checkpoint(crossed_state)
+
+    out_of_range_state = tmp_path / "out-of-range-riverswim-state"
+    shutil.copytree(checkpoint, out_of_range_state)
+    state_payload = json.loads(
+        (out_of_range_state / "life_state.json").read_text(encoding="ascii")
+    )
+    state_payload["environment"]["state_index"]["payload_hex"] = (
+        (99).to_bytes(4, byteorder="little", signed=True).hex()
+    )
+    _write_canonical_json(out_of_range_state / "life_state.json", state_payload)
+    _rehash_bundle(out_of_range_state)
+    with pytest.raises(ValueError, match="outside the chain"):
+        load_reference_life_checkpoint(out_of_range_state)
+
+    wrong_metrics = tmp_path / "wrong-riverswim-metrics-mode"
+    shutil.copytree(checkpoint, wrong_metrics)
+    manifest = json.loads((wrong_metrics / "manifest.json").read_text(encoding="ascii"))
+    manifest["life_config"]["metrics"]["config"]["mode"] = "switching_two_phase"
+    _write_canonical_json(wrong_metrics / "manifest.json", manifest)
+    _rehash_bundle(wrong_metrics)
+    with pytest.raises(ValueError, match="metrics mode"):
+        load_reference_life_checkpoint(wrong_metrics)
+
+    oversized = tmp_path / "oversized-riverswim"
+    shutil.copytree(checkpoint, oversized)
+    manifest = json.loads((oversized / "manifest.json").read_text(encoding="ascii"))
+    manifest["life_config"]["environment"]["config"]["n_states"] = 13
+    _write_canonical_json(oversized / "manifest.json", manifest)
+    _rehash_bundle(oversized)
+    oracle_called = False
+
+    def forbidden_oracle(self: RiverSwimMDP) -> float:
+        del self
+        nonlocal oracle_called
+        oracle_called = True
+        raise AssertionError("oversized restore must reject before oracle enumeration")
+
+    monkeypatch.setattr(RiverSwimMDP, "optimal_average_reward", forbidden_oracle)
+    with pytest.raises(ValueError, match="exceeds the RiverSwim reference bound"):
+        load_reference_life_checkpoint(oversized)
+    assert oracle_called is False

--- a/tests/test_reference_life_scorecard.py
+++ b/tests/test_reference_life_scorecard.py
@@ -1,0 +1,960 @@
+"""Cheap contracts for the permanently nonpromoting reference-life scorecard."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks import reference_life_scorecard as scorecard
+from alberta_framework.benchmarks.reference_life_scorecard import (
+    ARM_ROSTER,
+    ENVIRONMENT_ROSTER,
+    SEED_ROSTER,
+    ReferenceLifeDevelopmentPlan,
+    StreamingRunSummary,
+    build_development_plan,
+    canonical_json_bytes,
+    estimate_jax_resources,
+    parameter_change_check,
+    write_new_json,
+)
+from alberta_framework.reference_agent import ArrayValue
+from alberta_framework.reference_life_controls import (
+    DifferentialSARSAReferenceConfig,
+    DiscountedSARSAReferenceConfig,
+)
+from alberta_framework.streams.closed_loop import SwitchingTwoStateConfig
+
+pytestmark = pytest.mark.unit
+
+
+def test_fixed_plan_is_immutable_canonical_and_explicit() -> None:
+    plan = build_development_plan()
+    payload = plan.to_payload()
+
+    assert dataclasses.is_dataclass(plan)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        plan.plan_sha256 = "0" * 64  # type: ignore[misc]
+    assert plan.seeds == tuple(range(70_000, 70_012)) == SEED_ROSTER
+    assert plan.arms == ARM_ROSTER
+    assert plan.environments == ENVIRONMENT_ROSTER
+    assert payload["evidence_policy"]["permanently_nonpromoting"] is True
+    assert payload["evidence_policy"]["scientific_promotion_allowed"] is False
+    assert payload["protocols"]["switching_two_state"]["horizon"] == 4_000
+    assert payload["protocols"]["switching_two_state"]["phase_length"] == 250
+    assert payload["protocols"]["switching_two_state"]["post_switch_window"] == 50
+    assert payload["protocols"]["riverswim"]["horizon"] == 20_000
+    assert payload["protocols"]["riverswim"]["n_states"] == 6
+    assert payload["protocols"]["riverswim"]["early_window"] == 2_000
+    assert payload["protocols"]["riverswim"]["late_window"] == 2_000
+    assert canonical_json_bytes(payload) == canonical_json_bytes(
+        ReferenceLifeDevelopmentPlan.from_payload(payload).to_payload()
+    )
+    assert payload["plan_sha256"] == scorecard.REFERENCE_LIFE_SCORECARD_PLAN_V1_SHA256
+
+    payload["seed_roster"][0] = 1
+    assert plan.seeds == SEED_ROSTER, "returned JSON must not alias immutable plan state"
+
+
+def test_plan_rejects_tampering_even_if_digest_is_left_unchanged() -> None:
+    payload = build_development_plan().to_payload()
+    payload["protocols"]["riverswim"]["horizon"] -= 1
+    with pytest.raises(ValueError, match="canonical fixed development plan"):
+        ReferenceLifeDevelopmentPlan.from_payload(payload)
+
+
+def test_plan_rejects_boolean_integer_type_confusion() -> None:
+    payload = build_development_plan().to_payload()
+    payload["schema_version"] = True
+    with pytest.raises(ValueError, match="canonical fixed development plan"):
+        ReferenceLifeDevelopmentPlan.from_payload(payload)
+
+
+def test_cyclic_order_is_explicit_and_balanced() -> None:
+    plan = build_development_plan()
+    observed = [plan.arm_order(seed) for seed in SEED_ROSTER]
+    assert observed[0] == ARM_ROSTER
+    assert observed[1] == ARM_ROSTER[1:] + ARM_ROSTER[:1]
+    assert observed[6] == ARM_ROSTER
+    for position in range(len(ARM_ROSTER)):
+        assert sorted(order[position] for order in observed) == sorted(list(ARM_ROSTER) * 2)
+
+
+def test_streaming_switching_summary_keeps_only_fixed_aba_windows() -> None:
+    summary = StreamingRunSummary.for_switching(
+        horizon=8,
+        phase_length=2,
+        post_switch_window=2,
+    )
+    for index in range(8):
+        summary.observe(
+            reward=float(index),
+            oracle_reward=10.0,
+            regime_id=(index // 2) % 2,
+            parameters_changed=index == 3,
+            next_state_index=index % 2,
+        )
+
+    result = summary.finalize()
+    assert result["accepted_events"] == 8
+    assert result["parameter_change_events"] == 1
+    assert result["windows"] == {
+        "initial_a": {
+            "event_count": 2,
+            "reward_sum": 1.0,
+            "mean_reward": 0.5,
+            "mean_oracle_regret": 9.5,
+        },
+        "first_b": {
+            "event_count": 2,
+            "reward_sum": 5.0,
+            "mean_reward": 2.5,
+            "mean_oracle_regret": 7.5,
+        },
+        "return_a": {
+            "event_count": 2,
+            "reward_sum": 9.0,
+            "mean_reward": 4.5,
+            "mean_oracle_regret": 5.5,
+        },
+    }
+    assert not hasattr(summary, "events")
+    with pytest.raises(ValueError, match="horizon"):
+        summary.observe(
+            reward=0.0,
+            oracle_reward=1.0,
+            regime_id=0,
+            parameters_changed=False,
+            next_state_index=0,
+        )
+
+
+def test_streaming_river_summary_tracks_early_late_and_high_end_visits() -> None:
+    summary = StreamingRunSummary.for_riverswim(
+        horizon=6,
+        early_window=2,
+        late_window=2,
+        n_states=3,
+    )
+    for index, state_index in enumerate((0, 1, 2, 2, 1, 2)):
+        summary.observe(
+            reward=float(index + 1),
+            oracle_reward=7.0,
+            regime_id=0,
+            parameters_changed=False,
+            next_state_index=state_index,
+        )
+    result = summary.finalize()
+    assert result["windows"]["early"]["reward_sum"] == 3.0
+    assert result["windows"]["late"]["reward_sum"] == 11.0
+    assert result["high_end_visit_count"] == 3
+    assert result["high_end_visit_rate"] == 0.5
+
+
+@dataclasses.dataclass(frozen=True)
+class _TinyState:
+    weights: Any
+    counter: Any
+
+
+def test_resource_estimate_is_explicitly_a_pytree_estimate() -> None:
+    estimate = estimate_jax_resources(
+        _TinyState(
+            weights=jnp.zeros((2, 3), dtype=jnp.float32),
+            counter=jnp.asarray(0, dtype=jnp.int32),
+        )
+    )
+    assert estimate["persistent_jax_array_bytes"] == 28
+    assert estimate["persistent_jax_array_scalar_count"] == 7
+    assert estimate["trainable_scalar_count_estimate"] == 6
+    assert estimate["trainable_scalar_count_method"] == (
+        "floating_jax_pytree_leaves_upper_bound"
+    )
+
+
+def test_resource_estimate_counts_cached_array_value_payloads() -> None:
+    cached = ArrayValue(
+        semantic_id="test.cached_observation.v1",
+        dtype="float32",
+        shape=(2,),
+        payload=np.asarray([1.0, 0.0], dtype="<f4").tobytes(),
+    )
+    estimate = estimate_jax_resources(
+        {
+            "state": _TinyState(
+                weights=jnp.zeros((2, 3), dtype=jnp.float32),
+                counter=jnp.asarray(0, dtype=jnp.int32),
+            ),
+            "cached": cached,
+        }
+    )
+    assert estimate["persistent_jax_array_leaves"] == 3
+    assert estimate["persistent_jax_array_scalar_count"] == 9
+    assert estimate["persistent_jax_array_bytes"] == 36
+    assert estimate["trainable_scalar_count_estimate"] == 8
+
+
+def test_discounted_sarsa_persistent_resources_are_fixed_from_initialization() -> None:
+    plan = build_development_plan()
+    spec = next(
+        item
+        for item in scorecard.iter_run_specs(plan)
+        if item.environment_kind == "switching_two_state"
+        and item.arm == "sarsa"
+        and item.seed == SEED_ROSTER[0]
+    )
+    runner = scorecard.build_scorecard_runner(plan, spec)
+    initial = runner.init()
+    initial_resources = scorecard._agent_resource_payload(
+        runner.agent_adapter,
+        initial.agent_state,
+    )
+
+    step = runner.step(initial)
+
+    assert step.accepted
+    assert scorecard._agent_resource_payload(
+        runner.agent_adapter,
+        step.state.agent_state,
+    ) == initial_resources
+
+
+@pytest.mark.parametrize(
+    ("arm", "changes", "passed"),
+    [
+        ("prototype", 2, True),
+        ("prototype", 0, False),
+        ("prototype_frozen", 0, True),
+        ("prototype_frozen", 1, False),
+        ("random", 0, True),
+        ("privileged_oracle", 0, True),
+    ],
+)
+def test_parameter_change_checks_are_fail_closed(
+    arm: str, changes: int, passed: bool
+) -> None:
+    assert parameter_change_check(arm, changes)["passed"] is passed
+
+
+def _summary_records() -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    offsets = {
+        "random": 0.0,
+        "privileged_oracle": 100.0,
+        "prototype": 50.0,
+        "prototype_frozen": 0.0,
+        "differential_sarsa": 40.0,
+        "sarsa": 30.0,
+    }
+    for environment in ENVIRONMENT_ROSTER:
+        for arm in ARM_ROSTER:
+            for seed in SEED_ROSTER:
+                records.append(
+                    {
+                        "environment_kind": environment,
+                        "arm": arm,
+                        "seed": seed,
+                        "status": "completed",
+                        "outcome": {"reward_sum": offsets[arm]},
+                    }
+                )
+    return records
+
+
+def test_summary_normalizes_within_environment_and_never_pools() -> None:
+    records = _summary_records()
+    summary = scorecard._summarize_validated_run_records(
+        build_development_plan(), list(reversed(records))
+    )
+    assert summary["status"] == "development_scorecard_complete"
+    assert summary["cross_environment_pooled_score"] is None
+    assert summary["cross_environment_pooling_forbidden"] is True
+    future_gate = summary["pareto_resource_decision"][
+        "future_gate_if_latency_is_qualified_under_a_new_protocol"
+    ]
+    assert future_gate[
+        "requires_no_qualifying_sarsa_utility_noninferior_on_both_environments"
+    ] is True
+    for environment in ENVIRONMENT_ROSTER:
+        environment_summary = summary["environments"][environment]
+        assert environment_summary["normalization"]["scale"] == 100.0
+        assert environment_summary["arms"]["random"]["normalized_score_mean"] == 0.0
+        assert environment_summary["arms"]["privileged_oracle"][
+            "normalized_score_mean"
+        ] == 1.0
+        assert environment_summary["arms"]["differential_sarsa"][
+            "paired_t_lcb_95"
+        ] > 0.10
+    assert canonical_json_bytes(summary) == canonical_json_bytes(
+        scorecard._summarize_validated_run_records(build_development_plan(), records)
+    )
+
+
+def test_public_summary_rejects_unvalidated_skeletal_records() -> None:
+    with pytest.raises(ValueError, match="fields|record|contract"):
+        scorecard.summarize_run_records(build_development_plan(), _summary_records())
+
+
+def test_summary_retains_failures_and_reports_valid_baseline_failure() -> None:
+    records = _summary_records()
+    for record in records:
+        if record["arm"] in ("differential_sarsa", "sarsa"):
+            record["outcome"]["reward_sum"] = 5.0
+    records[0] = {
+        **records[0],
+        "status": "failed",
+        "outcome": None,
+        "failure": {"stage": "step", "type": "RuntimeError", "message": "boom"},
+    }
+    summary = scorecard._summarize_validated_run_records(
+        build_development_plan(), records
+    )
+    assert summary["failure_count"] == 1
+    assert summary["failures"][0]["failure"]["message"] == "boom"
+    assert summary["status"] == "valid_execution_failure"
+
+    complete = [record for record in records if record["status"] == "completed"]
+    complete.append(
+        {
+            **records[0],
+            "status": "completed",
+            "outcome": {"reward_sum": 0.0},
+        }
+    )
+    summary = scorecard._summarize_validated_run_records(
+        build_development_plan(), complete
+    )
+    assert summary["status"] == "valid_baseline_failure"
+
+
+def test_new_json_publication_is_canonical_and_refuses_overwrite(tmp_path: Path) -> None:
+    destination = tmp_path / "plan.json"
+    payload = build_development_plan().to_payload()
+    write_new_json(destination, payload)
+    assert destination.read_bytes() == json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        indent=2,
+        sort_keys=True,
+    ).encode("utf-8") + b"\n"
+    with pytest.raises(FileExistsError, match="refusing to overwrite"):
+        write_new_json(destination, {"different": math.pi})
+
+
+def test_new_json_publication_rejects_a_symlinked_parent(tmp_path: Path) -> None:
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    linked_parent = tmp_path / "linked"
+    linked_parent.symlink_to(real_parent, target_is_directory=True)
+    with pytest.raises(OSError):
+        write_new_json(linked_parent / "plan.json", build_development_plan().to_payload())
+    assert not (real_parent / "plan.json").exists()
+
+
+def test_failed_shard_is_retained_and_digest_tampering_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = {"schema": "test.identity.v1", "value": "fixed"}
+    monkeypatch.setattr(scorecard, "_checkpoint_source_identity", lambda: identity)
+    monkeypatch.setattr(scorecard, "_checkpoint_runtime_identity", lambda: identity)
+    monkeypatch.setattr(scorecard, "_checkpoint_dependency_identity", lambda: identity)
+
+    def fail_build(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise RuntimeError("intentional cheap build failure")
+
+    monkeypatch.setattr(scorecard, "build_scorecard_runner", fail_build)
+    plan = build_development_plan()
+    spec = scorecard.iter_run_specs(plan)[0]
+    record = scorecard.run_scorecard_shard(plan, spec)
+    assert record["status"] == "failed"
+    assert record["failure"] == {
+        "stage": "build",
+        "type": "RuntimeError",
+        "message": "intentional cheap build failure",
+        "accepted_events": 0,
+    }
+    assert record["partial_outcome"]["summary_mode"] == (
+        "streaming_o1_no_retained_events"
+    )
+    assert scorecard.validate_scorecard_run_record(record)["valid"] is True
+
+    tampered = json.loads(json.dumps(record))
+    tampered["failure"]["message"] = "forged"
+    with pytest.raises(ValueError, match="content digest mismatch"):
+        scorecard.validate_scorecard_run_record(tampered)
+
+
+def _completed_outcome(
+    plan: ReferenceLifeDevelopmentPlan,
+    spec: scorecard.ScorecardRunSpec,
+    runner: Any,
+) -> dict[str, Any]:
+    protocol = plan.protocol(spec.environment_kind)
+    horizon = protocol["horizon"]
+    if spec.environment_kind == "switching_two_state":
+        oracle_reward = 1.0
+        phase_counts = [horizon // 2, horizon // 2]
+        windows = {
+            name: {
+                "event_count": protocol["post_switch_window"],
+                "reward_sum": 0.0,
+                "mean_reward": 0.0,
+                "mean_oracle_regret": oracle_reward,
+            }
+            for name in ("initial_a", "first_b", "return_a")
+        }
+        high_end_visit_count = None
+        high_end_visit_rate = None
+    else:
+        oracle_reward = runner.environment_adapter.manifest.config[
+            "oracle_average_reward"
+        ]
+        phase_counts = [horizon, 0]
+        windows = {
+            name: {
+                "event_count": protocol[f"{name}_window"],
+                "reward_sum": 0.0,
+                "mean_reward": 0.0,
+                "mean_oracle_regret": oracle_reward,
+            }
+            for name in ("early", "late")
+        }
+        high_end_visit_count = 0
+        high_end_visit_rate = 0.0
+    changes = 1 if spec.arm in ("prototype", "differential_sarsa", "sarsa") else 0
+    resource = scorecard._canonical_initial_resource_payload(
+        spec.environment_kind,
+        spec.arm,
+    )
+    oracle_reward_sum = oracle_reward * horizon
+    return {
+        "summary_mode": "streaming_o1_no_retained_events",
+        "configured_horizon": horizon,
+        "accepted_events": horizon,
+        "reward_sum": 0.0,
+        "mean_reward": 0.0,
+        "oracle_reward_sum": oracle_reward_sum,
+        "regret_sum": oracle_reward_sum,
+        "parameter_change_events": changes,
+        "phase_event_counts": phase_counts,
+        "phase_reward_sums": [0.0, 0.0],
+        "windows": windows,
+        "high_end_visit_count": high_end_visit_count,
+        "high_end_visit_rate": high_end_visit_rate,
+        "environment_rng_cursor": horizon,
+        "transcript_sha256": "1" * 64,
+        "resources": {"initial": dict(resource), "final": dict(resource)},
+        "parameter_change_check": parameter_change_check(spec.arm, changes),
+    }
+
+
+def _completed_record(
+    plan: ReferenceLifeDevelopmentPlan,
+    spec: scorecard.ScorecardRunSpec,
+    *,
+    runner: Any | None = None,
+    identities: tuple[dict[str, Any], dict[str, Any], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    effective_runner = (
+        scorecard.build_scorecard_runner(plan, spec) if runner is None else runner
+    )
+    source, runtime, dependencies = (
+        scorecard._current_consistency_identities() if identities is None else identities
+    )
+    horizon = plan.protocol(spec.environment_kind)["horizon"]
+    record = {
+        "schema": scorecard.REFERENCE_LIFE_SCORECARD_RUN_SCHEMA,
+        "plan_sha256": plan.plan_sha256,
+        "schedule_index": spec.schedule_index,
+        "environment_kind": spec.environment_kind,
+        "arm": spec.arm,
+        "seed": spec.seed,
+        "lifecycle_id": spec.lifecycle_id,
+        "evidence_policy": dict(scorecard.NONPROMOTING_POLICY),
+        "source_identity": source,
+        "runtime_identity": runtime,
+        "dependency_identity": dependencies,
+        "status": "completed",
+        "failure": None,
+        "resolved": scorecard._resolved_components(plan, spec, effective_runner),
+        "outcome": _completed_outcome(plan, spec, effective_runner),
+        "partial_outcome": None,
+        "telemetry": {
+            "policy": dict(scorecard.TELEMETRY_POLICY),
+            "setup_seconds": 0.0,
+            "cold_step_seconds": 0.0,
+            "warmed_step_seconds_total": 0.0,
+            "warmed_step_count": horizon - 1,
+            "warmed_step_seconds_mean": 0.0,
+            "total_seconds": 0.0,
+        },
+    }
+    return scorecard._record_with_digest(record)
+
+
+def _redigest(record: dict[str, Any]) -> None:
+    record["record_sha256"] = scorecard._digest_excluding(record, "record_sha256")
+
+
+@pytest.mark.parametrize("environment", ENVIRONMENT_ROSTER)
+@pytest.mark.parametrize("arm", ARM_ROSTER)
+def test_valid_completed_shards_cover_every_scheduled_component(
+    environment: str,
+    arm: str,
+) -> None:
+    plan = build_development_plan()
+    spec = next(
+        item
+        for item in scorecard.iter_run_specs(plan)
+        if item.environment_kind == environment
+        and item.arm == arm
+        and item.seed == SEED_ROSTER[0]
+    )
+    record = _completed_record(plan, spec)
+
+    result = scorecard.validate_scorecard_run_record(record)
+
+    assert result["valid"] is True
+    assert result["status"] == "completed"
+    assert result["permanently_nonpromoting"] is True
+
+
+def test_sarsa_controls_are_constructed_from_plan_arm_definitions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = build_development_plan()
+    observed: dict[str, dict[str, Any]] = {}
+    original_differential = DifferentialSARSAReferenceConfig.for_switching.__func__
+    original_discounted = DiscountedSARSAReferenceConfig.for_switching.__func__
+
+    def differential_spy(
+        cls: type[DifferentialSARSAReferenceConfig],
+        environment_config: SwitchingTwoStateConfig,
+        **overrides: Any,
+    ) -> DifferentialSARSAReferenceConfig:
+        observed["differential_sarsa"] = dict(overrides)
+        return original_differential(cls, environment_config, **overrides)
+
+    def discounted_spy(
+        cls: type[DiscountedSARSAReferenceConfig],
+        environment_config: SwitchingTwoStateConfig,
+        **overrides: Any,
+    ) -> DiscountedSARSAReferenceConfig:
+        observed["sarsa"] = dict(overrides)
+        return original_discounted(cls, environment_config, **overrides)
+
+    monkeypatch.setattr(
+        DifferentialSARSAReferenceConfig,
+        "for_switching",
+        classmethod(differential_spy),
+    )
+    monkeypatch.setattr(
+        DiscountedSARSAReferenceConfig,
+        "for_switching",
+        classmethod(discounted_spy),
+    )
+    for arm in ("differential_sarsa", "sarsa"):
+        spec = next(
+            item
+            for item in scorecard.iter_run_specs(plan)
+            if item.environment_kind == "switching_two_state" and item.arm == arm
+        )
+        scorecard.build_scorecard_runner(plan, spec)
+
+    assert observed["differential_sarsa"] == plan.arm_definition(
+        "differential_sarsa"
+    )["config"]
+    assert observed["sarsa"] == plan.arm_definition("sarsa")["config"]
+
+
+def test_completed_shard_rejects_another_scheduled_arm_with_rehashed_bindings() -> None:
+    plan = build_development_plan()
+    random_spec = next(
+        item
+        for item in scorecard.iter_run_specs(plan)
+        if item.environment_kind == "switching_two_state"
+        and item.arm == "random"
+        and item.seed == SEED_ROSTER[0]
+    )
+    oracle_spec = next(
+        item
+        for item in scorecard.iter_run_specs(plan)
+        if item.environment_kind == "switching_two_state"
+        and item.arm == "privileged_oracle"
+        and item.seed == SEED_ROSTER[0]
+    )
+    random_record = _completed_record(plan, random_spec)
+    oracle_record = _completed_record(plan, oracle_spec)
+    swapped = copy.deepcopy(random_record["resolved"])
+    swapped["arm_definition"] = plan.arm_definition("privileged_oracle")
+    swapped["life_config"]["lifecycle_id"] = oracle_spec.lifecycle_id
+    swapped["life_config_sha256"] = scorecard._sha256_json(swapped["life_config"])
+    oracle_record["resolved"] = swapped
+    _redigest(oracle_record)
+
+    with pytest.raises(ValueError, match="scheduled arm|canonical resolved components"):
+        scorecard.validate_scorecard_run_record(oracle_record)
+
+
+def test_completed_shard_rejects_boolean_schedule_index_type_confusion() -> None:
+    plan = build_development_plan()
+    spec = scorecard.iter_run_specs(plan)[1]
+    record = _completed_record(plan, spec)
+    record["schedule_index"] = True
+    _redigest(record)
+    with pytest.raises(ValueError, match="canonical cyclic schedule"):
+        scorecard.validate_scorecard_run_record(record)
+
+
+def test_completed_shard_rejects_impossible_reward_lattice_total() -> None:
+    plan = build_development_plan()
+    spec = next(
+        item
+        for item in scorecard.iter_run_specs(plan)
+        if item.environment_kind == "riverswim"
+        and item.arm == "random"
+        and item.seed == SEED_ROSTER[0]
+    )
+    record = _completed_record(plan, spec)
+    outcome = record["outcome"]
+    outcome["reward_sum"] = 0.001
+    outcome["mean_reward"] = 0.001 / outcome["accepted_events"]
+    outcome["phase_reward_sums"] = [0.001, 0.0]
+    outcome["regret_sum"] = outcome["oracle_reward_sum"] - 0.001
+    _redigest(record)
+    with pytest.raises(ValueError, match="reward lattice"):
+        scorecard.validate_scorecard_run_record(record)
+
+
+def test_completed_shard_rejects_self_asserted_zero_resource_payload() -> None:
+    plan = build_development_plan()
+    spec = scorecard.iter_run_specs(plan)[0]
+    record = _completed_record(plan, spec)
+    for snapshot in record["outcome"]["resources"].values():
+        snapshot["persistent_jax_array_leaves"] = 0
+        snapshot["persistent_jax_array_scalar_count"] = 0
+        snapshot["persistent_jax_array_bytes"] = 0
+        snapshot["persistent_static_numeric_bytes"] = 0
+        snapshot["persistent_numeric_bytes_total"] = 0
+        snapshot["trainable_scalar_count_estimate"] = 0
+        if "trainable_parameter_tree_scalar_count" in snapshot:
+            snapshot["trainable_parameter_tree_scalar_count"] = 0
+    _redigest(record)
+    with pytest.raises(ValueError, match="canonical agent state"):
+        scorecard.validate_scorecard_run_record(record)
+
+
+def test_completed_oracle_shard_rejects_rehashed_swapped_payoffs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = build_development_plan()
+    spec = next(
+        item
+        for item in scorecard.iter_run_specs(plan)
+        if item.environment_kind == "switching_two_state"
+        and item.arm == "privileged_oracle"
+        and item.seed == SEED_ROSTER[0]
+    )
+    rogue_config = SwitchingTwoStateConfig(  # type: ignore[call-arg]
+        phase_length=scorecard.SWITCHING_PHASE_LENGTH,
+        payoffs_a=((1.0, 0.0), (0.0, 1.0)),
+        payoffs_b=((0.0, 1.0), (1.0, 0.0)),
+    )
+    with monkeypatch.context() as context:
+        context.setattr(scorecard, "_switching_environment_config", lambda _plan: rogue_config)
+        rogue_runner = scorecard.build_scorecard_runner(plan, spec)
+        record = _completed_record(plan, spec, runner=rogue_runner)
+
+    with pytest.raises(ValueError, match="environment definition|canonical resolved"):
+        scorecard.validate_scorecard_run_record(record)
+
+
+@pytest.mark.parametrize(
+    "tamper",
+    (
+        "telemetry_extra_field",
+        "resource_extra_field",
+        "window_extra_field",
+        "window_mean",
+        "fractional_resource_count",
+        "resource_count_relationship",
+        "telemetry_count",
+        "oracle_sum",
+        "inactive_phase_reward",
+    ),
+)
+def test_completed_shard_rejects_nested_schema_and_numeric_tampering(
+    tamper: str,
+) -> None:
+    plan = build_development_plan()
+    spec = next(
+        item
+        for item in scorecard.iter_run_specs(plan)
+        if item.environment_kind == "riverswim"
+        and item.arm == "prototype"
+        and item.seed == SEED_ROSTER[0]
+    )
+    record = _completed_record(plan, spec)
+    outcome = record["outcome"]
+    if tamper == "telemetry_extra_field":
+        record["telemetry"]["selection_latency"] = 0.0
+    elif tamper == "resource_extra_field":
+        outcome["resources"]["initial"]["unbound_estimate"] = 0
+    elif tamper == "window_extra_field":
+        outcome["windows"]["early"]["unbound_metric"] = 0.0
+    elif tamper == "window_mean":
+        outcome["windows"]["early"]["mean_reward"] = 0.5
+    elif tamper == "fractional_resource_count":
+        outcome["resources"]["initial"]["persistent_jax_array_leaves"] = 1.5
+    elif tamper == "resource_count_relationship":
+        outcome["resources"]["initial"]["trainable_scalar_count_estimate"] = 2
+    elif tamper == "telemetry_count":
+        record["telemetry"]["warmed_step_count"] = 0
+        record["telemetry"]["warmed_step_seconds_mean"] = None
+    elif tamper == "oracle_sum":
+        outcome["oracle_reward_sum"] += 1.0
+        outcome["regret_sum"] += 1.0
+    elif tamper == "inactive_phase_reward":
+        outcome["phase_reward_sums"] = [-1.0, 1.0]
+    else:
+        raise AssertionError(f"unknown tamper case {tamper}")
+    _redigest(record)
+
+    with pytest.raises(ValueError):
+        scorecard.validate_scorecard_run_record(record)
+
+
+def _assert_all_gate_flags_fail(summary: dict[str, Any]) -> None:
+    assert summary["control_calibration_gate_passed"] is False
+    assert summary["candidate_utility_gate_passed"] is False
+    for environment in ENVIRONMENT_ROSTER:
+        environment_summary = summary["environments"][environment]
+        assert environment_summary["control_calibration"]["qualified"] is False
+        checks = environment_summary["candidate_development_checks"]
+        assert checks["prototype_vs_frozen_passed"] is False
+        assert checks["sarsa_noninferiority_passed"] is False
+        assert checks["utility_gate_passed"] is False
+
+
+def test_execution_failure_forces_every_summary_gate_to_fail() -> None:
+    records = _summary_records()
+    failed = next(record for record in records if record["arm"] == "prototype_frozen")
+    failed["status"] = "failed"
+    failed["outcome"] = None
+    failed["failure"] = {"stage": "step", "type": "RuntimeError", "message": "boom"}
+
+    summary = scorecard._summarize_validated_run_records(
+        build_development_plan(), records
+    )
+
+    assert summary["status"] == "valid_execution_failure"
+    _assert_all_gate_flags_fail(summary)
+
+
+def test_parameter_change_failure_forces_every_summary_gate_to_fail() -> None:
+    records = _summary_records()
+    records[0]["outcome"]["parameter_change_check"] = {"passed": False}
+
+    summary = scorecard._summarize_validated_run_records(
+        build_development_plan(), records
+    )
+
+    assert summary["status"] == "valid_parameter_change_failure"
+    _assert_all_gate_flags_fail(summary)
+
+
+def test_strict_json_loader_rejects_symlinks(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    link = tmp_path / "link.json"
+    link.symlink_to(target)
+
+    with pytest.raises(ValueError, match="symlink|regular|strict JSON"):
+        scorecard.load_json_strict(link)
+
+
+def test_strict_json_loader_rejects_oversized_regular_files(tmp_path: Path) -> None:
+    path = tmp_path / "oversized.json"
+    path.touch()
+    os.truncate(path, scorecard.MAX_SCORECARD_JSON_INPUT_BYTES + 1)
+
+    with pytest.raises(ValueError, match="exceeds|too large"):
+        scorecard.load_json_strict(path)
+
+
+def test_strict_json_loader_rejects_nonregular_inputs_without_blocking(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "input.fifo"
+    os.mkfifo(path)
+
+    with pytest.raises(ValueError, match="regular file"):
+        scorecard.load_json_strict(path)
+
+
+def test_aggregate_rejects_wrong_path_count_before_loading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_load(path: Path) -> dict[str, Any]:
+        raise AssertionError(f"unexpected load: {path}")
+
+    monkeypatch.setattr(scorecard, "load_json_strict", unexpected_load)
+    with pytest.raises(ValueError, match="exactly 144"):
+        scorecard.summarize_shard_files([])
+
+
+def test_aggregate_rejects_hard_links_using_opened_file_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shard = tmp_path / "shard.json"
+    shard.write_text("{}", encoding="utf-8")
+    alias = tmp_path / "alias.json"
+    os.link(shard, alias)
+    monkeypatch.setattr(
+        scorecard,
+        "validate_scorecard_run_record",
+        lambda *args, **kwargs: {"valid": True},
+    )
+    paths = [shard, alias, *[shard] * 142]
+
+    with pytest.raises(ValueError, match="unique regular files"):
+        scorecard.summarize_shard_files(paths)
+
+
+@pytest.fixture(scope="module")
+def completed_artifact() -> dict[str, Any]:
+    plan = build_development_plan()
+    identities = scorecard._current_consistency_identities()
+    records = [
+        _completed_record(plan, spec, identities=identities)
+        for spec in scorecard.iter_run_specs(plan)
+    ]
+    return scorecard.build_scorecard_artifact(plan, records)
+
+
+def test_valid_completed_aggregate_recomputes_without_promotion(
+    completed_artifact: dict[str, Any],
+) -> None:
+    result = scorecard.validate_scorecard_artifact(completed_artifact)
+
+    assert result["valid"] is True
+    assert result["permanently_nonpromoting"] is True
+    assert completed_artifact["summary"]["cross_environment_pooled_score"] is None
+
+
+def test_aggregate_rejects_boolean_schema_version_and_summary_integer(
+    completed_artifact: dict[str, Any],
+) -> None:
+    for mutation in ("schema_version", "summary_run_count"):
+        artifact = copy.deepcopy(completed_artifact)
+        if mutation == "schema_version":
+            artifact["schema_version"] = True
+        else:
+            artifact["summary"]["run_count"] = True
+        artifact["artifact_sha256"] = scorecard._digest_excluding(
+            artifact, "artifact_sha256"
+        )
+        with pytest.raises(ValueError):
+            scorecard.validate_scorecard_artifact(artifact)
+
+
+def test_failed_record_requires_exact_partial_schema_and_stage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = {"schema": "test.identity.v1", "value": "fixed"}
+    monkeypatch.setattr(scorecard, "_checkpoint_source_identity", lambda: identity)
+    monkeypatch.setattr(scorecard, "_checkpoint_runtime_identity", lambda: identity)
+    monkeypatch.setattr(scorecard, "_checkpoint_dependency_identity", lambda: identity)
+    monkeypatch.setattr(
+        scorecard,
+        "build_scorecard_runner",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("build failed")),
+    )
+    plan = build_development_plan()
+    record = scorecard.run_scorecard_shard(plan, scorecard.iter_run_specs(plan)[0])
+    for mutation in ("extra_partial", "unknown_stage", "build_count"):
+        altered = copy.deepcopy(record)
+        if mutation == "extra_partial":
+            altered["partial_outcome"]["extra"] = 1
+        elif mutation == "unknown_stage":
+            altered["failure"]["stage"] = "unknown"
+        else:
+            altered["failure"]["accepted_events"] = 1
+            altered["partial_outcome"]["accepted_events"] = 1
+        _redigest(altered)
+        with pytest.raises(ValueError):
+            scorecard.validate_scorecard_run_record(altered, plan=plan)
+
+
+def test_run_shard_cli_validates_before_immutable_publication(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan = build_development_plan()
+    spec = scorecard.iter_run_specs(plan)[0]
+    malformed = _completed_record(plan, spec)
+    malformed["schedule_index"] = True
+    _redigest(malformed)
+    monkeypatch.setattr(scorecard, "run_scorecard_shard", lambda _plan, _spec: malformed)
+    output = tmp_path / "invalid-shard.json"
+    with pytest.raises(ValueError, match="canonical cyclic schedule"):
+        scorecard.main(
+            [
+                "run-shard",
+                "--environment",
+                spec.environment_kind,
+                "--arm",
+                spec.arm,
+                "--seed",
+                str(spec.seed),
+                "--output",
+                str(output),
+            ]
+        )
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("kind", ("shard", "aggregate"))
+def test_validate_cli_accepts_valid_completed_inputs(
+    kind: str,
+    completed_artifact: dict[str, Any],
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    if kind == "aggregate":
+        payload = completed_artifact
+    else:
+        plan = build_development_plan()
+        payload = _completed_record(plan, scorecard.iter_run_specs(plan)[0])
+    path = tmp_path / f"{kind}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert scorecard.main(["validate", str(path)]) == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["valid"] is True
+    assert result["permanently_nonpromoting"] is True
+
+
+def test_validate_cli_accepts_the_canonical_plan(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "plan.json"
+    scorecard.write_new_json(path, scorecard.build_development_plan().to_payload())
+
+    assert scorecard.main(["validate", str(path)]) == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["valid"] is True
+    assert result["evidence_policy"]["permanently_nonpromoting"] is True


### PR DESCRIPTION
Supersedes #1418 with a narrow current-main successor.

## Included
- preview1 transaction extensions, Prototype bridge, aggregate SwitchingTwoState/RiverSwim life runner, quiescent checkpoint codec, reference controls, and permanently nonpromoting scorecard
- directly required Prototype/checkpoint compatibility surfaces
- six focused reference-life test modules plus package, console-entrypoint, checkpoint, and hostile-boundary contracts
- package entry point and narrowly scoped README/CHANGELOG/protocol/roadmap/status guidance
- byte-identical AGENTS.md and CLAUDE.md

## Audit corrections
- adds `asi-reference-life-scorecard` to the exact wheel/sdist entry-point inventory (the package failure in #1418)
- removes two newly introduced `!r` hostile-repr paths from DispatchCommand/DispatchReceipt errors

## Deliberately omitted from #1418
All unrelated/stale Forager/OCI, evaluation/evidence, IA/multiagent, Step, unrelated core/stream, CITATION/VENDORING, repository-audit, IPMNIST-index, and SOTA-landscape collateral. No `outputs/**` changes and no benchmark execution.

## Verification
- focused transaction/life/checkpoint/control/scorecard panel: 201 passed
- checkpoint + console contracts: 36 passed
- rebuilt wheel/sdist package contract: 1 passed (3 deselected)
- Ruff: clean
- strict mypy on six stack modules: clean

This is development-only L0/preview1 machinery. It does not populate reference-dev or establish safety, robotics, performance, or scientific evidence.