### PR TITLE
fix(utils): reject leftover significance-result identities

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -6,8 +6,9 @@ effect sizes, and multiple comparison corrections.
 
 import operator
 from collections.abc import Mapping
+from dataclasses import asdict, dataclass, replace
 from fractions import Fraction
-from typing import TYPE_CHECKING, NamedTuple, SupportsIndex, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, SupportsIndex, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -45,6 +46,12 @@ def _require_exact_str(name: str, value: object) -> str:
     return value
 
 
+def _require_exact_bool(name: str, value: object) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an exact bool")
+    return value
+
+
 class StatisticalSummary(NamedTuple):
     """Summary statistics for a set of values.
 
@@ -69,7 +76,8 @@ class StatisticalSummary(NamedTuple):
     n_seeds: int
 
 
-class SignificanceResult(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class SignificanceResult:
     """Result of a statistical significance test.
 
     Attributes:
@@ -91,6 +99,19 @@ class SignificanceResult(NamedTuple):
     effect_size: float
     method_a: str
     method_b: str
+
+    def __post_init__(self) -> None:
+        """Reject leftover bool/int/string identities before they become a verdict."""
+        _require_exact_str("test_name", self.test_name)
+        _require_exact_bool("significant", self.significant)
+        _require_exact_str("method_a", self.method_a)
+        _require_exact_str("method_b", self.method_b)
+
+    def _asdict(self) -> dict[str, object]:
+        return asdict(self)
+
+    def _replace(self, **changes: Any) -> "SignificanceResult":
+        return replace(self, **changes)
 
 
 def _validate_confidence_level(confidence_level: object) -> None:

--- a/tests/test_significance_result_leftover_identities.py
+++ b/tests/test_significance_result_leftover_identities.py
@@ -1,0 +1,39 @@
+"""Leftover-identity gates for publication significance records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.utils.statistics import SignificanceResult
+
+
+def test_significance_result_rejects_leftover_identities() -> None:
+    """Public records must not keep leftover significant/name identities."""
+
+    with pytest.raises(ValueError, match="significant"):
+        SignificanceResult("t", 1.0, 0.01, 1, 0.05, 0.2, "a", "b")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="significant"):
+        SignificanceResult("t", 1.0, 0.99, 0, 0.05, 0.2, "a", "b")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="significant"):
+        SignificanceResult("t", 1.0, 0.01, "FIXED", 0.05, 0.2, "a", "b")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="test_name"):
+        SignificanceResult(True, 1.0, 0.01, True, 0.05, 0.2, "a", "b")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="method_a"):
+        SignificanceResult("t", 1.0, 0.01, True, 0.05, 0.2, 1, "b")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="method_b"):
+        SignificanceResult("t", 1.0, 0.01, True, 0.05, 0.2, "a", False)  # type: ignore[arg-type]
+
+    legal = SignificanceResult("t", 1.0, 0.01, True, 0.05, 0.2, "a", "b")
+    dumped = json.dumps(legal._asdict(), allow_nan=False)
+    assert dumped == (
+        '{"test_name": "t", "statistic": 1.0, "p_value": 0.01, '
+        '"significant": true, "alpha": 0.05, "effect_size": 0.2, '
+        '"method_a": "a", "method_b": "b"}'
+    )
+    assert '"significant": 1' not in dumped
+    assert '"significant": "FIXED"' not in dumped
+    assert type(legal.significant) is bool
+    rejected = SignificanceResult("t", 1.0, 0.99, False, 0.05, 0.2, "a", "b")
+    assert json.dumps(rejected._asdict(), allow_nan=False).count('"significant": false') == 1


### PR DESCRIPTION
Closes #1714.

## What changed

`SignificanceResult` now fail-closes leftover `significant=1` / `0` / `"FIXED"` identities and leftover `test_name=True` before `_asdict()` can emit `"significant": 1`. Exact names and an exact bool are required on the public record.

On `origin/main` `f62d157a`, leftover identities constructed. Legal exact `True`/`False` stay legal. `_asdict` / `_replace` compatibility kept for export fixtures that construct legal bools and domain errors, not leftover identities.

`StatisticalSummary` stays a `NamedTuple`. Leftover bool summaries remain export-owned `MetricSummary` fixtures.

Not a reprint of `#894` / `#1707`. File was FREE at occupancy.

## Scope

- `alberta_framework/utils/statistics.py`
- `tests/test_significance_result_leftover_identities.py`

## Occupancy

Open ASI PRs at publish (`scannedAt=2026-08-18T05:58:46.845Z`): ss251 `#1707` `experiments.py`, Shaw `#1704` `continual_ia.py`, Shaw `#1702` `ipmnist_gradual.py`. No open PR on `statistics.py`.

## Verification

Exact candidate head: `3facd971e1c5722f32c173859f4f1463a47a7685`

- Red on base: `SignificanceResult(..., significant=1)` constructed; `test_name=True` constructed; `_asdict()` dumped `"significant": 1`
- Leftover + export + statistics suites: 398 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary leftover-identity validation only. No kernel math, lifetime clocks, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3facd971e1c5722f32c173859f4f1463a47a7685 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
