### PR TITLE
fix(security): reject leftover oracle-experience identities

### DIFF
--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -412,6 +412,21 @@ class SecurityOracleExperience:
     policy_metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
     schema: str = "alberta.security_gym.oracle_experience.v1"
 
+    def __post_init__(self) -> None:
+        """Reject leftover action/reward/schema identities before JSON dump."""
+        if type(self.state) is not tuple:
+            raise ValueError("state must be an exact tuple")
+        state = tuple(
+            _require_finite_real(f"state[{index}]", value)
+            for index, value in enumerate(self.state)
+        )
+        if type(self.action) is not SecurityAction:
+            raise ValueError("action must be an exact SecurityAction")
+        reward = _require_finite_real("reward", self.reward)
+        _require_exact_str("schema", self.schema)
+        object.__setattr__(self, "state", state)
+        object.__setattr__(self, "reward", reward)
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable oracle experience mapping."""
         payload = {

--- a/tests/test_security_oracle_leftover_identities.py
+++ b/tests/test_security_oracle_leftover_identities.py
@@ -1,0 +1,51 @@
+"""Leftover-identity gates for security oracle-experience records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.security import SecurityAction, SecurityOracleExperience
+
+
+def _legal(**overrides: object) -> SecurityOracleExperience:
+    payload: dict[str, object] = {
+        "state": (0.5,),
+        "action": SecurityAction.PASS,
+        "reward": 0.0,
+        "outcome": {"label": "safe"},
+    }
+    payload.update(overrides)
+    return SecurityOracleExperience(**payload)  # type: ignore[arg-type]
+
+
+def test_security_oracle_experience_rejects_leftover_identities() -> None:
+    """Public oracle records must not keep leftover bool/string identities."""
+
+    with pytest.raises(ValueError, match="reward"):
+        _legal(reward=True)
+    with pytest.raises(ValueError, match="reward"):
+        _legal(reward=False)
+    with pytest.raises(ValueError, match="reward"):
+        _legal(reward="FIXED")
+    with pytest.raises(ValueError, match="action"):
+        _legal(action=0)
+    with pytest.raises(ValueError, match="action"):
+        _legal(action=True)
+    with pytest.raises(ValueError, match="schema"):
+        _legal(schema=True)
+    with pytest.raises(ValueError, match="exact tuple"):
+        _legal(state=[0.5])
+    with pytest.raises(ValueError, match=r"state\[0\]"):
+        _legal(state=(True,))
+
+    legal = _legal()
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert dumped.count('"reward": 0.0') == 1
+    assert '"reward": true' not in dumped
+    assert '"reward": "FIXED"' not in dumped
+    assert '"schema": true' not in dumped
+    assert '"state": [true]' not in dumped
+    assert legal.action is SecurityAction.PASS
+    assert type(legal.reward) is float


### PR DESCRIPTION
Closes #1721.

## What changed

`SecurityOracleExperience` now fail-closes leftover `reward=True` / `"FIXED"`, leftover `action=0`/`True`, leftover `schema=True`, and leftover `state=(True,)` before `to_dict()` can emit `"reward": true`. Exact `SecurityAction`, finite reward, and exact schema string are required on the public record.

On `origin/main` `c175b395`, leftover identities constructed and dumped. Legal records stay legal. Outcome/label hostile fixtures for dump/validate stay dump-owned — this PR does not gate those as leftover-tax.

Sibling of leftover-identity `#1288`. Not a reprint of `#1484`. File was FREE at occupancy.

## Scope

- `alberta_framework/security.py`
- `tests/test_security_oracle_leftover_identities.py`

## Occupancy

Open ASI PRs at publish (`scannedAt=2026-08-18T06:06:37.214Z`): Shaw `#1718` `experiments.py`/`statistics.py`, PrototypicNoise `#1720` actor-critic/horde. No open PR on `security.py`.

## Verification

Exact candidate head: `9c0dad5d0b4b6356f99f9fb0d86072db98fba80d`

- Red on base: `SecurityOracleExperience(..., reward=True)` constructed; `to_dict()` dumped `"reward": true`
- Leftover + sibling security suites: 45 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary leftover-identity validation only. No kernel math, lifetime clocks, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9c0dad5d0b4b6356f99f9fb0d86072db98fba80d -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
