### PR TITLE
fix(evaluation): preflight nested multiagent aggregation

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -939,12 +939,22 @@ def aggregate_evidence(
 
     if type(config) is not ContinualMultiAgentConfig:
         raise ValueError("config must be a ContinualMultiAgentConfig")
+    if type(results) not in (list, tuple):
+        raise ValueError("results must be an exact list or tuple")
     if not results:
         raise ValueError("results must be non-empty")
+    _require_resource_limit(
+        "aggregate condition result arrays",
+        len(results) * _condition_result_array_nbytes(config.phase_steps),
+    )
     validated: list[ConditionResult] = []
     for result in results:
         if type(result) is not ConditionResult:
             raise ValueError("results must contain exact ConditionResult records")
+        if type(result.controller_budget) is not ControllerBudget:
+            raise ValueError("controller_budget must be a ControllerBudget")
+        if type(result.timing) is not TimingMetrics:
+            raise ValueError("timing must be a TimingMetrics")
         budget = ControllerBudget(
             **{
                 field.name: getattr(result.controller_budget, field.name)

--- a/tests/test_multiagent_condition_result_hostile.py
+++ b/tests/test_multiagent_condition_result_hostile.py
@@ -198,3 +198,62 @@ def test_aggregation_revalidates_nested_records_at_consumption() -> None:
             ),
             bootstrap_resamples=2,
         )
+
+
+def test_aggregation_rejects_hostile_outer_container_before_hooks() -> None:
+    class HostileList(list[ConditionResult]):
+        def __len__(self) -> int:  # pragma: no cover - must not run
+            raise AssertionError("untrusted length hook executed")
+
+        def __iter__(self):  # type: ignore[no-untyped-def]  # pragma: no cover
+            raise AssertionError("untrusted iteration hook executed")
+
+    with pytest.raises(ValueError, match="exact list or tuple"):
+        aggregate_evidence(  # type: ignore[arg-type]
+            HostileList(),
+            config=ContinualMultiAgentConfig(),
+        )
+
+
+@pytest.mark.parametrize("field", ("controller_budget", "timing"))
+def test_aggregation_rejects_replaced_nested_record_before_hooks(field: str) -> None:
+    class HostileRecord:
+        def __getattribute__(self, name: str) -> object:  # pragma: no cover - must not run
+            raise AssertionError(f"untrusted attribute hook executed: {name}")
+
+    result = _legal()
+    object.__setattr__(result, field, HostileRecord())
+
+    with pytest.raises(ValueError, match=field):
+        aggregate_evidence(
+            [result],
+            config=ContinualMultiAgentConfig(
+                phase_steps=2,
+                probe_horizon=2,
+                probe_tail_steps=2,
+                recovery_window=1,
+            ),
+        )
+
+
+def test_aggregation_preflights_retained_arrays_before_record_iteration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = _legal()
+    config = ContinualMultiAgentConfig(
+        phase_steps=2,
+        probe_horizon=2,
+        probe_tail_steps=2,
+        recovery_window=1,
+    )
+    object.__setattr__(result, "controller_budget", None)
+    monkeypatch.setattr(
+        "alberta_framework.evaluation.continual_multiagent._MAX_CONFIGURED_ARRAY_NBYTES",
+        1,
+    )
+
+    with pytest.raises(ValueError, match="aggregate condition result arrays requires"):
+        aggregate_evidence(
+            [result],
+            config=config,
+        )


### PR DESCRIPTION
Post-merge corrective for #1713. Admit only exact outer result containers before length/iteration, preflight aggregate retained arrays before record reconstruction, and reject replaced budget/timing records before any attribute hook.\n\nVerification: 238 passed, 2 skipped focused multiagent tests; Ruff and mypy passed; diff-check clean. No benchmark execution or output mutation.