### PR TITLE
fix(benchmarks): reject hostile causal-map shape containers

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -172,7 +172,7 @@ class CausalMapForagerConfig:
 
     def __post_init__(self) -> None:
         if (
-            not isinstance(self.world_shape, tuple)
+            type(self.world_shape) is not tuple
             or len(self.world_shape) != 2
             or any(
                 type(value) is not int or value < 1

--- a/tests/test_causal_map_int_hostile.py
+++ b/tests/test_causal_map_int_hostile.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+from alberta_framework.benchmarks.causal_map_forager import CausalMapForagerConfig
+
 pytestmark = pytest.mark.unit
 
 
@@ -24,8 +26,6 @@ class _HostileInt(int):
 
 
 def test_world_shape_rejects_hostile_before_lt() -> None:
-    from alberta_framework.benchmarks.causal_map_forager import CausalMapForagerConfig
-
     hostile = _HostileInt(2)
     _HostileInt.calls = 0
     with pytest.raises(Exception, match="world_shape"):
@@ -34,6 +34,20 @@ def test_world_shape_rejects_hostile_before_lt() -> None:
     assert CausalMapForagerConfig(world_shape=(2, 2)).world_shape == (2, 2)
     with pytest.raises(Exception, match="world_shape"):
         CausalMapForagerConfig(world_shape=(True, 2))  # type: ignore[arg-type]
+
+
+def test_world_shape_rejects_hostile_tuple_before_length_hooks() -> None:
+    class HostileTuple(tuple[int, int]):
+        calls = 0
+
+        def __len__(self) -> int:
+            type(self).calls += 1
+            raise AssertionError("hostile len")
+
+    hostile = HostileTuple((2, 2))
+    with pytest.raises(ValueError, match="world_shape"):
+        CausalMapForagerConfig(world_shape=hostile)
+    assert HostileTuple.calls == 0
 
 
 def test_seed_rejects_hostile_before_range() -> None:


### PR DESCRIPTION
Follow-up to #1639. `world_shape` scalar identities were hardened, but the enclosing container still admitted a tuple subclass and invoked its hostile `__len__` hook. Require the exact immutable tuple before inspecting it. NumPy scalar seed compatibility is unchanged.\n\nVerification: full causal-map panel already passed at #1639 (149 tests); corrective hostile panel 5 passed; scoped Ruff, strict mypy (186 files), and diff check pass. No workflow or output/evidence artifact changed.\n\nCo-authored-by: byt61 <271805600+byt61@users.noreply.github.com>