### PR TITLE
fix(core): preserve canonical UPGD identity field errors

### DIFF
--- a/alberta_framework/core/canonical_upgd.py
+++ b/alberta_framework/core/canonical_upgd.py
@@ -1192,11 +1192,10 @@ def _require_exact_str_strict(name: object, value: object) -> str:
 def _require_exact_identity(value: Any, path: object, expected: str) -> str:
     host_path = _require_exact_str_strict("path", path)
     host_expected = _require_exact_str_strict("expected", expected)
-    host_value = _require_exact_str_strict("value", value)
+    host_value = _require_exact_str_strict(host_path, value)
     if host_value != host_expected:
         raise ValueError(f"{host_path} must equal the canonical identity '{host_expected}'")
     return host_value
-    return value
 
 
 def _require_exact_parity(value: Any, path: str, expected: bool) -> bool:

--- a/tests/test_canonical_upgd_validation.py
+++ b/tests/test_canonical_upgd_validation.py
@@ -692,7 +692,17 @@ def _legal_official_resources(**overrides: object) -> OfficialAdaUPGDResources:
         (_legal_alberta_resources, "profile", _HostileStringIdentity(ALBERTA_ADAUPGD_PROFILE)),
         (_legal_alberta_resources, "official_reference_parity", True),
         (_legal_official_resources, "profile", ALBERTA_ADAUPGD_PROFILE),
+        (
+            _legal_official_resources,
+            "profile",
+            _HostileStringIdentity(OFFICIAL_ADAUPGD_PROFILE),
+        ),
         (_legal_official_resources, "source_commit", "main"),
+        (
+            _legal_official_resources,
+            "source_commit",
+            _HostileStringIdentity(OFFICIAL_ADAUPGD_COMMIT),
+        ),
         (
             _legal_official_resources,
             "source_path",


### PR DESCRIPTION
## Summary
- retain the validated resource-field path when exact-string validation rejects hostile string subclasses
- preserve hook-free exact-type rejection while restoring field-specific errors
- cover all canonical AdaUPGD resource provenance strings (`profile`, `source_commit`, and `source_path`)
- remove one unreachable leftover return

## Reproduction and verification
- retained test module was red on current main: 2 failures (`profile`, `source_path`) with generic `value must be an exact string`
- `71 passed` in `tests/test_canonical_upgd_validation.py`
- `171 passed` across canonical AdaUPGD/UPGD and hostile-validation suites
- Ruff passed on changed files
- full mypy passed (174 source files)

No benchmark, output, or evidence artifact changed.