### PR TITLE
fix(evaluation): recursively bind evidence spec identities

### DIFF
--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -41,7 +41,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from types import FunctionType
-from typing import Literal, NoReturn, Protocol
+from typing import Literal, NoReturn, Protocol, cast
 
 from alberta_framework.evaluation.continual_ia import (
     ContinualIAConfig,
@@ -333,6 +333,8 @@ _PATH_TYPE = type(Path())
 _MAX_SPEC_TEXT_BYTES = 64 * 1024
 _MAX_SPEC_SEQUENCE_ITEMS = 256
 _MAX_SPEC_MAPPING_ITEMS = 256
+_MAX_SPEC_NESTING_DEPTH = 64
+_MAX_SPEC_TOTAL_VALUES = 4096
 
 DIRTY_STATE_POLICY: Mapping[str, object] = {
     "policy_version": DIRTY_STATE_POLICY_VERSION,
@@ -382,10 +384,16 @@ def _require_exact_bool(name: str, value: object) -> bool:
 def _require_exact_path(name: str, value: object) -> Path:
     if type(value) is not _PATH_TYPE:
         raise ValueError(f"{name} must be an exact platform Path")
-    encoded = value.as_posix().encode("utf-8")
-    if not encoded or len(encoded) > _MAX_SPEC_TEXT_BYTES:
-        raise ValueError(f"{name} must be a bounded non-empty Path")
-    return value
+    path = value
+    encoded = path.as_posix().encode("utf-8")
+    if (
+        not path.parts
+        or path.is_absolute()
+        or any(part == ".." for part in path.parts)
+        or len(encoded) > _MAX_SPEC_TEXT_BYTES
+    ):
+        raise ValueError(f"{name} must be a non-empty repository-relative Path")
+    return path
 
 
 def _require_exact_str_tuple(name: str, value: object) -> tuple[str, ...]:
@@ -407,20 +415,80 @@ def _require_path_tuple(name: str, value: object) -> tuple[Path, ...]:
         or len(value) > _MAX_SPEC_SEQUENCE_ITEMS
     ):
         raise ValueError(f"{name} must be a non-empty tuple of Path values")
-    for item in value:
-        _require_exact_path(name, item)
-    return value
+    return tuple(
+        _require_exact_path(f"{name}[{index}]", item)
+        for index, item in enumerate(value)
+    )
+
+
+def _require_exact_json_value(
+    name: str,
+    value: object,
+    *,
+    ancestors: frozenset[int] = frozenset(),
+    depth: int = 0,
+    remaining: int = _MAX_SPEC_TOTAL_VALUES,
+) -> int:
+    if depth > _MAX_SPEC_NESTING_DEPTH:
+        raise ValueError(f"{name} exceeds the maximum nesting depth")
+    if remaining < 1:
+        raise ValueError(f"{name} exceeds the aggregate value limit")
+    remaining -= 1
+    value_type = type(value)
+    if value_type is dict:
+        identity = id(value)
+        if identity in ancestors:
+            raise ValueError(f"{name} must not contain a cycle")
+        mapping = cast(dict[object, object], value)
+        if len(mapping) > _MAX_SPEC_MAPPING_ITEMS:
+            raise ValueError(f"{name} exceeds the mapping item limit")
+        next_ancestors = ancestors | {identity}
+        for key, item in mapping.items():
+            _require_exact_text(f"{name} key", key)
+            remaining = _require_exact_json_value(
+                f"{name}.{key}",
+                item,
+                ancestors=next_ancestors,
+                depth=depth + 1,
+                remaining=remaining,
+            )
+        return remaining
+    if value_type is list:
+        identity = id(value)
+        if identity in ancestors:
+            raise ValueError(f"{name} must not contain a cycle")
+        items = cast(list[object], value)
+        if len(items) > _MAX_SPEC_SEQUENCE_ITEMS:
+            raise ValueError(f"{name} exceeds the sequence item limit")
+        next_ancestors = ancestors | {identity}
+        for index, item in enumerate(items):
+            remaining = _require_exact_json_value(
+                f"{name}[{index}]",
+                item,
+                ancestors=next_ancestors,
+                depth=depth + 1,
+                remaining=remaining,
+            )
+        return remaining
+    if value_type is str:
+        if len(cast(str, value).encode("utf-8")) > _MAX_SPEC_TEXT_BYTES:
+            raise ValueError(f"{name} exceeds {_MAX_SPEC_TEXT_BYTES} UTF-8 bytes")
+        return remaining
+    if value_type is int:
+        if cast(int, value).bit_length() > _MAX_SPEC_TEXT_BYTES * 4:
+            raise ValueError(f"{name} exceeds the integer size limit")
+        return remaining
+    if value_type is bool or value is None:
+        return remaining
+    if value_type is float and math.isfinite(cast(float, value)):
+        return remaining
+    raise ValueError(f"{name} must contain only finite exact JSON values")
 
 
 def _require_identity_mapping(name: str, value: object) -> dict[str, object]:
-    if (
-        type(value) is not dict
-        or not value
-        or len(value) > _MAX_SPEC_MAPPING_ITEMS
-    ):
+    if type(value) is not dict or not value:
         raise ValueError(f"{name} must be a non-empty dict with exact string keys")
-    for key in value:
-        _require_exact_text(f"{name} key", key)
+    _require_exact_json_value(name, value)
     return value
 
 
@@ -775,6 +843,26 @@ EVIDENCE_SPECS: tuple[EvidenceSpec, ...] = (
         validator=validate_ia_evidence_artifact,
     ),
 )
+
+
+def _validated_evidence_specs(value: object) -> tuple[EvidenceSpec, ...]:
+    """Validate the exact registry roster before any claim is inspected."""
+
+    if type(value) is not tuple or not value:
+        raise ValueError("EVIDENCE_SPECS must be a non-empty exact tuple")
+    if not all(type(spec) is EvidenceSpec for spec in value):
+        raise ValueError("EVIDENCE_SPECS must contain only exact EvidenceSpec values")
+    specs = cast(tuple[EvidenceSpec, ...], value)
+    names = tuple(spec.name for spec in specs)
+    if len(set(names)) != len(names):
+        raise ValueError("EVIDENCE_SPECS claim names must be unique")
+    paths = tuple(spec.relative_path for spec in specs)
+    if len(set(paths)) != len(paths):
+        raise ValueError("EVIDENCE_SPECS artifact paths must be unique")
+    return specs
+
+
+EVIDENCE_SPECS = _validated_evidence_specs(EVIDENCE_SPECS)
 
 
 def _artifact_digest(artifact: Mapping[str, object]) -> str | None:

--- a/tests/test_evidence_manifest.py
+++ b/tests/test_evidence_manifest.py
@@ -317,14 +317,14 @@ def test_registry_rejects_empty_duplicate_or_escaping_specs(
     with pytest.raises(ValueError, match="names must be unique"):
         build_evidence_manifest(tmp_path, specs=(duplicated, duplicated))
 
-    with pytest.raises(ValueError, match="remain under the repository root"):
+    with pytest.raises(ValueError, match="repository-relative Path"):
         replace(
             duplicated,
             name="escape_artifact",
             relative_path=Path("../outside.json"),
         )
 
-    with pytest.raises(ValueError, match="source_paths must remain"):
+    with pytest.raises(ValueError, match="repository-relative Path"):
         replace(
             duplicated,
             name="escape_source",

--- a/tests/test_evidence_spec_hostile.py
+++ b/tests/test_evidence_spec_hostile.py
@@ -3,24 +3,61 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
-from alberta_framework.evaluation.evidence_manifest import EVIDENCE_SPECS, EvidenceSpec
+from alberta_framework.evaluation.evidence_manifest import (
+    EVIDENCE_SPECS,
+    EvidenceSpec,
+    _validated_evidence_specs,
+)
 
 
 class StringSubclass(str):
     """Leftover string identity that must not cross the spec boundary."""
 
 
-class PathSubclass(type(Path())):
+class PathSubclass(type(Path())):  # type: ignore[misc]
     """Leftover concrete-path identity that must not cross the spec boundary."""
 
 
 class CallableObject:
     def __call__(self, _value: object) -> object:
         return _value
+
+
+class HostileList(list[object]):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        type(self).calls += 1
+        raise AssertionError("hostile list iteration ran")
+
+
+class HostileCallable:
+    calls = 0
+
+    def __call__(self, *_args: object, **_kwargs: object) -> object:
+        type(self).calls += 1
+        raise AssertionError("hostile callable ran")
+
+
+class HostilePath(type(Path())):  # type: ignore[misc]
+    calls = 0
+
+    def is_absolute(self) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile path method ran")
+
+
+class HostileTuple(tuple[object, ...]):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        type(self).calls += 1
+        raise AssertionError("hostile tuple iteration ran")
 
 
 def _load(_path: Path) -> dict[str, object]:
@@ -48,7 +85,7 @@ def _legal(**overrides: object) -> EvidenceSpec:
         "command_argv": ("python", "-m", "fixture"),
         "protocol": {"protocol_version": "test.protocol.v1"},
         "configuration": {"steps": 1},
-        "seeds": {"development": (0,)},
+        "seeds": {"development": [0]},
         "thresholds": {"minimum_effect": 0.25},
         "limitations": ("test fixture only",),
         "source_paths": (Path("fixture.py"),),
@@ -105,7 +142,7 @@ def test_evidence_spec_rejects_leftover_path_tuple_and_mapping_identities() -> N
         _legal(relative_path="fixture.json")
     with pytest.raises(ValueError, match="relative_path must be an exact platform Path"):
         _legal(relative_path=PathSubclass("fixture.json"))
-    with pytest.raises(ValueError, match="must remain under the repository root"):
+    with pytest.raises(ValueError, match="repository-relative Path"):
         _legal(relative_path=Path("../fixture.json"))
     with pytest.raises(ValueError, match="command_argv must be a non-empty tuple"):
         _legal(command_argv=["python"])
@@ -128,7 +165,80 @@ def test_evidence_spec_rejects_leftover_path_tuple_and_mapping_identities() -> N
 def test_evidence_spec_preflights_sequence_and_mapping_counts() -> None:
     with pytest.raises(ValueError, match="command_argv must be a non-empty tuple"):
         _legal(command_argv=("x",) * 257)
-    with pytest.raises(ValueError, match="protocol must be a non-empty dict"):
+    with pytest.raises(ValueError, match="protocol exceeds the mapping item limit"):
         _legal(protocol={f"key-{index}": index for index in range(257)})
     with pytest.raises(ValueError, match="exceeds 65536 UTF-8 bytes"):
         _legal(name="x" * 65_537)
+
+
+def test_evidence_spec_rejects_unsafe_and_hostile_paths_without_hooks() -> None:
+    hostile = HostilePath("fixture.json")
+    HostilePath.calls = 0
+    with pytest.raises(ValueError, match="relative_path must be an exact platform Path"):
+        _legal(relative_path=hostile)
+    with pytest.raises(ValueError, match=r"source_paths\[0\] must be an exact platform Path"):
+        _legal(source_paths=(hostile,))
+    assert HostilePath.calls == 0
+
+    for path in (Path("/tmp/fixture.json"), Path("../fixture.json"), Path(".")):
+        with pytest.raises(ValueError, match="repository-relative Path"):
+            _legal(relative_path=path)
+
+
+def test_evidence_spec_rejects_nested_non_json_identities_without_hooks() -> None:
+    hostile = HostileList([1])
+    HostileList.calls = 0
+    with pytest.raises(ValueError, match="finite exact JSON values"):
+        _legal(protocol={"nested": hostile})
+    assert HostileList.calls == 0
+
+    with pytest.raises(ValueError, match="finite exact JSON values"):
+        _legal(configuration={"nested": StringSubclass("value")})
+    with pytest.raises(ValueError, match="finite exact JSON values"):
+        _legal(thresholds={"value": float("nan")})
+
+    cyclic: dict[str, object] = {}
+    cyclic["self"] = cyclic
+    with pytest.raises(ValueError, match="must not contain a cycle"):
+        _legal(protocol=cyclic)
+
+
+def test_evidence_spec_rejects_callable_objects_without_calling_them() -> None:
+    hostile = HostileCallable()
+    HostileCallable.calls = 0
+    with pytest.raises(ValueError, match="loader must be an exact function"):
+        _legal(loader=hostile)
+    assert HostileCallable.calls == 0
+
+
+def test_registry_rejects_hostile_rosters_and_duplicate_identities_without_hooks() -> None:
+    HostileTuple.calls = 0
+    with pytest.raises(ValueError, match="EVIDENCE_SPECS must be a non-empty exact tuple"):
+        _validated_evidence_specs(HostileTuple(EVIDENCE_SPECS))
+    assert HostileTuple.calls == 0
+
+    first = EVIDENCE_SPECS[0]
+    duplicate_name = replace(EVIDENCE_SPECS[1], name=first.name)
+    with pytest.raises(ValueError, match="claim names must be unique"):
+        _validated_evidence_specs((first, duplicate_name))
+
+    duplicate_path = replace(EVIDENCE_SPECS[1], relative_path=first.relative_path)
+    with pytest.raises(ValueError, match="artifact paths must be unique"):
+        _validated_evidence_specs((first, duplicate_path))
+
+
+def test_evidence_spec_recursively_bounds_nested_json_values() -> None:
+    with pytest.raises(ValueError, match="sequence item limit"):
+        _legal(protocol={"nested": [0] * 257})
+    with pytest.raises(ValueError, match="65536 UTF-8 bytes"):
+        _legal(protocol={"nested": "x" * 65_537})
+
+    nested: object = None
+    for _ in range(65):
+        nested = [nested]
+    with pytest.raises(ValueError, match="maximum nesting depth"):
+        _legal(protocol={"nested": nested})
+
+    aggregate = [[0] * 16 for _ in range(256)]
+    with pytest.raises(ValueError, match="aggregate value limit"):
+        _legal(protocol={"nested": aggregate})


### PR DESCRIPTION
Corrective follow-up to merged #1698. Recursively validates exact finite JSON identity mappings; rejects hostile nested values, cycles, excessive depth/count/size; enforces exact repository-relative paths and import-time unique registry identities. Verification: 22 focused tests, full Ruff, full strict mypy, diff check. No outputs or evidence artifacts changed.