### PR TITLE
ci: keep reference-life scorecard manual-only

### DIFF
--- a/.github/workflows/reference-life-scorecard-dev.yml
+++ b/.github/workflows/reference-life-scorecard-dev.yml
@@ -2,9 +2,6 @@ name: reference-life development scorecard
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - .github/workflows/reference-life-scorecard-dev.yml
 
 permissions:
   contents: read

--- a/tests/test_reference_life_scorecard_workflow.py
+++ b/tests/test_reference_life_scorecard_workflow.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/reference-life-scorecard-dev.yml")
+
+
+def test_reference_life_scorecard_is_manual_only() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    trigger_block = text.split("permissions:", maxsplit=1)[0]
+    assert "workflow_dispatch:" in trigger_block
+    assert "pull_request:" not in trigger_block
+    assert "push:" not in trigger_block
+
+
+def test_reference_life_scorecard_keeps_the_frozen_cross_product() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert all(f"- {seed}" in text for seed in range(70_000, 70_012))
+    assert 'test "$count" = 144' in text


### PR DESCRIPTION
Corrects merged #1637 before another workflow edit can automatically launch the 144-shard development campaign.

- removes the accidental pull_request trigger while retaining manual workflow_dispatch
- adds a retained regression that enforces manual-only dispatch and the literal 12-seed/144-shard cross product
- records that cancelled run 32101727660 executed zero shard steps and is not evidence

Verification: 2 focused tests, Ruff, actionlint, diff check. No benchmark run or output mutation. #1585 remains open until an intentional frozen-source dispatch succeeds, is independently validated, and is retained append-only.