### PR TITLE
fix(learners): reject leftover MLP constructor scalars

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -32,7 +32,10 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core._float32_scalars import (
+    validated_float32_scalar,
+    validated_float32_scalar_with_ratio,
+)
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.normalizers import (
     EMANormalizerState,
@@ -81,6 +84,7 @@ from alberta_framework.streams.base import ScanStream
 
 _INT32_MAX = 2**31 - 1
 _MAX_RESOURCE_BYTES = 256 * 1024 * 1024
+_FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -115,6 +119,35 @@ def _require_hidden_sizes(hidden_sizes: object) -> tuple[int, ...]:
         _require_int32(f"hidden_sizes[{index}]", width, minimum=1)
         for index, width in enumerate(hidden_sizes)
     )
+
+
+def _validated_nonnegative_float32_scalar(
+    name: str,
+    value: object,
+    *,
+    upper: float | None = None,
+    upper_inclusive: bool = True,
+) -> float:
+    """Validate a nonnegative float32 sink without erasing a nonzero."""
+    stored, numerator, denominator = validated_float32_scalar_with_ratio(
+        name,
+        value,
+        lower=0.0,
+        upper=upper,
+        upper_inclusive=upper_inclusive,
+    )
+    if (
+        numerator != 0
+        and numerator * _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR <= denominator
+    ):
+        raise ValueError(f"{name} must remain nonzero once narrowed to float32")
+    return stored
+
+
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an exact bool")
+    return value
 
 
 def _preflight_float32_resources(name: str, scalar_count: int) -> None:
@@ -996,6 +1029,31 @@ class MLPLearner:
                 Higher values track slower, smoother utility signals.
         """
         self._hidden_sizes = _require_hidden_sizes(hidden_sizes)
+        step_size = validated_float32_scalar("step_size", step_size, positive=True)
+        sparsity = _validated_nonnegative_float32_scalar(
+            "sparsity", sparsity, upper=1.0
+        )
+        leaky_relu_slope = _validated_nonnegative_float32_scalar(
+            "leaky_relu_slope", leaky_relu_slope
+        )
+        gamma = _validated_nonnegative_float32_scalar("gamma", gamma, upper=1.0)
+        lamda = _validated_nonnegative_float32_scalar("lamda", lamda, upper=1.0)
+        if gamma != 0.0 and lamda != 0.0:
+            _validated_nonnegative_float32_scalar(
+                "gamma * lamda",
+                gamma * lamda,
+                upper=1.0,
+            )
+        neuron_utility_decay = _validated_nonnegative_float32_scalar(
+            "neuron_utility_decay",
+            neuron_utility_decay,
+            upper=1.0,
+            upper_inclusive=False,
+        )
+        use_layer_norm = _require_exact_bool("use_layer_norm", use_layer_norm)
+        track_neuron_utility = _require_exact_bool(
+            "track_neuron_utility", track_neuron_utility
+        )
         self._optimizer: AnyOptimizer = optimizer or LMS(step_size=step_size)
         self._head_optimizer: AnyOptimizer | None = head_optimizer
         if not self._optimizer.supported_for_mlp():

--- a/tests/test_mlp_learner.py
+++ b/tests/test_mlp_learner.py
@@ -1396,6 +1396,115 @@ class TestResetDormantOptimizerState:
         assert mse_last < mse_first
 
 
+class TestMLPLearnerConstructorScalars:
+    """Leftover constructor scalars must not sit on the single-head MLP host."""
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("sparsity", True),
+            ("sparsity", False),
+            ("sparsity", float("nan")),
+            ("sparsity", float("inf")),
+            ("sparsity", 1.5),
+            ("gamma", True),
+            ("gamma", float("nan")),
+            ("lamda", True),
+            ("lamda", float("nan")),
+            ("leaky_relu_slope", True),
+            ("leaky_relu_slope", float("nan")),
+            ("step_size", True),
+            ("step_size", False),
+            ("step_size", float("nan")),
+            ("step_size", 0.0),
+            ("neuron_utility_decay", True),
+            ("neuron_utility_decay", float("nan")),
+            ("neuron_utility_decay", 1.0),
+        ],
+    )
+    def test_rejects_leftover_constructor_scalars(self, field: str, value: object) -> None:
+        kwargs: dict[str, object] = {"hidden_sizes": (8,), "sparsity": 0.0}
+        kwargs[field] = value
+        with pytest.raises(ValueError, match=field):
+            MLPLearner(**kwargs)  # type: ignore[arg-type]
+
+    def test_true_sparsity_does_not_serialize_as_full_mask(self) -> None:
+        with pytest.raises(ValueError, match="sparsity"):
+            MLPLearner(hidden_sizes=(8,), sparsity=True)
+
+    def test_true_gamma_does_not_store_as_undiscounted_one(self) -> None:
+        with pytest.raises(ValueError, match="gamma"):
+            MLPLearner(hidden_sizes=(8,), gamma=True, lamda=0.0)
+
+    def test_bool_flags_require_exact_bool(self) -> None:
+        with pytest.raises(ValueError, match="use_layer_norm"):
+            MLPLearner(hidden_sizes=(8,), use_layer_norm=1)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="track_neuron_utility"):
+            MLPLearner(hidden_sizes=(8,), track_neuron_utility=1)  # type: ignore[arg-type]
+
+    def test_from_config_rejects_nan_sparsity_and_bool_gamma(self) -> None:
+        config = MLPLearner(hidden_sizes=(8,), sparsity=0.0).to_config()
+        poisoned = dict(config)
+        poisoned["sparsity"] = float("nan")
+        with pytest.raises(ValueError, match="sparsity"):
+            MLPLearner.from_config(poisoned)
+        poisoned = dict(config)
+        poisoned["gamma"] = True
+        with pytest.raises(ValueError, match="gamma"):
+            MLPLearner.from_config(poisoned)
+
+    def test_rejects_class_spoofed_sparsity_without_invoking_float(self) -> None:
+        class Spoof:
+            @property
+            def __class__(self) -> type[float]:  # type: ignore[override]
+                return float
+
+            def __float__(self) -> float:
+                raise RuntimeError("must not run")
+
+        with pytest.raises(ValueError, match="sparsity"):
+            MLPLearner(hidden_sizes=(8,), sparsity=Spoof())  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"sparsity": 2.0**-150},
+            {"leaky_relu_slope": 5e-324},
+            {"gamma": 2.0**-150},
+            {"lamda": 2.0**-150},
+            {"neuron_utility_decay": 5e-324},
+        ],
+    )
+    def test_rejects_nonzero_float32_underflow(self, kwargs: dict[str, object]) -> None:
+        with pytest.raises(ValueError, match="must remain nonzero"):
+            MLPLearner(hidden_sizes=(8,), **kwargs)  # type: ignore[arg-type]
+
+    def test_rejects_trace_product_that_underflows_float32(self) -> None:
+        with pytest.raises(ValueError, match=r"gamma \* lamda must remain nonzero"):
+            MLPLearner(hidden_sizes=(), gamma=2.0**-100, lamda=2.0**-100)
+
+    def test_legal_zeros_and_exact_bools_still_construct(self) -> None:
+        smallest_float32 = 2.0**-149
+        learner = MLPLearner(
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            leaky_relu_slope=0.0,
+            gamma=0.0,
+            lamda=smallest_float32,
+            use_layer_norm=False,
+            track_neuron_utility=True,
+            neuron_utility_decay=0.0,
+            step_size=0.1,
+        )
+        config = learner.to_config()
+        assert config["sparsity"] == 0.0
+        assert config["leaky_relu_slope"] == 0.0
+        assert config["lamda"] == smallest_float32
+        assert config["use_layer_norm"] is False
+        assert config["track_neuron_utility"] is True
+        assert config["neuron_utility_decay"] == 0.0
+
+
 def test_mlp_dimensions_are_exact_canonical_and_preflighted() -> None:
     for invalid in ([8], (True,), (0,), (2**31,)):
         with pytest.raises(ValueError, match="hidden_sizes"):


### PR DESCRIPTION
Closes #1489.

## What changed

`MLPLearner` now fail-closes leftover constructor scalars before `True`/`NaN` become sparsity, gamma, step_size, or bool flags.

On `origin/main` `9319da6`, `sparsity=True` constructed and serialized as a full mask; `gamma=True` stored undiscounted `1`; `step_size=True` was passed to default `LMS`; `use_layer_norm=1` stored an int. Legal zeros and exact bools stay legal. Sibling `MultiHeadMLPLearner` (`#931`) and `TrueOnlineTDLearner` (`#905`) already reject this class.

Adopted unpublished head `1d2d608` (cherry-picked onto current main as `c568957`). Did not remine. Not a `#1372` lifetime-clock reprint.

## Scope

- `alberta_framework/core/learners.py`
- `tests/test_mlp_learner.py`

## Occupancy

Open ASI PRs at publish: `#1487` types leftover (ours), byt61 `#1485` historical forager. Grok A holds `optimizers.py`. No open PR on `learners.py`.

## Verification

- Red on base: `MLPLearner(sparsity=True)` / `gamma=True` / `step_size=True` / `use_layer_norm=1` constructed
- `test_mlp_learner.py` + `test_learners.py` + `test_true_online_td.py`: 196 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary constructor-scalar validation only. No kernel math, lifetime clocks, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c568957886f7f5662f397583cf9d3048fbd281dd -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
