### PR TITLE
fix(validation): finish hostile identity audit

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -239,7 +239,7 @@ def _require_real(value: Any, *, name: str) -> float:
     # Preserve the historical acceptance of NumPy's concrete float64 scalar,
     # which is a float subtype, without admitting arbitrary user-defined
     # int/float subclasses with overloaded conversion or arithmetic hooks.
-    if actual_type not in (int, float, np.float64):
+    if actual_type is not int and actual_type is not float and actual_type is not np.float64:
         raise ValueError(f"{name} must be a real number")
     try:
         converted = float(cast(Any, value))
@@ -636,12 +636,15 @@ class ForagerFeatureState:
     def __post_init__(self) -> None:
         if type(self.last_action) is not int or isinstance(self.last_action, bool):
             raise ValueError("last_action must be an integer")
-        if type(self.last_reward) not in (int, float) or not math.isfinite(self.last_reward):
+        if (
+            type(self.last_reward) is not int
+            and type(self.last_reward) is not float
+        ) or not math.isfinite(self.last_reward):
             raise ValueError("last_reward must be a finite float")
         if type(self.reward_traces) is not tuple:
             raise ValueError("reward_traces must be a tuple")
         for trace in self.reward_traces:
-            if type(trace) not in (int, float) or not math.isfinite(trace):
+            if (type(trace) is not int and type(trace) is not float) or not math.isfinite(trace):
                 raise ValueError("reward_traces values must be finite floats")
 
 

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -245,7 +245,7 @@ def _validated_wall_clock_seconds(value: object, path: Path | str) -> float:
     message = f"{path}: wall_clock_seconds must be a finite, non-negative number"
     if type(value) is not int and type(value) is not float:
         raise ValueError(message)
-    numeric_value = cast(int | float, value)
+    numeric_value = value
     try:
         wall_clock_seconds = float(numeric_value)
     except (OverflowError, ValueError) as exc:
@@ -7978,7 +7978,7 @@ def _is_finite_json_number(value: object) -> bool:
     if type(value) is not int and type(value) is not float:
         return False
     try:
-        return math.isfinite(float(cast(int | float, value)))
+        return math.isfinite(float(value))
     except (OverflowError, ValueError):
         return False
 

--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -206,7 +206,7 @@ def _require_builtin_finite_real(value: object, *, context: str) -> float:
     """Canonicalize a result scalar without invoking numeric subclass hooks."""
     if type(value) is not int and type(value) is not float:
         raise ValueError(f"{context} must be a finite built-in real number")
-    number = float(cast("int | float", value))
+    number = float(value)
     if not math.isfinite(number):
         raise ValueError(f"{context} must be a finite built-in real number")
     return number

--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -305,7 +305,7 @@ def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
 def _require_finite_real(name: str, value: object) -> float:
     if type(value) is not int and type(value) is not float:
         raise ValueError(f"{name} must be a finite real number")
-    number = float(cast("int | float", value))
+    number = float(value)
     if not math.isfinite(number):
         raise ValueError(f"{name} must be a finite real number")
     return number

--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -456,7 +456,7 @@ def build_schedule(key: Array, config: LabelEMNISTConfig, n_train: int) -> Label
 def _require_finite_real(name: str, value: object) -> float:
     if type(value) is not int and type(value) is not float:
         raise ValueError(f"{name} must be a finite real number")
-    number = float(cast("int | float", value))
+    number = float(value)
     if not math.isfinite(number):
         raise ValueError(f"{name} must be a finite real number")
     return number

--- a/tests/test_forager_dataclasses_hostile_validation.py
+++ b/tests/test_forager_dataclasses_hostile_validation.py
@@ -106,3 +106,34 @@ def test_paper_reference_target_rejects_invalid_inputs() -> None:
             central_estimate=1.0,
             privileged="no",  # type: ignore[arg-type]
         )
+
+
+def test_numeric_records_reject_before_hostile_metaclass_dispatch() -> None:
+    class HostileType(type):
+        calls = 0
+
+        def __hash__(cls) -> int:  # pragma: no cover - must not execute
+            type(cls).calls += 1
+            raise AssertionError("metaclass hash hook must not run")
+
+        def __eq__(cls, _other: object) -> bool:  # pragma: no cover - must not execute
+            type(cls).calls += 1
+            raise AssertionError("metaclass equality hook must not run")
+
+    class HostileValue(metaclass=HostileType):
+        pass
+
+    hostile = HostileValue()
+    checks = (
+        lambda: ForagerFeatureState(last_action=0, last_reward=hostile, reward_traces=()),
+        lambda: ForagerFeatureState(last_action=0, last_reward=0.0, reward_traces=(hostile,)),
+        lambda: PaperReferenceTarget(
+            method="method_1",
+            metric="metric_1",
+            central_estimate=hostile,
+        ),
+    )
+    for check in checks:
+        with pytest.raises(ValueError):
+            check()
+    assert HostileType.calls == 0


### PR DESCRIPTION
## Summary
- close the omitted hostile-metaclass dispatches in the #1386 Forager record surface after #1440
- add a failing-first regression covering state rewards, reward traces, and paper reference targets
- remove the five redundant casts introduced by #1440 so strict mypy is green on exact main

## Verification
- `324 passed` across the complete #1383–#1397 affected resource, record-boundary, and hostile-validation panel
- `ruff check` passes on all changed files
- `mypy` passes across 174 source files
- `git diff --check` passes

No evidence artifacts are changed or promoted.