### PR TITLE
fix(evaluation): revalidate nested multiagent records

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -945,8 +945,28 @@ def aggregate_evidence(
     for result in results:
         if type(result) is not ConditionResult:
             raise ValueError("results must contain exact ConditionResult records")
+        budget = ControllerBudget(
+            **{
+                field.name: getattr(result.controller_budget, field.name)
+                for field in fields(ControllerBudget)
+            }
+        )
+        timing = TimingMetrics(
+            **{field.name: getattr(result.timing, field.name) for field in fields(TimingMetrics)}
+        )
         result = ConditionResult(
-            **{field.name: getattr(result, field.name) for field in fields(ConditionResult)}
+            seed=result.seed,
+            condition=result.condition,
+            learning_mask=result.learning_mask,
+            online_rewards=result.online_rewards,
+            phase_mean_rewards=result.phase_mean_rewards,
+            performance_matrix=result.performance_matrix,
+            summary=result.summary,
+            recovery_lengths=result.recovery_lengths,
+            recurrence_recovery_steps=result.recurrence_recovery_steps,
+            interference_forgetting=result.interference_forgetting,
+            controller_budget=budget,
+            timing=timing,
         )
         if result.online_rewards.size != 3 * config.phase_steps:
             raise ValueError("result length does not match config.phase_steps")

--- a/tests/test_multiagent_condition_result_hostile.py
+++ b/tests/test_multiagent_condition_result_hostile.py
@@ -176,3 +176,25 @@ def test_aggregation_revalidates_records_at_consumption() -> None:
                 recovery_window=1,
             ),
         )
+
+
+def test_aggregation_revalidates_nested_records_at_consumption() -> None:
+    results = [
+        _legal(condition="frozen", learning_mask=(False, False)),
+        _legal(condition="learner_only", learning_mask=(True, False)),
+        _legal(condition="joint_adaptive", learning_mask=(True, True)),
+    ]
+    object.__setattr__(results[0].timing, "p95_update_latency_ms", float("nan"))
+
+    with pytest.raises(ValueError, match="p95_update_latency_ms must be a finite"):
+        aggregate_evidence(
+            results,
+            config=ContinualMultiAgentConfig(
+                phase_steps=2,
+                probe_horizon=2,
+                probe_tail_steps=2,
+                recovery_window=1,
+                stability_reference_reward=0.0,
+            ),
+            bootstrap_resamples=2,
+        )


### PR DESCRIPTION
Minimal current-main follow-up after merged #1706 and #1703.

The public aggregator reconstructed `ConditionResult` but reused its nested `ControllerBudget` and `TimingMetrics` objects. A post-construction mutation could therefore bypass their scalar validators and reach budget/timing aggregation. This reconstructs only those two nested records before reconstructing the result and adds a production-call regression. It does not duplicate the summary/recovery/config work already on main.

Validation on current main:
- 41 focused multiagent tests passed
- Ruff passed
- strict mypy passed (188 source files)
- diff check and main-ancestry check passed

No benchmark or evidence artifact was changed or produced.