### PR TITLE
docs(ipmnist): close reset ablation outcome

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -6341,14 +6341,6 @@ def _build_registry() -> dict[str, ScreeningSpec]:
             "rerun on the stable configuration)",
         ),
         (
-            "rls_head_resid_l1_noreset",
-            {"rls_lambda": 1.0, "rls_reset_frac": 2.0, "head_resid": 1.0},
-            "code-only issue-#184 endpoint: the standing residual-trained "
-            "incumbent with detector-driven covariance resets disabled; "
-            "this registry entry has no result artifact and does not "
-            "authorize execution",
-        ),
-        (
             "rls_head_resid_l1_preset005_nogate",
             {
                 "rls_lambda": 1.0,

--- a/docs/evidence/negative-results.md
+++ b/docs/evidence/negative-results.md
@@ -78,6 +78,22 @@ postmortem.
     replacing the readout. Record:
     [`summary_rls_head_confirm.json`](../../outputs/ipmnist_screening/summary_rls_head_confirm.json).
 
+12. **Detector-driven covariance reset is load-bearing for the selected
+    residual RLS head.** The permanently nonpromoting issue-#184 development
+    screen remeasured the reset incumbent and the otherwise identical no-reset
+    arm for seeds 0, 1, and 2. Candidate-minus-incumbent online-accuracy
+    differences were `[-0.008220, -0.007950, -0.008033]`; their mean was
+    `-0.00806778150000013` (standard error `0.00007982303614743532`). Every
+    seed was negative and the mean crossed the frozen `-0.002` threshold, so
+    the preregistered outcome is `reset_load_bearing`. The source was commit
+    `2f4f92afbdfea9f6b48144734f378b2af0987c60`, tree
+    `65b8390fd430149ddcca80ea8da75e1782ac8e3b`; GitHub Actions run
+    `32096417545` produced artifact `9310391499` (download SHA-256
+    `e15416fba53a3f1f408356da4748c3e19382447df17647c1a5c3de35ccf15ef8`).
+    The no-reset arm is retired from the live screening registry. This result
+    is development-only and cannot support scientific promotion. Record:
+    [`rls_preset_ablation_r1/`](../../outputs/ipmnist_screening/rls_preset_ablation_r1/).
+
 12. **Naive Bayes did not remove the post-permutation transient.** Its flat
     task-average curve hid poor early shifted-step performance, so ordinary
     voting added little. Resetting the member's annealing clock helped, but the

--- a/tests/test_ipmnist_local_prereg.py
+++ b/tests/test_ipmnist_local_prereg.py
@@ -8,8 +8,9 @@ import json
 import os
 import runpy
 import threading
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, cast
 
 import numpy as np
@@ -821,7 +822,9 @@ def _write_stage(
     dataset_provenance: dict[str, Any] | None = None,
     created_unix: float | None = None,
 ) -> Path:
+    import alberta_framework.benchmarks.ipmnist_screening as screening_module
     from alberta_framework.benchmarks.ipmnist_screening import (
+        SCREENING_REGISTRY,
         ScreeningRunResult,
         merge_shards,
         screening_spec,
@@ -830,6 +833,20 @@ def _write_stage(
     from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
 
     protocol = _PROTOCOLS[protocol_key]
+    historical_registry = None
+    if protocol_key == "issue184":
+        incumbent = screening_spec(protocol.control)
+        retired = replace(
+            incumbent,
+            name=protocol.candidate,
+            hyperparameters={
+                **incumbent.hyperparameters,
+                "rls_reset_frac": 2.0,
+            },
+        )
+        historical_registry = MappingProxyType(
+            {**SCREENING_REGISTRY, protocol.candidate: retired}
+        )
     stage = next(value for value in protocol.stages if value.key == stage_key)
     assert len(differences) == len(stage.seeds)
     dataset = _dataset_provenance() if dataset_provenance is None else dataset_provenance
@@ -851,7 +868,11 @@ def _write_stage(
             (protocol.control, 0.5),
             (protocol.candidate, 0.5 + difference),
         ):
-            spec = screening_spec(arm)
+            spec = (
+                historical_registry[arm]
+                if historical_registry is not None
+                else screening_spec(arm)
+            )
             result = ScreeningRunResult(
                 config_name=arm,
                 base_learner=spec.base_learner,
@@ -864,12 +885,19 @@ def _write_stage(
                 wall_clock_seconds=1.0,
             )
             path = shards_dir / f"{arm}_seed{seed}.json"
-            payload = shard_payload(
-                result,
-                source_provenance=_repository_identity()["source_provenance"],
-                dataset_provenance=dataset,
-                environment=_screening_environment(),
-            )
+            with pytest.MonkeyPatch.context() as registry_patch:
+                if historical_registry is not None:
+                    registry_patch.setattr(
+                        screening_module,
+                        "SCREENING_REGISTRY",
+                        historical_registry,
+                    )
+                payload = shard_payload(
+                    result,
+                    source_provenance=_repository_identity()["source_provenance"],
+                    dataset_provenance=dataset,
+                    environment=_screening_environment(),
+                )
             if created_unix is not None:
                 payload["created_unix"] = created_unix
             path.write_text(
@@ -879,11 +907,18 @@ def _write_stage(
     prior = Path.cwd()
     os.chdir(root)
     try:
-        summary = merge_shards(
-            [path.relative_to(root) for path in paths],
-            control_name=protocol.control,
-            slope_window=15,
-        )
+        with pytest.MonkeyPatch.context() as registry_patch:
+            if historical_registry is not None:
+                registry_patch.setattr(
+                    screening_module,
+                    "SCREENING_REGISTRY",
+                    historical_registry,
+                )
+            summary = merge_shards(
+                [path.relative_to(root) for path in paths],
+                control_name=protocol.control,
+                slope_window=15,
+            )
     finally:
         os.chdir(prior)
     summary_path = namespace / stage_name / "summary.json"
@@ -1114,16 +1149,49 @@ def _write_combined_summary(root: Path) -> Path:
 
 
 def _validate(root: Path, protocol_key: str) -> dict[str, Any]:
-    return cast(
-        dict[str, Any],
-        _validate_result_bundle(
-            protocol_key=protocol_key,
-            root=root,
-            repository_identity=_repository_identity(),
-            runner_receipt=_runner_receipt(),
-            verify_cache_file=False,
-        ),
+    if protocol_key != "issue184":
+        return cast(
+            dict[str, Any],
+            _validate_result_bundle(
+                protocol_key=protocol_key,
+                root=root,
+                repository_identity=_repository_identity(),
+                runner_receipt=_runner_receipt(),
+                verify_cache_file=False,
+            ),
+        )
+
+    import alberta_framework.benchmarks.ipmnist_screening as screening_module
+
+    protocol = _PROTOCOLS[protocol_key]
+    incumbent = screening_module.screening_spec(protocol.control)
+    retired = replace(
+        incumbent,
+        name=protocol.candidate,
+        hyperparameters={
+            **incumbent.hyperparameters,
+            "rls_reset_frac": 2.0,
+        },
     )
+    historical_registry = MappingProxyType(
+        {**screening_module.SCREENING_REGISTRY, protocol.candidate: retired}
+    )
+    with pytest.MonkeyPatch.context() as registry_patch:
+        registry_patch.setattr(
+            screening_module,
+            "SCREENING_REGISTRY",
+            historical_registry,
+        )
+        return cast(
+            dict[str, Any],
+            _validate_result_bundle(
+                protocol_key=protocol_key,
+                root=root,
+                repository_identity=_repository_identity(),
+                runner_receipt=_runner_receipt(),
+                verify_cache_file=False,
+            ),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -6,8 +6,9 @@ import json
 import runpy
 import urllib.request
 import zipfile
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, cast
 
 import numpy as np
@@ -1459,7 +1460,9 @@ def _write_protocol_bundle(
     protocol_key: str,
     candidate_accuracy: float,
 ) -> Path:
+    import alberta_framework.benchmarks.ipmnist_screening as screening_module
     from alberta_framework.benchmarks.ipmnist_screening import (
+        SCREENING_REGISTRY,
         ScreeningRunResult,
         merge_shards,
         screening_spec,
@@ -1468,6 +1471,21 @@ def _write_protocol_bundle(
     from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
 
     protocol = _PROTOCOLS[protocol_key]
+    if protocol_key == "issue184":
+        incumbent = screening_spec(protocol.control)
+        retired = replace(
+            incumbent,
+            name=protocol.candidate,
+            hyperparameters={
+                **incumbent.hyperparameters,
+                "rls_reset_frac": 2.0,
+            },
+        )
+        monkeypatch.setattr(
+            screening_module,
+            "SCREENING_REGISTRY",
+            MappingProxyType({**SCREENING_REGISTRY, protocol.candidate: retired}),
+        )
     namespace = root / "outputs" / "ipmnist_screening" / protocol.namespace
     shards_dir = namespace / "shards"
     shards_dir.mkdir(parents=True)

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -308,7 +308,6 @@ class TestRegistry:
             "rls_head_l1_preset003",
             "rls_head_l0999_pcap",
             "rls_head_resid_l1_preset005",
-            "rls_head_resid_l1_noreset",
             "rls_head_resid_l1_preset005_l2init",
             "rls_head_resid_l1_preset005_nogate",
             "rls_head_l0999_preset005_r01",
@@ -320,6 +319,11 @@ class TestRegistry:
         # Concurrent waves may register additional arms; this set must at
         # least be present (exact-set equality would race sibling lanes).
         assert expected <= set(SCREENING_REGISTRY)
+        assert "rls_head_resid_l1_noreset" not in SCREENING_REGISTRY
+
+    def test_concluded_noreset_arm_is_not_runnable(self):
+        with pytest.raises(ValueError, match="unknown screening config"):
+            screening_spec("rls_head_resid_l1_noreset")
 
     def test_unknown_config_rejected(self):
         with pytest.raises(ValueError, match="unknown screening config"):
@@ -5766,9 +5770,6 @@ class TestRLSHead:
             "rls_head_resid_l1_preset005": {
                 "rls_lambda": 1.0, "rls_reset_frac": 0.05, "head_resid": 1.0
             },
-            "rls_head_resid_l1_noreset": {
-                "rls_lambda": 1.0, "rls_reset_frac": 2.0, "head_resid": 1.0
-            },
             "rls_head_resid_l1_preset005_nogate": {
                 "rls_lambda": 1.0,
                 "rls_reset_frac": 0.05,
@@ -5827,145 +5828,6 @@ class TestRLSHead:
             "rls_head_resid_l1_preset005_nogate"
         ).hyperparameters
         assert nogate_hp == {**incumbent_hp, "gate_scale": 0.0}
-
-
-class TestRLSHeadNoReset:
-    """Issue #184's code-only detector-reset ablation endpoint."""
-
-    @staticmethod
-    def _assert_tree_equal(actual, expected):
-        actual_leaves, actual_tree = jax.tree_util.tree_flatten(actual)
-        expected_leaves, expected_tree = jax.tree_util.tree_flatten(expected)
-        assert actual_tree == expected_tree
-        assert len(actual_leaves) == len(expected_leaves)
-        for actual_leaf, expected_leaf in zip(actual_leaves, expected_leaves, strict=True):
-            np.testing.assert_array_equal(
-                np.asarray(actual_leaf), np.asarray(expected_leaf)
-            )
-
-    def test_registry_differs_from_incumbent_only_at_reset_fraction(self):
-        incumbent = screening_spec("rls_head_resid_l1_preset005")
-        candidate = screening_spec("rls_head_resid_l1_noreset")
-        assert candidate.base_learner == incumbent.base_learner == "upgd_w"
-        assert candidate.mechanism == incumbent.mechanism == "rls_readout"
-        assert candidate.factory is incumbent.factory
-        assert candidate.frozen_probe_input is incumbent.frozen_probe_input
-        assert candidate.noise_update is incumbent.noise_update is None
-        assert candidate.hyperparameters == {
-            **incumbent.hyperparameters,
-            "rls_reset_frac": 2.0,
-        }
-        assert {
-            name
-            for name in incumbent.hyperparameters
-            if incumbent.hyperparameters[name] != candidate.hyperparameters[name]
-        } == {"rls_reset_frac"}
-
-    @pytest.mark.parametrize("compiled", [False, True])
-    def test_pretrigger_trajectory_is_bitexact_incumbent(self, compiled):
-        incumbent = screening_spec("rls_head_resid_l1_preset005")
-        candidate = screening_spec("rls_head_resid_l1_noreset")
-        incumbent_init, incumbent_step = incumbent.factory(incumbent.hyperparameters)
-        candidate_init, candidate_step = candidate.factory(candidate.hyperparameters)
-        if compiled:
-            incumbent_step = jax.jit(incumbent_step)
-            candidate_step = jax.jit(candidate_step)
-
-        params = init_mlp_params(jr.key(184), SMALL)
-        incumbent_params = candidate_params = params
-        incumbent_state = incumbent_init(params)
-        candidate_state = candidate_init(params)
-        xs = [
-            jnp.linspace(0.05 * i, 0.05 * i + 0.3, SMALL.input_dim, dtype=jnp.float32)
-            for i in range(1, 7)
-        ]
-        ys = [jnp.array(i % SMALL.n_classes, jnp.int32) for i in range(6)]
-        for step, (x, y) in enumerate(zip(xs, ys)):
-            incumbent_out = incumbent_step(
-                incumbent_params, incumbent_state, x, y, jr.key(step)
-            )
-            candidate_out = candidate_step(
-                candidate_params, candidate_state, x, y, jr.key(step)
-            )
-            self._assert_tree_equal(candidate_out, incumbent_out)
-            incumbent_params, incumbent_state, _ = incumbent_out
-            candidate_params, candidate_state, _ = candidate_out
-
-    @pytest.mark.parametrize("compiled", [False, True])
-    def test_forced_trigger_resets_only_incumbent_covariance(self, compiled):
-        incumbent = screening_spec("rls_head_resid_l1_preset005")
-        candidate = screening_spec("rls_head_resid_l1_noreset")
-        incumbent_init, incumbent_step = incumbent.factory(incumbent.hyperparameters)
-        candidate_init, candidate_step = candidate.factory(candidate.hyperparameters)
-        if compiled:
-            incumbent_step = jax.jit(incumbent_step)
-            candidate_step = jax.jit(candidate_step)
-
-        params = init_mlp_params(jr.key(185), SMALL)
-        state = incumbent_init(params)
-        candidate_state = candidate_init(params)
-        self._assert_tree_equal(candidate_state, state)
-        mature = replace(
-            state,
-            norm=replace(
-                state.norm,
-                mean=jnp.zeros(SMALL.input_dim, jnp.float32),
-                var=jnp.full((SMALL.input_dim,), 1e-4, jnp.float32),
-                count=jnp.full((SMALL.input_dim,), 1000.0, jnp.float32),
-            ),
-            fast_mean=jnp.zeros(SMALL.input_dim, jnp.float32),
-        )
-        x_shift = jnp.full((SMALL.input_dim,), 10.0, jnp.float32)
-        y = jnp.array(2, jnp.int32)
-        incumbent_out = incumbent_step(params, mature, x_shift, y, jr.key(0))
-        candidate_out = candidate_step(params, mature, x_shift, y, jr.key(0))
-        incumbent_params, incumbent_state, incumbent_metrics = incumbent_out
-        candidate_params, candidate_state, candidate_metrics = candidate_out
-
-        self._assert_tree_equal(candidate_params, incumbent_params)
-        self._assert_tree_equal(candidate_metrics, incumbent_metrics)
-        np.testing.assert_array_equal(
-            np.asarray(candidate_state.wout), np.asarray(incumbent_state.wout)
-        )
-        ridge = incumbent.hyperparameters["rls_ridge_init"]
-        expected_reset = np.eye(mature.p.shape[0], dtype=np.float32) / ridge
-        np.testing.assert_array_equal(np.asarray(incumbent_state.p), expected_reset)
-        assert not np.array_equal(np.asarray(candidate_state.p), expected_reset)
-        assert not np.array_equal(np.asarray(candidate_state.p), np.asarray(mature.p))
-        assert np.any(np.asarray(candidate_state.wout))
-
-        x_norm, _, _, shifted = shift_adaptive_normalize(
-            mature.norm,
-            mature.fast_mean,
-            x_shift,
-            decay=incumbent.hyperparameters["norm_decay"],
-            fast_decay=incumbent.hyperparameters["fast_decay"],
-            epsilon=incumbent.hyperparameters["norm_epsilon"],
-            shift_k=incumbent.hyperparameters["shift_k"],
-            shift_delta=incumbent.hyperparameters["shift_delta"],
-            shift_refractory=incumbent.hyperparameters["shift_refractory"],
-        )
-        assert bool(jnp.all(shifted))
-        a1 = jax.nn.relu(x_norm @ params["w1"] + params["b1"])
-        a2 = jax.nn.relu(a1 @ params["w2"] + params["b2"])
-        phi = jnp.concatenate(
-            [
-                a2 / math.sqrt(SMALL.hidden2 + 1),
-                jnp.ones((1,), jnp.float32),
-            ]
-        )
-        pp = mature.p @ phi
-        gain = pp / (incumbent.hyperparameters["rls_lambda"] + phi @ pp)
-        expected_p = mature.p - jnp.outer(gain, pp)
-        expected_p = 0.5 * (expected_p + expected_p.T)
-        np.testing.assert_allclose(
-            np.asarray(candidate_state.p), np.asarray(expected_p), rtol=1e-6, atol=1e-7
-        )
-
-        for field in ("utility", "step", "norm", "fast_mean"):
-            self._assert_tree_equal(
-                getattr(candidate_state, field), getattr(incumbent_state, field)
-            )
 
 
 class TestRLSHeadL2Init:


### PR DESCRIPTION
Closes #184

Completes the frozen `reset_load_bearing` disposition after the successful, permanently nonpromoting development run and #1539 result integration.

- appends exact per-seed differences, mean/SE, source/tree, run, artifact, and archive digest to the negative-results ledger
- removes `rls_head_resid_l1_noreset` from the live screening registry and removes its endpoint-only behavior tests
- pins that the concluded arm is no longer runnable
- keeps historical prereg result-validation fixtures able to reconstruct the retired one-field delta without restoring a live registry entry
- leaves the sealed nine-file result namespace byte-untouched

Expected registered-source drift remains fail-closed; this PR does not rewrite evidence or outputs.

Verification on rebased main:
- 11 focused registry and GitHub/local result-reconstruction tests passed
- Ruff passed on changed source/tests
- strict mypy passed for `ipmnist_screening.py`
- `git diff --check` passed; output diff is empty

No benchmark was executed.