### PR TITLE
fix(scorecard): reject leftover ScorecardRunSpec identity contracts

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -228,6 +228,13 @@ def _is_sha256(value: object) -> bool:
     )
 
 
+def _is_scorecard_lifecycle_id(value: object) -> bool:
+    if type(value) is not str or not value.startswith("prototype."):
+        return False
+    digest = value[len("prototype.") :]
+    return len(digest) == 16 and all(character in "0123456789abcdef" for character in digest)
+
+
 def _arm_definitions() -> list[dict[str, Any]]:
     return [
         {
@@ -1351,6 +1358,22 @@ class ScorecardRunSpec:
     arm: str
     seed: int
     lifecycle_id: str
+
+    def __post_init__(self) -> None:
+        schedule_size = len(SEED_ROSTER) * len(ENVIRONMENT_ROSTER) * len(ARM_ROSTER)
+        if type(self.schedule_index) is not int or not 0 <= self.schedule_index < schedule_size:
+            raise ValueError("schedule_index must be a nonnegative integer in the fixed schedule")
+        if (
+            type(self.environment_kind) is not str
+            or self.environment_kind not in ENVIRONMENT_ROSTER
+        ):
+            raise ValueError(f"unsupported environment {self.environment_kind!r}")
+        if type(self.arm) is not str or self.arm not in ARM_ROSTER:
+            raise ValueError(f"unsupported scorecard arm {self.arm!r}")
+        if type(self.seed) is not int or self.seed not in SEED_ROSTER:
+            raise ValueError("seed is not in the fixed scorecard roster")
+        if not _is_scorecard_lifecycle_id(self.lifecycle_id):
+            raise ValueError("lifecycle_id must be a prototype.<16-hex> identity")
 
 
 def iter_run_specs(plan: ReferenceLifeDevelopmentPlan) -> tuple[ScorecardRunSpec, ...]:

--- a/tests/test_scorecard_run_spec_hostile.py
+++ b/tests/test_scorecard_run_spec_hostile.py
@@ -1,0 +1,68 @@
+"""Complete ScorecardRunSpec identity contract: leftover, roster, and type gates."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.reference_life_scorecard import (
+    ARM_ROSTER,
+    ENVIRONMENT_ROSTER,
+    SEED_ROSTER,
+    ScorecardRunSpec,
+    build_development_plan,
+    iter_run_specs,
+)
+
+
+class _StringSubclass(str):
+    """Leftover string identity that must not cross the spec boundary."""
+
+
+def _legal_spec(**overrides: object) -> ScorecardRunSpec:
+    payload = {
+        "schedule_index": 0,
+        "environment_kind": ENVIRONMENT_ROSTER[0],
+        "arm": ARM_ROSTER[0],
+        "seed": SEED_ROSTER[0],
+        "lifecycle_id": "prototype." + ("a" * 16),
+    }
+    payload.update(overrides)
+    return ScorecardRunSpec(**payload)  # type: ignore[arg-type]
+
+
+def test_scorecard_run_spec_accepts_canonical_schedule_identity() -> None:
+    spec = iter_run_specs(build_development_plan())[0]
+    assert spec.schedule_index == 0
+    assert spec.environment_kind == ENVIRONMENT_ROSTER[0]
+    assert spec.arm in ARM_ROSTER
+    assert spec.seed == SEED_ROSTER[0]
+    assert spec.lifecycle_id.startswith("prototype.")
+    assert len(spec.lifecycle_id) == len("prototype.") + 16
+
+
+def test_scorecard_run_spec_rejects_leftover_integer_identities() -> None:
+    with pytest.raises(ValueError, match="schedule_index must be a nonnegative integer"):
+        _legal_spec(schedule_index=True)
+    with pytest.raises(ValueError, match="seed is not in the fixed scorecard roster"):
+        _legal_spec(seed=True)
+    with pytest.raises(ValueError, match="schedule_index must be a nonnegative integer"):
+        _legal_spec(schedule_index=-1)
+    with pytest.raises(ValueError, match="seed is not in the fixed scorecard roster"):
+        _legal_spec(seed=0)
+
+
+def test_scorecard_run_spec_rejects_leftover_and_unknown_string_identities() -> None:
+    with pytest.raises(ValueError, match="unsupported environment"):
+        _legal_spec(environment_kind=True)
+    with pytest.raises(ValueError, match="unsupported scorecard arm"):
+        _legal_spec(arm=True)
+    with pytest.raises(ValueError, match="unsupported environment"):
+        _legal_spec(environment_kind=_StringSubclass(ENVIRONMENT_ROSTER[0]))
+    with pytest.raises(ValueError, match="unsupported scorecard arm"):
+        _legal_spec(arm=_StringSubclass(ARM_ROSTER[0]))
+    with pytest.raises(ValueError, match="lifecycle_id must be a prototype"):
+        _legal_spec(lifecycle_id=True)
+    with pytest.raises(ValueError, match="lifecycle_id must be a prototype"):
+        _legal_spec(lifecycle_id=_StringSubclass("prototype." + ("a" * 16)))
+    with pytest.raises(ValueError, match="lifecycle_id must be a prototype"):
+        _legal_spec(lifecycle_id="prototype.not-hex")


### PR DESCRIPTION
Closes #1658.

## What changed

`ScorecardRunSpec` now fail-closes leftover bool seed/index identities, unknown environment/arm hosts, string subclasses, and non-`prototype.<16-hex>` lifecycle ids — the same exact-type + roster bar the run-record validator already uses.

On `origin/main` `c00dc562`, `ScorecardRunSpec(seed=True, schedule_index=True)` constructed. Legal roster identities from `iter_run_specs` stay legal. Shaw `#1488` completed JSON/canonical identities; this is the omitted spec host, not a leftover-tax reprint.

No unpublished grok head on this file. Occupancy-free.

## Scope

- `alberta_framework/benchmarks/reference_life_scorecard.py`
- `tests/test_scorecard_run_spec_hostile.py`

## Occupancy

Open ASI PRs at publish: ss251 `#1651` (`ftl_decision_fidelity.py`); Shaw `#1647`/`#1643`/`#1640`. No open PR on `reference_life_scorecard.py`.

## Verification

- Red on base: `ScorecardRunSpec(seed=True, schedule_index=True)` constructed
- New spec contract + focused scorecard tests: 62 passed
- Hostile identity boundary tests: 9 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary identity validation only. No kernel math, lifetime clocks, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d282b3dfcf8e815dce1e3a9b00dc99d410357a36 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
