### PR TITLE
fix(benchmarks): close hostile Forager string boundaries

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_open_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_open_protocol.py
@@ -1016,7 +1016,7 @@ _UPSTREAM_CONFIGURATION_REQUIREMENTS: Final = MappingProxyType(
 
 
 def _require_real_sha256(value: str, path: str) -> None:
-    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+    if type(value) is not str or _SHA256_RE.fullmatch(value) is None:
         raise ForagerMatchedOpenProtocolBuildError(f"{path} must be a lowercase SHA-256")
     if _PLACEHOLDER_SHA256_RE.fullmatch(value) is not None:
         raise ForagerMatchedOpenProtocolBuildError(

--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -803,7 +803,7 @@ class RankedSelectionGroup:
     def __post_init__(self) -> None:
         _require_identifier(self.selection_group, "ranked_selection_group.selection_group")
         if type(self.ranked_candidate_ids) is not tuple or not all(
-            isinstance(cid, str) and cid for cid in self.ranked_candidate_ids
+            type(cid) is str and cid for cid in self.ranked_candidate_ids
         ):
             raise ForagerMatchedProtocolError(
                 "ranked_candidate_ids must be a tuple of candidate IDs"
@@ -912,7 +912,7 @@ class DescriptiveContext:
 
     def __post_init__(self) -> None:
         if type(self.candidate_ids) is not tuple or not all(
-            isinstance(cid, str) and cid for cid in self.candidate_ids
+            type(cid) is str and cid for cid in self.candidate_ids
         ):
             raise ForagerMatchedProtocolError("candidate_ids must be a tuple of candidate IDs")
         if self.analysis_role != "descriptive_only":
@@ -1088,7 +1088,7 @@ def _validate_json_complexity(value: Any) -> None:
             raise ForagerMatchedProtocolError("protocol exceeds the JSON nesting limit")
         if isinstance(item, Mapping):
             for key in item:
-                if not isinstance(key, str):
+                if type(key) is not str:
                     raise ForagerMatchedProtocolError("JSON object keys must be strings")
                 try:
                     key.encode("utf-8")
@@ -1145,7 +1145,7 @@ def decode_strict_json(data: bytes | str) -> Any:
 def _require_object(value: Any, path: str) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise ForagerMatchedProtocolError(f"{path} must be a JSON object")
-    if any(not isinstance(key, str) for key in value):
+    if any(type(key) is not str for key in value):
         raise ForagerMatchedProtocolError(f"{path} keys must be strings")
     return cast(Mapping[str, Any], value)
 
@@ -1171,7 +1171,7 @@ def _require_exact_keys(
 
 
 def _require_string(value: Any, path: str, *, maximum: int = 512) -> str:
-    if not isinstance(value, str) or not value or len(value) > maximum:
+    if type(value) is not str or not value or len(value) > maximum:
         raise ForagerMatchedProtocolError(
             f"{path} must be a non-empty string of at most {maximum} characters"
         )

--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -1121,10 +1121,9 @@ def decode_strict_json(data: bytes | str) -> Any:
         raise ForagerMatchedProtocolError("protocol must be exact bytes or string JSON")
     try:
         if type(data) is bytes:
-            raw_bytes = cast(bytes, data)
-            if len(raw_bytes) > _MAX_MANIFEST_BYTES:
+            if len(data) > _MAX_MANIFEST_BYTES:
                 raise ForagerMatchedProtocolError("protocol exceeds the file-size limit")
-            text = raw_bytes.decode("utf-8")
+            text = data.decode("utf-8")
         else:
             raw_text = cast(str, data)
             if len(raw_text) > _MAX_MANIFEST_BYTES:

--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -1099,7 +1099,7 @@ def _validate_json_complexity(value: Any) -> None:
             pending.extend((child, depth + 1) for child in item.values())
         elif isinstance(item, list):
             pending.extend((child, depth + 1) for child in item)
-        elif isinstance(item, str):
+        elif type(item) is str:
             try:
                 item.encode("utf-8")
             except UnicodeEncodeError as exc:
@@ -1117,17 +1117,21 @@ def _validate_json_complexity(value: Any) -> None:
 
 def decode_strict_json(data: bytes | str) -> Any:
     """Decode duplicate-free finite UTF-8 JSON with bounded complexity."""
+    if type(data) not in (bytes, str):
+        raise ForagerMatchedProtocolError("protocol must be exact bytes or string JSON")
     try:
-        if isinstance(data, bytes):
-            if len(data) > _MAX_MANIFEST_BYTES:
+        if type(data) is bytes:
+            raw_bytes = cast(bytes, data)
+            if len(raw_bytes) > _MAX_MANIFEST_BYTES:
                 raise ForagerMatchedProtocolError("protocol exceeds the file-size limit")
-            text = data.decode("utf-8")
+            text = raw_bytes.decode("utf-8")
         else:
-            if len(data) > _MAX_MANIFEST_BYTES:
+            raw_text = cast(str, data)
+            if len(raw_text) > _MAX_MANIFEST_BYTES:
                 raise ForagerMatchedProtocolError("protocol exceeds the file-size limit")
-            if len(data.encode("utf-8")) > _MAX_MANIFEST_BYTES:
+            if len(raw_text.encode("utf-8")) > _MAX_MANIFEST_BYTES:
                 raise ForagerMatchedProtocolError("protocol exceeds the file-size limit")
-            text = data
+            text = raw_text
         decoded = json.loads(
             text,
             object_pairs_hook=_duplicate_free_object,

--- a/tests/test_benchmark_hostile_identity_boundaries.py
+++ b/tests/test_benchmark_hostile_identity_boundaries.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from alberta_framework.benchmarks import _foragax_open_screen_probe as probe
 from alberta_framework.benchmarks import foragax_open_screen as screen
 from alberta_framework.benchmarks import forager_results as results
 from alberta_framework.benchmarks import ipmnist_screening as ipmnist
@@ -56,6 +57,17 @@ def test_open_screen_helpers_reject_hostile_identities_before_hooks() -> None:
         screen._require_dict(_HostileDict(), "payload")
     with pytest.raises(screen.ScreenError, match="array"):
         screen._require_list(_HostileList(), "records")
+    assert _HostileString.calls == 0
+
+
+def test_open_screen_probe_rejects_hostile_scalar_identities_before_hooks() -> None:
+    hostile = _HostileString("configs/agent.json")
+    _HostileString.calls = 0
+    with pytest.raises(RuntimeError, match="relative path"):
+        probe._relative_path(hostile, "configuration")
+    assert probe._is_exact_int(True) is False
+    assert probe._is_exact_int(1) is True
+    assert probe._is_exact_int(type("IntSubclass", (int,), {})(1)) is False
     assert _HostileString.calls == 0
 
 

--- a/tests/test_forager_candidate_universe_hostile_validation.py
+++ b/tests/test_forager_candidate_universe_hostile_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from alberta_framework.benchmarks import forager_matched_candidate_universe as universe
 from alberta_framework.benchmarks.forager_matched_candidate_universe import (
     BoundJsonArtifact,
     CandidateUniverseVerification,
@@ -22,6 +23,18 @@ class _HostileString(str):
     def __hash__(self) -> int:
         type(self).calls += 1
         raise AssertionError("hostile string hashing executed")
+
+
+class _HostileRealMeta(type):
+    calls = 0
+
+    def __eq__(cls, other: object) -> bool:
+        cls.calls += 1
+        raise AssertionError("hostile metaclass hook dispatched")
+
+
+class _HostileReal(metaclass=_HostileRealMeta):
+    pass
 
 
 def test_bound_json_artifact_validation() -> None:
@@ -88,6 +101,13 @@ def test_candidate_universe_string_boundaries_reject_subclasses_without_dispatch
         with pytest.raises(ForagerMatchedCandidateUniverseError):
             operation()
     assert _HostileString.calls == 0
+
+
+def test_finite_real_rejects_hostile_runtime_type_without_metaclass_hooks() -> None:
+    _HostileRealMeta.calls = 0
+    with pytest.raises(ForagerMatchedCandidateUniverseError, match="must be a finite number"):
+        universe._require_finite_real(_HostileReal(), "value")
+    assert _HostileRealMeta.calls == 0
 
 
 def test_local_candidate_generation_binding_artifact_tuple_validation() -> None:

--- a/tests/test_forager_candidate_universe_hostile_validation.py
+++ b/tests/test_forager_candidate_universe_hostile_validation.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 
-from alberta_framework.benchmarks import forager_matched_candidate_universe as universe
 from alberta_framework.benchmarks.forager_matched_candidate_universe import (
     BoundJsonArtifact,
     CandidateUniverseVerification,
@@ -18,19 +17,11 @@ class _HostileString(str):
 
     def __bool__(self) -> bool:
         type(self).calls += 1
-        raise AssertionError("hostile string hook dispatched")
+        raise AssertionError("hostile string truthiness executed")
 
-
-class _HostileRealMeta(type):
-    calls = 0
-
-    def __eq__(cls, other: object) -> bool:
-        cls.calls += 1
-        raise AssertionError("hostile metaclass hook dispatched")
-
-
-class _HostileReal(metaclass=_HostileRealMeta):
-    pass
+    def __hash__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile string hashing executed")
 
 
 def test_bound_json_artifact_validation() -> None:
@@ -83,24 +74,20 @@ def test_candidate_universe_verification_validation() -> None:
         )
 
 
-def test_candidate_universe_verification_rejects_string_subclass_without_hooks() -> None:
+def test_candidate_universe_string_boundaries_reject_subclasses_without_dispatch() -> None:
+    hostile = _HostileString("path.json")
     _HostileString.calls = 0
-    with pytest.raises(
-        ForagerMatchedCandidateUniverseError,
-        match="verified_json_paths must be a tuple of non-empty strings",
-    ):
-        CandidateUniverseVerification(
+    operations = (
+        lambda: BoundJsonArtifact(role=hostile, path="path.json", sha256="a" * 64),
+        lambda: CandidateUniverseVerification(
             candidate_universe_sha256="b" * 64,
-            verified_json_paths=(_HostileString("path.json"),),
-        )
+            verified_json_paths=(hostile,),
+        ),
+    )
+    for operation in operations:
+        with pytest.raises(ForagerMatchedCandidateUniverseError):
+            operation()
     assert _HostileString.calls == 0
-
-
-def test_finite_real_rejects_hostile_runtime_type_without_metaclass_hooks() -> None:
-    _HostileRealMeta.calls = 0
-    with pytest.raises(ForagerMatchedCandidateUniverseError, match="must be a finite number"):
-        universe._require_finite_real(_HostileReal(), "value")
-    assert _HostileRealMeta.calls == 0
 
 
 def test_local_candidate_generation_binding_artifact_tuple_validation() -> None:

--- a/tests/test_forager_matched_open_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_open_protocol_hostile_validation.py
@@ -21,6 +21,18 @@ def _digest(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
+class _HostileString(str):
+    calls = 0
+
+    def __hash__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile string hashing executed")
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile string equality executed")
+
+
 def test_runtime_qualification_valid_construction() -> None:
     qual = MatchedCurrentRuntimeQualification(
         image_sha256=_digest(b"image"),
@@ -61,6 +73,19 @@ def test_runtime_qualification_rejects_invalid_inputs() -> None:
             executor_qualification_receipt_sha256=_digest(b"executor"),
             qualification_trust_anchor_identity="",
         )
+
+
+def test_runtime_qualification_rejects_digest_subclass_without_dispatch() -> None:
+    hostile = _HostileString(_digest(b"image"))
+    _HostileString.calls = 0
+    with pytest.raises(ForagerMatchedOpenProtocolBuildError, match="SHA-256"):
+        MatchedCurrentRuntimeQualification(
+            image_sha256=hostile,
+            runtime_profile_sha256=_digest(b"profile"),
+            executor_qualification_receipt_sha256=_digest(b"executor"),
+            qualification_trust_anchor_identity="anchor_id",
+        )
+    assert _HostileString.calls == 0
 
 
 def test_candidate_qualification_rejects_invalid_types() -> None:

--- a/tests/test_forager_matched_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_protocol_hostile_validation.py
@@ -12,7 +12,29 @@ from alberta_framework.benchmarks.forager_matched_protocol import (
     RankedSelectionGroup,
     ResolvedSelectionSlot,
     SelectionSlot,
+    decode_strict_json,
+    parse_forager_matched_protocol,
 )
+
+
+class _HostileString(str):
+    calls = 0
+
+    def __bool__(self) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile string truthiness executed")
+
+    def __len__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile string length executed")
+
+    def __hash__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile string hashing executed")
+
+    def encode(self, *args: object, **kwargs: object) -> bytes:
+        type(self).calls += 1
+        raise AssertionError("hostile string encoding executed")
 
 
 def test_environment_rng_contract_validation() -> None:
@@ -122,3 +144,31 @@ def test_descriptive_context_validation() -> None:
             selection_eligible=False,
             pairing_eligible=True,  # type: ignore[arg-type]
         )
+
+
+def test_protocol_string_boundaries_reject_subclasses_without_dispatch() -> None:
+    hostile = _HostileString("candidate")
+    _HostileString.calls = 0
+    operations = (
+        lambda: EnvironmentRNGContract(
+            identity=hostile,
+            schedule_sha256="a" * 64,
+        ),
+        lambda: RankedSelectionGroup(
+            selection_group="group",
+            ranked_candidate_ids=(hostile,),
+            ranking_evidence_sha256="b" * 64,
+        ),
+        lambda: DescriptiveContext(
+            candidate_ids=(hostile,),
+            analysis_role="descriptive_only",
+            selection_eligible=False,
+            pairing_eligible=False,
+        ),
+        lambda: decode_strict_json(hostile),
+        lambda: parse_forager_matched_protocol({"hostile": hostile}),
+    )
+    for operation in operations:
+        with pytest.raises(ForagerMatchedProtocolError):
+            operation()
+    assert _HostileString.calls == 0


### PR DESCRIPTION
Contributor-preserving consolidation of #1515 and #1522, rebased after stronger merged #1525 (which already preserved #1518/#1519). Completes adjacent parser boundaries by rejecting hostile nested JSON strings and exact raw JSON aliases before encoding/length hooks, and adds executable zero-hook coverage for matched protocol and open-protocol digest identities.\n\n#1517 and #1525 were sanity-audited as the already-merged portions of this family.\n\nVerification: 183 focused tests; Ruff; strict mypy. Also 29 #1517-focused official tests passed before stopping its compile-heavy remainder once the merged code was established. No benchmark/evidence execution or output changes.\n\nSupersedes #1515 and #1522 while retaining both byt61 commits.