### PR TITLE
fix(evaluation): reject leftover multiagent ConditionResult identities

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -36,7 +36,7 @@ import operator
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from time import perf_counter, perf_counter_ns
-from typing import Literal, SupportsIndex, cast
+from typing import Any, Literal, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -109,6 +109,22 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 
 def _require_uint32(name: str, value: object) -> int:
     return _require_int32(name, value, minimum=0, maximum=_UINT32_MAX)
+
+
+def _require_ndarray(
+    name: str,
+    value: object,
+    *,
+    dtype: np.dtype[Any],
+    ndim: int = 1,
+) -> NDArray[Any]:
+    if type(value) is not np.ndarray:
+        raise ValueError(f"{name} must be an exact numpy.ndarray")
+    if value.dtype != dtype:
+        raise ValueError(f"{name} must have dtype {dtype}")
+    if value.ndim != ndim:
+        raise ValueError(f"{name} must be {ndim}-dimensional")
+    return value
 
 
 def _require_seed(value: object) -> int:
@@ -407,6 +423,59 @@ class ConditionResult:
     interference_forgetting: float
     controller_budget: ControllerBudget
     timing: TimingMetrics
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "seed", _require_seed(self.seed))
+        known = tuple(name for name, _mask in CONDITION_MASKS)
+        if type(self.condition) is not str or self.condition not in known:
+            raise ValueError("condition must be a known multiagent condition name")
+        if (
+            type(self.learning_mask) is not tuple
+            or len(self.learning_mask) != 2
+            or any(type(flag) is not bool for flag in self.learning_mask)
+        ):
+            raise ValueError("learning_mask must be a pair of booleans")
+        rewards = _require_ndarray(
+            "online_rewards", self.online_rewards, dtype=np.dtype(np.float64)
+        )
+        if int(rewards.shape[0]) < 1:
+            raise ValueError("online_rewards must contain at least one step")
+        _require_ndarray(
+            "phase_mean_rewards",
+            self.phase_mean_rewards,
+            dtype=np.dtype(np.float64),
+        )
+        _require_ndarray(
+            "performance_matrix",
+            self.performance_matrix,
+            dtype=np.dtype(np.float64),
+            ndim=2,
+        )
+        if not isinstance(self.summary, ContinualLearningSummary):
+            raise ValueError("summary must be a ContinualLearningSummary")
+        _require_ndarray(
+            "recovery_lengths",
+            self.recovery_lengths,
+            dtype=np.dtype(np.int64),
+        )
+        object.__setattr__(
+            self,
+            "recurrence_recovery_steps",
+            _require_int32(
+                "recurrence_recovery_steps",
+                self.recurrence_recovery_steps,
+                minimum=-1,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "interference_forgetting",
+            finite_real("interference_forgetting", self.interference_forgetting),
+        )
+        if not isinstance(self.controller_budget, ControllerBudget):
+            raise ValueError("controller_budget must be a ControllerBudget")
+        if not isinstance(self.timing, TimingMetrics):
+            raise ValueError("timing must be a TimingMetrics")
 
 
 @dataclass(frozen=True)

--- a/tests/test_multiagent_condition_result_hostile.py
+++ b/tests/test_multiagent_condition_result_hostile.py
@@ -1,0 +1,99 @@
+"""Complete ConditionResult identity contract: leftover, types, and arrays."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.evaluation.continual_multiagent import (
+    ConditionResult,
+    ControllerBudget,
+    TimingMetrics,
+)
+from alberta_framework.utils.metrics import ContinualLearningSummary
+
+
+class StringSubclass(str):
+    """Leftover string identity that must not cross the result boundary."""
+
+
+def _summary() -> ContinualLearningSummary:
+    return ContinualLearningSummary(
+        final_performance=0.0,
+        prequential_performance=0.0,
+        mean_forgetting=0.0,
+        max_forgetting=0.0,
+        backward_transfer=0.0,
+        stability_gap_mean=0.0,
+        stability_gap_max=0.0,
+        per_task_final_performance=np.zeros(2, dtype=np.float64),
+        per_task_forgetting=np.zeros(2, dtype=np.float64),
+        per_task_backward_transfer=np.zeros(2, dtype=np.float64),
+    )
+
+
+def _legal(**overrides: object) -> ConditionResult:
+    payload: dict[str, object] = {
+        "seed": 30,
+        "condition": "frozen",
+        "learning_mask": (False, False),
+        "online_rewards": np.zeros(4, dtype=np.float64),
+        "phase_mean_rewards": np.zeros(3, dtype=np.float64),
+        "performance_matrix": np.zeros((3, 2), dtype=np.float64),
+        "summary": _summary(),
+        "recovery_lengths": np.asarray([-1, -1], dtype=np.int64),
+        "recurrence_recovery_steps": -1,
+        "interference_forgetting": 0.0,
+        "controller_budget": ControllerBudget(
+            state_scalars=1, state_bytes=8, action_scalars_per_step=1
+        ),
+        "timing": TimingMetrics(
+            wall_seconds=0.1,
+            mean_step_latency_ms=0.1,
+            mean_update_latency_ms=0.1,
+            p95_update_latency_ms=0.1,
+        ),
+    }
+    payload.update(overrides)
+    return ConditionResult(**payload)  # type: ignore[arg-type]
+
+
+def test_condition_result_accepts_canonical_identity() -> None:
+    result = _legal()
+    assert result.seed == 30
+    assert result.condition == "frozen"
+    assert result.learning_mask == (False, False)
+    assert result.recurrence_recovery_steps == -1
+
+
+def test_condition_result_rejects_leftover_integer_and_float_identities() -> None:
+    with pytest.raises(ValueError, match="seeds must lie in"):
+        _legal(seed=True)
+    with pytest.raises(ValueError, match="recurrence_recovery_steps must be an integer"):
+        _legal(recurrence_recovery_steps=True)
+    with pytest.raises(ValueError, match="interference_forgetting must be a finite"):
+        _legal(interference_forgetting=True)
+
+
+def test_condition_result_rejects_leftover_condition_and_mask_identities() -> None:
+    with pytest.raises(ValueError, match="condition must be a known multiagent condition name"):
+        _legal(condition=True)
+    with pytest.raises(ValueError, match="condition must be a known multiagent condition name"):
+        _legal(condition=StringSubclass("frozen"))
+    with pytest.raises(ValueError, match="learning_mask must be a pair of booleans"):
+        _legal(learning_mask=(1, 0))
+    with pytest.raises(ValueError, match="learning_mask must be a pair of booleans"):
+        _legal(learning_mask=[False, False])
+
+
+def test_condition_result_rejects_invalid_arrays_and_hosts() -> None:
+    with pytest.raises(ValueError, match="online_rewards must be an exact numpy.ndarray"):
+        _legal(online_rewards=[0.0, 0.0, 0.0, 0.0])
+    with pytest.raises(ValueError, match="performance_matrix must be 2-dimensional"):
+        _legal(performance_matrix=np.zeros(3, dtype=np.float64))
+    with pytest.raises(ValueError, match="summary must be a ContinualLearningSummary"):
+        _legal(summary=None)
+    with pytest.raises(ValueError, match="controller_budget must be a ControllerBudget"):
+        _legal(controller_budget=None)
+    with pytest.raises(ValueError, match="timing must be a TimingMetrics"):
+        _legal(timing=None)


### PR DESCRIPTION
Closes #1670.

## What changed

`ConditionResult` now fail-closes leftover bool seed/step identities, leftover condition names, leftover `learning_mask` ints, exact ndarray hosts, and nested summary/budget/timing types — the same complete bar Kayvan `#1316` already applied to acceptance records.

On `origin/main` `8c54ad0d`, `ConditionResult(seed=True)` constructed and stored `bool True`. Legal integer seeds and the `-1` recovery sentinel stay legal.

No unpublished grok head on this file. Occupancy-free. Not a leftover-tax reprint.

## Scope

- `alberta_framework/evaluation/continual_multiagent.py`
- `tests/test_multiagent_condition_result_hostile.py`

## Occupancy

Open ASI PRs at publish: ss251 `#1667` (`continual_ia.py`), `#1659` (`reference_life_scorecard.py`); Shaw `#1657`/`#1647`/`#1643`. No open PR on `continual_multiagent.py`.

## Verification

- Red on base: `ConditionResult(seed=True)` constructed
- New result contract + acceptance hostile tests: 57 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary leftover-identity validation only. No kernel math, lifetime clocks, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7f656ab8dec476aec0ec572f7141b6fe97bf8171 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
