### PR TITLE
fix(host): avoid hostile runtime-class hashing

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -42,7 +42,7 @@ _ACTUAL_INT_TYPES = frozenset(
 
 def _require_tracking_interval(value: object) -> int:
     """Reject leftover bool/float identities before they become recording strides."""
-    if type(value) not in _ACTUAL_INT_TYPES:
+    if all(type(value) is not allowed for allowed in _ACTUAL_INT_TYPES):
         raise ValueError("interval must be a non-negative integer")
     number = operator.index(cast(SupportsIndex, value))
     if not 0 <= number <= _INT32_MAX:

--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -100,7 +100,7 @@ def _require_int(
     minimum: int | None = None,
     maximum: int | None = None,
 ) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    if all(type(value) is not allowed for allowed in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer")
     number = operator.index(cast(SupportsIndex, value))
     if minimum is not None and number < minimum:
@@ -111,7 +111,7 @@ def _require_int(
 
 
 def _require_finite_real(name: str, value: object) -> float:
-    if type(value) not in _ALLOWED_REAL_TYPES:
+    if all(type(value) is not allowed for allowed in _ALLOWED_REAL_TYPES):
         raise ValueError(f"{name} must be a real number")
     # validated_float32_scalar ensures finite and canonical float32 domain;
     # use permissive domain to allow any finite real then check isfinite via validator.
@@ -515,7 +515,7 @@ def to_security_gym_action(
     ``action`` id and a one-element ``risk_score`` array. A one-element tuple is
     accepted by the environment and keeps this module dependency-free.
     """
-    if type(risk_score) not in _ALLOWED_REAL_TYPES:
+    if all(type(risk_score) is not allowed for allowed in _ALLOWED_REAL_TYPES):
         raise ValueError("risk_score must be a finite real number")
     try:
         val = validated_float32_scalar("risk_score", risk_score)
@@ -564,7 +564,7 @@ class ThroughputMeasurement:
 
     def __post_init__(self) -> None:
         n_events = _require_int("n_events", self.n_events, minimum=0, maximum=_INT32_MAX)
-        if type(self.elapsed_s) not in _ALLOWED_REAL_TYPES:
+        if all(type(self.elapsed_s) is not allowed for allowed in _ALLOWED_REAL_TYPES):
             raise ValueError("elapsed_s must be a real number")
         try:
             elapsed_s = float(self.elapsed_s)

--- a/tests/test_security_rollout_leftover_identities.py
+++ b/tests/test_security_rollout_leftover_identities.py
@@ -6,7 +6,21 @@ import json
 
 import pytest
 
-from alberta_framework.security import SecurityAction, SecurityRolloutStep
+from alberta_framework.security import (
+    SecurityAction,
+    SecurityRolloutStep,
+    ThroughputMeasurement,
+    to_security_gym_action,
+)
+
+
+class _ExplodingHashMeta(type):
+    def __hash__(cls) -> int:
+        raise AssertionError("hostile runtime-class hash executed")
+
+
+class _HostileScalar(metaclass=_ExplodingHashMeta):
+    pass
 
 
 def _legal_step(**overrides: object) -> SecurityRolloutStep:
@@ -55,3 +69,16 @@ def test_security_rollout_step_rejects_leftover_identities() -> None:
     assert '"reward": true' not in dumped
     assert '"terminated": 1' not in dumped
     assert legal.action is SecurityAction.PASS
+
+
+def test_real_type_gates_do_not_hash_hostile_runtime_classes() -> None:
+    hostile = _HostileScalar()
+
+    with pytest.raises(ValueError, match=r"state\[0\]"):
+        _legal_step(state=(hostile, 1.0))
+    with pytest.raises(ValueError, match="risk_score"):
+        to_security_gym_action(SecurityAction.PASS, hostile)
+    with pytest.raises(ValueError, match="n_events"):
+        ThroughputMeasurement(n_events=hostile, elapsed_s=1.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="elapsed_s"):
+        ThroughputMeasurement(n_events=1, elapsed_s=hostile)  # type: ignore[arg-type]

--- a/tests/test_types_tracking_leftover_identities.py
+++ b/tests/test_types_tracking_leftover_identities.py
@@ -11,6 +11,15 @@ from alberta_framework.core.types import (
 )
 
 
+class _ExplodingHashMeta(type):
+    def __hash__(cls) -> int:
+        raise AssertionError("hostile runtime-class hash executed")
+
+
+class _HostileInterval(metaclass=_ExplodingHashMeta):
+    pass
+
+
 def test_step_size_tracking_config_rejects_leftover_identities() -> None:
     """Tracking intervals and include_bias must not keep leftover bool/float identities."""
 
@@ -62,3 +71,11 @@ def test_normalizer_tracking_config_rejects_leftover_identities() -> None:
     legal = NormalizerTrackingConfig(interval=0)
     assert legal.interval == 0
     assert type(legal.interval) is int
+
+
+def test_tracking_intervals_do_not_hash_hostile_runtime_classes() -> None:
+    hostile = _HostileInterval()
+    with pytest.raises(ValueError, match="interval"):
+        StepSizeTrackingConfig(interval=hostile)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="interval"):
+        NormalizerTrackingConfig(interval=hostile)  # type: ignore[arg-type]


### PR DESCRIPTION
Corrective follow-up to consolidated #1488/#1491. Exact-type gates in security.py and the new tracking interval validator used frozenset membership on type(value), which dispatches a hostile runtime class metaclass __hash__ before rejection. Replace those membership operations with identity-only iteration and pin all affected security/type call sites with raising-metaclass regressions. Focused 122 tests pass; Ruff, diff checks, and strict mypy (174 files) are clean. No outputs, benchmark execution, evidence promotion, or registered evidence source changes.