### PR TITLE
fix(benchmarks): consolidate scorecard hostile integer gates

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -686,9 +686,9 @@ class StreamingRunSummary:
     ) -> None:
         if self._accepted_events >= self._horizon:
             raise ValueError("streaming summary already reached its horizon")
-        if isinstance(reward, bool) or not isinstance(reward, (int, float)):
+        if type(reward) not in (int, float):
             raise ValueError("reward must be a finite number")
-        if isinstance(oracle_reward, bool) or not isinstance(oracle_reward, (int, float)):
+        if type(oracle_reward) not in (int, float):
             raise ValueError("oracle_reward must be a finite number")
         reward_value = float(reward)
         oracle_value = float(oracle_reward)
@@ -1005,9 +1005,9 @@ def _reward_sum(record: Mapping[str, Any]) -> float:
     if not isinstance(outcome, Mapping):
         raise ValueError("completed run record lacks an outcome")
     value = outcome.get("reward_sum")
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) not in (int, float):
         raise ValueError("completed run reward_sum must be finite")
-    result = float(value)
+    result = float(value)  # type: ignore[arg-type]
     if not math.isfinite(result):
         raise ValueError("completed run reward_sum must be finite")
     return result
@@ -1679,7 +1679,7 @@ def build_scorecard_artifact(
 
 
 def _require_finite_nonnegative(value: Any, *, path: str) -> float:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) not in (int, float):
         raise ValueError(f"{path} must be a finite nonnegative number")
     result = float(value)
     if not math.isfinite(result) or result < 0.0:
@@ -1694,7 +1694,7 @@ def _require_nonnegative_int(value: Any, *, path: str) -> int:
 
 
 def _require_finite_number(value: Any, *, path: str) -> float:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) not in (int, float):
         raise ValueError(f"{path} must be a finite number")
     result = float(value)
     if not math.isfinite(result):

--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -686,9 +686,9 @@ class StreamingRunSummary:
     ) -> None:
         if self._accepted_events >= self._horizon:
             raise ValueError("streaming summary already reached its horizon")
-        if type(reward) not in (int, float):
+        if type(reward) is not int and type(reward) is not float:
             raise ValueError("reward must be a finite number")
-        if type(oracle_reward) not in (int, float):
+        if type(oracle_reward) is not int and type(oracle_reward) is not float:
             raise ValueError("oracle_reward must be a finite number")
         if type(regime_id) is not int:
             raise ValueError("regime_id must be an integer")
@@ -1007,9 +1007,9 @@ def _reward_sum(record: Mapping[str, Any]) -> float:
     if not isinstance(outcome, Mapping):
         raise ValueError("completed run record lacks an outcome")
     value = outcome.get("reward_sum")
-    if type(value) not in (int, float):
+    if type(value) is not int and type(value) is not float:
         raise ValueError("completed run reward_sum must be finite")
-    result = float(value)  # type: ignore[arg-type]
+    result = float(value)
     if not math.isfinite(result):
         raise ValueError("completed run reward_sum must be finite")
     return result
@@ -1686,7 +1686,7 @@ def build_scorecard_artifact(
 
 
 def _require_finite_nonnegative(value: Any, *, path: str) -> float:
-    if type(value) not in (int, float):
+    if type(value) is not int and type(value) is not float:
         raise ValueError(f"{path} must be a finite nonnegative number")
     result = float(value)
     if not math.isfinite(result) or result < 0.0:
@@ -1701,7 +1701,7 @@ def _require_nonnegative_int(value: Any, *, path: str) -> int:
 
 
 def _require_finite_number(value: Any, *, path: str) -> float:
-    if type(value) not in (int, float):
+    if type(value) is not int and type(value) is not float:
         raise ValueError(f"{path} must be a finite number")
     result = float(value)
     if not math.isfinite(result):

--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -690,6 +690,8 @@ class StreamingRunSummary:
             raise ValueError("reward must be a finite number")
         if type(oracle_reward) not in (int, float):
             raise ValueError("oracle_reward must be a finite number")
+        if type(regime_id) is not int:
+            raise ValueError("regime_id must be an integer")
         reward_value = float(reward)
         oracle_value = float(oracle_reward)
         if not math.isfinite(reward_value) or not math.isfinite(oracle_value):
@@ -1642,7 +1644,12 @@ def build_scorecard_artifact(
 ) -> dict[str, Any]:
     """Assemble one immutable aggregate and bind its deterministic summary."""
 
-    ordered_records = sorted(records, key=lambda record: int(record["schedule_index"]))
+    if any(
+        not isinstance(record, Mapping) or type(record.get("schedule_index")) is not int
+        for record in records
+    ):
+        raise ValueError("every run record must have an integer schedule_index")
+    ordered_records = sorted(records, key=lambda record: cast(int, record["schedule_index"]))
     summary = summarize_run_records(plan, ordered_records)
     run_order = [
         {

--- a/tests/test_reference_scorecard_int_hostile.py
+++ b/tests/test_reference_scorecard_int_hostile.py
@@ -1,0 +1,124 @@
+"""Hostile integer validation for reference life scorecard."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:
+        type(self).calls += 1
+        raise AssertionError("hostile float")
+
+    def __lt__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile lt")
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq")
+
+
+def test_streaming_observe_rejects_hostile_before_float() -> None:
+    from alberta_framework.benchmarks.reference_life_scorecard import StreamingRunSummary
+
+    summary = StreamingRunSummary.for_switching(horizon=10, phase_length=3, post_switch_window=2)
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must be a finite number"):
+        summary.observe(
+            reward=hostile,  # type: ignore[arg-type]
+            oracle_reward=1.0,
+            regime_id=0,
+            parameters_changed=False,
+            next_state_index=0,
+        )
+    assert _HostileInt.calls == 0
+    _HostileInt.calls = 0
+    hostile2 = _HostileInt(2)
+    with pytest.raises(Exception, match="must be a finite number"):
+        summary.observe(
+            reward=1.0,
+            oracle_reward=hostile2,  # type: ignore[arg-type]
+            regime_id=0,
+            parameters_changed=False,
+            next_state_index=0,
+        )
+    assert _HostileInt.calls == 0
+    # bool rejected
+    with pytest.raises(Exception, match="must be a finite number"):
+        summary.observe(
+            reward=True,  # type: ignore[arg-type]
+            oracle_reward=1.0,
+            regime_id=0,
+            parameters_changed=False,
+            next_state_index=0,
+        )
+    # valid still works
+    summary.observe(
+        reward=1,
+        oracle_reward=2.0,
+        regime_id=0,
+        parameters_changed=False,
+        next_state_index=0,
+    )
+    assert summary.accepted_events == 1
+
+
+def test_reward_sum_rejects_hostile_before_float() -> None:
+    from alberta_framework.benchmarks.reference_life_scorecard import _reward_sum
+
+    hostile = _HostileInt(5)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must be finite"):
+        _reward_sum({"outcome": {"reward_sum": hostile}})  # type: ignore[dict-item]
+    assert _HostileInt.calls == 0
+    with pytest.raises(Exception, match="must be finite"):
+        _reward_sum({"outcome": {"reward_sum": True}})  # type: ignore[dict-item]
+    assert _HostileInt.calls == 0
+    assert _reward_sum({"outcome": {"reward_sum": 5}}) == 5.0
+    assert _reward_sum({"outcome": {"reward_sum": 5.0}}) == 5.0
+
+
+def test_finite_nonnegative_rejects_hostile_before_float() -> None:
+    from alberta_framework.benchmarks.reference_life_scorecard import _require_finite_nonnegative
+
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must be a finite nonnegative"):
+        _require_finite_nonnegative(hostile, path="p")  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    with pytest.raises(Exception, match="must be a finite nonnegative"):
+        _require_finite_nonnegative(True, path="p")  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    assert _require_finite_nonnegative(1.0, path="p") == 1.0
+    assert _require_finite_nonnegative(0, path="p") == 0.0
+
+
+def test_finite_number_rejects_hostile_before_float() -> None:
+    from alberta_framework.benchmarks.reference_life_scorecard import _require_finite_number
+
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must be a finite number"):
+        _require_finite_number(hostile, path="p")  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    with pytest.raises(Exception, match="must be a finite number"):
+        _require_finite_number(True, path="p")  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    assert _require_finite_number(1, path="p") == 1.0
+
+
+def test_hostile_not_in_error_message() -> None:
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    try:
+        if type(hostile) not in (int, float):
+            raise ValueError("must be a finite number")
+    except ValueError as exc:
+        assert "!r" not in str(exc)
+        assert _HostileInt.calls == 0

--- a/tests/test_reference_scorecard_int_hostile.py
+++ b/tests/test_reference_scorecard_int_hostile.py
@@ -30,6 +30,19 @@ class _HostileInt(int):
         raise AssertionError("hostile eq")
 
 
+class _HostileMeta(type):
+    calls = 0
+
+    def __eq__(cls, other: object) -> bool:
+        del other
+        cls.calls += 1
+        raise AssertionError("hostile metaclass eq")
+
+
+class _MetaclassHostileInt(int, metaclass=_HostileMeta):
+    pass
+
+
 def test_streaming_observe_rejects_hostile_before_float() -> None:
     from alberta_framework.benchmarks.reference_life_scorecard import StreamingRunSummary
 
@@ -74,6 +87,22 @@ def test_streaming_observe_rejects_hostile_before_float() -> None:
         next_state_index=0,
     )
     assert summary.accepted_events == 1
+
+
+def test_streaming_observe_uses_type_identity_without_metaclass_equality() -> None:
+    from alberta_framework.benchmarks.reference_life_scorecard import StreamingRunSummary
+
+    summary = StreamingRunSummary.for_switching(horizon=10, phase_length=3, post_switch_window=2)
+    _HostileMeta.calls = 0
+    with pytest.raises(ValueError, match="reward must be a finite number"):
+        summary.observe(
+            reward=_MetaclassHostileInt(1),
+            oracle_reward=1.0,
+            regime_id=0,
+            parameters_changed=False,
+            next_state_index=0,
+        )
+    assert _HostileMeta.calls == 0
 
 
 def test_run_shard_rejects_hostile_regime_without_dispatching_hooks(

--- a/tests/test_reference_scorecard_int_hostile.py
+++ b/tests/test_reference_scorecard_int_hostile.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import numpy as np
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -13,6 +16,10 @@ class _HostileInt(int):
     def __float__(self) -> float:
         type(self).calls += 1
         raise AssertionError("hostile float")
+
+    def __int__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile int")
 
     def __lt__(self, other: object) -> bool:
         type(self).calls += 1
@@ -67,6 +74,94 @@ def test_streaming_observe_rejects_hostile_before_float() -> None:
         next_state_index=0,
     )
     assert summary.accepted_events == 1
+
+
+def test_streaming_observe_rejects_hostile_regime_before_equality() -> None:
+    from alberta_framework.benchmarks.reference_life_scorecard import StreamingRunSummary
+
+    summary = StreamingRunSummary.for_switching(horizon=10, phase_length=3, post_switch_window=2)
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="regime_id must be an integer"):
+        summary.observe(
+            reward=1.0,
+            oracle_reward=1.0,
+            regime_id=_HostileInt(0),  # type: ignore[arg-type]
+            parameters_changed=False,
+            next_state_index=0,
+        )
+    assert _HostileInt.calls == 0
+
+
+def test_run_shard_rejects_hostile_reward_without_dispatching_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from alberta_framework.benchmarks import reference_life_scorecard as scorecard
+    from alberta_framework.reference_life import LifePhase
+
+    plan = scorecard.build_development_plan()
+    spec = scorecard.iter_run_specs(plan)[0]
+    state = SimpleNamespace(
+        phase=LifePhase.QUIESCENT,
+        agent_state=None,
+        accepted_events=0,
+        environment_rng_cursor=0,
+    )
+    hostile = _HostileInt(1)
+    event = SimpleNamespace(
+        transaction=SimpleNamespace(
+            reward=hostile,
+            next_decision_observation=SimpleNamespace(
+                to_numpy=lambda: np.asarray([1.0, 0.0])
+            ),
+        ),
+        oracle_reward=1.0,
+        regime_id=0,
+        step_result=SimpleNamespace(parameters_changed=False),
+    )
+    runner = SimpleNamespace(
+        agent_adapter=SimpleNamespace(),
+        init=lambda: state,
+        step=lambda _state: SimpleNamespace(
+            accepted=True,
+            event=event,
+            state=state,
+            rejection_reason=None,
+        ),
+    )
+    monkeypatch.setattr(scorecard, "build_scorecard_runner", lambda *_args: runner)
+    monkeypatch.setattr(scorecard, "_block_agent_state", lambda _state: None)
+    monkeypatch.setattr(scorecard, "_agent_resource_payload", lambda *_args: {})
+    monkeypatch.setattr(
+        scorecard,
+        "_resolved_components",
+        lambda *_args: {
+            "arm_definition": plan.arm_definition(spec.arm),
+            "agent_manifest": None,
+            "environment_manifest": None,
+            "life_config": None,
+            "life_config_sha256": None,
+        },
+    )
+
+    _HostileInt.calls = 0
+    record = scorecard.run_scorecard_shard(plan, spec)
+
+    assert record["status"] == "failed"
+    assert record["failure"]["stage"] == "step"
+    assert record["failure"]["message"] == "reward must be a finite number"
+    assert _HostileInt.calls == 0
+
+
+def test_artifact_builder_rejects_hostile_schedule_before_integer_coercion() -> None:
+    from alberta_framework.benchmarks import reference_life_scorecard as scorecard
+
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="integer schedule_index"):
+        scorecard.build_scorecard_artifact(
+            scorecard.build_development_plan(),
+            [{"schedule_index": _HostileInt(0)}],
+        )
+    assert _HostileInt.calls == 0
 
 
 def test_reward_sum_rejects_hostile_before_float() -> None:


### PR DESCRIPTION
Consolidates and preserves @byt61 commit from #1677, then closes two adjacent pre-validation hooks found in deep review: live `regime_id` equality dispatch and aggregate `schedule_index` coercion before canonical validation. Adds production `run_scorecard_shard` and aggregate-construction zero-hook tests. Permanently nonpromoting; changes current scorecard source identity by design; no artifact or workflow mutation.\n\nVerification: 76 focused tests passed; Ruff clean; strict mypy clean (187 files); diff check clean.\n\nSupersedes #1677.