### PR TITLE
fix(benchmarks): close hostile Forager config containers

### DIFF
--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -1659,6 +1659,8 @@ def parse_forager_matrix_manifest(
 
 def load_forager_matrix_manifest(path: str | Path) -> ForagerMatrixManifest:
     """Load a UTF-8 strict JSON matrix manifest, rejecting duplicate keys."""
+    if type(path) not in (str, type(Path())):
+        raise ForagerMatrixManifestError("manifest path must be an exact string or Path")
     source = Path(path).expanduser()
     try:
         text = _read_regular_file_bytes(
@@ -1691,7 +1693,7 @@ def _json_safe(value: Any) -> Any:
         if not bool(np.isfinite(value)):
             raise ForagerMatrixError("matrix artifact identity is not finite JSON")
         return float(value)
-    if isinstance(value, Path):
+    if type(value) is type(Path()):
         if value.is_absolute():
             raise ForagerMatrixError("absolute host paths are forbidden in matrix artifacts")
         return value.as_posix()
@@ -6684,11 +6686,12 @@ def run_forager_matrix(
     cryptographically and semantically validated, while a gap, unknown file,
     altered hash, or changed execution identity fails closed.
     """
-    if type(manifest) is str or isinstance(manifest, Path):
-        loaded = load_forager_matrix_manifest(manifest)
-    elif isinstance(manifest, ForagerMatrixManifest):
-        if manifest.source_path is not None and not isinstance(
-            manifest.source_path, Path
+    if type(manifest) in (str, type(Path())):
+        loaded = load_forager_matrix_manifest(cast(str | Path, manifest))
+    elif type(manifest) is ForagerMatrixManifest:
+        if (
+            manifest.source_path is not None
+            and type(manifest.source_path) is not type(Path())
         ):
             raise ForagerMatrixManifestError(
                 "programmatic manifest source_path must be a pathlib.Path"

--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -189,7 +189,7 @@ def _text_sha256(lines: Sequence[str]) -> str:
 
 def _flatten_json(value: Any, *, prefix: str = "") -> dict[str, Any]:
     """Match the dotted hyperparameter keys emitted by PyExpUtils v7."""
-    if isinstance(value, Mapping):
+    if type(value) in (dict, MappingProxyType):
         flattened: dict[str, Any] = {}
         for key, child in value.items():
             if type(key) is not str or not key:
@@ -197,7 +197,7 @@ def _flatten_json(value: Any, *, prefix: str = "") -> dict[str, Any]:
             child_prefix = f"{prefix}.{key}" if prefix else key
             flattened.update(_flatten_json(child, prefix=child_prefix))
         return flattened
-    if isinstance(value, list):
+    if type(value) is list:
         if not value:
             raise ValueError("legacy FOV configs with empty list hyperparameters are unsupported")
         flattened = {}

--- a/tests/test_forager_matrix_manifest_hostile.py
+++ b/tests/test_forager_matrix_manifest_hostile.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+
+from alberta_framework.benchmarks.forager_matrix import (
+    ForagerMatrixManifestError,
+    load_forager_matrix_manifest,
+    run_forager_matrix,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -26,6 +34,14 @@ class _HostileStr(str):
     def __str__(self) -> str:  # type: ignore[override]
         type(self).calls += 1
         raise AssertionError("hostile str")
+
+
+class _HostilePath(type(Path())):
+    calls = 0
+
+    def expanduser(self):  # type: ignore[no-untyped-def]
+        type(self).calls += 1
+        raise AssertionError("hostile path expansion")
 
 
 def test_jax_config_rejects_hostile_before_str() -> None:
@@ -55,6 +71,21 @@ def test_manifest_loader_rejects_hostile_before_dispatch() -> None:
     assert _HostileStr.calls == 0
     assert (str is str or isinstance("/tmp/x", Path)) is True
     assert (type(Path("/tmp/x")) is str or isinstance(Path("/tmp/x"), Path)) is True
+
+
+def test_manifest_entry_points_reject_subclasses_without_hooks(tmp_path: Path) -> None:
+    hostile_string = _HostileStr("manifest.json")
+    hostile_path = _HostilePath("manifest.json")
+    _HostileStr.calls = 0
+    _HostilePath.calls = 0
+
+    with pytest.raises(ForagerMatrixManifestError, match="exact string or Path"):
+        load_forager_matrix_manifest(hostile_path)
+    with pytest.raises(TypeError, match="manifest"):
+        run_forager_matrix(hostile_string, tmp_path, dry_run=True)
+
+    assert _HostileStr.calls == 0
+    assert _HostilePath.calls == 0
 
 
 def test_hostile_not_in_error_message() -> None:

--- a/tests/test_forager_results_config_hostile.py
+++ b/tests/test_forager_results_config_hostile.py
@@ -32,6 +32,22 @@ class _HostileFloat(float):
         raise AssertionError("hostile float bool")
 
 
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def items(self):  # type: ignore[no-untyped-def]
+        type(self).calls += 1
+        raise AssertionError("hostile mapping iteration")
+
+
+class _HostileList(list[object]):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        type(self).calls += 1
+        raise AssertionError("hostile list iteration")
+
+
 def test_flatten_json_rejects_hostile_str_before_dispatch() -> None:
     from alberta_framework.benchmarks.forager_results import _flatten_json
 
@@ -63,6 +79,16 @@ def test_flatten_json_rejects_hostile_float_before_isfinite() -> None:
     assert math.isfinite(1.0)
     with pytest.raises(ValueError, match="must be finite"):
         _flatten_json(float("inf"), prefix="p")
+
+
+@pytest.mark.parametrize("hostile", (_HostileDict({"x": 1}), _HostileList([1])))
+def test_flatten_json_rejects_container_subclasses_without_hooks(hostile: object) -> None:
+    from alberta_framework.benchmarks.forager_results import _flatten_json
+
+    type(hostile).calls = 0
+    with pytest.raises(ValueError, match="unsupported config hyperparameter"):
+        _flatten_json(hostile, prefix="p")
+    assert type(hostile).calls == 0
 
 
 def test_hostile_not_in_error_message() -> None:


### PR DESCRIPTION
Corrective follow-up to merged byt61 #1587 and #1589. Retains their exact scalar/string fixes and closes the adjacent container/path dispatch gaps found in deep review: Forager results flattening now rejects dict/list subclasses before iteration, and matrix loader/runner/artifact normalization accept only exact host strings, concrete platform Paths, and exact manifest records before path or method dispatch. Replaces condition-restatement coverage with actual zero-hook entry-point regressions.\n\nVerification: 9 dedicated tests; 92 broader results/matrix tests passed with only the pre-correction expected test mismatch; Ruff; strict mypy. No benchmark execution or output changes.