### PR TITLE
fix(matrix): complete exact string artifact boundaries

### DIFF
--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -1950,7 +1950,7 @@ def _hashed_payload(value: Mapping[str, Any]) -> dict[str, Any]:
 def _verify_hashed_payload(value: Any, *, description: str) -> Mapping[str, Any]:
     payload = _require_object(value, description)
     supplied = payload.get("payload_sha256")
-    if not isinstance(supplied, str) or _SHA256.fullmatch(supplied) is None:
+    if type(supplied) is not str or _SHA256.fullmatch(supplied) is None:
         raise ForagerMatrixStateError(f"{description} has no valid payload_sha256")
     unhashed = {key: item for key, item in payload.items() if key != "payload_sha256"}
     actual = _json_sha256(unhashed)
@@ -2843,7 +2843,7 @@ def _validate_source_snapshot_bytes(
             raise ForagerMatrixStateError(
                 f"{description} inventory file exceeds the size limit"
             )
-        if not isinstance(digest, str) or _SHA256.fullmatch(digest) is None:
+        if type(digest) is not str or _SHA256.fullmatch(digest) is None:
             raise ForagerMatrixStateError(f"{description} inventory digest is invalid")
         expected_names.append(path)
         normalized_files.append((path, size, digest))
@@ -4441,7 +4441,7 @@ def _validate_execution_manifest(
 
 
 def _validate_utc_timestamp(value: Any, path: str) -> datetime:
-    if not isinstance(value, str) or not value:
+    if type(value) is not str or not value:
         raise ForagerMatrixStateError(f"{path} must be a non-empty UTC timestamp")
     try:
         parsed = datetime.fromisoformat(value)

--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -870,10 +870,10 @@ def _decode_strict_json(data: str, *, description: str) -> Any:
 
 
 def _require_object(value: Any, path: str) -> Mapping[str, Any]:
-    if not isinstance(value, Mapping):
+    if type(value) is not dict and type(value) is not MappingProxyType:
         raise ForagerMatrixManifestError(f"{path} must be a JSON object")
-    if any(not isinstance(key, str) for key in value):
-        raise ForagerMatrixManifestError(f"{path} object keys must be strings")
+    if any(type(key) is not str for key in value):
+        raise ForagerMatrixManifestError(f"{path} object keys must be exact strings")
     return cast(Mapping[str, Any], value)
 
 
@@ -894,8 +894,8 @@ def _require_exact_keys(
 
 
 def _require_string(value: Any, path: str) -> str:
-    if not isinstance(value, str):
-        raise ForagerMatrixManifestError(f"{path} must be a string")
+    if type(value) is not str:
+        raise ForagerMatrixManifestError(f"{path} must be an exact string")
     return value
 
 
@@ -1714,6 +1714,8 @@ def _assert_path_sanitized(value: Any, path: str = "artifact") -> None:
         return
     if not isinstance(value, str):
         return
+    if type(value) is not str:
+        value = str.__str__(value)
     home = Path.home().as_posix()
     repo = REPO_ROOT.as_posix()
     absolute_path_fragment = re.search(
@@ -1844,9 +1846,9 @@ def validate_verifier_issued_tuning_envelope(
     for name, expected in expected_digests.items():
         actual = evidence[name]
         if (
-            not isinstance(expected, str)
+            type(expected) is not str
             or _SHA256.fullmatch(expected) is None
-            or not isinstance(actual, str)
+            or type(actual) is not str
             or _SHA256.fullmatch(actual) is None
             or not hmac.compare_digest(actual, expected)
         ):
@@ -2942,7 +2944,7 @@ def _installed_distribution_inventory() -> list[str]:
     rows: set[str] = set()
     for distribution in importlib.metadata.distributions():
         name = distribution.metadata.get("Name")
-        if not isinstance(name, str) or not name.strip():
+        if type(name) is not str or not name.strip():
             continue
         normalized = re.sub(r"[-_.]+", "-", name.strip()).lower()
         rows.add(f"{normalized}=={distribution.version}")
@@ -4493,7 +4495,7 @@ def _validate_execution_manifest_structure(payload: Mapping[str, Any]) -> None:
         "runtime_sha256",
     }
     for name in digest_names:
-        if not isinstance(identity[name], str) or _SHA256.fullmatch(identity[name]) is None:
+        if type(identity[name]) is not str or _SHA256.fullmatch(identity[name]) is None:
             raise ForagerMatrixStateError(f"execution identity {name} is invalid")
     if (
         isinstance(identity["source_archive_size"], bool)
@@ -4501,10 +4503,15 @@ def _validate_execution_manifest_structure(payload: Mapping[str, Any]) -> None:
         or not 0 < identity["source_archive_size"] <= _MAX_SOURCE_ARCHIVE_BYTES
     ):
         raise ForagerMatrixStateError("execution identity source_archive_size is invalid")
-    if identity["source_execution_mode"] not in SOURCE_EXECUTION_MODES:
+    if (
+        type(identity["source_execution_mode"]) is not str
+        or identity["source_execution_mode"] not in SOURCE_EXECUTION_MODES
+    ):
         raise ForagerMatrixStateError("execution source mode is invalid")
     if (
-        identity["source_isolation_mode"]
+        type(identity["source_isolation_mode"]) is not str
+        or type(identity["runtime_binding_mode"]) is not str
+        or identity["source_isolation_mode"]
         != (
             "content_verified_snapshot_subprocess"
             if identity["source_execution_mode"] == SNAPSHOT_SOURCE_EXECUTION_MODE
@@ -4574,12 +4581,12 @@ def _validate_execution_manifest_structure(payload: Mapping[str, Any]) -> None:
     if type(git["dirty"]) is not bool or not isinstance(git["status"], list):
         raise ForagerMatrixStateError("execution git provenance values are invalid")
     if git["commit"] is not None and (
-        not isinstance(git["commit"], str)
+        type(git["commit"]) is not str
         or _GIT_OBJECT.fullmatch(git["commit"]) is None
     ):
         raise ForagerMatrixStateError("execution git commit is invalid")
     if git["diff_sha256"] is not None and (
-        not isinstance(git["diff_sha256"], str)
+        type(git["diff_sha256"]) is not str
         or _SHA256.fullmatch(git["diff_sha256"]) is None
     ):
         raise ForagerMatrixStateError("execution git diff_sha256 is invalid")
@@ -4651,9 +4658,9 @@ def _validate_trace_descriptor(
         or not isinstance(steps, int)
         or steps != expected_steps
         or descriptor["biome_regret_present"] is not True
-        or not isinstance(location, str)
+        or type(location) is not str
         or (expected_output_path is not None and location != expected_output_path)
-        or not isinstance(descriptor["sha256"], str)
+        or type(descriptor["sha256"]) is not str
         or _SHA256.fullmatch(descriptor["sha256"]) is None
         or isinstance(descriptor["size"], bool)
         or not isinstance(descriptor["size"], int)

--- a/tests/test_forager_matrix_string_identity.py
+++ b/tests/test_forager_matrix_string_identity.py
@@ -1,0 +1,110 @@
+"""Exact string and hostile runtime-type gates for Forager matrix artifacts."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks import forager_matrix as matrix
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileString(str):
+    calls = 0
+
+    def __bool__(self) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile truth hook executed")
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile comparison hook executed")
+
+    def startswith(self, prefix: object, *args: object) -> bool:
+        del prefix, args
+        type(self).calls += 1
+        raise AssertionError("hostile startswith hook executed")
+
+    def strip(self, chars: object = None) -> str:
+        del chars
+        type(self).calls += 1
+        raise AssertionError("hostile strip hook executed")
+
+    __hash__ = str.__hash__
+
+
+class _ExplodingHashMeta(type):
+    def __hash__(cls) -> int:
+        raise AssertionError("hostile runtime-class hash executed")
+
+
+class _HostileObject(metaclass=_ExplodingHashMeta):
+    pass
+
+
+def test_central_json_string_gates_reject_subclasses_before_hooks() -> None:
+    hostile = _HostileString("a" * 64)
+    payload = {hostile: "value"}
+    _HostileString.calls = 0
+
+    with pytest.raises(matrix.ForagerMatrixManifestError, match="exact strings"):
+        matrix._require_object(payload, "payload")
+    with pytest.raises(matrix.ForagerMatrixManifestError, match="exact string"):
+        matrix._require_string(hostile, "value")
+    with pytest.raises(matrix.ForagerMatrixStateError, match="payload_sha256"):
+        matrix._verify_hashed_payload(
+            {"payload_sha256": hostile}, description="payload"
+        )
+    with pytest.raises(matrix.ForagerMatrixStateError, match="UTC timestamp"):
+        matrix._validate_utc_timestamp(hostile, "timestamp")
+    assert _HostileString.calls == 0
+
+    hostile_path = _HostileString("/tmp/hostile")
+    _HostileString.calls = 0
+    with pytest.raises(matrix.ForagerMatrixError, match="host path"):
+        matrix._assert_path_sanitized(hostile_path)
+    assert _HostileString.calls == 0
+
+
+def test_object_gate_does_not_hash_hostile_runtime_classes() -> None:
+    with pytest.raises(matrix.ForagerMatrixManifestError, match="JSON object"):
+        matrix._require_object(_HostileObject(), "payload")
+
+
+def test_trace_descriptor_rejects_hostile_location_before_path_hooks() -> None:
+    hostile = _HostileString("seed-0.npz")
+    descriptor = {
+        "schema_version": matrix._RAW_TRACE_SCHEMA,
+        "seed": 0,
+        "path": hostile,
+        "format": matrix._RAW_TRACE_FORMAT,
+        "steps": 1,
+        "biome_regret_present": True,
+        "arrays": {
+            "rewards": {
+                "member": matrix._RAW_TRACE_MEMBERS[0],
+                "dtype": matrix._RAW_TRACE_DTYPE.str,
+                "shape": [1],
+            },
+            "biome_regrets": {
+                "member": matrix._RAW_TRACE_MEMBERS[1],
+                "dtype": matrix._RAW_TRACE_DTYPE.str,
+                "shape": [1],
+            },
+        },
+        "sha256": "0" * 64,
+        "size": 1,
+    }
+    _HostileString.calls = 0
+
+    with pytest.raises(matrix.ForagerMatrixStateError, match="identity"):
+        matrix._validate_trace_descriptor(
+            descriptor,
+            path="trace",
+            expected_seed=0,
+            expected_steps=1,
+            expected_output_path=None,
+            exchange=False,
+        )
+
+    assert _HostileString.calls == 0


### PR DESCRIPTION
Supersedes #1493 while preserving its contributor-authored implementation commit. Completes the adjacent decoded-manifest boundary: exact JSON keys and central strings, trusted-envelope and execution identity/git digests, trace descriptor locations/digests, and hook-safe path sanitization (including legitimate str-backed JAX enums). Adds hostile string and hostile runtime-metaclass regressions. Validation: all 89 Forager matrix tests pass; Ruff, diff checks, and strict mypy across 174 files are clean. forager_matrix.py is not a registered EVIDENCE_SPECS source; no outputs, benchmark run, schema version, thresholds, or promotion state changed. Future matrix source identities will bind the new bytes.