### PR TITLE
fix(reference-life): enforce exact integer identities

### DIFF
--- a/alberta_framework/prototype_reference_adapter.py
+++ b/alberta_framework/prototype_reference_adapter.py
@@ -98,8 +98,7 @@ class PrototypeReferenceState:
         ) is None:
             raise ValueError("lifecycle_id must use the Prototype lifecycle codec")
         if (
-            isinstance(self.decision_index, bool)
-            or not isinstance(self.decision_index, int)
+            type(self.decision_index) is not int
             or self.decision_index < 0
             or self.decision_index > MAX_DECISION_INDEX
         ):

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -287,8 +287,7 @@ class SpaceSpec:
             if dtype.kind not in {"i", "u"}:
                 raise ValueError("a discrete space dtype must be integer")
             if (
-                isinstance(self.cardinality, bool)
-                or not isinstance(self.cardinality, int)
+                type(self.cardinality) is not int
                 or self.cardinality <= 0
             ):
                 raise ValueError("discrete cardinality must be a positive integer")
@@ -1141,8 +1140,7 @@ class ReferenceTransactionState:
         if self.lifecycle_id is not None:
             _require_safe_id(self.lifecycle_id, name="lifecycle_id")
         if (
-            isinstance(self.next_decision_index, bool)
-            or not isinstance(self.next_decision_index, int)
+            type(self.next_decision_index) is not int
             or self.next_decision_index < 0
             or self.next_decision_index > MAX_DECISION_INDEX
         ):

--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -257,8 +257,7 @@ class ReferenceEnvironmentManifest:
         if not isinstance(self.action_spec, SpaceSpec):
             raise ValueError("action_spec must be a SpaceSpec")
         if (
-            isinstance(self.max_executions, bool)
-            or not isinstance(self.max_executions, int)
+            type(self.max_executions) is not int
             or self.max_executions <= 0
         ):
             raise ValueError("max_executions must be a positive integer")
@@ -398,7 +397,7 @@ class ExactDispatchState:
         _require_digest(self.manifest_id, name="manifest_id")
         for name in ("authorizations", "commands_issued", "receipts_recorded"):
             value = getattr(self, name)
-            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            if type(value) is not int or value < 0:
                 raise ValueError(f"{name} must be a nonnegative integer")
         if not (self.receipts_recorded <= self.commands_issued <= self.authorizations):
             raise ValueError("dispatch counters are out of order")
@@ -534,7 +533,7 @@ class ReferenceLifeMetricsState:
             "current_segment_events",
         ):
             value = getattr(self, name)
-            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            if type(value) is not int or value < 0:
                 raise ValueError(f"{name} must be a nonnegative integer")
         if self.current_phase not in (0, 1):
             raise ValueError("current_phase must be 0 or 1")
@@ -850,8 +849,7 @@ class SwitchingTwoStateReferenceEnvironment:
         _require_id(executor_epoch, name="executor_epoch")
         phase_length = config.phase_length
         if (
-            isinstance(phase_length, bool)
-            or not isinstance(phase_length, int)
+            type(phase_length) is not int
             or phase_length <= 0
             or phase_length > _MAX_SWITCHING_EXECUTIONS
         ):
@@ -1057,7 +1055,7 @@ class SwitchingTwoStateReferenceEnvironment:
             raise DecisionOwnershipError("execution step counter did not advance exactly once")
         applied = self.manifest.action_spec.encode(execution.applied_action)
         applied_value = applied.to_python()
-        if not isinstance(applied_value, int):
+        if type(applied_value) is not int:
             raise DecisionOwnershipError("execution applied action is not a scalar integer")
         next_state_index = int(np.asarray(execution.state.state_index))
         if next_state_index != applied_value:
@@ -1160,8 +1158,7 @@ class RiverSwimReferenceEnvironment:
             raise ValueError("RiverSwim config has the wrong type")
         n_states = config.n_states
         if (
-            isinstance(n_states, bool)
-            or not isinstance(n_states, int)
+            type(n_states) is not int
             or n_states < 2
             or n_states > RIVERSWIM_REFERENCE_MAX_STATES
         ):
@@ -1171,8 +1168,7 @@ class RiverSwimReferenceEnvironment:
             )
         initial_state = config.initial_state
         if (
-            isinstance(initial_state, bool)
-            or not isinstance(initial_state, int)
+            type(initial_state) is not int
             or initial_state < 0
             or initial_state >= n_states
         ):
@@ -1371,7 +1367,7 @@ class RiverSwimReferenceEnvironment:
             raise DecisionOwnershipError("RiverSwim execution belongs to another command")
         applied = self.manifest.action_spec.encode(execution.applied_action)
         applied_value = applied.to_python()
-        if not isinstance(applied_value, int):
+        if type(applied_value) is not int:
             raise DecisionOwnershipError("RiverSwim applied action is not scalar int32")
         try:
             expected_observation, expected_reward_array, expected_state = self._environment.step(
@@ -1458,15 +1454,13 @@ class ReferenceLifeConfig:
             raise ValueError("unsupported reference-life config schema")
         _require_id(self.lifecycle_id, name="lifecycle_id")
         if (
-            isinstance(self.seed, bool)
-            or not isinstance(self.seed, int)
+            type(self.seed) is not int
             or self.seed < 0
             or self.seed > int(np.iinfo(np.uint32).max)
         ):
             raise ValueError("seed must be a uint32 integer")
         if (
-            isinstance(self.max_accepted_events, bool)
-            or not isinstance(self.max_accepted_events, int)
+            type(self.max_accepted_events) is not int
             or self.max_accepted_events <= 0
             or self.max_accepted_events > MAX_DECISION_INDEX + 1
         ):
@@ -1566,8 +1560,7 @@ class LifeHalt:
         if type(self.reason) is not str or not self.reason.strip():
             raise ValueError("halt reason must be nonempty")
         if (
-            isinstance(self.recovery_attempts, bool)
-            or not isinstance(self.recovery_attempts, int)
+            type(self.recovery_attempts) is not int
             or self.recovery_attempts < 0
         ):
             raise ValueError("recovery_attempts must be nonnegative")
@@ -1629,7 +1622,7 @@ class ReferenceLifeState:
             "checkpoint_generation",
         ):
             value = getattr(self, name)
-            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            if type(value) is not int or value < 0:
                 raise ValueError(f"{name} must be a nonnegative integer")
         if not (self.accepted_events <= self.executed_events <= self.dispatch_attempts):
             raise ValueError("life counters violate accepted <= outcomes <= dispatches")
@@ -2129,7 +2122,7 @@ class ReferenceLifeRunner:
             if metrics_mode != "switching_two_phase":
                 raise DecisionOwnershipError("checkpoint switching metrics mode is invalid")
             phase_length = environment_config.get("phase_length")
-            if isinstance(phase_length, bool) or not isinstance(phase_length, int):
+            if type(phase_length) is not int:
                 raise DecisionOwnershipError("checkpoint environment phase schedule is invalid")
             if phase_length <= 0:
                 raise DecisionOwnershipError("checkpoint environment phase schedule is invalid")

--- a/alberta_framework/reference_life_controls.py
+++ b/alberta_framework/reference_life_controls.py
@@ -102,8 +102,7 @@ def _require_environment_shape(
     ):
         raise ValueError("environment_kind must be switching_two_state or riverswim")
     if (
-        isinstance(observation_dim, bool)
-        or not isinstance(observation_dim, int)
+        type(observation_dim) is not int
         or observation_dim < 2
     ):
         raise ValueError("observation_dim must be an integer of at least two")
@@ -114,7 +113,7 @@ def _require_environment_shape(
             "RiverSwim controls require observation_dim <= "
             f"{_RIVERSWIM_REFERENCE_MAX_STATES}"
         )
-    if isinstance(n_actions, bool) or not isinstance(n_actions, int) or n_actions != 2:
+    if type(n_actions) is not int or n_actions != 2:
         raise ValueError("selected reference controls require exactly two actions")
 
 
@@ -235,8 +234,7 @@ def _canonical_switching_environment(
         raise ValueError("switching environment config has the wrong type")
     phase_length = config.phase_length
     if (
-        isinstance(phase_length, bool)
-        or not isinstance(phase_length, int)
+        type(phase_length) is not int
         or phase_length <= 0
         or phase_length > REFERENCE_CONTROL_MAX_ACCEPTED_EVENTS
     ):
@@ -265,8 +263,7 @@ def _canonical_riverswim_environment(
         raise ValueError("RiverSwim environment config has the wrong type")
     n_states = config.n_states
     if (
-        isinstance(n_states, bool)
-        or not isinstance(n_states, int)
+        type(n_states) is not int
         or n_states < 2
         or n_states > _RIVERSWIM_REFERENCE_MAX_STATES
     ):
@@ -276,8 +273,7 @@ def _canonical_riverswim_environment(
         )
     initial_state = config.initial_state
     if (
-        isinstance(initial_state, bool)
-        or not isinstance(initial_state, int)
+        type(initial_state) is not int
         or initial_state < 0
         or initial_state >= n_states
     ):
@@ -928,8 +924,7 @@ class ReferenceLifeControlState:
         ):
             raise ValueError("control state lifecycle_id must be a safe identifier")
         if (
-            isinstance(self.decision_index, bool)
-            or not isinstance(self.decision_index, int)
+            type(self.decision_index) is not int
             or self.decision_index < 0
             or self.decision_index > MAX_DECISION_INDEX
         ):

--- a/tests/test_reference_life.py
+++ b/tests/test_reference_life.py
@@ -23,6 +23,7 @@ from alberta_framework.prototype_reference_adapter import (
     PrototypeReferenceAdapter,
 )
 from alberta_framework.reference_agent import (
+    ArrayValue,
     AuthorizationStatus,
     DecisionOwnershipError,
     DispatchAck,
@@ -30,6 +31,7 @@ from alberta_framework.reference_agent import (
     DispatchCommand,
     DispatchStatus,
     ReferenceAgentUpdate,
+    SpaceSpec,
     ReferenceTransactionLedger,
     ReferenceTransactionReducer,
     TransactionPhase,
@@ -38,6 +40,7 @@ from alberta_framework.reference_life import (
     ExactDispatchAdapter,
     ExactDispatchConfig,
     HaltStage,
+    LifeHalt,
     LifePhase,
     RecoveryMode,
     ReferenceLifeConfig,
@@ -58,6 +61,20 @@ from alberta_framework.streams.closed_loop import (
 pytestmark = pytest.mark.unit
 
 _LIFECYCLE_ID = "prototype.0000000100000002"
+
+
+class _HostileInt(int):
+    hook_calls = 0
+
+    def _explode(self) -> bool:
+        type(self).hook_calls += 1
+        raise AssertionError("hostile integer comparison hook executed")
+
+    __eq__ = lambda self, other: self._explode()
+    __lt__ = lambda self, other: self._explode()
+    __le__ = lambda self, other: self._explode()
+    __gt__ = lambda self, other: self._explode()
+    __ge__ = lambda self, other: self._explode()
 
 
 class _HostileHaltReason(str):
@@ -108,6 +125,60 @@ def _runner(
         seed=7,
         max_accepted_events=horizon,
     )
+
+
+def test_reference_life_host_integer_identities_fail_before_comparison_hooks() -> None:
+    runner = _runner()
+    state = runner.init()
+    hostile = _HostileInt(1)
+    checks = (
+        lambda: SpaceSpec.discrete(
+            cardinality=hostile,
+            dtype="int32",
+            semantic_id="tests.hostile_action.v1",
+        ),
+        lambda: dataclasses.replace(
+            state.transaction_state, next_decision_index=hostile
+        ),
+        lambda: dataclasses.replace(state.agent_state, decision_index=hostile),
+        lambda: dataclasses.replace(runner.config, seed=hostile),
+        lambda: dataclasses.replace(runner.config, max_accepted_events=hostile),
+        lambda: LifeHalt(
+            stage=HaltStage.PRE_DISPATCH,
+            recovery_mode=RecoveryMode.RETRY_OUTCOME,
+            reason="fixture",
+            recovery_attempts=hostile,
+        ),
+        lambda: dataclasses.replace(state, accepted_events=hostile),
+    )
+    for check in checks:
+        _HostileInt.hook_calls = 0
+        with pytest.raises(ValueError, match="integer|count|uint32|nonnegative"):
+            check()
+        assert _HostileInt.hook_calls == 0
+
+
+def test_switching_execution_rejects_boolean_decoded_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner()
+    state = runner.init()
+    step = runner.step(state)
+    assert step.event is not None
+    execution = runner.environment_adapter.execute(
+        state.environment_state,
+        step.event.command,
+        key=jr.key(99),
+    )
+    monkeypatch.setattr(ArrayValue, "to_python", lambda self: True)
+
+    with pytest.raises(DecisionOwnershipError, match="not a scalar integer"):
+        runner.environment_adapter.validate_execution(
+            state.environment_state,
+            step.event.command,
+            execution,
+            key=jr.key(99),
+        )
 
 
 def _corrupt_accepted_update(


### PR DESCRIPTION
Implements the exact host-identity correction reported by @deepanshu-yd in #1603.

- rejects bool and hostile int subclasses before range/comparison hooks across reference manifests, transaction/life/control/Prototype state, environment configs, lifetime counters, seed/horizon, and recovery metadata
- requires decoded applied actions to be exact Python ints in both SwitchingTwoState and RiverSwim authoritative replay verification
- keeps traced/JAX action handling unchanged: arrays are validated by exact dtype/shape/cardinality codecs before execution, while these new checks apply only after host decoding
- adds failing-first coverage for seven public host boundaries with zero hostile comparison calls and a forged boolean decoded-action regression

Validation: 2 new focused tests pass; reference-agent/control/Prototype/RiverSwim panel passes; Ruff and strict mypy pass; no outputs or benchmark workloads.

Closes #1603