### PR TITLE
fix(core): complete Horde hidden-buffer envelope

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -131,7 +131,10 @@ def _preflight_nonlinear_state(*, n_demons: int, hidden_size: int, feature_dim: 
         3 * logical_scalars
         + parameter_scalars
         + 3 * one_gradient_scalars
-        + 2 * feature_dim
+        # Current observation, next observation, and the finite-safe next copy.
+        + 3 * feature_dim
+        # Current/next hidden activations and their two tanh-derivative vectors.
+        + 4 * hidden_size
         + 24 * n_demons
         + 32
     )

--- a/tests/test_off_policy_horde_update_working_set.py
+++ b/tests/test_off_policy_horde_update_working_set.py
@@ -66,7 +66,8 @@ def test_nonlinear_horde_one_bank_and_persistent_fit_while_update_working_set_do
         3 * logical_scalars
         + parameter_scalars
         + 3 * one_gradient_scalars
-        + 2 * fd
+        + 3 * fd
+        + 4 * _HIDDEN
         + 24 * _N_DEMONS
         + 32
     )
@@ -109,9 +110,9 @@ def test_legal_nonlinear_horde_update_identity_is_unchanged() -> None:
 
 
 def test_nonlinear_horde_update_working_set_has_exact_adjacent_byte_boundary() -> None:
-    # For D=H=1, the complete formula reduces exactly to 13*feature_dim+98.
+    # For D=H=1, the complete formula reduces exactly to 14*feature_dim+102.
     max_scalars = _INT32_MAX // 4
-    last_legal = (max_scalars - 98) // 13
+    last_legal = (max_scalars - 102) // 14
     first_overflowing = last_legal + 1
     learner = NonlinearSharedGTDHordeLearner(
         create_horde_spec(
@@ -134,6 +135,8 @@ def test_nonlinear_horde_update_working_set_has_exact_adjacent_byte_boundary() -
     with pytest.raises(ValueError, match="update working set byte count"):
         _preflight_nonlinear_state(n_demons=1, hidden_size=1, feature_dim=first_overflowing)
 
-    assert 4 * (13 * last_legal + 98) <= _INT32_MAX
-    assert 4 * (13 * first_overflowing + 98) > _INT32_MAX
+    contributor_scalars = 13 * first_overflowing + 98
+    assert 4 * contributor_scalars <= _INT32_MAX
+    assert 4 * (14 * last_legal + 102) <= _INT32_MAX
+    assert 4 * (14 * first_overflowing + 102) > _INT32_MAX
     assert learner.n_demons == 1


### PR DESCRIPTION
Deep-review corrective for merged #1411.

The claimed complete formula counted only the two caller observations. The kernel explicitly retains a third full-width finite-safe next-observation copy, plus current/next hidden activations and both tanh-derivative vectors. These were absent from the source-level envelope and matter independently of demon count.

The corrected formula adds `feature_dim + 4*hidden_size`. For `n_demons=hidden_size=1`, the exact boundary changes from the incomplete `13*feature_dim+98` to `14*feature_dim+102`; the test proves a first-overflow configuration that #1411 accepted while preserving exact last-fit/first-overflow arithmetic and legal update behavior.

Verification: 33 Horde tests pass; Ruff and strict mypy clean. No benchmark, output, evidence, or scientific-claim change.
