### PR TITLE
fix(optimizers): reject leftover LMS Autostep ObGD constructor scalars

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -24,7 +24,10 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
+from alberta_framework.core._float32_scalars import (
+    validated_float32_scalar,
+    validated_float32_scalar_with_ratio,
+)
 from alberta_framework.core.types import (
     AutostepGTDLambdaState,
     AutostepParamState,
@@ -586,8 +589,13 @@ class LMS(Optimizer[LMSState]):
 
         Args:
             step_size: Fixed learning rate
+
+        Raises:
+            ValueError: If ``step_size`` is not a finite non-bool positive real.
         """
-        self._step_size = step_size
+        self._step_size = validated_float32_scalar(
+            "step_size", step_size, positive=True
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""
@@ -1100,9 +1108,18 @@ class Autostep(Optimizer[AutostepState]):
             meta_step_size: Meta learning rate for adapting step-sizes
             tau: Time constant for normalizer adaptation (default: 10000).
                 Higher values mean slower normalizer decay.
+
+        Raises:
+            ValueError: If ``initial_step_size`` is not a finite non-bool
+                positive real, or ``meta_step_size`` is not a finite non-bool
+                nonnegative real.
         """
-        self._initial_step_size = initial_step_size
-        self._meta_step_size = meta_step_size
+        self._initial_step_size = validated_float32_scalar(
+            "initial_step_size", initial_step_size, positive=True
+        )
+        self._meta_step_size = validated_float32_scalar(
+            "meta_step_size", meta_step_size, lower=0.0
+        )
         self._tau = tau
 
     def to_config(self) -> dict[str, Any]:
@@ -1643,11 +1660,16 @@ class ObGD(Optimizer[ObGDState]):
             kappa: Bounding sensitivity parameter (default: 2.0)
             gamma: Discount factor for trace decay (default: 0.0 for supervised)
             lamda: Eligibility trace decay parameter (default: 0.0 for supervised)
+
+        Raises:
+            ValueError: If ``step_size`` is not a finite non-bool positive real,
+                ``kappa`` is not a finite non-bool nonnegative real, or
+                ``gamma`` / ``lamda`` are not finite non-bool reals in ``[0, 1]``.
         """
-        self._step_size = step_size
-        self._kappa = kappa
-        self._gamma = gamma
-        self._lamda = lamda
+        self._step_size = validated_float32_scalar("step_size", step_size, positive=True)
+        self._kappa = validated_float32_scalar("kappa", kappa, lower=0.0)
+        self._gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
+        self._lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -53,6 +53,11 @@ class TestLMS:
 
         assert result.new_state.step_size == state.step_size
 
+    @pytest.mark.parametrize("step_size", [float("nan"), float("inf"), 0.0, -0.1, True, False])
+    def test_rejects_illegal_step_size(self, step_size: object) -> None:
+        with pytest.raises(ValueError, match="step_size"):
+            LMS(step_size=step_size)  # type: ignore[arg-type]
+
 
 class TestIDBD:
     """Tests for the IDBD optimizer."""
@@ -221,6 +226,18 @@ class TestAutostep:
         chex.assert_trees_all_close(state.normalizers, jnp.zeros(10))
         assert state.meta_step_size == pytest.approx(0.001)
         assert state.tau == pytest.approx(10000.0)
+
+    @pytest.mark.parametrize(
+        "initial_step_size", [float("nan"), float("inf"), 0.0, -0.1, True, False]
+    )
+    def test_rejects_illegal_initial_step_size(self, initial_step_size: object) -> None:
+        with pytest.raises(ValueError, match="initial_step_size"):
+            Autostep(initial_step_size=initial_step_size)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("meta_step_size", [float("nan"), float("inf"), -0.1, True])
+    def test_rejects_illegal_meta_step_size(self, meta_step_size: object) -> None:
+        with pytest.raises(ValueError, match="meta_step_size"):
+            Autostep(meta_step_size=meta_step_size)  # type: ignore[arg-type]
 
     def test_update_returns_correct_shapes(self, sample_observation):
         """Autostep update should return correctly shaped deltas."""
@@ -643,6 +660,29 @@ class TestObGD:
         assert state.kappa == pytest.approx(2.0)
         assert state.gamma == pytest.approx(0.0)
         assert state.lamda == pytest.approx(0.0)
+
+    @pytest.mark.parametrize("step_size", [float("nan"), float("inf"), 0.0, -0.1, True, False])
+    def test_rejects_illegal_step_size(self, step_size: object) -> None:
+        with pytest.raises(ValueError, match="step_size"):
+            ObGD(step_size=step_size)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("kappa", [float("nan"), float("inf"), -0.1, True])
+    def test_rejects_illegal_kappa(self, kappa: object) -> None:
+        with pytest.raises(ValueError, match="kappa"):
+            ObGD(kappa=kappa)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("gamma", float("nan")),
+            ("gamma", True),
+            ("lamda", float("nan")),
+            ("lamda", True),
+        ],
+    )
+    def test_rejects_illegal_gamma_lamda(self, field: str, value: object) -> None:
+        with pytest.raises(ValueError, match=field):
+            ObGD(**{field: value})  # type: ignore[arg-type]
 
     def test_update_returns_correct_shapes(self, sample_observation):
         """ObGD update should return correctly shaped deltas."""


### PR DESCRIPTION
Closes #1614.

## What changed

`LMS`, `Autostep`, and `ObGD` now fail-close leftover constructor scalars through the already-imported `validated_float32_scalar` helper that sibling `IDBD` already uses.

On `origin/main` `2f4f92a`, `LMS(step_size=True)`, `Autostep(initial_step_size=True)`, and `ObGD(step_size=True)` / `kappa=True` / `gamma=True` constructed. Legal zeros stay legal.

Adopted unpublished grok A head `2ba657b` onto current main as `d63ea71`. Did not remine. Did not expand into TDIDBD / AutostepGTDLambda.

## Scope

- `alberta_framework/core/optimizers.py`
- `tests/test_optimizers.py`

## Occupancy

Open ASI PRs at publish: none. Grok leftover seats 6/13/14/16/18 were leftover-identity reprints already on main or forager*/closed-unmerged. Leftover-identity is dry vs grok. This is the FREE constructor-scalar sibling.

## Verification

- Red on base `2f4f92a`: `LMS(step_size=True)._step_size is True`; same for Autostep/ObGD
- `tests/test_optimizers.py` reject cases: 30 passed
- Full `tests/test_optimizers.py`: 113 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary constructor-scalar validation only. No kernel math, lifetime clocks, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d63ea718781d440c3399482dce38f48fd08893c5 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
