### PR TITLE
fix(benchmarks): consolidate hostile identity boundaries

### DIFF
--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -1950,7 +1950,7 @@ def _hashed_payload(value: Mapping[str, Any]) -> dict[str, Any]:
 def _verify_hashed_payload(value: Any, *, description: str) -> Mapping[str, Any]:
     payload = _require_object(value, description)
     supplied = payload.get("payload_sha256")
-    if not isinstance(supplied, str) or _SHA256.fullmatch(supplied) is None:
+    if type(supplied) is not str or _SHA256.fullmatch(supplied) is None:
         raise ForagerMatrixStateError(f"{description} has no valid payload_sha256")
     unhashed = {key: item for key, item in payload.items() if key != "payload_sha256"}
     actual = _json_sha256(unhashed)
@@ -2843,7 +2843,7 @@ def _validate_source_snapshot_bytes(
             raise ForagerMatrixStateError(
                 f"{description} inventory file exceeds the size limit"
             )
-        if not isinstance(digest, str) or _SHA256.fullmatch(digest) is None:
+        if type(digest) is not str or _SHA256.fullmatch(digest) is None:
             raise ForagerMatrixStateError(f"{description} inventory digest is invalid")
         expected_names.append(path)
         normalized_files.append((path, size, digest))
@@ -4441,7 +4441,7 @@ def _validate_execution_manifest(
 
 
 def _validate_utc_timestamp(value: Any, path: str) -> datetime:
-    if not isinstance(value, str) or not value:
+    if type(value) is not str or not value:
         raise ForagerMatrixStateError(f"{path} must be a non-empty UTC timestamp")
     try:
         parsed = datetime.fromisoformat(value)

--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -307,11 +307,11 @@ class LegacyFOVSQLiteRunSpec:
         if not isinstance(self.privileged, bool):
             raise ValueError("privileged must be a boolean")
         if (
-            not isinstance(self.expected_config_agent, str)
+            type(self.expected_config_agent) is not str
             or self.expected_config_agent not in LEGACY_FOV_CONFIG_AGENTS
         ):
             raise ValueError("expected_config_agent must name a checked-in paper FOV configuration")
-        if not isinstance(self.agent, str) or not self.agent:
+        if type(self.agent) is not str or not self.agent:
             raise ValueError("agent must be a non-empty string")
         if not isinstance(self.expected_aperture_size, int) or isinstance(
             self.expected_aperture_size, bool
@@ -812,7 +812,7 @@ def _validated_environment_provenance(
     if implementation["package"] != "foragax":
         raise ValueError("environment implementation must identify the foragax package")
     version = implementation["version"]
-    if not isinstance(version, str) or not version.strip():
+    if type(version) is not str or not version.strip():
         raise ValueError("environment implementation version must be non-empty")
     direct_url = implementation["direct_url"]
     if direct_url is not None and not isinstance(direct_url, dict):
@@ -890,7 +890,7 @@ class OfficialForagaxRunSpec:
     attestation_evidence: VerifiedOfficialForagaxEvidence | None = None
 
     def __post_init__(self) -> None:
-        if not isinstance(self.agent, str) or not self.agent.strip():
+        if type(self.agent) is not str or not self.agent.strip():
             raise ValueError("agent must be a non-empty string")
         if not isinstance(self.seed, int) or isinstance(self.seed, bool) or self.seed < 0:
             raise ValueError("seed must be a non-negative integer")

--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -104,7 +104,7 @@ def _validate_sha256(value: str | None, *, name: str) -> None:
     if value is None:
         return
     if (
-        not isinstance(value, str)
+        type(value) is not str
         or len(value) != 64
         or any(character not in "0123456789abcdef" for character in value)
     ):
@@ -115,7 +115,7 @@ def _validate_git_sha(value: str | None, *, name: str) -> None:
     if value is None:
         return
     if (
-        not isinstance(value, str)
+        type(value) is not str
         or len(value) != 40
         or any(character not in "0123456789abcdef" for character in value)
     ):
@@ -192,7 +192,7 @@ def _flatten_json(value: Any, *, prefix: str = "") -> dict[str, Any]:
     if isinstance(value, Mapping):
         flattened: dict[str, Any] = {}
         for key, child in value.items():
-            if not isinstance(key, str) or not key:
+            if type(key) is not str or not key:
                 raise ValueError("config object keys must be non-empty strings")
             child_prefix = f"{prefix}.{key}" if prefix else key
             flattened.update(_flatten_json(child, prefix=child_prefix))
@@ -260,7 +260,7 @@ def _sqlite_value_matches(actual: Any, expected: Any) -> bool:
             and math.isfinite(float(actual))
             and float(actual) == expected
         )
-    return isinstance(actual, str) and actual == expected
+    return type(actual) is str and actual == expected
 
 
 def _legacy_fov_display_agent(config_agent: str) -> str:
@@ -912,7 +912,7 @@ class OfficialForagaxRunSpec:
 
         explicit_repository = self.source_repository
         if explicit_repository is not None and (
-            not isinstance(explicit_repository, str) or not explicit_repository
+            type(explicit_repository) is not str or not explicit_repository
         ):
             raise ValueError("source_repository must be a non-empty string")
         _validate_git_sha(self.source_commit, name="source_commit")
@@ -961,7 +961,7 @@ class OfficialForagaxRunSpec:
         ):
             raise ValueError("expected_steps must be a positive integer")
         if self.config_path is not None:
-            if not isinstance(self.config_path, str) or not self.config_path.strip():
+            if type(self.config_path) is not str or not self.config_path.strip():
                 raise ValueError("config_path must be a non-empty string")
             logical_config = Path(self.config_path)
             windows_config = PureWindowsPath(self.config_path)
@@ -977,7 +977,7 @@ class OfficialForagaxRunSpec:
                 raise ValueError("config_path must be a safe repository-relative path")
         if self.artifact_relative_path is not None:
             if (
-                not isinstance(self.artifact_relative_path, str)
+                type(self.artifact_relative_path) is not str
                 or not self.artifact_relative_path.strip()
             ):
                 raise ValueError("artifact_relative_path must be a non-empty string")
@@ -1035,7 +1035,7 @@ class OfficialForagaxRunSpec:
                 )
 
         if not isinstance(self.package_freeze, tuple) or any(
-            not isinstance(line, str) or not line for line in self.package_freeze
+            type(line) is not str or not line for line in self.package_freeze
         ):
             raise ValueError("package_freeze must be a tuple of non-empty strings")
         if len(set(self.package_freeze)) != len(self.package_freeze):
@@ -1089,7 +1089,7 @@ class OfficialForagaxRunSpec:
                     + ", ".join(missing_runtime)
                 )
             if any(
-                not isinstance(runtime[name], str) or not runtime[name]
+                type(runtime[name]) is not str or not runtime[name]
                 for name in required_runtime - {"jax_devices"}
             ):
                 raise ValueError("execution_runtime identity fields must be non-empty strings")
@@ -1102,7 +1102,7 @@ class OfficialForagaxRunSpec:
                 raise ValueError("execution_runtime.jax_devices must be a non-empty object list")
             object.__setattr__(self, "execution_runtime", runtime)
         if not isinstance(self.relevant_environment, Mapping) or any(
-            not isinstance(key, str) or not isinstance(value, str)
+            type(key) is not str or type(value) is not str
             for key, value in self.relevant_environment.items()
         ):
             raise ValueError("relevant_environment must map strings to strings")
@@ -1410,7 +1410,7 @@ def _official_environment_runtime_profile(
         raise ValueError("official runtime profile lacks runtime provenance")
     package_inventory = execution["package_inventory"]
     if not isinstance(package_inventory, list) or not all(
-        isinstance(line, str) for line in package_inventory
+        type(line) is str for line in package_inventory
     ):
         raise ValueError("official runtime profile package inventory is invalid")
     relevant_prefixes = (
@@ -1428,7 +1428,7 @@ def _official_environment_runtime_profile(
     )
     command = execution["command"]
     if not isinstance(command, list) or not all(
-        isinstance(argument, str) for argument in command
+        type(argument) is str for argument in command
     ):
         raise ValueError("official runtime profile command is invalid")
     container_environment = sorted(
@@ -2077,7 +2077,7 @@ def _foragax_semantic_signature(run: ForagerRunResult) -> str | None:
     environment = run.environment
     env_id = environment.get("env_id")
     is_foragax = (
-        isinstance(env_id, str)
+        type(env_id) is str
         and env_id.startswith("Foragax")
         or environment.get("foragax_distribution") == FORAGAX_DISTRIBUTION
         or isinstance(environment.get("environment_implementation"), Mapping)
@@ -2176,7 +2176,7 @@ def _foragax_implementation_signature(run: ForagerRunResult) -> str | None:
         }
     if (
         normalized.get("distribution") != FORAGAX_DISTRIBUTION
-        or not isinstance(normalized.get("version"), str)
+        or type(normalized.get("version")) is not str
         or normalized.get("install_tree_hash_scheme") != FORAGAX_INSTALL_TREE_HASH_SCHEME
     ):
         return None

--- a/alberta_framework/benchmarks/historical_forager.py
+++ b/alberta_framework/benchmarks/historical_forager.py
@@ -236,9 +236,9 @@ def _distribution_version(name: str) -> str | None:
 def _module_or_distribution_version(module_name: str, distribution_name: str) -> str | None:
     module = sys.modules.get(module_name)
     version = getattr(module, "__version__", None)
-    if isinstance(version, str) and version:
-        return version
-    return _distribution_version(distribution_name)
+    if type(version) is not str or not version:
+        return _distribution_version(distribution_name)
+    return version
 
 
 def historical_forager_runtime_identity() -> dict[str, Any]:
@@ -439,7 +439,7 @@ def _require_read_only_non_tmp_factory_source(
     owner = factory if inspect.isclass(factory) or inspect.isfunction(factory) else type(factory)
     module = inspect.getmodule(owner)
     module_file = getattr(module, "__file__", None)
-    if not isinstance(module_file, str):
+    if type(module_file) is not str:
         raise HistoricalForagerContractError("factory source module has no filesystem identity")
     try:
         source_file = Path(module_file).resolve(strict=True)

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -6717,7 +6717,7 @@ def _validated_screening_noise_mode(
 ) -> str:
     """Validate one screening noise mode against the named arm's runner contract."""
     prefix = "" if context is None else f"{context}: "
-    if not isinstance(noise_mode, str) or noise_mode not in ("step", "pool"):
+    if type(noise_mode) is not str or noise_mode not in ("step", "pool"):
         raise ValueError(
             f"{prefix}noise_mode must be 'step' or 'pool', got {noise_mode!r}"
         )
@@ -7969,7 +7969,7 @@ def _require_exact_keys(
 
 
 def _required_nonempty_string(value: object, *, context: str) -> str:
-    if not isinstance(value, str) or not value:
+    if type(value) is not str or not value:
         raise ValueError(f"{context} must be a non-empty string")
     return value
 
@@ -8303,7 +8303,7 @@ def shard_payload(
     dataset_binding = _validated_dataset_provenance(dataset_provenance, context="new shard")
     runtime_binding = _validated_runtime_environment(environment, context="new shard")
     _validate_dataset_config_binding(dataset_binding, result.config, context="new shard")
-    if not isinstance(result.base_learner, str) or not result.base_learner:
+    if type(result.base_learner) is not str or not result.base_learner:
         raise ValueError("new shard base_learner must be a non-empty string")
     curves: dict[str, np.ndarray] = {}
     for field in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -6717,7 +6717,9 @@ def _validated_screening_noise_mode(
 ) -> str:
     """Validate one screening noise mode against the named arm's runner contract."""
     prefix = "" if context is None else f"{context}: "
-    if type(noise_mode) is not str or noise_mode not in ("step", "pool"):
+    if type(noise_mode) is not str:
+        raise ValueError(f"{prefix}noise_mode must be 'step' or 'pool'")
+    if noise_mode not in ("step", "pool"):
         raise ValueError(
             f"{prefix}noise_mode must be 'step' or 'pool', got {noise_mode!r}"
         )
@@ -6809,7 +6811,7 @@ def _array_bundle_sha256(domain: str, arrays: Mapping[str, object]) -> str:
 
 def _is_lower_hex(value: object, length: int) -> bool:
     return (
-        isinstance(value, str)
+        type(value) is str
         and len(value) == length
         and all(character in "0123456789abcdef" for character in value)
     )
@@ -8084,8 +8086,8 @@ def _validated_dataset_provenance(value: object, *, context: str) -> dict[str, A
         context=f"{context} dataset provenance source",
     )
     if (
-        not isinstance(source["provider"], str)
-        or not isinstance(source["name"], str)
+        type(source["provider"]) is not str
+        or type(source["name"]) is not str
         or type(source["version"]) is not int
         or type(source["row_start"]) is not int
         or type(source["row_stop_exclusive"]) is not int
@@ -8251,7 +8253,7 @@ def _validated_runtime_environment(value: object, *, context: str) -> dict[str, 
         if type(jax_config[field]) is not bool:
             raise ValueError(f"{context} runtime environment {field} must be boolean")
     precision = jax_config["jax_default_matmul_precision"]
-    if precision is not None and (not isinstance(precision, str) or not precision):
+    if precision is not None and (type(precision) is not str or not precision):
         raise ValueError(
             f"{context} runtime environment jax_default_matmul_precision must be a "
             "string or null"
@@ -8269,7 +8271,7 @@ def _validated_runtime_environment(value: object, *, context: str) -> dict[str, 
             f"{context} runtime environment jax_random_seed_offset must be an integer"
         )
     if any(
-        value is not None and not isinstance(value, str)
+        value is not None and type(value) is not str
         for value in process_environment.values()
     ):
         raise ValueError(
@@ -8287,6 +8289,8 @@ def shard_payload(
 ) -> dict[str, Any]:
     """Serialize one bound (config, seed) screening run as a strict v2 shard."""
     seed = require_jax_seed(result.seed, name="result seed")
+    if type(result.base_learner) is not str or not result.base_learner:
+        raise ValueError("new shard base_learner must be a non-empty string")
     spec = screening_spec(result.config_name)
     if result.base_learner != spec.base_learner:
         raise ValueError(
@@ -8303,8 +8307,6 @@ def shard_payload(
     dataset_binding = _validated_dataset_provenance(dataset_provenance, context="new shard")
     runtime_binding = _validated_runtime_environment(environment, context="new shard")
     _validate_dataset_config_binding(dataset_binding, result.config, context="new shard")
-    if type(result.base_learner) is not str or not result.base_learner:
-        raise ValueError("new shard base_learner must be a non-empty string")
     curves: dict[str, np.ndarray] = {}
     for field in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):
         try:
@@ -8438,7 +8440,7 @@ def load_shard(path: Path) -> dict[str, Any]:
     )
     payload["noise_mode"] = noise_mode
     payload["noise_pool_steps"] = noise_pool_steps
-    if not isinstance(payload.get("base_learner"), str) or not payload["base_learner"]:
+    if type(payload.get("base_learner")) is not str or not payload["base_learner"]:
         raise ValueError(f"{path}: base_learner must be a non-empty string")
     if not isinstance(payload.get("hyperparameters"), dict):
         raise ValueError(f"{path}: hyperparameters must be an object")
@@ -8446,7 +8448,7 @@ def load_shard(path: Path) -> dict[str, Any]:
         environment = payload.get("environment")
         required_environment_fields = ("jax", "numpy", "python", "platform")
         if not isinstance(environment, dict) or any(
-            not isinstance(environment.get(field), str) or not environment[field]
+            type(environment.get(field)) is not str or not environment[field]
             for field in required_environment_fields
         ):
             raise ValueError(
@@ -8511,7 +8513,7 @@ def _require_embedded_artifact_manifest_unchanged(
         size_bytes = item.get("size_bytes")
         sha256 = item.get("sha256")
         if (
-            not isinstance(path, str)
+            type(path) is not str
             or not path
             or type(size_bytes) is not int
             or size_bytes < 0

--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -268,7 +268,7 @@ class OfficialForagaxRunRequest:
             raise OfficialForagaxValidationError("config_path must not be empty")
         if not isinstance(self.gpu, bool):
             raise OfficialForagaxValidationError("gpu must be a boolean")
-        if not isinstance(self.expected_repository, str):
+        if type(self.expected_repository) is not str:
             raise OfficialForagaxValidationError(
                 "expected_repository must be a string"
             )
@@ -5213,7 +5213,7 @@ def _verified_agent_access_sections(
             "official manifest agent registry hash does not verify"
         )
     agent = run.get("agent")
-    if not isinstance(agent, str) or not agent:
+    if type(agent) is not str or not agent:
         raise OfficialForagaxValidationError(
             "official manifest agent identity is invalid"
         )
@@ -5427,7 +5427,7 @@ def prepare_official_foragax_run(
     problem = config_data.get("problem")
     configured_env_steps = config_data.get("total_steps")
     meta_parameters = config_data.get("metaParameters")
-    if not isinstance(agent, str) or not agent.strip():
+    if type(agent) is not str or not agent.strip():
         raise OfficialForagaxValidationError("official config has no non-empty agent")
     if problem != "Foragax":
         raise OfficialForagaxValidationError(

--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -4938,7 +4938,7 @@ def _validated_registry_identity(value: Any) -> dict[str, str]:
         )
     result: dict[str, str] = {}
     for key, item in value.items():
-        if not isinstance(item, str) or not item:
+        if type(item) is not str or not item:
             raise OfficialForagaxValidationError(
                 f"official agent registry {key} is invalid"
             )
@@ -5003,7 +5003,7 @@ def _validated_resolved_hyperparameters(
     def validate_strings(item: Any) -> None:
         if isinstance(item, dict):
             for key, nested in item.items():
-                if not isinstance(key, str):
+                if type(key) is not str:
                     raise OfficialForagaxValidationError(
                         "official resolved hyperparameter keys must be strings"
                     )
@@ -5011,7 +5011,7 @@ def _validated_resolved_hyperparameters(
         elif isinstance(item, list):
             for nested in item:
                 validate_strings(nested)
-        elif isinstance(item, str):
+        elif type(item) is str:
             if (
                 Path(item).is_absolute()
                 or PureWindowsPath(item).is_absolute()
@@ -5082,7 +5082,7 @@ def _classify_official_foragax_agent_access(
         and isinstance(temperature_prioritization, bool)
         and isinstance(use_sinusoidal_encoding, bool)
         and isinstance(channel_priorities, dict)
-        and all(isinstance(key, str) for key in channel_priorities)
+        and all(type(key) is str for key in channel_priorities)
         and all(finite_json_number(priority) for priority in channel_priorities.values())
     )
     aperture_size = semantic_environment.get("aperture_size")
@@ -5298,7 +5298,7 @@ sys.stdout.write(
     payload = _extract_probe_payload(result.stdout)
     packages = payload.get("packages")
     if not isinstance(packages, list) or not all(
-        isinstance(item, str) and item for item in packages
+        type(item) is str and item for item in packages
     ):
         raise OfficialForagaxValidationError(
             "supplied interpreter returned an invalid package freeze"
@@ -7837,7 +7837,7 @@ def _manifest_relative_file(
     *,
     label: str,
 ) -> Path:
-    if not isinstance(value, str):
+    if type(value) is not str:
         raise OfficialForagaxValidationError(f"official manifest {label} is invalid")
     relative = _canonical_relative_path(value, label=f"manifest {label}")
     return root / relative
@@ -9718,7 +9718,7 @@ def _verify_execution_and_logs(
 ) -> None:
     command = execution.get("command")
     if not isinstance(command, list) or not all(
-        isinstance(argument, str) for argument in command
+        type(argument) is str for argument in command
     ):
         raise OfficialForagaxValidationError("official manifest command is invalid")
     if any(Path(argument).is_absolute() for argument in command):
@@ -9741,7 +9741,7 @@ def _verify_execution_and_logs(
     if (
         not isinstance(freeze, list)
         or not freeze
-        or not all(isinstance(item, str) and item for item in freeze)
+        or not all(type(item) is str and item for item in freeze)
         or freeze != sorted(set(freeze))
     ):
         raise OfficialForagaxValidationError(
@@ -9789,7 +9789,7 @@ def _verify_execution_and_logs(
         not isinstance(relevant_environment, dict)
         or not required_environment_keys <= relevant_environment.keys()
         or any(
-            not isinstance(key, str) or not isinstance(value, str)
+            type(key) is not str or type(value) is not str
             for key, value in relevant_environment.items()
         )
     ):
@@ -9998,7 +9998,7 @@ def verify_official_foragax_manifest(
         or implementation.get("package") != "foragax"
         or implementation.get("install_tree_hash_scheme")
         != "relative-path+size+bytes-v1"
-        or not isinstance(implementation.get("install_tree_sha256"), str)
+        or type(implementation.get("install_tree_sha256")) is not str
     ):
         raise OfficialForagaxValidationError(
             "official Foragax implementation provenance is not verified"
@@ -10291,7 +10291,7 @@ def verify_official_foragax_batch_manifest(
         or implementation.get("package") != "foragax"
         or implementation.get("install_tree_hash_scheme")
         != "relative-path+size+bytes-v1"
-        or not isinstance(implementation.get("install_tree_sha256"), str)
+        or type(implementation.get("install_tree_sha256")) is not str
     ):
         raise OfficialForagaxValidationError(
             "official batch Foragax implementation is not verified"
@@ -11053,7 +11053,7 @@ def _official_spec_shared_kwargs(
     environment_provenance = manifest.get("environment")
     if (
         not isinstance(package_freeze, list)
-        or not all(isinstance(item, str) for item in package_freeze)
+        or not all(type(item) is str for item in package_freeze)
         or not isinstance(runtime, dict)
         or not isinstance(relevant_environment, dict)
         or not isinstance(environment_provenance, dict)

--- a/tests/test_benchmark_hostile_identity_boundaries.py
+++ b/tests/test_benchmark_hostile_identity_boundaries.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import numpy as np
 import pytest
 
 from alberta_framework.benchmarks import foragax_open_screen as screen
+from alberta_framework.benchmarks import forager_results as results
+from alberta_framework.benchmarks import ipmnist_screening as ipmnist
+from alberta_framework.benchmarks import official_foragax
 from alberta_framework.benchmarks import reference_life_scorecard as scorecard
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
 
 
 class _HostileString(str):
@@ -18,6 +25,14 @@ class _HostileString(str):
     def __eq__(self, other: object) -> bool:
         type(self).calls += 1
         raise AssertionError("hostile string comparison hook executed")
+
+    def __repr__(self) -> str:
+        type(self).calls += 1
+        raise AssertionError("hostile string repr hook executed")
+
+    def strip(self, _chars: str | None = None) -> str:
+        type(self).calls += 1
+        raise AssertionError("hostile string strip hook executed")
 
     __hash__ = str.__hash__
 
@@ -52,4 +67,92 @@ def test_scorecard_canonical_json_rejects_hostile_identities_before_hooks() -> N
     with pytest.raises(ValueError, match="canonical JSON"):
         scorecard.canonical_json_bytes(_HostileDict({"field": "value"}))
     assert scorecard._is_sha256(_HostileString("a" * 64)) is False
+    assert _HostileString.calls == 0
+
+
+def test_forager_result_specs_reject_hostile_strings_before_hooks(tmp_path: Path) -> None:
+    hostile = _HostileString("DQN-15")
+    _HostileString.calls = 0
+    with pytest.raises(ValueError, match="expected_config_agent"):
+        results.LegacyFOVSQLiteRunSpec(
+            agent="DQN",
+            path=tmp_path / "result.sqlite",
+            config_path=tmp_path / "config.json",
+            run_index=0,
+            stored_seed=0,
+            expected_config_agent=hostile,
+            expected_aperture_size=15,
+        )
+    with pytest.raises(ValueError, match="agent must be a non-empty string"):
+        results.LegacyFOVSQLiteRunSpec(
+            agent=hostile,
+            path=tmp_path / "result.sqlite",
+            config_path=tmp_path / "config.json",
+            run_index=0,
+            stored_seed=0,
+            expected_config_agent="DQN-15",
+            expected_aperture_size=15,
+        )
+    with pytest.raises(ValueError, match="agent must be a non-empty string"):
+        results.OfficialForagaxRunSpec(agent=hostile, seed=0, path=tmp_path / "run.npz")
+    with pytest.raises(ValueError, match="full lowercase SHA-256"):
+        results._validate_sha256(_HostileString("a" * 64), name="digest")
+    with pytest.raises(ValueError, match="40-character Git SHA"):
+        results._validate_git_sha(_HostileString("a" * 40), name="commit")
+    assert _HostileString.calls == 0
+
+
+def test_ipmnist_hostile_strings_fail_before_comparison_or_repr() -> None:
+    hostile = _HostileString("upgd_w")
+    _HostileString.calls = 0
+    with pytest.raises(ValueError, match="must be a non-empty string"):
+        ipmnist._required_nonempty_string(hostile, context="identity")
+    with pytest.raises(ValueError, match="noise_mode must be"):
+        ipmnist._validated_screening_noise_mode(
+            hostile,
+            ipmnist.screening_spec("upgd_w_control"),
+        )
+
+    config = IPMNISTConfig(n_tasks=1, task_length=1)
+    curve = np.zeros((1,), dtype=np.float64)
+    result = ipmnist.ScreeningRunResult(
+        config_name="upgd_w_control",
+        base_learner="upgd_w",
+        hyperparameters={},
+        seed=0,
+        config=config,
+        per_task_accuracy=curve,
+        per_task_loss=curve,
+        per_task_plasticity=curve,
+        wall_clock_seconds=0.0,
+    )
+    object.__setattr__(result, "base_learner", hostile)
+    with pytest.raises(ValueError, match="base_learner must be a non-empty string"):
+        ipmnist.shard_payload(
+            result,
+            source_provenance={},
+            dataset_provenance={},
+            environment={},
+        )
+    assert _HostileString.calls == 0
+
+
+def test_official_foragax_request_rejects_hostile_repository_before_hooks(
+    tmp_path: Path,
+) -> None:
+    hostile = _HostileString("https://github.com/Normal-Computing/foragax-agents")
+    _HostileString.calls = 0
+    with pytest.raises(
+        official_foragax.OfficialForagaxValidationError,
+        match="expected_repository must be a string",
+    ):
+        official_foragax.OfficialForagaxRunRequest(
+            repository=tmp_path,
+            execution_commit="a" * 40,
+            config_path=Path("config.json"),
+            interpreter=Path("python"),
+            output_dir=tmp_path / "output",
+            index=0,
+            expected_repository=hostile,
+        )
     assert _HostileString.calls == 0

--- a/tests/test_forager_matrix_manifest_hostile_validation.py
+++ b/tests/test_forager_matrix_manifest_hostile_validation.py
@@ -2,12 +2,33 @@
 
 from __future__ import annotations
 
+import hashlib
+from typing import Any
+
 import pytest
 
+from alberta_framework.benchmarks import forager_matrix as matrix
 from alberta_framework.benchmarks.forager_matrix import (
     ForagerMatrixManifest,
+    ForagerMatrixStateError,
     ForagerTuningRule,
 )
+
+
+class _HostileString(str):
+    calls = 0
+
+    def __bool__(self) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile string truthiness must not execute")
+
+
+class _ExplodingPattern:
+    calls = 0
+
+    def fullmatch(self, _value: str) -> None:
+        type(self).calls += 1
+        raise AssertionError("pattern matching must follow exact-type validation")
 
 
 @pytest.fixture
@@ -84,3 +105,57 @@ def test_forager_matrix_manifest_rejects_invalid_inputs(
             selection_rule=None,  # type: ignore[arg-type]
             variants={},
         )
+
+
+def test_state_payload_identity_gates_reject_string_subclasses_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hostile = _HostileString("0" * 64)
+    pattern = _ExplodingPattern()
+    monkeypatch.setattr(matrix, "_SHA256", pattern)
+
+    _HostileString.calls = 0
+    _ExplodingPattern.calls = 0
+    with pytest.raises(ForagerMatrixStateError, match="payload_sha256"):
+        matrix._verify_hashed_payload(
+            {"payload_sha256": hostile},
+            description="hostile payload",
+        )
+    assert _HostileString.calls == _ExplodingPattern.calls == 0
+
+    with pytest.raises(ForagerMatrixStateError, match="UTC timestamp"):
+        matrix._validate_utc_timestamp(hostile, "hostile timestamp")
+    assert _HostileString.calls == _ExplodingPattern.calls == 0
+
+    archive_bytes = b"x"
+    inventory = {
+        "schema_version": "1.0",
+        "tree_hash_scheme": matrix.SOURCE_TREE_HASH_SCHEME,
+        "files": [{"path": "alberta_framework/x.py", "size": 0, "sha256": hostile}],
+        "tree_sha256": "tree",
+    }
+    tree_sha256 = matrix._json_sha256(
+        {"tree_hash_scheme": matrix.SOURCE_TREE_HASH_SCHEME, "files": inventory["files"]}
+    )
+    inventory["tree_sha256"] = tree_sha256
+    metadata: dict[str, Any] = {
+        "path": matrix.SOURCE_SNAPSHOT_FILENAME,
+        "archive_format": matrix.SOURCE_ARCHIVE_FORMAT,
+        "archive_sha256": hashlib.sha256(archive_bytes).hexdigest(),
+        "archive_size": len(archive_bytes),
+        "tree_sha256": tree_sha256,
+        "inventory_sha256": hashlib.sha256(
+            matrix._canonical_json_bytes(inventory) + b"\n"
+        ).hexdigest(),
+        "inventory": inventory,
+        "source_execution_mode": matrix.SNAPSHOT_SOURCE_EXECUTION_MODE,
+    }
+    _HostileString.calls = 0
+    _ExplodingPattern.calls = 0
+    with pytest.raises(ForagerMatrixStateError, match="inventory digest"):
+        matrix._validate_source_snapshot_bytes(
+            archive_bytes,
+            metadata,
+            description="hostile snapshot",
+        )
+    assert _HostileString.calls == _ExplodingPattern.calls == 0

--- a/tests/test_historical_forager_hostile_validation.py
+++ b/tests/test_historical_forager_hostile_validation.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
 from alberta_framework.benchmarks import historical_forager
@@ -148,4 +151,39 @@ def test_historical_runtime_manifest_rejects_hostile_strings_before_hooks() -> N
     _HostileString.calls = 0
     with pytest.raises(historical_forager.HistoricalForagerArtifactError, match="runtime"):
         historical_forager._validate_runtime_manifest(runtime)
+    assert _HostileString.calls == 0
+
+
+def test_historical_module_identities_reject_hostile_strings_before_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hostile = _HostileString("identity")
+    module_name = "hostile_historical_version_fixture"
+    monkeypatch.setitem(
+        historical_forager.sys.modules,
+        module_name,
+        SimpleNamespace(__version__=hostile),
+    )
+    monkeypatch.setattr(
+        historical_forager,
+        "_distribution_version",
+        lambda _name: "fallback",
+    )
+    _HostileString.calls = 0
+    assert (
+        historical_forager._module_or_distribution_version(module_name, "fixture")
+        == "fallback"
+    )
+
+    monkeypatch.setattr(historical_forager.os, "access", lambda *_args: False)
+    monkeypatch.setattr(
+        historical_forager.inspect,
+        "getmodule",
+        lambda _owner: SimpleNamespace(__file__=hostile),
+    )
+    with pytest.raises(HistoricalForagerContractError, match="filesystem identity"):
+        historical_forager._require_read_only_non_tmp_factory_source(
+            lambda: None,
+            Path.home(),
+        )
     assert _HostileString.calls == 0


### PR DESCRIPTION
Supersedes #1493, #1496, #1497, #1499, #1501, #1502, and #1503; incorporates #1495, which merged while this consolidation was in progress.

## Summary
- preserves every contributor commit and authorship from the hostile-string PR wave, including redundant independent reports
- completes exact built-in string validation across the adjacent Forager results, historical Forager, IPMNIST screening, and official Foragax loader boundaries
- moves the forged IPMNIST `base_learner` gate before registered-arm comparison
- prevents rejected hostile noise-mode values from reaching `repr`
- adds failing-test-first hostile subclass/pattern dispatch coverage

## Verification
- 26 focused hostile/contract tests pass
- Ruff passes for all five source modules and added tests
- strict mypy passes for all five source modules
- no benchmarks run; no outputs or evidence artifacts changed