### PR TITLE
fix(ci): install locked prereg test environment

### DIFF
--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -219,7 +219,14 @@ jobs:
           "$UV_PATH" sync \
             --locked \
             --python "$PYTHON_PATH" \
+            --extra dev \
             --extra research
+          pytest_version="$("$UV_PATH" run --no-sync python -c \
+            'import importlib.metadata; print(importlib.metadata.version("pytest"))')"
+          if [[ "$pytest_version" != "9.1.1" ]]; then
+            echo "locked pytest version differs from 9.1.1" >&2
+            exit 1
+          fi
           "$UV_PATH" run --no-sync python - \
             "$cpu_brand" "$RUNNER_TEMP/prereg-metadata/runner.json" <<'PY'
           import importlib.metadata

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -128,6 +128,21 @@ def test_prereg_workflow_invokes_only_setup_uv_pinned_binary() -> None:
     assert sum('"$UV_PATH" ' in line for line in shell_lines) >= 13
 
 
+def test_prereg_workflow_syncs_locked_test_and_research_environments() -> None:
+    workflow = (_ROOT / ".github" / "workflows" / "ipmnist-prereg.yml").read_text(
+        encoding="utf-8"
+    )
+    assert '          "$UV_PATH" sync \\\n' in workflow
+    assert "            --locked \\\n" in workflow
+    assert "            --extra dev \\\n" in workflow
+    assert "            --extra research\n" in workflow
+    assert 'pytest_version="$("$UV_PATH" run --no-sync python -c ' in workflow
+    assert '[[ "$pytest_version" != "9.1.1" ]]' in workflow
+    # Pytest enables the code-only gate but is not measurement provenance.
+    expected_packages = cast(dict[str, str], _DRIVER["EXPECTED_PACKAGES"])
+    assert "pytest" not in expected_packages
+
+
 def test_issue184_github_and_local_protocols_cannot_drift() -> None:
     github = _PROTOCOLS["issue184"]
     local = cast(dict[str, Any], _LOCAL_DRIVER["LOCAL_PROTOCOLS"])["issue184"]


### PR DESCRIPTION
Attempt 4 passed source, authorization, uv digest, Python identity, sync, and post-sync reconstruction, then failed before data because the workflow synchronized only the research extra and pytest was absent.

This adds the locked dev extra alongside research before the code-only gate, verifies the uv.lock-selected pytest 9.1.1 identity, and leaves pytest intentionally outside the measurement runner package receipt.

Verification:
- failing workflow test first
- GitHub + local prereg modules: 232 passed (prior 231 plus new contract)
- actionlint: clean
- Ruff: clean
- cold driver mypy: clean

No benchmark, output, tag, authorization comment, or dispatch.