### PR TITLE
fix(scorecard): cross-bind run spec identities

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -235,6 +235,22 @@ def _is_scorecard_lifecycle_id(value: object) -> bool:
     return len(digest) == 16 and all(character in "0123456789abcdef" for character in digest)
 
 
+def _scorecard_spec_identity(environment_kind: str, arm: str, seed: int) -> tuple[int, str]:
+    seed_index = SEED_ROSTER.index(seed)
+    environment_index = ENVIRONMENT_ROSTER.index(environment_kind)
+    arm_index = _rotated_arms(seed_index).index(arm)
+    schedule_index = (
+        seed_index * len(ENVIRONMENT_ROSTER) * len(ARM_ROSTER)
+        + environment_index * len(ARM_ROSTER)
+        + arm_index
+    )
+    identity = (
+        f"{REFERENCE_LIFE_SCORECARD_PLAN_V1_SHA256}:{environment_kind}:{arm}:{seed}"
+    )
+    lifecycle_hex = hashlib.sha256(identity.encode("ascii")).hexdigest()[:16]
+    return schedule_index, f"prototype.{lifecycle_hex}"
+
+
 def _arm_definitions() -> list[dict[str, Any]]:
     return [
         {
@@ -1367,13 +1383,20 @@ class ScorecardRunSpec:
             type(self.environment_kind) is not str
             or self.environment_kind not in ENVIRONMENT_ROSTER
         ):
-            raise ValueError(f"unsupported environment {self.environment_kind!r}")
+            raise ValueError("environment_kind must be an exact fixed-roster identity")
         if type(self.arm) is not str or self.arm not in ARM_ROSTER:
-            raise ValueError(f"unsupported scorecard arm {self.arm!r}")
+            raise ValueError("arm must be an exact fixed-roster identity")
         if type(self.seed) is not int or self.seed not in SEED_ROSTER:
             raise ValueError("seed is not in the fixed scorecard roster")
         if not _is_scorecard_lifecycle_id(self.lifecycle_id):
             raise ValueError("lifecycle_id must be a prototype.<16-hex> identity")
+        expected_index, expected_lifecycle = _scorecard_spec_identity(
+            self.environment_kind, self.arm, self.seed
+        )
+        if self.schedule_index != expected_index:
+            raise ValueError("schedule_index does not match the fixed run identity")
+        if self.lifecycle_id != expected_lifecycle:
+            raise ValueError("lifecycle_id does not bind the fixed plan and run identity")
 
 
 def iter_run_specs(plan: ReferenceLifeDevelopmentPlan) -> tuple[ScorecardRunSpec, ...]:
@@ -1385,16 +1408,16 @@ def iter_run_specs(plan: ReferenceLifeDevelopmentPlan) -> tuple[ScorecardRunSpec
     for seed in plan.seeds:
         for environment in plan.environments:
             for arm in plan.arm_order(seed):
-                schedule_index = len(specs)
-                identity = f"{plan.plan_sha256}:{environment}:{arm}:{seed}"
-                lifecycle_hex = hashlib.sha256(identity.encode("ascii")).hexdigest()[:16]
+                schedule_index, lifecycle_id = _scorecard_spec_identity(
+                    environment, arm, seed
+                )
                 specs.append(
                     ScorecardRunSpec(
                         schedule_index=schedule_index,
                         environment_kind=environment,
                         arm=arm,
                         seed=seed,
-                        lifecycle_id=f"prototype.{lifecycle_hex}",
+                        lifecycle_id=lifecycle_id,
                     )
                 )
     return tuple(specs)

--- a/tests/test_scorecard_run_spec_hostile.py
+++ b/tests/test_scorecard_run_spec_hostile.py
@@ -18,13 +18,19 @@ class _StringSubclass(str):
     """Leftover string identity that must not cross the spec boundary."""
 
 
+class _HostileIdentity:
+    def __repr__(self) -> str:
+        raise AssertionError("hostile repr")
+
+
 def _legal_spec(**overrides: object) -> ScorecardRunSpec:
+    canonical = iter_run_specs(build_development_plan())[0]
     payload = {
-        "schedule_index": 0,
-        "environment_kind": ENVIRONMENT_ROSTER[0],
-        "arm": ARM_ROSTER[0],
-        "seed": SEED_ROSTER[0],
-        "lifecycle_id": "prototype." + ("a" * 16),
+        "schedule_index": canonical.schedule_index,
+        "environment_kind": canonical.environment_kind,
+        "arm": canonical.arm,
+        "seed": canonical.seed,
+        "lifecycle_id": canonical.lifecycle_id,
     }
     payload.update(overrides)
     return ScorecardRunSpec(**payload)  # type: ignore[arg-type]
@@ -52,17 +58,33 @@ def test_scorecard_run_spec_rejects_leftover_integer_identities() -> None:
 
 
 def test_scorecard_run_spec_rejects_leftover_and_unknown_string_identities() -> None:
-    with pytest.raises(ValueError, match="unsupported environment"):
+    with pytest.raises(ValueError, match="environment_kind must be an exact"):
         _legal_spec(environment_kind=True)
-    with pytest.raises(ValueError, match="unsupported scorecard arm"):
+    with pytest.raises(ValueError, match="arm must be an exact"):
         _legal_spec(arm=True)
-    with pytest.raises(ValueError, match="unsupported environment"):
+    with pytest.raises(ValueError, match="environment_kind must be an exact"):
         _legal_spec(environment_kind=_StringSubclass(ENVIRONMENT_ROSTER[0]))
-    with pytest.raises(ValueError, match="unsupported scorecard arm"):
+    with pytest.raises(ValueError, match="arm must be an exact"):
         _legal_spec(arm=_StringSubclass(ARM_ROSTER[0]))
+    with pytest.raises(ValueError, match="environment_kind must be an exact"):
+        _legal_spec(environment_kind=_HostileIdentity())
     with pytest.raises(ValueError, match="lifecycle_id must be a prototype"):
         _legal_spec(lifecycle_id=True)
     with pytest.raises(ValueError, match="lifecycle_id must be a prototype"):
         _legal_spec(lifecycle_id=_StringSubclass("prototype." + ("a" * 16)))
     with pytest.raises(ValueError, match="lifecycle_id must be a prototype"):
         _legal_spec(lifecycle_id="prototype.not-hex")
+
+
+def test_scorecard_run_spec_cross_binds_schedule_and_lifecycle() -> None:
+    canonical = iter_run_specs(build_development_plan())[0]
+    with pytest.raises(ValueError, match="schedule_index does not match"):
+        _legal_spec(schedule_index=canonical.schedule_index + 1)
+    with pytest.raises(ValueError, match="schedule_index does not match"):
+        _legal_spec(environment_kind=ENVIRONMENT_ROSTER[1])
+    with pytest.raises(ValueError, match="schedule_index does not match"):
+        _legal_spec(arm=ARM_ROSTER[1])
+    with pytest.raises(ValueError, match="schedule_index does not match"):
+        _legal_spec(seed=SEED_ROSTER[1])
+    with pytest.raises(ValueError, match="lifecycle_id does not bind"):
+        _legal_spec(lifecycle_id="prototype." + ("a" * 16))


### PR DESCRIPTION
Deep follow-up to #1659. Preserve its exact scalar/roster host gates, then bind the fields as one canonical identity: `(environment, arm, seed)` now derives the only legal schedule index and lifecycle hash under the frozen plan digest. Rejected hostile objects are no longer interpolated through `repr`. `iter_run_specs` shares the derivation helper, preventing drift.\n\nVerification: 72 focused scorecard/workflow/hostile tests; scoped Ruff; strict mypy (187 files); diff check. No workflow dispatch or output mutation.\n\nCo-authored-by: ss251 <ss251@users.noreply.github.com>