### PR TITLE
fix(forager): bind historical zero-based curves

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -1821,6 +1821,22 @@ class ForagerRunResult:
                 name,
                 _require_result_scalar(getattr(self, name), name=name),
             )
+        for name in ("environment", "metric_contract", "agent_metadata"):
+            value = getattr(self, name)
+            if type(value) is not dict:
+                raise ValueError(f"{name} must be a plain dict")
+            object.__setattr__(self, name, dict(value))
+        historical_curve = (
+            type(self.environment.get("runtime")) is str
+            and self.environment["runtime"] == "historical_numpy_forager"
+            and self.environment.get("pairable_with_current_foragax") is False
+            and type(self.metric_contract.get("stored_curve")) is str
+            and self.metric_contract["stored_curve"] == "unadjusted_ema_then_subsample"
+            and self.metric_contract.get("raw_reward_metrics_available") is False
+            and type(self.agent_metadata.get("result_source")) is str
+            and self.agent_metadata["result_source"] == "official_fov_sqlite"
+            and self.agent_metadata.get("raw_rewards_available") is False
+        )
         if type(self.curve_steps) is not tuple:
             raise ValueError("curve_steps must be a tuple of integers")
         curve_steps = tuple(
@@ -1829,6 +1845,7 @@ class ForagerRunResult:
         )
         if (
             not curve_steps
+            or (curve_steps[0] == 0 and not historical_curve)
             or curve_steps[-1] > steps
             or any(left >= right for left, right in zip(curve_steps, curve_steps[1:]))
         ):
@@ -1845,15 +1862,17 @@ class ForagerRunResult:
                 name,
                 tuple(_require_result_scalar(value, name=name) for value in values),
             )
-            if values and len(values) != len(curve_steps):
+            if name == "curve_ewm_reward" and len(values) != len(curve_steps):
+                raise ValueError(f"{name} length must match curve_steps")
+            if name == "curve_window_reward" and (
+                (values and len(values) != len(curve_steps))
+                or (not values and not historical_curve)
+            ):
                 raise ValueError(f"{name} length must match curve_steps")
         for name in ("duration_s", "frames_per_second"):
             value = getattr(self, name)
             if not math.isnan(value) and value < 0.0:
                 raise ValueError(f"{name} must be nonnegative or NaN")
-        for name in ("environment", "metric_contract", "agent_metadata"):
-            if not isinstance(getattr(self, name), Mapping):
-                raise ValueError(f"{name} must be a mapping")
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible result."""

--- a/tests/test_forager_legacy_sqlite.py
+++ b/tests/test_forager_legacy_sqlite.py
@@ -17,7 +17,6 @@ from alberta_framework.benchmarks.forager_results import (
     LEGACY_FOV_FRAMES,
     LegacyFOVSQLiteRunSpec,
     import_legacy_fov_sqlite,
-    paired_forager_comparison,
 )
 
 pytestmark = pytest.mark.integration
@@ -241,15 +240,10 @@ def test_rejects_dishonest_labels_and_current_foragax_pairing(tmp_path: Path) ->
 
     database_path, config_path = _write_artifacts(tmp_path)
     legacy = import_legacy_fov_sqlite(_spec(database_path, config_path))
-    current = dataclasses.replace(
-        legacy,
-        agent="alberta_horde_ac",
-        environment={"runtime": "foragax"},
-        agent_metadata={"seed": legacy.seed, "result_source": "in_tree"},
-    )
-    with pytest.raises(ValueError, match="unpaired orientation evidence"):
-        paired_forager_comparison(
-            [current],
-            [legacy],
-            metric="fov_last_10pct_ema_auc",
+    with pytest.raises(ValueError, match="curve_steps"):
+        dataclasses.replace(
+            legacy,
+            agent="alberta_horde_ac",
+            environment={"runtime": "foragax"},
+            agent_metadata={"seed": legacy.seed, "result_source": "in_tree"},
         )

--- a/tests/test_forager_paper_reference_leftover_identities.py
+++ b/tests/test_forager_paper_reference_leftover_identities.py
@@ -178,7 +178,22 @@ def test_forager_run_result_keeps_integer_json() -> None:
 
 
 def test_forager_run_result_preserves_zero_based_historical_curve_grid() -> None:
-    result = _legal_run_result(curve_steps=(0, 10), curve_window_reward=())
+    result = _legal_run_result(
+        curve_steps=(0, 10),
+        curve_window_reward=(),
+        environment={
+            "runtime": "historical_numpy_forager",
+            "pairable_with_current_foragax": False,
+        },
+        metric_contract={
+            "stored_curve": "unadjusted_ema_then_subsample",
+            "raw_reward_metrics_available": False,
+        },
+        agent_metadata={
+            "result_source": "official_fov_sqlite",
+            "raw_rewards_available": False,
+        },
+    )
     assert result.curve_steps == (0, 10)
     assert result.curve_window_reward == ()
 
@@ -210,10 +225,12 @@ def test_run_result_rejects_hostile_scalar_subclasses_before_hooks() -> None:
     [
         {"curve_steps": ()},
         {"curve_steps": (-1, 10)},
+        {"curve_steps": (0, 10)},
         {"curve_steps": (1, 1)},
         {"curve_steps": (1, 11)},
         {"curve_ewm_reward": (0.1,)},
         {"curve_window_reward": (0.1,)},
+        {"curve_ewm_reward": (), "curve_window_reward": ()},
         {"duration_s": -1.0},
         {"frames_per_second": -1.0},
     ],

--- a/tests/test_forager_results.py
+++ b/tests/test_forager_results.py
@@ -58,7 +58,7 @@ def test_pairing_identity_rejects_unsupported_values_without_string_hooks() -> N
         def items(self):  # type: ignore[no-untyped-def, override]
             raise AssertionError("pairing identity must not invoke mapping hooks")
 
-    with pytest.raises(ValueError, match="finite JSON"):
+    with pytest.raises(ValueError, match="plain dict"):
         _environment_signature(_run(environment=HostileMapping(kind="toy")))
 
     with pytest.raises(ValueError, match="environment pairing identity"):


### PR DESCRIPTION
Corrective follow-up to merged #1510.

Preserves its historical compatibility while binding the zero-based grid and unavailable window channel specifically to the declared official historical SQLite representation. Current Foragax runs remain one-based with complete curve channels; the EWM channel is always required. Exact outer result metadata dicts are snapshotted at construction.

Validation:
- 51 focused Forager/legacy tests passed
- Ruff passed
- mypy passed
- no benchmark/evidence execution and no output mutations