### PR TITLE
fix(experiments): complete measurement-record identities

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -14,8 +14,11 @@ Two conventions matter for downstream analysis:
   :func:`aggregate_metrics`.
 """
 
+from __future__ import annotations
+
 import math
 from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, replace
 from decimal import Decimal
 from fractions import Fraction
 from typing import Any, NamedTuple, NoReturn, cast
@@ -33,6 +36,8 @@ from alberta_framework.core.learners import (
 from alberta_framework.core.types import LearnerState
 from alberta_framework.streams.base import ScanStream
 from alberta_framework.utils.statistics import common_final_window
+
+_INT32_MAX = 2**31 - 1
 
 _NUMPY_COORDINATE_TYPES = frozenset(
     np.dtype(dtype_code).type
@@ -67,6 +72,24 @@ def _require_exact_str(name: str, value: object) -> str:
     return value
 
 
+def _require_positive_int(name: str, value: object) -> int:
+    if type(value) is not int or value < 1 or value > _INT32_MAX:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _require_callable(name: str, value: object) -> Callable[..., object]:
+    if not callable(value):
+        raise ValueError(f"{name} must be callable")
+    return value
+
+
+def _require_metrics_history(value: object) -> list[dict[str, float]]:
+    if type(value) is not list:
+        raise ValueError("metrics_history must be an exact list")
+    return value  # type: ignore[return-value]
+
+
 def _type_identity_in(
     value_type: type[object],
     candidates: Iterable[type[object]],
@@ -84,7 +107,7 @@ class _CanonicalFractionCoordinate(tuple[int, int]):
         cls,
         numerator: int,
         denominator: int,
-    ) -> "_CanonicalFractionCoordinate":
+    ) -> _CanonicalFractionCoordinate:
         if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
             raise ValueError("canonical Fraction coordinates require builtin integer components")
         normalized = Fraction(numerator, denominator)
@@ -143,7 +166,8 @@ _BYTES_COORDINATE_TYPES = (bytes, np.bytes_)
 _MAX_HYPERPARAMETER_COORDINATE_NESTING = 32
 
 
-class ExperimentConfig(NamedTuple):
+@dataclass(frozen=True)
+class ExperimentConfig:
     """Configuration for a single experiment.
 
     Attributes:
@@ -158,8 +182,24 @@ class ExperimentConfig(NamedTuple):
     stream_factory: Callable[[], ScanStream[Any]]
     num_steps: int
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", _require_exact_str("name", self.name))
+        object.__setattr__(
+            self, "learner_factory", _require_callable("learner_factory", self.learner_factory)
+        )
+        object.__setattr__(
+            self, "stream_factory", _require_callable("stream_factory", self.stream_factory)
+        )
+        object.__setattr__(
+            self, "num_steps", _require_positive_int("num_steps", self.num_steps)
+        )
 
-class SingleRunResult(NamedTuple):
+    def _replace(self, **changes: object) -> ExperimentConfig:
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class SingleRunResult:
     """Result from a single experiment run.
 
     Attributes:
@@ -173,6 +213,20 @@ class SingleRunResult(NamedTuple):
     seed: int
     metrics_history: list[dict[str, float]]
     final_state: LearnerState
+
+    def __post_init__(self) -> None:
+        if type(self.final_state) is not LearnerState:
+            raise TypeError("final_state must be an exact LearnerState")
+        object.__setattr__(
+            self, "config_name", _require_exact_str("config_name", self.config_name)
+        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        object.__setattr__(
+            self, "metrics_history", _require_metrics_history(self.metrics_history)
+        )
+
+    def _replace(self, **changes: object) -> SingleRunResult:
+        return replace(self, **changes)
 
 
 class MetricSummary(NamedTuple):

--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable, Iterable, Sequence
-from dataclasses import dataclass, replace
 from decimal import Decimal
 from fractions import Fraction
 from typing import Any, NamedTuple, NoReturn, cast
@@ -87,7 +86,31 @@ def _require_callable(name: str, value: object) -> Callable[..., object]:
 def _require_metrics_history(value: object) -> list[dict[str, float]]:
     if type(value) is not list:
         raise ValueError("metrics_history must be an exact list")
-    return value  # type: ignore[return-value]
+    if not value:
+        raise ValueError("metrics_history must contain at least one step")
+    canonical: list[dict[str, float]] = []
+    expected_keys: set[str] | None = None
+    for step_index, raw_metrics in enumerate(value):
+        if type(raw_metrics) is not dict:
+            raise ValueError(f"metrics_history[{step_index}] must be an exact dict")
+        metrics: dict[str, float] = {}
+        for key, raw_metric in raw_metrics.items():
+            if type(key) is not str or not key:
+                raise ValueError("metric names must be non-empty exact strings")
+            if type(raw_metric) is not int and type(raw_metric) is not float:
+                raise ValueError(f"metric '{key}' must be a finite builtin number")
+            metric = float(raw_metric)
+            if not math.isfinite(metric):
+                raise ValueError(f"metric '{key}' contains non-finite samples")
+            metrics[key] = metric
+        if not metrics:
+            raise ValueError("every metrics_history step must contain a metric")
+        if expected_keys is None:
+            expected_keys = set(metrics)
+        elif set(metrics) != expected_keys:
+            raise ValueError("all runs must contain the same metric keys at every step")
+        canonical.append(metrics)
+    return canonical
 
 
 def _type_identity_in(
@@ -166,8 +189,14 @@ _BYTES_COORDINATE_TYPES = (bytes, np.bytes_)
 _MAX_HYPERPARAMETER_COORDINATE_NESTING = 32
 
 
-@dataclass(frozen=True)
-class ExperimentConfig:
+class _ExperimentConfigTuple(NamedTuple):
+    name: str
+    learner_factory: Callable[[], LinearLearner]
+    stream_factory: Callable[[], ScanStream[Any]]
+    num_steps: int
+
+
+class ExperimentConfig(_ExperimentConfigTuple):
     """Configuration for a single experiment.
 
     Attributes:
@@ -177,29 +206,42 @@ class ExperimentConfig:
         num_steps: Number of learning steps to run
     """
 
-    name: str
-    learner_factory: Callable[[], LinearLearner]
-    stream_factory: Callable[[], ScanStream[Any]]
-    num_steps: int
+    __slots__ = ()
 
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "name", _require_exact_str("name", self.name))
-        object.__setattr__(
-            self, "learner_factory", _require_callable("learner_factory", self.learner_factory)
+    def __new__(
+        cls,
+        name: str,
+        learner_factory: Callable[[], LinearLearner],
+        stream_factory: Callable[[], ScanStream[Any]],
+        num_steps: int,
+    ) -> ExperimentConfig:
+        checked_learner = cast(
+            Callable[[], LinearLearner],
+            _require_callable("learner_factory", learner_factory),
         )
-        object.__setattr__(
-            self, "stream_factory", _require_callable("stream_factory", self.stream_factory)
+        checked_stream = cast(
+            Callable[[], ScanStream[Any]],
+            _require_callable("stream_factory", stream_factory),
         )
-        object.__setattr__(
-            self, "num_steps", _require_positive_int("num_steps", self.num_steps)
+        return tuple.__new__(
+            cls,
+            (
+                _require_exact_str("name", name),
+                checked_learner,
+                checked_stream,
+                _require_positive_int("num_steps", num_steps),
+            ),
         )
 
-    def _replace(self, **changes: object) -> ExperimentConfig:
-        return replace(self, **changes)
+
+class _SingleRunResultTuple(NamedTuple):
+    config_name: str
+    seed: int
+    metrics_history: list[dict[str, float]]
+    final_state: LearnerState
 
 
-@dataclass(frozen=True)
-class SingleRunResult:
+class SingleRunResult(_SingleRunResultTuple):
     """Result from a single experiment run.
 
     Attributes:
@@ -209,24 +251,26 @@ class SingleRunResult:
         final_state: Final learner state after training
     """
 
-    config_name: str
-    seed: int
-    metrics_history: list[dict[str, float]]
-    final_state: LearnerState
+    __slots__ = ()
 
-    def __post_init__(self) -> None:
-        if type(self.final_state) is not LearnerState:
+    def __new__(
+        cls,
+        config_name: str,
+        seed: int,
+        metrics_history: list[dict[str, float]],
+        final_state: LearnerState,
+    ) -> SingleRunResult:
+        if type(final_state) is not LearnerState:
             raise TypeError("final_state must be an exact LearnerState")
-        object.__setattr__(
-            self, "config_name", _require_exact_str("config_name", self.config_name)
+        return tuple.__new__(
+            cls,
+            (
+                _require_exact_str("config_name", config_name),
+                require_jax_seed(seed, name="seed"),
+                _require_metrics_history(metrics_history),
+                final_state,
+            ),
         )
-        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
-        object.__setattr__(
-            self, "metrics_history", _require_metrics_history(self.metrics_history)
-        )
-
-    def _replace(self, **changes: object) -> SingleRunResult:
-        return replace(self, **changes)
 
 
 class MetricSummary(NamedTuple):
@@ -288,6 +332,8 @@ def run_single_experiment(
     final_state, metrics = cast(tuple[LearnerState, Any], result)
     normalized = learner.normalizer is not None
     metrics_history = metrics_to_dicts(metrics, normalized=normalized)
+    if len(metrics_history) != config.num_steps:
+        raise ValueError("experiment metrics history must contain exactly num_steps records")
 
     return SingleRunResult(
         config_name=config_name,
@@ -337,6 +383,9 @@ def aggregate_metrics(results: list[SingleRunResult]) -> AggregatedResults:
     seeds = [require_jax_seed(r.seed, name="seed") for r in results]
     if len(set(seeds)) != len(seeds):
         raise ValueError(f"aggregate_metrics requires unique seed identities; got {seeds}")
+    step_counts = {len(r.metrics_history) for r in results}
+    if len(step_counts) != 1:
+        raise ValueError("aggregate_metrics requires one matched step count")
 
     # Get all metric keys from first result
     if any(

--- a/tests/test_experiments_hostile_validation.py
+++ b/tests/test_experiments_hostile_validation.py
@@ -2,12 +2,13 @@
 
 import pytest
 
+from alberta_framework.core.learners import LinearLearner
 from alberta_framework.utils.experiments import (
     ExperimentConfig,
+    SingleRunResult,
     _require_coordinate_hash,
     _require_finite_metric_array,
     _require_hyperparameter_coordinate,
-    run_multi_seed_experiment,
 )
 
 
@@ -101,9 +102,59 @@ def test_multi_seed_rejects_hostile_config_name_before_hash_or_factories() -> No
     def fail_factory():
         raise AssertionError("factory must not run")
 
-    config = ExperimentConfig(evil, fail_factory, fail_factory, 1)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="must be an exact string"):
-        run_multi_seed_experiment(
-            [config], seeds=[0], parallel=False, show_progress=False
-        )
+        ExperimentConfig(evil, fail_factory, fail_factory, 1)  # type: ignore[arg-type]
     assert _EvilStr.calls == 0
+
+
+def _legal_config(**overrides: object) -> ExperimentConfig:
+    def _learner() -> LinearLearner:
+        return LinearLearner()
+
+    payload: dict[str, object] = {
+        "name": "fixture",
+        "learner_factory": _learner,
+        "stream_factory": _learner,
+        "num_steps": 2,
+    }
+    payload.update(overrides)
+    return ExperimentConfig(**payload)  # type: ignore[arg-type]
+
+
+def _legal_run(**overrides: object) -> SingleRunResult:
+    payload: dict[str, object] = {
+        "config_name": "fixture",
+        "seed": 0,
+        "metrics_history": [{"squared_error": 0.1}],
+        "final_state": LinearLearner().init(2),
+    }
+    payload.update(overrides)
+    return SingleRunResult(**payload)  # type: ignore[arg-type]
+
+
+def test_experiment_records_accept_canonical_identities() -> None:
+    config = _legal_config()
+    run = _legal_run()
+    assert config.num_steps == 2
+    assert run.seed == 0
+    assert run.config_name == "fixture"
+
+
+def test_experiment_records_reject_leftover_integer_identities() -> None:
+    with pytest.raises(ValueError, match="num_steps must be a positive integer"):
+        _legal_config(num_steps=True)
+    with pytest.raises(ValueError, match="seed"):
+        _legal_run(seed=True)
+
+
+def test_experiment_records_reject_leftover_name_and_host_identities() -> None:
+    with pytest.raises(ValueError, match="name must be an exact string"):
+        _legal_config(name=True)
+    with pytest.raises(ValueError, match="config_name must be an exact string"):
+        _legal_run(config_name=True)
+    with pytest.raises(TypeError, match="final_state must be an exact LearnerState"):
+        _legal_run(final_state=None)
+    with pytest.raises(ValueError, match="learner_factory must be callable"):
+        _legal_config(learner_factory=None)
+    with pytest.raises(ValueError, match="metrics_history must be an exact list"):
+        _legal_run(metrics_history={"squared_error": 0.1})

--- a/tests/test_experiments_hostile_validation.py
+++ b/tests/test_experiments_hostile_validation.py
@@ -1,5 +1,7 @@
 """Hostile validation for experiments facade."""
 
+from typing import Any
+
 import pytest
 
 from alberta_framework.core.learners import LinearLearner
@@ -38,7 +40,7 @@ def test_finite_metric_hostile_without_repr() -> None:
     evil = _EvilStr("metric")
     _EvilStr.calls = 0
     with pytest.raises(ValueError, match="must be an exact string") as exc:
-        _require_finite_metric_array(np.array([1.0]), evil)  # type: ignore[arg-type]
+        _require_finite_metric_array(np.array([1.0]), evil)
     assert _EvilStr.calls == 0
     assert "EvilStr" not in str(exc.value)
 
@@ -48,7 +50,7 @@ def test_finite_metric_string_subclass_rejected() -> None:
 
     with pytest.raises(ValueError, match="must be an exact string"):
         _require_finite_metric_array(
-            np.array([1.0]), _StringSubclass("metric")  # type: ignore[arg-type]
+            np.array([1.0]), _StringSubclass("metric")
         )
 
 
@@ -65,14 +67,14 @@ def test_hyperparam_coordinate_hostile_name() -> None:
     evil = _EvilStr("bad")
     _EvilStr.calls = 0
     with pytest.raises(ValueError, match="must be an exact string"):
-        _require_hyperparameter_coordinate(1.0, name=evil)  # type: ignore[arg-type]
+        _require_hyperparameter_coordinate(1.0, name=evil)
     assert _EvilStr.calls == 0
 
 
 def test_hyperparam_string_subclass_rejected() -> None:
     with pytest.raises(ValueError, match="must be an exact string"):
         _require_hyperparameter_coordinate(
-            1.0, name=_StringSubclass("bad")  # type: ignore[arg-type]
+            1.0, name=_StringSubclass("bad")
         )
 
 
@@ -80,7 +82,7 @@ def test_coordinate_hash_hostile_name() -> None:
     evil = _EvilStr("bad")
     _EvilStr.calls = 0
     with pytest.raises(ValueError, match="must be an exact string"):
-        _require_coordinate_hash(1.0, name=evil)  # type: ignore[arg-type]
+        _require_coordinate_hash(1.0, name=evil)
     assert _EvilStr.calls == 0
 
 
@@ -99,11 +101,11 @@ def test_multi_seed_rejects_hostile_config_name_before_hash_or_factories() -> No
     evil = _EvilStr("candidate")
     _EvilStr.calls = 0
 
-    def fail_factory():
+    def fail_factory() -> Any:
         raise AssertionError("factory must not run")
 
     with pytest.raises(ValueError, match="must be an exact string"):
-        ExperimentConfig(evil, fail_factory, fail_factory, 1)  # type: ignore[arg-type]
+        ExperimentConfig(evil, fail_factory, fail_factory, 1)
     assert _EvilStr.calls == 0
 
 
@@ -138,6 +140,12 @@ def test_experiment_records_accept_canonical_identities() -> None:
     assert config.num_steps == 2
     assert run.seed == 0
     assert run.config_name == "fixture"
+    assert isinstance(config, tuple)
+    assert isinstance(run, tuple)
+    assert config._fields == ("name", "learner_factory", "stream_factory", "num_steps")
+    assert run._fields == ("config_name", "seed", "metrics_history", "final_state")
+    assert config._asdict()["num_steps"] == 2
+    assert run._replace(seed=1).seed == 1
 
 
 def test_experiment_records_reject_leftover_integer_identities() -> None:
@@ -158,3 +166,27 @@ def test_experiment_records_reject_leftover_name_and_host_identities() -> None:
         _legal_config(learner_factory=None)
     with pytest.raises(ValueError, match="metrics_history must be an exact list"):
         _legal_run(metrics_history={"squared_error": 0.1})
+
+
+def test_single_run_result_validates_nested_sufficient_statistics() -> None:
+    class HostileMetrics(list[object]):
+        calls = 0
+
+        def __len__(self) -> int:
+            self.calls += 1
+            raise AssertionError("must not size")
+
+    hostile = HostileMetrics()
+    with pytest.raises(ValueError, match="exact list"):
+        _legal_run(metrics_history=hostile)
+    assert hostile.calls == 0
+    with pytest.raises(ValueError, match="exact dict"):
+        _legal_run(metrics_history=[type("Metrics", (dict,), {})()])
+    with pytest.raises(ValueError, match="same metric keys"):
+        _legal_run(metrics_history=[{"loss": 1.0}, {"accuracy": 1.0}])
+    with pytest.raises(ValueError, match="finite builtin number"):
+        _legal_run(metrics_history=[{"loss": True}])
+    source = [{"loss": 1}]
+    run = _legal_run(metrics_history=source)
+    source[0]["loss"] = 9
+    assert run.metrics_history == [{"loss": 1.0}]


### PR DESCRIPTION
Preserves ss251 commit from #1707, then repairs its public compatibility break and closes nested sufficient-statistic gaps. ExperimentConfig and SingleRunResult retain their historical NamedTuple ABI (`tuple`, indexing, `_fields`, `_asdict`, `_replace`) through validating tuple subclasses. Metrics history is copied and admitted as an exact nonempty list of exact dicts, with exact names, finite builtin values, fixed per-step schema, matched aggregate step counts, and production num_steps length binding. Hostile container tests prove pre-iteration rejection.\n\nVerification: 538 experiment/export/statistics tests passed; 141 focused rerun after final fixes; Ruff clean; strict focused mypy clean; diff check clean. No output changes.\n\nSupersedes #1707 and closes #1705.