### PR TITLE
feat(benchmarks): fail closed before external qualification runs

### DIFF
--- a/alberta_framework/benchmarks/external_qualification.py
+++ b/alberta_framework/benchmarks/external_qualification.py
@@ -1,0 +1,225 @@
+"""Fail-closed plans for external continual-learning benchmark qualification.
+
+These records are development coordination metadata, not executable benchmarks or
+scientific evidence.  A lane may only acquire a runner after every qualification
+gate has a concrete, reviewable value.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_FULL_COMMIT_LENGTH = 40
+
+
+def _exact_string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a non-empty exact string")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalCodeRevision:
+    repository: str
+    commit: str
+
+    def __post_init__(self) -> None:
+        repository = _exact_string(self.repository, name="repository")
+        commit = _exact_string(self.commit, name="commit")
+        if not repository.startswith("https://github.com/") or not repository.endswith(".git"):
+            raise ValueError("repository must be a credential-free GitHub HTTPS clone URL")
+        if len(commit) != _FULL_COMMIT_LENGTH or any(c not in "0123456789abcdef" for c in commit):
+            raise ValueError("commit must be a full lowercase Git commit ID")
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalQualificationPlan:
+    issue: int
+    lane_id: str
+    paper_revisions: tuple[str, ...]
+    code_revisions: tuple[ExternalCodeRevision, ...]
+    required_gates: tuple[str, ...]
+    completed_gates: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if type(self.issue) is not int or self.issue <= 0:
+            raise ValueError("issue must be a positive exact integer")
+        _exact_string(self.lane_id, name="lane_id")
+        if type(self.paper_revisions) is not tuple or not self.paper_revisions:
+            raise ValueError("paper_revisions must be a non-empty exact tuple")
+        if type(self.code_revisions) is not tuple:
+            raise ValueError("code_revisions must be an exact tuple")
+        if type(self.required_gates) is not tuple or not self.required_gates:
+            raise ValueError("required_gates must be a non-empty exact tuple")
+        if type(self.completed_gates) is not tuple:
+            raise ValueError("completed_gates must be an exact tuple")
+        for name, values in (
+            ("paper_revisions", self.paper_revisions),
+            ("required_gates", self.required_gates),
+            ("completed_gates", self.completed_gates),
+        ):
+            if any(type(value) is not str or not value for value in values):
+                raise ValueError(f"{name} entries must be non-empty exact strings")
+            if len(values) != len(set(values)):
+                raise ValueError(f"{name} must not contain duplicates")
+        if any(type(revision) is not ExternalCodeRevision for revision in self.code_revisions):
+            raise ValueError("code_revisions entries must be exact ExternalCodeRevision values")
+        if not set(self.completed_gates).issubset(self.required_gates):
+            raise ValueError("completed_gates must be a subset of required_gates")
+
+    @property
+    def blockers(self) -> tuple[str, ...]:
+        completed = set(self.completed_gates)
+        return tuple(gate for gate in self.required_gates if gate not in completed)
+
+    def require_ready(self) -> None:
+        if self.blockers:
+            raise RuntimeError(
+                f"external lane {self.lane_id} is not qualified: {', '.join(self.blockers)}"
+            )
+
+
+COMMON_GATES: tuple[str, ...] = (
+    "external_code_available_and_license_reviewed",
+    "isolated_runtime_locked",
+    "assets_checksums_and_storage_approved",
+    "observation_action_and_boundary_contract_matched",
+    "seed_update_and_step_budget_frozen",
+    "persistent_bytes_steps_queries_and_timing_accounted",
+    "parity_and_mechanism_off_tests_pass",
+    "development_only_result_schema_and_validator_registered",
+)
+
+
+def _revision(repository: str, commit: str) -> ExternalCodeRevision:
+    return ExternalCodeRevision(repository=repository, commit=commit)
+
+
+# Primary papers and public repository heads were inspected on 2026-08-17.  A
+# full commit is deliberately recorded rather than a mutable branch or release
+# label.  Empty code revisions are an explicit blocker, never permission to
+# substitute an unofficial implementation.
+EXTERNAL_QUALIFICATION_PLANS: tuple[ExternalQualificationPlan, ...] = (
+    ExternalQualificationPlan(1574, "ftl-online-agent", ("arXiv:2507.09177v1",), (), COMMON_GATES),
+    ExternalQualificationPlan(
+        1575,
+        "action-conditioned-latent",
+        ("arXiv:2603.07083v2", "arXiv:2605.13013v1", "arXiv:2512.24497v3"),
+        (
+            _revision(
+                "https://github.com/facebookresearch/jepa-wms.git",
+                "13cf1d9c7e476f53c17714d2e0f1dc239a883ce0",
+            ),
+        ),
+        COMMON_GATES,
+    ),
+    ExternalQualificationPlan(
+        1576,
+        "dreamer-family",
+        ("arXiv:2301.04104v2", "arXiv:2401.16650v3"),
+        (
+            _revision(
+                "https://github.com/danijar/dreamerv3.git",
+                "e3f02248693a79dc8b0ebd62c93683888ddaccfe",
+            ),
+            _revision(
+                "https://github.com/cerenaut/wmar.git", "cb05e7d97ed83c3cf6e528960db0da6868e29232"
+            ),
+        ),
+        COMMON_GATES,
+    ),
+    ExternalQualificationPlan(
+        1577,
+        "jepa-transfer",
+        ("arXiv:2512.24497v3", "arXiv:2506.09985v1"),
+        (
+            _revision(
+                "https://github.com/facebookresearch/jepa-wms.git",
+                "13cf1d9c7e476f53c17714d2e0f1dc239a883ce0",
+            ),
+            _revision(
+                "https://github.com/facebookresearch/vjepa2.git",
+                "204698b45b3712590f06245fbfba32d3be539812",
+            ),
+        ),
+        COMMON_GATES + ("no_imported_pretraining_ablation_defined",),
+    ),
+    ExternalQualificationPlan(
+        1578,
+        "native-supervised-suite",
+        ("ContinualAI/Avalanche",),
+        (
+            _revision(
+                "https://github.com/ContinualAI/avalanche.git",
+                "eb075be393e1f458b2c352514ff6c17b5a2c0f4e",
+            ),
+        ),
+        COMMON_GATES,
+    ),
+    ExternalQualificationPlan(1579, "clear", ("arXiv:2201.06289v3",), (), COMMON_GATES),
+    ExternalQualificationPlan(
+        1580,
+        "continual-world-cw20",
+        ("Continual World",),
+        (
+            _revision(
+                "https://github.com/awarelab/continual_world.git",
+                "73f63bb4fa0b5d00bda973e20dfb783bfcf1b8aa",
+            ),
+        ),
+        COMMON_GATES + ("fixed_action_smoke_trace_matches",),
+    ),
+    ExternalQualificationPlan(
+        1581,
+        "cora",
+        ("arXiv:2110.10067v2",),
+        (
+            _revision(
+                "https://github.com/AGI-Labs/continual_rl.git",
+                "f2754bb282757829765beb4703f24b87efa13ff9",
+            ),
+        ),
+        COMMON_GATES,
+    ),
+    ExternalQualificationPlan(
+        1582,
+        "coom-vizdoom",
+        ("COOM NeurIPS 2023 Datasets and Benchmarks",),
+        (
+            _revision(
+                "https://github.com/TTomilin/COOM.git", "7929801176c6e2e036c7c1c7dd6ce9b84a9d1f3e"
+            ),
+        ),
+        COMMON_GATES + ("deterministic_smoke_trace_matches",),
+    ),
+    ExternalQualificationPlan(
+        1583,
+        "loss-of-plasticity",
+        ("arXiv:2306.13812v3",),
+        (
+            _revision(
+                "https://github.com/shibhansh/loss-of-plasticity.git",
+                "a6b79580d85f3025bdb601566d3627c5f489f13b",
+            ),
+        ),
+        COMMON_GATES + ("costly_imagenet_and_rl_lanes_budget_approved",),
+    ),
+)
+
+
+def qualification_plan(issue: object) -> ExternalQualificationPlan:
+    if type(issue) is not int:
+        raise ValueError("issue must be an exact integer")
+    for plan in EXTERNAL_QUALIFICATION_PLANS:
+        if plan.issue == issue:
+            return plan
+    raise KeyError("unknown external qualification issue")
+
+
+__all__ = [
+    "COMMON_GATES",
+    "EXTERNAL_QUALIFICATION_PLANS",
+    "ExternalCodeRevision",
+    "ExternalQualificationPlan",
+    "qualification_plan",
+]

--- a/tests/test_external_qualification.py
+++ b/tests/test_external_qualification.py
@@ -1,0 +1,69 @@
+"""Fail-closed contracts for external benchmark qualification plans."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.external_qualification import (
+    COMMON_GATES,
+    EXTERNAL_QUALIFICATION_PLANS,
+    ExternalCodeRevision,
+    ExternalQualificationPlan,
+    qualification_plan,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_registry_exactly_covers_research_wave_and_is_not_run_ready() -> None:
+    assert tuple(plan.issue for plan in EXTERNAL_QUALIFICATION_PLANS) == tuple(range(1574, 1584))
+    assert len({plan.lane_id for plan in EXTERNAL_QUALIFICATION_PLANS}) == 10
+    for plan in EXTERNAL_QUALIFICATION_PLANS:
+        assert plan.blockers == plan.required_gates
+        with pytest.raises(RuntimeError, match=f"external lane {plan.lane_id} is not qualified"):
+            plan.require_ready()
+
+
+def test_ready_plan_requires_every_gate_without_reordering() -> None:
+    plan = ExternalQualificationPlan(
+        issue=1,
+        lane_id="fixture",
+        paper_revisions=("paper-v1",),
+        code_revisions=(),
+        required_gates=("first", "second"),
+        completed_gates=("second", "first"),
+    )
+    assert plan.blockers == ()
+    plan.require_ready()
+
+
+@pytest.mark.parametrize("issue", [True, 1574.0, "1574"])
+def test_lookup_rejects_scalar_aliases(issue: object) -> None:
+    with pytest.raises(ValueError, match="exact integer"):
+        qualification_plan(issue)
+
+
+def test_plan_rejects_hostile_container_and_string_subclasses() -> None:
+    class StringSubclass(str):
+        pass
+
+    with pytest.raises(ValueError, match="lane_id"):
+        ExternalQualificationPlan(1, StringSubclass("lane"), ("paper",), (), COMMON_GATES)
+    with pytest.raises(ValueError, match="paper_revisions"):
+        ExternalQualificationPlan(1, "lane", ["paper"], (), COMMON_GATES)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="entries"):
+        ExternalQualificationPlan(1, "lane", (StringSubclass("paper"),), (), COMMON_GATES)
+
+
+def test_code_revision_requires_credential_free_url_and_full_commit() -> None:
+    with pytest.raises(ValueError, match="credential-free"):
+        ExternalCodeRevision("https://token@github.com/org/repo.git", "a" * 40)
+    with pytest.raises(ValueError, match="full lowercase"):
+        ExternalCodeRevision("https://github.com/org/repo.git", "A" * 40)
+
+
+def test_completed_gates_must_be_known_and_unique() -> None:
+    with pytest.raises(ValueError, match="subset"):
+        ExternalQualificationPlan(1, "lane", ("paper",), (), ("known",), ("unknown",))
+    with pytest.raises(ValueError, match="duplicates"):
+        ExternalQualificationPlan(1, "lane", ("paper",), (), ("known", "known"))


### PR DESCRIPTION
Adds an R0-only, non-executable qualification registry for #1574-#1583. It pins exact current paper versions and full external repository commits where official code is available, records the shared boundary/seed/resource/parity/result-schema gates, and refuses readiness until every gate is completed. Empty official-code entries remain explicit blockers rather than silently substituting unofficial implementations.

This does not close the research tickets, install external runtimes, download assets, run workloads, or create evidence. It makes their prerequisites machine-checkable while the individual adapters and isolated runtimes are built.

Focused verification: 8 tests pass; Ruff and strict mypy pass; diff-check clean. No outputs changed.

Refs #1574
Refs #1575
Refs #1576
Refs #1577
Refs #1578
Refs #1579
Refs #1580
Refs #1581
Refs #1582
Refs #1583