### PR TITLE
fix(validation): finish exact protocol dispatch

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -2738,7 +2738,7 @@ def _validate_cross_references(
 
 def parse_forager_matched_protocol(value: Any) -> ForagerMatchedProtocol:
     """Decode if needed, then validate and normalize a matched protocol."""
-    if isinstance(value, (bytes, str)):
+    if type(value) in (bytes, str):
         value = decode_strict_json(value)
     _validate_json_complexity(value)
     payload = _require_object(value, "protocol")
@@ -2884,9 +2884,9 @@ def parse_forager_matched_protocol(value: Any) -> ForagerMatchedProtocol:
 
 def parse_forager_matched_selection_result(value: Any) -> ForagerMatchedSelectionResult:
     """Validate a canonicalizable, reward-opaque open-tuning selection result."""
-    if isinstance(value, ForagerMatchedSelectionResult):
+    if type(value) is ForagerMatchedSelectionResult:
         value = value.to_dict()
-    if isinstance(value, (bytes, str)):
+    if type(value) in (bytes, str):
         value = decode_strict_json(value)
     _validate_json_complexity(value)
     path = "selection_result"

--- a/tests/test_forager_matched_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_protocol_hostile_validation.py
@@ -9,11 +9,13 @@ from alberta_framework.benchmarks.forager_matched_protocol import (
     DescriptiveContext,
     EnvironmentRNGContract,
     ForagerMatchedProtocolError,
+    ForagerMatchedSelectionResult,
     RankedSelectionGroup,
     ResolvedSelectionSlot,
     SelectionSlot,
     decode_strict_json,
     parse_forager_matched_protocol,
+    parse_forager_matched_selection_result,
 )
 
 
@@ -47,6 +49,14 @@ class _HostileInputMeta(type):
 
 class _HostileInput(metaclass=_HostileInputMeta):
     pass
+
+
+class _HostileSelectionResult(ForagerMatchedSelectionResult):
+    calls = 0
+
+    def to_dict(self) -> dict[str, object]:
+        type(self).calls += 1
+        raise AssertionError("hostile selection conversion executed")
 
 
 def test_environment_rng_contract_validation() -> None:
@@ -179,6 +189,8 @@ def test_protocol_string_boundaries_reject_subclasses_without_dispatch() -> None
         ),
         lambda: decode_strict_json(hostile),
         lambda: parse_forager_matched_protocol({"hostile": hostile}),
+        lambda: parse_forager_matched_protocol(hostile),
+        lambda: parse_forager_matched_selection_result(hostile),
     )
     for operation in operations:
         with pytest.raises(ForagerMatchedProtocolError):
@@ -191,3 +203,11 @@ def test_protocol_decoder_rejects_hostile_runtime_type_without_metaclass_hooks()
     with pytest.raises(ForagerMatchedProtocolError, match="exact bytes or string JSON"):
         decode_strict_json(_HostileInput())  # type: ignore[arg-type]
     assert _HostileInputMeta.calls == 0
+
+
+def test_selection_result_parser_rejects_subclass_without_conversion() -> None:
+    hostile = object.__new__(_HostileSelectionResult)
+    _HostileSelectionResult.calls = 0
+    with pytest.raises(ForagerMatchedProtocolError):
+        parse_forager_matched_selection_result(hostile)
+    assert _HostileSelectionResult.calls == 0


### PR DESCRIPTION
Narrow current-main successor to #1526, preserving its author on the residual commit. The broad #1526 diff duplicates already-merged #1521/#1524; this keeps only its genuine exact top-level parser delta and closes the adjacent `ForagerMatchedSelectionResult` subclass-dispatch gap. It is rebased after #1528’s hostile decoder-metaclass correction, and the tests retain both protections.\n\nVerification: 77 focused tests; Ruff; strict mypy. No benchmarks, evidence runs, or outputs.\n\nSupersedes #1526.