### PR TITLE
fix(benchmarks): reject hostile string identities in forager matrix

### DIFF
--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -1950,7 +1950,7 @@ def _hashed_payload(value: Mapping[str, Any]) -> dict[str, Any]:
 def _verify_hashed_payload(value: Any, *, description: str) -> Mapping[str, Any]:
     payload = _require_object(value, description)
     supplied = payload.get("payload_sha256")
-    if not isinstance(supplied, str) or _SHA256.fullmatch(supplied) is None:
+    if type(supplied) is not str or _SHA256.fullmatch(supplied) is None:
         raise ForagerMatrixStateError(f"{description} has no valid payload_sha256")
     unhashed = {key: item for key, item in payload.items() if key != "payload_sha256"}
     actual = _json_sha256(unhashed)
@@ -2843,7 +2843,7 @@ def _validate_source_snapshot_bytes(
             raise ForagerMatrixStateError(
                 f"{description} inventory file exceeds the size limit"
             )
-        if not isinstance(digest, str) or _SHA256.fullmatch(digest) is None:
+        if type(digest) is not str or _SHA256.fullmatch(digest) is None:
             raise ForagerMatrixStateError(f"{description} inventory digest is invalid")
         expected_names.append(path)
         normalized_files.append((path, size, digest))
@@ -4441,7 +4441,7 @@ def _validate_execution_manifest(
 
 
 def _validate_utc_timestamp(value: Any, path: str) -> datetime:
-    if not isinstance(value, str) or not value:
+    if type(value) is not str or not value:
         raise ForagerMatrixStateError(f"{path} must be a non-empty UTC timestamp")
     try:
         parsed = datetime.fromisoformat(value)


### PR DESCRIPTION
Closes #1493

## What changed

- `_verify_hashed_payload` `payload_sha256`: `isinstance(supplied, str)` → `type is not str` (before `_SHA256.fullmatch`)
- `_validate_source_snapshot_bytes` `digest`: `isinstance(digest, str)` → `type is not str` (before `fullmatch`)
- `_validate_utc_timestamp` `value`: `isinstance(value, str)` → `type is not str` (before `or not value` bool)

All use exact-type checks before `fullmatch`/`bool`, failing closed with 0 hook calls.

## Why

These are external trust boundaries (hashed payload JSON, source snapshot inventory, execution manifest timestamps deserialized from untrusted files). `isinstance(str)` admits hostile `str` subclasses that overload `__bool__` and dispatch during `or not value` before validation. `type is str` is the established hostile-identity pattern.

## Verification

- `ruff check .` — clean
- `mypy alberta_framework/benchmarks/forager_matrix.py` — clean
- No benchmark, `outputs/**`, or evidence promotion.

## Contribution provenance

- AI assistance: yes
- AI provider/model: Google / Gemini
- Attribution status: self-reported