### PR TITLE
ci: add macOS and Windows JAX portability lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,84 @@ jobs:
             --strict-config \
             --strict-markers
 
+  portability:
+    name: portability ${{ matrix.os }} py3.12
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up locked Python 3.12
+        uses: ./.github/actions/setup-locked-python
+        with:
+          python-version: "3.12"
+          extras: --extra dev
+
+      - name: Verify the portable JAX runtime
+        shell: bash
+        run: |
+          uv run --no-sync python - <<'PY'
+          import platform
+
+          import jax
+          import jax.numpy as jnp
+
+          @jax.jit
+          def update(weights, features):
+              prediction = jnp.dot(weights, features)
+              return weights + jnp.float32(0.1) * (jnp.float32(1.0) - prediction) * features
+
+          devices = jax.devices()
+          if jax.default_backend() != "cpu":
+              raise SystemExit(f"portable lane expected CPU JAX, got {jax.default_backend()}")
+          if not devices or any(device.platform != "cpu" for device in devices):
+              raise SystemExit(f"portable lane found unexpected JAX devices: {devices}")
+          result = update(jnp.zeros((3,), dtype=jnp.float32), jnp.ones((3,), dtype=jnp.float32))
+          if result.dtype != jnp.float32 or not bool(jnp.all(jnp.isfinite(result))):
+              raise SystemExit("portable JIT update did not produce finite float32 state")
+          print(platform.platform())
+          print(jax.__version__, devices)
+          PY
+
+      - name: Run cross-platform regression panel
+        shell: bash
+        run: |
+          uv run --no-sync python -m pytest \
+            tests/test_out_of_class_streams.py::TestFrequencyMismatchStream::test_frequency_bounds_narrow_the_original_real_once \
+            tests/test_out_of_class_streams.py::TestCompositionalStream::test_weight_scale_narrows_the_original_real_once \
+            tests/test_step11_production.py::test_step11_oak_validates_original_real_domain_before_narrowing \
+            tests/test_step11_production.py::test_step11_oak_narrows_the_original_real_once \
+            tests/test_step12_production.py::test_step12_narrows_original_real_directly_without_double_rounding \
+            tests/test_actor_critic.py::test_actor_critic_update_is_jittable \
+            tests/test_action_conditioned_world_model.py::test_action_conditioned_world_model_update_and_prediction_shapes \
+            -q \
+            -o addopts="" \
+            --strict-config \
+            --strict-markers
+
+      - name: Run installed model and benchmark smoke commands
+        shell: bash
+        run: |
+          uv run --no-sync alberta-step1-smoke --steps 16 --final-window 8 --seed 0
+          uv run --no-sync alberta-step2-smoke --steps 16 --final-window 8 --seed 0
+          uv run --no-sync asi-reference-life-scorecard --help
+          uv run --no-sync python - <<'PY'
+          from alberta_framework.benchmarks.reference_life_scorecard import (
+              build_development_plan,
+              iter_run_specs,
+          )
+
+          plan = build_development_plan()
+          specs = iter_run_specs(plan)
+          if len(specs) != 144:
+              raise SystemExit(f"expected 144 canonical scorecard shards, got {len(specs)}")
+          print(plan.plan_sha256, len(specs))
+          PY
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -316,7 +394,7 @@ jobs:
   # dynamic job names, so merge gating requires this single context instead.
   ci-ok:
     if: always()
-    needs: [package, robot-floor, lint, test-plan, test]
+    needs: [package, robot-floor, portability, lint, test-plan, test]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -745,15 +745,12 @@ class TestFrequencyMismatchStream:
         assert bool(jnp.all(state.omegas < expected_max))
 
     def test_frequency_bounds_narrow_the_original_real_once(self) -> None:
-        midpoint_plus = (
-            np.longdouble(1.0)
-            + np.longdouble(2.0) ** -24
-            + np.longdouble(2.0) ** -60
-        )
-        assert np.float32(midpoint_plus) != np.float32(float(midpoint_plus))
+        midpoint_plus = Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60)
+        directly_rounded = float(np.nextafter(np.float32(1.0), np.float32(2.0)))
+        assert directly_rounded != float(np.float32(float(midpoint_plus)))
 
         stream = FrequencyMismatchStream(omega_min=1.0, omega_max=midpoint_plus)
-        assert stream._omega_max == float(np.float32(midpoint_plus))  # noqa: SLF001
+        assert stream._omega_max == directly_rounded  # noqa: SLF001
 
     @pytest.mark.parametrize(
         ("omega_max", "expected"),
@@ -1020,15 +1017,12 @@ class TestCompositionalStream:
         assert state.outer_w.dtype == jnp.float32
 
     def test_weight_scale_narrows_the_original_real_once(self) -> None:
-        midpoint_plus = (
-            np.longdouble(1.0)
-            + np.longdouble(2.0) ** -24
-            + np.longdouble(2.0) ** -60
-        )
-        assert np.float32(midpoint_plus) != np.float32(float(midpoint_plus))
+        midpoint_plus = Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60)
+        directly_rounded = float(np.nextafter(np.float32(1.0), np.float32(2.0)))
+        assert directly_rounded != float(np.float32(float(midpoint_plus)))
 
         stream = CompositionalStream(weight_scale=midpoint_plus)
-        assert stream._weight_scale == float(np.float32(midpoint_plus))
+        assert stream._weight_scale == directly_rounded
 
     @pytest.mark.parametrize(
         ("offset", "expected"),

--- a/tests/test_step11_production.py
+++ b/tests/test_step11_production.py
@@ -474,8 +474,8 @@ def test_step11_oak_rejects_float32_overflow() -> None:
 
 
 def test_step11_oak_validates_original_real_domain_before_narrowing() -> None:
-    above_one = np.longdouble(1.0) + np.finfo(np.longdouble).eps
-    below_zero = -np.nextafter(np.longdouble(0.0), np.longdouble(1.0))
+    above_one = Fraction(2**53 + 1, 2**53)
+    below_zero = Fraction(-1, 10**400)
     assert float(above_one) == 1.0
     assert float(below_zero) == 0.0
 
@@ -491,20 +491,15 @@ def test_step11_oak_wraps_real_conversion_overflow() -> None:
 
 
 def test_step11_oak_narrows_the_original_real_once() -> None:
-    midpoint_plus = (
-        np.longdouble(1.0)
-        + np.longdouble(2.0) ** -24
-        + np.longdouble(2.0) ** -60
-    )
-    assert np.float32(midpoint_plus) != np.float32(float(midpoint_plus))
+    midpoint_plus = Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60)
+    directly_rounded = float(np.nextafter(np.float32(1.0), np.float32(2.0)))
+    assert directly_rounded != float(np.float32(float(midpoint_plus)))
     config = Step11OaKConfig(
         subtask_specs=(
             SubtaskSpec(feature_index=0, pseudo_reward_scale=midpoint_plus),
         ),
     )
-    assert config.subtask_specs[0].pseudo_reward_scale == float(
-        np.float32(midpoint_plus)
-    )
+    assert config.subtask_specs[0].pseudo_reward_scale == directly_rounded
 
 
 @pytest.mark.parametrize(

--- a/tests/test_step12_production.py
+++ b/tests/test_step12_production.py
@@ -617,12 +617,9 @@ def test_step12_wraps_real_conversion_overflow_as_config_error() -> None:
 
 
 def test_step12_narrows_original_real_directly_without_double_rounding() -> None:
-    midpoint_plus = (
-        np.longdouble(1.0)
-        + np.longdouble(2.0) ** -24
-        + np.longdouble(2.0) ** -60
-    )
-    assert np.float32(midpoint_plus) != np.float32(float(midpoint_plus))
+    midpoint_plus = Fraction(1, 1) + Fraction(1, 2**24) + Fraction(1, 2**60)
+    directly_rounded = float(np.nextafter(np.float32(1.0), np.float32(2.0)))
+    assert directly_rounded != float(np.float32(float(midpoint_plus)))
 
     config = _config_with(
         subtask_specs=(
@@ -630,9 +627,7 @@ def test_step12_narrows_original_real_directly_without_double_rounding() -> None
         )
     )
 
-    assert config.subtask_specs[0].pseudo_reward_scale == float(
-        np.float32(midpoint_plus)
-    )
+    assert config.subtask_specs[0].pseudo_reward_scale == directly_rounded
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add a locked Python 3.12 portability job on macOS 14 and Windows
- verify the JAX CPU backend, devices, float32 JIT execution, focused model tests, and installed smoke commands
- replace extended-precision-only test fixtures with exact rational inputs so float32 boundary checks are portable on Apple Silicon and Windows
- include the portability job in the single required `ci-ok` gate

## Platform scope

Official JAX supports CPU execution on macOS and experimental CPU execution on native Windows. NVIDIA CUDA execution remains Linux-only in the supported installation matrix; MLX interoperability is separate from the JAX backend. This lane makes those supported native paths explicit without claiming unavailable macOS JAX GPU acceleration.

## Validation

- Ruff passes on current main
- YAML parses and `ci-ok` depends on `portability`
- 9 focused portability and Step 7 regression tests pass
- local macOS JAX 0.11.0 CPU JIT run passes on Apple Silicon
- Step 1 and Step 2 installed smoke commands produce finite results
- canonical 144-shard reference-life scorecard plan builds successfully
- strict mypy passed before the final unrelated optimizer-only main update