### PR TITLE
fix(streams): saturate out-of-class lifetime clocks

### DIFF
--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -451,7 +451,7 @@ class OutOfClassPolynomialStream:
 
         timestep = TimeStep(observation=x, target=target)
         new_state = state.replace(  # type: ignore[attr-defined]
-            key=key, step_count=state.step_count + 1
+            key=key, step_count=_saturating_step_count(state.step_count)
         )
         return timestep, new_state
 

--- a/tests/test_out_of_class_lifetime_clock.py
+++ b/tests/test_out_of_class_lifetime_clock.py
@@ -1,0 +1,36 @@
+"""Saturating lifetime clocks keep out-of-class context identity at int32 exhaustion."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.streams.out_of_class import OutOfClassPolynomialStream
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_polynomial_stream_wrap_would_change_context_slot() -> None:
+    """INT32_MAX+1 wrap selects a different context than saturate."""
+
+    stream = OutOfClassPolynomialStream(
+        feature_dim=4,
+        n_tasks=1,
+        n_contexts=2,
+        context_length=1,
+        active_triples_per_context=1,
+        noise_std=0.0,
+        feature_std=1.0,
+        linear_scale=0.0,
+    )
+    planted = stream.init(jr.key(0)).replace(
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    _, advanced = stream.step(planted, jnp.asarray(0, dtype=jnp.int32))
+    assert int(advanced.step_count) == _INT32_MAX
+    wrap_slot = int((jnp.asarray(_INT32_MIN, dtype=jnp.int32) // 1) % 2)
+    sat_slot = int((advanced.step_count // 1) % 2)
+    assert sat_slot != wrap_slot
+    assert sat_slot == 1
+    assert wrap_slot == 0


### PR DESCRIPTION
Closes #1434.

## What changed

`OutOfClassPolynomialStream.step` now uses the existing `_saturating_step_count` helper. Wrapping `INT32_MAX+1` would pick context slot `0`; saturate stays at `INT32_MAX` and keeps slot `1`.

Legal construction and step identity are unchanged.

## Scope

- `alberta_framework/streams/out_of_class.py`
- `tests/test_out_of_class_lifetime_clock.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `out_of_class.py`.

## Verification

Exact candidate head: `7ce2e05f7376b6d419f1323e539b93cabc098f10`
Base: `f394a93`

- Red on base: planted `INT32_MAX` advances to `INT32_MIN`; wrap slot `0` ≠ saturate slot `1`
- Focused pytest plus `TestOutOfClassPolynomialStream`: 150 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary clock saturation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_out_of_class_lifetime_clock.py tests/test_out_of_class_streams.py::TestOutOfClassPolynomialStream -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: saturate stays at `INT32_MAX`; wrap slot differs from saturate slot
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7ce2e05f7376b6d419f1323e539b93cabc098f10 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
