### PR TITLE
fix(forager): complete hostile identity contracts

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -421,10 +421,10 @@ class ForagerEnvConfig:
     require_exact_version: bool = True
 
     def __post_init__(self) -> None:
-        if not isinstance(self.preset, str) or self.preset not in _PRESET_ENV_IDS:
+        if type(self.preset) is not str or self.preset not in _PRESET_ENV_IDS:
             raise ValueError(f"unknown Forager preset {self.preset!r}")
         if self.env_id is not None and (
-            not isinstance(self.env_id, str) or not self.env_id
+            type(self.env_id) is not str or not self.env_id
         ):
             raise ValueError("env_id must be a non-empty string when provided")
         if (
@@ -449,14 +449,13 @@ class ForagerEnvConfig:
             name="random_shift_max_steps",
             minimum=0,
         )
-        if self.observation_type is not None and self.observation_type not in (
-            "color",
-            "rgb",
-            "object",
+        if self.observation_type is not None and (
+            type(self.observation_type) is not str
+            or self.observation_type not in ("color", "rgb", "object")
         ):
             raise ValueError(f"unknown observation_type {self.observation_type!r}")
         if not isinstance(self.extra_kwargs, Mapping) or any(
-            not isinstance(key, str) for key in self.extra_kwargs
+            type(key) is not str for key in self.extra_kwargs
         ):
             raise ValueError("extra_kwargs must be a mapping with string keys")
         reserved = {

--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -206,11 +206,22 @@ FORAGER_FOV_EMA_SUBSAMPLE = 100
 FORAGER_FOV_TAIL_FRACTION = 0.10
 FORAGER_ENVIRONMENT_RNG_SCHEDULE = "dedicated_environment_split_chain_v1"
 _MAX_JAX_INT32 = 2**31 - 1
+_ACTUAL_NUMPY_INT_TYPES = frozenset(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
+)
+_ACTUAL_RESULT_SCALAR_TYPES = frozenset(
+    {
+        int,
+        float,
+        *_ACTUAL_NUMPY_INT_TYPES,
+        *(np.dtype(code).type for code in ("e", "f", "d", "g")),
+    }
+)
 
 
 def _validated_seed(value: Any, *, name: str = "seed") -> int:
     """Return one canonical JAX seed without accepting lossy coercions."""
-    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+    if type(value) is not int and type(value) not in _ACTUAL_NUMPY_INT_TYPES:
         raise ValueError(f"{name} must be an integer")
     seed = int(value)
     if not 0 <= seed <= _MAX_JAX_INT32:
@@ -252,9 +263,7 @@ def _require_real(value: Any, *, name: str) -> float:
 
 def _require_result_scalar(value: Any, *, name: str) -> float:
     """Reject bool/inf identities; NaN remains the historical unavailable marker."""
-    if isinstance(value, bool) or not isinstance(
-        value, (int, float, np.integer, np.floating)
-    ):
+    if type(value) not in _ACTUAL_RESULT_SCALAR_TYPES:
         raise ValueError(f"{name} must be a real number")
     converted = float(value)
     if math.isinf(converted):
@@ -439,16 +448,12 @@ class ForagerEnvConfig:
             type(self.env_id) is not str or not self.env_id
         ):
             raise ValueError("env_id must be a non-empty string when provided")
-        if (
-            isinstance(self.aperture_size, bool)
-            or not isinstance(self.aperture_size, int)
-            or (
+        if type(self.aperture_size) is not int or (
                 self.aperture_size != -1
                 and (
                     self.aperture_size < 1
                     or self.aperture_size % 2 == 0
                 )
-            )
         ):
             raise ValueError("aperture_size must be a positive odd integer or -1 for full world")
         _require_builtin_int(
@@ -466,10 +471,10 @@ class ForagerEnvConfig:
             or self.observation_type not in ("color", "rgb", "object")
         ):
             raise ValueError(f"unknown observation_type {self.observation_type!r}")
-        if not isinstance(self.extra_kwargs, Mapping) or any(
+        if type(self.extra_kwargs) is not dict or any(
             type(key) is not str for key in self.extra_kwargs
         ):
-            raise ValueError("extra_kwargs must be a mapping with string keys")
+            raise ValueError("extra_kwargs must be an actual dict with string keys")
         reserved = {
             "aperture_size",
             "observation_type",
@@ -1798,7 +1803,7 @@ class ForagerRunResult:
         if type(self.privileged) is not bool:
             raise ValueError("privileged must be a boolean")
         object.__setattr__(self, "seed", _validated_seed(self.seed))
-        _require_builtin_int(self.steps, name="steps", minimum=1)
+        steps = _require_builtin_int(self.steps, name="steps", minimum=1)
         for name in (
             "total_reward",
             "mean_reward",
@@ -1816,12 +1821,20 @@ class ForagerRunResult:
                 name,
                 _require_result_scalar(getattr(self, name), name=name),
             )
-        if type(self.curve_steps) is not tuple or any(
-            isinstance(step, bool)
-            or not isinstance(step, (int, np.integer))
-            for step in self.curve_steps
-        ):
+        if type(self.curve_steps) is not tuple:
             raise ValueError("curve_steps must be a tuple of integers")
+        curve_steps = tuple(
+            _validated_seed(step, name=f"curve_steps[{index}]")
+            for index, step in enumerate(self.curve_steps)
+        )
+        if (
+            not curve_steps
+            or curve_steps[0] < 1
+            or curve_steps[-1] > steps
+            or any(left >= right for left, right in zip(curve_steps, curve_steps[1:]))
+        ):
+            raise ValueError("curve_steps must be nonempty, increasing, and within steps")
+        object.__setattr__(self, "curve_steps", curve_steps)
         for name in ("curve_ewm_reward", "curve_window_reward"):
             values = getattr(self, name)
             if type(values) is not tuple:
@@ -1831,6 +1844,12 @@ class ForagerRunResult:
                 name,
                 tuple(_require_result_scalar(value, name=name) for value in values),
             )
+            if len(values) != len(curve_steps):
+                raise ValueError(f"{name} length must match curve_steps")
+        for name in ("duration_s", "frames_per_second"):
+            value = getattr(self, name)
+            if not math.isnan(value) and value < 0.0:
+                raise ValueError(f"{name} must be nonnegative or NaN")
         for name in ("environment", "metric_contract", "agent_metadata"):
             if not isinstance(getattr(self, name), Mapping):
                 raise ValueError(f"{name} must be a mapping")
@@ -4066,9 +4085,11 @@ class PaperForagerProtocol:
     def __post_init__(self) -> None:
         """Reject bool counts/windows before they shrink evaluation to one seed."""
 
+        if type(self.preset) is not str:
+            raise ValueError("preset must be an exact string")
         if self.preset not in ("relearning", "field_of_view", "unending"):
             raise ValueError("preset is invalid")
-        if not isinstance(self.environment, ForagerEnvConfig):
+        if type(self.environment) is not ForagerEnvConfig:
             raise ValueError("environment must be a ForagerEnvConfig")
         for name in (
             "tuning_steps",
@@ -4096,6 +4117,22 @@ class PaperForagerProtocol:
                 name="hidden_switch_interval_steps",
                 minimum=1,
             )
+        if self.final_window_steps > self.evaluation_steps:
+            raise ValueError("final_window_steps must not exceed evaluation_steps")
+        if (
+            self.frozen_ablation_after_steps is not None
+            and self.frozen_ablation_after_steps > self.evaluation_steps
+        ):
+            raise ValueError("frozen_ablation_after_steps must not exceed evaluation_steps")
+        if (
+            self.hidden_switch_interval_steps is not None
+            and self.hidden_switch_interval_steps > self.evaluation_steps
+        ):
+            raise ValueError("hidden_switch_interval_steps must not exceed evaluation_steps")
+        if self.tuning_seed_offset > _MAX_JAX_INT32 - (self.tuning_seeds - 1):
+            raise ValueError("tuning seed range must fit the JAX seed domain")
+        if self.evaluation_seed_start > _MAX_JAX_INT32 - (self.evaluation_seeds - 1):
+            raise ValueError("evaluation seed range must fit the JAX seed domain")
         tuning_fraction = _require_real(self.tuning_fraction, name="tuning_fraction")
         if not 0.0 <= tuning_fraction <= 1.0:
             raise ValueError("tuning_fraction must lie in [0, 1]")
@@ -4108,6 +4145,8 @@ class PaperForagerProtocol:
         if not 0.0 <= ewm_decay < 1.0:
             raise ValueError("ewm_decay must lie in [0, 1)")
         object.__setattr__(self, "ewm_decay", ewm_decay)
+        if type(self.primary_metric) is not str:
+            raise ValueError("primary_metric must be an exact string")
         if self.primary_metric not in (
             "final_window_mean_reward",
             "mean_ewm_reward",

--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -250,6 +250,18 @@ def _require_real(value: Any, *, name: str) -> float:
     return converted
 
 
+def _require_result_scalar(value: Any, *, name: str) -> float:
+    """Reject bool/inf identities; NaN remains the historical unavailable marker."""
+    if isinstance(value, bool) or not isinstance(
+        value, (int, float, np.integer, np.floating)
+    ):
+        raise ValueError(f"{name} must be a real number")
+    converted = float(value)
+    if math.isinf(converted):
+        raise ValueError(f"{name} must be finite")
+    return converted
+
+
 def _finite_jax_float32(value: int | float) -> bool:
     """Return whether a scalar remains finite in the benchmark's JAX dtype."""
     with np.errstate(over="ignore", invalid="ignore"):
@@ -1777,6 +1789,51 @@ class ForagerRunResult:
     environment: Mapping[str, Any]
     metric_contract: Mapping[str, Any]
     agent_metadata: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        """Reject bool/non-int identities before they become JSON ``true``."""
+
+        if type(self.agent) is not str or not self.agent:
+            raise ValueError("agent must be a non-empty string")
+        if type(self.privileged) is not bool:
+            raise ValueError("privileged must be a boolean")
+        object.__setattr__(self, "seed", _validated_seed(self.seed))
+        _require_builtin_int(self.steps, name="steps", minimum=1)
+        for name in (
+            "total_reward",
+            "mean_reward",
+            "final_window_mean_reward",
+            "final_ewm_reward",
+            "mean_ewm_reward",
+            "fov_last_10pct_ema_auc",
+            "mean_biome_regret",
+            "final_biome_regret",
+            "duration_s",
+            "frames_per_second",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_result_scalar(getattr(self, name), name=name),
+            )
+        if type(self.curve_steps) is not tuple or any(
+            isinstance(step, bool)
+            or not isinstance(step, (int, np.integer))
+            for step in self.curve_steps
+        ):
+            raise ValueError("curve_steps must be a tuple of integers")
+        for name in ("curve_ewm_reward", "curve_window_reward"):
+            values = getattr(self, name)
+            if type(values) is not tuple:
+                raise ValueError(f"{name} must be a tuple of real numbers")
+            object.__setattr__(
+                self,
+                name,
+                tuple(_require_result_scalar(value, name=name) for value in values),
+            )
+        for name in ("environment", "metric_contract", "agent_metadata"):
+            if not isinstance(getattr(self, name), Mapping):
+                raise ValueError(f"{name} must be a mapping")
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible result."""
@@ -4005,6 +4062,63 @@ class PaperForagerProtocol:
     hidden_switch_interval_steps: int | None
     metric_definition: str
     single_stream: bool = True
+
+    def __post_init__(self) -> None:
+        """Reject bool counts/windows before they shrink evaluation to one seed."""
+
+        if self.preset not in ("relearning", "field_of_view", "unending"):
+            raise ValueError("preset is invalid")
+        if not isinstance(self.environment, ForagerEnvConfig):
+            raise ValueError("environment must be a ForagerEnvConfig")
+        for name in (
+            "tuning_steps",
+            "tuning_seeds",
+            "evaluation_steps",
+            "evaluation_seeds",
+            "final_window_steps",
+        ):
+            _require_builtin_int(getattr(self, name), name=name, minimum=1)
+        _require_builtin_int(
+            self.tuning_seed_offset, name="tuning_seed_offset", minimum=0
+        )
+        _require_builtin_int(
+            self.evaluation_seed_start, name="evaluation_seed_start", minimum=0
+        )
+        if self.frozen_ablation_after_steps is not None:
+            _require_builtin_int(
+                self.frozen_ablation_after_steps,
+                name="frozen_ablation_after_steps",
+                minimum=1,
+            )
+        if self.hidden_switch_interval_steps is not None:
+            _require_builtin_int(
+                self.hidden_switch_interval_steps,
+                name="hidden_switch_interval_steps",
+                minimum=1,
+            )
+        tuning_fraction = _require_real(self.tuning_fraction, name="tuning_fraction")
+        if not 0.0 <= tuning_fraction <= 1.0:
+            raise ValueError("tuning_fraction must lie in [0, 1]")
+        object.__setattr__(self, "tuning_fraction", tuning_fraction)
+        confidence = _require_real(self.confidence, name="confidence")
+        if not 0.0 < confidence <= 1.0:
+            raise ValueError("confidence must lie in (0, 1]")
+        object.__setattr__(self, "confidence", confidence)
+        ewm_decay = _require_real(self.ewm_decay, name="ewm_decay")
+        if not 0.0 <= ewm_decay < 1.0:
+            raise ValueError("ewm_decay must lie in [0, 1)")
+        object.__setattr__(self, "ewm_decay", ewm_decay)
+        if self.primary_metric not in (
+            "final_window_mean_reward",
+            "mean_ewm_reward",
+            "final_ewm_reward",
+            "fov_last_10pct_ema_auc",
+        ):
+            raise ValueError("primary_metric is invalid")
+        if type(self.metric_definition) is not str or not self.metric_definition:
+            raise ValueError("metric_definition must be a non-empty string")
+        if type(self.single_stream) is not bool:
+            raise ValueError("single_stream must be a boolean")
 
     def to_dict(self) -> dict[str, Any]:
         data = dataclasses.asdict(self)

--- a/tests/test_forager_paper_reference_leftover_identities.py
+++ b/tests/test_forager_paper_reference_leftover_identities.py
@@ -7,8 +7,11 @@ import json
 import pytest
 
 from alberta_framework.benchmarks.forager import (
+    ForagerRunResult,
     PaperBaseline,
+    PaperForagerProtocol,
     PaperReferenceTarget,
+    paper_protocol,
     paper_reference_targets,
 )
 
@@ -73,3 +76,100 @@ def test_paper_reference_targets_remain_legal() -> None:
     assert rtu.central_estimate == pytest.approx(1.3)
     dumped = json.dumps(rtu.to_dict(), allow_nan=False)
     assert '"central_estimate": 1.3' in dumped
+
+
+def _legal_run_result(**overrides: object) -> ForagerRunResult:
+    payload: dict[str, object] = {
+        "agent": "toy",
+        "privileged": False,
+        "seed": 0,
+        "steps": 10,
+        "total_reward": 1.0,
+        "mean_reward": 0.1,
+        "final_window_mean_reward": 0.1,
+        "final_ewm_reward": 0.1,
+        "mean_ewm_reward": 0.1,
+        "fov_last_10pct_ema_auc": 0.1,
+        "mean_biome_regret": 0.0,
+        "final_biome_regret": 0.0,
+        "curve_steps": (1, 10),
+        "curve_ewm_reward": (0.1, 0.1),
+        "curve_window_reward": (0.1, 0.1),
+        "duration_s": 1.0,
+        "frames_per_second": 10.0,
+        "environment": {"env_id": "fake"},
+        "metric_contract": {"metric": "mean_reward"},
+        "agent_metadata": {"name": "toy"},
+    }
+    payload.update(overrides)
+    return ForagerRunResult(**payload)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("evaluation_seeds", True),
+        ("evaluation_seeds", False),
+        ("evaluation_seeds", 0),
+        ("final_window_steps", True),
+        ("final_window_steps", 0),
+        ("tuning_seeds", True),
+        ("evaluation_steps", True),
+        ("single_stream", 1),
+        ("confidence", True),
+        ("ewm_decay", True),
+    ],
+)
+def test_paper_forager_protocol_rejects_bool_counts_and_windows(
+    field: str, value: object
+) -> None:
+    legal = paper_protocol()
+    kwargs = {name: getattr(legal, name) for name in legal.__dataclass_fields__}
+    kwargs[field] = value
+    with pytest.raises(ValueError, match=field):
+        PaperForagerProtocol(**kwargs)  # type: ignore[arg-type]
+
+
+def test_paper_forager_protocol_keeps_integer_json_and_seed_range() -> None:
+    protocol = paper_protocol("relearning")
+    dumped = json.dumps(protocol.to_dict(), allow_nan=False)
+    assert '"evaluation_seeds": 30' in dumped
+    assert '"final_window_steps": 100000' in dumped
+    assert '"evaluation_seeds": true' not in dumped
+    assert '"final_window_steps": true' not in dumped
+    seeds = range(
+        protocol.evaluation_seed_start,
+        protocol.evaluation_seed_start + protocol.evaluation_seeds,
+    )
+    assert len(tuple(seeds)) == 30
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("steps", True),
+        ("steps", False),
+        ("steps", 0),
+        ("seed", True),
+        ("seed", -1),
+        ("privileged", 1),
+        ("mean_reward", True),
+        ("duration_s", True),
+        ("duration_s", float("inf")),
+    ],
+)
+def test_forager_run_result_rejects_bool_seed_and_steps(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        _legal_run_result(**{field: value})
+
+
+def test_forager_run_result_keeps_integer_json() -> None:
+    result = _legal_run_result()
+    dumped = json.dumps(result.to_dict(), allow_nan=False)
+    assert '"seed": 0' in dumped
+    assert '"steps": 10' in dumped
+    assert '"seed": true' not in dumped
+    assert '"steps": true' not in dumped
+    assert '"privileged": false' in dumped

--- a/tests/test_forager_paper_reference_leftover_identities.py
+++ b/tests/test_forager_paper_reference_leftover_identities.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 
+import numpy as np
 import pytest
 
 from alberta_framework.benchmarks.forager import (
+    ForagerEnvConfig,
     ForagerRunResult,
     PaperBaseline,
     PaperForagerProtocol,
@@ -173,3 +175,93 @@ def test_forager_run_result_keeps_integer_json() -> None:
     assert '"seed": true' not in dumped
     assert '"steps": true' not in dumped
     assert '"privileged": false' in dumped
+
+
+def test_run_result_rejects_hostile_scalar_subclasses_before_hooks() -> None:
+    calls = 0
+
+    class HostileInt(int):
+        def __int__(self) -> int:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("integer conversion hook reached")
+
+    class HostileFloat(float):
+        def __float__(self) -> float:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("float conversion hook reached")
+
+    with pytest.raises(ValueError, match="seed"):
+        _legal_run_result(seed=HostileInt(1))
+    with pytest.raises(ValueError, match="mean_reward"):
+        _legal_run_result(mean_reward=HostileFloat(1.0))
+    assert calls == 0
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"curve_steps": ()},
+        {"curve_steps": (1, 1)},
+        {"curve_steps": (1, 11)},
+        {"curve_ewm_reward": (0.1,)},
+        {"curve_window_reward": (0.1,)},
+        {"duration_s": -1.0},
+        {"frames_per_second": -1.0},
+    ],
+)
+def test_run_result_rejects_cross_field_and_domain_drift(
+    overrides: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        _legal_run_result(**overrides)
+
+
+def test_protocol_rejects_hostile_string_subclasses_before_comparison() -> None:
+    calls = 0
+
+    class HostileString(str):
+        def __eq__(self, other: object) -> bool:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("string comparison hook reached")
+
+        __hash__ = str.__hash__
+
+    legal = paper_protocol()
+    kwargs = {name: getattr(legal, name) for name in legal.__dataclass_fields__}
+    for field in ("preset", "primary_metric"):
+        hostile = dict(kwargs)
+        hostile[field] = HostileString(str(kwargs[field]))
+        with pytest.raises(ValueError, match=field):
+            PaperForagerProtocol(**hostile)  # type: ignore[arg-type]
+    assert calls == 0
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("final_window_steps", 10_000_001),
+        ("frozen_ablation_after_steps", 10_000_001),
+        ("hidden_switch_interval_steps", 10_000_001),
+        ("evaluation_seed_start", 2**31 - 20),
+    ],
+)
+def test_protocol_rejects_cross_field_resource_drift(field: str, value: int) -> None:
+    legal = paper_protocol()
+    kwargs = {name: getattr(legal, name) for name in legal.__dataclass_fields__}
+    kwargs[field] = value
+    with pytest.raises(ValueError):
+        PaperForagerProtocol(**kwargs)  # type: ignore[arg-type]
+
+
+def test_environment_rejects_hostile_container_and_scalar_subclasses() -> None:
+    with pytest.raises(ValueError, match="aperture_size"):
+        ForagerEnvConfig(aperture_size=np.int32(9))  # type: ignore[arg-type]
+
+    class MappingSubclass(dict[str, object]):
+        pass
+
+    with pytest.raises(ValueError, match="actual dict"):
+        ForagerEnvConfig(extra_kwargs=MappingSubclass())


### PR DESCRIPTION
Contributor-preserving corrective successor to #1458 and #1459. Closes #1457.

Preserves byt61 commit `ced5b10e` and ss251/Cursor commit `f1a5c141`. Deep review removes remaining hostile subclass dispatch in seeds, result scalars/curve steps, protocol preset/metric selection, and environment dimensions/containers. It also binds result curve lengths/order/lifetime bounds, nonnegative timing domains, protocol window/ablation/switch limits, and complete evaluation/tuning seed ranges inside the JAX seed domain.

Verification: 152 focused Forager tests passed; Ruff clean; mypy clean. No benchmarks, outputs, or evidence runs.