### PR TITLE
fix(reference): bind checkpoint empties and installed source identity

### DIFF
--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -180,6 +180,7 @@ def save_checkpoint(
     else:
         meta_to_save = _copy_mapping(metadata, name="checkpoint metadata")
     _require_json_safe_metadata(meta_to_save)
+    meta_to_save.pop(_EMPTY_ARRAYS_KEY, None)
     meta_to_save[_VERSION_KEY] = _FORMAT_VERSION
     empty_array_manifest = _empty_array_manifest(state)
     if empty_array_manifest is not None:

--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -52,6 +52,7 @@ _FORMAT_VERSION = 2
 
 # Internal metadata key — stripped from user-facing metadata
 _VERSION_KEY = "_format_version"
+_EMPTY_ARRAYS_KEY = "_empty_array_leaves"
 
 
 def _is_empty_array(value: object) -> bool:
@@ -76,8 +77,49 @@ def _orbax_compatible_tree(tree: Any) -> Any:
     return jax.tree.map(compatible, tree)
 
 
-def _restore_empty_arrays(template: Any, restored: Any) -> Any:
-    """Reinstate exact empty leaves from the structurally matched template."""
+def _empty_array_manifest(tree: Any) -> list[dict[str, Any] | None] | None:
+    """Describe exact empty leaves so sentinels cannot alias real data."""
+
+    manifest: list[dict[str, Any] | None] = []
+    has_empty = False
+    for leaf in jax.tree.leaves(tree):
+        if not _is_empty_array(leaf):
+            manifest.append(None)
+            continue
+        has_empty = True
+        manifest.append({"shape": list(leaf.shape), "dtype": str(leaf.dtype)})
+    return manifest if has_empty else None
+
+
+def _restore_empty_arrays(template: Any, restored: Any, manifest: object) -> Any:
+    """Validate and reinstate exact empty leaves from checkpoint metadata."""
+
+    template_leaves = jax.tree.leaves(template)
+    if manifest is None:
+        if any(_is_empty_array(leaf) for leaf in template_leaves):
+            raise ValueError("checkpoint does not identify its empty array leaves")
+        return restored
+    if type(manifest) is not list or len(manifest) != len(template_leaves):
+        raise ValueError("checkpoint empty array manifest does not match the state tree")
+
+    for expected, raw_spec in zip(template_leaves, manifest, strict=True):
+        if raw_spec is None:
+            if _is_empty_array(expected):
+                raise ValueError("checkpoint state leaf is nonempty but template leaf is empty")
+            continue
+        if type(raw_spec) is not dict or set(raw_spec) != {"shape", "dtype"}:
+            raise ValueError("checkpoint empty array manifest is invalid")
+        raw_shape = raw_spec["shape"]
+        raw_dtype = raw_spec["dtype"]
+        if (
+            not _is_empty_array(expected)
+            or type(raw_shape) is not list
+            or any(type(dimension) is not int or dimension < 0 for dimension in raw_shape)
+            or type(raw_dtype) is not str
+            or list(expected.shape) != raw_shape
+            or str(expected.dtype) != raw_dtype
+        ):
+            raise ValueError("checkpoint empty array leaf does not match the restore template")
 
     return jax.tree.map(
         lambda expected, actual: expected if _is_empty_array(expected) else actual,
@@ -139,6 +181,9 @@ def save_checkpoint(
         meta_to_save = _copy_mapping(metadata, name="checkpoint metadata")
     _require_json_safe_metadata(meta_to_save)
     meta_to_save[_VERSION_KEY] = _FORMAT_VERSION
+    empty_array_manifest = _empty_array_manifest(state)
+    if empty_array_manifest is not None:
+        meta_to_save[_EMPTY_ARRAYS_KEY] = empty_array_manifest
     path.parent.mkdir(parents=True, exist_ok=True)
 
     with ocp.Checkpointer(ocp.CompositeCheckpointHandler()) as ckptr:
@@ -200,8 +245,12 @@ def load_checkpoint(
     raw_metadata = loaded.metadata
     user_metadata = _copy_mapping(raw_metadata, name="checkpoint metadata")
     user_metadata.pop(_VERSION_KEY, None)
+    empty_array_manifest = user_metadata.pop(_EMPTY_ARRAYS_KEY, None)
     _require_json_safe_metadata(user_metadata)
-    return _restore_empty_arrays(state_template, loaded.state), user_metadata
+    return (
+        _restore_empty_arrays(state_template, loaded.state, empty_array_manifest),
+        user_metadata,
+    )
 
 
 def load_checkpoint_metadata(path: str | Path) -> dict[str, Any]:
@@ -235,6 +284,7 @@ def load_checkpoint_metadata(path: str | Path) -> dict[str, Any]:
     raw_metadata = loaded.metadata
     user_metadata = _copy_mapping(raw_metadata, name="checkpoint metadata")
     user_metadata.pop(_VERSION_KEY, None)
+    user_metadata.pop(_EMPTY_ARRAYS_KEY, None)
     _require_json_safe_metadata(user_metadata)
     return user_metadata
 

--- a/alberta_framework/reference_life_checkpoint.py
+++ b/alberta_framework/reference_life_checkpoint.py
@@ -238,19 +238,41 @@ def _repository_root() -> Path:
 
 def _source_identity() -> dict[str, Any]:
     root = _repository_root()
-    paths = [
-        *sorted((root / "alberta_framework").rglob("*.py")),
-        root / "pyproject.toml",
-        root / "uv.lock",
-    ]
-    if len(paths) > _MAX_INVENTORY_FILES:
+    package_paths = sorted((root / "alberta_framework").rglob("*.py"))
+    inventory = [(path.relative_to(root).as_posix(), path) for path in package_paths]
+    checkout_paths = (root / "pyproject.toml", root / "uv.lock")
+    if all(path.is_file() and not path.is_symlink() for path in checkout_paths):
+        inventory.extend((path.relative_to(root).as_posix(), path) for path in checkout_paths)
+    else:
+        try:
+            distribution = importlib.metadata.distribution("alberta-framework")
+            distribution_files = distribution.files
+        except importlib.metadata.PackageNotFoundError as exc:
+            raise ValueError("installed checkpoint source metadata is unavailable") from exc
+        if distribution_files is None:
+            raise ValueError("installed checkpoint source inventory is unavailable")
+        required_names = {"METADATA", "RECORD", "WHEEL", "entry_points.txt"}
+        selected: dict[str, Path] = {}
+        for entry in distribution_files:
+            parts = entry.parts
+            if (
+                len(parts) >= 2
+                and parts[-2].endswith(".dist-info")
+                and parts[-1] in required_names
+            ):
+                selected[parts[-1]] = Path(str(distribution.locate_file(entry)))
+        if set(selected) != required_names:
+            raise ValueError("installed checkpoint distribution metadata is incomplete")
+        inventory.extend(
+            (f"distribution/{name}", selected[name]) for name in sorted(required_names)
+        )
+    if len(inventory) > _MAX_INVENTORY_FILES:
         raise ValueError("checkpoint source inventory exceeds its file-count limit")
     files: dict[str, Any] = {}
-    for path in paths:
+    for relative, path in inventory:
         if not path.is_file() or path.is_symlink():
             raise ValueError(f"checkpoint source inventory entry is unavailable: {path}")
         digest, size = _sha256_file(path, max_bytes=_MAX_JSON_BYTES)
-        relative = path.relative_to(root).as_posix()
         if len(relative.encode("utf-8")) > _MAX_PATH_BYTES:
             raise ValueError("checkpoint source inventory path is too long")
         files[relative] = {"sha256": digest, "size": size}
@@ -1451,7 +1473,36 @@ _PROTOTYPE_METADATA_KEYS = {
     "empty_array_codec",
     "prng_impl",
 }
-_PROTOTYPE_RAW_METADATA_KEYS = {*_PROTOTYPE_METADATA_KEYS, "_format_version"}
+_PROTOTYPE_RAW_METADATA_KEYS = {
+    *_PROTOTYPE_METADATA_KEYS,
+    "_format_version",
+    "_empty_array_leaves",
+}
+
+
+def _validate_prototype_empty_array_manifest(value: object) -> None:
+    """Validate the generic checkpoint codec's internal empty-leaf manifest."""
+
+    if type(value) is not list or not value:
+        _fail("prototype.metadata._empty_array_leaves must be a nonempty array")
+    saw_empty = False
+    for index, raw_spec in enumerate(value):
+        if raw_spec is None:
+            continue
+        saw_empty = True
+        if type(raw_spec) is not dict or set(raw_spec) != {"shape", "dtype"}:
+            _fail(f"prototype.metadata._empty_array_leaves[{index}] is invalid")
+        raw_shape = raw_spec["shape"]
+        raw_dtype = raw_spec["dtype"]
+        if (
+            type(raw_shape) is not list
+            or any(type(dimension) is not int or dimension < 0 for dimension in raw_shape)
+            or type(raw_dtype) is not str
+            or not raw_dtype
+        ):
+            _fail(f"prototype.metadata._empty_array_leaves[{index}] is invalid")
+    if not saw_empty:
+        _fail("prototype.metadata._empty_array_leaves identifies no empty leaf")
 
 
 def _load_raw_prototype_metadata(path: Path) -> dict[str, Any]:
@@ -1475,6 +1526,7 @@ def _load_raw_prototype_metadata(path: Path) -> dict[str, Any]:
         != 2
     ):
         _fail("nested Prototype metadata format version is unsupported")
+    _validate_prototype_empty_array_manifest(data["_empty_array_leaves"])
     if _require_str(data["schema"], path="prototype.metadata.schema") != (
         PROTOTYPE_CHECKPOINT_SCHEMA
     ):

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -36,6 +36,7 @@ class TestSaveLoadRoundTrip:
         assert loaded["empty"].dtype == jnp.float32
         chex.assert_trees_all_equal(loaded["payload"], state["payload"])
         assert metadata == {}
+        assert load_checkpoint_metadata(tmp_path / "empty_leaf") == {}
 
     def test_empty_template_cannot_discard_nonempty_saved_array(self, tmp_path):
         saved = {"x": jnp.array([42.0], dtype=jnp.float32)}
@@ -54,6 +55,21 @@ class TestSaveLoadRoundTrip:
 
         with pytest.raises(ValueError, match="does not match the restore template"):
             load_checkpoint(template, tmp_path / "empty_shape")
+
+    def test_user_metadata_cannot_forge_empty_array_manifest(self, tmp_path):
+        saved = {"x": jnp.array([42.0], dtype=jnp.float32)}
+        template = {"x": jnp.empty((0,), dtype=jnp.float32)}
+
+        save_checkpoint(
+            saved,
+            tmp_path / "forged_empty",
+            metadata={
+                "_empty_array_leaves": [{"shape": [0], "dtype": "float32"}],
+            },
+        )
+
+        with pytest.raises(ValueError, match="does not identify its empty array leaves"):
+            load_checkpoint(template, tmp_path / "forged_empty")
 
     def test_linear_learner_state(self, tmp_path):
         """LinearLearner state should round-trip correctly."""

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -37,6 +37,24 @@ class TestSaveLoadRoundTrip:
         chex.assert_trees_all_equal(loaded["payload"], state["payload"])
         assert metadata == {}
 
+    def test_empty_template_cannot_discard_nonempty_saved_array(self, tmp_path):
+        saved = {"x": jnp.array([42.0], dtype=jnp.float32)}
+        template = {"x": jnp.empty((0,), dtype=jnp.float32)}
+
+        save_checkpoint(saved, tmp_path / "nonempty")
+
+        with pytest.raises(ValueError, match="does not identify its empty array leaves"):
+            load_checkpoint(template, tmp_path / "nonempty")
+
+    def test_empty_saved_array_requires_exact_template_shape(self, tmp_path):
+        saved = {"x": jnp.empty((0, 3), dtype=jnp.float32)}
+        template = {"x": jnp.empty((0, 4), dtype=jnp.float32)}
+
+        save_checkpoint(saved, tmp_path / "empty_shape")
+
+        with pytest.raises(ValueError, match="does not match the restore template"):
+            load_checkpoint(template, tmp_path / "empty_shape")
+
     def test_linear_learner_state(self, tmp_path):
         """LinearLearner state should round-trip correctly."""
         learner = LinearLearner()

--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -339,6 +339,21 @@ console_scripts = [item for item in entry_points if item.group == "console_scrip
 for entry_point in console_scripts:
     entry_point.load()
 
+scorecard = next(
+    item for item in console_scripts if item.name == "asi-reference-life-scorecard"
+)
+scorecard_plan = install_root / "reference-life-plan.json"
+if scorecard.load()(["plan", "--output", str(scorecard_plan)]) != 0:
+    raise SystemExit("installed reference-life scorecard plan command failed")
+from alberta_framework.reference_life_checkpoint import _source_identity
+
+scorecard_source = _source_identity()
+source_files = scorecard_source["files"]
+if not scorecard_plan.is_file():
+    raise SystemExit("installed reference-life scorecard did not write its plan")
+if "distribution/METADATA" not in source_files or "pyproject.toml" in source_files:
+    raise SystemExit("installed reference-life source identity is not distribution-bound")
+
 official_module = "alberta_framework.benchmarks.official_foragax"
 if official_module in sys.modules:
     raise SystemExit("entry-point loading eagerly imported the official verifier")
@@ -378,6 +393,7 @@ print(
             "historical_family": historical_payload["family_id"],
             "historical_status": historical_status,
             "names": [item.name for item in console_scripts],
+            "scorecard_source_files": len(source_files),
             "strict_failure": strict_failure,
         }
     )
@@ -400,6 +416,7 @@ print(
     assert smoke["historical_status"] == 0
     assert smoke["historical_errors"] == ""
     assert smoke["historical_family"] == HISTORICAL_FORAGER_FAMILY_ID
+    assert smoke["scorecard_source_files"] > 4
     assert smoke["strict_failure"] == {
         "message": (
             "official harness source "


### PR DESCRIPTION
Narrow corrective atop merged #1432, superseding the broad duplicate #1431.

Deep review found two correctness/packaging gaps in the integrated reference-life stack:

1. Generic Orbax projection encoded an empty array as a one-element sentinel without recording which saved leaves were actually empty. A saved `[42.]` could therefore be restored through an empty template and silently discarded. The codec now records exact empty-leaf position/shape/dtype in reserved internal metadata, validates it before rehydration, strips it from user metadata, and prevents user metadata forgery.
2. Reference-life source identity required repository-root `pyproject.toml` and `uv.lock`, so the advertised installed wheel entry point failed before a shard/checkpoint could run. Source checkouts retain the existing identity. Installed distributions now bind package Python bytes plus exact `METADATA`, `RECORD`, `WHEEL`, and `entry_points.txt` bytes.

The strict nested Prototype checkpoint parser validates and permits the generic internal manifest. No output artifact or scientific evidence is changed.

Verification:

- 47 generic + Switching/RiverSwim whole-life checkpoint tests passed
- built wheel/sdist package test passed, including installed scorecard plan and distribution source-identity probe
- Ruff passed
- strict mypy passed
- `git diff --check` clean
