### PR TITLE
fix(scorecard): deeply admit aggregate records

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -159,7 +159,8 @@ def _fail(message: str) -> NoReturn:
 def _validate_json_value(value: Any, *, path: str = "$", depth: int = 0) -> None:
     if depth > 64:
         _fail(f"{path}: JSON nesting exceeds 64 levels")
-    if value is None or type(value) in (str, bool, int):
+    value_type = type(value)
+    if value is None or value_type is str or value_type is bool or value_type is int:
         return
     if type(value) is float:
         if not math.isfinite(value):
@@ -993,13 +994,33 @@ def _record_identity(record: Mapping[str, Any]) -> tuple[str, str, int]:
     environment = record.get("environment_kind")
     arm = record.get("arm")
     seed = record.get("seed")
-    if environment not in ENVIRONMENT_ROSTER:
+    if type(environment) is not str or environment not in ENVIRONMENT_ROSTER:
         raise ValueError("run record has an unsupported environment")
-    if arm not in ARM_ROSTER:
+    if type(arm) is not str or arm not in ARM_ROSTER:
         raise ValueError("run record has an unsupported arm")
     if type(seed) is not int or seed not in SEED_ROSTER:
         raise ValueError("run record has a seed outside the fixed roster")
-    return cast(str, environment), cast(str, arm), seed
+    return environment, arm, seed
+
+
+def _admit_aggregate_records(
+    records: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Admit an exact canonical-JSON record sequence before any foreign hooks."""
+
+    if type(records) is not list and type(records) is not tuple:
+        raise ValueError("run records must be an exact list or tuple")
+    canonical_records: list[dict[str, Any]] = []
+    for raw_record in records:
+        if type(raw_record) is not dict:
+            raise ValueError("every run record must be an exact string-keyed object")
+        if any(type(key) is not str for key in raw_record):
+            raise ValueError("every run record must be an exact string-keyed object")
+        if type(raw_record.get("schedule_index")) is not int:
+            raise ValueError("every run record must have an integer schedule_index")
+        _validate_json_value(raw_record, path="$.runs[]")
+        canonical_records.append(cast(dict[str, Any], raw_record))
+    return canonical_records
 
 
 def _reward_sum(record: Mapping[str, Any]) -> float:
@@ -1324,13 +1345,12 @@ def summarize_run_records(
 
     if not isinstance(plan, ReferenceLifeDevelopmentPlan):
         raise TypeError("plan must be a ReferenceLifeDevelopmentPlan")
+    canonical_records = _admit_aggregate_records(records)
     specs = iter_run_specs(plan)
-    if len(records) != len(specs):
+    if len(canonical_records) != len(specs):
         raise ValueError("run records must contain exactly the fixed 144-shard matrix")
     by_identity: dict[tuple[str, str, int], Mapping[str, Any]] = {}
-    for record in records:
-        if not isinstance(record, Mapping):
-            raise ValueError("every run record must be an object")
+    for record in canonical_records:
         identity = _record_identity(record)
         if identity in by_identity:
             raise ValueError(f"duplicate run identity {identity!r}")
@@ -1644,19 +1664,7 @@ def build_scorecard_artifact(
 ) -> dict[str, Any]:
     """Assemble one immutable aggregate and bind its deterministic summary."""
 
-    if type(records) is not list and type(records) is not tuple:
-        raise ValueError("run records must be an exact list or tuple")
-    canonical_records: list[dict[str, Any]] = []
-    for raw_record in records:
-        if type(raw_record) is not dict:
-            raise ValueError("every run record must be an exact string-keyed object")
-        record = cast(dict[object, Any], raw_record)
-        if any(type(key) is not str for key in record):
-            raise ValueError("every run record must be an exact string-keyed object")
-        canonical = cast(dict[str, Any], record)
-        if type(canonical.get("schedule_index")) is not int:
-            raise ValueError("every run record must have an integer schedule_index")
-        canonical_records.append(canonical)
+    canonical_records = _admit_aggregate_records(records)
     ordered_records = sorted(
         canonical_records, key=lambda record: cast(int, record["schedule_index"])
     )

--- a/tests/test_reference_scorecard_int_hostile.py
+++ b/tests/test_reference_scorecard_int_hostile.py
@@ -206,13 +206,30 @@ def test_artifact_builder_admits_exact_record_containers_before_hooks() -> None:
     plan = scorecard.build_development_plan()
     hostile_records = HostileRecords()
     with pytest.raises(ValueError, match="exact list or tuple"):
-        scorecard.build_scorecard_artifact(plan, hostile_records)
+        scorecard.build_scorecard_artifact(plan, hostile_records)  # type: ignore[arg-type]
+    assert hostile_records.calls == 0
+    with pytest.raises(ValueError, match="exact list or tuple"):
+        scorecard.summarize_run_records(plan, hostile_records)  # type: ignore[arg-type]
     assert hostile_records.calls == 0
 
     hostile_record = HostileRecord()
     with pytest.raises(ValueError, match="exact string-keyed object"):
         scorecard.build_scorecard_artifact(plan, [hostile_record])
     assert hostile_record.calls == 0
+
+
+def test_aggregate_deep_admission_rejects_metaclass_value_before_hooks() -> None:
+    from alberta_framework.benchmarks import reference_life_scorecard as scorecard
+
+    record = {
+        "schedule_index": 0,
+        "nested": {"value": _MetaclassHostileInt(1)},
+    }
+    records = [record] * len(scorecard.iter_run_specs(scorecard.build_development_plan()))
+    _HostileMeta.calls = 0
+    with pytest.raises(ValueError, match="canonical JSON"):
+        scorecard.build_scorecard_artifact(scorecard.build_development_plan(), records)
+    assert _HostileMeta.calls == 0
 
 
 def test_reward_sum_rejects_hostile_before_float() -> None:


### PR DESCRIPTION
Corrective audit for merged #1699. Extends exact admission to the public summarize path, requires exact roster string identities before membership, validates every nested record value as canonical JSON before digest/validator traversal, and replaces the remaining metaclass-dispatching type tuple in canonical JSON validation with identity chains. Real aggregate tests cover hostile outer sequences and nested metaclass values with zero hook calls. No workflow/output changes; current source identity changes by design.\n\nVerification: 77 focused scorecard tests passed; Ruff clean; strict focused mypy clean; diff check clean.