### PR TITLE
fix(benchmarks): expose traced comparator invalidity

### DIFF
--- a/alberta_framework/benchmarks/plasticity_comparators.py
+++ b/alberta_framework/benchmarks/plasticity_comparators.py
@@ -209,7 +209,9 @@ def _threefry_key(name: str, value: object) -> Array:
 def _finite_result(candidate: Array, fallback: Array, *, name: str) -> Array:
     valid = jnp.all(jnp.isfinite(candidate))
     safe = jnp.where(valid, candidate, fallback)
-    if not isinstance(valid, core.Tracer) and not bool(valid):
+    if isinstance(valid, core.Tracer):
+        return jnp.where(valid, safe, jnp.full_like(safe, jnp.nan))
+    if not bool(valid):
         raise ValueError(f"{name} must produce only finite values")
     return safe
 
@@ -229,9 +231,10 @@ def persistent_array_bytes(*arrays: Array | np.ndarray) -> int:
     total = 0
     for value in arrays:
         array: Array | np.ndarray
-        if type(value) is np.ndarray:
+        actual_type = type(value)
+        if actual_type is np.ndarray:
             array = value
-        elif isinstance(value, Array):
+        elif issubclass(actual_type, Array):
             array = value
         else:
             raise ValueError("persistent comparator values must be arrays")
@@ -381,14 +384,15 @@ def adamo_update(
         & jnp.all(jnp.isfinite(moment))
         & jnp.all(jnp.isfinite(variance))
     )
-    safe = (
-        jnp.where(valid, candidate, weights),
-        jnp.where(valid, moment, first_moment),
-        jnp.where(valid, variance, second_moment),
-    )
-    if not isinstance(valid, core.Tracer) and not bool(valid):
+    if isinstance(valid, core.Tracer):
+        return (
+            jnp.where(valid, candidate, jnp.full_like(candidate, jnp.nan)),
+            jnp.where(valid, moment, jnp.full_like(moment, jnp.nan)),
+            jnp.where(valid, variance, jnp.full_like(variance, jnp.nan)),
+        )
+    if not bool(valid):
         raise ValueError("AdamO update must produce only finite values")
-    return safe
+    return candidate, moment, variance
 
 
 def intentional_td_step_size(
@@ -453,16 +457,18 @@ def bounded_elastic_mask(
     prune: int,
 ) -> Array:
     """Static-shape adaptive elastic transition under a hard peak-width bound."""
-    if type(active) is not np.ndarray and not isinstance(active, Array):
+    active_type = type(active)
+    utilities_type = type(utilities)
+    if active_type is not np.ndarray and not issubclass(active_type, Array):
         raise ValueError("active must be a NumPy or JAX array")
-    if type(utilities) is not np.ndarray and not isinstance(utilities, Array):
+    if utilities_type is not np.ndarray and not issubclass(utilities_type, Array):
         raise ValueError("utilities must be a NumPy or JAX array")
     active_np = np.asarray(active)
     utilities_np = np.asarray(utilities)
     if active_np.ndim != 1 or utilities_np.shape != active_np.shape:
         raise ValueError("active and utilities must be matching vectors")
-    if active_np.size > _INT32_MAX:
-        raise ValueError("active mask exceeds the signed-int32 element limit")
+    if active_np.size > _MAX_ARRAY_ELEMENTS:
+        raise ValueError("active mask exceeds the 1000000-element limit")
     if active_np.dtype != np.bool_ or utilities_np.dtype.kind not in "iuf":
         raise ValueError("active must be bool and utilities must be real numeric")
     if not np.isfinite(utilities_np).all():

--- a/tests/test_plasticity_comparators.py
+++ b/tests/test_plasticity_comparators.py
@@ -255,6 +255,29 @@ def test_protocol_and_formula_boundaries_fail_before_dispatch() -> None:
             mode=HostileValue(),  # type: ignore[arg-type]
         )
 
+    class HostileArrayIdentity:
+        calls = 0
+
+        @property
+        def __class__(self) -> type[object]:
+            self.calls += 1
+            raise AssertionError("hostile __class__ must not run")
+
+    hostile_array = HostileArrayIdentity()
+    with pytest.raises(ValueError, match="arrays"):
+        persistent_array_bytes(hostile_array)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="active"):
+        bounded_elastic_mask(hostile_array, np.ones(1), grow=0, prune=0)  # type: ignore[arg-type]
+    assert hostile_array.calls == 0
+
+    with pytest.raises(ValueError, match="element limit"):
+        bounded_elastic_mask(
+            np.zeros(1_000_001, dtype=np.bool_),
+            np.zeros(1_000_001, dtype=np.float32),
+            grow=0,
+            prune=0,
+        )
+
 
 def test_jitted_pure_kernel_matches_eager_without_partial_state() -> None:
     eager = isometry_gradient(jnp.eye(3, dtype=jnp.float32))
@@ -264,8 +287,19 @@ def test_jitted_pure_kernel_matches_eager_without_partial_state() -> None:
     overflowing = jnp.full((2, 2), 1e30, dtype=jnp.float32)
     with pytest.raises(ValueError, match="finite"):
         isometry_gradient(overflowing)
-    np.testing.assert_array_equal(
-        jax.jit(isometry_gradient)(overflowing), jnp.zeros_like(overflowing)
-    )
+    assert bool(jnp.all(jnp.isnan(jax.jit(isometry_gradient)(overflowing))))
+
+    updated = jax.jit(
+        lambda weights: adamo_update(
+            weights,
+            jnp.ones_like(weights),
+            jnp.zeros_like(weights),
+            jnp.zeros_like(weights),
+            step=1,
+            learning_rate=0.01,
+            isometry_strength=1.0,
+        )
+    )(overflowing)
+    assert all(bool(jnp.all(jnp.isnan(value))) for value in updated)
     with pytest.raises(ValueError, match="Threefry"):
         interval_dropout(jnp.ones(1), jnp.asarray([0, 0], dtype=jnp.uint32), relu_probability=1)


### PR DESCRIPTION
## Summary

Residual exact-merge audit for #1618 atop #1617:

- preserve #1618's stronger counter/string/container/array/derived-allocation caps
- stop outer-JIT overflow from being laundered into plausible zeros or unchanged AdamO state; invalid compatibility results now carry NaN while eager calls still raise
- replace remaining `isinstance` array host gates with runtime-type identity/subclass checks so hostile `__class__` hooks cannot execute
- enforce the stated one-million-element elastic-mask cap

Explicit finite-fallback-plus-validity transactions remain the required pattern where a caller needs an inert JIT candidate. These legacy array-only comparator APIs cannot silently discard validity.

## Scope

No benchmark execution, output, result, evidence change, or promotion. #1559-#1567 remain open for end-to-end integration and matched reports.

## Validation

- `python -m pytest tests/test_plasticity_comparators.py -q -o addopts=''` — 13 passed
- scoped Ruff — clean
- strict mypy — clean
- `git diff --check` — clean
