### PR TITLE
fix(benchmarks): reject bool candidate-spec horizon identities

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_open_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_open_protocol.py
@@ -283,6 +283,36 @@ class MatchedCurrentCandidateQualification:
             )
 
 
+def _require_spec_text(value: object, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ForagerMatchedOpenProtocolBuildError(f"{name} must be a non-empty string")
+    return value
+
+
+def _require_spec_choice(value: object, name: str, allowed: tuple[str, ...]) -> str:
+    if type(value) is not str:
+        raise ForagerMatchedOpenProtocolBuildError(f"{name} must be an exact string")
+    if value not in allowed:
+        raise ForagerMatchedOpenProtocolBuildError(f"{name} is invalid")
+    return value
+
+
+def _require_spec_bool(value: object, name: str) -> bool:
+    if type(value) is not bool:
+        raise ForagerMatchedOpenProtocolBuildError(f"{name} must be a boolean")
+    return value
+
+
+def _require_spec_int(value: object, name: str, *, minimum: int) -> int:
+    if isinstance(value, bool) or type(value) is not int:
+        raise ForagerMatchedOpenProtocolBuildError(f"{name} must be an integer")
+    if value < minimum:
+        raise ForagerMatchedOpenProtocolBuildError(
+            f"{name} must be an integer >= {minimum}"
+        )
+    return value
+
+
 @dataclass(frozen=True)
 class _CandidateSpec:
     candidate_id: str
@@ -309,6 +339,77 @@ class _CandidateSpec:
     privileged_fields: tuple[str, ...]
     pairing_eligible: bool
     exclusion_reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Reject bool horizons before they become one-step identities."""
+
+        _require_spec_text(self.candidate_id, "candidate_id")
+        _require_spec_text(self.selection_group, "selection_group")
+        _require_spec_choice(
+            self.stratum,
+            "stratum",
+            ("alberta_learning", "external_learning", "privileged_context"),
+        )
+        _require_spec_text(self.implementation_kind, "implementation_kind")
+        _require_spec_text(self.entrypoint_family, "entrypoint_family")
+        _require_spec_choice(
+            self.seed_transport,
+            "seed_transport",
+            ("direct", "top_level_seed", "adapter_injected"),
+        )
+        if self.rollout_steps is not None:
+            _require_spec_int(self.rollout_steps, "rollout_steps", minimum=1)
+        _require_spec_text(self.update_semantics, "update_semantics")
+        _require_spec_text(self.source_repository, "source_repository")
+        _require_spec_text(self.source_base_commit, "source_base_commit")
+        _require_spec_choice(
+            self.source_provenance_kind,
+            "source_provenance_kind",
+            ("git_tree", "reviewed_snapshot"),
+        )
+        _require_spec_choice(
+            self.agent_rng_identity,
+            "agent_rng_identity",
+            ("isolated_agent_rng_v1", "shared_agent_environment_rng_v1"),
+        )
+        _require_spec_bool(self.environment_key_shared, "environment_key_shared")
+        _require_spec_choice(
+            self.environment_rng_identity,
+            "environment_rng_identity",
+            (
+                "dedicated_environment_split_chain_v1",
+                "shared_agent_environment_rng_v1",
+            ),
+        )
+        _require_spec_choice(
+            self.access_mode,
+            "access_mode",
+            (
+                "partial_observation",
+                "privileged_global_objects",
+                "privileged_reward_grid",
+            ),
+        )
+        _require_spec_text(self.observation_type, "observation_type")
+        if isinstance(self.aperture_size, bool) or type(self.aperture_size) is not int:
+            raise ForagerMatchedOpenProtocolBuildError("aperture_size must be an integer")
+        if self.aperture_size != -1 and self.aperture_size not in range(1, 16, 2):
+            raise ForagerMatchedOpenProtocolBuildError(
+                "aperture_size must be -1 or one of 1, 3, 5, 7, 9, 11, 13, 15"
+            )
+        if type(self.privileged_fields) is not tuple or any(
+            type(field) is not str or not field for field in self.privileged_fields
+        ):
+            raise ForagerMatchedOpenProtocolBuildError(
+                "privileged_fields must be a tuple of non-empty strings"
+            )
+        _require_spec_bool(self.pairing_eligible, "pairing_eligible")
+        if type(self.exclusion_reasons) is not tuple or any(
+            type(reason) is not str or not reason for reason in self.exclusion_reasons
+        ):
+            raise ForagerMatchedOpenProtocolBuildError(
+                "exclusion_reasons must be a tuple of non-empty strings"
+            )
 
 
 def _causal_specs() -> tuple[_CandidateSpec, ...]:

--- a/tests/test_forager_matched_open_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_open_protocol_hostile_validation.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import hashlib
+from dataclasses import replace
 
 import pytest
 
 from alberta_framework.benchmarks.forager_matched_open_protocol import (
+    _CANDIDATE_SPECS,
+    MATCHED_CURRENT_HORIZON,
     ForagerMatchedOpenProtocolBuildError,
     MatchedCurrentCandidateQualification,
     MatchedCurrentRuntimeQualification,
+    _CandidateSpec,
 )
 
 
@@ -70,3 +74,57 @@ def test_candidate_qualification_rejects_invalid_types() -> None:
             capability_qualification_receipt_sha256=_digest(b"receipt"),
             resources=None,  # type: ignore[arg-type]
         )
+
+
+def _legal_spec(candidate_id: str = "isolated_ppo") -> _CandidateSpec:
+    return next(spec for spec in _CANDIDATE_SPECS if spec.candidate_id == candidate_id)
+
+
+def test_frozen_candidate_specs_remain_legal() -> None:
+    assert len(_CANDIDATE_SPECS) == 23
+    isolated_ppo = _legal_spec("isolated_ppo")
+    isolated_rtu = _legal_spec("isolated_rtu")
+    oracle = _legal_spec("search_oracle")
+    causal = _legal_spec("causal_e025_q050")
+    assert isolated_ppo.rollout_steps == 2_048
+    assert MATCHED_CURRENT_HORIZON // isolated_ppo.rollout_steps == 244
+    assert isolated_rtu.rollout_steps == 128
+    assert MATCHED_CURRENT_HORIZON // isolated_rtu.rollout_steps == 3_904
+    assert causal.rollout_steps is None
+    assert isolated_ppo.aperture_size == 9
+    assert oracle.aperture_size == -1
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("rollout_steps", True),
+        ("rollout_steps", False),
+        ("rollout_steps", 0),
+        ("aperture_size", True),
+        ("aperture_size", False),
+        ("aperture_size", 0),
+        ("aperture_size", 8),
+        ("environment_key_shared", 1),
+        ("pairing_eligible", 1),
+        ("seed_transport", "not_a_transport"),
+        ("candidate_id", ""),
+    ],
+)
+def test_candidate_spec_rejects_bool_horizon_identities(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ForagerMatchedOpenProtocolBuildError, match=field):
+        replace(_legal_spec(), **{field: value})
+
+
+def test_candidate_spec_bool_rollout_would_collapse_horizon_identity() -> None:
+    """On origin/main, True constructed and MATCHED_CURRENT_HORIZON // True == 499712."""
+
+    legal = _legal_spec("isolated_ppo")
+    assert MATCHED_CURRENT_HORIZON // legal.rollout_steps == 244
+    assert MATCHED_CURRENT_HORIZON // True == MATCHED_CURRENT_HORIZON
+    with pytest.raises(ForagerMatchedOpenProtocolBuildError, match="rollout_steps"):
+        replace(legal, rollout_steps=True)
+    with pytest.raises(ForagerMatchedOpenProtocolBuildError, match="aperture_size"):
+        replace(legal, aperture_size=True)


### PR DESCRIPTION
Closes #1462.

## What changed

`_CandidateSpec` now fail-closes in `__post_init__` before bool `rollout_steps` / `aperture_size` become a one-step horizon identity.

On `origin/main` `d9a0308`, `rollout_steps=True` constructed and `MATCHED_CURRENT_HORIZON // True` was `499712` instead of isolated-PPO `244`. `aperture_size=True` stored a 1-cell aperture. Legal frozen panel stays legal (`2048`/`128`/`None` rollouts; aperture `9` or oracle `-1`).

Kayvan `#1331` post_init’d the qualifications only. This is the omitted spec contract, not closed leftover `#1356`.

## Scope

- `alberta_framework/benchmarks/forager_matched_open_protocol.py`
- `tests/test_forager_matched_open_protocol_hostile_validation.py`

## Occupancy

Open ASI PRs at publish: `#1459` (our `forager.py` protocol/result), byt61 `#1458`/`#1461` (`forager.py` string identities). No open PR on this file. Not `#1356`. Not grok constructor seats.

## Verification

- Red on base: `replace(isolated_ppo, rollout_steps=True)` constructed; `499712 // True == 499712`
- Red on base: `replace(isolated_ppo, aperture_size=True)` constructed
- `PYTHONPATH=<worktree> pytest tests/test_forager_matched_open_protocol_hostile_validation.py tests/test_forager_matched_open_protocol.py::test_isolated_policy_gradient_and_descriptive_boundaries_are_exact -q -o addopts=""` → 17 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary validation only. No kernel math, frozen panel values, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f7a6543658df03e39451cadefb2ae1ede36a8f54 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
