### PR TITLE
fix(security): seal oracle experience boundary

### DIFF
--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -412,6 +412,21 @@ class SecurityOracleExperience:
     policy_metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
     schema: str = "alberta.security_gym.oracle_experience.v1"
 
+    def __post_init__(self) -> None:
+        """Reject leftover action/reward/schema identities before JSON dump."""
+        if type(self.state) is not tuple:
+            raise ValueError("state must be an exact tuple")
+        state = tuple(
+            _require_finite_real(f"state[{index}]", value)
+            for index, value in enumerate(self.state)
+        )
+        if type(self.action) is not SecurityAction:
+            raise ValueError("action must be an exact SecurityAction")
+        reward = _require_finite_real("reward", self.reward)
+        _require_exact_str("schema", self.schema)
+        object.__setattr__(self, "state", state)
+        object.__setattr__(self, "reward", reward)
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable oracle experience mapping."""
         payload = {

--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -33,6 +33,11 @@ def _require_rfc_json_mapping(payload: Mapping[str, Any], *, name: str) -> None:
 
 
 _INT32_MAX: int = 2**31 - 1
+_JSON_MAX_DEPTH: int = 32
+_JSON_MAX_NODES: int = 4096
+_JSON_MAX_STRING_LENGTH: int = 65_536
+_JSON_MAX_INTEGER_BITS: int = 64
+_ORACLE_EXPERIENCE_SCHEMA = "alberta.security_gym.oracle_experience.v1"
 
 _ACTUAL_INT_TYPES = frozenset(
     {
@@ -56,7 +61,8 @@ _ALLOWED_REAL_TYPES = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
 
 
 def _copy_mapping(payload: object, *, name: str) -> dict[str, Any]:
-    if type(payload) not in (dict, MappingProxyType):
+    payload_type = type(payload)
+    if payload_type is not dict and payload_type is not MappingProxyType:
         raise ValueError(f"{name} must be a mapping")
     try:
         values = dict(cast(Mapping[str, Any], payload))
@@ -67,24 +73,59 @@ def _copy_mapping(payload: object, *, name: str) -> dict[str, Any]:
     return values
 
 
-def _copy_json_value(value: object, *, name: str) -> Any:
-    if value is None or type(value) in (bool, int, str):
+def _copy_json_value(
+    value: object,
+    *,
+    name: str,
+    depth: int = 0,
+    budget: list[int] | None = None,
+) -> Any:
+    if budget is None:
+        budget = [_JSON_MAX_NODES]
+    budget[0] -= 1
+    if budget[0] < 0:
+        raise ValueError(f"{name} exceeds the JSON value resource limit")
+    if depth > _JSON_MAX_DEPTH:
+        raise ValueError(f"{name} exceeds the JSON nesting limit")
+    value_type = type(value)
+    if value is None or value_type is bool:
         return value
-    if type(value) is float:
-        if not math.isfinite(value):
+    if value_type is int:
+        integer = cast(int, value)
+        if integer.bit_length() > _JSON_MAX_INTEGER_BITS:
+            raise ValueError(f"{name} contains an integer outside the supported range")
+        return integer
+    if value_type is str:
+        string = cast(str, value)
+        if len(string) > _JSON_MAX_STRING_LENGTH:
+            raise ValueError(f"{name} contains an oversized string")
+        return string
+    if value_type is float:
+        number = cast(float, value)
+        if not math.isfinite(number):
             raise ValueError(f"{name} must be RFC-compliant JSON with finite numbers")
-        return value
-    if type(value) in (list, tuple):
-        return [_copy_json_value(item, name=name) for item in cast(Sequence[object], value)]
-    if type(value) in (dict, MappingProxyType):
+        return number
+    if value_type is list or value_type is tuple:
+        return [
+            _copy_json_value(item, name=name, depth=depth + 1, budget=budget)
+            for item in cast(Sequence[object], value)
+        ]
+    if value_type is dict or value_type is MappingProxyType:
         payload = _copy_mapping(value, name=name)
-        return {key: _copy_json_value(item, name=name) for key, item in payload.items()}
+        return {
+            key: _copy_json_value(item, name=name, depth=depth + 1, budget=budget)
+            for key, item in payload.items()
+        }
     raise ValueError(f"{name} must contain exact JSON values")
 
 
 def _copy_json_mapping(payload: object, *, name: str) -> dict[str, Any]:
     copied = _copy_mapping(payload, name=name)
-    return {key: _copy_json_value(value, name=name) for key, value in copied.items()}
+    budget = [_JSON_MAX_NODES]
+    return {
+        key: _copy_json_value(value, name=name, depth=1, budget=budget)
+        for key, value in copied.items()
+    }
 
 
 def _require_exact_str(name: str, value: object) -> str:
@@ -410,7 +451,7 @@ class SecurityOracleExperience:
     reward: float
     outcome: Mapping[str, Any]
     policy_metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
-    schema: str = "alberta.security_gym.oracle_experience.v1"
+    schema: str = _ORACLE_EXPERIENCE_SCHEMA
 
     def __post_init__(self) -> None:
         """Reject leftover action/reward/schema identities before JSON dump."""
@@ -423,9 +464,28 @@ class SecurityOracleExperience:
         if type(self.action) is not SecurityAction:
             raise ValueError("action must be an exact SecurityAction")
         reward = _require_finite_real("reward", self.reward)
-        _require_exact_str("schema", self.schema)
+        schema = _require_exact_str("schema", self.schema)
+        if schema != _ORACLE_EXPERIENCE_SCHEMA:
+            raise ValueError("schema must identify the oracle-experience v1 contract")
+        outcome = _copy_json_mapping(self.outcome, name="security oracle outcome")
+        policy_metadata = _copy_json_mapping(self.policy_metadata, name="policy_metadata")
+        for flag in ("terminated", "truncated"):
+            if flag in outcome and type(outcome[flag]) is not bool:
+                raise ValueError(f"security oracle outcome {flag} must be an exact bool")
+        if "is_malicious" in policy_metadata and type(policy_metadata["is_malicious"]) is not bool:
+            raise ValueError("policy_metadata is_malicious must be an exact bool")
+        if "is_malicious" in policy_metadata:
+            label = outcome.get("label")
+            expected_label = _security_outcome_label(
+                action=self.action,
+                is_malicious=cast(bool, policy_metadata["is_malicious"]),
+            )
+            if type(label) is not str or label != expected_label:
+                raise ValueError("security oracle outcome label does not match action metadata")
         object.__setattr__(self, "state", state)
         object.__setattr__(self, "reward", reward)
+        object.__setattr__(self, "outcome", MappingProxyType(outcome))
+        object.__setattr__(self, "policy_metadata", MappingProxyType(policy_metadata))
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable oracle experience mapping."""
@@ -452,19 +512,7 @@ def security_rollout_step_to_oracle_experience(
     is_malicious = policy_metadata.get("is_malicious", False)
     if type(is_malicious) is not bool:
         raise ValueError("policy_metadata is_malicious must be an exact bool")
-    defensive_action = step.action in (
-        SecurityAction.THROTTLE,
-        SecurityAction.BLOCK,
-        SecurityAction.ISOLATE,
-    )
-    if is_malicious and defensive_action:
-        label = "true_positive"
-    elif is_malicious:
-        label = "false_negative"
-    elif defensive_action:
-        label = "false_positive"
-    else:
-        label = "true_negative"
+    label = _security_outcome_label(action=step.action, is_malicious=is_malicious)
     return SecurityOracleExperience(
         state=step.state,
         action=step.action,
@@ -478,17 +526,39 @@ def security_rollout_step_to_oracle_experience(
     )
 
 
+def _security_outcome_label(*, action: SecurityAction, is_malicious: bool) -> str:
+    defensive_action = (
+        action is SecurityAction.THROTTLE
+        or action is SecurityAction.BLOCK
+        or action is SecurityAction.ISOLATE
+    )
+    if is_malicious and defensive_action:
+        return "true_positive"
+    if is_malicious:
+        return "false_negative"
+    if defensive_action:
+        return "false_positive"
+    return "true_negative"
+
+
 def validate_security_oracle_experience(
     records: Sequence[SecurityOracleExperience],
     schema: SecurityFeatureSchema,
 ) -> None:
     """Validate oracle-review records against a feature schema."""
+    if type(records) is not list and type(records) is not tuple:
+        raise ValueError("oracle experience records must be an exact list or tuple")
+    if type(schema) is not SecurityFeatureSchema:
+        raise ValueError("schema must be an exact SecurityFeatureSchema")
     for idx, record in enumerate(records):
+        if type(record) is not SecurityOracleExperience:
+            raise ValueError(f"invalid oracle experience {idx}: wrong record type")
         try:
             schema.validate_observation(record.state)
         except ValueError as exc:
             raise ValueError(f"invalid oracle experience {idx}: {exc}") from exc
-        if type(record.outcome.get("label")) is not str or not record.outcome["label"]:
+        label = record.outcome.get("label")
+        if type(label) is not str or len(label) == 0:
             raise ValueError(f"invalid oracle experience {idx}: missing outcome label")
 
 

--- a/tests/test_security_integration.py
+++ b/tests/test_security_integration.py
@@ -226,13 +226,12 @@ def test_security_to_dict_rejects_nonfinite_numbers() -> None:
             next_state=(0.0, 1.0),
             terminated=False,
         )
-    experience = SecurityOracleExperience(
-        state=(0.0, 1.0),
-        action=SecurityAction.PASS,
-        reward=0.0,
-        outcome={"label": "true_negative", "score": float("nan")},
-    )
     with pytest.raises(ValueError, match="RFC-compliant JSON"):
         weights.to_dict()
     with pytest.raises(ValueError, match="RFC-compliant JSON"):
-        experience.to_dict()
+        SecurityOracleExperience(
+            state=(0.0, 1.0),
+            action=SecurityAction.PASS,
+            reward=0.0,
+            outcome={"label": "true_negative", "score": float("nan")},
+        )

--- a/tests/test_security_oracle_label_hostile.py
+++ b/tests/test_security_oracle_label_hostile.py
@@ -48,13 +48,13 @@ def test_validate_oracle_experience_rejects_hostile_label_before_bool() -> None:
     schema = _schema()
     hostile = _HostileStr("safe")
     _HostileStr.calls = 0
-    record = SecurityOracleExperience(
-        state=(0.5,),
-        action=SecurityAction.PASS,
-        reward=0.0,
-        outcome={"label": hostile},  # type: ignore[dict-item]
-    )
-    with pytest.raises(ValueError, match="missing outcome label"):
+    with pytest.raises(ValueError, match="exact JSON values"):
+        record = SecurityOracleExperience(
+            state=(0.5,),
+            action=SecurityAction.PASS,
+            reward=0.0,
+            outcome={"label": hostile},  # type: ignore[dict-item]
+        )
         validate_security_oracle_experience([record], schema)
     assert _HostileStr.calls == 0
 
@@ -88,12 +88,12 @@ def test_hostile_empty_string_still_rejects_before_len() -> None:
     hostile = _HostileStr("")
     _HostileStr.calls = 0
     schema = _schema()
-    record = SecurityOracleExperience(
-        state=(0.5,),
-        action=SecurityAction.PASS,
-        reward=0.0,
-        outcome={"label": hostile},  # type: ignore[dict-item]
-    )
-    with pytest.raises(ValueError, match="missing outcome label"):
+    with pytest.raises(ValueError, match="exact JSON values"):
+        record = SecurityOracleExperience(
+            state=(0.5,),
+            action=SecurityAction.PASS,
+            reward=0.0,
+            outcome={"label": hostile},  # type: ignore[dict-item]
+        )
         validate_security_oracle_experience([record], schema)
     assert _HostileStr.calls == 0

--- a/tests/test_security_oracle_leftover_identities.py
+++ b/tests/test_security_oracle_leftover_identities.py
@@ -1,0 +1,51 @@
+"""Leftover-identity gates for security oracle-experience records."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alberta_framework.security import SecurityAction, SecurityOracleExperience
+
+
+def _legal(**overrides: object) -> SecurityOracleExperience:
+    payload: dict[str, object] = {
+        "state": (0.5,),
+        "action": SecurityAction.PASS,
+        "reward": 0.0,
+        "outcome": {"label": "safe"},
+    }
+    payload.update(overrides)
+    return SecurityOracleExperience(**payload)  # type: ignore[arg-type]
+
+
+def test_security_oracle_experience_rejects_leftover_identities() -> None:
+    """Public oracle records must not keep leftover bool/string identities."""
+
+    with pytest.raises(ValueError, match="reward"):
+        _legal(reward=True)
+    with pytest.raises(ValueError, match="reward"):
+        _legal(reward=False)
+    with pytest.raises(ValueError, match="reward"):
+        _legal(reward="FIXED")
+    with pytest.raises(ValueError, match="action"):
+        _legal(action=0)
+    with pytest.raises(ValueError, match="action"):
+        _legal(action=True)
+    with pytest.raises(ValueError, match="schema"):
+        _legal(schema=True)
+    with pytest.raises(ValueError, match="exact tuple"):
+        _legal(state=[0.5])
+    with pytest.raises(ValueError, match=r"state\[0\]"):
+        _legal(state=(True,))
+
+    legal = _legal()
+    dumped = json.dumps(legal.to_dict(), allow_nan=False)
+    assert dumped.count('"reward": 0.0') == 1
+    assert '"reward": true' not in dumped
+    assert '"reward": "FIXED"' not in dumped
+    assert '"schema": true' not in dumped
+    assert '"state": [true]' not in dumped
+    assert legal.action is SecurityAction.PASS
+    assert type(legal.reward) is float

--- a/tests/test_security_oracle_leftover_identities.py
+++ b/tests/test_security_oracle_leftover_identities.py
@@ -3,10 +3,18 @@
 from __future__ import annotations
 
 import json
+from types import MappingProxyType
 
 import pytest
 
-from alberta_framework.security import SecurityAction, SecurityOracleExperience
+from alberta_framework.security import (
+    SecurityAction,
+    SecurityFeatureSchema,
+    SecurityOracleExperience,
+    SecurityRolloutStep,
+    security_rollout_step_to_oracle_experience,
+    validate_security_oracle_experience,
+)
 
 
 def _legal(**overrides: object) -> SecurityOracleExperience:
@@ -49,3 +57,86 @@ def test_security_oracle_experience_rejects_leftover_identities() -> None:
     assert '"state": [true]' not in dumped
     assert legal.action is SecurityAction.PASS
     assert type(legal.reward) is float
+
+
+def test_oracle_experience_snapshots_nested_payloads_on_real_conversion_path() -> None:
+    nested = ["source"]
+    step = SecurityRolloutStep(
+        state=(0.5,),
+        action=SecurityAction.BLOCK,
+        reward=1.0,
+        next_state=(0.25,),
+        terminated=False,
+        policy_metadata={"is_malicious": True, "nested": nested},
+    )
+    record = security_rollout_step_to_oracle_experience(step)
+    nested.append("changed")
+
+    validate_security_oracle_experience(
+        [record], SecurityFeatureSchema(names=("risk",))
+    )
+    assert type(record.outcome) is MappingProxyType
+    assert type(record.policy_metadata) is MappingProxyType
+    assert record.to_dict()["policy_metadata"]["nested"] == ["source"]
+    assert record.to_dict()["outcome"] == {
+        "label": "true_positive",
+        "terminated": False,
+        "truncated": False,
+    }
+
+    outcome_nested = ["source"]
+    metadata_nested = ["source"]
+    direct = _legal(
+        outcome={"label": "safe", "nested": outcome_nested},
+        policy_metadata={"nested": metadata_nested},
+    )
+    outcome_nested.append("changed")
+    metadata_nested.append("changed")
+    assert direct.to_dict()["outcome"]["nested"] == ["source"]
+    assert direct.to_dict()["policy_metadata"]["nested"] == ["source"]
+
+
+def test_oracle_experience_cross_binds_derived_label_to_action_metadata() -> None:
+    with pytest.raises(ValueError, match="does not match action metadata"):
+        _legal(
+            action=SecurityAction.BLOCK,
+            outcome={"label": "false_negative"},
+            policy_metadata={"is_malicious": True},
+        )
+
+
+def test_oracle_experience_rejects_hostile_nested_type_without_hooks() -> None:
+    class _HostileMeta(type):
+        calls = 0
+
+        def __eq__(cls, other: object) -> bool:
+            cls.calls += 1
+            raise AssertionError("metaclass equality hook executed")
+
+    class _Hostile(metaclass=_HostileMeta):
+        pass
+
+    with pytest.raises(ValueError, match="exact JSON values"):
+        _legal(outcome={"label": "safe", "nested": _Hostile()})
+    assert _HostileMeta.calls == 0
+
+
+def test_oracle_experience_enforces_nested_resource_limits() -> None:
+    nested: object = "leaf"
+    for _ in range(34):
+        nested = [nested]
+    with pytest.raises(ValueError, match="nesting limit"):
+        _legal(outcome={"label": "safe", "nested": nested})
+    with pytest.raises(ValueError, match="oversized string"):
+        _legal(outcome={"label": "safe", "nested": "x" * 65_537})
+
+
+def test_oracle_validator_rejects_hostile_outer_container_without_hooks() -> None:
+    class _HostileRecords(list[SecurityOracleExperience]):
+        def __iter__(self):
+            raise AssertionError("container iteration hook executed")
+
+    with pytest.raises(ValueError, match="exact list or tuple"):
+        validate_security_oracle_experience(
+            _HostileRecords([_legal()]), SecurityFeatureSchema(names=("risk",))
+        )


### PR DESCRIPTION
Consolidates and preserves ss251's #1723 contribution (`bf4496cd`) while repairing the remaining public oracle-record boundary.

- retain exact/canonical state, action, reward, and fixed schema identities
- snapshot bounded exact JSON outcome/metadata before aliases or hostile hooks can escape
- cross-bind derived labels to action + malicious metadata
- admit only exact validator containers, schemas, and records before iteration/access
- exercise the real rollout -> oracle -> validation -> serialization path

Verification:
- 50 security tests passed
- Ruff passed on security source/tests
- strict mypy passed (188 source files)
- git diff --check passed

Supersedes #1723 and closes #1721.