### PR TITLE
docs: define inbound contribution terms

### DIFF
--- a/.github/slop-project.json
+++ b/.github/slop-project.json
@@ -1,6 +1,6 @@
 {
   "kind": "slop-project-authority",
-  "policyRevision": "2026-08-16.3",
+  "policyRevision": "2026-08-18.1",
   "projectId": "asi",
   "proposal": "https://github.com/elizaOS/slopdotcash/issues/115",
   "repository": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing to ASI
+
+Contributions are accepted through GitHub pull requests against `main` and
+are reviewed under the repository's normal maintainer process. By submitting
+a contribution, you agree that it is licensed under the repository's
+Apache-2.0 license and that you have the right to submit it on those terms.
+
+Keep changes bounded, include reproducible commands and evidence for benchmark
+claims, and follow the requirements in `AGENTS.md`. Maintainers decide whether
+to accept, reject, hold, or request changes to a contribution.

--- a/README.md
+++ b/README.md
@@ -347,6 +347,9 @@ Before repeating a failed or bounded idea, check
 
 ## Development and testing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the inbound licensing terms and
+maintainer review policy.
+
 Run targeted tests first, then broaden verification as appropriate:
 
 ```bash


### PR DESCRIPTION
Adds an explicit Apache-2.0 inbound contribution policy and advances the repository-owned Slop authority revision so contribution receipts can be activated without inferring legal terms. Maintainers remain the acceptance authority.