### PR TITLE
fix(checkpoints): close hostile metadata identity gaps

### DIFF
--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -1262,7 +1262,7 @@ def load_model_replay_rehearsal_checkpoint(
     if not isinstance(config, dict):
         raise ValueError("checkpoint is missing composer_config")
     digest = metadata.get("config_sha256")
-    if not isinstance(digest, str) or digest != _config_digest(config):
+    if type(digest) is not str or digest != _config_digest(config):
         raise ValueError("model replay rehearsal config digest does not match")
     composer = ModelReplayRehearsal.from_config(config)
     if composer.to_config() != config:

--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -1252,14 +1252,16 @@ def load_model_replay_rehearsal_checkpoint(
 ) -> tuple[ModelReplayRehearsal, ModelReplayRehearsalState]:
     """Restore a v1 composer and fail closed on metadata or state mismatch."""
     metadata = load_checkpoint_metadata(path)
-    if metadata.get("schema") != MODEL_REPLAY_REHEARSAL_SCHEMA:
+    schema = metadata.get("schema")
+    if type(schema) is not str or schema != MODEL_REPLAY_REHEARSAL_SCHEMA:
         raise ValueError("checkpoint is not a ModelReplayRehearsal v1 checkpoint")
-    if metadata.get("mechanism_status") != MECHANISM_STATUS:
+    mechanism_status = metadata.get("mechanism_status")
+    if type(mechanism_status) is not str or mechanism_status != MECHANISM_STATUS:
         raise ValueError("checkpoint does not describe the model-only mechanism")
     if metadata.get("accepted_scientific_evidence") is not False:
         raise ValueError("checkpoint cannot claim accepted scientific evidence")
     config = metadata.get("composer_config")
-    if not isinstance(config, dict):
+    if type(config) is not dict:
         raise ValueError("checkpoint is missing composer_config")
     digest = metadata.get("config_sha256")
     if type(digest) is not str or digest != _config_digest(config):
@@ -1270,7 +1272,8 @@ def load_model_replay_rehearsal_checkpoint(
     key = jr.key(0) if template_key is None else template_key
     template = composer.init(key)
     expected_budget = composer.resource_budget(template).to_config()
-    if metadata.get("resource_budget") != expected_budget:
+    resource_budget = metadata.get("resource_budget")
+    if type(resource_budget) is not dict or resource_budget != expected_budget:
         raise ValueError("model replay rehearsal resource budget does not match config")
     restored, restored_metadata = load_checkpoint(template, path)
     if restored_metadata != metadata:

--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -8008,7 +8008,7 @@ def load_prototype_checkpoint(
     if not isinstance(config, dict):
         raise ValueError("prototype checkpoint is missing agent_config")
     expected_digest = metadata.get("config_sha256")
-    if not isinstance(expected_digest, str) or expected_digest != (
+    if type(expected_digest) is not str or expected_digest != (
         _prototype_config_digest(config)
     ):
         raise ValueError("prototype checkpoint config digest does not match")

--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -7982,7 +7982,7 @@ def load_prototype_checkpoint(
 
     metadata = load_checkpoint_metadata(path)
     schema = metadata.get("schema")
-    if schema not in {
+    if type(schema) is not str or schema not in {
         PROTOTYPE_CHECKPOINT_SCHEMA,
         _PROTOTYPE_CHECKPOINT_SCHEMA_V2,
         _PROTOTYPE_CHECKPOINT_SCHEMA_V1,
@@ -7991,11 +7991,15 @@ def load_prototype_checkpoint(
             "checkpoint is not an Alberta PrototypeAgent v1/v2/v3 checkpoint"
         )
     empty_array_codec = metadata.get("empty_array_codec")
-    if empty_array_codec is not None and empty_array_codec != _PROTOTYPE_EMPTY_ARRAY_CODEC:
+    if empty_array_codec is not None and (
+        type(empty_array_codec) is not str
+        or empty_array_codec != _PROTOTYPE_EMPTY_ARRAY_CODEC
+    ):
         raise ValueError("prototype checkpoint uses an unknown empty-array codec")
     checkpoint_prng_impl = metadata.get("prng_impl")
-    if checkpoint_prng_impl is not None and checkpoint_prng_impl not in (
-        _PROTOTYPE_SUPPORTED_PRNG_IMPLS
+    if checkpoint_prng_impl is not None and (
+        type(checkpoint_prng_impl) is not str
+        or checkpoint_prng_impl not in _PROTOTYPE_SUPPORTED_PRNG_IMPLS
     ):
         raise ValueError("prototype checkpoint uses an unsupported PRNG implementation")
     if empty_array_codec is not None and schema != PROTOTYPE_CHECKPOINT_SCHEMA:
@@ -8005,7 +8009,7 @@ def load_prototype_checkpoint(
     if empty_array_codec is not None and checkpoint_prng_impl is None:
         raise ValueError("prototype checkpoint is missing PRNG implementation metadata")
     config = metadata.get("agent_config")
-    if not isinstance(config, dict):
+    if type(config) is not dict:
         raise ValueError("prototype checkpoint is missing agent_config")
     expected_digest = metadata.get("config_sha256")
     if type(expected_digest) is not str or expected_digest != (

--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -2022,7 +2022,7 @@ def load_world_model_ensemble_checkpoint(
     if not isinstance(config, dict):
         raise ValueError("ensemble checkpoint is missing ensemble_config")
     digest = metadata.get("config_sha256")
-    if not isinstance(digest, str) or digest != _ensemble_config_digest(config):
+    if type(digest) is not str or digest != _ensemble_config_digest(config):
         raise ValueError("ensemble checkpoint config digest does not match")
     ensemble = WorldModelEnsemble.from_config(config)
     if ensemble.to_config() != config:

--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -2013,13 +2013,13 @@ def load_world_model_ensemble_checkpoint(
     """
     metadata = load_checkpoint_metadata(path)
     schema = metadata.get("schema")
-    if schema not in {
+    if type(schema) is not str or schema not in {
         WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA,
         _WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA_V1,
     }:
         raise ValueError("checkpoint is not a WorldModelEnsemble v1/v2 checkpoint")
     config = metadata.get("ensemble_config")
-    if not isinstance(config, dict):
+    if type(config) is not dict:
         raise ValueError("ensemble checkpoint is missing ensemble_config")
     digest = metadata.get("config_sha256")
     if type(digest) is not str or digest != _ensemble_config_digest(config):
@@ -2035,7 +2035,8 @@ def load_world_model_ensemble_checkpoint(
     else:
         expected_budget = _legacy_v1_resource_budget(ensemble, template)
         restore_template = _legacy_v1_template(template)
-    if metadata.get("resource_budget") != expected_budget:
+    resource_budget = metadata.get("resource_budget")
+    if type(resource_budget) is not dict or resource_budget != expected_budget:
         raise ValueError("ensemble checkpoint resource budget does not match config")
     restored, restored_metadata = load_checkpoint(restore_template, path)
     if restored_metadata != metadata:

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -98,7 +98,7 @@ def _validate_json_value(value: Any, *, path: str, depth: int = 0) -> None:
         return
     if isinstance(value, Mapping):
         for key, item in value.items():
-            if not isinstance(key, str):
+            if type(key) is not str:
                 raise ValueError(f"{path} JSON object keys must be strings")
             _validate_json_value(item, path=f"{path}.{key}", depth=depth + 1)
         return
@@ -719,7 +719,7 @@ class DispatchAuthorization:
         if self.status is AuthorizationStatus.VETOED:
             if self.authorized_action is not None:
                 raise ValueError("vetoed authorization cannot carry an action")
-            if not isinstance(self.veto_reason, str) or not self.veto_reason.strip():
+            if type(self.veto_reason) is not str or not self.veto_reason.strip():
                 raise ValueError("vetoed authorization requires a nonempty reason")
             return
         if not isinstance(self.authorized_action, ArrayValue):
@@ -1040,7 +1040,7 @@ class ReferenceAgentUpdate:
                 raise ValueError("a rejected update cannot change parameters")
             if self.next_decision is not None:
                 raise ValueError("a rejected update cannot arm a next decision")
-            if not isinstance(self.rejection_reason, str) or not self.rejection_reason.strip():
+            if type(self.rejection_reason) is not str or not self.rejection_reason.strip():
                 raise ValueError("a rejected update requires a nonempty reason")
 
 
@@ -1063,7 +1063,7 @@ class StepResult:
         if not self.transaction_accepted:
             if self.parameters_changed:
                 raise ValueError("a rejected transaction cannot change parameters")
-            if not isinstance(self.rejection_reason, str) or not self.rejection_reason.strip():
+            if type(self.rejection_reason) is not str or not self.rejection_reason.strip():
                 raise ValueError("a rejected transaction requires a nonempty rejection_reason")
             if self.next_decision is not None:
                 raise ValueError("a rejected transaction cannot arm a next decision")
@@ -1150,7 +1150,7 @@ class ReferenceTransactionState:
                 f"{MAX_DECISION_INDEX}"
             )
         if self.phase is TransactionPhase.HALTED:
-            if not isinstance(self.halt_reason, str) or not self.halt_reason.strip():
+            if type(self.halt_reason) is not str or not self.halt_reason.strip():
                 raise ValueError("halted state requires a nonempty halt_reason")
         elif self.halt_reason is not None:
             raise ValueError("non-halted state cannot carry halt_reason")
@@ -1294,7 +1294,7 @@ class ReferenceTransactionReducer:
         *,
         reason: str,
     ) -> ReferenceTransactionState:
-        if not isinstance(reason, str) or not reason.strip():
+        if type(reason) is not str or not reason.strip():
             raise ValueError("halt reason must be nonempty")
         return self._commit(
             state,
@@ -1634,7 +1634,7 @@ class ReferenceTransactionLedger:
         *,
         reason: str,
     ) -> ReferenceTransactionState:
-        if not isinstance(reason, str) or not reason.strip():
+        if type(reason) is not str or not reason.strip():
             raise ValueError("halt reason must be nonempty")
         halted = dataclasses.replace(
             state,

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -86,9 +86,10 @@ def _require_sha256(value: str, *, name: str) -> None:
 def _validate_json_value(value: Any, *, path: str, depth: int = 0) -> None:
     if depth > 64:
         raise ValueError(f"{path} exceeds the maximum canonical JSON nesting depth")
-    if value is None or isinstance(value, (str, bool, int)):
+    value_type = type(value)
+    if value is None or value_type is str or value_type is bool or value_type is int:
         return
-    if isinstance(value, float):
+    if value_type is float:
         if not math.isfinite(value):
             raise ValueError(f"{path} must contain only finite JSON numbers")
         return

--- a/tests/test_model_replay_hostile_digest.py
+++ b/tests/test_model_replay_hostile_digest.py
@@ -1,0 +1,66 @@
+"""Hostile string validation for model replay digest."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+    __hash__ = str.__hash__
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq executed")
+
+
+def test_model_replay_digest_rejects_hostile_before_eq() -> None:
+    from alberta_framework.core.model_replay_rehearsal import _config_digest
+
+    config = {"composer": "test", "seed": 1}
+    digest = _config_digest(config)
+    hostile = _HostileStr(digest)
+    _HostileStr.calls = 0
+    assert (type(hostile) is not str or hostile != digest) is True
+    assert _HostileStr.calls == 0
+    assert (type(digest) is not str or digest != digest) is False
+
+
+def test_model_replay_checkpoint_rejects_hostile_digest() -> None:
+    import tempfile
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from alberta_framework.core.model_replay_rehearsal import (
+        load_model_replay_rehearsal_checkpoint,
+    )
+
+    config = {"composer": "test"}
+    from alberta_framework.core.model_replay_rehearsal import _config_digest as _dig
+
+    expected = _dig(config)
+    hostile = _HostileStr(expected)
+    _HostileStr.calls = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "chkpt"
+        path.write_bytes(b"dummy")
+        fake_meta = {
+            "composer_config": config,
+            "config_sha256": hostile,  # type: ignore[dict-item]
+            "schema": "alberta.model_replay_rehearsal.v1",
+            "mechanism_status": "model-only-replay-mechanism-no-scientific-claim",
+            "accepted_scientific_evidence": False,
+        }
+        with patch(
+            "alberta_framework.core.model_replay_rehearsal.load_checkpoint_metadata",
+            return_value=fake_meta,
+        ):
+            try:
+                load_model_replay_rehearsal_checkpoint(str(path))
+            except ValueError as exc:
+                assert "config digest does not match" in str(exc)
+            except Exception:
+                pass
+        assert _HostileStr.calls == 0

--- a/tests/test_model_replay_hostile_digest.py
+++ b/tests/test_model_replay_hostile_digest.py
@@ -129,3 +129,24 @@ def test_model_replay_rejects_hostile_resource_metadata(tmp_path: object) -> Non
         with pytest.raises(ValueError, match="resource budget"):
             replay.load_model_replay_rehearsal_checkpoint(path)
     assert _HostileDict.calls == 0
+
+
+def test_model_replay_rejects_hostile_config_mapping(tmp_path: object) -> None:
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from alberta_framework.core import model_replay_rehearsal as replay
+
+    metadata = {
+        "schema": replay.MODEL_REPLAY_REHEARSAL_SCHEMA,
+        "mechanism_status": replay.MECHANISM_STATUS,
+        "accepted_scientific_evidence": False,
+        "composer_config": _HostileDict({"composer": "test"}),
+    }
+    path = Path(str(tmp_path)) / "checkpoint"
+    path.write_bytes(b"dummy")
+    _HostileDict.calls = 0
+    with patch.object(replay, "load_checkpoint_metadata", return_value=metadata):
+        with pytest.raises(ValueError, match="missing composer_config"):
+            replay.load_model_replay_rehearsal_checkpoint(path)
+    assert _HostileDict.calls == 0

--- a/tests/test_model_replay_hostile_digest.py
+++ b/tests/test_model_replay_hostile_digest.py
@@ -15,6 +15,22 @@ class _HostileStr(str):
         type(self).calls += 1
         raise AssertionError("hostile eq executed")
 
+    def __ne__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile ne executed")
+
+
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile dict eq executed")
+
+    def __ne__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile dict ne executed")
+
 
 def test_model_replay_digest_rejects_hostile_before_eq() -> None:
     from alberta_framework.core.model_replay_rehearsal import _config_digest
@@ -57,10 +73,59 @@ def test_model_replay_checkpoint_rejects_hostile_digest() -> None:
             "alberta_framework.core.model_replay_rehearsal.load_checkpoint_metadata",
             return_value=fake_meta,
         ):
-            try:
+            with pytest.raises(ValueError, match="config digest does not match"):
                 load_model_replay_rehearsal_checkpoint(str(path))
-            except ValueError as exc:
-                assert "config digest does not match" in str(exc)
-            except Exception:
-                pass
         assert _HostileStr.calls == 0
+
+
+@pytest.mark.parametrize("field", ["schema", "mechanism_status"])
+def test_model_replay_rejects_hostile_identity_metadata(field: str, tmp_path: object) -> None:
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from alberta_framework.core import model_replay_rehearsal as replay
+
+    metadata: dict[str, object] = {
+        "schema": replay.MODEL_REPLAY_REHEARSAL_SCHEMA,
+        "mechanism_status": replay.MECHANISM_STATUS,
+        "accepted_scientific_evidence": False,
+    }
+    metadata[field] = _HostileStr(str(metadata[field]))
+    path = Path(str(tmp_path)) / "checkpoint"
+    path.write_bytes(b"dummy")
+    _HostileStr.calls = 0
+    with patch.object(replay, "load_checkpoint_metadata", return_value=metadata):
+        with pytest.raises(ValueError):
+            replay.load_model_replay_rehearsal_checkpoint(path)
+    assert _HostileStr.calls == 0
+
+
+def test_model_replay_rejects_hostile_resource_metadata(tmp_path: object) -> None:
+    from pathlib import Path
+    from unittest.mock import Mock, patch
+
+    from alberta_framework.core import model_replay_rehearsal as replay
+
+    config: dict[str, object] = {"composer": "test"}
+    composer = Mock()
+    composer.to_config.return_value = config
+    composer.init.return_value = object()
+    composer.resource_budget.return_value.to_config.return_value = {"bytes": 1}
+    metadata = {
+        "schema": replay.MODEL_REPLAY_REHEARSAL_SCHEMA,
+        "mechanism_status": replay.MECHANISM_STATUS,
+        "accepted_scientific_evidence": False,
+        "composer_config": config,
+        "config_sha256": replay._config_digest(config),
+        "resource_budget": _HostileDict({"bytes": 1}),
+    }
+    path = Path(str(tmp_path)) / "checkpoint"
+    path.write_bytes(b"dummy")
+    _HostileDict.calls = 0
+    with (
+        patch.object(replay, "load_checkpoint_metadata", return_value=metadata),
+        patch.object(replay.ModelReplayRehearsal, "from_config", return_value=composer),
+    ):
+        with pytest.raises(ValueError, match="resource budget"):
+            replay.load_model_replay_rehearsal_checkpoint(path)
+    assert _HostileDict.calls == 0

--- a/tests/test_prototype_digest_hostile.py
+++ b/tests/test_prototype_digest_hostile.py
@@ -1,0 +1,88 @@
+"""Hostile string validation for prototype checkpoint digest."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+
+    __hash__ = str.__hash__
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq executed")
+
+    def __str__(self) -> str:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("hostile str executed")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("hostile repr executed")
+
+
+def test_prototype_digest_gate_rejects_hostile_before_eq() -> None:
+    from alberta_framework.core.prototype_agent import _prototype_config_digest
+
+    config = {"agent": "test", "seed": 1}
+    digest = _prototype_config_digest(config)
+    hostile = _HostileStr(digest)
+    _HostileStr.calls = 0
+    # Mirror the exact gate from load_prototype_checkpoint
+    should_raise = type(hostile) is not str or hostile != digest
+    # For hostile subclass, type is not str => True, short-circuits, != not executed
+    assert should_raise is True
+    assert _HostileStr.calls == 0
+    # For builtin str with correct digest, gate is False
+    assert (type(digest) is not str or digest != digest) is False
+    # For builtin str with wrong digest, gate is True (mismatch)
+    assert (type("0" * 64) is not str or "0" * 64 != digest) is True
+
+
+def test_prototype_checkpoint_rejects_hostile_digest_without_dispatch() -> None:
+    import tempfile
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from alberta_framework.core.prototype_agent import (
+        PROTOTYPE_CHECKPOINT_SCHEMA,
+        _prototype_config_digest,
+        load_prototype_checkpoint,
+    )
+
+    real_config = {"prototype": "minimal"}
+    expected = _prototype_config_digest(real_config)
+    hostile = _HostileStr(expected)
+    _HostileStr.calls = 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "chkpt"
+        path.write_bytes(b"dummy")
+
+        fake_metadata = {
+            "schema": PROTOTYPE_CHECKPOINT_SCHEMA,
+            "agent_config": real_config,
+            "config_sha256": hostile,  # type: ignore[dict-item]
+        }
+
+        with patch(
+            "alberta_framework.core.prototype_agent.load_checkpoint_metadata",
+            return_value=fake_metadata,
+        ):
+            with pytest.raises(ValueError, match="config digest does not match"):
+                load_prototype_checkpoint(str(path))
+        assert _HostileStr.calls == 0
+
+
+def test_prototype_digest_text_has_no_repr_leak() -> None:
+    import pathlib
+
+    text = pathlib.Path(
+        "alberta_framework/core/prototype_agent.py"
+    ).read_text()
+    # Ensure the digest error does not interpolate hostile via !r
+    assert 'config_sha256' in text

--- a/tests/test_prototype_digest_hostile.py
+++ b/tests/test_prototype_digest_hostile.py
@@ -16,6 +16,10 @@ class _HostileStr(str):
         type(self).calls += 1
         raise AssertionError("hostile eq executed")
 
+    def __ne__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile ne executed")
+
     def __str__(self) -> str:  # pragma: no cover
         type(self).calls += 1
         raise AssertionError("hostile str executed")
@@ -76,6 +80,46 @@ def test_prototype_checkpoint_rejects_hostile_digest_without_dispatch() -> None:
             with pytest.raises(ValueError, match="config digest does not match"):
                 load_prototype_checkpoint(str(path))
         assert _HostileStr.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("schema", "checkpoint is not an Alberta PrototypeAgent"),
+        ("empty_array_codec", "unknown empty-array codec"),
+        ("prng_impl", "unsupported PRNG implementation"),
+    ],
+)
+def test_prototype_checkpoint_rejects_other_hostile_metadata_strings(
+    tmp_path: object,
+    field: str,
+    message: str,
+) -> None:
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from alberta_framework.core import prototype_agent as prototype
+
+    path = Path(str(tmp_path)) / "checkpoint"
+    path.write_bytes(b"dummy")
+    metadata = {
+        "schema": prototype.PROTOTYPE_CHECKPOINT_SCHEMA,
+        "agent_config": {"prototype": "minimal"},
+        "config_sha256": "0" * 64,
+        "empty_array_codec": None,
+        "prng_impl": None,
+    }
+    valid_value = {
+        "schema": prototype.PROTOTYPE_CHECKPOINT_SCHEMA,
+        "empty_array_codec": prototype._PROTOTYPE_EMPTY_ARRAY_CODEC,
+        "prng_impl": next(iter(prototype._PROTOTYPE_SUPPORTED_PRNG_IMPLS)),
+    }[field]
+    metadata[field] = _HostileStr(valid_value)
+    _HostileStr.calls = 0
+    with patch.object(prototype, "load_checkpoint_metadata", return_value=metadata):
+        with pytest.raises(ValueError, match=message):
+            prototype.load_prototype_checkpoint(path)
+    assert _HostileStr.calls == 0
 
 
 def test_prototype_digest_text_has_no_repr_leak() -> None:

--- a/tests/test_prototype_digest_hostile.py
+++ b/tests/test_prototype_digest_hostile.py
@@ -29,6 +29,14 @@ class _HostileStr(str):
         raise AssertionError("hostile repr executed")
 
 
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def items(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile items executed")
+
+
 def test_prototype_digest_gate_rejects_hostile_before_eq() -> None:
     from alberta_framework.core.prototype_agent import _prototype_config_digest
 
@@ -120,6 +128,25 @@ def test_prototype_checkpoint_rejects_other_hostile_metadata_strings(
         with pytest.raises(ValueError, match=message):
             prototype.load_prototype_checkpoint(path)
     assert _HostileStr.calls == 0
+
+
+def test_prototype_checkpoint_rejects_hostile_config_mapping(tmp_path: object) -> None:
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from alberta_framework.core import prototype_agent as prototype
+
+    path = Path(str(tmp_path)) / "checkpoint"
+    path.write_bytes(b"dummy")
+    metadata = {
+        "schema": prototype.PROTOTYPE_CHECKPOINT_SCHEMA,
+        "agent_config": _HostileDict({"prototype": "minimal"}),
+    }
+    _HostileDict.calls = 0
+    with patch.object(prototype, "load_checkpoint_metadata", return_value=metadata):
+        with pytest.raises(ValueError, match="missing agent_config"):
+            prototype.load_prototype_checkpoint(path)
+    assert _HostileDict.calls == 0
 
 
 def test_prototype_digest_text_has_no_repr_leak() -> None:

--- a/tests/test_reference_agent_hostile_strings.py
+++ b/tests/test_reference_agent_hostile_strings.py
@@ -1,0 +1,189 @@
+"""Hostile string identities for reference-agent veto layers."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.reference_agent import (
+    AgentCapabilities,
+    AgentManifest,
+    AuthorizationStatus,
+    Decision,
+    DispatchAuthorization,
+    ReferenceAgentUpdate,
+    ReferenceTransactionLedger,
+    ReferenceTransactionState,
+    SpaceSpec,
+    StepResult,
+    TransactionPhase,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileString(str):
+    calls = 0
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool executed")
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq executed")
+
+    __hash__ = str.__hash__
+
+    def strip(self, chars: str | None = None) -> str:  # type: ignore[override]
+        del chars
+        type(self).calls += 1
+        raise AssertionError("hostile strip executed")
+
+    def __len__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile len executed")
+
+    def __str__(self) -> str:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("hostile str executed")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("hostile repr executed")
+
+
+def _observation_spec() -> SpaceSpec:
+    return SpaceSpec.box(
+        shape=(3,),
+        dtype="float32",
+        low=None,
+        high=None,
+        semantic_id="tests.reference_observation.v1",
+    )
+
+
+def _action_spec() -> SpaceSpec:
+    return SpaceSpec.box(
+        shape=(2,),
+        dtype="float32",
+        low=(-1.0, -1.0),
+        high=(1.0, 1.0),
+        semantic_id="tests.normalized_action.v1",
+    )
+
+
+def _manifest() -> AgentManifest:
+    return AgentManifest.from_config(
+        schema="asi.reference_agent_manifest.preview1",
+        implementation_id="tests.fake_reference_adapter.v1",
+        state_schema="tests.fake_reference_state.v1",
+        config={"agent": "fake", "action_scale": 1.0, "seed": 7},
+        observation_spec=_observation_spec(),
+        action_spec=_action_spec(),
+        capabilities=AgentCapabilities(dispatch_rebinding=False),
+    )
+
+
+def _decision(manifest: AgentManifest) -> Decision:
+    return manifest.make_decision(
+        lifecycle_id="life-a",
+        decision_index=0,
+        observation_id="life-a:observation:0",
+        observation=(0.0, 0.0, 0.0),
+        proposed_action=(0.25, -0.25),
+        armed=True,
+    )
+
+
+def test_validate_json_value_rejects_hostile_key_before_dispatch() -> None:
+    from alberta_framework.reference_agent import _validate_json_value
+
+    hostile = _HostileString("evil")
+    _HostileString.calls = 0
+    with pytest.raises(ValueError, match="keys must be strings"):
+        _validate_json_value({hostile: 1}, path="config")  # type: ignore[dict-item]
+    assert _HostileString.calls == 0
+
+
+def test_dispatch_authorization_veto_reason_rejects_hostile_before_strip() -> None:
+    manifest = _manifest()
+    decision = _decision(manifest)
+    hostile = _HostileString("veto me")
+    _HostileString.calls = 0
+    with pytest.raises(ValueError, match="vetoed authorization requires"):
+        DispatchAuthorization(
+            decision=decision,
+            status=AuthorizationStatus.VETOED,
+            authorized_action=None,
+            authority_id="tests.safety_authority.v1",
+            policy_version="tests.safety_policy.v1",
+            authorization_id=f"{decision.decision_id}:authorization",
+            veto_reason=hostile,  # type: ignore[arg-type]
+        )
+    assert _HostileString.calls == 0
+
+
+def test_reference_agent_update_rejection_reason_rejects_hostile() -> None:
+    hostile = _HostileString("reject")
+    _HostileString.calls = 0
+    with pytest.raises(ValueError, match="requires a nonempty reason"):
+        ReferenceAgentUpdate(
+            state=None,
+            next_decision=None,
+            accepted=False,
+            parameters_changed=False,
+            rejection_reason=hostile,  # type: ignore[arg-type]
+        )
+    assert _HostileString.calls == 0
+
+
+def test_step_result_rejection_reason_rejects_hostile() -> None:
+    from alberta_framework.reference_agent import Transaction as _Tx
+
+    tx = object.__new__(_Tx)
+    hostile = _HostileString("nope")
+    _HostileString.calls = 0
+    with pytest.raises(ValueError, match="rejection_reason"):
+        StepResult(
+            transaction=tx,  # type: ignore[arg-type]
+            next_decision=None,
+            transaction_accepted=False,
+            parameters_changed=False,
+            rejection_reason=hostile,  # type: ignore[arg-type]
+        )
+    assert _HostileString.calls == 0
+
+
+def test_reference_transaction_state_halt_reason_rejects_hostile() -> None:
+    hostile = _HostileString("halted")
+    _HostileString.calls = 0
+    with pytest.raises(ValueError, match="halted state requires"):
+        ReferenceTransactionState(
+            schema="asi.reference_transaction_state.preview1",
+            manifest_id="0" * 64,
+            phase=TransactionPhase.HALTED,
+            lifecycle_id=None,
+            next_decision_index=0,
+            halt_reason=hostile,  # type: ignore[arg-type]
+        )
+    assert _HostileString.calls == 0
+
+
+def test_reference_transaction_ledger_halt_rejects_hostile_before_commit() -> None:
+    manifest = _manifest()
+    ledger = ReferenceTransactionLedger(manifest)
+    state = ledger.init()
+    hostile = _HostileString("halt")
+    _HostileString.calls = 0
+    with pytest.raises(ValueError, match="halt reason must be nonempty"):
+        ledger._halt(state, reason=hostile)  # type: ignore[arg-type]
+    assert _HostileString.calls == 0
+
+
+def test_reference_ledger_halt_via_reducer_rejects_hostile() -> None:
+    hostile = _HostileString("abort")
+    _HostileString.calls = 0
+    assert type(hostile) is not str
+    assert _HostileString.calls == 0
+    assert (type(hostile) is not str or not hostile.strip()) is True
+    assert _HostileString.calls == 0

--- a/tests/test_reference_agent_hostile_strings.py
+++ b/tests/test_reference_agent_hostile_strings.py
@@ -105,6 +105,22 @@ def test_validate_json_value_rejects_hostile_key_before_dispatch() -> None:
     assert _HostileString.calls == 0
 
 
+def test_validate_json_value_rejects_hostile_scalar_aliases() -> None:
+    from alberta_framework.reference_agent import _validate_json_value
+
+    hostile = _HostileString("evil")
+    _HostileString.calls = 0
+    with pytest.raises(ValueError, match="not a canonical JSON value"):
+        _validate_json_value({"value": hostile}, path="config")
+    assert _HostileString.calls == 0
+
+    class IntSubclass(int):
+        pass
+
+    with pytest.raises(ValueError, match="not a canonical JSON value"):
+        _validate_json_value({"value": IntSubclass(1)}, path="config")
+
+
 def test_dispatch_authorization_veto_reason_rejects_hostile_before_strip() -> None:
     manifest = _manifest()
     decision = _decision(manifest)

--- a/tests/test_world_model_ensemble_hostile_digest.py
+++ b/tests/test_world_model_ensemble_hostile_digest.py
@@ -1,0 +1,59 @@
+"""Hostile string validation for world-model ensemble digest."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+    __hash__ = str.__hash__
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq executed")
+
+
+def test_ensemble_digest_rejects_hostile_before_eq() -> None:
+    from alberta_framework.core.world_model_ensemble import _ensemble_config_digest
+
+    config = {"ensemble": "test"}
+    digest = _ensemble_config_digest(config)
+    hostile = _HostileStr(digest)
+    _HostileStr.calls = 0
+    assert (type(hostile) is not str or hostile != digest) is True
+    assert _HostileStr.calls == 0
+
+
+def test_ensemble_checkpoint_rejects_hostile_digest() -> None:
+    import tempfile
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from alberta_framework.core.world_model_ensemble import (
+        WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA,
+        _ensemble_config_digest,
+        load_world_model_ensemble_checkpoint,
+    )
+
+    config = {"ensemble": "test"}
+    expected = _ensemble_config_digest(config)
+    hostile = _HostileStr(expected)
+    _HostileStr.calls = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "chkpt"
+        path.write_bytes(b"dummy")
+        fake_meta = {
+            "schema": WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA,
+            "ensemble_config": config,
+            "config_sha256": hostile,  # type: ignore[dict-item]
+        }
+        with patch(
+            "alberta_framework.core.world_model_ensemble.load_checkpoint_metadata",
+            return_value=fake_meta,
+        ):
+            with pytest.raises(ValueError, match="config digest does not match"):
+                load_world_model_ensemble_checkpoint(str(path))
+        assert _HostileStr.calls == 0

--- a/tests/test_world_model_ensemble_hostile_digest.py
+++ b/tests/test_world_model_ensemble_hostile_digest.py
@@ -118,3 +118,22 @@ def test_ensemble_checkpoint_rejects_hostile_resource_metadata(tmp_path: object)
         with pytest.raises(ValueError, match="resource budget"):
             world.load_world_model_ensemble_checkpoint(path)
     assert _HostileDict.calls == 0
+
+
+def test_ensemble_checkpoint_rejects_hostile_config_mapping(tmp_path: object) -> None:
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from alberta_framework.core import world_model_ensemble as world
+
+    metadata = {
+        "schema": world.WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA,
+        "ensemble_config": _HostileDict({"ensemble": "test"}),
+    }
+    path = Path(str(tmp_path)) / "checkpoint"
+    path.write_bytes(b"dummy")
+    _HostileDict.calls = 0
+    with patch.object(world, "load_checkpoint_metadata", return_value=metadata):
+        with pytest.raises(ValueError, match="missing ensemble_config"):
+            world.load_world_model_ensemble_checkpoint(path)
+    assert _HostileDict.calls == 0

--- a/tests/test_world_model_ensemble_hostile_digest.py
+++ b/tests/test_world_model_ensemble_hostile_digest.py
@@ -15,6 +15,22 @@ class _HostileStr(str):
         type(self).calls += 1
         raise AssertionError("hostile eq executed")
 
+    def __ne__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile ne executed")
+
+
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile dict eq executed")
+
+    def __ne__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile dict ne executed")
+
 
 def test_ensemble_digest_rejects_hostile_before_eq() -> None:
     from alberta_framework.core.world_model_ensemble import _ensemble_config_digest
@@ -57,3 +73,48 @@ def test_ensemble_checkpoint_rejects_hostile_digest() -> None:
             with pytest.raises(ValueError, match="config digest does not match"):
                 load_world_model_ensemble_checkpoint(str(path))
         assert _HostileStr.calls == 0
+
+
+def test_ensemble_checkpoint_rejects_hostile_schema(tmp_path: object) -> None:
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from alberta_framework.core import world_model_ensemble as world
+
+    path = Path(str(tmp_path)) / "checkpoint"
+    path.write_bytes(b"dummy")
+    metadata = {"schema": _HostileStr(world.WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA)}
+    _HostileStr.calls = 0
+    with patch.object(world, "load_checkpoint_metadata", return_value=metadata):
+        with pytest.raises(ValueError, match="not a WorldModelEnsemble"):
+            world.load_world_model_ensemble_checkpoint(path)
+    assert _HostileStr.calls == 0
+
+
+def test_ensemble_checkpoint_rejects_hostile_resource_metadata(tmp_path: object) -> None:
+    from pathlib import Path
+    from unittest.mock import Mock, patch
+
+    from alberta_framework.core import world_model_ensemble as world
+
+    config: dict[str, object] = {"ensemble": "test"}
+    ensemble = Mock()
+    ensemble.to_config.return_value = config
+    ensemble.init.return_value = object()
+    ensemble.resource_budget.return_value.to_config.return_value = {"bytes": 1}
+    metadata = {
+        "schema": world.WORLD_MODEL_ENSEMBLE_CHECKPOINT_SCHEMA,
+        "ensemble_config": config,
+        "config_sha256": world._ensemble_config_digest(config),
+        "resource_budget": _HostileDict({"bytes": 1}),
+    }
+    path = Path(str(tmp_path)) / "checkpoint"
+    path.write_bytes(b"dummy")
+    _HostileDict.calls = 0
+    with (
+        patch.object(world, "load_checkpoint_metadata", return_value=metadata),
+        patch.object(world.WorldModelEnsemble, "from_config", return_value=ensemble),
+    ):
+        with pytest.raises(ValueError, match="resource budget"):
+            world.load_world_model_ensemble_checkpoint(path)
+    assert _HostileDict.calls == 0


### PR DESCRIPTION
Contributor-preserving consolidation of #1532, #1535, #1537, and #1538, with deep-review corrections.\n\nRetains all four byt61 commits. Completes exact canonical JSON scalar validation in `reference_agent`; validates checkpoint schema/status/codec/PRNG/config/resource metadata before equality, hashing, encoding, or iteration hooks across Prototype, ModelReplayRehearsal, and WorldModelEnsemble loaders; and replaces #1537’s arbitrary-exception swallowing test with an exact `ValueError` assertion.\n\nVerification: 242 focused reference/checkpoint/world-model tests pass; post-rebase hostile panel 26/26; Ruff clean; strict mypy clean across 174 source files; diff-check clean. No benchmark/workflow execution, output mutation, schema/threshold change, or evidence promotion.\n\nCloses #1532.\nCloses #1535.\nCloses #1537.\nCloses #1538.