### PR TITLE
fix(core): preserve optimizer config identities

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -1592,8 +1592,9 @@ class NonlinearHordeActorCriticAgent:
         cfg = dict(cfg)
         cfg.pop("type", None)
         actor_opt: Autostep | None = None
-        if cfg.get("actor_optimizer"):
-            actor_opt = cast(Autostep, optimizer_from_config(cfg["actor_optimizer"]))
+        actor_optimizer_cfg = cfg.get("actor_optimizer")
+        if actor_optimizer_cfg is not None:
+            actor_opt = cast(Autostep, optimizer_from_config(actor_optimizer_cfg))
         return cls(
             config=NonlinearHordeActorCriticConfig.from_config(cfg["config"]),
             critic=HordeLearner.from_config(cfg["critic"]),
@@ -2264,8 +2265,9 @@ class NonlinearQHordeActorCriticAgent:
         payload = dict(config)
         payload.pop("type", None)
         actor_opt: Autostep | None = None
-        if payload.get("actor_optimizer"):
-            actor_opt = cast(Autostep, optimizer_from_config(payload["actor_optimizer"]))
+        actor_optimizer_cfg = payload.get("actor_optimizer")
+        if actor_optimizer_cfg is not None:
+            actor_opt = cast(Autostep, optimizer_from_config(actor_optimizer_cfg))
         return cls(
             config=NonlinearQHordeActorCriticConfig.from_config(payload["config"]),
             critic=HordeLearner.from_config(payload["critic"]),

--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -991,7 +991,11 @@ class OffPolicyHordeLearner:
         normalizer_cfg = config.pop("normalizer", None)
         normalizer = normalizer_from_config(normalizer_cfg) if normalizer_cfg else None
         head_optimizer_cfg = config.pop("head_optimizer", None)
-        head_optimizer = optimizer_from_config(head_optimizer_cfg) if head_optimizer_cfg else None
+        head_optimizer = (
+            optimizer_from_config(head_optimizer_cfg)
+            if head_optimizer_cfg is not None
+            else None
+        )
         trace_mode = TraceMode(config.pop("trace_mode", TraceMode.ACCUMULATING.value))
 
         return cls(

--- a/tests/test_learner_optimizer_fallback_truthiness.py
+++ b/tests/test_learner_optimizer_fallback_truthiness.py
@@ -45,6 +45,14 @@ class _HostileTD(TDIDBD):
         raise AssertionError("td optimizer truth hook executed")
 
 
+class _HostileOptimizerConfig(dict[str, object]):
+    calls = 0
+
+    def __bool__(self) -> bool:
+        type(self).calls += 1
+        raise AssertionError("optimizer config truth hook executed")
+
+
 class _MockUnsupportedOptimizer(Autostep):
     def supported_for_mlp(self) -> object:  # type: ignore[override]
         return "truthy-non-bool"
@@ -205,6 +213,16 @@ class TestOffPolicyHordeLearnerOptimizerTruthiness:
         assert horde.to_config()["head_optimizer"] == head_opt.to_config()
         assert _HostileLMS.calls == 0
 
+    def test_off_policy_horde_config_adoption_does_not_invoke_truthiness(self) -> None:
+        payload = OffPolicyHordeLearner(_sample_horde_spec()).to_config()
+        payload["head_optimizer"] = _HostileOptimizerConfig(LMS(step_size=0.02).to_config())
+        _HostileOptimizerConfig.calls = 0
+
+        restored = OffPolicyHordeLearner.from_config(payload)
+
+        assert restored._head_optimizer is not None
+        assert _HostileOptimizerConfig.calls == 0
+
 
 class TestHordeActorCriticOptimizerSupportedCheck:
     def test_horde_actor_critic_rejects_non_true_supported_for_mlp(self) -> None:
@@ -239,3 +257,28 @@ class TestHordeActorCriticOptimizerSupportedCheck:
                 critic=critic,
                 actor_optimizer=bad_opt,  # type: ignore[arg-type]
             )
+
+    @pytest.mark.parametrize("q_control", (False, True))
+    def test_actor_optimizer_config_adoption_does_not_invoke_truthiness(
+        self, q_control: bool
+    ) -> None:
+        from alberta_framework.core.horde import HordeLearner
+
+        if q_control:
+            agent = NonlinearQHordeActorCriticAgent(
+                NonlinearQHordeActorCriticConfig(n_actions=1),
+                HordeLearner(_sample_control_horde_spec()),
+            )
+        else:
+            agent = NonlinearHordeActorCriticAgent(
+                NonlinearHordeActorCriticConfig(n_actions=2, value_head_index=0),
+                HordeLearner(_sample_horde_spec()),
+            )
+        payload = agent.to_config()
+        payload["actor_optimizer"] = _HostileOptimizerConfig(payload["actor_optimizer"])
+        _HostileOptimizerConfig.calls = 0
+
+        restored = type(agent).from_config(payload)
+
+        assert restored.actor_optimizer.to_config() == agent.actor_optimizer.to_config()
+        assert _HostileOptimizerConfig.calls == 0


### PR DESCRIPTION
Narrow current-main successor to #1554. #1553 already preserves deepanshu-yd’s constructor/capability work; this extracts the genuine residual from #1554 with its author preserved: off-policy Horde and both nonlinear Horde actor-critic restorers now distinguish only `None` from an explicitly supplied optimizer config, without invoking hostile truth hooks or silently treating `{}` as omission. Adds executable zero-hook coverage for all three adoption paths.\n\nVerification: 17 dedicated tests; Ruff; strict mypy. No #184 workflow/tag/comment/run changes and no output changes.\n\nSupersedes #1554.