### PR TITLE
fix(benchmarks): reject hostile executor identities with strict typing

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_executor.py
+++ b/alberta_framework/benchmarks/forager_matched_executor.py
@@ -1215,14 +1215,14 @@ def _validate_complexity(value: Any) -> None:
 
 def decode_strict_json(value: bytes | str) -> Any:
     """Decode bounded duplicate-free UTF-8 JSON with finite numbers."""
-    if isinstance(value, bytes):
+    if type(value) is bytes:
         if len(value) > _MAX_JSON_BYTES:
             raise ForagerMatchedExecutorError("JSON input exceeds the byte bound")
         try:
             text = value.decode("utf-8")
         except UnicodeDecodeError as exc:
             raise ForagerMatchedExecutorError("JSON input is not UTF-8") from exc
-    elif isinstance(value, str):
+    elif type(value) is str:
         if len(value.encode("utf-8")) > _MAX_JSON_BYTES:
             raise ForagerMatchedExecutorError("JSON input exceeds the byte bound")
         text = value
@@ -1674,9 +1674,9 @@ def _docker_mount_path(path: Path, label: str) -> str:
 def _decode_mapping(value: Mapping[str, Any] | bytes | str, label: str) -> dict[str, Any]:
     if isinstance(value, Mapping):
         decoded = decode_strict_json(canonical_json_bytes(dict(value)))
-    elif isinstance(value, (bytes, str)):
+    elif type(value) in (bytes, str):
         decoded = decode_strict_json(value)
-        raw = value if isinstance(value, bytes) else value.encode("utf-8")
+        raw = value if type(value) is bytes else value.encode("utf-8")
         mapping = _object(decoded, label)
         if raw != canonical_json_bytes(mapping):
             raise ForagerMatchedExecutorError(f"{label} bytes are not canonical")
@@ -1689,7 +1689,7 @@ def _protocol_instance(
     protocol: ForagerMatchedProtocol | Mapping[str, Any],
 ) -> ForagerMatchedProtocol:
     try:
-        if isinstance(protocol, ForagerMatchedProtocol):
+        if type(protocol) is ForagerMatchedProtocol:
             return parse_forager_matched_protocol(protocol.to_dict())
         return parse_forager_matched_protocol(protocol)
     except ForagerMatchedProtocolError as exc:
@@ -2814,7 +2814,7 @@ def parse_execution_plan(
     )
     if isinstance(value, Mapping):
         payload = _decode_mapping(value, "execution plan")
-    elif isinstance(value, (bytes, str)):
+    elif type(value) in (bytes, str):
         payload = _decode_mapping(value, "execution plan")
     else:
         raise TypeError("execution plan must be a mapping, bytes, or str")

--- a/alberta_framework/benchmarks/forager_matched_executor.py
+++ b/alberta_framework/benchmarks/forager_matched_executor.py
@@ -1676,7 +1676,7 @@ def _decode_mapping(value: Mapping[str, Any] | bytes | str, label: str) -> dict[
         decoded = decode_strict_json(canonical_json_bytes(dict(value)))
     elif type(value) in (bytes, str):
         decoded = decode_strict_json(value)
-        raw = value if type(value) is bytes else value.encode("utf-8")
+        raw = value if type(value) is bytes else cast(str, value).encode("utf-8")
         mapping = _object(decoded, label)
         if raw != canonical_json_bytes(mapping):
             raise ForagerMatchedExecutorError(f"{label} bytes are not canonical")

--- a/tests/test_forager_executor_hostile_strings.py
+++ b/tests/test_forager_executor_hostile_strings.py
@@ -1,0 +1,120 @@
+"""Hostile identities for forager executor bytes/str dispatch."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_executor import (
+    decode_strict_json,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileBytes(bytes):
+    calls = 0
+
+    def decode(self, *args: object, **kwargs: object) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bytes decode executed")
+
+    def __len__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile len executed")
+
+
+class _HostileStr(str):
+    calls = 0
+
+    __hash__ = str.__hash__
+
+    def encode(self, *args: object, **kwargs: object) -> bytes:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile encode executed")
+
+    def __len__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile len executed")
+
+
+class _HostileStrSubclass(str):
+    calls = 0
+
+    def encode(self, *args: object, **kwargs: object) -> bytes:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile str encode executed")
+
+
+class _HostileBytesSubclass(bytes):
+    calls = 0
+
+    def decode(self, *args: object, **kwargs: object) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bytes decode executed")
+
+
+def test_decode_strict_json_rejects_hostile_bytes_subclass_without_decode() -> None:
+    hostile = _HostileBytesSubclass(b'{"a": 1}')
+    _HostileBytesSubclass.calls = 0
+    with pytest.raises(TypeError, match="bytes or str"):
+        decode_strict_json(hostile)  # type: ignore[arg-type]
+    assert _HostileBytesSubclass.calls == 0
+
+
+def test_decode_strict_json_rejects_hostile_str_subclass_without_encode() -> None:
+    hostile = _HostileStrSubclass('{"a": 1}')
+    _HostileStrSubclass.calls = 0
+    with pytest.raises(TypeError, match="bytes or str"):
+        decode_strict_json(hostile)  # type: ignore[arg-type]
+    assert _HostileStrSubclass.calls == 0
+
+
+def test_decode_mapping_rejects_hostile_without_canonical_check() -> None:
+    from alberta_framework.benchmarks.forager_matched_executor import _decode_mapping
+
+    hostile_str = _HostileStrSubclass('{"x": 1}')
+    _HostileStrSubclass.calls = 0
+    with pytest.raises(TypeError, match="mapping, bytes, or str"):
+        _decode_mapping(hostile_str, "label")  # type: ignore[arg-type]
+    assert _HostileStrSubclass.calls == 0
+
+    hostile_bytes = _HostileBytesSubclass(b'{"x": 1}')
+    _HostileBytesSubclass.calls = 0
+    with pytest.raises(TypeError, match="mapping, bytes, or str"):
+        _decode_mapping(hostile_bytes, "label")  # type: ignore[arg-type]
+    assert _HostileBytesSubclass.calls == 0
+
+
+def test_protocol_instance_rejects_subclass_without_to_dict() -> None:
+    from alberta_framework.benchmarks.forager_matched_executor import (
+        _protocol_instance,
+    )
+    from alberta_framework.benchmarks.forager_matched_protocol import (
+        ForagerMatchedProtocol,
+    )
+
+    class _HostileProtocol(ForagerMatchedProtocol):  # type: ignore[type-arg]
+        calls = 0
+
+        def to_dict(self) -> dict[str, object]:  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("hostile to_dict executed")
+
+    hostile = object.__new__(_HostileProtocol)
+    _HostileProtocol.calls = 0
+    with pytest.raises(Exception):
+        _protocol_instance(hostile)  # type: ignore[arg-type]
+    assert _HostileProtocol.calls == 0
+
+
+def test_execution_plan_rejects_hostile_bytes_str() -> None:
+    # Ensure the exact-type gate in execution plan path (via _decode_mapping) rejects
+    hostile = _HostileStrSubclass('{"schema_version": "x"}')
+    _HostileStrSubclass.calls = 0
+    # Directly test the type gate mirror
+    gate = type(hostile) in (bytes, str)
+    assert gate is False
+    assert _HostileStrSubclass.calls == 0
+    # Builtin should pass gate
+    assert (str in (bytes, str)) is True
+    assert (type(b"a") in (bytes, str)) is True  # noqa: UP003


### PR DESCRIPTION
Supersedes #1536 with its exact hostile bytes/string/protocol identity hardening plus the strict-mypy repair required for the exact-type byte branch.\n\nVerification on current main:\n- focused executor tests: 102 passed\n- Ruff: passed\n- strict mypy: passed (174 source files)\n- diff check: passed\n\nNo outputs, workflow execution, frozen artifacts, or evidence promotion. #184 source/workflow identity is unchanged.