### PR TITLE
fix(cbp): reject boolean constructor step sizes

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -180,6 +180,7 @@ def _validated_config_float(
     lower: float | None = None,
     upper: float | None = None,
     upper_inclusive: bool = True,
+    positive: bool = False,
 ) -> float:
     if type(value) not in _ALLOWED_REAL_TYPES:
         raise ValueError(f"{name} must be a finite real number")
@@ -189,6 +190,7 @@ def _validated_config_float(
         lower=lower,
         upper=upper,
         upper_inclusive=upper_inclusive,
+        positive=positive,
     )
     if numerator != 0 and abs(numerator) * (1 << 149) <= denominator:
         raise ValueError(f"{name} must remain nonzero once narrowed to float32")
@@ -882,6 +884,15 @@ class CBPMultiHeadMLPLearner:
             "leaky_relu_slope",
             leaky_relu_slope,
             lower=0.0,
+        )
+        step_size = _validated_config_float("step_size", step_size, positive=True)
+        gamma = _validated_config_float("gamma", gamma, lower=0.0, upper=1.0)
+        lamda = _validated_config_float("lamda", lamda, lower=0.0, upper=1.0)
+        utility_decay = _validated_config_float(
+            "utility_decay",
+            utility_decay,
+            lower=0.0,
+            upper=1.0,
         )
         self._sparsity = sparsity
         self._leaky_relu_slope = leaky_relu_slope

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -887,6 +887,14 @@ class TestCBPWrapperConstructorIdentities:
             ({"leaky_relu_slope": True}, "leaky_relu_slope"),
             ({"leaky_relu_slope": float("inf")}, "leaky_relu_slope"),
             ({"leaky_relu_slope": -0.1}, "leaky_relu_slope"),
+            ({"step_size": True}, "step_size"),
+            ({"step_size": float("nan")}, "step_size"),
+            ({"step_size": float("inf")}, "step_size"),
+            ({"step_size": 0.0}, "step_size"),
+            ({"step_size": -0.1}, "step_size"),
+            ({"gamma": True}, "gamma"),
+            ({"gamma": float("nan")}, "gamma"),
+            ({"gamma": 1.5}, "gamma"),
         ],
     )
     def test_multihead_rejects_identity_aliases(
@@ -901,6 +909,8 @@ class TestCBPWrapperConstructorIdentities:
             ({"use_layer_norm": 1}, "use_layer_norm"),
             ({"sparsity": True}, "sparsity"),
             ({"leaky_relu_slope": True}, "leaky_relu_slope"),
+            ({"step_size": True}, "step_size"),
+            ({"step_size": float("nan")}, "step_size"),
         ],
     )
     def test_single_head_adapter_rejects_identity_aliases(


### PR DESCRIPTION
Closes #1455.

## What changed

`CBPMultiHeadMLPLearner` now validates `step_size` (positive finite real), `gamma`, `lamda`, and `utility_decay` at the host boundary before constructing the default `LMS` / `MultiHeadMLPLearner`. The thin `CBPMLPLearner` adapter inherits the gates.

On `origin/main` `a0a80db`, `step_size=True` stored a bool on `LMS._step_size` and `step_size=nan` published NaN as the live alpha.

Legal values stay legal: omitted defaults, builtin positive floats, and supported NumPy scalars already accepted by `_validated_config_float`.

## Scope

- `alberta_framework/core/continual_backprop.py`
- `tests/test_continual_backprop.py`

## Occupancy

Grok cmux constructor seats: workspace 7 on `optimizers.py` (FREE A); workspace 14 unclaimed. This file is not in an open ASI PR. Not Kayvan `#1330`–`#1362`. Not `#560` / `#905` / `#1062`.

## Verification

- Red on base: `CBPMultiHeadMLPLearner(..., step_size=True)` stored `True` on `LMS._step_size`; `step_size=nan` stored NaN
- `PYTHONPATH=<worktree> pytest tests/test_continual_backprop.py -q -o addopts=""` → 80 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary validation only. No kernel math, protocol, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:e1387b12ae7b7c9337c3f4d2b4167d738271623f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
