### PR TITLE
feat(benchmarks): add audited Intentional Updates IPMNIST screen

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -117,6 +117,13 @@ identical seeds):
   ``sgd_ema_norm_d099`` the mechanism-free floor. Each factory reduces to
   the shared normalized-SGD base when its mechanism constant is inert
   (pinned).
+- ``intentional_updates_*``: a batch-size-one supervised protocol extension
+  of Intentional Updates (Sharifnassab et al., arXiv:2604.19033v1).  It
+  targets a fixed fractional decrease of current-example surprisal using the
+  paper's Eq. 5 and RMSProp diagonal direction.  The registered family pins
+  a fixed-step mechanism-off control, diagonal-normalization and clipping
+  ablations, and a head-only feature-learning control.  This is not the
+  paper's RL algorithm or a publication-equivalent reproduction.
 
 Everything here is a development screening diagnostic — never promotable
 scientific evidence. Benchmark executions happen through the CLI
@@ -217,6 +224,11 @@ VALIDATION_SCHEMA = "alberta.ipmnist_screening.proxy_validation.v2"
 SOURCE_PROVENANCE_SCHEMA = "alberta.ipmnist_screening.source_provenance.v1"
 DATASET_PROVENANCE_SCHEMA = "alberta.ipmnist_screening.dataset_provenance.v1"
 RUNTIME_SCHEMA = "alberta.ipmnist_screening.runtime.v1"
+INTENTIONAL_UPDATES_RECORD_SCHEMA = "asi.ipmnist.intentional_updates.development.v1"
+INTENTIONAL_UPDATES_PAPER_REVISION = "arXiv:2604.19033v1"
+INTENTIONAL_UPDATES_CODE_REVISION = (
+    "sharifnassab/Intentional_RL@e86e26fd8613ac212e9a52c3fed8a01d0a31f685"
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SOURCE_SCOPE = ("alberta_framework", "pyproject.toml", "uv.lock")
@@ -1385,6 +1397,144 @@ def _make_sgd_ema_norm_learner(
         }
         metrics = _step_metrics(new_params, x_norm, y, loss, logits)
         return new_params, SGDNormState(norm=new_norm), metrics  # type: ignore[call-arg]
+
+    return init_fn, full_step
+
+
+# =============================================================================
+# Intentional Updates: supervised IPMNIST protocol extension
+# =============================================================================
+
+
+@chex.dataclass(frozen=True)
+class IntentionalUpdatesIPMNISTState:
+    """RMS direction and adaptive-error scale owned by the extension.
+
+    There is deliberately no eligibility trace: unlike the paper's RL
+    trajectories, successive IPMNIST examples have no temporal-credit
+    semantics.  This is the paper's lambda=0 construction applied to the
+    correct-class log probability.
+    """
+
+    squared_gradient: dict[str, Array]
+    step: Array
+    clip_squared_error: Array
+    clip_step: Array
+    norm: EMANormState
+
+
+def _make_intentional_updates_learner(
+    hp: Mapping[str, float],
+) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    """Build the frozen supervised Intentional Updates screening slice.
+
+    For surprisal ``L=-log p(y|x)``, the controlled scalar is ``log p(y|x)``.
+    The intended change is ``eta * L`` and the direction is
+    ``-rho * grad(L)``.  Paper Eq. 5 therefore gives
+
+    ``alpha = eta * safe(L) / <grad(L), rho * grad(L)>``.
+
+    This is an explicitly non-publication-equivalent supervised extension.
+    ``intentional_enabled=0`` delegates to the exact normalized-SGD factory,
+    which makes the mechanism-off path bit-for-bit identical rather than
+    merely numerically close.
+    """
+    if hp["intentional_enabled"] == 0.0:
+        return _make_sgd_ema_norm_learner({
+            "step_size": hp["fixed_step_size"],
+            "weight_decay": hp["weight_decay"],
+            "norm_decay": hp["norm_decay"],
+            "norm_epsilon": hp["norm_epsilon"],
+        })
+
+    eta = hp["intended_fraction"]
+    beta2 = hp["beta2"]
+    beta_clip = hp["beta_clip"]
+    clip_mult = hp["clip_mult"]
+    epsilon = hp["optimizer_epsilon"]
+    norm_decay = hp["norm_decay"]
+    norm_epsilon = hp["norm_epsilon"]
+    use_diagonal = hp["use_diagonal_normalization"] == 1.0
+    use_adaptive_clip = hp["use_adaptive_clip"] == 1.0
+    update_features = hp["update_features"] == 1.0
+
+    def init_fn(params: dict[str, Array]) -> IntentionalUpdatesIPMNISTState:
+        input_dim = params["w1"].shape[0]
+        return IntentionalUpdatesIPMNISTState(  # type: ignore[call-arg]
+            squared_gradient={name: jnp.zeros_like(value) for name, value in params.items()},
+            step=jnp.asarray(0, dtype=jnp.int32),
+            clip_squared_error=jnp.asarray(0.0, dtype=jnp.float32),
+            clip_step=jnp.asarray(0, dtype=jnp.int32),
+            norm=EMANormState(  # type: ignore[call-arg]
+                mean=jnp.zeros(input_dim, dtype=jnp.float32),
+                var=jnp.ones(input_dim, dtype=jnp.float32),
+                count=jnp.asarray(0.0, dtype=jnp.float32),
+            ),
+        )
+
+    def full_step(
+        params: dict[str, Array],
+        state: IntentionalUpdatesIPMNISTState,
+        x: Array,
+        y: Array,
+        key: Array,
+    ) -> tuple[dict[str, Array], IntentionalUpdatesIPMNISTState, StepMetrics]:
+        del key
+        x_norm, new_norm = ema_normalize(state.norm, x, norm_decay, norm_epsilon)
+        (loss, logits), raw_grads = jax.value_and_grad(
+            cross_entropy_loss, has_aux=True
+        )(params, x_norm, y)
+        grads = {
+            name: (
+                gradient
+                if update_features or name in ("w3", "b3")
+                else jnp.zeros_like(gradient)
+            )
+            for name, gradient in raw_grads.items()
+        }
+        new_step = state.step + jnp.asarray(1, dtype=jnp.int32)
+        squared_gradient = {
+            name: beta2 * state.squared_gradient[name]
+            + (1.0 - beta2) * jnp.square(gradient)
+            for name, gradient in grads.items()
+        }
+        bias_correction = 1.0 - beta2 ** new_step.astype(jnp.float32)
+        scale = {
+            name: (
+                1.0 / (jnp.sqrt(value / bias_correction) + epsilon)
+                if use_diagonal
+                else jnp.ones_like(value)
+            )
+            for name, value in squared_gradient.items()
+        }
+        denominator = sum(
+            (
+                jnp.vdot(grads[name], scale[name] * grads[name]).real
+                for name in sorted(grads)
+            ),
+            jnp.asarray(0.0, dtype=jnp.float32),
+        )
+
+        new_clip_step = state.clip_step + jnp.asarray(1, dtype=jnp.int32)
+        clip_squared_error = (
+            beta_clip * state.clip_squared_error + (1.0 - beta_clip) * jnp.square(loss)
+        )
+        clip_bias_correction = 1.0 - beta_clip ** new_clip_step.astype(jnp.float32)
+        adaptive_cap = clip_mult * jnp.sqrt(clip_squared_error / clip_bias_correction)
+        safe_loss = jnp.minimum(loss, adaptive_cap) if use_adaptive_clip else loss
+        multiplier = eta * safe_loss / jnp.maximum(denominator, epsilon)
+        new_params = {
+            name: params[name] - multiplier * scale[name] * grads[name]
+            for name in params
+        }
+        metrics = _step_metrics(new_params, x_norm, y, loss, logits)
+        return new_params, IntentionalUpdatesIPMNISTState(  # type: ignore[call-arg]
+            squared_gradient=squared_gradient,
+            step=new_step,
+            clip_squared_error=clip_squared_error,
+            clip_step=new_clip_step,
+            norm=new_norm,
+        ), metrics
 
     return init_fn, full_step
 
@@ -7221,6 +7371,63 @@ def _build_registry() -> dict[str, ScreeningSpec]:
                 ),
             )
         )
+    # Intentional Updates is published for streaming RL, not supervised
+    # classification.  These arms freeze the smallest IPMNIST extension and
+    # its required controls; they must never be described as a reproduction
+    # of the paper's experiments or results.
+    intentional_base = {
+        "intentional_enabled": 1.0,
+        "intended_fraction": 0.5,
+        "fixed_step_size": 0.01,
+        "beta2": 0.999,
+        "optimizer_epsilon": 1e-8,
+        "beta_clip": 0.9998,
+        "clip_mult": 20.0,
+        "use_diagonal_normalization": 1.0,
+        "use_adaptive_clip": 1.0,
+        "update_features": 1.0,
+        "weight_decay": 0.0,
+        "norm_decay": 0.99,
+        "norm_epsilon": 1e-8,
+    }
+    intentional_arms = (
+        (
+            "intentional_updates_ipmnist",
+            intentional_base,
+            "Full supervised Eq. 5 extension: correct-class log-probability target, "
+            "RMSProp diagonal direction, and official adaptive clipping constants.",
+        ),
+        (
+            "intentional_updates_no_diag",
+            {**intentional_base, "use_diagonal_normalization": 0.0},
+            "Ablation removing the paper's RMSProp diagonal normalization.",
+        ),
+        (
+            "intentional_updates_no_clip",
+            {**intentional_base, "use_adaptive_clip": 0.0},
+            "Ablation removing delta/surprisal clipping entirely.",
+        ),
+        (
+            "intentional_updates_head_only",
+            {**intentional_base, "update_features": 0.0},
+            "Feature-control ablation: backpropagate normally but update only the head.",
+        ),
+        (
+            "intentional_updates_off",
+            {**intentional_base, "intentional_enabled": 0.0},
+            "Matched mechanism-off control: fixed-step normalized SGD with no decay.",
+        ),
+    )
+    for name, hyperparameters, description in intentional_arms:
+        specs.append(ScreeningSpec(
+            name=name,
+            base_learner="upgd_w",
+            mechanism="intentional_updates",
+            hyperparameters=hyperparameters,
+            factory=_make_intentional_updates_learner,
+            frozen_probe_input=_ema_frozen_probe_input,
+            description=description,
+        ))
     return {spec.name: spec for spec in specs}
 
 
@@ -8346,6 +8553,151 @@ def l2er_development_result_payload(
         "scientific_promotion_allowed": False,
     }
     return validate_l2er_development_result(payload)
+def _intentional_updates_persistent_numeric_bytes(
+    config: IPMNISTConfig, *, mechanism_enabled: bool
+) -> int:
+    """Exact params + learner-state numeric payload, excluding runtime buffers."""
+    parameter_bytes = config.parameter_count * np.dtype(np.float32).itemsize
+    normalizer_bytes = (2 * config.input_dim + 1) * np.dtype(np.float32).itemsize
+    if not mechanism_enabled:
+        return parameter_bytes + normalizer_bytes
+    # One RMS bank plus int32 step, float32 clip EMA, and int32 clip step.
+    mechanism_bytes = parameter_bytes + 3 * np.dtype(np.float32).itemsize
+    return parameter_bytes + normalizer_bytes + mechanism_bytes
+
+
+def intentional_updates_development_record(
+    result: ScreeningRunResult,
+) -> dict[str, Any]:
+    """Project one real screening run into a strict, nonpromoting record.
+
+    The existing screening shard remains the canonical campaign artifact.
+    This in-memory projection adds the mechanism-specific gates and exact
+    resource counters requested by issue #1561 without creating or mutating
+    anything under ``outputs/``.
+    """
+    if type(result) is not ScreeningRunResult:
+        raise TypeError("result must be an exact ScreeningRunResult")
+    spec = SCREENING_REGISTRY.get(result.config_name)
+    if spec is None or spec.mechanism != "intentional_updates":
+        raise ValueError("result must use a registered Intentional Updates arm")
+    if result.hyperparameters != spec.hyperparameters:
+        raise ValueError("result hyperparameters must match the registered arm")
+    steps = result.config.n_steps
+    mechanism_enabled = spec.hyperparameters["intentional_enabled"] == 1.0
+    feature_updates = spec.hyperparameters["update_features"] == 1.0
+    return {
+        "schema": INTENTIONAL_UPDATES_RECORD_SCHEMA,
+        "references": {
+            "paper": INTENTIONAL_UPDATES_PAPER_REVISION,
+            "official_code": INTENTIONAL_UPDATES_CODE_REVISION,
+            "equation": "Eq. 5 with y=log p(label|x), Delta=eta*surprisal",
+            "protocol_difference": (
+                "supervised IPMNIST, lambda=0, no RL transition/trace; this is a "
+                "protocol extension, not the publication algorithm"
+            ),
+        },
+        "arm": result.config_name,
+        "seed": result.seed,
+        "config": result.config.to_config(),
+        "hyperparameters": dict(result.hyperparameters),
+        "matched_axes": [
+            "seed",
+            "example_schedule",
+            "observations",
+            "updates",
+            "allowed_boundary_information:none",
+        ],
+        "policy": {
+            "development_only": True,
+            "scientific_promotion_allowed": False,
+            "publication_equivalent": False,
+        },
+        "gates": {
+            "mechanism_enabled": mechanism_enabled,
+            "backpropagation": True,
+            "feature_updates": feature_updates,
+            "head_updates": True,
+        },
+        "resources": {
+            "observations": steps,
+            "updates": steps,
+            "backward_passes": steps,
+            # value_and_grad performs one pre-update model evaluation and
+            # _step_metrics performs the post-update same-example query.
+            "model_queries": 2 * steps,
+            "persistent_numeric_bytes": _intentional_updates_persistent_numeric_bytes(
+                result.config, mechanism_enabled=mechanism_enabled
+            ),
+            "timing_telemetry_seconds": float(result.wall_clock_seconds),
+            "timing_is_selection_metric": False,
+        },
+        "metrics": {
+            "per_task_accuracy": result.per_task_accuracy.tolist(),
+            "per_task_loss": result.per_task_loss.tolist(),
+            "per_task_plasticity": result.per_task_plasticity.tolist(),
+        },
+    }
+
+
+def validate_intentional_updates_development_record(
+    record: object,
+) -> dict[str, Any]:
+    """Fail closed over an Intentional Updates development record."""
+    if type(record) is not dict:
+        raise ValueError("Intentional Updates record must be an exact object")
+    payload = cast(dict[str, Any], record)
+    policy = payload.get("policy")
+    if policy != {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "publication_equivalent": False,
+    }:
+        raise ValueError("Intentional Updates records are permanently nonpromoting")
+    try:
+        config_raw = payload["config"]
+        if type(config_raw) is not dict:
+            raise TypeError
+        config = IPMNISTConfig(**config_raw)
+        arm = payload["arm"]
+        seed = require_jax_seed(payload["seed"], name="record seed")
+        hyperparameters = payload["hyperparameters"]
+        metrics = payload["metrics"]
+        resources = payload["resources"]
+        if type(arm) is not str or type(hyperparameters) is not dict:
+            raise TypeError
+        if type(metrics) is not dict or type(resources) is not dict:
+            raise TypeError
+        result = ScreeningRunResult(
+            config_name=arm,
+            base_learner=screening_spec(arm).base_learner,
+            hyperparameters=hyperparameters,
+            seed=seed,
+            config=config,
+            per_task_accuracy=np.asarray(metrics["per_task_accuracy"], dtype=np.float64),
+            per_task_loss=np.asarray(metrics["per_task_loss"], dtype=np.float64),
+            per_task_plasticity=np.asarray(
+                metrics["per_task_plasticity"], dtype=np.float64
+            ),
+            wall_clock_seconds=resources["timing_telemetry_seconds"],
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("invalid Intentional Updates result fields") from error
+    expected = intentional_updates_development_record(result)
+    # Canonical JSON distinguishes hostile booleans from integers and also
+    # guarantees the record remains finite/serializable.
+    try:
+        actual_json = json.dumps(payload, allow_nan=False, sort_keys=True, separators=(",", ":"))
+        expected_json = json.dumps(
+            expected, allow_nan=False, sort_keys=True, separators=(",", ":")
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError("Intentional Updates record must be finite strict JSON") from error
+    if actual_json != expected_json:
+        if payload.get("resources") != expected["resources"]:
+            raise ValueError("Intentional Updates resource counters do not match the run")
+        raise ValueError("Intentional Updates record does not match the frozen protocol")
+    return expected
 
 
 def run_screening_config(

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -1423,6 +1423,121 @@ class IntentionalUpdatesIPMNISTState:
     norm: EMANormState
 
 
+_INTENTIONAL_HP_KEYS = frozenset(
+    {
+        "intentional_enabled",
+        "intended_fraction",
+        "fixed_step_size",
+        "beta2",
+        "optimizer_epsilon",
+        "beta_clip",
+        "clip_mult",
+        "use_diagonal_normalization",
+        "use_adaptive_clip",
+        "update_features",
+        "weight_decay",
+        "norm_decay",
+        "norm_epsilon",
+    }
+)
+_INTENTIONAL_FLAG_KEYS = frozenset(
+    {
+        "intentional_enabled",
+        "use_diagonal_normalization",
+        "use_adaptive_clip",
+        "update_features",
+    }
+)
+
+
+def _intentional_hp(hp: object) -> dict[str, float]:
+    if type(hp) is not dict or frozenset(hp) != _INTENTIONAL_HP_KEYS:
+        raise ValueError("Intentional Updates hyperparameters must be one exact object")
+    checked: dict[str, float] = {}
+    for name in _INTENTIONAL_HP_KEYS:
+        value = hp[name]
+        if type(value) is not float or not math.isfinite(value):
+            raise ValueError(f"Intentional Updates hyperparameter {name} must be a finite float")
+        checked[name] = value
+    if any(checked[name] not in (0.0, 1.0) for name in _INTENTIONAL_FLAG_KEYS):
+        raise ValueError("Intentional Updates feature gates must be exact float identities")
+    if (
+        checked["intended_fraction"] != 0.5
+        or checked["fixed_step_size"] != 0.01
+        or checked["beta2"] != 0.999
+        or checked["optimizer_epsilon"] != 1e-8
+        or checked["beta_clip"] != 0.9998
+        or checked["clip_mult"] != 20.0
+        or checked["weight_decay"] != 0.0
+        or checked["norm_decay"] != 0.99
+        or checked["norm_epsilon"] != 1e-8
+    ):
+        raise ValueError("Intentional Updates hyperparameters drift from the frozen protocol")
+    return checked
+
+
+def _intentional_scalar(value: object, *, name: str, dtype: jnp.dtype) -> Array:
+    actual_type = type(value)
+    if actual_type is not np.ndarray and not issubclass(
+        actual_type, (jax.Array, jax.core.Tracer)
+    ):
+        raise ValueError(f"{name} must be an exact NumPy or JAX scalar array")
+    array = jnp.asarray(value)
+    if array.shape != () or array.dtype != dtype:
+        raise ValueError(f"{name} must be one scalar {dtype}")
+    return array
+
+
+def _intentional_state(
+    state: object, params: dict[str, Array]
+) -> IntentionalUpdatesIPMNISTState:
+    if type(state) is not IntentionalUpdatesIPMNISTState:
+        raise ValueError("state must be an exact IntentionalUpdatesIPMNISTState")
+    if type(state.squared_gradient) is not dict or frozenset(state.squared_gradient) != _L2ER_KEYS:
+        raise ValueError("state.squared_gradient must be one exact protocol MLP tree")
+    squared_gradient = {
+        name: _l2er_array(value, name=f"state.squared_gradient.{name}")
+        for name, value in state.squared_gradient.items()
+    }
+    if any(
+        squared_gradient[name].shape != value.shape
+        or squared_gradient[name].dtype != value.dtype
+        for name, value in params.items()
+    ):
+        raise ValueError("state.squared_gradient must match parameter shapes and dtypes")
+    step = _intentional_scalar(state.step, name="state.step", dtype=jnp.dtype(jnp.int32))
+    clip_squared_error = _intentional_scalar(
+        state.clip_squared_error,
+        name="state.clip_squared_error",
+        dtype=jnp.dtype(jnp.float32),
+    )
+    clip_step = _intentional_scalar(
+        state.clip_step, name="state.clip_step", dtype=jnp.dtype(jnp.int32)
+    )
+    if type(state.norm) is not EMANormState:
+        raise ValueError("state.norm must be an exact EMANormState")
+    mean = _l2er_array(state.norm.mean, name="state.norm.mean", ndim=1)
+    var = _l2er_array(state.norm.var, name="state.norm.var", ndim=1)
+    count = _intentional_scalar(
+        state.norm.count, name="state.norm.count", dtype=jnp.dtype(jnp.float32)
+    )
+    input_dim = params["w1"].shape[0]
+    if (
+        mean.shape != (input_dim,)
+        or var.shape != (input_dim,)
+        or mean.dtype != jnp.dtype(jnp.float32)
+        or var.dtype != jnp.dtype(jnp.float32)
+    ):
+        raise ValueError("state.norm must match the float32 input dimension")
+    return IntentionalUpdatesIPMNISTState(  # type: ignore[call-arg]
+        squared_gradient=squared_gradient,
+        step=step,
+        clip_squared_error=clip_squared_error,
+        clip_step=clip_step,
+        norm=EMANormState(mean=mean, var=var, count=count),  # type: ignore[call-arg]
+    )
+
+
 def _make_intentional_updates_learner(
     hp: Mapping[str, float],
 ) -> tuple[LearnerInitFn, ScreeningStepFn]:
@@ -1439,29 +1554,33 @@ def _make_intentional_updates_learner(
     which makes the mechanism-off path bit-for-bit identical rather than
     merely numerically close.
     """
-    if hp["intentional_enabled"] == 0.0:
+    checked_hp = _intentional_hp(hp)
+    if checked_hp["intentional_enabled"] == 0.0:
         return _make_sgd_ema_norm_learner({
-            "step_size": hp["fixed_step_size"],
-            "weight_decay": hp["weight_decay"],
-            "norm_decay": hp["norm_decay"],
-            "norm_epsilon": hp["norm_epsilon"],
+            "step_size": checked_hp["fixed_step_size"],
+            "weight_decay": checked_hp["weight_decay"],
+            "norm_decay": checked_hp["norm_decay"],
+            "norm_epsilon": checked_hp["norm_epsilon"],
         })
 
-    eta = hp["intended_fraction"]
-    beta2 = hp["beta2"]
-    beta_clip = hp["beta_clip"]
-    clip_mult = hp["clip_mult"]
-    epsilon = hp["optimizer_epsilon"]
-    norm_decay = hp["norm_decay"]
-    norm_epsilon = hp["norm_epsilon"]
-    use_diagonal = hp["use_diagonal_normalization"] == 1.0
-    use_adaptive_clip = hp["use_adaptive_clip"] == 1.0
-    update_features = hp["update_features"] == 1.0
+    eta = checked_hp["intended_fraction"]
+    beta2 = checked_hp["beta2"]
+    beta_clip = checked_hp["beta_clip"]
+    clip_mult = checked_hp["clip_mult"]
+    epsilon = checked_hp["optimizer_epsilon"]
+    norm_decay = checked_hp["norm_decay"]
+    norm_epsilon = checked_hp["norm_epsilon"]
+    use_diagonal = checked_hp["use_diagonal_normalization"] == 1.0
+    use_adaptive_clip = checked_hp["use_adaptive_clip"] == 1.0
+    update_features = checked_hp["update_features"] == 1.0
 
     def init_fn(params: dict[str, Array]) -> IntentionalUpdatesIPMNISTState:
-        input_dim = params["w1"].shape[0]
+        checked_params = _l2er_params(params)
+        input_dim = checked_params["w1"].shape[0]
         return IntentionalUpdatesIPMNISTState(  # type: ignore[call-arg]
-            squared_gradient={name: jnp.zeros_like(value) for name, value in params.items()},
+            squared_gradient={
+                name: jnp.zeros_like(value) for name, value in checked_params.items()
+            },
             step=jnp.asarray(0, dtype=jnp.int32),
             clip_squared_error=jnp.asarray(0.0, dtype=jnp.float32),
             clip_step=jnp.asarray(0, dtype=jnp.int32),
@@ -1480,10 +1599,67 @@ def _make_intentional_updates_learner(
         key: Array,
     ) -> tuple[dict[str, Array], IntentionalUpdatesIPMNISTState, StepMetrics]:
         del key
-        x_norm, new_norm = ema_normalize(state.norm, x, norm_decay, norm_epsilon)
+        checked_params = _l2er_params(params)
+        checked_state = _intentional_state(state, checked_params)
+        x = _l2er_array(x, name="x", ndim=1)
+        if x.shape != (checked_params["w1"].shape[0],) or x.dtype != jnp.dtype(jnp.float32):
+            raise ValueError("x must match the float32 input dimension")
+        y = _intentional_scalar(y, name="y", dtype=jnp.dtype(jnp.int32))
+        int32_max = jnp.asarray((1 << 31) - 1, dtype=jnp.int32)
+        counter_valid = (
+            (checked_state.step >= 0)
+            & (checked_state.clip_step == checked_state.step)
+            & (checked_state.step < int32_max)
+        )
+        label_valid = (y >= 0) & (y < checked_params["b3"].shape[0])
+        prior_finite = (
+            floating_tree_is_finite(checked_params)
+            & floating_tree_is_finite(checked_state)
+            & jnp.all(jnp.isfinite(x))
+        )
+        runtime_valid = counter_valid & label_valid & prior_finite
+        safe_params = jax.tree.map(
+            lambda value: jnp.where(jnp.isfinite(value), value, jnp.zeros_like(value)),
+            checked_params,
+        )
+        safe_state = IntentionalUpdatesIPMNISTState(  # type: ignore[call-arg]
+            squared_gradient=jax.tree.map(
+                lambda value: jnp.where(jnp.isfinite(value), value, jnp.zeros_like(value)),
+                checked_state.squared_gradient,
+            ),
+            step=jnp.where(counter_valid, checked_state.step, jnp.asarray(0, jnp.int32)),
+            clip_squared_error=jnp.where(
+                jnp.isfinite(checked_state.clip_squared_error),
+                checked_state.clip_squared_error,
+                jnp.asarray(0.0, jnp.float32),
+            ),
+            clip_step=jnp.where(
+                counter_valid, checked_state.clip_step, jnp.asarray(0, jnp.int32)
+            ),
+            norm=EMANormState(  # type: ignore[call-arg]
+                mean=jnp.where(
+                    jnp.isfinite(checked_state.norm.mean),
+                    checked_state.norm.mean,
+                    jnp.zeros_like(checked_state.norm.mean),
+                ),
+                var=jnp.where(
+                    jnp.isfinite(checked_state.norm.var) & (checked_state.norm.var > 0.0),
+                    checked_state.norm.var,
+                    jnp.ones_like(checked_state.norm.var),
+                ),
+                count=jnp.where(
+                    jnp.isfinite(checked_state.norm.count) & (checked_state.norm.count >= 0.0),
+                    checked_state.norm.count,
+                    jnp.asarray(0.0, jnp.float32),
+                ),
+            ),
+        )
+        safe_x = jnp.where(jnp.isfinite(x), x, jnp.zeros_like(x))
+        safe_y = jnp.clip(y, 0, checked_params["b3"].shape[0] - 1)
+        x_norm, new_norm = ema_normalize(safe_state.norm, safe_x, norm_decay, norm_epsilon)
         (loss, logits), raw_grads = jax.value_and_grad(
             cross_entropy_loss, has_aux=True
-        )(params, x_norm, y)
+        )(safe_params, x_norm, safe_y)
         grads = {
             name: (
                 gradient
@@ -1492,9 +1668,9 @@ def _make_intentional_updates_learner(
             )
             for name, gradient in raw_grads.items()
         }
-        new_step = state.step + jnp.asarray(1, dtype=jnp.int32)
+        new_step = safe_state.step + jnp.asarray(1, dtype=jnp.int32)
         squared_gradient = {
-            name: beta2 * state.squared_gradient[name]
+            name: beta2 * safe_state.squared_gradient[name]
             + (1.0 - beta2) * jnp.square(gradient)
             for name, gradient in grads.items()
         }
@@ -1515,26 +1691,38 @@ def _make_intentional_updates_learner(
             jnp.asarray(0.0, dtype=jnp.float32),
         )
 
-        new_clip_step = state.clip_step + jnp.asarray(1, dtype=jnp.int32)
+        new_clip_step = safe_state.clip_step + jnp.asarray(1, dtype=jnp.int32)
         clip_squared_error = (
-            beta_clip * state.clip_squared_error + (1.0 - beta_clip) * jnp.square(loss)
+            beta_clip * safe_state.clip_squared_error + (1.0 - beta_clip) * jnp.square(loss)
         )
         clip_bias_correction = 1.0 - beta_clip ** new_clip_step.astype(jnp.float32)
         adaptive_cap = clip_mult * jnp.sqrt(clip_squared_error / clip_bias_correction)
         safe_loss = jnp.minimum(loss, adaptive_cap) if use_adaptive_clip else loss
         multiplier = eta * safe_loss / jnp.maximum(denominator, epsilon)
         new_params = {
-            name: params[name] - multiplier * scale[name] * grads[name]
-            for name in params
+            name: safe_params[name] - multiplier * scale[name] * grads[name]
+            for name in safe_params
         }
-        metrics = _step_metrics(new_params, x_norm, y, loss, logits)
-        return new_params, IntentionalUpdatesIPMNISTState(  # type: ignore[call-arg]
+        metrics = _step_metrics(new_params, x_norm, safe_y, loss, logits)
+        candidate_state = IntentionalUpdatesIPMNISTState(  # type: ignore[call-arg]
             squared_gradient=squared_gradient,
             step=new_step,
             clip_squared_error=clip_squared_error,
             clip_step=new_clip_step,
             norm=new_norm,
-        ), metrics
+        )
+        update_applied = (
+            runtime_valid
+            & floating_tree_is_finite(new_params)
+            & floating_tree_is_finite(candidate_state)
+            & floating_tree_is_finite(metrics)
+        )
+        zero_metrics = jax.tree.map(jnp.zeros_like, metrics)
+        return (
+            select_transaction(update_applied, new_params, safe_params),
+            select_transaction(update_applied, candidate_state, safe_state),
+            select_transaction(update_applied, metrics, zero_metrics),
+        )
 
     return init_fn, full_step
 
@@ -8553,6 +8741,8 @@ def l2er_development_result_payload(
         "scientific_promotion_allowed": False,
     }
     return validate_l2er_development_result(payload)
+
+
 def _intentional_updates_persistent_numeric_bytes(
     config: IPMNISTConfig, *, mechanism_enabled: bool
 ) -> int:
@@ -8566,6 +8756,85 @@ def _intentional_updates_persistent_numeric_bytes(
     return parameter_bytes + normalizer_bytes + mechanism_bytes
 
 
+_INTENTIONAL_RECORD_KEYS = frozenset(
+    {
+        "schema",
+        "references",
+        "arm",
+        "seed",
+        "config",
+        "hyperparameters",
+        "matched_axes",
+        "policy",
+        "gates",
+        "resources",
+        "metrics",
+    }
+)
+_INTENTIONAL_CONFIG_KEYS = frozenset(
+    {"n_tasks", "task_length", "input_dim", "hidden1", "hidden2", "n_classes"}
+)
+_INTENTIONAL_MATCHED_AXES = (
+    "seed",
+    "example_schedule",
+    "observations",
+    "updates",
+    "allowed_boundary_information:none",
+)
+_INTENTIONAL_MAX_TASKS = 1_000_000
+_INTENTIONAL_MAX_BYTES = 256 * 1024 * 1024
+
+
+def _intentional_object(
+    value: object, keys: frozenset[str], *, context: str
+) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise ValueError(f"{context} must be an exact object")
+    resolved = cast(dict[str, Any], value)
+    if frozenset(resolved) != keys:
+        raise ValueError(f"{context} keys must be exactly {sorted(keys)}")
+    return resolved
+
+
+def _intentional_record_int(value: object, *, context: str, positive: bool = False) -> int:
+    minimum = 1 if positive else 0
+    if type(value) is not int or not minimum <= value <= (1 << 31) - 1:
+        raise ValueError(f"{context} must be a bounded exact integer")
+    return value
+
+
+def _intentional_record_float(
+    value: object, *, context: str, nonnegative: bool = False
+) -> float:
+    if type(value) is not float or not math.isfinite(value):
+        raise ValueError(f"{context} must be an exact finite float")
+    if nonnegative and value < 0.0:
+        raise ValueError(f"{context} must be nonnegative")
+    return value
+
+
+def _canonical_intentional_result(result: object) -> ScreeningRunResult:
+    """Re-run all host dataclass gates after possible ``object.__setattr__`` mutation."""
+    if type(result) is not ScreeningRunResult:
+        raise TypeError("result must be an exact ScreeningRunResult")
+    if type(result.config) is not IPMNISTConfig:
+        raise TypeError("result.config must be an exact IPMNISTConfig")
+    config = IPMNISTConfig(**result.config.to_config())
+    return ScreeningRunResult(
+        config_name=result.config_name,
+        base_learner=result.base_learner,
+        hyperparameters=result.hyperparameters,
+        seed=result.seed,
+        config=config,
+        per_task_accuracy=result.per_task_accuracy,
+        per_task_loss=result.per_task_loss,
+        per_task_plasticity=result.per_task_plasticity,
+        wall_clock_seconds=result.wall_clock_seconds,
+        noise_mode=result.noise_mode,
+        noise_pool_steps=result.noise_pool_steps,
+    )
+
+
 def intentional_updates_development_record(
     result: ScreeningRunResult,
 ) -> dict[str, Any]:
@@ -8576,16 +8845,32 @@ def intentional_updates_development_record(
     resource counters requested by issue #1561 without creating or mutating
     anything under ``outputs/``.
     """
-    if type(result) is not ScreeningRunResult:
-        raise TypeError("result must be an exact ScreeningRunResult")
+    result = _canonical_intentional_result(result)
+    if result.noise_mode != "step" or result.noise_pool_steps is not None:
+        raise ValueError("Intentional Updates records require exact-step execution")
     spec = SCREENING_REGISTRY.get(result.config_name)
     if spec is None or spec.mechanism != "intentional_updates":
         raise ValueError("result must use a registered Intentional Updates arm")
-    if result.hyperparameters != spec.hyperparameters:
+    if result.base_learner != spec.base_learner:
+        raise ValueError("result base learner must match the registered arm")
+    if _intentional_hp(result.hyperparameters) != spec.hyperparameters:
         raise ValueError("result hyperparameters must match the registered arm")
     steps = result.config.n_steps
     mechanism_enabled = spec.hyperparameters["intentional_enabled"] == 1.0
     feature_updates = spec.hyperparameters["update_features"] == 1.0
+    persistent_bytes = _intentional_updates_persistent_numeric_bytes(
+        result.config, mechanism_enabled=mechanism_enabled
+    )
+    if steps > ((1 << 31) - 1) // 2:
+        raise ValueError("Intentional Updates model-query budget exceeds signed int32")
+    if persistent_bytes > _INTENTIONAL_MAX_BYTES:
+        raise ValueError("Intentional Updates persistent state exceeds 256 MiB")
+    scaled_correct = result.per_task_accuracy * result.config.task_length
+    per_task_correct_array = np.rint(scaled_correct)
+    if not np.allclose(scaled_correct, per_task_correct_array, rtol=0.0, atol=1e-5):
+        raise ValueError("per_task_accuracy must derive from integer online-correct counts")
+    per_task_correct = [int(value) for value in per_task_correct_array]
+    online_correct = sum(per_task_correct)
     return {
         "schema": INTENTIONAL_UPDATES_RECORD_SCHEMA,
         "references": {
@@ -8601,13 +8886,7 @@ def intentional_updates_development_record(
         "seed": result.seed,
         "config": result.config.to_config(),
         "hyperparameters": dict(result.hyperparameters),
-        "matched_axes": [
-            "seed",
-            "example_schedule",
-            "observations",
-            "updates",
-            "allowed_boundary_information:none",
-        ],
+        "matched_axes": list(_INTENTIONAL_MATCHED_AXES),
         "policy": {
             "development_only": True,
             "scientific_promotion_allowed": False,
@@ -8626,14 +8905,16 @@ def intentional_updates_development_record(
             # value_and_grad performs one pre-update model evaluation and
             # _step_metrics performs the post-update same-example query.
             "model_queries": 2 * steps,
-            "persistent_numeric_bytes": _intentional_updates_persistent_numeric_bytes(
-                result.config, mechanism_enabled=mechanism_enabled
-            ),
+            "persistent_numeric_bytes": persistent_bytes,
             "timing_telemetry_seconds": float(result.wall_clock_seconds),
             "timing_is_selection_metric": False,
         },
         "metrics": {
-            "per_task_accuracy": result.per_task_accuracy.tolist(),
+            "per_task_correct": per_task_correct,
+            "online_correct": online_correct,
+            "per_task_accuracy": [
+                value / result.config.task_length for value in per_task_correct
+            ],
             "per_task_loss": result.per_task_loss.tolist(),
             "per_task_plasticity": result.per_task_plasticity.tolist(),
         },
@@ -8644,58 +8925,189 @@ def validate_intentional_updates_development_record(
     record: object,
 ) -> dict[str, Any]:
     """Fail closed over an Intentional Updates development record."""
-    if type(record) is not dict:
-        raise ValueError("Intentional Updates record must be an exact object")
-    payload = cast(dict[str, Any], record)
-    policy = payload.get("policy")
+    payload = _intentional_object(record, _INTENTIONAL_RECORD_KEYS, context="record")
+    if type(payload["schema"]) is not str or payload["schema"] != INTENTIONAL_UPDATES_RECORD_SCHEMA:
+        raise ValueError("Intentional Updates schema does not match the frozen protocol")
+    references = _intentional_object(
+        payload["references"],
+        frozenset({"paper", "official_code", "equation", "protocol_difference"}),
+        context="references",
+    )
+    expected_references = {
+        "paper": INTENTIONAL_UPDATES_PAPER_REVISION,
+        "official_code": INTENTIONAL_UPDATES_CODE_REVISION,
+        "equation": "Eq. 5 with y=log p(label|x), Delta=eta*surprisal",
+        "protocol_difference": (
+            "supervised IPMNIST, lambda=0, no RL transition/trace; this is a "
+            "protocol extension, not the publication algorithm"
+        ),
+    }
+    if (
+        any(type(references[key]) is not str for key in references)
+        or references != expected_references
+    ):
+        raise ValueError("Intentional Updates references do not match the frozen protocol")
+    if type(payload["arm"]) is not str:
+        raise ValueError("arm must be an exact string")
+    spec = screening_spec(payload["arm"])
+    if spec.mechanism != "intentional_updates":
+        raise ValueError("arm must be a registered Intentional Updates arm")
+    seed = _intentional_record_int(payload["seed"], context="seed")
+    config_raw = _intentional_object(
+        payload["config"], _INTENTIONAL_CONFIG_KEYS, context="config"
+    )
+    config_values = {
+        key: _intentional_record_int(config_raw[key], context=f"config.{key}", positive=True)
+        for key in _INTENTIONAL_CONFIG_KEYS
+    }
+    config = IPMNISTConfig(**config_values)
+    if config.n_tasks > _INTENTIONAL_MAX_TASKS:
+        raise ValueError("config.n_tasks exceeds the bounded record limit")
+    hyperparameters = _intentional_object(
+        payload["hyperparameters"], _INTENTIONAL_HP_KEYS, context="hyperparameters"
+    )
+    if _intentional_hp(hyperparameters) != spec.hyperparameters:
+        raise ValueError("hyperparameters do not match the registered arm")
+    matched_axes = payload["matched_axes"]
+    if (
+        type(matched_axes) is not list
+        or len(matched_axes) != len(_INTENTIONAL_MATCHED_AXES)
+        or any(type(value) is not str for value in matched_axes)
+        or tuple(matched_axes) != _INTENTIONAL_MATCHED_AXES
+    ):
+        raise ValueError("matched_axes do not match the frozen protocol")
+    policy = _intentional_object(
+        payload["policy"],
+        frozenset({"development_only", "scientific_promotion_allowed", "publication_equivalent"}),
+        context="policy",
+    )
     if policy != {
         "development_only": True,
         "scientific_promotion_allowed": False,
         "publication_equivalent": False,
-    }:
+    } or any(type(value) is not bool for value in policy.values()):
         raise ValueError("Intentional Updates records are permanently nonpromoting")
-    try:
-        config_raw = payload["config"]
-        if type(config_raw) is not dict:
-            raise TypeError
-        config = IPMNISTConfig(**config_raw)
-        arm = payload["arm"]
-        seed = require_jax_seed(payload["seed"], name="record seed")
-        hyperparameters = payload["hyperparameters"]
-        metrics = payload["metrics"]
-        resources = payload["resources"]
-        if type(arm) is not str or type(hyperparameters) is not dict:
-            raise TypeError
-        if type(metrics) is not dict or type(resources) is not dict:
-            raise TypeError
-        result = ScreeningRunResult(
-            config_name=arm,
-            base_learner=screening_spec(arm).base_learner,
-            hyperparameters=hyperparameters,
-            seed=seed,
-            config=config,
-            per_task_accuracy=np.asarray(metrics["per_task_accuracy"], dtype=np.float64),
-            per_task_loss=np.asarray(metrics["per_task_loss"], dtype=np.float64),
-            per_task_plasticity=np.asarray(
-                metrics["per_task_plasticity"], dtype=np.float64
-            ),
-            wall_clock_seconds=resources["timing_telemetry_seconds"],
+    gates = _intentional_object(
+        payload["gates"],
+        frozenset({"mechanism_enabled", "backpropagation", "feature_updates", "head_updates"}),
+        context="gates",
+    )
+    if any(type(value) is not bool for value in gates.values()):
+        raise ValueError("gates must use exact boolean identities")
+    expected_gates = {
+        "mechanism_enabled": spec.hyperparameters["intentional_enabled"] == 1.0,
+        "backpropagation": True,
+        "feature_updates": spec.hyperparameters["update_features"] == 1.0,
+        "head_updates": True,
+    }
+    if gates != expected_gates:
+        raise ValueError("Intentional Updates gates do not match the frozen protocol")
+    resources = _intentional_object(
+        payload["resources"],
+        frozenset(
+            {
+                "observations",
+                "updates",
+                "backward_passes",
+                "model_queries",
+                "persistent_numeric_bytes",
+                "timing_telemetry_seconds",
+                "timing_is_selection_metric",
+            }
+        ),
+        context="resources",
+    )
+    for key in (
+        "observations",
+        "updates",
+        "backward_passes",
+        "model_queries",
+        "persistent_numeric_bytes",
+    ):
+        _intentional_record_int(resources[key], context=f"resources.{key}")
+    timing = _intentional_record_float(
+        resources["timing_telemetry_seconds"],
+        context="resources.timing_telemetry_seconds",
+        nonnegative=True,
+    )
+    if timing > 604_800.0 or resources["persistent_numeric_bytes"] > _INTENTIONAL_MAX_BYTES:
+        raise ValueError("resources exceed the bounded development protocol")
+    if resources["timing_is_selection_metric"] is not False:
+        raise ValueError("timing_is_selection_metric must permanently remain False")
+    expected_steps = config.n_steps
+    expected_persistent = _intentional_updates_persistent_numeric_bytes(
+        config, mechanism_enabled=expected_gates["mechanism_enabled"]
+    )
+    if (
+        resources["observations"] != expected_steps
+        or resources["updates"] != expected_steps
+        or resources["backward_passes"] != expected_steps
+        or resources["model_queries"] != 2 * expected_steps
+        or resources["persistent_numeric_bytes"] != expected_persistent
+    ):
+        raise ValueError("Intentional Updates resource counters do not match the run")
+    metrics = _intentional_object(
+        payload["metrics"],
+        frozenset(
+            {
+                "per_task_correct",
+                "online_correct",
+                "per_task_accuracy",
+                "per_task_loss",
+                "per_task_plasticity",
+            }
+        ),
+        context="metrics",
+    )
+    correct_values = metrics["per_task_correct"]
+    if (
+        type(correct_values) is not list
+        or len(correct_values) != config.n_tasks
+        or any(
+            type(value) is not int or not 0 <= value <= config.task_length
+            for value in correct_values
         )
-    except (KeyError, TypeError, ValueError) as error:
-        raise ValueError("invalid Intentional Updates result fields") from error
+    ):
+        raise ValueError("metrics.per_task_correct must contain bounded exact integers")
+    online_correct = _intentional_record_int(
+        metrics["online_correct"], context="metrics.online_correct"
+    )
+    if online_correct != sum(correct_values):
+        raise ValueError("metrics.online_correct must equal the per-task numerator sum")
+
+    def float_list(
+        name: str, *, unit_interval: bool = False, nonnegative: bool = False
+    ) -> list[float]:
+        values = metrics[name]
+        if type(values) is not list or len(values) != config.n_tasks:
+            raise ValueError(f"metrics.{name} must be one exact bounded list per task")
+        resolved = [
+            _intentional_record_float(value, context=f"metrics.{name}", nonnegative=nonnegative)
+            for value in values
+        ]
+        if unit_interval and any(value > 1.0 for value in resolved):
+            raise ValueError(f"metrics.{name} must lie in [0,1]")
+        return resolved
+
+    accuracy = float_list("per_task_accuracy", unit_interval=True, nonnegative=True)
+    loss = float_list("per_task_loss", nonnegative=True)
+    plasticity = float_list("per_task_plasticity", unit_interval=True, nonnegative=True)
+    expected_accuracy = [value / config.task_length for value in correct_values]
+    if accuracy != expected_accuracy:
+        raise ValueError("per_task_accuracy must exactly derive from per_task_correct")
+    result = ScreeningRunResult(
+        config_name=payload["arm"],
+        base_learner=spec.base_learner,
+        hyperparameters=hyperparameters,
+        seed=require_jax_seed(seed, name="record seed"),
+        config=config,
+        per_task_accuracy=np.asarray(accuracy, dtype=np.float64),
+        per_task_loss=np.asarray(loss, dtype=np.float64),
+        per_task_plasticity=np.asarray(plasticity, dtype=np.float64),
+        wall_clock_seconds=timing,
+    )
     expected = intentional_updates_development_record(result)
-    # Canonical JSON distinguishes hostile booleans from integers and also
-    # guarantees the record remains finite/serializable.
-    try:
-        actual_json = json.dumps(payload, allow_nan=False, sort_keys=True, separators=(",", ":"))
-        expected_json = json.dumps(
-            expected, allow_nan=False, sort_keys=True, separators=(",", ":")
-        )
-    except (TypeError, ValueError) as error:
-        raise ValueError("Intentional Updates record must be finite strict JSON") from error
-    if actual_json != expected_json:
-        if payload.get("resources") != expected["resources"]:
-            raise ValueError("Intentional Updates resource counters do not match the run")
+    if payload != expected:
         raise ValueError("Intentional Updates record does not match the frozen protocol")
     return expected
 
@@ -8736,6 +9148,15 @@ def run_screening_config(
         er_batch_size = int(spec.hyperparameters["er_batch_size"])
         if config.task_length % er_batch_size != 0:
             raise ValueError("L2-ER requires task_length divisible by er_batch_size")
+    if spec.mechanism == "intentional_updates":
+        enabled = spec.hyperparameters["intentional_enabled"] == 1.0
+        persistent_bytes = _intentional_updates_persistent_numeric_bytes(
+            config, mechanism_enabled=enabled
+        )
+        if config.n_steps > ((1 << 31) - 1) // 2:
+            raise ValueError("Intentional Updates model-query budget exceeds signed int32")
+        if persistent_bytes > _INTENTIONAL_MAX_BYTES:
+            raise ValueError("Intentional Updates persistent state exceeds 256 MiB")
     effective_noise_pool_steps = _validated_screening_noise_pool_steps(
         noise_mode,
         noise_pool_steps if noise_mode == "pool" else None,

--- a/docs/research/sota-landscape.md
+++ b/docs/research/sota-landscape.md
@@ -85,6 +85,16 @@ local same-runner development ranking, not a paper-level SOTA claim.
   (2026)](https://arxiv.org/abs/2607.24996) reports utility-scaled partial
   resets on Continual MetaWorld, Continual MinAtar, and SlipperyAnt. Both are
   candidates for causal ablations, not IPMNIST results.
+- [Intentional Updates](https://arxiv.org/abs/2604.19033v1) reports strong
+  fully streaming reinforcement-learning results by solving for step sizes in
+  prediction or policy units. ASI pins paper v1 and official code commit
+  `e86e26fd8613ac212e9a52c3fed8a01d0a31f685`. The registered
+  `intentional_updates_*` IPMNIST arms are a supervised protocol extension of
+  Eq. 5, not a reproduction of the paper: they control current-example
+  correct-class log probability, omit RL eligibility traces, and include
+  diagonal-normalization, clipping, fixed-step, and head-only feature
+  controls. The implementation and its tests are development infrastructure;
+  no screening result exists until a matched campaign is run.
 - [Optimization Readiness](https://arxiv.org/abs/2605.09044v1) evaluates whether
   a checkpoint diagnostic prospectively ranks future relative loss reduction.
   Its empirical estimator uses a full-validation-set gradient for gradient

--- a/tests/test_intentional_updates_ipmnist.py
+++ b/tests/test_intentional_updates_ipmnist.py
@@ -1,0 +1,191 @@
+"""Intentional Updates' development-only IPMNIST protocol extension."""
+
+from __future__ import annotations
+
+import copy
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.ipmnist_screening import (
+    INTENTIONAL_UPDATES_CODE_REVISION,
+    INTENTIONAL_UPDATES_PAPER_REVISION,
+    IPMNISTConfig,
+    _make_intentional_updates_learner,
+    _make_sgd_ema_norm_learner,
+    intentional_updates_development_record,
+    run_screening_config,
+    screening_spec,
+    validate_intentional_updates_development_record,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import init_mlp_params
+
+SMALL = IPMNISTConfig(
+    n_tasks=2, task_length=4, input_dim=6, hidden1=5, hidden2=4, n_classes=3
+)
+
+
+def _data() -> tuple[np.ndarray, np.ndarray]:
+    return (
+        np.arange(72, dtype=np.float32).reshape(12, 6) / 71.0,
+        np.arange(12, dtype=np.int32) % 3,
+    )
+
+
+def test_references_and_required_arm_set_are_pinned() -> None:
+    assert INTENTIONAL_UPDATES_PAPER_REVISION == "arXiv:2604.19033v1"
+    assert INTENTIONAL_UPDATES_CODE_REVISION == (
+        "sharifnassab/Intentional_RL@e86e26fd8613ac212e9a52c3fed8a01d0a31f685"
+    )
+    expected = {
+        "intentional_updates_ipmnist",
+        "intentional_updates_no_diag",
+        "intentional_updates_no_clip",
+        "intentional_updates_head_only",
+        "intentional_updates_off",
+    }
+    assert expected <= {name for name in expected if screening_spec(name).name == name}
+
+
+def test_mechanism_off_is_bit_exact_fixed_step_control_under_jit() -> None:
+    off = screening_spec("intentional_updates_off")
+    init_off, step_off = off.factory(off.hyperparameters)
+    control_hp = {
+        "step_size": off.hyperparameters["fixed_step_size"],
+        "weight_decay": off.hyperparameters["weight_decay"],
+        "norm_decay": off.hyperparameters["norm_decay"],
+        "norm_epsilon": off.hyperparameters["norm_epsilon"],
+    }
+    init_control, step_control = _make_sgd_ema_norm_learner(control_hp)
+    params = init_mlp_params(jr.key(7), SMALL)
+    x = jr.normal(jr.key(8), (SMALL.input_dim,))
+    y = jnp.asarray(2, dtype=jnp.int32)
+    result_off = jax.jit(step_off)(params, init_off(params), x, y, jr.key(9))
+    result_control = jax.jit(step_control)(params, init_control(params), x, y, jr.key(99))
+    for name in params:
+        np.testing.assert_array_equal(result_off[0][name], result_control[0][name])
+    assert jax.tree_util.tree_all(
+        jax.tree_util.tree_map(jnp.array_equal, result_off[1], result_control[1])
+    )
+    assert jax.tree_util.tree_all(
+        jax.tree_util.tree_map(jnp.array_equal, result_off[2], result_control[2])
+    )
+
+
+@pytest.mark.parametrize(
+    "name", [
+        "intentional_updates_ipmnist",
+        "intentional_updates_no_diag",
+        "intentional_updates_no_clip",
+        "intentional_updates_head_only",
+    ]
+)
+def test_candidate_and_ablations_have_finite_jittable_autodiff_steps(name: str) -> None:
+    spec = screening_spec(name)
+    init_fn, step_fn = _make_intentional_updates_learner(spec.hyperparameters)
+    params = init_mlp_params(jr.key(1), SMALL)
+    x = jnp.zeros((SMALL.input_dim,), dtype=jnp.float32)
+    y = jnp.asarray(0, dtype=jnp.int32)
+    new_params, new_state, metrics = jax.jit(step_fn)(
+        params, init_fn(params), x, y, jr.key(2)
+    )
+    leaves = jax.tree_util.tree_leaves((new_params, new_state, metrics))
+    assert all(bool(jnp.all(jnp.isfinite(value))) for value in leaves)
+
+
+def test_head_only_feature_control_freezes_hidden_parameters() -> None:
+    spec = screening_spec("intentional_updates_head_only")
+    init_fn, step_fn = spec.factory(spec.hyperparameters)
+    params = init_mlp_params(jr.key(3), SMALL)
+    new_params, _, _ = step_fn(
+        params,
+        init_fn(params),
+        jr.normal(jr.key(4), (SMALL.input_dim,)),
+        jnp.asarray(1, dtype=jnp.int32),
+        jr.key(5),
+    )
+    for name in ("w1", "b1", "w2", "b2"):
+        np.testing.assert_array_equal(new_params[name], params[name])
+    assert any(
+        not np.array_equal(np.asarray(new_params[name]), np.asarray(params[name]))
+        for name in ("w3", "b3")
+    )
+
+
+def test_zero_gradient_one_class_path_is_finite_and_stationary() -> None:
+    one_class = IPMNISTConfig(
+        n_tasks=1, task_length=1, input_dim=3, hidden1=2, hidden2=2, n_classes=1
+    )
+    spec = screening_spec("intentional_updates_ipmnist")
+    init_fn, step_fn = spec.factory(spec.hyperparameters)
+    params = init_mlp_params(jr.key(30), one_class)
+    new_params, new_state, metrics = jax.jit(step_fn)(
+        params,
+        init_fn(params),
+        jnp.zeros((one_class.input_dim,), dtype=jnp.float32),
+        jnp.asarray(0, dtype=jnp.int32),
+        jr.key(31),
+    )
+    for name in params:
+        np.testing.assert_array_equal(new_params[name], params[name])
+    assert all(
+        bool(jnp.all(jnp.isfinite(value)))
+        for value in jax.tree_util.tree_leaves((new_state, metrics))
+    )
+
+
+def test_strict_development_record_binds_resources_gates_and_metrics() -> None:
+    x, y = _data()
+    result = run_screening_config(
+        x, y, screening_spec("intentional_updates_ipmnist"), seed=11, config=SMALL
+    )
+    record = intentional_updates_development_record(result)
+    validated = validate_intentional_updates_development_record(record)
+    assert validated == record
+    assert record["policy"] == {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "publication_equivalent": False,
+    }
+    assert record["gates"]["backpropagation"] is True
+    assert record["gates"]["feature_updates"] is True
+    assert record["resources"]["observations"] == 8
+    assert record["resources"]["updates"] == 8
+    assert record["resources"]["backward_passes"] == 8
+    assert record["resources"]["model_queries"] == 16
+    assert record["resources"]["persistent_numeric_bytes"] > 0
+
+    hostile = copy.deepcopy(record)
+    hostile["policy"]["scientific_promotion_allowed"] = True
+    with pytest.raises(ValueError, match="permanently nonpromoting"):
+        validate_intentional_updates_development_record(hostile)
+
+    hostile = copy.deepcopy(record)
+    hostile["resources"]["updates"] -= 1
+    with pytest.raises(ValueError, match="resource counters"):
+        validate_intentional_updates_development_record(hostile)
+
+    hostile = copy.deepcopy(record)
+    hostile["gates"]["backpropagation"] = False
+    with pytest.raises(ValueError, match="frozen protocol"):
+        validate_intentional_updates_development_record(hostile)
+
+    hostile = copy.deepcopy(record)
+    hostile["references"]["official_code"] = "moving-main"
+    with pytest.raises(ValueError, match="frozen protocol"):
+        validate_intentional_updates_development_record(hostile)
+
+
+def test_matched_runs_share_seed_schedule_update_and_observation_budgets() -> None:
+    x, y = _data()
+    records = []
+    for name in ("intentional_updates_ipmnist", "intentional_updates_off"):
+        result = run_screening_config(x, y, screening_spec(name), seed=19, config=SMALL)
+        records.append(intentional_updates_development_record(result))
+    assert records[0]["seed"] == records[1]["seed"]
+    assert records[0]["config"] == records[1]["config"]
+    for counter in ("observations", "updates", "backward_passes", "model_queries"):
+        assert records[0]["resources"][counter] == records[1]["resources"][counter]

--- a/tests/test_intentional_updates_ipmnist.py
+++ b/tests/test_intentional_updates_ipmnist.py
@@ -137,6 +137,57 @@ def test_zero_gradient_one_class_path_is_finite_and_stationary() -> None:
     )
 
 
+def test_factory_and_state_reject_hostile_structures_without_dispatch() -> None:
+    class HostileMapping:
+        def __iter__(self) -> object:
+            raise AssertionError("hostile mapping hook must not run")
+
+    with pytest.raises(ValueError, match="one exact object"):
+        _make_intentional_updates_learner(HostileMapping())  # type: ignore[arg-type]
+
+    spec = screening_spec("intentional_updates_ipmnist")
+    init_fn, step_fn = spec.factory(spec.hyperparameters)
+    params = init_mlp_params(jr.key(40), SMALL)
+    state = init_fn(params)
+    hostile_state = state.replace(squared_gradient={})
+    with pytest.raises(ValueError, match="exact protocol MLP tree"):
+        step_fn(
+            params,
+            hostile_state,
+            jnp.zeros((SMALL.input_dim,), dtype=jnp.float32),
+            jnp.asarray(0, dtype=jnp.int32),
+            jr.key(41),
+        )
+
+
+@pytest.mark.parametrize("invalid", ["counter", "input"])
+def test_jit_runtime_invalidity_is_finite_and_atomic(invalid: str) -> None:
+    spec = screening_spec("intentional_updates_ipmnist")
+    init_fn, step_fn = spec.factory(spec.hyperparameters)
+    params = init_mlp_params(jr.key(42), SMALL)
+    state = init_fn(params)
+    x = jnp.zeros((SMALL.input_dim,), dtype=jnp.float32)
+    if invalid == "counter":
+        state = state.replace(
+            step=jnp.asarray((1 << 31) - 1, dtype=jnp.int32),
+            clip_step=jnp.asarray((1 << 31) - 1, dtype=jnp.int32),
+        )
+    else:
+        x = jnp.full_like(x, jnp.inf)
+    new_params, new_state, metrics = jax.jit(step_fn)(
+        params, state, x, jnp.asarray(0, dtype=jnp.int32), jr.key(43)
+    )
+    for name in params:
+        np.testing.assert_array_equal(new_params[name], params[name])
+    assert all(
+        bool(jnp.all(jnp.isfinite(value)))
+        for value in jax.tree_util.tree_leaves((new_state, metrics))
+    )
+    if invalid == "counter":
+        assert int(new_state.step) == 0
+        assert int(new_state.clip_step) == 0
+
+
 def test_strict_development_record_binds_resources_gates_and_metrics() -> None:
     x, y = _data()
     result = run_screening_config(
@@ -174,10 +225,44 @@ def test_strict_development_record_binds_resources_gates_and_metrics() -> None:
         validate_intentional_updates_development_record(hostile)
 
     hostile = copy.deepcopy(record)
+    original_accuracy = hostile["metrics"]["per_task_accuracy"][0]
+    hostile["metrics"]["per_task_accuracy"][0] = (
+        0.25 if original_accuracy != 0.25 else 0.5
+    )
+    with pytest.raises(ValueError, match="derive from per_task_correct"):
+        validate_intentional_updates_development_record(hostile)
+
+    class HostileArray:
+        def __array__(self) -> object:
+            raise AssertionError("hostile array hook must not run")
+
+    hostile = copy.deepcopy(record)
+    hostile["metrics"]["per_task_loss"] = HostileArray()
+    with pytest.raises(ValueError, match="one exact bounded list"):
+        validate_intentional_updates_development_record(hostile)
+
+    hostile = copy.deepcopy(record)
+    hostile["gates"]["head_updates"] = 1
+    with pytest.raises(ValueError, match="exact boolean"):
+        validate_intentional_updates_development_record(hostile)
+
+    hostile = copy.deepcopy(record)
     hostile["references"]["official_code"] = "moving-main"
     with pytest.raises(ValueError, match="frozen protocol"):
         validate_intentional_updates_development_record(hostile)
 
+
+def test_record_revalidates_forged_host_dataclasses() -> None:
+    x, y = _data()
+    config = IPMNISTConfig(
+        n_tasks=2, task_length=4, input_dim=6, hidden1=5, hidden2=4, n_classes=3
+    )
+    result = run_screening_config(
+        x, y, screening_spec("intentional_updates_ipmnist"), seed=23, config=config
+    )
+    object.__setattr__(result.config, "n_tasks", True)
+    with pytest.raises(ValueError, match="n_tasks"):
+        intentional_updates_development_record(result)
 
 def test_matched_runs_share_seed_schedule_update_and_observation_budgets() -> None:
     x, y = _data()


### PR DESCRIPTION
Preserves the contributor implementation from #1643 and adds the deep state/record/resource audit required before merge.\n\nThe successor enforces exact trusted parameter/state/input/hyperparameter identities, shape/dtype and counter/label gates, signed-int32 horizon and 256 MiB persistent-state preflight, finite atomic JIT fallback, exact nested record schemas/scalars/containers, reconstructed dataclass validation, and canonical integer accuracy numerators. It remains a supervised non-publication-equivalent prerequisite; #1561 stays open until a retained matched run/report and distinct TD/control slice exist.\n\nValidation: 14 focused Intentional tests; 13 L2-ER adjacency tests; 335 screening regressions; scoped Ruff; strict mypy.\n\nRelates to #1561. Supersedes #1643.