### PR TITLE
fix(benchmarks): reject bool seed-execution artifact identities

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_executor.py
+++ b/alberta_framework/benchmarks/forager_matched_executor.py
@@ -729,6 +729,18 @@ class SeedExecutionArtifacts:
     trace_artifact: Mapping[str, Any]
     scoring_record: Mapping[str, Any]
 
+    def __post_init__(self) -> None:
+        """Reject bool seed/score identities before they become JSON ``true``."""
+
+        _identifier(self.candidate_id, "candidate_id")
+        _integer(self.seed, "seed", minimum=0, maximum=2**31 - 1)
+        if type(self.score) is not float or not math.isfinite(self.score):
+            raise ForagerMatchedExecutorError("score must be a finite built-in float")
+        _sha256(self.live_runtime_identity_sha256, "live_runtime_identity_sha256")
+        for name in ("raw_artifact", "trace_artifact", "scoring_record"):
+            if not isinstance(getattr(self, name), Mapping):
+                raise ForagerMatchedExecutorError(f"{name} must be a mapping")
+
     @property
     def raw_artifact_sha256(self) -> str:
         return _canonical_sha256(self.raw_artifact)

--- a/tests/test_forager_matched_executor_hostile_validation.py
+++ b/tests/test_forager_matched_executor_hostile_validation.py
@@ -10,6 +10,7 @@ from alberta_framework.benchmarks.forager_matched_executor import (
     ForagerMatchedExecutorError,
     LiveRuntimeIdentity,
     PreparedCandidate,
+    SeedExecutionArtifacts,
 )
 
 
@@ -59,3 +60,49 @@ def test_prepared_candidate_validation() -> None:
             capability_receipt_sha256="c" * 64,
             source_inventory={},
         )
+
+
+def _legal_seed_artifacts(**overrides: object) -> SeedExecutionArtifacts:
+    payload: dict[str, object] = {
+        "candidate_id": "isolated_ppo",
+        "seed": 2_200_001,
+        "score": 1.25,
+        "live_runtime_identity_sha256": "a" * 64,
+        "raw_artifact": {"kind": "raw"},
+        "trace_artifact": {"kind": "trace"},
+        "scoring_record": {"kind": "score"},
+    }
+    payload.update(overrides)
+    return SeedExecutionArtifacts(**payload)  # type: ignore[arg-type]
+
+
+def test_seed_execution_artifacts_remain_legal() -> None:
+    legal = _legal_seed_artifacts()
+    dumped = legal.to_dict()
+    assert dumped["seed"] == 2_200_001
+    assert dumped["seed"] is not True
+    assert dumped["score_hex"] == (1.25).hex()
+    assert dumped["candidate_id"] == "isolated_ppo"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("seed", True),
+        ("seed", False),
+        ("seed", -1),
+        ("score", True),
+        ("score", False),
+        ("score", float("nan")),
+        ("score", float("inf")),
+        ("score", 1),
+        ("candidate_id", ""),
+        ("live_runtime_identity_sha256", "not-a-digest"),
+        ("raw_artifact", ["not-a-mapping"]),
+    ],
+)
+def test_seed_execution_artifacts_reject_bool_seed_and_score(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ForagerMatchedExecutorError, match=field):
+        _legal_seed_artifacts(**{field: value})


### PR DESCRIPTION
Closes #1466.

## What changed

`SeedExecutionArtifacts` now fail-closes in `__post_init__` before bool `seed` / `score` become live artifact identities.

On `origin/main` `4ef3830`, `seed=True` constructed and `to_dict()` published JSON `true`. `score=True` constructed and then crashed `score_hex()` (`bool` has no `.hex()`). Legal reconstructed bundles stay legal. Neighbor `LiveRuntimeIdentity` / `IndexedExecutionReceipt` were already gated.

## Scope

- `alberta_framework/benchmarks/forager_matched_executor.py`
- `tests/test_forager_matched_executor_hostile_validation.py`

## Occupancy

Open ASI PRs at publish: `#1463` (our `_CandidateSpec`), byt61 `#1461`/`#1464`. No open PR on this file. Not scorers. Not grok constructor seats.

## Verification

- Red on base: `SeedExecutionArtifacts(..., seed=True)` constructed; `to_dict()["seed"] is True`
- Red on base: `SeedExecutionArtifacts(..., score=True)` constructed; `to_dict()` raised `AttributeError`
- Targeted executor + hostile tests: 18 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary validation only. No kernel math, scorer, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9d5cb2fbda036c9eb4d8675bb83c25d2265e23e5 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
