### PR TITLE
fix(reference-life): complete event identity contracts

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -96,8 +96,34 @@ def _require_id(value: str, *, name: str) -> None:
 
 
 def _require_digest(value: str, *, name: str) -> None:
-    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+    if type(value) is not str or _SHA256.fullmatch(value) is None:
         raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+def _require_exact_bool(name: str, value: object) -> bool:
+    """Reject leftover int/string identities before they become a verdict."""
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an exact bool")
+    return value
+
+
+def _require_regime_id(value: object, *, name: str = "regime_id") -> int:
+    """Reject leftover bool identities that compare equal to 0 or 1."""
+    if type(value) is not int:
+        raise ValueError(f"{name} must be an exact integer")
+    if value not in (0, 1):
+        raise ValueError(f"{name} must be 0 or 1")
+    return value
+
+
+def _require_finite_real(name: str, value: object) -> float:
+    """Reject leftover bool/NaN identities before they become recorded rewards."""
+    if type(value) is bool or type(value) not in (int, float):
+        raise ValueError(f"{name} must be a finite real number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be a finite real number")
+    return number
 
 
 def _require_prototype_lifecycle_id(value: str) -> None:
@@ -671,10 +697,9 @@ class ReferenceEnvironmentStart:
     regime_id: int
 
     def __post_init__(self) -> None:
+        _require_regime_id(self.regime_id, name="environment start regime_id")
         if not isinstance(self.observation, ArrayValue):
             raise ValueError("environment start observation must be an ArrayValue")
-        if self.regime_id not in (0, 1):
-            raise ValueError("environment start regime_id must be 0 or 1")
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -694,24 +719,24 @@ class ReferenceEnvironmentExecution:
     oracle_reward: float
 
     def __post_init__(self) -> None:
+        reward = _require_finite_real("reward", self.reward)
+        discount = _require_finite_real("discount", self.discount)
+        oracle_reward = _require_finite_real("oracle_reward", self.oracle_reward)
+        if discount < 0.0 or discount > 1.0:
+            raise ValueError("discount must be in [0, 1]")
+        _require_exact_bool("terminated", self.terminated)
+        _require_exact_bool("truncated", self.truncated)
+        _require_exact_bool("autoreset", self.autoreset)
+        _require_regime_id(self.regime_id)
+        object.__setattr__(self, "reward", reward)
+        object.__setattr__(self, "discount", discount)
+        object.__setattr__(self, "oracle_reward", oracle_reward)
         if not isinstance(self.command, DispatchCommand):
             raise ValueError("environment execution requires a DispatchCommand")
         if not isinstance(self.applied_action, ArrayValue):
             raise ValueError("applied_action must be an ArrayValue")
         if not isinstance(self.next_observation, ArrayValue):
             raise ValueError("next_observation must be an ArrayValue")
-        for name in ("reward", "discount", "oracle_reward"):
-            if not math.isfinite(float(getattr(self, name))):
-                raise ValueError(f"{name} must be finite")
-        if self.discount < 0.0 or self.discount > 1.0:
-            raise ValueError("discount must be in [0, 1]")
-        if any(
-            not isinstance(getattr(self, name), bool)
-            for name in ("terminated", "truncated", "autoreset")
-        ):
-            raise ValueError("environment boundary flags must be boolean")
-        if self.regime_id not in (0, 1):
-            raise ValueError("regime_id must be 0 or 1")
 
 
 # Compatibility names retained for the original deterministic slice.
@@ -1554,12 +1579,13 @@ class PendingOutcome:
     oracle_reward: float
 
     def __post_init__(self) -> None:
+        _require_regime_id(self.regime_id, name="pending outcome regime_id")
+        oracle_reward = _require_finite_real(
+            "pending outcome oracle reward", self.oracle_reward
+        )
+        object.__setattr__(self, "oracle_reward", oracle_reward)
         if not isinstance(self.transaction, Transaction):
             raise ValueError("pending outcome requires a Transaction")
-        if self.regime_id not in (0, 1):
-            raise ValueError("pending outcome regime_id must be 0 or 1")
-        if not math.isfinite(self.oracle_reward):
-            raise ValueError("pending outcome oracle reward must be finite")
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -1652,6 +1678,14 @@ class ReferenceLifeEvent:
     transcript_sha256: str
     recovered: bool
 
+    def __post_init__(self) -> None:
+        """Reject leftover recovered/regime/reward identities before they record."""
+        _require_exact_bool("recovered", self.recovered)
+        _require_regime_id(self.regime_id)
+        oracle_reward = _require_finite_real("oracle_reward", self.oracle_reward)
+        _require_digest(self.transcript_sha256, name="transcript_sha256")
+        object.__setattr__(self, "oracle_reward", oracle_reward)
+
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class ReferenceLifeStep:
@@ -1661,8 +1695,7 @@ class ReferenceLifeStep:
     rejection_reason: str | None
 
     def __post_init__(self) -> None:
-        if not isinstance(self.accepted, bool):
-            raise ValueError("accepted must be boolean")
+        _require_exact_bool("accepted", self.accepted)
         if self.accepted and self.rejection_reason is not None:
             raise ValueError("accepted life step cannot carry a rejection reason")
         if not self.accepted and (

--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -23,7 +23,7 @@ import re
 import struct
 import threading
 from collections.abc import Callable, Mapping
-from typing import Any, Protocol, TypeVar
+from typing import Any, Protocol, TypeVar, cast
 
 import jax.numpy as jnp
 import jax.random as jr
@@ -120,7 +120,7 @@ def _require_finite_real(name: str, value: object) -> float:
     """Reject leftover bool/NaN identities before they become recorded rewards."""
     if type(value) is bool or type(value) not in (int, float):
         raise ValueError(f"{name} must be a finite real number")
-    number = float(value)
+    number = float(cast(int | float, value))
     if not math.isfinite(number):
         raise ValueError(f"{name} must be a finite real number")
     return number
@@ -698,7 +698,7 @@ class ReferenceEnvironmentStart:
 
     def __post_init__(self) -> None:
         _require_regime_id(self.regime_id, name="environment start regime_id")
-        if not isinstance(self.observation, ArrayValue):
+        if type(self.observation) is not ArrayValue:
             raise ValueError("environment start observation must be an ArrayValue")
 
 
@@ -731,11 +731,11 @@ class ReferenceEnvironmentExecution:
         object.__setattr__(self, "reward", reward)
         object.__setattr__(self, "discount", discount)
         object.__setattr__(self, "oracle_reward", oracle_reward)
-        if not isinstance(self.command, DispatchCommand):
+        if type(self.command) is not DispatchCommand:
             raise ValueError("environment execution requires a DispatchCommand")
-        if not isinstance(self.applied_action, ArrayValue):
+        if type(self.applied_action) is not ArrayValue:
             raise ValueError("applied_action must be an ArrayValue")
-        if not isinstance(self.next_observation, ArrayValue):
+        if type(self.next_observation) is not ArrayValue:
             raise ValueError("next_observation must be an ArrayValue")
 
 
@@ -1584,7 +1584,7 @@ class PendingOutcome:
             "pending outcome oracle reward", self.oracle_reward
         )
         object.__setattr__(self, "oracle_reward", oracle_reward)
-        if not isinstance(self.transaction, Transaction):
+        if type(self.transaction) is not Transaction:
             raise ValueError("pending outcome requires a Transaction")
 
 
@@ -1685,6 +1685,14 @@ class ReferenceLifeEvent:
         oracle_reward = _require_finite_real("oracle_reward", self.oracle_reward)
         _require_digest(self.transcript_sha256, name="transcript_sha256")
         object.__setattr__(self, "oracle_reward", oracle_reward)
+        for name, expected_type in (
+            ("command", DispatchCommand),
+            ("receipt", DispatchReceipt),
+            ("transaction", Transaction),
+            ("step_result", StepResult),
+        ):
+            if type(getattr(self, name)) is not expected_type:
+                raise ValueError(f"{name} has the wrong exact reference-life type")
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -1696,12 +1704,27 @@ class ReferenceLifeStep:
 
     def __post_init__(self) -> None:
         _require_exact_bool("accepted", self.accepted)
+        if type(self.state) is not ReferenceLifeState:
+            raise ValueError("state must be a ReferenceLifeState")
+        if self.event is not None and type(self.event) is not ReferenceLifeEvent:
+            raise ValueError("event must be a ReferenceLifeEvent or None")
         if self.accepted and self.rejection_reason is not None:
             raise ValueError("accepted life step cannot carry a rejection reason")
         if not self.accepted and (
-            not isinstance(self.rejection_reason, str) or not self.rejection_reason.strip()
+            type(self.rejection_reason) is not str or not self.rejection_reason.strip()
         ):
             raise ValueError("rejected life step requires a reason")
+        if self.accepted and self.event is None:
+            raise ValueError("accepted life step requires an event")
+        if self.event is not None:
+            if self.event.step_result.transaction_accepted is not self.accepted:
+                raise ValueError("life step acceptance disagrees with its event")
+            if self.event.transcript_sha256 != self.state.transcript_sha256:
+                raise ValueError("life step event transcript disagrees with state")
+            if not self.accepted and self.event.step_result.rejection_reason != (
+                self.rejection_reason
+            ):
+                raise ValueError("life step rejection reason disagrees with its event")
 
     @property
     def recovery_required(self) -> bool:

--- a/tests/test_reference_life_event_leftover_identities.py
+++ b/tests/test_reference_life_event_leftover_identities.py
@@ -1,0 +1,127 @@
+"""Leftover-identity gates for reference-life event and regime records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.reference_life import (
+    PendingOutcome,
+    ReferenceEnvironmentExecution,
+    ReferenceEnvironmentStart,
+    ReferenceLifeEvent,
+)
+
+_DIGEST = "0" * 64
+
+
+class _ExplodingHashMeta(type):
+    def __hash__(cls) -> int:
+        raise AssertionError("hostile runtime-class hash executed")
+
+
+class _HostileScalar(metaclass=_ExplodingHashMeta):
+    pass
+
+
+def _legal_event(**overrides: object) -> ReferenceLifeEvent:
+    payload: dict[str, object] = {
+        "command": object(),
+        "receipt": object(),
+        "transaction": object(),
+        "step_result": object(),
+        "regime_id": 0,
+        "oracle_reward": 0.5,
+        "transcript_sha256": _DIGEST,
+        "recovered": False,
+    }
+    payload.update(overrides)
+    return ReferenceLifeEvent(**payload)  # type: ignore[arg-type]
+
+
+def test_reference_life_event_rejects_leftover_identities() -> None:
+    """Public life events must not keep leftover recovered/regime/reward identities."""
+
+    with pytest.raises(ValueError, match="recovered"):
+        _legal_event(recovered=1)
+    with pytest.raises(ValueError, match="recovered"):
+        _legal_event(recovered=0)
+    with pytest.raises(ValueError, match="recovered"):
+        _legal_event(recovered="FIXED")
+    with pytest.raises(ValueError, match="regime_id"):
+        _legal_event(regime_id=True)
+    with pytest.raises(ValueError, match="regime_id"):
+        _legal_event(regime_id=False)
+    with pytest.raises(ValueError, match="oracle_reward"):
+        _legal_event(oracle_reward=True)
+    with pytest.raises(ValueError, match="oracle_reward"):
+        _legal_event(oracle_reward=float("nan"))
+    with pytest.raises(ValueError, match="transcript_sha256"):
+        _legal_event(transcript_sha256="FIXED")
+    with pytest.raises(ValueError, match="transcript_sha256"):
+        _legal_event(transcript_sha256=True)
+
+    legal = _legal_event(recovered=True, oracle_reward=0.5)
+    dumped = json.dumps(
+        {
+            "recovered": legal.recovered,
+            "regime_id": legal.regime_id,
+            "oracle_reward": legal.oracle_reward,
+        },
+        allow_nan=False,
+    )
+    assert dumped == '{"recovered": true, "regime_id": 0, "oracle_reward": 0.5}'
+    assert '"recovered": 1' not in dumped
+    assert legal.recovered is True
+    assert legal.regime_id == 0
+
+
+def test_reference_life_hosts_reject_leftover_regime_and_reward_identities() -> None:
+    """Sibling start/execution/pending hosts must reject leftover True==1 identities."""
+
+    with pytest.raises(ValueError, match="regime_id"):
+        ReferenceEnvironmentStart(state=object(), observation=object(), regime_id=True)
+    with pytest.raises(ValueError, match="regime_id"):
+        PendingOutcome(transaction=object(), regime_id=True, oracle_reward=0.0)
+    with pytest.raises(ValueError, match="oracle reward"):
+        PendingOutcome(transaction=object(), regime_id=0, oracle_reward=True)
+    with pytest.raises(ValueError, match="reward"):
+        ReferenceEnvironmentExecution(
+            command=object(),
+            state=object(),
+            applied_action=object(),
+            next_observation=object(),
+            reward=True,
+            discount=1.0,
+            terminated=False,
+            truncated=False,
+            autoreset=False,
+            regime_id=0,
+            oracle_reward=0.0,
+        )
+    with pytest.raises(ValueError, match="terminated"):
+        ReferenceEnvironmentExecution(
+            command=object(),
+            state=object(),
+            applied_action=object(),
+            next_observation=object(),
+            reward=0.0,
+            discount=1.0,
+            terminated=1,
+            truncated=False,
+            autoreset=False,
+            regime_id=0,
+            oracle_reward=0.0,
+        )
+
+
+def test_real_type_gates_do_not_hash_hostile_runtime_classes() -> None:
+    hostile = _HostileScalar()
+
+    with pytest.raises(ValueError, match="recovered"):
+        _legal_event(recovered=hostile)
+    with pytest.raises(ValueError, match="regime_id"):
+        _legal_event(regime_id=hostile)
+    with pytest.raises(ValueError, match="oracle_reward"):
+        _legal_event(oracle_reward=hostile)

--- a/tests/test_reference_life_event_leftover_identities.py
+++ b/tests/test_reference_life_event_leftover_identities.py
@@ -6,6 +6,12 @@ import json
 
 import pytest
 
+from alberta_framework.reference_agent import (
+    DispatchCommand,
+    DispatchReceipt,
+    StepResult,
+    Transaction,
+)
 from alberta_framework.reference_life import (
     PendingOutcome,
     ReferenceEnvironmentExecution,
@@ -27,10 +33,10 @@ class _HostileScalar(metaclass=_ExplodingHashMeta):
 
 def _legal_event(**overrides: object) -> ReferenceLifeEvent:
     payload: dict[str, object] = {
-        "command": object(),
-        "receipt": object(),
-        "transaction": object(),
-        "step_result": object(),
+        "command": object.__new__(DispatchCommand),
+        "receipt": object.__new__(DispatchReceipt),
+        "transaction": object.__new__(Transaction),
+        "step_result": object.__new__(StepResult),
         "regime_id": 0,
         "oracle_reward": 0.5,
         "transcript_sha256": _DIGEST,
@@ -75,6 +81,15 @@ def test_reference_life_event_rejects_leftover_identities() -> None:
     assert '"recovered": 1' not in dumped
     assert legal.recovered is True
     assert legal.regime_id == 0
+
+    with pytest.raises(ValueError, match="command"):
+        _legal_event(command=object())
+    with pytest.raises(ValueError, match="receipt"):
+        _legal_event(receipt=object())
+    with pytest.raises(ValueError, match="transaction"):
+        _legal_event(transaction=object())
+    with pytest.raises(ValueError, match="step_result"):
+        _legal_event(step_result=object())
 
 
 def test_reference_life_hosts_reject_leftover_regime_and_reward_identities() -> None:


### PR DESCRIPTION
Contributor-preserving corrective successor to #1506.

Preserves 3a131362, then completes exact event component types and life-step event/state transcript, verdict, and rejection-reason coherence.

Closes #1505.

Validation:
- 43 focused reference-life tests passed
- Ruff passed
- mypy passed
- no benchmark/evidence execution and no output mutations