### PR TITLE
fix(benchmarks): reject hostile Forager action containers

### DIFF
--- a/alberta_framework/benchmarks/forager_rng_parity.py
+++ b/alberta_framework/benchmarks/forager_rng_parity.py
@@ -169,7 +169,7 @@ class FixedActionProbeConfig:
             raise ForagerRngParityError("seed must be an integer")
         if not 0 <= self.seed <= MAX_SEED:
             raise ForagerRngParityError(f"seed must lie in [0, {MAX_SEED}]")
-        if not isinstance(self.actions, tuple):
+        if type(self.actions) is not tuple:
             raise ForagerRngParityError("actions must be an immutable tuple")
         if not self.actions or len(self.actions) > MAX_ACTIONS:
             raise ForagerRngParityError(f"actions must contain between 1 and {MAX_ACTIONS} entries")

--- a/tests/test_forager_rng_parity_int_hostile.py
+++ b/tests/test_forager_rng_parity_int_hostile.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import pytest
 
+from alberta_framework.benchmarks.forager_rng_parity import (
+    FixedActionProbeConfig,
+    ForagerRngParityError,
+)
+
 pytestmark = pytest.mark.unit
 
 
@@ -32,15 +37,13 @@ class _HostileInt(int):
 
 
 def test_seed_rejects_hostile_before_comparison() -> None:
-    from alberta_framework.benchmarks.forager_rng_parity import FixedActionProbeConfig
-
     hostile = _HostileInt(0)
     _HostileInt.calls = 0
-    with pytest.raises(Exception, match="must be an integer"):
+    with pytest.raises(ForagerRngParityError, match="must be an integer"):
         FixedActionProbeConfig(seed=hostile, actions=(0,))  # type: ignore[arg-type]
     assert _HostileInt.calls == 0
     # bool also rejected
-    with pytest.raises(Exception, match="must be an integer"):
+    with pytest.raises(ForagerRngParityError, match="must be an integer"):
         FixedActionProbeConfig(seed=True, actions=(0,))  # type: ignore[arg-type]
     # valid still works
     cfg = FixedActionProbeConfig(seed=0, actions=(0,))
@@ -48,14 +51,25 @@ def test_seed_rejects_hostile_before_comparison() -> None:
 
 
 def test_action_rejects_hostile_before_comparison() -> None:
-    from alberta_framework.benchmarks.forager_rng_parity import FixedActionProbeConfig
-
     hostile = _HostileInt(1)
     _HostileInt.calls = 0
-    with pytest.raises(Exception, match="must be an integer"):
+    with pytest.raises(ForagerRngParityError, match="must be an integer"):
         FixedActionProbeConfig(seed=0, actions=(hostile,))  # type: ignore[arg-type]
     assert _HostileInt.calls == 0
-    assert _HostileInt.calls == 0
+
+
+def test_actions_rejects_hostile_tuple_before_container_hooks() -> None:
+    class HostileTuple(tuple[int, ...]):
+        calls = 0
+
+        def __len__(self) -> int:
+            type(self).calls += 1
+            raise AssertionError("hostile len")
+
+    hostile = HostileTuple((0,))
+    with pytest.raises(ForagerRngParityError, match="immutable tuple"):
+        FixedActionProbeConfig(seed=0, actions=hostile)
+    assert HostileTuple.calls == 0
 
 
 def test_hostile_not_in_error_message() -> None:


### PR DESCRIPTION
Follow-up to #1629. The integer identities are now exact, but `FixedActionProbeConfig.actions` still admitted a tuple subclass and invoked its hostile `__len__` before rejection. This applies the same exact-type boundary to the immutable container and tightens the contributor tests to assert the precise exception.\n\nVerification: 54 focused RNG parity/qualification tests, scoped Ruff, strict mypy (186 files), and diff check pass. No workflow was launched and no output/evidence artifact changed.\n\nCo-authored-by: byt61 <271805600+byt61@users.noreply.github.com>