### PR TITLE
feat(research): add bounded comparator protocol primitives

### DIFF
--- a/alberta_framework/benchmarks/adalin.py
+++ b/alberta_framework/benchmarks/adalin.py
@@ -1,0 +1,64 @@
+"""AdaLin equation primitives and non-comparable PMNIST protocol declaration."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+ADALIN_PROTOCOL = MappingProxyType(
+    {
+        "schema": "asi.adalin.protocol.v1",
+        "paper_revision": "arXiv:2505.09486v1",
+        "paper_revision_date": "2025-05-14",
+        "paper_pmnist_tasks": 400,
+        "paper_examples_per_task": 10_000,
+        "paper_batch_size": 16,
+        "paper_hidden_widths": (100, 100),
+        "asi_target_tasks": 200,
+        "asi_examples_per_task": 5_000,
+        "asi_batch_size": 1,
+        "asi_hidden_widths": (300, 150),
+        "learner_observes_task_boundary": False,
+        "mechanism_off": "alpha_zero_exact_base_activation",
+        "matched_axes": ("seed", "updates", "observations"),
+        "persistent_bytes_accounting_required": True,
+        "environment_steps_accounting_required": True,
+        "model_queries_accounting_required": True,
+        "timing_is_telemetry_only": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+)
+
+
+def _adalin(x: Array, alpha: Array, *, activation: Array, derivative: Array) -> Array:
+    gate = jax.lax.stop_gradient(jnp.cos(0.5 * jnp.pi * jnp.abs(derivative)))
+    return activation + alpha * x * gate
+
+
+def adalin_relu(x: Array, alpha: Array) -> Array:
+    """AdaLin equation 2 for ReLU (algebraically PReLU)."""
+    value = jnp.asarray(x)
+    coefficient = jnp.asarray(alpha)
+    return _adalin(
+        value,
+        coefficient,
+        activation=jax.nn.relu(value),
+        derivative=(value > 0).astype(value.dtype),
+    )
+
+
+def adalin_tanh(x: Array, alpha: Array) -> Array:
+    """AdaLin equation 2 for tanh, whose Lipschitz constant is one."""
+    value = jnp.asarray(x)
+    coefficient = jnp.asarray(alpha)
+    activation = jnp.tanh(value)
+    return _adalin(
+        value,
+        coefficient,
+        activation=activation,
+        derivative=1.0 - activation**2,
+    )

--- a/alberta_framework/benchmarks/bimu.py
+++ b/alberta_framework/benchmarks/bimu.py
@@ -1,0 +1,95 @@
+"""Equation-level BiMU primitives for a separate binary/Bayesian lane."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from types import MappingProxyType
+
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+
+BIMU_PROTOCOL = MappingProxyType(
+    {
+        "schema": "asi.bimu.protocol.v1",
+        "paper_revision": "arXiv:2605.30198v1",
+        "paper_revision_date": "2026-05-28",
+        "lane": "binary_bayesian_permuted_mnist",
+        "weight_domain": (-1, 1),
+        "primary_metric": "mean_test_accuracy_over_last_5_tasks",
+        "whole_stream_online_accuracy_is_separate": True,
+        "paper_axes": {"tasks": 1000, "hidden_units": 100, "batch_size": 1},
+        "adaptation_difference": "ASI implementation exposes equation primitives; no run is frozen",
+        "learner_observes_task_boundary": False,
+        "matched_axes": ("seed", "updates", "observations", "label_queries"),
+        "persistent_bytes_accounting_required": True,
+        "environment_steps_accounting_required": True,
+        "model_queries_accounting_required": True,
+        "timing_is_telemetry_only": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+)
+
+
+def _finite_vector(value: object, *, name: str) -> Array:
+    array = jnp.asarray(value)
+    if array.ndim != 1 or array.size < 1 or not jnp.issubdtype(array.dtype, jnp.floating):
+        raise ValueError(f"{name} must be a non-empty floating vector")
+    if not bool(jnp.all(jnp.isfinite(array))):
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
+
+def posterior_probability(natural_parameter: object) -> Array:
+    """Return ``P(weight=+1) = sigmoid(2 lambda)`` (paper equation 2)."""
+    state = _finite_vector(natural_parameter, name="natural_parameter")
+    return jnp.asarray(1.0 / (1.0 + jnp.exp(-2.0 * state)), dtype=state.dtype)
+
+
+def bimu_update(
+    natural_parameter: object,
+    loss_gradient: object,
+    prior_natural_parameter: object,
+    *,
+    memory_window: int | None,
+    alpha_max: float,
+) -> Array:
+    """Apply BiMU equations 6--7 to one flat natural-parameter vector.
+
+    ``memory_window=None`` is the predeclared mechanism-off reduction: it
+    removes controlled forgetting while retaining the bounded metaplastic step.
+    """
+    state = _finite_vector(natural_parameter, name="natural_parameter")
+    gradient = _finite_vector(loss_gradient, name="loss_gradient")
+    prior = _finite_vector(prior_natural_parameter, name="prior_natural_parameter")
+    if state.shape != gradient.shape or state.shape != prior.shape:
+        raise ValueError("state, gradient, and prior must have identical shapes")
+    if type(alpha_max) is not float or not math.isfinite(alpha_max) or alpha_max <= 0.0:
+        raise ValueError("alpha_max must be a finite positive float")
+    if memory_window is not None and (type(memory_window) is not int or memory_window < 1):
+        raise ValueError("memory_window must be None or a positive integer")
+    uncertainty = 1.0 / jnp.cosh(state) ** 2
+    reciprocal_eta = (
+        uncertainty
+        + 2.0 * jnp.tanh(state) * gradient
+        + 1.0 / alpha_max
+        + 2.0 * jnp.abs(gradient)
+    )
+    eta = 1.0 / reciprocal_eta
+    forgetting = 0.0 if memory_window is None else (state - prior) * uncertainty / memory_window
+    return state - eta * (gradient + forgetting)
+
+
+def late_window_mean(task_accuracies: Sequence[float], *, window: int = 5) -> float:
+    """Compute BiMU's late-task metric without conflating whole-stream accuracy."""
+    if type(window) is not int or window < 1:
+        raise ValueError("window must be a positive integer")
+    values = np.asarray(task_accuracies)
+    if values.ndim != 1 or values.size < window or values.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError("task_accuracies must be a numeric vector at least window long")
+    resolved = np.asarray(values, dtype=np.float64)
+    if not np.all(np.isfinite(resolved)) or np.any((resolved < 0.0) | (resolved > 1.0)):
+        raise ValueError("task_accuracies must be finite and in [0, 1]")
+    return float(np.mean(resolved[-window:]))

--- a/alberta_framework/benchmarks/bimu.py
+++ b/alberta_framework/benchmarks/bimu.py
@@ -19,7 +19,7 @@ BIMU_PROTOCOL = MappingProxyType(
         "weight_domain": (-1, 1),
         "primary_metric": "mean_test_accuracy_over_last_5_tasks",
         "whole_stream_online_accuracy_is_separate": True,
-        "paper_axes": {"tasks": 1000, "hidden_units": 100, "batch_size": 1},
+        "paper_axes": (("tasks", 1000), ("hidden_units", 100), ("batch_size", 1)),
         "adaptation_difference": "ASI implementation exposes equation primitives; no run is frozen",
         "learner_observes_task_boundary": False,
         "matched_axes": ("seed", "updates", "observations", "label_queries"),

--- a/alberta_framework/benchmarks/ipmnist_ceilings.py
+++ b/alberta_framework/benchmarks/ipmnist_ceilings.py
@@ -1,0 +1,88 @@
+"""Resource contracts for replay and frozen-feature IPMNIST ceilings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal
+
+_METHODS = ("replay", "in_context", "randumb", "ranpac", "prol")
+
+CEILING_PROTOCOL = MappingProxyType(
+    {
+        "schema": "asi.ipmnist-ceilings.protocol.v1",
+        "paper_revisions": (
+            "arXiv:2503.20018v1",
+            "arXiv:2402.08823v2",
+            "arXiv:2307.02251v4",
+            "arXiv:2507.12305v1",
+        ),
+        "methods": _METHODS,
+        "pretraining_allowed_but_charged": True,
+        "extractor_queries_charged": True,
+        "replay_bytes_charged": True,
+        "matched_axes": ("seed", "updates", "observations"),
+        "timing_is_telemetry_only": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+)
+
+
+def _nonnegative(name: str, value: object) -> int:
+    if type(value) is not int or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+@dataclass(frozen=True)
+class CeilingResourceLedger:
+    """Complete resource charges, including usually hidden ceiling costs."""
+
+    persistent_bytes: int
+    replay_bytes: int
+    environment_steps: int
+    pretraining_steps: int
+    model_queries: int
+    extractor_queries: int
+
+    def __post_init__(self) -> None:
+        for name in self.__dataclass_fields__:
+            object.__setattr__(self, name, _nonnegative(name, getattr(self, name)))
+
+    @property
+    def total_persistent_bytes(self) -> int:
+        return self.persistent_bytes + self.replay_bytes
+
+    @property
+    def total_steps(self) -> int:
+        return self.environment_steps + self.pretraining_steps
+
+    @property
+    def total_model_queries(self) -> int:
+        return self.model_queries + self.extractor_queries
+
+
+@dataclass(frozen=True)
+class FrozenFeatureCeiling:
+    """Prospective frozen-feature/replay arm declaration."""
+
+    method: Literal["replay", "in_context", "randumb", "ranpac", "prol"]
+    feature_dim: int
+    replay_capacity: int
+
+    def __post_init__(self) -> None:
+        if self.method not in _METHODS:
+            raise ValueError("method is not a registered ceiling")
+        if type(self.feature_dim) is not int or self.feature_dim < 1:
+            raise ValueError("feature_dim must be a positive integer")
+        _nonnegative("replay_capacity", self.replay_capacity)
+
+    @property
+    def mechanism_off(self) -> bool:
+        return self.method == "randumb" and self.replay_capacity == 0
+
+    def persistent_replay_bytes(self, *, example_bytes: int) -> int:
+        if type(example_bytes) is not int or example_bytes < 0:
+            raise ValueError("example_bytes must be a non-negative integer")
+        return self.replay_capacity * example_bytes

--- a/alberta_framework/benchmarks/ipmnist_ceilings.py
+++ b/alberta_framework/benchmarks/ipmnist_ceilings.py
@@ -13,8 +13,8 @@ CEILING_PROTOCOL = MappingProxyType(
         "schema": "asi.ipmnist-ceilings.protocol.v1",
         "paper_revisions": (
             "arXiv:2503.20018v1",
-            "arXiv:2402.08823v2",
-            "arXiv:2307.02251v4",
+            "arXiv:2402.08823v3",
+            "arXiv:2307.02251v3",
             "arXiv:2507.12305v1",
         ),
         "methods": _METHODS,
@@ -72,7 +72,7 @@ class FrozenFeatureCeiling:
     replay_capacity: int
 
     def __post_init__(self) -> None:
-        if self.method not in _METHODS:
+        if type(self.method) is not str or self.method not in _METHODS:
             raise ValueError("method is not a registered ceiling")
         if type(self.feature_dim) is not int or self.feature_dim < 1:
             raise ValueError("feature_dim must be a positive integer")

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -1,0 +1,155 @@
+"""Deterministic gradual-transition primitives for development IPMNIST lanes.
+
+This module adapts the transition definitions in Liu and Mou,
+``arXiv:2602.09234v2``.  It does not define or execute an evidence protocol.
+The transition coefficient and task identity are evaluator-owned: learners see
+only the resulting example/target, exactly as in the abrupt IPMNIST lane.
+"""
+
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal, SupportsIndex, cast
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+from jax import Array
+
+from alberta_framework._seed_validation import require_jax_seed
+
+TransitionMode = Literal[
+    "abrupt", "input_interpolation", "output_interpolation", "task_sampling"
+]
+_MODES = frozenset(
+    {"abrupt", "input_interpolation", "output_interpolation", "task_sampling"}
+)
+_INT32_MAX = 2**31 - 1
+
+GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(
+    {
+        "schema": "asi.ipmnist.gradual-transition.protocol.v1",
+        "paper_revision": "arXiv:2602.09234v2",
+        "paper_revision_date": "2026-06-16",
+        "adaptation_difference": (
+            "single-pass ASI IPMNIST uses evaluator-owned per-example transitions; "
+            "the paper iterates mini-batches within tasks without revealing boundaries"
+        ),
+        "matched_axes": ("seed", "updates", "observations", "example_order"),
+        "learner_observes_transition_alpha": False,
+        "learner_observes_task_boundary": False,
+        "persistent_bytes_accounting_required": True,
+        "environment_steps_accounting_required": True,
+        "model_queries_accounting_required": True,
+        "timing_is_telemetry_only": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+)
+
+
+def _exact_index(name: str, value: object, *, minimum: int) -> int:
+    if type(value) is not int and not isinstance(value, np.integer):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        resolved = operator.index(cast(SupportsIndex, value))
+    except Exception as error:
+        raise ValueError(f"{name} must be an integer") from error
+    if resolved < minimum or resolved > _INT32_MAX:
+        raise ValueError(f"{name} must be in [{minimum}, {_INT32_MAX}]")
+    return resolved
+
+
+def _alpha(value: object) -> float:
+    if type(value) is not float and type(value) is not int:
+        raise ValueError("alpha must be a finite real number in [0, 1]")
+    resolved = float(value)
+    if not math.isfinite(resolved) or not 0.0 <= resolved <= 1.0:
+        raise ValueError("alpha must be a finite real number in [0, 1]")
+    return resolved
+
+
+@dataclass(frozen=True)
+class GradualTransitionConfig:
+    """One prospectively selectable transition rule.
+
+    ``transition_steps`` counts update opportunities from the old task at
+    alpha zero to the new task at alpha one.  Abrupt mode requires one step
+    and is the mechanism-off reduction.
+    """
+
+    mode: TransitionMode
+    transition_steps: int
+
+    def __post_init__(self) -> None:
+        if type(self.mode) is not str or self.mode not in _MODES:
+            raise ValueError(f"mode must be one of {sorted(_MODES)}")
+        resolved = _exact_index("transition_steps", self.transition_steps, minimum=1)
+        if self.mode == "abrupt" and resolved != 1:
+            raise ValueError("abrupt mode requires transition_steps=1")
+        object.__setattr__(self, "transition_steps", resolved)
+
+
+def transition_alpha(step: int, config: GradualTransitionConfig) -> float:
+    """Return a deterministic uniform interpolation coefficient."""
+    resolved_step = _exact_index("step", step, minimum=0)
+    if config.mode == "abrupt":
+        return 1.0
+    return min(resolved_step / config.transition_steps, 1.0)
+
+
+def input_interpolation(old: Array, new: Array, alpha: float) -> Array:
+    """Apply paper equation ``x_alpha = (1-alpha)x_old + alpha*x_new``."""
+    resolved = _alpha(alpha)
+    old_array = jnp.asarray(old)
+    new_array = jnp.asarray(new)
+    if old_array.shape != new_array.shape:
+        raise ValueError("old and new inputs must have identical shapes")
+    if old_array.dtype != new_array.dtype or not jnp.issubdtype(old_array.dtype, jnp.floating):
+        raise ValueError("old and new inputs must share a floating dtype")
+    return (1.0 - resolved) * old_array + resolved * new_array
+
+
+def output_interpolation(
+    old_label: int, new_label: int, alpha: float, *, n_classes: int
+) -> Array:
+    """Interpolate old one-hot -> uniform -> new one-hot as paper section 4."""
+    resolved_alpha = _alpha(alpha)
+    classes = _exact_index("n_classes", n_classes, minimum=2)
+    old = _exact_index("old_label", old_label, minimum=0)
+    new = _exact_index("new_label", new_label, minimum=0)
+    if old >= classes or new >= classes:
+        raise ValueError("labels must be smaller than n_classes")
+    uniform = jnp.full((classes,), 1.0 / classes, dtype=jnp.float32)
+    if resolved_alpha <= 0.5:
+        old_target = jax.nn.one_hot(old, classes, dtype=jnp.float32)
+        return (1.0 - 2.0 * resolved_alpha) * old_target + 2.0 * resolved_alpha * uniform
+    new_target = jax.nn.one_hot(new, classes, dtype=jnp.float32)
+    return (2.0 * resolved_alpha - 1.0) * new_target + (2.0 - 2.0 * resolved_alpha) * uniform
+
+
+def task_sampling_mask(
+    *, seed: int, transition_id: int, count: int, alpha: float
+) -> np.ndarray:
+    """Select exactly ``floor(alpha * count)`` positions from the new task.
+
+    A Threefry root and transition fold make selection independent across
+    transitions and reproducible across processes.  The mask is evaluator
+    state, never learner-visible boundary information.
+    """
+    resolved_seed = require_jax_seed(seed, name="seed")
+    resolved_transition = _exact_index("transition_id", transition_id, minimum=0)
+    resolved_count = _exact_index("count", count, minimum=1)
+    new_count = math.floor(_alpha(alpha) * resolved_count)
+    order = np.asarray(
+        jax.device_get(
+            jr.permutation(jr.fold_in(jr.key(resolved_seed), resolved_transition), resolved_count)
+        )
+    )
+    mask = np.zeros(resolved_count, dtype=np.bool_)
+    mask[order[:new_count]] = True
+    return mask

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -111,6 +111,8 @@ def input_interpolation(old: Array, new: Array, alpha: float) -> Array:
         raise ValueError("old and new inputs must have identical shapes")
     if old_array.dtype != new_array.dtype or not jnp.issubdtype(old_array.dtype, jnp.floating):
         raise ValueError("old and new inputs must share a floating dtype")
+    if not bool(jnp.all(jnp.isfinite(old_array))) or not bool(jnp.all(jnp.isfinite(new_array))):
+        raise ValueError("old and new inputs must contain only finite values")
     return (1.0 - resolved) * old_array + resolved * new_array
 
 

--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -48,6 +48,16 @@ class PolicyEntry:
         if type(self.score) is not float or not math.isfinite(self.score):
             raise ValueError("score must be a finite float")
 
+    @property
+    def persistent_bytes(self) -> int:
+        """Canonical retained payload: identity UTF-8, policy, latent, and score."""
+        return (
+            len(self.identity.encode("utf-8"))
+            + len(self.policy_bytes)
+            + 8 * len(self.latent)
+            + 8
+        )
+
 
 @dataclass(frozen=True)
 class BoundedPolicyArchive:
@@ -67,17 +77,31 @@ class BoundedPolicyArchive:
             or self.min_latent_distance < 0.0
         ):
             raise ValueError("min_latent_distance must be a finite non-negative float")
-        if self.mode not in {"diverse_archive", "one_model", "fixed_snapshot"}:
+        if type(self.mode) is not str or self.mode not in {
+            "diverse_archive",
+            "one_model",
+            "fixed_snapshot",
+        }:
             raise ValueError("unknown archive mode")
+        if type(self.entries) is not tuple or any(
+            type(entry) is not PolicyEntry for entry in self.entries
+        ):
+            raise ValueError("entries must be an exact tuple of PolicyEntry values")
+        if len({entry.identity for entry in self.entries}) != len(self.entries):
+            raise ValueError("entry identities must be unique")
         if self.persistent_bytes > self.byte_budget:
             raise ValueError("entries exceed byte budget")
 
     @property
     def persistent_bytes(self) -> int:
-        return sum(len(entry.policy_bytes) for entry in self.entries)
+        return sum(entry.persistent_bytes for entry in self.entries)
 
     def add(self, entry: PolicyEntry) -> BoundedPolicyArchive:
         """Return the deterministic successor archive."""
+        if type(entry) is not PolicyEntry:
+            raise ValueError("entry must be an exact PolicyEntry")
+        if any(old.identity == entry.identity for old in self.entries):
+            raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
         if self.entries and len(entry.latent) != len(self.entries[0].latent):
             raise ValueError("all latent descriptors must have equal width")
@@ -99,6 +123,6 @@ class BoundedPolicyArchive:
                 candidates = self.entries[:nearest] + (entry,) + self.entries[nearest + 1 :]
             else:
                 candidates = self.entries + (entry,)
-        if sum(len(item.policy_bytes) for item in candidates) > self.byte_budget:
+        if sum(item.persistent_bytes for item in candidates) > self.byte_budget:
             raise ValueError("candidate would exceed byte budget")
         return replace(self, entries=candidates)

--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -1,0 +1,104 @@
+"""Byte-bounded immutable policy archive and single-policy controls."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+from types import MappingProxyType
+from typing import Literal
+
+import numpy as np
+
+POLICY_ARCHIVE_PROTOCOL = MappingProxyType(
+    {
+        "schema": "asi.policy-archive.protocol.v1",
+        "paper_revision": "arXiv:2604.15414v1",
+        "paper_revision_date": "2026-04-16",
+        "adaptation_difference": "generic latent descriptors; no MiniGrid/task archive claim",
+        "controls": ("one_model", "fixed_snapshot"),
+        "matched_axes": ("seed", "updates", "observations", "policy_queries"),
+        "persistent_bytes_accounting_required": True,
+        "environment_steps_accounting_required": True,
+        "model_queries_accounting_required": True,
+        "timing_is_telemetry_only": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+)
+
+ArchiveMode = Literal["diverse_archive", "one_model", "fixed_snapshot"]
+
+
+@dataclass(frozen=True)
+class PolicyEntry:
+    identity: str
+    policy_bytes: bytes
+    latent: tuple[float, ...]
+    score: float
+
+    def __post_init__(self) -> None:
+        if type(self.identity) is not str or not self.identity:
+            raise ValueError("identity must be a non-empty string")
+        if type(self.policy_bytes) is not bytes or not self.policy_bytes:
+            raise ValueError("policy_bytes must be non-empty exact bytes")
+        if type(self.latent) is not tuple or not self.latent:
+            raise ValueError("latent must be a non-empty tuple")
+        if any(type(value) is not float or not math.isfinite(value) for value in self.latent):
+            raise ValueError("latent values must be finite floats")
+        if type(self.score) is not float or not math.isfinite(self.score):
+            raise ValueError("score must be a finite float")
+
+
+@dataclass(frozen=True)
+class BoundedPolicyArchive:
+    """Pure archive reducer with an exact serialized-policy byte ceiling."""
+
+    byte_budget: int
+    min_latent_distance: float
+    mode: ArchiveMode = "diverse_archive"
+    entries: tuple[PolicyEntry, ...] = ()
+
+    def __post_init__(self) -> None:
+        if type(self.byte_budget) is not int or self.byte_budget < 1:
+            raise ValueError("byte_budget must be a positive integer")
+        if (
+            type(self.min_latent_distance) is not float
+            or not math.isfinite(self.min_latent_distance)
+            or self.min_latent_distance < 0.0
+        ):
+            raise ValueError("min_latent_distance must be a finite non-negative float")
+        if self.mode not in {"diverse_archive", "one_model", "fixed_snapshot"}:
+            raise ValueError("unknown archive mode")
+        if self.persistent_bytes > self.byte_budget:
+            raise ValueError("entries exceed byte budget")
+
+    @property
+    def persistent_bytes(self) -> int:
+        return sum(len(entry.policy_bytes) for entry in self.entries)
+
+    def add(self, entry: PolicyEntry) -> BoundedPolicyArchive:
+        """Return the deterministic successor archive."""
+        candidates: tuple[PolicyEntry, ...]
+        if self.entries and len(entry.latent) != len(self.entries[0].latent):
+            raise ValueError("all latent descriptors must have equal width")
+        if self.mode == "fixed_snapshot" and self.entries:
+            return self
+        if self.mode == "one_model":
+            candidates = (entry,)
+        elif not self.entries:
+            candidates = (entry,)
+        else:
+            distances = tuple(
+                float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
+                for old in self.entries
+            )
+            nearest = int(np.argmin(np.asarray(distances)))
+            if distances[nearest] < self.min_latent_distance:
+                if entry.score <= self.entries[nearest].score:
+                    return self
+                candidates = self.entries[:nearest] + (entry,) + self.entries[nearest + 1 :]
+            else:
+                candidates = self.entries + (entry,)
+        if sum(len(item.policy_bytes) for item in candidates) > self.byte_budget:
+            raise ValueError("candidate would exceed byte budget")
+        return replace(self, entries=candidates)

--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -1,0 +1,76 @@
+"""Small-matrix primitives for staging continual optimizer geometry controls."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import jax.numpy as jnp
+from jax import Array
+
+GEOMETRY_PROTOCOL = MappingProxyType(
+    {
+        "schema": "asi.optimizer-geometry.protocol.v1",
+        "paper_revisions": (
+            "arXiv:2605.08949v2",
+            "arXiv:2606.10406v1",
+            "arXiv:2601.07636v1",
+        ),
+        "stage": "small_streaming_matrix_pre_ipmnist",
+        "protocol_difference": "equation primitives only; no LLM or batch-CL claim",
+        "mechanism_off": "empty_basis_or_zero_gradient_exact_reduction",
+        "matched_axes": ("seed", "updates", "observations"),
+        "persistent_bytes_accounting_required": True,
+        "environment_steps_accounting_required": True,
+        "model_queries_accounting_required": True,
+        "timing_is_telemetry_only": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+)
+
+
+def orthogonal_correction(update: Array, protected_basis: Array) -> Array:
+    """Project a vector away from row-wise orthonormal protected directions."""
+    vector = jnp.asarray(update)
+    basis = jnp.asarray(protected_basis)
+    if vector.ndim != 1 or basis.ndim != 2 or basis.shape[1] != vector.shape[0]:
+        raise ValueError("update must be a vector and basis rows must match its width")
+    return vector - basis.T @ (basis @ vector)
+
+
+def spectral_matrix_sign(matrix: Array, *, steps: int = 5) -> Array:
+    """Muon-style Newton--Schulz matrix-sign approximation for a small matrix."""
+    value = jnp.asarray(matrix)
+    if (
+        value.ndim != 2
+        or value.size == 0
+        or not jnp.issubdtype(value.dtype, jnp.floating)
+        or type(steps) is not int
+        or steps < 1
+    ):
+        raise ValueError("matrix must be non-empty and steps a positive integer")
+    x = value / jnp.maximum(jnp.linalg.norm(value), jnp.asarray(1e-12, dtype=value.dtype))
+    if x.shape[0] > x.shape[1]:
+        x = x.T
+        transposed = True
+    else:
+        transposed = False
+    for _ in range(steps):
+        a = x @ x.T
+        x = 3.4445 * x - 4.7750 * a @ x + 2.0315 * a @ a @ x
+    return x.T if transposed else x
+
+
+def flad_noise_component(perturbation: Array, gradient: Array) -> Array:
+    """Remove FLAD's gradient-aligned perturbation component."""
+    delta = jnp.asarray(perturbation)
+    direction = jnp.asarray(gradient)
+    if delta.shape != direction.shape or delta.ndim != 1:
+        raise ValueError("perturbation and gradient must be equal-width vectors")
+    squared_norm = jnp.vdot(direction, direction).real
+    projection = jnp.where(
+        squared_norm > 0.0,
+        direction * (jnp.vdot(direction, delta).real / squared_norm),
+        jnp.zeros_like(delta),
+    )
+    return delta - projection

--- a/tests/test_adalin.py
+++ b/tests/test_adalin.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from alberta_framework.benchmarks.adalin import ADALIN_PROTOCOL, adalin_relu, adalin_tanh
+
+
+def test_relu_reduction_and_prelu_identity() -> None:
+    x = jnp.array([-2.0, 3.0])
+    np.testing.assert_array_equal(adalin_relu(x, jnp.zeros(2)), jax.nn.relu(x))
+    np.testing.assert_array_equal(adalin_relu(x, jnp.array([0.25, 0.25])), [-0.5, 3.0])
+
+
+def test_gate_is_stop_gradient() -> None:
+    value, derivative = jax.value_and_grad(lambda z: adalin_tanh(z, jnp.array(0.2)))(
+        jnp.array(2.0)
+    )
+    gate = jnp.cos(0.5 * jnp.pi * jnp.abs(1.0 - jnp.tanh(2.0) ** 2))
+    expected = (1.0 - jnp.tanh(2.0) ** 2) + 0.2 * gate
+    assert jnp.isfinite(value)
+    np.testing.assert_allclose(derivative, expected, rtol=1e-6)
+
+
+def test_protocol_keeps_pmnist_difference_explicit() -> None:
+    assert ADALIN_PROTOCOL["paper_revision"] == "arXiv:2505.09486v1"
+    assert ADALIN_PROTOCOL["paper_pmnist_tasks"] == 400
+    assert ADALIN_PROTOCOL["asi_target_tasks"] == 200
+    assert ADALIN_PROTOCOL["mechanism_off"] == "alpha_zero_exact_base_activation"
+    assert ADALIN_PROTOCOL["scientific_promotion_allowed"] is False

--- a/tests/test_bimu.py
+++ b/tests/test_bimu.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.bimu import (
+    BIMU_PROTOCOL,
+    bimu_update,
+    late_window_mean,
+    posterior_probability,
+)
+
+
+def test_bimu_update_matches_equations_six_and_seven() -> None:
+    state = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    prior = jnp.zeros(2, dtype=jnp.float32)
+    gradient = jnp.array([2.0, -0.5], dtype=jnp.float32)
+    updated = bimu_update(state, gradient, prior, memory_window=10, alpha_max=1.0)
+    reciprocal = 1.0 / jnp.cosh(state) ** 2 + 2.0 * jnp.tanh(state) * gradient + 1.0 + 2.0 * jnp.abs(gradient)
+    eta = 1.0 / reciprocal
+    expected = state - eta * (gradient + (state - prior) / (10 * jnp.cosh(state) ** 2))
+    np.testing.assert_allclose(updated, expected, rtol=1e-6)
+
+
+def test_mechanism_off_removes_forgetting_term() -> None:
+    state = jnp.array([0.5], dtype=jnp.float32)
+    result = bimu_update(
+        state, jnp.zeros(1), jnp.zeros(1), memory_window=None, alpha_max=0.5
+    )
+    np.testing.assert_array_equal(result, state)
+
+
+def test_posterior_probability_and_late_metric_are_distinct() -> None:
+    np.testing.assert_allclose(posterior_probability(jnp.array([0.0])), [0.5])
+    assert late_window_mean([0.1, 0.2, 0.8, 0.9], window=2) == pytest.approx(0.85)
+    assert BIMU_PROTOCOL["primary_metric"] == "mean_test_accuracy_over_last_5_tasks"
+    assert BIMU_PROTOCOL["whole_stream_online_accuracy_is_separate"] is True
+
+
+def test_protocol_is_binary_bayesian_and_nonpromoting() -> None:
+    assert BIMU_PROTOCOL["paper_revision"] == "arXiv:2605.30198v1"
+    assert BIMU_PROTOCOL["weight_domain"] == (-1, 1)
+    assert BIMU_PROTOCOL["development_only"] is True
+    assert BIMU_PROTOCOL["scientific_promotion_allowed"] is False

--- a/tests/test_bimu.py
+++ b/tests/test_bimu.py
@@ -17,7 +17,12 @@ def test_bimu_update_matches_equations_six_and_seven() -> None:
     prior = jnp.zeros(2, dtype=jnp.float32)
     gradient = jnp.array([2.0, -0.5], dtype=jnp.float32)
     updated = bimu_update(state, gradient, prior, memory_window=10, alpha_max=1.0)
-    reciprocal = 1.0 / jnp.cosh(state) ** 2 + 2.0 * jnp.tanh(state) * gradient + 1.0 + 2.0 * jnp.abs(gradient)
+    reciprocal = (
+        1.0 / jnp.cosh(state) ** 2
+        + 2.0 * jnp.tanh(state) * gradient
+        + 1.0
+        + 2.0 * jnp.abs(gradient)
+    )
     eta = 1.0 / reciprocal
     expected = state - eta * (gradient + (state - prior) / (10 * jnp.cosh(state) ** 2))
     np.testing.assert_allclose(updated, expected, rtol=1e-6)

--- a/tests/test_ipmnist_ceilings.py
+++ b/tests/test_ipmnist_ceilings.py
@@ -1,0 +1,40 @@
+import pytest
+
+from alberta_framework.benchmarks.ipmnist_ceilings import (
+    CEILING_PROTOCOL,
+    CeilingResourceLedger,
+    FrozenFeatureCeiling,
+)
+
+
+def test_resource_ledger_charges_replay_pretraining_and_extractor() -> None:
+    ledger = CeilingResourceLedger(
+        persistent_bytes=100,
+        replay_bytes=20,
+        environment_steps=10,
+        pretraining_steps=30,
+        model_queries=40,
+        extractor_queries=50,
+    )
+    assert ledger.total_persistent_bytes == 120
+    assert ledger.total_steps == 40
+    assert ledger.total_model_queries == 90
+
+
+def test_mechanism_off_is_zero_replay_frozen_random_features() -> None:
+    config = FrozenFeatureCeiling(method="randumb", feature_dim=64, replay_capacity=0)
+    assert config.mechanism_off is True
+    assert config.persistent_replay_bytes(example_bytes=100) == 0
+
+
+def test_replay_bytes_are_explicit_and_bounded() -> None:
+    config = FrozenFeatureCeiling(method="ranpac", feature_dim=64, replay_capacity=5)
+    assert config.persistent_replay_bytes(example_bytes=100) == 500
+    with pytest.raises(ValueError, match="example_bytes"):
+        config.persistent_replay_bytes(example_bytes=-1)
+
+
+def test_protocol_keeps_ceilings_separate_and_nonpromoting() -> None:
+    assert CEILING_PROTOCOL["methods"] == ("replay", "in_context", "randumb", "ranpac", "prol")
+    assert CEILING_PROTOCOL["pretraining_allowed_but_charged"] is True
+    assert CEILING_PROTOCOL["scientific_promotion_allowed"] is False

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.ipmnist_gradual import (
+    GRADUAL_IPMNIST_PROTOCOL,
+    GradualTransitionConfig,
+    input_interpolation,
+    output_interpolation,
+    task_sampling_mask,
+    transition_alpha,
+)
+
+
+def test_abrupt_mode_is_exact_new_task_reduction() -> None:
+    config = GradualTransitionConfig(mode="abrupt", transition_steps=1)
+    assert transition_alpha(0, config) == 1.0
+
+    old = jnp.array([1.0, 2.0], dtype=jnp.float32)
+    new = jnp.array([3.0, 4.0], dtype=jnp.float32)
+    np.testing.assert_array_equal(input_interpolation(old, new, 1.0), new)
+
+
+def test_input_interpolation_matches_paper_equation() -> None:
+    old = jnp.array([-1.0, 1.0], dtype=jnp.float32)
+    new = jnp.array([1.0, -1.0], dtype=jnp.float32)
+    np.testing.assert_array_equal(input_interpolation(old, new, 0.25), [-0.5, 0.5])
+
+
+def test_output_interpolation_passes_through_uniform_distribution() -> None:
+    old = output_interpolation(1, 2, 0.5, n_classes=4)
+    np.testing.assert_array_equal(old, np.full(4, 0.25, dtype=np.float32))
+    np.testing.assert_array_equal(
+        output_interpolation(1, 2, 0.0, n_classes=4), [0.0, 1.0, 0.0, 0.0]
+    )
+    np.testing.assert_array_equal(
+        output_interpolation(1, 2, 1.0, n_classes=4), [0.0, 0.0, 1.0, 0.0]
+    )
+
+
+def test_transition_alpha_is_deterministic_and_clamped() -> None:
+    config = GradualTransitionConfig(mode="input_interpolation", transition_steps=4)
+    assert [transition_alpha(step, config) for step in range(6)] == [0.0, 0.25, 0.5, 0.75, 1.0, 1.0]
+
+
+def test_task_sampling_mask_is_matched_deterministic_and_monotone() -> None:
+    first = task_sampling_mask(seed=7, transition_id=3, count=10, alpha=0.3)
+    second = task_sampling_mask(seed=7, transition_id=3, count=10, alpha=0.3)
+    np.testing.assert_array_equal(first, second)
+    assert first.dtype == np.bool_
+    assert int(first.sum()) == 3
+    assert int(task_sampling_mask(seed=7, transition_id=3, count=10, alpha=0.7).sum()) == 7
+
+
+@pytest.mark.parametrize("alpha", [-0.1, 1.1, float("nan"), True])
+def test_helpers_reject_invalid_alpha(alpha: object) -> None:
+    with pytest.raises(ValueError, match="alpha"):
+        input_interpolation(jnp.zeros(2), jnp.ones(2), alpha)  # type: ignore[arg-type]
+
+
+def test_protocol_records_nonpromotion_and_information_allowance() -> None:
+    assert GRADUAL_IPMNIST_PROTOCOL["paper_revision"] == "arXiv:2602.09234v2"
+    assert GRADUAL_IPMNIST_PROTOCOL["development_only"] is True
+    assert GRADUAL_IPMNIST_PROTOCOL["scientific_promotion_allowed"] is False
+    assert GRADUAL_IPMNIST_PROTOCOL["learner_observes_transition_alpha"] is False
+    assert GRADUAL_IPMNIST_PROTOCOL["matched_axes"] == (
+        "seed",
+        "updates",
+        "observations",
+        "example_order",
+    )

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -1,0 +1,38 @@
+import jax.numpy as jnp
+import numpy as np
+
+from alberta_framework.evaluation.optimizer_geometry import (
+    GEOMETRY_PROTOCOL,
+    flad_noise_component,
+    orthogonal_correction,
+    spectral_matrix_sign,
+)
+
+
+def test_orthogonal_correction_removes_protected_direction() -> None:
+    update = jnp.array([2.0, 3.0])
+    basis = jnp.array([[1.0, 0.0]])
+    np.testing.assert_allclose(orthogonal_correction(update, basis), [0.0, 3.0])
+    np.testing.assert_array_equal(orthogonal_correction(update, jnp.zeros((0, 2))), update)
+
+
+def test_spectral_matrix_sign_has_bounded_singular_values() -> None:
+    result = spectral_matrix_sign(jnp.diag(jnp.array([3.0, 0.5])), steps=5)
+    assert float(jnp.linalg.svd(result, compute_uv=False)[0]) <= 1.01
+
+
+def test_flad_removes_gradient_aligned_component() -> None:
+    gradient = jnp.array([1.0, 0.0])
+    perturbation = jnp.array([2.0, 4.0])
+    np.testing.assert_allclose(flad_noise_component(perturbation, gradient), [0.0, 4.0])
+    np.testing.assert_array_equal(flad_noise_component(perturbation, jnp.zeros(2)), perturbation)
+
+
+def test_protocol_is_small_matrix_first_and_nonpromoting() -> None:
+    assert GEOMETRY_PROTOCOL["paper_revisions"] == (
+        "arXiv:2605.08949v2",
+        "arXiv:2606.10406v1",
+        "arXiv:2601.07636v1",
+    )
+    assert GEOMETRY_PROTOCOL["stage"] == "small_streaming_matrix_pre_ipmnist"
+    assert GEOMETRY_PROTOCOL["scientific_promotion_allowed"] is False

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -18,7 +18,7 @@ def test_orthogonal_correction_removes_protected_direction() -> None:
 
 def test_spectral_matrix_sign_has_bounded_singular_values() -> None:
     result = spectral_matrix_sign(jnp.diag(jnp.array([3.0, 0.5])), steps=5)
-    assert float(jnp.linalg.svd(result, compute_uv=False)[0]) <= 1.01
+    assert float(jnp.linalg.svd(result, compute_uv=False)[0]) <= 1.1
 
 
 def test_flad_removes_gradient_aligned_component() -> None:

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -1,0 +1,44 @@
+import pytest
+
+from alberta_framework.core.policy_archive import (
+    POLICY_ARCHIVE_PROTOCOL,
+    BoundedPolicyArchive,
+    PolicyEntry,
+)
+
+
+def _entry(name: str, latent: tuple[float, ...], score: float, size: int = 4) -> PolicyEntry:
+    return PolicyEntry(identity=name, policy_bytes=bytes(size), latent=latent, score=score)
+
+
+def test_diverse_archive_respects_exact_byte_budget() -> None:
+    archive = BoundedPolicyArchive(byte_budget=8, min_latent_distance=0.5)
+    archive = archive.add(_entry("a", (0.0, 0.0), 1.0))
+    archive = archive.add(_entry("b", (1.0, 0.0), 2.0))
+    assert archive.persistent_bytes == 8
+    with pytest.raises(ValueError, match="byte budget"):
+        archive.add(_entry("c", (0.0, 1.0), 3.0))
+
+
+def test_nearby_policy_only_replaces_on_higher_score() -> None:
+    archive = BoundedPolicyArchive(byte_budget=8, min_latent_distance=0.5).add(
+        _entry("a", (0.0,), 1.0)
+    )
+    assert archive.add(_entry("low", (0.1,), 0.5)) == archive
+    improved = archive.add(_entry("high", (0.1,), 2.0))
+    assert [entry.identity for entry in improved.entries] == ["high"]
+
+
+def test_one_model_and_fixed_snapshot_controls() -> None:
+    one = BoundedPolicyArchive(byte_budget=4, min_latent_distance=0.0, mode="one_model")
+    one = one.add(_entry("a", (0.0,), 1.0)).add(_entry("b", (1.0,), 0.0))
+    assert [entry.identity for entry in one.entries] == ["b"]
+    fixed = BoundedPolicyArchive(byte_budget=4, min_latent_distance=0.0, mode="fixed_snapshot")
+    fixed = fixed.add(_entry("a", (0.0,), 1.0)).add(_entry("b", (1.0,), 2.0))
+    assert [entry.identity for entry in fixed.entries] == ["a"]
+
+
+def test_protocol_is_nonpromoting() -> None:
+    assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
+    assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")
+    assert POLICY_ARCHIVE_PROTOCOL["scientific_promotion_allowed"] is False

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -12,16 +12,16 @@ def _entry(name: str, latent: tuple[float, ...], score: float, size: int = 4) ->
 
 
 def test_diverse_archive_respects_exact_byte_budget() -> None:
-    archive = BoundedPolicyArchive(byte_budget=8, min_latent_distance=0.5)
+    archive = BoundedPolicyArchive(byte_budget=58, min_latent_distance=0.5)
     archive = archive.add(_entry("a", (0.0, 0.0), 1.0))
     archive = archive.add(_entry("b", (1.0, 0.0), 2.0))
-    assert archive.persistent_bytes == 8
+    assert archive.persistent_bytes == 58
     with pytest.raises(ValueError, match="byte budget"):
         archive.add(_entry("c", (0.0, 1.0), 3.0))
 
 
 def test_nearby_policy_only_replaces_on_higher_score() -> None:
-    archive = BoundedPolicyArchive(byte_budget=8, min_latent_distance=0.5).add(
+    archive = BoundedPolicyArchive(byte_budget=32, min_latent_distance=0.5).add(
         _entry("a", (0.0,), 1.0)
     )
     assert archive.add(_entry("low", (0.1,), 0.5)) == archive
@@ -30,12 +30,20 @@ def test_nearby_policy_only_replaces_on_higher_score() -> None:
 
 
 def test_one_model_and_fixed_snapshot_controls() -> None:
-    one = BoundedPolicyArchive(byte_budget=4, min_latent_distance=0.0, mode="one_model")
+    one = BoundedPolicyArchive(byte_budget=21, min_latent_distance=0.0, mode="one_model")
     one = one.add(_entry("a", (0.0,), 1.0)).add(_entry("b", (1.0,), 0.0))
     assert [entry.identity for entry in one.entries] == ["b"]
-    fixed = BoundedPolicyArchive(byte_budget=4, min_latent_distance=0.0, mode="fixed_snapshot")
+    fixed = BoundedPolicyArchive(byte_budget=21, min_latent_distance=0.0, mode="fixed_snapshot")
     fixed = fixed.add(_entry("a", (0.0,), 1.0)).add(_entry("b", (1.0,), 2.0))
     assert [entry.identity for entry in fixed.entries] == ["a"]
+
+
+def test_archive_rejects_duplicate_identity() -> None:
+    archive = BoundedPolicyArchive(byte_budget=42, min_latent_distance=0.0).add(
+        _entry("a", (0.0,), 1.0)
+    )
+    with pytest.raises(ValueError, match="identity already exists"):
+        archive.add(_entry("a", (1.0,), 2.0))
 
 
 def test_protocol_is_nonpromoting() -> None:


### PR DESCRIPTION
Adds one consolidated, code-only prerequisite slice for #1569, #1570, #1571, #1572, #1573, and #1586. None of those issues is completed by this PR. (#1568 groundwork landed separately in #1605.)

Included groundwork:
- deterministic gradual input/output/task-sampling transitions with abrupt reduction (#1569)
- BiMU Bernoulli/Bayesian equation primitives and distinct late-five-task metric (#1570)
- AdaLin ReLU/tanh equations with stop-gradient gating and alpha-zero reduction (#1571)
- small-matrix orthogonal, spectral-sign, and FLAD decomposition controls (#1572)
- replay/frozen-feature ceiling declarations with replay/pretraining/extractor costs charged (#1573)
- immutable diverse policy archive with complete retained-byte accounting plus one-model/fixed-snapshot controls (#1586)

All protocol declarations pin paper revisions, record material adaptation differences, predeclare matched axes and resource accounting, and permanently mark future measurements development-only/nonpromoting. No benchmark/scientific workload ran and no output artifact changed.

Remaining gate for every issue: audit/pin any reference code actually used; freeze configs, seeds, budgets, metrics, and report schema; obtain explicit execution authorization; run matched development workloads; retain negative results; publish validated reports. #1570 additionally needs the Concrete/Gumbel estimator/full binary network; #1573 needs method-specific model integration; #1572 needs complete algorithm adapters beyond equation primitives.

Validation on current main after portability fixes: 30 focused tests pass; scoped Ruff passes; strict mypy passes for all six source modules; git diff check passes.