### PR TITLE
fix(benchmarks): remove inferred Intentional counts

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -8797,11 +8797,6 @@ def intentional_updates_development_record(
         raise ValueError("Intentional Updates model-query budget exceeds signed int32")
     if persistent_bytes > _INTENTIONAL_MAX_PERSISTENT_BYTES:
         raise ValueError("Intentional Updates persistent state exceeds 256 MiB")
-    scaled_correct = result.per_task_accuracy * result.config.task_length
-    correct_array = np.rint(scaled_correct)
-    if not np.allclose(scaled_correct, correct_array, rtol=0.0, atol=1e-5):
-        raise ValueError("per_task_accuracy must derive from integer correct counts")
-    per_task_correct = [int(value) for value in correct_array]
     return {
         "schema": INTENTIONAL_UPDATES_RECORD_SCHEMA,
         "references": {
@@ -8847,11 +8842,7 @@ def intentional_updates_development_record(
             "timing_is_selection_metric": False,
         },
         "metrics": {
-            "per_task_correct": per_task_correct,
-            "online_correct": sum(per_task_correct),
-            "per_task_accuracy": [
-                value / result.config.task_length for value in per_task_correct
-            ],
+            "per_task_accuracy": result.per_task_accuracy.tolist(),
             "per_task_loss": result.per_task_loss.tolist(),
             "per_task_plasticity": result.per_task_plasticity.tolist(),
         },
@@ -9020,8 +9011,6 @@ def validate_intentional_updates_development_record(
         payload["metrics"],
         frozenset(
             {
-                "per_task_correct",
-                "online_correct",
                 "per_task_accuracy",
                 "per_task_loss",
                 "per_task_plasticity",
@@ -9030,21 +9019,6 @@ def validate_intentional_updates_development_record(
         context="metrics",
     )
     n_tasks = config_raw["n_tasks"]
-    per_task_correct = metrics["per_task_correct"]
-    if (
-        type(per_task_correct) is not list
-        or len(per_task_correct) != n_tasks
-        or any(
-            type(value) is not int or not 0 <= value <= config_raw["task_length"]
-            for value in per_task_correct
-        )
-    ):
-        raise ValueError("per_task_correct must contain bounded exact integers")
-    online_correct = _intentional_exact_int(
-        metrics["online_correct"], context="metrics.online_correct"
-    )
-    if online_correct != sum(per_task_correct):
-        raise ValueError("online_correct must equal the per-task numerator sum")
     for key in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):
         values = metrics[key]
         if (
@@ -9053,9 +9027,6 @@ def validate_intentional_updates_development_record(
             or any(type(value) is not float or not math.isfinite(value) for value in values)
         ):
             raise ValueError(f"{key} must contain one exact finite float per task")
-    expected_accuracy = [value / config_raw["task_length"] for value in per_task_correct]
-    if metrics["per_task_accuracy"] != expected_accuracy:
-        raise ValueError("per_task_accuracy must derive exactly from per_task_correct")
     try:
         config = IPMNISTConfig(**config_raw)
         arm = payload["arm"]

--- a/tests/test_intentional_updates_ipmnist.py
+++ b/tests/test_intentional_updates_ipmnist.py
@@ -16,6 +16,7 @@ from alberta_framework.benchmarks.ipmnist_screening import (
     INTENTIONAL_UPDATES_CODE_REVISION,
     INTENTIONAL_UPDATES_PAPER_REVISION,
     IPMNISTConfig,
+    ScreeningRunResult,
     _make_intentional_updates_learner,
     _make_sgd_ema_norm_learner,
     intentional_updates_development_record,
@@ -278,14 +279,6 @@ def test_strict_development_record_binds_resources_gates_and_metrics() -> None:
     with pytest.raises(ValueError, match="frozen protocol"):
         validate_intentional_updates_development_record(hostile)
 
-    hostile = copy.deepcopy(record)
-    original_accuracy = hostile["metrics"]["per_task_accuracy"][0]
-    hostile["metrics"]["per_task_accuracy"][0] = (
-        0.25 if original_accuracy != 0.25 else 0.5
-    )
-    with pytest.raises(ValueError, match="derive exactly"):
-        validate_intentional_updates_development_record(hostile)
-
     class HostileArray:
         def __array__(self) -> Never:
             raise AssertionError("must not coerce")
@@ -315,6 +308,32 @@ def test_record_revalidates_forged_dataclasses() -> None:
     object.__setattr__(result.config, "n_tasks", True)
     with pytest.raises(ValueError, match="n_tasks"):
         intentional_updates_development_record(result)
+
+
+def test_record_preserves_valid_float32_accuracy_without_inferred_counts() -> None:
+    spec = screening_spec("intentional_updates_ipmnist")
+    config = IPMNISTConfig(
+        n_tasks=1, task_length=5000, input_dim=1, hidden1=1, hidden2=1, n_classes=1
+    )
+    accuracy = float(np.float32(2501 / 5000))
+    result = ScreeningRunResult(
+        config_name=spec.name,
+        base_learner=spec.base_learner,
+        hyperparameters=spec.hyperparameters,
+        seed=31,
+        config=config,
+        per_task_accuracy=np.asarray([accuracy], dtype=np.float64),
+        per_task_loss=np.asarray([0.5], dtype=np.float64),
+        per_task_plasticity=np.asarray([0.25], dtype=np.float64),
+        wall_clock_seconds=0.0,
+    )
+    record = intentional_updates_development_record(result)
+    assert record["metrics"] == {
+        "per_task_accuracy": [accuracy],
+        "per_task_loss": [0.5],
+        "per_task_plasticity": [0.25],
+    }
+    assert validate_intentional_updates_development_record(record) == record
 
 
 def test_matched_runs_share_seed_schedule_update_and_observation_budgets() -> None:


### PR DESCRIPTION
Removes pseudo-provenance added to the Intentional Updates development receipt. The runner retains per-task accuracy as a float32 mean, not the raw integer numerator; reverse-engineering `per_task_correct` with a `1e-5` tolerance both overstated provenance and rejected valid default-horizon results.

At `task_length=5000`, 553 of the 5001 possible exact correct counts round through float32 far enough to violate that tolerance; `2501/5000` scales back to `2501.0001659...`. The receipt now preserves the actually retained accuracy value and continues strict type/domain/resource validation. No campaign artifact exists, so no persisted schema is migrated.

Validation: 16 focused Intentional tests; scoped Ruff; strict mypy; diff check.