### PR TITLE
fix(security): reject leftover rollout-step identities

### DIFF
--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -316,6 +316,18 @@ class SecurityRolloutStep:
     truncated: bool = False
     policy_metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        """Reject leftover action/reward/termination identities before JSON dump."""
+
+        if type(self.action) is not SecurityAction:
+            raise ValueError("action must be an exact SecurityAction")
+        if type(self.reward) is bool or type(self.reward) not in _ALLOWED_REAL_TYPES:
+            raise ValueError("reward must be a finite real number")
+        if type(self.terminated) is not bool:
+            raise ValueError("terminated must be an exact bool")
+        if type(self.truncated) is not bool:
+            raise ValueError("truncated must be an exact bool")
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable transition mapping."""
         payload = {

--- a/tests/test_security_rollout_leftover_identities.py
+++ b/tests/test_security_rollout_leftover_identities.py
@@ -1,0 +1,49 @@
+"""Leftover-identity gates for security rollout-step records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.security import SecurityAction, SecurityRolloutStep
+
+
+def _legal_step(**overrides: object) -> SecurityRolloutStep:
+    payload: dict[str, object] = {
+        "state": (0.0, 1.0),
+        "action": SecurityAction.PASS,
+        "reward": 0.5,
+        "next_state": (0.0, 1.0),
+        "terminated": False,
+        "truncated": False,
+    }
+    payload.update(overrides)
+    return SecurityRolloutStep(**payload)  # type: ignore[arg-type]
+
+
+def test_security_rollout_step_rejects_leftover_identities() -> None:
+    """Public rollout records must not keep leftover bool/string identities."""
+
+    with pytest.raises(ValueError, match="reward"):
+        _legal_step(reward=True)
+    with pytest.raises(ValueError, match="reward"):
+        _legal_step(reward=False)
+    with pytest.raises(ValueError, match="terminated"):
+        _legal_step(terminated=1)
+    with pytest.raises(ValueError, match="truncated"):
+        _legal_step(truncated=0)
+    with pytest.raises(ValueError, match="action"):
+        _legal_step(action=True)
+    with pytest.raises(ValueError, match="action"):
+        _legal_step(action="FIXED")
+    with pytest.raises(ValueError, match="action"):
+        _legal_step(action="BLOCK")
+
+    legal = _legal_step()
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert '"reward": 0.5' in dumped
+    assert '"terminated": false' in dumped
+    assert '"reward": true' not in dumped
+    assert '"terminated": 1' not in dumped
+    assert legal.action is SecurityAction.PASS


### PR DESCRIPTION
Closes #1483.

## What changed

`SecurityRolloutStep` now fail-closes leftover action/reward/termination identities before `to_dict()` can dump them as JSON `true` / `1` / leftover action names.

On `origin/main` `7b0fa1b`, `reward=True` constructed and dumped JSON `true`; `terminated=1` / `truncated=0` constructed; `action="FIXED"` / `"BLOCK"` / `True` constructed. `from_dict` already rejected those leftovers. Legal `SecurityAction.PASS` and finite `reward=0.5` stay legal.

Adopted unpublished grok head `5ceb33e` (cherry-picked onto current main as `9bbc950`). Did not remine.

## Scope

- `alberta_framework/security.py`
- `tests/test_security_rollout_leftover_identities.py`

## Occupancy

Open ASI PRs at publish: `#1480` (ours, `recurring_feature_gate.py`), byt61 `#1478` `foragax_open_screen.py`, byt61 `#1482` `reference_life_scorecard.py`. Grok A holds `optimizers.py`. No open PR on `security.py`.

## Verification

- Red on base: `SecurityRolloutStep(..., reward=True)` constructed; `terminated=1` constructed
- Leftover + sibling reward-weight + hostile-validation: 21 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary leftover-identity validation only. No kernel math, reward weights, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9bbc950c26b30600025cd343afc7f00abe7c5fa2 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
