### PR TITLE
fix(validation): reject hostile integer identities in replay and visualization

### DIFF
--- a/alberta_framework/core/dual_replay.py
+++ b/alberta_framework/core/dual_replay.py
@@ -651,7 +651,7 @@ def reservoir_selection(
     ``[0, n)`` and the candidate replaces slot ``draw`` iff ``draw < capacity``.
     The caller owns key advancement; this pure calculation does not return a key.
     """
-    if isinstance(capacity, bool) or not isinstance(capacity, int) or capacity < 1:
+    if type(capacity) is not int or capacity < 1:
         raise ValueError("capacity must be a positive integer")
     _require_array(candidate_number, name="candidate_number", shape=(), dtype=jnp.int32)
     candidate_valid = candidate_number >= 1
@@ -2177,8 +2177,7 @@ class DualReplayMemory:
         expected = np.dtype(dtype)
         if np.issubdtype(expected, np.floating):
             if any(
-                isinstance(item, bool) or not isinstance(item, int | float)
-                for item in untyped.flat
+                type(item) not in (int, float) for item in untyped.flat
             ):
                 raise ValueError(f"{name} must contain only JSON real numbers")
             with np.errstate(over="ignore", under="ignore", invalid="ignore"):
@@ -2190,7 +2189,7 @@ class DualReplayMemory:
             if any(not isinstance(item, bool) for item in untyped.flat):
                 raise ValueError(f"{name} must contain only booleans")
             return jnp.asarray(value, dtype=jnp.bool_)
-        if any(isinstance(item, bool) or not isinstance(item, int) for item in untyped.flat):
+        if any(type(item) is not int for item in untyped.flat):
             raise ValueError(f"{name} must contain only JSON integers")
         minimum = 0 if expected == np.dtype(np.uint32) else -_INT32_MAX - 1
         maximum = _UINT32_MAX if expected == np.dtype(np.uint32) else _INT32_MAX
@@ -2201,7 +2200,7 @@ class DualReplayMemory:
 
     @staticmethod
     def _checkpoint_counter(value: object, *, name: str, uint32: bool = False) -> Array:
-        if isinstance(value, bool) or not isinstance(value, int):
+        if type(value) is not int:
             raise ValueError(f"{name} must be a JSON integer")
         maximum = _UINT32_MAX if uint32 else _INT32_MAX
         if not 0 <= value <= maximum:

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -39,7 +39,7 @@ def _require_exact_bool(name: str, value: object) -> bool:
 
 
 def _require_finite_positive(name: str, value: object) -> float:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) not in (int, float):
         raise ValueError(f"{name} must be a real number")
     number = float(cast(Any, value))
     if not math.isfinite(number) or number <= 0.0:

--- a/tests/test_dual_replay_int_hostile.py
+++ b/tests/test_dual_replay_int_hostile.py
@@ -1,0 +1,114 @@
+"""Hostile integer validation for dual replay."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __lt__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile lt")
+
+    def __le__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile le")
+
+    def __gt__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile gt")
+
+    def __float__(self) -> float:
+        type(self).calls += 1
+        raise AssertionError("hostile float")
+
+    def __hash__(self) -> int:
+        return int.__hash__(self)
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:
+        type(self).calls += 1
+        raise AssertionError("hostile float")
+
+
+def test_reservoir_capacity_rejects_hostile_before_lt() -> None:
+    import jax.numpy as jnp
+    import jax.random as jr
+
+    from alberta_framework.core.dual_replay import reservoir_selection
+
+    hostile = _HostileInt(5)
+    _HostileInt.calls = 0
+    key = jr.PRNGKey(0)
+    with pytest.raises(Exception, match="positive integer"):
+        reservoir_selection(key, jnp.asarray(1, dtype=jnp.int32), hostile)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    # bool rejected
+    with pytest.raises(Exception, match="positive integer"):
+        reservoir_selection(key, jnp.asarray(1, dtype=jnp.int32), True)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+
+
+def test_checkpoint_array_real_rejects_hostile_before_float() -> None:
+    from alberta_framework.core.dual_replay import DualReplayMemory
+
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must contain only JSON real numbers"):
+        DualReplayMemory._checkpoint_array([[hostile]], name="x", shape=(1, 1), dtype=np.float32)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    # also hostile float subclass
+    hf = _HostileFloat(1.0)
+    _HostileFloat.calls = 0
+    with pytest.raises(Exception, match="must contain only JSON real numbers"):
+        DualReplayMemory._checkpoint_array([[hf]], name="x", shape=(1, 1), dtype=np.float32)  # type: ignore[arg-type]
+    assert _HostileFloat.calls == 0
+    # valid
+    arr = DualReplayMemory._checkpoint_array([[1.0]], name="x", shape=(1, 1), dtype=np.float32)
+    assert arr.shape == (1, 1)
+
+
+def test_checkpoint_array_int_rejects_hostile_before_int_check() -> None:
+    from alberta_framework.core.dual_replay import DualReplayMemory
+
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must contain only JSON integers"):
+        DualReplayMemory._checkpoint_array([[hostile]], name="x", shape=(1, 1), dtype=np.int32)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    with pytest.raises(Exception, match="must contain only JSON integers"):
+        DualReplayMemory._checkpoint_array([[True]], name="x", shape=(1, 1), dtype=np.int32)  # type: ignore[arg-type]
+    arr = DualReplayMemory._checkpoint_array([[1]], name="x", shape=(1, 1), dtype=np.int32)
+    assert arr.shape == (1, 1)
+
+
+def test_checkpoint_counter_rejects_hostile_before_range() -> None:
+    from alberta_framework.core.dual_replay import DualReplayMemory
+
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must be a JSON integer"):
+        DualReplayMemory._checkpoint_counter(hostile, name="c")  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    with pytest.raises(Exception, match="must be a JSON integer"):
+        DualReplayMemory._checkpoint_counter(True, name="c")  # type: ignore[arg-type]
+    assert DualReplayMemory._checkpoint_counter(1, name="c").shape == ()
+
+
+def test_hostile_not_in_error_message() -> None:
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    try:
+        if type(hostile) is not int:
+            raise ValueError("must be a JSON integer")
+    except ValueError as exc:
+        assert "!r" not in str(exc)
+        assert _HostileInt.calls == 0

--- a/tests/test_visualization_int_hostile.py
+++ b/tests/test_visualization_int_hostile.py
@@ -1,0 +1,58 @@
+"""Hostile integer validation for visualization."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:
+        type(self).calls += 1
+        raise AssertionError("hostile float")
+
+    def __hash__(self) -> int:
+        return int.__hash__(self)
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:
+        type(self).calls += 1
+        raise AssertionError("hostile float")
+
+
+def test_finite_positive_rejects_hostile_before_float() -> None:
+    from alberta_framework.utils.visualization import _require_finite_positive
+
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(Exception, match="must be a real number"):
+        _require_finite_positive("x", hostile)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+    hf = _HostileFloat(1.0)
+    _HostileFloat.calls = 0
+    with pytest.raises(Exception, match="must be a real number"):
+        _require_finite_positive("x", hf)  # type: ignore[arg-type]
+    assert _HostileFloat.calls == 0
+    with pytest.raises(Exception, match="must be a real number"):
+        _require_finite_positive("x", True)  # type: ignore[arg-type]
+    assert _require_finite_positive("x", 1) == 1.0
+    assert _require_finite_positive("x", 1.0) == 1.0
+    with pytest.raises(Exception, match="must be a finite positive"):
+        _require_finite_positive("x", 0)
+
+
+def test_hostile_not_in_error_message() -> None:
+    hostile = _HostileInt(1)
+    _HostileInt.calls = 0
+    try:
+        if type(hostile) not in (int, float):
+            raise ValueError("must be a real number")
+    except ValueError as exc:
+        assert "!r" not in str(exc)
+        assert _HostileInt.calls == 0


### PR DESCRIPTION
Contributor-preserving consolidation of #1678 and #1680 after auditing the adjacent scalar/config/checkpoint/resource gates. The residual changes are narrow: exact builtin numeric identity is required before range or float dispatch in reservoir selection, checkpoint numeric leaves/counters, and visualization positive-real settings. Current main already contains the stronger feature-router successor for #1684/#1691, so no duplicate router patch is included.\n\nValidation: 173 dual-replay tests; 2 visualization hostile tests; 44 adjacent feature-router tests; scoped Ruff; strict mypy.\n\nSupersedes #1678 and #1680.