### PR TITLE
fix(benchmarks): preserve L2-ER rank invalidity

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -522,33 +522,36 @@ class L2ERState:
     buffer_count: Array
 
 
-def l2er_effective_rank(features: Array, epsilon: float = 1e-8) -> Array:
-    """Official entropy effective-rank estimator for one activation matrix."""
+def l2er_effective_rank_transaction(
+    features: Array, epsilon: float = 1e-8
+) -> tuple[Array, Array]:
+    """Return the scale-stable entropy rank and caller-visible validity."""
     features = _l2er_array(features, name="features", ndim=2)
     if type(epsilon) is not float or not math.isfinite(epsilon) or epsilon <= 0.0:
         raise ValueError("epsilon must be an exact finite positive float")
     _l2er_preflight_svd(features)
     finite = jnp.all(jnp.isfinite(features))
-    if not isinstance(finite, jax.core.Tracer) and not bool(finite):
-        raise ValueError("features must contain only finite values")
-    features = jnp.where(finite, features, jnp.zeros_like(features))
-    singular_values = jnp.abs(jnp.linalg.svdvals(features.T))
-
-    def normalized(values: Array) -> Array:
-        scale = jnp.max(values)
-        scaled = values / scale
-        denominator = jnp.maximum(jnp.sum(scaled), epsilon / scale)
-        return scaled / denominator
-
-    probabilities = jax.lax.cond(
-        jnp.max(singular_values) > 0.0,
-        normalized,
-        jnp.zeros_like,
-        singular_values,
-    )
+    safe_features = jnp.where(finite, features, jnp.zeros_like(features))
+    scale = jnp.max(jnp.abs(safe_features))
+    _, exponent = jnp.frexp(scale)
+    scaled_features = jnp.ldexp(safe_features, -exponent)
+    singular_values = jnp.abs(jnp.linalg.svdvals(scaled_features.T))
+    total = jnp.sum(singular_values)
+    probabilities = singular_values / jnp.maximum(total, epsilon)
     entropy = -jnp.sum(probabilities * jnp.log(probabilities + epsilon))
     candidate = jnp.exp(entropy)
-    return jnp.where(jnp.isfinite(candidate), candidate, jnp.asarray(1.0, features.dtype))
+    valid = finite & jnp.all(jnp.isfinite(singular_values)) & jnp.isfinite(candidate)
+    return jnp.where(valid, candidate, jnp.zeros_like(candidate)), valid
+
+
+def l2er_effective_rank(features: Array, epsilon: float = 1e-8) -> Array:
+    """Official entropy effective-rank estimator with explicit invalidity."""
+    candidate, valid = l2er_effective_rank_transaction(features, epsilon)
+    if isinstance(valid, jax.core.Tracer):
+        return jnp.where(valid, candidate, jnp.full_like(candidate, jnp.nan))
+    if not bool(valid):
+        raise ValueError("effective rank must be finite")
+    return candidate
 
 
 def l2er_effective_rank_loss(

--- a/tests/test_l2er_ipmnist.py
+++ b/tests/test_l2er_ipmnist.py
@@ -14,6 +14,7 @@ from alberta_framework.benchmarks.ipmnist_screening import (
     l2er_development_result_payload,
     l2er_effective_rank,
     l2er_effective_rank_loss,
+    l2er_effective_rank_transaction,
     l2er_update,
     run_screening_config,
     screening_spec,
@@ -57,6 +58,16 @@ def test_effective_rank_matches_official_entropy_estimator() -> None:
     assert float(l2er_effective_rank(jnp.zeros((4, 3)))) == pytest.approx(1.0)
     huge = jnp.eye(4, dtype=jnp.float32) * jnp.asarray(1e38, dtype=jnp.float32)
     assert float(l2er_effective_rank(huge)) == pytest.approx(4.0, rel=1e-5)
+
+
+def test_effective_rank_preserves_invalidity_in_eager_and_traced_calls() -> None:
+    invalid = jnp.asarray([[jnp.inf]], dtype=jnp.float32)
+    with pytest.raises(ValueError, match="effective rank must be finite"):
+        l2er_effective_rank(invalid)
+    assert bool(jnp.isnan(jax.jit(l2er_effective_rank)(invalid)))
+    safe, valid = jax.jit(l2er_effective_rank_transaction)(invalid)
+    assert float(safe) == 0.0
+    assert not bool(valid)
 
 
 def test_l2_and_mechanism_off_are_exact_reductions() -> None:


### PR DESCRIPTION
Narrow follow-up to the merged L2-ER comparator. The public effective-rank diagnostic no longer turns traced nonfinite inputs or a nonfinite SVD/result into rank `1.0`. It now uses power-of-two input scaling before SVD (avoiding float32 reciprocal underflow), exposes a validity-carrying transaction, raises eagerly on invalidity, and returns NaN under JIT so the enclosing checked update can reject it. Ordinary, zero, and finite `1e38` parity remain covered. Validation: 13 focused tests; scoped Ruff; strict mypy. No benchmark or issue closure.