### PR TITLE
fix(research): bound protocol hosts and traced kernels

### DIFF
--- a/alberta_framework/benchmarks/adalin.py
+++ b/alberta_framework/benchmarks/adalin.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import math
 from types import MappingProxyType
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 
 ADALIN_PROTOCOL = MappingProxyType(
@@ -23,6 +25,7 @@ ADALIN_PROTOCOL = MappingProxyType(
         "asi_hidden_widths": (300, 150),
         "learner_observes_task_boundary": False,
         "mechanism_off": "alpha_zero_exact_base_activation",
+        "finite_kernel_preflight_required": True,
         "matched_axes": ("seed", "updates", "observations"),
         "persistent_bytes_accounting_required": True,
         "environment_steps_accounting_required": True,
@@ -33,17 +36,67 @@ ADALIN_PROTOCOL = MappingProxyType(
     }
 )
 
+_MAX_ARRAY_ELEMENTS = 1_000_000
 
-def _adalin(x: Array, alpha: Array, *, activation: Array, derivative: Array) -> Array:
+
+def _trusted_float_array(value: object, *, name: str) -> Array:
+    actual_type = type(value)
+    if not (actual_type is np.ndarray or issubclass(actual_type, (jax.Array, jax.core.Tracer))):
+        raise ValueError(f"{name} must be an exact NumPy or JAX array")
+    array = jnp.asarray(value)
+    if (
+        array.size < 1
+        or array.size > _MAX_ARRAY_ELEMENTS
+        or not jnp.issubdtype(array.dtype, jnp.floating)
+    ):
+        raise ValueError(f"{name} must be a bounded floating array")
+    return array
+
+
+def _adalin_transaction(
+    x: Array, alpha: Array, *, activation: Array, derivative: Array
+) -> tuple[Array, Array]:
+    try:
+        output_shape = np.broadcast_shapes(x.shape, alpha.shape, activation.shape, derivative.shape)
+    except ValueError as error:
+        raise ValueError("x and alpha must have compatible shapes") from error
+    if math.prod(output_shape) > _MAX_ARRAY_ELEMENTS:
+        raise ValueError("broadcast output exceeds the 1000000-element limit")
     gate = jax.lax.stop_gradient(jnp.cos(0.5 * jnp.pi * jnp.abs(derivative)))
-    return activation + alpha * x * gate
+    candidate = activation + alpha * x * gate
+    valid = (
+        jnp.all(jnp.isfinite(x)) & jnp.all(jnp.isfinite(alpha)) & jnp.all(jnp.isfinite(candidate))
+    )
+    safe = jnp.where(valid, candidate, jnp.zeros_like(candidate))
+    return safe, valid
+
+
+def _unwrap_transaction(result: tuple[Array, Array]) -> Array:
+    safe, valid = result
+    if not isinstance(valid, jax.core.Tracer) and not bool(valid):
+        raise ValueError("AdaLin activation must be finite")
+    return safe
 
 
 def adalin_relu(x: Array, alpha: Array) -> Array:
     """AdaLin equation 2 for ReLU (algebraically PReLU)."""
-    value = jnp.asarray(x)
-    coefficient = jnp.asarray(alpha)
-    return _adalin(
+    value = _trusted_float_array(x, name="x")
+    coefficient = _trusted_float_array(alpha, name="alpha")
+    return _unwrap_transaction(
+        _adalin_transaction(
+            value,
+            coefficient,
+            activation=jax.nn.relu(value),
+            derivative=(value > 0).astype(value.dtype),
+        )
+    )
+
+
+def adalin_relu_transaction(x: object, alpha: object) -> tuple[Array, Array]:
+    """Return a finite ReLU-AdaLin value and caller-visible validity bit."""
+    value = _trusted_float_array(x, name="x")
+    coefficient = _trusted_float_array(alpha, name="alpha")
+    return _adalin_transaction(
         value,
         coefficient,
         activation=jax.nn.relu(value),
@@ -53,10 +106,25 @@ def adalin_relu(x: Array, alpha: Array) -> Array:
 
 def adalin_tanh(x: Array, alpha: Array) -> Array:
     """AdaLin equation 2 for tanh, whose Lipschitz constant is one."""
-    value = jnp.asarray(x)
-    coefficient = jnp.asarray(alpha)
+    value = _trusted_float_array(x, name="x")
+    coefficient = _trusted_float_array(alpha, name="alpha")
     activation = jnp.tanh(value)
-    return _adalin(
+    return _unwrap_transaction(
+        _adalin_transaction(
+            value,
+            coefficient,
+            activation=activation,
+            derivative=1.0 - activation**2,
+        )
+    )
+
+
+def adalin_tanh_transaction(x: object, alpha: object) -> tuple[Array, Array]:
+    """Return a finite tanh-AdaLin value and caller-visible validity bit."""
+    value = _trusted_float_array(x, name="x")
+    coefficient = _trusted_float_array(alpha, name="alpha")
+    activation = jnp.tanh(value)
+    return _adalin_transaction(
         value,
         coefficient,
         activation=activation,

--- a/alberta_framework/benchmarks/bimu.py
+++ b/alberta_framework/benchmarks/bimu.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 from types import MappingProxyType
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
@@ -22,6 +22,7 @@ BIMU_PROTOCOL = MappingProxyType(
         "paper_axes": (("tasks", 1000), ("hidden_units", 100), ("batch_size", 1)),
         "adaptation_difference": "ASI implementation exposes equation primitives; no run is frozen",
         "learner_observes_task_boundary": False,
+        "finite_kernel_preflight_required": True,
         "matched_axes": ("seed", "updates", "observations", "label_queries"),
         "persistent_bytes_accounting_required": True,
         "environment_steps_accounting_required": True,
@@ -32,30 +33,55 @@ BIMU_PROTOCOL = MappingProxyType(
     }
 )
 
+_INT32_MAX = 2**31 - 1
+_MAX_VECTOR_ELEMENTS = 1_000_000
+
 
 def _finite_vector(value: object, *, name: str) -> Array:
+    actual_type = type(value)
+    if not (actual_type is np.ndarray or issubclass(actual_type, (jax.Array, jax.core.Tracer))):
+        raise ValueError(f"{name} must be an exact NumPy or JAX array")
     array = jnp.asarray(value)
-    if array.ndim != 1 or array.size < 1 or not jnp.issubdtype(array.dtype, jnp.floating):
+    if (
+        array.ndim != 1
+        or array.size < 1
+        or array.size > _MAX_VECTOR_ELEMENTS
+        or not jnp.issubdtype(array.dtype, jnp.floating)
+    ):
         raise ValueError(f"{name} must be a non-empty floating vector")
-    if not bool(jnp.all(jnp.isfinite(array))):
+    valid = jnp.all(jnp.isfinite(array))
+    if not isinstance(valid, jax.core.Tracer) and not bool(valid):
         raise ValueError(f"{name} must contain only finite values")
     return array
 
 
+def posterior_probability_transaction(natural_parameter: object) -> tuple[Array, Array]:
+    """Return a finite posterior probability and caller-visible validity bit."""
+    state = _finite_vector(natural_parameter, name="natural_parameter")
+    logit = 2.0 * state
+    result = jax.nn.sigmoid(logit)
+    valid = (
+        jnp.all(jnp.isfinite(state)) & jnp.all(jnp.isfinite(logit)) & jnp.all(jnp.isfinite(result))
+    )
+    return jnp.where(valid, result, jnp.full_like(result, 0.5)), valid
+
+
 def posterior_probability(natural_parameter: object) -> Array:
     """Return ``P(weight=+1) = sigmoid(2 lambda)`` (paper equation 2)."""
-    state = _finite_vector(natural_parameter, name="natural_parameter")
-    return jnp.asarray(1.0 / (1.0 + jnp.exp(-2.0 * state)), dtype=state.dtype)
+    safe, valid = posterior_probability_transaction(natural_parameter)
+    if not isinstance(valid, jax.core.Tracer) and not bool(valid):
+        raise ValueError("posterior probability must be finite")
+    return safe
 
 
-def bimu_update(
+def bimu_update_transaction(
     natural_parameter: object,
     loss_gradient: object,
     prior_natural_parameter: object,
     *,
     memory_window: int | None,
     alpha_max: float,
-) -> Array:
+) -> tuple[Array, Array]:
     """Apply BiMU equations 6--7 to one flat natural-parameter vector.
 
     ``memory_window=None`` is the predeclared mechanism-off reduction: it
@@ -68,24 +94,66 @@ def bimu_update(
         raise ValueError("state, gradient, and prior must have identical shapes")
     if type(alpha_max) is not float or not math.isfinite(alpha_max) or alpha_max <= 0.0:
         raise ValueError("alpha_max must be a finite positive float")
-    if memory_window is not None and (type(memory_window) is not int or memory_window < 1):
+    if memory_window is not None and (
+        type(memory_window) is not int or memory_window < 1 or memory_window > _INT32_MAX
+    ):
         raise ValueError("memory_window must be None or a positive integer")
     uncertainty = 1.0 / jnp.cosh(state) ** 2
     reciprocal_eta = (
-        uncertainty
-        + 2.0 * jnp.tanh(state) * gradient
-        + 1.0 / alpha_max
-        + 2.0 * jnp.abs(gradient)
+        uncertainty + 2.0 * jnp.tanh(state) * gradient + 1.0 / alpha_max + 2.0 * jnp.abs(gradient)
     )
     eta = 1.0 / reciprocal_eta
     forgetting = 0.0 if memory_window is None else (state - prior) * uncertainty / memory_window
-    return state - eta * (gradient + forgetting)
+    summed_update = gradient + forgetting
+    candidate = state - eta * summed_update
+    source_valid = (
+        jnp.all(jnp.isfinite(state))
+        & jnp.all(jnp.isfinite(gradient))
+        & jnp.all(jnp.isfinite(prior))
+    )
+    candidate_valid = jnp.all(jnp.isfinite(candidate))
+    intermediate_valid = (
+        jnp.all(jnp.isfinite(uncertainty))
+        & jnp.all(jnp.isfinite(reciprocal_eta))
+        & jnp.all(jnp.isfinite(eta))
+        & jnp.all(jnp.isfinite(forgetting))
+        & jnp.all(jnp.isfinite(summed_update))
+    )
+    valid = source_valid & intermediate_valid & candidate_valid
+    fallback = jnp.where(source_valid, state, jnp.zeros_like(state))
+    safe = jnp.where(valid, candidate, fallback)
+    return safe, valid
 
 
-def late_window_mean(task_accuracies: Sequence[float], *, window: int = 5) -> float:
+def bimu_update(
+    natural_parameter: object,
+    loss_gradient: object,
+    prior_natural_parameter: object,
+    *,
+    memory_window: int | None,
+    alpha_max: float,
+) -> Array:
+    """Compatibility wrapper that fails closed eagerly and returns a traced safe value."""
+    safe, valid = bimu_update_transaction(
+        natural_parameter,
+        loss_gradient,
+        prior_natural_parameter,
+        memory_window=memory_window,
+        alpha_max=alpha_max,
+    )
+    if not isinstance(valid, jax.core.Tracer) and not bool(valid):
+        raise ValueError("BiMU update must produce only finite values")
+    return safe
+
+
+def late_window_mean(task_accuracies: list[float] | tuple[float, ...], *, window: int = 5) -> float:
     """Compute BiMU's late-task metric without conflating whole-stream accuracy."""
-    if type(window) is not int or window < 1:
-        raise ValueError("window must be a positive integer")
+    if type(window) is not int or window < 1 or window > _MAX_VECTOR_ELEMENTS:
+        raise ValueError("window must be an integer in [1, 1000000]")
+    if type(task_accuracies) not in {list, tuple} or len(task_accuracies) > _MAX_VECTOR_ELEMENTS:
+        raise ValueError("task_accuracies must be an exact bounded list or tuple")
+    if any(type(value) not in {int, float} for value in task_accuracies):
+        raise ValueError("task_accuracies must contain exact real numbers")
     values = np.asarray(task_accuracies)
     if values.ndim != 1 or values.size < window or values.dtype.kind not in {"i", "u", "f"}:
         raise ValueError("task_accuracies must be a numeric vector at least window long")

--- a/alberta_framework/benchmarks/ipmnist_ceilings.py
+++ b/alberta_framework/benchmarks/ipmnist_ceilings.py
@@ -7,6 +7,9 @@ from types import MappingProxyType
 from typing import Literal
 
 _METHODS = ("replay", "in_context", "randumb", "ranpac", "prol")
+_INT32_MAX = 2**31 - 1
+_MAX_PERSISTENT_BYTES = 256 * 1024 * 1024
+_MAX_FEATURE_DIM = 1_000_000
 
 CEILING_PROTOCOL = MappingProxyType(
     {
@@ -29,9 +32,9 @@ CEILING_PROTOCOL = MappingProxyType(
 )
 
 
-def _nonnegative(name: str, value: object) -> int:
-    if type(value) is not int or value < 0:
-        raise ValueError(f"{name} must be a non-negative integer")
+def _nonnegative(name: str, value: object, *, maximum: int = _INT32_MAX) -> int:
+    if type(value) is not int or value < 0 or value > maximum:
+        raise ValueError(f"{name} must be an integer in [0, {maximum}]")
     return value
 
 
@@ -48,7 +51,16 @@ class CeilingResourceLedger:
 
     def __post_init__(self) -> None:
         for name in self.__dataclass_fields__:
-            object.__setattr__(self, name, _nonnegative(name, getattr(self, name)))
+            maximum = _MAX_PERSISTENT_BYTES if name.endswith("bytes") else _INT32_MAX
+            object.__setattr__(
+                self, name, _nonnegative(name, getattr(self, name), maximum=maximum)
+            )
+        if self.persistent_bytes + self.replay_bytes > _MAX_PERSISTENT_BYTES:
+            raise ValueError("total persistent bytes exceed 256 MiB")
+        if self.environment_steps + self.pretraining_steps > _INT32_MAX:
+            raise ValueError("total steps exceed signed int32")
+        if self.model_queries + self.extractor_queries > _INT32_MAX:
+            raise ValueError("total model queries exceed signed int32")
 
     @property
     def total_persistent_bytes(self) -> int:
@@ -74,8 +86,12 @@ class FrozenFeatureCeiling:
     def __post_init__(self) -> None:
         if type(self.method) is not str or self.method not in _METHODS:
             raise ValueError("method is not a registered ceiling")
-        if type(self.feature_dim) is not int or self.feature_dim < 1:
-            raise ValueError("feature_dim must be a positive integer")
+        if (
+            type(self.feature_dim) is not int
+            or self.feature_dim < 1
+            or self.feature_dim > _MAX_FEATURE_DIM
+        ):
+            raise ValueError("feature_dim must be in [1, 1000000]")
         _nonnegative("replay_capacity", self.replay_capacity)
 
     @property
@@ -83,6 +99,9 @@ class FrozenFeatureCeiling:
         return self.method == "randumb" and self.replay_capacity == 0
 
     def persistent_replay_bytes(self, *, example_bytes: int) -> int:
-        if type(example_bytes) is not int or example_bytes < 0:
-            raise ValueError("example_bytes must be a non-negative integer")
-        return self.replay_capacity * example_bytes
+        resolved = _nonnegative(
+            "example_bytes", example_bytes, maximum=_MAX_PERSISTENT_BYTES
+        )
+        if self.replay_capacity and resolved > _MAX_PERSISTENT_BYTES // self.replay_capacity:
+            raise ValueError("derived replay bytes exceed 256 MiB")
+        return self.replay_capacity * resolved

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -29,6 +29,7 @@ _MODES = frozenset(
     {"abrupt", "input_interpolation", "output_interpolation", "task_sampling"}
 )
 _INT32_MAX = 2**31 - 1
+_MAX_ARRAY_ELEMENTS = 1_000_000
 
 GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(
     {
@@ -42,6 +43,7 @@ GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(
         "matched_axes": ("seed", "updates", "observations", "example_order"),
         "learner_observes_transition_alpha": False,
         "learner_observes_task_boundary": False,
+        "transaction_validity_required": True,
         "persistent_bytes_accounting_required": True,
         "environment_steps_accounting_required": True,
         "model_queries_accounting_required": True,
@@ -102,18 +104,43 @@ def transition_alpha(step: int, config: GradualTransitionConfig) -> float:
     return min(resolved_step / config.transition_steps, 1.0)
 
 
-def input_interpolation(old: Array, new: Array, alpha: float) -> Array:
-    """Apply paper equation ``x_alpha = (1-alpha)x_old + alpha*x_new``."""
+def input_interpolation_transaction(
+    old: object, new: object, alpha: float
+) -> tuple[Array, Array]:
+    """Return a finite interpolation candidate and a traced validity bit."""
     resolved = _alpha(alpha)
+    old_type = type(old)
+    new_type = type(new)
+    if not (
+        old_type is np.ndarray or issubclass(old_type, (jax.Array, jax.core.Tracer))
+    ) or not (
+        new_type is np.ndarray or issubclass(new_type, (jax.Array, jax.core.Tracer))
+    ):
+        raise ValueError("old and new inputs must be exact NumPy or JAX arrays")
     old_array = jnp.asarray(old)
     new_array = jnp.asarray(new)
     if old_array.shape != new_array.shape:
         raise ValueError("old and new inputs must have identical shapes")
+    if old_array.size < 1 or old_array.size > _MAX_ARRAY_ELEMENTS:
+        raise ValueError("input size must be in [1, 1000000]")
     if old_array.dtype != new_array.dtype or not jnp.issubdtype(old_array.dtype, jnp.floating):
         raise ValueError("old and new inputs must share a floating dtype")
-    if not bool(jnp.all(jnp.isfinite(old_array))) or not bool(jnp.all(jnp.isfinite(new_array))):
-        raise ValueError("old and new inputs must contain only finite values")
-    return (1.0 - resolved) * old_array + resolved * new_array
+    candidate = (1.0 - resolved) * old_array + resolved * new_array
+    valid = (
+        jnp.all(jnp.isfinite(old_array))
+        & jnp.all(jnp.isfinite(new_array))
+        & jnp.all(jnp.isfinite(candidate))
+    )
+    safe = jnp.where(valid, candidate, jnp.zeros_like(candidate))
+    return safe, valid
+
+
+def input_interpolation(old: object, new: object, alpha: float) -> Array:
+    """Apply paper equation ``x_alpha = (1-alpha)x_old + alpha*x_new``."""
+    safe, valid = input_interpolation_transaction(old, new, alpha)
+    if not isinstance(valid, jax.core.Tracer) and not bool(valid):
+        raise ValueError("old and new inputs must produce only finite values")
+    return safe
 
 
 def output_interpolation(
@@ -122,6 +149,8 @@ def output_interpolation(
     """Interpolate old one-hot -> uniform -> new one-hot as paper section 4."""
     resolved_alpha = _alpha(alpha)
     classes = _exact_index("n_classes", n_classes, minimum=2)
+    if classes > _MAX_ARRAY_ELEMENTS:
+        raise ValueError("n_classes must be at most 1000000")
     old = _exact_index("old_label", old_label, minimum=0)
     new = _exact_index("new_label", new_label, minimum=0)
     if old >= classes or new >= classes:
@@ -146,6 +175,8 @@ def task_sampling_mask(
     resolved_seed = require_jax_seed(seed, name="seed")
     resolved_transition = _exact_index("transition_id", transition_id, minimum=0)
     resolved_count = _exact_index("count", count, minimum=1)
+    if resolved_count > _MAX_ARRAY_ELEMENTS:
+        raise ValueError("count must be at most 1000000")
     new_count = math.floor(_alpha(alpha) * resolved_count)
     order = np.asarray(
         jax.device_get(

--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -9,6 +9,12 @@ from typing import Literal
 
 import numpy as np
 
+_MAX_ARCHIVE_BYTES = 256 * 1024 * 1024
+_MAX_ARCHIVE_ENTRIES = 4096
+_MAX_IDENTITY_CHARACTERS = 1024
+_MAX_POLICY_BYTES = 64 * 1024 * 1024
+_MAX_LATENT_WIDTH = 65_536
+
 POLICY_ARCHIVE_PROTOCOL = MappingProxyType(
     {
         "schema": "asi.policy-archive.protocol.v1",
@@ -37,11 +43,23 @@ class PolicyEntry:
     score: float
 
     def __post_init__(self) -> None:
-        if type(self.identity) is not str or not self.identity:
+        if (
+            type(self.identity) is not str
+            or not self.identity
+            or len(self.identity) > _MAX_IDENTITY_CHARACTERS
+        ):
             raise ValueError("identity must be a non-empty string")
-        if type(self.policy_bytes) is not bytes or not self.policy_bytes:
+        if (
+            type(self.policy_bytes) is not bytes
+            or not self.policy_bytes
+            or len(self.policy_bytes) > _MAX_POLICY_BYTES
+        ):
             raise ValueError("policy_bytes must be non-empty exact bytes")
-        if type(self.latent) is not tuple or not self.latent:
+        if (
+            type(self.latent) is not tuple
+            or not self.latent
+            or len(self.latent) > _MAX_LATENT_WIDTH
+        ):
             raise ValueError("latent must be a non-empty tuple")
         if any(type(value) is not float or not math.isfinite(value) for value in self.latent):
             raise ValueError("latent values must be finite floats")
@@ -69,8 +87,12 @@ class BoundedPolicyArchive:
     entries: tuple[PolicyEntry, ...] = ()
 
     def __post_init__(self) -> None:
-        if type(self.byte_budget) is not int or self.byte_budget < 1:
-            raise ValueError("byte_budget must be a positive integer")
+        if (
+            type(self.byte_budget) is not int
+            or self.byte_budget < 1
+            or self.byte_budget > _MAX_ARCHIVE_BYTES
+        ):
+            raise ValueError("byte_budget must be in [1, 256 MiB]")
         if (
             type(self.min_latent_distance) is not float
             or not math.isfinite(self.min_latent_distance)
@@ -83,14 +105,19 @@ class BoundedPolicyArchive:
             "fixed_snapshot",
         }:
             raise ValueError("unknown archive mode")
-        if type(self.entries) is not tuple or any(
-            type(entry) is not PolicyEntry for entry in self.entries
-        ):
+        if type(self.entries) is not tuple or len(self.entries) > _MAX_ARCHIVE_ENTRIES:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
-        if len({entry.identity for entry in self.entries}) != len(self.entries):
-            raise ValueError("entry identities must be unique")
-        if self.persistent_bytes > self.byte_budget:
-            raise ValueError("entries exceed byte budget")
+        retained_bytes = 0
+        identities: set[str] = set()
+        for entry in self.entries:
+            if type(entry) is not PolicyEntry:
+                raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            retained_bytes += entry.persistent_bytes
+            if retained_bytes > self.byte_budget:
+                raise ValueError("entries exceed byte budget")
+            if entry.identity in identities:
+                raise ValueError("entry identities must be unique")
+            identities.add(entry.identity)
 
     @property
     def persistent_bytes(self) -> int:
@@ -122,6 +149,10 @@ class BoundedPolicyArchive:
                     return self
                 candidates = self.entries[:nearest] + (entry,) + self.entries[nearest + 1 :]
             else:
+                if len(self.entries) >= _MAX_ARCHIVE_ENTRIES:
+                    raise ValueError("candidate would exceed archive entry limit")
+                if self.persistent_bytes + entry.persistent_bytes > self.byte_budget:
+                    raise ValueError("candidate would exceed byte budget")
                 candidates = self.entries + (entry,)
         if sum(item.persistent_bytes for item in candidates) > self.byte_budget:
             raise ValueError("candidate would exceed byte budget")

--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from types import MappingProxyType
 
+import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 
 GEOMETRY_PROTOCOL = MappingProxyType(
@@ -18,6 +20,7 @@ GEOMETRY_PROTOCOL = MappingProxyType(
         "stage": "small_streaming_matrix_pre_ipmnist",
         "protocol_difference": "equation primitives only; no LLM or batch-CL claim",
         "mechanism_off": "empty_basis_or_zero_gradient_exact_reduction",
+        "finite_kernel_preflight_required": True,
         "matched_axes": ("seed", "updates", "observations"),
         "persistent_bytes_accounting_required": True,
         "environment_steps_accounting_required": True,
@@ -28,28 +31,69 @@ GEOMETRY_PROTOCOL = MappingProxyType(
     }
 )
 
+_MAX_MATRIX_ELEMENTS = 1_000_000
+
+
+def _trusted_array(value: object, *, name: str) -> Array:
+    actual_type = type(value)
+    if not (actual_type is np.ndarray or issubclass(actual_type, (jax.Array, jax.core.Tracer))):
+        raise ValueError(f"{name} must be an exact NumPy or JAX array")
+    result = jnp.asarray(value)
+    if result.size > _MAX_MATRIX_ELEMENTS or not jnp.issubdtype(result.dtype, jnp.floating):
+        raise ValueError(f"{name} must be a bounded floating array")
+    return result
+
+
+def orthogonal_correction_transaction(update: Array, protected_basis: Array) -> tuple[Array, Array]:
+    """Return a finite orthogonal correction and caller-visible validity bit."""
+    vector = _trusted_array(update, name="update")
+    basis = _trusted_array(protected_basis, name="protected_basis")
+    if vector.ndim != 1 or basis.ndim != 2 or basis.shape[1] != vector.shape[0]:
+        raise ValueError("update must be a vector and basis rows must match its width")
+    coordinates = basis @ vector
+    projection = basis.T @ coordinates
+    candidate = vector - projection
+    valid = (
+        jnp.all(jnp.isfinite(vector))
+        & jnp.all(jnp.isfinite(basis))
+        & jnp.all(jnp.isfinite(coordinates))
+        & jnp.all(jnp.isfinite(projection))
+        & jnp.all(jnp.isfinite(candidate))
+    )
+    safe = jnp.where(valid, candidate, jnp.zeros_like(candidate))
+    return safe, valid
+
+
+def _unwrap_transaction(result: tuple[Array, Array], *, name: str) -> Array:
+    safe, valid = result
+    if not isinstance(valid, jax.core.Tracer) and not bool(valid):
+        raise ValueError(f"{name} must be finite")
+    return safe
+
 
 def orthogonal_correction(update: Array, protected_basis: Array) -> Array:
     """Project a vector away from row-wise orthonormal protected directions."""
-    vector = jnp.asarray(update)
-    basis = jnp.asarray(protected_basis)
-    if vector.ndim != 1 or basis.ndim != 2 or basis.shape[1] != vector.shape[0]:
-        raise ValueError("update must be a vector and basis rows must match its width")
-    return vector - basis.T @ (basis @ vector)
+    return _unwrap_transaction(
+        orthogonal_correction_transaction(update, protected_basis),
+        name="orthogonal correction",
+    )
 
 
-def spectral_matrix_sign(matrix: Array, *, steps: int = 5) -> Array:
-    """Muon-style Newton--Schulz matrix-sign approximation for a small matrix."""
-    value = jnp.asarray(matrix)
+def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[Array, Array]:
+    """Return a finite matrix-sign approximation and caller-visible validity bit."""
+    value = _trusted_array(matrix, name="matrix")
     if (
         value.ndim != 2
         or value.size == 0
         or not jnp.issubdtype(value.dtype, jnp.floating)
         or type(steps) is not int
         or steps < 1
+        or steps > 32
     ):
         raise ValueError("matrix must be non-empty and steps a positive integer")
-    x = value / jnp.maximum(jnp.linalg.norm(value), jnp.asarray(1e-12, dtype=value.dtype))
+    norm = jnp.linalg.norm(value)
+    valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
+    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True
@@ -57,20 +101,50 @@ def spectral_matrix_sign(matrix: Array, *, steps: int = 5) -> Array:
         transposed = False
     for _ in range(steps):
         a = x @ x.T
-        x = 3.4445 * x - 4.7750 * a @ x + 2.0315 * a @ a @ x
-    return x.T if transposed else x
+        next_x = 3.4445 * x - 4.7750 * a @ x + 2.0315 * a @ a @ x
+        valid = valid & jnp.all(jnp.isfinite(a)) & jnp.all(jnp.isfinite(next_x))
+        x = next_x
+    candidate = x.T if transposed else x
+    valid = valid & jnp.all(jnp.isfinite(candidate))
+    safe = jnp.where(valid, candidate, jnp.zeros_like(candidate))
+    return safe, valid
+
+
+def spectral_matrix_sign(matrix: Array, *, steps: int = 5) -> Array:
+    """Muon-style Newton--Schulz matrix-sign approximation for a small matrix."""
+    return _unwrap_transaction(
+        spectral_matrix_sign_transaction(matrix, steps=steps), name="matrix sign"
+    )
+
+
+def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tuple[Array, Array]:
+    """Return a finite FLAD noise component and caller-visible validity bit."""
+    delta = _trusted_array(perturbation, name="perturbation")
+    direction = _trusted_array(gradient, name="gradient")
+    if delta.shape != direction.shape or delta.ndim != 1 or delta.size < 1:
+        raise ValueError("perturbation and gradient must be non-empty equal-width vectors")
+    squared_norm = jnp.vdot(direction, direction).real
+    numerator = jnp.vdot(direction, delta).real
+    denominator = jnp.where(squared_norm > 0.0, squared_norm, 1.0)
+    coefficient = numerator / denominator
+    projection = jnp.where(squared_norm > 0.0, direction * coefficient, jnp.zeros_like(delta))
+    candidate = delta - projection
+    valid = (
+        jnp.all(jnp.isfinite(delta))
+        & jnp.all(jnp.isfinite(direction))
+        & jnp.isfinite(squared_norm)
+        & jnp.isfinite(numerator)
+        & jnp.isfinite(coefficient)
+        & jnp.all(jnp.isfinite(projection))
+        & jnp.all(jnp.isfinite(candidate))
+    )
+    safe = jnp.where(valid, candidate, jnp.zeros_like(candidate))
+    return safe, valid
 
 
 def flad_noise_component(perturbation: Array, gradient: Array) -> Array:
     """Remove FLAD's gradient-aligned perturbation component."""
-    delta = jnp.asarray(perturbation)
-    direction = jnp.asarray(gradient)
-    if delta.shape != direction.shape or delta.ndim != 1:
-        raise ValueError("perturbation and gradient must be equal-width vectors")
-    squared_norm = jnp.vdot(direction, direction).real
-    projection = jnp.where(
-        squared_norm > 0.0,
-        direction * (jnp.vdot(direction, delta).real / squared_norm),
-        jnp.zeros_like(delta),
+    return _unwrap_transaction(
+        flad_noise_component_transaction(perturbation, gradient),
+        name="FLAD decomposition",
     )
-    return delta - projection

--- a/tests/test_adalin.py
+++ b/tests/test_adalin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from alberta_framework.benchmarks.adalin import ADALIN_PROTOCOL, adalin_relu, adalin_tanh
 
@@ -14,9 +15,7 @@ def test_relu_reduction_and_prelu_identity() -> None:
 
 
 def test_gate_is_stop_gradient() -> None:
-    value, derivative = jax.value_and_grad(lambda z: adalin_tanh(z, jnp.array(0.2)))(
-        jnp.array(2.0)
-    )
+    value, derivative = jax.value_and_grad(lambda z: adalin_tanh(z, jnp.array(0.2)))(jnp.array(2.0))
     gate = jnp.cos(0.5 * jnp.pi * jnp.abs(1.0 - jnp.tanh(2.0) ** 2))
     expected = (1.0 - jnp.tanh(2.0) ** 2) + 0.2 * gate
     assert jnp.isfinite(value)
@@ -29,3 +28,25 @@ def test_protocol_keeps_pmnist_difference_explicit() -> None:
     assert ADALIN_PROTOCOL["asi_target_tasks"] == 200
     assert ADALIN_PROTOCOL["mechanism_off"] == "alpha_zero_exact_base_activation"
     assert ADALIN_PROTOCOL["scientific_promotion_allowed"] is False
+
+
+def test_adalin_is_outer_jit_safe() -> None:
+    transformed = jax.jit(adalin_relu)(jnp.array([-1.0, 1.0]), jnp.array([0.2, 0.2]))
+    np.testing.assert_allclose(transformed, [-0.2, 1.0])
+
+
+def test_adalin_preflights_cross_broadcast_and_hostile_array() -> None:
+    with pytest.raises(ValueError, match="broadcast output"):
+        adalin_relu(jnp.ones((1, 1_000_000)), jnp.ones((1_000_000, 1)))
+
+    class Hostile:
+        calls = 0
+
+        def __array__(self) -> np.ndarray:
+            self.calls += 1
+            raise AssertionError("must not run")
+
+    hostile = Hostile()
+    with pytest.raises(ValueError, match="exact NumPy or JAX"):
+        adalin_relu(hostile, jnp.ones(1))  # type: ignore[arg-type]
+    assert hostile.calls == 0

--- a/tests/test_bimu.py
+++ b/tests/test_bimu.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -7,8 +8,10 @@ import pytest
 from alberta_framework.benchmarks.bimu import (
     BIMU_PROTOCOL,
     bimu_update,
+    bimu_update_transaction,
     late_window_mean,
     posterior_probability,
+    posterior_probability_transaction,
 )
 
 
@@ -30,9 +33,7 @@ def test_bimu_update_matches_equations_six_and_seven() -> None:
 
 def test_mechanism_off_removes_forgetting_term() -> None:
     state = jnp.array([0.5], dtype=jnp.float32)
-    result = bimu_update(
-        state, jnp.zeros(1), jnp.zeros(1), memory_window=None, alpha_max=0.5
-    )
+    result = bimu_update(state, jnp.zeros(1), jnp.zeros(1), memory_window=None, alpha_max=0.5)
     np.testing.assert_array_equal(result, state)
 
 
@@ -48,3 +49,58 @@ def test_protocol_is_binary_bayesian_and_nonpromoting() -> None:
     assert BIMU_PROTOCOL["weight_domain"] == (-1, 1)
     assert BIMU_PROTOCOL["development_only"] is True
     assert BIMU_PROTOCOL["scientific_promotion_allowed"] is False
+
+
+def test_bimu_update_is_outer_jit_safe() -> None:
+    update = jax.jit(
+        lambda state, gradient, prior: bimu_update(
+            state, gradient, prior, memory_window=10, alpha_max=1.0
+        )
+    )
+    assert bool(jnp.all(jnp.isfinite(update(jnp.zeros(2), jnp.ones(2), jnp.zeros(2)))))
+    transact = jax.jit(
+        lambda state, gradient: bimu_update_transaction(
+            state, gradient, jnp.zeros(2), memory_window=10, alpha_max=1.0
+        )
+    )
+    for state, gradient in (
+        (jnp.array([jnp.nan, 0.0]), jnp.ones(2)),
+        (jnp.zeros(2), jnp.array([jnp.inf, 0.0])),
+    ):
+        safe, valid = transact(state, gradient)
+        assert bool(jnp.all(jnp.isfinite(safe)))
+        assert not bool(valid)
+
+
+def test_bimu_rejects_array_protocol_object_without_calling_it() -> None:
+    class Hostile:
+        calls = 0
+
+        def __array__(self) -> np.ndarray:
+            self.calls += 1
+            raise AssertionError("must not run")
+
+    hostile = Hostile()
+    with pytest.raises(ValueError, match="exact NumPy or JAX"):
+        posterior_probability(hostile)
+    assert hostile.calls == 0
+
+
+def test_bimu_float32_overflow_is_invalid_not_laundered() -> None:
+    maximum = jnp.finfo(jnp.float32).max
+    transact = jax.jit(
+        lambda gradient: bimu_update_transaction(
+            jnp.zeros(2), gradient, jnp.zeros(2), memory_window=10, alpha_max=1.0
+        )
+    )
+    safe, valid = transact(jnp.full((2,), maximum))
+    assert bool(jnp.all(jnp.isfinite(safe)))
+    assert not bool(valid)
+    posterior, posterior_valid = jax.jit(posterior_probability_transaction)(jnp.array([jnp.inf]))
+    np.testing.assert_array_equal(posterior, [0.5])
+    assert not bool(posterior_valid)
+    finite_posterior, finite_valid = jax.jit(posterior_probability_transaction)(
+        jnp.array([maximum])
+    )
+    np.testing.assert_array_equal(finite_posterior, [0.5])
+    assert not bool(finite_valid)

--- a/tests/test_ipmnist_ceilings.py
+++ b/tests/test_ipmnist_ceilings.py
@@ -38,3 +38,18 @@ def test_protocol_keeps_ceilings_separate_and_nonpromoting() -> None:
     assert CEILING_PROTOCOL["methods"] == ("replay", "in_context", "randumb", "ranpac", "prol")
     assert CEILING_PROTOCOL["pretraining_allowed_but_charged"] is True
     assert CEILING_PROTOCOL["scientific_promotion_allowed"] is False
+
+
+def test_ceiling_resources_reject_derived_overflow() -> None:
+    with pytest.raises(ValueError, match="total steps"):
+        CeilingResourceLedger(
+            persistent_bytes=0,
+            replay_bytes=0,
+            environment_steps=2**31 - 1,
+            pretraining_steps=1,
+            model_queries=0,
+            extractor_queries=0,
+        )
+    config = FrozenFeatureCeiling(method="replay", feature_dim=1, replay_capacity=2)
+    with pytest.raises(ValueError, match="derived replay"):
+        config.persistent_replay_bytes(example_bytes=256 * 1024 * 1024)

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -8,6 +9,7 @@ from alberta_framework.benchmarks.ipmnist_gradual import (
     GRADUAL_IPMNIST_PROTOCOL,
     GradualTransitionConfig,
     input_interpolation,
+    input_interpolation_transaction,
     output_interpolation,
     task_sampling_mask,
     transition_alpha,
@@ -71,3 +73,31 @@ def test_protocol_records_nonpromotion_and_information_allowance() -> None:
         "observations",
         "example_order",
     )
+
+
+def test_input_interpolation_is_outer_jit_safe() -> None:
+    interpolate = jax.jit(lambda old, new: input_interpolation(old, new, 0.5))
+    np.testing.assert_array_equal(
+        interpolate(jnp.array([0.0]), jnp.array([2.0])), jnp.array([1.0])
+    )
+
+    transact = jax.jit(
+        lambda old, new: input_interpolation_transaction(old, new, 0.5)
+    )
+    safe, valid = transact(jnp.array([jnp.inf]), jnp.array([2.0]))
+    np.testing.assert_array_equal(safe, jnp.zeros(1))
+    assert not bool(valid)
+
+
+def test_input_interpolation_rejects_array_protocol_objects_without_calling_them() -> None:
+    class Hostile:
+        calls = 0
+
+        def __array__(self) -> np.ndarray:
+            self.calls += 1
+            raise AssertionError("must not run")
+
+    hostile = Hostile()
+    with pytest.raises(ValueError, match="exact NumPy or JAX"):
+        input_interpolation(hostile, jnp.ones(1), 0.5)  # type: ignore[arg-type]
+    assert hostile.calls == 0

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -1,11 +1,15 @@
+import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from alberta_framework.evaluation.optimizer_geometry import (
     GEOMETRY_PROTOCOL,
     flad_noise_component,
+    flad_noise_component_transaction,
     orthogonal_correction,
     spectral_matrix_sign,
+    spectral_matrix_sign_transaction,
 )
 
 
@@ -36,3 +40,37 @@ def test_protocol_is_small_matrix_first_and_nonpromoting() -> None:
     )
     assert GEOMETRY_PROTOCOL["stage"] == "small_streaming_matrix_pre_ipmnist"
     assert GEOMETRY_PROTOCOL["scientific_promotion_allowed"] is False
+
+
+def test_geometry_primitives_are_outer_jit_safe() -> None:
+    corrected = jax.jit(orthogonal_correction)(jnp.array([1.0, 2.0]), jnp.array([[1.0, 0.0]]))
+    np.testing.assert_allclose(corrected, [0.0, 2.0])
+
+
+def test_geometry_rejects_empty_flad_and_hostile_array() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        flad_noise_component(jnp.zeros(0), jnp.zeros(0))
+
+    class Hostile:
+        calls = 0
+
+        def __array__(self) -> np.ndarray:
+            self.calls += 1
+            raise AssertionError("must not run")
+
+    hostile = Hostile()
+    with pytest.raises(ValueError, match="exact NumPy or JAX"):
+        spectral_matrix_sign(hostile)  # type: ignore[arg-type]
+    assert hostile.calls == 0
+
+
+def test_geometry_float32_overflow_is_invalid_not_laundered() -> None:
+    maximum = jnp.finfo(jnp.float32).max
+    matrix, matrix_valid = jax.jit(spectral_matrix_sign_transaction)(jnp.full((2, 2), maximum))
+    assert bool(jnp.all(jnp.isfinite(matrix)))
+    assert not bool(matrix_valid)
+    component, component_valid = jax.jit(flad_noise_component_transaction)(
+        jnp.full((2,), maximum), jnp.full((2,), maximum)
+    )
+    assert bool(jnp.all(jnp.isfinite(component)))
+    assert not bool(component_valid)

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -46,6 +46,20 @@ def test_archive_rejects_duplicate_identity() -> None:
         archive.add(_entry("a", (1.0,), 2.0))
 
 
+def test_archive_preflights_host_dimensions() -> None:
+    with pytest.raises(ValueError, match="256 MiB"):
+        BoundedPolicyArchive(byte_budget=256 * 1024 * 1024 + 1, min_latent_distance=0.0)
+    with pytest.raises(ValueError, match="identity"):
+        _entry("x" * 1025, (0.0,), 1.0)
+    entry = _entry("a", (0.0,), 1.0)
+    with pytest.raises(ValueError, match="exact tuple"):
+        BoundedPolicyArchive(
+            byte_budget=256 * 1024 * 1024,
+            min_latent_distance=0.0,
+            entries=(entry,) * 4097,
+        )
+
+
 def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")


### PR DESCRIPTION
Immediate hardening follow-up to #1607.

- caps archive total bytes at 256 MiB, entries at 4096, policy payloads at 64 MiB, latent width at 65,536, and identity characters at 1,024
- preflights archive tuple count/type, cumulative bytes, and identities in bounded order; complete retained bytes include UTF-8 identity, policy, latent, and score
- caps ceiling ledger fields/derived totals, feature dimensions, and replay byte products before allocation
- replaces arbitrary array-protocol coercion in gradual, BiMU, AdaLin, and geometry helpers with exact NumPy/JAX host gates
- caps array/vector/matrix sizes, class/count/window/iteration controls, and derived outputs
- makes value-dependent finite handling outer-JIT safe: traced paths return finite fallback values while eager invalid calls fail closed
- adds hostile/preflight/overflow and outer-jit regressions

No workloads or outputs. Issues #1569-#1573/#1586 remain open for full adapters/frozen matched executions/reports.

Validation: 37 focused tests; scoped Ruff; strict mypy on all six modules; diff check.