### PR TITLE
ci: let superseded runs terminate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,9 @@ jobs:
   # Stable aggregate check for branch rulesets: the runtime matrix has
   # dynamic job names, so merge gating requires this single context instead.
   ci-ok:
-    if: always()
+    # A superseded run must terminate instead of scheduling this aggregate
+    # after its dependencies were cancelled. Failures still reach the jq gate.
+    if: ${{ !cancelled() }}
     needs: [package, robot-floor, portability, lint, test-plan, test]
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

- skip the aggregate `ci-ok` job only when the workflow itself has been cancelled
- keep the aggregate jq gate active for ordinary test, lint, package, portability, and robot-floor failures
- let superseded pull-request and main runs terminate so the concurrency group can start the newest run

## Root cause

The workflow uses `cancel-in-progress: true`, but `ci-ok` was declared with `if: always()`. When a newer commit cancelled the upstream matrix, GitHub still queued `ci-ok`; that stale job held the serialized concurrency group and left newer runs waiting indefinitely.

## Validation

- workflow YAML parses
- `ci-ok` still depends on every required job, including the macOS/Windows portability matrix
- the condition is `!cancelled()`, so dependency failures still execute the aggregate failure gate