### PR TITLE
fix(validation): close hostile type dispatches in audit wave

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_campaign.py
@@ -301,7 +301,7 @@ def canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
 
 
 def _freeze_json(value: Any) -> Any:
-    if type(value) in (dict, MappingProxyType):
+    if type(value) is dict or type(value) is MappingProxyType:
         result: dict[str, Any] = {}
         for key, item in value.items():
             if type(key) is not str:
@@ -316,7 +316,7 @@ def _freeze_json(value: Any) -> Any:
 
 
 def _plain(value: Any) -> Any:
-    if type(value) in (dict, MappingProxyType):
+    if type(value) is dict or type(value) is MappingProxyType:
         result: dict[str, Any] = {}
         for key, item in value.items():
             if type(key) is not str:
@@ -333,7 +333,7 @@ def _plain(value: Any) -> Any:
                 "canonical content contains a non-finite JSON number"
             )
         return value
-    if value is None or type(value) in (str, bool, int):
+    if value is None or type(value) is str or type(value) is bool or type(value) is int:
         return value
     raise ForagerMatchedCampaignError(
         f"canonical content contains unsupported {type(value).__name__}"

--- a/alberta_framework/benchmarks/forager_matched_qualification.py
+++ b/alberta_framework/benchmarks/forager_matched_qualification.py
@@ -568,16 +568,16 @@ def _plain_json(value: Any, path: str = "value") -> Any:
                 f"{path} contains a non-finite JSON number"
             )
         return value
-    if value is None or type(value) in {str, bool, int}:
+    if value is None or type(value) is str or type(value) is bool or type(value) is int:
         return value
-    if type(value) in (dict, MappingProxyType):
+    if type(value) is dict or type(value) is MappingProxyType:
         result: dict[str, Any] = {}
         for key, item in value.items():
             if type(key) is not str:
                 raise ForagerMatchedQualificationError(f"{path} has a non-string key")
             result[key] = _plain_json(item, f"{path}.{key}")
         return result
-    if type(value) in (list, tuple):
+    if type(value) is list or type(value) is tuple:
         return [_plain_json(item, f"{path}[]") for item in value]
     raise ForagerMatchedQualificationError(f"{path} contains unsupported {type(value).__name__}")
 

--- a/alberta_framework/benchmarks/forager_matched_seal.py
+++ b/alberta_framework/benchmarks/forager_matched_seal.py
@@ -158,14 +158,14 @@ class _OpenDirectory:
 
 
 def _plain(value: Any) -> Any:
-    if type(value) in (dict, MappingProxyType):
+    if type(value) is dict or type(value) is MappingProxyType:
         result: dict[str, Any] = {}
         for key, item in value.items():
             if type(key) is not str:
                 raise ForagerMatchedSealError("canonical mappings require string keys")
             result[key] = _plain(item)
         return result
-    if type(value) in (list, tuple):
+    if type(value) is list or type(value) is tuple:
         return [_plain(item) for item in value]
     if type(value) is float:
         if not math.isfinite(value):
@@ -173,7 +173,7 @@ def _plain(value: Any) -> Any:
                 "canonical content contains a non-finite JSON number"
             )
         return value
-    if value is None or type(value) in {str, bool, int}:
+    if value is None or type(value) is str or type(value) is bool or type(value) is int:
         return value
     raise ForagerMatchedSealError(
         f"canonical content contains unsupported {type(value).__name__}"

--- a/alberta_framework/benchmarks/forager_rng_parity.py
+++ b/alberta_framework/benchmarks/forager_rng_parity.py
@@ -602,7 +602,7 @@ def _validate_json_value(value: Any) -> None:
             raise ForagerRngParityError("JSON value exceeds the node limit")
         if depth > MAX_JSON_DEPTH:
             raise ForagerRngParityError("JSON value exceeds the nesting limit")
-        if isinstance(item, Mapping):
+        if type(item) is dict:
             for key in item:
                 if type(key) is not str:
                     raise ForagerRngParityError("JSON object keys must be strings")
@@ -613,7 +613,7 @@ def _validate_json_value(value: Any) -> None:
                         "JSON object keys must contain valid Unicode"
                     ) from exc
             pending.extend((child, depth + 1) for child in item.values())
-        elif isinstance(item, (list, tuple)):
+        elif type(item) is list or type(item) is tuple:
             pending.extend((child, depth + 1) for child in item)
         elif type(item) is str:
             try:
@@ -623,7 +623,7 @@ def _validate_json_value(value: Any) -> None:
         elif type(item) is float:
             if not math.isfinite(item):
                 raise ForagerRngParityError("non-finite JSON numbers are forbidden")
-        elif item is not None and type(item) not in (bool, int):
+        elif item is not None and type(item) is not bool and type(item) is not int:
             raise ForagerRngParityError(f"value contains non-JSON type {type(item).__name__}")
 
 
@@ -784,7 +784,7 @@ def _path_component(value: Any) -> list[Any]:
     name = type(value).__name__
     if name == "DictKey":
         key = value.key
-        if type(key) not in (str, int):
+        if type(key) is not str and type(key) is not int:
             raise ForagerRngParityError("pytree dictionary keys must be strings or integers")
         return ["dict", key]
     if name == "SequenceKey":

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -243,7 +243,7 @@ _MISSING_NOISE_POOL_STEPS = object()
 def _validated_wall_clock_seconds(value: object, path: Path | str) -> float:
     """Return one shard wall clock as a finite, non-negative Python float."""
     message = f"{path}: wall_clock_seconds must be a finite, non-negative number"
-    if type(value) not in (int, float):
+    if type(value) is not int and type(value) is not float:
         raise ValueError(message)
     numeric_value = cast(int | float, value)
     try:
@@ -5336,7 +5336,7 @@ class ScreeningSpec:
         for key, value in self.hyperparameters.items():
             if type(key) is not str or not key:
                 raise TypeError("hyperparameter keys must be exact non-empty strings")
-            if type(value) not in (int, float) or not math.isfinite(value):
+            if (type(value) is not int and type(value) is not float) or not math.isfinite(value):
                 raise ValueError("hyperparameter values must be finite built-in numbers")
             normalized[key] = float(value)
         object.__setattr__(self, "hyperparameters", normalized)
@@ -7720,16 +7720,21 @@ class ScreeningRunResult:
         for key, value in self.hyperparameters.items():
             if type(key) is not str or not key:
                 raise TypeError("hyperparameter keys must be exact non-empty strings")
-            if type(value) not in (int, float) or not math.isfinite(value):
+            if (type(value) is not int and type(value) is not float) or not math.isfinite(value):
                 raise ValueError("hyperparameter values must be finite built-in numbers")
             normalized[key] = float(value)
         object.__setattr__(self, "hyperparameters", normalized)
         object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
         if type(self.config) is not IPMNISTConfig:
             raise TypeError("config must be an IPMNISTConfig")
-        if type(self.wall_clock_seconds) not in (int, float) or not math.isfinite(
-            self.wall_clock_seconds
-        ) or self.wall_clock_seconds < 0.0:
+        if (
+            (
+                type(self.wall_clock_seconds) is not int
+                and type(self.wall_clock_seconds) is not float
+            )
+            or not math.isfinite(self.wall_clock_seconds)
+            or self.wall_clock_seconds < 0.0
+        ):
             raise ValueError("wall_clock_seconds must be a finite float")
         for arr_name in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):
             array = getattr(self, arr_name)
@@ -7970,7 +7975,7 @@ def _required_nonempty_string(value: object, *, context: str) -> str:
 
 
 def _is_finite_json_number(value: object) -> bool:
-    if type(value) not in (int, float):
+    if type(value) is not int and type(value) is not float:
         return False
     try:
         return math.isfinite(float(cast(int | float, value)))
@@ -8363,7 +8368,7 @@ def load_shard(path: Path) -> dict[str, Any]:
             payload["evidence_policy"], context=str(path)
         )
         created_unix = payload["created_unix"]
-        if type(created_unix) not in (int, float):
+        if type(created_unix) is not int and type(created_unix) is not float:
             raise ValueError(f"{path}: created_unix must be a finite, non-negative number")
         try:
             created_value = float(created_unix)

--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -204,7 +204,7 @@ def _require_nonempty_string(value: object, *, context: str) -> str:
 
 def _require_builtin_finite_real(value: object, *, context: str) -> float:
     """Canonicalize a result scalar without invoking numeric subclass hooks."""
-    if type(value) not in (int, float):
+    if type(value) is not int and type(value) is not float:
         raise ValueError(f"{context} must be a finite built-in real number")
     number = float(cast("int | float", value))
     if not math.isfinite(number):
@@ -234,7 +234,8 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
 
 def _require_positive_int32(value: object, *, name: str, minimum: int = 1) -> int:
     """Canonicalize one trusted positive integer in JAX's shape/index domain."""
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
     number = operator.index(cast(SupportsIndex, value))
     if not minimum <= number <= _INT32_MAX:

--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -290,7 +290,8 @@ _ACTUAL_INT_TYPES = frozenset(
 
 
 def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer")
     try:
         number = operator.index(cast(SupportsIndex, value))
@@ -302,7 +303,7 @@ def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
 
 
 def _require_finite_real(name: str, value: object) -> float:
-    if type(value) not in (int, float):
+    if type(value) is not int and type(value) is not float:
         raise ValueError(f"{name} must be a finite real number")
     number = float(cast("int | float", value))
     if not math.isfinite(number):
@@ -781,7 +782,7 @@ _LEARNER_DEFAULT_HYPERPARAMETERS: dict[str, dict[str, float]] = {
 def _validated_hyperparameter(name: object, value: object) -> float:
     """Validate one JSON override in its exact host and float32 execution domains."""
     host_name = _require_exact_str("name", name)
-    if type(value) not in (int, float):
+    if type(value) is not int and type(value) is not float:
         raise ValueError(f"hyperparameter '{host_name}' must be a finite JSON number")
     label = f"hyperparameter '{host_name}'"
     if name in {"step_size", "eps"}:
@@ -826,7 +827,7 @@ class IPMNISTRunResult:
         for name, value in self.hyperparameters.items():
             if type(name) is not str or not name:
                 raise TypeError("hyperparameters keys must be exact non-empty strings")
-            if type(value) not in (int, float) or not math.isfinite(value):
+            if (type(value) is not int and type(value) is not float) or not math.isfinite(value):
                 raise ValueError("hyperparameters values must be finite built-in numbers")
             normalized_hyperparameters[name] = float(value)
         object.__setattr__(self, "hyperparameters", normalized_hyperparameters)

--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -259,7 +259,7 @@ _LEARNER_DEFAULT_HYPERPARAMETERS: dict[str, dict[str, float]] = {
 def _validated_hyperparameter(name: object, value: object) -> float:
     """Validate one JSON override in its exact host and float32 execution domains."""
     host_name = _require_exact_str("name", name)
-    if type(value) not in (int, float):
+    if type(value) is not int and type(value) is not float:
         raise ValueError(f"hyperparameter '{host_name}' must be a finite JSON number")
     label = f"hyperparameter '{host_name}'"
     if host_name in {"step_size", "eps", "norm_epsilon"}:
@@ -368,7 +368,11 @@ class LabelEMNISTConfig:
         for name in ("n_tasks", "task_length", "input_dim", "hidden1", "hidden2", "n_classes"):
             host_name = _require_exact_str("name", name)
             value = getattr(self, host_name)
-            if type(value) not in _ACTUAL_INT_TYPES or value <= 0:
+            actual_type = type(value)
+            if (
+                not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES)
+                or value <= 0
+            ):
                 raise ValueError(f"{host_name} must be a positive integer")
 
     @property
@@ -450,7 +454,7 @@ def build_schedule(key: Array, config: LabelEMNISTConfig, n_train: int) -> Label
 
 
 def _require_finite_real(name: str, value: object) -> float:
-    if type(value) not in (int, float):
+    if type(value) is not int and type(value) is not float:
         raise ValueError(f"{name} must be a finite real number")
     number = float(cast("int | float", value))
     if not math.isfinite(number):
@@ -502,7 +506,7 @@ class LabelEMNISTRunResult:
         for name, value in self.hyperparameters.items():
             if type(name) is not str or not name:
                 raise TypeError("hyperparameters keys must be exact non-empty strings")
-            if type(value) not in (int, float) or not math.isfinite(value):
+            if (type(value) is not int and type(value) is not float) or not math.isfinite(value):
                 raise ValueError("hyperparameters values must be finite built-in numbers")
             normalized_hyperparameters[name] = float(value)
         object.__setattr__(self, "hyperparameters", normalized_hyperparameters)

--- a/alberta_framework/core/baseline_optimizers.py
+++ b/alberta_framework/core/baseline_optimizers.py
@@ -64,7 +64,8 @@ _ACTUAL_INT_TYPES: tuple[type, ...] = (
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:

--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -107,7 +107,8 @@ _ACTUAL_INT_TYPES = frozenset(
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:

--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -99,7 +99,8 @@ _ACTUAL_INT_TYPES = frozenset(
 
 
 def _require_int32(name: str, value: object, *, minimum: int) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= _INT32_MAX:

--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -104,7 +104,8 @@ def _require_feature_dim(
     augmented: bool = False,
 ) -> int:
     maximum = _INT32_MAX - 1 if augmented else _INT32_MAX
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"feature_dim must be an integer in [1, {maximum}]")
     feature_dim = operator.index(cast(SupportsIndex, value))
     if not 1 <= feature_dim <= maximum:
@@ -122,11 +123,13 @@ def _require_feature_dim(
 def _positive_float32_or_infinity(name: str, value: object) -> float:
     """Preserve the documented infinity sentinel but reject finite overflow."""
     actual_type = type(value)
-    if actual_type not in _TRUSTED_REAL_TYPES:
+    if not any(actual_type is allowed_type for allowed_type in _TRUSTED_REAL_TYPES):
         raise ValueError(f"{name} must be positive or infinity")
     try:
         numeric_value = cast(Any, value)
-        if actual_type in _INFINITY_TYPES and bool(np.isinf(numeric_value)):
+        if any(actual_type is allowed_type for allowed_type in _INFINITY_TYPES) and bool(
+            np.isinf(numeric_value)
+        ):
             if bool(np.signbit(numeric_value)):
                 raise ValueError(f"{name} must be positive or infinity")
             return math.inf
@@ -136,7 +139,8 @@ def _positive_float32_or_infinity(name: str, value: object) -> float:
 
 
 def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
-    if type(value) not in _TRUSTED_REAL_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _TRUSTED_REAL_TYPES):
         raise ValueError(f"{name} must be a finite real scalar")
     return validated_float32_scalar(name, value, **bounds)
 
@@ -170,7 +174,8 @@ def _array_metadata(name: str, value: object, shape: tuple[int, ...]) -> Array:
 
 
 def _scalar_operand(name: str, value: object) -> Array:
-    if type(value) in _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES:
+    actual_type = type(value)
+    if any(actual_type is allowed_type for allowed_type in _TRUSTED_REAL_TYPES):
         canonical = validated_float32_scalar(name, value)
         return jnp.asarray(canonical, dtype=jnp.float32)
     return _array_metadata(name, value, ())
@@ -178,7 +183,8 @@ def _scalar_operand(name: str, value: object) -> Array:
 
 def _discount_operand(value: object) -> Array:
     """Validate a discount in its exact host and consumed float32 domains."""
-    if type(value) in _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES:
+    actual_type = type(value)
+    if any(actual_type is allowed_type for allowed_type in _TRUSTED_REAL_TYPES):
         canonical = validated_float32_scalar("gamma", value, lower=0.0, upper=1.0)
         return jnp.asarray(canonical, dtype=jnp.float32)
     return _array_metadata("gamma", value, ())
@@ -217,7 +223,7 @@ def _serialized_payload(
     marker = payload.pop("type")
     if type(marker) is not str or marker != type_name:
         raise ValueError("config type differs")
-    if any(type(value) not in (int, float) for value in payload.values()):
+    if any(type(value) is not int and type(value) is not float for value in payload.values()):
         raise ValueError("serialized scalar fields must be exact JSON numbers")
     return payload
 

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -76,7 +76,8 @@ _ACTUAL_INT_TYPES = frozenset(
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:

--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -49,7 +49,8 @@ _ACTUAL_FLOAT_TYPES = frozenset(
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:
@@ -80,7 +81,11 @@ def _preflight_update_working_set(feature_dim: int) -> None:
 
 
 def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
-    if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
+    actual_type = type(value)
+    if not any(
+        actual_type is allowed_type
+        for allowed_type in (*_ACTUAL_INT_TYPES, *_ACTUAL_FLOAT_TYPES)
+    ):
         raise ValueError(f"{name} must be a finite real scalar")
     return validated_float32_scalar(name, value, **bounds)
 

--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -108,7 +108,8 @@ def _require_integer(
     maximum: int = _INT32_MAX,
 ) -> int:
     """Canonicalize only trusted Python/NumPy integer scalar families."""
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:
@@ -1450,7 +1451,7 @@ def run_continual_ia_benchmark(
 
     benchmark_config = ContinualIAConfig() if config is None else config
     limits = IAAcceptanceThresholds() if thresholds is None else thresholds
-    if type(seeds) not in (tuple, list):
+    if type(seeds) is not tuple and type(seeds) is not list:
         raise ValueError("seeds must be an actual tuple or list")
     seed_count = len(seeds)
     if seed_count < 1:

--- a/alberta_framework/evaluation/ftl_decision_fidelity.py
+++ b/alberta_framework/evaluation/ftl_decision_fidelity.py
@@ -98,7 +98,8 @@ _ACTUAL_INT_TYPES = frozenset(
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:
@@ -1027,7 +1028,7 @@ def run_ftl_decision_fidelity_evaluation(
     """
 
     resolved = DecisionFidelityConfig() if config is None else config
-    if type(seeds) not in (tuple, list):
+    if type(seeds) is not tuple and type(seeds) is not list:
         raise ValueError("seeds must be an actual tuple or list of exact integers")
     seed_count = len(seeds)
     if seed_count == 0:

--- a/tests/test_wave_1383_1397_hostile_type_identity.py
+++ b/tests/test_wave_1383_1397_hostile_type_identity.py
@@ -1,0 +1,105 @@
+"""Regression checks for exact-type gates audited after PRs 1383--1397."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_campaign import (
+    ForagerMatchedCampaignError,
+)
+from alberta_framework.benchmarks.forager_matched_campaign import (
+    _plain as campaign_plain,
+)
+from alberta_framework.benchmarks.forager_matched_qualification import (
+    ForagerMatchedQualificationError,
+    _plain_json,
+)
+from alberta_framework.benchmarks.forager_matched_seal import (
+    ForagerMatchedSealError,
+)
+from alberta_framework.benchmarks.forager_matched_seal import (
+    _plain as seal_plain,
+)
+from alberta_framework.benchmarks.forager_rng_parity import (
+    ForagerRngParityError,
+    _validate_json_value,
+)
+from alberta_framework.benchmarks.ipmnist_screening import (
+    _validated_wall_clock_seconds,
+)
+from alberta_framework.benchmarks.micro_continual import _require_positive_int32
+from alberta_framework.benchmarks.upgd_ipmnist import (
+    _require_finite_real as require_ipmnist_real,
+)
+from alberta_framework.benchmarks.upgd_label_emnist import _validated_hyperparameter
+from alberta_framework.core.baseline_optimizers import (
+    _require_int32 as require_baseline_int,
+)
+from alberta_framework.core.intelligence_amplification import (
+    _require_int32 as require_ia_int,
+)
+from alberta_framework.core.learners import _require_int32 as require_learner_int
+from alberta_framework.core.off_policy_td import _validated_config_float
+from alberta_framework.core.optimizers import _require_int32 as require_optimizer_int
+from alberta_framework.core.reward_model import _require_int32 as require_reward_int
+from alberta_framework.evaluation.continual_ia import _require_integer
+from alberta_framework.evaluation.ftl_decision_fidelity import (
+    _require_int32 as require_fidelity_int,
+)
+
+
+class _HostileType(type):
+    calls = 0
+
+    def __hash__(cls) -> int:  # pragma: no cover - must not execute
+        type(cls).calls += 1
+        raise AssertionError("metaclass hash hook must not run")
+
+    def __eq__(cls, other: object) -> bool:  # pragma: no cover - must not execute
+        type(cls).calls += 1
+        raise AssertionError("metaclass equality hook must not run")
+
+
+class _HostileValue(metaclass=_HostileType):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_calls() -> None:
+    _HostileType.calls = 0
+
+
+def test_numeric_gates_reject_before_hostile_metaclass_dispatch() -> None:
+    hostile = _HostileValue()
+    checks = (
+        lambda: require_ia_int("value", hostile, minimum=1),
+        lambda: require_learner_int("value", hostile, minimum=1),
+        lambda: require_baseline_int("value", hostile, minimum=1),
+        lambda: require_optimizer_int("value", hostile, minimum=1),
+        lambda: require_reward_int("value", hostile, minimum=1),
+        lambda: _validated_config_float("value", hostile),
+        lambda: _require_positive_int32(hostile, name="value"),
+        lambda: require_ipmnist_real("value", hostile),
+        lambda: _validated_hyperparameter("step_size", hostile),
+        lambda: _validated_wall_clock_seconds(hostile, "record"),
+        lambda: _require_integer("value", hostile, minimum=0),
+        lambda: require_fidelity_int("value", hostile, minimum=0),
+    )
+    for check in checks:
+        with pytest.raises((TypeError, ValueError)):
+            check()
+    assert _HostileType.calls == 0
+
+
+def test_json_gates_reject_before_hostile_metaclass_dispatch() -> None:
+    hostile = _HostileValue()
+    checks = (
+        (lambda: campaign_plain(hostile), ForagerMatchedCampaignError),
+        (lambda: _plain_json(hostile), ForagerMatchedQualificationError),
+        (lambda: seal_plain(hostile), ForagerMatchedSealError),
+        (lambda: _validate_json_value(hostile), ForagerRngParityError),
+    )
+    for check, error in checks:
+        with pytest.raises(error):
+            check()
+    assert _HostileType.calls == 0


### PR DESCRIPTION
## Summary
- replace equality/hash-based type membership with identity-only dispatch across the #1383–#1397 validation wave
- reject hostile metaclass values without invoking user-controlled `__eq__` or `__hash__`
- tighten RNG-parity JSON validation to exact built-in container types

## Verification
- `237 passed` across the affected resource, record-boundary, and hostile-validation suites
- Ruff passes on all changed files

This is a narrow validation hardening correction. It does not change or promote any evidence artifact.