### PR TITLE
fix(benchmarks): pin official CLEAR curation source

### DIFF
--- a/alberta_framework/benchmarks/external_qualification.py
+++ b/alberta_framework/benchmarks/external_qualification.py
@@ -214,7 +214,18 @@ EXTERNAL_QUALIFICATION_PLANS: tuple[ExternalQualificationPlan, ...] = (
         ),
         COMMON_GATES,
     ),
-    ExternalQualificationPlan(1579, "clear", ("arXiv:2201.06289v3",), (), COMMON_GATES),
+    ExternalQualificationPlan(
+        1579,
+        "clear",
+        ("arXiv:2201.06289v3",),
+        (
+            _revision(
+                "https://github.com/linzhiqiu/continual-learning.git",
+                "620cab4a7d99921fde73b67b53879470533cb39a",
+            ),
+        ),
+        COMMON_GATES,
+    ),
     ExternalQualificationPlan(
         1580,
         "continual-world-cw20",

--- a/tests/test_external_qualification.py
+++ b/tests/test_external_qualification.py
@@ -24,6 +24,18 @@ def test_registry_exactly_covers_research_wave_and_is_not_run_ready() -> None:
             plan.require_ready()
 
 
+def test_clear_uses_official_curation_source_without_claiming_asset_readiness() -> None:
+    plan = qualification_plan(1579)
+    assert plan.code_revisions == (
+        ExternalCodeRevision(
+            "https://github.com/linzhiqiu/continual-learning.git",
+            "620cab4a7d99921fde73b67b53879470533cb39a",
+        ),
+    )
+    assert "assets_checksums_and_storage_approved" in plan.blockers
+    assert "external_code_available_and_license_reviewed" in plan.blockers
+
+
 def test_completed_r0_plan_still_cannot_authorize_external_execution() -> None:
     revision = ExternalCodeRevision("https://github.com/org/repo.git", "a" * 40)
     plan = ExternalQualificationPlan(


### PR DESCRIPTION
Corrects the #1579 source audit after exhausting the paper/project links: the authors do publish the CLEAR curation code at `linzhiqiu/continual-learning`, pinned here to full commit `620cab4a7d99921fde73b67b53879470533cb39a`.

This does not mark the lane ready. The pinned tree has no root license, requires external YFCC100M/AWS acquisition, and does not supply checksums for the curated dataset payload, so license review and asset/checksum/storage gates remain fail-closed. No unofficial implementation or asset was substituted.

The #1574 paper and ICML/OpenReview records still expose no official OA/Continual Bench code; the paper references `mbrl-lib` as an underlying dependency, not an OA implementation, so that lane remains blocked rather than silently substituting it.

Validation: 17 focused tests pass; Ruff and strict mypy pass; no assets, outputs, or workloads.

Refs #1574
Refs #1579