### PR TITLE
fix(core): preserve invalid AdamO penalty semantics

### DIFF
--- a/alberta_framework/core/adamo.py
+++ b/alberta_framework/core/adamo.py
@@ -153,7 +153,12 @@ def isometry_penalty(weight: Array) -> Array:
         gram = matrix @ matrix.T
         identity = jnp.eye(rows, dtype=matrix.dtype)
     candidate = jnp.sum(jnp.square(gram - identity))
-    return jnp.where(jnp.isfinite(candidate), candidate, jnp.zeros_like(candidate))
+    valid = jnp.isfinite(candidate)
+    if isinstance(valid, jax.core.Tracer):
+        return jnp.where(valid, candidate, jnp.full_like(candidate, jnp.nan))
+    if not bool(valid):
+        raise ValueError("isometry penalty must be finite")
+    return candidate
 
 
 def isometry_gradient(weight: Array) -> Array:

--- a/tests/test_adamo.py
+++ b/tests/test_adamo.py
@@ -32,6 +32,22 @@ def test_closed_form_gradient_matches_autodiff(shape: tuple[int, int]) -> None:
     np.testing.assert_allclose(isometry_gradient(weight), expected, rtol=1e-5, atol=1e-5)
 
 
+@pytest.mark.parametrize(
+    "weight",
+    [
+        jnp.full((2, 2), jnp.finfo(jnp.float32).max),
+        jnp.asarray([[jnp.nan]], dtype=jnp.float32),
+    ],
+)
+def test_penalty_preserves_invalidity_in_eager_and_traced_calls(weight: jax.Array) -> None:
+    with pytest.raises(ValueError, match="isometry penalty must be finite"):
+        isometry_penalty(weight)
+
+    traced = jax.jit(isometry_penalty)(weight)
+    assert bool(jnp.isnan(traced))
+    assert float(traced) != 0.0
+
+
 def test_zero_strength_reduces_exactly_to_adam_task_step() -> None:
     config = AdamOConfig(
         step_size=1e-3, beta1=0.9, beta2=0.99, eps=1e-8, isometry_strength=0.0


### PR DESCRIPTION
A narrow post-merge correction for the AdamO penalty diagnostic.

`isometry_penalty` previously converted a nonfinite Gram-deviation result to `0.0`, which is the exact value for perfect isometry. Finite overflow and NaN inputs could therefore be misreported as the optimum.

This change follows the repository comparator boundary convention:

- eager invalid results raise `ValueError`
- traced/JIT invalid results carry NaN so enclosing checked transactions can reject them
- valid eager, JIT, and autodiff behavior remains unchanged
- regressions cover both finite float32 overflow and an explicit NaN input

Validation:

- `tests/test_adamo.py`: 18 passed
- `tests/test_adamo.py tests/test_ipmnist_screening.py`: 353 passed
- scoped Ruff: passed
- strict mypy on `core/adamo.py`: passed
- diff check: passed

No benchmark, workflow, output artifact, evidence claim, or issue closure is included.