### PR TITLE
fix(benchmarks): complete open-screen scorer host contracts

### DIFF
--- a/alberta_framework/benchmarks/_foragax_open_screen_scorer.py
+++ b/alberta_framework/benchmarks/_foragax_open_screen_scorer.py
@@ -25,6 +25,24 @@ MAX_UNCOMPRESSED_BYTES = 64 * 1024**2
 MAX_REWARD_MEMBER_BYTES = 4 * 1024**2
 
 
+def _require_host_int(name: str, value: object, *, minimum: int) -> int:
+    """Reject bool/float aliases that ordered comparisons treat as legal counts."""
+    if type(name) is not str:
+        raise ValueError("name must be an exact string")
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _require_seed_list(seeds: object) -> list[int]:
+    if type(seeds) is not list:
+        raise ValueError("seeds must be a list of built-in integers")
+    return [
+        _require_host_int(f"seeds[{index}]", seed, minimum=0)
+        for index, seed in enumerate(seeds)
+    ]
+
+
 def _sha256_stream(stream: BinaryIO) -> str:
     digest = hashlib.sha256()
     stream.seek(0)
@@ -39,6 +57,7 @@ def _validate_reward_header(
     horizon: int,
     path: Path,
 ) -> None:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     with archive.open(info, "r") as member:
         version = np.lib.format.read_magic(member)
         if version == (1, 0):
@@ -66,6 +85,7 @@ def _validate_reward_header(
 
 
 def _validate_zip(stream: BinaryIO, path: Path, horizon: int) -> None:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     stream.seek(0)
     with zipfile.ZipFile(stream, "r") as archive:
         infos = archive.infolist()
@@ -110,6 +130,7 @@ def _load_reward_archive(
     path: Path,
     horizon: int,
 ) -> tuple[np.ndarray, str, int]:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     descriptor = os.open(path, flags)
     with os.fdopen(descriptor, "rb") as stream:
@@ -149,6 +170,7 @@ def _load_reward_archive(
 
 def score_rewards(rewards: np.ndarray, horizon: int) -> dict[str, Any]:
     """Compute the frozen scorer with bit-identical arithmetic."""
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     if rewards.shape != (horizon,):
         raise ValueError(f"raw reward array must have exact shape ({horizon},)")
     if rewards.dtype.kind not in {"i", "u", "f"}:
@@ -209,6 +231,8 @@ def score_archives(
     seeds: list[int],
     horizon: int,
 ) -> dict[str, Any]:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
+    seeds = _require_seed_list(seeds)
     root = payload_root.resolve(strict=True)
     relative_root = _relative(result_root)
     records: list[dict[str, Any]] = []

--- a/alberta_framework/benchmarks/_foragax_open_screen_scorer.py
+++ b/alberta_framework/benchmarks/_foragax_open_screen_scorer.py
@@ -37,10 +37,19 @@ def _require_host_int(name: str, value: object, *, minimum: int) -> int:
 def _require_seed_list(seeds: object) -> list[int]:
     if type(seeds) is not list:
         raise ValueError("seeds must be a list of built-in integers")
-    return [
+    canonical = [
         _require_host_int(f"seeds[{index}]", seed, minimum=0)
         for index, seed in enumerate(seeds)
     ]
+    if not canonical or len(canonical) != len(set(canonical)):
+        raise ValueError("seeds must be nonempty and unique")
+    return canonical
+
+
+def _require_payload_root(value: object) -> Path:
+    if not isinstance(value, Path) or not type(value).__module__.startswith("pathlib"):
+        raise ValueError("payload_root must be a pathlib Path")
+    return Path(value)
 
 
 def _sha256_stream(stream: BinaryIO) -> str:
@@ -171,10 +180,14 @@ def _load_reward_archive(
 def score_rewards(rewards: np.ndarray, horizon: int) -> dict[str, Any]:
     """Compute the frozen scorer with bit-identical arithmetic."""
     horizon = _require_host_int("horizon", horizon, minimum=1)
+    if type(rewards) is not np.ndarray:
+        raise ValueError("raw rewards must be an exact numpy ndarray")
     if rewards.shape != (horizon,):
         raise ValueError(f"raw reward array must have exact shape ({horizon},)")
     if rewards.dtype.kind not in {"i", "u", "f"}:
         raise ValueError("raw rewards must have a numeric dtype")
+    if rewards.nbytes > MAX_REWARD_MEMBER_BYTES:
+        raise ValueError("raw rewards exceed the scorer byte bound")
     if not bool(np.all(np.isfinite(rewards))):
         raise ValueError("raw rewards must all be finite")
     rewards64 = rewards.astype(np.float64, copy=False)
@@ -213,6 +226,8 @@ def score_rewards(rewards: np.ndarray, horizon: int) -> dict[str, Any]:
 
 
 def _relative(value: str) -> PurePosixPath:
+    if type(value) is not str:
+        raise ValueError("result root must be an exact string")
     path = PurePosixPath(value)
     if (
         not path.parts
@@ -233,6 +248,7 @@ def score_archives(
 ) -> dict[str, Any]:
     horizon = _require_host_int("horizon", horizon, minimum=1)
     seeds = _require_seed_list(seeds)
+    payload_root = _require_payload_root(payload_root)
     root = payload_root.resolve(strict=True)
     relative_root = _relative(result_root)
     records: list[dict[str, Any]] = []

--- a/alberta_framework/benchmarks/_foragax_open_screen_scorer_v3.py
+++ b/alberta_framework/benchmarks/_foragax_open_screen_scorer_v3.py
@@ -26,6 +26,24 @@ MAX_UNCOMPRESSED_BYTES = 64 * 1024**2
 MAX_REWARD_MEMBER_BYTES = 4 * 1024**2
 
 
+def _require_host_int(name: str, value: object, *, minimum: int) -> int:
+    """Reject bool/float aliases that ordered comparisons treat as legal counts."""
+    if type(name) is not str:
+        raise ValueError("name must be an exact string")
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _require_seed_list(seeds: object) -> list[int]:
+    if type(seeds) is not list:
+        raise ValueError("seeds must be a list of built-in integers")
+    return [
+        _require_host_int(f"seeds[{index}]", seed, minimum=0)
+        for index, seed in enumerate(seeds)
+    ]
+
+
 def _sha256_stream(stream: BinaryIO) -> str:
     digest = hashlib.sha256()
     stream.seek(0)
@@ -40,6 +58,7 @@ def _validate_reward_header(
     horizon: int,
     path: Path,
 ) -> None:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     with archive.open(info, "r") as member:
         version = np.lib.format.read_magic(member)
         if version == (1, 0):
@@ -67,6 +86,7 @@ def _validate_reward_header(
 
 
 def _validate_zip(stream: BinaryIO, path: Path, horizon: int) -> None:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     stream.seek(0)
     try:
         with zipfile.ZipFile(stream, "r") as archive:
@@ -114,6 +134,7 @@ def _load_reward_archive(
     path: Path,
     horizon: int,
 ) -> tuple[np.ndarray, str, int]:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     descriptor = os.open(path, flags)
     with os.fdopen(descriptor, "rb") as stream:
@@ -153,6 +174,7 @@ def _load_reward_archive(
 
 def score_rewards(rewards: np.ndarray, horizon: int) -> dict[str, Any]:
     """Compute the frozen scorer with bit-identical arithmetic."""
+    horizon = _require_host_int("horizon", horizon, minimum=1)
     if rewards.shape != (horizon,):
         raise ValueError(f"raw reward array must have exact shape ({horizon},)")
     if rewards.dtype.kind not in {"i", "u", "f"}:
@@ -213,6 +235,8 @@ def score_archives(
     seeds: list[int],
     horizon: int,
 ) -> dict[str, Any]:
+    horizon = _require_host_int("horizon", horizon, minimum=1)
+    seeds = _require_seed_list(seeds)
     root = payload_root.resolve(strict=True)
     relative_root = _relative(result_root)
     records: list[dict[str, Any]] = []

--- a/alberta_framework/benchmarks/_foragax_open_screen_scorer_v3.py
+++ b/alberta_framework/benchmarks/_foragax_open_screen_scorer_v3.py
@@ -38,10 +38,19 @@ def _require_host_int(name: str, value: object, *, minimum: int) -> int:
 def _require_seed_list(seeds: object) -> list[int]:
     if type(seeds) is not list:
         raise ValueError("seeds must be a list of built-in integers")
-    return [
+    canonical = [
         _require_host_int(f"seeds[{index}]", seed, minimum=0)
         for index, seed in enumerate(seeds)
     ]
+    if not canonical or len(canonical) != len(set(canonical)):
+        raise ValueError("seeds must be nonempty and unique")
+    return canonical
+
+
+def _require_payload_root(value: object) -> Path:
+    if not isinstance(value, Path) or not type(value).__module__.startswith("pathlib"):
+        raise ValueError("payload_root must be a pathlib Path")
+    return Path(value)
 
 
 def _sha256_stream(stream: BinaryIO) -> str:
@@ -175,10 +184,14 @@ def _load_reward_archive(
 def score_rewards(rewards: np.ndarray, horizon: int) -> dict[str, Any]:
     """Compute the frozen scorer with bit-identical arithmetic."""
     horizon = _require_host_int("horizon", horizon, minimum=1)
+    if type(rewards) is not np.ndarray:
+        raise ValueError("raw rewards must be an exact numpy ndarray")
     if rewards.shape != (horizon,):
         raise ValueError(f"raw reward array must have exact shape ({horizon},)")
     if rewards.dtype.kind not in {"i", "u", "f"}:
         raise ValueError("raw rewards must have a numeric dtype")
+    if rewards.nbytes > MAX_REWARD_MEMBER_BYTES:
+        raise ValueError("raw rewards exceed the scorer byte bound")
     if not bool(np.all(np.isfinite(rewards))):
         raise ValueError("raw rewards must all be finite")
     rewards64 = rewards.astype(np.float64, copy=False)
@@ -217,6 +230,8 @@ def score_rewards(rewards: np.ndarray, horizon: int) -> dict[str, Any]:
 
 
 def _relative(value: str) -> PurePosixPath:
+    if type(value) is not str:
+        raise ValueError("result root must be an exact string")
     path = PurePosixPath(value)
     if (
         not path.parts
@@ -237,6 +252,7 @@ def score_archives(
 ) -> dict[str, Any]:
     horizon = _require_host_int("horizon", horizon, minimum=1)
     seeds = _require_seed_list(seeds)
+    payload_root = _require_payload_root(payload_root)
     root = payload_root.resolve(strict=True)
     relative_root = _relative(result_root)
     records: list[dict[str, Any]] = []

--- a/tests/test_foragax_open_screen_scorer.py
+++ b/tests/test_foragax_open_screen_scorer.py
@@ -1,0 +1,45 @@
+"""Host-boundary identities for the pinned Foragax open-screen scorer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks._foragax_open_screen_scorer import (
+    score_archives,
+    score_rewards,
+)
+
+
+@pytest.mark.parametrize("horizon", [True, False, 0, -1, 1.0])
+def test_score_rewards_rejects_noncanonical_horizon_before_aggregates(
+    horizon: object,
+) -> None:
+    with pytest.raises(ValueError, match="horizon"):
+        score_rewards(np.zeros(1, dtype=np.float64), horizon)  # type: ignore[arg-type]
+
+
+def test_score_rewards_keeps_builtin_horizon_identity() -> None:
+    scored = score_rewards(np.zeros(1, dtype=np.float64), 1)
+    assert scored["reward_shape"] == [1]
+    assert type(scored["reward_shape"][0]) is int
+
+
+@pytest.mark.parametrize("horizon", [True, False, 0, -1, 1.0])
+def test_score_archives_rejects_noncanonical_horizon_before_payload_io(
+    tmp_path: Path,
+    horizon: object,
+) -> None:
+    with pytest.raises(ValueError, match="horizon"):
+        score_archives(tmp_path, "results", [0], horizon)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("seeds", [True, False, 0, [True], [False], [1.0], [-1]])
+def test_score_archives_rejects_noncanonical_seeds_before_payload_io(
+    tmp_path: Path,
+    seeds: object,
+) -> None:
+    with pytest.raises(ValueError, match="seeds"):
+        score_archives(tmp_path, "results", seeds, 1)  # type: ignore[arg-type]

--- a/tests/test_foragax_open_screen_scorer.py
+++ b/tests/test_foragax_open_screen_scorer.py
@@ -43,3 +43,38 @@ def test_score_archives_rejects_noncanonical_seeds_before_payload_io(
 ) -> None:
     with pytest.raises(ValueError, match="seeds"):
         score_archives(tmp_path, "results", seeds, 1)  # type: ignore[arg-type]
+
+
+class _RewardArraySubclass(np.ndarray):
+    pass
+
+
+@pytest.mark.parametrize(
+    "rewards",
+    [[0.0], np.zeros(1, dtype=np.float64).view(_RewardArraySubclass)],
+)
+def test_score_rewards_rejects_noncanonical_array_types(rewards: object) -> None:
+    with pytest.raises(ValueError, match="exact numpy ndarray"):
+        score_rewards(rewards, 1)  # type: ignore[arg-type]
+
+
+def test_score_rewards_rejects_arrays_beyond_archive_byte_bound() -> None:
+    rewards = np.zeros(4 * 1024**2 + 1, dtype=np.int8)
+    with pytest.raises(ValueError, match="byte bound"):
+        score_rewards(rewards, rewards.size)
+
+
+@pytest.mark.parametrize("seeds", [[], [0, 0]])
+def test_score_archives_requires_nonempty_unique_seeds(
+    tmp_path: Path,
+    seeds: list[int],
+) -> None:
+    with pytest.raises(ValueError, match="nonempty and unique"):
+        score_archives(tmp_path, "results", seeds, 1)
+
+
+def test_score_archives_rejects_noncanonical_path_identities(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="payload_root"):
+        score_archives(str(tmp_path), "results", [0], 1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="result root"):
+        score_archives(tmp_path, True, [0], 1)  # type: ignore[arg-type]

--- a/tests/test_foragax_open_screen_scorer_v3.py
+++ b/tests/test_foragax_open_screen_scorer_v3.py
@@ -1,0 +1,45 @@
+"""Host-boundary identities for the pinned Foragax open-screen v3 scorer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks._foragax_open_screen_scorer_v3 import (
+    score_archives,
+    score_rewards,
+)
+
+
+@pytest.mark.parametrize("horizon", [True, False, 0, -1, 1.0])
+def test_score_rewards_rejects_noncanonical_horizon_before_aggregates(
+    horizon: object,
+) -> None:
+    with pytest.raises(ValueError, match="horizon"):
+        score_rewards(np.zeros(1, dtype=np.float64), horizon)  # type: ignore[arg-type]
+
+
+def test_score_rewards_keeps_builtin_horizon_identity() -> None:
+    scored = score_rewards(np.zeros(1, dtype=np.float64), 1)
+    assert scored["reward_shape"] == [1]
+    assert type(scored["reward_shape"][0]) is int
+
+
+@pytest.mark.parametrize("horizon", [True, False, 0, -1, 1.0])
+def test_score_archives_rejects_noncanonical_horizon_before_payload_io(
+    tmp_path: Path,
+    horizon: object,
+) -> None:
+    with pytest.raises(ValueError, match="horizon"):
+        score_archives(tmp_path, "results", [0], horizon)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("seeds", [True, False, 0, [True], [False], [1.0], [-1]])
+def test_score_archives_rejects_noncanonical_seeds_before_payload_io(
+    tmp_path: Path,
+    seeds: object,
+) -> None:
+    with pytest.raises(ValueError, match="seeds"):
+        score_archives(tmp_path, "results", seeds, 1)  # type: ignore[arg-type]

--- a/tests/test_foragax_open_screen_scorer_v3.py
+++ b/tests/test_foragax_open_screen_scorer_v3.py
@@ -43,3 +43,38 @@ def test_score_archives_rejects_noncanonical_seeds_before_payload_io(
 ) -> None:
     with pytest.raises(ValueError, match="seeds"):
         score_archives(tmp_path, "results", seeds, 1)  # type: ignore[arg-type]
+
+
+class _RewardArraySubclass(np.ndarray):
+    pass
+
+
+@pytest.mark.parametrize(
+    "rewards",
+    [[0.0], np.zeros(1, dtype=np.float64).view(_RewardArraySubclass)],
+)
+def test_score_rewards_rejects_noncanonical_array_types(rewards: object) -> None:
+    with pytest.raises(ValueError, match="exact numpy ndarray"):
+        score_rewards(rewards, 1)  # type: ignore[arg-type]
+
+
+def test_score_rewards_rejects_arrays_beyond_archive_byte_bound() -> None:
+    rewards = np.zeros(4 * 1024**2 + 1, dtype=np.int8)
+    with pytest.raises(ValueError, match="byte bound"):
+        score_rewards(rewards, rewards.size)
+
+
+@pytest.mark.parametrize("seeds", [[], [0, 0]])
+def test_score_archives_requires_nonempty_unique_seeds(
+    tmp_path: Path,
+    seeds: list[int],
+) -> None:
+    with pytest.raises(ValueError, match="nonempty and unique"):
+        score_archives(tmp_path, "results", seeds, 1)
+
+
+def test_score_archives_rejects_noncanonical_path_identities(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="payload_root"):
+        score_archives(str(tmp_path), "results", [0], 1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="result root"):
+        score_archives(tmp_path, True, [0], 1)  # type: ignore[arg-type]


### PR DESCRIPTION
Contributor-preserving corrective successor to #1445 and #1448. Closes #1444 and #1447.

Preserves ss251/Cursor commits `979b4ca8` and `0b5451e5` for the v2 and v3 image scorers. Deep host-boundary review additionally rejects hostile/noncanonical reward containers and ndarray subclasses, reward buffers beyond the pinned 4 MiB archive bound, non-pathlib payload roots, non-string result roots, and empty/duplicate seed identities. Legal built-in horizons/seeds and scorer arithmetic remain unchanged.

Verification: 48 focused scorer tests passed; Ruff clean; mypy clean. The broader frozen-protocol tests correctly report scorer hash drift after source changes; pinned `outputs/**` were not modified or rerun, per immutability policy. No benchmarks or evidence runs.