### PR TITLE
fix(core): require exact bounder config identities

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -956,8 +956,10 @@ class OffPolicyHordeLearner:
             "horde_spec": self._horde_spec.to_config(),
             "hidden_sizes": list(self._hidden_sizes),
             "optimizer": self._optimizer.to_config(),
-            "bounder": self._bounder.to_config() if self._bounder else None,
-            "normalizer": self._normalizer.to_config() if self._normalizer else None,
+            "bounder": self._bounder.to_config() if self._bounder is not None else None,
+            "normalizer": (
+                self._normalizer.to_config() if self._normalizer is not None else None
+            ),
             "sparsity": self._sparsity,
             "leaky_relu_slope": self._leaky_relu_slope,
             "use_layer_norm": self._use_layer_norm,

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -2415,6 +2415,8 @@ def bounder_from_config(config: dict[str, Any]) -> Bounder:
     Raises:
         ValueError: If the bounder type is unknown
     """
+    if type(config) is not dict:
+        raise ValueError("bounder config must be an exact dict")
     config = dict(config)
     type_name = config.pop("type")
     host_type = _require_exact_str("type_name", type_name)

--- a/tests/test_bounder_normalizer_config_truthiness.py
+++ b/tests/test_bounder_normalizer_config_truthiness.py
@@ -84,9 +84,9 @@ class TestActorCriticBounderConfigTruthiness:
         payload = agent.to_config()
         payload["bounder"] = _HostileBounderConfig(payload["bounder"])
 
-        restored = ActorCriticAgent.from_config(payload)
+        with pytest.raises(ValueError, match="bounder config must be an exact dict"):
+            ActorCriticAgent.from_config(payload)
 
-        assert restored.bounder is not None
         assert _HostileBounderConfig.calls == 0
 
     def test_continuous_actor_critic_config_does_not_invoke_truthiness(self) -> None:
@@ -98,9 +98,9 @@ class TestActorCriticBounderConfigTruthiness:
         payload = agent.to_config()
         payload["bounder"] = _HostileBounderConfig(payload["bounder"])
 
-        restored = ContinuousActorCriticAgent.from_config(payload)
+        with pytest.raises(ValueError, match="bounder config must be an exact dict"):
+            ContinuousActorCriticAgent.from_config(payload)
 
-        assert restored.bounder is not None
         assert _HostileBounderConfig.calls == 0
 
 
@@ -119,9 +119,9 @@ class TestHordeActorCriticBounderConfigTruthiness:
         payload = agent.to_config()
         payload["actor_bounder"] = _HostileBounderConfig(payload["actor_bounder"])
 
-        restored = HordeActorCriticAgent.from_config(payload)
+        with pytest.raises(ValueError, match="bounder config must be an exact dict"):
+            HordeActorCriticAgent.from_config(payload)
 
-        assert restored.actor_bounder is not None
         assert _HostileBounderConfig.calls == 0
 
     def test_q_horde_actor_critic_config_does_not_invoke_truthiness(self) -> None:
@@ -139,9 +139,9 @@ class TestHordeActorCriticBounderConfigTruthiness:
         payload = agent.to_config()
         payload["actor_bounder"] = _HostileBounderConfig(payload["actor_bounder"])
 
-        restored = QHordeActorCriticAgent.from_config(payload)
+        with pytest.raises(ValueError, match="bounder config must be an exact dict"):
+            QHordeActorCriticAgent.from_config(payload)
 
-        assert restored.actor_bounder is not None
         assert _HostileBounderConfig.calls == 0
 
     def test_nonlinear_horde_actor_critic_config_does_not_invoke_truthiness(self) -> None:
@@ -154,9 +154,9 @@ class TestHordeActorCriticBounderConfigTruthiness:
         payload = agent.to_config()
         payload["actor_bounder"] = _HostileBounderConfig(payload["actor_bounder"])
 
-        restored = NonlinearHordeActorCriticAgent.from_config(payload)
+        with pytest.raises(ValueError, match="bounder config must be an exact dict"):
+            NonlinearHordeActorCriticAgent.from_config(payload)
 
-        assert restored.actor_bounder is not None
         assert _HostileBounderConfig.calls == 0
 
     def test_nonlinear_q_horde_actor_critic_config_does_not_invoke_truthiness(self) -> None:
@@ -169,9 +169,9 @@ class TestHordeActorCriticBounderConfigTruthiness:
         payload = agent.to_config()
         payload["actor_bounder"] = _HostileBounderConfig(payload["actor_bounder"])
 
-        restored = NonlinearQHordeActorCriticAgent.from_config(payload)
+        with pytest.raises(ValueError, match="bounder config must be an exact dict"):
+            NonlinearQHordeActorCriticAgent.from_config(payload)
 
-        assert restored.actor_bounder is not None
         assert _HostileBounderConfig.calls == 0
 
 
@@ -186,9 +186,9 @@ class TestOffPolicyHordeBounderNormalizerConfigTruthiness:
         payload = horde.to_config()
         payload["bounder"] = _HostileBounderConfig(payload["bounder"])
 
-        restored = OffPolicyHordeLearner.from_config(payload)
+        with pytest.raises(ValueError, match="bounder config must be an exact dict"):
+            OffPolicyHordeLearner.from_config(payload)
 
-        assert restored._bounder is not None
         assert _HostileBounderConfig.calls == 0
 
     def test_off_policy_horde_normalizer_config_does_not_invoke_truthiness(self) -> None:


### PR DESCRIPTION
Post-merge corrective for #1720. Reject bounder config subclasses before copying or dispatch, matching the normalizer fail-closed contract, and remove remaining serializer truth coercion. Preserves contributor tests while strengthening them to prove hostile hooks remain uncalled.\n\nVerification: 175 focused tests passed; Ruff and mypy passed; diff-check clean. No benchmark or output changes.