### PR TITLE
fix(scorecard): admit exact aggregate records before hooks

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -1644,12 +1644,22 @@ def build_scorecard_artifact(
 ) -> dict[str, Any]:
     """Assemble one immutable aggregate and bind its deterministic summary."""
 
-    if any(
-        not isinstance(record, Mapping) or type(record.get("schedule_index")) is not int
-        for record in records
-    ):
-        raise ValueError("every run record must have an integer schedule_index")
-    ordered_records = sorted(records, key=lambda record: cast(int, record["schedule_index"]))
+    if type(records) is not list and type(records) is not tuple:
+        raise ValueError("run records must be an exact list or tuple")
+    canonical_records: list[dict[str, Any]] = []
+    for raw_record in records:
+        if type(raw_record) is not dict:
+            raise ValueError("every run record must be an exact string-keyed object")
+        record = cast(dict[object, Any], raw_record)
+        if any(type(key) is not str for key in record):
+            raise ValueError("every run record must be an exact string-keyed object")
+        canonical = cast(dict[str, Any], record)
+        if type(canonical.get("schedule_index")) is not int:
+            raise ValueError("every run record must have an integer schedule_index")
+        canonical_records.append(canonical)
+    ordered_records = sorted(
+        canonical_records, key=lambda record: cast(int, record["schedule_index"])
+    )
     summary = summarize_run_records(plan, ordered_records)
     run_order = [
         {

--- a/tests/test_reference_scorecard_int_hostile.py
+++ b/tests/test_reference_scorecard_int_hostile.py
@@ -176,6 +176,45 @@ def test_artifact_builder_rejects_hostile_schedule_before_integer_coercion() -> 
     assert _HostileInt.calls == 0
 
 
+def test_artifact_builder_admits_exact_record_containers_before_hooks() -> None:
+    from collections.abc import Iterator, Mapping
+
+    from alberta_framework.benchmarks import reference_life_scorecard as scorecard
+
+    class HostileRecords(list[object]):
+        calls = 0
+
+        def __iter__(self) -> Iterator[object]:
+            self.calls += 1
+            raise AssertionError("must not iterate")
+
+    class HostileRecord(Mapping[str, object]):
+        calls = 0
+
+        def __getitem__(self, key: str) -> object:
+            self.calls += 1
+            raise AssertionError("must not index")
+
+        def __iter__(self) -> Iterator[str]:
+            self.calls += 1
+            raise AssertionError("must not iterate")
+
+        def __len__(self) -> int:
+            self.calls += 1
+            raise AssertionError("must not size")
+
+    plan = scorecard.build_development_plan()
+    hostile_records = HostileRecords()
+    with pytest.raises(ValueError, match="exact list or tuple"):
+        scorecard.build_scorecard_artifact(plan, hostile_records)
+    assert hostile_records.calls == 0
+
+    hostile_record = HostileRecord()
+    with pytest.raises(ValueError, match="exact string-keyed object"):
+        scorecard.build_scorecard_artifact(plan, [hostile_record])
+    assert hostile_record.calls == 0
+
+
 def test_reward_sum_rejects_hostile_before_float() -> None:
     from alberta_framework.benchmarks.reference_life_scorecard import _reward_sum
 


### PR DESCRIPTION
Narrow follow-up to the merged scorecard hostile-scalar consolidation. `build_scorecard_artifact` previously called `isinstance` and `.get` on arbitrary Mapping records before exact container admission. It now requires an exact list/tuple of exact builtin dicts with exact string keys before lookup or sorting, and zero-hook regressions cover hostile sequence and Mapping implementations. Validation: 72 focused scorecard tests; scoped Ruff; strict mypy. No run/output; #1585 remains open.