### PR TITLE
fix(benchmarks): reject bool open-screen v3 scorer horizon identities

### DIFF
--- a/alberta_framework/benchmarks/_foragax_open_screen_scorer_v3.py
+++ b/alberta_framework/benchmarks/_foragax_open_screen_scorer_v3.py
@@ -26,6 +26,24 @@ MAX_UNCOMPRESSED_BYTES = 64 * 1024**2
 MAX_REWARD_MEMBER_BYTES = 4 * 1024**2
 
 
+def _require_host_int(name: str, value: object, *, minimum: int) -> int:
+    """Reject bool/float aliases that ordered comparisons treat as legal counts."""
+    if type(name) is not str:
+        raise ValueError("name must be an exact string")
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _require_seed_list(seeds: object) -> list[int]:
+    if type(seeds) is not list:
+        raise ValueError("seeds must be a list of built-in integers")
+    return [
+        _require_host_int(f"seeds[{index}]", seed, minimum=0)
+        for index, seed in enumerate(seeds)
+    ]
+
+
 def _sha256_stream(stream: BinaryIO) -> str:
     digest = hashlib.sha256()
     stream.seek(0)
@@ -40,6 +58,7 @@ def _validate_reward_header(
     horizon: int,
     path: Path,
 ) -> None:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     with archive.open(info, "r") as member:
         version = np.lib.format.read_magic(member)
         if version == (1, 0):
@@ -67,6 +86,7 @@ def _validate_reward_header(
 
 
 def _validate_zip(stream: BinaryIO, path: Path, horizon: int) -> None:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     stream.seek(0)
     try:
         with zipfile.ZipFile(stream, "r") as archive:
@@ -114,6 +134,7 @@ def _load_reward_archive(
     path: Path,
     horizon: int,
 ) -> tuple[np.ndarray, str, int]:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     descriptor = os.open(path, flags)
     with os.fdopen(descriptor, "rb") as stream:
@@ -153,6 +174,7 @@ def _load_reward_archive(
 
 def score_rewards(rewards: np.ndarray, horizon: int) -> dict[str, Any]:
     """Compute the frozen scorer with bit-identical arithmetic."""
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     if rewards.shape != (horizon,):
         raise ValueError(f"raw reward array must have exact shape ({horizon},)")
     if rewards.dtype.kind not in {"i", "u", "f"}:
@@ -213,6 +235,8 @@ def score_archives(
     seeds: list[int],
     horizon: int,
 ) -> dict[str, Any]:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
+    seeds = _require_seed_list(seeds)
     root = payload_root.resolve(strict=True)
     relative_root = _relative(result_root)
     records: list[dict[str, Any]] = []

--- a/tests/test_foragax_open_screen_scorer_v3.py
+++ b/tests/test_foragax_open_screen_scorer_v3.py
@@ -1,0 +1,45 @@
+"""Host-boundary identities for the pinned Foragax open-screen v3 scorer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks._foragax_open_screen_scorer_v3 import (
+    score_archives,
+    score_rewards,
+)
+
+
+@pytest.mark.parametrize("horizon", [True, False, 0, -1, 1.0])
+def test_score_rewards_rejects_noncanonical_horizon_before_aggregates(
+    horizon: object,
+) -> None:
+    with pytest.raises(ValueError, match="horizon"):
+        score_rewards(np.zeros(1, dtype=np.float64), horizon)  # type: ignore[arg-type]
+
+
+def test_score_rewards_keeps_builtin_horizon_identity() -> None:
+    scored = score_rewards(np.zeros(1, dtype=np.float64), 1)
+    assert scored["reward_shape"] == [1]
+    assert type(scored["reward_shape"][0]) is int
+
+
+@pytest.mark.parametrize("horizon", [True, False, 0, -1, 1.0])
+def test_score_archives_rejects_noncanonical_horizon_before_payload_io(
+    tmp_path: Path,
+    horizon: object,
+) -> None:
+    with pytest.raises(ValueError, match="horizon"):
+        score_archives(tmp_path, "results", [0], horizon)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("seeds", [True, False, 0, [True], [False], [1.0], [-1]])
+def test_score_archives_rejects_noncanonical_seeds_before_payload_io(
+    tmp_path: Path,
+    seeds: object,
+) -> None:
+    with pytest.raises(ValueError, match="seeds"):
+        score_archives(tmp_path, "results", seeds, 1)  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #1447.

## What changed

Pinned Foragax open-screen **v3** scorer host APIs now reject boolean and non-canonical horizon / seed identities before a published score can mint a false window.

On `origin/main` `d1f60f9`:

- `score_rewards(zeros(1), True)` returned `reward_shape: [True]` and JSON `{"horizon": true}`;
- `score_archives(..., horizon=True)` would publish that boolean as the scoring window;
- `seeds=[True]` would look up `True.npz`.

Legal `horizon=1` / `seeds=[0]` still score. CLI `--horizon` / `--seed` already coerce through argparse. Sibling #1445 covers `_foragax_open_screen_scorer.py` only.

## Scope

- `alberta_framework/benchmarks/_foragax_open_screen_scorer_v3.py`
- `tests/test_foragax_open_screen_scorer_v3.py`

## Why this is unowned

No open ASI PRs touch this file. Zero issue/PR hits on `_foragax_open_screen_scorer_v3.py`. Not on do-not-twin. Not #1431. #1445 owns the v1 scorer only.

## Verification

Exact candidate head: `0b5451e5715fd3594b08d5a680320766b5960e3e`
Base: `d1f60f9`

- Red on base: `score_rewards(np.zeros(1), True)` → `reward_shape [True]`
- `PYTHONPATH=<worktree> pytest tests/test_foragax_open_screen_scorer_v3.py -q -o addopts=""` → 18 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary / measurement-trustworthiness validation only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0b5451e5715fd3594b08d5a680320766b5960e3e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
