### PR TITLE
fix(ci): keep reference scorecard manual-only

### DIFF
--- a/.github/workflows/reference-life-scorecard-dev.yml
+++ b/.github/workflows/reference-life-scorecard-dev.yml
@@ -2,9 +2,6 @@ name: reference-life development scorecard
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - .github/workflows/reference-life-scorecard-dev.yml
 
 permissions:
   contents: read
@@ -68,7 +65,7 @@ jobs:
           name: reference-life-shards-${{ matrix.seed }}
           path: scorecard/shards/*.json
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 90
 
   aggregate:
     name: aggregate and validate
@@ -110,7 +107,7 @@ jobs:
       - name: Upload complete validated campaign
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: reference-life-scorecard-validated
+          name: reference-life-scorecard-validated-${{ github.sha }}
           path: scorecard
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 90


### PR DESCRIPTION
Removes the accidental pull-request trigger from the long 144-process development scorecard. The campaign now runs only through explicit workflow dispatch, retains temporary Actions artifacts for 90 days, and includes the executed source SHA in the aggregate artifact name. A successful run still requires independent validation and append-only repository integration before #1585 can close.