### PR TITLE
feat(evaluation): add strict matched development report gate

### DIFF
--- a/alberta_framework/evaluation/matched_development.py
+++ b/alberta_framework/evaluation/matched_development.py
@@ -69,8 +69,8 @@ def _finite_float(name: str, value: object, *, nonnegative: bool = False) -> flo
 class MatchedDevelopmentPlan:
     """Frozen two-arm schedule and resource contract.
 
-    ``source_sha256`` is the deterministic aggregate digest of every runner and mechanism
-    source file named by the protocol, rather than a digest of only one entry point.
+    ``source_sha256`` is supplied by the issue-specific protocol.  This generic contract
+    validates and binds that identifier; it does not derive or authenticate current source.
     """
 
     protocol_id: str
@@ -423,6 +423,8 @@ def build_matched_report(
 def _exact_dict(name: str, value: object) -> dict[str, Any]:
     if type(value) is not dict:
         raise ValueError(f"{name} must be an exact dict")
+    if any(type(key) is not str for key in value):
+        raise ValueError(f"{name} keys must be exact strings")
     return value
 
 

--- a/alberta_framework/evaluation/matched_development.py
+++ b/alberta_framework/evaluation/matched_development.py
@@ -1,26 +1,42 @@
-"""Strict aggregation contract for matched, permanently nonpromoting runs."""
+"""Strict aggregation and retention for matched, permanently nonpromoting runs."""
 
 from __future__ import annotations
 
+import hashlib
+import json
 import math
+import os
 import re
-from dataclasses import asdict, dataclass
-from typing import Any
-
-import numpy as np
+from dataclasses import dataclass
+from pathlib import Path, PosixPath
+from typing import Any, cast
 
 _INT32_MAX = 2**31 - 1
 _MAX_BYTES = 256 * 1024 * 1024
 _MAX_ARMS = 16
 _MAX_SEEDS = 128
-_MAX_TEXT = 512
+_MAX_TEXT_BYTES = 512
+_MAX_TIMING_SECONDS = 604_800.0
+_MAX_REPORT_BYTES = 16 * 1024 * 1024
 _SHA256 = re.compile(r"[0-9a-f]{64}")
-_NAMESPACE = re.compile(r"outputs/[a-z0-9][a-z0-9._/-]{0,255}")
+_PATH_SEGMENT = re.compile(r"[a-z0-9][a-z0-9._-]{0,63}")
 
 
 def _text(name: str, value: object) -> str:
-    if type(value) is not str or not value or len(value) > _MAX_TEXT:
+    if type(value) is not str or not value:
         raise ValueError(f"{name} must be a bounded non-empty string")
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise ValueError(f"{name} must be valid UTF-8") from error
+    if len(encoded) > _MAX_TEXT_BYTES:
+        raise ValueError(f"{name} must be a bounded non-empty string")
+    return value
+
+
+def _sha256(name: str, value: object) -> str:
+    if type(value) is not str or _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{name} must be lowercase hexadecimal SHA-256")
     return value
 
 
@@ -30,57 +46,109 @@ def _count(name: str, value: object, *, maximum: int = _INT32_MAX) -> int:
     return value
 
 
+def _namespace(value: object) -> str:
+    resolved = _text("report_namespace", value)
+    segments = resolved.split("/")
+    if (
+        len(segments) < 2
+        or segments[0] != "outputs"
+        or any(_PATH_SEGMENT.fullmatch(segment) is None for segment in segments)
+    ):
+        raise ValueError("report_namespace must be a canonical bounded relative outputs path")
+    return resolved
+
+
+def _finite_float(name: str, value: object, *, nonnegative: bool = False) -> float:
+    if type(value) is not float or not math.isfinite(value) or (nonnegative and value < 0.0):
+        qualifier = "finite non-negative" if nonnegative else "finite"
+        raise ValueError(f"{name} must be a {qualifier} float")
+    return value
+
+
 @dataclass(frozen=True)
 class MatchedDevelopmentPlan:
+    """Frozen two-arm schedule and resource contract.
+
+    ``source_sha256`` is the deterministic aggregate digest of every runner and mechanism
+    source file named by the protocol, rather than a digest of only one entry point.
+    """
+
     protocol_id: str
     paper_revision: str
     reference_code_revision: str
     source_sha256: str
     report_namespace: str
     metric_name: str
+    higher_is_better: bool
+    tie_tolerance: float
     control: str
     arms: tuple[str, ...]
     seeds: tuple[int, ...]
-    steps: int
+    expected_updates: int
+    expected_observations: int
+    expected_data_steps: int
+    expected_model_queries: int
+    persistent_byte_budget: int
+    working_set_byte_budget: int
 
     def __post_init__(self) -> None:
         for name in (
             "protocol_id",
             "paper_revision",
             "reference_code_revision",
-            "report_namespace",
             "metric_name",
             "control",
         ):
             object.__setattr__(self, name, _text(name, getattr(self, name)))
-        if type(self.source_sha256) is not str or _SHA256.fullmatch(self.source_sha256) is None:
-            raise ValueError("source_sha256 must be lowercase hexadecimal SHA-256")
-        if (
-            _NAMESPACE.fullmatch(self.report_namespace) is None
-            or ".." in self.report_namespace.split("/")
-        ):
-            raise ValueError("report_namespace must be a bounded relative outputs path")
+        object.__setattr__(self, "source_sha256", _sha256("source_sha256", self.source_sha256))
+        object.__setattr__(self, "report_namespace", _namespace(self.report_namespace))
+        if type(self.higher_is_better) is not bool:
+            raise ValueError("higher_is_better must be a bool")
+        object.__setattr__(
+            self,
+            "tie_tolerance",
+            _finite_float("tie_tolerance", self.tie_tolerance, nonnegative=True),
+        )
         if type(self.arms) is not tuple or not 2 <= len(self.arms) <= _MAX_ARMS:
             raise ValueError("arms must be an exact tuple with 2 to 16 entries")
         resolved_arms = tuple(_text("arm", arm) for arm in self.arms)
         if len(set(resolved_arms)) != len(resolved_arms) or self.control not in resolved_arms:
             raise ValueError("arms must be unique and contain control")
+        if len(resolved_arms) != 2:
+            raise ValueError("matched report v1 requires exactly one candidate and one control")
         if type(self.seeds) is not tuple or not 1 <= len(self.seeds) <= _MAX_SEEDS:
             raise ValueError("seeds must be an exact tuple with 1 to 128 entries")
         resolved_seeds = tuple(_count("seed", seed) for seed in self.seeds)
         if len(set(resolved_seeds)) != len(resolved_seeds):
             raise ValueError("seeds must be unique")
-        object.__setattr__(self, "steps", _count("steps", self.steps, maximum=1_000_000))
-        if self.steps < 1:
-            raise ValueError("steps must be positive")
+        for name in (
+            "expected_updates",
+            "expected_observations",
+            "expected_data_steps",
+            "expected_model_queries",
+        ):
+            object.__setattr__(self, name, _count(name, getattr(self, name), maximum=1_000_000))
+        for name in ("persistent_byte_budget", "working_set_byte_budget"):
+            object.__setattr__(self, name, _count(name, getattr(self, name), maximum=_MAX_BYTES))
+        record_count = len(resolved_arms) * len(resolved_seeds)
+        for name in (
+            "expected_updates",
+            "expected_observations",
+            "expected_data_steps",
+            "expected_model_queries",
+        ):
+            if getattr(self, name) > _INT32_MAX // record_count:
+                raise ValueError(f"aggregate {name} exceeds the signed-int32 bound")
 
 
 @dataclass(frozen=True)
 class ArmRecord:
+    plan_sha256: str
     arm: str
     seed: int
     observation_sha256: str
     updates: int
+    observations: int
     data_steps: int
     model_queries: int
     persistent_bytes: int
@@ -90,85 +158,356 @@ class ArmRecord:
     transaction_valid: bool
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "plan_sha256", _sha256("plan_sha256", self.plan_sha256))
         object.__setattr__(self, "arm", _text("arm", self.arm))
         object.__setattr__(self, "seed", _count("seed", self.seed))
-        if (
-            type(self.observation_sha256) is not str
-            or _SHA256.fullmatch(self.observation_sha256) is None
-        ):
-            raise ValueError("observation_sha256 must be lowercase hexadecimal SHA-256")
-        for name in ("updates", "data_steps", "model_queries"):
+        object.__setattr__(
+            self,
+            "observation_sha256",
+            _sha256("observation_sha256", self.observation_sha256),
+        )
+        for name in ("updates", "observations", "data_steps", "model_queries"):
             object.__setattr__(self, name, _count(name, getattr(self, name)))
         for name in ("persistent_bytes", "peak_working_set_bytes"):
-            object.__setattr__(
-                self, name, _count(name, getattr(self, name), maximum=_MAX_BYTES)
-            )
-        if (
-            type(self.timing_seconds) is not float
-            or not math.isfinite(self.timing_seconds)
-            or self.timing_seconds < 0.0
-            or self.timing_seconds > 604_800.0
-        ):
-            raise ValueError("timing_seconds must be a finite non-negative float")
-        if type(self.metric) is not float or not math.isfinite(self.metric):
-            raise ValueError("metric must be a finite float")
+            object.__setattr__(self, name, _count(name, getattr(self, name), maximum=_MAX_BYTES))
+        object.__setattr__(
+            self,
+            "timing_seconds",
+            _finite_float("timing_seconds", self.timing_seconds, nonnegative=True),
+        )
+        if self.timing_seconds > _MAX_TIMING_SECONDS:
+            raise ValueError("timing_seconds exceeds the protocol ceiling")
+        object.__setattr__(self, "metric", _finite_float("metric", self.metric))
         if type(self.transaction_valid) is not bool:
             raise ValueError("transaction_valid must be a bool")
+
+
+def _plan_dict(plan: MatchedDevelopmentPlan) -> dict[str, Any]:
+    return {
+        "protocol_id": plan.protocol_id,
+        "paper_revision": plan.paper_revision,
+        "reference_code_revision": plan.reference_code_revision,
+        "source_sha256": plan.source_sha256,
+        "report_namespace": plan.report_namespace,
+        "metric_name": plan.metric_name,
+        "higher_is_better": plan.higher_is_better,
+        "tie_tolerance": plan.tie_tolerance,
+        "control": plan.control,
+        "arms": plan.arms,
+        "seeds": plan.seeds,
+        "expected_updates": plan.expected_updates,
+        "expected_observations": plan.expected_observations,
+        "expected_data_steps": plan.expected_data_steps,
+        "expected_model_queries": plan.expected_model_queries,
+        "persistent_byte_budget": plan.persistent_byte_budget,
+        "working_set_byte_budget": plan.working_set_byte_budget,
+    }
+
+
+def _record_dict(record: ArmRecord) -> dict[str, Any]:
+    return {
+        "plan_sha256": record.plan_sha256,
+        "arm": record.arm,
+        "seed": record.seed,
+        "observation_sha256": record.observation_sha256,
+        "updates": record.updates,
+        "observations": record.observations,
+        "data_steps": record.data_steps,
+        "model_queries": record.model_queries,
+        "persistent_bytes": record.persistent_bytes,
+        "peak_working_set_bytes": record.peak_working_set_bytes,
+        "timing_seconds": record.timing_seconds,
+        "metric": record.metric,
+        "transaction_valid": record.transaction_valid,
+    }
+
+
+def _revalidate_plan(plan: object) -> MatchedDevelopmentPlan:
+    if type(plan) is not MatchedDevelopmentPlan:
+        raise ValueError("plan must use the exact MatchedDevelopmentPlan type")
+    return MatchedDevelopmentPlan(**_plan_dict(plan))
+
+
+def _revalidate_record(record: object) -> ArmRecord:
+    if type(record) is not ArmRecord:
+        raise ValueError("records must contain exact ArmRecord values")
+    return ArmRecord(**_record_dict(record))
+
+
+def _canonical_json_bytes_raw(value: object) -> bytes:
+    try:
+        encoded = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (TypeError, ValueError, UnicodeEncodeError) as error:
+        raise ValueError("report must have one finite canonical JSON representation") from error
+    if len(encoded) > _MAX_REPORT_BYTES:
+        raise ValueError("canonical report exceeds the byte ceiling")
+    return encoded
+
+
+def plan_sha256(plan: MatchedDevelopmentPlan) -> str:
+    """Return the canonical identity of a fully revalidated plan."""
+    resolved = _revalidate_plan(plan)
+    return hashlib.sha256(_canonical_json_bytes_raw(_plan_dict(resolved))).hexdigest()
+
+
+def _finite_mean(name: str, values: tuple[float, ...]) -> float:
+    try:
+        result = math.fsum(values) / len(values)
+    except OverflowError as error:
+        raise ValueError(f"{name} must fit in finite float64") from error
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must fit in finite float64")
+    return result
+
+
+def _stderr(values: tuple[float, ...], mean: float) -> float:
+    if len(values) == 1:
+        return 0.0
+    centered = tuple(value - mean for value in values)
+    if not all(math.isfinite(value) for value in centered):
+        raise ValueError("paired stderr must fit in finite float64")
+    scale = max(abs(value) for value in centered)
+    if scale == 0.0:
+        return 0.0
+    normalized = math.fsum((value / scale) ** 2 for value in centered)
+    result = scale * math.sqrt(normalized / (len(values) * (len(values) - 1)))
+    if not math.isfinite(result):
+        raise ValueError("paired stderr must fit in finite float64")
+    return result
+
+
+def _arm_summary(records: tuple[ArmRecord, ...]) -> dict[str, int | float]:
+    metrics = tuple(record.metric for record in records)
+    metric_mean = _finite_mean("arm mean metric", metrics)
+    return {
+        "record_count": len(records),
+        "mean_metric": metric_mean,
+        "metric_stderr": _stderr(metrics, metric_mean),
+        "total_updates": sum(record.updates for record in records),
+        "total_observations": sum(record.observations for record in records),
+        "total_data_steps": sum(record.data_steps for record in records),
+        "total_model_queries": sum(record.model_queries for record in records),
+        "mean_persistent_bytes": _finite_mean(
+            "mean persistent bytes", tuple(float(record.persistent_bytes) for record in records)
+        ),
+        "max_persistent_bytes": max(record.persistent_bytes for record in records),
+        "mean_peak_working_set_bytes": _finite_mean(
+            "mean peak working bytes",
+            tuple(float(record.peak_working_set_bytes) for record in records),
+        ),
+        "max_peak_working_set_bytes": max(
+            record.peak_working_set_bytes for record in records
+        ),
+        "total_timing_seconds": _finite_mean(
+            "mean timing", tuple(record.timing_seconds for record in records)
+        )
+        * len(records),
+    }
 
 
 def build_matched_report(
     plan: MatchedDevelopmentPlan, records: tuple[ArmRecord, ...]
 ) -> dict[str, Any]:
     """Validate and aggregate one exact arm-by-seed cross product."""
-    if type(plan) is not MatchedDevelopmentPlan or type(records) is not tuple:
-        raise ValueError("plan and records must use exact protocol types")
-    expected_count = len(plan.arms) * len(plan.seeds)
+    resolved_plan = _revalidate_plan(plan)
+    if type(records) is not tuple:
+        raise ValueError("records must be an exact tuple")
+    expected_count = len(resolved_plan.arms) * len(resolved_plan.seeds)
     if len(records) != expected_count:
         raise ValueError("records must contain the complete arm-seed cross product")
+    identity = plan_sha256(resolved_plan)
     indexed: dict[tuple[str, int], ArmRecord] = {}
     observation_by_seed: dict[int, str] = {}
-    for record in records:
-        if type(record) is not ArmRecord:
-            raise ValueError("records must contain exact ArmRecord values")
+    total_persistent = 0
+    total_working = 0
+    total_timing = 0.0
+    for untrusted_record in records:
+        record = _revalidate_record(untrusted_record)
+        if record.plan_sha256 != identity:
+            raise ValueError("every record must bind the exact canonical plan identity")
         key = (record.arm, record.seed)
-        if record.arm not in plan.arms or record.seed not in plan.seeds or key in indexed:
+        if (
+            record.arm not in resolved_plan.arms
+            or record.seed not in resolved_plan.seeds
+            or key in indexed
+        ):
             raise ValueError("records contain an unknown or duplicate arm-seed identity")
         if not record.transaction_valid:
             raise ValueError("every record transaction must be valid")
-        if (record.updates, record.data_steps, record.model_queries) != (
-            plan.steps,
-            plan.steps,
-            plan.steps,
+        if (record.updates, record.observations, record.data_steps, record.model_queries) != (
+            resolved_plan.expected_updates,
+            resolved_plan.expected_observations,
+            resolved_plan.expected_data_steps,
+            resolved_plan.expected_model_queries,
         ):
-            raise ValueError("updates, data steps, and queries must match matched steps")
+            raise ValueError("record counters must equal the plan's expected counters")
+        if (
+            record.persistent_bytes > resolved_plan.persistent_byte_budget
+            or record.peak_working_set_bytes > resolved_plan.working_set_byte_budget
+        ):
+            raise ValueError("record resources exceed the plan budget")
+        if record.persistent_bytes > _MAX_BYTES - total_persistent:
+            raise ValueError("aggregate resource totals exceed the byte ceiling")
+        if record.peak_working_set_bytes > _MAX_BYTES - total_working:
+            raise ValueError("aggregate resource totals exceed the byte ceiling")
+        total_persistent += record.persistent_bytes
+        total_working += record.peak_working_set_bytes
+        total_timing += record.timing_seconds
+        if not math.isfinite(total_timing) or total_timing > _MAX_TIMING_SECONDS:
+            raise ValueError("aggregate timing exceeds the protocol ceiling")
         prior = observation_by_seed.setdefault(record.seed, record.observation_sha256)
         if prior != record.observation_sha256:
             raise ValueError("arms for one seed must share one observation identity")
         indexed[key] = record
-    expected = {(arm, seed) for arm in plan.arms for seed in plan.seeds}
+    expected = {
+        (arm, seed) for seed in resolved_plan.seeds for arm in resolved_plan.arms
+    }
     if set(indexed) != expected:
         raise ValueError("records must contain the complete arm-seed cross product")
-    candidates = tuple(arm for arm in plan.arms if arm != plan.control)
-    if len(candidates) != 1:
-        raise ValueError("v1 reports require exactly one candidate and one control")
-    candidate = candidates[0]
-    differences = tuple(
-        indexed[(candidate, seed)].metric - indexed[(plan.control, seed)].metric
-        for seed in plan.seeds
+    canonical_records = tuple(
+        indexed[(arm, seed)] for seed in resolved_plan.seeds for arm in resolved_plan.arms
     )
-    if not all(math.isfinite(difference) for difference in differences):
+    candidate = next(arm for arm in resolved_plan.arms if arm != resolved_plan.control)
+    raw_differences = tuple(
+        indexed[(candidate, seed)].metric - indexed[(resolved_plan.control, seed)].metric
+        for seed in resolved_plan.seeds
+    )
+    if not all(math.isfinite(difference) for difference in raw_differences):
         raise ValueError("paired differences must fit in finite float64")
-    mean_difference = float(np.mean(np.asarray(differences, dtype=np.float64)))
-    if not math.isfinite(mean_difference):
-        raise ValueError("mean paired difference must fit in finite float64")
-    return {
-        "schema": "asi.matched-development.report.v1",
-        "plan": asdict(plan),
-        "records": tuple(asdict(record) for record in records),
+    oriented = tuple(
+        difference if resolved_plan.higher_is_better else -difference
+        for difference in raw_differences
+    )
+    mean_improvement = _finite_mean("mean paired difference", oriented)
+    if mean_improvement > resolved_plan.tie_tolerance:
+        outcome = "improved"
+    elif mean_improvement < -resolved_plan.tie_tolerance:
+        outcome = "worse"
+    else:
+        outcome = "tied"
+    summaries = {
+        arm: _arm_summary(tuple(indexed[(arm, seed)] for seed in resolved_plan.seeds))
+        for arm in resolved_plan.arms
+    }
+    payload: dict[str, Any] = {
+        "schema": "asi.matched-development.report.v2",
+        "plan_sha256": identity,
+        "plan": _plan_dict(resolved_plan),
+        "records": tuple(_record_dict(record) for record in canonical_records),
         "candidate": candidate,
-        "paired_differences": differences,
-        "mean_paired_difference": mean_difference,
+        "paired_differences": raw_differences,
+        "mean_paired_difference": _finite_mean(
+            "mean raw paired difference", raw_differences
+        ),
+        "mean_oriented_improvement": mean_improvement,
+        "paired_stderr": _stderr(oriented, mean_improvement),
+        "outcome": outcome,
+        "arm_summaries": summaries,
+        "aggregate_persistent_bytes": total_persistent,
+        "aggregate_peak_working_set_bytes": total_working,
+        "aggregate_timing_seconds": total_timing,
         "timing_is_telemetry_only": True,
         "development_only": True,
         "scientific_promotion_allowed": False,
     }
+    payload["report_sha256"] = hashlib.sha256(_canonical_json_bytes_raw(payload)).hexdigest()
+    return payload
+
+
+def _exact_dict(name: str, value: object) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise ValueError(f"{name} must be an exact dict")
+    return value
+
+
+def _from_report_plan(value: object) -> MatchedDevelopmentPlan:
+    raw = _exact_dict("report plan", value)
+    expected = tuple(MatchedDevelopmentPlan.__dataclass_fields__)
+    if len(raw) != len(expected) or not all(name in raw for name in expected):
+        raise ValueError("report plan fields do not match the exact schema")
+    converted = dict(raw)
+    if type(converted["arms"]) is list:
+        converted["arms"] = tuple(converted["arms"])
+    if type(converted["seeds"]) is list:
+        converted["seeds"] = tuple(converted["seeds"])
+    return MatchedDevelopmentPlan(**converted)
+
+
+def _from_report_record(value: object) -> ArmRecord:
+    raw = _exact_dict("report record", value)
+    expected = tuple(ArmRecord.__dataclass_fields__)
+    if len(raw) != len(expected) or not all(name in raw for name in expected):
+        raise ValueError("report record fields do not match the exact schema")
+    return ArmRecord(**raw)
+
+
+def validate_matched_report(report: object) -> dict[str, Any]:
+    """Strictly reload and reconstruct a report; caller fields are never trusted."""
+    raw = _exact_dict("report", report)
+    if len(raw) > 32:
+        raise ValueError("report has too many top-level fields")
+    plan = _from_report_plan(raw.get("plan"))
+    raw_records = raw.get("records")
+    if type(raw_records) not in (tuple, list):
+        raise ValueError("report records must be an exact tuple or JSON list")
+    record_values = cast(tuple[object, ...] | list[object], raw_records)
+    expected_count = len(plan.arms) * len(plan.seeds)
+    if len(record_values) != expected_count:
+        raise ValueError("report records do not match the bounded plan cross product")
+    records = tuple(_from_report_record(record) for record in record_values)
+    rebuilt = build_matched_report(plan, records)
+    if _canonical_json_bytes_raw(raw) != _canonical_json_bytes_raw(rebuilt):
+        raise ValueError("report does not match the canonical report derived from its records")
+    return rebuilt
+
+
+def canonical_report_bytes(report: object) -> bytes:
+    """Return the one allowed finite, sorted UTF-8 JSON encoding."""
+    return _canonical_json_bytes_raw(validate_matched_report(report))
+
+
+def retain_matched_report(report: object, *, repository_root: Path) -> Path:
+    """Publish one report with exclusive create, then strictly reload it."""
+    if type(repository_root) is not PosixPath or not repository_root.is_absolute():
+        raise ValueError("repository_root must be an exact absolute POSIX Path")
+    validated = validate_matched_report(report)
+    namespace = _from_report_plan(validated["plan"]).report_namespace
+    root_resolved = repository_root.resolve(strict=True)
+    if not root_resolved.is_dir():
+        raise ValueError("repository_root must resolve to an existing directory")
+    directory = root_resolved
+    for segment in namespace.split("/"):
+        directory /= segment
+        if directory.exists():
+            if directory.is_symlink() or not directory.is_dir():
+                raise ValueError("report namespace contains a non-directory or symbolic link")
+        else:
+            directory.mkdir(mode=0o755)
+    destination = directory / "report.v2.json"
+    encoded = _canonical_json_bytes_raw(validated)
+    temporary = directory / f".report.v2.{validated['report_sha256']}.tmp"
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o444)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=False) as stream:
+            stream.write(encoded)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, destination, follow_symlinks=False)
+    finally:
+        os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+    loaded = destination.read_bytes()
+    if loaded != encoded or canonical_report_bytes(json.loads(loaded)) != encoded:
+        raise RuntimeError("retained matched report failed strict reload validation")
+    directory_descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(directory_descriptor)
+    finally:
+        os.close(directory_descriptor)
+    return destination

--- a/alberta_framework/evaluation/matched_development.py
+++ b/alberta_framework/evaluation/matched_development.py
@@ -1,0 +1,174 @@
+"""Strict aggregation contract for matched, permanently nonpromoting runs."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+
+_INT32_MAX = 2**31 - 1
+_MAX_BYTES = 256 * 1024 * 1024
+_MAX_ARMS = 16
+_MAX_SEEDS = 128
+_MAX_TEXT = 512
+_SHA256 = re.compile(r"[0-9a-f]{64}")
+_NAMESPACE = re.compile(r"outputs/[a-z0-9][a-z0-9._/-]{0,255}")
+
+
+def _text(name: str, value: object) -> str:
+    if type(value) is not str or not value or len(value) > _MAX_TEXT:
+        raise ValueError(f"{name} must be a bounded non-empty string")
+    return value
+
+
+def _count(name: str, value: object, *, maximum: int = _INT32_MAX) -> int:
+    if type(value) is not int or value < 0 or value > maximum:
+        raise ValueError(f"{name} must be an integer in [0, {maximum}]")
+    return value
+
+
+@dataclass(frozen=True)
+class MatchedDevelopmentPlan:
+    protocol_id: str
+    paper_revision: str
+    reference_code_revision: str
+    source_sha256: str
+    report_namespace: str
+    metric_name: str
+    control: str
+    arms: tuple[str, ...]
+    seeds: tuple[int, ...]
+    steps: int
+
+    def __post_init__(self) -> None:
+        for name in (
+            "protocol_id",
+            "paper_revision",
+            "reference_code_revision",
+            "report_namespace",
+            "metric_name",
+            "control",
+        ):
+            object.__setattr__(self, name, _text(name, getattr(self, name)))
+        if type(self.source_sha256) is not str or _SHA256.fullmatch(self.source_sha256) is None:
+            raise ValueError("source_sha256 must be lowercase hexadecimal SHA-256")
+        if (
+            _NAMESPACE.fullmatch(self.report_namespace) is None
+            or ".." in self.report_namespace.split("/")
+        ):
+            raise ValueError("report_namespace must be a bounded relative outputs path")
+        if type(self.arms) is not tuple or not 2 <= len(self.arms) <= _MAX_ARMS:
+            raise ValueError("arms must be an exact tuple with 2 to 16 entries")
+        resolved_arms = tuple(_text("arm", arm) for arm in self.arms)
+        if len(set(resolved_arms)) != len(resolved_arms) or self.control not in resolved_arms:
+            raise ValueError("arms must be unique and contain control")
+        if type(self.seeds) is not tuple or not 1 <= len(self.seeds) <= _MAX_SEEDS:
+            raise ValueError("seeds must be an exact tuple with 1 to 128 entries")
+        resolved_seeds = tuple(_count("seed", seed) for seed in self.seeds)
+        if len(set(resolved_seeds)) != len(resolved_seeds):
+            raise ValueError("seeds must be unique")
+        object.__setattr__(self, "steps", _count("steps", self.steps, maximum=1_000_000))
+        if self.steps < 1:
+            raise ValueError("steps must be positive")
+
+
+@dataclass(frozen=True)
+class ArmRecord:
+    arm: str
+    seed: int
+    observation_sha256: str
+    updates: int
+    data_steps: int
+    model_queries: int
+    persistent_bytes: int
+    peak_working_set_bytes: int
+    timing_seconds: float
+    metric: float
+    transaction_valid: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "arm", _text("arm", self.arm))
+        object.__setattr__(self, "seed", _count("seed", self.seed))
+        if (
+            type(self.observation_sha256) is not str
+            or _SHA256.fullmatch(self.observation_sha256) is None
+        ):
+            raise ValueError("observation_sha256 must be lowercase hexadecimal SHA-256")
+        for name in ("updates", "data_steps", "model_queries"):
+            object.__setattr__(self, name, _count(name, getattr(self, name)))
+        for name in ("persistent_bytes", "peak_working_set_bytes"):
+            object.__setattr__(
+                self, name, _count(name, getattr(self, name), maximum=_MAX_BYTES)
+            )
+        if (
+            type(self.timing_seconds) is not float
+            or not math.isfinite(self.timing_seconds)
+            or self.timing_seconds < 0.0
+            or self.timing_seconds > 604_800.0
+        ):
+            raise ValueError("timing_seconds must be a finite non-negative float")
+        if type(self.metric) is not float or not math.isfinite(self.metric):
+            raise ValueError("metric must be a finite float")
+        if type(self.transaction_valid) is not bool:
+            raise ValueError("transaction_valid must be a bool")
+
+
+def build_matched_report(
+    plan: MatchedDevelopmentPlan, records: tuple[ArmRecord, ...]
+) -> dict[str, Any]:
+    """Validate and aggregate one exact arm-by-seed cross product."""
+    if type(plan) is not MatchedDevelopmentPlan or type(records) is not tuple:
+        raise ValueError("plan and records must use exact protocol types")
+    expected_count = len(plan.arms) * len(plan.seeds)
+    if len(records) != expected_count:
+        raise ValueError("records must contain the complete arm-seed cross product")
+    indexed: dict[tuple[str, int], ArmRecord] = {}
+    observation_by_seed: dict[int, str] = {}
+    for record in records:
+        if type(record) is not ArmRecord:
+            raise ValueError("records must contain exact ArmRecord values")
+        key = (record.arm, record.seed)
+        if record.arm not in plan.arms or record.seed not in plan.seeds or key in indexed:
+            raise ValueError("records contain an unknown or duplicate arm-seed identity")
+        if not record.transaction_valid:
+            raise ValueError("every record transaction must be valid")
+        if (record.updates, record.data_steps, record.model_queries) != (
+            plan.steps,
+            plan.steps,
+            plan.steps,
+        ):
+            raise ValueError("updates, data steps, and queries must match matched steps")
+        prior = observation_by_seed.setdefault(record.seed, record.observation_sha256)
+        if prior != record.observation_sha256:
+            raise ValueError("arms for one seed must share one observation identity")
+        indexed[key] = record
+    expected = {(arm, seed) for arm in plan.arms for seed in plan.seeds}
+    if set(indexed) != expected:
+        raise ValueError("records must contain the complete arm-seed cross product")
+    candidates = tuple(arm for arm in plan.arms if arm != plan.control)
+    if len(candidates) != 1:
+        raise ValueError("v1 reports require exactly one candidate and one control")
+    candidate = candidates[0]
+    differences = tuple(
+        indexed[(candidate, seed)].metric - indexed[(plan.control, seed)].metric
+        for seed in plan.seeds
+    )
+    if not all(math.isfinite(difference) for difference in differences):
+        raise ValueError("paired differences must fit in finite float64")
+    mean_difference = float(np.mean(np.asarray(differences, dtype=np.float64)))
+    if not math.isfinite(mean_difference):
+        raise ValueError("mean paired difference must fit in finite float64")
+    return {
+        "schema": "asi.matched-development.report.v1",
+        "plan": asdict(plan),
+        "records": tuple(asdict(record) for record in records),
+        "candidate": candidate,
+        "paired_differences": differences,
+        "mean_paired_difference": mean_difference,
+        "timing_is_telemetry_only": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }

--- a/tests/test_matched_development.py
+++ b/tests/test_matched_development.py
@@ -109,6 +109,29 @@ def test_report_rejects_identity_observation_or_counter_mismatch() -> None:
         build_matched_report(plan, (off, replace(on, model_queries=1)))
 
 
+def test_distinct_matched_counter_budgets_are_representable() -> None:
+    plan = replace(
+        _plan(seeds=(0,)),
+        expected_updates=10_000,
+        expected_observations=10_000,
+        expected_data_steps=10_000,
+        expected_model_queries=10_128,
+    )
+    records = tuple(
+        replace(
+            _record(plan, arm, 0, metric),
+            updates=10_000,
+            observations=10_000,
+            data_steps=10_000,
+            model_queries=10_128,
+        )
+        for arm, metric in (("off", 1.0), ("on", 2.0))
+    )
+    report = build_matched_report(plan, records)
+    assert report["arm_summaries"]["off"]["total_model_queries"] == 10_128
+    assert report["arm_summaries"]["on"]["total_data_steps"] == 10_000
+
+
 def test_consumption_revalidates_mutated_frozen_values() -> None:
     plan = _plan(seeds=(0,))
     off = _record(plan, "off", 0, 1.0)
@@ -144,8 +167,32 @@ def test_plan_rejects_hostile_or_unbounded_values_without_iteration() -> None:
         replace(_plan(), arms=HostileTuple())  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="bounded"):
         replace(_plan(), metric_name="é" * 300)
+    with pytest.raises(ValueError, match="valid UTF-8"):
+        replace(_plan(), metric_name="\ud800")
     with pytest.raises(ValueError, match="expected_updates"):
         replace(_plan(), expected_updates=2**100)
+
+
+def test_report_rejects_non_string_mapping_keys_without_hooks() -> None:
+    class HostileKey:
+        calls = 0
+
+        def __hash__(self) -> int:
+            return hash("plan")
+
+        def __eq__(self, other: object) -> bool:
+            type(self).calls += 1
+            raise AssertionError("hostile key equality executed")
+
+    report = build_matched_report(_plan(), _records(_plan()))
+    hostile = HostileKey()
+    forged = dict(report)
+    del forged["plan"]
+    forged[hostile] = None  # type: ignore[index]
+    HostileKey.calls = 0
+    with pytest.raises(ValueError, match="keys must be exact strings"):
+        validate_matched_report(forged)
+    assert HostileKey.calls == 0
 
 
 def test_report_rejects_invalid_transaction_numeric_and_total_resource_overflow() -> None:

--- a/tests/test_matched_development.py
+++ b/tests/test_matched_development.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from alberta_framework.evaluation.matched_development import (
@@ -25,10 +27,23 @@ def _record(arm: str, seed: int, metric: float) -> ArmRecord:
     )
 
 
-def test_report_requires_complete_matched_cross_product() -> None:
-    plan = MatchedDevelopmentPlan(
-        protocol_id="test.v1", control="off", arms=("off", "on"), seeds=(0, 1), steps=4
+def _plan(*, seeds: tuple[int, ...] = (0, 1)) -> MatchedDevelopmentPlan:
+    return MatchedDevelopmentPlan(
+        protocol_id="test.v1",
+        paper_revision="paper.v1",
+        reference_code_revision="not-used",
+        source_sha256="a" * 64,
+        report_namespace="outputs/test.v1",
+        metric_name="score",
+        control="off",
+        arms=("off", "on"),
+        seeds=seeds,
+        steps=4,
     )
+
+
+def test_report_requires_complete_matched_cross_product() -> None:
+    plan = _plan()
     records = (
         _record("off", 0, 1.0),
         _record("on", 0, 2.0),
@@ -43,26 +58,33 @@ def test_report_requires_complete_matched_cross_product() -> None:
 
 
 def test_report_rejects_observation_or_counter_mismatch() -> None:
-    plan = MatchedDevelopmentPlan(
-        protocol_id="test.v1", control="off", arms=("off", "on"), seeds=(0,), steps=4
-    )
-    bad_hash = _record("on", 0, 2.0)
-    object.__setattr__(bad_hash, "observation_sha256", "f" * 64)
+    plan = _plan(seeds=(0,))
+    bad_hash = replace(_record("on", 0, 2.0), observation_sha256="f" * 64)
     with pytest.raises(ValueError, match="observation identity"):
         build_matched_report(plan, (_record("off", 0, 1.0), bad_hash))
-    bad_steps = _record("on", 0, 2.0)
-    object.__setattr__(bad_steps, "updates", 3)
+    bad_steps = replace(_record("on", 0, 2.0), updates=3)
     with pytest.raises(ValueError, match="matched steps"):
         build_matched_report(plan, (_record("off", 0, 1.0), bad_steps))
 
 
 def test_report_rejects_invalid_transaction_and_incomplete_plan() -> None:
-    plan = MatchedDevelopmentPlan(
-        protocol_id="test.v1", control="off", arms=("off", "on"), seeds=(0,), steps=4
-    )
-    invalid = _record("on", 0, 2.0)
-    object.__setattr__(invalid, "transaction_valid", False)
+    plan = _plan(seeds=(0,))
+    invalid = replace(_record("on", 0, 2.0), transaction_valid=False)
     with pytest.raises(ValueError, match="transaction"):
         build_matched_report(plan, (_record("off", 0, 1.0), invalid))
     with pytest.raises(ValueError, match="complete arm-seed cross product"):
         build_matched_report(plan, (_record("off", 0, 1.0),))
+
+
+def test_plan_and_report_reject_path_escape_and_numeric_overflow() -> None:
+    with pytest.raises(ValueError, match="outputs path"):
+        replace(_plan(), report_namespace="outputs/../escape")
+    plan = _plan(seeds=(0,))
+    with pytest.raises(ValueError, match="paired differences"):
+        build_matched_report(
+            plan,
+            (
+                _record("off", 0, -float.fromhex("0x1.fffffffffffffp+1023")),
+                _record("on", 0, float.fromhex("0x1.fffffffffffffp+1023")),
+            ),
+        )

--- a/tests/test_matched_development.py
+++ b/tests/test_matched_development.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.matched_development import (
+    ArmRecord,
+    MatchedDevelopmentPlan,
+    build_matched_report,
+)
+
+
+def _record(arm: str, seed: int, metric: float) -> ArmRecord:
+    return ArmRecord(
+        arm=arm,
+        seed=seed,
+        observation_sha256=f"{seed:064x}",
+        updates=4,
+        data_steps=4,
+        model_queries=4,
+        persistent_bytes=8,
+        peak_working_set_bytes=16,
+        timing_seconds=0.1,
+        metric=metric,
+        transaction_valid=True,
+    )
+
+
+def test_report_requires_complete_matched_cross_product() -> None:
+    plan = MatchedDevelopmentPlan(
+        protocol_id="test.v1", control="off", arms=("off", "on"), seeds=(0, 1), steps=4
+    )
+    records = (
+        _record("off", 0, 1.0),
+        _record("on", 0, 2.0),
+        _record("off", 1, 3.0),
+        _record("on", 1, 5.0),
+    )
+    report = build_matched_report(plan, records)
+    assert report["paired_differences"] == (1.0, 2.0)
+    assert report["mean_paired_difference"] == pytest.approx(1.5)
+    assert report["development_only"] is True
+    assert report["scientific_promotion_allowed"] is False
+
+
+def test_report_rejects_observation_or_counter_mismatch() -> None:
+    plan = MatchedDevelopmentPlan(
+        protocol_id="test.v1", control="off", arms=("off", "on"), seeds=(0,), steps=4
+    )
+    bad_hash = _record("on", 0, 2.0)
+    object.__setattr__(bad_hash, "observation_sha256", "f" * 64)
+    with pytest.raises(ValueError, match="observation identity"):
+        build_matched_report(plan, (_record("off", 0, 1.0), bad_hash))
+    bad_steps = _record("on", 0, 2.0)
+    object.__setattr__(bad_steps, "updates", 3)
+    with pytest.raises(ValueError, match="matched steps"):
+        build_matched_report(plan, (_record("off", 0, 1.0), bad_steps))
+
+
+def test_report_rejects_invalid_transaction_and_incomplete_plan() -> None:
+    plan = MatchedDevelopmentPlan(
+        protocol_id="test.v1", control="off", arms=("off", "on"), seeds=(0,), steps=4
+    )
+    invalid = _record("on", 0, 2.0)
+    object.__setattr__(invalid, "transaction_valid", False)
+    with pytest.raises(ValueError, match="transaction"):
+        build_matched_report(plan, (_record("off", 0, 1.0), invalid))
+    with pytest.raises(ValueError, match="complete arm-seed cross product"):
+        build_matched_report(plan, (_record("off", 0, 1.0),))

--- a/tests/test_matched_development.py
+++ b/tests/test_matched_development.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
@@ -8,17 +10,47 @@ from alberta_framework.evaluation.matched_development import (
     ArmRecord,
     MatchedDevelopmentPlan,
     build_matched_report,
+    canonical_report_bytes,
+    plan_sha256,
+    retain_matched_report,
+    validate_matched_report,
 )
 
 
-def _record(arm: str, seed: int, metric: float) -> ArmRecord:
+def _plan(
+    *, seeds: tuple[int, ...] = (0, 1), higher_is_better: bool = True
+) -> MatchedDevelopmentPlan:
+    return MatchedDevelopmentPlan(
+        protocol_id="test.v1",
+        paper_revision="paper.v1",
+        reference_code_revision="code.v1",
+        source_sha256="a" * 64,
+        report_namespace="outputs/test.v1",
+        metric_name="score",
+        higher_is_better=higher_is_better,
+        tie_tolerance=0.0,
+        control="off",
+        arms=("off", "on"),
+        seeds=seeds,
+        expected_updates=4,
+        expected_observations=5,
+        expected_data_steps=6,
+        expected_model_queries=0,
+        persistent_byte_budget=64,
+        working_set_byte_budget=128,
+    )
+
+
+def _record(plan: MatchedDevelopmentPlan, arm: str, seed: int, metric: float) -> ArmRecord:
     return ArmRecord(
+        plan_sha256=plan_sha256(plan),
         arm=arm,
         seed=seed,
         observation_sha256=f"{seed:064x}",
         updates=4,
-        data_steps=4,
-        model_queries=4,
+        observations=5,
+        data_steps=6,
+        model_queries=0,
         persistent_bytes=8,
         peak_working_set_bytes=16,
         timing_seconds=0.1,
@@ -27,64 +59,154 @@ def _record(arm: str, seed: int, metric: float) -> ArmRecord:
     )
 
 
-def _plan(*, seeds: tuple[int, ...] = (0, 1)) -> MatchedDevelopmentPlan:
-    return MatchedDevelopmentPlan(
-        protocol_id="test.v1",
-        paper_revision="paper.v1",
-        reference_code_revision="not-used",
-        source_sha256="a" * 64,
-        report_namespace="outputs/test.v1",
-        metric_name="score",
-        control="off",
-        arms=("off", "on"),
-        seeds=seeds,
-        steps=4,
+def _records(plan: MatchedDevelopmentPlan) -> tuple[ArmRecord, ...]:
+    return (
+        _record(plan, "on", 1, 5.0),
+        _record(plan, "off", 0, 1.0),
+        _record(plan, "off", 1, 3.0),
+        _record(plan, "on", 0, 2.0),
     )
 
 
-def test_report_requires_complete_matched_cross_product() -> None:
+def test_report_is_canonical_paired_and_resource_explicit() -> None:
     plan = _plan()
-    records = (
-        _record("off", 0, 1.0),
-        _record("on", 0, 2.0),
-        _record("off", 1, 3.0),
-        _record("on", 1, 5.0),
-    )
-    report = build_matched_report(plan, records)
+    report = build_matched_report(plan, _records(plan))
+    assert [(row["seed"], row["arm"]) for row in report["records"]] == [
+        (0, "off"),
+        (0, "on"),
+        (1, "off"),
+        (1, "on"),
+    ]
     assert report["paired_differences"] == (1.0, 2.0)
     assert report["mean_paired_difference"] == pytest.approx(1.5)
+    assert report["paired_stderr"] == pytest.approx(0.5)
+    assert report["outcome"] == "improved"
+    assert report["arm_summaries"]["off"]["total_updates"] == 8
+    assert report["arm_summaries"]["on"]["mean_metric"] == pytest.approx(3.5)
     assert report["development_only"] is True
     assert report["scientific_promotion_allowed"] is False
+    assert len(report["report_sha256"]) == 64
 
 
-def test_report_rejects_observation_or_counter_mismatch() -> None:
+def test_direction_and_single_seed_stderr_are_frozen() -> None:
+    plan = _plan(seeds=(0,), higher_is_better=False)
+    records = (_record(plan, "on", 0, 1.0), _record(plan, "off", 0, 2.0))
+    report = build_matched_report(plan, records)
+    assert report["paired_differences"] == (-1.0,)
+    assert report["paired_stderr"] == 0.0
+    assert report["outcome"] == "improved"
+
+
+def test_report_rejects_identity_observation_or_counter_mismatch() -> None:
     plan = _plan(seeds=(0,))
-    bad_hash = replace(_record("on", 0, 2.0), observation_sha256="f" * 64)
+    off = _record(plan, "off", 0, 1.0)
+    on = _record(plan, "on", 0, 2.0)
+    with pytest.raises(ValueError, match="plan identity"):
+        build_matched_report(plan, (off, replace(on, plan_sha256="f" * 64)))
     with pytest.raises(ValueError, match="observation identity"):
-        build_matched_report(plan, (_record("off", 0, 1.0), bad_hash))
-    bad_steps = replace(_record("on", 0, 2.0), updates=3)
-    with pytest.raises(ValueError, match="matched steps"):
-        build_matched_report(plan, (_record("off", 0, 1.0), bad_steps))
+        build_matched_report(plan, (off, replace(on, observation_sha256="f" * 64)))
+    with pytest.raises(ValueError, match="expected counters"):
+        build_matched_report(plan, (off, replace(on, model_queries=1)))
 
 
-def test_report_rejects_invalid_transaction_and_incomplete_plan() -> None:
+def test_consumption_revalidates_mutated_frozen_values() -> None:
     plan = _plan(seeds=(0,))
-    invalid = replace(_record("on", 0, 2.0), transaction_valid=False)
-    with pytest.raises(ValueError, match="transaction"):
-        build_matched_report(plan, (_record("off", 0, 1.0), invalid))
-    with pytest.raises(ValueError, match="complete arm-seed cross product"):
-        build_matched_report(plan, (_record("off", 0, 1.0),))
+    off = _record(plan, "off", 0, 1.0)
+    on = _record(plan, "on", 0, 2.0)
+    object.__setattr__(plan, "seeds", [0])
+    with pytest.raises(ValueError, match="seeds"):
+        build_matched_report(plan, (off, on))
+    plan = _plan(seeds=(0,))
+    off = _record(plan, "off", 0, 1.0)
+    object.__setattr__(off, "updates", 2**100)
+    with pytest.raises(ValueError, match="updates"):
+        build_matched_report(plan, (off, _record(plan, "on", 0, 2.0)))
 
 
-def test_plan_and_report_reject_path_escape_and_numeric_overflow() -> None:
+@pytest.mark.parametrize(
+    "namespace",
+    ("outputs/../escape", "outputs/./x", "outputs//x", "outputs/x/", "elsewhere/x"),
+)
+def test_plan_rejects_noncanonical_namespaces(namespace: str) -> None:
     with pytest.raises(ValueError, match="outputs path"):
-        replace(_plan(), report_namespace="outputs/../escape")
+        replace(_plan(), report_namespace=namespace)
+
+
+def test_plan_rejects_hostile_or_unbounded_values_without_iteration() -> None:
+    class HostileTuple:
+        def __iter__(self) -> object:
+            raise AssertionError("must not iterate")
+
+        def __len__(self) -> int:
+            raise AssertionError("must not inspect")
+
+    with pytest.raises(ValueError, match="arms"):
+        replace(_plan(), arms=HostileTuple())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="bounded"):
+        replace(_plan(), metric_name="é" * 300)
+    with pytest.raises(ValueError, match="expected_updates"):
+        replace(_plan(), expected_updates=2**100)
+
+
+def test_report_rejects_invalid_transaction_numeric_and_total_resource_overflow() -> None:
     plan = _plan(seeds=(0,))
+    off = _record(plan, "off", 0, 1.0)
+    on = _record(plan, "on", 0, 2.0)
+    with pytest.raises(ValueError, match="transaction"):
+        build_matched_report(plan, (off, replace(on, transaction_valid=False)))
     with pytest.raises(ValueError, match="paired differences"):
         build_matched_report(
             plan,
             (
-                _record("off", 0, -float.fromhex("0x1.fffffffffffffp+1023")),
-                _record("on", 0, float.fromhex("0x1.fffffffffffffp+1023")),
+                replace(off, metric=-float.fromhex("0x1.fffffffffffffp+1023")),
+                replace(on, metric=float.fromhex("0x1.fffffffffffffp+1023")),
             ),
         )
+    large_plan = replace(plan, persistent_byte_budget=256 * 1024 * 1024)
+    large_off = replace(
+        off,
+        plan_sha256=plan_sha256(large_plan),
+        persistent_bytes=200 * 1024 * 1024,
+    )
+    large_on = replace(
+        on,
+        plan_sha256=plan_sha256(large_plan),
+        persistent_bytes=200 * 1024 * 1024,
+    )
+    with pytest.raises(ValueError, match="aggregate resource"):
+        build_matched_report(large_plan, (large_off, large_on))
+
+
+def test_canonical_serialization_strict_validation_and_exclusive_retention(tmp_path: Path) -> None:
+    plan = _plan()
+    report = build_matched_report(plan, _records(plan))
+    encoded = canonical_report_bytes(report)
+    assert encoded == canonical_report_bytes(validate_matched_report(json.loads(encoded)))
+    destination = retain_matched_report(report, repository_root=tmp_path)
+    assert destination == tmp_path / "outputs/test.v1/report.v2.json"
+    assert destination.read_bytes() == encoded
+    with pytest.raises(FileExistsError):
+        retain_matched_report(report, repository_root=tmp_path)
+    forged = dict(report)
+    forged["outcome"] = "worse"
+    with pytest.raises(ValueError, match="canonical report"):
+        validate_matched_report(forged)
+
+
+def test_retention_rejects_namespace_symlink(tmp_path: Path) -> None:
+    plan = _plan()
+    report = build_matched_report(plan, _records(plan))
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (tmp_path / "outputs").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError, match="symbolic link"):
+        retain_matched_report(report, repository_root=tmp_path)
+    assert not (outside / "test.v1").exists()
+
+
+def test_serialization_rejects_nan() -> None:
+    report = build_matched_report(_plan(), _records(_plan()))
+    forged = dict(report)
+    forged["mean_paired_difference"] = float("nan")
+    with pytest.raises(ValueError, match="canonical JSON"):
+        canonical_report_bytes(forged)


### PR DESCRIPTION
Adds the shared aggregation, validation, and append-only retention prerequisite for #1568-#1573 and #1586.

- canonical UTF-8 plan fields and canonical relative `outputs/...` namespaces
- exact plan identity binds protocol, paper revision, reference-code revision, a caller-supplied source SHA-256, namespace, metric direction, arms, seeds, and explicit resource budgets
- issue-specific adapters remain responsible for deriving and authenticating the source digest they supply
- separate expected updates, observations, data steps, and model queries support matched arms whose query budget differs from update/data counts
- strict records require the complete arm-by-seed cross product, one observation identity per seed across arms, exact matched counters, explicit transaction validity, bounded persistent/working-set bytes, and timing telemetry
- canonical v2 reconstruction rejects hostile/non-string mapping keys, duplicate or missing shards, mismatched observations/counters, invalid transactions, noncanonical paths, invalid UTF-8, and floating/resource overflow
- exclusive POSIX retention publishes one immutable report and strictly reloads its canonical bytes
- v2 deliberately supports exactly one control/candidate comparison and permanently forbids scientific promotion

This does not complete any linked issue: issue-specific adapters, frozen plans, authenticated source derivation, executions, validators, and retained reports remain required. No workload or `outputs/` mutation occurred.

Validation after rebasing onto current main:
- `tests/test_matched_development.py`: 16 passed
- focused Ruff: passed
- strict mypy on source and tests: passed
- `git diff --check`: passed