### PR TITLE
fix(statistics): preserve validated tuple verdict contract

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -69,7 +69,18 @@ class StatisticalSummary(NamedTuple):
     n_seeds: int
 
 
-class SignificanceResult(NamedTuple):
+class _SignificanceResultTuple(NamedTuple):
+    test_name: str
+    statistic: float
+    p_value: float
+    significant: bool
+    alpha: float
+    effect_size: float
+    method_a: str
+    method_b: str
+
+
+class SignificanceResult(_SignificanceResultTuple):
     """Result of a statistical significance test.
 
     Attributes:
@@ -83,14 +94,37 @@ class SignificanceResult(NamedTuple):
         method_b: Name of second method
     """
 
-    test_name: str
-    statistic: float
-    p_value: float
-    significant: bool
-    alpha: float
-    effect_size: float
-    method_a: str
-    method_b: str
+    __slots__ = ()
+
+    def __new__(
+        cls,
+        test_name: str,
+        statistic: float,
+        p_value: float,
+        significant: bool,
+        alpha: float,
+        effect_size: float,
+        method_a: str,
+        method_b: str,
+    ) -> "SignificanceResult":
+        checked_test_name = _require_exact_str("test_name", test_name)
+        if type(significant) is not bool:
+            raise ValueError("significant must be an exact bool")
+        checked_method_a = _require_exact_str("method_a", method_a)
+        checked_method_b = _require_exact_str("method_b", method_b)
+        return tuple.__new__(
+            cls,
+            (
+                checked_test_name,
+                statistic,
+                p_value,
+                significant,
+                alpha,
+                effect_size,
+                checked_method_a,
+                checked_method_b,
+            ),
+        )
 
 
 def _validate_confidence_level(confidence_level: object) -> None:

--- a/tests/test_significance_result_leftover_identities.py
+++ b/tests/test_significance_result_leftover_identities.py
@@ -1,0 +1,53 @@
+"""Leftover-identity gates for publication significance records."""
+
+import pickle
+
+import pytest
+
+from alberta_framework.utils.statistics import SignificanceResult
+
+
+def _legal() -> SignificanceResult:
+    return SignificanceResult("paired", 1.0, 0.01, True, 0.05, 0.2, "a", "b")
+
+
+@pytest.mark.parametrize("significant", [1, 0, "FIXED"])
+def test_significance_result_rejects_leftover_bool_identities(significant: object) -> None:
+    with pytest.raises(ValueError, match="significant"):
+        SignificanceResult(  # type: ignore[arg-type]
+            "paired", 1.0, 0.01, significant, 0.05, 0.2, "a", "b"
+        )
+
+
+@pytest.mark.parametrize(
+    ("position", "value", "message"),
+    [(0, True, "test_name"), (6, 1, "method_a"), (7, False, "method_b")],
+)
+def test_significance_result_rejects_leftover_name_identities(
+    position: int, value: object, message: str
+) -> None:
+    fields: list[object] = ["paired", 1.0, 0.01, True, 0.05, 0.2, "a", "b"]
+    fields[position] = value
+    with pytest.raises(ValueError, match=message):
+        SignificanceResult(*fields)  # type: ignore[arg-type]
+
+
+def test_significance_result_preserves_namedtuple_contract() -> None:
+    result = _legal()
+    assert isinstance(result, tuple)
+    assert tuple(result) == ("paired", 1.0, 0.01, True, 0.05, 0.2, "a", "b")
+    assert result._fields == (
+        "test_name",
+        "statistic",
+        "p_value",
+        "significant",
+        "alpha",
+        "effect_size",
+        "method_a",
+        "method_b",
+    )
+    assert result._asdict()["significant"] is True
+    assert result._replace(significant=False).significant is False
+    restored = pickle.loads(pickle.dumps(result))
+    assert isinstance(restored, SignificanceResult)
+    assert restored == result


### PR DESCRIPTION
Closes #1714. Supersedes the incompatible implementation in #1715. The experiment-record portion originally included here was independently superseded by merged #1719 and has been removed during the current-main rebase.\n\nThis adds exact significance-bool and record-name identity gates while preserving the complete public `NamedTuple` contract: tuple identity, indexing/unpacking, `_fields`, `_asdict`, `_replace`, and pickle round trips.\n\nValidation on current main:\n- 404 focused statistics/export tests passed\n- Ruff passed\n- strict mypy passed\n- diff check passed\n\nNo benchmark or evidence artifact changed.