### PR TITLE
fix(cbp): complete constructor and config scalar contracts

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -180,6 +180,7 @@ def _validated_config_float(
     lower: float | None = None,
     upper: float | None = None,
     upper_inclusive: bool = True,
+    positive: bool = False,
 ) -> float:
     if type(value) not in _ALLOWED_REAL_TYPES:
         raise ValueError(f"{name} must be a finite real number")
@@ -189,6 +190,7 @@ def _validated_config_float(
         lower=lower,
         upper=upper,
         upper_inclusive=upper_inclusive,
+        positive=positive,
     )
     if numerator != 0 and abs(numerator) * (1 << 149) <= denominator:
         raise ValueError(f"{name} must remain nonzero once narrowed to float32")
@@ -882,6 +884,15 @@ class CBPMultiHeadMLPLearner:
             "leaky_relu_slope",
             leaky_relu_slope,
             lower=0.0,
+        )
+        step_size = _validated_config_float("step_size", step_size, positive=True)
+        gamma = _validated_config_float("gamma", gamma, lower=0.0, upper=1.0)
+        lamda = _validated_config_float("lamda", lamda, lower=0.0, upper=1.0)
+        utility_decay = _validated_config_float(
+            "utility_decay",
+            utility_decay,
+            lower=0.0,
+            upper=1.0,
         )
         self._sparsity = sparsity
         self._leaky_relu_slope = leaky_relu_slope

--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -284,6 +284,13 @@ class ContinualBackpropConfig:
         payload = _copy_mapping(config, name="ContinualBackpropConfig")
         if set(payload) != _CBP_CONFIG_FIELDS:
             raise ValueError("ContinualBackpropConfig fields do not match the schema")
+        for name in ("decay_rate", "replacement_rate"):
+            if type(payload[name]) is not float:
+                raise ValueError(f"serialized {name} must be an exact JSON float")
+        if type(payload["maturity_threshold"]) is not int:
+            raise ValueError("serialized maturity_threshold must be an exact JSON integer")
+        if type(payload["enabled"]) is not bool:
+            raise ValueError("serialized enabled must be an exact JSON bool")
         return cls(**payload)  # type: ignore[arg-type]
 
 
@@ -871,7 +878,11 @@ class CBPMultiHeadMLPLearner:
             utility_decay: EMA decay for the underlying MLP's native
                 hidden-unit utility diagnostics.
         """
-        self._cbp_config = cbp_config or ContinualBackpropConfig()
+        if cbp_config is None:
+            cbp_config = ContinualBackpropConfig()
+        elif type(cbp_config) is not ContinualBackpropConfig:
+            raise ValueError("cbp_config must be an actual ContinualBackpropConfig or None")
+        self._cbp_config = cbp_config
         if type(use_layer_norm) is not bool:
             raise ValueError("use_layer_norm must be an actual bool")
         sparsity = _validated_config_float(
@@ -893,6 +904,7 @@ class CBPMultiHeadMLPLearner:
             utility_decay,
             lower=0.0,
             upper=1.0,
+            upper_inclusive=False,
         )
         self._sparsity = sparsity
         self._leaky_relu_slope = leaky_relu_slope
@@ -975,6 +987,21 @@ class CBPMultiHeadMLPLearner:
             and type(config["per_head_gamma_lamda"]) is not list
         ):
             raise ValueError("per_head_gamma_lamda must be a list")
+        if type(config["n_heads"]) is not int:
+            raise ValueError("serialized n_heads must be an exact JSON integer")
+        if any(type(width) is not int for width in config["hidden_sizes"]):
+            raise ValueError("serialized hidden_sizes entries must be exact JSON integers")
+        for name in ("sparsity", "leaky_relu_slope", "gamma", "lamda", "utility_decay"):
+            if type(config[name]) is not float:
+                raise ValueError(f"serialized {name} must be an exact JSON float")
+        if type(config["use_layer_norm"]) is not bool:
+            raise ValueError("serialized use_layer_norm must be an exact JSON bool")
+        if config["per_head_gamma_lamda"] is not None and any(
+            type(value) is not float for value in config["per_head_gamma_lamda"]
+        ):
+            raise ValueError(
+                "serialized per_head_gamma_lamda entries must be exact JSON floats"
+            )
         config = config.copy()
         config.pop("type")
         config.pop("state_schema")

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -887,6 +887,14 @@ class TestCBPWrapperConstructorIdentities:
             ({"leaky_relu_slope": True}, "leaky_relu_slope"),
             ({"leaky_relu_slope": float("inf")}, "leaky_relu_slope"),
             ({"leaky_relu_slope": -0.1}, "leaky_relu_slope"),
+            ({"step_size": True}, "step_size"),
+            ({"step_size": float("nan")}, "step_size"),
+            ({"step_size": float("inf")}, "step_size"),
+            ({"step_size": 0.0}, "step_size"),
+            ({"step_size": -0.1}, "step_size"),
+            ({"gamma": True}, "gamma"),
+            ({"gamma": float("nan")}, "gamma"),
+            ({"gamma": 1.5}, "gamma"),
         ],
     )
     def test_multihead_rejects_identity_aliases(
@@ -901,6 +909,8 @@ class TestCBPWrapperConstructorIdentities:
             ({"use_layer_norm": 1}, "use_layer_norm"),
             ({"sparsity": True}, "sparsity"),
             ({"leaky_relu_slope": True}, "leaky_relu_slope"),
+            ({"step_size": True}, "step_size"),
+            ({"step_size": float("nan")}, "step_size"),
         ],
     )
     def test_single_head_adapter_rejects_identity_aliases(

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -895,6 +895,9 @@ class TestCBPWrapperConstructorIdentities:
             ({"gamma": True}, "gamma"),
             ({"gamma": float("nan")}, "gamma"),
             ({"gamma": 1.5}, "gamma"),
+            ({"utility_decay": 1.0}, "utility_decay"),
+            ({"cbp_config": False}, "cbp_config"),
+            ({"cbp_config": 0}, "cbp_config"),
         ],
     )
     def test_multihead_rejects_identity_aliases(
@@ -911,6 +914,8 @@ class TestCBPWrapperConstructorIdentities:
             ({"leaky_relu_slope": True}, "leaky_relu_slope"),
             ({"step_size": True}, "step_size"),
             ({"step_size": float("nan")}, "step_size"),
+            ({"utility_decay": 1.0}, "utility_decay"),
+            ({"cbp_config": False}, "cbp_config"),
         ],
     )
     def test_single_head_adapter_rejects_identity_aliases(
@@ -939,3 +944,47 @@ class TestCBPWrapperConstructorIdentities:
         assert learner._sparsity == pytest.approx(0.25)
         assert learner._leaky_relu_slope == pytest.approx(0.02)
         assert learner._use_layer_norm is False
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("decay_rate", 1),
+            ("replacement_rate", np.float32(0.1)),
+            ("maturity_threshold", np.int32(1)),
+            ("enabled", 1),
+        ],
+    )
+    def test_cbp_config_parser_requires_exact_json_scalars(
+        self,
+        field: str,
+        value: object,
+    ) -> None:
+        payload = ContinualBackpropConfig().to_config()
+        payload[field] = value
+        with pytest.raises(ValueError, match="serialized"):
+            ContinualBackpropConfig.from_config(payload)
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("n_heads", np.int32(1)),
+            ("hidden_sizes", [np.int32(4)]),
+            ("sparsity", 0),
+            ("gamma", np.float32(0.0)),
+            ("use_layer_norm", 1),
+            ("per_head_gamma_lamda", [np.float32(0.0)]),
+        ],
+    )
+    def test_wrapper_parser_requires_exact_json_scalars(
+        self,
+        field: str,
+        value: object,
+    ) -> None:
+        payload = CBPMultiHeadMLPLearner(
+            n_heads=1,
+            hidden_sizes=(4,),
+            per_head_gamma_lamda=(0.0,),
+        ).to_config()
+        payload[field] = value
+        with pytest.raises(ValueError, match="serialized"):
+            CBPMultiHeadMLPLearner.from_config(payload)


### PR DESCRIPTION
Contributor-preserving corrective successor to #1456. Closes #1455.

Preserves ss251/Cursor commit `e1387b12` and its constructor step-size/gamma/lambda/utility gates. Deep review additionally rejects falsey wrong-type `cbp_config` values that previously silently selected defaults, aligns `utility_decay` with its strict `[0,1)` runtime domain, and enforces exact JSON scalar identities for nested CBP and wrapper configs before optimizer/parser construction.

Verification: 95 CBP tests passed; Ruff clean; mypy clean. No benchmarks or outputs changed.