### PR TITLE
fix(ipmnist): complete screening identity gates

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -6701,11 +6701,10 @@ SCREENING_REGISTRY: Mapping[str, ScreeningSpec] = MappingProxyType(_build_regist
 
 def screening_spec(name: str) -> ScreeningSpec:
     """Look up a screening configuration by name."""
+    if type(name) is not str:
+        raise ValueError("screening config name must be an exact string")
     if name not in SCREENING_REGISTRY:
-        raise ValueError(
-            f"unknown screening config {name!r}; expected one of "
-            f"{sorted(SCREENING_REGISTRY)}"
-        )
+        raise ValueError(f"unknown screening config; expected one of {sorted(SCREENING_REGISTRY)}")
     return SCREENING_REGISTRY[name]
 
 
@@ -8418,10 +8417,16 @@ def load_shard(path: Path) -> dict[str, Any]:
         payload.get("wall_clock_seconds"), path
     )
     payload["seed"] = require_jax_seed(payload.get("seed"), name=f"{path}: seed")
-    if payload.get("config_name") not in SCREENING_REGISTRY:
-        raise ValueError(f"{path}: unknown config_name {payload.get('config_name')!r}")
-    spec = SCREENING_REGISTRY[payload["config_name"]]
-    if is_v2 and payload.get("base_learner") != spec.base_learner:
+    config_name = _required_nonempty_string(
+        payload.get("config_name"), context=f"{path}: config_name"
+    )
+    if config_name not in SCREENING_REGISTRY:
+        raise ValueError(f"{path}: unknown config_name")
+    spec = SCREENING_REGISTRY[config_name]
+    base_learner = _required_nonempty_string(
+        payload.get("base_learner"), context=f"{path}: base_learner"
+    )
+    if is_v2 and base_learner != spec.base_learner:
         raise ValueError(
             f"{path}: base_learner must match registered arm {spec.base_learner!r}"
         )
@@ -8440,8 +8445,8 @@ def load_shard(path: Path) -> dict[str, Any]:
     )
     payload["noise_mode"] = noise_mode
     payload["noise_pool_steps"] = noise_pool_steps
-    if type(payload.get("base_learner")) is not str or not payload["base_learner"]:
-        raise ValueError(f"{path}: base_learner must be a non-empty string")
+    payload["config_name"] = config_name
+    payload["base_learner"] = base_learner
     if not isinstance(payload.get("hyperparameters"), dict):
         raise ValueError(f"{path}: hyperparameters must be an object")
     if not is_v2:

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -915,11 +915,11 @@ class TestCBPReplacement:
 class TestWeightClipping:
     """UPGD-W + weight clipping (Elsayed et al., RLC 2024)."""
 
-    def test_kappa_inf_reduces_exactly_to_control(self, small_data):
-        """With kappa=inf the clip is a no-op: bit-exact control trajectory."""
+    def test_max_finite_kappa_reduces_exactly_to_control(self, small_data):
+        """With max-finite kappa the clip is a no-op: bit-exact control trajectory."""
         x, y = small_data
         hp = dict(UPGD_W_PROTOCOL_HYPERPARAMETERS)
-        hp["clip_kappa"] = math.inf
+        hp["clip_kappa"] = float(np.finfo(np.float32).max)
         spec = ScreeningSpec(
             name="upgd_w_control",  # reuse control identity for shard plumbing
             base_learner="upgd_w",
@@ -2061,22 +2061,20 @@ class TestPoolConfirmation:
         self, noise_pool_steps: object
     ) -> None:
         spec = screening_spec("upgd_w_control")
-        result = ipmnist_screening.ScreeningRunResult(
-            config_name=spec.name,
-            base_learner=spec.base_learner,
-            hyperparameters=dict(spec.hyperparameters),
-            seed=0,
-            config=SMALL,
-            per_task_accuracy=np.zeros(SMALL.n_tasks),
-            per_task_loss=np.zeros(SMALL.n_tasks),
-            per_task_plasticity=np.zeros(SMALL.n_tasks),
-            wall_clock_seconds=0.0,
-            noise_mode="pool",
-            noise_pool_steps=noise_pool_steps,  # type: ignore[arg-type]
-        )
-
         with pytest.raises(ValueError, match="noise_pool_steps"):
-            _bound_shard_payload(result)
+            ipmnist_screening.ScreeningRunResult(
+                config_name=spec.name,
+                base_learner=spec.base_learner,
+                hyperparameters=dict(spec.hyperparameters),
+                seed=0,
+                config=SMALL,
+                per_task_accuracy=np.zeros(SMALL.n_tasks),
+                per_task_loss=np.zeros(SMALL.n_tasks),
+                per_task_plasticity=np.zeros(SMALL.n_tasks),
+                wall_clock_seconds=0.0,
+                noise_mode="pool",
+                noise_pool_steps=noise_pool_steps,  # type: ignore[arg-type]
+            )
 
     def test_pool_control_matches_run_ipmnist_pool(self, small_data):
         """Control arm under pool mode reproduces run_ipmnist's pool chain."""
@@ -4293,15 +4291,18 @@ class TestComparisonArms:
             factory=factory,
         )
 
-    def test_wclip_kappa_inf_reduces_to_sgd_base_bitwise(self, small_data):
-        """clip_kappa=inf makes the clip a no-op: bit-exact sgd_ema_norm_d099."""
+    def test_wclip_max_finite_kappa_reduces_to_sgd_base_bitwise(self, small_data):
+        """Max-finite clip_kappa is a no-op: bit-exact sgd_ema_norm_d099."""
         x, y = small_data
         ref_spec = screening_spec("sgd_ema_norm_d099")
         ours = run_screening_config(
             x, y,
             self._cloned(
                 "sgd_ema_norm_d099", _make_wclip_ema_norm_learner,
-                {**ref_spec.hyperparameters, "clip_kappa": math.inf},
+                {
+                    **ref_spec.hyperparameters,
+                    "clip_kappa": float(np.finfo(np.float32).max),
+                },
             ),
             seed=5, config=SMALL,
         )
@@ -4329,7 +4330,7 @@ class TestComparisonArms:
             assert np.all(values >= -bound - 1e-7), n
 
     def test_fade_lambda_zero_reduces_to_sgd_base_bitwise(self, small_data):
-        """theta=0 and gamma0=-inf (lambda=0) pin the head to the plain SGD
+        """theta=0 and a min-finite gamma0 (lambda=0) pin the head to the plain SGD
         step, so the whole arm equals the wd=0 normalized-SGD base."""
         x, y = small_data
         base_hp = {**self.BASE, "weight_decay": 0.0}
@@ -4340,7 +4341,7 @@ class TestComparisonArms:
                 {
                     **base_hp,
                     "fade_alpha": 0.005,
-                    "fade_gamma0": -math.inf,
+                    "fade_gamma0": -float(np.finfo(np.float32).max),
                     "fade_theta_lambda": 0.0,
                 },
             ),

--- a/tests/test_ipmnist_screening_hostile_validation.py
+++ b/tests/test_ipmnist_screening_hostile_validation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from alberta_framework.benchmarks import ipmnist_screening
 from alberta_framework.benchmarks.ipmnist_screening import (
     ScreeningRunResult,
     ScreeningSpec,
@@ -71,3 +72,28 @@ def test_screening_run_result_rejects_invalid_inputs() -> None:
             per_task_plasticity=dummy_arr,
             wall_clock_seconds=float("inf"),
         )
+
+
+def test_screening_string_boundaries_reject_hostile_subclasses_without_hooks() -> None:
+    class HostileStr(str):
+        calls = 0
+
+        def _called(self) -> bool:
+            type(self).calls += 1
+            raise AssertionError("hostile string hook executed")
+
+        __bool__ = _called
+        __eq__ = _called
+        __hash__ = _called
+
+        def __repr__(self) -> str:
+            self._called()
+            return "unreachable"
+
+    hostile = HostileStr("upgd_w_control")
+    with pytest.raises(ValueError, match="exact string"):
+        screening_spec(hostile)
+
+    with pytest.raises(ValueError, match="non-empty string"):
+        ipmnist_screening._required_nonempty_string(hostile, context="config_name")
+    assert HostileStr.calls == 0


### PR DESCRIPTION
## Summary

- reject hostile config-name and decoded shard identities before dictionary lookup, equality, truthiness, repr, or hashing
- move decoded `config_name`/`base_learner` validation ahead of registered-arm comparisons
- repair retained screening tests after the exact finite-hyperparameter and constructor-level pool-size contracts moved fail-closed boundaries earlier
- retain exact reduction pins using finite float32 endpoints instead of forbidden infinities

## Verification

- full `tests/test_ipmnist_screening.py`: 339 passed
- focused hostile/provenance and corrected-boundary panel: 65 passed
- post-rebase exact residual panel: 13 passed
- Ruff: passed
- strict source mypy: passed
- diff-check: passed

This changes the active development screening source identity. It does not edit outputs, run a benchmark, consume a seed, promote evidence, or alter the already sealed #51 result. The forthcoming #184 launch will bind this new source only after the queue freezes.
