### PR TITLE
fix(validation): reconcile protocol string identities

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_open_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_open_protocol.py
@@ -1016,7 +1016,7 @@ _UPSTREAM_CONFIGURATION_REQUIREMENTS: Final = MappingProxyType(
 
 
 def _require_real_sha256(value: str, path: str) -> None:
-    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+    if type(value) is not str or _SHA256_RE.fullmatch(value) is None:
         raise ForagerMatchedOpenProtocolBuildError(f"{path} must be a lowercase SHA-256")
     if _PLACEHOLDER_SHA256_RE.fullmatch(value) is not None:
         raise ForagerMatchedOpenProtocolBuildError(

--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -803,7 +803,7 @@ class RankedSelectionGroup:
     def __post_init__(self) -> None:
         _require_identifier(self.selection_group, "ranked_selection_group.selection_group")
         if type(self.ranked_candidate_ids) is not tuple or not all(
-            isinstance(cid, str) and cid for cid in self.ranked_candidate_ids
+            type(cid) is str and cid for cid in self.ranked_candidate_ids
         ):
             raise ForagerMatchedProtocolError(
                 "ranked_candidate_ids must be a tuple of candidate IDs"
@@ -912,7 +912,7 @@ class DescriptiveContext:
 
     def __post_init__(self) -> None:
         if type(self.candidate_ids) is not tuple or not all(
-            isinstance(cid, str) and cid for cid in self.candidate_ids
+            type(cid) is str and cid for cid in self.candidate_ids
         ):
             raise ForagerMatchedProtocolError("candidate_ids must be a tuple of candidate IDs")
         if self.analysis_role != "descriptive_only":
@@ -1088,7 +1088,7 @@ def _validate_json_complexity(value: Any) -> None:
             raise ForagerMatchedProtocolError("protocol exceeds the JSON nesting limit")
         if isinstance(item, Mapping):
             for key in item:
-                if not isinstance(key, str):
+                if type(key) is not str:
                     raise ForagerMatchedProtocolError("JSON object keys must be strings")
                 try:
                     key.encode("utf-8")
@@ -1145,7 +1145,7 @@ def decode_strict_json(data: bytes | str) -> Any:
 def _require_object(value: Any, path: str) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise ForagerMatchedProtocolError(f"{path} must be a JSON object")
-    if any(not isinstance(key, str) for key in value):
+    if any(type(key) is not str for key in value):
         raise ForagerMatchedProtocolError(f"{path} keys must be strings")
     return cast(Mapping[str, Any], value)
 
@@ -1171,7 +1171,7 @@ def _require_exact_keys(
 
 
 def _require_string(value: Any, path: str, *, maximum: int = 512) -> str:
-    if not isinstance(value, str) or not value or len(value) > maximum:
+    if type(value) is not str or not value or len(value) > maximum:
         raise ForagerMatchedProtocolError(
             f"{path} must be a non-empty string of at most {maximum} characters"
         )

--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -1099,7 +1099,7 @@ def _validate_json_complexity(value: Any) -> None:
             pending.extend((child, depth + 1) for child in item.values())
         elif isinstance(item, list):
             pending.extend((child, depth + 1) for child in item)
-        elif isinstance(item, str):
+        elif type(item) is str:
             try:
                 item.encode("utf-8")
             except UnicodeEncodeError as exc:
@@ -1117,17 +1117,21 @@ def _validate_json_complexity(value: Any) -> None:
 
 def decode_strict_json(data: bytes | str) -> Any:
     """Decode duplicate-free finite UTF-8 JSON with bounded complexity."""
+    if type(data) not in (bytes, str):
+        raise ForagerMatchedProtocolError("protocol must be exact bytes or string JSON")
     try:
-        if isinstance(data, bytes):
-            if len(data) > _MAX_MANIFEST_BYTES:
+        if type(data) is bytes:
+            byte_data = data
+            if len(byte_data) > _MAX_MANIFEST_BYTES:
                 raise ForagerMatchedProtocolError("protocol exceeds the file-size limit")
-            text = data.decode("utf-8")
+            text = byte_data.decode("utf-8")
         else:
-            if len(data) > _MAX_MANIFEST_BYTES:
+            string_data = cast(str, data)
+            if len(string_data) > _MAX_MANIFEST_BYTES:
                 raise ForagerMatchedProtocolError("protocol exceeds the file-size limit")
-            if len(data.encode("utf-8")) > _MAX_MANIFEST_BYTES:
+            if len(string_data.encode("utf-8")) > _MAX_MANIFEST_BYTES:
                 raise ForagerMatchedProtocolError("protocol exceeds the file-size limit")
-            text = data
+            text = string_data
         decoded = json.loads(
             text,
             object_pairs_hook=_duplicate_free_object,
@@ -2734,7 +2738,7 @@ def _validate_cross_references(
 
 def parse_forager_matched_protocol(value: Any) -> ForagerMatchedProtocol:
     """Decode if needed, then validate and normalize a matched protocol."""
-    if isinstance(value, (bytes, str)):
+    if type(value) in (bytes, str):
         value = decode_strict_json(value)
     _validate_json_complexity(value)
     payload = _require_object(value, "protocol")
@@ -2882,7 +2886,7 @@ def parse_forager_matched_selection_result(value: Any) -> ForagerMatchedSelectio
     """Validate a canonicalizable, reward-opaque open-tuning selection result."""
     if isinstance(value, ForagerMatchedSelectionResult):
         value = value.to_dict()
-    if isinstance(value, (bytes, str)):
+    if type(value) in (bytes, str):
         value = decode_strict_json(value)
     _validate_json_complexity(value)
     path = "selection_result"

--- a/tests/test_forager_matched_open_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_open_protocol_hostile_validation.py
@@ -14,6 +14,7 @@ from alberta_framework.benchmarks.forager_matched_open_protocol import (
     MatchedCurrentCandidateQualification,
     MatchedCurrentRuntimeQualification,
     _CandidateSpec,
+    _require_real_sha256,
 )
 
 
@@ -61,6 +62,27 @@ def test_runtime_qualification_rejects_invalid_inputs() -> None:
             executor_qualification_receipt_sha256=_digest(b"executor"),
             qualification_trust_anchor_identity="",
         )
+
+
+def test_real_digest_rejects_string_subclass_before_hooks() -> None:
+    calls = 0
+
+    class HostileDigest(str):
+        def __bool__(self) -> bool:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("truth hook reached")
+
+        def __eq__(self, other: object) -> bool:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("comparison hook reached")
+
+        __hash__ = str.__hash__
+
+    with pytest.raises(ForagerMatchedOpenProtocolBuildError, match="SHA-256"):
+        _require_real_sha256(HostileDigest(_digest(b"real")), "digest")
+    assert calls == 0
 
 
 def test_candidate_qualification_rejects_invalid_types() -> None:

--- a/tests/test_forager_matched_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_protocol_hostile_validation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import NoReturn
+
 import pytest
 
 from alberta_framework.benchmarks.forager_matched_protocol import (
@@ -12,7 +14,39 @@ from alberta_framework.benchmarks.forager_matched_protocol import (
     RankedSelectionGroup,
     ResolvedSelectionSlot,
     SelectionSlot,
+    _validate_json_complexity,
+    decode_strict_json,
+    parse_forager_matched_protocol,
+    parse_forager_matched_selection_result,
 )
+
+
+class _HookedString(str):
+    calls: int
+
+    def __new__(cls, value: str) -> _HookedString:
+        instance = super().__new__(cls, value)
+        instance.calls = 0
+        return instance
+
+    def _called(self) -> NoReturn:
+        self.calls += 1
+        raise AssertionError("hostile string hook must not run")
+
+    def __bool__(self) -> bool:
+        return self._called()
+
+    def __len__(self) -> int:
+        return self._called()
+
+    def __eq__(self, other: object) -> bool:
+        return self._called()
+
+    def __hash__(self) -> int:
+        return self._called()
+
+    def encode(self, *args: object, **kwargs: object) -> bytes:
+        return self._called()
 
 
 def test_environment_rng_contract_validation() -> None:
@@ -122,3 +156,31 @@ def test_descriptive_context_validation() -> None:
             selection_eligible=False,
             pairing_eligible=True,  # type: ignore[arg-type]
         )
+
+
+def test_protocol_string_subclasses_reject_before_hooks() -> None:
+    for operation in (
+        lambda value: EnvironmentRNGContract(
+            identity=value,
+            schedule_sha256="a" * 64,
+        ),
+        lambda value: RankedSelectionGroup(
+            selection_group="group_a",
+            ranked_candidate_ids=(value,),
+            ranking_evidence_sha256="b" * 64,
+        ),
+        lambda value: DescriptiveContext(
+            candidate_ids=(value,),
+            analysis_role="descriptive_only",
+            selection_eligible=False,
+            pairing_eligible=False,
+        ),
+        lambda value: _validate_json_complexity([value]),
+        lambda value: decode_strict_json(value),
+        lambda value: parse_forager_matched_protocol(value),
+        lambda value: parse_forager_matched_selection_result(value),
+    ):
+        hostile = _HookedString("candidate_a")
+        with pytest.raises(ForagerMatchedProtocolError):
+            operation(hostile)
+        assert hostile.calls == 0

--- a/tests/test_prototype_reference_adapter.py
+++ b/tests/test_prototype_reference_adapter.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 import pickle
+from typing import NoReturn
 
 import chex
 import jax.numpy as jnp
@@ -16,6 +17,7 @@ import jax.random as jr
 import numpy as np
 import pytest
 
+from alberta_framework import prototype_reference_adapter as adapter_module
 from alberta_framework.core.dreaming import DreamingConfig
 from alberta_framework.core.oak import OaKConfig
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
@@ -53,6 +55,31 @@ pytestmark = pytest.mark.unit
 
 _LIFE_A = "prototype.0000000100000002"
 _LIFE_B = "prototype.0000000300000004"
+
+
+class _HookedString(str):
+    calls: int
+
+    def __new__(cls, value: str) -> _HookedString:
+        instance = super().__new__(cls, value)
+        instance.calls = 0
+        return instance
+
+    def _called(self) -> NoReturn:
+        self.calls += 1
+        raise AssertionError("hostile string hook must not run")
+
+    def __bool__(self) -> bool:
+        return self._called()
+
+    def __eq__(self, other: object) -> bool:
+        return self._called()
+
+    def __hash__(self) -> int:
+        return self._called()
+
+    def strip(self, chars: str | None = None) -> str:
+        return self._called()
 
 
 def _config(*, base_step_size: float = 0.05) -> PrototypeAgentConfig:
@@ -786,3 +813,24 @@ def test_premature_prototype_disarm_discards_the_functional_candidate() -> None:
     assert rejected.rejection_reason is not None
     assert "disarmed" in rejected.rejection_reason or "capacity" in rejected.rejection_reason
     assert int(rejected.state.agent_state.step_count) == np.iinfo(np.int32).max - 1
+
+
+def test_reference_state_rejects_string_subclasses_before_hooks() -> None:
+    adapter = PrototypeReferenceAdapter.from_config(_config())
+    state = adapter.init(jr.key(0), lifecycle_id=_LIFE_A)
+    cases = (
+        ("manifest_id", "a" * 64),
+        ("config_sha256", "b" * 64),
+        ("lifecycle_id", _LIFE_A),
+        ("current_observation_id", "observation:0"),
+    )
+    for field, value in cases:
+        hostile = _HookedString(value)
+        with pytest.raises(ValueError):
+            dataclasses.replace(state, **{field: hostile})
+        assert hostile.calls == 0
+
+    hostile_lifecycle = _HookedString(_LIFE_A)
+    with pytest.raises(ValueError, match="lifecycle"):
+        adapter_module._lifecycle_words(hostile_lifecycle)
+    assert hostile_lifecycle.calls == 0


### PR DESCRIPTION
Supersedes #1515 and #1522 while preserving both contributor commits and authorship; adds regression coverage for the already-consolidated #1514 adapter gates.

## Scope

- exact string identities in the Prototype reference adapter, matched protocol, and matched open-protocol layers
- closes matched-protocol residual hook paths for JSON string values, direct decoder inputs, and both top-level parse entry points
- failing-test coverage proves hostile truth/length/equality/hash/encode/strip hooks remain at zero calls

## Verification

- 140 full relevant tests pass on current main
- Ruff clean across all changed source/tests
- strict mypy clean (174 files)
- diff-check clean

No workflows, benchmarks, outputs, or evidence promotion.