### PR TITLE
fix(benchmarks): keep external R0 plans non-executable

### DIFF
--- a/alberta_framework/benchmarks/external_qualification.py
+++ b/alberta_framework/benchmarks/external_qualification.py
@@ -1,8 +1,9 @@
 """Fail-closed plans for external continual-learning benchmark qualification.
 
-These records are development coordination metadata, not executable benchmarks or
-scientific evidence.  A lane may only acquire a runner after every qualification
-gate has a concrete, reviewable value.
+These records are development coordination metadata, not executable benchmarks,
+launch authorization, or scientific evidence.  A lane may only acquire a runner
+after every qualification gate has a concrete, reviewable value and a separate
+execution surface enforces its own explicit authorization.
 """
 
 from __future__ import annotations
@@ -70,6 +71,8 @@ class ExternalQualificationPlan:
     @property
     def blockers(self) -> tuple[str, ...]:
         completed = set(self.completed_gates)
+        if not self.code_revisions:
+            completed.discard("external_code_available_and_license_reviewed")
         return tuple(gate for gate in self.required_gates if gate not in completed)
 
     def require_ready(self) -> None:
@@ -77,10 +80,15 @@ class ExternalQualificationPlan:
             raise RuntimeError(
                 f"external lane {self.lane_id} is not qualified: {', '.join(self.blockers)}"
             )
+        raise RuntimeError(
+            "R0 qualification metadata cannot authorize external execution; "
+            "a separately reviewed runner and explicit launch authorization are required"
+        )
 
 
 COMMON_GATES: tuple[str, ...] = (
     "external_code_available_and_license_reviewed",
+    "paper_code_and_asset_provenance_verified",
     "isolated_runtime_locked",
     "assets_checksums_and_storage_approved",
     "observation_action_and_boundary_contract_matched",
@@ -88,6 +96,7 @@ COMMON_GATES: tuple[str, ...] = (
     "persistent_bytes_steps_queries_and_timing_accounted",
     "parity_and_mechanism_off_tests_pass",
     "development_only_result_schema_and_validator_registered",
+    "external_execution_separately_authorized",
 )
 
 

--- a/tests/test_external_qualification.py
+++ b/tests/test_external_qualification.py
@@ -24,17 +24,38 @@ def test_registry_exactly_covers_research_wave_and_is_not_run_ready() -> None:
             plan.require_ready()
 
 
-def test_ready_plan_requires_every_gate_without_reordering() -> None:
+def test_completed_r0_plan_still_cannot_authorize_external_execution() -> None:
+    revision = ExternalCodeRevision("https://github.com/org/repo.git", "a" * 40)
+    plan = ExternalQualificationPlan(
+        issue=1,
+        lane_id="fixture",
+        paper_revisions=("paper-v1",),
+        code_revisions=(revision,),
+        required_gates=("first", "second"),
+        completed_gates=("second", "first"),
+    )
+    assert plan.blockers == ()
+    with pytest.raises(RuntimeError, match="cannot authorize external execution"):
+        plan.require_ready()
+
+
+def test_missing_official_code_remains_a_blocker_even_if_claimed_complete() -> None:
     plan = ExternalQualificationPlan(
         issue=1,
         lane_id="fixture",
         paper_revisions=("paper-v1",),
         code_revisions=(),
-        required_gates=("first", "second"),
-        completed_gates=("second", "first"),
+        required_gates=COMMON_GATES,
+        completed_gates=COMMON_GATES,
     )
-    assert plan.blockers == ()
-    plan.require_ready()
+    assert "external_code_available_and_license_reviewed" in plan.blockers
+    with pytest.raises(RuntimeError, match="external_code_available_and_license_reviewed"):
+        plan.require_ready()
+
+
+def test_common_gates_require_provenance_and_separate_launch_authorization() -> None:
+    assert "paper_code_and_asset_provenance_verified" in COMMON_GATES
+    assert "external_execution_separately_authorized" in COMMON_GATES
 
 
 @pytest.mark.parametrize("issue", [True, 1574.0, "1574"])


### PR DESCRIPTION
Corrective follow-up to merged #1606 after exact-current-main audit.\n\n- an R0 qualification record can never itself authorize an external execution, even when every coordination gate is marked complete\n- an empty official-code revision remains a blocker even if a caller claims the code/license gate complete\n- provenance verification and separate execution authorization are explicit common gates\n- preserves the current static registry as non-executable coordination metadata\n\nAlso audited merged #1607: it explicitly leaves #1569-#1573/#1586 open as groundwork, and its current paper pins include the corrected RanDumb/RanPAC v3 identities. No revert is warranted.\n\nVerification: 40 focused #1606/#1607 tests; Ruff; strict mypy (183 files); diff check. No external workload, workflow, or output mutation.