### PR TITLE
fix(evaluation): complete UPGD validation identities

### DIFF
--- a/alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/upgd_ipmnist_nonpromoting.py
@@ -229,14 +229,26 @@ class UPGDIPMNISTValidation:
     def __post_init__(self) -> None:
         if type(self.valid) is not bool:
             raise ValueError("valid must be a boolean")
-        if type(self.errors) is not tuple or not all(isinstance(e, str) for e in self.errors):
+        if type(self.errors) is not tuple or not all(type(e) is str for e in self.errors):
             raise ValueError("errors must be a tuple of strings")
-        if type(self.partial_sha256) is not tuple:
-            raise ValueError("partial_sha256 must be a tuple")
+        if type(self.partial_sha256) is not tuple or not all(
+            type(pair) is tuple
+            and len(pair) == 2
+            and type(pair[0]) is str
+            and type(pair[1]) is str
+            for pair in self.partial_sha256
+        ):
+            raise ValueError("partial_sha256 must be a tuple of exact string pairs")
         if self.artifact_sha256 is not None and type(self.artifact_sha256) is not str:
             raise ValueError("artifact_sha256 must be a string or None")
-        if type(self.observed_seed_pairs) is not tuple:
-            raise ValueError("observed_seed_pairs must be a tuple")
+        if type(self.observed_seed_pairs) is not tuple or not all(
+            type(pair) is tuple
+            and len(pair) == 2
+            and type(pair[0]) is str
+            and type(pair[1]) is int
+            for pair in self.observed_seed_pairs
+        ):
+            raise ValueError("observed_seed_pairs must be exact string/integer pairs")
         if self.development_only is not True:
             raise ValueError("development_only must permanently remain True")
         if self.scientific_promotion_allowed is not False:
@@ -930,7 +942,7 @@ def validate_upgd_ipmnist_v2_artifact(
     elif any(type(value) is not str or not value for value in environment.values()):
         errors.append("v2 artifact environment values must be non-empty strings")
     notes = artifact.get("notes")
-    if not isinstance(notes, list) or any(not isinstance(note, str) for note in notes):
+    if not isinstance(notes, list) or any(type(note) is not str for note in notes):
         errors.append("v2 artifact notes must be a list of strings")
 
     if partial_validation.valid:

--- a/tests/test_upgd_ipmnist_learner_hostile.py
+++ b/tests/test_upgd_ipmnist_learner_hostile.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+from alberta_framework.evaluation.upgd_ipmnist_nonpromoting import UPGDIPMNISTValidation
+
 pytestmark = pytest.mark.unit
 
 
@@ -73,4 +75,24 @@ def test_hostile_not_in_error_message() -> None:
         assert "!r" not in str(exc) or hostile not in str(exc)
         # ensure hostile string value not leaked via !r
         assert "evil" not in str(exc) or "must be" in str(exc)
+    assert _HostileStr.calls == 0
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    (
+        {"errors": (_HostileStr("error"),)},
+        {"partial_sha256": ((_HostileStr("partial.json"), "a" * 64),)},
+        {"partial_sha256": (("partial.json", _HostileStr("a" * 64)),)},
+        {"artifact_sha256": _HostileStr("a" * 64)},
+        {"observed_seed_pairs": ((_HostileStr("upgd_w"), 0),)},
+    ),
+)
+def test_validation_record_rejects_hostile_strings_without_hooks(
+    overrides: dict[str, object],
+) -> None:
+    _HostileStr.calls = 0
+    arguments: dict[str, object] = {"valid": False, "errors": (), **overrides}
+    with pytest.raises(ValueError):
+        UPGDIPMNISTValidation(**arguments)  # type: ignore[arg-type]
     assert _HostileStr.calls == 0


### PR DESCRIPTION
Corrective follow-up to merged byt61 #1555. The original learner/provenance/manifest gates are retained. Deep review closes adjacent validation-record and v2-note identity gaps: errors, artifact digests, partial digest pairs, observed learner/seed pairs, and notes now require exact built-in string identities before downstream use. Adds zero-hook regression coverage for every validation-record string position.\n\nVerification: 42 focused tests; Ruff; strict mypy. No benchmark/evidence execution or output changes.