### PR TITLE
fix(benchmarks): pin official Dreamer-CDP source

### DIFF
--- a/alberta_framework/benchmarks/external_qualification.py
+++ b/alberta_framework/benchmarks/external_qualification.py
@@ -165,6 +165,10 @@ EXTERNAL_QUALIFICATION_PLANS: tuple[ExternalQualificationPlan, ...] = (
         ("arXiv:2603.07083v2", "arXiv:2605.13013v1", "arXiv:2512.24497v3"),
         (
             _revision(
+                "https://github.com/fmi-basel/Dreamer-CDP.git",
+                "a851fa3e3d70b624b094ee1810ad4bb602346092",
+            ),
+            _revision(
                 "https://github.com/facebookresearch/jepa-wms.git",
                 "13cf1d9c7e476f53c17714d2e0f1dc239a883ce0",
             ),

--- a/tests/test_external_qualification.py
+++ b/tests/test_external_qualification.py
@@ -36,6 +36,15 @@ def test_clear_uses_official_curation_source_without_claiming_asset_readiness() 
     assert "external_code_available_and_license_reviewed" in plan.blockers
 
 
+def test_action_conditioned_lane_pins_official_dreamer_cdp_source() -> None:
+    plan = qualification_plan(1575)
+    assert plan.code_revisions[0] == ExternalCodeRevision(
+        "https://github.com/fmi-basel/Dreamer-CDP.git",
+        "a851fa3e3d70b624b094ee1810ad4bb602346092",
+    )
+    assert "isolated_runtime_locked" in plan.blockers
+
+
 def test_completed_r0_plan_still_cannot_authorize_external_execution() -> None:
     revision = ExternalCodeRevision("https://github.com/org/repo.git", "a" * 40)
     plan = ExternalQualificationPlan(


### PR DESCRIPTION
Pins the official #1575 Dreamer-CDP repository to full commit `a851fa3e3d70b624b094ee1810ad4bb602346092` after the source audit found it.

The lane remains fail-closed: the upstream requirements are partially unpinned, its Dockerfile installs mutable apt/PyPI/gist inputs, and its declared JAX versions conflict across install steps. This PR records the faithful source without pretending that upstream Docker instructions constitute a locked isolated runtime. No external workload or output is created.

Validation: focused registry tests, Ruff, strict mypy.

Refs #1575