### PR TITLE
fix(reference-life): fail closed on hostile control identities

### DIFF
--- a/alberta_framework/reference_life_controls.py
+++ b/alberta_framework/reference_life_controls.py
@@ -733,7 +733,7 @@ class AnalyticOracleReferenceConfig:
             self.n_actions,
         )
         horizon = _canonical_oracle_horizon(self.horizon)
-        if not isinstance(self.policy_sha256, str) or _SHA256.fullmatch(
+        if type(self.policy_sha256) is not str or _SHA256.fullmatch(
             self.policy_sha256
         ) is None:
             raise ValueError("oracle policy_sha256 must be a lowercase SHA-256 digest")
@@ -907,17 +907,17 @@ class ReferenceLifeControlState:
     _owner_token: object = dataclasses.field(repr=False, compare=False)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.schema, str) or _SAFE_ID.fullmatch(self.schema) is None:
+        if type(self.schema) is not str or _SAFE_ID.fullmatch(self.schema) is None:
             raise ValueError("control state schema must be a safe identifier")
-        if not isinstance(self.manifest_id, str) or _SHA256.fullmatch(self.manifest_id) is None:
+        if type(self.manifest_id) is not str or _SHA256.fullmatch(self.manifest_id) is None:
             raise ValueError("control state manifest_id must be a SHA-256 digest")
         if (
-            not isinstance(self.config_sha256, str)
+            type(self.config_sha256) is not str
             or _SHA256.fullmatch(self.config_sha256) is None
         ):
             raise ValueError("control state config_sha256 must be a SHA-256 digest")
         if (
-            not isinstance(self.lifecycle_id, str)
+            type(self.lifecycle_id) is not str
             or len(self.lifecycle_id) > _MAX_ID_LENGTH
             or _SAFE_ID.fullmatch(self.lifecycle_id) is None
         ):
@@ -939,7 +939,7 @@ class ReferenceLifeControlState:
         ):
             raise ValueError("control state decision cache must be wholly fresh or armed")
         if self.current_observation_id is not None and (
-            not isinstance(self.current_observation_id, str)
+            type(self.current_observation_id) is not str
             or _SAFE_ID.fullmatch(self.current_observation_id) is None
         ):
             raise ValueError("current_observation_id must be a safe identifier")
@@ -1346,7 +1346,7 @@ class _BaseReferenceControlAdapter:
     def init(self, key: Array, *, lifecycle_id: str) -> ReferenceLifeControlState:
         _require_prng_key(key, name="initial control key")
         if (
-            not isinstance(lifecycle_id, str)
+            type(lifecycle_id) is not str
             or len(lifecycle_id) > _MAX_ID_LENGTH
             or _SAFE_ID.fullmatch(lifecycle_id) is None
         ):

--- a/alberta_framework/reference_life_controls.py
+++ b/alberta_framework/reference_life_controls.py
@@ -96,7 +96,10 @@ def _require_environment_shape(
     observation_dim: int,
     n_actions: int,
 ) -> None:
-    if environment_kind not in ("switching_two_state", "riverswim"):
+    if type(environment_kind) is not str or environment_kind not in (
+        "switching_two_state",
+        "riverswim",
+    ):
         raise ValueError("environment_kind must be switching_two_state or riverswim")
     if (
         isinstance(observation_dim, bool)
@@ -737,6 +740,8 @@ class AnalyticOracleReferenceConfig:
             self.policy_sha256
         ) is None:
             raise ValueError("oracle policy_sha256 must be a lowercase SHA-256 digest")
+        if type(self.environment_config_json) is not str:
+            raise ValueError("oracle environment config must be canonical JSON")
         try:
             decoded = json.loads(self.environment_config_json)
         except (TypeError, json.JSONDecodeError) as exc:

--- a/tests/test_reference_life_controls.py
+++ b/tests/test_reference_life_controls.py
@@ -110,6 +110,22 @@ def _uniform_switching() -> UniformRandomReferenceAdapter:
     )
 
 
+class _HostileString(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile string equality executed")
+
+    def __hash__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile string hashing executed")
+
+    def __len__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile string length executed")
+
+
 def _differential_switching() -> DifferentialSARSAReferenceAdapter:
     environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
     return DifferentialSARSAReferenceAdapter(
@@ -366,6 +382,48 @@ def test_environment_scalar_gate_rejects_non_real_overflow_and_positive_collapse
                 p_right_up=math.nextafter(0.0, 1.0),
             )
         )
+
+
+def test_control_identity_gates_reject_string_subclasses_without_dispatch() -> None:
+    environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    adapter = _uniform_switching()
+    state = adapter.init(
+        jr.key(7, impl="threefry2x32"),
+        lifecycle_id="control.identity.baseline",
+    )
+    started, _ = adapter.start(
+        state,
+        observation_id="observation.0",
+        observation=np.asarray((1.0, 0.0), dtype=np.float32),
+    )
+    oracle = AnalyticOracleReferenceConfig.for_switching(environment, horizon=2)
+    hostile = _HostileString("switching_two_state")
+
+    rejected = (
+        lambda: UniformRandomReferenceConfig(  # type: ignore[arg-type]
+            environment_kind=hostile,
+            observation_dim=2,
+        ),
+        lambda: dataclasses.replace(oracle, policy_sha256=hostile),
+        lambda: dataclasses.replace(oracle, environment_config_json=hostile),
+        lambda: dataclasses.replace(state, schema=hostile),
+        lambda: dataclasses.replace(state, manifest_id=hostile),
+        lambda: dataclasses.replace(state, config_sha256=hostile),
+        lambda: dataclasses.replace(state, lifecycle_id=hostile),
+        lambda: dataclasses.replace(started, current_observation_id=hostile),
+        lambda: adapter.init(
+            jr.key(8, impl="threefry2x32"),
+            lifecycle_id=hostile,
+        ),
+    )
+    _HostileString.calls = 0
+    for operation in rejected:
+        with pytest.raises(
+            ValueError,
+            match="environment|policy|schema|manifest|config|lifecycle|observation",
+        ):
+            operation()
+    assert _HostileString.calls == 0
 
 
 def test_decay_counts_and_discounted_network_shapes_are_resource_bounded() -> None:


### PR DESCRIPTION
Preserves byt61’s #1513 fix and closes the two adjacent string-identity gaps in the same trust boundary: `environment_kind` and the oracle canonical JSON payload. Adds executable hostile-subclass coverage for every affected config, persisted-state, and lifecycle field, asserting zero hostile hook calls.\n\n#1512 is disjoint (IPMNIST screening only); this branch is based on main after #1517.\n\nVerification: 32 focused tests; Ruff; strict mypy. No benchmarks, evidence runs, or output changes.\n\nSupersedes #1513 while retaining its authored commit.