### PR TITLE
fix(forager): preserve historical zero-based curves

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -1829,11 +1829,12 @@ class ForagerRunResult:
         )
         if (
             not curve_steps
-            or curve_steps[0] < 1
             or curve_steps[-1] > steps
             or any(left >= right for left, right in zip(curve_steps, curve_steps[1:]))
         ):
-            raise ValueError("curve_steps must be nonempty, increasing, and within steps")
+            raise ValueError(
+                "curve_steps must be nonempty, increasing, and within [0, steps]"
+            )
         object.__setattr__(self, "curve_steps", curve_steps)
         for name in ("curve_ewm_reward", "curve_window_reward"):
             values = getattr(self, name)
@@ -1844,7 +1845,7 @@ class ForagerRunResult:
                 name,
                 tuple(_require_result_scalar(value, name=name) for value in values),
             )
-            if len(values) != len(curve_steps):
+            if values and len(values) != len(curve_steps):
                 raise ValueError(f"{name} length must match curve_steps")
         for name in ("duration_s", "frames_per_second"):
             value = getattr(self, name)

--- a/tests/test_forager_paper_reference_leftover_identities.py
+++ b/tests/test_forager_paper_reference_leftover_identities.py
@@ -177,6 +177,12 @@ def test_forager_run_result_keeps_integer_json() -> None:
     assert '"privileged": false' in dumped
 
 
+def test_forager_run_result_preserves_zero_based_historical_curve_grid() -> None:
+    result = _legal_run_result(curve_steps=(0, 10), curve_window_reward=())
+    assert result.curve_steps == (0, 10)
+    assert result.curve_window_reward == ()
+
+
 def test_run_result_rejects_hostile_scalar_subclasses_before_hooks() -> None:
     calls = 0
 
@@ -203,6 +209,7 @@ def test_run_result_rejects_hostile_scalar_subclasses_before_hooks() -> None:
     "overrides",
     [
         {"curve_steps": ()},
+        {"curve_steps": (-1, 10)},
         {"curve_steps": (1, 1)},
         {"curve_steps": (1, 11)},
         {"curve_ewm_reward": (0.1,)},


### PR DESCRIPTION
## Summary

Restore compatibility between the strict `ForagerRunResult` constructor and the checked-in historical SQLite import contract:

- accept the exact nonnegative historical curve grid (`0, 100, ...`) without relabelling it
- allow an empty optional curve channel to continue meaning “unavailable”
- retain exact built-in integer validation, strict increase, the `<= steps` bound, and exact length for every nonempty curve channel

The importer and its metric metadata both bind `LEGACY_FOV_FRAMES` with first coordinate 0, and the historical archive has only the already-smoothed EMA channel; shifting the grid or manufacturing window values would falsify the historical representation.

## Verification

- 46 focused constructor + legacy SQLite tests pass after rebase on current main
- 278 full relevant Forager/historical tests pass
- Ruff clean
- strict mypy clean (174 files)
- diff-check clean

No benchmark execution, output mutation, evidence promotion, or workflow launch.