### PR TITLE
fix(replay): preflight checkpoint arrays without hooks

### DIFF
--- a/alberta_framework/core/dual_replay.py
+++ b/alberta_framework/core/dual_replay.py
@@ -2168,16 +2168,22 @@ class DualReplayMemory:
         shape: tuple[int, ...],
         dtype: Any,
     ) -> Array:
-        try:
-            untyped = np.asarray(value, dtype=object)
-        except ValueError as error:
-            raise ValueError(f"{name} must be a rectangular array") from error
-        if untyped.shape != shape:
-            raise ValueError(f"{name} must have shape {shape}; got {untyped.shape}")
+        def leaves(node: object, remaining_shape: tuple[int, ...]) -> list[object]:
+            if not remaining_shape:
+                return [node]
+            if type(node) is not list or len(node) != remaining_shape[0]:
+                raise ValueError(f"{name} must have shape {shape}")
+            result: list[object] = []
+            for child in node:
+                result.extend(leaves(child, remaining_shape[1:]))
+            return result
+
+        untyped = leaves(value, shape)
         expected = np.dtype(dtype)
         if np.issubdtype(expected, np.floating):
             if any(
-                type(item) not in (int, float) for item in untyped.flat
+                type(item) is not int and type(item) is not float
+                for item in untyped
             ):
                 raise ValueError(f"{name} must contain only JSON real numbers")
             with np.errstate(over="ignore", under="ignore", invalid="ignore"):
@@ -2186,14 +2192,15 @@ class DualReplayMemory:
                 raise ValueError(f"{name} must contain finite float32 values")
             return jnp.asarray(array, dtype=jnp.float32)
         if np.issubdtype(expected, np.bool_):
-            if any(not isinstance(item, bool) for item in untyped.flat):
+            if any(type(item) is not bool for item in untyped):
                 raise ValueError(f"{name} must contain only booleans")
             return jnp.asarray(value, dtype=jnp.bool_)
-        if any(type(item) is not int for item in untyped.flat):
+        if any(type(item) is not int for item in untyped):
             raise ValueError(f"{name} must contain only JSON integers")
+        integer_values = cast(list[int], untyped)
         minimum = 0 if expected == np.dtype(np.uint32) else -_INT32_MAX - 1
         maximum = _UINT32_MAX if expected == np.dtype(np.uint32) else _INT32_MAX
-        if any(item < minimum or item > maximum for item in untyped.flat):
+        if any(item < minimum or item > maximum for item in integer_values):
             raise ValueError(f"{name} contains an out-of-range integer")
         output_dtype = jnp.uint32 if expected == np.dtype(np.uint32) else jnp.int32
         return jnp.asarray(value, dtype=output_dtype)

--- a/tests/test_dual_replay_int_hostile.py
+++ b/tests/test_dual_replay_int_hostile.py
@@ -39,6 +39,19 @@ class _HostileFloat(float):
         raise AssertionError("hostile float")
 
 
+class _HostileMeta(type):
+    calls = 0
+
+    def __eq__(cls, other: object) -> bool:
+        del other
+        cls.calls += 1
+        raise AssertionError("hostile metaclass eq")
+
+
+class _MetaclassHostileInt(int, metaclass=_HostileMeta):
+    pass
+
+
 def test_reservoir_capacity_rejects_hostile_before_lt() -> None:
     import jax.numpy as jnp
     import jax.random as jr
@@ -48,12 +61,12 @@ def test_reservoir_capacity_rejects_hostile_before_lt() -> None:
     hostile = _HostileInt(5)
     _HostileInt.calls = 0
     key = jr.PRNGKey(0)
-    with pytest.raises(Exception, match="positive integer"):
-        reservoir_selection(key, jnp.asarray(1, dtype=jnp.int32), hostile)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="positive integer"):
+        reservoir_selection(key, jnp.asarray(1, dtype=jnp.int32), hostile)
     assert _HostileInt.calls == 0
     # bool rejected
-    with pytest.raises(Exception, match="positive integer"):
-        reservoir_selection(key, jnp.asarray(1, dtype=jnp.int32), True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="positive integer"):
+        reservoir_selection(key, jnp.asarray(1, dtype=jnp.int32), True)
     assert _HostileInt.calls == 0
 
 
@@ -62,18 +75,51 @@ def test_checkpoint_array_real_rejects_hostile_before_float() -> None:
 
     hostile = _HostileInt(1)
     _HostileInt.calls = 0
-    with pytest.raises(Exception, match="must contain only JSON real numbers"):
-        DualReplayMemory._checkpoint_array([[hostile]], name="x", shape=(1, 1), dtype=np.float32)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must contain only JSON real numbers"):
+        DualReplayMemory._checkpoint_array([[hostile]], name="x", shape=(1, 1), dtype=np.float32)
     assert _HostileInt.calls == 0
     # also hostile float subclass
     hf = _HostileFloat(1.0)
     _HostileFloat.calls = 0
-    with pytest.raises(Exception, match="must contain only JSON real numbers"):
-        DualReplayMemory._checkpoint_array([[hf]], name="x", shape=(1, 1), dtype=np.float32)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must contain only JSON real numbers"):
+        DualReplayMemory._checkpoint_array([[hf]], name="x", shape=(1, 1), dtype=np.float32)
     assert _HostileFloat.calls == 0
     # valid
     arr = DualReplayMemory._checkpoint_array([[1.0]], name="x", shape=(1, 1), dtype=np.float32)
     assert arr.shape == (1, 1)
+
+
+def test_checkpoint_restore_rejects_metaclass_hostile_real_without_hooks() -> None:
+    import jax.random as jr
+
+    from alberta_framework.core import dual_replay
+    from alberta_framework.core.dual_replay import DualReplayConfig, DualReplayMemory
+
+    memory = DualReplayMemory(
+        DualReplayConfig(
+            total_capacity=2,
+            short_term_capacity=1,
+            observation_dim=2,
+            action_dim=2,
+            short_term_sample_size=1,
+            long_term_sample_size=1,
+            long_term_policy="reservoir",
+        )
+    )
+    payload = memory.checkpoint_payload(memory.init(jr.key(3)))
+    state = payload["state"]
+    assert isinstance(state, dict)
+    short_term = state["short_term"]
+    assert isinstance(short_term, dict)
+    rewards = short_term["rewards"]
+    assert isinstance(rewards, list)
+    rewards[0] = _MetaclassHostileInt(1)
+    payload["state_digest"] = dual_replay._payload_digest(state)
+
+    _HostileMeta.calls = 0
+    with pytest.raises(ValueError, match="must contain only JSON real numbers"):
+        DualReplayMemory.from_checkpoint_payload(payload)
+    assert _HostileMeta.calls == 0
 
 
 def test_checkpoint_array_int_rejects_hostile_before_int_check() -> None:
@@ -81,11 +127,11 @@ def test_checkpoint_array_int_rejects_hostile_before_int_check() -> None:
 
     hostile = _HostileInt(1)
     _HostileInt.calls = 0
-    with pytest.raises(Exception, match="must contain only JSON integers"):
-        DualReplayMemory._checkpoint_array([[hostile]], name="x", shape=(1, 1), dtype=np.int32)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must contain only JSON integers"):
+        DualReplayMemory._checkpoint_array([[hostile]], name="x", shape=(1, 1), dtype=np.int32)
     assert _HostileInt.calls == 0
-    with pytest.raises(Exception, match="must contain only JSON integers"):
-        DualReplayMemory._checkpoint_array([[True]], name="x", shape=(1, 1), dtype=np.int32)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must contain only JSON integers"):
+        DualReplayMemory._checkpoint_array([[True]], name="x", shape=(1, 1), dtype=np.int32)
     arr = DualReplayMemory._checkpoint_array([[1]], name="x", shape=(1, 1), dtype=np.int32)
     assert arr.shape == (1, 1)
 
@@ -95,11 +141,11 @@ def test_checkpoint_counter_rejects_hostile_before_range() -> None:
 
     hostile = _HostileInt(1)
     _HostileInt.calls = 0
-    with pytest.raises(Exception, match="must be a JSON integer"):
-        DualReplayMemory._checkpoint_counter(hostile, name="c")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be a JSON integer"):
+        DualReplayMemory._checkpoint_counter(hostile, name="c")
     assert _HostileInt.calls == 0
-    with pytest.raises(Exception, match="must be a JSON integer"):
-        DualReplayMemory._checkpoint_counter(True, name="c")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must be a JSON integer"):
+        DualReplayMemory._checkpoint_counter(True, name="c")
     assert DualReplayMemory._checkpoint_counter(1, name="c").shape == ()
 
 


### PR DESCRIPTION
Deep-review corrective for merged #1693 / superseded #1678. The merged float gate still used tuple membership, and NumPy object-array construction itself consulted hostile element metaclasses before that gate. This validates exact JSON list shape and builtin leaf identity before NumPy conversion, then preserves the same JAX dtypes/state/resource contract. Adds a real `from_checkpoint_payload` zero-hook test and tightens contributor tests to require ValueError. No output/workflow changes.\n\nVerification: 174 dual-replay tests passed; scoped Ruff clean; strict mypy clean; diff check clean.