### PR TITLE
fix(forager): reject bool paper-protocol and run-result identities

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -250,6 +250,18 @@ def _require_real(value: Any, *, name: str) -> float:
     return converted
 
 
+def _require_result_scalar(value: Any, *, name: str) -> float:
+    """Reject bool/inf identities; NaN remains the historical unavailable marker."""
+    if isinstance(value, bool) or not isinstance(
+        value, (int, float, np.integer, np.floating)
+    ):
+        raise ValueError(f"{name} must be a real number")
+    converted = float(value)
+    if math.isinf(converted):
+        raise ValueError(f"{name} must be finite")
+    return converted
+
+
 def _finite_jax_float32(value: int | float) -> bool:
     """Return whether a scalar remains finite in the benchmark's JAX dtype."""
     with np.errstate(over="ignore", invalid="ignore"):
@@ -1778,6 +1790,51 @@ class ForagerRunResult:
     environment: Mapping[str, Any]
     metric_contract: Mapping[str, Any]
     agent_metadata: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        """Reject bool/non-int identities before they become JSON ``true``."""
+
+        if type(self.agent) is not str or not self.agent:
+            raise ValueError("agent must be a non-empty string")
+        if type(self.privileged) is not bool:
+            raise ValueError("privileged must be a boolean")
+        object.__setattr__(self, "seed", _validated_seed(self.seed))
+        _require_builtin_int(self.steps, name="steps", minimum=1)
+        for name in (
+            "total_reward",
+            "mean_reward",
+            "final_window_mean_reward",
+            "final_ewm_reward",
+            "mean_ewm_reward",
+            "fov_last_10pct_ema_auc",
+            "mean_biome_regret",
+            "final_biome_regret",
+            "duration_s",
+            "frames_per_second",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_result_scalar(getattr(self, name), name=name),
+            )
+        if type(self.curve_steps) is not tuple or any(
+            isinstance(step, bool)
+            or not isinstance(step, (int, np.integer))
+            for step in self.curve_steps
+        ):
+            raise ValueError("curve_steps must be a tuple of integers")
+        for name in ("curve_ewm_reward", "curve_window_reward"):
+            values = getattr(self, name)
+            if type(values) is not tuple:
+                raise ValueError(f"{name} must be a tuple of real numbers")
+            object.__setattr__(
+                self,
+                name,
+                tuple(_require_result_scalar(value, name=name) for value in values),
+            )
+        for name in ("environment", "metric_contract", "agent_metadata"):
+            if not isinstance(getattr(self, name), Mapping):
+                raise ValueError(f"{name} must be a mapping")
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible result."""
@@ -4006,6 +4063,63 @@ class PaperForagerProtocol:
     hidden_switch_interval_steps: int | None
     metric_definition: str
     single_stream: bool = True
+
+    def __post_init__(self) -> None:
+        """Reject bool counts/windows before they shrink evaluation to one seed."""
+
+        if self.preset not in ("relearning", "field_of_view", "unending"):
+            raise ValueError("preset is invalid")
+        if not isinstance(self.environment, ForagerEnvConfig):
+            raise ValueError("environment must be a ForagerEnvConfig")
+        for name in (
+            "tuning_steps",
+            "tuning_seeds",
+            "evaluation_steps",
+            "evaluation_seeds",
+            "final_window_steps",
+        ):
+            _require_builtin_int(getattr(self, name), name=name, minimum=1)
+        _require_builtin_int(
+            self.tuning_seed_offset, name="tuning_seed_offset", minimum=0
+        )
+        _require_builtin_int(
+            self.evaluation_seed_start, name="evaluation_seed_start", minimum=0
+        )
+        if self.frozen_ablation_after_steps is not None:
+            _require_builtin_int(
+                self.frozen_ablation_after_steps,
+                name="frozen_ablation_after_steps",
+                minimum=1,
+            )
+        if self.hidden_switch_interval_steps is not None:
+            _require_builtin_int(
+                self.hidden_switch_interval_steps,
+                name="hidden_switch_interval_steps",
+                minimum=1,
+            )
+        tuning_fraction = _require_real(self.tuning_fraction, name="tuning_fraction")
+        if not 0.0 <= tuning_fraction <= 1.0:
+            raise ValueError("tuning_fraction must lie in [0, 1]")
+        object.__setattr__(self, "tuning_fraction", tuning_fraction)
+        confidence = _require_real(self.confidence, name="confidence")
+        if not 0.0 < confidence <= 1.0:
+            raise ValueError("confidence must lie in (0, 1]")
+        object.__setattr__(self, "confidence", confidence)
+        ewm_decay = _require_real(self.ewm_decay, name="ewm_decay")
+        if not 0.0 <= ewm_decay < 1.0:
+            raise ValueError("ewm_decay must lie in [0, 1)")
+        object.__setattr__(self, "ewm_decay", ewm_decay)
+        if self.primary_metric not in (
+            "final_window_mean_reward",
+            "mean_ewm_reward",
+            "final_ewm_reward",
+            "fov_last_10pct_ema_auc",
+        ):
+            raise ValueError("primary_metric is invalid")
+        if type(self.metric_definition) is not str or not self.metric_definition:
+            raise ValueError("metric_definition must be a non-empty string")
+        if type(self.single_stream) is not bool:
+            raise ValueError("single_stream must be a boolean")
 
     def to_dict(self) -> dict[str, Any]:
         data = dataclasses.asdict(self)

--- a/tests/test_forager_paper_reference_leftover_identities.py
+++ b/tests/test_forager_paper_reference_leftover_identities.py
@@ -7,8 +7,11 @@ import json
 import pytest
 
 from alberta_framework.benchmarks.forager import (
+    ForagerRunResult,
     PaperBaseline,
+    PaperForagerProtocol,
     PaperReferenceTarget,
+    paper_protocol,
     paper_reference_targets,
 )
 
@@ -73,3 +76,100 @@ def test_paper_reference_targets_remain_legal() -> None:
     assert rtu.central_estimate == pytest.approx(1.3)
     dumped = json.dumps(rtu.to_dict(), allow_nan=False)
     assert '"central_estimate": 1.3' in dumped
+
+
+def _legal_run_result(**overrides: object) -> ForagerRunResult:
+    payload: dict[str, object] = {
+        "agent": "toy",
+        "privileged": False,
+        "seed": 0,
+        "steps": 10,
+        "total_reward": 1.0,
+        "mean_reward": 0.1,
+        "final_window_mean_reward": 0.1,
+        "final_ewm_reward": 0.1,
+        "mean_ewm_reward": 0.1,
+        "fov_last_10pct_ema_auc": 0.1,
+        "mean_biome_regret": 0.0,
+        "final_biome_regret": 0.0,
+        "curve_steps": (1, 10),
+        "curve_ewm_reward": (0.1, 0.1),
+        "curve_window_reward": (0.1, 0.1),
+        "duration_s": 1.0,
+        "frames_per_second": 10.0,
+        "environment": {"env_id": "fake"},
+        "metric_contract": {"metric": "mean_reward"},
+        "agent_metadata": {"name": "toy"},
+    }
+    payload.update(overrides)
+    return ForagerRunResult(**payload)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("evaluation_seeds", True),
+        ("evaluation_seeds", False),
+        ("evaluation_seeds", 0),
+        ("final_window_steps", True),
+        ("final_window_steps", 0),
+        ("tuning_seeds", True),
+        ("evaluation_steps", True),
+        ("single_stream", 1),
+        ("confidence", True),
+        ("ewm_decay", True),
+    ],
+)
+def test_paper_forager_protocol_rejects_bool_counts_and_windows(
+    field: str, value: object
+) -> None:
+    legal = paper_protocol()
+    kwargs = {name: getattr(legal, name) for name in legal.__dataclass_fields__}
+    kwargs[field] = value
+    with pytest.raises(ValueError, match=field):
+        PaperForagerProtocol(**kwargs)  # type: ignore[arg-type]
+
+
+def test_paper_forager_protocol_keeps_integer_json_and_seed_range() -> None:
+    protocol = paper_protocol("relearning")
+    dumped = json.dumps(protocol.to_dict(), allow_nan=False)
+    assert '"evaluation_seeds": 30' in dumped
+    assert '"final_window_steps": 100000' in dumped
+    assert '"evaluation_seeds": true' not in dumped
+    assert '"final_window_steps": true' not in dumped
+    seeds = range(
+        protocol.evaluation_seed_start,
+        protocol.evaluation_seed_start + protocol.evaluation_seeds,
+    )
+    assert len(tuple(seeds)) == 30
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("steps", True),
+        ("steps", False),
+        ("steps", 0),
+        ("seed", True),
+        ("seed", -1),
+        ("privileged", 1),
+        ("mean_reward", True),
+        ("duration_s", True),
+        ("duration_s", float("inf")),
+    ],
+)
+def test_forager_run_result_rejects_bool_seed_and_steps(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        _legal_run_result(**{field: value})
+
+
+def test_forager_run_result_keeps_integer_json() -> None:
+    result = _legal_run_result()
+    dumped = json.dumps(result.to_dict(), allow_nan=False)
+    assert '"seed": 0' in dumped
+    assert '"steps": 10' in dumped
+    assert '"seed": true' not in dumped
+    assert '"steps": true' not in dumped
+    assert '"privileged": false' in dumped


### PR DESCRIPTION
Closes #1457.

## What changed

`PaperForagerProtocol` and `ForagerRunResult` now fail closed in `__post_init__` before bool seed/window/step identities become JSON `true` or shrink `range(start, start+True)` to one seed.

On `origin/main` `a0a80db`, `evaluation_seeds=True` / `final_window_steps=True` constructed and serialized as JSON `true`. `ForagerRunResult(seed=True, steps=True)` did the same. Legal `paper_protocol()` and existing result helpers stay legal. Historical NaN unavailable markers on result scalars stay legal.

This is the omitted sibling of `#901` + `#1287` (`PaperReferenceTarget` / `PaperBaseline`). Shaw `#1442` only closed hostile-metaclass on this file. Whole protocol + result contract, not a thin leftover reprint.

## Scope

- `alberta_framework/benchmarks/forager.py`
- `tests/test_forager_paper_reference_leftover_identities.py`

## Occupancy

Open ASI PRs at publish: only `#1456` CBP (left alone). No open PR on `forager.py`. Not Kayvan `#1331` / `#1351` / `#1352` / `#1356` / `#1341`. Not scorers `#1445`/`#1448`. Not grok constructor seats.

## Verification

- Red on base: `PaperForagerProtocol(..., evaluation_seeds=True)` / `final_window_steps=True` constructed; JSON `true`; `range(0, True)` length 1
- Red on base: `ForagerRunResult(..., seed=True, steps=True)` constructed; JSON `{"seed": true, "steps": true}`
- `PYTHONPATH=<worktree> pytest tests/test_forager_paper_reference_leftover_identities.py tests/test_forager_results.py tests/test_forager_dataclasses_hostile_validation.py tests/test_forager_benchmark.py -q -o addopts=""` → 135 passed, 3 skipped
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary validation only. No kernel math, protocol preset values, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f1a5c141b0f077ed28f9144cc131c2658df767d9 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
