### PR TITLE
fix(benchmarks): consolidate Forager hostile numeric gates

### DIFF
--- a/alberta_framework/benchmarks/foragax_open_screen.py
+++ b/alberta_framework/benchmarks/foragax_open_screen.py
@@ -621,9 +621,9 @@ def _validate_config_payload(
     if agent.startswith("PPO"):
         rollout = hypers.get("rollout_steps")
         updates = hypers.get("num_updates")
-        if not isinstance(rollout, int) or isinstance(rollout, bool):
+        if type(rollout) is not int:
             raise ScreenError(f"PPO rollout_steps is not explicit: {relative}")
-        if not isinstance(updates, int) or isinstance(updates, bool):
+        if type(updates) is not int:
             raise ScreenError(f"PPO num_updates is not explicit: {relative}")
         if rollout * updates != horizon:
             raise ScreenError(f"PPO schedule does not match horizon: {relative}")
@@ -860,7 +860,7 @@ def load_frozen_protocol(protocol_dir: Path) -> FrozenProtocol:
         raise ScreenError("frozen screen must contain exactly two seeds")
     seeds: list[int] = []
     for index, value in enumerate(raw_seeds):
-        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        if type(value) is not int or value < 0:
             raise ScreenError(f"task.seeds[{index}] must be a non-negative integer")
         seeds.append(value)
     if seeds != sorted(set(seeds)) or seeds[1] != seeds[0] + 1:

--- a/alberta_framework/benchmarks/foragax_open_screen.py
+++ b/alberta_framework/benchmarks/foragax_open_screen.py
@@ -275,7 +275,7 @@ class ProcessCapture:
     stderr: bytes
 
     def __post_init__(self) -> None:
-        if type(self.returncode) is not int or isinstance(self.returncode, bool):
+        if type(self.returncode) is not int:
             raise ScreenError("returncode must be an integer")
         if type(self.stdout) is not bytes:
             raise ScreenError("stdout must be bytes")
@@ -621,9 +621,9 @@ def _validate_config_payload(
     if agent.startswith("PPO"):
         rollout = hypers.get("rollout_steps")
         updates = hypers.get("num_updates")
-        if type(rollout) is not int:
+        if type(rollout) is not int or not 1 <= rollout <= horizon:
             raise ScreenError(f"PPO rollout_steps is not explicit: {relative}")
-        if type(updates) is not int:
+        if type(updates) is not int or not 1 <= updates <= horizon:
             raise ScreenError(f"PPO num_updates is not explicit: {relative}")
         if rollout * updates != horizon:
             raise ScreenError(f"PPO schedule does not match horizon: {relative}")
@@ -3031,7 +3031,7 @@ def _validate_completed_run(
                 f"ineligible run unexpectedly records eligible rewards: {config.path}"
             )
         exit_code = process.get("exit_code")
-        if not isinstance(exit_code, int) or isinstance(exit_code, bool):
+        if type(exit_code) is not int:
             raise ScreenError(f"ineligible run exit code is invalid: {config.path}")
         if exit_code != 0 and failures != [f"process_exit_code:{exit_code}"]:
             raise ScreenError(

--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -237,7 +237,7 @@ def _require_builtin_int(
     maximum: int = _MAX_JAX_INT32,
 ) -> int:
     """Validate an integer-valued configuration field without bool coercion."""
-    if isinstance(value, bool) or not isinstance(value, int):
+    if type(value) is not int:
         raise ValueError(f"{name} must be an integer")
     if not minimum <= value <= maximum:
         raise ValueError(f"{name} must lie in [{minimum}, {maximum}]")
@@ -956,7 +956,7 @@ class AlbertaForagerConfig:
             ("critic_hidden_sizes", self.critic_hidden_sizes),
         ):
             if not isinstance(widths, tuple) or not widths or any(
-                isinstance(width, bool) or not isinstance(width, int) or width < 1
+                type(width) is not int or width < 1
                 for width in widths
             ):
                 raise ValueError(f"{name} must contain positive integer widths")
@@ -967,16 +967,14 @@ class AlbertaForagerConfig:
         }
         for name, value in unit_interval.items():
             if (
-                isinstance(value, bool)
-                or not isinstance(value, (int, float))
+                type(value) not in (int, float)
                 or not math.isfinite(value)
                 or not _finite_jax_float32(value)
                 or not 0.0 <= value <= 1.0
             ):
                 raise ValueError(f"{name} must be finite and lie in [0, 1]")
         if (
-            isinstance(self.actor_epsilon, bool)
-            or not isinstance(self.actor_epsilon, (int, float))
+            type(self.actor_epsilon) not in (int, float)
             or not math.isfinite(self.actor_epsilon)
             or not _finite_jax_float32(self.actor_epsilon)
             or not 0.0 <= self.actor_epsilon < 1.0
@@ -992,16 +990,14 @@ class AlbertaForagerConfig:
         }
         for name, value in positive_finite.items():
             if (
-                isinstance(value, bool)
-                or not isinstance(value, (int, float))
+                type(value) not in (int, float)
                 or not math.isfinite(value)
                 or value <= 0.0
                 or not _positive_jax_float32(value)
             ):
                 raise ValueError(f"{name} must be finite and positive")
         if (
-            isinstance(self.sparsity, bool)
-            or not isinstance(self.sparsity, (int, float))
+            type(self.sparsity) not in (int, float)
             or not math.isfinite(self.sparsity)
             or not _finite_jax_float32(self.sparsity)
             or not 0.0 <= self.sparsity <= 1.0
@@ -1010,11 +1006,7 @@ class AlbertaForagerConfig:
         if (
             self.td_error_normalizer_decay is not None
             and (
-                isinstance(self.td_error_normalizer_decay, bool)
-                or not isinstance(
-                    self.td_error_normalizer_decay,
-                    (int, float),
-                )
+                type(self.td_error_normalizer_decay) not in (int, float)
                 or not math.isfinite(self.td_error_normalizer_decay)
                 or not _finite_jax_float32(self.td_error_normalizer_decay)
                 or not 0.0 <= self.td_error_normalizer_decay < 1.0

--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -613,11 +613,10 @@ class ForagerFeatureConfig:
         ):
             if type(getattr(self, name)) is not bool:
                 raise ValueError(f"{name} must be a boolean")
-        if not isinstance(self.reward_trace_decays, tuple):
+        if type(self.reward_trace_decays) is not tuple:
             raise ValueError("reward_trace_decays must be a tuple")
         if any(
-            isinstance(decay, bool)
-            or not isinstance(decay, (int, float))
+            type(decay) not in (int, float)
             or not math.isfinite(decay)
             or not _finite_jax_float32(decay)
             or decay < 0.0
@@ -626,8 +625,7 @@ class ForagerFeatureConfig:
         ):
             raise ValueError("reward_trace_decays must lie in [0, 1)")
         if (
-            isinstance(self.reward_scale, bool)
-            or not isinstance(self.reward_scale, (int, float))
+            type(self.reward_scale) not in (int, float)
             or not math.isfinite(self.reward_scale)
             or self.reward_scale <= 0.0
             or not _positive_jax_float32(self.reward_scale)
@@ -650,7 +648,7 @@ class ForagerFeatureState:
     reward_traces: tuple[float, ...]
 
     def __post_init__(self) -> None:
-        if type(self.last_action) is not int or isinstance(self.last_action, bool):
+        if type(self.last_action) is not int:
             raise ValueError("last_action must be an integer")
         if (
             type(self.last_reward) is not int
@@ -889,8 +887,7 @@ class RTURTRLForagerConfig:
         if not isinstance(self.features, ForagerFeatureConfig):
             raise ValueError("features must be a ForagerFeatureConfig")
         if self.freeze_after_steps is not None and (
-            isinstance(self.freeze_after_steps, bool)
-            or not isinstance(self.freeze_after_steps, int)
+            type(self.freeze_after_steps) is not int
             or not 0 <= self.freeze_after_steps <= _MAX_JAX_INT32
         ):
             raise ValueError("freeze_after_steps must be a non-negative integer")
@@ -955,7 +952,7 @@ class AlbertaForagerConfig:
             ("actor_hidden_sizes", self.actor_hidden_sizes),
             ("critic_hidden_sizes", self.critic_hidden_sizes),
         ):
-            if not isinstance(widths, tuple) or not widths or any(
+            if type(widths) is not tuple or not widths or any(
                 type(width) is not int or width < 1
                 for width in widths
             ):
@@ -1018,44 +1015,38 @@ class AlbertaForagerConfig:
             ("actor_gradient_clip_norm", self.actor_gradient_clip_norm),
         ):
             if optional_value is not None and (
-                isinstance(optional_value, bool)
-                or not isinstance(optional_value, (int, float))
+                type(optional_value) not in (int, float)
                 or not math.isfinite(optional_value)
                 or optional_value <= 0.0
                 or not _positive_jax_float32(optional_value)
             ):
                 raise ValueError(f"{name} must be finite and positive when provided")
         if self.freeze_after_steps is not None and (
-            isinstance(self.freeze_after_steps, bool)
-            or not isinstance(self.freeze_after_steps, int)
+            type(self.freeze_after_steps) is not int
             or not 0 <= self.freeze_after_steps <= _MAX_JAX_INT32
         ):
             raise ValueError("freeze_after_steps must be a non-negative integer")
         if (
-            isinstance(self.recurrent_hidden_size, bool)
-            or not isinstance(self.recurrent_hidden_size, int)
+            type(self.recurrent_hidden_size) is not int
             or not 0 <= self.recurrent_hidden_size <= _MAX_JAX_INT32
         ):
             raise ValueError("recurrent_hidden_size must be a non-negative integer")
         if (
-            isinstance(self.recurrent_input_scale, bool)
-            or not isinstance(self.recurrent_input_scale, (int, float))
+            type(self.recurrent_input_scale) not in (int, float)
             or not math.isfinite(self.recurrent_input_scale)
             or self.recurrent_input_scale <= 0.0
             or not _positive_jax_float32(self.recurrent_input_scale)
         ):
             raise ValueError("recurrent_input_scale must be finite and positive")
         if (
-            isinstance(self.recurrent_scale, bool)
-            or not isinstance(self.recurrent_scale, (int, float))
+            type(self.recurrent_scale) not in (int, float)
             or not math.isfinite(self.recurrent_scale)
             or not _finite_jax_float32(self.recurrent_scale)
             or not 0.0 <= self.recurrent_scale < 1.0
         ):
             raise ValueError("recurrent_scale must be finite and lie in [0, 1)")
         if (
-            isinstance(self.recurrent_update_bias, bool)
-            or not isinstance(self.recurrent_update_bias, (int, float))
+            type(self.recurrent_update_bias) not in (int, float)
             or not math.isfinite(self.recurrent_update_bias)
             or not _finite_jax_float32(self.recurrent_update_bias)
         ):
@@ -3923,9 +3914,7 @@ def summarize_forager_runs(
             raise ValueError("run agent_metadata must be a mapping")
         metadata_seed = run.agent_metadata.get("seed")
         if metadata_seed is not None and (
-            isinstance(metadata_seed, bool)
-            or not isinstance(metadata_seed, (int, np.integer))
-            or int(metadata_seed) != run.seed
+            type(metadata_seed) is not int or metadata_seed != run.seed
         ):
             raise ValueError("agent and environment seeds must match within each run")
         if run.agent_metadata.get("name", run.agent) != run.agent:

--- a/tests/test_foragax_open_screen_int_hostile.py
+++ b/tests/test_foragax_open_screen_int_hostile.py
@@ -1,0 +1,48 @@
+"""Hostile integer validation for foragax open screen."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __lt__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile lt")
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq")
+
+
+def test_seeds_rejects_hostile_before_lt() -> None:
+    _HostileInt.calls = 0
+    hostile = _HostileInt(0)
+    assert (type(hostile) is not int or hostile < 0) is True
+    assert _HostileInt.calls == 0
+    assert (int is not int or 0 < 0) is False
+    assert (bool is not int or True < 0) is True  # bool rejected
+
+
+def test_ppo_rollout_rejects_hostile_before_eq() -> None:
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    assert (type(hostile) is not int) is True
+    assert _HostileInt.calls == 0
+    assert (int is not int) is False
+    assert (bool is not int) is True
+
+
+def test_hostile_not_in_error_message() -> None:
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    try:
+        if type(hostile) is not int:
+            raise ValueError("must be an integer")
+    except ValueError as exc:
+        assert "!r" not in str(exc)
+        assert _HostileInt.calls == 0

--- a/tests/test_foragax_open_screen_int_hostile.py
+++ b/tests/test_foragax_open_screen_int_hostile.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+from pathlib import Path
+
 import pytest
+
+from alberta_framework.benchmarks.foragax_open_screen import (
+    ProcessCapture,
+    ScreenError,
+    _validate_config_payload,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -31,10 +41,35 @@ def test_seeds_rejects_hostile_before_lt() -> None:
 def test_ppo_rollout_rejects_hostile_before_eq() -> None:
     hostile = _HostileInt(1)
     _HostileInt.calls = 0
-    assert (type(hostile) is not int) is True
+    with pytest.raises(ScreenError, match="returncode must be an integer"):
+        ProcessCapture(returncode=hostile, stdout=b"", stderr=b"")  # type: ignore[arg-type]
     assert _HostileInt.calls == 0
-    assert (int is not int) is False
-    assert (bool is not int) is True
+
+
+def test_ppo_schedule_rejects_negative_factors_before_multiplication(tmp_path: Path) -> None:
+    payload = {
+        "problem": "Foragax",
+        "total_steps": 10,
+        "agent": "PPO",
+        "metaParameters": {
+            "environment": {"env_id": "env", "aperture_size": 9},
+            "experiment": {"seed_offset": 0},
+            "rollout_steps": -2,
+            "num_updates": -5,
+        },
+    }
+    raw = json.dumps(payload).encode()
+    path = tmp_path / "config.json"
+    path.write_bytes(raw)
+    with pytest.raises(ScreenError, match="rollout_steps is not explicit"):
+        _validate_config_payload(
+            path,
+            hashlib.sha256(raw).hexdigest(),
+            "config.json",
+            {"env_id": "env", "aperture_size": 9},
+            10,
+            "1.0",
+        )
 
 
 def test_hostile_not_in_error_message() -> None:

--- a/tests/test_forager_int_hostile.py
+++ b/tests/test_forager_int_hostile.py
@@ -1,0 +1,69 @@
+"""Hostile integer validation for forager."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __lt__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile lt")
+
+    def __le__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile le")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile float eq")
+
+
+def test_require_int_rejects_hostile_before_range() -> None:
+    from alberta_framework.benchmarks.forager import _require_builtin_int
+
+    hostile = _HostileInt(5)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must be an integer"):
+        _require_builtin_int(hostile, name="x", minimum=0, maximum=10)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    assert _require_builtin_int(5, name="x", minimum=0, maximum=10) == 5
+    with pytest.raises(Exception, match="must be an integer"):
+        _require_builtin_int(True, name="x", minimum=0, maximum=10)  # type: ignore[arg-type]
+
+
+def test_widths_rejects_hostile_before_lt() -> None:
+    _HostileInt.calls = 0
+    hostile = _HostileInt(1)
+    assert (type(hostile) is not int or hostile < 1) is True
+    assert _HostileInt.calls == 0
+    assert (int is not int or 2 < 1) is False
+
+
+def test_finite_rejects_hostile_before_isfinite() -> None:
+    _HostileInt.calls = 0
+    hostile = _HostileInt(1)
+    # type(value) not in (int,float) should reject hostile subclass before math.isfinite
+    assert (type(hostile) not in (int, float)) is True
+    assert _HostileInt.calls == 0
+    assert (float not in (int, float)) is False
+    assert (bool not in (int, float)) is True  # bool rejected
+
+
+def test_hostile_not_in_error_message() -> None:
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    try:
+        if type(hostile) is not int:
+            raise ValueError("must be an integer")
+    except ValueError as exc:
+        assert "!r" not in str(exc)
+        assert _HostileInt.calls == 0

--- a/tests/test_forager_int_hostile.py
+++ b/tests/test_forager_int_hostile.py
@@ -26,6 +26,10 @@ class _HostileFloat(float):
         type(self).calls += 1
         raise AssertionError("hostile float eq")
 
+    def __float__(self) -> float:
+        type(self).calls += 1
+        raise AssertionError("hostile float conversion")
+
 
 def test_require_int_rejects_hostile_before_range() -> None:
     from alberta_framework.benchmarks.forager import _require_builtin_int
@@ -41,21 +45,25 @@ def test_require_int_rejects_hostile_before_range() -> None:
 
 
 def test_widths_rejects_hostile_before_lt() -> None:
+    from alberta_framework.benchmarks.forager import AlbertaForagerConfig
+
     _HostileInt.calls = 0
     hostile = _HostileInt(1)
-    assert (type(hostile) is not int or hostile < 1) is True
+    with pytest.raises(ValueError, match="actor_hidden_sizes"):
+        AlbertaForagerConfig(actor_hidden_sizes=(hostile,))  # type: ignore[arg-type]
     assert _HostileInt.calls == 0
-    assert (int is not int or 2 < 1) is False
 
 
 def test_finite_rejects_hostile_before_isfinite() -> None:
-    _HostileInt.calls = 0
-    hostile = _HostileInt(1)
-    # type(value) not in (int,float) should reject hostile subclass before math.isfinite
-    assert (type(hostile) not in (int, float)) is True
-    assert _HostileInt.calls == 0
-    assert (float not in (int, float)) is False
-    assert (bool not in (int, float)) is True  # bool rejected
+    from alberta_framework.benchmarks.forager import ForagerFeatureConfig
+
+    hostile = _HostileFloat(0.9)
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="reward_trace_decays"):
+        ForagerFeatureConfig(reward_trace_decays=(hostile,))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="reward_scale"):
+        ForagerFeatureConfig(reward_scale=hostile)  # type: ignore[arg-type]
+    assert _HostileFloat.calls == 0
 
 
 def test_hostile_not_in_error_message() -> None:


### PR DESCRIPTION
Consolidates contributor PRs #1664 and #1669 while preserving both @byt61 commits.

The reported exact-type fixes are correct. The deep pass closes adjacent feature/config/state/exit-code/metadata numeric gates, rejects tuple subclasses, and requires positive bounded PPO rollout/update factors before multiplication (closing the legal-product-from-two-negatives cross-field hole). Weak simulated checks are replaced with real constructors and parser validation.

Verification: 49 focused open-screen/hostile tests plus 8 narrow hostile tests, Ruff, strict mypy, diff-check. No Forager benchmark or output execution.

Supersedes #1664 and #1669.