### PR TITLE
fix(evaluation): bind condition results and evidence specs exactly

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -36,7 +36,7 @@ import operator
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from time import perf_counter, perf_counter_ns
-from typing import Literal, SupportsIndex, cast
+from typing import Any, Literal, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -109,6 +109,22 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 
 def _require_uint32(name: str, value: object) -> int:
     return _require_int32(name, value, minimum=0, maximum=_UINT32_MAX)
+
+
+def _require_ndarray(
+    name: str,
+    value: object,
+    *,
+    dtype: np.dtype[Any],
+    ndim: int = 1,
+) -> NDArray[Any]:
+    if type(value) is not np.ndarray:
+        raise ValueError(f"{name} must be an exact numpy.ndarray")
+    if value.dtype != dtype:
+        raise ValueError(f"{name} must have dtype {dtype}")
+    if value.ndim != ndim:
+        raise ValueError(f"{name} must be {ndim}-dimensional")
+    return value
 
 
 def _require_seed(value: object) -> int:
@@ -407,6 +423,59 @@ class ConditionResult:
     interference_forgetting: float
     controller_budget: ControllerBudget
     timing: TimingMetrics
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "seed", _require_seed(self.seed))
+        known = tuple(name for name, _mask in CONDITION_MASKS)
+        if type(self.condition) is not str or self.condition not in known:
+            raise ValueError("condition must be a known multiagent condition name")
+        if (
+            type(self.learning_mask) is not tuple
+            or len(self.learning_mask) != 2
+            or any(type(flag) is not bool for flag in self.learning_mask)
+        ):
+            raise ValueError("learning_mask must be a pair of booleans")
+        rewards = _require_ndarray(
+            "online_rewards", self.online_rewards, dtype=np.dtype(np.float64)
+        )
+        if int(rewards.shape[0]) < 1:
+            raise ValueError("online_rewards must contain at least one step")
+        _require_ndarray(
+            "phase_mean_rewards",
+            self.phase_mean_rewards,
+            dtype=np.dtype(np.float64),
+        )
+        _require_ndarray(
+            "performance_matrix",
+            self.performance_matrix,
+            dtype=np.dtype(np.float64),
+            ndim=2,
+        )
+        if not isinstance(self.summary, ContinualLearningSummary):
+            raise ValueError("summary must be a ContinualLearningSummary")
+        _require_ndarray(
+            "recovery_lengths",
+            self.recovery_lengths,
+            dtype=np.dtype(np.int64),
+        )
+        object.__setattr__(
+            self,
+            "recurrence_recovery_steps",
+            _require_int32(
+                "recurrence_recovery_steps",
+                self.recurrence_recovery_steps,
+                minimum=-1,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "interference_forgetting",
+            finite_real("interference_forgetting", self.interference_forgetting),
+        )
+        if not isinstance(self.controller_budget, ControllerBudget):
+            raise ValueError("controller_budget must be a ControllerBudget")
+        if not isinstance(self.timing, TimingMetrics):
+            raise ValueError("timing must be a TimingMetrics")
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -127,6 +127,12 @@ def _require_ndarray(
     return value
 
 
+def _freeze_ndarray(value: NDArray[Any]) -> NDArray[Any]:
+    result = np.array(value, copy=True)
+    result.setflags(write=False)
+    return result
+
+
 def _require_seed(value: object) -> int:
     try:
         return _require_int32("seed", value, minimum=0)
@@ -426,7 +432,7 @@ class ConditionResult:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "seed", _require_seed(self.seed))
-        known = tuple(name for name, _mask in CONDITION_MASKS)
+        known = dict(CONDITION_MASKS)
         if type(self.condition) is not str or self.condition not in known:
             raise ValueError("condition must be a known multiagent condition name")
         if (
@@ -435,47 +441,72 @@ class ConditionResult:
             or any(type(flag) is not bool for flag in self.learning_mask)
         ):
             raise ValueError("learning_mask must be a pair of booleans")
+        if self.learning_mask != known[self.condition]:
+            raise ValueError("learning_mask must match the named multiagent condition")
         rewards = _require_ndarray(
             "online_rewards", self.online_rewards, dtype=np.dtype(np.float64)
         )
-        if int(rewards.shape[0]) < 1:
-            raise ValueError("online_rewards must contain at least one step")
-        _require_ndarray(
+        if int(rewards.shape[0]) < 6 or int(rewards.shape[0]) % 3 != 0:
+            raise ValueError("online_rewards must contain three equal non-empty phases")
+        phase_steps = int(rewards.shape[0]) // 3
+        _require_resource_limit(
+            "condition result arrays",
+            _condition_result_array_nbytes(phase_steps),
+        )
+        phase_rewards = _require_ndarray(
             "phase_mean_rewards",
             self.phase_mean_rewards,
             dtype=np.dtype(np.float64),
         )
-        _require_ndarray(
+        if phase_rewards.shape != (3,):
+            raise ValueError("phase_mean_rewards must have shape (3,)")
+        performance = _require_ndarray(
             "performance_matrix",
             self.performance_matrix,
             dtype=np.dtype(np.float64),
             ndim=2,
         )
-        if not isinstance(self.summary, ContinualLearningSummary):
+        if performance.shape != (3, 2):
+            raise ValueError("performance_matrix must have shape (3, 2)")
+        if not all(np.all(np.isfinite(array)) for array in (rewards, phase_rewards, performance)):
+            raise ValueError("condition result floating arrays must contain only finite values")
+        expected_phase_rewards = np.mean(rewards.reshape(3, phase_steps), axis=1)
+        if not np.array_equal(phase_rewards, expected_phase_rewards):
+            raise ValueError("phase_mean_rewards must reconstruct from online_rewards")
+        if type(self.summary) is not ContinualLearningSummary:
             raise ValueError("summary must be a ContinualLearningSummary")
-        _require_ndarray(
+        recovery = _require_ndarray(
             "recovery_lengths",
             self.recovery_lengths,
             dtype=np.dtype(np.int64),
         )
-        object.__setattr__(
-            self,
+        if recovery.shape != (2,) or np.any(recovery < -1) or np.any(recovery > phase_steps):
+            raise ValueError("recovery_lengths must be a shape-(2,) vector in [-1, phase_steps]")
+        recurrence = _require_int32(
             "recurrence_recovery_steps",
-            _require_int32(
-                "recurrence_recovery_steps",
-                self.recurrence_recovery_steps,
-                minimum=-1,
-            ),
+            self.recurrence_recovery_steps,
+            minimum=-1,
+            maximum=phase_steps,
         )
-        object.__setattr__(
-            self,
-            "interference_forgetting",
-            finite_real("interference_forgetting", self.interference_forgetting),
+        if recurrence != int(recovery[1]):
+            raise ValueError("recurrence_recovery_steps must match recovery_lengths[1]")
+        interference = finite_real("interference_forgetting", self.interference_forgetting)
+        expected_interference = max(
+            0.0,
+            float(performance[0, MEET_CONTEXT]) - float(performance[1, MEET_CONTEXT]),
         )
-        if not isinstance(self.controller_budget, ControllerBudget):
+        if interference != expected_interference:
+            raise ValueError("interference_forgetting must reconstruct from performance_matrix")
+        if type(self.controller_budget) is not ControllerBudget:
             raise ValueError("controller_budget must be a ControllerBudget")
-        if not isinstance(self.timing, TimingMetrics):
+        if type(self.timing) is not TimingMetrics:
             raise ValueError("timing must be a TimingMetrics")
+        object.__setattr__(self, "online_rewards", _freeze_ndarray(rewards))
+        object.__setattr__(self, "phase_mean_rewards", _freeze_ndarray(phase_rewards))
+        object.__setattr__(self, "performance_matrix", _freeze_ndarray(performance))
+        object.__setattr__(self, "recovery_lengths", _freeze_ndarray(recovery))
+        object.__setattr__(self, "recurrence_recovery_steps", recurrence)
+        object.__setattr__(self, "interference_forgetting", interference)
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -326,6 +326,8 @@ _IA_ATTESTATION_LIMITATIONS = (
 
 EvidenceClass = Literal["unit", "smoke", "scientific"]
 EvidenceLevel = Literal["L0", "L1", "L2", "L3"]
+_EVIDENCE_CLASSES: frozenset[str] = frozenset({"unit", "smoke", "scientific"})
+_EVIDENCE_LEVELS: frozenset[str] = frozenset({"L0", "L1", "L2", "L3"})
 
 DIRTY_STATE_POLICY: Mapping[str, object] = {
     "policy_version": DIRTY_STATE_POLICY_VERSION,
@@ -358,6 +360,54 @@ class ValidationResult(Protocol):
         """Fail-closed validation errors."""
 
 
+def _require_exact_text(name: str, value: object) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+def _require_exact_path(name: str, value: object) -> Path:
+    if not isinstance(value, Path) or not value.as_posix():
+        raise ValueError(f"{name} must be a Path")
+    return value
+
+
+def _require_exact_str_tuple(name: str, value: object) -> tuple[str, ...]:
+    if type(value) is not tuple or not value:
+        raise ValueError(f"{name} must be a non-empty tuple of non-empty strings")
+    if not all(type(item) is str and item for item in value):
+        raise ValueError(f"{name} must be a non-empty tuple of non-empty strings")
+    return value
+
+
+def _require_path_tuple(name: str, value: object) -> tuple[Path, ...]:
+    if type(value) is not tuple or not value:
+        raise ValueError(f"{name} must be a non-empty tuple of Path values")
+    if not all(isinstance(item, Path) for item in value):
+        raise ValueError(f"{name} must be a non-empty tuple of Path values")
+    return value
+
+
+def _require_identity_mapping(name: str, value: object) -> dict[str, object]:
+    if type(value) is not dict or not value:
+        raise ValueError(f"{name} must be a non-empty dict with exact string keys")
+    if not all(type(key) is str and key for key in value):
+        raise ValueError(f"{name} must be a non-empty dict with exact string keys")
+    return value
+
+
+def _require_identity_callable(name: str, value: object) -> Callable[..., object]:
+    if not callable(value):
+        raise ValueError(f"{name} must be callable")
+    return value
+
+
 @dataclass(frozen=True)
 class EvidenceSpec:
     """One immutable evidence-claim contract."""
@@ -379,6 +429,27 @@ class EvidenceSpec:
     required_environment_fields: tuple[str, ...]
     loader: Callable[[Path], Mapping[str, object]]
     validator: Callable[[Mapping[str, object]], ValidationResult]
+
+    def __post_init__(self) -> None:
+        _require_exact_text("name", self.name)
+        _require_exact_text("claim_scope", self.claim_scope)
+        if type(self.evidence_class) is not str or self.evidence_class not in _EVIDENCE_CLASSES:
+            raise ValueError("evidence_class must be a known evidence class")
+        if type(self.evidence_level) is not str or self.evidence_level not in _EVIDENCE_LEVELS:
+            raise ValueError("evidence_level must be a known evidence level")
+        _require_exact_bool("promotes_scientific_claim", self.promotes_scientific_claim)
+        _require_exact_path("relative_path", self.relative_path)
+        _require_exact_text("expected_schema", self.expected_schema)
+        _require_exact_str_tuple("command_argv", self.command_argv)
+        _require_identity_mapping("protocol", self.protocol)
+        _require_identity_mapping("configuration", self.configuration)
+        _require_identity_mapping("seeds", self.seeds)
+        _require_identity_mapping("thresholds", self.thresholds)
+        _require_exact_str_tuple("limitations", self.limitations)
+        _require_path_tuple("source_paths", self.source_paths)
+        _require_exact_str_tuple("required_environment_fields", self.required_environment_fields)
+        _require_identity_callable("loader", self.loader)
+        _require_identity_callable("validator", self.validator)
 
 
 @dataclass(frozen=True)

--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -40,6 +40,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from types import FunctionType
 from typing import Literal, NoReturn, Protocol
 
 from alberta_framework.evaluation.continual_ia import (
@@ -328,6 +329,10 @@ EvidenceClass = Literal["unit", "smoke", "scientific"]
 EvidenceLevel = Literal["L0", "L1", "L2", "L3"]
 _EVIDENCE_CLASSES: frozenset[str] = frozenset({"unit", "smoke", "scientific"})
 _EVIDENCE_LEVELS: frozenset[str] = frozenset({"L0", "L1", "L2", "L3"})
+_PATH_TYPE = type(Path())
+_MAX_SPEC_TEXT_BYTES = 64 * 1024
+_MAX_SPEC_SEQUENCE_ITEMS = 256
+_MAX_SPEC_MAPPING_ITEMS = 256
 
 DIRTY_STATE_POLICY: Mapping[str, object] = {
     "policy_version": DIRTY_STATE_POLICY_VERSION,
@@ -363,6 +368,8 @@ class ValidationResult(Protocol):
 def _require_exact_text(name: str, value: object) -> str:
     if type(value) is not str or not value:
         raise ValueError(f"{name} must be a non-empty string")
+    if len(value) > _MAX_SPEC_TEXT_BYTES or len(value.encode("utf-8")) > _MAX_SPEC_TEXT_BYTES:
+        raise ValueError(f"{name} exceeds {_MAX_SPEC_TEXT_BYTES} UTF-8 bytes")
     return value
 
 
@@ -373,38 +380,53 @@ def _require_exact_bool(name: str, value: object) -> bool:
 
 
 def _require_exact_path(name: str, value: object) -> Path:
-    if not isinstance(value, Path) or not value.as_posix():
-        raise ValueError(f"{name} must be a Path")
+    if type(value) is not _PATH_TYPE:
+        raise ValueError(f"{name} must be an exact platform Path")
+    encoded = value.as_posix().encode("utf-8")
+    if not encoded or len(encoded) > _MAX_SPEC_TEXT_BYTES:
+        raise ValueError(f"{name} must be a bounded non-empty Path")
     return value
 
 
 def _require_exact_str_tuple(name: str, value: object) -> tuple[str, ...]:
-    if type(value) is not tuple or not value:
+    if (
+        type(value) is not tuple
+        or not value
+        or len(value) > _MAX_SPEC_SEQUENCE_ITEMS
+    ):
         raise ValueError(f"{name} must be a non-empty tuple of non-empty strings")
-    if not all(type(item) is str and item for item in value):
-        raise ValueError(f"{name} must be a non-empty tuple of non-empty strings")
+    for item in value:
+        _require_exact_text(name, item)
     return value
 
 
 def _require_path_tuple(name: str, value: object) -> tuple[Path, ...]:
-    if type(value) is not tuple or not value:
+    if (
+        type(value) is not tuple
+        or not value
+        or len(value) > _MAX_SPEC_SEQUENCE_ITEMS
+    ):
         raise ValueError(f"{name} must be a non-empty tuple of Path values")
-    if not all(isinstance(item, Path) for item in value):
-        raise ValueError(f"{name} must be a non-empty tuple of Path values")
+    for item in value:
+        _require_exact_path(name, item)
     return value
 
 
 def _require_identity_mapping(name: str, value: object) -> dict[str, object]:
-    if type(value) is not dict or not value:
+    if (
+        type(value) is not dict
+        or not value
+        or len(value) > _MAX_SPEC_MAPPING_ITEMS
+    ):
         raise ValueError(f"{name} must be a non-empty dict with exact string keys")
-    if not all(type(key) is str and key for key in value):
-        raise ValueError(f"{name} must be a non-empty dict with exact string keys")
+    for key in value:
+        _require_exact_text(f"{name} key", key)
     return value
 
 
 def _require_identity_callable(name: str, value: object) -> Callable[..., object]:
-    if not callable(value):
-        raise ValueError(f"{name} must be callable")
+    if type(value) is not FunctionType:
+        raise ValueError(f"{name} must be an exact function")
     return value
 
 
@@ -438,7 +460,9 @@ class EvidenceSpec:
         if type(self.evidence_level) is not str or self.evidence_level not in _EVIDENCE_LEVELS:
             raise ValueError("evidence_level must be a known evidence level")
         _require_exact_bool("promotes_scientific_claim", self.promotes_scientific_claim)
-        _require_exact_path("relative_path", self.relative_path)
+        relative_path = _require_exact_path("relative_path", self.relative_path)
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ValueError("relative_path must remain under the repository root")
         _require_exact_text("expected_schema", self.expected_schema)
         _require_exact_str_tuple("command_argv", self.command_argv)
         _require_identity_mapping("protocol", self.protocol)
@@ -446,7 +470,11 @@ class EvidenceSpec:
         _require_identity_mapping("seeds", self.seeds)
         _require_identity_mapping("thresholds", self.thresholds)
         _require_exact_str_tuple("limitations", self.limitations)
-        _require_path_tuple("source_paths", self.source_paths)
+        source_paths = _require_path_tuple("source_paths", self.source_paths)
+        if len(set(source_paths)) != len(source_paths):
+            raise ValueError("source_paths must be unique")
+        if any(path.is_absolute() or ".." in path.parts for path in source_paths):
+            raise ValueError("source_paths must remain under the repository root")
         _require_exact_str_tuple("required_environment_fields", self.required_environment_fields)
         _require_identity_callable("loader", self.loader)
         _require_identity_callable("validator", self.validator)

--- a/tests/test_evidence_manifest.py
+++ b/tests/test_evidence_manifest.py
@@ -317,21 +317,19 @@ def test_registry_rejects_empty_duplicate_or_escaping_specs(
     with pytest.raises(ValueError, match="names must be unique"):
         build_evidence_manifest(tmp_path, specs=(duplicated, duplicated))
 
-    escaping_artifact = replace(
-        duplicated,
-        name="escape_artifact",
-        relative_path=Path("../outside.json"),
-    )
-    with pytest.raises(ValueError, match="remain under root"):
-        build_evidence_manifest(tmp_path, specs=(escaping_artifact,))
+    with pytest.raises(ValueError, match="remain under the repository root"):
+        replace(
+            duplicated,
+            name="escape_artifact",
+            relative_path=Path("../outside.json"),
+        )
 
-    escaping_source = replace(
-        duplicated,
-        name="escape_source",
-        source_paths=(Path("../outside.py"),),
-    )
-    with pytest.raises(ValueError, match="source provenance"):
-        build_evidence_manifest(tmp_path, specs=(escaping_source,))
+    with pytest.raises(ValueError, match="source_paths must remain"):
+        replace(
+            duplicated,
+            name="escape_source",
+            source_paths=(Path("../outside.py"),),
+        )
 
 
 @pytest.mark.integration

--- a/tests/test_evidence_spec_hostile.py
+++ b/tests/test_evidence_spec_hostile.py
@@ -1,0 +1,110 @@
+"""Complete EvidenceSpec identity contract: leftover, types, and roster gates."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.evaluation.evidence_manifest import EVIDENCE_SPECS, EvidenceSpec
+
+
+class StringSubclass(str):
+    """Leftover string identity that must not cross the spec boundary."""
+
+
+def _load(_path: Path) -> dict[str, object]:
+    return {"ok": True}
+
+
+def _validate(_artifact: Mapping[str, object]) -> object:
+    class _Result:
+        valid = True
+        accepted = True
+        errors: tuple[str, ...] = ()
+
+    return _Result()
+
+
+def _legal(**overrides: object) -> EvidenceSpec:
+    payload: dict[str, object] = {
+        "name": "fixture_claim",
+        "claim_scope": "test-only scope",
+        "evidence_class": "scientific",
+        "evidence_level": "L2",
+        "promotes_scientific_claim": True,
+        "relative_path": Path("fixture.json"),
+        "expected_schema": "test.schema.v1",
+        "command_argv": ("python", "-m", "fixture"),
+        "protocol": {"protocol_version": "test.protocol.v1"},
+        "configuration": {"steps": 1},
+        "seeds": {"development": (0,)},
+        "thresholds": {"minimum_effect": 0.25},
+        "limitations": ("test fixture only",),
+        "source_paths": (Path("fixture.py"),),
+        "required_environment_fields": ("python",),
+        "loader": _load,
+        "validator": _validate,
+    }
+    payload.update(overrides)
+    return EvidenceSpec(**payload)  # type: ignore[arg-type]
+
+
+def test_evidence_spec_accepts_canonical_and_registered_identities() -> None:
+    spec = _legal()
+    assert spec.name == "fixture_claim"
+    assert spec.evidence_class == "scientific"
+    assert spec.promotes_scientific_claim is True
+    assert spec.relative_path == Path("fixture.json")
+    names = {registered.name for registered in EVIDENCE_SPECS}
+    assert names == {
+        "recurring_pair_features",
+        "scale_robust_pair_features",
+        "ftl_world_model_decision_fidelity",
+        "recurring_multiagent_coadaptation",
+        "continual_intelligence_amplification",
+    }
+
+
+def test_evidence_spec_rejects_leftover_string_identities() -> None:
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        _legal(name=True)
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        _legal(name=StringSubclass("fixture_claim"))
+    with pytest.raises(ValueError, match="claim_scope must be a non-empty string"):
+        _legal(claim_scope=True)
+    with pytest.raises(ValueError, match="expected_schema must be a non-empty string"):
+        _legal(expected_schema="")
+
+
+def test_evidence_spec_rejects_leftover_class_level_and_bool_identities() -> None:
+    with pytest.raises(ValueError, match="evidence_class must be a known evidence class"):
+        _legal(evidence_class=True)
+    with pytest.raises(ValueError, match="evidence_class must be a known evidence class"):
+        _legal(evidence_class=StringSubclass("scientific"))
+    with pytest.raises(ValueError, match="evidence_class must be a known evidence class"):
+        _legal(evidence_class="anecdote")
+    with pytest.raises(ValueError, match="evidence_level must be a known evidence level"):
+        _legal(evidence_level="L9")
+    with pytest.raises(ValueError, match="promotes_scientific_claim must be a boolean"):
+        _legal(promotes_scientific_claim=1)
+
+
+def test_evidence_spec_rejects_leftover_path_tuple_and_mapping_identities() -> None:
+    with pytest.raises(ValueError, match="relative_path must be a Path"):
+        _legal(relative_path="fixture.json")
+    with pytest.raises(ValueError, match="command_argv must be a non-empty tuple"):
+        _legal(command_argv=["python"])
+    with pytest.raises(ValueError, match="limitations must be a non-empty tuple"):
+        _legal(limitations=["test fixture only"])
+    with pytest.raises(ValueError, match="source_paths must be a non-empty tuple"):
+        _legal(source_paths=["fixture.py"])
+    with pytest.raises(ValueError, match="protocol must be a non-empty dict"):
+        _legal(protocol=True)
+    with pytest.raises(ValueError, match="seeds must be a non-empty dict"):
+        _legal(seeds={True: 0})
+    with pytest.raises(ValueError, match="loader must be callable"):
+        _legal(loader=None)
+    with pytest.raises(ValueError, match="validator must be callable"):
+        _legal(validator="validate")

--- a/tests/test_evidence_spec_hostile.py
+++ b/tests/test_evidence_spec_hostile.py
@@ -14,6 +14,15 @@ class StringSubclass(str):
     """Leftover string identity that must not cross the spec boundary."""
 
 
+class PathSubclass(type(Path())):
+    """Leftover concrete-path identity that must not cross the spec boundary."""
+
+
+class CallableObject:
+    def __call__(self, _value: object) -> object:
+        return _value
+
+
 def _load(_path: Path) -> dict[str, object]:
     return {"ok": True}
 
@@ -92,8 +101,12 @@ def test_evidence_spec_rejects_leftover_class_level_and_bool_identities() -> Non
 
 
 def test_evidence_spec_rejects_leftover_path_tuple_and_mapping_identities() -> None:
-    with pytest.raises(ValueError, match="relative_path must be a Path"):
+    with pytest.raises(ValueError, match="relative_path must be an exact platform Path"):
         _legal(relative_path="fixture.json")
+    with pytest.raises(ValueError, match="relative_path must be an exact platform Path"):
+        _legal(relative_path=PathSubclass("fixture.json"))
+    with pytest.raises(ValueError, match="must remain under the repository root"):
+        _legal(relative_path=Path("../fixture.json"))
     with pytest.raises(ValueError, match="command_argv must be a non-empty tuple"):
         _legal(command_argv=["python"])
     with pytest.raises(ValueError, match="limitations must be a non-empty tuple"):
@@ -102,9 +115,20 @@ def test_evidence_spec_rejects_leftover_path_tuple_and_mapping_identities() -> N
         _legal(source_paths=["fixture.py"])
     with pytest.raises(ValueError, match="protocol must be a non-empty dict"):
         _legal(protocol=True)
-    with pytest.raises(ValueError, match="seeds must be a non-empty dict"):
+    with pytest.raises(ValueError, match="seeds key must be a non-empty string"):
         _legal(seeds={True: 0})
-    with pytest.raises(ValueError, match="loader must be callable"):
+    with pytest.raises(ValueError, match="loader must be an exact function"):
         _legal(loader=None)
-    with pytest.raises(ValueError, match="validator must be callable"):
+    with pytest.raises(ValueError, match="loader must be an exact function"):
+        _legal(loader=CallableObject())
+    with pytest.raises(ValueError, match="validator must be an exact function"):
         _legal(validator="validate")
+
+
+def test_evidence_spec_preflights_sequence_and_mapping_counts() -> None:
+    with pytest.raises(ValueError, match="command_argv must be a non-empty tuple"):
+        _legal(command_argv=("x",) * 257)
+    with pytest.raises(ValueError, match="protocol must be a non-empty dict"):
+        _legal(protocol={f"key-{index}": index for index in range(257)})
+    with pytest.raises(ValueError, match="exceeds 65536 UTF-8 bytes"):
+        _legal(name="x" * 65_537)

--- a/tests/test_multiagent_condition_result_hostile.py
+++ b/tests/test_multiagent_condition_result_hostile.py
@@ -1,0 +1,99 @@
+"""Complete ConditionResult identity contract: leftover, types, and arrays."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.evaluation.continual_multiagent import (
+    ConditionResult,
+    ControllerBudget,
+    TimingMetrics,
+)
+from alberta_framework.utils.metrics import ContinualLearningSummary
+
+
+class StringSubclass(str):
+    """Leftover string identity that must not cross the result boundary."""
+
+
+def _summary() -> ContinualLearningSummary:
+    return ContinualLearningSummary(
+        final_performance=0.0,
+        prequential_performance=0.0,
+        mean_forgetting=0.0,
+        max_forgetting=0.0,
+        backward_transfer=0.0,
+        stability_gap_mean=0.0,
+        stability_gap_max=0.0,
+        per_task_final_performance=np.zeros(2, dtype=np.float64),
+        per_task_forgetting=np.zeros(2, dtype=np.float64),
+        per_task_backward_transfer=np.zeros(2, dtype=np.float64),
+    )
+
+
+def _legal(**overrides: object) -> ConditionResult:
+    payload: dict[str, object] = {
+        "seed": 30,
+        "condition": "frozen",
+        "learning_mask": (False, False),
+        "online_rewards": np.zeros(4, dtype=np.float64),
+        "phase_mean_rewards": np.zeros(3, dtype=np.float64),
+        "performance_matrix": np.zeros((3, 2), dtype=np.float64),
+        "summary": _summary(),
+        "recovery_lengths": np.asarray([-1, -1], dtype=np.int64),
+        "recurrence_recovery_steps": -1,
+        "interference_forgetting": 0.0,
+        "controller_budget": ControllerBudget(
+            state_scalars=1, state_bytes=8, action_scalars_per_step=1
+        ),
+        "timing": TimingMetrics(
+            wall_seconds=0.1,
+            mean_step_latency_ms=0.1,
+            mean_update_latency_ms=0.1,
+            p95_update_latency_ms=0.1,
+        ),
+    }
+    payload.update(overrides)
+    return ConditionResult(**payload)  # type: ignore[arg-type]
+
+
+def test_condition_result_accepts_canonical_identity() -> None:
+    result = _legal()
+    assert result.seed == 30
+    assert result.condition == "frozen"
+    assert result.learning_mask == (False, False)
+    assert result.recurrence_recovery_steps == -1
+
+
+def test_condition_result_rejects_leftover_integer_and_float_identities() -> None:
+    with pytest.raises(ValueError, match="seeds must lie in"):
+        _legal(seed=True)
+    with pytest.raises(ValueError, match="recurrence_recovery_steps must be an integer"):
+        _legal(recurrence_recovery_steps=True)
+    with pytest.raises(ValueError, match="interference_forgetting must be a finite"):
+        _legal(interference_forgetting=True)
+
+
+def test_condition_result_rejects_leftover_condition_and_mask_identities() -> None:
+    with pytest.raises(ValueError, match="condition must be a known multiagent condition name"):
+        _legal(condition=True)
+    with pytest.raises(ValueError, match="condition must be a known multiagent condition name"):
+        _legal(condition=StringSubclass("frozen"))
+    with pytest.raises(ValueError, match="learning_mask must be a pair of booleans"):
+        _legal(learning_mask=(1, 0))
+    with pytest.raises(ValueError, match="learning_mask must be a pair of booleans"):
+        _legal(learning_mask=[False, False])
+
+
+def test_condition_result_rejects_invalid_arrays_and_hosts() -> None:
+    with pytest.raises(ValueError, match="online_rewards must be an exact numpy.ndarray"):
+        _legal(online_rewards=[0.0, 0.0, 0.0, 0.0])
+    with pytest.raises(ValueError, match="performance_matrix must be 2-dimensional"):
+        _legal(performance_matrix=np.zeros(3, dtype=np.float64))
+    with pytest.raises(ValueError, match="summary must be a ContinualLearningSummary"):
+        _legal(summary=None)
+    with pytest.raises(ValueError, match="controller_budget must be a ControllerBudget"):
+        _legal(controller_budget=None)
+    with pytest.raises(ValueError, match="timing must be a TimingMetrics"):
+        _legal(timing=None)

--- a/tests/test_multiagent_condition_result_hostile.py
+++ b/tests/test_multiagent_condition_result_hostile.py
@@ -37,7 +37,7 @@ def _legal(**overrides: object) -> ConditionResult:
         "seed": 30,
         "condition": "frozen",
         "learning_mask": (False, False),
-        "online_rewards": np.zeros(4, dtype=np.float64),
+        "online_rewards": np.zeros(6, dtype=np.float64),
         "phase_mean_rewards": np.zeros(3, dtype=np.float64),
         "performance_matrix": np.zeros((3, 2), dtype=np.float64),
         "summary": _summary(),
@@ -84,6 +84,8 @@ def test_condition_result_rejects_leftover_condition_and_mask_identities() -> No
         _legal(learning_mask=(1, 0))
     with pytest.raises(ValueError, match="learning_mask must be a pair of booleans"):
         _legal(learning_mask=[False, False])
+    with pytest.raises(ValueError, match="must match the named"):
+        _legal(condition="joint_adaptive", learning_mask=(False, False))
 
 
 def test_condition_result_rejects_invalid_arrays_and_hosts() -> None:
@@ -91,9 +93,32 @@ def test_condition_result_rejects_invalid_arrays_and_hosts() -> None:
         _legal(online_rewards=[0.0, 0.0, 0.0, 0.0])
     with pytest.raises(ValueError, match="performance_matrix must be 2-dimensional"):
         _legal(performance_matrix=np.zeros(3, dtype=np.float64))
+    with pytest.raises(ValueError, match="phase_mean_rewards must have shape"):
+        _legal(phase_mean_rewards=np.zeros(4, dtype=np.float64))
+    with pytest.raises(ValueError, match="floating arrays must contain only finite"):
+        _legal(online_rewards=np.full(6, np.nan, dtype=np.float64))
+    with pytest.raises(ValueError, match="must reconstruct from online_rewards"):
+        _legal(phase_mean_rewards=np.ones(3, dtype=np.float64))
+    with pytest.raises(ValueError, match="must match recovery_lengths"):
+        _legal(recurrence_recovery_steps=0)
+    with pytest.raises(ValueError, match="must reconstruct from performance_matrix"):
+        _legal(
+            performance_matrix=np.asarray(((1.0, 0.0), (0.0, 0.0), (0.0, 0.0))),
+        )
     with pytest.raises(ValueError, match="summary must be a ContinualLearningSummary"):
         _legal(summary=None)
     with pytest.raises(ValueError, match="controller_budget must be a ControllerBudget"):
         _legal(controller_budget=None)
     with pytest.raises(ValueError, match="timing must be a TimingMetrics"):
         _legal(timing=None)
+
+
+def test_condition_result_owns_read_only_array_snapshots() -> None:
+    rewards = np.zeros(6, dtype=np.float64)
+    result = _legal(online_rewards=rewards)
+    rewards[0] = 1.0
+    assert result.online_rewards[0] == 0.0
+    assert not result.online_rewards.flags.writeable
+    assert not result.phase_mean_rewards.flags.writeable
+    assert not result.performance_matrix.flags.writeable
+    assert not result.recovery_lengths.flags.writeable


### PR DESCRIPTION
Supersedes #1672 and #1685 while preserving both original ss251 commits and authorship.

Closes #1670.
Closes #1683.

The contributor changes establish the exact scalar/container host gates. The current-main deep audit adds the adjacent contracts needed for these records to be safe rather than merely type-shaped:

- bind each multiagent condition to its exact learning mask
- require the fixed three-phase and 3x2 result shapes, finite payloads, reconstructed phase means, recurrence identity, and interference identity
- preflight retained result bytes before copies, then own immutable NumPy snapshots
- require exact nested summary/budget/timing record hosts
- require exact platform Path and function hosts in EvidenceSpec
- reject escaping/duplicate paths at construction and bound UTF-8 text, tuple counts, and mapping counts before iteration
- update the pre-existing path-escape test to expect the new authoritative constructor gate

Validation:
- 255 passed, 2 skipped across multiagent benchmark/validation/CLI, evidence manifest, and hostile suites
- scoped Ruff clean
- strict mypy clean on both production modules
- diff check clean

No benchmark execution and no outputs mutation.
