### PR TITLE
test(forager): align placeholder check with constructor gate

### DIFF
--- a/tests/test_forager_matched_open_protocol.py
+++ b/tests/test_forager_matched_open_protocol.py
@@ -564,15 +564,10 @@ def test_placeholder_or_mismatched_trust_bindings_fail_closed() -> None:
             candidate_qualifications=_qualifications(),
         )
 
-    qualifications = _qualifications()
-    target = qualifications["isolated_rtu"]
-    qualifications["isolated_rtu"] = replace(
-        target,
-        capability_qualification_receipt_sha256="f" * 64,
-    )
     with pytest.raises(builder.ForagerMatchedOpenProtocolBuildError, match="placeholder"):
-        builder.build_forager_matched_open_protocol(
-            runtime=_runtime(), candidate_qualifications=qualifications
+        replace(
+            _qualifications()["isolated_rtu"],
+            capability_qualification_receipt_sha256="f" * 64,
         )
 
 


### PR DESCRIPTION
Repairs the retained current-main failure in test_placeholder_or_mismatched_trust_bindings_fail_closed after exact qualification validation moved into MatchedCurrentCandidateQualification.__post_init__.

The runtime behavior is correct: a placeholder capability receipt must fail at construction. The stale test previously constructed the invalid object outside pytest.raises and expected the later builder call to reject it. This narrow correction wraps the actual constructor boundary and preserves the two builder-time runtime identity mismatch assertions.

Verification on current main 984a10e0:
- 44 tests passed across test_forager_matched_open_protocol.py and its hostile-validation companion
- Ruff clean
- strict mypy clean (174 source files)
- git diff --check clean

An expanded fixture-consumer run reached 217 passed and one unrelated final-analysis golden-manifest hash mismatch caused by current source identity movement; it was interrupted after 136 seconds. No outputs, benchmark execution, protocol source, or evidence promotion.