### PR TITLE
feat(research): add bounded comparator protocol primitives

### DIFF
--- a/alberta_framework/evaluation/optimization_readiness.py
+++ b/alberta_framework/evaluation/optimization_readiness.py
@@ -1,0 +1,117 @@
+"""Prospective optimization-readiness diagnostic for development evaluation.
+
+The equations follow Wang et al., arXiv:2605.09044v1.  This module evaluates
+already-collected mini-batch gradients; it neither trains nor reads benchmark
+data, and therefore cannot itself create a performance result.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from types import MappingProxyType
+
+import numpy as np
+from numpy.typing import NDArray
+
+OPTIMIZATION_READINESS_PROTOCOL = MappingProxyType(
+    {
+        "schema": "asi.optimization-readiness.protocol.v1",
+        "paper_revision": "arXiv:2605.09044v1",
+        "paper_revision_date": "2026-05-09",
+        "diagnostics": (
+            "optimization_readiness",
+            "gradient_norm",
+            "representation_energy_rank_0.99",
+            "curvature_energy_rank_0.99",
+            "parameter_norm",
+        ),
+        "target": "future_relative_loss_reduction_after_matched_updates",
+        "matched_axes": ("seed", "updates", "observations", "mini_batch_size"),
+        "persistent_bytes_accounting_required": True,
+        "environment_steps_accounting_required": True,
+        "model_queries_accounting_required": True,
+        "timing_is_telemetry_only": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+)
+
+
+@dataclass(frozen=True)
+class OptimizationReadiness:
+    """Equation-level diagnostic values for one checkpoint/task pair."""
+
+    gradient_squared_norm: float
+    expected_batch_gradient_squared_norm: float
+    gradient_strength: float
+    gradient_reliability: float
+    optimization_readiness: float
+    gradient_norm: float
+    batch_count: int
+    parameter_count: int
+
+
+def _finite_matrix(value: object, *, name: str) -> NDArray[np.float64]:
+    raw = np.asarray(value)
+    if raw.ndim != 2 or raw.shape[0] < 1 or raw.shape[1] < 1:
+        raise ValueError(f"{name} must be a non-empty two-dimensional matrix")
+    if raw.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError(f"{name} must have a real numeric dtype")
+    resolved = np.asarray(raw, dtype=np.float64)
+    if not np.all(np.isfinite(resolved)):
+        raise ValueError(f"{name} must contain only finite values")
+    return resolved
+
+
+def estimate_optimization_readiness(
+    *, loss: float, batch_gradients: object, include_reliability: bool = True
+) -> OptimizationReadiness:
+    """Estimate OR from independent mini-batch gradient vectors.
+
+    The row mean estimates the population gradient.  The mean row squared norm
+    estimates the expected squared mini-batch-gradient norm.  Setting
+    ``include_reliability=False`` is the predeclared gradient-strength-only
+    mechanism-off reduction.
+    """
+    if type(loss) is not float and type(loss) is not int:
+        raise ValueError("loss must be a finite positive real number")
+    resolved_loss = float(loss)
+    if not math.isfinite(resolved_loss) or resolved_loss <= 0.0:
+        raise ValueError("loss must be a finite positive real number")
+    if type(include_reliability) is not bool:
+        raise ValueError("include_reliability must be a bool")
+    gradients = _finite_matrix(batch_gradients, name="batch_gradients")
+    mean_gradient = np.mean(gradients, axis=0)
+    gradient_squared_norm = float(np.dot(mean_gradient, mean_gradient))
+    expected_squared_norm = float(np.mean(np.sum(np.square(gradients), axis=1)))
+    strength = gradient_squared_norm / resolved_loss
+    reliability = (
+        gradient_squared_norm / expected_squared_norm if expected_squared_norm > 0.0 else 0.0
+    )
+    readiness = strength * reliability if include_reliability else strength
+    return OptimizationReadiness(
+        gradient_squared_norm=gradient_squared_norm,
+        expected_batch_gradient_squared_norm=expected_squared_norm,
+        gradient_strength=strength,
+        gradient_reliability=reliability,
+        optimization_readiness=readiness,
+        gradient_norm=math.sqrt(gradient_squared_norm),
+        batch_count=int(gradients.shape[0]),
+        parameter_count=int(gradients.shape[1]),
+    )
+
+
+def energy_rank(matrix: object, *, threshold: float = 0.99) -> int:
+    """Return the smallest singular-value count reaching squared-energy mass."""
+    if type(threshold) is not float:
+        raise ValueError("threshold must be a float in (0, 1]")
+    if not math.isfinite(threshold) or not 0.0 < threshold <= 1.0:
+        raise ValueError("threshold must be a float in (0, 1]")
+    resolved = _finite_matrix(matrix, name="matrix")
+    singular_values = np.linalg.svd(resolved, compute_uv=False)
+    squared = np.square(singular_values)
+    total = float(np.sum(squared))
+    if total == 0.0:
+        return 0
+    return int(np.searchsorted(np.cumsum(squared) / total, threshold, side="left") + 1)

--- a/tests/test_optimization_readiness.py
+++ b/tests/test_optimization_readiness.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.evaluation.optimization_readiness import (
+    OPTIMIZATION_READINESS_PROTOCOL,
+    energy_rank,
+    estimate_optimization_readiness,
+)
+
+
+def test_readiness_matches_paper_equations() -> None:
+    gradients = np.asarray([[1.0, 0.0], [3.0, 0.0]], dtype=np.float64)
+    report = estimate_optimization_readiness(loss=2.0, batch_gradients=gradients)
+    assert report.gradient_squared_norm == pytest.approx(4.0)
+    assert report.expected_batch_gradient_squared_norm == pytest.approx(5.0)
+    assert report.gradient_strength == pytest.approx(2.0)
+    assert report.gradient_reliability == pytest.approx(0.8)
+    assert report.optimization_readiness == pytest.approx(1.6)
+    assert report.gradient_norm == pytest.approx(2.0)
+
+
+def test_zero_and_mechanism_off_reductions() -> None:
+    zero = estimate_optimization_readiness(
+        loss=1.0, batch_gradients=np.zeros((2, 3), dtype=np.float64)
+    )
+    assert zero.optimization_readiness == 0.0
+    strength_only = estimate_optimization_readiness(
+        loss=2.0,
+        batch_gradients=np.asarray([[1.0], [3.0]]),
+        include_reliability=False,
+    )
+    assert strength_only.optimization_readiness == strength_only.gradient_strength
+
+
+def test_energy_rank_baseline() -> None:
+    matrix = np.diag([3.0, 1.0])
+    assert energy_rank(matrix, threshold=0.9) == 1
+    assert energy_rank(matrix, threshold=0.99) == 2
+    assert energy_rank(np.zeros((2, 2)), threshold=0.99) == 0
+
+
+@pytest.mark.parametrize("loss", [0.0, -1.0, float("nan"), True])
+def test_readiness_rejects_invalid_loss(loss: object) -> None:
+    with pytest.raises(ValueError, match="loss"):
+        estimate_optimization_readiness(  # type: ignore[arg-type]
+            loss=loss, batch_gradients=np.ones((2, 2))
+        )
+
+
+def test_protocol_is_prospective_and_nonpromoting() -> None:
+    assert OPTIMIZATION_READINESS_PROTOCOL["paper_revision"] == "arXiv:2605.09044v1"
+    assert OPTIMIZATION_READINESS_PROTOCOL["diagnostics"] == (
+        "optimization_readiness",
+        "gradient_norm",
+        "representation_energy_rank_0.99",
+        "curvature_energy_rank_0.99",
+        "parameter_norm",
+    )
+    assert OPTIMIZATION_READINESS_PROTOCOL["development_only"] is True
+    assert OPTIMIZATION_READINESS_PROTOCOL["scientific_promotion_allowed"] is False


### PR DESCRIPTION
Adds one consolidated, code-only prerequisite slice for #1568, #1569, #1570, #1571, #1572, #1573, and #1586. None of those issues is completed by this PR.

Included groundwork:
- exact optimization-readiness equations, strength-only reduction, and energy-rank baseline (#1568)
- deterministic gradual input/output/task-sampling transitions with abrupt reduction (#1569)
- BiMU Bernoulli/Bayesian equation primitives and distinct late-five-task metric (#1570)
- AdaLin ReLU/tanh equations with stop-gradient gating and alpha-zero reduction (#1571)
- small-matrix orthogonal, spectral-sign, and FLAD decomposition controls (#1572)
- replay/frozen-feature ceiling declarations with replay/pretraining/extractor costs charged (#1573)
- immutable diverse policy archive with complete retained-byte accounting plus one-model/fixed-snapshot controls (#1586)

All protocol declarations pin paper revisions, record material adaptation differences, predeclare matched axes and resource accounting, and permanently mark future measurements development-only/nonpromoting. No benchmark/scientific workload ran and no output artifact changed.

Remaining gate for every issue: audit/pin any reference code actually used; freeze configs, seeds, budgets, metrics, and report schema; obtain explicit execution authorization; run matched development workloads; retain negative results; publish validated reports. #1570 additionally needs the Concrete/Gumbel estimator/full binary network; #1573 needs method-specific model integration; #1572 needs complete algorithm adapters beyond equation primitives.

Validation on current main after the portability fix: 38 focused tests pass; scoped Ruff passes; strict mypy passes for all seven source modules; git diff check passes.