### PR TITLE
fix(optimizers): harden constructor scalars without breaking frozen LMS

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -591,10 +591,10 @@ class LMS(Optimizer[LMSState]):
             step_size: Fixed learning rate
 
         Raises:
-            ValueError: If ``step_size`` is not a finite non-bool positive real.
+            ValueError: If ``step_size`` is not a finite non-bool nonnegative real.
         """
         self._step_size = validated_float32_scalar(
-            "step_size", step_size, positive=True
+            "step_size", step_size, lower=0.0
         )
 
     def to_config(self) -> dict[str, Any]:
@@ -1112,7 +1112,8 @@ class Autostep(Optimizer[AutostepState]):
         Raises:
             ValueError: If ``initial_step_size`` is not a finite non-bool
                 positive real, or ``meta_step_size`` is not a finite non-bool
-                nonnegative real.
+                nonnegative real, or ``tau`` is not a finite non-bool positive
+                real.
         """
         self._initial_step_size = validated_float32_scalar(
             "initial_step_size", initial_step_size, positive=True
@@ -1120,7 +1121,7 @@ class Autostep(Optimizer[AutostepState]):
         self._meta_step_size = validated_float32_scalar(
             "meta_step_size", meta_step_size, lower=0.0
         )
-        self._tau = tau
+        self._tau = validated_float32_scalar("tau", tau, positive=True)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -24,7 +24,10 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float
 
-from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
+from alberta_framework.core._float32_scalars import (
+    validated_float32_scalar,
+    validated_float32_scalar_with_ratio,
+)
 from alberta_framework.core.types import (
     AutostepGTDLambdaState,
     AutostepParamState,
@@ -586,8 +589,13 @@ class LMS(Optimizer[LMSState]):
 
         Args:
             step_size: Fixed learning rate
+
+        Raises:
+            ValueError: If ``step_size`` is not a finite non-bool positive real.
         """
-        self._step_size = step_size
+        self._step_size = validated_float32_scalar(
+            "step_size", step_size, positive=True
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""
@@ -1100,9 +1108,18 @@ class Autostep(Optimizer[AutostepState]):
             meta_step_size: Meta learning rate for adapting step-sizes
             tau: Time constant for normalizer adaptation (default: 10000).
                 Higher values mean slower normalizer decay.
+
+        Raises:
+            ValueError: If ``initial_step_size`` is not a finite non-bool
+                positive real, or ``meta_step_size`` is not a finite non-bool
+                nonnegative real.
         """
-        self._initial_step_size = initial_step_size
-        self._meta_step_size = meta_step_size
+        self._initial_step_size = validated_float32_scalar(
+            "initial_step_size", initial_step_size, positive=True
+        )
+        self._meta_step_size = validated_float32_scalar(
+            "meta_step_size", meta_step_size, lower=0.0
+        )
         self._tau = tau
 
     def to_config(self) -> dict[str, Any]:
@@ -1643,11 +1660,16 @@ class ObGD(Optimizer[ObGDState]):
             kappa: Bounding sensitivity parameter (default: 2.0)
             gamma: Discount factor for trace decay (default: 0.0 for supervised)
             lamda: Eligibility trace decay parameter (default: 0.0 for supervised)
+
+        Raises:
+            ValueError: If ``step_size`` is not a finite non-bool positive real,
+                ``kappa`` is not a finite non-bool nonnegative real, or
+                ``gamma`` / ``lamda`` are not finite non-bool reals in ``[0, 1]``.
         """
-        self._step_size = step_size
-        self._kappa = kappa
-        self._gamma = gamma
-        self._lamda = lamda
+        self._step_size = validated_float32_scalar("step_size", step_size, positive=True)
+        self._kappa = validated_float32_scalar("kappa", kappa, lower=0.0)
+        self._gamma = validated_float32_scalar("gamma", gamma, lower=0.0, upper=1.0)
+        self._lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize configuration to dict."""

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,5 +1,8 @@
 """Tests for LMS, IDBD, Autostep, and ObGD optimizers."""
 
+from collections.abc import Callable
+from typing import NoReturn
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -18,6 +21,64 @@ from alberta_framework import (
 from alberta_framework.core.optimizers import TDIDBD, AutoTDIDBD
 
 _INT32_MAX = 2**31 - 1
+
+
+class _HostileScalar:
+    calls = 0
+
+    def _explode(self) -> NoReturn:
+        type(self).calls += 1
+        raise AssertionError("hostile scalar hook executed")
+
+    def __float__(self) -> float:
+        self._explode()
+
+    def __eq__(self, other: object) -> bool:
+        self._explode()
+
+    def __lt__(self, other: object) -> bool:
+        self._explode()
+
+
+@pytest.mark.parametrize(
+    ("factory", "field"),
+    [
+        (lambda value: LMS(step_size=value), "step_size"),
+        (lambda value: Autostep(initial_step_size=value), "initial_step_size"),
+        (lambda value: Autostep(meta_step_size=value), "meta_step_size"),
+        (lambda value: Autostep(tau=value), "tau"),
+        (lambda value: ObGD(step_size=value), "step_size"),
+        (lambda value: ObGD(kappa=value), "kappa"),
+        (lambda value: ObGD(gamma=value), "gamma"),
+        (lambda value: ObGD(lamda=value), "lamda"),
+    ],
+)
+def test_optimizer_constructors_reject_hostile_scalars_without_hooks(
+    factory: Callable[[object], object], field: str
+) -> None:
+    hostile = _HostileScalar()
+    _HostileScalar.calls = 0
+    with pytest.raises(ValueError, match=field):
+        factory(hostile)
+    assert _HostileScalar.calls == 0
+
+
+def test_optimizer_constructors_accept_canonical_numpy_scalars() -> None:
+    lms = LMS(step_size=np.float32(0.0))
+    autostep = Autostep(
+        initial_step_size=np.float64(0.01),
+        meta_step_size=np.int32(0),
+        tau=np.float32(2.0),
+    )
+    obgd = ObGD(
+        step_size=np.float32(0.5),
+        kappa=np.int32(0),
+        gamma=np.float64(1.0),
+        lamda=np.float32(0.0),
+    )
+    assert lms.init(1).step_size == 0.0
+    assert autostep.init(1).tau == 2.0
+    assert obgd.init(1).gamma == 1.0
 
 
 class TestLMS:
@@ -53,10 +114,15 @@ class TestLMS:
 
         assert result.new_state.step_size == state.step_size
 
-    @pytest.mark.parametrize("step_size", [float("nan"), float("inf"), 0.0, -0.1, True, False])
+    @pytest.mark.parametrize("step_size", [float("nan"), float("inf"), -0.1, True, False])
     def test_rejects_illegal_step_size(self, step_size: object) -> None:
         with pytest.raises(ValueError, match="step_size"):
             LMS(step_size=step_size)  # type: ignore[arg-type]
+
+    def test_zero_step_size_remains_a_supported_frozen_weight_control(self) -> None:
+        optimizer = LMS(step_size=0.0)
+        assert optimizer.to_config()["step_size"] == 0.0
+        assert optimizer.init(1).step_size == 0.0
 
 
 class TestIDBD:
@@ -238,6 +304,11 @@ class TestAutostep:
     def test_rejects_illegal_meta_step_size(self, meta_step_size: object) -> None:
         with pytest.raises(ValueError, match="meta_step_size"):
             Autostep(meta_step_size=meta_step_size)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("tau", [float("nan"), float("inf"), 0.0, -0.1, True, False])
+    def test_rejects_illegal_tau(self, tau: object) -> None:
+        with pytest.raises(ValueError, match="tau"):
+            Autostep(tau=tau)  # type: ignore[arg-type]
 
     def test_update_returns_correct_shapes(self, sample_observation):
         """Autostep update should return correctly shaped deltas."""
@@ -675,8 +746,14 @@ class TestObGD:
         "field,value",
         [
             ("gamma", float("nan")),
+            ("gamma", float("inf")),
+            ("gamma", -0.1),
+            ("gamma", 1.1),
             ("gamma", True),
             ("lamda", float("nan")),
+            ("lamda", float("inf")),
+            ("lamda", -0.1),
+            ("lamda", 1.1),
             ("lamda", True),
         ],
     )

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -53,6 +53,11 @@ class TestLMS:
 
         assert result.new_state.step_size == state.step_size
 
+    @pytest.mark.parametrize("step_size", [float("nan"), float("inf"), 0.0, -0.1, True, False])
+    def test_rejects_illegal_step_size(self, step_size: object) -> None:
+        with pytest.raises(ValueError, match="step_size"):
+            LMS(step_size=step_size)  # type: ignore[arg-type]
+
 
 class TestIDBD:
     """Tests for the IDBD optimizer."""
@@ -221,6 +226,18 @@ class TestAutostep:
         chex.assert_trees_all_close(state.normalizers, jnp.zeros(10))
         assert state.meta_step_size == pytest.approx(0.001)
         assert state.tau == pytest.approx(10000.0)
+
+    @pytest.mark.parametrize(
+        "initial_step_size", [float("nan"), float("inf"), 0.0, -0.1, True, False]
+    )
+    def test_rejects_illegal_initial_step_size(self, initial_step_size: object) -> None:
+        with pytest.raises(ValueError, match="initial_step_size"):
+            Autostep(initial_step_size=initial_step_size)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("meta_step_size", [float("nan"), float("inf"), -0.1, True])
+    def test_rejects_illegal_meta_step_size(self, meta_step_size: object) -> None:
+        with pytest.raises(ValueError, match="meta_step_size"):
+            Autostep(meta_step_size=meta_step_size)  # type: ignore[arg-type]
 
     def test_update_returns_correct_shapes(self, sample_observation):
         """Autostep update should return correctly shaped deltas."""
@@ -643,6 +660,29 @@ class TestObGD:
         assert state.kappa == pytest.approx(2.0)
         assert state.gamma == pytest.approx(0.0)
         assert state.lamda == pytest.approx(0.0)
+
+    @pytest.mark.parametrize("step_size", [float("nan"), float("inf"), 0.0, -0.1, True, False])
+    def test_rejects_illegal_step_size(self, step_size: object) -> None:
+        with pytest.raises(ValueError, match="step_size"):
+            ObGD(step_size=step_size)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("kappa", [float("nan"), float("inf"), -0.1, True])
+    def test_rejects_illegal_kappa(self, kappa: object) -> None:
+        with pytest.raises(ValueError, match="kappa"):
+            ObGD(kappa=kappa)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("gamma", float("nan")),
+            ("gamma", True),
+            ("lamda", float("nan")),
+            ("lamda", True),
+        ],
+    )
+    def test_rejects_illegal_gamma_lamda(self, field: str, value: object) -> None:
+        with pytest.raises(ValueError, match=field):
+            ObGD(**{field: value})  # type: ignore[arg-type]
 
     def test_update_returns_correct_shapes(self, sample_observation):
         """ObGD update should return correctly shaped deltas."""


### PR DESCRIPTION
Corrective follow-up to merged #1622. The contributor commit/authorship is already preserved on main.

This repair restores the established `LMS(step_size=0.0)` frozen-weight control used by the real forward-view equivalence path, while retaining exact rejection of bool/negative/nonfinite values. It also keeps the exact positive finite `Autostep.tau` divisor gate and expands zero-hook hostile-scalar, canonical NumPy-scalar, and gamma/lambda boundary coverage across all touched constructors.

Verification on current main: `tests/test_optimizers.py tests/test_forward_view_equivalence.py` 140 passed; scoped Ruff passed; strict mypy on `optimizers.py` passed; diff check passed. No outputs or benchmark execution.