### PR TITLE
fix(research): complete bounded protocol host hardening

### DIFF
--- a/alberta_framework/benchmarks/adalin.py
+++ b/alberta_framework/benchmarks/adalin.py
@@ -73,7 +73,9 @@ def _adalin_transaction(
 
 def _unwrap_transaction(result: tuple[Array, Array]) -> Array:
     safe, valid = result
-    if not isinstance(valid, jax.core.Tracer) and not bool(valid):
+    if isinstance(valid, jax.core.Tracer):
+        return jnp.where(valid, safe, jnp.full_like(safe, jnp.nan))
+    if not bool(valid):
         raise ValueError("AdaLin activation must be finite")
     return safe
 

--- a/alberta_framework/benchmarks/bimu.py
+++ b/alberta_framework/benchmarks/bimu.py
@@ -69,7 +69,9 @@ def posterior_probability_transaction(natural_parameter: object) -> tuple[Array,
 def posterior_probability(natural_parameter: object) -> Array:
     """Return ``P(weight=+1) = sigmoid(2 lambda)`` (paper equation 2)."""
     safe, valid = posterior_probability_transaction(natural_parameter)
-    if not isinstance(valid, jax.core.Tracer) and not bool(valid):
+    if isinstance(valid, jax.core.Tracer):
+        return jnp.where(valid, safe, jnp.full_like(safe, jnp.nan))
+    if not bool(valid):
         raise ValueError("posterior probability must be finite")
     return safe
 
@@ -133,7 +135,7 @@ def bimu_update(
     memory_window: int | None,
     alpha_max: float,
 ) -> Array:
-    """Compatibility wrapper that fails closed eagerly and returns a traced safe value."""
+    """Compatibility wrapper; traced callers use NaN to expose invalid transactions."""
     safe, valid = bimu_update_transaction(
         natural_parameter,
         loss_gradient,
@@ -141,7 +143,9 @@ def bimu_update(
         memory_window=memory_window,
         alpha_max=alpha_max,
     )
-    if not isinstance(valid, jax.core.Tracer) and not bool(valid):
+    if isinstance(valid, jax.core.Tracer):
+        return jnp.where(valid, safe, jnp.full_like(safe, jnp.nan))
+    if not bool(valid):
         raise ValueError("BiMU update must produce only finite values")
     return safe
 
@@ -150,9 +154,12 @@ def late_window_mean(task_accuracies: list[float] | tuple[float, ...], *, window
     """Compute BiMU's late-task metric without conflating whole-stream accuracy."""
     if type(window) is not int or window < 1 or window > _MAX_VECTOR_ELEMENTS:
         raise ValueError("window must be an integer in [1, 1000000]")
-    if type(task_accuracies) not in {list, tuple} or len(task_accuracies) > _MAX_VECTOR_ELEMENTS:
+    if (
+        (type(task_accuracies) is not list and type(task_accuracies) is not tuple)
+        or len(task_accuracies) > _MAX_VECTOR_ELEMENTS
+    ):
         raise ValueError("task_accuracies must be an exact bounded list or tuple")
-    if any(type(value) not in {int, float} for value in task_accuracies):
+    if any(type(value) is not int and type(value) is not float for value in task_accuracies):
         raise ValueError("task_accuracies must contain exact real numbers")
     values = np.asarray(task_accuracies)
     if values.ndim != 1 or values.size < window or values.dtype.kind not in {"i", "u", "f"}:

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -138,7 +138,9 @@ def input_interpolation_transaction(
 def input_interpolation(old: object, new: object, alpha: float) -> Array:
     """Apply paper equation ``x_alpha = (1-alpha)x_old + alpha*x_new``."""
     safe, valid = input_interpolation_transaction(old, new, alpha)
-    if not isinstance(valid, jax.core.Tracer) and not bool(valid):
+    if isinstance(valid, jax.core.Tracer):
+        return jnp.where(valid, safe, jnp.full_like(safe, jnp.nan))
+    if not bool(valid):
         raise ValueError("old and new inputs must produce only finite values")
     return safe
 

--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -49,6 +49,10 @@ class PolicyEntry:
             or len(self.identity) > _MAX_IDENTITY_CHARACTERS
         ):
             raise ValueError("identity must be a non-empty string")
+        try:
+            self.identity.encode("utf-8")
+        except UnicodeEncodeError as error:
+            raise ValueError("identity must be valid UTF-8 text") from error
         if (
             type(self.policy_bytes) is not bytes
             or not self.policy_bytes

--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -48,8 +48,13 @@ def orthogonal_correction_transaction(update: Array, protected_basis: Array) -> 
     """Return a finite orthogonal correction and caller-visible validity bit."""
     vector = _trusted_array(update, name="update")
     basis = _trusted_array(protected_basis, name="protected_basis")
-    if vector.ndim != 1 or basis.ndim != 2 or basis.shape[1] != vector.shape[0]:
-        raise ValueError("update must be a vector and basis rows must match its width")
+    if (
+        vector.ndim != 1
+        or vector.size < 1
+        or basis.ndim != 2
+        or basis.shape[1] != vector.shape[0]
+    ):
+        raise ValueError("update must be a non-empty vector and basis rows must match its width")
     coordinates = basis @ vector
     projection = basis.T @ coordinates
     candidate = vector - projection
@@ -66,7 +71,9 @@ def orthogonal_correction_transaction(update: Array, protected_basis: Array) -> 
 
 def _unwrap_transaction(result: tuple[Array, Array], *, name: str) -> Array:
     safe, valid = result
-    if not isinstance(valid, jax.core.Tracer) and not bool(valid):
+    if isinstance(valid, jax.core.Tracer):
+        return jnp.where(valid, safe, jnp.full_like(safe, jnp.nan))
+    if not bool(valid):
         raise ValueError(f"{name} must be finite")
     return safe
 

--- a/tests/test_adalin.py
+++ b/tests/test_adalin.py
@@ -5,7 +5,12 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from alberta_framework.benchmarks.adalin import ADALIN_PROTOCOL, adalin_relu, adalin_tanh
+from alberta_framework.benchmarks.adalin import (
+    ADALIN_PROTOCOL,
+    adalin_relu,
+    adalin_relu_transaction,
+    adalin_tanh,
+)
 
 
 def test_relu_reduction_and_prelu_identity() -> None:
@@ -33,6 +38,11 @@ def test_protocol_keeps_pmnist_difference_explicit() -> None:
 def test_adalin_is_outer_jit_safe() -> None:
     transformed = jax.jit(adalin_relu)(jnp.array([-1.0, 1.0]), jnp.array([0.2, 0.2]))
     np.testing.assert_allclose(transformed, [-0.2, 1.0])
+    invalid = jax.jit(adalin_relu)(jnp.array([jnp.nan]), jnp.array([0.2]))
+    assert bool(jnp.all(jnp.isnan(invalid)))
+    safe, valid = jax.jit(adalin_relu_transaction)(jnp.array([jnp.nan]), jnp.array([0.2]))
+    np.testing.assert_array_equal(safe, jnp.zeros(1))
+    assert not bool(valid)
 
 
 def test_adalin_preflights_cross_broadcast_and_hostile_array() -> None:

--- a/tests/test_bimu.py
+++ b/tests/test_bimu.py
@@ -71,6 +71,17 @@ def test_bimu_update_is_outer_jit_safe() -> None:
         assert bool(jnp.all(jnp.isfinite(safe)))
         assert not bool(valid)
 
+    invalid_update = update(jnp.array([jnp.nan, 0.0]), jnp.ones(2), jnp.zeros(2))
+    assert bool(jnp.all(jnp.isnan(invalid_update)))
+
+    posterior = jax.jit(posterior_probability)
+    assert bool(jnp.all(jnp.isnan(posterior(jnp.array([jnp.nan])))))
+    posterior_safe, posterior_valid = jax.jit(posterior_probability_transaction)(
+        jnp.array([jnp.nan])
+    )
+    np.testing.assert_array_equal(posterior_safe, jnp.array([0.5]))
+    assert not bool(posterior_valid)
+
 
 def test_bimu_rejects_array_protocol_object_without_calling_it() -> None:
     class Hostile:
@@ -104,3 +115,20 @@ def test_bimu_float32_overflow_is_invalid_not_laundered() -> None:
     )
     np.testing.assert_array_equal(finite_posterior, [0.5])
     assert not bool(finite_valid)
+
+
+def test_late_window_mean_does_not_hash_hostile_runtime_types() -> None:
+    class HostileMeta(type):
+        def __hash__(cls) -> int:
+            raise AssertionError("hostile metaclass hash must not run")
+
+    class HostileContainer(metaclass=HostileMeta):
+        pass
+
+    class HostileNumber(metaclass=HostileMeta):
+        pass
+
+    with pytest.raises(ValueError, match="exact bounded list or tuple"):
+        late_window_mean(HostileContainer())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="exact real numbers"):
+        late_window_mean([HostileNumber()] * 5)  # type: ignore[list-item]

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -87,6 +87,7 @@ def test_input_interpolation_is_outer_jit_safe() -> None:
     safe, valid = transact(jnp.array([jnp.inf]), jnp.array([2.0]))
     np.testing.assert_array_equal(safe, jnp.zeros(1))
     assert not bool(valid)
+    assert bool(jnp.all(jnp.isnan(interpolate(jnp.array([jnp.inf]), jnp.array([2.0])))))
 
 
 def test_input_interpolation_rejects_array_protocol_objects_without_calling_them() -> None:

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -45,11 +45,20 @@ def test_protocol_is_small_matrix_first_and_nonpromoting() -> None:
 def test_geometry_primitives_are_outer_jit_safe() -> None:
     corrected = jax.jit(orthogonal_correction)(jnp.array([1.0, 2.0]), jnp.array([[1.0, 0.0]]))
     np.testing.assert_allclose(corrected, [0.0, 2.0])
+    invalid = jax.jit(flad_noise_component)(jnp.array([jnp.nan]), jnp.ones(1))
+    assert bool(jnp.all(jnp.isnan(invalid)))
+    safe, valid = jax.jit(flad_noise_component_transaction)(
+        jnp.array([jnp.nan]), jnp.ones(1)
+    )
+    np.testing.assert_array_equal(safe, jnp.zeros(1))
+    assert not bool(valid)
 
 
 def test_geometry_rejects_empty_flad_and_hostile_array() -> None:
     with pytest.raises(ValueError, match="non-empty"):
         flad_noise_component(jnp.zeros(0), jnp.zeros(0))
+    with pytest.raises(ValueError, match="non-empty"):
+        orthogonal_correction(jnp.zeros(0), jnp.zeros((0, 0)))
 
     class Hostile:
         calls = 0

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -51,6 +51,8 @@ def test_archive_preflights_host_dimensions() -> None:
         BoundedPolicyArchive(byte_budget=256 * 1024 * 1024 + 1, min_latent_distance=0.0)
     with pytest.raises(ValueError, match="identity"):
         _entry("x" * 1025, (0.0,), 1.0)
+    with pytest.raises(ValueError, match="UTF-8"):
+        _entry("\ud800", (0.0,), 1.0)
     entry = _entry("a", (0.0,), 1.0)
     with pytest.raises(ValueError, match="exact tuple"):
         BoundedPolicyArchive(


### PR DESCRIPTION
## Summary

Contributor-preserving successor to #1611. It retains exact contributor head `101b26ad41778529f9fcddad9e187578876191f6`, including the stronger intermediate-overflow checks, and closes the remaining audit blockers:

- replace attacker-hashable runtime-type set membership with identity checks
- expose invalid traced/JIT compatibility-wrapper results as NaN instead of laundering them into plausible neutral zeros, prior state, or posterior 0.5
- retain explicit transaction APIs with finite fallback plus caller-visible validity bits
- add the missing BiMU posterior transaction path
- reject empty orthogonal updates and invalid UTF-8 archive identities during bounded preflight

The archive and ceiling formulas were checked in bounded order: UTF-8 identity + policy bytes + 8-byte latent scalars + 8-byte score, cumulative archive budget, replay products before multiplication/allocation, and combined ledger totals.

## Scope

These remain equation/protocol primitives without end-to-end benchmark consumers. No workload or output was produced and no evidence was promoted. #1569-#1573 and #1586 remain open for adapters, matched executions, and reports.

## Validation

- `python -m pytest tests/test_bimu.py tests/test_ipmnist_gradual.py tests/test_adalin.py tests/test_optimizer_geometry.py tests/test_policy_archive.py tests/test_ipmnist_ceilings.py -q -o addopts=''` — 43 passed
- scoped Ruff — clean
- strict mypy on all six modules — clean
- `git diff --check` — clean
