### PR TITLE
fix(forager): require one available result curve

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -1847,6 +1847,8 @@ class ForagerRunResult:
             )
             if values and len(values) != len(curve_steps):
                 raise ValueError(f"{name} length must match curve_steps")
+        if not self.curve_ewm_reward and not self.curve_window_reward:
+            raise ValueError("at least one result curve must be available")
         for name in ("duration_s", "frames_per_second"):
             value = getattr(self, name)
             if not math.isnan(value) and value < 0.0:

--- a/tests/test_forager_paper_reference_leftover_identities.py
+++ b/tests/test_forager_paper_reference_leftover_identities.py
@@ -214,6 +214,7 @@ def test_run_result_rejects_hostile_scalar_subclasses_before_hooks() -> None:
         {"curve_steps": (1, 11)},
         {"curve_ewm_reward": (0.1,)},
         {"curve_window_reward": (0.1,)},
+        {"curve_ewm_reward": (), "curve_window_reward": ()},
         {"duration_s": -1.0},
         {"frames_per_second": -1.0},
     ],


### PR DESCRIPTION
Follow-up fail-closed invariant for #1510: historical results may omit either optional curve channel, but a nonempty step grid cannot omit both. Every nonempty channel still must align exactly with the grid.

Verification: 47 focused constructor + legacy SQLite tests pass; Ruff clean; strict mypy clean (174 files); diff-check clean. No outputs or workflows.