### PR TITLE
fix(core): close feature router integer identity gaps

### DIFF
--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -532,7 +532,7 @@ class FeatureBankRouter:
         normalized_axes: list[int] = []
         for index, (leaf, raw_axis) in enumerate(zip(leaves, raw_axes, strict=True)):
             value = jnp.asarray(leaf)
-            if isinstance(raw_axis, bool) or not isinstance(raw_axis, int):
+            if type(raw_axis) is not int:
                 raise TypeError(f"feature axis for consumer leaf {index} must be an integer")
             axis = raw_axis if raw_axis >= 0 else value.ndim + raw_axis
             if axis < 0 or axis >= value.ndim:

--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -52,7 +52,8 @@ _ACTUAL_INT_TYPES = frozenset(
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     canonical = operator.index(cast(SupportsIndex, value))
     if not minimum <= canonical <= maximum:
@@ -68,7 +69,8 @@ def _require_derived_int32(name: str, value: int, *, minimum: int = 0) -> int:
 
 def _require_host_count(name: str, value: object, *, minimum: int = 0) -> int:
     """Canonicalize one exact host-only accounting integer without narrowing it."""
-    if type(value) not in _ACTUAL_INT_TYPES:
+    actual_type = type(value)
+    if not any(actual_type is allowed_type for allowed_type in _ACTUAL_INT_TYPES):
         raise ValueError(f"{name} must be an integer >= {minimum}")
     canonical = operator.index(cast(SupportsIndex, value))
     if canonical < minimum:

--- a/tests/test_feature_bank_router_int_hostile.py
+++ b/tests/test_feature_bank_router_int_hostile.py
@@ -1,0 +1,58 @@
+"""Hostile integer validation for feature bank router."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __lt__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile lt")
+
+    def __ge__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile ge")
+
+    def __hash__(self) -> int:
+        return int.__hash__(self)
+
+
+def test_feature_axis_rejects_hostile_before_lt() -> None:
+    from alberta_framework.core.feature_bank_router import (
+        FeatureBankRouter,
+        FeatureBankRouterConfig,
+    )
+
+    config = FeatureBankRouterConfig(base_dim=2, active_slots=1)
+    router = FeatureBankRouter(config)
+    hostile = _HostileInt(0)
+    _HostileInt.calls = 0
+    consumers = [jnp.ones((2, 3))]
+    with pytest.raises(Exception, match="must be an integer"):
+        router._consumer_layout(consumers, [hostile])  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    with pytest.raises(Exception, match="must be an integer"):
+        router._consumer_layout(consumers, [True])  # type: ignore[arg-type]
+    # valid
+    arrays, _, axes = router._consumer_layout(consumers, [1])
+    assert axes == (1,)
+    # also negative axis allowed via ndim calc after type check, but still int
+    arrays, _, axes = router._consumer_layout(consumers, [-1])
+    assert axes == (1,)
+
+
+def test_hostile_not_in_error_message() -> None:
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    try:
+        if type(hostile) is not int:
+            raise TypeError("feature axis must be an integer")
+    except TypeError as exc:
+        assert "!r" not in str(exc)
+        assert _HostileInt.calls == 0

--- a/tests/test_feature_bank_router_int_hostile.py
+++ b/tests/test_feature_bank_router_int_hostile.py
@@ -20,7 +20,20 @@ class _HostileInt(int):
         raise AssertionError("hostile ge")
 
     def __hash__(self) -> int:
-        return int.__hash__(self)
+        type(self).calls += 1
+        raise AssertionError("hostile hash")
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq")
+
+    def __index__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile index")
+
+    def __repr__(self) -> str:
+        type(self).calls += 1
+        raise AssertionError("hostile repr")
 
 
 def test_feature_axis_rejects_hostile_before_lt() -> None:
@@ -34,10 +47,10 @@ def test_feature_axis_rejects_hostile_before_lt() -> None:
     hostile = _HostileInt(0)
     _HostileInt.calls = 0
     consumers = [jnp.ones((2, 3))]
-    with pytest.raises(Exception, match="must be an integer"):
+    with pytest.raises(TypeError, match="must be an integer"):
         router._consumer_layout(consumers, [hostile])  # type: ignore[arg-type]
     assert _HostileInt.calls == 0
-    with pytest.raises(Exception, match="must be an integer"):
+    with pytest.raises(TypeError, match="must be an integer"):
         router._consumer_layout(consumers, [True])  # type: ignore[arg-type]
     # valid
     arrays, _, axes = router._consumer_layout(consumers, [1])
@@ -47,12 +60,17 @@ def test_feature_axis_rejects_hostile_before_lt() -> None:
     assert axes == (1,)
 
 
-def test_hostile_not_in_error_message() -> None:
-    hostile = _HostileInt(1)
+def test_config_and_resource_counts_reject_hostile_before_runtime_hooks() -> None:
+    from alberta_framework.core.feature_bank_router import (
+        FeatureBankRouterConfig,
+        _require_host_count,
+    )
+
+    hostile = _HostileInt(2)
     _HostileInt.calls = 0
-    try:
-        if type(hostile) is not int:
-            raise TypeError("feature axis must be an integer")
-    except TypeError as exc:
-        assert "!r" not in str(exc)
-        assert _HostileInt.calls == 0
+    with pytest.raises(ValueError, match="base_dim must be an integer"):
+        FeatureBankRouterConfig(base_dim=hostile, active_slots=1)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    with pytest.raises(ValueError, match="consumer_total_scalars must be an integer"):
+        _require_host_count("consumer_total_scalars", hostile)
+    assert _HostileInt.calls == 0


### PR DESCRIPTION
Contributor-preserving successor to #1684. Retains the exact built-in axis gate and extends the same zero-hook identity rule to the router config and resource-accounting integer canonicalizers, which previously hashed attacker runtime classes through frozenset membership. Regressions make comparison/hash/index/repr hooks fail and assert zero dispatch.\n\nVerified: 44 router tests; Ruff; strict mypy; diff check. No evidence/output changes.