### PR TITLE
fix(benchmarks): make L2-ER matched screen honest

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -8704,6 +8704,7 @@ def l2er_development_result_payload(
         "n_classes": config.n_classes,
         "observations": observations,
         "updates": observations,
+        "effective_rank_updates": er_updates,
         "allowed_boundary_information": [],
         "allowed_task_information": ["current_example_label"],
         "hyperparameters": dict(spec.hyperparameters),

--- a/alberta_framework/benchmarks/l2er_matched_development.py
+++ b/alberta_framework/benchmarks/l2er_matched_development.py
@@ -35,18 +35,20 @@ from alberta_framework.evaluation.l2er_ipmnist_nonpromoting import (
 
 SCHEMA = "asi.l2er-ipmnist.matched-development-report.v1"
 PLAN_ID = "asi.l2er-ipmnist.cheap-screen.v1"
-OUTPUT_PATH = Path("outputs/l2er_matched_development/report.v1.json")
 ARMS = (
     "l2er_mechanism_off",
     "l2er_l2_only",
     "l2er_er_only",
     "l2er_combined",
 )
-SEEDS = (1701, 1702, 1703)
+SEEDS = (1711, 1712, 1713)
 CONFIG = IPMNISTConfig(n_tasks=2, task_length=500)
-_Z95 = 1.96
+CONSUMED_AUDIT_SEEDS = (1701,)
+_T95_DF2 = 4.302652729696142
 _MAX_REPORT_RECORDS = 32
 _PATH_TYPE = type(Path())
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+OUTPUT_PATH = _REPO_ROOT / "outputs/l2er_matched_development/report.v1.json"
 
 
 def frozen_plan() -> dict[str, object]:
@@ -55,12 +57,28 @@ def frozen_plan() -> dict[str, object]:
         "plan_id": PLAN_ID,
         "arms": list(ARMS),
         "seeds": list(SEEDS),
+        "consumed_preplan_audit_seeds": list(CONSUMED_AUDIT_SEEDS),
+        "consumed_preplan_audit_note": (
+            "seed 1701 ran once across all four arms during executable-path audit; "
+            "no complete report was produced"
+        ),
         "config": CONFIG.to_config(),
         "primary_metric": "mean_online_accuracy",
         "control_arm": "l2er_mechanism_off",
         "paired_direction": "higher_is_better",
+        "matched_axes": [
+            "example_schedule",
+            "observations",
+            "supervised_updates",
+            "allowed_boundary_information",
+            "allowed_task_information",
+        ],
+        "arm_specific_charged_axis": "effective_rank_updates",
         "null_delta": 0.0,
-        "confidence_z": _Z95,
+        "confidence_method": "two_sided_student_t",
+        "confidence_level": 0.95,
+        "confidence_degrees_of_freedom": 2,
+        "confidence_critical": _T95_DF2,
         "allowed_boundary_information": [],
         "allowed_task_information": ["current_example_label"],
         "development_only": True,
@@ -163,7 +181,7 @@ def _canonical_result(value: object) -> ScreeningRunResult:
     if type(value.config) is not IPMNISTConfig:
         raise ValueError("result.config must be an exact IPMNISTConfig")
     config = IPMNISTConfig(**value.config.to_config())
-    return ScreeningRunResult(
+    result = ScreeningRunResult(
         config_name=value.config_name,
         base_learner=value.base_learner,
         hyperparameters=value.hyperparameters,
@@ -176,11 +194,25 @@ def _canonical_result(value: object) -> ScreeningRunResult:
         noise_mode=value.noise_mode,
         noise_pool_steps=value.noise_pool_steps,
     )
+    spec = screening_spec(result.config_name)
+    if result.base_learner != spec.base_learner:
+        raise ValueError("result base learner does not match the registered arm")
+    if result.noise_mode != "step" or result.noise_pool_steps is not None:
+        raise ValueError("matched L2-ER results require exact-step execution")
+    return result
 
 
 def _validated_plan(value: object) -> dict[str, object]:
     plan = _object(value, frozenset(frozen_plan()), context="plan")
-    for key in ("plan_id", "primary_metric", "control_arm", "paired_direction"):
+    for key in (
+        "plan_id",
+        "primary_metric",
+        "control_arm",
+        "paired_direction",
+        "confidence_method",
+        "consumed_preplan_audit_note",
+        "arm_specific_charged_axis",
+    ):
         if type(plan[key]) is not str:
             raise ValueError(f"plan.{key} must be an exact string")
     for key in ("development_only", "scientific_promotion_allowed", "outcome_retention_required"):
@@ -188,6 +220,8 @@ def _validated_plan(value: object) -> dict[str, object]:
             raise ValueError(f"plan.{key} must be an exact bool")
     arms = plan["arms"]
     seeds = plan["seeds"]
+    consumed_seeds = plan["consumed_preplan_audit_seeds"]
+    matched_axes = plan["matched_axes"]
     boundary = plan["allowed_boundary_information"]
     task = plan["allowed_task_information"]
     if (
@@ -202,6 +236,18 @@ def _validated_plan(value: object) -> dict[str, object]:
         or any(type(item) is not int for item in seeds)
     ):
         raise ValueError("plan.seeds must be an exact integer list")
+    if (
+        type(consumed_seeds) is not list
+        or len(consumed_seeds) != len(CONSUMED_AUDIT_SEEDS)
+        or any(type(item) is not int for item in consumed_seeds)
+    ):
+        raise ValueError("plan.consumed_preplan_audit_seeds must be an exact integer list")
+    if (
+        type(matched_axes) is not list
+        or len(matched_axes) != 5
+        or any(type(item) is not str for item in matched_axes)
+    ):
+        raise ValueError("plan.matched_axes must be an exact string list")
     if type(boundary) is not list or boundary or any(type(item) is not str for item in boundary):
         raise ValueError("plan.allowed_boundary_information must be an exact string list")
     if type(task) is not list or len(task) != 1 or any(type(item) is not str for item in task):
@@ -210,7 +256,12 @@ def _validated_plan(value: object) -> dict[str, object]:
     if any(type(item) is not int for item in config.values()):
         raise ValueError("plan.config must contain exact integers")
     _finite_float(plan["null_delta"], context="plan.null_delta")
-    _finite_float(plan["confidence_z"], context="plan.confidence_z", nonnegative=True)
+    _finite_float(plan["confidence_level"], context="plan.confidence_level")
+    if type(plan["confidence_degrees_of_freedom"]) is not int:
+        raise ValueError("plan.confidence_degrees_of_freedom must be an exact integer")
+    _finite_float(
+        plan["confidence_critical"], context="plan.confidence_critical", nonnegative=True
+    )
     if plan != frozen_plan():
         raise ValueError("report plan does not match the literal frozen plan")
     return cast(dict[str, object], plan)
@@ -220,8 +271,8 @@ def _outcome(deltas: tuple[float, ...]) -> tuple[float, float, float, str]:
     values = np.asarray(deltas, dtype=np.float64)
     mean = float(values.mean())
     stderr = float(values.std(ddof=1) / math.sqrt(len(values)))
-    lower = mean - _Z95 * stderr
-    upper = mean + _Z95 * stderr
+    lower = mean - _T95_DF2 * stderr
+    upper = mean + _T95_DF2 * stderr
     outcome = "supported" if lower > 0.0 else "rejected" if upper <= 0.0 else "inconclusive"
     return mean, lower, upper, outcome
 
@@ -241,8 +292,6 @@ def build_report(
     by_identity: dict[tuple[int, str], ScreeningRunResult] = {}
     for raw_result in results:
         result = _canonical_result(raw_result)
-        if result.noise_mode != "step" or result.noise_pool_steps is not None:
-            raise ValueError("results must come from exact-step execution")
         identity = (result.seed, result.config_name)
         if identity in by_identity:
             raise ValueError("results must not contain duplicate seed-by-arm identities")
@@ -376,6 +425,12 @@ def validate_report(
                 ("n_classes", CONFIG.n_classes),
                 ("observations", CONFIG.n_steps),
                 ("updates", CONFIG.n_steps),
+                (
+                    "effective_rank_updates",
+                    CONFIG.n_steps // 100
+                    if screening_spec(identity[1]).hyperparameters["er_enabled"] == 1.0
+                    else 0,
+                ),
             )
         ):
             raise ValueError("record configuration drifts from the frozen plan")

--- a/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 
 PAPER_REVISION = "arXiv:2509.22335v3"
 OFFICIAL_COMMIT = "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5"
-RESULT_SCHEMA = "asi.l2er-ipmnist.development-result.v1"
+RESULT_SCHEMA = "asi.l2er-ipmnist.development-result.v2"
 COMPARISON_ID = "asi.l2er-ipmnist.current-runner.v1"
 
 L2ER_PROTOCOL = MappingProxyType(
@@ -37,6 +37,10 @@ L2ER_PROTOCOL = MappingProxyType(
         "official_er_batch": 100,
         "official_er_steps_per_batch": 1,
         "effective_rank_epsilon": 1e-8,
+        "update_accounting": (
+            "updates counts one supervised update per observation; "
+            "effective_rank_updates separately counts arm-specific auxiliary ER steps"
+        ),
         "persistent_bytes_scope": (
             "float32 parameters plus the fixed 100-example float32 ER buffer, int32 count, "
             "and sticky bool transaction-validity flag; "
@@ -133,6 +137,7 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
                 "n_classes",
                 "observations",
                 "updates",
+                "effective_rank_updates",
                 "allowed_boundary_information",
                 "allowed_task_information",
                 "hyperparameters",
@@ -166,6 +171,9 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
     n_classes = _int(outer["n_classes"], context="n_classes", positive=True)
     observations = _int(outer["observations"], context="observations", positive=True)
     updates = _int(outer["updates"], context="updates", positive=True)
+    effective_rank_updates = _int(
+        outer["effective_rank_updates"], context="effective_rank_updates"
+    )
     if n_tasks > _INT32_MAX // task_length:
         raise ValueError("n_tasks * task_length exceeds signed int32")
     if observations != n_tasks * task_length or updates != observations:
@@ -237,6 +245,8 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
     if environment_steps != 0 or data_steps != observations:
         raise ValueError("environment_steps/data_steps do not match the supervised protocol")
     er_updates = observations // 100 if expected_enabled == 1.0 else 0
+    if effective_rank_updates != er_updates:
+        raise ValueError("effective_rank_updates does not match the executed ER schedule")
     if model_queries != 2 * observations + er_updates:
         raise ValueError("model_queries does not match the executed update semantics")
     if resources["timing_is_telemetry_only"] is not True:
@@ -281,6 +291,7 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
         "n_classes": n_classes,
         "observations": observations,
         "updates": updates,
+        "effective_rank_updates": effective_rank_updates,
         "allowed_boundary_information": list(boundary),
         "allowed_task_information": list(task_info),
         "hyperparameters": normalized_hp,

--- a/tests/test_l2er_ipmnist.py
+++ b/tests/test_l2er_ipmnist.py
@@ -280,6 +280,8 @@ def test_result_receipt_accounts_resources_and_is_permanently_nonpromoting() -> 
     assert payload["outcome_retained"] is True
     assert payload["development_only"] is True
     assert payload["scientific_promotion_allowed"] is False
+    assert payload["updates"] == 100
+    assert payload["effective_rank_updates"] == 1
     resources = payload["resources"]
     assert isinstance(resources, dict)
     assert resources["data_steps"] == 100
@@ -293,6 +295,11 @@ def test_result_receipt_accounts_resources_and_is_permanently_nonpromoting() -> 
     hostile_resources["model_queries"] = 200
     with pytest.raises(ValueError, match="model_queries"):
         validate_l2er_development_result(hostile)
+
+    hostile_er_updates = deepcopy(payload)
+    hostile_er_updates["effective_rank_updates"] = 0
+    with pytest.raises(ValueError, match="effective_rank_updates"):
+        validate_l2er_development_result(hostile_er_updates)
 
     hostile_bytes = deepcopy(payload)
     hostile_byte_resources = hostile_bytes["resources"]

--- a/tests/test_l2er_matched_development.py
+++ b/tests/test_l2er_matched_development.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from copy import deepcopy
 from typing import Never
 
@@ -150,7 +151,32 @@ def test_validator_recomputes_paired_arithmetic(
         matched.validate_report(reordered, require_current_source=False)
 
 
+def test_three_seed_interval_uses_student_t_not_normal_critical_value() -> None:
+    mean, lower, upper, outcome = matched._outcome((0.01, 0.01, 0.0))
+    assert mean > 0.0
+    assert lower < 0.0 < upper
+    assert outcome == "inconclusive"
+    assert matched.frozen_plan()["confidence_method"] == "two_sided_student_t"
+
+
+def test_report_revalidates_result_identity_before_reading_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(matched, "_validated_source_provenance", lambda value, **_: value)
+    monkeypatch.setattr(matched, "_validated_dataset_provenance", lambda value, **_: value)
+    monkeypatch.setattr(matched, "_validated_runtime_environment", lambda value, **_: value)
+    results = _results()
+    results[0] = dataclasses.replace(results[0], base_learner="adamw")
+    with pytest.raises(ValueError, match="base learner"):
+        matched.build_report(
+            results, source_provenance={}, dataset_provenance={}, environment={}
+        )
+
+
 def test_output_namespace_is_one_new_development_path() -> None:
-    assert str(matched.OUTPUT_PATH) == "outputs/l2er_matched_development/report.v1.json"
+    assert matched.OUTPUT_PATH.relative_to(matched._REPO_ROOT).as_posix() == (
+        "outputs/l2er_matched_development/report.v1.json"
+    )
+    assert matched.frozen_plan()["consumed_preplan_audit_seeds"] == [1701]
     assert matched.frozen_plan()["development_only"] is True
     assert matched.frozen_plan()["scientific_promotion_allowed"] is False


### PR DESCRIPTION
## Summary

- replace the three-seed normal approximation with the preregistered two-sided Student-t interval
- distinguish one supervised update per observation from the arm-specific auxiliary effective-rank updates, and validate both exactly
- bind result identities to the registered base learner before consuming metrics
- anchor the immutable output path to the repository rather than the caller working directory
- preserve the merged hostile-input/runtime provenance hardening and permanently nonpromoting policy

## Development-seed disclosure

During executable-path review of #1700, seed 1701 was run once across all four arms with the 2-task x 500-step configuration. No complete report or retained artifact was produced. This PR records that audit execution in the frozen plan and mechanically replaces the prospective complete-screen seeds with 1711-1713. The replacement was chosen without using audit performance to tune the protocol.

This remains development-only and permanently nonpromoting. It does not close issue 1559; that issue still requires a complete retained matched outcome.

## Validation

- 24 focused tests passed
- Ruff passed on all touched files
- strict mypy passed (188 source files)
- all four arms were previously exercised end to end for seed 1701 during audit; no audit artifact was retained