### PR TITLE
fix(benchmarks): close adjacent hostile numeric gates

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -59,6 +59,26 @@ CAUSAL_MAP_VARIANT_KIND = "alberta_causal_map"
 _CAUSAL_MAP_RNG_NAMESPACE = 0xCA05A14
 _CAUSAL_MAP_PRNG_IMPL = "threefry2x32"
 _CAUSAL_MAP_ENVIRONMENT_PRNG_IMPL = "threefry2x32"
+_EXACT_NUMPY_INTEGER_TYPES = (
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+)
+_EXACT_INTEGER_TYPES = (int, *_EXACT_NUMPY_INTEGER_TYPES)
+_EXACT_REAL_TYPES = (
+    int,
+    float,
+    *_EXACT_NUMPY_INTEGER_TYPES,
+    np.float16,
+    np.float32,
+    np.float64,
+    np.longdouble,
+)
 
 
 def _require_exact_str(name: object, value: object) -> str:
@@ -196,8 +216,7 @@ class CausalMapForagerConfig:
         ):
             value = getattr(self, name)
             if (
-                isinstance(value, bool)
-                or not isinstance(value, (int, float, np.integer, np.floating))
+                type(value) not in _EXACT_REAL_TYPES
                 or not math.isfinite(value)
                 or not _finite_float32(value)
             ):
@@ -213,8 +232,7 @@ class CausalMapForagerConfig:
         for name in positive_float:
             value = getattr(self, name)
             if (
-                isinstance(value, bool)
-                or not isinstance(value, (int, float, np.integer, np.floating))
+                type(value) not in _EXACT_REAL_TYPES
                 or not math.isfinite(value)
                 or value <= 0.0
                 or not _finite_float32(value)
@@ -234,8 +252,7 @@ class CausalMapForagerConfig:
         for name in nonnegative_float:
             value = getattr(self, name)
             if (
-                isinstance(value, bool)
-                or not isinstance(value, (int, float, np.integer, np.floating))
+                type(value) not in _EXACT_REAL_TYPES
                 or not math.isfinite(value)
                 or value < 0.0
                 or not _finite_float32(value)
@@ -243,11 +260,7 @@ class CausalMapForagerConfig:
                 raise ValueError(f"{name} must be finite and non-negative")
             object.__setattr__(self, name, float(value))
         if (
-            isinstance(self.exploration_probability, bool)
-            or not isinstance(
-                self.exploration_probability,
-                (int, float, np.integer, np.floating),
-            )
+            type(self.exploration_probability) not in _EXACT_REAL_TYPES
             or not math.isfinite(self.exploration_probability)
             or not 0.0 <= self.exploration_probability <= 1.0
             or not _finite_float32(self.exploration_probability)
@@ -258,7 +271,7 @@ class CausalMapForagerConfig:
             "exploration_probability",
             float(self.exploration_probability),
         )
-        if not isinstance(self.arrival_aware_readiness, bool):
+        if type(self.arrival_aware_readiness) is not bool:
             raise ValueError("arrival_aware_readiness must be a boolean")
         positive_int = (
             "initial_retry_delay",
@@ -270,16 +283,14 @@ class CausalMapForagerConfig:
         for name in positive_int:
             value = getattr(self, name)
             if (
-                isinstance(value, bool)
-                or not isinstance(value, (int, np.integer))
+                type(value) not in _EXACT_INTEGER_TYPES
                 or value < 1
                 or value > _INT32_MAX
             ):
                 raise ValueError(f"{name} must be a positive integer")
             object.__setattr__(self, name, int(value))
         if (
-            isinstance(self.maximum_retry_exponent, bool)
-            or not isinstance(self.maximum_retry_exponent, (int, np.integer))
+            type(self.maximum_retry_exponent) not in _EXACT_INTEGER_TYPES
             or self.maximum_retry_exponent < 0
             or self.maximum_retry_exponent > _INT32_MAX
         ):
@@ -290,8 +301,7 @@ class CausalMapForagerConfig:
             int(self.maximum_retry_exponent),
         )
         if (
-            isinstance(self.maximum_exact_interval_width, bool)
-            or not isinstance(self.maximum_exact_interval_width, (int, np.integer))
+            type(self.maximum_exact_interval_width) not in _EXACT_INTEGER_TYPES
             or self.maximum_exact_interval_width < 0
             or self.maximum_exact_interval_width > _INT32_MAX
         ):
@@ -315,11 +325,7 @@ class CausalMapForagerConfig:
                 "maximum_respawn_delay must be at least minimum_respawn_delay"
             )
         if (
-            isinstance(self.respawn_safety_quantile, bool)
-            or not isinstance(
-                self.respawn_safety_quantile,
-                (int, float, np.integer, np.floating),
-            )
+            type(self.respawn_safety_quantile) not in _EXACT_REAL_TYPES
             or not math.isfinite(self.respawn_safety_quantile)
             or not 0.5 <= self.respawn_safety_quantile < 1.0
             or not _finite_float32(self.respawn_safety_quantile)
@@ -433,8 +439,7 @@ class CausalMapForagerConfig:
             raise ValueError(f"unknown causal-map config fields: {sorted(unknown)}")
         config = cls(**data)
         if declared_quantile_z is not None and (
-            isinstance(declared_quantile_z, bool)
-            or not isinstance(declared_quantile_z, (int, float))
+            type(declared_quantile_z) not in (int, float)
             or not math.isclose(
                 float(declared_quantile_z),
                 config.respawn_quantile_z,
@@ -2034,8 +2039,7 @@ def validate_causal_map_state(
     if channel_count < 1:
         raise ValueError("state must contain at least one observation channel")
     if observation_channels is not None and (
-        isinstance(observation_channels, bool)
-        or not isinstance(observation_channels, (int, np.integer))
+        type(observation_channels) not in _EXACT_INTEGER_TYPES
         or observation_channels < 1
     ):
         raise ValueError("observation_channels must be a positive integer")
@@ -2637,7 +2641,7 @@ class CausalMapForagerAgent:
         if config is not None and not isinstance(config, CausalMapForagerConfig):
             raise TypeError("config must be a CausalMapForagerConfig")
         self.config = config if config is not None else CausalMapForagerConfig()
-        if type(seed) is not int and not isinstance(seed, np.integer):
+        if type(seed) not in _EXACT_INTEGER_TYPES:
             raise ValueError("seed must be a uint32-compatible integer")
         self.seed = int(seed)
         if not 0 <= self.seed <= np.iinfo(np.uint32).max:
@@ -2848,8 +2852,7 @@ def _validate_benchmark_contract(
 ) -> None:
     env = benchmark_config.environment
     if (
-        isinstance(benchmark_config.steps, bool)
-        or not isinstance(benchmark_config.steps, int)
+        type(benchmark_config.steps) is not int
         or benchmark_config.steps < 1
         or benchmark_config.steps >= _INT32_MAX
     ):
@@ -2857,8 +2860,7 @@ def _validate_benchmark_contract(
             "causal-map benchmark steps must be a positive int below int32 maximum"
         )
     if (
-        isinstance(benchmark_config.jax_chunk_size, bool)
-        or not isinstance(benchmark_config.jax_chunk_size, int)
+        type(benchmark_config.jax_chunk_size) is not int
         or benchmark_config.jax_chunk_size < 1
         or benchmark_config.jax_chunk_size >= _INT32_MAX
     ):
@@ -3530,7 +3532,7 @@ def run_causal_map_forager_seeds(
     if not raw_seeds:
         raise ValueError("seeds must be non-empty")
     if any(
-        type(seed) is not int and not isinstance(seed, np.integer)
+        type(seed) not in _EXACT_INTEGER_TYPES
         for seed in raw_seeds
     ):
         raise ValueError("seeds must be uint32-compatible integers without coercion")

--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -474,7 +474,7 @@ class ForagerMatrixManifest:
             raise ValueError("schema_version must be a non-empty string")
         for attr in ("steps", "jax_chunk_size", "seed_batch_size"):
             val = getattr(self, attr)
-            if type(val) is not int or isinstance(val, bool) or val <= 0:
+            if type(val) is not int or val <= 0:
                 raise ValueError(f"{attr} must be a positive integer")
         if type(self.selection_rule) is not ForagerTuningRule:
             raise TypeError("selection_rule must be a ForagerTuningRule")
@@ -1106,8 +1106,7 @@ def _parse_tuning_rule(value: Any) -> ForagerTuningRule:
     try:
         normalized_confidence = (
             float(confidence_value)
-            if not isinstance(confidence_value, bool)
-            and isinstance(confidence_value, (int, float))
+            if type(confidence_value) in (int, float)
             else math.nan
         )
     except (OverflowError, ValueError):
@@ -2800,8 +2799,7 @@ def _validate_source_snapshot_bytes(
         raise ForagerMatrixStateError(f"{description} metadata contract is invalid")
     archive_size = metadata["archive_size"]
     if (
-        isinstance(archive_size, bool)
-        or not isinstance(archive_size, int)
+        type(archive_size) is not int
         or not 0 < archive_size <= _MAX_SOURCE_ARCHIVE_BYTES
         or len(archive_bytes) != archive_size
     ):
@@ -4500,8 +4498,7 @@ def _validate_execution_manifest_structure(payload: Mapping[str, Any]) -> None:
         if type(identity[name]) is not str or _SHA256.fullmatch(identity[name]) is None:
             raise ForagerMatrixStateError(f"execution identity {name} is invalid")
     if (
-        isinstance(identity["source_archive_size"], bool)
-        or not isinstance(identity["source_archive_size"], int)
+        type(identity["source_archive_size"]) is not int
         or not 0 < identity["source_archive_size"] <= _MAX_SOURCE_ARCHIVE_BYTES
     ):
         raise ForagerMatrixStateError("execution identity source_archive_size is invalid")
@@ -4652,20 +4649,17 @@ def _validate_trace_descriptor(
     maximum_size = _maximum_canonical_trace_size(expected_steps)
     if (
         descriptor["schema_version"] != _RAW_TRACE_SCHEMA
-        or isinstance(seed, bool)
-        or not isinstance(seed, int)
+        or type(seed) is not int
         or seed != expected_seed
         or descriptor["format"] != _RAW_TRACE_FORMAT
-        or isinstance(steps, bool)
-        or not isinstance(steps, int)
+        or type(steps) is not int
         or steps != expected_steps
         or descriptor["biome_regret_present"] is not True
         or type(location) is not str
         or (expected_output_path is not None and location != expected_output_path)
         or type(descriptor["sha256"]) is not str
         or _SHA256.fullmatch(descriptor["sha256"]) is None
-        or isinstance(descriptor["size"], bool)
-        or not isinstance(descriptor["size"], int)
+        or type(descriptor["size"]) is not int
         or descriptor["size"] < 1
         or descriptor["size"] > maximum_size
     ):
@@ -5444,14 +5438,14 @@ def _run_from_payload(
         )
     seed = payload["seed"]
     steps = payload["steps"]
-    if isinstance(seed, bool) or not isinstance(seed, int) or seed != expected_seed:
+    if type(seed) is not int or seed != expected_seed:
         raise ForagerMatrixStateError(f"{path}.seed does not match its batch")
-    if isinstance(steps, bool) or not isinstance(steps, int) or steps != expected_steps:
+    if type(steps) is not int or steps != expected_steps:
         raise ForagerMatrixStateError(f"{path}.steps does not match the matrix horizon")
 
     curve_steps_raw = payload["curve_steps"]
     if not isinstance(curve_steps_raw, list) or any(
-        isinstance(item, bool) or not isinstance(item, int) or item < 1 or item > steps
+        type(item) is not int or item < 1 or item > steps
         for item in curve_steps_raw
     ):
         raise ForagerMatrixStateError(f"{path}.curve_steps is invalid")
@@ -5473,7 +5467,7 @@ def _run_from_payload(
             f"{path}.curve_steps must increase strictly from 1 through steps"
         )
     record_every = expected_metric_contract.get("record_every_steps")
-    if isinstance(record_every, bool) or not isinstance(record_every, int) or record_every < 1:
+    if type(record_every) is not int or record_every < 1:
         raise ForagerMatrixStateError(f"{path} metric contract has invalid record cadence")
     expected_curve_steps = sorted(
         {
@@ -5507,8 +5501,7 @@ def _run_from_payload(
         raise ForagerMatrixStateError(f"{path} Alberta configuration hash mismatch")
     metadata_seed = agent_metadata.get("seed")
     if (
-        isinstance(metadata_seed, bool)
-        or not isinstance(metadata_seed, int)
+        type(metadata_seed) is not int
         or metadata_seed != seed
     ):
         raise ForagerMatrixStateError(f"{path} agent and environment seeds differ")
@@ -5554,11 +5547,9 @@ def _run_from_payload(
     chunk_size = runner.get("chunk_size")
     runner_kind = runner.get("kind")
     if (
-        isinstance(batch_size, bool)
-        or not isinstance(batch_size, int)
+        type(batch_size) is not int
         or batch_size != len(expected_batch_seeds)
-        or isinstance(chunk_size, bool)
-        or not isinstance(chunk_size, int)
+        or type(chunk_size) is not int
         or chunk_size != expected_chunk_size
     ):
         raise ForagerMatrixStateError(f"{path} runner batch/chunk metadata is invalid")

--- a/alberta_framework/benchmarks/forager_rng_parity.py
+++ b/alberta_framework/benchmarks/forager_rng_parity.py
@@ -874,8 +874,7 @@ def _validate_key_frame(value: KeyFrame, expected: KeyFrame, path: str) -> None:
             not isinstance(words, tuple)
             or len(words) != 2
             or any(
-                isinstance(word, bool)
-                or not isinstance(word, int)
+                type(word) is not int
                 or not 0 <= word <= _KEY_WORD_MAX
                 for word in words
             )

--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -266,7 +266,7 @@ class OfficialForagaxRunRequest:
                 )
         if not self.config_path.parts:
             raise OfficialForagaxValidationError("config_path must not be empty")
-        if not isinstance(self.gpu, bool):
+        if type(self.gpu) is not bool:
             raise OfficialForagaxValidationError("gpu must be a boolean")
         if type(self.expected_repository) is not str:
             raise OfficialForagaxValidationError(
@@ -287,8 +287,7 @@ class OfficialForagaxRunRequest:
                 "config_commit must be a full lowercase 40-character Git SHA"
             )
         if (
-            isinstance(self.index, bool)
-            or not isinstance(self.index, int)
+            type(self.index) is not int
             or self.index < 0
             or self.index > OFFICIAL_FORAGAX_MAX_SEED
         ):
@@ -296,8 +295,7 @@ class OfficialForagaxRunRequest:
                 f"index must be an integer in [0, {OFFICIAL_FORAGAX_MAX_SEED}]"
             )
         if self.expected_seed is not None and (
-            isinstance(self.expected_seed, bool)
-            or not isinstance(self.expected_seed, int)
+            type(self.expected_seed) is not int
             or self.expected_seed < 0
             or self.expected_seed > OFFICIAL_FORAGAX_MAX_SEED
         ):
@@ -306,8 +304,7 @@ class OfficialForagaxRunRequest:
                 f"[0, {OFFICIAL_FORAGAX_MAX_SEED}]"
             )
         if self.max_env_steps is not None and (
-            isinstance(self.max_env_steps, bool)
-            or not isinstance(self.max_env_steps, int)
+            type(self.max_env_steps) is not int
             or self.max_env_steps < 1
         ):
             raise OfficialForagaxValidationError("max_env_steps must be positive")
@@ -350,8 +347,7 @@ class OfficialForagaxBatchRunRequest:
                 "a batch request must contain at least two indices"
             )
         if any(
-            isinstance(index, bool)
-            or not isinstance(index, int)
+            type(index) is not int
             or index < 0
             or index > OFFICIAL_FORAGAX_MAX_SEED
             for index in indices
@@ -376,8 +372,7 @@ class OfficialForagaxBatchRunRequest:
                     "expected_seeds must have one entry per requested index"
                 )
             if any(
-                isinstance(seed, bool)
-                or not isinstance(seed, int)
+                type(seed) is not int
                 or seed < 0
                 or seed > OFFICIAL_FORAGAX_MAX_SEED
                 for seed in expected_seeds
@@ -4859,8 +4854,7 @@ def _semantic_environment(probe: Mapping[str, Any]) -> dict[str, Any]:
     reward_delay = raw.get("reward_delay", 0)
     random_shift_max_steps = raw.get("random_shift_max_steps", 0)
     if (
-        isinstance(aperture_size, bool)
-        or not isinstance(aperture_size, int)
+        type(aperture_size) is not int
         or (aperture_size != -1 and (aperture_size < 1 or aperture_size % 2 == 0))
     ):
         raise OfficialForagaxValidationError(
@@ -5442,8 +5436,7 @@ def prepare_official_foragax_run(
             "official config problem must be exactly 'Foragax'"
         )
     if (
-        isinstance(configured_env_steps, bool)
-        or not isinstance(configured_env_steps, int)
+        type(configured_env_steps) is not int
         or configured_env_steps < 1
     ):
         raise OfficialForagaxValidationError(
@@ -5601,8 +5594,7 @@ def prepare_official_foragax_run(
         family: Literal["continuing", "ppo"] = "ppo"
         entrypoint = "src/rtu_ppo.py"
         if (
-            isinstance(rollout_steps, bool)
-            or not isinstance(rollout_steps, int)
+            type(rollout_steps) is not int
             or rollout_steps < 1
         ):
             raise OfficialForagaxValidationError(
@@ -5612,8 +5604,7 @@ def prepare_official_foragax_run(
         if configured_updates is None:
             configured_updates = configured_env_steps // rollout_steps + 1
         if (
-            isinstance(configured_updates, bool)
-            or not isinstance(configured_updates, int)
+            type(configured_updates) is not int
             or configured_updates < 1
         ):
             raise OfficialForagaxValidationError(
@@ -10055,8 +10046,7 @@ def verify_official_foragax_manifest(
     )
     expected_steps = run.get("expected_result_env_steps")
     if (
-        isinstance(expected_steps, bool)
-        or not isinstance(expected_steps, int)
+        type(expected_steps) is not int
         or expected_steps < 1
     ):
         raise OfficialForagaxValidationError(
@@ -10409,8 +10399,7 @@ def verify_official_foragax_batch_manifest(
         )
         expected_steps = run_entry.get("expected_result_env_steps")
         if (
-            isinstance(expected_steps, bool)
-            or not isinstance(expected_steps, int)
+            type(expected_steps) is not int
             or expected_steps < 1
         ):
             raise OfficialForagaxValidationError(

--- a/tests/test_causal_map_int_hostile.py
+++ b/tests/test_causal_map_int_hostile.py
@@ -23,6 +23,18 @@ class _HostileInt(int):
         raise AssertionError("hostile gt")
 
 
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:
+        type(self).calls += 1
+        raise AssertionError("hostile float conversion")
+
+    def __lt__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile float lt")
+
+
 def test_world_shape_rejects_hostile_before_lt() -> None:
     from alberta_framework.benchmarks.causal_map_forager import CausalMapForagerConfig
 
@@ -45,6 +57,20 @@ def test_seed_rejects_hostile_before_range() -> None:
         CausalMapForagerAgent(seed=hostile)  # type: ignore[arg-type]
     assert _HostileInt.calls == 0
     assert CausalMapForagerAgent(seed=0).seed == 0
+
+
+def test_config_rejects_hostile_numeric_subclasses_before_hooks() -> None:
+    from alberta_framework.benchmarks.causal_map_forager import CausalMapForagerConfig
+
+    hostile_int = _HostileInt(10)
+    hostile_float = _HostileFloat(0.1)
+    _HostileInt.calls = 0
+    _HostileFloat.calls = 0
+    with pytest.raises(Exception, match="initial_retry_delay"):
+        CausalMapForagerConfig(initial_retry_delay=hostile_int)  # type: ignore[arg-type]
+    with pytest.raises(Exception, match="distance_cost"):
+        CausalMapForagerConfig(distance_cost=hostile_float)  # type: ignore[arg-type]
+    assert _HostileInt.calls == _HostileFloat.calls == 0
 
 
 def test_seeds_rejects_hostile_before_lt() -> None:

--- a/tests/test_forager_matrix_int_hostile.py
+++ b/tests/test_forager_matrix_int_hostile.py
@@ -101,6 +101,26 @@ def test_finite_number_rejects_hostile_before_float() -> None:
     assert _finite_number(1.0, "p") == 1.0
 
 
+def test_tuning_rule_rejects_hostile_confidence_before_float() -> None:
+    from alberta_framework.benchmarks.forager_matrix import _parse_tuning_rule
+
+    hostile = _HostileFloat(0.95)
+    _HostileFloat.calls = 0
+    with pytest.raises(Exception, match="confidence must be finite"):
+        _parse_tuning_rule(
+            {
+                "metric": "mean_reward",
+                "direction": "maximize",
+                "statistic": "mean",
+                "confidence": hostile,
+                "bootstrap_resamples": 100,
+                "bootstrap_seed": 0,
+                "tie_break": "variant_id_lexicographic",
+            }
+        )
+    assert _HostileFloat.calls == 0
+
+
 def test_hostile_not_in_error_message() -> None:
     hostile = _HostileInt(1)
     _HostileInt.calls = 0

--- a/tests/test_forager_matrix_manifest_hostile_validation.py
+++ b/tests/test_forager_matrix_manifest_hostile_validation.py
@@ -31,6 +31,18 @@ class _ExplodingPattern:
         raise AssertionError("pattern matching must follow exact-type validation")
 
 
+class _HostileInt(int):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile integer equality must not execute")
+
+    def __lt__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile integer ordering must not execute")
+
+
 @pytest.fixture
 def dummy_rule() -> ForagerTuningRule:
     return ForagerTuningRule(
@@ -122,6 +134,27 @@ def test_state_payload_identity_gates_reject_string_subclasses_before_dispatch(
             description="hostile payload",
         )
     assert _HostileString.calls == _ExplodingPattern.calls == 0
+
+
+def test_source_snapshot_rejects_hostile_archive_size_before_comparison() -> None:
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(ForagerMatrixStateError, match="archive size is invalid"):
+        matrix._validate_source_snapshot_bytes(
+            b"x",
+            {
+                "path": matrix.SOURCE_SNAPSHOT_FILENAME,
+                "archive_format": matrix.SOURCE_ARCHIVE_FORMAT,
+                "archive_sha256": hashlib.sha256(b"x").hexdigest(),
+                "archive_size": hostile,
+                "tree_sha256": "0" * 64,
+                "inventory_sha256": "0" * 64,
+                "inventory": {},
+                "source_execution_mode": matrix.SNAPSHOT_SOURCE_EXECUTION_MODE,
+            },
+            description="hostile snapshot",
+        )
+    assert _HostileInt.calls == 0
 
     with pytest.raises(ForagerMatrixStateError, match="UTC timestamp"):
         matrix._validate_utc_timestamp(hostile, "hostile timestamp")

--- a/tests/test_official_foragax_int_hostile.py
+++ b/tests/test_official_foragax_int_hostile.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+
+from alberta_framework.benchmarks.official_foragax import (
+    OfficialForagaxBatchRunRequest,
+    OfficialForagaxRunRequest,
+    OfficialForagaxValidationError,
+    _semantic_environment,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -25,33 +34,47 @@ class _HostileInt(int):
 
 def test_reward_delay_rejects_hostile_before_lt() -> None:
     _HostileInt.calls = 0
-    # Simulate the gate: if type(value) is not int or value < 0
     hostile = _HostileInt(0)
-    assert (type(hostile) is not int or hostile < 0) is True  # type check first
+    with pytest.raises(OfficialForagaxValidationError, match="reward_delay is invalid"):
+        _semantic_environment(
+            {
+                "environment": {
+                    "env_id": "ForagaxTwoBiomeLarge-v1",
+                    "reward_delay": hostile,
+                }
+            }
+        )
     assert _HostileInt.calls == 0
-    assert (int is not int or 0 < 0) is False
-    # bool also rejected
-    assert (bool is not int or True < 0) is True  # type(True) is bool != int
 
 
 def test_batch_indices_rejects_hostile_before_range() -> None:
     _HostileInt.calls = 0
     hostile = _HostileInt(1)
-    # any(type(index) is not int for index in indices)
-    indices = [hostile]  # type: ignore[list-item]
-    assert any(type(x) is not int for x in indices) is True
+    with pytest.raises(OfficialForagaxValidationError, match="batch indices"):
+        OfficialForagaxBatchRunRequest(
+            repository=Path("repo"),
+            execution_commit="0" * 40,
+            config_path=Path("config.json"),
+            interpreter=Path("python"),
+            output_dir=Path("out"),
+            indices=(0, hostile),  # type: ignore[arg-type]
+        )
     assert _HostileInt.calls == 0
-    # valid
-    assert any(type(x) is not int for x in [1, 2, 3]) is False
 
 
 def test_batch_entry_rejects_hostile_before_eq() -> None:
     _HostileInt.calls = 0
     hostile = _HostileInt(1)
-    # type(index) is not int or type(seed) is not int
-    assert (type(hostile) is not int or int is not int) is True
+    with pytest.raises(OfficialForagaxValidationError, match="index must be"):
+        OfficialForagaxRunRequest(
+            repository=Path("repo"),
+            execution_commit="0" * 40,
+            config_path=Path("config.json"),
+            interpreter=Path("python"),
+            output_dir=Path("out"),
+            index=hostile,  # type: ignore[arg-type]
+        )
     assert _HostileInt.calls == 0
-    assert (int is not int or int is not int) is False
 
 
 def test_hostile_not_in_error_message() -> None:


### PR DESCRIPTION
Deep follow-up to contributor PRs #1629, #1633, #1635, and #1639, whose commits are now on main.

The originals correctly closed their reported venues. This successor closes adjacent exact-type gaps in the same four trust boundaries: decoded source/trace/run identities, tuning confidence, official request/config/result records, RNG key frames, and causal-map numeric configuration/state gates. It preserves supported exact NumPy scalar types while rejecting user-defined numeric subclasses before conversion/comparison hooks. Weak simulated tests are replaced by real parser/constructor calls.

Verification: 24 focused hostile tests, Ruff, strict mypy, and an earlier broader 220-test Forager panel all passed. No benchmark or output execution.

Credits @byt61 for the four original audits and tests.