### PR TITLE
feat(evaluation): complete optimizer geometry stage

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -231,8 +231,12 @@ def muon_ogd_dual_update(
         raise ValueError("dual must contain one multiplier per constraint")
     if type(dual_learning_rate) is not float or not math.isfinite(dual_learning_rate):
         raise ValueError("dual_learning_rate must be a finite float")
-    if dual_learning_rate < 0.0 or type(dual_steps) is not int or dual_steps < 1:
-        raise ValueError("dual learning rate must be non-negative and dual_steps positive")
+    if (
+        dual_learning_rate < 0.0
+        or type(dual_steps) is not int
+        or not 1 <= dual_steps <= 32
+    ):
+        raise ValueError("dual learning rate must be non-negative and dual_steps bounded positive")
     for _ in range(dual_steps):
         shifted = value + jnp.einsum("k,kij->ij", multipliers, protected)
         matrix_sign = spectral_matrix_sign(shifted, steps=newton_schulz_steps)

--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -1,32 +1,84 @@
-"""Small-matrix primitives for staging continual optimizer geometry controls."""
+"""Bounded development evaluation for continual optimizer geometry controls.
+
+This module deliberately stops before IPMNIST. It binds three paper revisions,
+runs their smallest useful matrix-geometry slices on one frozen synthetic stream,
+and emits a strict, permanently nonpromoting result. The FOGO and FLAD arms are
+mechanism probes rather than complete optimizer ports; those differences are part
+of the validated protocol rather than being left implicit.
+"""
 
 from __future__ import annotations
 
+import hashlib
+import math
+import time
+from collections.abc import Mapping, Sequence
 from types import MappingProxyType
+from typing import cast
 
 import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
 from jax import Array
 
+GEOMETRY_RESULT_SCHEMA = "asi.optimizer-geometry.streaming-matrix-result.v1"
+FROZEN_GEOMETRY_CONFIG = MappingProxyType(
+    {
+        "seed": 20_260_817,
+        "updates": 8,
+        "rows": 3,
+        "columns": 2,
+        "newton_schulz_steps": 5,
+        "muon_dual_steps": 2,
+        "muon_dual_learning_rate": 0.25,
+        "allowed_boundary_information": "none",
+        "target_definition": "sum_of_stream_updates_projected_away_from_fixed_e0",
+    }
+)
 GEOMETRY_PROTOCOL = MappingProxyType(
     {
-        "schema": "asi.optimizer-geometry.protocol.v1",
+        "schema": "asi.optimizer-geometry.protocol.v2",
         "paper_revisions": (
             "arXiv:2605.08949v2",
             "arXiv:2606.10406v1",
             "arXiv:2601.07636v1",
         ),
-        "stage": "small_streaming_matrix_pre_ipmnist",
-        "protocol_difference": "equation primitives only; no LLM or batch-CL claim",
-        "mechanism_off": "empty_basis_or_zero_gradient_exact_reduction",
-        "matched_axes": ("seed", "updates", "observations"),
-        "persistent_bytes_accounting_required": True,
-        "environment_steps_accounting_required": True,
-        "model_queries_accounting_required": True,
+        "stage": "frozen_small_streaming_matrix_pre_ipmnist",
+        "protocol_differences": (
+            "Muon-OGD is the paper-v2 NS5 and two-step dual update on one fixed constraint",
+            "FOGO is only its long-term orthogonal-correction equation; no codebook, random "
+            "projection, slow-fast streams, or proximal lift",
+            "FLAD is only the ideal gradient-orthogonal decomposition in equation 6; no EMA "
+            "approximation, Hessian-vector product, sharpness objective, or schedule",
+            "the synthetic target is a mechanism diagnostic defined by the protected complement; "
+            "its outcome is not comparative performance evidence",
+        ),
+        "matched_axes": (
+            "seed",
+            "ordered_matrices",
+            "updates",
+            "observations",
+            "allowed_boundary_information",
+        ),
         "timing_is_telemetry_only": True,
         "development_only": True,
         "scientific_promotion_allowed": False,
     }
 )
+
+_ARM_SPECS = (
+    ("muon_ns5_empty_constraints", "muon_ogd_v2_dual", "empty_constraints"),
+    ("muon_ogd_v2_dual", "muon_ogd_v2_dual", "active_constraint"),
+    ("fogo_empty_basis", "fogo_v1_long_term_correction", "empty_basis"),
+    ("fogo_projection", "fogo_v1_long_term_correction", "active_basis"),
+    ("flad_zero_gradient", "flad_v1_ideal_noise_component", "zero_gradient"),
+    ("flad_ideal_noise", "flad_v1_ideal_noise_component", "active_gradient"),
+)
+_CONTROL_BY_CANDIDATE = {
+    "muon_ogd_v2_dual": "muon_ns5_empty_constraints",
+    "fogo_projection": "fogo_empty_basis",
+    "flad_ideal_noise": "flad_zero_gradient",
+}
 
 
 def orthogonal_correction(update: Array, protected_basis: Array) -> Array:
@@ -39,7 +91,12 @@ def orthogonal_correction(update: Array, protected_basis: Array) -> Array:
 
 
 def spectral_matrix_sign(matrix: Array, *, steps: int = 5) -> Array:
-    """Muon-style Newton--Schulz matrix-sign approximation for a small matrix."""
+    """Apply Muon-OGD v2's cubic NS5 matrix-sign approximation.
+
+    The pinned paper defines ``f(X) = 3/2 X - 1/2 XX^T X``. Frobenius
+    normalization places every singular value in its convergence interval and
+    preserves an exact zero for a zero matrix.
+    """
     value = jnp.asarray(matrix)
     if (
         value.ndim != 2
@@ -56,21 +113,327 @@ def spectral_matrix_sign(matrix: Array, *, steps: int = 5) -> Array:
     else:
         transposed = False
     for _ in range(steps):
-        a = x @ x.T
-        x = 3.4445 * x - 4.7750 * a @ x + 2.0315 * a @ a @ x
+        x = 1.5 * x - 0.5 * (x @ x.T) @ x
     return x.T if transposed else x
 
 
+def muon_ogd_dual_update(
+    momentum: Array,
+    constraints: Array,
+    dual: Array,
+    *,
+    dual_learning_rate: float,
+    dual_steps: int,
+    newton_schulz_steps: int = 5,
+) -> tuple[Array, Array]:
+    """Run the bounded matrix form of Muon-OGD v2 Algorithm 1."""
+    value = jnp.asarray(momentum)
+    protected = jnp.asarray(constraints)
+    multipliers = jnp.asarray(dual)
+    if value.ndim != 2 or value.size == 0 or not jnp.issubdtype(value.dtype, jnp.floating):
+        raise ValueError("momentum must be a non-empty floating matrix")
+    if protected.ndim != 3 or protected.shape[1:] != value.shape:
+        raise ValueError("constraints must have shape (count, rows, columns)")
+    if multipliers.ndim != 1 or multipliers.shape[0] != protected.shape[0]:
+        raise ValueError("dual must contain one multiplier per constraint")
+    if type(dual_learning_rate) is not float or not math.isfinite(dual_learning_rate):
+        raise ValueError("dual_learning_rate must be a finite float")
+    if dual_learning_rate < 0.0 or type(dual_steps) is not int or dual_steps < 1:
+        raise ValueError("dual learning rate must be non-negative and dual_steps positive")
+    for _ in range(dual_steps):
+        shifted = value + jnp.einsum("k,kij->ij", multipliers, protected)
+        matrix_sign = spectral_matrix_sign(shifted, steps=newton_schulz_steps)
+        conflicts = jnp.einsum("kij,ij->k", protected, matrix_sign)
+        multipliers = multipliers - dual_learning_rate * conflicts
+    shifted = value + jnp.einsum("k,kij->ij", multipliers, protected)
+    return spectral_matrix_sign(shifted, steps=newton_schulz_steps), multipliers
+
+
 def flad_noise_component(perturbation: Array, gradient: Array) -> Array:
-    """Remove FLAD's gradient-aligned perturbation component."""
+    """Remove the ideal FLAD gradient-aligned perturbation component safely."""
     delta = jnp.asarray(perturbation)
     direction = jnp.asarray(gradient)
     if delta.shape != direction.shape or delta.ndim != 1:
         raise ValueError("perturbation and gradient must be equal-width vectors")
     squared_norm = jnp.vdot(direction, direction).real
-    projection = jnp.where(
-        squared_norm > 0.0,
-        direction * (jnp.vdot(direction, delta).real / squared_norm),
-        jnp.zeros_like(delta),
-    )
+    active = squared_norm > 0.0
+    safe_squared_norm = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
+    coefficient = jnp.vdot(direction, delta).real / safe_squared_norm
+    projection = direction * coefficient * active.astype(delta.dtype)
     return delta - projection
+
+
+def _frozen_stream() -> Array:
+    config = FROZEN_GEOMETRY_CONFIG
+    key = jr.key(cast(int, config["seed"]), impl="threefry2x32")
+    shape = (
+        cast(int, config["updates"]),
+        cast(int, config["rows"]),
+        cast(int, config["columns"]),
+    )
+    return jr.normal(key, shape, dtype=jnp.float32)
+
+
+def _stream_sha256(stream: Array) -> str:
+    canonical = np.asarray(stream, dtype="<f4")
+    descriptor = f"float32:{canonical.shape}".encode()
+    return hashlib.sha256(descriptor + canonical.tobytes(order="C")).hexdigest()
+
+
+def _protected_geometry(rows: int, columns: int) -> tuple[Array, Array]:
+    vector = jnp.zeros((rows * columns,), dtype=jnp.float32).at[0].set(1.0)
+    return vector.reshape((1, rows, columns)), vector.reshape((1, rows * columns))
+
+
+def _outcome(delta: float) -> str:
+    if delta < -1e-7:
+        return "improved"
+    if delta > 1e-7:
+        return "worse"
+    return "tied"
+
+
+def _protocol_payload() -> dict[str, object]:
+    return {
+        "schema": GEOMETRY_PROTOCOL["schema"],
+        "paper_revisions": list(cast(tuple[str, ...], GEOMETRY_PROTOCOL["paper_revisions"])),
+        "stage": GEOMETRY_PROTOCOL["stage"],
+        "protocol_differences": list(
+            cast(tuple[str, ...], GEOMETRY_PROTOCOL["protocol_differences"])
+        ),
+        "matched_axes": list(cast(tuple[str, ...], GEOMETRY_PROTOCOL["matched_axes"])),
+        "timing_is_telemetry_only": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+
+
+def _execute_frozen_stream(*, measure_timing: bool) -> dict[str, object]:
+    config = FROZEN_GEOMETRY_CONFIG
+    stream = _frozen_stream()
+    updates = cast(int, config["updates"])
+    rows = cast(int, config["rows"])
+    columns = cast(int, config["columns"])
+    ns_steps = cast(int, config["newton_schulz_steps"])
+    dual_steps = cast(int, config["muon_dual_steps"])
+    dual_learning_rate = cast(float, config["muon_dual_learning_rate"])
+    constraints, basis = _protected_geometry(rows, columns)
+    target = jnp.sum(
+        jnp.stack(
+            [
+                orthogonal_correction(matrix.reshape(-1), basis).reshape((rows, columns))
+                for matrix in stream
+            ]
+        ),
+        axis=0,
+    )
+    arm_records: list[dict[str, object]] = []
+    for arm, mechanism, mode in _ARM_SPECS:
+        started = time.perf_counter_ns() if measure_timing else 0
+        state = jnp.zeros((rows, columns), dtype=jnp.float32)
+        dual = jnp.zeros((constraints.shape[0],), dtype=jnp.float32)
+        processed_updates: list[Array] = []
+        for matrix in stream:
+            if arm == "muon_ns5_empty_constraints":
+                processed = spectral_matrix_sign(matrix, steps=ns_steps)
+            elif arm == "muon_ogd_v2_dual":
+                processed, dual = muon_ogd_dual_update(
+                    matrix,
+                    constraints,
+                    dual,
+                    dual_learning_rate=dual_learning_rate,
+                    dual_steps=dual_steps,
+                    newton_schulz_steps=ns_steps,
+                )
+            elif arm == "fogo_empty_basis":
+                processed = orthogonal_correction(
+                    matrix.reshape(-1), jnp.zeros((0, rows * columns), dtype=matrix.dtype)
+                ).reshape((rows, columns))
+            elif arm == "fogo_projection":
+                processed = orthogonal_correction(matrix.reshape(-1), basis).reshape(
+                    (rows, columns)
+                )
+            elif arm == "flad_zero_gradient":
+                processed = flad_noise_component(
+                    matrix.reshape(-1), jnp.zeros((rows * columns,), dtype=matrix.dtype)
+                ).reshape((rows, columns))
+            else:
+                processed = flad_noise_component(matrix.reshape(-1), basis[0]).reshape(
+                    (rows, columns)
+                )
+            processed_updates.append(processed)
+            state = state + processed
+        if measure_timing:
+            state.block_until_ready()
+        elapsed = time.perf_counter_ns() - started if measure_timing else 0
+        stacked = jnp.stack(processed_updates)
+        final_error = float(jnp.mean(jnp.square(state - target)))
+        interference = float(jnp.mean(jnp.abs(stacked[:, 0, 0])))
+        mean_update_norm = float(jnp.mean(jnp.linalg.norm(stacked, axis=(1, 2))))
+        persistent_bytes = int(state.nbytes)
+        if arm == "muon_ogd_v2_dual":
+            persistent_bytes += int(dual.nbytes + constraints.nbytes)
+        elif mode == "active_basis":
+            persistent_bytes += int(basis.nbytes)
+        elif mode == "active_gradient":
+            persistent_bytes += int(basis[0].nbytes)
+        arm_records.append(
+            {
+                "arm": arm,
+                "mechanism": mechanism,
+                "mode": mode,
+                "metrics": {
+                    "final_target_mse": final_error,
+                    "mean_protected_interference": interference,
+                    "mean_update_frobenius_norm": mean_update_norm,
+                },
+                "resources": {
+                    "persistent_bytes": persistent_bytes,
+                    "observations": updates,
+                    "updates": updates,
+                    "data_steps": updates,
+                    "environment_steps": 0,
+                    "model_queries": 0,
+                    "timing_ns": elapsed,
+                    "timing_qualified": False,
+                },
+            }
+        )
+    records_by_arm = {cast(str, record["arm"]): record for record in arm_records}
+    comparisons: list[dict[str, object]] = []
+    for candidate, control in _CONTROL_BY_CANDIDATE.items():
+        candidate_metrics = cast(Mapping[str, float], records_by_arm[candidate]["metrics"])
+        control_metrics = cast(Mapping[str, float], records_by_arm[control]["metrics"])
+        delta = candidate_metrics["final_target_mse"] - control_metrics["final_target_mse"]
+        comparisons.append(
+            {
+                "candidate": candidate,
+                "control": control,
+                "final_target_mse_delta": delta,
+                "outcome": _outcome(delta),
+            }
+        )
+    return {
+        "schema": GEOMETRY_RESULT_SCHEMA,
+        "protocol": _protocol_payload(),
+        "config": dict(FROZEN_GEOMETRY_CONFIG),
+        "stream": {
+            "generator": "jax.random.threefry2x32.normal.float32",
+            "sha256": _stream_sha256(stream),
+            "shape": [updates, rows, columns],
+        },
+        "policy": {
+            "status": "development-only-nonpromoting",
+            "development_only": True,
+            "scientific_promotion_allowed": False,
+            "negative_outcomes_retained": True,
+        },
+        "arms": arm_records,
+        "comparisons": comparisons,
+    }
+
+
+def run_streaming_matrix_evaluation() -> dict[str, object]:
+    """Run and strictly validate the literal frozen development slice."""
+    result = _execute_frozen_stream(measure_timing=True)
+    validate_streaming_matrix_result(result)
+    return result
+
+
+def _mapping(value: object, *, name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or not all(type(key) is str for key in value):
+        raise ValueError(f"{name} must be a string-keyed mapping")
+    return cast(Mapping[str, object], value)
+
+
+def _sequence(value: object, *, name: str) -> Sequence[object]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise ValueError(f"{name} must be a sequence")
+    return cast(Sequence[object], value)
+
+
+def _same_float(actual: object, expected: object, *, name: str) -> None:
+    if type(actual) is not float or type(expected) is not float:
+        raise ValueError(f"{name} must be a float")
+    if not math.isfinite(actual) or actual != expected:
+        raise ValueError(f"{name} does not match the frozen evaluation")
+
+
+def _exact_equal(actual: object, expected: object) -> bool:
+    if type(actual) is not type(expected):
+        return False
+    if isinstance(expected, Mapping):
+        if not isinstance(actual, Mapping) or set(actual) != set(expected):
+            return False
+        return all(_exact_equal(actual[key], value) for key, value in expected.items())
+    if isinstance(expected, list):
+        return isinstance(actual, list) and len(actual) == len(expected) and all(
+            _exact_equal(left, right) for left, right in zip(actual, expected, strict=True)
+        )
+    return bool(actual == expected)
+
+
+def validate_streaming_matrix_result(result: Mapping[str, object]) -> None:
+    """Fail closed unless ``result`` is an exact current frozen-run record."""
+    expected = _execute_frozen_stream(measure_timing=False)
+    required_top = {"schema", "protocol", "config", "stream", "policy", "arms", "comparisons"}
+    if set(result) != required_top or result.get("schema") != GEOMETRY_RESULT_SCHEMA:
+        raise ValueError("result fields or schema do not match the frozen protocol")
+    for field in ("protocol", "config", "stream", "policy"):
+        actual_mapping = _mapping(result[field], name=field)
+        expected_mapping = _mapping(expected[field], name=f"expected.{field}")
+        if not _exact_equal(actual_mapping, expected_mapping):
+            raise ValueError(f"{field} does not match the frozen protocol")
+    arms = _sequence(result["arms"], name="arms")
+    expected_arms = _sequence(expected["arms"], name="expected.arms")
+    if len(arms) != len(_ARM_SPECS):
+        raise ValueError("arms must contain every frozen candidate and control exactly once")
+    for index, (raw_arm, raw_expected_arm) in enumerate(zip(arms, expected_arms, strict=True)):
+        arm = _mapping(raw_arm, name=f"arms[{index}]")
+        expected_arm = _mapping(raw_expected_arm, name=f"expected.arms[{index}]")
+        if set(arm) != {"arm", "mechanism", "mode", "metrics", "resources"}:
+            raise ValueError(f"arms[{index}] fields do not match the schema")
+        for field in ("arm", "mechanism", "mode"):
+            if arm[field] != expected_arm[field]:
+                raise ValueError(f"arms[{index}].{field} does not match the frozen plan")
+        metrics = _mapping(arm["metrics"], name=f"arms[{index}].metrics")
+        expected_metrics = _mapping(
+            expected_arm["metrics"], name=f"expected.arms[{index}].metrics"
+        )
+        if set(metrics) != set(expected_metrics):
+            raise ValueError(f"arms[{index}].metrics fields do not match the schema")
+        for metric, expected_value in expected_metrics.items():
+            _same_float(metrics[metric], expected_value, name=f"arms[{index}].metrics.{metric}")
+        resources = _mapping(arm["resources"], name=f"arms[{index}].resources")
+        expected_resources = _mapping(
+            expected_arm["resources"], name=f"expected.arms[{index}].resources"
+        )
+        if set(resources) != set(expected_resources):
+            raise ValueError(f"arms[{index}].resources fields do not match the schema")
+        for resource, expected_value in expected_resources.items():
+            if resource == "timing_ns":
+                if type(resources[resource]) is not int or cast(int, resources[resource]) < 0:
+                    raise ValueError(f"arms[{index}].resources.timing_ns must be non-negative")
+            elif not _exact_equal(resources[resource], expected_value):
+                raise ValueError(f"arms[{index}].resources.{resource} is not canonical")
+    comparisons = _sequence(result["comparisons"], name="comparisons")
+    expected_comparisons = _sequence(expected["comparisons"], name="expected.comparisons")
+    if len(comparisons) != len(expected_comparisons):
+        raise ValueError("comparisons must contain every matched A/B pair")
+    for index, (raw_comparison, raw_expected_comparison) in enumerate(
+        zip(comparisons, expected_comparisons, strict=True)
+    ):
+        comparison = _mapping(raw_comparison, name=f"comparisons[{index}]")
+        expected_comparison = _mapping(
+            raw_expected_comparison, name=f"expected.comparisons[{index}]"
+        )
+        if set(comparison) != {"candidate", "control", "final_target_mse_delta", "outcome"}:
+            raise ValueError(f"comparisons[{index}] fields do not match the schema")
+        for field in ("candidate", "control", "outcome"):
+            if comparison[field] != expected_comparison[field]:
+                raise ValueError(f"comparisons[{index}].{field} is not canonical")
+        _same_float(
+            comparison["final_target_mse_delta"],
+            expected_comparison["final_target_mse_delta"],
+            name=f"comparisons[{index}].final_target_mse_delta",
+        )

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -1,12 +1,32 @@
+import copy
+import json
+
+import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from alberta_framework.evaluation.optimizer_geometry import (
+    FROZEN_GEOMETRY_CONFIG,
     GEOMETRY_PROTOCOL,
+    GEOMETRY_RESULT_SCHEMA,
     flad_noise_component,
+    muon_ogd_dual_update,
     orthogonal_correction,
+    run_streaming_matrix_evaluation,
     spectral_matrix_sign,
+    validate_streaming_matrix_result,
 )
+
+
+def _paper_ns5(matrix: jax.Array, *, steps: int) -> jax.Array:
+    value = matrix / jnp.maximum(jnp.linalg.norm(matrix), jnp.asarray(1e-12, matrix.dtype))
+    transposed = value.shape[0] > value.shape[1]
+    if transposed:
+        value = value.T
+    for _ in range(steps):
+        value = 1.5 * value - 0.5 * (value @ value.T) @ value
+    return value.T if transposed else value
 
 
 def test_orthogonal_correction_removes_protected_direction() -> None:
@@ -16,23 +36,94 @@ def test_orthogonal_correction_removes_protected_direction() -> None:
     np.testing.assert_array_equal(orthogonal_correction(update, jnp.zeros((0, 2))), update)
 
 
-def test_spectral_matrix_sign_has_bounded_singular_values() -> None:
-    result = spectral_matrix_sign(jnp.diag(jnp.array([3.0, 0.5])), steps=5)
-    assert float(jnp.linalg.svd(result, compute_uv=False)[0]) <= 1.1
-
-
-def test_flad_removes_gradient_aligned_component() -> None:
-    gradient = jnp.array([1.0, 0.0])
-    perturbation = jnp.array([2.0, 4.0])
-    np.testing.assert_allclose(flad_noise_component(perturbation, gradient), [0.0, 4.0])
-    np.testing.assert_array_equal(flad_noise_component(perturbation, jnp.zeros(2)), perturbation)
-
-
-def test_protocol_is_small_matrix_first_and_nonpromoting() -> None:
-    assert GEOMETRY_PROTOCOL["paper_revisions"] == (
-        "arXiv:2605.08949v2",
-        "arXiv:2606.10406v1",
-        "arXiv:2601.07636v1",
+@pytest.mark.parametrize("shape", [(2, 2), (2, 3), (3, 2)])
+def test_spectral_matrix_sign_matches_pinned_muon_ogd_ns5(shape: tuple[int, int]) -> None:
+    matrix = jnp.arange(1, shape[0] * shape[1] + 1, dtype=jnp.float32).reshape(shape)
+    np.testing.assert_allclose(
+        spectral_matrix_sign(matrix, steps=5), _paper_ns5(matrix, steps=5), rtol=1e-6
     )
-    assert GEOMETRY_PROTOCOL["stage"] == "small_streaming_matrix_pre_ipmnist"
+
+
+def test_spectral_matrix_sign_zero_and_jit_paths() -> None:
+    zero = jnp.zeros((3, 2), dtype=jnp.float32)
+    np.testing.assert_array_equal(spectral_matrix_sign(zero), zero)
+    jitted = jax.jit(spectral_matrix_sign)
+    np.testing.assert_allclose(jitted(jnp.eye(2, dtype=jnp.float32)), jnp.eye(2), rtol=1e-5)
+
+
+def test_muon_ogd_empty_constraints_reduces_exactly_to_ns5() -> None:
+    matrix = jnp.array([[2.0, 1.0], [0.5, -1.0]], dtype=jnp.float32)
+    update, dual = muon_ogd_dual_update(
+        matrix,
+        jnp.zeros((0, 2, 2), dtype=jnp.float32),
+        jnp.zeros((0,), dtype=jnp.float32),
+        dual_learning_rate=0.25,
+        dual_steps=2,
+    )
+    np.testing.assert_array_equal(dual, jnp.zeros((0,), dtype=jnp.float32))
+    np.testing.assert_allclose(update, spectral_matrix_sign(matrix), rtol=1e-6)
+
+
+def test_flad_zero_gradient_is_primal_and_derivative_safe() -> None:
+    perturbation = jnp.array([2.0, 4.0])
+    zero = jnp.zeros(2)
+    np.testing.assert_array_equal(flad_noise_component(perturbation, zero), perturbation)
+    delta_jacobian, gradient_jacobian = jax.jacrev(flad_noise_component, argnums=(0, 1))(
+        perturbation, zero
+    )
+    assert bool(jnp.all(jnp.isfinite(delta_jacobian)))
+    assert bool(jnp.all(jnp.isfinite(gradient_jacobian)))
+    np.testing.assert_array_equal(delta_jacobian, jnp.eye(2))
+
+
+def test_flad_jit_removes_gradient_aligned_component() -> None:
+    result = jax.jit(flad_noise_component)(jnp.array([2.0, 4.0]), jnp.array([1.0, 0.0]))
+    np.testing.assert_allclose(result, [0.0, 4.0])
+
+
+def test_streaming_matrix_evaluation_is_frozen_matched_and_nonpromoting() -> None:
+    result = run_streaming_matrix_evaluation()
+    assert result["schema"] == GEOMETRY_RESULT_SCHEMA
+    assert result["config"] == dict(FROZEN_GEOMETRY_CONFIG)
+    assert GEOMETRY_PROTOCOL["stage"] == "frozen_small_streaming_matrix_pre_ipmnist"
     assert GEOMETRY_PROTOCOL["scientific_promotion_allowed"] is False
+    arms = result["arms"]
+    assert isinstance(arms, list)
+    assert len(arms) == 6
+    for arm in arms:
+        resources = arm["resources"]
+        assert resources["observations"] == FROZEN_GEOMETRY_CONFIG["updates"]
+        assert resources["updates"] == FROZEN_GEOMETRY_CONFIG["updates"]
+        assert resources["data_steps"] == FROZEN_GEOMETRY_CONFIG["updates"]
+        assert resources["persistent_bytes"] > 0
+        assert resources["timing_qualified"] is False
+    assert result["policy"] == {
+        "status": "development-only-nonpromoting",
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "negative_outcomes_retained": True,
+    }
+    validate_streaming_matrix_result(json.loads(json.dumps(result)))
+
+
+@pytest.mark.parametrize(
+    ("path", "replacement"),
+    [
+        (("config", "seed"), 1),
+        (("config", "updates"), 8.0),
+        (("policy", "scientific_promotion_allowed"), True),
+        (("arms", 0, "resources", "updates"), 7),
+        (("arms", 0, "metrics", "final_target_mse"), 0.0),
+        (("comparisons", 0, "outcome"), "unexpected"),
+    ],
+)
+def test_streaming_matrix_validator_rejects_tampering(
+    path: tuple[object, ...], replacement: object
+) -> None:
+    result = copy.deepcopy(run_streaming_matrix_evaluation())
+    target: object = result
+    for component in path[:-1]:
+        target = target[component]  # type: ignore[index]
+    target[path[-1]] = replacement  # type: ignore[index]
+    with pytest.raises(ValueError):
+        validate_streaming_matrix_result(result)


### PR DESCRIPTION
Replaces the closed helper-only #1600 with an executable, validated development diagnostic for #1572.

- corrects Muon-OGD to the pinned v2 cubic NS5 and bounded dual loop
- makes FLAD zero-gradient behavior finite under autodiff
- freezes a Threefry streaming-matrix protocol with matched candidate/control arms
- validates deterministic replay, exact builtin schemas and policies, comparison axes, metrics, persistent-state bytes, steps, queries, and timing telemetry
- retains improved/worse/tied outcomes and permanently forbids promotion
- records exact FOGO/FLAD adaptations and omitted paper mechanisms
- preserves the host, bounded-input, finite-kernel, JIT-validity, and resource-field hardening from #1611

This is a bounded mechanism diagnostic, not a complete working-set measurement, comparative performance result, or SOTA evidence. #1572 remains open for the explicitly recorded full ports and IPMNIST evaluation gates.