### PR TITLE
fix(workflow): sync prereg test dependencies

### DIFF
--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -219,6 +219,7 @@ jobs:
           "$UV_PATH" sync \
             --locked \
             --python "$PYTHON_PATH" \
+            --extra dev \
             --extra research
           "$UV_PATH" run --no-sync python - \
             "$cpu_brand" "$RUNNER_TEMP/prereg-metadata/runner.json" <<'PY'

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -96,6 +96,11 @@ def test_issue184_workflow_pins_every_shell_mapping() -> None:
         < test_index
         < measurement_index
     )
+    sync_step = workflow[sync_index:authorization_index]
+    assert '"$UV_PATH" sync \\' in sync_step
+    assert "--locked" in sync_step
+    assert "--extra research" in sync_step
+    assert "--extra dev" in sync_step
     assert "python3 .github/scripts/ipmnist_prereg.py authorize" in workflow
     assert '"$UV_PATH" run --no-sync python .github/scripts/ipmnist_prereg.py preflight' in workflow
     upload = workflow[workflow.index("- name: Upload 90-day result or partial recovery bundle") :]


### PR DESCRIPTION
Attempt 4 failed closed before MNIST/data/seeds because the workflow synchronized only the `research` extra, then invoked pytest from the `dev` extra.

This adds the committed locked `dev` extra to the same exact uv sync. It does not loosen the lock, interpreter, uv digest, authorization, runner, namespace, or source gates.

Failing-test-first verification:
- new workflow contract test fails on the parent because `--extra dev` is absent
- 231 local/workflow prereg tests pass
- exact offline `uv sync --locked --extra dev --extra research` into a fresh environment installs pytest 9.1.1 and JAX 0.11.0; `python -m pytest --version` passes
- actionlint clean
- Ruff clean
- strict prereg driver mypy clean
- diff-check clean

No benchmark, output, tag, authorization, or dispatch is created by this PR. Attempt 4 failure is recorded on #51.
