### PR TITLE
fix(benchmarks): reject hostile string identities in forager results

### DIFF
--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -307,11 +307,11 @@ class LegacyFOVSQLiteRunSpec:
         if not isinstance(self.privileged, bool):
             raise ValueError("privileged must be a boolean")
         if (
-            not isinstance(self.expected_config_agent, str)
+            type(self.expected_config_agent) is not str
             or self.expected_config_agent not in LEGACY_FOV_CONFIG_AGENTS
         ):
             raise ValueError("expected_config_agent must name a checked-in paper FOV configuration")
-        if not isinstance(self.agent, str) or not self.agent:
+        if type(self.agent) is not str or not self.agent:
             raise ValueError("agent must be a non-empty string")
         if not isinstance(self.expected_aperture_size, int) or isinstance(
             self.expected_aperture_size, bool
@@ -812,7 +812,7 @@ def _validated_environment_provenance(
     if implementation["package"] != "foragax":
         raise ValueError("environment implementation must identify the foragax package")
     version = implementation["version"]
-    if not isinstance(version, str) or not version.strip():
+    if type(version) is not str or not version.strip():
         raise ValueError("environment implementation version must be non-empty")
     direct_url = implementation["direct_url"]
     if direct_url is not None and not isinstance(direct_url, dict):
@@ -890,7 +890,7 @@ class OfficialForagaxRunSpec:
     attestation_evidence: VerifiedOfficialForagaxEvidence | None = None
 
     def __post_init__(self) -> None:
-        if not isinstance(self.agent, str) or not self.agent.strip():
+        if type(self.agent) is not str or not self.agent.strip():
             raise ValueError("agent must be a non-empty string")
         if not isinstance(self.seed, int) or isinstance(self.seed, bool) or self.seed < 0:
             raise ValueError("seed must be a non-negative integer")


### PR DESCRIPTION
Closes #1495

## What changed

- `LegacyFOVSQLiteRunSpec` `expected_config_agent`: `isinstance(..., str)` → `type is not str` (before `in LEGACY_FOV_CONFIG_AGENTS`)
- `LegacyFOVSQLiteRunSpec` `agent`: `isinstance(self.agent, str)` → `type is not str` (before `or not self.agent`)
- `_validated_environment_provenance` `version`: `isinstance(version, str)` → `type is not str` (before `strip()`)
- `OfficialForagaxRunSpec` `agent`: `isinstance(self.agent, str)` → `type is not str` (before `strip()`)

All use exact-type checks before `in`/`bool`/`strip`, failing closed with 0 hook calls.

## Why

These are external trust boundaries (legacy run specs, provenance JSON, official run specs deserialized from artifacts). `isinstance(str)` admits hostile `str` subclasses that overload `__bool__`/`strip`/`__eq__` and dispatch during `or not value` or `strip()` before validation. `type is str` is the established hostile-identity pattern.

## Verification

- `ruff check .` — clean
- `mypy alberta_framework/benchmarks/forager_results.py` — clean
- No benchmark, `outputs/**`, or evidence promotion.

## Contribution provenance

- AI assistance: yes
- AI provider/model: Google / Gemini
- Attribution status: self-reported