### PR TITLE
fix(step3): reject leftover Step3SmokeResult identities

### DIFF
--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -47,6 +47,7 @@ from alberta_framework.steps._float32_validation import (
     canonical_float32_storage,
     finite_real_and_float32,
 )
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 Step3NormalizerName = Literal["none", "ema"]
 Step3TraceModeName = Literal["accumulating", "replacing"]
@@ -330,6 +331,32 @@ class Step3SmokeResult:
     finite: bool
     handoff: Step3HandoffArrays
     horde_config: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        if type(self.config) is not Step3HordeConfig:
+            raise TypeError("config must be an exact Step3HordeConfig")
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(
+            self,
+            "final_window_mse",
+            _require_nonnegative_real("final_window_mse", self.final_window_mse),
+        )
+        for name in ("per_demon_metrics_shape", "td_errors_shape"):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
+        if type(self.handoff) is not Step3HandoffArrays:
+            raise TypeError("handoff must be an exact Step3HandoffArrays")
+        if type(self.horde_config) is not dict or any(
+            type(key) is not str for key in self.horde_config
+        ):
+            raise ValueError("horde_config must be an exact dict with exact string keys")
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/tests/test_step3_smoke_result_hostile.py
+++ b/tests/test_step3_smoke_result_hostile.py
@@ -1,0 +1,77 @@
+"""Complete Step3SmokeResult identity contract: leftover, types, and shapes."""
+
+from __future__ import annotations
+
+import json
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.steps.step3 import (
+    Step3HandoffArrays,
+    Step3HordeConfig,
+    Step3SmokeResult,
+)
+
+
+def _handoff() -> Step3HandoffArrays:
+    return Step3HandoffArrays(
+        jnp.ones((8, 3), dtype=jnp.float32),
+        jnp.ones((8, 1), dtype=jnp.float32),
+        jnp.ones((8, 3), dtype=jnp.float32),
+    )
+
+
+def _legal(**overrides: object) -> Step3SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step3HordeConfig(),
+        "steps": 8,
+        "seed": 0,
+        "final_window_mse": 0.1,
+        "per_demon_metrics_shape": (8, 3, 1),
+        "td_errors_shape": (8, 3),
+        "finite": True,
+        "handoff": _handoff(),
+        "horde_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step3SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step3_smoke_result_accepts_canonical_identity() -> None:
+    result = _legal()
+    assert result.steps == 8
+    assert result.seed == 0
+    assert result.finite is True
+    assert result.per_demon_metrics_shape == (8, 3, 1)
+    dumped = json.dumps(
+        {"steps": result.steps, "seed": result.seed, "finite": result.finite},
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+
+
+def test_step3_smoke_result_rejects_leftover_integer_and_bool_identities() -> None:
+    with pytest.raises(ValueError, match="steps must be an integer"):
+        _legal(steps=True)
+    with pytest.raises(ValueError, match="seed"):
+        _legal(seed=True)
+    with pytest.raises(ValueError, match="finite must be a boolean"):
+        _legal(finite=1)
+
+
+def test_step3_smoke_result_rejects_leftover_float_and_host_identities() -> None:
+    with pytest.raises(ValueError, match="final_window_mse"):
+        _legal(final_window_mse=True)
+    with pytest.raises(TypeError, match="config must be an exact Step3HordeConfig"):
+        _legal(config=None)
+    with pytest.raises(TypeError, match="handoff must be an exact Step3HandoffArrays"):
+        _legal(handoff=None)
+    with pytest.raises(ValueError, match="horde_config must be an exact dict"):
+        _legal(horde_config=True)
+    with pytest.raises(ValueError, match="per_demon_metrics_shape"):
+        _legal(per_demon_metrics_shape=[8, 3, 1])
+    with pytest.raises(ValueError, match="td_errors_shape"):
+        _legal(td_errors_shape=(7, 3))


### PR DESCRIPTION
Closes #1694.

## What changed

`Step3SmokeResult` now fail-closes leftover bool seed/step identities, leftover `finite` ints, leftover `final_window_mse` bools, exact config/handoff hosts, exact `horde_config` keys, and smoke-record shapes — the same complete bar ss251 already applied to the other Step smoke records.

On `origin/main` `3e4a746a`, `Step3SmokeResult(steps=True)` and `seed=True` constructed. Legal integer seeds stay legal.

No unpublished grok head on this file. Occupancy-free. Not a leftover-tax reprint.

## Scope

- `alberta_framework/steps/step3.py`
- `tests/test_step3_smoke_result_hostile.py`

## Occupancy

Open ASI PRs at publish: ss251 `#1685` (`evidence_manifest.py`), `#1672` (`continual_multiagent.py`); Shaw `#1692` (scorecard), `#1647` (bimu). No open PR on `step3.py`.

## Verification

- Red on base: `Step3SmokeResult(steps=True)` and `seed=True` constructed
- New smoke-result contract + existing Step 3 tests: 102 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary leftover-identity validation only. No kernel math, lifetime clocks, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ba19b121b8fc3d143b11bf4cfc235ade426fc5a1 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
