### PR TITLE
fix(step3): bind smoke result cross-identities

### DIFF
--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -47,6 +47,7 @@ from alberta_framework.steps._float32_validation import (
     canonical_float32_storage,
     finite_real_and_float32,
 )
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 Step3NormalizerName = Literal["none", "ema"]
 Step3TraceModeName = Literal["accumulating", "replacing"]
@@ -330,6 +331,32 @@ class Step3SmokeResult:
     finite: bool
     handoff: Step3HandoffArrays
     horde_config: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        if type(self.config) is not Step3HordeConfig:
+            raise TypeError("config must be an exact Step3HordeConfig")
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(
+            self,
+            "final_window_mse",
+            _require_nonnegative_real("final_window_mse", self.final_window_mse),
+        )
+        for name in ("per_demon_metrics_shape", "td_errors_shape"):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
+        if type(self.handoff) is not Step3HandoffArrays:
+            raise TypeError("handoff must be an exact Step3HandoffArrays")
+        if type(self.horde_config) is not dict or any(
+            type(key) is not str for key in self.horde_config
+        ):
+            raise ValueError("horde_config must be an exact dict with exact string keys")
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -14,6 +14,7 @@ Research-scale evidence and open boundaries for Step 3 are tracked in
 
 from __future__ import annotations
 
+import math
 import operator
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass, fields
@@ -84,6 +85,54 @@ _STEP3_CONFIG_FIELDS = frozenset(
         "routing",
     }
 )
+_MAX_SMOKE_CONFIG_NODES = 4096
+_MAX_SMOKE_CONFIG_TEXT_BYTES = 64 * 1024
+
+
+def _bounded_json_clone(value: object, *, path: str, budget: list[int]) -> Any:
+    """Copy one bounded exact JSON tree without invoking user hooks."""
+    budget[0] += 1
+    if budget[0] > _MAX_SMOKE_CONFIG_NODES:
+        raise ValueError(f"{path} exceeds the smoke config node limit")
+    if value is None or type(value) is bool:
+        return value
+    if type(value) is int:
+        if abs(value).bit_length() > 63:
+            raise ValueError(f"{path} integer must fit signed 64-bit magnitude")
+        return value
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ValueError(f"{path} number must be finite")
+        return value
+    if type(value) is str:
+        if (
+            len(value) > _MAX_SMOKE_CONFIG_TEXT_BYTES
+            or len(value.encode("utf-8")) > _MAX_SMOKE_CONFIG_TEXT_BYTES
+        ):
+            raise ValueError(f"{path} text exceeds the smoke config byte limit")
+        return value
+    if type(value) is list:
+        if len(value) > _MAX_SMOKE_CONFIG_NODES - budget[0]:
+            raise ValueError(f"{path} exceeds the smoke config node limit")
+        return [
+            _bounded_json_clone(item, path=f"{path}[{index}]", budget=budget)
+            for index, item in enumerate(value)
+        ]
+    if type(value) is dict:
+        if len(value) > _MAX_SMOKE_CONFIG_NODES - budget[0]:
+            raise ValueError(f"{path} exceeds the smoke config node limit")
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            if type(key) is not str:
+                raise ValueError(f"{path} keys must be exact strings")
+            cloned_key = _bounded_json_clone(key, path=f"{path} key", budget=budget)
+            result[cloned_key] = _bounded_json_clone(
+                item,
+                path=f"{path}.{key}",
+                budget=budget,
+            )
+        return result
+    raise ValueError(f"{path} must contain only exact JSON values")
 
 
 def _require_exact_str(name: str, value: object) -> str:
@@ -353,10 +402,25 @@ class Step3SmokeResult:
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
         if type(self.handoff) is not Step3HandoffArrays:
             raise TypeError("handoff must be an exact Step3HandoffArrays")
-        if type(self.horde_config) is not dict or any(
-            type(key) is not str for key in self.horde_config
-        ):
+        if self.handoff.observations.shape[0] != self.steps:
+            raise ValueError("handoff rows must match steps")
+        if self.handoff.n_demons != self.config.n_demons:
+            raise ValueError("handoff demons must match config")
+        if self.per_demon_metrics_shape != (self.steps, self.config.n_demons, 3):
+            raise ValueError("per_demon_metrics_shape must match steps and config demons")
+        if self.td_errors_shape != (self.steps, self.config.n_demons):
+            raise ValueError("td_errors_shape must match steps and config demons")
+        if type(self.horde_config) is not dict:
             raise ValueError("horde_config must be an exact dict with exact string keys")
+        horde_config = _bounded_json_clone(
+            self.horde_config,
+            path="horde_config",
+            budget=[0],
+        )
+        expected_horde_config = make_step3_horde(self.config).to_config()
+        if horde_config != expected_horde_config:
+            raise ValueError("horde_config must match the exact Step3HordeConfig projection")
+        object.__setattr__(self, "horde_config", horde_config)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/tests/test_step3_smoke_result_hostile.py
+++ b/tests/test_step3_smoke_result_hostile.py
@@ -1,0 +1,77 @@
+"""Complete Step3SmokeResult identity contract: leftover, types, and shapes."""
+
+from __future__ import annotations
+
+import json
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.steps.step3 import (
+    Step3HandoffArrays,
+    Step3HordeConfig,
+    Step3SmokeResult,
+)
+
+
+def _handoff() -> Step3HandoffArrays:
+    return Step3HandoffArrays(
+        jnp.ones((8, 3), dtype=jnp.float32),
+        jnp.ones((8, 1), dtype=jnp.float32),
+        jnp.ones((8, 3), dtype=jnp.float32),
+    )
+
+
+def _legal(**overrides: object) -> Step3SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step3HordeConfig(),
+        "steps": 8,
+        "seed": 0,
+        "final_window_mse": 0.1,
+        "per_demon_metrics_shape": (8, 3, 1),
+        "td_errors_shape": (8, 3),
+        "finite": True,
+        "handoff": _handoff(),
+        "horde_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step3SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step3_smoke_result_accepts_canonical_identity() -> None:
+    result = _legal()
+    assert result.steps == 8
+    assert result.seed == 0
+    assert result.finite is True
+    assert result.per_demon_metrics_shape == (8, 3, 1)
+    dumped = json.dumps(
+        {"steps": result.steps, "seed": result.seed, "finite": result.finite},
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+
+
+def test_step3_smoke_result_rejects_leftover_integer_and_bool_identities() -> None:
+    with pytest.raises(ValueError, match="steps must be an integer"):
+        _legal(steps=True)
+    with pytest.raises(ValueError, match="seed"):
+        _legal(seed=True)
+    with pytest.raises(ValueError, match="finite must be a boolean"):
+        _legal(finite=1)
+
+
+def test_step3_smoke_result_rejects_leftover_float_and_host_identities() -> None:
+    with pytest.raises(ValueError, match="final_window_mse"):
+        _legal(final_window_mse=True)
+    with pytest.raises(TypeError, match="config must be an exact Step3HordeConfig"):
+        _legal(config=None)
+    with pytest.raises(TypeError, match="handoff must be an exact Step3HandoffArrays"):
+        _legal(handoff=None)
+    with pytest.raises(ValueError, match="horde_config must be an exact dict"):
+        _legal(horde_config=True)
+    with pytest.raises(ValueError, match="per_demon_metrics_shape"):
+        _legal(per_demon_metrics_shape=[8, 3, 1])
+    with pytest.raises(ValueError, match="td_errors_shape"):
+        _legal(td_errors_shape=(7, 3))

--- a/tests/test_step3_smoke_result_hostile.py
+++ b/tests/test_step3_smoke_result_hostile.py
@@ -11,13 +11,14 @@ from alberta_framework.steps.step3 import (
     Step3HandoffArrays,
     Step3HordeConfig,
     Step3SmokeResult,
+    make_step3_horde,
 )
 
 
 def _handoff() -> Step3HandoffArrays:
     return Step3HandoffArrays(
         jnp.ones((8, 3), dtype=jnp.float32),
-        jnp.ones((8, 1), dtype=jnp.float32),
+        jnp.ones((8, 3), dtype=jnp.float32),
         jnp.ones((8, 3), dtype=jnp.float32),
     )
 
@@ -28,11 +29,11 @@ def _legal(**overrides: object) -> Step3SmokeResult:
         "steps": 8,
         "seed": 0,
         "final_window_mse": 0.1,
-        "per_demon_metrics_shape": (8, 3, 1),
+        "per_demon_metrics_shape": (8, 3, 3),
         "td_errors_shape": (8, 3),
         "finite": True,
         "handoff": _handoff(),
-        "horde_config": {"ok": True},
+        "horde_config": make_step3_horde(Step3HordeConfig()).to_config(),
     }
     payload.update(overrides)
     return Step3SmokeResult(**payload)  # type: ignore[arg-type]
@@ -43,7 +44,7 @@ def test_step3_smoke_result_accepts_canonical_identity() -> None:
     assert result.steps == 8
     assert result.seed == 0
     assert result.finite is True
-    assert result.per_demon_metrics_shape == (8, 3, 1)
+    assert result.per_demon_metrics_shape == (8, 3, 3)
     dumped = json.dumps(
         {"steps": result.steps, "seed": result.seed, "finite": result.finite},
         allow_nan=False,
@@ -75,3 +76,29 @@ def test_step3_smoke_result_rejects_leftover_float_and_host_identities() -> None
         _legal(per_demon_metrics_shape=[8, 3, 1])
     with pytest.raises(ValueError, match="td_errors_shape"):
         _legal(td_errors_shape=(7, 3))
+
+
+def test_step3_smoke_result_binds_cross_field_shapes_and_config() -> None:
+    with pytest.raises(ValueError, match="handoff rows must match steps"):
+        _legal(steps=7, per_demon_metrics_shape=(7, 3, 3), td_errors_shape=(7, 3))
+    with pytest.raises(ValueError, match="handoff demons must match config"):
+        _legal(config=Step3HordeConfig(gammas=(0.0,), lamdas=(0.0,)))
+    with pytest.raises(ValueError, match="per_demon_metrics_shape must match"):
+        _legal(per_demon_metrics_shape=(8, 3, 2))
+    with pytest.raises(ValueError, match="td_errors_shape must match"):
+        _legal(td_errors_shape=(8, 3, 1))
+    hostile = make_step3_horde(Step3HordeConfig()).to_config()
+    hostile["type"] = "IndependentDemonHorde"
+    with pytest.raises(ValueError, match="must match the exact"):
+        _legal(horde_config=hostile)
+
+
+def test_step3_smoke_result_owns_bounded_horde_config_snapshot() -> None:
+    config = make_step3_horde(Step3HordeConfig()).to_config()
+    result = _legal(horde_config=config)
+    config["type"] = "forged"
+    assert result.horde_config["type"] == "HordeLearner"
+    with pytest.raises(ValueError, match="must contain only exact JSON values"):
+        _legal(horde_config={"type": object()})
+    with pytest.raises(ValueError, match="node limit"):
+        _legal(horde_config={f"key-{index}": None for index in range(4096)})


### PR DESCRIPTION
Supersedes #1695 while preserving ss251's original commit and authorship.

Closes #1694.

The contributor commit closes the scalar and container host gaps. The current-main deep audit adds the adjacent record invariants:

- exact metric shapes `(steps, n_demons, 3)` and `(steps, n_demons)`
- exact handoff row/demon binding to `steps` and `Step3HordeConfig`
- bounded, exact-JSON, hook-free deep snapshot of `horde_config`
- exact equality between that snapshot and the configured Horde projection
- immutable ownership of the nested configuration rather than a mutable caller alias

Validation on current main:
- 231 Step 3 production, pipeline, and hostile tests passed
- scoped Ruff clean
- strict mypy clean
- diff check clean

No benchmark execution and no outputs mutation.
