### PR TITLE
fix(step3): complete Step3 smoke result contract

### DIFF
--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -86,6 +86,32 @@ _STEP3_CONFIG_FIELDS = frozenset(
 )
 
 
+def _exact_builtin_tree_equal(observed: object, expected: object) -> bool:
+    """Compare one JSON-like tree without invoking hooks on foreign types."""
+
+    if type(observed) is not type(expected):
+        return False
+    if type(expected) is dict:
+        observed_dict = cast(dict[object, object], observed)
+        expected_dict = cast(dict[object, object], expected)
+        if any(type(key) is not str for key in observed_dict):
+            return False
+        if set(observed_dict) != set(expected_dict):
+            return False
+        return all(
+            _exact_builtin_tree_equal(observed_dict[key], value)
+            for key, value in expected_dict.items()
+        )
+    if type(expected) is list:
+        observed_list = cast(list[object], observed)
+        expected_list = cast(list[object], expected)
+        return len(observed_list) == len(expected_list) and all(
+            _exact_builtin_tree_equal(left, right)
+            for left, right in zip(observed_list, expected_list, strict=True)
+        )
+    return observed == expected
+
+
 def _require_exact_str(name: str, value: object) -> str:
     if type(value) is not str:
         raise ValueError(f"{name} must be an exact string")
@@ -353,10 +379,22 @@ class Step3SmokeResult:
         object.__setattr__(self, "finite", _require_bool("finite", self.finite))
         if type(self.handoff) is not Step3HandoffArrays:
             raise TypeError("handoff must be an exact Step3HandoffArrays")
+        if self.handoff.observations.shape[0] != self.steps:
+            raise ValueError("handoff row count must equal steps")
+        if self.handoff.n_demons != self.config.n_demons:
+            raise ValueError("handoff demon count must equal config.n_demons")
+        expected_metrics_shape = (self.steps, self.config.n_demons, 3)
+        if self.per_demon_metrics_shape != expected_metrics_shape:
+            raise ValueError("per_demon_metrics_shape does not match the smoke contract")
+        if self.td_errors_shape != (self.steps, self.config.n_demons):
+            raise ValueError("td_errors_shape does not match the smoke contract")
         if type(self.horde_config) is not dict or any(
             type(key) is not str for key in self.horde_config
         ):
             raise ValueError("horde_config must be an exact dict with exact string keys")
+        expected_horde_config = make_step3_horde(self.config).to_config()
+        if not _exact_builtin_tree_equal(self.horde_config, expected_horde_config):
+            raise ValueError("horde_config does not match config and routing")
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -47,6 +47,7 @@ from alberta_framework.steps._float32_validation import (
     canonical_float32_storage,
     finite_real_and_float32,
 )
+from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 Step3NormalizerName = Literal["none", "ema"]
 Step3TraceModeName = Literal["accumulating", "replacing"]
@@ -330,6 +331,32 @@ class Step3SmokeResult:
     finite: bool
     handoff: Step3HandoffArrays
     horde_config: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        if type(self.config) is not Step3HordeConfig:
+            raise TypeError("config must be an exact Step3HordeConfig")
+        object.__setattr__(
+            self, "steps", _require_int("steps", self.steps, minimum=1, maximum=_INT32_MAX)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(
+            self,
+            "final_window_mse",
+            _require_nonnegative_real("final_window_mse", self.final_window_mse),
+        )
+        for name in ("per_demon_metrics_shape", "td_errors_shape"):
+            object.__setattr__(
+                self,
+                name,
+                require_step_shape(name, getattr(self, name), steps=self.steps),
+            )
+        object.__setattr__(self, "finite", _require_bool("finite", self.finite))
+        if type(self.handoff) is not Step3HandoffArrays:
+            raise TypeError("handoff must be an exact Step3HandoffArrays")
+        if type(self.horde_config) is not dict or any(
+            type(key) is not str for key in self.horde_config
+        ):
+            raise ValueError("horde_config must be an exact dict with exact string keys")
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""

--- a/tests/test_step3_smoke_result_hostile.py
+++ b/tests/test_step3_smoke_result_hostile.py
@@ -1,0 +1,77 @@
+"""Complete Step3SmokeResult identity contract: leftover, types, and shapes."""
+
+from __future__ import annotations
+
+import json
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.steps.step3 import (
+    Step3HandoffArrays,
+    Step3HordeConfig,
+    Step3SmokeResult,
+)
+
+
+def _handoff() -> Step3HandoffArrays:
+    return Step3HandoffArrays(
+        jnp.ones((8, 3), dtype=jnp.float32),
+        jnp.ones((8, 1), dtype=jnp.float32),
+        jnp.ones((8, 3), dtype=jnp.float32),
+    )
+
+
+def _legal(**overrides: object) -> Step3SmokeResult:
+    payload: dict[str, object] = {
+        "config": Step3HordeConfig(),
+        "steps": 8,
+        "seed": 0,
+        "final_window_mse": 0.1,
+        "per_demon_metrics_shape": (8, 3, 1),
+        "td_errors_shape": (8, 3),
+        "finite": True,
+        "handoff": _handoff(),
+        "horde_config": {"ok": True},
+    }
+    payload.update(overrides)
+    return Step3SmokeResult(**payload)  # type: ignore[arg-type]
+
+
+def test_step3_smoke_result_accepts_canonical_identity() -> None:
+    result = _legal()
+    assert result.steps == 8
+    assert result.seed == 0
+    assert result.finite is True
+    assert result.per_demon_metrics_shape == (8, 3, 1)
+    dumped = json.dumps(
+        {"steps": result.steps, "seed": result.seed, "finite": result.finite},
+        allow_nan=False,
+    )
+    assert '"steps": 8' in dumped
+    assert '"seed": 0' in dumped
+    assert '"finite": true' in dumped
+
+
+def test_step3_smoke_result_rejects_leftover_integer_and_bool_identities() -> None:
+    with pytest.raises(ValueError, match="steps must be an integer"):
+        _legal(steps=True)
+    with pytest.raises(ValueError, match="seed"):
+        _legal(seed=True)
+    with pytest.raises(ValueError, match="finite must be a boolean"):
+        _legal(finite=1)
+
+
+def test_step3_smoke_result_rejects_leftover_float_and_host_identities() -> None:
+    with pytest.raises(ValueError, match="final_window_mse"):
+        _legal(final_window_mse=True)
+    with pytest.raises(TypeError, match="config must be an exact Step3HordeConfig"):
+        _legal(config=None)
+    with pytest.raises(TypeError, match="handoff must be an exact Step3HandoffArrays"):
+        _legal(handoff=None)
+    with pytest.raises(ValueError, match="horde_config must be an exact dict"):
+        _legal(horde_config=True)
+    with pytest.raises(ValueError, match="per_demon_metrics_shape"):
+        _legal(per_demon_metrics_shape=[8, 3, 1])
+    with pytest.raises(ValueError, match="td_errors_shape"):
+        _legal(td_errors_shape=(7, 3))

--- a/tests/test_step3_smoke_result_hostile.py
+++ b/tests/test_step3_smoke_result_hostile.py
@@ -11,13 +11,15 @@ from alberta_framework.steps.step3 import (
     Step3HandoffArrays,
     Step3HordeConfig,
     Step3SmokeResult,
+    make_step3_horde,
+    run_step3_smoke,
 )
 
 
 def _handoff() -> Step3HandoffArrays:
     return Step3HandoffArrays(
         jnp.ones((8, 3), dtype=jnp.float32),
-        jnp.ones((8, 1), dtype=jnp.float32),
+        jnp.ones((8, 3), dtype=jnp.float32),
         jnp.ones((8, 3), dtype=jnp.float32),
     )
 
@@ -28,11 +30,11 @@ def _legal(**overrides: object) -> Step3SmokeResult:
         "steps": 8,
         "seed": 0,
         "final_window_mse": 0.1,
-        "per_demon_metrics_shape": (8, 3, 1),
+        "per_demon_metrics_shape": (8, 3, 3),
         "td_errors_shape": (8, 3),
         "finite": True,
         "handoff": _handoff(),
-        "horde_config": {"ok": True},
+        "horde_config": make_step3_horde(Step3HordeConfig()).to_config(),
     }
     payload.update(overrides)
     return Step3SmokeResult(**payload)  # type: ignore[arg-type]
@@ -43,7 +45,7 @@ def test_step3_smoke_result_accepts_canonical_identity() -> None:
     assert result.steps == 8
     assert result.seed == 0
     assert result.finite is True
-    assert result.per_demon_metrics_shape == (8, 3, 1)
+    assert result.per_demon_metrics_shape == (8, 3, 3)
     dumped = json.dumps(
         {"steps": result.steps, "seed": result.seed, "finite": result.finite},
         allow_nan=False,
@@ -51,6 +53,19 @@ def test_step3_smoke_result_accepts_canonical_identity() -> None:
     assert '"steps": 8' in dumped
     assert '"seed": 0' in dumped
     assert '"finite": true' in dumped
+
+
+def test_step3_smoke_binds_real_shapes_handoff_and_serialized_config() -> None:
+    config = Step3HordeConfig(gammas=(0.0, 0.5), lamdas=(0.0, 0.5))
+    result = run_step3_smoke(config, steps=8, final_window=4, seed=3)
+    payload = result.to_dict()
+
+    assert result.per_demon_metrics_shape == (8, 2, 3)
+    assert result.td_errors_shape == (8, 2)
+    assert result.handoff.observations.shape[0] == result.steps
+    assert result.handoff.n_demons == result.config.n_demons
+    assert payload["horde_config"] == make_step3_horde(config).to_config()
+    json.dumps(payload, allow_nan=False)
 
 
 def test_step3_smoke_result_rejects_leftover_integer_and_bool_identities() -> None:
@@ -75,3 +90,30 @@ def test_step3_smoke_result_rejects_leftover_float_and_host_identities() -> None
         _legal(per_demon_metrics_shape=[8, 3, 1])
     with pytest.raises(ValueError, match="td_errors_shape"):
         _legal(td_errors_shape=(7, 3))
+
+
+def test_step3_smoke_result_rejects_cross_field_mismatches() -> None:
+    with pytest.raises(ValueError, match="per_demon_metrics_shape"):
+        _legal(per_demon_metrics_shape=(8, 2, 3))
+    with pytest.raises(ValueError, match="td_errors_shape"):
+        _legal(td_errors_shape=(8, 2))
+    with pytest.raises(ValueError, match="handoff row count"):
+        _legal(
+            handoff=Step3HandoffArrays(
+                jnp.ones((7, 3), dtype=jnp.float32),
+                jnp.ones((7, 3), dtype=jnp.float32),
+                jnp.ones((7, 3), dtype=jnp.float32),
+            )
+        )
+    with pytest.raises(ValueError, match="handoff demon count"):
+        _legal(
+            handoff=Step3HandoffArrays(
+                jnp.ones((8, 3), dtype=jnp.float32),
+                jnp.ones((8, 2), dtype=jnp.float32),
+                jnp.ones((8, 3), dtype=jnp.float32),
+            )
+        )
+    forged_config = make_step3_horde(Step3HordeConfig()).to_config()
+    forged_config["type"] = "forged"
+    with pytest.raises(ValueError, match="horde_config does not match"):
+        _legal(horde_config=forged_config)


### PR DESCRIPTION
Preserves ss251 commit from #1695, then closes the cross-field gaps found in deep review. The result now binds exact metric ranks/demon axes, handoff rows/demons, and the complete routing-specific Horde config to the declared Step3HordeConfig using hook-safe builtin-tree comparison. Contributor fixtures are corrected to the real metric shape, and a real run_step3_smoke/serialization test covers the production path. No outputs or kernel math changed.\n\nVerification: 104 Step 3 production/boundary/hostile tests passed; Ruff clean; strict focused mypy clean; diff check clean.\n\nSupersedes #1695 and closes #1694.