### PR TITLE
fix(validation): close MLP container and scalar type hooks

### DIFF
--- a/alberta_framework/_float32.py
+++ b/alberta_framework/_float32.py
@@ -37,7 +37,8 @@ _ALLOWED_REAL_TYPES = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
 
 
 def _is_actual_int(value: object) -> bool:
-    return type(value) in _ACTUAL_INT_TYPES
+    actual_type = type(value)
+    return any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES)
 
 
 def _round_quotient_ties_to_even(numerator: int, denominator: int) -> int:
@@ -113,7 +114,7 @@ def _float32_from_ratio(
 def _real_ratio(value: object) -> tuple[int, int, bool]:
     """Return one normalized exact ratio and its zero-sign metadata."""
     actual_type = type(value)
-    if actual_type not in _ALLOWED_REAL_TYPES:
+    if not any(actual_type is allowed_type for allowed_type in _ALLOWED_REAL_TYPES):
         raise TypeError("value must be an actual non-bool real")
     if _is_actual_int(value):
         ratio: object = (int(cast(Any, value)), 1)

--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -85,6 +85,23 @@ from alberta_framework.streams.base import ScanStream
 _INT32_MAX = 2**31 - 1
 _MAX_RESOURCE_BYTES = 256 * 1024 * 1024
 _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
+_MLP_CONFIG_FIELDS = frozenset(
+    {
+        "type",
+        "hidden_sizes",
+        "optimizer",
+        "bounder",
+        "normalizer",
+        "head_optimizer",
+        "sparsity",
+        "leaky_relu_slope",
+        "use_layer_norm",
+        "gamma",
+        "lamda",
+        "track_neuron_utility",
+        "neuron_utility_decay",
+    }
+)
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -1241,10 +1258,16 @@ class MLPLearner:
             optimizer_from_config,
         )
 
-        if type(config) is not dict or any(type(key) is not str for key in config):
-            raise ValueError("MLPLearner config must be a plain dict with exact string keys")
-        config = dict(config)
-        config.pop("type", None)
+        if type(config) is not dict:
+            raise ValueError("MLPLearner config must be a plain dict")
+        if not all(type(key) is str for key in config) or set(config) != _MLP_CONFIG_FIELDS:
+            raise ValueError("MLPLearner config fields do not match the schema")
+        if type(config["type"]) is not str or config["type"] != "MLPLearner":
+            raise ValueError("unexpected MLPLearner config type")
+        if type(config["hidden_sizes"]) is not list:
+            raise ValueError("hidden_sizes must be a list")
+        config = config.copy()
+        config.pop("type")
 
         optimizer = optimizer_from_config(config.pop("optimizer"))
         bounder_cfg = config.pop("bounder", None)

--- a/tests/test_float32_hostile_validation.py
+++ b/tests/test_float32_hostile_validation.py
@@ -35,6 +35,22 @@ class _StringSubclass(str):
     pass
 
 
+class _HostileType(type):
+    calls = 0
+
+    def __hash__(cls) -> int:  # pragma: no cover - must not execute
+        type(cls).calls += 1
+        raise AssertionError("metaclass hash hook")
+
+    def __eq__(cls, other: object) -> bool:  # pragma: no cover - must not execute
+        type(cls).calls += 1
+        raise AssertionError("metaclass equality hook")
+
+
+class _HostileTypedValue(metaclass=_HostileType):
+    pass
+
+
 def test_rejects_bool() -> None:
     with pytest.raises(TypeError, match="actual non-bool real"):
         round_real_to_float32(True)
@@ -128,6 +144,15 @@ def test_rejects_class_spoof_without_invoking_class_property() -> None:
     with pytest.raises(TypeError, match="actual non-bool real"):
         round_real_to_float32(ClassSpoof())
     assert calls == 0
+
+
+def test_rejects_before_hostile_metaclass_dispatch() -> None:
+    _HostileType.calls = 0
+    with pytest.raises(TypeError, match="actual non-bool real"):
+        round_real_to_float32(_HostileTypedValue())
+    with pytest.raises(ValueError, match="finite real"):
+        validated_float32_scalar("value", _HostileTypedValue())
+    assert _HostileType.calls == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mlp_learner.py
+++ b/tests/test_mlp_learner.py
@@ -1453,6 +1453,46 @@ class TestMLPLearnerConstructorScalars:
         with pytest.raises(ValueError, match="gamma"):
             MLPLearner.from_config(poisoned)
 
+    def test_from_config_rejects_hostile_containers_before_hooks(self) -> None:
+        calls = 0
+
+        class HostileDict(dict[str, object]):
+            def __iter__(self):  # type: ignore[no-untyped-def]
+                nonlocal calls
+                calls += 1
+                raise AssertionError("mapping iteration hook reached")
+
+        class HostileList(list[int]):
+            def __iter__(self):  # type: ignore[no-untyped-def]
+                nonlocal calls
+                calls += 1
+                raise AssertionError("list iteration hook reached")
+
+        config = MLPLearner(hidden_sizes=(8,), sparsity=0.0).to_config()
+        with pytest.raises(ValueError, match="plain dict"):
+            MLPLearner.from_config(HostileDict(config))  # type: ignore[arg-type]
+        config["hidden_sizes"] = HostileList([8])
+        with pytest.raises(ValueError, match="hidden_sizes must be a list"):
+            MLPLearner.from_config(config)
+        assert calls == 0
+
+    def test_from_config_rejects_hostile_keys_before_comparison(self) -> None:
+        calls = 0
+
+        class HostileKey(str):
+            def __eq__(self, other: object) -> bool:  # pragma: no cover
+                nonlocal calls
+                calls += 1
+                raise AssertionError("key comparison hook reached")
+
+            __hash__ = str.__hash__
+
+        config = MLPLearner(hidden_sizes=(8,), sparsity=0.0).to_config()
+        config[HostileKey("unexpected")] = config.pop("gamma")
+        with pytest.raises(ValueError, match="fields do not match"):
+            MLPLearner.from_config(config)
+        assert calls == 0
+
     def test_rejects_class_spoofed_sparsity_without_invoking_float(self) -> None:
         class Spoof:
             @property


### PR DESCRIPTION
Residual deep-review corrective after #1498/#1492.

The merged scalar validation correctly rejects bool/nonfinite values and preserves supported built-in, Fraction, and NumPy scalar families. Two adjacent trust-boundary gaps remained:

- _float32 allow-list set membership hashed type(value), dispatching a hostile metaclass __hash__ before rejection. A direct reproduction observed one hook call. Identity-only comparison now rejects with zero metaclass hash/equality calls for every consumer of the shared float32 validator.
- MLPLearner.from_config gated only the outer dict/key identities, then iterated a hostile hidden_sizes list and accepted missing/unknown schema fields or wrong type identity. It now requires the exact to_config schema, exact MLPLearner discriminator, and a built-in hidden_sizes list before copying/iteration.

Compatibility/resource audit:
- supported int/float/Fraction/NumPy scalar acceptance and canonicalization are unchanged
- ordinary to_config/from_config round trips remain accepted
- constructor/JIT learner math, array allocation, state size, and lifetime clocks are unchanged
- new work is bounded host validation over small fixed allow-lists/schema fields

Verification on current main 9ff94eea:
- 285 passed across MLP learner, learner, True Online TD, shared float32 hostile, and config-serialization suites
- rebased targeted panel: 119 passed
- Ruff clean
- strict mypy clean (174 source files)
- git diff --check clean

No outputs, workflow launch, benchmark execution, frozen protocol, or evidence promotion.