### PR TITLE
fix(utils): reject leftover experiment measurement-record identities

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -14,8 +14,11 @@ Two conventions matter for downstream analysis:
   :func:`aggregate_metrics`.
 """
 
+from __future__ import annotations
+
 import math
 from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, replace
 from decimal import Decimal
 from fractions import Fraction
 from typing import Any, NamedTuple, NoReturn, cast
@@ -33,6 +36,8 @@ from alberta_framework.core.learners import (
 from alberta_framework.core.types import LearnerState
 from alberta_framework.streams.base import ScanStream
 from alberta_framework.utils.statistics import common_final_window
+
+_INT32_MAX = 2**31 - 1
 
 _NUMPY_COORDINATE_TYPES = frozenset(
     np.dtype(dtype_code).type
@@ -67,6 +72,24 @@ def _require_exact_str(name: str, value: object) -> str:
     return value
 
 
+def _require_positive_int(name: str, value: object) -> int:
+    if type(value) is not int or value < 1 or value > _INT32_MAX:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _require_callable(name: str, value: object) -> Callable[..., object]:
+    if not callable(value):
+        raise ValueError(f"{name} must be callable")
+    return value
+
+
+def _require_metrics_history(value: object) -> list[dict[str, float]]:
+    if type(value) is not list:
+        raise ValueError("metrics_history must be an exact list")
+    return value  # type: ignore[return-value]
+
+
 def _type_identity_in(
     value_type: type[object],
     candidates: Iterable[type[object]],
@@ -84,7 +107,7 @@ class _CanonicalFractionCoordinate(tuple[int, int]):
         cls,
         numerator: int,
         denominator: int,
-    ) -> "_CanonicalFractionCoordinate":
+    ) -> _CanonicalFractionCoordinate:
         if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
             raise ValueError("canonical Fraction coordinates require builtin integer components")
         normalized = Fraction(numerator, denominator)
@@ -143,7 +166,8 @@ _BYTES_COORDINATE_TYPES = (bytes, np.bytes_)
 _MAX_HYPERPARAMETER_COORDINATE_NESTING = 32
 
 
-class ExperimentConfig(NamedTuple):
+@dataclass(frozen=True)
+class ExperimentConfig:
     """Configuration for a single experiment.
 
     Attributes:
@@ -158,8 +182,24 @@ class ExperimentConfig(NamedTuple):
     stream_factory: Callable[[], ScanStream[Any]]
     num_steps: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", _require_exact_str("name", self.name))
+        object.__setattr__(
+            self, "learner_factory", _require_callable("learner_factory", self.learner_factory)
+        )
+        object.__setattr__(
+            self, "stream_factory", _require_callable("stream_factory", self.stream_factory)
+        )
+        object.__setattr__(
+            self, "num_steps", _require_positive_int("num_steps", self.num_steps)
+        )
 
-class SingleRunResult(NamedTuple):
+    def _replace(self, **changes: object) -> ExperimentConfig:
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class SingleRunResult:
     """Result from a single experiment run.
 
     Attributes:
@@ -173,6 +213,20 @@ class SingleRunResult(NamedTuple):
     seed: int
     metrics_history: list[dict[str, float]]
     final_state: LearnerState
+
+    def __post_init__(self) -> None:
+        if type(self.final_state) is not LearnerState:
+            raise TypeError("final_state must be an exact LearnerState")
+        object.__setattr__(
+            self, "config_name", _require_exact_str("config_name", self.config_name)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(
+            self, "metrics_history", _require_metrics_history(self.metrics_history)
+        )
+
+    def _replace(self, **changes: object) -> SingleRunResult:
+        return replace(self, **changes)
 
 
 class MetricSummary(NamedTuple):

--- a/tests/test_experiments_hostile_validation.py
+++ b/tests/test_experiments_hostile_validation.py
@@ -2,12 +2,13 @@
 
 import pytest
 
+from alberta_framework.core.learners import LinearLearner
 from alberta_framework.utils.experiments import (
     ExperimentConfig,
+    SingleRunResult,
     _require_coordinate_hash,
     _require_finite_metric_array,
     _require_hyperparameter_coordinate,
-    run_multi_seed_experiment,
 )
 
 
@@ -101,9 +102,59 @@ def test_multi_seed_rejects_hostile_config_name_before_hash_or_factories() -> No
     def fail_factory():
         raise AssertionError("factory must not run")
 
-    config = ExperimentConfig(evil, fail_factory, fail_factory, 1)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="must be an exact string"):
-        run_multi_seed_experiment(
-            [config], seeds=[0], parallel=False, show_progress=False
-        )
+        ExperimentConfig(evil, fail_factory, fail_factory, 1)  # type: ignore[arg-type]
     assert _EvilStr.calls == 0
+
+
+def _legal_config(**overrides: object) -> ExperimentConfig:
+    def _learner() -> LinearLearner:
+        return LinearLearner()
+
+    payload: dict[str, object] = {
+        "name": "fixture",
+        "learner_factory": _learner,
+        "stream_factory": _learner,
+        "num_steps": 2,
+    }
+    payload.update(overrides)
+    return ExperimentConfig(**payload)  # type: ignore[arg-type]
+
+
+def _legal_run(**overrides: object) -> SingleRunResult:
+    payload: dict[str, object] = {
+        "config_name": "fixture",
+        "seed": 0,
+        "metrics_history": [{"squared_error": 0.1}],
+        "final_state": LinearLearner().init(2),
+    }
+    payload.update(overrides)
+    return SingleRunResult(**payload)  # type: ignore[arg-type]
+
+
+def test_experiment_records_accept_canonical_identities() -> None:
+    config = _legal_config()
+    run = _legal_run()
+    assert config.num_steps == 2
+    assert run.seed == 0
+    assert run.config_name == "fixture"
+
+
+def test_experiment_records_reject_leftover_integer_identities() -> None:
+    with pytest.raises(ValueError, match="num_steps must be a positive integer"):
+        _legal_config(num_steps=True)
+    with pytest.raises(ValueError, match="seed"):
+        _legal_run(seed=True)
+
+
+def test_experiment_records_reject_leftover_name_and_host_identities() -> None:
+    with pytest.raises(ValueError, match="name must be an exact string"):
+        _legal_config(name=True)
+    with pytest.raises(ValueError, match="config_name must be an exact string"):
+        _legal_run(config_name=True)
+    with pytest.raises(TypeError, match="final_state must be an exact LearnerState"):
+        _legal_run(final_state=None)
+    with pytest.raises(ValueError, match="learner_factory must be callable"):
+        _legal_config(learner_factory=None)
+    with pytest.raises(ValueError, match="metrics_history must be an exact list"):
+        _legal_run(metrics_history={"squared_error": 0.1})


### PR DESCRIPTION
Closes #1705.

## What changed

`ExperimentConfig` and `SingleRunResult` now fail-close leftover bool step/seed identities, leftover names, non-callable factories, and non-`LearnerState` hosts — the same leftover-identity bar ss251 `#1107` already applied to `ContinualLearningSummary`.

On `origin/main` `7b714694`, `ExperimentConfig(num_steps=True)` and `SingleRunResult(seed=True)` constructed. `num_steps=True` reached `run_learning_loop`. Legal positive integers and JAX seeds stay legal.

`MetricSummary` / `AggregatedResults` stay NamedTuples so export hostile fixtures can still construct leftover/nonfinite summaries.

No unpublished grok head on this file. Occupancy-free. Not leftover-tax.

## Scope

- `alberta_framework/utils/experiments.py`
- `tests/test_experiments_hostile_validation.py`

## Occupancy

Open ASI PRs at publish: ss251 `#1695` (`step3.py`); Shaw `#1702` (`ipmnist_gradual.py`), `#1700` (`l2er_matched_development.py`). No open PR on `experiments.py`. `#1685`/`#1672` left uncommented if still open.

## Verification

- Red on base: `ExperimentConfig(num_steps=True)` and `SingleRunResult(seed=True)` constructed
- Hostile + experiment/export/statistics tests: 553 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary leftover-identity validation only. No kernel math, lifetime clocks, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:94e9a0f8c6b8755bde5200f09f9810bd3554f643 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
