### PR TITLE
fix(evaluation): revalidate IA results at aggregation

### DIFF
--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import functools
 import operator
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from time import perf_counter
 from typing import Any, Literal, SupportsIndex, cast
 
@@ -133,7 +133,9 @@ def _require_ndarray(
         raise ValueError(f"{name} must be one-dimensional")
     if length is not None and int(value.shape[0]) != length:
         raise ValueError(f"{name} must have length {length}")
-    return value
+    snapshot = np.array(value, copy=True, order="C")
+    snapshot.flags.writeable = False
+    return snapshot
 
 
 def _require_derived_int32(name: str, value: int) -> None:
@@ -462,6 +464,7 @@ class IAConditionResult:
         if type(self.condition) is not str or self.condition not in CONDITION_NAMES:
             raise ValueError("condition must be a known IA condition name")
         rewards = _require_ndarray("rewards", self.rewards, dtype=np.dtype(np.float64))
+        object.__setattr__(self, "rewards", rewards)
         steps = int(rewards.shape[0])
         if steps < 1:
             raise ValueError("rewards must contain at least one step")
@@ -472,18 +475,21 @@ class IAConditionResult:
             "recommendations",
             "partner_proposals",
         ):
-            action_arrays.append(_require_ndarray(
+            action = _require_ndarray(
                 name,
                 getattr(self, name),
                 dtype=np.dtype(np.int64),
                 length=steps,
-            ))
+            )
+            object.__setattr__(self, name, action)
+            action_arrays.append(action)
         accepted = _require_ndarray(
             "accepted_recommendations",
             self.accepted_recommendations,
             dtype=np.dtype(np.bool_),
             length=steps,
         )
+        object.__setattr__(self, "accepted_recommendations", accepted)
         mean_reward = finite_real("mean_reward", self.mean_reward)
         object.__setattr__(self, "mean_reward", mean_reward)
         phase_means = _require_ndarray(
@@ -491,11 +497,13 @@ class IAConditionResult:
             self.phase_mean_rewards,
             dtype=np.dtype(np.float64),
         )
+        object.__setattr__(self, "phase_mean_rewards", phase_means)
         recoveries = _require_ndarray(
             "recovery_lengths",
             self.recovery_lengths,
             dtype=np.dtype(np.int64),
         )
+        object.__setattr__(self, "recovery_lengths", recoveries)
         arrays = (rewards, *action_arrays, accepted, phase_means, recoveries)
         if sum(array.nbytes for array in arrays) > _MAX_CONDITION_RESULT_BYTES:
             raise ValueError("condition result arrays exceed the bounded record budget")
@@ -562,10 +570,21 @@ class IAConditionResult:
             raise ValueError("recommendation conditions must contain concrete actions")
         if type(self.controller_budget) is not ControllerBudget:
             raise ValueError("controller_budget must be a ControllerBudget")
-        if self.controller_budget.interaction_steps != steps:
+        controller_budget = ControllerBudget(
+            **{
+                field.name: getattr(self.controller_budget, field.name)
+                for field in fields(ControllerBudget)
+            }
+        )
+        object.__setattr__(self, "controller_budget", controller_budget)
+        if controller_budget.interaction_steps != steps:
             raise ValueError("controller budget interaction_steps must match result length")
         if type(self.timing) is not ConditionTiming:
             raise ValueError("timing must be a ConditionTiming")
+        timing = ConditionTiming(
+            **{field.name: getattr(self.timing, field.name) for field in fields(ConditionTiming)}
+        )
+        object.__setattr__(self, "timing", timing)
 
 
 @dataclass(frozen=True)
@@ -1299,8 +1318,30 @@ def aggregate_ia_evidence(
 ) -> IAAggregateEvidence:
     """Aggregate paired conditions without dropping seeds or failed recoveries."""
 
+    if type(config) is not ContinualIAConfig:
+        raise ValueError("config must be a ContinualIAConfig")
+    config = ContinualIAConfig(
+        **{field.name: getattr(config, field.name) for field in fields(ContinualIAConfig)}
+    )
     if not results:
         raise ValueError("results must be non-empty")
+    validated: list[IAConditionResult] = []
+    for result in results:
+        if type(result) is not IAConditionResult:
+            raise ValueError("results must contain exact IAConditionResult records")
+        result = IAConditionResult(
+            **{field.name: getattr(result, field.name) for field in fields(IAConditionResult)}
+        )
+        if result.rewards.size != config.num_steps:
+            raise ValueError("result length does not match config.num_steps")
+        expected_phase_means = _phase_means(result.rewards, config)
+        if not np.array_equal(result.phase_mean_rewards, expected_phase_means):
+            raise ValueError("phase_mean_rewards do not match rewards and config")
+        expected_recoveries = _recovery_lengths(result.rewards, config)
+        if not np.array_equal(result.recovery_lengths, expected_recoveries):
+            raise ValueError("recovery_lengths do not match rewards and config")
+        validated.append(result)
+    results = tuple(validated)
     groups = {condition: _condition_group(results, condition) for condition in CONDITION_NAMES}
     seed_sets = {
         condition: tuple(result.seed for result in group) for condition, group in groups.items()

--- a/tests/test_ia_condition_result_hostile.py
+++ b/tests/test_ia_condition_result_hostile.py
@@ -8,8 +8,10 @@ import pytest
 from alberta_framework.evaluation.continual_ia import (
     CONDITION_NAMES,
     ConditionTiming,
+    ContinualIAConfig,
     ControllerBudget,
     IAConditionResult,
+    aggregate_ia_evidence,
 )
 
 
@@ -137,3 +139,47 @@ def test_ia_condition_result_rejects_hostile_array_subclasses_without_hooks() ->
     with pytest.raises(ValueError, match="rewards must be an exact numpy.ndarray"):
         _legal(rewards=hostile)
     assert HostileArray.calls == 0
+
+
+def test_ia_condition_result_owns_read_only_array_snapshots() -> None:
+    rewards = np.zeros(2, dtype=np.float64)
+    result = _legal(rewards=rewards)
+
+    rewards[0] = 1.0
+
+    np.testing.assert_array_equal(result.rewards, np.zeros(2, dtype=np.float64))
+    assert not result.rewards.flags.writeable
+    with pytest.raises(ValueError, match="read-only"):
+        result.rewards[0] = 1.0
+
+
+def test_ia_condition_result_rejects_nested_subclasses() -> None:
+    class BudgetSubclass(ControllerBudget):
+        pass
+
+    class TimingSubclass(ConditionTiming):
+        pass
+
+    with pytest.raises(ValueError, match="controller_budget must be"):
+        _legal(controller_budget=BudgetSubclass(**vars(_budget())))
+    with pytest.raises(ValueError, match="timing must be"):
+        _legal(timing=TimingSubclass(**vars(_timing())))
+
+
+def test_ia_aggregation_revalidates_records_at_consumption() -> None:
+    result = _legal()
+    object.__setattr__(result, "mean_reward", 1.0)
+
+    with pytest.raises(ValueError, match="mean_reward does not match"):
+        aggregate_ia_evidence(
+            [result],
+            config=ContinualIAConfig(num_steps=2, phase_length=2, recovery_window=1),
+        )
+
+
+def test_ia_aggregation_revalidates_config_at_consumption() -> None:
+    config = ContinualIAConfig(num_steps=2, phase_length=2, recovery_window=1)
+    object.__setattr__(config, "phase_length", 0)
+
+    with pytest.raises(ValueError, match="phase_length must be an integer"):
+        aggregate_ia_evidence([_legal()], config=config)


### PR DESCRIPTION
Follow-up to the constructor contract consolidated in #1681 (superseding #1667).

- owns read-only copies of every IA result array
- reconstructs nested budget/timing values rather than retaining mutable aliases
- reconstructs the exact config at aggregation so forged frozen configs cannot bypass invariants
- revalidates exact records at the public aggregation boundary
- derives phase means and recovery lengths from primitive rewards plus the supplied config
- covers external mutation, nested subclasses, forged configs, and post-construction mutation through production calls

Validation on current main:
- 34 focused IA tests passed
- 11 hostile result/config tests passed after final rebase
- Ruff passed
- strict mypy passed (188 source files)
- diff check and main-ancestry check passed

No benchmark or evidence artifact was changed or produced. This is validation hardening only.