### PR TITLE
fix(evaluation): consolidate IA condition result contracts

### DIFF
--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -117,6 +117,24 @@ def _require_integer(
     return canonical
 
 
+def _require_ndarray(
+    name: str,
+    value: object,
+    *,
+    dtype: np.dtype[Any],
+    length: int | None = None,
+) -> NDArray[Any]:
+    if type(value) is not np.ndarray:
+        raise ValueError(f"{name} must be an exact numpy.ndarray")
+    if value.dtype != dtype:
+        raise ValueError(f"{name} must have dtype {dtype}")
+    if value.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    if length is not None and int(value.shape[0]) != length:
+        raise ValueError(f"{name} must have length {length}")
+    return value
+
+
 def _require_derived_int32(name: str, value: int) -> None:
     if not 0 <= value <= _INT32_MAX:
         raise ValueError(f"derived {name} must be in [0, {_INT32_MAX}]")
@@ -433,6 +451,71 @@ class IAConditionResult:
     executed_action_credit_mismatches: int
     controller_budget: ControllerBudget
     timing: ConditionTiming
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "seed",
+            _require_integer("seed", self.seed, minimum=0, maximum=JAX_KEY_SEED_MAX),
+        )
+        if type(self.condition) is not str or self.condition not in CONDITION_NAMES:
+            raise ValueError("condition must be a known IA condition name")
+        rewards = _require_ndarray("rewards", self.rewards, dtype=np.dtype(np.float64))
+        steps = int(rewards.shape[0])
+        if steps < 1:
+            raise ValueError("rewards must contain at least one step")
+        for name in (
+            "executed_actions",
+            "credited_actions",
+            "recommendations",
+            "partner_proposals",
+        ):
+            _require_ndarray(
+                name,
+                getattr(self, name),
+                dtype=np.dtype(np.int64),
+                length=steps,
+            )
+        _require_ndarray(
+            "accepted_recommendations",
+            self.accepted_recommendations,
+            dtype=np.dtype(np.bool_),
+            length=steps,
+        )
+        object.__setattr__(self, "mean_reward", finite_real("mean_reward", self.mean_reward))
+        _require_ndarray(
+            "phase_mean_rewards",
+            self.phase_mean_rewards,
+            dtype=np.dtype(np.float64),
+        )
+        _require_ndarray(
+            "recovery_lengths",
+            self.recovery_lengths,
+            dtype=np.dtype(np.int64),
+        )
+        for name in (
+            "nominal_recommendation_decisions",
+            "nominal_accepted_recommendations",
+            "executed_accepted_recommendations",
+            "action_changing_interventions",
+            "executed_action_credit_mismatches",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _require_integer(name, getattr(self, name), minimum=0),
+            )
+        rate = finite_real(
+            "changed_action_intervention_rate",
+            self.changed_action_intervention_rate,
+        )
+        if not 0.0 <= rate <= 1.0:
+            raise ValueError("changed_action_intervention_rate must lie in [0, 1]")
+        object.__setattr__(self, "changed_action_intervention_rate", rate)
+        if not isinstance(self.controller_budget, ControllerBudget):
+            raise ValueError("controller_budget must be a ControllerBudget")
+        if not isinstance(self.timing, ConditionTiming):
+            raise ValueError("timing must be a ConditionTiming")
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -95,6 +95,7 @@ RECOMMENDATION_CONDITIONS: tuple[IAConditionName, ...] = (
 _INT32_MAX = 2**31 - 1
 _MAX_BOOTSTRAP_RESAMPLES = 1_000_000
 _MAX_BOOTSTRAP_DRAW_COUNT = 50_000_000
+_MAX_CONDITION_RESULT_BYTES = 512 * 1024 * 1024
 _ACTUAL_INT_TYPES = frozenset(
     {int, *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))}
 )
@@ -464,35 +465,53 @@ class IAConditionResult:
         steps = int(rewards.shape[0])
         if steps < 1:
             raise ValueError("rewards must contain at least one step")
+        action_arrays: list[NDArray[Any]] = []
         for name in (
             "executed_actions",
             "credited_actions",
             "recommendations",
             "partner_proposals",
         ):
-            _require_ndarray(
+            action_arrays.append(_require_ndarray(
                 name,
                 getattr(self, name),
                 dtype=np.dtype(np.int64),
                 length=steps,
-            )
-        _require_ndarray(
+            ))
+        accepted = _require_ndarray(
             "accepted_recommendations",
             self.accepted_recommendations,
             dtype=np.dtype(np.bool_),
             length=steps,
         )
-        object.__setattr__(self, "mean_reward", finite_real("mean_reward", self.mean_reward))
-        _require_ndarray(
+        mean_reward = finite_real("mean_reward", self.mean_reward)
+        object.__setattr__(self, "mean_reward", mean_reward)
+        phase_means = _require_ndarray(
             "phase_mean_rewards",
             self.phase_mean_rewards,
             dtype=np.dtype(np.float64),
         )
-        _require_ndarray(
+        recoveries = _require_ndarray(
             "recovery_lengths",
             self.recovery_lengths,
             dtype=np.dtype(np.int64),
         )
+        arrays = (rewards, *action_arrays, accepted, phase_means, recoveries)
+        if sum(array.nbytes for array in arrays) > _MAX_CONDITION_RESULT_BYTES:
+            raise ValueError("condition result arrays exceed the bounded record budget")
+        if phase_means.size < 1 or recoveries.size != phase_means.size - 1:
+            raise ValueError("phase and recovery arrays do not describe one shared schedule")
+        if not bool(np.all(np.isfinite(rewards))) or not bool(np.all(np.isfinite(phase_means))):
+            raise ValueError("reward summaries must contain only finite values")
+        if mean_reward != float(np.mean(rewards)):
+            raise ValueError("mean_reward does not match the primitive rewards")
+        executed, credited, recommendations, proposals = action_arrays
+        if any(array.min() < 0 or array.max() > 1 for array in (executed, credited)):
+            raise ValueError("executed and credited actions must lie in [0, 1]")
+        if any(array.min() < -1 or array.max() > 1 for array in (recommendations, proposals)):
+            raise ValueError("recommendation and proposal actions must lie in {-1, 0, 1}")
+        if recoveries.size and (recoveries.min() < -1 or recoveries.max() > steps):
+            raise ValueError("recovery lengths must be -1 or lie within the interaction schedule")
         for name in (
             "nominal_recommendation_decisions",
             "nominal_accepted_recommendations",
@@ -512,9 +531,40 @@ class IAConditionResult:
         if not 0.0 <= rate <= 1.0:
             raise ValueError("changed_action_intervention_rate must lie in [0, 1]")
         object.__setattr__(self, "changed_action_intervention_rate", rate)
-        if not isinstance(self.controller_budget, ControllerBudget):
+        executed_accepted = int(np.count_nonzero(accepted))
+        changed = int(np.count_nonzero(accepted & (recommendations != proposals)))
+        mismatches = int(np.count_nonzero(executed != credited))
+        if self.executed_accepted_recommendations != executed_accepted:
+            raise ValueError("executed accepted count does not match accepted_recommendations")
+        if self.action_changing_interventions != changed:
+            raise ValueError("action-changing count does not match primitive actions")
+        if self.executed_action_credit_mismatches != mismatches:
+            raise ValueError("action-credit mismatch count does not match primitive actions")
+        if rate != changed / steps:
+            raise ValueError("changed action intervention rate does not match primitive actions")
+        if not (
+            self.nominal_accepted_recommendations <= self.nominal_recommendation_decisions <= steps
+            and self.executed_accepted_recommendations <= steps
+            and self.action_changing_interventions <= self.executed_accepted_recommendations
+        ):
+            raise ValueError("recommendation counts exceed the shared interaction schedule")
+        if self.condition not in RECOMMENDATION_CONDITIONS and (
+            bool(np.any(recommendations != -1))
+            or bool(np.any(proposals != -1))
+            or bool(np.any(accepted))
+            or self.nominal_recommendation_decisions != 0
+            or self.nominal_accepted_recommendations != 0
+        ):
+            raise ValueError("plain conditions must not contain recommendation activity")
+        if self.condition in RECOMMENDATION_CONDITIONS and (
+            bool(np.any(recommendations < 0)) or bool(np.any(proposals < 0))
+        ):
+            raise ValueError("recommendation conditions must contain concrete actions")
+        if type(self.controller_budget) is not ControllerBudget:
             raise ValueError("controller_budget must be a ControllerBudget")
-        if not isinstance(self.timing, ConditionTiming):
+        if self.controller_budget.interaction_steps != steps:
+            raise ValueError("controller budget interaction_steps must match result length")
+        if type(self.timing) is not ConditionTiming:
             raise ValueError("timing must be a ConditionTiming")
 
 
@@ -613,6 +663,34 @@ class ContinualIAReport:
     condition_results: tuple[IAConditionResult, ...]
     aggregate: IAAggregateEvidence
     acceptance: IAAcceptanceResult
+
+    def __post_init__(self) -> None:
+        if type(self.config) is not ContinualIAConfig:
+            raise ValueError("config must be a ContinualIAConfig")
+        if type(self.thresholds) is not IAAcceptanceThresholds:
+            raise ValueError("thresholds must be IAAcceptanceThresholds")
+        if type(self.condition_results) is not tuple or not self.condition_results:
+            raise ValueError("condition_results must be a non-empty exact tuple")
+        if not all(type(result) is IAConditionResult for result in self.condition_results):
+            raise ValueError("condition_results must contain exact IAConditionResult records")
+        if len(self.condition_results) % len(CONDITION_NAMES) != 0:
+            raise ValueError("condition_results must contain one complete tuple per seed")
+        seeds: list[int] = []
+        for offset in range(0, len(self.condition_results), len(CONDITION_NAMES)):
+            group = self.condition_results[offset : offset + len(CONDITION_NAMES)]
+            if tuple(result.condition for result in group) != CONDITION_NAMES:
+                raise ValueError("each seed must contain the exact ordered IA condition tuple")
+            if len({result.seed for result in group}) != 1:
+                raise ValueError("each IA condition tuple must share one seed")
+            seeds.append(group[0].seed)
+        if len(set(seeds)) != len(seeds):
+            raise ValueError("IA report seeds must be unique")
+        if type(self.aggregate) is not IAAggregateEvidence:
+            raise ValueError("aggregate must be an IAAggregateEvidence")
+        if tuple(seeds) != self.aggregate.seeds:
+            raise ValueError("aggregate seeds must match the ordered condition results")
+        if type(self.acceptance) is not IAAcceptanceResult:
+            raise ValueError("acceptance must be an IAAcceptanceResult")
 
 
 def paired_bootstrap_mean_interval(

--- a/tests/test_ia_condition_result_hostile.py
+++ b/tests/test_ia_condition_result_hostile.py
@@ -1,0 +1,106 @@
+"""Complete IAConditionResult identity contract: leftover, types, and arrays."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.evaluation.continual_ia import (
+    CONDITION_NAMES,
+    ConditionTiming,
+    ControllerBudget,
+    IAConditionResult,
+)
+
+
+class StringSubclass(str):
+    """Leftover string identity that must not cross the result boundary."""
+
+
+def _budget() -> ControllerBudget:
+    return ControllerBudget(
+        state_scalars=1,
+        state_bytes=8,
+        observation_scalars=2,
+        action_scalars_per_step=1,
+        interaction_steps=1,
+        ia_attached=True,
+    )
+
+
+def _timing() -> ConditionTiming:
+    return ConditionTiming(wall_seconds=0.1, mean_step_latency_ms=0.1)
+
+
+def _legal(**overrides: object) -> IAConditionResult:
+    steps = 2
+    payload: dict[str, object] = {
+        "seed": 30,
+        "condition": CONDITION_NAMES[0],
+        "rewards": np.zeros(steps, dtype=np.float64),
+        "executed_actions": np.zeros(steps, dtype=np.int64),
+        "credited_actions": np.zeros(steps, dtype=np.int64),
+        "recommendations": np.zeros(steps, dtype=np.int64),
+        "partner_proposals": np.zeros(steps, dtype=np.int64),
+        "accepted_recommendations": np.zeros(steps, dtype=np.bool_),
+        "mean_reward": 0.0,
+        "phase_mean_rewards": np.zeros(1, dtype=np.float64),
+        "recovery_lengths": np.zeros(1, dtype=np.int64),
+        "nominal_recommendation_decisions": 0,
+        "nominal_accepted_recommendations": 0,
+        "executed_accepted_recommendations": 0,
+        "action_changing_interventions": 0,
+        "changed_action_intervention_rate": 0.0,
+        "executed_action_credit_mismatches": 0,
+        "controller_budget": _budget(),
+        "timing": _timing(),
+    }
+    payload.update(overrides)
+    return IAConditionResult(**payload)  # type: ignore[arg-type]
+
+
+def test_ia_condition_result_accepts_canonical_identity() -> None:
+    result = _legal()
+    assert result.seed == 30
+    assert result.condition == "partner_alone"
+    assert result.changed_action_intervention_rate == 0.0
+
+
+def test_ia_condition_result_rejects_leftover_integer_identities() -> None:
+    with pytest.raises(ValueError, match="seed must be an integer"):
+        _legal(seed=True)
+    with pytest.raises(ValueError, match="action_changing_interventions must be an integer"):
+        _legal(action_changing_interventions=True)
+    with pytest.raises(ValueError, match="executed_action_credit_mismatches must be an integer"):
+        _legal(executed_action_credit_mismatches=True)
+
+
+def test_ia_condition_result_rejects_leftover_float_identities() -> None:
+    with pytest.raises(ValueError, match="mean_reward must be a finite real number"):
+        _legal(mean_reward=True)
+    with pytest.raises(ValueError, match="changed_action_intervention_rate must be a finite"):
+        _legal(changed_action_intervention_rate=True)
+    with pytest.raises(ValueError, match="changed_action_intervention_rate must lie in"):
+        _legal(changed_action_intervention_rate=1.5)
+
+
+def test_ia_condition_result_rejects_leftover_condition_identities() -> None:
+    with pytest.raises(ValueError, match="condition must be a known IA condition name"):
+        _legal(condition=True)
+    with pytest.raises(ValueError, match="condition must be a known IA condition name"):
+        _legal(condition=StringSubclass("partner_alone"))
+    with pytest.raises(ValueError, match="condition must be a known IA condition name"):
+        _legal(condition="not_a_condition")
+
+
+def test_ia_condition_result_rejects_invalid_arrays_and_hosts() -> None:
+    with pytest.raises(ValueError, match="rewards must be an exact numpy.ndarray"):
+        _legal(rewards=[0.0, 0.0])
+    with pytest.raises(ValueError, match="executed_actions must have dtype"):
+        _legal(executed_actions=np.zeros(2, dtype=np.int32))
+    with pytest.raises(ValueError, match="accepted_recommendations must have length"):
+        _legal(accepted_recommendations=np.zeros(1, dtype=np.bool_))
+    with pytest.raises(ValueError, match="controller_budget must be a ControllerBudget"):
+        _legal(controller_budget=None)
+    with pytest.raises(ValueError, match="timing must be a ConditionTiming"):
+        _legal(timing=None)

--- a/tests/test_ia_condition_result_hostile.py
+++ b/tests/test_ia_condition_result_hostile.py
@@ -23,7 +23,7 @@ def _budget() -> ControllerBudget:
         state_bytes=8,
         observation_scalars=2,
         action_scalars_per_step=1,
-        interaction_steps=1,
+        interaction_steps=2,
         ia_attached=True,
     )
 
@@ -40,12 +40,12 @@ def _legal(**overrides: object) -> IAConditionResult:
         "rewards": np.zeros(steps, dtype=np.float64),
         "executed_actions": np.zeros(steps, dtype=np.int64),
         "credited_actions": np.zeros(steps, dtype=np.int64),
-        "recommendations": np.zeros(steps, dtype=np.int64),
-        "partner_proposals": np.zeros(steps, dtype=np.int64),
+        "recommendations": np.full(steps, -1, dtype=np.int64),
+        "partner_proposals": np.full(steps, -1, dtype=np.int64),
         "accepted_recommendations": np.zeros(steps, dtype=np.bool_),
         "mean_reward": 0.0,
         "phase_mean_rewards": np.zeros(1, dtype=np.float64),
-        "recovery_lengths": np.zeros(1, dtype=np.int64),
+        "recovery_lengths": np.zeros(0, dtype=np.int64),
         "nominal_recommendation_decisions": 0,
         "nominal_accepted_recommendations": 0,
         "executed_accepted_recommendations": 0,
@@ -104,3 +104,36 @@ def test_ia_condition_result_rejects_invalid_arrays_and_hosts() -> None:
         _legal(controller_budget=None)
     with pytest.raises(ValueError, match="timing must be a ConditionTiming"):
         _legal(timing=None)
+
+
+def test_ia_condition_result_cross_binds_primitive_summaries() -> None:
+    with pytest.raises(ValueError, match="mean_reward does not match"):
+        _legal(rewards=np.ones(2, dtype=np.float64))
+    with pytest.raises(ValueError, match="mismatch count does not match"):
+        _legal(executed_action_credit_mismatches=1)
+    with pytest.raises(ValueError, match="rate does not match"):
+        _legal(changed_action_intervention_rate=0.5)
+    with pytest.raises(ValueError, match="interaction_steps must match"):
+        _legal(controller_budget=ControllerBudget(
+            state_scalars=1,
+            state_bytes=8,
+            observation_scalars=2,
+            action_scalars_per_step=1,
+            interaction_steps=1,
+            ia_attached=True,
+        ))
+
+
+def test_ia_condition_result_rejects_hostile_array_subclasses_without_hooks() -> None:
+    class HostileArray(np.ndarray):
+        calls = 0
+
+        def __array_function__(self, *args: object, **kwargs: object) -> object:
+            type(self).calls += 1
+            raise AssertionError("hostile array hook")
+
+    hostile = np.zeros(2, dtype=np.float64).view(HostileArray)
+    HostileArray.calls = 0
+    with pytest.raises(ValueError, match="rewards must be an exact numpy.ndarray"):
+        _legal(rewards=hostile)
+    assert HostileArray.calls == 0


### PR DESCRIPTION
Consolidates contributor PR #1667 / issue #1666 while preserving @ss251’s commit.

The original exact host gates are correct. The deeper pass adds bounded preflight before array scans; exact dtype/shape/finite/action-domain checks; phase/recovery schedule binding; exact mean/count/rate reconstruction from primitive arrays; recommendation-vs-plain condition semantics; controller interaction-step binding; and report-level exact ordered condition tuples with unique seed and aggregate-seed cross-binding.

Verification: 54 focused IA tests in 182.86s, 7 narrow hostile tests post-change, Ruff, strict mypy, diff-check. No scientific run or output mutation.

Closes #1666
Supersedes #1667.