### PR TITLE
fix(scorecard): bind run specs to the frozen schedule

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -1367,13 +1367,33 @@ class ScorecardRunSpec:
             type(self.environment_kind) is not str
             or self.environment_kind not in ENVIRONMENT_ROSTER
         ):
-            raise ValueError(f"unsupported environment {self.environment_kind!r}")
+            raise ValueError("environment_kind is not in the fixed scorecard roster")
         if type(self.arm) is not str or self.arm not in ARM_ROSTER:
-            raise ValueError(f"unsupported scorecard arm {self.arm!r}")
+            raise ValueError("arm is not in the fixed scorecard roster")
         if type(self.seed) is not int or self.seed not in SEED_ROSTER:
             raise ValueError("seed is not in the fixed scorecard roster")
         if not _is_scorecard_lifecycle_id(self.lifecycle_id):
             raise ValueError("lifecycle_id must be a prototype.<16-hex> identity")
+        runs_per_seed = len(ENVIRONMENT_ROSTER) * len(ARM_ROSTER)
+        seed_index, within_seed = divmod(self.schedule_index, runs_per_seed)
+        environment_index, arm_index = divmod(within_seed, len(ARM_ROSTER))
+        expected_seed = SEED_ROSTER[seed_index]
+        expected_environment = ENVIRONMENT_ROSTER[environment_index]
+        expected_arm = _rotated_arms(seed_index)[arm_index]
+        if (
+            self.seed != expected_seed
+            or self.environment_kind != expected_environment
+            or self.arm != expected_arm
+        ):
+            raise ValueError("run identity does not match its fixed schedule_index")
+        identity = (
+            f"{REFERENCE_LIFE_SCORECARD_PLAN_V1_SHA256}:"
+            f"{expected_environment}:{expected_arm}:{expected_seed}"
+        )
+        lifecycle_hex = hashlib.sha256(identity.encode("ascii")).hexdigest()[:16]
+        expected_lifecycle = f"prototype.{lifecycle_hex}"
+        if self.lifecycle_id != expected_lifecycle:
+            raise ValueError("lifecycle_id does not match the fixed run identity")
 
 
 def iter_run_specs(plan: ReferenceLifeDevelopmentPlan) -> tuple[ScorecardRunSpec, ...]:

--- a/tests/test_scorecard_run_spec_hostile.py
+++ b/tests/test_scorecard_run_spec_hostile.py
@@ -17,14 +17,21 @@ from alberta_framework.benchmarks.reference_life_scorecard import (
 class _StringSubclass(str):
     """Leftover string identity that must not cross the spec boundary."""
 
+    calls = 0
+
+    def __repr__(self) -> str:
+        type(self).calls += 1
+        raise AssertionError("hostile repr")
+
 
 def _legal_spec(**overrides: object) -> ScorecardRunSpec:
+    canonical = iter_run_specs(build_development_plan())[0]
     payload = {
-        "schedule_index": 0,
-        "environment_kind": ENVIRONMENT_ROSTER[0],
-        "arm": ARM_ROSTER[0],
-        "seed": SEED_ROSTER[0],
-        "lifecycle_id": "prototype." + ("a" * 16),
+        "schedule_index": canonical.schedule_index,
+        "environment_kind": canonical.environment_kind,
+        "arm": canonical.arm,
+        "seed": canonical.seed,
+        "lifecycle_id": canonical.lifecycle_id,
     }
     payload.update(overrides)
     return ScorecardRunSpec(**payload)  # type: ignore[arg-type]
@@ -52,13 +59,14 @@ def test_scorecard_run_spec_rejects_leftover_integer_identities() -> None:
 
 
 def test_scorecard_run_spec_rejects_leftover_and_unknown_string_identities() -> None:
-    with pytest.raises(ValueError, match="unsupported environment"):
+    with pytest.raises(ValueError, match="environment_kind is not"):
         _legal_spec(environment_kind=True)
-    with pytest.raises(ValueError, match="unsupported scorecard arm"):
+    with pytest.raises(ValueError, match="arm is not"):
         _legal_spec(arm=True)
-    with pytest.raises(ValueError, match="unsupported environment"):
+    _StringSubclass.calls = 0
+    with pytest.raises(ValueError, match="environment_kind is not"):
         _legal_spec(environment_kind=_StringSubclass(ENVIRONMENT_ROSTER[0]))
-    with pytest.raises(ValueError, match="unsupported scorecard arm"):
+    with pytest.raises(ValueError, match="arm is not"):
         _legal_spec(arm=_StringSubclass(ARM_ROSTER[0]))
     with pytest.raises(ValueError, match="lifecycle_id must be a prototype"):
         _legal_spec(lifecycle_id=True)
@@ -66,3 +74,16 @@ def test_scorecard_run_spec_rejects_leftover_and_unknown_string_identities() -> 
         _legal_spec(lifecycle_id=_StringSubclass("prototype." + ("a" * 16)))
     with pytest.raises(ValueError, match="lifecycle_id must be a prototype"):
         _legal_spec(lifecycle_id="prototype.not-hex")
+    assert _StringSubclass.calls == 0
+
+
+def test_scorecard_run_spec_cross_binds_schedule_and_lifecycle() -> None:
+    specs = iter_run_specs(build_development_plan())
+    assert len(specs) == 144
+    first = specs[0]
+    second = specs[1]
+    with pytest.raises(ValueError, match="does not match its fixed schedule_index"):
+        _legal_spec(arm=second.arm)
+    with pytest.raises(ValueError, match="does not match the fixed run identity"):
+        _legal_spec(lifecycle_id=second.lifecycle_id)
+    assert first.lifecycle_id != second.lifecycle_id


### PR DESCRIPTION
Post-merge deep corrective for contributor #1659 / issue #1658 after the workflow gates in #1662.

`ScorecardRunSpec` now derives the exact seed/environment/rotated-arm identity from `schedule_index` and binds the lifecycle digest to that complete identity and the frozen plan SHA. Hostile string subclasses are rejected without invoking representation hooks. This closes combinations where every field was individually legal but belonged to different scheduled shards.

Contributor authorship remains on main through @ss251’s #1659.

Verification: 104 focused scorecard/control/workflow tests, 8 post-rebase contract tests, actionlint, Ruff, strict mypy, diff-check. No scorecard run/output.

Closes #1658
Refs #1585