### PR TITLE
fix(benchmarks): close hostile candidate and probe identity gaps

### DIFF
--- a/alberta_framework/benchmarks/_foragax_open_screen_probe.py
+++ b/alberta_framework/benchmarks/_foragax_open_screen_probe.py
@@ -122,7 +122,7 @@ def _validate_ppo_schedule(
 
 
 def _relative_path(value: Any, label: str) -> str:
-    if not isinstance(value, str) or not value:
+    if type(value) is not str or not value:
         _fail(f"{label} must be a non-empty relative path")
     path = PurePosixPath(value)
     if path.is_absolute() or ".." in path.parts or "." in path.parts:
@@ -146,7 +146,7 @@ def _source_records(protocol: dict[str, Any]) -> list[dict[str, str]]:
             _fail(f"source_files[{index}] must be an object")
         relative = _relative_path(item.get("path"), f"source_files[{index}].path")
         expected = item.get("sha256")
-        if not isinstance(expected, str) or len(expected) != 64:
+        if type(expected) is not str or len(expected) != 64:
             _fail(f"source_files[{index}].sha256 is invalid")
         if relative in seen:
             _fail(f"duplicate source path: {relative}")
@@ -241,7 +241,7 @@ def _validate_scorer_equivalence(
 
     expected_reference = scoring.get("reference_implementation_sha256")
     if (
-        not isinstance(expected_reference, str)
+        type(expected_reference) is not str
         or _sha256(_REFERENCE_SCORER_PATH) != expected_reference
     ):
         _fail("reference scorer identity drift")
@@ -352,7 +352,7 @@ def _validate_configurations(
         if not isinstance(nested_experiment, dict) or nested_experiment.get("seed_offset", 0) != 0:
             _fail(f"configuration seed offset drift: {relative}")
         agent = config.get("agent")
-        if not isinstance(agent, str) or not agent:
+        if type(agent) is not str or not agent:
             _fail(f"configuration agent is invalid: {relative}")
         if agent.startswith("PPO"):
             rollout, updates = _validate_ppo_schedule(
@@ -519,7 +519,7 @@ def main() -> None:
     protocol_path = _PROTOCOL_ROOT / "PROTOCOL.json"
     protocol = _load_config(protocol_path)
     schema = protocol.get("schema_version")
-    if not isinstance(schema, str) or schema not in _CPU_SCHEMAS:
+    if type(schema) is not str or schema not in _CPU_SCHEMAS:
         _fail("unsupported frozen screening protocol schema")
     protocol_sha256 = _sha256(protocol_path)
     if protocol_sha256 != _FROZEN_PROTOCOL_SHA256[schema]:

--- a/alberta_framework/benchmarks/_foragax_open_screen_probe.py
+++ b/alberta_framework/benchmarks/_foragax_open_screen_probe.py
@@ -92,7 +92,7 @@ def _sha256(path: Path) -> str:
 
 def _is_exact_int(value: Any) -> TypeGuard[int]:
     """True only for exact ints; bool is an int subclass and must not alias 0/1."""
-    return isinstance(value, int) and not isinstance(value, bool)
+    return type(value) is int
 
 
 def _validate_task_intake(protocol: dict[str, Any]) -> tuple[dict[str, Any], int, list[int]]:

--- a/alberta_framework/benchmarks/forager_matched_candidate_universe.py
+++ b/alberta_framework/benchmarks/forager_matched_candidate_universe.py
@@ -383,7 +383,7 @@ class CandidateUniverseVerification:
             _require_sha256(self.candidate_universe_sha256, "candidate_universe_sha256"),
         )
         if type(self.verified_json_paths) is not tuple or not all(
-            isinstance(p, str) and p for p in self.verified_json_paths
+            type(p) is str and p for p in self.verified_json_paths
         ):
             raise ForagerMatchedCandidateUniverseError(
                 "verified_json_paths must be a tuple of non-empty strings"
@@ -1661,7 +1661,7 @@ def _verify_one_screen(
     if (
         input_snapshot.get("schema_version") != "alberta.foragax_open_screen_inputs.v3"
         or not isinstance(directories, list)
-        or any(not isinstance(item, str) for item in directories)
+        or any(type(item) is not str for item in directories)
         or not isinstance(files, list)
     ):
         raise ForagerMatchedCandidateUniverseError(
@@ -1686,7 +1686,7 @@ def _verify_one_screen(
         path = record.get("path")
         size_bytes = record.get("size_bytes")
         if (
-            not isinstance(path, str)
+            type(path) is not str
             or path in file_records
             or type(size_bytes) is not int
             or size_bytes < 0
@@ -1751,7 +1751,7 @@ def _verify_one_screen(
     if (
         not isinstance(configuration_order, list)
         or len(configuration_order) != binding.candidate_count
-        or any(not isinstance(item, str) for item in configuration_order)
+        or any(type(item) is not str for item in configuration_order)
         or len(set(configuration_order)) != binding.candidate_count
         or set(configuration_order) != expected_configurations
     ):
@@ -1768,7 +1768,7 @@ def _require_mapping(value: Any, context: str) -> Mapping[str, Any]:
 
 def _verified_payload_sha256(value: Mapping[str, Any], context: str) -> str:
     supplied = value.get("payload_sha256")
-    if not isinstance(supplied, str):
+    if type(supplied) is not str:
         raise ForagerMatchedCandidateUniverseError(
             f"{context} payload_sha256 is missing or malformed"
         )
@@ -2279,7 +2279,7 @@ def _verify_rtu_candidate_generation(
             "rtu_schema23_screening_v1 protocol variants must be an array"
         )
     if len(protocol_variants_value) != binding.candidate_count or any(
-        not isinstance(item, Mapping) or not isinstance(item.get("id"), str)
+        not isinstance(item, Mapping) or type(item.get("id")) is not str
         for item in protocol_variants_value
     ):
         raise ForagerMatchedCandidateUniverseError(

--- a/alberta_framework/benchmarks/forager_matched_candidate_universe.py
+++ b/alberta_framework/benchmarks/forager_matched_candidate_universe.py
@@ -83,7 +83,8 @@ def _require_exact_bool(value: Any, path: str) -> bool:
 
 
 def _require_finite_real(value: Any, path: str) -> float:
-    if type(value) not in (int, float):
+    value_type = type(value)
+    if value_type is not int and value_type is not float:
         raise ForagerMatchedCandidateUniverseError(f"{path} must be a finite number")
     number = float(cast("int | float", value))
     if not math.isfinite(number):

--- a/tests/test_foragax_open_screen.py
+++ b/tests/test_foragax_open_screen.py
@@ -1174,6 +1174,9 @@ def test_mocked_screen_preserves_initial_diagnostics_rescores_and_validates_comm
 
 
 def test_probe_exact_int_rejects_bool_and_non_int_aliases() -> None:
+    class IntSubclass(int):
+        pass
+
     assert probe._is_exact_int(1)
     assert probe._is_exact_int(0)
     assert not probe._is_exact_int(True)
@@ -1181,6 +1184,20 @@ def test_probe_exact_int_rejects_bool_and_non_int_aliases() -> None:
     assert not probe._is_exact_int(1.0)
     assert not probe._is_exact_int("1")
     assert not probe._is_exact_int(None)
+    assert not probe._is_exact_int(IntSubclass(1))
+
+
+def test_probe_relative_path_rejects_string_subclass_without_hooks() -> None:
+    class HostileString(str):
+        calls = 0
+
+        def __bool__(self) -> bool:
+            type(self).calls += 1
+            raise AssertionError("hostile string hook dispatched")
+
+    with pytest.raises(RuntimeError, match="must be a non-empty relative path"):
+        probe._relative_path(HostileString("config.json"), "path")
+    assert HostileString.calls == 0
 
 
 def test_probe_task_intake_accepts_exact_int_horizon_and_seeds() -> None:

--- a/tests/test_forager_candidate_universe_hostile_validation.py
+++ b/tests/test_forager_candidate_universe_hostile_validation.py
@@ -4,12 +4,33 @@ from __future__ import annotations
 
 import pytest
 
+from alberta_framework.benchmarks import forager_matched_candidate_universe as universe
 from alberta_framework.benchmarks.forager_matched_candidate_universe import (
     BoundJsonArtifact,
     CandidateUniverseVerification,
     ForagerMatchedCandidateUniverseError,
     LocalCandidateGenerationBinding,
 )
+
+
+class _HostileString(str):
+    calls = 0
+
+    def __bool__(self) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile string hook dispatched")
+
+
+class _HostileRealMeta(type):
+    calls = 0
+
+    def __eq__(cls, other: object) -> bool:
+        cls.calls += 1
+        raise AssertionError("hostile metaclass hook dispatched")
+
+
+class _HostileReal(metaclass=_HostileRealMeta):
+    pass
 
 
 def test_bound_json_artifact_validation() -> None:
@@ -60,6 +81,26 @@ def test_candidate_universe_verification_validation() -> None:
             candidate_universe_sha256="b" * 64,
             verified_json_paths=["path1.json"],  # type: ignore[arg-type]
         )
+
+
+def test_candidate_universe_verification_rejects_string_subclass_without_hooks() -> None:
+    _HostileString.calls = 0
+    with pytest.raises(
+        ForagerMatchedCandidateUniverseError,
+        match="verified_json_paths must be a tuple of non-empty strings",
+    ):
+        CandidateUniverseVerification(
+            candidate_universe_sha256="b" * 64,
+            verified_json_paths=(_HostileString("path.json"),),
+        )
+    assert _HostileString.calls == 0
+
+
+def test_finite_real_rejects_hostile_runtime_type_without_metaclass_hooks() -> None:
+    _HostileRealMeta.calls = 0
+    with pytest.raises(ForagerMatchedCandidateUniverseError, match="must be a finite number"):
+        universe._require_finite_real(_HostileReal(), "value")
+    assert _HostileRealMeta.calls == 0
 
 
 def test_local_candidate_generation_binding_artifact_tuple_validation() -> None:


### PR DESCRIPTION
Supersedes #1518 and #1519 while preserving both contributor commits and completing their deep review.\n\nAdds regression coverage for the candidate-universe and frozen probe exact identity boundaries. The review found and fixes two additional gaps: `_is_exact_int` admitted `int` subclasses despite its contract, and `_require_finite_real` used tuple membership on an attacker runtime class, which can dispatch a hostile metaclass `__eq__`.\n\nValidation: 79 focused tests pass; Ruff passes; strict mypy passes across 174 source files; `git diff --check` passes. No workflow execution, benchmark run, output mutation, schema/threshold change, or evidence promotion.\n\nOriginal contributor commits remain authored by byt61.\n\nCloses #1518.\nCloses #1519.