### PR TITLE
fix(foragax): complete exact manifest strings

### DIFF
--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -272,12 +272,16 @@ class OfficialForagaxRunRequest:
             raise OfficialForagaxValidationError(
                 "expected_repository must be a string"
             )
-        if not _COMMIT_PATTERN.fullmatch(self.execution_commit):
+        if (
+            type(self.execution_commit) is not str
+            or _COMMIT_PATTERN.fullmatch(self.execution_commit) is None
+        ):
             raise OfficialForagaxValidationError(
                 "execution_commit must be a full lowercase 40-character Git SHA"
             )
-        if self.config_commit is not None and not _COMMIT_PATTERN.fullmatch(
-            self.config_commit
+        if self.config_commit is not None and (
+            type(self.config_commit) is not str
+            or _COMMIT_PATTERN.fullmatch(self.config_commit) is None
         ):
             raise OfficialForagaxValidationError(
                 "config_commit must be a full lowercase 40-character Git SHA"
@@ -3637,8 +3641,10 @@ def _sanitized_runtime(runtime: Mapping[str, Any]) -> dict[str, Any]:
         if isinstance(direct_url, Mapping):
             normalized_url = dict(direct_url)
             url = normalized_url.get("url")
-            if isinstance(url, str) and url.startswith("file:"):
-                normalized_url["url"] = "<LOCAL_PATH>"
+            if isinstance(url, str):
+                normalized_url["url"] = str.__str__(url)
+                if normalized_url["url"].startswith("file:"):
+                    normalized_url["url"] = "<LOCAL_PATH>"
             normalized["direct_url"] = normalized_url
         result["foragax_implementation"] = normalized
     return result
@@ -3696,8 +3702,10 @@ def _sanitize_package_freeze_line(line: str) -> str:
         return prefix + " ; direct_url=<REDACTED>"
     if isinstance(direct_url, dict):
         url = direct_url.get("url")
-        if isinstance(url, str) and url.startswith("file:"):
-            direct_url["url"] = "<LOCAL_PATH>"
+        if isinstance(url, str):
+            direct_url["url"] = str.__str__(url)
+            if direct_url["url"].startswith("file:"):
+                direct_url["url"] = "<LOCAL_PATH>"
     try:
         encoded = json.dumps(
             direct_url,
@@ -4938,7 +4946,7 @@ def _validated_registry_identity(value: Any) -> dict[str, str]:
         )
     result: dict[str, str] = {}
     for key, item in value.items():
-        if type(item) is not str or not item:
+        if type(key) is not str or type(item) is not str or not item:
             raise OfficialForagaxValidationError(
                 f"official agent registry {key} is invalid"
             )

--- a/tests/test_official_foragax_run_plans_hostile_validation.py
+++ b/tests/test_official_foragax_run_plans_hostile_validation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from alberta_framework.benchmarks import official_foragax
 from alberta_framework.benchmarks.official_foragax import (
     OfficialForagaxBatchRunPlan,
     OfficialForagaxBatchRunRequest,
@@ -13,6 +14,30 @@ from alberta_framework.benchmarks.official_foragax import (
     OfficialForagaxRunRequest,
     OfficialForagaxValidationError,
 )
+
+
+class _HostileString(str):
+    calls = 0
+
+    def __bool__(self) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile truth hook executed")
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile comparison hook executed")
+
+    def strip(self, chars: object = None) -> str:
+        del chars
+        type(self).calls += 1
+        raise AssertionError("hostile strip hook executed")
+
+    def startswith(self, prefix: object, *args: object) -> bool:
+        del prefix, args
+        type(self).calls += 1
+        raise AssertionError("hostile startswith hook executed")
+
+    __hash__ = str.__hash__
 
 
 @pytest.fixture
@@ -131,3 +156,63 @@ def test_official_foragax_batch_run_plan_rejects_invalid_inputs(
             config_snapshot_bytes="not bytes",  # type: ignore[arg-type]
             execution_config_bytes=b"{}",
         )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("expected_repository", official_foragax.OFFICIAL_FORAGAX_REPOSITORY, "repository"),
+        ("execution_commit", "a" * 40, "execution_commit"),
+        ("config_commit", "b" * 40, "config_commit"),
+    ],
+)
+def test_run_request_rejects_hostile_string_identities_before_hooks(
+    tmp_path: Path, field: str, value: str, message: str
+) -> None:
+    kwargs = {
+        "repository": tmp_path,
+        "execution_commit": "a" * 40,
+        "config_path": Path("config.json"),
+        "config_commit": "b" * 40,
+        "interpreter": Path("python"),
+        "output_dir": tmp_path / "output",
+        "index": 0,
+        field: _HostileString(value),
+    }
+    _HostileString.calls = 0
+
+    with pytest.raises(OfficialForagaxValidationError, match=message):
+        OfficialForagaxRunRequest(**kwargs)  # type: ignore[arg-type]
+
+    assert _HostileString.calls == 0
+
+
+def test_manifest_identity_helpers_reject_or_normalize_hostile_strings(
+    tmp_path: Path,
+) -> None:
+    hostile = _HostileString("algorithms.registry")
+    registry = {
+        "module": hostile,
+        "class": "algorithms.RandomAgent.RandomAgent",
+        "registry_source_path": "src/algorithms/registry.py",
+        "registry_source_sha256": "a" * 64,
+        "class_source_path": "src/algorithms/RandomAgent.py",
+        "class_source_sha256": "b" * 64,
+    }
+    _HostileString.calls = 0
+    with pytest.raises(OfficialForagaxValidationError, match="registry module"):
+        official_foragax._validated_registry_identity(registry)
+    with pytest.raises(OfficialForagaxValidationError, match="manifest artifact"):
+        official_foragax._manifest_relative_file(
+            tmp_path, _HostileString("artifact.json"), label="artifact"
+        )
+    assert _HostileString.calls == 0
+
+    runtime = {
+        "foragax_implementation": {
+            "direct_url": {"url": _HostileString("file:///host/path")}
+        }
+    }
+    sanitized = official_foragax._sanitized_runtime(runtime)
+    assert sanitized["foragax_implementation"]["direct_url"]["url"] == "<LOCAL_PATH>"
+    assert _HostileString.calls == 0


### PR DESCRIPTION
Corrective follow-up to consolidated #1507, retaining the reviewed #1497 intent. Closes remaining hostile string paths for request execution/config commits and registry keys, and normalizes str-subclass direct URLs through base str behavior before redaction so hooks cannot bypass path sanitization. The broader exact manifest gates from #1507 remain unchanged. Validation: 84 focused official/hostile tests pass; Ruff and diff checks clean; strict mypy passes 174 files. This module is one of the official harness source-identity files, so new run receipts bind the changed bytes and old source-bound manifests remain archival/fail closed; no protocol descriptor, output, workflow, schema, threshold, or promotion mutation.