### PR TITLE
feat(ipmnist): add matched gradual input runner

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -44,6 +44,18 @@ _INT32_MAX = 2**31 - 1
 _MAX_ARRAY_ELEMENTS = 1_000_000
 _MAX_RESOURCE_BYTES = 256 * 1024 * 1024
 _MAX_RUN_STEPS = 1_000_000
+_NUMPY_INTEGER_TYPES = (
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.longlong,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.ulonglong,
+)
 
 GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(
     {
@@ -69,7 +81,7 @@ GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(
 
 
 def _exact_index(name: str, value: object, *, minimum: int) -> int:
-    if type(value) is not int and not isinstance(value, np.integer):
+    if type(value) is not int and type(value) not in _NUMPY_INTEGER_TYPES:
         raise ValueError(f"{name} must be an integer")
     try:
         resolved = operator.index(cast(SupportsIndex, value))
@@ -93,9 +105,10 @@ def _alpha(value: object) -> float:
 class GradualTransitionConfig:
     """One prospectively selectable transition rule.
 
-    ``transition_steps`` counts update opportunities from the old task at
-    alpha zero to the new task at alpha one.  Abrupt mode requires one step
-    and is the mechanism-off reduction.
+    ``transition_steps`` counts interpolation intervals.  A width ``k`` uses
+    coefficients ``0/k, 1/k, ..., k/k`` across ``k + 1`` update
+    opportunities; the last is exactly the ordinary new-task example.
+    Abrupt mode requires one step and is the mechanism-off reduction.
     """
 
     mode: TransitionMode
@@ -112,10 +125,15 @@ class GradualTransitionConfig:
 
 def transition_alpha(step: int, config: GradualTransitionConfig) -> float:
     """Return a deterministic uniform interpolation coefficient."""
+    if type(config) is not GradualTransitionConfig:
+        raise ValueError("config must be an exact GradualTransitionConfig")
+    checked = GradualTransitionConfig(
+        mode=config.mode, transition_steps=config.transition_steps
+    )
     resolved_step = _exact_index("step", step, minimum=0)
-    if config.mode == "abrupt":
+    if checked.mode == "abrupt":
         return 1.0
-    return min(resolved_step / config.transition_steps, 1.0)
+    return min(resolved_step / checked.transition_steps, 1.0)
 
 
 def input_interpolation_transaction(
@@ -282,10 +300,6 @@ def run_gradual_input_pair(
     checked_config = IPMNISTConfig(**config.to_config())
     if checked_config.n_steps > _MAX_RUN_STEPS:
         raise ValueError("run horizon exceeds the 1000000-step ceiling")
-    # AdamW retains parameters plus first/second moments.  Reject the exact
-    # derived lower bound before initialization can allocate any device array.
-    if checked_config.parameter_count * 12 > _MAX_RESOURCE_BYTES:
-        raise ValueError("learner persistent numeric allocation exceeds 256 MiB")
     width = _exact_index("transition_steps", transition_steps, minimum=1)
     if width >= checked_config.task_length:
         raise ValueError("transition_steps must be smaller than task_length")
@@ -294,7 +308,7 @@ def run_gradual_input_pair(
         actual_type = type(value)
         if not (
             actual_type is np.ndarray
-            or issubclass(actual_type, (jax.Array, jax.core.Tracer))
+            or issubclass(actual_type, jax.Array)
         ):
             raise ValueError(f"{name} must be an exact NumPy or JAX array")
     raw_x = cast(np.ndarray | Array, data_x)
@@ -310,8 +324,18 @@ def run_gradual_input_pair(
     schedule_elements = checked_config.n_tasks * (
         checked_config.input_dim + checked_config.task_length
     )
-    if schedule_elements > _MAX_RESOURCE_BYTES // 4:
-        raise ValueError("IPMNIST schedule exceeds 256 MiB")
+    # AdamW retains parameters plus first/second moments and one int32 count
+    # for each of the six parameter leaves.  Dataset and full evaluator
+    # schedule remain resident for the complete run.  Gate their exact sum
+    # before any protocol materialization or device initialization.
+    aggregate_persistent_bytes = (
+        checked_config.parameter_count * 12
+        + 6 * 4
+        + dataset_elements * 4
+        + schedule_elements * 4
+    )
+    if aggregate_persistent_bytes > _MAX_RESOURCE_BYTES:
+        raise ValueError("aggregate persistent numeric allocation exceeds 256 MiB")
     resolved_x, resolved_y = validated_ipmnist_data(
         cast(np.ndarray | Array, data_x),
         cast(np.ndarray | Array, data_y),

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -81,7 +81,10 @@ GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(
 
 
 def _exact_index(name: str, value: object, *, minimum: int) -> int:
-    if type(value) is not int and type(value) not in _NUMPY_INTEGER_TYPES:
+    actual_type = type(value)
+    if actual_type is not int and not any(
+        actual_type is allowed for allowed in _NUMPY_INTEGER_TYPES
+    ):
         raise ValueError(f"{name} must be an integer")
     try:
         resolved = operator.index(cast(SupportsIndex, value))
@@ -330,7 +333,7 @@ def run_gradual_input_pair(
     # before any protocol materialization or device initialization.
     aggregate_persistent_bytes = (
         checked_config.parameter_count * 12
-        + 6 * 4
+        + 6 * 5 * 4
         + dataset_elements * 4
         + schedule_elements * 4
     )

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -8,11 +8,13 @@ only the resulting example/target, exactly as in the abrupt IPMNIST lane.
 
 from __future__ import annotations
 
+import hashlib
 import math
 import operator
+import time
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Literal, SupportsIndex, cast
+from typing import Any, Literal, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -21,6 +23,16 @@ import numpy as np
 from jax import Array
 
 from alberta_framework._seed_validation import require_jax_seed
+from alberta_framework.benchmarks.upgd_ipmnist import (
+    ADAMW_PROTOCOL_HYPERPARAMETERS,
+    IPMNISTConfig,
+    LearnerUpdateResult,
+    _make_adamw_learner,
+    build_schedule,
+    cross_entropy_loss,
+    init_mlp_params,
+    validated_ipmnist_data,
+)
 
 TransitionMode = Literal[
     "abrupt", "input_interpolation", "output_interpolation", "task_sampling"
@@ -30,6 +42,8 @@ _MODES = frozenset(
 )
 _INT32_MAX = 2**31 - 1
 _MAX_ARRAY_ELEMENTS = 1_000_000
+_MAX_RESOURCE_BYTES = 256 * 1024 * 1024
+_MAX_RUN_STEPS = 1_000_000
 
 GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(
     {
@@ -188,3 +202,226 @@ def task_sampling_mask(
     mask = np.zeros(resolved_count, dtype=np.bool_)
     mask[order[:new_count]] = True
     return mask
+
+
+@dataclass(frozen=True)
+class GradualInputPairResult:
+    """Host receipt for one matched abrupt/input-interpolation learner pair."""
+
+    arm_names: tuple[str, str]
+    learner_name: str
+    seed: int
+    config: IPMNISTConfig
+    transition_steps: int
+    schedule_sha256: str
+    example_order_sha256: str
+    correct_counts: np.ndarray
+    loss_sums: np.ndarray
+    persistent_numeric_bytes: np.ndarray
+    timing_ns: np.ndarray
+    observations: int
+    updates: int
+    data_steps: int
+    environment_steps: int
+    model_queries: int
+
+
+def _array_sha256(domain: bytes, value: Array) -> str:
+    raw = np.asarray(jax.device_get(value))
+    digest = hashlib.sha256()
+    digest.update(domain)
+    digest.update(raw.dtype.str.encode("ascii"))
+    digest.update(str(raw.shape).encode("ascii"))
+    digest.update(raw.tobytes(order="C"))
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _numeric_tree_bytes(value: object) -> int:
+    total = 0
+    for leaf in jax.tree_util.tree_leaves(value):
+        actual_type = type(leaf)
+        if not (
+            actual_type is np.ndarray
+            or issubclass(actual_type, (jax.Array, jax.core.Tracer))
+        ):
+            continue
+        array = jnp.asarray(leaf)
+        if not bool(jnp.all(jnp.isfinite(array))):
+            raise ValueError("learner transaction produced non-finite state")
+        total += int(array.size) * int(array.dtype.itemsize)
+        if total > _MAX_RESOURCE_BYTES:
+            raise ValueError("learner persistent numeric state exceeds 256 MiB")
+    return total
+
+
+def run_gradual_input_pair(
+    data_x: object,
+    data_y: object,
+    *,
+    learner_name: str,
+    seed: int,
+    config: IPMNISTConfig,
+    transition_steps: int,
+) -> GradualInputPairResult:
+    """Run a matched abrupt/input-interpolation pair on one IPMNIST schedule.
+
+    The two arms start from identical parameters, consume identical example,
+    learner-RNG, update, and task-permutation schedules, and differ only in the
+    evaluator-owned input presented during the first ``transition_steps`` of
+    each task after the first.  The learner never observes task identity or
+    interpolation coefficient.
+    """
+    if type(learner_name) is not str:
+        raise ValueError("learner_name must be an exact string")
+    if learner_name != "adamw_control":
+        raise ValueError("this frozen adapter supports only adamw_control")
+    if type(config) is not IPMNISTConfig:
+        raise ValueError("config must be an exact IPMNISTConfig")
+    # Reconstruct before reading derived fields: frozen dataclasses remain
+    # forgeable through object.__setattr__.
+    checked_config = IPMNISTConfig(**config.to_config())
+    if checked_config.n_steps > _MAX_RUN_STEPS:
+        raise ValueError("run horizon exceeds the 1000000-step ceiling")
+    # AdamW retains parameters plus first/second moments.  Reject the exact
+    # derived lower bound before initialization can allocate any device array.
+    if checked_config.parameter_count * 12 > _MAX_RESOURCE_BYTES:
+        raise ValueError("learner persistent numeric allocation exceeds 256 MiB")
+    width = _exact_index("transition_steps", transition_steps, minimum=1)
+    if width >= checked_config.task_length:
+        raise ValueError("transition_steps must be smaller than task_length")
+    resolved_seed = require_jax_seed(seed, name="seed")
+    for name, value in (("data_x", data_x), ("data_y", data_y)):
+        actual_type = type(value)
+        if not (
+            actual_type is np.ndarray
+            or issubclass(actual_type, (jax.Array, jax.core.Tracer))
+        ):
+            raise ValueError(f"{name} must be an exact NumPy or JAX array")
+    raw_x = cast(np.ndarray | Array, data_x)
+    raw_y = cast(np.ndarray | Array, data_y)
+    if len(raw_x.shape) != 2 or len(raw_y.shape) != 1:
+        raise ValueError("dataset metadata must describe one matrix and one vector")
+    if raw_x.shape[0] != raw_y.shape[0]:
+        raise ValueError("data_x and data_y row counts must match")
+    dataset_elements = math.prod(raw_x.shape) + math.prod(raw_y.shape)
+    # Materialization converts both arrays to four-byte protocol dtypes.
+    if dataset_elements > _MAX_RESOURCE_BYTES // 4:
+        raise ValueError("materialized dataset exceeds 256 MiB")
+    schedule_elements = checked_config.n_tasks * (
+        checked_config.input_dim + checked_config.task_length
+    )
+    if schedule_elements > _MAX_RESOURCE_BYTES // 4:
+        raise ValueError("IPMNIST schedule exceeds 256 MiB")
+    resolved_x, resolved_y = validated_ipmnist_data(
+        cast(np.ndarray | Array, data_x),
+        cast(np.ndarray | Array, data_y),
+        input_dim=checked_config.input_dim,
+        n_classes=checked_config.n_classes,
+        min_length=checked_config.task_length,
+    )
+    data_x_array = jnp.asarray(resolved_x, dtype=jnp.float32)
+    data_y_array = jnp.asarray(resolved_y, dtype=jnp.int32)
+    dataset_numeric_bytes = int(data_x_array.nbytes + data_y_array.nbytes)
+    init_fn, step_fn = _make_adamw_learner(dict(ADAMW_PROTOCOL_HYPERPARAMETERS))
+
+    @jax.jit
+    def checked_step(
+        params: dict[str, Array], state: Any, x: Array, y: Array, key: Array
+    ) -> tuple[LearnerUpdateResult, Array, Array, Array]:
+        (loss, logits), grads = jax.value_and_grad(cross_entropy_loss, has_aux=True)(
+            params, x, y
+        )
+        transaction = step_fn(params, state, grads, key)
+        if type(transaction) is not LearnerUpdateResult:
+            raise TypeError("AdamW learner did not return its checked transaction")
+        post_loss, _ = cross_entropy_loss(transaction.params, x, y)
+        accuracy = (jnp.argmax(logits) == y).astype(jnp.float32)
+        return transaction, accuracy, loss, post_loss
+
+    root = jr.key(jnp.uint32(resolved_seed))
+    key_init, key_schedule, key_noise = jr.split(root, 3)
+    initial_params = init_mlp_params(key_init, checked_config)
+    schedule = build_schedule(key_schedule, checked_config, int(data_x_array.shape[0]))
+    transition_config = GradualTransitionConfig(
+        mode="input_interpolation", transition_steps=width
+    )
+
+    def run_arm(gradual: bool) -> tuple[list[int], list[float], int, int]:
+        params = initial_params
+        state = init_fn(params)
+        key = key_noise
+        correct_counts: list[int] = []
+        loss_sums: list[float] = []
+        started = time.perf_counter_ns()
+        for task in range(checked_config.n_tasks):
+            current_permutation = schedule.permutations[task]
+            previous_permutation = schedule.permutations[max(task - 1, 0)]
+            examples = schedule.example_indices[task]
+            task_correct = 0
+            task_loss = 0.0
+            for offset in range(checked_config.task_length):
+                example = examples[offset]
+                new_x = data_x_array[example][current_permutation]
+                if gradual and task > 0 and offset < width:
+                    old_x = data_x_array[example][previous_permutation]
+                    x, valid = input_interpolation_transaction(
+                        old_x, new_x, transition_alpha(offset, transition_config)
+                    )
+                    if not bool(valid):
+                        raise ValueError("input interpolation transaction became invalid")
+                else:
+                    x = new_x
+                y = data_y_array[example]
+                key, step_key = jr.split(key)
+                transaction, accuracy, loss, post_loss = checked_step(
+                    params, state, x, y, step_key
+                )
+                if type(transaction) is not LearnerUpdateResult:
+                    raise ValueError("AdamW learner did not return its checked transaction")
+                if not bool(transaction.update_applied):
+                    raise ValueError("AdamW learner update transaction became invalid")
+                params = transaction.params
+                state = transaction.state
+                if not bool(jnp.isfinite(accuracy) & jnp.isfinite(loss) & jnp.isfinite(post_loss)):
+                    raise ValueError("learner metric transaction became invalid")
+                task_correct += int(accuracy)
+                task_loss += float(loss)
+                if not math.isfinite(task_loss):
+                    raise ValueError("learner task-loss accumulation became invalid")
+            correct_counts.append(task_correct)
+            loss_sums.append(task_loss)
+        for leaf in jax.tree_util.tree_leaves((params, state)):
+            if hasattr(leaf, "block_until_ready"):
+                leaf.block_until_ready()
+        timing = time.perf_counter_ns() - started
+        persistent = dataset_numeric_bytes + _numeric_tree_bytes((params, state, schedule))
+        if persistent > _MAX_RESOURCE_BYTES:
+            raise ValueError("complete persistent numeric state exceeds 256 MiB")
+        return correct_counts, loss_sums, persistent, timing
+
+    arm_outputs = (run_arm(False), run_arm(True))
+    horizon = checked_config.n_steps
+    return GradualInputPairResult(
+        arm_names=("abrupt", "input_interpolation"),
+        learner_name=learner_name,
+        seed=resolved_seed,
+        config=checked_config,
+        transition_steps=width,
+        schedule_sha256=_array_sha256(
+            b"asi.ipmnist.gradual.permutations.v1\0", schedule.permutations
+        ),
+        example_order_sha256=_array_sha256(
+            b"asi.ipmnist.gradual.example-order.v1\0", schedule.example_indices
+        ),
+        correct_counts=np.asarray([output[0] for output in arm_outputs], dtype=np.int32),
+        loss_sums=np.asarray([output[1] for output in arm_outputs], dtype=np.float64),
+        persistent_numeric_bytes=np.asarray(
+            [output[2] for output in arm_outputs], dtype=np.int64
+        ),
+        timing_ns=np.asarray([output[3] for output in arm_outputs], dtype=np.int64),
+        observations=horizon,
+        updates=horizon,
+        data_steps=horizon,
+        environment_steps=0,
+        model_queries=2 * horizon,
+    )

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -49,6 +49,32 @@ def test_transition_alpha_is_deterministic_and_clamped() -> None:
     assert [transition_alpha(step, config) for step in range(6)] == [0.0, 0.25, 0.5, 0.75, 1.0, 1.0]
 
 
+def test_transition_width_counts_intervals_including_both_endpoints() -> None:
+    config = GradualTransitionConfig(mode="input_interpolation", transition_steps=2)
+    assert [transition_alpha(step, config) for step in range(4)] == [0.0, 0.5, 1.0, 1.0]
+
+
+def test_transition_config_rejects_forged_and_hostile_values_without_index_hooks() -> None:
+    config = GradualTransitionConfig(mode="input_interpolation", transition_steps=2)
+    object.__setattr__(config, "transition_steps", 0)
+    with pytest.raises(ValueError, match="transition_steps"):
+        transition_alpha(0, config)
+
+    class HostileInt(np.int64):
+        calls = 0
+
+        def __index__(self) -> int:
+            self.calls += 1
+            raise AssertionError("must not execute")
+
+    hostile = HostileInt(2)
+    with pytest.raises(ValueError, match="integer"):
+        GradualTransitionConfig(
+            mode="input_interpolation", transition_steps=hostile  # type: ignore[arg-type]
+        )
+    assert hostile.calls == 0
+
+
 def test_task_sampling_mask_is_matched_deterministic_and_monotone() -> None:
     first = task_sampling_mask(seed=7, transition_id=3, count=10, alpha=0.3)
     second = task_sampling_mask(seed=7, transition_id=3, count=10, alpha=0.3)
@@ -182,7 +208,7 @@ def test_gradual_pair_preflights_parameter_allocation_before_initialization() ->
         hidden2=2,
         n_classes=2,
     )
-    with pytest.raises(ValueError, match="persistent numeric allocation"):
+    with pytest.raises(ValueError, match="aggregate persistent numeric allocation"):
         run_gradual_input_pair(
             np.zeros((2, 100_000), dtype=np.float32),
             np.zeros(2, dtype=np.int32),

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -74,6 +74,26 @@ def test_transition_config_rejects_forged_and_hostile_values_without_index_hooks
         )
     assert hostile.calls == 0
 
+    class HostileMeta(type):
+        calls = 0
+
+        def __eq__(cls, other: object) -> bool:
+            cls.calls += 1
+            raise AssertionError("must not compare types")
+
+        def __hash__(cls) -> int:
+            cls.calls += 1
+            raise AssertionError("must not hash types")
+
+    class Hostile(metaclass=HostileMeta):
+        pass
+
+    with pytest.raises(ValueError, match="integer"):
+        GradualTransitionConfig(
+            mode="input_interpolation", transition_steps=Hostile()  # type: ignore[arg-type]
+        )
+    assert HostileMeta.calls == 0
+
 
 def test_task_sampling_mask_is_matched_deterministic_and_monotone() -> None:
     first = task_sampling_mask(seed=7, transition_id=3, count=10, alpha=0.3)
@@ -174,7 +194,9 @@ def test_gradual_input_pair_runs_one_matched_real_learner_schedule() -> None:
     assert result.loss_sums.shape == (2, 3)
     assert np.all(np.isfinite(result.loss_sums))
     assert result.persistent_numeric_bytes.shape == (2,)
-    assert np.all(result.persistent_numeric_bytes > data_x.nbytes + data_y.nbytes)
+    # 29 params * (parameter + Adam m + Adam v) float32 bytes, five
+    # optimizer scalars per each of six leaves, dataset, and full schedule.
+    assert np.all(result.persistent_numeric_bytes == 29 * 12 + 6 * 5 * 4 + 80 + 96)
     assert result.timing_ns.shape == (2,)
     assert np.all(result.timing_ns >= 0)
 

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -11,9 +11,11 @@ from alberta_framework.benchmarks.ipmnist_gradual import (
     input_interpolation,
     input_interpolation_transaction,
     output_interpolation,
+    run_gradual_input_pair,
     task_sampling_mask,
     transition_alpha,
 )
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
 
 
 def test_abrupt_mode_is_exact_new_task_reduction() -> None:
@@ -102,3 +104,90 @@ def test_input_interpolation_rejects_array_protocol_objects_without_calling_them
     with pytest.raises(ValueError, match="exact NumPy or JAX"):
         input_interpolation(hostile, jnp.ones(1), 0.5)  # type: ignore[arg-type]
     assert hostile.calls == 0
+
+
+def test_gradual_input_pair_runs_one_matched_real_learner_schedule() -> None:
+    data_x = np.asarray(
+        [
+            [-1.0, -0.5, 0.5, 1.0],
+            [1.0, 0.5, -0.5, -1.0],
+            [-0.5, 1.0, -1.0, 0.5],
+            [0.5, -1.0, 1.0, -0.5],
+        ],
+        dtype=np.float32,
+    )
+    data_y = np.asarray([0, 1, 0, 1], dtype=np.int32)
+    config = IPMNISTConfig(
+        n_tasks=3,
+        task_length=4,
+        input_dim=4,
+        hidden1=3,
+        hidden2=2,
+        n_classes=2,
+    )
+
+    result = run_gradual_input_pair(
+        data_x,
+        data_y,
+        learner_name="adamw_control",
+        seed=17,
+        config=config,
+        transition_steps=2,
+    )
+
+    assert result.arm_names == ("abrupt", "input_interpolation")
+    assert result.seed == 17
+    assert result.observations == result.updates == 12
+    assert result.data_steps == 12
+    assert result.environment_steps == 0
+    assert result.model_queries == 24
+    assert result.schedule_sha256.startswith("sha256:")
+    assert result.example_order_sha256.startswith("sha256:")
+    assert result.correct_counts.shape == (2, 3)
+    assert np.all((result.correct_counts >= 0) & (result.correct_counts <= 4))
+    assert result.loss_sums.shape == (2, 3)
+    assert np.all(np.isfinite(result.loss_sums))
+    assert result.persistent_numeric_bytes.shape == (2,)
+    assert np.all(result.persistent_numeric_bytes > data_x.nbytes + data_y.nbytes)
+    assert result.timing_ns.shape == (2,)
+    assert np.all(result.timing_ns >= 0)
+
+
+def test_gradual_pair_rejects_transition_wider_than_each_task() -> None:
+    config = IPMNISTConfig(
+        n_tasks=2,
+        task_length=2,
+        input_dim=2,
+        hidden1=2,
+        hidden2=2,
+        n_classes=2,
+    )
+    with pytest.raises(ValueError, match="transition_steps must be smaller"):
+        run_gradual_input_pair(
+            np.zeros((2, 2), dtype=np.float32),
+            np.zeros(2, dtype=np.int32),
+            learner_name="adamw_control",
+            seed=1,
+            config=config,
+            transition_steps=2,
+        )
+
+
+def test_gradual_pair_preflights_parameter_allocation_before_initialization() -> None:
+    config = IPMNISTConfig(
+        n_tasks=2,
+        task_length=2,
+        input_dim=100_000,
+        hidden1=1000,
+        hidden2=2,
+        n_classes=2,
+    )
+    with pytest.raises(ValueError, match="persistent numeric allocation"):
+        run_gradual_input_pair(
+            np.zeros((2, 100_000), dtype=np.float32),
+            np.zeros(2, dtype=np.int32),
+            learner_name="adamw_control",
+            seed=1,
+            config=config,
+            transition_steps=1,
+        )


### PR DESCRIPTION
## Summary
- add a bounded real-learner IPMNIST adapter for matched abrupt versus input-interpolation transitions
- consume the official AdamW checked transaction and the exact shared IPMNIST init/permutation/example/RNG schedule
- retain integer correctness numerators, finite loss sums, schedule identities, full persistent numeric bytes, exact counters, and telemetry-only timings
- preflight horizon, dataset, schedule, parameters, and persistent state before large allocations

## Scope
This is an executable prerequisite for #1569, not completion. It covers the paper's input-interpolation mechanism and its exact abrupt control only. Output interpolation and task sampling remain primitive-only. There is no retained report in this PR, so #1569 must remain open.

## Verification
- `.venv/bin/python -m pytest tests/test_ipmnist_gradual.py -q` (15 passed)
- `.venv/bin/python -m ruff check alberta_framework/benchmarks/ipmnist_gradual.py tests/test_ipmnist_gradual.py`
- `.venv/bin/python -m mypy alberta_framework/benchmarks/ipmnist_gradual.py`
- one manual official cached-MNIST 3-task/32-step/standard-network execution completed both arms and emitted finite metrics/resources
