### PR TITLE
fix(reference-life): close hostile veto string identities

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -1562,7 +1562,7 @@ class LifeHalt:
             raise ValueError("halt stage must be a HaltStage")
         if not isinstance(self.recovery_mode, RecoveryMode):
             raise ValueError("recovery_mode must be a RecoveryMode")
-        if not isinstance(self.reason, str) or not self.reason.strip():
+        if type(self.reason) is not str or not self.reason.strip():
             raise ValueError("halt reason must be nonempty")
         if (
             isinstance(self.recovery_attempts, bool)
@@ -3268,7 +3268,7 @@ class ReferenceLifeRunner:
     ) -> ReferenceLifeState:
         """Terminate the current life without relabelling an unconsumed event."""
 
-        if not isinstance(reason, str) or not reason.strip():
+        if type(reason) is not str or not reason.strip():
             raise ValueError("abort reason must be nonempty")
         with self._lock:
             self._require_current_locked(state)

--- a/tests/test_reference_life_event_leftover_identities.py
+++ b/tests/test_reference_life_event_leftover_identities.py
@@ -13,10 +13,14 @@ from alberta_framework.reference_agent import (
     Transaction,
 )
 from alberta_framework.reference_life import (
+    HaltStage,
+    LifeHalt,
     PendingOutcome,
+    RecoveryMode,
     ReferenceEnvironmentExecution,
     ReferenceEnvironmentStart,
     ReferenceLifeEvent,
+    ReferenceLifeRunner,
 )
 
 _DIGEST = "0" * 64
@@ -29,6 +33,14 @@ class _ExplodingHashMeta(type):
 
 class _HostileScalar(metaclass=_ExplodingHashMeta):
     pass
+
+
+class _HostileString(str):
+    calls = 0
+
+    def strip(self, chars: str | None = None) -> str:
+        type(self).calls += 1
+        raise AssertionError("hostile string method executed")
 
 
 def _legal_event(**overrides: object) -> ReferenceLifeEvent:
@@ -140,3 +152,22 @@ def test_real_type_gates_do_not_hash_hostile_runtime_classes() -> None:
         _legal_event(regime_id=hostile)
     with pytest.raises(ValueError, match="oracle_reward"):
         _legal_event(oracle_reward=hostile)
+
+
+def test_life_veto_reasons_reject_hostile_string_identities_before_dispatch() -> None:
+    hostile = _HostileString("operator stop")
+
+    with pytest.raises(ValueError, match="halt reason"):
+        LifeHalt(
+            stage=HaltStage.PRE_DISPATCH,
+            recovery_mode=RecoveryMode.ABORT_ONLY,
+            reason=hostile,
+        )
+    with pytest.raises(ValueError, match="abort reason"):
+        ReferenceLifeRunner.abort(  # type: ignore[arg-type]
+            object.__new__(ReferenceLifeRunner),
+            object(),
+            reason=hostile,
+        )
+
+    assert _HostileString.calls == 0


### PR DESCRIPTION
Supersedes #1523 with the contributor commit preserved unchanged, rebased onto current main, plus a failing-first regression.

The audit found two veto-specific public boundaries: `LifeHalt.reason` and `ReferenceLifeRunner.abort(reason=...)`. Both now require an exact built-in `str` before `.strip()` can dispatch. The adjacent `ReferenceLifeStep.rejection_reason` boundary is already exact on main.

Authorship: the production fix remains a separate commit authored by @byt61.

Verification:
- 44 focused reference-life tests passed
- Ruff passed for source and regression test
- strict mypy passed for `alberta_framework/reference_life.py`
- regression fails on pre-fix main by dispatching hostile `str.strip()`

No benchmarks or outputs were run or modified.