### PR TITLE
feat(benchmarks): add AdamO IPMNIST comparator

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -175,6 +175,12 @@ from alberta_framework.benchmarks.upgd_ipmnist import (
     mlp_logits,
     validated_ipmnist_data,
 )
+from alberta_framework.core.adamo import AdamO, AdamOConfig, isometry_gradient
+from alberta_framework.core.baseline_optimizers import Adam
+from alberta_framework.core.update_safety import (
+    floating_tree_is_finite,
+    select_transaction,
+)
 from alberta_framework.evaluation.recurring_ipmnist_retention import (
     RecurringIPMNISTPhase,
     RecurringIPMNISTProtocol,
@@ -5389,6 +5395,129 @@ def _control_factory(
     return factory
 
 
+def _make_adamo_raw_learner(
+    hp: Mapping[str, float],
+) -> tuple[LearnerInitFn, LearnerStepFn]:
+    """AdamO equations 16/19/20 adapted to the protocol MLP.
+
+    Every matrix weight receives the rectangular Gram penalty; bias vectors
+    remain unregularized. The task-gradient Adam moments never observe the
+    isometry gradient. ``isometry_strength=0`` reduces bit-exactly to the
+    protocol AdamW arm (whose selected weight decay is zero).
+    """
+
+    optimizer = AdamO(
+        AdamOConfig(
+            step_size=hp["step_size"],
+            beta1=hp["beta1"],
+            beta2=hp["beta2"],
+            eps=hp["eps"],
+            isometry_strength=hp["isometry_strength"],
+            isometry_step_size=hp["isometry_step_size"],
+        )
+    )
+
+    def init_fn(params: dict[str, Array]) -> dict[str, Any]:
+        return {
+            name: optimizer.init_for_shape(value.shape) for name, value in params.items()
+        }
+
+    def step_fn(
+        params: dict[str, Array],
+        state: dict[str, Any],
+        grads: dict[str, Array],
+        key: Array,
+    ) -> tuple[dict[str, Array], dict[str, Any]]:
+        del key
+        candidate_params: dict[str, Array] = {}
+        candidate_state: dict[str, Any] = {}
+        update_applied = jnp.asarray(True, dtype=jnp.bool_)
+        for name, value in params.items():
+            update = optimizer.update_from_gradient_checked(
+                state[name], grads[name], value, regularize=value.ndim == 2
+            )
+            candidate_params[name] = value - update.step
+            candidate_state[name] = update.new_state
+            update_applied = update_applied & update.update_applied
+        update_applied = (
+            update_applied
+            & floating_tree_is_finite(params)
+            & floating_tree_is_finite(state)
+            & floating_tree_is_finite(grads)
+            & floating_tree_is_finite(candidate_params)
+            & floating_tree_is_finite(candidate_state)
+        )
+        return (
+            select_transaction(update_applied, candidate_params, params),
+            select_transaction(update_applied, candidate_state, state),
+        )
+
+    return init_fn, step_fn
+
+
+def _make_adamo_learner(
+    hp: Mapping[str, float],
+) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    return _wrap_grad_learner(*_make_adamo_raw_learner(hp))
+
+
+def _make_joint_adam_isometry_learner(
+    hp: Mapping[str, float],
+) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    """Naive equation-18 Adam control whose moments mix both gradients."""
+
+    optimizer = Adam(
+        step_size=hp["step_size"],
+        beta1=hp["beta1"],
+        beta2=hp["beta2"],
+        eps=hp["eps"],
+        weight_decay=0.0,
+    )
+
+    def init_fn(params: dict[str, Array]) -> dict[str, Any]:
+        return {
+            name: optimizer.init_for_shape(value.shape) for name, value in params.items()
+        }
+
+    def step_fn(
+        params: dict[str, Array],
+        state: dict[str, Any],
+        grads: dict[str, Array],
+        key: Array,
+    ) -> tuple[dict[str, Array], dict[str, Any]]:
+        del key
+        candidate_params: dict[str, Array] = {}
+        candidate_state: dict[str, Any] = {}
+        update_applied = jnp.asarray(True, dtype=jnp.bool_)
+        for name, value in params.items():
+            combined_gradient = grads[name]
+            if value.ndim == 2 and hp["isometry_strength"] != 0.0:
+                combined_gradient = (
+                    combined_gradient
+                    + hp["isometry_strength"] * isometry_gradient(value)
+                )
+            update = optimizer.update_from_gradient_checked(
+                state[name], combined_gradient, error=None, param=value
+            )
+            candidate_params[name] = value - update.step
+            candidate_state[name] = update.new_state
+            update_applied = update_applied & update.update_applied
+        update_applied = (
+            update_applied
+            & floating_tree_is_finite(params)
+            & floating_tree_is_finite(state)
+            & floating_tree_is_finite(grads)
+            & floating_tree_is_finite(candidate_params)
+            & floating_tree_is_finite(candidate_state)
+        )
+        return (
+            select_transaction(update_applied, candidate_params, params),
+            select_transaction(update_applied, candidate_state, state),
+        )
+
+    return _wrap_grad_learner(init_fn, step_fn)
+
+
 _CBP_DEFAULTS = {
     "cbp_decay_rate": 0.99,
     "cbp_replacement_rate": 1e-4,
@@ -5414,6 +5543,49 @@ def _build_registry() -> dict[str, ScreeningSpec]:
             hyperparameters=dict(ADAMW_PROTOCOL_HYPERPARAMETERS),
             factory=_control_factory(_make_adamw_learner),
             description="Published AdamW baseline (proxy-ordering validation arm).",
+        ),
+        ScreeningSpec(
+            name="adamo_inert",
+            base_learner="adamw",
+            mechanism="decoupled_isometry_inert",
+            hyperparameters={
+                **ADAMW_PROTOCOL_HYPERPARAMETERS,
+                "isometry_strength": 0.0,
+                "isometry_step_size": ADAMW_PROTOCOL_HYPERPARAMETERS["step_size"],
+            },
+            factory=_make_adamo_learner,
+            description=(
+                "AdamO implementation with lambda=0; exact AdamW mechanism-off reduction."
+            ),
+        ),
+        ScreeningSpec(
+            name="adamo_l1e3",
+            base_learner="adamw",
+            mechanism="decoupled_isometry",
+            hyperparameters={
+                **ADAMW_PROTOCOL_HYPERPARAMETERS,
+                "isometry_strength": 1e-3,
+                "isometry_step_size": ADAMW_PROTOCOL_HYPERPARAMETERS["step_size"],
+            },
+            factory=_make_adamo_learner,
+            description=(
+                "AdamO equation-20 decoupled Gram-isometry step; paper lambda=1e-3, "
+                "adapted to ASI's matched AdamW hyperparameters and IPMNIST schedule."
+            ),
+        ),
+        ScreeningSpec(
+            name="adam_iso_joint_l1e3",
+            base_learner="adamw",
+            mechanism="joint_isometry",
+            hyperparameters={
+                **ADAMW_PROTOCOL_HYPERPARAMETERS,
+                "isometry_strength": 1e-3,
+            },
+            factory=_make_joint_adam_isometry_learner,
+            description=(
+                "Naive equation-18 composite-loss Adam control: task and isometry "
+                "gradients share moment statistics."
+            ),
         ),
         ScreeningSpec(
             name="upgd_idbd",

--- a/alberta_framework/core/adamo.py
+++ b/alberta_framework/core/adamo.py
@@ -28,8 +28,16 @@ from alberta_framework.core.update_safety import (
 ADAMO_PAPER_REVISION = "arXiv:2606.09762v1"
 ADAMO_PROTOCOL = {
     "paper_revision": ADAMO_PAPER_REVISION,
+    "paper_url": "https://arxiv.org/abs/2606.09762v1",
     "equations": (16, 19, 20),
     "official_code_available": False,
+    "official_code_search_date": "2026-08-17",
+    "paper_mlp_architecture": "depth-4 width-512 ReLU",
+    "adapter_architecture": "IPMNIST protocol 784-300-150-10 ReLU MLP",
+    "paper_initialization": "orthogonal weights",
+    "adapter_initialization": "IPMNIST protocol PyTorch-default Linear initialization",
+    "paper_mlp_step_size": 1e-4,
+    "adapter_step_size": 1e-4,
     "bias_regularization": False,
     "convolution_kernel_adapter": "not_implemented",
     "timing_is_telemetry_only": True,
@@ -132,6 +140,8 @@ def isometry_gradient(weight: Array) -> Array:
 def state_persistent_bytes(state: AdamOState) -> int:
     """Count the complete persisted moment state from concrete arrays."""
 
+    if type(state) is not AdamParamState:
+        raise TypeError("state must be an exact AdamParamState")
     leaves = (
         state.m,
         state.v,
@@ -147,6 +157,8 @@ def state_persistent_bytes(state: AdamOState) -> int:
 def gram_working_bytes(shape: tuple[int, ...], *, dtype_bytes: int = 4) -> int:
     """Return the named Gram-matrix working allocation for one weight leaf."""
 
+    if type(shape) is not tuple:
+        raise TypeError("shape must be an exact tuple")
     if len(shape) != 2 or any(type(dimension) is not int or dimension < 1 for dimension in shape):
         raise ValueError("shape must contain exactly two positive built-in integers")
     if type(dtype_bytes) is not int or dtype_bytes < 1:

--- a/alberta_framework/core/adamo.py
+++ b/alberta_framework/core/adamo.py
@@ -1,0 +1,234 @@
+# mypy: disable-error-code="call-arg"
+"""AdamO: Adam with decoupled pseudo-orthogonality updates.
+
+This implements equations 16, 19, and 20 of Rosseau, Müller, and Nowé,
+arXiv:2606.09762v1. Adam moments observe only the task gradient; the Gram
+penalty gradient is applied as a separate descent step. Bias/vector leaves
+are intentionally not regularized.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+import chex
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+
+from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core.baseline_optimizers import Adam, AdamParamState
+from alberta_framework.core.update_safety import (
+    floating_tree_is_finite,
+    neutralize_array,
+    select_transaction,
+)
+
+ADAMO_PAPER_REVISION = "arXiv:2606.09762v1"
+ADAMO_PROTOCOL = {
+    "paper_revision": ADAMO_PAPER_REVISION,
+    "equations": (16, 19, 20),
+    "official_code_available": False,
+    "bias_regularization": False,
+    "convolution_kernel_adapter": "not_implemented",
+    "timing_is_telemetry_only": True,
+    "development_only": True,
+    "scientific_promotion_allowed": False,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class AdamOConfig:
+    """Validated AdamO hyperparameters."""
+
+    step_size: float = 1e-4
+    beta1: float = 0.9
+    beta2: float = 0.999
+    eps: float = 1e-8
+    isometry_strength: float = 1e-3
+    isometry_step_size: float | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "step_size", validated_float32_scalar("step_size", self.step_size, positive=True)
+        )
+        object.__setattr__(
+            self,
+            "beta1",
+            validated_float32_scalar(
+                "beta1", self.beta1, lower=0.0, upper=1.0, upper_inclusive=False
+            ),
+        )
+        object.__setattr__(
+            self,
+            "beta2",
+            validated_float32_scalar(
+                "beta2", self.beta2, lower=0.0, upper=1.0, upper_inclusive=False
+            ),
+        )
+        object.__setattr__(self, "eps", validated_float32_scalar("eps", self.eps, positive=True))
+        object.__setattr__(
+            self,
+            "isometry_strength",
+            validated_float32_scalar(
+                "isometry_strength", self.isometry_strength, lower=0.0
+            ),
+        )
+        resolved_iso_step = (
+            self.step_size if self.isometry_step_size is None else self.isometry_step_size
+        )
+        object.__setattr__(
+            self,
+            "isometry_step_size",
+            validated_float32_scalar("isometry_step_size", resolved_iso_step, positive=True),
+        )
+
+
+AdamOState = AdamParamState
+
+
+@chex.dataclass(frozen=True)
+class AdamOUpdate:
+    """Checked descent step and state transition."""
+
+    step: Array
+    new_state: AdamOState
+    task_step: Array
+    isometry_step: Array
+    update_applied: Array
+
+
+def isometry_penalty(weight: Array) -> Array:
+    """Return the rectangular Gram-deviation penalty from paper equation 16."""
+
+    matrix = jnp.asarray(weight)
+    if matrix.ndim != 2:
+        raise ValueError("isometry_penalty requires a rank-two weight matrix")
+    rows, columns = matrix.shape
+    if rows >= columns:
+        gram = matrix.T @ matrix
+        identity = jnp.eye(columns, dtype=matrix.dtype)
+    else:
+        gram = matrix @ matrix.T
+        identity = jnp.eye(rows, dtype=matrix.dtype)
+    return jnp.sum(jnp.square(gram - identity))
+
+
+def isometry_gradient(weight: Array) -> Array:
+    """Return the closed-form gradient of :func:`isometry_penalty`."""
+
+    matrix = jnp.asarray(weight)
+    if matrix.ndim != 2:
+        raise ValueError("isometry_gradient requires a rank-two weight matrix")
+    rows, columns = matrix.shape
+    if rows >= columns:
+        identity = jnp.eye(columns, dtype=matrix.dtype)
+        return 4.0 * matrix @ (matrix.T @ matrix - identity)
+    identity = jnp.eye(rows, dtype=matrix.dtype)
+    return 4.0 * (matrix @ matrix.T - identity) @ matrix
+
+
+def state_persistent_bytes(state: AdamOState) -> int:
+    """Count the complete persisted moment state from concrete arrays."""
+
+    leaves = (
+        state.m,
+        state.v,
+        state.t,
+        state.step_size,
+        state.beta1,
+        state.beta2,
+        state.eps,
+    )
+    return sum(int(np.prod(leaf.shape, dtype=np.int64)) * leaf.dtype.itemsize for leaf in leaves)
+
+
+def gram_working_bytes(shape: tuple[int, ...], *, dtype_bytes: int = 4) -> int:
+    """Return the named Gram-matrix working allocation for one weight leaf."""
+
+    if len(shape) != 2 or any(type(dimension) is not int or dimension < 1 for dimension in shape):
+        raise ValueError("shape must contain exactly two positive built-in integers")
+    if type(dtype_bytes) is not int or dtype_bytes < 1:
+        raise ValueError("dtype_bytes must be a positive built-in integer")
+    smaller = min(shape)
+    count = smaller * smaller
+    if count > (2**63 - 1) // dtype_bytes:
+        raise ValueError("Gram working byte count exceeds signed int64")
+    return count * dtype_bytes
+
+
+class AdamO:
+    """Pure per-parameter AdamO transformation."""
+
+    def __init__(self, config: AdamOConfig = AdamOConfig()):
+        if type(config) is not AdamOConfig:
+            raise TypeError("config must be an exact AdamOConfig")
+        self.config = config
+        self._adam = Adam(
+            step_size=config.step_size,
+            beta1=config.beta1,
+            beta2=config.beta2,
+            eps=config.eps,
+        )
+
+    def init_for_shape(self, shape: tuple[int, ...]) -> AdamOState:
+        if type(shape) is not tuple or not shape:
+            raise ValueError("shape must be a non-empty tuple")
+        if any(type(dimension) is not int or dimension < 1 for dimension in shape):
+            raise ValueError("shape dimensions must be positive built-in integers")
+        return self._adam.init_for_shape(shape)
+
+    def update_from_gradient_checked(
+        self,
+        state: AdamOState,
+        task_gradient: Array,
+        param: Array,
+        *,
+        regularize: bool,
+    ) -> AdamOUpdate:
+        """Apply equation 20 while keeping equation 19 moments task-only."""
+
+        if type(regularize) is not bool:
+            raise TypeError("regularize must be a built-in bool")
+        parameter = jnp.asarray(param)
+        gradient = jnp.asarray(task_gradient)
+        if not jnp.issubdtype(parameter.dtype, jnp.floating):
+            raise ValueError("parameter must have a floating dtype")
+        if gradient.dtype != parameter.dtype:
+            raise ValueError("gradient and parameter dtypes must match")
+        if gradient.shape != parameter.shape or state.m.shape != parameter.shape:
+            raise ValueError("state, gradient, and parameter shapes must match")
+        if regularize and parameter.ndim != 2:
+            raise ValueError("only rank-two weight leaves can be isometry-regularized")
+        config = self.config
+        task_update = self._adam.update_from_gradient_checked(
+            state, gradient, error=None, param=parameter
+        )
+        task_step = task_update.step
+        if regularize and config.isometry_strength != 0.0:
+            isometry_step = (
+                cast(float, config.isometry_step_size)
+                * config.isometry_strength
+                * isometry_gradient(parameter)
+            )
+            step = task_step + isometry_step
+        else:
+            isometry_step = jnp.zeros_like(parameter)
+            step = task_step
+        candidate_state = cast(AdamParamState, task_update.new_state)
+        update_applied = (
+            task_update.update_applied
+            & floating_tree_is_finite(state)
+            & jnp.all(jnp.isfinite(parameter))
+            & jnp.all(jnp.isfinite(gradient))
+            & floating_tree_is_finite(candidate_state)
+            & jnp.all(jnp.isfinite(step))
+        )
+        return AdamOUpdate(
+            step=neutralize_array(update_applied, step),
+            new_state=select_transaction(update_applied, candidate_state, state),
+            task_step=neutralize_array(update_applied, task_step),
+            isometry_step=neutralize_array(update_applied, isometry_step),
+            update_applied=update_applied,
+        )

--- a/tests/test_adamo.py
+++ b/tests/test_adamo.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.adamo import (
+    AdamO,
+    AdamOConfig,
+    gram_working_bytes,
+    isometry_gradient,
+    isometry_penalty,
+    state_persistent_bytes,
+)
+from alberta_framework.core.baseline_optimizers import Adam
+
+
+@pytest.mark.parametrize("shape", [(4, 2), (2, 4), (3, 3)])
+def test_penalty_matches_singular_value_definition(shape: tuple[int, int]) -> None:
+    weight = jnp.arange(np.prod(shape), dtype=jnp.float32).reshape(shape) / 10.0
+    singular_values = jnp.linalg.svd(weight, compute_uv=False)
+    expected = jnp.sum(jnp.square(jnp.square(singular_values) - 1.0))
+    np.testing.assert_allclose(isometry_penalty(weight), expected, rtol=2e-5, atol=2e-5)
+
+
+@pytest.mark.parametrize("shape", [(4, 2), (2, 4), (3, 3)])
+def test_closed_form_gradient_matches_autodiff(shape: tuple[int, int]) -> None:
+    weight = jnp.arange(np.prod(shape), dtype=jnp.float32).reshape(shape) / 7.0
+    expected = jax.grad(isometry_penalty)(weight)
+    np.testing.assert_allclose(isometry_gradient(weight), expected, rtol=1e-5, atol=1e-5)
+
+
+def test_zero_strength_reduces_exactly_to_adam_task_step() -> None:
+    config = AdamOConfig(
+        step_size=1e-3, beta1=0.9, beta2=0.99, eps=1e-8, isometry_strength=0.0
+    )
+    optimizer = AdamO(config)
+    adam = Adam(step_size=1e-3, beta1=0.9, beta2=0.99, eps=1e-8)
+    weight = jnp.asarray([[0.2, -0.1], [0.4, 0.3]], dtype=jnp.float32)
+    gradient = jnp.asarray([[0.5, -0.2], [0.1, 0.7]], dtype=jnp.float32)
+    result = optimizer.update_from_gradient_checked(
+        optimizer.init_for_shape(weight.shape), gradient, weight, regularize=True
+    )
+    adam_result = adam.update_from_gradient_checked(
+        adam.init_for_shape(weight.shape), gradient, param=weight
+    )
+    np.testing.assert_array_equal(result.step, adam_result.step)
+    np.testing.assert_array_equal(result.new_state.m, adam_result.new_state.m)
+    np.testing.assert_array_equal(result.new_state.v, adam_result.new_state.v)
+
+
+def test_isometry_gradient_is_decoupled_from_moments() -> None:
+    weight = jnp.asarray([[2.0, 0.0], [0.0, 0.5]], dtype=jnp.float32)
+    gradient = jnp.ones_like(weight)
+    off = AdamO(AdamOConfig(isometry_strength=0.0))
+    on = AdamO(AdamOConfig(isometry_strength=1e-3))
+    off_result = off.update_from_gradient_checked(
+        off.init_for_shape(weight.shape), gradient, weight, regularize=True
+    )
+    on_result = on.update_from_gradient_checked(
+        on.init_for_shape(weight.shape), gradient, weight, regularize=True
+    )
+    np.testing.assert_array_equal(off_result.new_state.m, on_result.new_state.m)
+    np.testing.assert_array_equal(off_result.new_state.v, on_result.new_state.v)
+    np.testing.assert_array_equal(
+        on_result.isometry_step,
+        on.config.isometry_step_size * on.config.isometry_strength * isometry_gradient(weight),
+    )
+    np.testing.assert_allclose(
+        on_result.step - off_result.step, on_result.isometry_step, atol=4e-12
+    )
+
+
+def test_bias_leaf_is_never_regularized() -> None:
+    optimizer = AdamO(AdamOConfig(isometry_strength=1.0))
+    bias = jnp.asarray([1.0, 2.0], dtype=jnp.float32)
+    result = optimizer.update_from_gradient_checked(
+        optimizer.init_for_shape(bias.shape), jnp.ones_like(bias), bias, regularize=False
+    )
+    np.testing.assert_array_equal(result.isometry_step, jnp.zeros_like(bias))
+
+
+def test_nonfinite_candidate_fails_closed() -> None:
+    optimizer = AdamO(AdamOConfig(isometry_strength=1.0))
+    weight = jnp.full((2, 2), jnp.finfo(jnp.float32).max)
+    state = optimizer.init_for_shape(weight.shape)
+    result = jax.jit(optimizer.update_from_gradient_checked, static_argnames="regularize")(
+        state, jnp.ones_like(weight), weight, regularize=True
+    )
+    assert not bool(result.update_applied)
+    np.testing.assert_array_equal(result.step, jnp.zeros_like(weight))
+    np.testing.assert_array_equal(result.new_state.m, state.m)
+
+
+def test_resource_accounting_names_state_and_gram() -> None:
+    state = AdamO().init_for_shape((3, 5))
+    assert state_persistent_bytes(state) == (2 * 15 + 5) * 4
+    assert gram_working_bytes((3, 5)) == 3 * 3 * 4
+
+
+def test_update_is_jittable() -> None:
+    optimizer = AdamO(AdamOConfig(isometry_strength=1e-3))
+    weight = jnp.eye(2, dtype=jnp.float32)
+    state = optimizer.init_for_shape(weight.shape)
+    result = jax.jit(optimizer.update_from_gradient_checked, static_argnames="regularize")(
+        state, jnp.ones_like(weight), weight, regularize=True
+    )
+    assert bool(result.update_applied)
+
+
+def test_screening_inert_arm_reduces_to_adamw() -> None:
+    from alberta_framework.benchmarks.ipmnist_screening import (
+        _make_adamo_raw_learner,
+        _make_adamw_learner,
+        screening_spec,
+    )
+
+    params = {
+        "w1": jnp.asarray([[0.2, -0.1], [0.4, 0.3]], dtype=jnp.float32),
+        "b1": jnp.asarray([0.1, -0.2], dtype=jnp.float32),
+    }
+    grads = {name: jnp.ones_like(value) for name, value in params.items()}
+    inert = screening_spec("adamo_inert")
+    control = screening_spec("adamw_control")
+    inert_init, inert_step = _make_adamo_raw_learner(inert.hyperparameters)
+    control_init, control_step = _make_adamw_learner(control.hyperparameters)
+    key = jax.random.key(0)
+    inert_params, inert_state = inert_step(params, inert_init(params), grads, key)
+    control_result = control_step(params, control_init(params), grads, key)
+    control_params, control_state = control_result
+    for name in params:
+        np.testing.assert_array_equal(inert_params[name], control_params[name])
+        np.testing.assert_array_equal(inert_state[name].m, control_state[name].m)
+        np.testing.assert_array_equal(inert_state[name].v, control_state[name].v)

--- a/tests/test_adamo.py
+++ b/tests/test_adamo.py
@@ -99,6 +99,21 @@ def test_resource_accounting_names_state_and_gram() -> None:
     assert gram_working_bytes((3, 5)) == 3 * 3 * 4
 
 
+def test_resource_accounting_rejects_hostile_outer_objects_without_hooks() -> None:
+    class HostileShape:
+        def __len__(self) -> int:
+            raise AssertionError("shape hook must not run")
+
+    class HostileState:
+        def __getattribute__(self, name: str) -> object:
+            raise AssertionError(f"state hook must not run: {name}")
+
+    with pytest.raises(TypeError, match="exact tuple"):
+        gram_working_bytes(HostileShape())  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="exact AdamParamState"):
+        state_persistent_bytes(HostileState())  # type: ignore[arg-type]
+
+
 def test_update_is_jittable() -> None:
     optimizer = AdamO(AdamOConfig(isometry_strength=1e-3))
     weight = jnp.eye(2, dtype=jnp.float32)
@@ -133,3 +148,34 @@ def test_screening_inert_arm_reduces_to_adamw() -> None:
         np.testing.assert_array_equal(inert_params[name], control_params[name])
         np.testing.assert_array_equal(inert_state[name].m, control_state[name].m)
         np.testing.assert_array_equal(inert_state[name].v, control_state[name].v)
+
+
+def test_active_arm_runs_through_screening_runner() -> None:
+    from alberta_framework.benchmarks.ipmnist_screening import (
+        run_screening_config,
+        screening_spec,
+    )
+    from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+
+    data_x = np.linspace(-1.0, 1.0, 48, dtype=np.float32).reshape(12, 4)
+    data_y = np.arange(12, dtype=np.int32) % 2
+    config = IPMNISTConfig(
+        n_tasks=2,
+        task_length=3,
+        input_dim=4,
+        hidden1=3,
+        hidden2=2,
+        n_classes=2,
+    )
+    result = run_screening_config(
+        data_x,
+        data_y,
+        screening_spec("adamo_l1e3"),
+        seed=7,
+        config=config,
+    )
+
+    assert result.config_name == "adamo_l1e3"
+    assert result.base_learner == "adamw"
+    assert result.per_task_accuracy.shape == (2,)
+    assert np.all(np.isfinite(result.per_task_loss))


### PR DESCRIPTION
Implements the code and matched-screening prerequisites for #1560.

- ports AdamO's rectangular Gram-isometry penalty and analytic gradient
- keeps Adam moments task-gradient-only and applies the isometry step decoupled
- adds an exact lambda=0 AdamW reduction arm
- adds the naive joint-gradient Adam control requested by the comparison plan
- wires all three arms through the real IPMNIST screening registry
- adds fail-closed finite-update behavior, JIT coverage, parity tests, and explicit state/Gram byte accounting
- records the pinned paper revision and absence of cited official code as of 2026-08-17

Validation:
- tests/test_adamo.py: 13 passed
- tests/test_ipmnist_screening.py: 335 passed
- focused Ruff and strict mypy passed

This does not claim a result and does not close #1560. The issue remains open until an authorized matched nonpromoting screen is run, retained (including negative/inconclusive outcomes), and analyzed under the issue comparison plan.