### PR TITLE
fix(ci): bind prereg uv by executable digest

### DIFF
--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -173,16 +173,19 @@ jobs:
         shell: bash
         env:
           UV_PATH: ${{ steps.uv.outputs.uv-path }}
+          UV_SHA256: "613eda52458300fa7af03231280d252b8cde8f96df56e43d10c0bcd0d583afea"
         run: |
           set -euo pipefail
           if [[ "$UV_PATH" != /* || ! -x "$UV_PATH" ]]; then
             echo "setup-uv did not return an absolute executable uv path" >&2
             exit 1
           fi
-          if [[ "$("$UV_PATH" --version)" != "uv 0.9.24" ]]; then
-            echo "setup-uv did not install exact uv 0.9.24" >&2
+          actual_uv_sha256="$(shasum -a 256 "$UV_PATH" | awk '{print $1}')"
+          if [[ "$actual_uv_sha256" != "$UV_SHA256" ]]; then
+            echo "setup-uv executable digest differs from official uv 0.9.24" >&2
             exit 1
           fi
+          "$UV_PATH" --version
           if [[ "$PYTHONOPTIMIZE" != "0" ]]; then
             echo "PYTHONOPTIMIZE must be exactly zero" >&2
             exit 1

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -113,6 +113,16 @@ def test_prereg_workflow_invokes_only_setup_uv_pinned_binary() -> None:
     assert "      - name: Set up exact uv 0.9.24\n        id: uv\n" in workflow
     assert 'UV_PATH: ${{ steps.uv.outputs.uv-path }}' in workflow
     assert '[[ "$UV_PATH" != /* || ! -x "$UV_PATH" ]]' in workflow
+    assert (
+        'UV_SHA256: "613eda52458300fa7af03231280d252b8cde8f96df56e43d10c0bcd0d583afea"'
+        in workflow
+    )
+    assert 'actual_uv_sha256="$(shasum -a 256 "$UV_PATH" | awk \'{print $1}\')"' in workflow
+    assert '[[ "$actual_uv_sha256" != "$UV_SHA256" ]]' in workflow
+    # Official release builds may decorate their display version with commit
+    # metadata. Identity is the pinned executable digest, not presentation.
+    assert '"$UV_PATH" --version' in workflow
+    assert '[[ "$("$UV_PATH" --version)" != "uv 0.9.24" ]]' not in workflow
     shell_lines = [line.strip() for line in workflow.splitlines()]
     assert not any(line.startswith("uv ") or "$(uv " in line for line in shell_lines)
     assert sum('"$UV_PATH" ' in line for line in shell_lines) >= 13


### PR DESCRIPTION
Attempt 2 failed before sync because official uv release binaries may decorate `--version` with embedded commit metadata, making byte-equality with `uv 0.9.24` brittle even when setup-uv installs the correct pinned executable.

This keeps the absolute/executable path gate and replaces display-string identity with the independently verified SHA-256 of the official uv 0.9.24 aarch64-apple-darwin executable: `613eda52458300fa7af03231280d252b8cde8f96df56e43d10c0bcd0d583afea`. The informational version is logged only after digest verification. Tests pin the action/version/path/digest and forbid restoration of the brittle equality.

Verification:
- failing test first against old workflow
- prereg workflow tests: 126 passed
- actionlint: clean
- Ruff: clean
- cold driver mypy: clean
- independently downloaded official executable digest matches

No benchmark, output, tag, comment, authorization, or dispatch.