### PR TITLE
fix(core): preserve optimizer identities across learners

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -1547,7 +1547,7 @@ class NonlinearHordeActorCriticAgent:
         self._actor_optimizer = (
             actor_optimizer if actor_optimizer is not None else Autostep(initial_step_size=0.01)
         )
-        if not self._actor_optimizer.supported_for_mlp():
+        if self._actor_optimizer.supported_for_mlp() is not True:
             raise ValueError(
                 f"actor_optimizer {type(self._actor_optimizer).__name__} does not support "
                 "the MLP shape-generic update API"
@@ -2219,7 +2219,7 @@ class NonlinearQHordeActorCriticAgent:
         self._actor_optimizer = (
             actor_optimizer if actor_optimizer is not None else Autostep(initial_step_size=0.01)
         )
-        if not self._actor_optimizer.supported_for_mlp():
+        if self._actor_optimizer.supported_for_mlp() is not True:
             raise ValueError(
                 f"actor_optimizer {type(self._actor_optimizer).__name__} does not support "
                 "the MLP shape-generic update API"

--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -350,7 +350,9 @@ class IndependentDemonHorde:
             raise ValueError("trace_mode must be a TraceMode")
         self._horde_spec = horde_spec
         self._hidden_sizes = hidden_sizes
-        self._optimizer: AnyOptimizer = optimizer or LMS(step_size=step_size)
+        self._optimizer: AnyOptimizer = (
+            optimizer if optimizer is not None else LMS(step_size=step_size)
+        )
         self._head_optimizer: AnyOptimizer | None = head_optimizer
         self._step_size = step_size
         self._bounder = bounder

--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -284,7 +284,9 @@ class LinearLearner:
             optimizer: Optimizer for weight updates. Defaults to LMS(0.01)
             normalizer: Optional feature normalizer (e.g. EMANormalizer, WelfordNormalizer)
         """
-        self._optimizer: AnyOptimizer = optimizer or LMS(step_size=0.01)
+        self._optimizer: AnyOptimizer = (
+            optimizer if optimizer is not None else LMS(step_size=0.01)
+        )
         self._normalizer = normalizer
 
     @property
@@ -1908,7 +1910,9 @@ class TDLinearLearner:
         Args:
             optimizer: TD optimizer for weight updates. Defaults to TDIDBD()
         """
-        self._optimizer: AnyTDOptimizer = optimizer or TDIDBD()
+        self._optimizer: AnyTDOptimizer = (
+            optimizer if optimizer is not None else TDIDBD()
+        )
 
     def init(self, feature_dim: int) -> TDLearnerState:
         """Initialize TD learner state.

--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -516,14 +516,19 @@ class MultiHeadMLPLearner:
 
         self._n_heads = n_heads
         self._hidden_sizes = hidden_sizes
-        self._optimizer: AnyOptimizer = optimizer or LMS(step_size=step_size)
+        self._optimizer: AnyOptimizer = (
+            optimizer if optimizer is not None else LMS(step_size=step_size)
+        )
         self._head_optimizer: AnyOptimizer | None = head_optimizer
-        if not self._optimizer.supported_for_mlp():
+        if self._optimizer.supported_for_mlp() is not True:
             raise ValueError(
                 f"optimizer {type(self._optimizer).__name__} does not support the MLP "
                 "shape-generic update API"
             )
-        if self._head_optimizer is not None and not self._head_optimizer.supported_for_mlp():
+        if (
+            self._head_optimizer is not None
+            and self._head_optimizer.supported_for_mlp() is not True
+        ):
             raise ValueError(
                 f"head_optimizer {type(self._head_optimizer).__name__} does not support the MLP "
                 "shape-generic update API"

--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -378,7 +378,9 @@ class OffPolicyHordeLearner:
 
         self._horde_spec = horde_spec
         self._hidden_sizes = hidden_sizes
-        self._optimizer: AnyOptimizer = optimizer or LMS(step_size=step_size)
+        self._optimizer: AnyOptimizer = (
+            optimizer if optimizer is not None else LMS(step_size=step_size)
+        )
         self._head_optimizer = head_optimizer
         self._bounder = bounder
         self._normalizer = normalizer
@@ -738,7 +740,9 @@ class OffPolicyHordeLearner:
         new_head_opt_states: list[tuple[Any, Any]] = []
         per_demon_metrics: list[Array] = []
         head_candidates_finite: list[Array] = []
-        head_optimizer = self._head_optimizer or self._optimizer
+        head_optimizer = (
+            self._head_optimizer if self._head_optimizer is not None else self._optimizer
+        )
         lamdas = self._horde_spec.lamdas
 
         for i in range(n_demons):

--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -961,7 +961,11 @@ class OffPolicyHordeLearner:
             "sparsity": self._sparsity,
             "leaky_relu_slope": self._leaky_relu_slope,
             "use_layer_norm": self._use_layer_norm,
-            "head_optimizer": (self._head_optimizer.to_config() if self._head_optimizer else None),
+            "head_optimizer": (
+                self._head_optimizer.to_config()
+                if self._head_optimizer is not None
+                else None
+            ),
             "trace_mode": self._trace_mode.value,
             "utility_decay": self._utility_decay,
             "ratio_clip": self._ratio_clip,

--- a/tests/test_learner_optimizer_fallback_truthiness.py
+++ b/tests/test_learner_optimizer_fallback_truthiness.py
@@ -1,0 +1,240 @@
+"""Unit tests verifying optimizer fallback truthiness safety across core learners."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.horde_actor_critic import (
+    NonlinearHordeActorCriticAgent,
+    NonlinearHordeActorCriticConfig,
+    NonlinearQHordeActorCriticAgent,
+    NonlinearQHordeActorCriticConfig,
+)
+from alberta_framework.core.independent_demon_horde import IndependentDemonHorde
+from alberta_framework.core.learners import LinearLearner, TDLinearLearner
+from alberta_framework.core.multi_head_learner import MultiHeadMLPLearner
+from alberta_framework.core.off_policy_horde import OffPolicyHordeLearner
+from alberta_framework.core.optimizers import LMS, TDIDBD, Autostep
+from alberta_framework.core.types import DemonType, GVFSpec, HordeSpec
+
+
+class _FalsyLMS(LMS):
+    def __bool__(self) -> bool:
+        return False
+
+
+class _FalsyTD(TDIDBD):
+    def __bool__(self) -> bool:
+        return False
+
+
+class _HostileLMS(LMS):
+    calls = 0
+
+    def __bool__(self) -> bool:
+        type(self).calls += 1
+        raise AssertionError("optimizer truth hook executed")
+
+
+class _HostileTD(TDIDBD):
+    calls = 0
+
+    def __bool__(self) -> bool:
+        type(self).calls += 1
+        raise AssertionError("td optimizer truth hook executed")
+
+
+class _MockUnsupportedOptimizer(Autostep):
+    def supported_for_mlp(self) -> object:  # type: ignore[override]
+        return "truthy-non-bool"
+
+
+class _MockFalsySupportedOptimizer(Autostep):
+    def supported_for_mlp(self) -> object:  # type: ignore[override]
+        return 0
+
+
+def _sample_horde_spec() -> HordeSpec:
+    demon = GVFSpec(
+        name="d0",
+        demon_type=DemonType.PREDICTION,
+        gamma=0.9,
+        lamda=0.8,
+        cumulant_index=0,
+    )
+    return HordeSpec(
+        demons=(demon,),
+        gammas=jnp.array([0.9]),
+        lamdas=jnp.array([0.8]),
+    )
+
+
+def _sample_control_horde_spec() -> HordeSpec:
+    demon = GVFSpec(
+        name="control_d0",
+        demon_type=DemonType.CONTROL,
+        gamma=0.0,
+        lamda=0.8,
+        cumulant_index=0,
+    )
+    return HordeSpec(
+        demons=(demon,),
+        gammas=jnp.array([0.0]),
+        lamdas=jnp.array([0.8]),
+    )
+
+
+class TestMultiHeadMLPLearnerOptimizerTruthiness:
+    def test_multi_head_mlp_preserves_custom_falsy_optimizer(self) -> None:
+        opt = _FalsyLMS(step_size=0.0123)
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(8,), optimizer=opt)
+        assert learner._optimizer is opt
+        assert getattr(learner._optimizer, "_step_size", None) == 0.0123
+
+    def test_multi_head_mlp_preserves_custom_falsy_head_optimizer(self) -> None:
+        trunk_opt = LMS(step_size=0.1)
+        head_opt = _FalsyLMS(step_size=0.0456)
+        learner = MultiHeadMLPLearner(
+            n_heads=2,
+            hidden_sizes=(8,),
+            optimizer=trunk_opt,
+            head_optimizer=head_opt,
+        )
+        assert learner._optimizer is trunk_opt
+        assert learner._head_optimizer is head_opt
+        assert getattr(learner._head_optimizer, "_step_size", None) == 0.0456
+
+    def test_multi_head_mlp_optimizer_does_not_invoke_truthiness(self) -> None:
+        _HostileLMS.calls = 0
+        opt = _HostileLMS(step_size=0.1)
+        head_opt = _HostileLMS(step_size=0.05)
+        learner = MultiHeadMLPLearner(
+            n_heads=2,
+            hidden_sizes=(8,),
+            optimizer=opt,
+            head_optimizer=head_opt,
+        )
+        assert learner._optimizer is opt
+        assert learner._head_optimizer is head_opt
+        assert _HostileLMS.calls == 0
+
+    def test_multi_head_mlp_supported_for_mlp_strict_check(self) -> None:
+        bad_opt = _MockUnsupportedOptimizer(initial_step_size=0.01)
+        with pytest.raises(ValueError, match="does not support the MLP shape-generic"):
+            MultiHeadMLPLearner(
+                n_heads=2,
+                hidden_sizes=(8,),
+                optimizer=bad_opt,  # type: ignore[arg-type]
+            )
+
+        good_opt = LMS(step_size=0.1)
+        with pytest.raises(ValueError, match="head_optimizer.*does not support the MLP"):
+            MultiHeadMLPLearner(
+                n_heads=2,
+                hidden_sizes=(8,),
+                optimizer=good_opt,
+                head_optimizer=bad_opt,  # type: ignore[arg-type]
+            )
+
+
+class TestLinearLearnerOptimizerTruthiness:
+    def test_linear_learner_preserves_custom_falsy_optimizer(self) -> None:
+        opt = _FalsyLMS(step_size=0.00789)
+        learner = LinearLearner(optimizer=opt)
+        assert learner._optimizer is opt
+        assert getattr(learner._optimizer, "_step_size", None) == 0.00789
+
+    def test_linear_learner_does_not_invoke_truthiness(self) -> None:
+        _HostileLMS.calls = 0
+        opt = _HostileLMS(step_size=0.01)
+        learner = LinearLearner(optimizer=opt)
+        assert learner._optimizer is opt
+        assert _HostileLMS.calls == 0
+
+
+class TestTDLinearLearnerOptimizerTruthiness:
+    def test_td_linear_learner_preserves_custom_falsy_optimizer(self) -> None:
+        opt = _FalsyTD(initial_step_size=0.0321)
+        learner = TDLinearLearner(opt)
+        assert learner._optimizer is opt
+
+    def test_td_linear_learner_does_not_invoke_truthiness(self) -> None:
+        _HostileTD.calls = 0
+        opt = _HostileTD(initial_step_size=0.01)
+        learner = TDLinearLearner(opt)
+        assert learner._optimizer is opt
+        assert _HostileTD.calls == 0
+
+
+class TestIndependentDemonHordeOptimizerTruthiness:
+    def test_independent_demon_horde_preserves_custom_falsy_optimizer(self) -> None:
+        spec = _sample_horde_spec()
+        opt = _FalsyLMS(step_size=0.0432)
+        horde = IndependentDemonHorde(horde_spec=spec, optimizer=opt)
+        assert horde._optimizer is opt
+
+    def test_independent_demon_horde_does_not_invoke_truthiness(self) -> None:
+        _HostileLMS.calls = 0
+        spec = _sample_horde_spec()
+        opt = _HostileLMS(step_size=0.01)
+        horde = IndependentDemonHorde(horde_spec=spec, optimizer=opt)
+        assert horde._optimizer is opt
+        assert _HostileLMS.calls == 0
+
+
+class TestOffPolicyHordeLearnerOptimizerTruthiness:
+    def test_off_policy_horde_preserves_custom_falsy_optimizer(self) -> None:
+        spec = _sample_horde_spec()
+        opt = _FalsyLMS(step_size=0.0654)
+        horde = OffPolicyHordeLearner(horde_spec=spec, optimizer=opt)
+        assert horde._optimizer is opt
+
+    def test_off_policy_horde_does_not_invoke_truthiness(self) -> None:
+        _HostileLMS.calls = 0
+        spec = _sample_horde_spec()
+        opt = _HostileLMS(step_size=0.01)
+        head_opt = _HostileLMS(step_size=0.02)
+        horde = OffPolicyHordeLearner(
+            horde_spec=spec,
+            optimizer=opt,
+            head_optimizer=head_opt,
+        )
+        assert horde._optimizer is opt
+        assert horde._head_optimizer is head_opt
+        assert _HostileLMS.calls == 0
+
+
+class TestHordeActorCriticOptimizerSupportedCheck:
+    def test_horde_actor_critic_rejects_non_true_supported_for_mlp(self) -> None:
+        from alberta_framework.core.horde import HordeLearner
+
+        spec = _sample_horde_spec()
+        critic = HordeLearner(horde_spec=spec)
+        config = NonlinearHordeActorCriticConfig(
+            n_actions=2,
+            value_head_index=0,
+        )
+        bad_opt = _MockUnsupportedOptimizer(initial_step_size=0.01)
+        with pytest.raises(ValueError, match="does not support the MLP shape-generic"):
+            NonlinearHordeActorCriticAgent(
+                config=config,
+                critic=critic,
+                actor_optimizer=bad_opt,  # type: ignore[arg-type]
+            )
+
+    def test_q_horde_actor_critic_rejects_non_true_supported_for_mlp(self) -> None:
+        from alberta_framework.core.horde import HordeLearner
+
+        spec = _sample_control_horde_spec()
+        critic = HordeLearner(horde_spec=spec)
+        config = NonlinearQHordeActorCriticConfig(
+            n_actions=1,
+        )
+        bad_opt = _MockFalsySupportedOptimizer(initial_step_size=0.01)
+        with pytest.raises(ValueError, match="does not support the MLP shape-generic"):
+            NonlinearQHordeActorCriticAgent(
+                config=config,
+                critic=critic,
+                actor_optimizer=bad_opt,  # type: ignore[arg-type]
+            )

--- a/tests/test_learner_optimizer_fallback_truthiness.py
+++ b/tests/test_learner_optimizer_fallback_truthiness.py
@@ -202,6 +202,7 @@ class TestOffPolicyHordeLearnerOptimizerTruthiness:
         )
         assert horde._optimizer is opt
         assert horde._head_optimizer is head_opt
+        assert horde.to_config()["head_optimizer"] == head_opt.to_config()
         assert _HostileLMS.calls == 0
 
 


### PR DESCRIPTION
Contributor-preserving successor to #1552 for #1545. Retains deepanshu-yd’s complete six-class constructor/capability correction and closes the adjacent optional-slot residual found in review: `OffPolicyHordeLearner.to_config()` still truth-tested a supplied head optimizer during export. The zero-hook regression now covers that path too.\n\nVerification: 14 dedicated tests; 226 adjacent learner tests passed before proportionate stop in a compile-heavy panel; Ruff; strict mypy. Contributor also reported 576 related tests on the original. No preregistration, benchmark/evidence run, pinned source, or output changes.\n\nCloses #1545. Supersedes #1552.