### PR TITLE
fix(benchmarks): retain L2-ER transaction invalidity

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -532,6 +532,7 @@ class L2ERState:
 
     example_buffer: Array
     buffer_count: Array
+    transaction_valid: Array
 
 
 def l2er_effective_rank_transaction(
@@ -642,6 +643,11 @@ def l2er_update(
         count.shape != () or count.dtype != jnp.dtype(jnp.int32)
     ):
         raise ValueError("buffer_count must be one scalar int32 JAX array")
+    transaction_valid = state.transaction_valid
+    if not isinstance(transaction_valid, (jax.Array, jax.core.Tracer)) or (
+        transaction_valid.shape != () or transaction_valid.dtype != jnp.dtype(jnp.bool_)
+    ):
+        raise ValueError("transaction_valid must be one scalar bool JAX array")
     step_size = checked_hp["step_size"]
     weight_decay = checked_hp["weight_decay"]
     supervised_params = {
@@ -679,8 +685,14 @@ def l2er_update(
             complete, jnp.zeros_like, lambda value: value, buffered
         ),
         buffer_count=jnp.where(complete, jnp.asarray(0, dtype=jnp.int32), next_count),
+        transaction_valid=jnp.asarray(True, dtype=jnp.bool_),
     )
-    valid = count_valid & floating_tree_is_finite(params) & floating_tree_is_finite(grads)
+    valid = (
+        transaction_valid
+        & count_valid
+        & floating_tree_is_finite(params)
+        & floating_tree_is_finite(grads)
+    )
     valid = valid & floating_tree_is_finite(new_params) & floating_tree_is_finite(candidate_state)
     safe_prior_params = jax.tree.map(
         lambda value: jnp.where(jnp.isfinite(value), value, jnp.zeros_like(value)),
@@ -689,6 +701,7 @@ def l2er_update(
     safe_prior_state = L2ERState(  # type: ignore[call-arg]
         example_buffer=jnp.where(jnp.isfinite(buffer), buffer, jnp.zeros_like(buffer)),
         buffer_count=jnp.where(count_valid, count, jnp.asarray(0, dtype=jnp.int32)),
+        transaction_valid=jnp.asarray(False, dtype=jnp.bool_),
     )
     return (
         select_transaction(valid, new_params, safe_prior_params),
@@ -712,6 +725,7 @@ def _make_l2er_learner(
                 (int(checked_hp["er_batch_size"]), input_dim), dtype=jnp.float32
             ),
             buffer_count=jnp.asarray(0, dtype=jnp.int32),
+            transaction_valid=jnp.asarray(True, dtype=jnp.bool_),
         )
 
     def full_step(
@@ -8674,7 +8688,7 @@ def l2er_development_result_payload(
         + config.hidden2 * config.n_classes
         + config.n_classes
     )
-    persistent_bytes = 4 * (parameter_count + er_batch_size * config.input_dim + 1)
+    persistent_bytes = 4 * (parameter_count + er_batch_size * config.input_dim + 1) + 1
     payload: dict[str, object] = {
         "schema": L2ER_RESULT_SCHEMA,
         "comparison_id": L2ER_COMPARISON_ID,
@@ -9227,6 +9241,9 @@ def run_screening_config(
             schedule.permutations[task],
             schedule.example_indices[task],
         )
+        if spec.mechanism == "l2_effective_rank":
+            if type(state) is not L2ERState or not bool(state.transaction_valid):
+                raise RuntimeError("L2-ER update transaction became invalid")
         task_accuracy.append(float(jnp.mean(accuracies)))
         task_loss.append(float(jnp.mean(losses)))
         task_plasticity.append(float(jnp.mean(plasticities)))

--- a/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
@@ -38,7 +38,8 @@ L2ER_PROTOCOL = MappingProxyType(
         "official_er_steps_per_batch": 1,
         "effective_rank_epsilon": 1e-8,
         "persistent_bytes_scope": (
-            "float32 parameters plus the fixed 100-example float32 ER buffer and int32 count; "
+            "float32 parameters plus the fixed 100-example float32 ER buffer, int32 count, "
+            "and sticky bool transaction-validity flag; "
             "runner RNG and the externally supplied schedule are excluded"
         ),
         "development_only": True,
@@ -251,7 +252,7 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
     parameter_count = sum(products[:3]) + hidden1 + hidden2 + n_classes
     if parameter_count > _INT32_MAX - products[3] - 1:
         raise ValueError("derived persistent scalar count exceeds signed int32")
-    expected_persistent_bytes = 4 * (parameter_count + products[3] + 1)
+    expected_persistent_bytes = 4 * (parameter_count + products[3] + 1) + 1
     if expected_persistent_bytes > _MAX_BYTES:
         raise ValueError("derived persistent bytes exceed 256 MiB")
     if persistent_bytes != expected_persistent_bytes:

--- a/tests/test_l2er_ipmnist.py
+++ b/tests/test_l2er_ipmnist.py
@@ -76,6 +76,7 @@ def test_l2_and_mechanism_off_are_exact_reductions() -> None:
     state = L2ERState(  # type: ignore[call-arg]
         example_buffer=jnp.zeros((100, 2), dtype=jnp.float32),
         buffer_count=jnp.asarray(0, dtype=jnp.int32),
+        transaction_valid=jnp.asarray(True, dtype=jnp.bool_),
     )
     example = jnp.asarray([0.4, 0.7], dtype=jnp.float32)
     off, off_state = l2er_update(params, state, grads, example, _hp(wd=0.0, er_lr=0.0, enabled=0.0))
@@ -95,6 +96,7 @@ def test_er_update_matches_official_separate_post_batch_step() -> None:
     state = L2ERState(  # type: ignore[call-arg]
         example_buffer=buffer,
         buffer_count=jnp.asarray(99, dtype=jnp.int32),
+        transaction_valid=jnp.asarray(True, dtype=jnp.bool_),
     )
     example = jnp.asarray([0.3, 0.9], dtype=jnp.float32)
     hp = _hp(wd=1e-4, er_lr=1e-3, enabled=1.0)
@@ -122,6 +124,7 @@ def test_l2er_update_is_jittable() -> None:
     state = L2ERState(  # type: ignore[call-arg]
         example_buffer=jnp.ones((100, 2), dtype=jnp.float32),
         buffer_count=jnp.asarray(99, dtype=jnp.int32),
+        transaction_valid=jnp.asarray(True, dtype=jnp.bool_),
     )
     update = jax.jit(
         lambda p, s, g, x: l2er_update(
@@ -143,6 +146,7 @@ def test_update_rejects_hostile_structure_and_is_atomic_on_runtime_invalidity() 
     state = L2ERState(  # type: ignore[call-arg]
         example_buffer=jnp.zeros((100, 2), dtype=jnp.float32),
         buffer_count=jnp.asarray(0, dtype=jnp.int32),
+        transaction_valid=jnp.asarray(True, dtype=jnp.bool_),
     )
     with pytest.raises(ValueError, match="hyperparameters"):
         l2er_update(  # type: ignore[arg-type]
@@ -168,10 +172,11 @@ def test_update_rejects_hostile_structure_and_is_atomic_on_runtime_invalidity() 
     for name in params:
         np.testing.assert_array_equal(unchanged[name], params[name])
     assert int(repaired.buffer_count) == 0
+    assert not bool(repaired.transaction_valid)
 
     nonfinite = dict(grads)
     nonfinite["w1"] = jnp.full_like(grads["w1"], jnp.inf)
-    unchanged, _ = l2er_update(
+    unchanged, invalid_state = l2er_update(
         params,
         state,
         nonfinite,
@@ -180,6 +185,15 @@ def test_update_rejects_hostile_structure_and_is_atomic_on_runtime_invalidity() 
     )
     for name in params:
         np.testing.assert_array_equal(unchanged[name], params[name])
+    assert not bool(invalid_state.transaction_valid)
+    _, still_invalid = l2er_update(
+        unchanged,
+        invalid_state,
+        grads,
+        jnp.ones(2),
+        _hp(wd=0.0, er_lr=0.0, enabled=0.0),
+    )
+    assert not bool(still_invalid.transaction_valid)
 
 
 def test_buffer_and_svd_resources_are_preflighted() -> None:
@@ -271,7 +285,7 @@ def test_result_receipt_accounts_resources_and_is_permanently_nonpromoting() -> 
     assert resources["data_steps"] == 100
     assert resources["environment_steps"] == 0
     assert resources["model_queries"] == 201
-    assert resources["persistent_bytes"] == 876
+    assert resources["persistent_bytes"] == 877
 
     hostile = deepcopy(payload)
     hostile_resources = hostile["resources"]


### PR DESCRIPTION
Narrow follow-up audit for merged #1665. Its rank transaction exposed NaN correctly, but the enclosing `l2er_update` selected a finite prior state and could silently continue, allowing a later development receipt to launder the invalid ER rank. This adds a sticky charged transaction-validity bit, keeps invalid updates atomic and finite, and makes the end-to-end runner abort before constructing a result whenever the bit is false. Resource accounting includes the added byte.\n\nNo benchmark or output. #1559 remains open pending a retained matched report.\n\nValidation: 27 focused L2-ER/Intentional tests; scoped Ruff; strict mypy.