### PR TITLE
fix(types): reject leftover tracking-config identities

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -40,6 +40,22 @@ _ACTUAL_INT_TYPES = frozenset(
 )
 
 
+def _require_tracking_interval(value: object) -> int:
+    """Reject leftover bool/float identities before they become recording strides."""
+    if type(value) not in _ACTUAL_INT_TYPES:
+        raise ValueError("interval must be a non-negative integer")
+    number = operator.index(cast(SupportsIndex, value))
+    if number < 0:
+        raise ValueError("interval must be a non-negative integer")
+    return number
+
+
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an actual bool")
+    return value
+
+
 @chex.dataclass(frozen=True)
 class TimeStep:
     """Single experience from an experience stream.
@@ -277,6 +293,13 @@ class StepSizeTrackingConfig:
     interval: int
     include_bias: bool = True
 
+    def __post_init__(self) -> None:
+        """Reject leftover bool/float identities before they become recording strides."""
+        object.__setattr__(self, "interval", _require_tracking_interval(self.interval))
+        object.__setattr__(
+            self, "include_bias", _require_exact_bool("include_bias", self.include_bias)
+        )
+
 
 @chex.dataclass(frozen=True)
 class StepSizeHistory:
@@ -305,6 +328,10 @@ class NormalizerTrackingConfig:
     """
 
     interval: int
+
+    def __post_init__(self) -> None:
+        """Reject leftover bool/float identities before they become recording strides."""
+        object.__setattr__(self, "interval", _require_tracking_interval(self.interval))
 
 
 @chex.dataclass(frozen=True)

--- a/tests/test_types_tracking_leftover_identities.py
+++ b/tests/test_types_tracking_leftover_identities.py
@@ -1,0 +1,60 @@
+"""Leftover-identity gates for step-size and normalizer tracking configs."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.types import (
+    NormalizerTrackingConfig,
+    StepSizeTrackingConfig,
+)
+
+
+def test_step_size_tracking_config_rejects_leftover_identities() -> None:
+    """Tracking intervals and include_bias must not keep leftover bool/float identities."""
+
+    with pytest.raises(ValueError, match="interval"):
+        StepSizeTrackingConfig(interval=True)
+    with pytest.raises(ValueError, match="interval"):
+        StepSizeTrackingConfig(interval=False)
+    with pytest.raises(ValueError, match="interval"):
+        StepSizeTrackingConfig(interval=np.bool_(True))
+    with pytest.raises(ValueError, match="interval"):
+        StepSizeTrackingConfig(interval=1.0)
+    with pytest.raises(ValueError, match="interval"):
+        StepSizeTrackingConfig(interval=float("nan"))
+    with pytest.raises(ValueError, match="interval"):
+        StepSizeTrackingConfig(interval=-1)
+    with pytest.raises(ValueError, match="include_bias"):
+        StepSizeTrackingConfig(interval=10, include_bias=1)
+    with pytest.raises(ValueError, match="include_bias"):
+        StepSizeTrackingConfig(interval=10, include_bias=0)
+    with pytest.raises(ValueError, match="include_bias"):
+        StepSizeTrackingConfig(interval=10, include_bias=np.bool_(False))
+
+    legal = StepSizeTrackingConfig(interval=10, include_bias=False)
+    assert legal.interval == 10
+    assert legal.include_bias is False
+    assert type(legal.interval) is int
+    assert type(legal.include_bias) is bool
+    zero = StepSizeTrackingConfig(interval=0)
+    assert zero.interval == 0
+    assert zero.include_bias is True
+
+
+def test_normalizer_tracking_config_rejects_leftover_identities() -> None:
+    """Normalizer recording intervals must not keep leftover bool/float identities."""
+
+    with pytest.raises(ValueError, match="interval"):
+        NormalizerTrackingConfig(interval=True)
+    with pytest.raises(ValueError, match="interval"):
+        NormalizerTrackingConfig(interval=False)
+    with pytest.raises(ValueError, match="interval"):
+        NormalizerTrackingConfig(interval=float("nan"))
+    with pytest.raises(ValueError, match="interval"):
+        NormalizerTrackingConfig(interval=-1)
+
+    legal = NormalizerTrackingConfig(interval=0)
+    assert legal.interval == 0
+    assert type(legal.interval) is int


### PR DESCRIPTION
Closes #1486.

## What changed

`StepSizeTrackingConfig` and `NormalizerTrackingConfig` now fail-close leftover interval/`include_bias` identities before they become recording strides.

On `origin/main` `7b0fa1b`, `interval=True` constructed and compared as `1`, so `run_learning_loop`'s `interval < 1` check did not fire and a boolean recorded every step. `include_bias=1` stored an int. Legal `interval=0/1/10` and exact bools stay legal.

Adopted unpublished grok head `706a0e9` (cherry-picked onto current main as `c83bf88`). Did not remine.

## Scope

- `alberta_framework/core/types.py`
- `tests/test_types_tracking_leftover_identities.py`

## Occupancy

Open ASI PRs at publish: `#1480` recurring-gate, `#1484` security rollout, byt61 `#1478`/`#1482`/`#1485`. Grok A holds `optimizers.py`. No open PR on `types.py`.

## Verification

- Red on base: `StepSizeTrackingConfig(interval=True)` stored `bool`; `include_bias=1` stored `int`
- Leftover + GVF types suite: 82 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary leftover-identity validation only. No kernel math, learning-loop schedule, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c83bf885820f31b461ea6af516b39734855f8c19 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
