### PR TITLE
docs: expand hillclimb contribution and comparison guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,184 @@
 # Contributing to ASI
 
-Contributions are accepted through GitHub pull requests against `main` and
-are reviewed under the repository's normal maintainer process. By submitting
-a contribution, you agree that it is licensed under the repository's
-Apache-2.0 license and that you have the right to submit it on those terms.
+ASI is a continual-learning hillclimb. Contributions are judged by the uncertainty they resolve
+and the end-to-end progress they enable, not by diff size or the number of new mechanisms.
 
-Keep changes bounded, include reproducible commands and evidence for benchmark
-claims, and follow the requirements in `AGENTS.md`. Maintainers decide whether
-to accept, reject, hold, or request changes to a contribution.
+Contributions are accepted through GitHub pull requests against `main` and reviewed under the
+repository's normal maintainer process. By submitting a contribution, you agree that it is
+licensed under the repository's Apache-2.0 license and that you have the right to submit it on
+those terms. Maintainers decide whether to accept, reject, hold, or request changes.
+
+Before starting, read the [research roadmap](docs/research/asi-roadmap.md),
+[current status](docs/status.md), [SOTA landscape](docs/research/sota-landscape.md),
+[evidence methodology](docs/evidence/methodology.md), and
+[negative-results ledger](docs/evidence/negative-results.md). For Forager work, also read
+[FORAGER_BENCHMARK.md](FORAGER_BENCHMARK.md).
+
+## Choose an uphill contribution
+
+The strongest contributions do at least one of the following:
+
+- complete or challenge the current reference-life scorecard;
+- reproduce a competitive published method under an ASI protocol;
+- connect an existing mechanism to a real observation-to-action consumer;
+- disprove a plausible mechanism hypothesis with a cheap, decisive ablation;
+- demonstrate recurrence, transfer, or control benefit for a subsystem winner;
+- close an ownership, checkpoint, resource, safety, or application gate; or
+- improve strict reproducibility, provenance, or claim validation.
+
+A new API without a named consumer and metric is usually not uphill. A favorable benchmark result
+without a matched control, resource accounting, and protocol identity is not a result ASI can
+use.
+
+## Propose the experiment before the expensive run
+
+An experiment proposal should answer:
+
+1. **Bottleneck:** What observed failure or uncertainty limits the current baseline?
+2. **Hypothesis:** What mechanism should change which metric, and why?
+3. **Control:** What current-source baseline and contemporary competitor will be rerun?
+4. **Ablation:** What smallest comparison distinguishes the proposed mechanism from capacity,
+   compute, replay, pretraining, task cues, or tuning?
+5. **Protocol:** What stream/environment version, horizon, schedule, seeds, primary statistic,
+   uncertainty calculation, and multiple-comparison rule are fixed?
+6. **Resources:** What trainable and persistent state, examples, updates, replay, model queries,
+   wall time, peak memory, and latency are charged?
+7. **Failure condition:** What result ends or redirects the idea?
+8. **Integration:** Which reference-agent path could consume the winner, and what regression panel
+   must it pass?
+
+Use development data to choose and reject ideas. Do not describe a development protocol as
+preregistered, held out, or promoting. A scientific evaluation is a separate, explicitly
+authorized protocol frozen before its untouched seeds are observed.
+
+## Reproducing a paper
+
+The [research library](docs/research/sota-landscape.md) is the comparison backlog. When adding or
+updating an entry, record:
+
+- paper title, stable primary-source link, version/date, and official code when available;
+- the exact claimed setting and metric;
+- architecture, optimizer, task information, replay/pretraining, and update budget;
+- why the result is or is not comparable to an ASI lane;
+- local status: unreviewed, paper-audited, implementation-planned, implemented, smoke-checked,
+  development-screened, development-confirmed, or scientifically evaluated;
+- the smallest faithful implementation and an inert/reduction test where possible; and
+- licenses or dependency constraints that affect reuse.
+
+Do not copy a reported number into an ASI leaderboard unless the protocol is demonstrably the
+same. Permuted-MNIST variants often differ in task count, examples per task, batch size, boundary
+signals, replay, pretraining, evaluation timing, and metric. World-model comparisons often differ
+in observation modality, replay ratio, pretraining data, planning budget, and model size. Report
+those differences rather than normalizing them away in prose.
+
+For a faithful local comparator:
+
+- pin the source revision and dependency/runtime identities;
+- preserve the authors' method before adding ASI adaptations;
+- test the published update rule on a small deterministic case;
+- add a reduction test showing that disabling the mechanism recovers its declared base when the
+  mathematics says it should;
+- rerun the base in the same runner, process model, and seed schedule; and
+- keep paper reproduction, protocol adaptation, and novel composition as separate arms.
+
+## Development workflow
+
+Use Python 3.12 and the project virtual environment:
+
+```bash
+python3.12 -m venv .venv
+.venv/bin/python -m pip install -e '.[dev]'
+```
+
+Library changes are failing-test-first. State is normally an immutable Chex dataclass/JAX PyTree,
+and all stochastic roots use explicit `jax.random` keys. Keep `requires-python >= 3.12`,
+`numpy >= 1.26`, and the existing `alberta_framework` import surface intact because the sibling
+robot track imports it in-process.
+
+Run the narrowest useful checks first:
+
+```bash
+.venv/bin/python -m pytest tests/path/to/test_file.py -q
+.venv/bin/python -m pytest -m "not slow and not package" tests -q
+.venv/bin/python -m ruff check .
+.venv/bin/python -m mypy
+```
+
+Before handoff, broaden in proportion to risk:
+
+```bash
+.venv/bin/python -m pytest tests -q
+.venv/bin/python -m pytest --collect-only -q
+.venv/bin/alberta-evidence-status
+```
+
+The test markers are:
+
+- `unit`: fast isolated behavior and contracts;
+- `integration`: component, persistence, process, or CLI boundaries;
+- `scientific`: a frozen promoted-evidence protocol;
+- `slow`: more than roughly 30 seconds serial and excluded from fast CI; and
+- `package`: built-distribution and installed-entry-point checks.
+
+Benchmarks and campaigns run through their scripts or CLIs, never inside ordinary pytest. Keep
+tests cheap unless a lane is deliberately registered as scientific.
+
+## Evidence and output safety
+
+Never auto-promote. Passing tests, successful replay, more seeds, or a larger effect does not
+change a run's promotion class.
+
+Pinned evidence and sealed campaign artifacts are immutable. Do not edit, overwrite, regenerate
+in place, or delete them. In particular, preserve the paths named in `CLAUDE.md`/`AGENTS.md`,
+including the five-claim registry artifacts and sealed Forager roots. Active IPMNIST and UPGD
+campaign directories are append-only. New work uses a new path and, when its contract requires
+it, a new schema version.
+
+Registered source hashes are load-bearing. Before editing evaluation or benchmark code:
+
+```bash
+.venv/bin/alberta-evidence-status
+```
+
+Source drift making an artifact `invalid` is correct fail-closed behavior. Do not silence it by
+changing hashes, broadening a compatibility exception, weakening validation, or editing the
+artifact. Explain the invalidation and follow the protocol's re-evaluation rules.
+
+Development, calibration, and consumed evidence seeds never become untouched promotion seeds.
+Thresholds are calibrated on development data with margin, then frozen before a claim-bearing
+run. A failed frozen gate remains a valid rejection.
+
+## Pull-request checklist
+
+- [ ] The change names a bottleneck, hypothesis, consumer, and success/failure condition.
+- [ ] The live control is rerun or the reason it is unnecessary is explicit.
+- [ ] Comparators are strong, current, and protocol-matched; mismatches are disclosed.
+- [ ] RNG, state ownership, checkpointing, and resource costs are explicit.
+- [ ] Tests cover the failure first and include reduction/inert behavior where relevant.
+- [ ] Development, release, and scientific evidence classes are not conflated.
+- [ ] No pinned artifact was mutated and no consumed seed was relabeled.
+- [ ] Negative or bounded outcomes are recorded durably.
+- [ ] `README.md`, `docs/status.md`, the research library, and runbooks are updated only where the
+      implementation or evidence actually changed.
+- [ ] `CLAUDE.md` and `AGENTS.md` remain byte-identical.
+- [ ] Targeted tests, fast tests, Ruff, mypy, and evidence status were run or any environment
+      blocker is reported.
+
+## Documentation style
+
+Use **ASI** for the current project. Preserve Alberta names for upstream history, Plan-specific
+mechanisms, compatibility APIs/CLIs, and historical evidence IDs. Avoid unscoped words such as
+“solved,” “SOTA,” “production,” “safe,” or “complete.” A SOTA statement must name its benchmark
+and version, protocol, resource envelope, metric, comparison roster, statistical rule, evidence
+class, and as-of date.
+
+Overview documents point to mutable result indexes instead of copying rankings that will drift.
+If adding a root document, link it from `README.md`. `CLAUDE.md` and `AGENTS.md` are identical by
+policy: author the former and copy the exact content to the latter.
+
+## Review standard
+
+Reviewers should ask whether the change makes the next decision more reliable. Correctness and
+reproducibility are necessary, but mechanism count is not progress by itself. A clean negative
+result that closes an attractive dead end is welcome; record it so the project does not pay for
+the same lesson twice.

--- a/docs/research/sota-landscape.md
+++ b/docs/research/sota-landscape.md
@@ -147,6 +147,107 @@ questions. They belong in an application comparison only after ASI names a
 matching allowance and metric; importing their headline accuracy into the
 IPMNIST or Forager table would be misleading.
 
+## Alberta Plan and adjacent programs
+
+The [Alberta Plan](https://arxiv.org/abs/2208.11173) is a research agenda for continual,
+computationally limited, model-based intelligence. It is neither a benchmark nor a completed
+architecture, so repositories that expose all twelve named surfaces are not automatically
+competitors at the whole-agent evidence level.
+
+- [`lalalune/alberta`](https://github.com/lalalune/alberta) is ASI's direct upstream. Its README
+  describes all twelve Steps as implemented and benchmarked; ASI's fork-point audit and current
+  evidence rules deliberately interpret mechanism/API presence more narrowly. See
+  [`VENDORING.md`](../../VENDORING.md).
+- [OpenMind Research Institute](https://www.openmindresearch.org/) explicitly uses the Alberta
+  Plan as a starting point and publishes adjacent research proposals. Monitor its work on
+  continual meta-learning, real-time robotics, average-reward learning, and big-world agents for
+  concrete algorithms and public code; an agenda reference alone is not a comparator.
+- [Position: Deployed RL Should Be Continual](https://arxiv.org/abs/2606.04029) (ICML 2026
+  position track) argues against train-then-fix deployment and emphasizes monitoring,
+  nonstationarity, and continual adaptation. It supports ASI's application framing but reports no
+  algorithmic result to beat.
+- Sutton's [publication index](https://incompleteideas.net/publications.html) is a useful primary
+  discovery route for SwiftTD/Swift-Sarsa, reward centering, big-world work, Horde, Dyna, options,
+  and follow-ons that may not use the words “Alberta Plan” in their titles.
+
+Searches for “ASI” are dominated by unrelated Artificial Superintelligence projects and do not
+define a technical comparison class. ASI comparisons should be selected by operational
+properties—continual updates, retention/reuse, prediction, planning, control, and bounded
+resources—not by name overlap.
+
+## Continual reinforcement learning and benchmarks
+
+The single machine-readable setup authority is
+[`external_qualification.py`](../../alberta_framework/benchmarks/external_qualification.py).
+It pins audited upstream revisions and bounded qualification contracts while keeping incompatible
+external stacks out of ASI's base environment. A registered source or smoke qualification does
+not mean an agent adapter or comparison result exists.
+
+| Benchmark or system | What it measures | Fit and gap for ASI |
+|---|---|---|
+| [Forager](https://arxiv.org/abs/2605.01131) / [agents](https://github.com/steventango/continual-foragax-agents) | Lightweight, constant-memory-footprint, partially observable continual RL; emphasizes state construction and unending tasks. | Closest active R3 benchmark. ASI has extensive tooling but no completed matched-resource scientific comparison. |
+| [Continual World](https://arxiv.org/abs/2105.10919) / [code](https://github.com/awarelab/continual_world) | Meta-World robot-task sequences emphasizing forward transfer, forgetting, and compute/capacity constraints. | Valuable R3→R4 bridge, but task boundaries, episodic resets, MuJoCo version, and million-step budgets differ from the current life. |
+| [CORA](https://arxiv.org/abs/2110.10067) / [code](https://github.com/AGI-Labs/continual_rl) | Atari, Procgen, NetHack, and CHORES with continual evaluation, isolated forgetting, and zero-shot forward transfer. | Strong metric and baseline source; expensive and predominantly task-sequence based. |
+| [COOM](https://github.com/TTomilin/COOM) | Pixel-based Doom task sequences with average performance, forgetting, and forward transfer. | Useful robustness/representation lane after a smaller R3 control closes. |
+| [Continual Bench / FTL Online Agent](https://arxiv.org/abs/2507.09177) | Online shallow world model plus MPC across reward-defined continual tasks, with a regret result under stated assumptions. | Closest model-based competitor to ASI's FTL line; reproduce before extending the historically accepted, currently invalid narrow decision-fidelity artifact. |
+| [C-CHAIN](https://arxiv.org/abs/2506.00592) | Continual nonstationarity across Gym Control, ProcGen, DMC, and MinAtar. | Contemporary plasticity baseline; audit precise task sequences and replay/batch settings first. |
+
+Additional project sources:
+
+- [Papers of Continual RL](https://github.com/datake/Papers-Of-Continual-RL) and
+  [ContinualAI papers](https://github.com/ContinualAI/continual-learning-papers) are discovery
+  indexes, not primary evidence.
+- [CompoNet](https://github.com/mikelma/componet) provides code for self-composing policies on
+  Atari and Meta-World; potentially relevant to options/composition after primitive reference-life
+  gates close.
+- [FAME](https://github.com/datake/FAME) is a contemporary continual-RL implementation to audit
+  for fast/meta learner controls after the reference baseline exists.
+
+## World models, JEPA, and prediction architectures
+
+World-model results answer at least four different questions: representation quality, prediction,
+planning/control, and continual retention/adaptation. ASI should not infer one from another.
+
+### Online and continual world models
+
+| Work | Main reported result | Required ASI comparison discipline |
+|---|---|---|
+| [DreamerV3](https://arxiv.org/abs/2301.04104) / [JAX code](https://github.com/danijar/dreamerv3) | One configuration across more than 150 tasks; learns behavior through latent imagination. | Charge replay capacity, train ratio, model size, imagination queries, and environment interaction. It is a strong general MBRL baseline, not inherently continual. |
+| [Continual-Dreamer](https://arxiv.org/abs/2211.15944) | Studies world-model design choices for continual RL and task-agnostic continual exploration. | Reproduce on a modern, version-pinned base before comparison. |
+| [WMAR](https://arxiv.org/abs/2401.16650) | Augments DreamerV3 replay for Procgen/Atari continual sequences and reports improved forgetting behavior. | Explicitly compare equal replay bytes and task sequences; separate retention from online utility. |
+| [FTL Online Agent](https://arxiv.org/abs/2507.09177) | Shallow online world model plus MPC reportedly outperforms deep-world-model CL variants on Continual Bench. | Priority because it is online and analytically bounded; reproduce model/planning assumptions exactly. |
+
+### JEPA and reconstruction-free prediction
+
+| Work | Main reported result | ASI use |
+|---|---|---|
+| [V-JEPA 2](https://arxiv.org/abs/2506.09985) | Large-scale self-supervised video model; action-conditioned post-training enables zero-shot image-goal robot planning. | R4 reference for physical prediction. Web-scale pretraining makes it incomparable to from-scratch continual learning; isolate architecture from imported data. |
+| [JEPA-WM physical planning study](https://arxiv.org/abs/2512.24497) / [code](https://github.com/facebookresearch/jepa-wms) | Studies architecture, objective, and planner choices and reports gains over DINO-WM and V-JEPA-2-AC on navigation/manipulation. | Best current design/ablation reference for latent physical planning; paper/code/checkpoints available. |
+| [Dreamer-CDP](https://arxiv.org/abs/2603.07083) / [code](https://github.com/fmi-basel/Dreamer-CDP) | JEPA-style continuous deterministic representation prediction matches reconstruction-based Dreamer on Crafter. | Highest-priority small reconstruction-free comparator; JAX and close to an actionable ablation. |
+| [JEDI](https://arxiv.org/abs/2605.13013) | End-to-end latent diffusion world model reports competitive Atari100k performance with lower VRAM and faster training/sampling than pixel diffusion. | Longer-term stochastic latent model; resource accounting is central, and it is not yet continual evidence. |
+| [NE-Dreamer](https://github.com/corl-team/nedreamer) | Decoder-free next-embedding prediction with a temporal transformer. | Candidate after Dreamer-CDP; reproduce only when its final paper/protocol is stable. |
+| [DayDreamer](https://github.com/danijar/daydreamer) | World-model learning on physical robots using replay and latent imagination. | Robotics systems reference for actor/learner separation, not evidence of continual adaptation or ASI readiness. |
+
+For each world-model proposal, measure one-step and rollout prediction only as diagnostics. The
+acceptance metric must include decision or control utility under a matched real-transition,
+model-query, update, memory, and latency budget. Test model error under recurrence and dynamics
+change, not only stationary held-out sequences.
+
+## Open-source comparison ecosystem
+
+| Project | Useful role | Caution |
+|---|---|---|
+| [Avalanche](https://github.com/ContinualAI/avalanche) | Standard strategies, scenarios, metrics, and dataset construction. | Mostly PyTorch and conventional experience-based CL; metrics are not automatically compatible with ASI streams. |
+| [Mammoth](https://github.com/aimagelab/mammoth) | Broad maintained method/dataset roster including Permuted MNIST and MNIST-360. | Many methods rely on pretrained encoders, replay, epochs, or task/class scenarios. Use as discovery and regression reference. |
+| [ContinualAI baselines](https://github.com/ContinualAI/continual-learning-baselines) | Reproduction ledger showing expected versus reproduced performance. | Excellent warning against trusting paper tables; not a common-runner result for ASI. |
+| [GM van de Ven continual-learning](https://github.com/GMvandeVen/continual-learning) | Clear implementations of replay, regularization, generative replay, and task-free streams. | PyTorch and different evaluation semantics; useful for algorithm audits. |
+| [lop-jax](https://github.com/KevinGuo27/lop-jax) | JAX implementations of L2-ER, CBP, layer norm, spectral controls across PMNIST, ImageNet, CIFAR, and Slippery Ant. | Most direct source for the priority L2-ER port; pin a revision and audit the PMNIST protocol. |
+| [UPGD](https://github.com/mohmdelsayed/upgd) | Official source for ASI's IPMNIST anchor. | Keep official reproduction distinct from local adaptations. |
+
+Repository popularity is not evidence quality. Before reusing code, inspect its license, last
+working revision, dependencies, configuration defaults, data preprocessing, metric implementation,
+and whether reported results can actually be regenerated.
+
 ## Measurement work required before any SOTA claim
 
 1. Stabilize and bind the source tree; the current merge work invalidates new


### PR DESCRIPTION
Narrow salvage from closed #1630, rebuilt on current main in response to the maintainer review.

- expands the already-merged inbound CONTRIBUTING policy with the hillclimb experiment proposal, paper-reproduction, matched-resource, evidence/artifact, testing, and PR review standards
- extends the existing protocol-aware comparison landscape with Alberta-adjacent programs, continual-RL benchmarks/projects, Dreamer and JEPA/world-model work, and open-source comparison ecosystems
- points setup identity to the one existing bounded external_qualification.py authority
- preserves README and agent-guide artifact pointers; adds no moving local measurements, live registry verdict, duplicate catalog, backlog publisher, or issue manifest

Validation: release-metadata tests passed and diff check is clean. Documentation only; no output/evidence mutation and no SOTA claim.