### PR TITLE
fix(benchmarks): reject hostile string identities in IPMNIST screening

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -6717,7 +6717,7 @@ def _validated_screening_noise_mode(
 ) -> str:
     """Validate one screening noise mode against the named arm's runner contract."""
     prefix = "" if context is None else f"{context}: "
-    if not isinstance(noise_mode, str) or noise_mode not in ("step", "pool"):
+    if type(noise_mode) is not str or noise_mode not in ("step", "pool"):
         raise ValueError(
             f"{prefix}noise_mode must be 'step' or 'pool', got {noise_mode!r}"
         )
@@ -7969,7 +7969,7 @@ def _require_exact_keys(
 
 
 def _required_nonempty_string(value: object, *, context: str) -> str:
-    if not isinstance(value, str) or not value:
+    if type(value) is not str or not value:
         raise ValueError(f"{context} must be a non-empty string")
     return value
 
@@ -8303,7 +8303,7 @@ def shard_payload(
     dataset_binding = _validated_dataset_provenance(dataset_provenance, context="new shard")
     runtime_binding = _validated_runtime_environment(environment, context="new shard")
     _validate_dataset_config_binding(dataset_binding, result.config, context="new shard")
-    if not isinstance(result.base_learner, str) or not result.base_learner:
+    if type(result.base_learner) is not str or not result.base_learner:
         raise ValueError("new shard base_learner must be a non-empty string")
     curves: dict[str, np.ndarray] = {}
     for field in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):


### PR DESCRIPTION
Closes #1496

## What changed

- `_required_nonempty_string(value)`: `isinstance(value, str)` → `type is not str` (before `or not value`) — used for provider/name/precision/learner strings
- `_validated_screening_noise_mode(noise_mode)`: `isinstance(noise_mode, str)` → `type is not str` (before `in ("step", "pool")`)
- `shard_payload` `result.base_learner`: `isinstance(result.base_learner, str)` → `type is not str` (before `or not result.base_learner`)

All use exact-type checks before `in`/`bool`, failing closed with 0 hook calls.

## Why

These are external trust boundaries (screening lane configs, noise contracts, shard payloads deserialized from strict JSON). `isinstance(str)` admits hostile `str` subclasses that overload `__bool__`/`__eq__` and dispatch during `or not value` or `in` before validation. `type is str` is the established hostile-identity pattern.

## Verification

- `ruff check .` — clean
- `mypy alberta_framework/benchmarks/ipmnist_screening.py` — clean
- No benchmark, `outputs/**`, or evidence promotion.

## Contribution provenance

- AI assistance: yes
- AI provider/model: Google / Gemini
- Attribution status: self-reported