### PR TITLE
ci: harden merged portability lane

### DIFF
--- a/.github/actions/setup-locked-python/action.yml
+++ b/.github/actions/setup-locked-python/action.yml
@@ -15,12 +15,12 @@ runs:
   using: composite
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       with:
         version: "0.9.24"
         enable-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up locked Python 3.12
         uses: ./.github/actions/setup-locked-python
@@ -64,10 +64,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip
@@ -186,7 +186,7 @@ jobs:
       matrix:
         os: [macos-14, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up locked Python 3.12
         uses: ./.github/actions/setup-locked-python
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up locked Python 3.12
         uses: ./.github/actions/setup-locked-python
@@ -279,7 +279,7 @@ jobs:
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up locked Python 3.12
         uses: ./.github/actions/setup-locked-python
@@ -319,7 +319,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.test-plan.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up locked Python ${{ matrix.python }}
         uses: ./.github/actions/setup-locked-python
@@ -380,7 +380,7 @@ jobs:
 
       - name: Upload runtime timing evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: >-
             junit-runtime-py${{ matrix.python }}-shard-${{ matrix.shard }}

--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -68,6 +68,24 @@ from alberta_framework.streams.closed_loop import (
 # the state-agnostic update contract, not PrototypeAdapterUpdate.
 _REFERENCE_UPDATE_TYPE = ReferenceAgentUpdate
 
+
+def _checkpoint_source_identity() -> dict[str, Any]:
+    from alberta_framework.reference_life_checkpoint import _source_identity
+
+    return _source_identity()
+
+
+def _checkpoint_runtime_identity() -> dict[str, Any]:
+    from alberta_framework.reference_life_checkpoint import _runtime_identity
+
+    return _runtime_identity()
+
+
+def _checkpoint_dependency_identity() -> dict[str, Any]:
+    from alberta_framework.reference_life_checkpoint import _dependency_identity
+
+    return _dependency_identity()
+
 REFERENCE_LIFE_SCORECARD_PLAN_SCHEMA = "asi.reference_life_scorecard.plan.v1"
 REFERENCE_LIFE_SCORECARD_RUN_SCHEMA = "asi.reference_life_scorecard.run.v1"
 REFERENCE_LIFE_SCORECARD_ARTIFACT_SCHEMA = "asi.reference_life_scorecard.artifact.v1"
@@ -1568,16 +1586,6 @@ def _current_consistency_identities() -> tuple[dict[str, Any], dict[str, Any], d
     # Whole-life checkpoint publication is intentionally Linux-only. Keep that
     # dependency behind the artifact-construction boundary so the portable
     # scorecard CLI, help, and deterministic plan remain importable elsewhere.
-    from alberta_framework.reference_life_checkpoint import (
-        _dependency_identity as _checkpoint_dependency_identity,
-    )
-    from alberta_framework.reference_life_checkpoint import (
-        _runtime_identity as _checkpoint_runtime_identity,
-    )
-    from alberta_framework.reference_life_checkpoint import (
-        _source_identity as _checkpoint_source_identity,
-    )
-
     return (
         _checkpoint_source_identity(),
         _checkpoint_runtime_identity(),


### PR DESCRIPTION
Final corrective audit of merged #1557/#1592. The actual Windows logs show #1592 fixed interpreter resolution and passed environment setup, CPU JAX/JIT, and all seven regression nodes. Its successor commits also made scorecard planning/import portable and checkpoint publication fail explicitly without POSIX `fcntl`.\n\nThis follow-up preserves the lazy checkpoint-identity module seams used by retained scorecard fault/tamper tests (the merged inner imports broke two monkeypatch contracts), and pins every external action used by `ci.yml` and its shared setup composite to reviewed immutable SHAs.\n\nValidation: actual Windows logs audited; 63 scorecard tests passed before final rebase; post-rebase portability/no-fcntl/fault-seam panel 3/3; 746 changed-file tests and seven exact matrix nodes passed; Step 1/2 smoke, scorecard help, and 144-plan construction pass; actionlint, Ruff, strict mypy (175 files), YAML parse, and diff-check clean. No scorecard shards/scientific lanes executed and no outputs/evidence artifacts mutated.