### PR TITLE
ci: execute scorecard from the locked virtualenv

### DIFF
--- a/.github/workflows/reference-life-scorecard-dev.yml
+++ b/.github/workflows/reference-life-scorecard-dev.yml
@@ -52,11 +52,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python_path="$(realpath "$(command -v python)")"
+          python_path="$GITHUB_WORKSPACE/.venv/bin/python"
           uv_path="$(realpath "$(command -v uv)")"
           test -x "$python_path"
           test -x "$uv_path"
           test "$("$python_path" -c 'import platform; print(platform.python_version())')" = "3.12.12"
+          "$python_path" -c 'import alberta_framework, jax; print(jax.__version__)'
           uv_version="$("$uv_path" --version | sed -E 's/^uv ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
           test "$uv_version" = "0.9.24"
           printf 'PYTHON_PATH=%s\nUV_PATH=%s\n' "$python_path" "$uv_path" >> "$GITHUB_ENV"
@@ -71,12 +72,11 @@ jobs:
           set -euo pipefail
           mkdir -p scorecard/shards
           output="scorecard/shards/${ENVIRONMENT}__${ARM}__${SEED}.json"
-          "$UV_PATH" run --no-sync "$PYTHON_PATH" \
-            -m alberta_framework.benchmarks.reference_life_scorecard \
+          "$PYTHON_PATH" -m alberta_framework.benchmarks.reference_life_scorecard \
             run-shard --environment "$ENVIRONMENT" --arm "$ARM" --seed "$SEED" \
             --output "$output"
-          "$UV_PATH" run --no-sync "$PYTHON_PATH" \
-            -m alberta_framework.benchmarks.reference_life_scorecard validate "$output"
+          "$PYTHON_PATH" -m alberta_framework.benchmarks.reference_life_scorecard \
+            validate "$output"
 
       - name: Upload immutable shard record
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -117,11 +117,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python_path="$(realpath "$(command -v python)")"
+          python_path="$GITHUB_WORKSPACE/.venv/bin/python"
           uv_path="$(realpath "$(command -v uv)")"
           test -x "$python_path"
           test -x "$uv_path"
           test "$("$python_path" -c 'import platform; print(platform.python_version())')" = "3.12.12"
+          "$python_path" -c 'import alberta_framework, jax; print(jax.__version__)'
           uv_version="$("$uv_path" --version | sed -E 's/^uv ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
           test "$uv_version" = "0.9.24"
           printf 'PYTHON_PATH=%s\nUV_PATH=%s\n' "$python_path" "$uv_path" >> "$GITHUB_ENV"
@@ -143,15 +144,12 @@ jobs:
           set -euo pipefail
           count=$(find scorecard/shards -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')
           test "$count" = 144
-          "$UV_PATH" run --no-sync "$PYTHON_PATH" \
-            -m alberta_framework.benchmarks.reference_life_scorecard \
+          "$PYTHON_PATH" -m alberta_framework.benchmarks.reference_life_scorecard \
             plan --output scorecard/plan.json
-          "$UV_PATH" run --no-sync "$PYTHON_PATH" \
-            -m alberta_framework.benchmarks.reference_life_scorecard \
+          "$PYTHON_PATH" -m alberta_framework.benchmarks.reference_life_scorecard \
             summarize --plan scorecard/plan.json --output scorecard/artifact.json \
             scorecard/shards/*.json
-          "$UV_PATH" run --no-sync "$PYTHON_PATH" \
-            -m alberta_framework.benchmarks.reference_life_scorecard \
+          "$PYTHON_PATH" -m alberta_framework.benchmarks.reference_life_scorecard \
             validate scorecard/artifact.json
           SOURCE_TREE="$(git rev-parse 'HEAD^{tree}')" \
           WORKFLOW_BLOB="$(git hash-object .github/workflows/reference-life-scorecard-dev.yml)" \

--- a/tests/test_reference_life_scorecard_workflow.py
+++ b/tests/test_reference_life_scorecard_workflow.py
@@ -40,7 +40,10 @@ def test_reference_life_scorecard_fails_closed_on_source_and_runtime() -> None:
     assert text.count('test "$(git rev-parse HEAD)" = "$LAUNCH_SHA"') == 2
     assert text.count('python-version: "3.12.12"') == 2
     assert text.count('test "$uv_version" = "0.9.24"') == 2
-    assert '"$UV_PATH" run --no-sync "$PYTHON_PATH"' in text
+    assert text.count('python_path="$GITHUB_WORKSPACE/.venv/bin/python"') == 2
+    assert 'python_path="$(realpath' not in text
+    assert '"$PYTHON_PATH" -m alberta_framework.benchmarks.reference_life_scorecard' in text
+    assert "import alberta_framework, jax" in text
     assert "retention-days: 90" in text
     assert "retention-days: 30" not in text
 


### PR DESCRIPTION
Corrects the prelaunch interpreter boundary in #1652. The setup action syncs into `.venv`; `command -v python` names setup-python toolcache and an absolute interpreter argument to `uv run` bypasses the project venv.

This uses the exact lexical `$GITHUB_WORKSPACE/.venv/bin/python` (without resolving its symlink), verifies Python 3.12.12 plus project and JAX imports, and invokes every plan/shard/validation command directly through that interpreter. The separately pinned/resolved uv identity remains in the receipt.

Static verification only: workflow contract tests, actionlint, Ruff, diff-check. No dispatch or output mutation.

Refs #1585