### PR TITLE
feat(benchmarks): add AdaLin adaptive-linearity comparator

### DIFF
--- a/alberta_framework/benchmarks/adalin.py
+++ b/alberta_framework/benchmarks/adalin.py
@@ -1,0 +1,64 @@
+"""AdaLin equation primitives and non-comparable PMNIST protocol declaration."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+ADALIN_PROTOCOL = MappingProxyType(
+    {
+        "schema": "asi.adalin.protocol.v1",
+        "paper_revision": "arXiv:2505.09486v1",
+        "paper_revision_date": "2025-05-14",
+        "paper_pmnist_tasks": 400,
+        "paper_examples_per_task": 10_000,
+        "paper_batch_size": 16,
+        "paper_hidden_widths": (100, 100),
+        "asi_target_tasks": 200,
+        "asi_examples_per_task": 5_000,
+        "asi_batch_size": 1,
+        "asi_hidden_widths": (300, 150),
+        "learner_observes_task_boundary": False,
+        "mechanism_off": "alpha_zero_exact_base_activation",
+        "matched_axes": ("seed", "updates", "observations"),
+        "persistent_bytes_accounting_required": True,
+        "environment_steps_accounting_required": True,
+        "model_queries_accounting_required": True,
+        "timing_is_telemetry_only": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+)
+
+
+def _adalin(x: Array, alpha: Array, *, activation: Array, derivative: Array) -> Array:
+    gate = jax.lax.stop_gradient(jnp.cos(0.5 * jnp.pi * jnp.abs(derivative)))
+    return activation + alpha * x * gate
+
+
+def adalin_relu(x: Array, alpha: Array) -> Array:
+    """AdaLin equation 2 for ReLU (algebraically PReLU)."""
+    value = jnp.asarray(x)
+    coefficient = jnp.asarray(alpha)
+    return _adalin(
+        value,
+        coefficient,
+        activation=jax.nn.relu(value),
+        derivative=(value > 0).astype(value.dtype),
+    )
+
+
+def adalin_tanh(x: Array, alpha: Array) -> Array:
+    """AdaLin equation 2 for tanh, whose Lipschitz constant is one."""
+    value = jnp.asarray(x)
+    coefficient = jnp.asarray(alpha)
+    activation = jnp.tanh(value)
+    return _adalin(
+        value,
+        coefficient,
+        activation=activation,
+        derivative=1.0 - activation**2,
+    )

--- a/tests/test_adalin.py
+++ b/tests/test_adalin.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from alberta_framework.benchmarks.adalin import ADALIN_PROTOCOL, adalin_relu, adalin_tanh
+
+
+def test_relu_reduction_and_prelu_identity() -> None:
+    x = jnp.array([-2.0, 3.0])
+    np.testing.assert_array_equal(adalin_relu(x, jnp.zeros(2)), jax.nn.relu(x))
+    np.testing.assert_array_equal(adalin_relu(x, jnp.array([0.25, 0.25])), [-0.5, 3.0])
+
+
+def test_gate_is_stop_gradient() -> None:
+    value, derivative = jax.value_and_grad(lambda z: adalin_tanh(z, jnp.array(0.2)))(
+        jnp.array(2.0)
+    )
+    gate = jnp.cos(0.5 * jnp.pi * jnp.abs(1.0 - jnp.tanh(2.0) ** 2))
+    expected = (1.0 - jnp.tanh(2.0) ** 2) + 0.2 * gate
+    assert jnp.isfinite(value)
+    np.testing.assert_allclose(derivative, expected, rtol=1e-6)
+
+
+def test_protocol_keeps_pmnist_difference_explicit() -> None:
+    assert ADALIN_PROTOCOL["paper_revision"] == "arXiv:2505.09486v1"
+    assert ADALIN_PROTOCOL["paper_pmnist_tasks"] == 400
+    assert ADALIN_PROTOCOL["asi_target_tasks"] == 200
+    assert ADALIN_PROTOCOL["mechanism_off"] == "alpha_zero_exact_base_activation"
+    assert ADALIN_PROTOCOL["scientific_promotion_allowed"] is False


### PR DESCRIPTION
Implements the bounded mechanism/protocol slice for #1571.

- pins arXiv:2505.09486v1
- implements equation 2 for ReLU and tanh with the gate correctly stop-gradient detached
- pins alpha=0 as an exact base-activation reduction and ReLU parity with PReLU
- records every material paper-vs-ASI PMNIST schedule, batching, and architecture difference
- predeclares matched axes/resource accounting and nonpromotion

No benchmark/output mutation occurred. A frozen hyperparameter policy, seeds, and separately authorized matched run remain required for empirical comparison.

Validation: 3 focused tests; Ruff; strict mypy.

Closes #1571.