### PR TITLE
ci: retain source-bound reference scorecard artifacts

### DIFF
--- a/.github/workflows/reference-life-scorecard-dev.yml
+++ b/.github/workflows/reference-life-scorecard-dev.yml
@@ -65,7 +65,7 @@ jobs:
           name: reference-life-shards-${{ matrix.seed }}
           path: scorecard/shards/*.json
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 90
 
   aggregate:
     name: aggregate and validate
@@ -107,7 +107,7 @@ jobs:
       - name: Upload complete validated campaign
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: reference-life-scorecard-validated
+          name: reference-life-scorecard-validated-${{ github.sha }}
           path: scorecard
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 90


### PR DESCRIPTION
Contributor-preserving current-main successor to #1645 after #1644 already removed the accidental automatic trigger. Keeps only the unique improvements: 90-day retention for shard and aggregate artifacts, and the exact checkout SHA in the aggregate artifact name. The workflow remains manual-only and #1585 remains open pending an intentional successful run, independent validation, and append-only integration. Verification: actionlint, 2 workflow regressions, diff check. No workflow dispatched and no outputs mutated.