### PR TITLE
feat(benchmarks): add audited L2-ER IPMNIST comparator

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -181,6 +181,21 @@ from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
     select_transaction,
 )
+from alberta_framework.evaluation.l2er_ipmnist_nonpromoting import (
+    COMPARISON_ID as L2ER_COMPARISON_ID,
+)
+from alberta_framework.evaluation.l2er_ipmnist_nonpromoting import (
+    OFFICIAL_COMMIT as L2ER_OFFICIAL_COMMIT,
+)
+from alberta_framework.evaluation.l2er_ipmnist_nonpromoting import (
+    PAPER_REVISION as L2ER_PAPER_REVISION,
+)
+from alberta_framework.evaluation.l2er_ipmnist_nonpromoting import (
+    RESULT_SCHEMA as L2ER_RESULT_SCHEMA,
+)
+from alberta_framework.evaluation.l2er_ipmnist_nonpromoting import (
+    validate_l2er_development_result,
+)
 from alberta_framework.evaluation.recurring_ipmnist_retention import (
     RecurringIPMNISTPhase,
     RecurringIPMNISTProtocol,
@@ -408,6 +423,139 @@ def _step_metrics(
         1.0 - loss_after / jnp.maximum(loss, _PLASTICITY_LOSS_FLOOR), 0.0, 1.0
     )
     return accuracy, loss, plasticity
+
+
+# =============================================================================
+# Adapted L2-ER comparator (Prakash et al., ICML 2026)
+# =============================================================================
+
+
+@chex.dataclass(frozen=True, mappable_dataclass=False)
+class L2ERState:
+    """The charged 100-example ER buffer and its next insertion index."""
+
+    example_buffer: Array
+    buffer_count: Array
+
+
+def l2er_effective_rank(features: Array, epsilon: float = 1e-8) -> Array:
+    """Official entropy effective-rank estimator for one activation matrix."""
+    singular_values = jnp.abs(jnp.linalg.svdvals(features.T))
+
+    def normalized(values: Array) -> Array:
+        scale = jnp.max(values)
+        scaled = values / scale
+        denominator = jnp.maximum(jnp.sum(scaled), epsilon / scale)
+        return scaled / denominator
+
+    probabilities = jax.lax.cond(
+        jnp.max(singular_values) > 0.0,
+        normalized,
+        jnp.zeros_like,
+        singular_values,
+    )
+    entropy = -jnp.sum(probabilities * jnp.log(probabilities + epsilon))
+    return jnp.exp(entropy)
+
+
+def l2er_effective_rank_loss(
+    params: dict[str, Array], examples: Array, epsilon: float = 1e-8
+) -> Array:
+    """Negative mean effective rank over the current MLP's hidden layers."""
+    hidden1 = jax.nn.relu(examples @ params["w1"] + params["b1"])
+    hidden2 = jax.nn.relu(hidden1 @ params["w2"] + params["b2"])
+    return -jnp.mean(
+        jnp.stack(
+            (
+                l2er_effective_rank(hidden1, epsilon),
+                l2er_effective_rank(hidden2, epsilon),
+            )
+        )
+    )
+
+
+def l2er_update(
+    params: dict[str, Array],
+    state: L2ERState,
+    grads: dict[str, Array],
+    example: Array,
+    hp: Mapping[str, float],
+) -> tuple[dict[str, Array], L2ERState]:
+    """One supervised SGD/L2 step and the scheduled separate ER step.
+
+    This restates ``lop-jax``'s Permuted-MNIST ordering: each ordinary update
+    first uses ``grad + weight_decay * parameter``; after each full ER block,
+    one gradient step minimizes negative mean hidden effective rank.  The ER
+    step does not advance or alter the ordinary optimizer state.
+    """
+    step_size = hp["step_size"]
+    weight_decay = hp["weight_decay"]
+    supervised_params = {
+        name: value - step_size * (grads[name] + weight_decay * value)
+        for name, value in params.items()
+    }
+    batch_size = int(hp["er_batch_size"])
+    buffered = state.example_buffer.at[state.buffer_count].set(example)
+    next_count = state.buffer_count + jnp.asarray(1, dtype=jnp.int32)
+    complete = next_count == batch_size
+
+    if hp["er_enabled"] == 1.0:
+        er_step_size = hp["er_step_size"]
+        epsilon = hp["er_epsilon"]
+
+        def apply_er(operand: tuple[dict[str, Array], Array]) -> dict[str, Array]:
+            current_params, batch = operand
+            er_grads = jax.grad(l2er_effective_rank_loss)(current_params, batch, epsilon)
+            return {
+                name: value - er_step_size * er_grads[name]
+                for name, value in current_params.items()
+            }
+
+        new_params = jax.lax.cond(
+            complete,
+            apply_er,
+            lambda operand: operand[0],
+            (supervised_params, buffered),
+        )
+    else:
+        new_params = supervised_params
+    new_state = L2ERState(  # type: ignore[call-arg]
+        example_buffer=jax.lax.cond(
+            complete, jnp.zeros_like, lambda value: value, buffered
+        ),
+        buffer_count=jnp.where(complete, jnp.asarray(0, dtype=jnp.int32), next_count),
+    )
+    return new_params, new_state
+
+
+def _make_l2er_learner(
+    hp: Mapping[str, float],
+) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    """Build one registered L2/ER reduction on the current IPMNIST MLP."""
+    if hp["er_batch_size"] != 100.0 or hp["er_steps_per_batch"] != 1.0:
+        raise ValueError("the audited lop-jax comparator requires ER batch 100 and one ER step")
+    if hp["er_epsilon"] != 1e-8 or hp["er_enabled"] not in (0.0, 1.0):
+        raise ValueError("the L2-ER estimator constants do not match the audited revision")
+
+    def init_fn(params: dict[str, Array]) -> L2ERState:
+        return L2ERState(  # type: ignore[call-arg]
+            example_buffer=jnp.zeros(
+                (int(hp["er_batch_size"]), params["w1"].shape[0]), dtype=jnp.float32
+            ),
+            buffer_count=jnp.asarray(0, dtype=jnp.int32),
+        )
+
+    def full_step(
+        params: dict[str, Array], state: L2ERState, x: Array, y: Array, key: Array
+    ) -> tuple[dict[str, Array], L2ERState, StepMetrics]:
+        del key
+        (loss, logits), grads = jax.value_and_grad(cross_entropy_loss, has_aux=True)(
+            params, x, y
+        )
+        new_params, new_state = l2er_update(params, state, grads, x, hp)
+        return new_params, new_state, _step_metrics(new_params, x, y, loss, logits)
+
+    return init_fn, full_step
 
 
 def _wrap_grad_learner(
@@ -6857,6 +7005,65 @@ def _build_registry() -> dict[str, ScreeningSpec]:
             ),
         )
     )
+    # L2-ER is adapted from lop-jax commit 52ae3eb: exact estimator and
+    # alternating update semantics on ASI's current, matched IPMNIST runner.
+    # The center of each official sweep grid is predeclared here; this is not
+    # represented as the paper's selected hyperparameter configuration.
+    l2er_base: dict[str, float] = {
+        "step_size": 1e-3,
+        "er_batch_size": 100.0,
+        "er_steps_per_batch": 1.0,
+        "er_epsilon": 1e-8,
+    }
+    for arm_name, weight_decay, er_step_size, er_enabled, arm_description in (
+        (
+            "l2er_mechanism_off",
+            0.0,
+            0.0,
+            0.0,
+            "Matched plain-SGD mechanism-off control with the charged ER buffer.",
+        ),
+        (
+            "l2er_l2_only",
+            1e-4,
+            0.0,
+            0.0,
+            "L2-only reduction at the center of the official weight-decay grid.",
+        ),
+        (
+            "l2er_er_only",
+            0.0,
+            1e-3,
+            1.0,
+            "Effective-rank-only reduction at the center of the official ER grid.",
+        ),
+        (
+            "l2er_combined",
+            1e-4,
+            1e-3,
+            1.0,
+            "Combined L2-ER at the centers of the official sweep grids.",
+        ),
+    ):
+        specs.append(
+            ScreeningSpec(
+                name=arm_name,
+                base_learner="upgd_w",
+                mechanism="l2_effective_rank",
+                hyperparameters={
+                    **l2er_base,
+                    "weight_decay": weight_decay,
+                    "er_step_size": er_step_size,
+                    "er_enabled": er_enabled,
+                },
+                factory=_make_l2er_learner,
+                description=(
+                    arm_description
+                    + " Exact lop-jax entropy-rank estimator and update ordering; "
+                    "adapted architecture/stream differences are protocol-bound."
+                ),
+            )
+        )
     return {spec.name: spec for spec in specs}
 
 
@@ -7922,6 +8129,68 @@ class ScreeningRunResult:
         )
 
 
+def l2er_development_result_payload(
+    result: ScreeningRunResult, *, outcome: str
+) -> dict[str, object]:
+    """Build and strictly validate one nonpromoting L2-ER result receipt."""
+    spec = screening_spec(result.config_name)
+    if spec.mechanism != "l2_effective_rank" or result.noise_mode != "step":
+        raise ValueError("an L2-ER receipt requires an exact-step registered L2-ER arm")
+    if result.hyperparameters != spec.hyperparameters:
+        raise ValueError("result hyperparameters drift from the registered L2-ER arm")
+    config = result.config
+    observations = config.n_tasks * config.task_length
+    er_enabled = spec.hyperparameters["er_enabled"] == 1.0
+    er_batch_size = int(spec.hyperparameters["er_batch_size"])
+    er_updates = observations // er_batch_size if er_enabled else 0
+    parameter_count = (
+        config.input_dim * config.hidden1
+        + config.hidden1
+        + config.hidden1 * config.hidden2
+        + config.hidden2
+        + config.hidden2 * config.n_classes
+        + config.n_classes
+    )
+    persistent_bytes = 4 * (parameter_count + er_batch_size * config.input_dim + 1)
+    payload: dict[str, object] = {
+        "schema": L2ER_RESULT_SCHEMA,
+        "comparison_id": L2ER_COMPARISON_ID,
+        "paper_revision": L2ER_PAPER_REVISION,
+        "official_commit": L2ER_OFFICIAL_COMMIT,
+        "arm": result.config_name,
+        "seed": result.seed,
+        "n_tasks": config.n_tasks,
+        "task_length": config.task_length,
+        "input_dim": config.input_dim,
+        "hidden1": config.hidden1,
+        "hidden2": config.hidden2,
+        "n_classes": config.n_classes,
+        "observations": observations,
+        "updates": observations,
+        "allowed_boundary_information": [],
+        "allowed_task_information": ["current_example_label"],
+        "hyperparameters": dict(spec.hyperparameters),
+        "metrics": {
+            "mean_online_accuracy": float(np.mean(result.per_task_accuracy)),
+            "mean_loss": float(np.mean(result.per_task_loss)),
+            "mean_plasticity": float(np.mean(result.per_task_plasticity)),
+        },
+        "resources": {
+            "persistent_bytes": persistent_bytes,
+            "environment_steps": 0,
+            "data_steps": observations,
+            "model_queries": 2 * observations + er_updates,
+            "timing_seconds": float(result.wall_clock_seconds),
+            "timing_is_telemetry_only": True,
+        },
+        "outcome": outcome,
+        "outcome_retained": True,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+    }
+    return validate_l2er_development_result(payload)
+
+
 def run_screening_config(
     data_x: np.ndarray | Array,
     data_y: np.ndarray | Array,
@@ -7954,6 +8223,10 @@ def run_screening_config(
         raise ValueError("progress_every must be a positive integer or None")
     resolved_seed = require_jax_seed(seed, name="seed")
     noise_mode = _validated_screening_noise_mode(noise_mode, spec)
+    if spec.mechanism == "l2_effective_rank":
+        er_batch_size = int(spec.hyperparameters["er_batch_size"])
+        if config.task_length % er_batch_size != 0:
+            raise ValueError("L2-ER requires task_length divisible by er_batch_size")
     effective_noise_pool_steps = _validated_screening_noise_pool_steps(
         noise_mode,
         noise_pool_steps if noise_mode == "pool" else None,

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -429,6 +429,90 @@ def _step_metrics(
 # Adapted L2-ER comparator (Prakash et al., ICML 2026)
 # =============================================================================
 
+_L2ER_ARRAY_ELEMENTS = 1_000_000
+_L2ER_MAX_WORKING_BYTES = 256 * 1024 * 1024
+_L2ER_KEYS = frozenset(("w1", "b1", "w2", "b2", "w3", "b3"))
+_L2ER_HP_KEYS = frozenset(
+    (
+        "step_size",
+        "weight_decay",
+        "er_step_size",
+        "er_batch_size",
+        "er_steps_per_batch",
+        "er_epsilon",
+        "er_enabled",
+    )
+)
+
+
+def _l2er_array(value: object, *, name: str, ndim: int | None = None) -> Array:
+    actual_type = type(value)
+    if actual_type is not np.ndarray and not issubclass(
+        actual_type, (jax.Array, jax.core.Tracer)
+    ):
+        raise ValueError(f"{name} must be an exact NumPy or JAX array")
+    array = jnp.asarray(value)
+    if (
+        array.size < 1
+        or array.size > _L2ER_ARRAY_ELEMENTS
+        or not jnp.issubdtype(array.dtype, jnp.floating)
+        or (ndim is not None and array.ndim != ndim)
+    ):
+        raise ValueError(f"{name} must be a bounded float array with the required rank")
+    return array
+
+
+def _l2er_hp(hp: object) -> dict[str, float]:
+    if type(hp) is not dict or frozenset(hp) != _L2ER_HP_KEYS:
+        raise ValueError("L2-ER hyperparameters must be one exact registered object")
+    checked: dict[str, float] = {}
+    for name in _L2ER_HP_KEYS:
+        value = hp[name]
+        if type(value) is not float or not math.isfinite(value) or value < 0.0:
+            raise ValueError(f"L2-ER hyperparameter {name} must be a finite float")
+        checked[name] = value
+    if (
+        checked["er_batch_size"] != 100.0
+        or checked["er_steps_per_batch"] != 1.0
+        or checked["er_epsilon"] != 1e-8
+        or checked["er_enabled"] not in (0.0, 1.0)
+    ):
+        raise ValueError("L2-ER hyperparameters do not match the audited protocol")
+    return checked
+
+
+def _l2er_preflight_svd(features: Array) -> None:
+    smaller = min(features.shape)
+    if smaller and smaller > (2**31 - 1) // smaller:
+        raise ValueError("L2-ER SVD working elements exceed signed int32")
+    if smaller * smaller * features.dtype.itemsize > _L2ER_MAX_WORKING_BYTES:
+        raise ValueError("L2-ER SVD working set exceeds 256 MiB")
+
+
+def _l2er_params(params: object) -> dict[str, Array]:
+    if type(params) is not dict or frozenset(params) != _L2ER_KEYS:
+        raise ValueError("params must be one exact protocol MLP tree")
+    checked = {
+        name: _l2er_array(value, name=f"params.{name}")
+        for name, value in params.items()
+    }
+    w1, b1 = checked["w1"], checked["b1"]
+    w2, b2 = checked["w2"], checked["b2"]
+    w3, b3 = checked["w3"], checked["b3"]
+    if (
+        w1.ndim != 2
+        or b1.shape != (w1.shape[1],)
+        or w2.ndim != 2
+        or w2.shape[0] != w1.shape[1]
+        or b2.shape != (w2.shape[1],)
+        or w3.ndim != 2
+        or w3.shape[0] != w2.shape[1]
+        or b3.shape != (w3.shape[1],)
+        or any(value.dtype != jnp.dtype(jnp.float32) for value in checked.values())
+    ):
+        raise ValueError("params must match the float32 protocol MLP shapes")
+    return checked
+
 
 @chex.dataclass(frozen=True, mappable_dataclass=False)
 class L2ERState:
@@ -440,6 +524,14 @@ class L2ERState:
 
 def l2er_effective_rank(features: Array, epsilon: float = 1e-8) -> Array:
     """Official entropy effective-rank estimator for one activation matrix."""
+    features = _l2er_array(features, name="features", ndim=2)
+    if type(epsilon) is not float or not math.isfinite(epsilon) or epsilon <= 0.0:
+        raise ValueError("epsilon must be an exact finite positive float")
+    _l2er_preflight_svd(features)
+    finite = jnp.all(jnp.isfinite(features))
+    if not isinstance(finite, jax.core.Tracer) and not bool(finite):
+        raise ValueError("features must contain only finite values")
+    features = jnp.where(finite, features, jnp.zeros_like(features))
     singular_values = jnp.abs(jnp.linalg.svdvals(features.T))
 
     def normalized(values: Array) -> Array:
@@ -455,15 +547,32 @@ def l2er_effective_rank(features: Array, epsilon: float = 1e-8) -> Array:
         singular_values,
     )
     entropy = -jnp.sum(probabilities * jnp.log(probabilities + epsilon))
-    return jnp.exp(entropy)
+    candidate = jnp.exp(entropy)
+    return jnp.where(jnp.isfinite(candidate), candidate, jnp.asarray(1.0, features.dtype))
 
 
 def l2er_effective_rank_loss(
     params: dict[str, Array], examples: Array, epsilon: float = 1e-8
 ) -> Array:
     """Negative mean effective rank over the current MLP's hidden layers."""
-    hidden1 = jax.nn.relu(examples @ params["w1"] + params["b1"])
-    hidden2 = jax.nn.relu(hidden1 @ params["w2"] + params["b2"])
+    examples = _l2er_array(examples, name="examples", ndim=2)
+    checked_params = _l2er_params(params)
+    if examples.shape[1] != checked_params["w1"].shape[0]:
+        raise ValueError("examples and first-layer parameter shapes must match")
+    for width in (checked_params["w1"].shape[1], checked_params["w2"].shape[1]):
+        if examples.shape[0] > _L2ER_ARRAY_ELEMENTS // width:
+            raise ValueError("L2-ER activation allocation exceeds the element limit")
+    finite = jnp.asarray(True, dtype=jnp.bool_)
+    for value in checked_params.values():
+        finite = finite & jnp.all(jnp.isfinite(value))
+    if not isinstance(finite, jax.core.Tracer) and not bool(finite):
+        raise ValueError("params must contain only finite values")
+    checked_params = {
+        name: jnp.where(finite, value, jnp.zeros_like(value))
+        for name, value in checked_params.items()
+    }
+    hidden1 = jax.nn.relu(examples @ checked_params["w1"] + checked_params["b1"])
+    hidden2 = jax.nn.relu(hidden1 @ checked_params["w2"] + checked_params["b2"])
     return -jnp.mean(
         jnp.stack(
             (
@@ -488,20 +597,51 @@ def l2er_update(
     one gradient step minimizes negative mean hidden effective rank.  The ER
     step does not advance or alter the ordinary optimizer state.
     """
-    step_size = hp["step_size"]
-    weight_decay = hp["weight_decay"]
-    supervised_params = {
-        name: value - step_size * (grads[name] + weight_decay * value)
-        for name, value in params.items()
+    checked_hp = _l2er_hp(hp)
+    if type(state) is not L2ERState:
+        raise ValueError("state must be an exact L2ERState")
+    if type(params) is not dict or type(grads) is not dict:
+        raise ValueError("params and grads must be exact dicts")
+    if frozenset(params) != _L2ER_KEYS or frozenset(grads) != _L2ER_KEYS:
+        raise ValueError("params and grads must contain the exact protocol MLP keys")
+    example = _l2er_array(example, name="example", ndim=1)
+    checked_params = _l2er_params(params)
+    checked_grads = {
+        name: _l2er_array(value, name=f"grads.{name}") for name, value in grads.items()
     }
-    batch_size = int(hp["er_batch_size"])
-    buffered = state.example_buffer.at[state.buffer_count].set(example)
-    next_count = state.buffer_count + jnp.asarray(1, dtype=jnp.int32)
+    if any(
+        checked_grads[name].shape != value.shape
+        or checked_grads[name].dtype != value.dtype
+        for name, value in checked_params.items()
+    ):
+        raise ValueError("params and grads must have identical shapes and dtypes")
+    w1 = checked_params["w1"]
+    if w1.ndim != 2 or example.shape != (w1.shape[0],):
+        raise ValueError("example and first-layer parameter shapes must match")
+    batch_size = int(checked_hp["er_batch_size"])
+    buffer = _l2er_array(state.example_buffer, name="state.example_buffer", ndim=2)
+    if buffer.shape != (batch_size, example.shape[0]) or buffer.dtype != example.dtype:
+        raise ValueError("L2-ER buffer shape and dtype must match the protocol")
+    count = state.buffer_count
+    if not isinstance(count, (jax.Array, jax.core.Tracer)) or (
+        count.shape != () or count.dtype != jnp.dtype(jnp.int32)
+    ):
+        raise ValueError("buffer_count must be one scalar int32 JAX array")
+    step_size = checked_hp["step_size"]
+    weight_decay = checked_hp["weight_decay"]
+    supervised_params = {
+        name: value - step_size * (checked_grads[name] + weight_decay * value)
+        for name, value in checked_params.items()
+    }
+    count_valid = (count >= 0) & (count < batch_size)
+    safe_count = jnp.clip(count, 0, batch_size - 1)
+    buffered = buffer.at[safe_count].set(example)
+    next_count = safe_count + jnp.asarray(1, dtype=jnp.int32)
     complete = next_count == batch_size
 
-    if hp["er_enabled"] == 1.0:
-        er_step_size = hp["er_step_size"]
-        epsilon = hp["er_epsilon"]
+    if checked_hp["er_enabled"] == 1.0:
+        er_step_size = checked_hp["er_step_size"]
+        epsilon = checked_hp["er_epsilon"]
 
         def apply_er(operand: tuple[dict[str, Array], Array]) -> dict[str, Array]:
             current_params, batch = operand
@@ -519,28 +659,42 @@ def l2er_update(
         )
     else:
         new_params = supervised_params
-    new_state = L2ERState(  # type: ignore[call-arg]
+    candidate_state = L2ERState(  # type: ignore[call-arg]
         example_buffer=jax.lax.cond(
             complete, jnp.zeros_like, lambda value: value, buffered
         ),
         buffer_count=jnp.where(complete, jnp.asarray(0, dtype=jnp.int32), next_count),
     )
-    return new_params, new_state
+    valid = count_valid & floating_tree_is_finite(params) & floating_tree_is_finite(grads)
+    valid = valid & floating_tree_is_finite(new_params) & floating_tree_is_finite(candidate_state)
+    safe_prior_params = jax.tree.map(
+        lambda value: jnp.where(jnp.isfinite(value), value, jnp.zeros_like(value)),
+        checked_params,
+    )
+    safe_prior_state = L2ERState(  # type: ignore[call-arg]
+        example_buffer=jnp.where(jnp.isfinite(buffer), buffer, jnp.zeros_like(buffer)),
+        buffer_count=jnp.where(count_valid, count, jnp.asarray(0, dtype=jnp.int32)),
+    )
+    return (
+        select_transaction(valid, new_params, safe_prior_params),
+        select_transaction(valid, candidate_state, safe_prior_state),
+    )
 
 
 def _make_l2er_learner(
     hp: Mapping[str, float],
 ) -> tuple[LearnerInitFn, ScreeningStepFn]:
     """Build one registered L2/ER reduction on the current IPMNIST MLP."""
-    if hp["er_batch_size"] != 100.0 or hp["er_steps_per_batch"] != 1.0:
-        raise ValueError("the audited lop-jax comparator requires ER batch 100 and one ER step")
-    if hp["er_epsilon"] != 1e-8 or hp["er_enabled"] not in (0.0, 1.0):
-        raise ValueError("the L2-ER estimator constants do not match the audited revision")
+    checked_hp = _l2er_hp(hp)
 
     def init_fn(params: dict[str, Array]) -> L2ERState:
+        checked_params = _l2er_params(params)
+        input_dim = checked_params["w1"].shape[0]
+        if input_dim > _L2ER_ARRAY_ELEMENTS // int(checked_hp["er_batch_size"]):
+            raise ValueError("L2-ER buffer exceeds the 1000000-element limit")
         return L2ERState(  # type: ignore[call-arg]
             example_buffer=jnp.zeros(
-                (int(hp["er_batch_size"]), params["w1"].shape[0]), dtype=jnp.float32
+                (int(checked_hp["er_batch_size"]), input_dim), dtype=jnp.float32
             ),
             buffer_count=jnp.asarray(0, dtype=jnp.int32),
         )
@@ -552,7 +706,7 @@ def _make_l2er_learner(
         (loss, logits), grads = jax.value_and_grad(cross_entropy_loss, has_aux=True)(
             params, x, y
         )
-        new_params, new_state = l2er_update(params, state, grads, x, hp)
+        new_params, new_state = l2er_update(params, state, grads, x, checked_hp)
         return new_params, new_state, _step_metrics(new_params, x, y, loss, logits)
 
     return init_fn, full_step

--- a/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
@@ -1,0 +1,299 @@
+"""Strict development-only receipts for the adapted L2-ER IPMNIST comparator."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from types import MappingProxyType
+from typing import Any, cast
+
+PAPER_REVISION = "arXiv:2509.22335v3"
+OFFICIAL_COMMIT = "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5"
+RESULT_SCHEMA = "asi.l2er-ipmnist.development-result.v1"
+COMPARISON_ID = "asi.l2er-ipmnist.current-runner.v1"
+
+L2ER_PROTOCOL = MappingProxyType(
+    {
+        "paper_revision": PAPER_REVISION,
+        "official_repository": "https://github.com/KevinGuo27/lop-jax",
+        "official_commit": OFFICIAL_COMMIT,
+        "official_files": (
+            "permuted_mnist/train_permuted_mnist.py",
+            "permuted_mnist/config.py",
+            "permuted_mnist/scripts/hyperparams/{l2,er,l2_er}.py",
+        ),
+        "protocol_differences": (
+            "ASI uses its current 784-300-150-10 two-hidden-layer MLP, not 3x1000",
+            "ASI uses 200x5000 IPMNIST by default, not 800x60000 P-MNIST",
+            "ASI inputs are scaled to [-1,1], while lop-jax uses ToTensor [0,1]",
+            "ASI uses its seed-derived task/example schedule",
+            "ASI retains the 100-example ER buffer as charged persistent state",
+            "ASI plasticity telemetry is an additional post-update metric",
+            "ASI evaluates the same entropy-rank ratio with overflow-safe scaling",
+        ),
+        "official_er_batch": 100,
+        "official_er_steps_per_batch": 1,
+        "effective_rank_epsilon": 1e-8,
+        "persistent_bytes_scope": (
+            "float32 parameters plus the fixed 100-example float32 ER buffer and int32 count; "
+            "runner RNG and the externally supplied schedule are excluded"
+        ),
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "outcome_retention_required": True,
+    }
+)
+
+_ARMS = {
+    "l2er_mechanism_off": (0.0, 0.0, 0.0),
+    "l2er_l2_only": (1e-4, 0.0, 0.0),
+    "l2er_er_only": (0.0, 1e-3, 1.0),
+    "l2er_combined": (1e-4, 1e-3, 1.0),
+}
+_HYPERPARAMETER_KEYS = frozenset(
+    {
+        "step_size",
+        "weight_decay",
+        "er_step_size",
+        "er_batch_size",
+        "er_steps_per_batch",
+        "er_epsilon",
+        "er_enabled",
+    }
+)
+
+
+def _object(value: object, keys: frozenset[str], *, context: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{context} must be an object")
+    actual = set(value)
+    if actual != keys:
+        raise ValueError(f"{context} keys must be exactly {sorted(keys)}")
+    return cast(Mapping[str, Any], value)
+
+
+def _int(value: object, *, context: str, positive: bool = False) -> int:
+    if type(value) is not int or value < int(positive):
+        raise ValueError(f"{context} must be a {'positive' if positive else 'nonnegative'} int")
+    return value
+
+
+def _float(value: object, *, context: str, nonnegative: bool = False) -> float:
+    if type(value) is not float or not math.isfinite(value):
+        raise ValueError(f"{context} must be a finite float")
+    if nonnegative and value < 0.0:
+        raise ValueError(f"{context} must be nonnegative")
+    return value
+
+
+def _strings(value: object, *, context: str) -> tuple[str, ...]:
+    if type(value) is not list or any(type(item) is not str or not item for item in value):
+        raise ValueError(f"{context} must be a list of non-empty strings")
+    resolved = tuple(value)
+    if len(set(resolved)) != len(resolved):
+        raise ValueError(f"{context} must not contain duplicates")
+    return resolved
+
+
+def validate_l2er_development_result(payload: object) -> dict[str, object]:
+    """Return a normalized copy after strict schema and accounting validation."""
+    outer = _object(
+        payload,
+        frozenset(
+            {
+                "schema",
+                "comparison_id",
+                "paper_revision",
+                "official_commit",
+                "arm",
+                "seed",
+                "n_tasks",
+                "task_length",
+                "input_dim",
+                "hidden1",
+                "hidden2",
+                "n_classes",
+                "observations",
+                "updates",
+                "allowed_boundary_information",
+                "allowed_task_information",
+                "hyperparameters",
+                "metrics",
+                "resources",
+                "outcome",
+                "outcome_retained",
+                "development_only",
+                "scientific_promotion_allowed",
+            }
+        ),
+        context="result",
+    )
+    for key, expected in (
+        ("schema", RESULT_SCHEMA),
+        ("comparison_id", COMPARISON_ID),
+        ("paper_revision", PAPER_REVISION),
+        ("official_commit", OFFICIAL_COMMIT),
+    ):
+        if outer[key] != expected:
+            raise ValueError(f"{key} does not match the frozen L2-ER protocol")
+    arm = outer["arm"]
+    if type(arm) is not str or arm not in _ARMS:
+        raise ValueError(f"arm must be one of {sorted(_ARMS)}")
+    seed = _int(outer["seed"], context="seed")
+    n_tasks = _int(outer["n_tasks"], context="n_tasks", positive=True)
+    task_length = _int(outer["task_length"], context="task_length", positive=True)
+    input_dim = _int(outer["input_dim"], context="input_dim", positive=True)
+    hidden1 = _int(outer["hidden1"], context="hidden1", positive=True)
+    hidden2 = _int(outer["hidden2"], context="hidden2", positive=True)
+    n_classes = _int(outer["n_classes"], context="n_classes", positive=True)
+    observations = _int(outer["observations"], context="observations", positive=True)
+    updates = _int(outer["updates"], context="updates", positive=True)
+    if observations != n_tasks * task_length or updates != observations:
+        raise ValueError("observations and updates must equal n_tasks * task_length")
+    boundary = _strings(
+        outer["allowed_boundary_information"], context="allowed_boundary_information"
+    )
+    task_info = _strings(outer["allowed_task_information"], context="allowed_task_information")
+    if boundary or task_info != ("current_example_label",):
+        raise ValueError("allowed boundary/task information does not match the protocol")
+
+    hp = _object(outer["hyperparameters"], _HYPERPARAMETER_KEYS, context="hyperparameters")
+    normalized_hp = {
+        key: _float(hp[key], context=f"hyperparameters.{key}", nonnegative=True)
+        for key in _HYPERPARAMETER_KEYS
+    }
+    expected_wd, expected_er_lr, expected_enabled = _ARMS[arm]
+    expected_hp = {
+        "step_size": 1e-3,
+        "weight_decay": expected_wd,
+        "er_step_size": expected_er_lr,
+        "er_batch_size": 100.0,
+        "er_steps_per_batch": 1.0,
+        "er_epsilon": 1e-8,
+        "er_enabled": expected_enabled,
+    }
+    if normalized_hp != expected_hp:
+        raise ValueError("hyperparameters do not match the registered L2-ER arm")
+    if task_length % int(normalized_hp["er_batch_size"]) != 0:
+        raise ValueError("task_length must be divisible by er_batch_size")
+
+    metrics = _object(
+        outer["metrics"],
+        frozenset({"mean_online_accuracy", "mean_loss", "mean_plasticity"}),
+        context="metrics",
+    )
+    normalized_metrics = {
+        key: _float(metrics[key], context=f"metrics.{key}", nonnegative=True)
+        for key in metrics
+    }
+    if normalized_metrics["mean_online_accuracy"] > 1.0:
+        raise ValueError("mean_online_accuracy must lie in [0,1]")
+    if normalized_metrics["mean_plasticity"] > 1.0:
+        raise ValueError("mean_plasticity must lie in [0,1]")
+
+    resources = _object(
+        outer["resources"],
+        frozenset(
+            {
+                "persistent_bytes",
+                "environment_steps",
+                "data_steps",
+                "model_queries",
+                "timing_seconds",
+                "timing_is_telemetry_only",
+            }
+        ),
+        context="resources",
+    )
+    persistent_bytes = _int(resources["persistent_bytes"], context="persistent_bytes")
+    environment_steps = _int(resources["environment_steps"], context="environment_steps")
+    data_steps = _int(resources["data_steps"], context="data_steps")
+    model_queries = _int(resources["model_queries"], context="model_queries")
+    timing_seconds = _float(
+        resources["timing_seconds"], context="timing_seconds", nonnegative=True
+    )
+    if environment_steps != 0 or data_steps != observations:
+        raise ValueError("environment_steps/data_steps do not match the supervised protocol")
+    er_updates = observations // 100 if expected_enabled == 1.0 else 0
+    if model_queries != 2 * observations + er_updates:
+        raise ValueError("model_queries does not match the executed update semantics")
+    if resources["timing_is_telemetry_only"] is not True:
+        raise ValueError("timing_is_telemetry_only must permanently remain True")
+    parameter_count = (
+        input_dim * hidden1
+        + hidden1
+        + hidden1 * hidden2
+        + hidden2
+        + hidden2 * n_classes
+        + n_classes
+    )
+    expected_persistent_bytes = 4 * (parameter_count + 100 * input_dim + 1)
+    if persistent_bytes != expected_persistent_bytes:
+        raise ValueError("persistent_bytes must exactly include parameters and ER buffer")
+    if type(outer["outcome"]) is not str or outer["outcome"] not in {
+        "supported",
+        "rejected",
+        "inconclusive",
+    }:
+        raise ValueError("outcome must be supported, rejected, or inconclusive")
+    if outer["outcome_retained"] is not True:
+        raise ValueError("outcome_retained must permanently remain True")
+    if outer["development_only"] is not True:
+        raise ValueError("development_only must permanently remain True")
+    if outer["scientific_promotion_allowed"] is not False:
+        raise ValueError("scientific_promotion_allowed must permanently remain False")
+
+    return {
+        **dict(outer),
+        "seed": seed,
+        "n_tasks": n_tasks,
+        "task_length": task_length,
+        "input_dim": input_dim,
+        "hidden1": hidden1,
+        "hidden2": hidden2,
+        "n_classes": n_classes,
+        "observations": observations,
+        "updates": updates,
+        "allowed_boundary_information": list(boundary),
+        "allowed_task_information": list(task_info),
+        "hyperparameters": normalized_hp,
+        "metrics": normalized_metrics,
+        "resources": {
+            "persistent_bytes": persistent_bytes,
+            "environment_steps": environment_steps,
+            "data_steps": data_steps,
+            "model_queries": model_queries,
+            "timing_seconds": timing_seconds,
+            "timing_is_telemetry_only": True,
+        },
+    }
+
+
+def validate_matched_l2er_development_results(
+    payloads: Sequence[object],
+) -> tuple[dict[str, object], ...]:
+    """Validate the four-arm comparison and every required matched axis."""
+    if type(payloads) not in {list, tuple} or len(payloads) != len(_ARMS):
+        raise ValueError("the matched comparison must contain exactly four results")
+    results = tuple(validate_l2er_development_result(payload) for payload in payloads)
+    if {result["arm"] for result in results} != set(_ARMS):
+        raise ValueError("the matched comparison must contain each registered arm exactly once")
+    first = results[0]
+    axes = (
+        "comparison_id",
+        "seed",
+        "n_tasks",
+        "task_length",
+        "input_dim",
+        "hidden1",
+        "hidden2",
+        "n_classes",
+        "observations",
+        "updates",
+        "allowed_boundary_information",
+        "allowed_task_information",
+    )
+    for result in results[1:]:
+        if any(result[axis] != first[axis] for axis in axes):
+            raise ValueError("all required L2-ER comparison axes must match")
+    return results

--- a/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
@@ -61,11 +61,15 @@ _HYPERPARAMETER_KEYS = frozenset(
         "er_enabled",
     }
 )
+_INT32_MAX = (1 << 31) - 1
+_MAX_BYTES = 256 * 1024 * 1024
+_MAX_STRINGS = 16
+_MAX_STRING_BYTES = 512
 
 
 def _object(value: object, keys: frozenset[str], *, context: str) -> Mapping[str, Any]:
-    if not isinstance(value, Mapping):
-        raise ValueError(f"{context} must be an object")
+    if type(value) is not dict:
+        raise ValueError(f"{context} must be an exact object")
     actual = set(value)
     if actual != keys:
         raise ValueError(f"{context} keys must be exactly {sorted(keys)}")
@@ -73,7 +77,7 @@ def _object(value: object, keys: frozenset[str], *, context: str) -> Mapping[str
 
 
 def _int(value: object, *, context: str, positive: bool = False) -> int:
-    if type(value) is not int or value < int(positive):
+    if type(value) is not int or not int(positive) <= value <= _INT32_MAX:
         raise ValueError(f"{context} must be a {'positive' if positive else 'nonnegative'} int")
     return value
 
@@ -87,7 +91,17 @@ def _float(value: object, *, context: str, nonnegative: bool = False) -> float:
 
 
 def _strings(value: object, *, context: str) -> tuple[str, ...]:
-    if type(value) is not list or any(type(item) is not str or not item for item in value):
+    if (
+        type(value) is not list
+        or len(value) > _MAX_STRINGS
+        or any(
+            type(item) is not str
+            or not item
+            or "\x00" in item
+            or len(item.encode("utf-8")) > _MAX_STRING_BYTES
+            for item in value
+        )
+    ):
         raise ValueError(f"{context} must be a list of non-empty strings")
     resolved = tuple(value)
     if len(set(resolved)) != len(resolved):
@@ -134,7 +148,7 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
         ("paper_revision", PAPER_REVISION),
         ("official_commit", OFFICIAL_COMMIT),
     ):
-        if outer[key] != expected:
+        if type(outer[key]) is not str or outer[key] != expected:
             raise ValueError(f"{key} does not match the frozen L2-ER protocol")
     arm = outer["arm"]
     if type(arm) is not str or arm not in _ARMS:
@@ -148,6 +162,8 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
     n_classes = _int(outer["n_classes"], context="n_classes", positive=True)
     observations = _int(outer["observations"], context="observations", positive=True)
     updates = _int(outer["updates"], context="updates", positive=True)
+    if n_tasks > _INT32_MAX // task_length:
+        raise ValueError("n_tasks * task_length exceeds signed int32")
     if observations != n_tasks * task_length or updates != observations:
         raise ValueError("observations and updates must equal n_tasks * task_length")
     boundary = _strings(
@@ -212,6 +228,8 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
     timing_seconds = _float(
         resources["timing_seconds"], context="timing_seconds", nonnegative=True
     )
+    if persistent_bytes > _MAX_BYTES or timing_seconds > 604_800.0:
+        raise ValueError("resources exceed the bounded development protocol")
     if environment_steps != 0 or data_steps != observations:
         raise ValueError("environment_steps/data_steps do not match the supervised protocol")
     er_updates = observations // 100 if expected_enabled == 1.0 else 0
@@ -219,15 +237,20 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
         raise ValueError("model_queries does not match the executed update semantics")
     if resources["timing_is_telemetry_only"] is not True:
         raise ValueError("timing_is_telemetry_only must permanently remain True")
-    parameter_count = (
-        input_dim * hidden1
-        + hidden1
-        + hidden1 * hidden2
-        + hidden2
-        + hidden2 * n_classes
-        + n_classes
+    products = (
+        input_dim * hidden1,
+        hidden1 * hidden2,
+        hidden2 * n_classes,
+        100 * input_dim,
     )
-    expected_persistent_bytes = 4 * (parameter_count + 100 * input_dim + 1)
+    if any(product > _INT32_MAX for product in products):
+        raise ValueError("derived parameter/buffer size exceeds signed int32")
+    parameter_count = sum(products[:3]) + hidden1 + hidden2 + n_classes
+    if parameter_count > _INT32_MAX - products[3] - 1:
+        raise ValueError("derived persistent scalar count exceeds signed int32")
+    expected_persistent_bytes = 4 * (parameter_count + products[3] + 1)
+    if expected_persistent_bytes > _MAX_BYTES:
+        raise ValueError("derived persistent bytes exceed 256 MiB")
     if persistent_bytes != expected_persistent_bytes:
         raise ValueError("persistent_bytes must exactly include parameters and ER buffer")
     if type(outer["outcome"]) is not str or outer["outcome"] not in {

--- a/tests/test_l2er_ipmnist.py
+++ b/tests/test_l2er_ipmnist.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.ipmnist_screening import (
+    L2ERState,
+    ScreeningRunResult,
+    l2er_development_result_payload,
+    l2er_effective_rank,
+    l2er_effective_rank_loss,
+    l2er_update,
+    run_screening_config,
+    screening_spec,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+from alberta_framework.evaluation.l2er_ipmnist_nonpromoting import (
+    L2ER_PROTOCOL,
+    validate_l2er_development_result,
+    validate_matched_l2er_development_results,
+)
+
+
+def _params() -> dict[str, jax.Array]:
+    return {
+        "w1": jnp.asarray([[0.8, 0.2], [0.1, 0.6]], dtype=jnp.float32),
+        "b1": jnp.asarray([0.2, 0.1], dtype=jnp.float32),
+        "w2": jnp.asarray([[0.7, 0.1], [0.2, 0.9]], dtype=jnp.float32),
+        "b2": jnp.asarray([0.1, 0.3], dtype=jnp.float32),
+        "w3": jnp.asarray([[0.5, -0.2], [0.3, 0.4]], dtype=jnp.float32),
+        "b3": jnp.asarray([0.0, 0.1], dtype=jnp.float32),
+    }
+
+
+def _hp(*, wd: float, er_lr: float, enabled: float) -> dict[str, float]:
+    return {
+        "step_size": 1e-3,
+        "weight_decay": wd,
+        "er_step_size": er_lr,
+        "er_batch_size": 100.0,
+        "er_steps_per_batch": 1.0,
+        "er_epsilon": 1e-8,
+        "er_enabled": enabled,
+    }
+
+
+def test_effective_rank_matches_official_entropy_estimator() -> None:
+    features = jnp.diag(jnp.asarray([3.0, 1.0], dtype=jnp.float32))
+    probabilities = np.asarray([0.75, 0.25])
+    expected = np.exp(-np.sum(probabilities * np.log(probabilities + 1e-8)))
+    assert float(l2er_effective_rank(features)) == pytest.approx(expected, rel=1e-6)
+    assert float(l2er_effective_rank(jnp.zeros((4, 3)))) == pytest.approx(1.0)
+    huge = jnp.eye(4, dtype=jnp.float32) * jnp.asarray(1e38, dtype=jnp.float32)
+    assert float(l2er_effective_rank(huge)) == pytest.approx(4.0, rel=1e-5)
+
+
+def test_l2_and_mechanism_off_are_exact_reductions() -> None:
+    params = _params()
+    grads = jax.tree.map(jnp.ones_like, params)
+    state = L2ERState(  # type: ignore[call-arg]
+        example_buffer=jnp.zeros((100, 2), dtype=jnp.float32),
+        buffer_count=jnp.asarray(0, dtype=jnp.int32),
+    )
+    example = jnp.asarray([0.4, 0.7], dtype=jnp.float32)
+    off, off_state = l2er_update(params, state, grads, example, _hp(wd=0.0, er_lr=0.0, enabled=0.0))
+    l2, _ = l2er_update(params, state, grads, example, _hp(wd=1e-4, er_lr=0.0, enabled=0.0))
+    for name in params:
+        np.testing.assert_array_equal(off[name], params[name] - 1e-3 * grads[name])
+        np.testing.assert_allclose(
+            l2[name], params[name] - 1e-3 * (grads[name] + 1e-4 * params[name])
+        )
+    assert int(off_state.buffer_count) == 1
+
+
+def test_er_update_matches_official_separate_post_batch_step() -> None:
+    params = _params()
+    grads = jax.tree.map(lambda value: jnp.full_like(value, 0.05), params)
+    buffer = jnp.linspace(0.1, 1.0, 200, dtype=jnp.float32).reshape(100, 2)
+    state = L2ERState(  # type: ignore[call-arg]
+        example_buffer=buffer,
+        buffer_count=jnp.asarray(99, dtype=jnp.int32),
+    )
+    example = jnp.asarray([0.3, 0.9], dtype=jnp.float32)
+    hp = _hp(wd=1e-4, er_lr=1e-3, enabled=1.0)
+    actual, new_state = l2er_update(params, state, grads, example, hp)
+
+    supervised = {
+        name: value - 1e-3 * (grads[name] + 1e-4 * value)
+        for name, value in params.items()
+    }
+    completed_batch = buffer.at[99].set(example)
+    er_grads = jax.grad(l2er_effective_rank_loss)(supervised, completed_batch, 1e-8)
+    expected = {
+        name: value - 1e-3 * er_grads[name] for name, value in supervised.items()
+    }
+    for name in params:
+        np.testing.assert_allclose(actual[name], expected[name], rtol=1e-6, atol=1e-7)
+        assert bool(jnp.all(jnp.isfinite(actual[name])))
+    assert int(new_state.buffer_count) == 0
+    np.testing.assert_array_equal(new_state.example_buffer, jnp.zeros_like(buffer))
+
+
+def test_l2er_update_is_jittable() -> None:
+    params = _params()
+    grads = jax.tree.map(jnp.ones_like, params)
+    state = L2ERState(  # type: ignore[call-arg]
+        example_buffer=jnp.ones((100, 2), dtype=jnp.float32),
+        buffer_count=jnp.asarray(99, dtype=jnp.int32),
+    )
+    update = jax.jit(
+        lambda p, s, g, x: l2er_update(
+            p, s, g, x, _hp(wd=0.0, er_lr=1e-3, enabled=1.0)
+        )
+    )
+    new_params, new_state = update(params, state, grads, jnp.asarray([0.2, 0.8]))
+    assert int(new_state.buffer_count) == 0
+    assert all(bool(jnp.all(jnp.isfinite(value))) for value in new_params.values())
+
+
+def test_registry_contains_complete_matched_ablation() -> None:
+    expected = {
+        "l2er_mechanism_off": (0.0, 0.0, 0.0),
+        "l2er_l2_only": (1e-4, 0.0, 0.0),
+        "l2er_er_only": (0.0, 1e-3, 1.0),
+        "l2er_combined": (1e-4, 1e-3, 1.0),
+    }
+    for name, values in expected.items():
+        spec = screening_spec(name)
+        assert spec.mechanism == "l2_effective_rank"
+        assert (
+            spec.hyperparameters["weight_decay"],
+            spec.hyperparameters["er_step_size"],
+            spec.hyperparameters["er_enabled"],
+        ) == values
+
+
+def test_runner_rejects_er_batches_crossing_task_boundaries() -> None:
+    config = IPMNISTConfig(
+        n_tasks=1, task_length=99, input_dim=2, hidden1=2, hidden2=2, n_classes=2
+    )
+    with pytest.raises(ValueError, match="task_length divisible"):
+        run_screening_config(
+            np.zeros((99, 2), dtype=np.float32),
+            np.zeros(99, dtype=np.int32),
+            screening_spec("l2er_combined"),
+            seed=0,
+            config=config,
+        )
+
+
+def test_combined_arm_runs_end_to_end_on_a_synthetic_task() -> None:
+    config = IPMNISTConfig(
+        n_tasks=1, task_length=100, input_dim=2, hidden1=3, hidden2=2, n_classes=2
+    )
+    data_x = np.random.default_rng(11).normal(size=(100, 2)).astype(np.float32)
+    data_y = np.arange(100, dtype=np.int32) % 2
+    result = run_screening_config(
+        data_x,
+        data_y,
+        screening_spec("l2er_combined"),
+        seed=3,
+        config=config,
+    )
+    assert result.per_task_accuracy.shape == (1,)
+    assert np.isfinite(result.per_task_loss).all()
+    receipt = l2er_development_result_payload(result, outcome="inconclusive")
+    assert receipt["arm"] == "l2er_combined"
+
+
+def _result(name: str) -> ScreeningRunResult:
+    config = IPMNISTConfig(
+        n_tasks=1, task_length=100, input_dim=2, hidden1=2, hidden2=2, n_classes=2
+    )
+    return ScreeningRunResult(
+        config_name=name,
+        base_learner="upgd_w",
+        hyperparameters=dict(screening_spec(name).hyperparameters),
+        seed=7,
+        config=config,
+        per_task_accuracy=np.asarray([0.6], dtype=np.float64),
+        per_task_loss=np.asarray([0.7], dtype=np.float64),
+        per_task_plasticity=np.asarray([0.1], dtype=np.float64),
+        wall_clock_seconds=1.5,
+    )
+
+
+def test_result_receipt_accounts_resources_and_is_permanently_nonpromoting() -> None:
+    payload = l2er_development_result_payload(_result("l2er_combined"), outcome="rejected")
+    assert payload["outcome_retained"] is True
+    assert payload["development_only"] is True
+    assert payload["scientific_promotion_allowed"] is False
+    resources = payload["resources"]
+    assert isinstance(resources, dict)
+    assert resources["data_steps"] == 100
+    assert resources["environment_steps"] == 0
+    assert resources["model_queries"] == 201
+    assert resources["persistent_bytes"] == 876
+
+    hostile = deepcopy(payload)
+    hostile_resources = hostile["resources"]
+    assert isinstance(hostile_resources, dict)
+    hostile_resources["model_queries"] = 200
+    with pytest.raises(ValueError, match="model_queries"):
+        validate_l2er_development_result(hostile)
+
+    hostile_bytes = deepcopy(payload)
+    hostile_byte_resources = hostile_bytes["resources"]
+    assert isinstance(hostile_byte_resources, dict)
+    hostile_byte_resources["persistent_bytes"] = 872
+    with pytest.raises(ValueError, match="persistent_bytes"):
+        validate_l2er_development_result(hostile_bytes)
+
+    hostile_schema = deepcopy(payload)
+    hostile_schema["unregistered_claim"] = True
+    with pytest.raises(ValueError, match="result keys"):
+        validate_l2er_development_result(hostile_schema)
+
+
+def test_matched_validator_requires_all_arms_and_axes() -> None:
+    names = ("l2er_mechanism_off", "l2er_l2_only", "l2er_er_only", "l2er_combined")
+    payloads = [
+        l2er_development_result_payload(_result(name), outcome="inconclusive")
+        for name in names
+    ]
+    assert len(validate_matched_l2er_development_results(payloads)) == 4
+    mismatched = deepcopy(payloads)
+    mismatched[1]["updates"] = 99
+    with pytest.raises(ValueError, match="observations and updates"):
+        validate_matched_l2er_development_results(mismatched)
+
+
+def test_protocol_pins_sources_and_records_material_differences() -> None:
+    assert L2ER_PROTOCOL["paper_revision"] == "arXiv:2509.22335v3"
+    assert L2ER_PROTOCOL["official_commit"] == "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5"
+    differences = L2ER_PROTOCOL["protocol_differences"]
+    assert isinstance(differences, tuple)
+    assert len(differences) == 7
+    assert L2ER_PROTOCOL["development_only"] is True
+    assert L2ER_PROTOCOL["scientific_promotion_allowed"] is False

--- a/tests/test_l2er_ipmnist.py
+++ b/tests/test_l2er_ipmnist.py
@@ -10,6 +10,7 @@ import pytest
 from alberta_framework.benchmarks.ipmnist_screening import (
     L2ERState,
     ScreeningRunResult,
+    _make_l2er_learner,
     l2er_development_result_payload,
     l2er_effective_rank,
     l2er_effective_rank_loss,
@@ -121,6 +122,67 @@ def test_l2er_update_is_jittable() -> None:
     assert all(bool(jnp.all(jnp.isfinite(value))) for value in new_params.values())
 
 
+def test_update_rejects_hostile_structure_and_is_atomic_on_runtime_invalidity() -> None:
+    class HostileMapping:
+        def __iter__(self) -> object:
+            raise AssertionError("hostile iteration must not run")
+
+    params = _params()
+    grads = jax.tree.map(jnp.ones_like, params)
+    state = L2ERState(  # type: ignore[call-arg]
+        example_buffer=jnp.zeros((100, 2), dtype=jnp.float32),
+        buffer_count=jnp.asarray(0, dtype=jnp.int32),
+    )
+    with pytest.raises(ValueError, match="hyperparameters"):
+        l2er_update(  # type: ignore[arg-type]
+            params, state, grads, jnp.ones(2), HostileMapping()
+        )
+    bad_grads = dict(grads)
+    bad_grads["w2"] = jnp.ones((1, 3), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="identical shapes"):
+        l2er_update(
+            params,
+            state,
+            bad_grads,
+            jnp.ones(2),
+            _hp(wd=0.0, er_lr=0.0, enabled=0.0),
+        )
+
+    bad_state = state.replace(buffer_count=jnp.asarray(100, dtype=jnp.int32))
+    unchanged, repaired = jax.jit(
+        lambda p, s, g: l2er_update(
+            p, s, g, jnp.ones(2), _hp(wd=0.0, er_lr=0.0, enabled=0.0)
+        )
+    )(params, bad_state, grads)
+    for name in params:
+        np.testing.assert_array_equal(unchanged[name], params[name])
+    assert int(repaired.buffer_count) == 0
+
+    nonfinite = dict(grads)
+    nonfinite["w1"] = jnp.full_like(grads["w1"], jnp.inf)
+    unchanged, _ = l2er_update(
+        params,
+        state,
+        nonfinite,
+        jnp.ones(2),
+        _hp(wd=0.0, er_lr=0.0, enabled=0.0),
+    )
+    for name in params:
+        np.testing.assert_array_equal(unchanged[name], params[name])
+
+
+def test_buffer_and_svd_resources_are_preflighted() -> None:
+    init, _ = _make_l2er_learner(_hp(wd=0.0, er_lr=0.0, enabled=0.0))
+    with pytest.raises(ValueError, match="exact protocol MLP tree"):
+        init({})
+    params = _params()
+    params["w1"] = jnp.ones((10_001, 2), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="buffer exceeds"):
+        init(params)
+    with pytest.raises(ValueError, match="bounded float array"):
+        l2er_effective_rank(jnp.ones((1001, 1000), dtype=jnp.float32))
+
+
 def test_registry_contains_complete_matched_ablation() -> None:
     expected = {
         "l2er_mechanism_off": (0.0, 0.0, 0.0),
@@ -218,6 +280,18 @@ def test_result_receipt_accounts_resources_and_is_permanently_nonpromoting() -> 
     hostile_schema["unregistered_claim"] = True
     with pytest.raises(ValueError, match="result keys"):
         validate_l2er_development_result(hostile_schema)
+
+    hostile_counter = deepcopy(payload)
+    hostile_counter["n_tasks"] = 2**31
+    with pytest.raises(ValueError, match="n_tasks"):
+        validate_l2er_development_result(hostile_counter)
+
+    class HostileObject:
+        def __iter__(self) -> object:
+            raise AssertionError("hostile iteration must not run")
+
+    with pytest.raises(ValueError, match="exact object"):
+        validate_l2er_development_result(HostileObject())
 
 
 def test_matched_validator_requires_all_arms_and_axes() -> None:


### PR DESCRIPTION
Preserves the contributor implementation from #1640 and adds the deep contract/resource audit needed before merge.\n\nHardening covers exact trusted array/tree/hyperparameter identities, shape/dtype and finite-state gates, bounded ER buffer and SVD preflights, runtime buffer-count validation, atomic finite JIT fallback, and hostile receipt/schema/counter/resource validation. The matched development issue remains open until a retained matched run/report exists.\n\nFocused validation: 12 L2-ER tests; 335 screening tests; scoped Ruff; strict mypy.\n\nRelates to #1559. Supersedes #1640.