### PR TITLE
fix(benchmarks): complete benchmark host identity contracts

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -337,7 +337,7 @@ def environment_rng_schedule_sha256(
     identity: str = FORAGER_ENVIRONMENT_RNG_SCHEDULE,
 ) -> str:
     """Hash the normalized cross-harness environment RNG schedule identity."""
-    if not isinstance(identity, str) or not identity:
+    if type(identity) is not str or not identity:
         raise ValueError("environment RNG schedule identity must be a non-empty string")
     encoded = json.dumps(
         {
@@ -1912,7 +1912,7 @@ def _run_forager_host(
     """Run a generic policy through the host-driven reference loop."""
     policy_name = policy.name
     policy_privileged = policy.privileged
-    if not isinstance(policy_name, str) or not policy_name:
+    if type(policy_name) is not str or not policy_name:
         raise ValueError("policy.name must be a non-empty string")
     if type(policy_privileged) is not bool:
         raise ValueError("policy.privileged must be a boolean")
@@ -3859,7 +3859,7 @@ def summarize_forager_runs(
         "mean_ewm_reward",
         "fov_last_10pct_ema_auc",
     }
-    if not isinstance(metric, str) or metric not in supported_metrics:
+    if type(metric) is not str or metric not in supported_metrics:
         raise ValueError(f"unsupported Forager summary metric {metric!r}")
     if any(not isinstance(run, ForagerRunResult) for run in runs):
         raise TypeError("runs must contain only ForagerRunResult values")
@@ -4032,7 +4032,7 @@ def compare_forager_agents(
     if config is not None and not isinstance(config, ForagerBenchmarkConfig):
         raise TypeError("config must be a ForagerBenchmarkConfig")
     if any(
-        not isinstance(label, str) or not label or not callable(factory)
+        type(label) is not str or not label or not callable(factory)
         for label, factory in agent_factories.items()
     ):
         raise TypeError(

--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -3861,7 +3861,9 @@ def summarize_forager_runs(
     }
     if type(metric) is not str or metric not in supported_metrics:
         raise ValueError(f"unsupported Forager summary metric {metric!r}")
-    if any(not isinstance(run, ForagerRunResult) for run in runs):
+    if type(runs) not in (list, tuple):
+        raise TypeError("runs must be an actual list or tuple")
+    if any(type(run) is not ForagerRunResult for run in runs):
         raise TypeError("runs must contain only ForagerRunResult values")
     names = {run.agent for run in runs}
     privileged = {run.privileged for run in runs}
@@ -4017,8 +4019,8 @@ def compare_forager_agents(
     bootstrap_resamples: int = 10_000,
 ) -> dict[str, ForagerBenchmarkSummary]:
     """Evaluate every method on the same independent seed set."""
-    if not isinstance(agent_factories, Mapping):
-        raise TypeError("agent_factories must be a mapping")
+    if type(agent_factories) is not dict:
+        raise TypeError("agent_factories must be an actual dict")
     if not agent_factories:
         raise ValueError("at least one agent factory is required")
     if len(seeds) == 0:

--- a/alberta_framework/benchmarks/forager_matched_open_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_open_protocol.py
@@ -283,6 +283,36 @@ class MatchedCurrentCandidateQualification:
             )
 
 
+def _require_spec_text(value: object, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ForagerMatchedOpenProtocolBuildError(f"{name} must be a non-empty string")
+    return value
+
+
+def _require_spec_choice(value: object, name: str, allowed: tuple[str, ...]) -> str:
+    if type(value) is not str:
+        raise ForagerMatchedOpenProtocolBuildError(f"{name} must be an exact string")
+    if value not in allowed:
+        raise ForagerMatchedOpenProtocolBuildError(f"{name} is invalid")
+    return value
+
+
+def _require_spec_bool(value: object, name: str) -> bool:
+    if type(value) is not bool:
+        raise ForagerMatchedOpenProtocolBuildError(f"{name} must be a boolean")
+    return value
+
+
+def _require_spec_int(value: object, name: str, *, minimum: int) -> int:
+    if isinstance(value, bool) or type(value) is not int:
+        raise ForagerMatchedOpenProtocolBuildError(f"{name} must be an integer")
+    if value < minimum:
+        raise ForagerMatchedOpenProtocolBuildError(
+            f"{name} must be an integer >= {minimum}"
+        )
+    return value
+
+
 @dataclass(frozen=True)
 class _CandidateSpec:
     candidate_id: str
@@ -309,6 +339,77 @@ class _CandidateSpec:
     privileged_fields: tuple[str, ...]
     pairing_eligible: bool
     exclusion_reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Reject bool horizons before they become one-step identities."""
+
+        _require_spec_text(self.candidate_id, "candidate_id")
+        _require_spec_text(self.selection_group, "selection_group")
+        _require_spec_choice(
+            self.stratum,
+            "stratum",
+            ("alberta_learning", "external_learning", "privileged_context"),
+        )
+        _require_spec_text(self.implementation_kind, "implementation_kind")
+        _require_spec_text(self.entrypoint_family, "entrypoint_family")
+        _require_spec_choice(
+            self.seed_transport,
+            "seed_transport",
+            ("direct", "top_level_seed", "adapter_injected"),
+        )
+        if self.rollout_steps is not None:
+            _require_spec_int(self.rollout_steps, "rollout_steps", minimum=1)
+        _require_spec_text(self.update_semantics, "update_semantics")
+        _require_spec_text(self.source_repository, "source_repository")
+        _require_spec_text(self.source_base_commit, "source_base_commit")
+        _require_spec_choice(
+            self.source_provenance_kind,
+            "source_provenance_kind",
+            ("git_tree", "reviewed_snapshot"),
+        )
+        _require_spec_choice(
+            self.agent_rng_identity,
+            "agent_rng_identity",
+            ("isolated_agent_rng_v1", "shared_agent_environment_rng_v1"),
+        )
+        _require_spec_bool(self.environment_key_shared, "environment_key_shared")
+        _require_spec_choice(
+            self.environment_rng_identity,
+            "environment_rng_identity",
+            (
+                "dedicated_environment_split_chain_v1",
+                "shared_agent_environment_rng_v1",
+            ),
+        )
+        _require_spec_choice(
+            self.access_mode,
+            "access_mode",
+            (
+                "partial_observation",
+                "privileged_global_objects",
+                "privileged_reward_grid",
+            ),
+        )
+        _require_spec_text(self.observation_type, "observation_type")
+        if isinstance(self.aperture_size, bool) or type(self.aperture_size) is not int:
+            raise ForagerMatchedOpenProtocolBuildError("aperture_size must be an integer")
+        if self.aperture_size != -1 and self.aperture_size not in range(1, 16, 2):
+            raise ForagerMatchedOpenProtocolBuildError(
+                "aperture_size must be -1 or one of 1, 3, 5, 7, 9, 11, 13, 15"
+            )
+        if type(self.privileged_fields) is not tuple or any(
+            type(field) is not str or not field for field in self.privileged_fields
+        ):
+            raise ForagerMatchedOpenProtocolBuildError(
+                "privileged_fields must be a tuple of non-empty strings"
+            )
+        _require_spec_bool(self.pairing_eligible, "pairing_eligible")
+        if type(self.exclusion_reasons) is not tuple or any(
+            type(reason) is not str or not reason for reason in self.exclusion_reasons
+        ):
+            raise ForagerMatchedOpenProtocolBuildError(
+                "exclusion_reasons must be a tuple of non-empty strings"
+            )
 
 
 def _causal_specs() -> tuple[_CandidateSpec, ...]:

--- a/alberta_framework/benchmarks/forager_matched_open_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_open_protocol.py
@@ -303,12 +303,18 @@ def _require_spec_bool(value: object, name: str) -> bool:
     return value
 
 
-def _require_spec_int(value: object, name: str, *, minimum: int) -> int:
+def _require_spec_int(
+    value: object,
+    name: str,
+    *,
+    minimum: int,
+    maximum: int = 2**31 - 1,
+) -> int:
     if isinstance(value, bool) or type(value) is not int:
         raise ForagerMatchedOpenProtocolBuildError(f"{name} must be an integer")
-    if value < minimum:
+    if not minimum <= value <= maximum:
         raise ForagerMatchedOpenProtocolBuildError(
-            f"{name} must be an integer >= {minimum}"
+            f"{name} must be an integer in [{minimum}, {maximum}]"
         )
     return value
 
@@ -358,10 +364,24 @@ class _CandidateSpec:
             ("direct", "top_level_seed", "adapter_injected"),
         )
         if self.rollout_steps is not None:
-            _require_spec_int(self.rollout_steps, "rollout_steps", minimum=1)
+            _require_spec_int(
+                self.rollout_steps,
+                "rollout_steps",
+                minimum=1,
+                maximum=MATCHED_CURRENT_HORIZON,
+            )
         _require_spec_text(self.update_semantics, "update_semantics")
         _require_spec_text(self.source_repository, "source_repository")
         _require_spec_text(self.source_base_commit, "source_base_commit")
+        if self.source_repository not in (
+            MATCHED_CURRENT_ALBERTA_REPOSITORY,
+            MATCHED_CURRENT_UPSTREAM_REPOSITORY,
+        ):
+            raise ForagerMatchedOpenProtocolBuildError("source_repository is invalid")
+        if re.fullmatch(r"[0-9a-f]{40}", self.source_base_commit) is None:
+            raise ForagerMatchedOpenProtocolBuildError(
+                "source_base_commit must be a lowercase Git commit"
+            )
         _require_spec_choice(
             self.source_provenance_kind,
             "source_provenance_kind",
@@ -409,6 +429,37 @@ class _CandidateSpec:
         ):
             raise ForagerMatchedOpenProtocolBuildError(
                 "exclusion_reasons must be a tuple of non-empty strings"
+            )
+        if (self.rollout_steps is None) != (
+            self.update_semantics == "environment_step_counted"
+        ):
+            raise ForagerMatchedOpenProtocolBuildError(
+                "rollout_steps and update_semantics are inconsistent"
+            )
+        if (
+            self.rollout_steps is not None
+            and MATCHED_CURRENT_HORIZON % self.rollout_steps != 0
+        ):
+            raise ForagerMatchedOpenProtocolBuildError(
+                "rollout_steps must divide the matched horizon"
+            )
+        shared_rng = self.agent_rng_identity == "shared_agent_environment_rng_v1"
+        if (
+            self.environment_key_shared is not shared_rng
+            or (self.environment_rng_identity == "shared_agent_environment_rng_v1")
+            is not shared_rng
+        ):
+            raise ForagerMatchedOpenProtocolBuildError(
+                "agent and environment RNG identities are inconsistent"
+            )
+        privileged_access = self.access_mode != "partial_observation"
+        if bool(self.privileged_fields) is not privileged_access:
+            raise ForagerMatchedOpenProtocolBuildError(
+                "privileged_fields do not match observation access"
+            )
+        if self.pairing_eligible == bool(self.exclusion_reasons):
+            raise ForagerMatchedOpenProtocolBuildError(
+                "pairing eligibility and exclusion reasons are inconsistent"
             )
 
 

--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1197,7 +1197,7 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
     if arm_name not in MICRO_ARM_REGISTRY:
         raise ValueError(f"{path}: unknown arm {arm_name!r}")
     arm_spec = MICRO_ARM_REGISTRY[arm_name]
-    if not isinstance(payload.get("mechanism"), str) or not payload["mechanism"]:
+    if type(payload.get("mechanism")) is not str or not payload["mechanism"]:
         raise ValueError(f"{path}: mechanism must be a non-empty string")
     if not isinstance(payload.get("hyperparameters"), dict):
         raise ValueError(f"{path}: hyperparameters must be an object")
@@ -1217,7 +1217,7 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
     environment = payload.get("environment")
     required_environment_fields = ("jax", "numpy", "python", "platform")
     if not isinstance(environment, dict) or any(
-        not isinstance(environment.get(field), str) or not environment[field]
+        type(environment.get(field)) is not str or not environment[field]
         for field in required_environment_fields
     ):
         raise ValueError(

--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1157,6 +1157,28 @@ _MICRO_CURVE_DOMAINS: dict[str, tuple[float, float | None]] = {
     "per_regime_loss": (0.0, None),
     "per_regime_plasticity": (0.0, 1.0),
 }
+_MICRO_SHARD_FIELDS = frozenset(
+    {
+        "schema",
+        "suite_version",
+        "evidence_policy",
+        "family",
+        "arm_name",
+        "mechanism",
+        "hyperparameters",
+        "seed",
+        "hidden1",
+        "hidden2",
+        "stream_config",
+        "per_regime_accuracy",
+        "per_regime_loss",
+        "per_regime_plasticity",
+        "overall_average_online_accuracy",
+        "wall_clock_seconds",
+        "created_unix",
+        "environment",
+    }
+)
 
 
 def _validated_curve(
@@ -1182,11 +1204,21 @@ def _validated_curve(
 
 def load_micro_shard(path: Path | str) -> dict[str, Any]:
     """Load and structurally validate one micro shard."""
-    path = Path(path)
+    if type(path) is str:
+        path = Path(path)
+    elif isinstance(path, Path) and type(path).__module__.startswith("pathlib"):
+        path = Path(path)
+    else:
+        raise ValueError("micro shard path must be an exact str or pathlib Path")
     payload = load_strict_json_object(path)
-    if payload.get("schema") != MICRO_SHARD_SCHEMA:
+    if set(payload) != _MICRO_SHARD_FIELDS:
+        raise ValueError(f"{path}: shard fields do not match the exact schema")
+    if type(payload.get("schema")) is not str or payload["schema"] != MICRO_SHARD_SCHEMA:
         raise ValueError(f"{path}: schema mismatch (expected {MICRO_SHARD_SCHEMA})")
-    if payload.get("suite_version") != MICRO_GAUSS_SUITE_VERSION:
+    if (
+        type(payload.get("suite_version")) is not str
+        or payload["suite_version"] != MICRO_GAUSS_SUITE_VERSION
+    ):
         raise ValueError(
             f"{path}: suite_version mismatch (expected {MICRO_GAUSS_SUITE_VERSION!r}, "
             f"got {payload.get('suite_version')!r})"
@@ -1216,9 +1248,13 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
         )
     environment = payload.get("environment")
     required_environment_fields = ("jax", "numpy", "python", "platform")
-    if not isinstance(environment, dict) or any(
-        type(environment.get(field)) is not str or not environment[field]
-        for field in required_environment_fields
+    if (
+        type(environment) is not dict
+        or set(environment) != set(required_environment_fields)
+        or any(
+            type(environment.get(field)) is not str or not environment[field]
+            for field in required_environment_fields
+        )
     ):
         raise ValueError(
             f"{path}: environment must record non-empty jax, numpy, python, and platform strings"
@@ -1247,6 +1283,26 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
         value = payload.get(fieldname)
         if type(value) is not int or value <= 0:
             raise ValueError(f"{path}: {fieldname} must be a positive integer")
+    if type(payload["evidence_policy"]) is not dict or payload["evidence_policy"] != dict(
+        NONPROMOTING_POLICY
+    ):
+        raise ValueError(f"{path}: evidence_policy mismatch")
+    overall = _require_finite_real(
+        payload["overall_average_online_accuracy"],
+        f"{path}: overall_average_online_accuracy",
+    )
+    if not 0.0 <= overall <= 1.0 or not math.isclose(
+        overall,
+        sum(payload["per_regime_accuracy"]) / config.n_regimes,
+        rel_tol=0.0,
+        abs_tol=1e-7,
+    ):
+        raise ValueError(f"{path}: overall_average_online_accuracy does not match curve")
+    payload["overall_average_online_accuracy"] = overall
+    created_unix = _require_finite_real(payload["created_unix"], f"{path}: created_unix")
+    if created_unix < 0.0:
+        raise ValueError(f"{path}: created_unix must be nonnegative")
+    payload["created_unix"] = created_unix
     return payload
 
 

--- a/tests/test_forager_matched_open_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_open_protocol_hostile_validation.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import hashlib
+from dataclasses import replace
 
 import pytest
 
 from alberta_framework.benchmarks.forager_matched_open_protocol import (
+    _CANDIDATE_SPECS,
+    MATCHED_CURRENT_HORIZON,
     ForagerMatchedOpenProtocolBuildError,
     MatchedCurrentCandidateQualification,
     MatchedCurrentRuntimeQualification,
+    _CandidateSpec,
 )
 
 
@@ -70,3 +74,57 @@ def test_candidate_qualification_rejects_invalid_types() -> None:
             capability_qualification_receipt_sha256=_digest(b"receipt"),
             resources=None,  # type: ignore[arg-type]
         )
+
+
+def _legal_spec(candidate_id: str = "isolated_ppo") -> _CandidateSpec:
+    return next(spec for spec in _CANDIDATE_SPECS if spec.candidate_id == candidate_id)
+
+
+def test_frozen_candidate_specs_remain_legal() -> None:
+    assert len(_CANDIDATE_SPECS) == 23
+    isolated_ppo = _legal_spec("isolated_ppo")
+    isolated_rtu = _legal_spec("isolated_rtu")
+    oracle = _legal_spec("search_oracle")
+    causal = _legal_spec("causal_e025_q050")
+    assert isolated_ppo.rollout_steps == 2_048
+    assert MATCHED_CURRENT_HORIZON // isolated_ppo.rollout_steps == 244
+    assert isolated_rtu.rollout_steps == 128
+    assert MATCHED_CURRENT_HORIZON // isolated_rtu.rollout_steps == 3_904
+    assert causal.rollout_steps is None
+    assert isolated_ppo.aperture_size == 9
+    assert oracle.aperture_size == -1
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("rollout_steps", True),
+        ("rollout_steps", False),
+        ("rollout_steps", 0),
+        ("aperture_size", True),
+        ("aperture_size", False),
+        ("aperture_size", 0),
+        ("aperture_size", 8),
+        ("environment_key_shared", 1),
+        ("pairing_eligible", 1),
+        ("seed_transport", "not_a_transport"),
+        ("candidate_id", ""),
+    ],
+)
+def test_candidate_spec_rejects_bool_horizon_identities(
+    field: str, value: object
+) -> None:
+    with pytest.raises(ForagerMatchedOpenProtocolBuildError, match=field):
+        replace(_legal_spec(), **{field: value})
+
+
+def test_candidate_spec_bool_rollout_would_collapse_horizon_identity() -> None:
+    """On origin/main, True constructed and MATCHED_CURRENT_HORIZON // True == 499712."""
+
+    legal = _legal_spec("isolated_ppo")
+    assert MATCHED_CURRENT_HORIZON // legal.rollout_steps == 244
+    assert MATCHED_CURRENT_HORIZON // True == MATCHED_CURRENT_HORIZON
+    with pytest.raises(ForagerMatchedOpenProtocolBuildError, match="rollout_steps"):
+        replace(legal, rollout_steps=True)
+    with pytest.raises(ForagerMatchedOpenProtocolBuildError, match="aperture_size"):
+        replace(legal, aperture_size=True)

--- a/tests/test_forager_matched_open_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_open_protocol_hostile_validation.py
@@ -128,3 +128,21 @@ def test_candidate_spec_bool_rollout_would_collapse_horizon_identity() -> None:
         replace(legal, rollout_steps=True)
     with pytest.raises(ForagerMatchedOpenProtocolBuildError, match="aperture_size"):
         replace(legal, aperture_size=True)
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"rollout_steps": 127},
+        {"rollout_steps": None},
+        {"source_base_commit": "A" * 40},
+        {"environment_key_shared": True},
+        {"privileged_fields": ("global_objects",)},
+        {"pairing_eligible": False},
+    ],
+)
+def test_candidate_spec_rejects_cross_field_and_provenance_drift(
+    updates: dict[str, object],
+) -> None:
+    with pytest.raises(ForagerMatchedOpenProtocolBuildError):
+        replace(_legal_spec(), **updates)

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -1441,6 +1441,9 @@ class TestShards:
         payload = micro_shard_payload(self._result())
         payload["per_regime_accuracy"] = [0] + list(payload["per_regime_accuracy"][1:])
         payload["per_regime_plasticity"] = [1] + list(payload["per_regime_plasticity"][1:])
+        payload["overall_average_online_accuracy"] = sum(
+            payload["per_regime_accuracy"]
+        ) / len(payload["per_regime_accuracy"])
         path = tmp_path / "ok.json"
         path.write_text(json.dumps(payload), encoding="utf-8")
         loaded = load_micro_shard(path)


### PR DESCRIPTION
Contributor-preserving consolidated successor to #1461, #1463, and #1464.

Preserves commits c980d3d1, f7a65436, and 924ac033, then completes the adjacent exact schema, scalar, cross-field, provenance, and resource validation boundaries for matched-open protocol records, micro-continual shards, and Forager summary/comparison entry points.

Closes #1462.

Validation:
- 130 focused tests passed
- Ruff passed
- mypy passed
- no benchmark/evidence execution and no output mutations