### PR TITLE
fix(reference-life): bind complete event aggregate identities

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -118,7 +118,8 @@ def _require_regime_id(value: object, *, name: str = "regime_id") -> int:
 
 def _require_finite_real(name: str, value: object) -> float:
     """Reject leftover bool/NaN identities before they become recorded rewards."""
-    if type(value) is bool or type(value) not in (int, float):
+    value_type = type(value)
+    if value_type is not int and value_type is not float:
         raise ValueError(f"{name} must be a finite real number")
     number = float(cast(int | float, value))
     if not math.isfinite(number):
@@ -1693,6 +1694,12 @@ class ReferenceLifeEvent:
         ):
             if type(getattr(self, name)) is not expected_type:
                 raise ValueError(f"{name} has the wrong exact reference-life type")
+        if self.receipt.command is not self.command:
+            raise ValueError("receipt does not belong to the event command")
+        if self.transaction.receipt is not self.receipt:
+            raise ValueError("transaction does not belong to the event receipt")
+        if self.step_result.transaction is not self.transaction:
+            raise ValueError("step result does not belong to the event transaction")
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -1735,6 +1742,16 @@ class ReferenceLifeStep:
 class ReferenceLifeRun:
     state: ReferenceLifeState
     events: tuple[ReferenceLifeEvent, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.state) is not ReferenceLifeState:
+            raise ValueError("state must be a ReferenceLifeState")
+        if type(self.events) is not tuple:
+            raise ValueError("events must be an exact tuple")
+        if any(type(event) is not ReferenceLifeEvent for event in self.events):
+            raise ValueError("events must contain only ReferenceLifeEvent records")
+        if self.events and self.events[-1].transcript_sha256 != self.state.transcript_sha256:
+            raise ValueError("final event transcript disagrees with run state")
 
 
 @dataclasses.dataclass(slots=True)

--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -87,7 +87,7 @@ _CheckpointPublishResult = TypeVar("_CheckpointPublishResult")
 
 def _require_id(value: str, *, name: str) -> None:
     if (
-        not isinstance(value, str)
+        type(value) is not str
         or not value
         or len(value) > _MAX_ID_LENGTH
         or _SAFE_ID.fullmatch(value) is None
@@ -128,7 +128,7 @@ def _require_finite_real(name: str, value: object) -> float:
 
 
 def _require_prototype_lifecycle_id(value: str) -> None:
-    if not isinstance(value, str) or _PROTOTYPE_LIFECYCLE.fullmatch(value) is None:
+    if type(value) is not str or _PROTOTYPE_LIFECYCLE.fullmatch(value) is None:
         raise ValueError(
             "lifecycle_id must use the Prototype lifecycle codec "
             "'prototype.' followed by 16 lowercase hexadecimal digits"

--- a/tests/test_reference_life.py
+++ b/tests/test_reference_life.py
@@ -36,8 +36,8 @@ from alberta_framework.reference_agent import (
 )
 from alberta_framework.reference_life import (
     ExactDispatchAdapter,
+    ExactDispatchConfig,
     HaltStage,
-    LifeHalt,
     LifePhase,
     RecoveryMode,
     ReferenceLifeConfig,
@@ -45,6 +45,7 @@ from alberta_framework.reference_life import (
     ReferenceLifeRunner,
     SwitchingEnvironmentExecution,
     SwitchingTwoStateReferenceEnvironment,
+    _require_prototype_lifecycle_id,
     build_prototype_switching_life,
 )
 from alberta_framework.streams.closed_loop import (
@@ -66,11 +67,18 @@ class _HostileHaltReason(str):
         type(self).hook_calls += 1
         raise AssertionError("hostile halt-reason truth hook executed")
 
-    def strip(self, *args: str) -> str:
-        del args
+    def __eq__(self, other: object) -> bool:
+        del other
         type(self).hook_calls += 1
-        raise AssertionError("hostile halt-reason strip hook executed")
+        raise AssertionError("hostile halt-reason equality hook executed")
 
+    def __hash__(self) -> int:
+        type(self).hook_calls += 1
+        raise AssertionError("hostile halt-reason hash hook executed")
+
+    def __len__(self) -> int:
+        type(self).hook_calls += 1
+        raise AssertionError("hostile halt-reason length hook executed")
 
 def _agent_config() -> PrototypeAgentConfig:
     return PrototypeAgentConfig(
@@ -1511,17 +1519,12 @@ def test_abort_is_terminal_and_preserves_pending_execution() -> None:
         runner.step(aborted)
 
 
-def test_halt_and_abort_reject_hostile_reason_without_hooks() -> None:
+def test_reference_life_id_helpers_reject_hostile_strings_without_hooks() -> None:
     _HostileHaltReason.hook_calls = 0
-    hostile = _HostileHaltReason("operator stop")
-    with pytest.raises(ValueError, match="halt reason"):
-        LifeHalt(
-            stage=HaltStage.PRE_DISPATCH,
-            recovery_mode=RecoveryMode.RETRY_OUTCOME,
-            reason=hostile,
+    with pytest.raises(ValueError, match="authority_id"):
+        ExactDispatchConfig(authority_id=_HostileHaltReason("asi.hostile.authority"))
+    with pytest.raises(ValueError, match="lifecycle_id"):
+        _require_prototype_lifecycle_id(
+            _HostileHaltReason("prototype.0000000100000002")
         )
-
-    runner = _runner(horizon=1)
-    with pytest.raises(ValueError, match="abort reason"):
-        runner.abort(runner.init(), reason=hostile)
     assert _HostileHaltReason.hook_calls == 0

--- a/tests/test_reference_life.py
+++ b/tests/test_reference_life.py
@@ -37,6 +37,7 @@ from alberta_framework.reference_agent import (
 from alberta_framework.reference_life import (
     ExactDispatchAdapter,
     HaltStage,
+    LifeHalt,
     LifePhase,
     RecoveryMode,
     ReferenceLifeConfig,
@@ -56,6 +57,19 @@ from alberta_framework.streams.closed_loop import (
 pytestmark = pytest.mark.unit
 
 _LIFECYCLE_ID = "prototype.0000000100000002"
+
+
+class _HostileHaltReason(str):
+    hook_calls = 0
+
+    def __bool__(self) -> bool:
+        type(self).hook_calls += 1
+        raise AssertionError("hostile halt-reason truth hook executed")
+
+    def strip(self, *args: str) -> str:
+        del args
+        type(self).hook_calls += 1
+        raise AssertionError("hostile halt-reason strip hook executed")
 
 
 def _agent_config() -> PrototypeAgentConfig:
@@ -1495,3 +1509,19 @@ def test_abort_is_terminal_and_preserves_pending_execution() -> None:
     assert aborted.halt.recovery_mode is RecoveryMode.ABORT_ONLY
     with pytest.raises(DecisionOwnershipError, match="aborted"):
         runner.step(aborted)
+
+
+def test_halt_and_abort_reject_hostile_reason_without_hooks() -> None:
+    _HostileHaltReason.hook_calls = 0
+    hostile = _HostileHaltReason("operator stop")
+    with pytest.raises(ValueError, match="halt reason"):
+        LifeHalt(
+            stage=HaltStage.PRE_DISPATCH,
+            recovery_mode=RecoveryMode.RETRY_OUTCOME,
+            reason=hostile,
+        )
+
+    runner = _runner(horizon=1)
+    with pytest.raises(ValueError, match="abort reason"):
+        runner.abort(runner.init(), reason=hostile)
+    assert _HostileHaltReason.hook_calls == 0

--- a/tests/test_reference_life_event_leftover_identities.py
+++ b/tests/test_reference_life_event_leftover_identities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 
 import pytest
@@ -20,18 +21,27 @@ from alberta_framework.reference_life import (
     ReferenceEnvironmentExecution,
     ReferenceEnvironmentStart,
     ReferenceLifeEvent,
+    ReferenceLifeRun,
     ReferenceLifeRunner,
+    ReferenceLifeState,
 )
 
 _DIGEST = "0" * 64
 
 
-class _ExplodingHashMeta(type):
+class _ExplodingTypeHookMeta(type):
+    equality_calls = 0
+
     def __hash__(cls) -> int:
         raise AssertionError("hostile runtime-class hash executed")
 
+    def __eq__(cls, other: object) -> bool:
+        del other
+        _ExplodingTypeHookMeta.equality_calls += 1
+        raise AssertionError("hostile runtime-class equality executed")
 
-class _HostileScalar(metaclass=_ExplodingHashMeta):
+
+class _HostileScalar(metaclass=_ExplodingTypeHookMeta):
     pass
 
 
@@ -39,16 +49,24 @@ class _HostileString(str):
     calls = 0
 
     def strip(self, chars: str | None = None) -> str:
+        del chars
         type(self).calls += 1
         raise AssertionError("hostile string method executed")
 
 
 def _legal_event(**overrides: object) -> ReferenceLifeEvent:
+    command = object.__new__(DispatchCommand)
+    receipt = object.__new__(DispatchReceipt)
+    transaction = object.__new__(Transaction)
+    step_result = object.__new__(StepResult)
+    object.__setattr__(receipt, "command", command)
+    object.__setattr__(transaction, "receipt", receipt)
+    object.__setattr__(step_result, "transaction", transaction)
     payload: dict[str, object] = {
-        "command": object.__new__(DispatchCommand),
-        "receipt": object.__new__(DispatchReceipt),
-        "transaction": object.__new__(Transaction),
-        "step_result": object.__new__(StepResult),
+        "command": command,
+        "receipt": receipt,
+        "transaction": transaction,
+        "step_result": step_result,
         "regime_id": 0,
         "oracle_reward": 0.5,
         "transcript_sha256": _DIGEST,
@@ -143,7 +161,8 @@ def test_reference_life_hosts_reject_leftover_regime_and_reward_identities() -> 
         )
 
 
-def test_real_type_gates_do_not_hash_hostile_runtime_classes() -> None:
+def test_real_type_gates_do_not_invoke_hostile_runtime_class_hooks() -> None:
+    _ExplodingTypeHookMeta.equality_calls = 0
     hostile = _HostileScalar()
 
     with pytest.raises(ValueError, match="recovered"):
@@ -152,6 +171,41 @@ def test_real_type_gates_do_not_hash_hostile_runtime_classes() -> None:
         _legal_event(regime_id=hostile)
     with pytest.raises(ValueError, match="oracle_reward"):
         _legal_event(oracle_reward=hostile)
+    assert _ExplodingTypeHookMeta.equality_calls == 0
+
+
+def test_reference_life_event_requires_one_component_identity_chain() -> None:
+    event = _legal_event()
+    with pytest.raises(ValueError, match="receipt does not belong"):
+        dataclasses.replace(event, command=object.__new__(DispatchCommand))
+
+    replacement_receipt = object.__new__(DispatchReceipt)
+    object.__setattr__(replacement_receipt, "command", event.command)
+    with pytest.raises(ValueError, match="transaction does not belong"):
+        dataclasses.replace(event, receipt=replacement_receipt)
+
+    replacement_transaction = object.__new__(Transaction)
+    object.__setattr__(replacement_transaction, "receipt", event.receipt)
+    with pytest.raises(ValueError, match="step result does not belong"):
+        dataclasses.replace(event, transaction=replacement_transaction)
+
+
+def test_reference_life_run_rejects_leftover_container_and_transcript_identities() -> None:
+    state = object.__new__(ReferenceLifeState)
+    object.__setattr__(state, "transcript_sha256", _DIGEST)
+    event = _legal_event()
+
+    with pytest.raises(ValueError, match="state"):
+        ReferenceLifeRun(state=object(), events=())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="exact tuple"):
+        ReferenceLifeRun(state=state, events=[event])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="only ReferenceLifeEvent"):
+        ReferenceLifeRun(state=state, events=(object(),))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="transcript"):
+        ReferenceLifeRun(state=state, events=(_legal_event(transcript_sha256="1" * 64),))
+
+    run = ReferenceLifeRun(state=state, events=(event,))
+    assert run.events == (event,)
 
 
 def test_life_veto_reasons_reject_hostile_string_identities_before_dispatch() -> None:


### PR DESCRIPTION
Independent post-merge audit of #1508 found three retained trust-boundary gaps: hostile metaclass equality in the finite-real type tuple, internally mixed event component graphs, and an unvalidated public run aggregate. This corrective uses exact identity checks, binds the command→receipt→transaction→step-result chain, validates exact run state/event containers and final transcript coherence, and closes the adjacent shared safe-ID / Prototype lifecycle string-subclass gates.

#1527 already preserves and expands byt61’s #1523 veto fix; this branch rebases on that merged successor and retains its tests. #1520 already preserves #1513, so no duplicate control change remains here.

Verification on exact current main: 7 focused hostile/event/id tests; Ruff on changed files; strict mypy (174 files); diff check. Earlier expanded relevant panel before the final disjoint main rebase: 161 tests across life, RiverSwim, both checkpoint lanes, controls, and scorecard; plus 46 full core-life/event tests and 38 event/control tests. No workflows, outputs, benchmark execution, or evidence promotion.