### PR TITLE
fix(scorecard): close hostile numeric gates with real tests

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -686,9 +686,9 @@ class StreamingRunSummary:
     ) -> None:
         if self._accepted_events >= self._horizon:
             raise ValueError("streaming summary already reached its horizon")
-        if isinstance(reward, bool) or not isinstance(reward, (int, float)):
+        if type(reward) not in (int, float):
             raise ValueError("reward must be a finite number")
-        if isinstance(oracle_reward, bool) or not isinstance(oracle_reward, (int, float)):
+        if type(oracle_reward) not in (int, float):
             raise ValueError("oracle_reward must be a finite number")
         reward_value = float(reward)
         oracle_value = float(oracle_reward)
@@ -1005,9 +1005,9 @@ def _reward_sum(record: Mapping[str, Any]) -> float:
     if not isinstance(outcome, Mapping):
         raise ValueError("completed run record lacks an outcome")
     value = outcome.get("reward_sum")
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) not in (int, float):
         raise ValueError("completed run reward_sum must be finite")
-    result = float(value)
+    result = float(value)  # type: ignore[arg-type]
     if not math.isfinite(result):
         raise ValueError("completed run reward_sum must be finite")
     return result
@@ -1679,7 +1679,7 @@ def build_scorecard_artifact(
 
 
 def _require_finite_nonnegative(value: Any, *, path: str) -> float:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) not in (int, float):
         raise ValueError(f"{path} must be a finite nonnegative number")
     result = float(value)
     if not math.isfinite(result) or result < 0.0:
@@ -1694,7 +1694,7 @@ def _require_nonnegative_int(value: Any, *, path: str) -> int:
 
 
 def _require_finite_number(value: Any, *, path: str) -> float:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) not in (int, float):
         raise ValueError(f"{path} must be a finite number")
     result = float(value)
     if not math.isfinite(result):

--- a/tests/test_reference_scorecard_int_hostile.py
+++ b/tests/test_reference_scorecard_int_hostile.py
@@ -1,0 +1,124 @@
+"""Hostile integer validation for reference life scorecard."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:
+        type(self).calls += 1
+        raise AssertionError("hostile float")
+
+    def __lt__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile lt")
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq")
+
+
+def test_streaming_observe_rejects_hostile_before_float() -> None:
+    from alberta_framework.benchmarks.reference_life_scorecard import StreamingRunSummary
+
+    summary = StreamingRunSummary.for_switching(horizon=10, phase_length=3, post_switch_window=2)
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must be a finite number"):
+        summary.observe(
+            reward=hostile,  # type: ignore[arg-type]
+            oracle_reward=1.0,
+            regime_id=0,
+            parameters_changed=False,
+            next_state_index=0,
+        )
+    assert _HostileInt.calls == 0
+    _HostileInt.calls = 0
+    hostile2 = _HostileInt(2)
+    with pytest.raises(Exception, match="must be a finite number"):
+        summary.observe(
+            reward=1.0,
+            oracle_reward=hostile2,  # type: ignore[arg-type]
+            regime_id=0,
+            parameters_changed=False,
+            next_state_index=0,
+        )
+    assert _HostileInt.calls == 0
+    # bool rejected
+    with pytest.raises(Exception, match="must be a finite number"):
+        summary.observe(
+            reward=True,  # type: ignore[arg-type]
+            oracle_reward=1.0,
+            regime_id=0,
+            parameters_changed=False,
+            next_state_index=0,
+        )
+    # valid still works
+    summary.observe(
+        reward=1,
+        oracle_reward=2.0,
+        regime_id=0,
+        parameters_changed=False,
+        next_state_index=0,
+    )
+    assert summary.accepted_events == 1
+
+
+def test_reward_sum_rejects_hostile_before_float() -> None:
+    from alberta_framework.benchmarks.reference_life_scorecard import _reward_sum
+
+    hostile = _HostileInt(5)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must be finite"):
+        _reward_sum({"outcome": {"reward_sum": hostile}})  # type: ignore[dict-item]
+    assert _HostileInt.calls == 0
+    with pytest.raises(Exception, match="must be finite"):
+        _reward_sum({"outcome": {"reward_sum": True}})  # type: ignore[dict-item]
+    assert _HostileInt.calls == 0
+    assert _reward_sum({"outcome": {"reward_sum": 5}}) == 5.0
+    assert _reward_sum({"outcome": {"reward_sum": 5.0}}) == 5.0
+
+
+def test_finite_nonnegative_rejects_hostile_before_float() -> None:
+    from alberta_framework.benchmarks.reference_life_scorecard import _require_finite_nonnegative
+
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must be a finite nonnegative"):
+        _require_finite_nonnegative(hostile, path="p")  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    with pytest.raises(Exception, match="must be a finite nonnegative"):
+        _require_finite_nonnegative(True, path="p")  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    assert _require_finite_nonnegative(1.0, path="p") == 1.0
+    assert _require_finite_nonnegative(0, path="p") == 0.0
+
+
+def test_finite_number_rejects_hostile_before_float() -> None:
+    from alberta_framework.benchmarks.reference_life_scorecard import _require_finite_number
+
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must be a finite number"):
+        _require_finite_number(hostile, path="p")  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    with pytest.raises(Exception, match="must be a finite number"):
+        _require_finite_number(True, path="p")  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    assert _require_finite_number(1, path="p") == 1.0
+
+
+def test_hostile_not_in_error_message() -> None:
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    try:
+        if type(hostile) not in (int, float):
+            raise ValueError("must be a finite number")
+    except ValueError as exc:
+        assert "!r" not in str(exc)
+        assert _HostileInt.calls == 0

--- a/tests/test_reference_scorecard_int_hostile.py
+++ b/tests/test_reference_scorecard_int_hostile.py
@@ -29,9 +29,9 @@ def test_streaming_observe_rejects_hostile_before_float() -> None:
     summary = StreamingRunSummary.for_switching(horizon=10, phase_length=3, post_switch_window=2)
     hostile = _HostileInt(1)
     _HostileInt.calls = 0
-    with pytest.raises(Exception, match="must be a finite number"):
+    with pytest.raises(ValueError, match="must be a finite number"):
         summary.observe(
-            reward=hostile,  # type: ignore[arg-type]
+            reward=hostile,
             oracle_reward=1.0,
             regime_id=0,
             parameters_changed=False,
@@ -40,19 +40,19 @@ def test_streaming_observe_rejects_hostile_before_float() -> None:
     assert _HostileInt.calls == 0
     _HostileInt.calls = 0
     hostile2 = _HostileInt(2)
-    with pytest.raises(Exception, match="must be a finite number"):
+    with pytest.raises(ValueError, match="must be a finite number"):
         summary.observe(
             reward=1.0,
-            oracle_reward=hostile2,  # type: ignore[arg-type]
+            oracle_reward=hostile2,
             regime_id=0,
             parameters_changed=False,
             next_state_index=0,
         )
     assert _HostileInt.calls == 0
     # bool rejected
-    with pytest.raises(Exception, match="must be a finite number"):
+    with pytest.raises(ValueError, match="must be a finite number"):
         summary.observe(
-            reward=True,  # type: ignore[arg-type]
+            reward=True,
             oracle_reward=1.0,
             regime_id=0,
             parameters_changed=False,
@@ -74,11 +74,11 @@ def test_reward_sum_rejects_hostile_before_float() -> None:
 
     hostile = _HostileInt(5)
     _HostileInt.calls = 0
-    with pytest.raises(Exception, match="must be finite"):
-        _reward_sum({"outcome": {"reward_sum": hostile}})  # type: ignore[dict-item]
+    with pytest.raises(ValueError, match="must be finite"):
+        _reward_sum({"outcome": {"reward_sum": hostile}})
     assert _HostileInt.calls == 0
-    with pytest.raises(Exception, match="must be finite"):
-        _reward_sum({"outcome": {"reward_sum": True}})  # type: ignore[dict-item]
+    with pytest.raises(ValueError, match="must be finite"):
+        _reward_sum({"outcome": {"reward_sum": True}})
     assert _HostileInt.calls == 0
     assert _reward_sum({"outcome": {"reward_sum": 5}}) == 5.0
     assert _reward_sum({"outcome": {"reward_sum": 5.0}}) == 5.0
@@ -89,11 +89,11 @@ def test_finite_nonnegative_rejects_hostile_before_float() -> None:
 
     hostile = _HostileInt(1)
     _HostileInt.calls = 0
-    with pytest.raises(Exception, match="must be a finite nonnegative"):
-        _require_finite_nonnegative(hostile, path="p")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be a finite nonnegative"):
+        _require_finite_nonnegative(hostile, path="p")
     assert _HostileInt.calls == 0
-    with pytest.raises(Exception, match="must be a finite nonnegative"):
-        _require_finite_nonnegative(True, path="p")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be a finite nonnegative"):
+        _require_finite_nonnegative(True, path="p")
     assert _HostileInt.calls == 0
     assert _require_finite_nonnegative(1.0, path="p") == 1.0
     assert _require_finite_nonnegative(0, path="p") == 0.0
@@ -104,21 +104,10 @@ def test_finite_number_rejects_hostile_before_float() -> None:
 
     hostile = _HostileInt(1)
     _HostileInt.calls = 0
-    with pytest.raises(Exception, match="must be a finite number"):
-        _require_finite_number(hostile, path="p")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be a finite number"):
+        _require_finite_number(hostile, path="p")
     assert _HostileInt.calls == 0
-    with pytest.raises(Exception, match="must be a finite number"):
-        _require_finite_number(True, path="p")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be a finite number"):
+        _require_finite_number(True, path="p")
     assert _HostileInt.calls == 0
     assert _require_finite_number(1, path="p") == 1.0
-
-
-def test_hostile_not_in_error_message() -> None:
-    hostile = _HostileInt(1)
-    _HostileInt.calls = 0
-    try:
-        if type(hostile) not in (int, float):
-            raise ValueError("must be a finite number")
-    except ValueError as exc:
-        assert "!r" not in str(exc)
-        assert _HostileInt.calls == 0


### PR DESCRIPTION
Supersedes #1677 while preserving byt61 authorship and the exact production hardening.

- rejects integer/float subclasses before hostile conversion or comparison hooks in the real scorecard numeric boundaries
- exercises only production `StreamingRunSummary.observe`, `_reward_sum`, `_require_finite_nonnegative`, and `_require_finite_number` paths
- requires the documented `ValueError`, so a hostile-hook `AssertionError` cannot make a test pass
- removes the simulated error-message test that only raised its own exception

Validation after rebasing onto current main:
- focused hostile test: 4 passed
- hostile + reference-life scorecard + run-spec panel: 72 passed
- focused Ruff: passed
- strict mypy on source and tests: passed
- diff check: passed

No run or output mutation. The currently queued scorecard run is independently bound to its dispatch SHA; this source change does not alter its checkout, although that run is already historical relative to newer main source.