### PR TITLE
fix(optimizers): restore frozen LMS zero-step control

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -591,10 +591,10 @@ class LMS(Optimizer[LMSState]):
             step_size: Fixed learning rate
 
         Raises:
-            ValueError: If ``step_size`` is not a finite non-bool positive real.
+            ValueError: If ``step_size`` is not a finite non-bool nonnegative real.
         """
         self._step_size = validated_float32_scalar(
-            "step_size", step_size, positive=True
+            "step_size", step_size, lower=0.0
         )
 
     def to_config(self) -> dict[str, Any]:

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,5 +1,8 @@
 """Tests for LMS, IDBD, Autostep, and ObGD optimizers."""
 
+from collections.abc import Callable
+from typing import NoReturn
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -18,6 +21,64 @@ from alberta_framework import (
 from alberta_framework.core.optimizers import TDIDBD, AutoTDIDBD
 
 _INT32_MAX = 2**31 - 1
+
+
+class _HostileScalar:
+    calls = 0
+
+    def _explode(self) -> NoReturn:
+        type(self).calls += 1
+        raise AssertionError("hostile scalar hook executed")
+
+    def __float__(self) -> float:
+        self._explode()
+
+    def __eq__(self, other: object) -> bool:
+        self._explode()
+
+    def __lt__(self, other: object) -> bool:
+        self._explode()
+
+
+@pytest.mark.parametrize(
+    ("factory", "field"),
+    [
+        (lambda value: LMS(step_size=value), "step_size"),
+        (lambda value: Autostep(initial_step_size=value), "initial_step_size"),
+        (lambda value: Autostep(meta_step_size=value), "meta_step_size"),
+        (lambda value: Autostep(tau=value), "tau"),
+        (lambda value: ObGD(step_size=value), "step_size"),
+        (lambda value: ObGD(kappa=value), "kappa"),
+        (lambda value: ObGD(gamma=value), "gamma"),
+        (lambda value: ObGD(lamda=value), "lamda"),
+    ],
+)
+def test_optimizer_constructors_reject_hostile_scalars_without_hooks(
+    factory: Callable[[object], object], field: str
+) -> None:
+    hostile = _HostileScalar()
+    _HostileScalar.calls = 0
+    with pytest.raises(ValueError, match=field):
+        factory(hostile)
+    assert _HostileScalar.calls == 0
+
+
+def test_optimizer_constructors_accept_canonical_numpy_scalars() -> None:
+    lms = LMS(step_size=np.float32(0.0))
+    autostep = Autostep(
+        initial_step_size=np.float64(0.01),
+        meta_step_size=np.int32(0),
+        tau=np.float32(2.0),
+    )
+    obgd = ObGD(
+        step_size=np.float32(0.5),
+        kappa=np.int32(0),
+        gamma=np.float64(1.0),
+        lamda=np.float32(0.0),
+    )
+    assert lms.init(1).step_size == 0.0
+    assert autostep.init(1).tau == 2.0
+    assert obgd.init(1).gamma == 1.0
 
 
 class TestLMS:
@@ -53,10 +114,15 @@ class TestLMS:
 
         assert result.new_state.step_size == state.step_size
 
-    @pytest.mark.parametrize("step_size", [float("nan"), float("inf"), 0.0, -0.1, True, False])
+    @pytest.mark.parametrize("step_size", [float("nan"), float("inf"), -0.1, True, False])
     def test_rejects_illegal_step_size(self, step_size: object) -> None:
         with pytest.raises(ValueError, match="step_size"):
             LMS(step_size=step_size)  # type: ignore[arg-type]
+
+    def test_zero_step_size_remains_a_supported_frozen_weight_control(self) -> None:
+        optimizer = LMS(step_size=0.0)
+        assert optimizer.to_config()["step_size"] == 0.0
+        assert optimizer.init(1).step_size == 0.0
 
 
 class TestIDBD:
@@ -680,8 +746,14 @@ class TestObGD:
         "field,value",
         [
             ("gamma", float("nan")),
+            ("gamma", float("inf")),
+            ("gamma", -0.1),
+            ("gamma", 1.1),
             ("gamma", True),
             ("lamda", float("nan")),
+            ("lamda", float("inf")),
+            ("lamda", -0.1),
+            ("lamda", 1.1),
             ("lamda", True),
         ],
     )


### PR DESCRIPTION
Corrective follow-up to merged #1622. The contributor commit/authorship is already preserved on main.

This restores the established `LMS(step_size=0.0)` frozen-weight control used by the real forward-view equivalence path, while retaining exact rejection of bool/negative/nonfinite values. It also keeps the exact positive finite `Autostep.tau` divisor gate and expands zero-hook hostile-scalar, canonical NumPy-scalar, and gamma/lambda boundary coverage across all touched constructors.

Verification: `tests/test_optimizers.py tests/test_forward_view_equivalence.py` 140 passed; scoped Ruff passed; strict mypy on `optimizers.py` passed; diff check passed. No outputs or benchmark execution.