### PR TITLE
fix(benchmarks): reject bool cell-scan attempt identities

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_campaign.py
@@ -1377,6 +1377,45 @@ class _CellScan:
     pointer_present: bool
     retained_raw_bytes: int
 
+    def __post_init__(self) -> None:
+        """Reject bool attempt/byte identities before they become one-step scans."""
+
+        if self.artifact is not None and type(self.artifact) is not executor.SeedExecutionArtifacts:
+            raise ForagerMatchedCampaignError(
+                "artifact must be a SeedExecutionArtifacts or None"
+            )
+        for name in ("completed_attempt", "resumable_attempt"):
+            value = getattr(self, name)
+            if value is not None and not isinstance(value, Path):
+                raise ForagerMatchedCampaignError(f"{name} must be a Path or None")
+        for name in ("raw_binding_sha256", "bundle_sha256"):
+            value = getattr(self, name)
+            if value is not None and (
+                type(value) is not str or _SHA256_RE.fullmatch(value) is None
+            ):
+                raise ForagerMatchedCampaignError(f"{name} must be a SHA-256 or None")
+        if self.resumable_binding is not None and not isinstance(
+            self.resumable_binding, Mapping
+        ):
+            raise ForagerMatchedCampaignError("resumable_binding must be a mapping or None")
+        if (
+            type(self.next_attempt_number) is not int
+            or not 1 <= self.next_attempt_number <= _MAX_ATTEMPTS_PER_CELL + 1
+        ):
+            raise ForagerMatchedCampaignError(
+                "next_attempt_number must be an integer in "
+                f"[1, {_MAX_ATTEMPTS_PER_CELL + 1}]"
+            )
+        if type(self.pointer_present) is not bool:
+            raise ForagerMatchedCampaignError("pointer_present must be a boolean")
+        if (
+            type(self.retained_raw_bytes) is not int
+            or not 0 <= self.retained_raw_bytes <= _MAX_RETAINED_RAW_BYTES_PER_CELL
+        ):
+            raise ForagerMatchedCampaignError(
+                "retained_raw_bytes must be a non-negative int"
+            )
+
 
 def _validate_failures(
     attempt: Path,

--- a/tests/test_forager_matched_campaign_hostile_validation.py
+++ b/tests/test_forager_matched_campaign_hostile_validation.py
@@ -10,6 +10,7 @@ from alberta_framework.benchmarks.forager_matched_campaign import (
     CampaignStatus,
     CompletedCampaignBundle,
     ForagerMatchedCampaignError,
+    _CellScan,
 )
 
 
@@ -102,3 +103,59 @@ def test_completed_campaign_bundle_validation() -> None:
             completion_summary={},
             final_file_sha256={},
         )
+
+
+def _legal_cell_scan(**overrides: object) -> _CellScan:
+    payload: dict[str, object] = {
+        "artifact": None,
+        "completed_attempt": None,
+        "raw_binding_sha256": None,
+        "bundle_sha256": None,
+        "resumable_attempt": None,
+        "resumable_binding": None,
+        "next_attempt_number": 1,
+        "pointer_present": False,
+        "retained_raw_bytes": 0,
+    }
+    payload.update(overrides)
+    return _CellScan(**payload)  # type: ignore[arg-type]
+
+
+def test_cell_scan_legal_empty_and_completed_shapes() -> None:
+    empty = _legal_cell_scan()
+    assert empty.next_attempt_number == 1
+    assert empty.pointer_present is False
+    assert empty.retained_raw_bytes == 0
+    completed = _legal_cell_scan(
+        completed_attempt=Path("attempts/attempt-001"),
+        raw_binding_sha256="a" * 64,
+        bundle_sha256="b" * 64,
+        next_attempt_number=2,
+        pointer_present=True,
+        retained_raw_bytes=1024,
+    )
+    assert completed.pointer_present is True
+    assert completed.next_attempt_number == 2
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("next_attempt_number", True),
+        ("next_attempt_number", False),
+        ("next_attempt_number", 0),
+        ("retained_raw_bytes", True),
+        ("retained_raw_bytes", False),
+        ("retained_raw_bytes", -1),
+        ("pointer_present", 1),
+        ("pointer_present", 0),
+        ("completed_attempt", "attempts/attempt-001"),
+        ("raw_binding_sha256", "not-a-digest"),
+        ("resumable_binding", ["not-a-mapping"]),
+    ],
+)
+def test_cell_scan_rejects_bool_attempt_and_byte_identities(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ForagerMatchedCampaignError, match=field):
+        _legal_cell_scan(**{field: value})


### PR DESCRIPTION
Closes #1469.

## What changed

`_CellScan` now fail-closes in `__post_init__` before bool `next_attempt_number` / `retained_raw_bytes` or int `pointer_present` become a one-step resume identity.

On `origin/main` `4ef3830`, `True` constructed for both integer fields and `pointer_present=1` stored an int. Legal empty and completed scans stay legal. Neighbor `CampaignStatus` / `CompletedCampaignBundle` were already gated.

## Scope

- `alberta_framework/benchmarks/forager_matched_campaign.py`
- `tests/test_forager_matched_campaign_hostile_validation.py`

## Occupancy

Open ASI PRs at publish: `#1468` / `#1463` (ours, other files), byt61 `#1461`/`#1464`/`#1467`. No open PR on this file. Not scorers. Not grok constructor seats.

## Verification

- Red on base: `_CellScan(..., next_attempt_number=True, retained_raw_bytes=True)` constructed
- Red on base: `_CellScan(..., pointer_present=1)` constructed with `type is int`
- Hostile + bounded-attempt + cell-binding tests: 17 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary validation only. No kernel math, campaign schedule, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:066a1ca48922baf0dcb65754bbbbb06751afa1cc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
