### PR TITLE
feat(evaluation): add faithful optimization-readiness diagnostic

### DIFF
--- a/alberta_framework/evaluation/optimization_readiness.py
+++ b/alberta_framework/evaluation/optimization_readiness.py
@@ -1,0 +1,117 @@
+"""Prospective optimization-readiness diagnostic for development evaluation.
+
+The equations follow Wang et al., arXiv:2605.09044v1.  This module evaluates
+already-collected mini-batch gradients; it neither trains nor reads benchmark
+data, and therefore cannot itself create a performance result.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from types import MappingProxyType
+
+import numpy as np
+from numpy.typing import NDArray
+
+OPTIMIZATION_READINESS_PROTOCOL = MappingProxyType(
+    {
+        "schema": "asi.optimization-readiness.protocol.v1",
+        "paper_revision": "arXiv:2605.09044v1",
+        "paper_revision_date": "2026-05-09",
+        "diagnostics": (
+            "optimization_readiness",
+            "gradient_norm",
+            "representation_energy_rank_0.99",
+            "curvature_energy_rank_0.99",
+            "parameter_norm",
+        ),
+        "target": "future_relative_loss_reduction_after_matched_updates",
+        "matched_axes": ("seed", "updates", "observations", "mini_batch_size"),
+        "persistent_bytes_accounting_required": True,
+        "environment_steps_accounting_required": True,
+        "model_queries_accounting_required": True,
+        "timing_is_telemetry_only": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+)
+
+
+@dataclass(frozen=True)
+class OptimizationReadiness:
+    """Equation-level diagnostic values for one checkpoint/task pair."""
+
+    gradient_squared_norm: float
+    expected_batch_gradient_squared_norm: float
+    gradient_strength: float
+    gradient_reliability: float
+    optimization_readiness: float
+    gradient_norm: float
+    batch_count: int
+    parameter_count: int
+
+
+def _finite_matrix(value: object, *, name: str) -> NDArray[np.float64]:
+    raw = np.asarray(value)
+    if raw.ndim != 2 or raw.shape[0] < 1 or raw.shape[1] < 1:
+        raise ValueError(f"{name} must be a non-empty two-dimensional matrix")
+    if raw.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError(f"{name} must have a real numeric dtype")
+    resolved = np.asarray(raw, dtype=np.float64)
+    if not np.all(np.isfinite(resolved)):
+        raise ValueError(f"{name} must contain only finite values")
+    return resolved
+
+
+def estimate_optimization_readiness(
+    *, loss: float, batch_gradients: object, include_reliability: bool = True
+) -> OptimizationReadiness:
+    """Estimate OR from independent mini-batch gradient vectors.
+
+    The row mean estimates the population gradient.  The mean row squared norm
+    estimates the expected squared mini-batch-gradient norm.  Setting
+    ``include_reliability=False`` is the predeclared gradient-strength-only
+    mechanism-off reduction.
+    """
+    if type(loss) is not float and type(loss) is not int:
+        raise ValueError("loss must be a finite positive real number")
+    resolved_loss = float(loss)
+    if not math.isfinite(resolved_loss) or resolved_loss <= 0.0:
+        raise ValueError("loss must be a finite positive real number")
+    if type(include_reliability) is not bool:
+        raise ValueError("include_reliability must be a bool")
+    gradients = _finite_matrix(batch_gradients, name="batch_gradients")
+    mean_gradient = np.mean(gradients, axis=0)
+    gradient_squared_norm = float(np.dot(mean_gradient, mean_gradient))
+    expected_squared_norm = float(np.mean(np.sum(np.square(gradients), axis=1)))
+    strength = gradient_squared_norm / resolved_loss
+    reliability = (
+        gradient_squared_norm / expected_squared_norm if expected_squared_norm > 0.0 else 0.0
+    )
+    readiness = strength * reliability if include_reliability else strength
+    return OptimizationReadiness(
+        gradient_squared_norm=gradient_squared_norm,
+        expected_batch_gradient_squared_norm=expected_squared_norm,
+        gradient_strength=strength,
+        gradient_reliability=reliability,
+        optimization_readiness=readiness,
+        gradient_norm=math.sqrt(gradient_squared_norm),
+        batch_count=int(gradients.shape[0]),
+        parameter_count=int(gradients.shape[1]),
+    )
+
+
+def energy_rank(matrix: object, *, threshold: float = 0.99) -> int:
+    """Return the smallest singular-value count reaching squared-energy mass."""
+    if type(threshold) is not float:
+        raise ValueError("threshold must be a float in (0, 1]")
+    if not math.isfinite(threshold) or not 0.0 < threshold <= 1.0:
+        raise ValueError("threshold must be a float in (0, 1]")
+    resolved = _finite_matrix(matrix, name="matrix")
+    singular_values = np.linalg.svd(resolved, compute_uv=False)
+    squared = np.square(singular_values)
+    total = float(np.sum(squared))
+    if total == 0.0:
+        return 0
+    return int(np.searchsorted(np.cumsum(squared) / total, threshold, side="left") + 1)

--- a/alberta_framework/evaluation/optimization_readiness.py
+++ b/alberta_framework/evaluation/optimization_readiness.py
@@ -19,6 +19,10 @@ OPTIMIZATION_READINESS_PROTOCOL = MappingProxyType(
         "schema": "asi.optimization-readiness.protocol.v1",
         "paper_revision": "arXiv:2605.09044v1",
         "paper_revision_date": "2026-05-09",
+        "population_gradient_estimator": "full_validation_set_gradient",
+        "reliability_estimator": "independently_sampled_minibatch_gradients",
+        "reference_reliability_batch_count": 128,
+        "reference_reliability_batch_size": 4,
         "diagnostics": (
             "optimization_readiness",
             "gradient_norm",
@@ -27,13 +31,26 @@ OPTIMIZATION_READINESS_PROTOCOL = MappingProxyType(
             "parameter_norm",
         ),
         "target": "future_relative_loss_reduction_after_matched_updates",
-        "matched_axes": ("seed", "updates", "observations", "mini_batch_size"),
+        "future_gain_steps": (1, 10, 100),
+        "primary_comparison": "pairwise_checkpoint_ranking_accuracy",
+        "matched_axes": (
+            "seed",
+            "checkpoint",
+            "task",
+            "updates",
+            "observations",
+            "mini_batch_size",
+        ),
+        "execution_protocol_required": True,
+        "matrix_shape_and_dtype_accounting_required": True,
+        "working_set_bytes_accounting_required": True,
         "persistent_bytes_accounting_required": True,
         "environment_steps_accounting_required": True,
         "model_queries_accounting_required": True,
         "timing_is_telemetry_only": True,
         "development_only": True,
         "scientific_promotion_allowed": False,
+        "completed_result_exists": False,
     }
 )
 
@@ -52,10 +69,14 @@ class OptimizationReadiness:
     parameter_count: int
 
 
-def _finite_matrix(value: object, *, name: str) -> NDArray[np.float64]:
-    raw = np.asarray(value)
-    if raw.ndim != 2 or raw.shape[0] < 1 or raw.shape[1] < 1:
-        raise ValueError(f"{name} must be a non-empty two-dimensional matrix")
+def _finite_array(
+    value: object, *, name: str, dimensions: int
+) -> NDArray[np.float64]:
+    if type(value) is not np.ndarray:
+        raise ValueError(f"{name} must be an exact numpy.ndarray")
+    raw = value
+    if raw.ndim != dimensions or any(size < 1 for size in raw.shape):
+        raise ValueError(f"{name} must be a non-empty {dimensions}-dimensional array")
     if raw.dtype.kind not in {"i", "u", "f"}:
         raise ValueError(f"{name} must have a real numeric dtype")
     resolved = np.asarray(raw, dtype=np.float64)
@@ -64,32 +85,72 @@ def _finite_matrix(value: object, *, name: str) -> NDArray[np.float64]:
     return resolved
 
 
-def estimate_optimization_readiness(
-    *, loss: float, batch_gradients: object, include_reliability: bool = True
-) -> OptimizationReadiness:
-    """Estimate OR from independent mini-batch gradient vectors.
+def _squared_norm(value: NDArray[np.float64], *, name: str) -> float:
+    scale = float(np.max(np.abs(value)))
+    if scale == 0.0:
+        return 0.0
+    scaled_squared_norm = float(np.sum(np.square(value / scale)))
+    if scale > math.sqrt(np.finfo(np.float64).max / scaled_squared_norm):
+        raise ValueError(f"{name} squared norm must fit in a finite float64")
+    result = scale * scale * scaled_squared_norm
+    if not math.isfinite(result):
+        raise ValueError(f"{name} squared norm must fit in a finite float64")
+    return result
 
-    The row mean estimates the population gradient.  The mean row squared norm
-    estimates the expected squared mini-batch-gradient norm.  Setting
-    ``include_reliability=False`` is the predeclared gradient-strength-only
-    mechanism-off reduction.
+
+def estimate_optimization_readiness(
+    *,
+    loss: float,
+    full_validation_gradient: object,
+    batch_gradients: object,
+    include_reliability: bool = True,
+) -> OptimizationReadiness:
+    """Estimate OR using the paper's full-data and mini-batch estimators.
+
+    ``full_validation_gradient`` estimates the population gradient separately.
+    The rows of ``batch_gradients`` must come from independently sampled
+    mini-batches and estimate the expected squared mini-batch-gradient norm.
+    Setting ``include_reliability=False`` is the predeclared
+    gradient-strength-only mechanism-off reduction.
     """
     if type(loss) is not float and type(loss) is not int:
-        raise ValueError("loss must be a finite positive real number")
-    resolved_loss = float(loss)
-    if not math.isfinite(resolved_loss) or resolved_loss <= 0.0:
-        raise ValueError("loss must be a finite positive real number")
+        raise ValueError("loss must be a finite non-negative real number")
+    try:
+        resolved_loss = float(loss)
+    except (OverflowError, ValueError) as exc:
+        raise ValueError("loss must be a finite non-negative real number") from exc
+    if not math.isfinite(resolved_loss) or resolved_loss < 0.0:
+        raise ValueError("loss must be a finite non-negative real number")
     if type(include_reliability) is not bool:
         raise ValueError("include_reliability must be a bool")
-    gradients = _finite_matrix(batch_gradients, name="batch_gradients")
-    mean_gradient = np.mean(gradients, axis=0)
-    gradient_squared_norm = float(np.dot(mean_gradient, mean_gradient))
-    expected_squared_norm = float(np.mean(np.sum(np.square(gradients), axis=1)))
-    strength = gradient_squared_norm / resolved_loss
+    gradient = _finite_array(
+        full_validation_gradient,
+        name="full_validation_gradient",
+        dimensions=1,
+    )
+    gradients = _finite_array(batch_gradients, name="batch_gradients", dimensions=2)
+    if gradients.shape[1] != gradient.shape[0]:
+        raise ValueError(
+            "full_validation_gradient and batch_gradients must share a parameter axis"
+        )
+    gradient_squared_norm = _squared_norm(
+        gradient, name="full_validation_gradient"
+    )
+    row_squared_norms = np.asarray(
+        [_squared_norm(row, name="batch gradient") for row in gradients],
+        dtype=np.float64,
+    )
+    expected_squared_norm = float(np.mean(row_squared_norms))
+    strength = gradient_squared_norm / resolved_loss if resolved_loss > 0.0 else 0.0
     reliability = (
         gradient_squared_norm / expected_squared_norm if expected_squared_norm > 0.0 else 0.0
     )
-    readiness = strength * reliability if include_reliability else strength
+    if not include_reliability:
+        readiness = strength
+    elif resolved_loss > 0.0 and expected_squared_norm > 0.0:
+        readiness = strength * reliability
+    else:
+        readiness = 0.0
     return OptimizationReadiness(
         gradient_squared_norm=gradient_squared_norm,
         expected_batch_gradient_squared_norm=expected_squared_norm,
@@ -108,10 +169,15 @@ def energy_rank(matrix: object, *, threshold: float = 0.99) -> int:
         raise ValueError("threshold must be a float in (0, 1]")
     if not math.isfinite(threshold) or not 0.0 < threshold <= 1.0:
         raise ValueError("threshold must be a float in (0, 1]")
-    resolved = _finite_matrix(matrix, name="matrix")
-    singular_values = np.linalg.svd(resolved, compute_uv=False)
-    squared = np.square(singular_values)
-    total = float(np.sum(squared))
-    if total == 0.0:
+    resolved = _finite_array(matrix, name="matrix", dimensions=2)
+    try:
+        singular_values = np.linalg.svd(resolved, compute_uv=False)
+    except np.linalg.LinAlgError as exc:
+        raise ValueError("matrix singular-value decomposition did not converge") from exc
+    leading = float(singular_values[0])
+    if leading == 0.0:
         return 0
-    return int(np.searchsorted(np.cumsum(squared) / total, threshold, side="left") + 1)
+    squared = np.square(singular_values / leading)
+    total = float(np.sum(squared))
+    target = np.nextafter(threshold * total, -math.inf)
+    return int(np.searchsorted(np.cumsum(squared), target, side="left") + 1)

--- a/docs/research/sota-landscape.md
+++ b/docs/research/sota-landscape.md
@@ -85,6 +85,15 @@ local same-runner development ranking, not a paper-level SOTA claim.
   (2026)](https://arxiv.org/abs/2607.24996) reports utility-scaled partial
   resets on Continual MetaWorld, Continual MinAtar, and SlipperyAnt. Both are
   candidates for causal ablations, not IPMNIST results.
+- [Optimization Readiness](https://arxiv.org/abs/2605.09044v1) evaluates whether
+  a checkpoint diagnostic prospectively ranks future relative loss reduction.
+  Its empirical estimator uses a full-validation-set gradient for gradient
+  strength and the same numerator over 128 independently sampled mini-batch
+  squared-gradient norms for reliability; it compares against representation,
+  eNTK, and curvature rank diagnostics. ASI has only a development-only
+  equation-level utility and protocol descriptor for this direction. It has no
+  completed ranking result, and any future run must separately freeze tasks,
+  checkpoints, sampling, future-gain rollouts, and resource accounting.
 
 The defensible present statement is: ASI has a 20-seed local development leader
 at 0.87114 on its implementation of the ICLR-2024 protocol, but no current

--- a/tests/test_optimization_readiness.py
+++ b/tests/test_optimization_readiness.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.evaluation.optimization_readiness import (
+    OPTIMIZATION_READINESS_PROTOCOL,
+    energy_rank,
+    estimate_optimization_readiness,
+)
+
+
+def test_readiness_matches_paper_equations() -> None:
+    gradients = np.asarray([[1.0, 0.0], [3.0, 0.0]], dtype=np.float64)
+    report = estimate_optimization_readiness(loss=2.0, batch_gradients=gradients)
+    assert report.gradient_squared_norm == pytest.approx(4.0)
+    assert report.expected_batch_gradient_squared_norm == pytest.approx(5.0)
+    assert report.gradient_strength == pytest.approx(2.0)
+    assert report.gradient_reliability == pytest.approx(0.8)
+    assert report.optimization_readiness == pytest.approx(1.6)
+    assert report.gradient_norm == pytest.approx(2.0)
+
+
+def test_zero_and_mechanism_off_reductions() -> None:
+    zero = estimate_optimization_readiness(
+        loss=1.0, batch_gradients=np.zeros((2, 3), dtype=np.float64)
+    )
+    assert zero.optimization_readiness == 0.0
+    strength_only = estimate_optimization_readiness(
+        loss=2.0,
+        batch_gradients=np.asarray([[1.0], [3.0]]),
+        include_reliability=False,
+    )
+    assert strength_only.optimization_readiness == strength_only.gradient_strength
+
+
+def test_energy_rank_baseline() -> None:
+    matrix = np.diag([3.0, 1.0])
+    assert energy_rank(matrix, threshold=0.9) == 1
+    assert energy_rank(matrix, threshold=0.99) == 2
+    assert energy_rank(np.zeros((2, 2)), threshold=0.99) == 0
+
+
+@pytest.mark.parametrize("loss", [0.0, -1.0, float("nan"), True])
+def test_readiness_rejects_invalid_loss(loss: object) -> None:
+    with pytest.raises(ValueError, match="loss"):
+        estimate_optimization_readiness(  # type: ignore[arg-type]
+            loss=loss, batch_gradients=np.ones((2, 2))
+        )
+
+
+def test_protocol_is_prospective_and_nonpromoting() -> None:
+    assert OPTIMIZATION_READINESS_PROTOCOL["paper_revision"] == "arXiv:2605.09044v1"
+    assert OPTIMIZATION_READINESS_PROTOCOL["diagnostics"] == (
+        "optimization_readiness",
+        "gradient_norm",
+        "representation_energy_rank_0.99",
+        "curvature_energy_rank_0.99",
+        "parameter_norm",
+    )
+    assert OPTIMIZATION_READINESS_PROTOCOL["development_only"] is True
+    assert OPTIMIZATION_READINESS_PROTOCOL["scientific_promotion_allowed"] is False

--- a/tests/test_optimization_readiness.py
+++ b/tests/test_optimization_readiness.py
@@ -12,22 +12,29 @@ from alberta_framework.evaluation.optimization_readiness import (
 
 def test_readiness_matches_paper_equations() -> None:
     gradients = np.asarray([[1.0, 0.0], [3.0, 0.0]], dtype=np.float64)
-    report = estimate_optimization_readiness(loss=2.0, batch_gradients=gradients)
-    assert report.gradient_squared_norm == pytest.approx(4.0)
+    report = estimate_optimization_readiness(
+        loss=2.0,
+        full_validation_gradient=np.asarray([1.0, 0.0]),
+        batch_gradients=gradients,
+    )
+    assert report.gradient_squared_norm == pytest.approx(1.0)
     assert report.expected_batch_gradient_squared_norm == pytest.approx(5.0)
-    assert report.gradient_strength == pytest.approx(2.0)
-    assert report.gradient_reliability == pytest.approx(0.8)
-    assert report.optimization_readiness == pytest.approx(1.6)
-    assert report.gradient_norm == pytest.approx(2.0)
+    assert report.gradient_strength == pytest.approx(0.5)
+    assert report.gradient_reliability == pytest.approx(0.2)
+    assert report.optimization_readiness == pytest.approx(0.1)
+    assert report.gradient_norm == pytest.approx(1.0)
 
 
 def test_zero_and_mechanism_off_reductions() -> None:
     zero = estimate_optimization_readiness(
-        loss=1.0, batch_gradients=np.zeros((2, 3), dtype=np.float64)
+        loss=0.0,
+        full_validation_gradient=np.zeros(3, dtype=np.float64),
+        batch_gradients=np.zeros((2, 3), dtype=np.float64),
     )
     assert zero.optimization_readiness == 0.0
     strength_only = estimate_optimization_readiness(
         loss=2.0,
+        full_validation_gradient=np.asarray([2.0]),
         batch_gradients=np.asarray([[1.0], [3.0]]),
         include_reliability=False,
     )
@@ -41,16 +48,46 @@ def test_energy_rank_baseline() -> None:
     assert energy_rank(np.zeros((2, 2)), threshold=0.99) == 0
 
 
-@pytest.mark.parametrize("loss", [0.0, -1.0, float("nan"), True])
+@pytest.mark.parametrize("loss", [-1.0, float("nan"), True])
 def test_readiness_rejects_invalid_loss(loss: object) -> None:
     with pytest.raises(ValueError, match="loss"):
         estimate_optimization_readiness(  # type: ignore[arg-type]
-            loss=loss, batch_gradients=np.ones((2, 2))
+            loss=loss,
+            full_validation_gradient=np.ones(2),
+            batch_gradients=np.ones((2, 2)),
         )
+
+
+def test_readiness_rejects_mismatched_parameter_axes() -> None:
+    with pytest.raises(ValueError, match="parameter axis"):
+        estimate_optimization_readiness(
+            loss=1.0,
+            full_validation_gradient=np.ones(3),
+            batch_gradients=np.ones((2, 2)),
+        )
+
+
+def test_readiness_rejects_nonrepresentable_squared_norms() -> None:
+    with pytest.raises(ValueError, match="finite float64"):
+        estimate_optimization_readiness(
+            loss=1.0,
+            full_validation_gradient=np.asarray([1e308]),
+            batch_gradients=np.asarray([[1e308]]),
+        )
+
+
+def test_energy_rank_is_scale_stable() -> None:
+    assert energy_rank(np.diag([9e307, 1e307]), threshold=0.99) == 2
 
 
 def test_protocol_is_prospective_and_nonpromoting() -> None:
     assert OPTIMIZATION_READINESS_PROTOCOL["paper_revision"] == "arXiv:2605.09044v1"
+    assert OPTIMIZATION_READINESS_PROTOCOL["population_gradient_estimator"] == (
+        "full_validation_set_gradient"
+    )
+    assert OPTIMIZATION_READINESS_PROTOCOL["reference_reliability_batch_count"] == 128
+    assert OPTIMIZATION_READINESS_PROTOCOL["reference_reliability_batch_size"] == 4
+    assert OPTIMIZATION_READINESS_PROTOCOL["execution_protocol_required"] is True
     assert OPTIMIZATION_READINESS_PROTOCOL["diagnostics"] == (
         "optimization_readiness",
         "gradient_norm",
@@ -60,3 +97,4 @@ def test_protocol_is_prospective_and_nonpromoting() -> None:
     )
     assert OPTIMIZATION_READINESS_PROTOCOL["development_only"] is True
     assert OPTIMIZATION_READINESS_PROTOCOL["scientific_promotion_allowed"] is False
+    assert OPTIMIZATION_READINESS_PROTOCOL["completed_result_exists"] is False


### PR DESCRIPTION
Preserving repaired successor to #1595. Original commits `904e1388` and `64b603c5` are retained as rebased commits `efe27a0e` and `5306d034`; the follow-up repairs a material paper-estimator mismatch found in review.

The pinned arXiv v1 estimator uses a separate full-validation-set gradient for the numerator and independently sampled mini-batch gradients only for the expected squared-norm denominator. #1595 instead averaged those same mini-batch gradients into its numerator, so it could not reproduce the claimed empirical estimator.

This successor:
- requires the separate full-validation gradient and matching parameter axes
- pins the reference 128 mini-batches of size 4, future-gain steps, checkpoint ranking comparison, and execution/resource gates
- implements the paper zero-loss convention
- makes squared norms and energy rank scale-safe and fail-closed on nonrepresentable values
- grounds the paper and exact protocol distinction in the canonical landscape
- explicitly records that no completed result exists and all future results remain development-only/nonpromoting

This is only an equation-level utility/protocol prerequisite. It intentionally does **not** close #1568; a separately frozen, reviewed, authorized prospective checkpoint-ranking execution is still required.

Verification on rebased main:
- focused: 10 passed
- Ruff: all passed
- strict mypy: 176 source files passed
- collection: 15,026 tests
- `git diff --check`: passed
- no benchmark, workflow, or output mutation.