### PR TITLE
fix(evaluation): bind L2-ER validator identities

### DIFF
--- a/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Any, cast
 
@@ -30,6 +30,9 @@ L2ER_PROTOCOL = MappingProxyType(
             "ASI retains the 100-example ER buffer as charged persistent state",
             "ASI plasticity telemetry is an additional post-update metric",
             "ASI evaluates the same entropy-rank ratio with overflow-safe scaling",
+            "ASI follows the pinned official implementation by buffering raw examples and "
+            "recomputing features after each block, rather than buffering contemporaneous "
+            "hidden features as shown in paper Algorithm 1",
         ),
         "official_er_batch": 100,
         "official_er_steps_per_batch": 1,
@@ -293,12 +296,16 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
 
 
 def validate_matched_l2er_development_results(
-    payloads: Sequence[object],
+    payloads: object,
 ) -> tuple[dict[str, object], ...]:
     """Validate the four-arm comparison and every required matched axis."""
-    if type(payloads) not in {list, tuple} or len(payloads) != len(_ARMS):
+    payload_type = type(payloads)
+    if not (payload_type is list or payload_type is tuple):
         raise ValueError("the matched comparison must contain exactly four results")
-    results = tuple(validate_l2er_development_result(payload) for payload in payloads)
+    trusted_payloads = cast(list[object] | tuple[object, ...], payloads)
+    if len(trusted_payloads) != len(_ARMS):
+        raise ValueError("the matched comparison must contain exactly four results")
+    results = tuple(validate_l2er_development_result(payload) for payload in trusted_payloads)
     if {result["arm"] for result in results} != set(_ARMS):
         raise ValueError("the matched comparison must contain each registered arm exactly once")
     first = results[0]

--- a/tests/test_l2er_ipmnist.py
+++ b/tests/test_l2er_ipmnist.py
@@ -306,12 +306,27 @@ def test_matched_validator_requires_all_arms_and_axes() -> None:
     with pytest.raises(ValueError, match="observations and updates"):
         validate_matched_l2er_development_results(mismatched)
 
+    class HostileMeta(type):
+        calls = 0
+
+        def __hash__(cls) -> int:
+            cls.calls += 1
+            raise AssertionError("runtime type must not be hashed")
+
+    class HostileContainer(metaclass=HostileMeta):
+        def __len__(self) -> int:
+            raise AssertionError("hostile length must not run")
+
+    with pytest.raises(ValueError, match="exactly four"):
+        validate_matched_l2er_development_results(HostileContainer())
+    assert HostileMeta.calls == 0
+
 
 def test_protocol_pins_sources_and_records_material_differences() -> None:
     assert L2ER_PROTOCOL["paper_revision"] == "arXiv:2509.22335v3"
     assert L2ER_PROTOCOL["official_commit"] == "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5"
     differences = L2ER_PROTOCOL["protocol_differences"]
     assert isinstance(differences, tuple)
-    assert len(differences) == 7
+    assert len(differences) == 8
     assert L2ER_PROTOCOL["development_only"] is True
     assert L2ER_PROTOCOL["scientific_promotion_allowed"] is False


### PR DESCRIPTION
Follow-up to #1656. Avoids hashing an attacker-controlled runtime container type in the matched receipt gate and adds a zero-hook regression. Also records the material pinned-code versus paper-Algorithm-1 difference: the official implementation buffers raw examples and recomputes features after the block. No run, output, evidence artifact, or promotion claim. #1559 remains open.\n\nVerified: 12 focused tests; Ruff; strict mypy; diff check.