### PR TITLE
fix(benchmarks): restore strict mypy launch gate

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -245,7 +245,7 @@ def _validated_wall_clock_seconds(value: object, path: Path | str) -> float:
     message = f"{path}: wall_clock_seconds must be a finite, non-negative number"
     if type(value) is not int and type(value) is not float:
         raise ValueError(message)
-    numeric_value = cast(int | float, value)
+    numeric_value = value
     try:
         wall_clock_seconds = float(numeric_value)
     except (OverflowError, ValueError) as exc:
@@ -7978,7 +7978,7 @@ def _is_finite_json_number(value: object) -> bool:
     if type(value) is not int and type(value) is not float:
         return False
     try:
-        return math.isfinite(float(cast(int | float, value)))
+        return math.isfinite(float(value))
     except (OverflowError, ValueError):
         return False
 

--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -206,7 +206,7 @@ def _require_builtin_finite_real(value: object, *, context: str) -> float:
     """Canonicalize a result scalar without invoking numeric subclass hooks."""
     if type(value) is not int and type(value) is not float:
         raise ValueError(f"{context} must be a finite built-in real number")
-    number = float(cast("int | float", value))
+    number = float(value)
     if not math.isfinite(number):
         raise ValueError(f"{context} must be a finite built-in real number")
     return number

--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -305,7 +305,7 @@ def _require_int32(name: str, value: object, *, minimum: int = 1) -> int:
 def _require_finite_real(name: str, value: object) -> float:
     if type(value) is not int and type(value) is not float:
         raise ValueError(f"{name} must be a finite real number")
-    number = float(cast("int | float", value))
+    number = float(value)
     if not math.isfinite(number):
         raise ValueError(f"{name} must be a finite real number")
     return number

--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -456,7 +456,7 @@ def build_schedule(key: Array, config: LabelEMNISTConfig, n_train: int) -> Label
 def _require_finite_real(name: str, value: object) -> float:
     if type(value) is not int and type(value) is not float:
         raise ValueError(f"{name} must be a finite real number")
-    number = float(cast("int | float", value))
+    number = float(value)
     if not math.isfinite(number):
         raise ValueError(f"{name} must be a finite real number")
     return number

--- a/tests/test_ipmnist_screening_provenance.py
+++ b/tests/test_ipmnist_screening_provenance.py
@@ -360,7 +360,11 @@ def test_v2_writer_and_loader_bind_registered_mechanism(
 ) -> None:
     result = _result()
     if field == "base_learner":
-        changed_result = replace(result, base_learner="forged")
+        # Construction now rejects unsupported learner identities before the
+        # writer boundary.  Simulate a hostile adopted instance so this test
+        # continues to prove that the writer independently binds the registry.
+        changed_result = replace(result)
+        object.__setattr__(changed_result, "base_learner", "forged")
         replacement: object = "forged"
     else:
         changed_result = replace(
@@ -396,8 +400,11 @@ def test_v2_writer_and_loader_reject_registered_float_type_aliases(
         _result(),
         config_name=spec.name,
         base_learner=spec.base_learner,
-        hyperparameters=aliased_hyperparameters,
+        hyperparameters=dict(spec.hyperparameters),
     )
+    # Bypass the now-stricter constructor to retain an independent writer
+    # boundary test for JSON bool/int aliases of registered float fields.
+    object.__setattr__(result, "hyperparameters", aliased_hyperparameters)
     with pytest.raises(ValueError, match="registered arm"):
         screening.shard_payload(
             result,
@@ -445,8 +452,11 @@ def test_v2_curves_reject_boolean_and_string_numbers(tmp_path: Path, value: obje
     with pytest.raises(ValueError, match="list of finite JSON numbers"):
         screening.load_shard(path)
 
-    bool_result = replace(
-        _result(), per_task_accuracy=np.asarray([True, False, True], dtype=np.bool_)
+    bool_result = replace(_result())
+    object.__setattr__(
+        bool_result,
+        "per_task_accuracy",
+        np.asarray([True, False, True], dtype=np.bool_),
     )
     with pytest.raises(ValueError, match="per_task_accuracy"):
         screening.shard_payload(
@@ -472,7 +482,8 @@ def test_v2_writer_and_loader_reject_out_of_domain_curves(
 ) -> None:
     curve = np.full(SMALL.n_tasks, 0.5, dtype=np.float64)
     curve[1] = invalid
-    result = replace(_result(), **{field: curve})
+    result = replace(_result())
+    object.__setattr__(result, field, curve)
     with pytest.raises(ValueError, match=field):
         screening.shard_payload(
             result,
@@ -495,12 +506,13 @@ def test_v2_writer_and_atomic_publish_reject_nonfinite_json(
 ) -> None:
     result = _result()
     if failure == "curve":
-        result = replace(
+        object.__setattr__(
             result,
-            per_task_loss=np.asarray([0.1, np.nan, 0.1], dtype=np.float64),
+            "per_task_loss",
+            np.asarray([0.1, np.nan, 0.1], dtype=np.float64),
         )
     else:
-        result = replace(result, wall_clock_seconds=float("inf"))
+        object.__setattr__(result, "wall_clock_seconds", float("inf"))
     with pytest.raises(ValueError, match="finite"):
         screening.shard_payload(
             result,


### PR DESCRIPTION
Restores the strict prereg launch typecheck on current main.

- removes five redundant `int | float` casts after exact built-in type gates (the three imported by the prereg driver plus two additional failures found by cold full mypy)
- preserves runtime behavior and hostile-subclass rejection
- repairs provenance writer tests whose forged values became unreachable after constructor hardening, by explicitly simulating hostile adopted frozen state at the writer boundary

Verification:
- cold imported-driver mypy: clean
- cold full strict mypy: 174 source files clean
- prereg/hostile focused panel: 144 passed before exposing pre-existing fixture drift
- corrected provenance panel: 52 passed
- Ruff: clean

No benchmark execution or output changes.