### PR TITLE
fix(benchmarks): reject hostile decoder metaclass

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -1117,7 +1117,8 @@ def _validate_json_complexity(value: Any) -> None:
 
 def decode_strict_json(data: bytes | str) -> Any:
     """Decode duplicate-free finite UTF-8 JSON with bounded complexity."""
-    if type(data) not in (bytes, str):
+    data_type = type(data)
+    if data_type is not bytes and data_type is not str:
         raise ForagerMatchedProtocolError("protocol must be exact bytes or string JSON")
     try:
         if type(data) is bytes:

--- a/tests/test_forager_matched_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_protocol_hostile_validation.py
@@ -37,6 +37,18 @@ class _HostileString(str):
         raise AssertionError("hostile string encoding executed")
 
 
+class _HostileInputMeta(type):
+    calls = 0
+
+    def __eq__(cls, other: object) -> bool:
+        cls.calls += 1
+        raise AssertionError("hostile metaclass equality executed")
+
+
+class _HostileInput(metaclass=_HostileInputMeta):
+    pass
+
+
 def test_environment_rng_contract_validation() -> None:
     contract = EnvironmentRNGContract(
         identity="env_rng.v1",
@@ -172,3 +184,10 @@ def test_protocol_string_boundaries_reject_subclasses_without_dispatch() -> None
         with pytest.raises(ForagerMatchedProtocolError):
             operation()
     assert _HostileString.calls == 0
+
+
+def test_protocol_decoder_rejects_hostile_runtime_type_without_metaclass_hooks() -> None:
+    _HostileInputMeta.calls = 0
+    with pytest.raises(ForagerMatchedProtocolError, match="exact bytes or string JSON"):
+        decode_strict_json(_HostileInput())  # type: ignore[arg-type]
+    assert _HostileInputMeta.calls == 0


### PR DESCRIPTION
Corrective follow-up to #1524. `decode_strict_json` used tuple membership on `type(data)`, allowing an attacker runtime metaclass to execute `__eq__` before the decoder rejected a non-bytes/non-string input. Use explicit class identity checks and add a failing-first zero-hook regression.\n\nValidation: 150 focused Forager tests pass; post-rebase hostile protocol file 8/8; Ruff clean; strict mypy clean across 174 source files; diff-check clean. No workflow/benchmark execution, output mutation, schema/threshold change, or evidence promotion.