### PR TITLE
fix(core): complete FTL sparse-update envelope

### DIFF
--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -146,9 +146,16 @@ def _preflight_update_working_set(
         + 2 * feature_dim * feature_dim  # stored and proposed Grams
         + 4 * feature_dim * observation_dim  # stored/proposed cross and weights
         + feature_dim  # dense sparse-feature materialization
-        + 2 * active_dim * active_dim  # active Gram and ridge system
-        + 4 * active_dim * observation_dim  # active solve/cross/weight intermediates
+        # Sparse outer product, active Gram, ridge identity, and ridge system.
+        + 4 * active_dim * active_dim
+        # Prediction gather plus active cross, gathers/products, RHS, and solve.
+        + 8 * active_dim * observation_dim
+        + active_dim * feature_dim  # selected Gram rows used by the dense product
         + 2 * active_dim  # sparse indices and values
+        + input_dim  # concatenated observation-action input
+        # Projection, bin location/lower/fraction/offset/index, and complement
+        # vectors retained while the final sparse indices and values form.
+        + 8 * projection_dim
         + 6 * observation_dim  # observation/prediction/target/error vectors
         + action_dim
         + 8  # scalar statistics, counters, and update outputs

--- a/tests/test_ftl_world_model_update_working_set.py
+++ b/tests/test_ftl_world_model_update_working_set.py
@@ -25,9 +25,12 @@ def _working_scalars(config: SparseFTLWorldModelConfig) -> int:
         + 2 * feature_dim * feature_dim
         + 4 * feature_dim * config.observation_dim
         + feature_dim
-        + 2 * active_dim * active_dim
-        + 4 * active_dim * config.observation_dim
+        + 4 * active_dim * active_dim
+        + 8 * active_dim * config.observation_dim
+        + active_dim * feature_dim
         + 2 * active_dim
+        + config.input_dim
+        + 8 * config.projection_dim
         + 6 * config.observation_dim
         + config.action_dim
         + 8
@@ -57,15 +60,28 @@ def test_ftl_one_bank_and_persistent_fit_while_update_working_set_does_not() -> 
     config = SparseFTLWorldModelConfig(
         observation_dim=1,
         action_dim=1,
-        projection_dim=_WORKING_SET_OVERFLOW,
+        projection_dim=4_500,
         bins=2,
     )
     feature_dim = config.feature_dim
     one_bank_bytes = 4 * (feature_dim * feature_dim)
     persistent_bytes = SparseFTLWorldModel(config).state_nbytes
+    contributor_formula = (
+        config.projection_dim * config.input_dim
+        + 2 * feature_dim * feature_dim
+        + 4 * feature_dim * config.observation_dim
+        + feature_dim
+        + 2 * config.active_feature_count**2
+        + 4 * config.active_feature_count * config.observation_dim
+        + 2 * config.active_feature_count
+        + 6 * config.observation_dim
+        + config.action_dim
+        + 8
+    )
     update_bytes = 4 * _working_scalars(config)
     assert one_bank_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
+    assert 4 * contributor_formula <= _INT32_MAX
     assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
         SparseFTLWorldModel(config).init(jr.key(0))


### PR DESCRIPTION
Deep-review corrective for merged #1407.

The merged formula counted the returned sparse vectors and active solve matrices, but not several much larger arrays explicitly materialized by the kernel: selected Gram rows (`active_dim * feature_dim`), the sparse outer product and ridge identity, prediction/solve gathers and RHS/product arrays, the concatenated input, and projection/binning vectors.

A concrete `projection_dim=4500, bins=2, observation_dim=action_dim=1` configuration proves the gap: persistent state and #1407's full formula both fit signed int32, while the complete named source-level update envelope exceeds it.

The corrected dimension-dependent preflight charges those arrays before RNG/allocation. Tests preserve persistent-first ordering, legal runtime identity, general high-observation coverage, and exact adjacent last-fit/first-overflow arithmetic.

Verification: 184 passed, 7 skipped across FTL model/resource/decision artifact panels; Ruff and strict mypy clean. No benchmark, output artifact, threshold, promotion, or protocol change. Registered evidence remains fail-closed as documented.
