### PR TITLE
fix(benchmarks): version corrected L2-ER report contract

### DIFF
--- a/alberta_framework/benchmarks/l2er_matched_development.py
+++ b/alberta_framework/benchmarks/l2er_matched_development.py
@@ -33,8 +33,8 @@ from alberta_framework.evaluation.l2er_ipmnist_nonpromoting import (
     validate_l2er_development_result,
 )
 
-SCHEMA = "asi.l2er-ipmnist.matched-development-report.v1"
-PLAN_ID = "asi.l2er-ipmnist.cheap-screen.v1"
+SCHEMA = "asi.l2er-ipmnist.matched-development-report.v2"
+PLAN_ID = "asi.l2er-ipmnist.cheap-screen.v2"
 ARMS = (
     "l2er_mechanism_off",
     "l2er_l2_only",
@@ -48,7 +48,7 @@ _T95_DF2 = 4.302652729696142
 _MAX_REPORT_RECORDS = 32
 _PATH_TYPE = type(Path())
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-OUTPUT_PATH = _REPO_ROOT / "outputs/l2er_matched_development/report.v1.json"
+OUTPUT_PATH = _REPO_ROOT / "outputs/l2er_matched_development/report.v2.json"
 
 
 def frozen_plan() -> dict[str, object]:

--- a/tests/test_l2er_matched_development.py
+++ b/tests/test_l2er_matched_development.py
@@ -159,6 +159,20 @@ def test_three_seed_interval_uses_student_t_not_normal_critical_value() -> None:
     assert matched.frozen_plan()["confidence_method"] == "two_sided_student_t"
 
 
+def test_validator_rejects_obsolete_v1_report_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(matched, "_validated_source_provenance", lambda value, **_: value)
+    monkeypatch.setattr(matched, "_validated_dataset_provenance", lambda value, **_: value)
+    monkeypatch.setattr(matched, "_validated_runtime_environment", lambda value, **_: value)
+    report = matched.build_report(
+        _results(), source_provenance={}, dataset_provenance={}, environment={}
+    )
+    report["schema"] = "asi.l2er-ipmnist.matched-development-report.v1"
+    with pytest.raises(ValueError, match="schema does not match"):
+        matched.validate_report(report, require_current_source=False)
+
+
 def test_report_revalidates_result_identity_before_reading_metrics(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -174,8 +188,10 @@ def test_report_revalidates_result_identity_before_reading_metrics(
 
 
 def test_output_namespace_is_one_new_development_path() -> None:
+    assert matched.SCHEMA == "asi.l2er-ipmnist.matched-development-report.v2"
+    assert matched.PLAN_ID == "asi.l2er-ipmnist.cheap-screen.v2"
     assert matched.OUTPUT_PATH.relative_to(matched._REPO_ROOT).as_posix() == (
-        "outputs/l2er_matched_development/report.v1.json"
+        "outputs/l2er_matched_development/report.v2.json"
     )
     assert matched.frozen_plan()["consumed_preplan_audit_seeds"] == [1701]
     assert matched.frozen_plan()["development_only"] is True


### PR DESCRIPTION
## Summary

- bump the matched development report and frozen plan identities to v2 because #1717 changed the exact plan/report contract after v1 landed
- publish the prospective immutable outcome at report.v2.json
- add an exact regression that rejects the obsolete v1 report identity

This is a contract-version correction only. It preserves the seed-1701 audit disclosure, permanently nonpromoting policy, and all accounting/statistical fixes from #1717. It does not close issue 1559.

## Validation

- 25 focused tests passed
- Ruff passed on touched files
- strict mypy passed (188 source files)
- diff check passed