### PR TITLE
fix(evaluation): harden optimization readiness protocol

### DIFF
--- a/alberta_framework/evaluation/optimization_readiness.py
+++ b/alberta_framework/evaluation/optimization_readiness.py
@@ -1,28 +1,44 @@
 """Prospective optimization-readiness diagnostic for development evaluation.
 
-The equations follow Wang et al., arXiv:2605.09044v1.  This module evaluates
-already-collected mini-batch gradients; it neither trains nor reads benchmark
-data, and therefore cannot itself create a performance result.
+The equations and empirical estimator follow Wang et al., arXiv:2605.09044v1.
+This module evaluates caller-provided measurements; it neither trains nor reads
+benchmark data, and therefore cannot itself create a performance result.
 """
 
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
 
+PROTOCOL_SCHEMA = "asi.optimization-readiness.protocol.v1"
+RESOURCE_SCHEMA = "asi.optimization-readiness.resources.v1"
+RESULT_SCHEMA = "asi.optimization-readiness.development-result.v1"
+
 OPTIMIZATION_READINESS_PROTOCOL = MappingProxyType(
     {
-        "schema": "asi.optimization-readiness.protocol.v1",
+        "schema": PROTOCOL_SCHEMA,
         "paper_revision": "arXiv:2605.09044v1",
         "paper_revision_date": "2026-05-09",
         "population_gradient_estimator": "full_validation_set_gradient",
         "reliability_estimator": "independently_sampled_minibatch_gradients",
         "reference_reliability_batch_count": 128,
         "reference_reliability_batch_size": 4,
+        "official_code_revision": "none-cited-in-arxiv-v1-as-of-2026-08-17",
+        "estimator": "appendix-c.1-full-gradient-plus-independent-mini-batches",
+        "paper_defaults": MappingProxyType(
+            {"validation_observations": 10_000, "mini_batch_size": 4, "batch_count": 128}
+        ),
+        "asi_protocol_differences": (
+            "caller_supplies_precomputed_full_and_mini_batch_gradients",
+            "sample_counts_are_bound_by_each_development_protocol",
+            "resource_nonpromotion_and_outcome_retention_receipts_are_added",
+        ),
         "diagnostics": (
             "optimization_readiness",
             "gradient_norm",
@@ -40,16 +56,24 @@ OPTIMIZATION_READINESS_PROTOCOL = MappingProxyType(
             "updates",
             "observations",
             "mini_batch_size",
+            "diagnostic_batch_count",
+            "allowed_boundary_information",
+            "allowed_task_information",
         ),
-        "execution_protocol_required": True,
-        "matrix_shape_and_dtype_accounting_required": True,
-        "working_set_bytes_accounting_required": True,
-        "persistent_bytes_accounting_required": True,
-        "environment_steps_accounting_required": True,
-        "model_queries_accounting_required": True,
+        "resource_fields": (
+            "persistent_bytes",
+            "environment_steps",
+            "data_steps",
+            "model_queries",
+            "timing_seconds",
+        ),
         "timing_is_telemetry_only": True,
         "development_only": True,
         "scientific_promotion_allowed": False,
+        "outcome_retention_required": True,
+        "execution_protocol_required": True,
+        "matrix_shape_and_dtype_accounting_required": True,
+        "working_set_bytes_accounting_required": True,
         "completed_result_exists": False,
     }
 )
@@ -67,6 +91,49 @@ class OptimizationReadiness:
     gradient_norm: float
     batch_count: int
     parameter_count: int
+
+
+@dataclass(frozen=True)
+class ProspectiveDevelopmentProtocol:
+    """Matched axes and permitted information for one prospective comparison arm."""
+
+    seed: int
+    checkpoint: str
+    task: str
+    updates: int
+    observations: int
+    mini_batch_size: int
+    diagnostic_batch_count: int
+    allowed_boundary_information: tuple[str, ...]
+    allowed_task_information: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ResourceReceipt:
+    """Resource accounting required for every prospective result."""
+
+    persistent_bytes: int
+    environment_steps: int
+    data_steps: int
+    model_queries: int
+    timing_seconds: float
+
+
+@dataclass(frozen=True)
+class DevelopmentResultReceipt:
+    """Strictly validated, permanently nonpromoting prospective result."""
+
+    comparison_id: str
+    arm_id: str
+    protocol: ProspectiveDevelopmentProtocol
+    resources: ResourceReceipt
+    optimization_readiness: float
+    gradient_norm: float
+    representation_energy_rank_0_99: int
+    curvature_energy_rank_0_99: int
+    parameter_norm: float
+    future_relative_loss_reduction: float
+    outcome: str
 
 
 def _finite_array(
@@ -151,6 +218,9 @@ def estimate_optimization_readiness(
         readiness = strength * reliability
     else:
         readiness = 0.0
+    outputs = (strength, reliability, readiness)
+    if not all(math.isfinite(value) for value in outputs):
+        raise ValueError("optimization-readiness outputs must be finite")
     return OptimizationReadiness(
         gradient_squared_norm=gradient_squared_norm,
         expected_batch_gradient_squared_norm=expected_squared_norm,
@@ -180,4 +250,216 @@ def energy_rank(matrix: object, *, threshold: float = 0.99) -> int:
     squared = np.square(singular_values / leading)
     total = float(np.sum(squared))
     target = np.nextafter(threshold * total, -math.inf)
-    return int(np.searchsorted(np.cumsum(squared), target, side="left") + 1)
+    if not math.isfinite(total):
+        raise ValueError("matrix singular-value energy must be finite")
+    found = int(np.searchsorted(np.cumsum(squared), target, side="left") + 1)
+    return min(found, int(singular_values.shape[0]))
+
+
+def _strict_mapping(value: object, *, name: str, keys: set[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    actual = set(value)
+    if actual != keys:
+        raise ValueError(f"{name} keys must be exactly {sorted(keys)}")
+    return value
+
+
+def _strict_nonnegative_int(value: object, *, name: str, positive: bool = False) -> int:
+    if type(value) is not int or value < int(positive):
+        qualifier = "positive" if positive else "nonnegative"
+        raise ValueError(f"{name} must be a {qualifier} int")
+    return value
+
+
+def _strict_finite_float(value: object, *, name: str, nonnegative: bool = False) -> float:
+    if type(value) is not float or not math.isfinite(value) or (nonnegative and value < 0.0):
+        qualifier = " finite nonnegative" if nonnegative else " finite"
+        raise ValueError(f"{name} must be a{qualifier} float")
+    return value
+
+
+def _strict_string_tuple(value: object, *, name: str) -> tuple[str, ...]:
+    if type(value) is not list or any(type(item) is not str or not item for item in value):
+        raise ValueError(f"{name} must be a list of non-empty strings")
+    resolved = tuple(value)
+    if len(set(resolved)) != len(resolved):
+        raise ValueError(f"{name} must not contain duplicates")
+    return resolved
+
+
+def validate_development_result(payload: object) -> DevelopmentResultReceipt:
+    """Fail closed while adopting one prospective development-result payload."""
+    outer = _strict_mapping(
+        payload,
+        name="result",
+        keys={
+            "schema",
+            "comparison_id",
+            "arm_id",
+            "protocol",
+            "resources",
+            "metrics",
+            "outcome",
+            "outcome_retained",
+            "development_only",
+            "scientific_promotion_allowed",
+        },
+    )
+    if outer["schema"] != RESULT_SCHEMA:
+        raise ValueError("result schema is not supported")
+    for name in ("comparison_id", "arm_id"):
+        if type(outer[name]) is not str or not outer[name]:
+            raise ValueError(f"{name} must be a non-empty string")
+    if type(outer["outcome"]) is not str or outer["outcome"] not in {
+        "supported",
+        "rejected",
+        "inconclusive",
+    }:
+        raise ValueError("outcome must be supported, rejected, or inconclusive")
+    if outer["outcome_retained"] is not True:
+        raise ValueError("outcome_retained must permanently remain True")
+    if outer["development_only"] is not True:
+        raise ValueError("development_only must permanently remain True")
+    if outer["scientific_promotion_allowed"] is not False:
+        raise ValueError("scientific_promotion_allowed must permanently remain False")
+
+    protocol_payload = _strict_mapping(
+        outer["protocol"],
+        name="protocol",
+        keys={
+            "schema",
+            "seed",
+            "checkpoint",
+            "task",
+            "updates",
+            "observations",
+            "mini_batch_size",
+            "diagnostic_batch_count",
+            "allowed_boundary_information",
+            "allowed_task_information",
+        },
+    )
+    if protocol_payload["schema"] != PROTOCOL_SCHEMA:
+        raise ValueError("protocol schema is not supported")
+    for name in ("checkpoint", "task"):
+        if type(protocol_payload[name]) is not str or not protocol_payload[name]:
+            raise ValueError(f"{name} must be a non-empty string")
+    protocol = ProspectiveDevelopmentProtocol(
+        seed=_strict_nonnegative_int(protocol_payload["seed"], name="seed"),
+        checkpoint=protocol_payload["checkpoint"],
+        task=protocol_payload["task"],
+        updates=_strict_nonnegative_int(protocol_payload["updates"], name="updates", positive=True),
+        observations=_strict_nonnegative_int(
+            protocol_payload["observations"], name="observations", positive=True
+        ),
+        mini_batch_size=_strict_nonnegative_int(
+            protocol_payload["mini_batch_size"], name="mini_batch_size", positive=True
+        ),
+        diagnostic_batch_count=_strict_nonnegative_int(
+            protocol_payload["diagnostic_batch_count"],
+            name="diagnostic_batch_count",
+            positive=True,
+        ),
+        allowed_boundary_information=_strict_string_tuple(
+            protocol_payload["allowed_boundary_information"],
+            name="allowed_boundary_information",
+        ),
+        allowed_task_information=_strict_string_tuple(
+            protocol_payload["allowed_task_information"], name="allowed_task_information"
+        ),
+    )
+
+    resource_payload = _strict_mapping(
+        outer["resources"],
+        name="resources",
+        keys={
+            "schema",
+            "persistent_bytes",
+            "environment_steps",
+            "data_steps",
+            "model_queries",
+            "timing_seconds",
+            "timing_is_telemetry_only",
+        },
+    )
+    if resource_payload["schema"] != RESOURCE_SCHEMA:
+        raise ValueError("resource schema is not supported")
+    if resource_payload["timing_is_telemetry_only"] is not True:
+        raise ValueError("timing_is_telemetry_only must permanently remain True")
+    resources = ResourceReceipt(
+        persistent_bytes=_strict_nonnegative_int(
+            resource_payload["persistent_bytes"], name="persistent_bytes"
+        ),
+        environment_steps=_strict_nonnegative_int(
+            resource_payload["environment_steps"], name="environment_steps"
+        ),
+        data_steps=_strict_nonnegative_int(resource_payload["data_steps"], name="data_steps"),
+        model_queries=_strict_nonnegative_int(
+            resource_payload["model_queries"], name="model_queries"
+        ),
+        timing_seconds=_strict_finite_float(
+            resource_payload["timing_seconds"], name="timing_seconds", nonnegative=True
+        ),
+    )
+
+    metric_payload = _strict_mapping(
+        outer["metrics"],
+        name="metrics",
+        keys={
+            "optimization_readiness",
+            "gradient_norm",
+            "representation_energy_rank_0_99",
+            "curvature_energy_rank_0_99",
+            "parameter_norm",
+            "future_relative_loss_reduction",
+        },
+    )
+    return DevelopmentResultReceipt(
+        comparison_id=outer["comparison_id"],
+        arm_id=outer["arm_id"],
+        protocol=protocol,
+        resources=resources,
+        optimization_readiness=_strict_finite_float(
+            metric_payload["optimization_readiness"],
+            name="optimization_readiness",
+            nonnegative=True,
+        ),
+        gradient_norm=_strict_finite_float(
+            metric_payload["gradient_norm"], name="gradient_norm", nonnegative=True
+        ),
+        representation_energy_rank_0_99=_strict_nonnegative_int(
+            metric_payload["representation_energy_rank_0_99"],
+            name="representation_energy_rank_0_99",
+        ),
+        curvature_energy_rank_0_99=_strict_nonnegative_int(
+            metric_payload["curvature_energy_rank_0_99"],
+            name="curvature_energy_rank_0_99",
+        ),
+        parameter_norm=_strict_finite_float(
+            metric_payload["parameter_norm"], name="parameter_norm", nonnegative=True
+        ),
+        future_relative_loss_reduction=_strict_finite_float(
+            metric_payload["future_relative_loss_reduction"],
+            name="future_relative_loss_reduction",
+        ),
+        outcome=outer["outcome"],
+    )
+
+
+def validate_matched_development_results(
+    payloads: Sequence[object],
+) -> tuple[DevelopmentResultReceipt, ...]:
+    """Validate two or more receipts and require all predeclared matched axes."""
+    if type(payloads) not in {list, tuple} or len(payloads) < 2:
+        raise ValueError("payloads must contain at least two development results")
+    receipts = tuple(validate_development_result(payload) for payload in payloads)
+    first = receipts[0]
+    if len({receipt.arm_id for receipt in receipts}) != len(receipts):
+        raise ValueError("development result arm_id values must be unique")
+    for receipt in receipts[1:]:
+        if receipt.comparison_id != first.comparison_id:
+            raise ValueError("comparison_id must match across development results")
+        if receipt.protocol != first.protocol:
+            raise ValueError("all predeclared matched protocol axes must be equal")
+    return receipts

--- a/alberta_framework/evaluation/optimization_readiness.py
+++ b/alberta_framework/evaluation/optimization_readiness.py
@@ -8,10 +8,9 @@ benchmark data, and therefore cannot itself create a performance result.
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any
+from typing import Final
 
 import numpy as np
 from numpy.typing import NDArray
@@ -20,24 +19,53 @@ PROTOCOL_SCHEMA = "asi.optimization-readiness.protocol.v1"
 RESOURCE_SCHEMA = "asi.optimization-readiness.resources.v1"
 RESULT_SCHEMA = "asi.optimization-readiness.development-result.v1"
 
+_INT32_MAX: Final[int] = (1 << 31) - 1
+_UINT32_MAX: Final[int] = (1 << 32) - 1
+_MAX_STRING_BYTES: Final[int] = 4_096
+_MAX_INFORMATION_ITEMS: Final[int] = 256
+_MAX_RESULT_COUNT: Final[int] = 256
+_MAX_PERSISTENT_BYTES: Final[int] = 256 * 1024 * 1024
+_MAX_WORKING_SET_BYTES: Final[int] = 512 * 1024 * 1024
+_MAX_ARRAY_BYTES: Final[int] = 512 * 1024 * 1024
+_FLOAT64_BYTES: Final[int] = np.dtype(np.float64).itemsize
+_APPENDIX_C1_VALIDATION_OBSERVATIONS: Final[int] = 10_000
+_APPENDIX_C1_BATCH_SIZE: Final[int] = 4
+_APPENDIX_C1_BATCH_COUNT: Final[int] = 128
+_APPENDIX_C1_ROLLOUT_COUNT: Final[int] = 128
+_APPENDIX_C1_GAIN_STEPS: Final[frozenset[int]] = frozenset({1, 10, 100})
+_PERMITTED_BOUNDARY_INFORMATION: Final[tuple[str, ...]] = ("task_start",)
+_PERMITTED_TASK_INFORMATION: Final[tuple[str, ...]] = (
+    "current_validation_inputs",
+    "current_validation_labels",
+)
+_SAMPLING_PROVENANCE: Final[str] = (
+    "caller_reported_independent_with_replacement_not_verified_from_gradients"
+)
+
 OPTIMIZATION_READINESS_PROTOCOL = MappingProxyType(
     {
         "schema": PROTOCOL_SCHEMA,
         "paper_revision": "arXiv:2605.09044v1",
         "paper_revision_date": "2026-05-09",
         "population_gradient_estimator": "full_validation_set_gradient",
-        "reliability_estimator": "independently_sampled_minibatch_gradients",
+        "reliability_estimator": "caller-provided_minibatch_gradients",
         "reference_reliability_batch_count": 128,
         "reference_reliability_batch_size": 4,
         "official_code_revision": "none-cited-in-arxiv-v1-as-of-2026-08-17",
-        "estimator": "appendix-c.1-full-gradient-plus-independent-mini-batches",
+        "estimator": "generic-equation-helper-plus-appendix-c.1-declared-mode",
         "paper_defaults": MappingProxyType(
-            {"validation_observations": 10_000, "mini_batch_size": 4, "batch_count": 128}
+            {
+                "validation_observations": 10_000,
+                "mini_batch_size": 4,
+                "batch_count": 128,
+                "future_gain_rollout_count": 128,
+                "future_gain_step_size": 1e-3,
+            }
         ),
         "asi_protocol_differences": (
-            "caller_supplies_precomputed_full_and_mini_batch_gradients",
-            "sample_counts_are_bound_by_each_development_protocol",
-            "resource_nonpromotion_and_outcome_retention_receipts_are_added",
+            "caller_supplies_precomputed gradients",
+            "gradient arrays cannot prove sample membership or independence",
+            "result metrics, outcomes, and execution identities are caller-reported",
         ),
         "diagnostics": (
             "optimization_readiness",
@@ -55,16 +83,25 @@ OPTIMIZATION_READINESS_PROTOCOL = MappingProxyType(
             "task",
             "updates",
             "observations",
+            "full_validation_observations",
             "mini_batch_size",
             "diagnostic_batch_count",
+            "future_gain_steps",
+            "future_gain_rollout_count",
+            "future_gain_batch_size",
+            "future_gain_step_size",
+            "parameter_count",
+            "sampling_provenance",
             "allowed_boundary_information",
             "allowed_task_information",
         ),
         "resource_fields": (
             "persistent_bytes",
+            "peak_working_set_bytes",
             "environment_steps",
             "data_steps",
             "model_queries",
+            "parameter_updates",
             "timing_seconds",
         ),
         "timing_is_telemetry_only": True,
@@ -72,8 +109,9 @@ OPTIMIZATION_READINESS_PROTOCOL = MappingProxyType(
         "scientific_promotion_allowed": False,
         "outcome_retention_required": True,
         "execution_protocol_required": True,
-        "matrix_shape_and_dtype_accounting_required": True,
-        "working_set_bytes_accounting_required": True,
+        "resource_receipts_are_authenticated": False,
+        "metrics_are_recomputed_by_this_module": False,
+        "outcomes_are_derived_by_this_module": False,
         "completed_result_exists": False,
     }
 )
@@ -102,26 +140,35 @@ class ProspectiveDevelopmentProtocol:
     task: str
     updates: int
     observations: int
+    full_validation_observations: int
     mini_batch_size: int
     diagnostic_batch_count: int
+    future_gain_steps: int
+    future_gain_rollout_count: int
+    future_gain_batch_size: int
+    future_gain_step_size: float
+    parameter_count: int
+    sampling_provenance: str
     allowed_boundary_information: tuple[str, ...]
     allowed_task_information: tuple[str, ...]
 
 
 @dataclass(frozen=True)
 class ResourceReceipt:
-    """Resource accounting required for every prospective result."""
+    """Bounded caller-reported resource accounting for a prospective result."""
 
     persistent_bytes: int
+    peak_working_set_bytes: int
     environment_steps: int
     data_steps: int
     model_queries: int
+    parameter_updates: int
     timing_seconds: float
 
 
 @dataclass(frozen=True)
 class DevelopmentResultReceipt:
-    """Strictly validated, permanently nonpromoting prospective result."""
+    """Schema-validated, permanently nonpromoting prospective result report."""
 
     comparison_id: str
     arm_id: str
@@ -133,7 +180,7 @@ class DevelopmentResultReceipt:
     curvature_energy_rank_0_99: int
     parameter_norm: float
     future_relative_loss_reduction: float
-    outcome: str
+    reported_outcome: str
 
 
 def _finite_array(
@@ -146,6 +193,8 @@ def _finite_array(
         raise ValueError(f"{name} must be a non-empty {dimensions}-dimensional array")
     if raw.dtype.kind not in {"i", "u", "f"}:
         raise ValueError(f"{name} must have a real numeric dtype")
+    if raw.nbytes > _MAX_ARRAY_BYTES or raw.size > _MAX_ARRAY_BYTES // _FLOAT64_BYTES:
+        raise ValueError(f"{name} exceeds the bounded numeric payload")
     resolved = np.asarray(raw, dtype=np.float64)
     if not np.all(np.isfinite(resolved)):
         raise ValueError(f"{name} must contain only finite values")
@@ -172,11 +221,13 @@ def estimate_optimization_readiness(
     batch_gradients: object,
     include_reliability: bool = True,
 ) -> OptimizationReadiness:
-    """Estimate OR using the paper's full-data and mini-batch estimators.
+    """Evaluate the OR equations for bounded caller-provided gradients.
 
-    ``full_validation_gradient`` estimates the population gradient separately.
-    The rows of ``batch_gradients`` must come from independently sampled
-    mini-batches and estimate the expected squared mini-batch-gradient norm.
+    This generic equation helper does not know how the gradients were sampled.
+    In particular, array values cannot establish mini-batch size, membership,
+    replacement, or independence.  Use
+    :func:`estimate_appendix_c1_optimization_readiness` when the observable
+    Appendix C.1 shape and caller-reported sampling design must be checked.
     Setting ``include_reliability=False`` is the predeclared
     gradient-strength-only mechanism-off reduction.
     """
@@ -233,6 +284,44 @@ def estimate_optimization_readiness(
     )
 
 
+def estimate_appendix_c1_optimization_readiness(
+    *,
+    loss: float,
+    full_validation_gradient: object,
+    batch_gradients: object,
+    full_validation_observations: int,
+    mini_batch_size: int,
+    sampling_provenance: str,
+    include_reliability: bool = True,
+) -> OptimizationReadiness:
+    """Validate the observable Appendix C.1 contract and evaluate OR.
+
+    The function requires the paper's 10,000-observation validation set and
+    128 reported size-4 mini-batch gradients.  ``sampling_provenance`` is an
+    explicit caller report: precomputed gradient arrays cannot prove that the
+    underlying samples were independent or drawn with replacement.
+    """
+    if (
+        type(full_validation_observations) is not int
+        or full_validation_observations != _APPENDIX_C1_VALIDATION_OBSERVATIONS
+    ):
+        raise ValueError("Appendix C.1 requires exactly 10,000 validation observations")
+    if type(mini_batch_size) is not int or mini_batch_size != _APPENDIX_C1_BATCH_SIZE:
+        raise ValueError("Appendix C.1 requires reported mini-batch size 4")
+    if type(sampling_provenance) is not str or sampling_provenance != _SAMPLING_PROVENANCE:
+        raise ValueError("Appendix C.1 sampling provenance must use the explicit unverified label")
+    if type(batch_gradients) is not np.ndarray:
+        raise ValueError("batch_gradients must be an exact numpy.ndarray")
+    if batch_gradients.ndim != 2 or batch_gradients.shape[0] != _APPENDIX_C1_BATCH_COUNT:
+        raise ValueError("Appendix C.1 requires exactly 128 mini-batch gradient rows")
+    return estimate_optimization_readiness(
+        loss=loss,
+        full_validation_gradient=full_validation_gradient,
+        batch_gradients=batch_gradients,
+        include_reliability=include_reliability,
+    )
+
+
 def energy_rank(matrix: object, *, threshold: float = 0.99) -> int:
     """Return the smallest singular-value count reaching squared-energy mass."""
     if type(threshold) is not float:
@@ -256,19 +345,29 @@ def energy_rank(matrix: object, *, threshold: float = 0.99) -> int:
     return min(found, int(singular_values.shape[0]))
 
 
-def _strict_mapping(value: object, *, name: str, keys: set[str]) -> Mapping[str, Any]:
-    if not isinstance(value, Mapping):
-        raise ValueError(f"{name} must be a mapping")
-    actual = set(value)
+def _strict_mapping(value: object, *, name: str, keys: set[str]) -> dict[str, object]:
+    if type(value) is not dict:
+        raise ValueError(f"{name} must be an exact dict")
+    actual_keys = tuple(value.keys())
+    if any(type(key) is not str for key in actual_keys):
+        raise ValueError(f"{name} keys must be exact strings")
+    actual = set(actual_keys)
     if actual != keys:
         raise ValueError(f"{name} keys must be exactly {sorted(keys)}")
     return value
 
 
-def _strict_nonnegative_int(value: object, *, name: str, positive: bool = False) -> int:
-    if type(value) is not int or value < int(positive):
+def _strict_nonnegative_int(
+    value: object,
+    *,
+    name: str,
+    positive: bool = False,
+    maximum: int = _INT32_MAX,
+) -> int:
+    minimum = 1 if positive else 0
+    if type(value) is not int or not minimum <= value <= maximum:
         qualifier = "positive" if positive else "nonnegative"
-        raise ValueError(f"{name} must be a {qualifier} int")
+        raise ValueError(f"{name} must be a bounded {qualifier} built-in int")
     return value
 
 
@@ -280,16 +379,48 @@ def _strict_finite_float(value: object, *, name: str, nonnegative: bool = False)
 
 
 def _strict_string_tuple(value: object, *, name: str) -> tuple[str, ...]:
-    if type(value) is not list or any(type(item) is not str or not item for item in value):
-        raise ValueError(f"{name} must be a list of non-empty strings")
-    resolved = tuple(value)
+    if type(value) is not list:
+        raise ValueError(f"{name} must be an exact list")
+    if len(value) > _MAX_INFORMATION_ITEMS:
+        raise ValueError(f"{name} exceeds its bounded item count")
+    resolved = tuple(_strict_string(item, name=f"{name} item") for item in value)
     if len(set(resolved)) != len(resolved):
         raise ValueError(f"{name} must not contain duplicates")
     return resolved
 
 
+def _strict_string(value: object, *, name: str) -> str:
+    if type(value) is not str:
+        raise ValueError(f"{name} must be an exact string")
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{name} must be valid UTF-8") from exc
+    if not encoded or len(encoded) > _MAX_STRING_BYTES or "\x00" in value:
+        raise ValueError(f"{name} must be a bounded non-empty string")
+    return value
+
+
+def _checked_product(name: str, *factors: int, maximum: int = _INT32_MAX) -> int:
+    product = 1
+    for factor in factors:
+        if factor and product > maximum // factor:
+            raise ValueError(f"{name} exceeds its bounded accounting domain")
+        product *= factor
+    return product
+
+
+def _checked_sum(name: str, *values: int, maximum: int = _INT32_MAX) -> int:
+    total = 0
+    for value in values:
+        if total > maximum - value:
+            raise ValueError(f"{name} exceeds its bounded accounting domain")
+        total += value
+    return total
+
+
 def validate_development_result(payload: object) -> DevelopmentResultReceipt:
-    """Fail closed while adopting one prospective development-result payload."""
+    """Validate a bounded, explicitly nonauthenticated development report."""
     outer = _strict_mapping(
         payload,
         name="result",
@@ -300,25 +431,27 @@ def validate_development_result(payload: object) -> DevelopmentResultReceipt:
             "protocol",
             "resources",
             "metrics",
-            "outcome",
-            "outcome_retained",
+            "reported_outcome",
+            "reported_outcome_retained",
             "development_only",
             "scientific_promotion_allowed",
         },
     )
-    if outer["schema"] != RESULT_SCHEMA:
+    if _strict_string(outer["schema"], name="result schema") != RESULT_SCHEMA:
         raise ValueError("result schema is not supported")
-    for name in ("comparison_id", "arm_id"):
-        if type(outer[name]) is not str or not outer[name]:
-            raise ValueError(f"{name} must be a non-empty string")
-    if type(outer["outcome"]) is not str or outer["outcome"] not in {
+    comparison_id = _strict_string(outer["comparison_id"], name="comparison_id")
+    arm_id = _strict_string(outer["arm_id"], name="arm_id")
+    reported_outcome = _strict_string(
+        outer["reported_outcome"], name="reported_outcome"
+    )
+    if reported_outcome not in {
         "supported",
         "rejected",
         "inconclusive",
     }:
-        raise ValueError("outcome must be supported, rejected, or inconclusive")
-    if outer["outcome_retained"] is not True:
-        raise ValueError("outcome_retained must permanently remain True")
+        raise ValueError("reported_outcome must be supported, rejected, or inconclusive")
+    if outer["reported_outcome_retained"] is not True:
+        raise ValueError("reported_outcome_retained must permanently remain True")
     if outer["development_only"] is not True:
         raise ValueError("development_only must permanently remain True")
     if outer["scientific_promotion_allowed"] is not False:
@@ -334,24 +467,35 @@ def validate_development_result(payload: object) -> DevelopmentResultReceipt:
             "task",
             "updates",
             "observations",
+            "full_validation_observations",
             "mini_batch_size",
             "diagnostic_batch_count",
+            "future_gain_steps",
+            "future_gain_rollout_count",
+            "future_gain_batch_size",
+            "future_gain_step_size",
+            "parameter_count",
+            "sampling_provenance",
             "allowed_boundary_information",
             "allowed_task_information",
         },
     )
-    if protocol_payload["schema"] != PROTOCOL_SCHEMA:
+    if _strict_string(protocol_payload["schema"], name="protocol schema") != PROTOCOL_SCHEMA:
         raise ValueError("protocol schema is not supported")
-    for name in ("checkpoint", "task"):
-        if type(protocol_payload[name]) is not str or not protocol_payload[name]:
-            raise ValueError(f"{name} must be a non-empty string")
     protocol = ProspectiveDevelopmentProtocol(
-        seed=_strict_nonnegative_int(protocol_payload["seed"], name="seed"),
-        checkpoint=protocol_payload["checkpoint"],
-        task=protocol_payload["task"],
+        seed=_strict_nonnegative_int(
+            protocol_payload["seed"], name="seed", maximum=_UINT32_MAX
+        ),
+        checkpoint=_strict_string(protocol_payload["checkpoint"], name="checkpoint"),
+        task=_strict_string(protocol_payload["task"], name="task"),
         updates=_strict_nonnegative_int(protocol_payload["updates"], name="updates", positive=True),
         observations=_strict_nonnegative_int(
             protocol_payload["observations"], name="observations", positive=True
+        ),
+        full_validation_observations=_strict_nonnegative_int(
+            protocol_payload["full_validation_observations"],
+            name="full_validation_observations",
+            positive=True,
         ),
         mini_batch_size=_strict_nonnegative_int(
             protocol_payload["mini_batch_size"], name="mini_batch_size", positive=True
@@ -360,6 +504,30 @@ def validate_development_result(payload: object) -> DevelopmentResultReceipt:
             protocol_payload["diagnostic_batch_count"],
             name="diagnostic_batch_count",
             positive=True,
+        ),
+        future_gain_steps=_strict_nonnegative_int(
+            protocol_payload["future_gain_steps"], name="future_gain_steps", positive=True
+        ),
+        future_gain_rollout_count=_strict_nonnegative_int(
+            protocol_payload["future_gain_rollout_count"],
+            name="future_gain_rollout_count",
+            positive=True,
+        ),
+        future_gain_batch_size=_strict_nonnegative_int(
+            protocol_payload["future_gain_batch_size"],
+            name="future_gain_batch_size",
+            positive=True,
+        ),
+        future_gain_step_size=_strict_finite_float(
+            protocol_payload["future_gain_step_size"],
+            name="future_gain_step_size",
+            nonnegative=True,
+        ),
+        parameter_count=_strict_nonnegative_int(
+            protocol_payload["parameter_count"], name="parameter_count", positive=True
+        ),
+        sampling_provenance=_strict_string(
+            protocol_payload["sampling_provenance"], name="sampling_provenance"
         ),
         allowed_boundary_information=_strict_string_tuple(
             protocol_payload["allowed_boundary_information"],
@@ -376,20 +544,29 @@ def validate_development_result(payload: object) -> DevelopmentResultReceipt:
         keys={
             "schema",
             "persistent_bytes",
+            "peak_working_set_bytes",
             "environment_steps",
             "data_steps",
             "model_queries",
+            "parameter_updates",
             "timing_seconds",
             "timing_is_telemetry_only",
         },
     )
-    if resource_payload["schema"] != RESOURCE_SCHEMA:
+    if _strict_string(resource_payload["schema"], name="resource schema") != RESOURCE_SCHEMA:
         raise ValueError("resource schema is not supported")
     if resource_payload["timing_is_telemetry_only"] is not True:
         raise ValueError("timing_is_telemetry_only must permanently remain True")
     resources = ResourceReceipt(
         persistent_bytes=_strict_nonnegative_int(
-            resource_payload["persistent_bytes"], name="persistent_bytes"
+            resource_payload["persistent_bytes"],
+            name="persistent_bytes",
+            maximum=_MAX_PERSISTENT_BYTES,
+        ),
+        peak_working_set_bytes=_strict_nonnegative_int(
+            resource_payload["peak_working_set_bytes"],
+            name="peak_working_set_bytes",
+            maximum=_MAX_WORKING_SET_BYTES,
         ),
         environment_steps=_strict_nonnegative_int(
             resource_payload["environment_steps"], name="environment_steps"
@@ -398,10 +575,80 @@ def validate_development_result(payload: object) -> DevelopmentResultReceipt:
         model_queries=_strict_nonnegative_int(
             resource_payload["model_queries"], name="model_queries"
         ),
+        parameter_updates=_strict_nonnegative_int(
+            resource_payload["parameter_updates"], name="parameter_updates"
+        ),
         timing_seconds=_strict_finite_float(
             resource_payload["timing_seconds"], name="timing_seconds", nonnegative=True
         ),
     )
+
+    if (
+        protocol.full_validation_observations != _APPENDIX_C1_VALIDATION_OBSERVATIONS
+        or protocol.mini_batch_size != _APPENDIX_C1_BATCH_SIZE
+        or protocol.diagnostic_batch_count != _APPENDIX_C1_BATCH_COUNT
+        or protocol.future_gain_rollout_count != _APPENDIX_C1_ROLLOUT_COUNT
+        or protocol.future_gain_batch_size != _APPENDIX_C1_BATCH_SIZE
+        or protocol.future_gain_steps not in _APPENDIX_C1_GAIN_STEPS
+        or protocol.future_gain_step_size != 1e-3
+        or protocol.sampling_provenance != _SAMPLING_PROVENANCE
+    ):
+        raise ValueError("diagnostic and rollout sampling must match pinned Appendix C.1")
+    reliability_observations = _checked_product(
+        "diagnostic mini-batch observations",
+        protocol.mini_batch_size,
+        protocol.diagnostic_batch_count,
+    )
+    rollout_updates = _checked_product(
+        "future-gain updates",
+        protocol.future_gain_steps,
+        protocol.future_gain_rollout_count,
+    )
+    if protocol.updates != rollout_updates:
+        raise ValueError("updates must equal future-gain steps times rollout count")
+    if resources.parameter_updates != protocol.updates:
+        raise ValueError("parameter_updates must equal protocol updates")
+    rollout_training_observations = _checked_product(
+        "future-gain training observations",
+        rollout_updates,
+        protocol.future_gain_batch_size,
+    )
+    terminal_validation_observations = _checked_product(
+        "future-gain terminal validation observations",
+        protocol.future_gain_rollout_count,
+        protocol.full_validation_observations,
+    )
+    # The initial full-validation loss is co-computed with the full-validation
+    # gradient. Each rollout additionally charges its training mini-batches and
+    # one complete terminal validation evaluation, as in Appendix C.1.
+    expected_observations = _checked_sum(
+        "prospective observations",
+        protocol.full_validation_observations,
+        reliability_observations,
+        rollout_training_observations,
+        terminal_validation_observations,
+    )
+    if protocol.observations != expected_observations:
+        raise ValueError("observations must equal the pinned diagnostic and rollout charges")
+    if _checked_sum(
+        "environment/data steps", resources.environment_steps, resources.data_steps
+    ) != protocol.observations:
+        raise ValueError("environment_steps plus data_steps must equal observations")
+    if resources.model_queries != protocol.observations:
+        raise ValueError("model_queries must equal charged prospective observations")
+    minimum_working_set_bytes = _checked_product(
+        "diagnostic gradient bytes",
+        protocol.diagnostic_batch_count + 1,
+        protocol.parameter_count,
+        _FLOAT64_BYTES,
+        maximum=_MAX_WORKING_SET_BYTES,
+    )
+    if resources.peak_working_set_bytes < minimum_working_set_bytes:
+        raise ValueError("peak_working_set_bytes is below the bound diagnostic gradients")
+    if protocol.allowed_boundary_information != _PERMITTED_BOUNDARY_INFORMATION:
+        raise ValueError("allowed_boundary_information exceeds the frozen protocol")
+    if protocol.allowed_task_information != _PERMITTED_TASK_INFORMATION:
+        raise ValueError("allowed_task_information exceeds the frozen protocol")
 
     metric_payload = _strict_mapping(
         outer["metrics"],
@@ -415,9 +662,27 @@ def validate_development_result(payload: object) -> DevelopmentResultReceipt:
             "future_relative_loss_reduction",
         },
     )
+    representation_rank = _strict_nonnegative_int(
+        metric_payload["representation_energy_rank_0_99"],
+        name="representation_energy_rank_0_99",
+    )
+    if representation_rank > protocol.full_validation_observations:
+        raise ValueError("representation_energy_rank_0_99 exceeds the validation row count")
+    curvature_rank = _strict_nonnegative_int(
+        metric_payload["curvature_energy_rank_0_99"],
+        name="curvature_energy_rank_0_99",
+    )
+    if curvature_rank > protocol.parameter_count:
+        raise ValueError("curvature_energy_rank_0_99 exceeds parameter_count")
+    future_gain = _strict_finite_float(
+        metric_payload["future_relative_loss_reduction"],
+        name="future_relative_loss_reduction",
+    )
+    if future_gain > 1.0:
+        raise ValueError("future_relative_loss_reduction cannot exceed one")
     return DevelopmentResultReceipt(
-        comparison_id=outer["comparison_id"],
-        arm_id=outer["arm_id"],
+        comparison_id=comparison_id,
+        arm_id=arm_id,
         protocol=protocol,
         resources=resources,
         optimization_readiness=_strict_finite_float(
@@ -428,31 +693,28 @@ def validate_development_result(payload: object) -> DevelopmentResultReceipt:
         gradient_norm=_strict_finite_float(
             metric_payload["gradient_norm"], name="gradient_norm", nonnegative=True
         ),
-        representation_energy_rank_0_99=_strict_nonnegative_int(
-            metric_payload["representation_energy_rank_0_99"],
-            name="representation_energy_rank_0_99",
-        ),
-        curvature_energy_rank_0_99=_strict_nonnegative_int(
-            metric_payload["curvature_energy_rank_0_99"],
-            name="curvature_energy_rank_0_99",
-        ),
+        representation_energy_rank_0_99=representation_rank,
+        curvature_energy_rank_0_99=curvature_rank,
         parameter_norm=_strict_finite_float(
             metric_payload["parameter_norm"], name="parameter_norm", nonnegative=True
         ),
-        future_relative_loss_reduction=_strict_finite_float(
-            metric_payload["future_relative_loss_reduction"],
-            name="future_relative_loss_reduction",
-        ),
-        outcome=outer["outcome"],
+        future_relative_loss_reduction=future_gain,
+        reported_outcome=reported_outcome,
     )
 
 
 def validate_matched_development_results(
-    payloads: Sequence[object],
+    payloads: object,
 ) -> tuple[DevelopmentResultReceipt, ...]:
-    """Validate two or more receipts and require all predeclared matched axes."""
-    if type(payloads) not in {list, tuple} or len(payloads) < 2:
-        raise ValueError("payloads must contain at least two development results")
+    """Validate receipts with equal protocol axes and resource budgets.
+
+    Timing remains telemetry and may differ.  Equality of caller-reported
+    budgets does not authenticate the underlying execution.
+    """
+    if type(payloads) is not list and type(payloads) is not tuple:
+        raise ValueError("payloads must be an exact list or tuple")
+    if not 2 <= len(payloads) <= _MAX_RESULT_COUNT:
+        raise ValueError("payloads must contain a bounded count of development results")
     receipts = tuple(validate_development_result(payload) for payload in payloads)
     first = receipts[0]
     if len({receipt.arm_id for receipt in receipts}) != len(receipts):
@@ -462,4 +724,20 @@ def validate_matched_development_results(
             raise ValueError("comparison_id must match across development results")
         if receipt.protocol != first.protocol:
             raise ValueError("all predeclared matched protocol axes must be equal")
+        if (
+            receipt.resources.persistent_bytes,
+            receipt.resources.peak_working_set_bytes,
+            receipt.resources.environment_steps,
+            receipt.resources.data_steps,
+            receipt.resources.model_queries,
+            receipt.resources.parameter_updates,
+        ) != (
+            first.resources.persistent_bytes,
+            first.resources.peak_working_set_bytes,
+            first.resources.environment_steps,
+            first.resources.data_steps,
+            first.resources.model_queries,
+            first.resources.parameter_updates,
+        ):
+            raise ValueError("all caller-reported resource budgets must be equal")
     return receipts

--- a/tests/test_optimization_readiness.py
+++ b/tests/test_optimization_readiness.py
@@ -8,6 +8,7 @@ import pytest
 from alberta_framework.evaluation.optimization_readiness import (
     OPTIMIZATION_READINESS_PROTOCOL,
     energy_rank,
+    estimate_appendix_c1_optimization_readiness,
     estimate_optimization_readiness,
     validate_development_result,
     validate_matched_development_results,
@@ -29,6 +30,42 @@ def test_readiness_matches_paper_empirical_equations() -> None:
     assert report.gradient_norm == pytest.approx(1.0)
 
 
+def test_appendix_c1_mode_checks_observable_contract_without_claiming_independence() -> None:
+    gradients = np.ones((128, 2), dtype=np.float64)
+    report = estimate_appendix_c1_optimization_readiness(
+        loss=1.0,
+        full_validation_gradient=np.ones(2, dtype=np.float64),
+        batch_gradients=gradients,
+        full_validation_observations=10_000,
+        mini_batch_size=4,
+        sampling_provenance=(
+            "caller_reported_independent_with_replacement_not_verified_from_gradients"
+        ),
+    )
+    assert report.batch_count == 128
+
+    with pytest.raises(ValueError, match="128 mini-batch gradient rows"):
+        estimate_appendix_c1_optimization_readiness(
+            loss=1.0,
+            full_validation_gradient=np.ones(2, dtype=np.float64),
+            batch_gradients=gradients[:127],
+            full_validation_observations=10_000,
+            mini_batch_size=4,
+            sampling_provenance=(
+                "caller_reported_independent_with_replacement_not_verified_from_gradients"
+            ),
+        )
+
+
+def test_generic_equation_helper_remains_explicitly_sampling_agnostic() -> None:
+    report = estimate_optimization_readiness(
+        loss=1.0,
+        full_validation_gradient=np.ones(1),
+        batch_gradients=np.ones((1, 1)),
+    )
+    assert report.batch_count == 1
+
+
 def test_zero_and_mechanism_off_reductions() -> None:
     zero = estimate_optimization_readiness(
         loss=0.0,
@@ -45,24 +82,6 @@ def test_zero_and_mechanism_off_reductions() -> None:
     assert strength_only.optimization_readiness == strength_only.gradient_strength
 
 
-def test_readiness_fails_closed_on_overflowing_finite_inputs() -> None:
-    with pytest.raises(ValueError, match="finite float64"):
-        estimate_optimization_readiness(
-            loss=1.0,
-            full_validation_gradient=np.asarray([1e308]),
-            batch_gradients=np.asarray([[1e308], [1e308]]),
-        )
-
-
-def test_readiness_rejects_mismatched_parameter_counts() -> None:
-    with pytest.raises(ValueError, match="parameter axis"):
-        estimate_optimization_readiness(
-            loss=1.0,
-            full_validation_gradient=np.ones(3),
-            batch_gradients=np.ones((2, 2)),
-        )
-
-
 def test_energy_rank_baseline_and_exact_threshold() -> None:
     matrix = np.diag([3.0, 1.0])
     assert energy_rank(matrix, threshold=0.9) == 1
@@ -75,8 +94,8 @@ def test_energy_rank_baseline_and_exact_threshold() -> None:
 @pytest.mark.parametrize("loss", [-1.0, float("nan"), True])
 def test_readiness_rejects_invalid_loss(loss: object) -> None:
     with pytest.raises(ValueError, match="loss"):
-        estimate_optimization_readiness(  # type: ignore[arg-type]
-            loss=loss,
+        estimate_optimization_readiness(
+            loss=loss,  # type: ignore[arg-type]
             full_validation_gradient=np.ones(2),
             batch_gradients=np.ones((2, 2)),
         )
@@ -131,19 +150,33 @@ def _result_payload(*, arm_id: str = "candidate") -> dict[str, object]:
             "seed": 7,
             "checkpoint": "checkpoint-0042",
             "task": "ipmnist-permutation-3",
-            "updates": 100,
-            "observations": 10_000,
+            "updates": 128,
+            "observations": 1_291_024,
+            "full_validation_observations": 10_000,
             "mini_batch_size": 4,
             "diagnostic_batch_count": 128,
+            "future_gain_steps": 1,
+            "future_gain_rollout_count": 128,
+            "future_gain_batch_size": 4,
+            "future_gain_step_size": 1e-3,
+            "parameter_count": 2,
+            "sampling_provenance": (
+                "caller_reported_independent_with_replacement_not_verified_from_gradients"
+            ),
             "allowed_boundary_information": ["task_start"],
-            "allowed_task_information": ["labels_for_current_validation_task"],
+            "allowed_task_information": [
+                "current_validation_inputs",
+                "current_validation_labels",
+            ],
         },
         "resources": {
             "schema": "asi.optimization-readiness.resources.v1",
             "persistent_bytes": 4096,
+            "peak_working_set_bytes": 129 * 2 * 8,
             "environment_steps": 0,
-            "data_steps": 10_000,
-            "model_queries": 10_128,
+            "data_steps": 1_291_024,
+            "model_queries": 1_291_024,
+            "parameter_updates": 128,
             "timing_seconds": 1.25,
             "timing_is_telemetry_only": True,
         },
@@ -155,8 +188,8 @@ def _result_payload(*, arm_id: str = "candidate") -> dict[str, object]:
             "parameter_norm": 12.0,
             "future_relative_loss_reduction": -0.1,
         },
-        "outcome": "rejected",
-        "outcome_retained": True,
+        "reported_outcome": "rejected",
+        "reported_outcome_retained": True,
         "development_only": True,
         "scientific_promotion_allowed": False,
     }
@@ -164,8 +197,8 @@ def _result_payload(*, arm_id: str = "candidate") -> dict[str, object]:
 
 def test_strict_result_and_resource_receipt_validation() -> None:
     receipt = validate_development_result(_result_payload())
-    assert receipt.outcome == "rejected"
-    assert receipt.resources.data_steps == 10_000
+    assert receipt.reported_outcome == "rejected"
+    assert receipt.resources.data_steps == 1_291_024
     assert receipt.protocol.allowed_boundary_information == ("task_start",)
 
     payload = _result_payload()
@@ -183,7 +216,7 @@ def test_strict_result_and_resource_receipt_validation() -> None:
         (("resources", "timing_seconds"), float("nan"), "timing_seconds"),
         (("resources", "timing_is_telemetry_only"), False, "telemetry"),
         (("scientific_promotion_allowed",), True, "scientific_promotion_allowed"),
-        (("outcome_retained",), False, "outcome_retained"),
+        (("reported_outcome_retained",), False, "reported_outcome_retained"),
     ],
 )
 def test_result_validator_fails_closed(
@@ -209,9 +242,145 @@ def test_matched_result_validation_enforces_all_axes() -> None:
     mismatched = deepcopy(control)
     protocol = mismatched["protocol"]
     assert isinstance(protocol, dict)
-    protocol["observations"] = 9_999
+    protocol["seed"] = 8
     with pytest.raises(ValueError, match="matched protocol axes"):
         validate_matched_development_results([candidate, mismatched])
+
+    mismatched_budget = deepcopy(control)
+    resources = mismatched_budget["resources"]
+    assert isinstance(resources, dict)
+    resources["persistent_bytes"] = 4097
+    with pytest.raises(ValueError, match="resource budgets"):
+        validate_matched_development_results([candidate, mismatched_budget])
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value", "match"),
+    [
+        ("protocol", "observations", 1_291_023, "pinned diagnostic and rollout"),
+        ("protocol", "mini_batch_size", 5, "Appendix C.1"),
+        ("protocol", "diagnostic_batch_count", 127, "Appendix C.1"),
+        ("protocol", "updates", 129, "future-gain steps times rollout count"),
+        ("resources", "data_steps", 1_291_023, "environment_steps plus data_steps"),
+        ("resources", "model_queries", 1_291_023, "model_queries"),
+        ("resources", "parameter_updates", 127, "parameter_updates"),
+        ("resources", "peak_working_set_bytes", 2_063, "peak_working_set_bytes"),
+    ],
+)
+def test_resource_receipt_enforces_live_cross_field_identities(
+    section: str, field: str, value: object, match: str
+) -> None:
+    payload = _result_payload()
+    nested = payload[section]
+    assert isinstance(nested, dict)
+    nested[field] = value
+    with pytest.raises(ValueError, match=match):
+        validate_development_result(payload)
+
+
+def test_receipt_boundaries_reject_hostile_runtime_classes_without_hooks() -> None:
+    class HostileDict(dict[str, object]):
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("mapping iteration hook must not run")
+
+    class HostileList(list[object]):
+        def __len__(self) -> int:
+            raise AssertionError("list length hook must not run")
+
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("list iteration hook must not run")
+
+    class HostileString(str):
+        def __bool__(self) -> bool:
+            raise AssertionError("string truth hook must not run")
+
+        def __eq__(self, other: object) -> bool:
+            del other
+            raise AssertionError("string equality hook must not run")
+
+        def encode(self, *args: object, **kwargs: object) -> bytes:
+            del args, kwargs
+            raise AssertionError("string encode hook must not run")
+
+    class HostileInt(int):
+        def __lt__(self, other: object) -> bool:
+            del other
+            raise AssertionError("integer comparison hook must not run")
+
+        def __le__(self, other: object) -> bool:
+            del other
+            raise AssertionError("integer comparison hook must not run")
+
+    with pytest.raises(ValueError, match="exact dict"):
+        validate_development_result(HostileDict(_result_payload()))
+    with pytest.raises(ValueError, match="exact list or tuple"):
+        validate_matched_development_results(HostileList())
+
+    payload = _result_payload()
+    payload["schema"] = HostileString(str(payload["schema"]))
+    with pytest.raises(ValueError, match="exact string"):
+        validate_development_result(payload)
+
+    payload = _result_payload()
+    protocol = payload["protocol"]
+    assert isinstance(protocol, dict)
+    protocol["seed"] = HostileInt(7)
+    with pytest.raises(ValueError, match="bounded nonnegative built-in int"):
+        validate_development_result(payload)
+
+    payload = _result_payload()
+    protocol = payload["protocol"]
+    assert isinstance(protocol, dict)
+    protocol["allowed_task_information"] = HostileList(["label"])
+    with pytest.raises(ValueError, match="exact list"):
+        validate_development_result(payload)
+
+
+def test_receipt_payloads_and_scalars_are_bounded() -> None:
+    payload = _result_payload()
+    payload["comparison_id"] = "x" * 4_097
+    with pytest.raises(ValueError, match="bounded non-empty string"):
+        validate_development_result(payload)
+
+    payload = _result_payload()
+    resources = payload["resources"]
+    assert isinstance(resources, dict)
+    resources["persistent_bytes"] = 256 * 1024 * 1024 + 1
+    with pytest.raises(ValueError, match="persistent_bytes"):
+        validate_development_result(payload)
+
+    with pytest.raises(ValueError, match="bounded count"):
+        validate_matched_development_results([_result_payload()] * 257)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("allowed_boundary_information", ["future_task_boundary"]),
+        ("allowed_task_information", ["held_out_answers"]),
+    ],
+)
+def test_receipt_rejects_information_outside_frozen_permissions(
+    field: str, value: list[str]
+) -> None:
+    payload = _result_payload()
+    protocol = payload["protocol"]
+    assert isinstance(protocol, dict)
+    protocol[field] = value
+    with pytest.raises(ValueError, match=field):
+        validate_development_result(payload)
+
+
+def test_numeric_payloads_are_bounded_before_conversion_or_svd() -> None:
+    oversized = np.broadcast_to(np.zeros(1, dtype=np.float64), (67_108_865,))
+    with pytest.raises(ValueError, match="bounded"):
+        estimate_optimization_readiness(
+            loss=1.0,
+            full_validation_gradient=oversized,
+            batch_gradients=np.ones((1, 1)),
+        )
+    with pytest.raises(ValueError, match="bounded"):
+        energy_rank(oversized.reshape(1, -1))
 
 
 def test_protocol_records_estimator_differences_and_nonpromotion() -> None:
@@ -222,10 +391,12 @@ def test_protocol_records_estimator_differences_and_nonpromotion() -> None:
     )
     assert (
         OPTIMIZATION_READINESS_PROTOCOL["estimator"]
-        == "appendix-c.1-full-gradient-plus-independent-mini-batches"
+        == "generic-equation-helper-plus-appendix-c.1-declared-mode"
     )
     assert OPTIMIZATION_READINESS_PROTOCOL["asi_protocol_differences"]
     assert OPTIMIZATION_READINESS_PROTOCOL["development_only"] is True
     assert OPTIMIZATION_READINESS_PROTOCOL["scientific_promotion_allowed"] is False
     assert OPTIMIZATION_READINESS_PROTOCOL["completed_result_exists"] is False
     assert OPTIMIZATION_READINESS_PROTOCOL["outcome_retention_required"] is True
+    assert OPTIMIZATION_READINESS_PROTOCOL["resource_receipts_are_authenticated"] is False
+    assert OPTIMIZATION_READINESS_PROTOCOL["outcomes_are_derived_by_this_module"] is False

--- a/tests/test_optimization_readiness.py
+++ b/tests/test_optimization_readiness.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
 import numpy as np
 import pytest
 
@@ -7,10 +9,12 @@ from alberta_framework.evaluation.optimization_readiness import (
     OPTIMIZATION_READINESS_PROTOCOL,
     energy_rank,
     estimate_optimization_readiness,
+    validate_development_result,
+    validate_matched_development_results,
 )
 
 
-def test_readiness_matches_paper_equations() -> None:
+def test_readiness_matches_paper_empirical_equations() -> None:
     gradients = np.asarray([[1.0, 0.0], [3.0, 0.0]], dtype=np.float64)
     report = estimate_optimization_readiness(
         loss=2.0,
@@ -41,11 +45,31 @@ def test_zero_and_mechanism_off_reductions() -> None:
     assert strength_only.optimization_readiness == strength_only.gradient_strength
 
 
-def test_energy_rank_baseline() -> None:
+def test_readiness_fails_closed_on_overflowing_finite_inputs() -> None:
+    with pytest.raises(ValueError, match="finite float64"):
+        estimate_optimization_readiness(
+            loss=1.0,
+            full_validation_gradient=np.asarray([1e308]),
+            batch_gradients=np.asarray([[1e308], [1e308]]),
+        )
+
+
+def test_readiness_rejects_mismatched_parameter_counts() -> None:
+    with pytest.raises(ValueError, match="parameter axis"):
+        estimate_optimization_readiness(
+            loss=1.0,
+            full_validation_gradient=np.ones(3),
+            batch_gradients=np.ones((2, 2)),
+        )
+
+
+def test_energy_rank_baseline_and_exact_threshold() -> None:
     matrix = np.diag([3.0, 1.0])
     assert energy_rank(matrix, threshold=0.9) == 1
     assert energy_rank(matrix, threshold=0.99) == 2
     assert energy_rank(np.zeros((2, 2)), threshold=0.99) == 0
+    rounding_case = np.random.default_rng(7).normal(size=(10, 10))
+    assert energy_rank(rounding_case, threshold=1.0) == 10
 
 
 @pytest.mark.parametrize("loss", [-1.0, float("nan"), True])
@@ -95,6 +119,113 @@ def test_protocol_is_prospective_and_nonpromoting() -> None:
         "curvature_energy_rank_0.99",
         "parameter_norm",
     )
+
+
+def _result_payload(*, arm_id: str = "candidate") -> dict[str, object]:
+    return {
+        "schema": "asi.optimization-readiness.development-result.v1",
+        "comparison_id": "or-dev-001",
+        "arm_id": arm_id,
+        "protocol": {
+            "schema": "asi.optimization-readiness.protocol.v1",
+            "seed": 7,
+            "checkpoint": "checkpoint-0042",
+            "task": "ipmnist-permutation-3",
+            "updates": 100,
+            "observations": 10_000,
+            "mini_batch_size": 4,
+            "diagnostic_batch_count": 128,
+            "allowed_boundary_information": ["task_start"],
+            "allowed_task_information": ["labels_for_current_validation_task"],
+        },
+        "resources": {
+            "schema": "asi.optimization-readiness.resources.v1",
+            "persistent_bytes": 4096,
+            "environment_steps": 0,
+            "data_steps": 10_000,
+            "model_queries": 10_128,
+            "timing_seconds": 1.25,
+            "timing_is_telemetry_only": True,
+        },
+        "metrics": {
+            "optimization_readiness": 0.25,
+            "gradient_norm": 0.5,
+            "representation_energy_rank_0_99": 8,
+            "curvature_energy_rank_0_99": 5,
+            "parameter_norm": 12.0,
+            "future_relative_loss_reduction": -0.1,
+        },
+        "outcome": "rejected",
+        "outcome_retained": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+
+
+def test_strict_result_and_resource_receipt_validation() -> None:
+    receipt = validate_development_result(_result_payload())
+    assert receipt.outcome == "rejected"
+    assert receipt.resources.data_steps == 10_000
+    assert receipt.protocol.allowed_boundary_information == ("task_start",)
+
+    payload = _result_payload()
+    resources = payload["resources"]
+    assert isinstance(resources, dict)
+    resources["unaccounted_gpu_queries"] = 1
+    with pytest.raises(ValueError, match="resources keys must be exactly"):
+        validate_development_result(payload)
+
+
+@pytest.mark.parametrize(
+    ("path", "value", "match"),
+    [
+        (("resources", "persistent_bytes"), -1, "persistent_bytes"),
+        (("resources", "timing_seconds"), float("nan"), "timing_seconds"),
+        (("resources", "timing_is_telemetry_only"), False, "telemetry"),
+        (("scientific_promotion_allowed",), True, "scientific_promotion_allowed"),
+        (("outcome_retained",), False, "outcome_retained"),
+    ],
+)
+def test_result_validator_fails_closed(
+    path: tuple[str, ...], value: object, match: str
+) -> None:
+    payload = _result_payload()
+    target = payload
+    for key in path[:-1]:
+        nested = target[key]
+        assert isinstance(nested, dict)
+        target = nested
+    target[path[-1]] = value
+    with pytest.raises(ValueError, match=match):
+        validate_development_result(payload)
+
+
+def test_matched_result_validation_enforces_all_axes() -> None:
+    candidate = _result_payload()
+    control = _result_payload(arm_id="control")
+    receipts = validate_matched_development_results([candidate, control])
+    assert len(receipts) == 2
+
+    mismatched = deepcopy(control)
+    protocol = mismatched["protocol"]
+    assert isinstance(protocol, dict)
+    protocol["observations"] = 9_999
+    with pytest.raises(ValueError, match="matched protocol axes"):
+        validate_matched_development_results([candidate, mismatched])
+
+
+def test_protocol_records_estimator_differences_and_nonpromotion() -> None:
+    assert OPTIMIZATION_READINESS_PROTOCOL["paper_revision"] == "arXiv:2605.09044v1"
+    assert (
+        OPTIMIZATION_READINESS_PROTOCOL["official_code_revision"]
+        == "none-cited-in-arxiv-v1-as-of-2026-08-17"
+    )
+    assert (
+        OPTIMIZATION_READINESS_PROTOCOL["estimator"]
+        == "appendix-c.1-full-gradient-plus-independent-mini-batches"
+    )
+    assert OPTIMIZATION_READINESS_PROTOCOL["asi_protocol_differences"]
     assert OPTIMIZATION_READINESS_PROTOCOL["development_only"] is True
     assert OPTIMIZATION_READINESS_PROTOCOL["scientific_promotion_allowed"] is False
     assert OPTIMIZATION_READINESS_PROTOCOL["completed_result_exists"] is False
+    assert OPTIMIZATION_READINESS_PROTOCOL["outcome_retention_required"] is True

--- a/tests/test_optimization_readiness.py
+++ b/tests/test_optimization_readiness.py
@@ -56,6 +56,38 @@ def test_appendix_c1_mode_checks_observable_contract_without_claiming_independen
             ),
         )
 
+    with pytest.raises(ValueError, match="10,000 validation"):
+        estimate_appendix_c1_optimization_readiness(
+            loss=1.0,
+            full_validation_gradient=np.ones(2, dtype=np.float64),
+            batch_gradients=gradients,
+            full_validation_observations=9_999,
+            mini_batch_size=4,
+            sampling_provenance=(
+                "caller_reported_independent_with_replacement_not_verified_from_gradients"
+            ),
+        )
+    with pytest.raises(ValueError, match="mini-batch size 4"):
+        estimate_appendix_c1_optimization_readiness(
+            loss=1.0,
+            full_validation_gradient=np.ones(2, dtype=np.float64),
+            batch_gradients=gradients,
+            full_validation_observations=10_000,
+            mini_batch_size=1,
+            sampling_provenance=(
+                "caller_reported_independent_with_replacement_not_verified_from_gradients"
+            ),
+        )
+    with pytest.raises(ValueError, match="explicit unverified label"):
+        estimate_appendix_c1_optimization_readiness(
+            loss=1.0,
+            full_validation_gradient=np.ones(2, dtype=np.float64),
+            batch_gradients=gradients,
+            full_validation_observations=10_000,
+            mini_batch_size=4,
+            sampling_provenance="independence_proven",
+        )
+
 
 def test_generic_equation_helper_remains_explicitly_sampling_agnostic() -> None:
     report = estimate_optimization_readiness(
@@ -159,7 +191,7 @@ def _result_payload(*, arm_id: str = "candidate") -> dict[str, object]:
             "future_gain_rollout_count": 128,
             "future_gain_batch_size": 4,
             "future_gain_step_size": 1e-3,
-            "parameter_count": 2,
+            "parameter_count": 16,
             "sampling_provenance": (
                 "caller_reported_independent_with_replacement_not_verified_from_gradients"
             ),
@@ -172,7 +204,7 @@ def _result_payload(*, arm_id: str = "candidate") -> dict[str, object]:
         "resources": {
             "schema": "asi.optimization-readiness.resources.v1",
             "persistent_bytes": 4096,
-            "peak_working_set_bytes": 129 * 2 * 8,
+            "peak_working_set_bytes": 129 * 16 * 8,
             "environment_steps": 0,
             "data_steps": 1_291_024,
             "model_queries": 1_291_024,
@@ -264,7 +296,7 @@ def test_matched_result_validation_enforces_all_axes() -> None:
         ("resources", "data_steps", 1_291_023, "environment_steps plus data_steps"),
         ("resources", "model_queries", 1_291_023, "model_queries"),
         ("resources", "parameter_updates", 127, "parameter_updates"),
-        ("resources", "peak_working_set_bytes", 2_063, "peak_working_set_bytes"),
+        ("resources", "peak_working_set_bytes", 16_511, "peak_working_set_bytes"),
     ],
 )
 def test_resource_receipt_enforces_live_cross_field_identities(
@@ -274,6 +306,25 @@ def test_resource_receipt_enforces_live_cross_field_identities(
     nested = payload[section]
     assert isinstance(nested, dict)
     nested[field] = value
+    with pytest.raises(ValueError, match=match):
+        validate_development_result(payload)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("representation_energy_rank_0_99", 10_001, "validation row count"),
+        ("curvature_energy_rank_0_99", 17, "parameter_count"),
+        ("future_relative_loss_reduction", 1.0001, "cannot exceed one"),
+    ],
+)
+def test_reported_metrics_respect_mathematical_domains(
+    field: str, value: object, match: str
+) -> None:
+    payload = _result_payload()
+    metrics = payload["metrics"]
+    assert isinstance(metrics, dict)
+    metrics[field] = value
     with pytest.raises(ValueError, match=match):
         validate_development_result(payload)
 
@@ -399,4 +450,5 @@ def test_protocol_records_estimator_differences_and_nonpromotion() -> None:
     assert OPTIMIZATION_READINESS_PROTOCOL["completed_result_exists"] is False
     assert OPTIMIZATION_READINESS_PROTOCOL["outcome_retention_required"] is True
     assert OPTIMIZATION_READINESS_PROTOCOL["resource_receipts_are_authenticated"] is False
+    assert OPTIMIZATION_READINESS_PROTOCOL["metrics_are_recomputed_by_this_module"] is False
     assert OPTIMIZATION_READINESS_PROTOCOL["outcomes_are_derived_by_this_module"] is False


### PR DESCRIPTION
Repairs the optimization-readiness prerequisite for #1568 while keeping the validation boundary explicit.

- keeps a bounded generic OR equation helper that accepts caller-provided gradient batches without claiming how they were sampled
- adds a separate Appendix C.1 declared mode that enforces the observable 10,000-validation-example, 128-row, reported-size-4 contract
- labels independence and sampling-with-replacement as caller-reported provenance that cannot be verified from precomputed gradient arrays
- records the pinned arXiv:2605.09044v1 defaults and ASI adaptations without claiming an official reference implementation
- bounds exact NumPy payloads before conversion, norms, or SVD and rejects nonprimitive receipt containers, hostile subclasses, oversized strings/lists/counts, overflow, and invalid metric domains
- freezes permitted boundary/task information and the 1/10/100-step, 128-rollout, size-4, step-size-1e-3 prospective protocol
- validates observation, model-query, update, and minimum gradient working-set accounting and requires matched non-timing resource budgets across arms
- keeps timing telemetry-only and marks metrics, outcomes, resource receipts, and execution identities as caller-reported rather than authenticated or derived by this module
- retains only explicitly reported supported/rejected/inconclusive development outcomes under permanent nonpromotion

Validation on current main:
- `tests/test_optimization_readiness.py`: 36 passed
- repo-wide Ruff: passed
- strict mypy: passed (186 source files)

No prospective workload ran and no performance, scientific, or SOTA evidence is claimed. #1568 remains open for reviewed frozen checkpoints, actual measurements and future-gain rollouts, retained artifacts, and ranking analysis.
