### PR TITLE
fix(evaluation): preserve IA action snapshot roles

### DIFF
--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -509,8 +509,8 @@ class IAConditionResult:
         for name, array in zip(
             (
                 "rewards",
-                "credited_actions",
                 "executed_actions",
+                "credited_actions",
                 "recommendations",
                 "partner_proposals",
                 "accepted_recommendations",

--- a/tests/test_ia_condition_result_hostile.py
+++ b/tests/test_ia_condition_result_hostile.py
@@ -153,6 +153,18 @@ def test_ia_condition_result_owns_read_only_array_snapshots() -> None:
         result.rewards[0] = 1.0
 
 
+def test_ia_condition_result_preserves_executed_and_credited_array_roles() -> None:
+    executed = np.asarray([0, 1], dtype=np.int64)
+    credited = np.asarray([1, 1], dtype=np.int64)
+    result = _legal(
+        executed_actions=executed,
+        credited_actions=credited,
+        executed_action_credit_mismatches=1,
+    )
+    np.testing.assert_array_equal(result.executed_actions, executed)
+    np.testing.assert_array_equal(result.credited_actions, credited)
+
+
 def test_ia_condition_result_rejects_nested_subclasses() -> None:
     class BudgetSubclass(ControllerBudget):
         pass


### PR DESCRIPTION
Follow-up to #1724. That preflight fix correctly delays ownership copies until after the byte gate, but its zip labels are reversed for the two primitive action arrays: the source tuple is `(executed_actions, credited_actions)` while the destination names are `("credited_actions", "executed_actions")`. Every valid result with an action-credit mismatch therefore stores the two arrays under the wrong public fields.\n\nThis one-line repair restores the field order and adds a regression with deliberately distinct executed/credited arrays.\n\nValidation on current main:\n- 169 focused IA tests passed, 9 skipped\n- Ruff passed\n- strict mypy passed\n- diff check passed\n\nNo evidence artifact or benchmark output changed.