### PR TITLE
fix(evaluation): bind multiagent aggregation to config

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import operator
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from time import perf_counter, perf_counter_ns
 from typing import Any, Literal, SupportsIndex, cast
 
@@ -469,6 +469,12 @@ class ConditionResult:
             raise ValueError("phase_mean_rewards must reconstruct from online_rewards")
         if type(self.summary) is not ContinualLearningSummary:
             raise ValueError("summary must be a ContinualLearningSummary")
+        summary = ContinualLearningSummary(
+            **{
+                field.name: getattr(self.summary, field.name)
+                for field in fields(ContinualLearningSummary)
+            }
+        )
         summary_without_reference = summarize_continual_learning(
             performance,
             [0, 1],
@@ -482,7 +488,7 @@ class ConditionResult:
             "max_forgetting",
             "backward_transfer",
         ):
-            if getattr(self.summary, name) != getattr(summary_without_reference, name):
+            if getattr(summary, name) != getattr(summary_without_reference, name):
                 raise ValueError(f"summary.{name} must reconstruct from primitive arrays")
         for name in (
             "per_task_final_performance",
@@ -490,7 +496,7 @@ class ConditionResult:
             "per_task_backward_transfer",
         ):
             if not np.array_equal(
-                getattr(self.summary, name), getattr(summary_without_reference, name)
+                getattr(summary, name), getattr(summary_without_reference, name)
             ):
                 raise ValueError(f"summary.{name} must reconstruct from performance_matrix")
         recovery = _require_ndarray(
@@ -517,14 +523,26 @@ class ConditionResult:
             raise ValueError("interference_forgetting must reconstruct from performance_matrix")
         if type(self.controller_budget) is not ControllerBudget:
             raise ValueError("controller_budget must be a ControllerBudget")
+        budget = ControllerBudget(
+            **{
+                field.name: getattr(self.controller_budget, field.name)
+                for field in fields(ControllerBudget)
+            }
+        )
         if type(self.timing) is not TimingMetrics:
             raise ValueError("timing must be a TimingMetrics")
+        timing = TimingMetrics(
+            **{field.name: getattr(self.timing, field.name) for field in fields(TimingMetrics)}
+        )
         object.__setattr__(self, "online_rewards", _freeze_ndarray(rewards))
         object.__setattr__(self, "phase_mean_rewards", _freeze_ndarray(phase_rewards))
         object.__setattr__(self, "performance_matrix", _freeze_ndarray(performance))
         object.__setattr__(self, "recovery_lengths", _freeze_ndarray(recovery))
         object.__setattr__(self, "recurrence_recovery_steps", recurrence)
         object.__setattr__(self, "interference_forgetting", interference)
+        object.__setattr__(self, "summary", summary)
+        object.__setattr__(self, "controller_budget", budget)
+        object.__setattr__(self, "timing", timing)
 
 
 @dataclass(frozen=True)
@@ -914,30 +932,53 @@ def paired_bootstrap_mean_interval(
 def aggregate_evidence(
     results: Sequence[ConditionResult],
     *,
+    config: ContinualMultiAgentConfig,
     confidence_level: float = 0.95,
     bootstrap_resamples: int = 10_000,
     bootstrap_seed: int = 2_026_073_000,
-    stability_reference_reward: float = 0.75,
 ) -> AggregateEvidence:
     """Aggregate paired condition results without discarding failed seeds."""
 
+    if type(config) is not ContinualMultiAgentConfig:
+        raise ValueError("config must be a ContinualMultiAgentConfig")
     if not results:
         raise ValueError("results must be non-empty")
-    reference = finite_real("stability_reference_reward", stability_reference_reward)
+    validated: list[ConditionResult] = []
     for result in results:
+        if type(result) is not ConditionResult:
+            raise ValueError("results must contain exact ConditionResult records")
+        result = ConditionResult(
+            **{field.name: getattr(result, field.name) for field in fields(ConditionResult)}
+        )
+        if result.online_rewards.size != 3 * config.phase_steps:
+            raise ValueError("result length does not match config.phase_steps")
+        expected_recoveries = compute_recovery_lengths(
+            result.online_rewards,
+            [config.phase_steps, 2 * config.phase_steps],
+            config.recovery_reward_threshold,
+            window_size=config.recovery_window,
+        )
+        if not np.array_equal(result.recovery_lengths, expected_recoveries):
+            raise ValueError("recovery_lengths do not match rewards and config")
         expected_summary = summarize_continual_learning(
             result.performance_matrix,
             [0, 1],
             result.online_rewards,
-            reference,
+            config.stability_reference_reward,
         )
-        if (
-            result.summary.stability_gap_mean != expected_summary.stability_gap_mean
-            or result.summary.stability_gap_max != expected_summary.stability_gap_max
-        ):
-            raise ValueError(
-                "condition summary must reconstruct from primitive arrays and stability reference"
+        summary_matches = all(
+            np.array_equal(
+                getattr(result.summary, field.name),
+                getattr(expected_summary, field.name),
             )
+            if isinstance(getattr(result.summary, field.name), np.ndarray)
+            else getattr(result.summary, field.name) == getattr(expected_summary, field.name)
+            for field in fields(ContinualLearningSummary)
+        )
+        if not summary_matches:
+            raise ValueError("summary does not match primitive arrays and config")
+        validated.append(result)
+    results = tuple(validated)
     frozen = _condition_results(results, "frozen")
     learner_only = _condition_results(results, "learner_only")
     joint_adaptive = _condition_results(results, "joint_adaptive")
@@ -1243,6 +1284,7 @@ def run_continual_multiagent_benchmark(
     )
     aggregate = aggregate_evidence(
         results,
+        config=benchmark_config,
         confidence_level=benchmark_config.confidence_level,
         bootstrap_resamples=benchmark_config.bootstrap_resamples,
         bootstrap_seed=benchmark_config.bootstrap_seed,

--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -495,9 +495,7 @@ class ConditionResult:
             "per_task_forgetting",
             "per_task_backward_transfer",
         ):
-            if not np.array_equal(
-                getattr(summary, name), getattr(summary_without_reference, name)
-            ):
+            if not np.array_equal(getattr(summary, name), getattr(summary_without_reference, name)):
                 raise ValueError(f"summary.{name} must reconstruct from performance_matrix")
         recovery = _require_ndarray(
             "recovery_lengths",
@@ -1288,7 +1286,6 @@ def run_continual_multiagent_benchmark(
         confidence_level=benchmark_config.confidence_level,
         bootstrap_resamples=benchmark_config.bootstrap_resamples,
         bootstrap_seed=benchmark_config.bootstrap_seed,
-        stability_reference_reward=benchmark_config.stability_reference_reward,
     )
     acceptance = evaluate_acceptance(aggregate, acceptance_thresholds)
     return ContinualMultiAgentReport(

--- a/tests/test_continual_multiagent_benchmark.py
+++ b/tests/test_continual_multiagent_benchmark.py
@@ -138,6 +138,7 @@ def test_seeded_learning_evidence_is_exactly_reproducible(
         )
     repeated_aggregate = aggregate_evidence(
         benchmark_report.condition_results,
+        config=benchmark_report.config,
         confidence_level=benchmark_report.config.confidence_level,
         bootstrap_resamples=benchmark_report.config.bootstrap_resamples,
         bootstrap_seed=benchmark_report.config.bootstrap_seed,
@@ -280,7 +281,7 @@ def test_public_aggregation_rejects_duplicate_seed_weighting(
         if result.seed == evidence_seed
     )
     with pytest.raises(ValueError, match="unique"):
-        aggregate_evidence(one_seed + one_seed)
+        aggregate_evidence(one_seed + one_seed, config=benchmark_report.config)
 
 
 def test_artifact_has_deterministic_scientific_content_and_digest(

--- a/tests/test_multiagent_condition_result_hostile.py
+++ b/tests/test_multiagent_condition_result_hostile.py
@@ -7,6 +7,7 @@ import pytest
 
 from alberta_framework.evaluation.continual_multiagent import (
     ConditionResult,
+    ContinualMultiAgentConfig,
     ControllerBudget,
     TimingMetrics,
     aggregate_evidence,
@@ -137,8 +138,17 @@ def test_aggregate_binds_stability_summary_to_live_reference() -> None:
         _legal(condition="learner_only", learning_mask=(True, False)),
         _legal(condition="joint_adaptive", learning_mask=(True, True)),
     )
-    with pytest.raises(ValueError, match="stability reference"):
-        aggregate_evidence(results, bootstrap_resamples=2)
+    with pytest.raises(ValueError, match="primitive arrays and config"):
+        aggregate_evidence(
+            results,
+            config=ContinualMultiAgentConfig(
+                phase_steps=2,
+                probe_horizon=2,
+                probe_tail_steps=2,
+                recovery_window=1,
+            ),
+            bootstrap_resamples=2,
+        )
 
 
 def test_condition_result_owns_read_only_array_snapshots() -> None:
@@ -150,3 +160,19 @@ def test_condition_result_owns_read_only_array_snapshots() -> None:
     assert not result.phase_mean_rewards.flags.writeable
     assert not result.performance_matrix.flags.writeable
     assert not result.recovery_lengths.flags.writeable
+
+
+def test_aggregation_revalidates_records_at_consumption() -> None:
+    result = _legal()
+    object.__setattr__(result, "recurrence_recovery_steps", 0)
+
+    with pytest.raises(ValueError, match="must match recovery_lengths"):
+        aggregate_evidence(
+            [result],
+            config=ContinualMultiAgentConfig(
+                phase_steps=2,
+                probe_horizon=2,
+                probe_tail_steps=2,
+                recovery_window=1,
+            ),
+        )


### PR DESCRIPTION
Follow-up to the constructor contract consolidated in #1698 (superseding #1672).

- snapshots nested summary/budget/timing records
- makes the public aggregator require the protocol config
- reconstructs exact result records at consumption time
- derives recovery lengths and the continual-learning summary from primitive arrays plus config
- rejects protocol-length mismatches and post-construction mutation

Validation:
- 38 focused multiagent tests passed
- Ruff passed
- mypy passed (187 source files)

No benchmark or evidence artifact was changed or produced. This is validation hardening only.