### PR TITLE
fix(evaluation): bind multiagent aggregate identities

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -571,6 +571,68 @@ class AggregateEvidence:
     budgets_identical: bool
     all_values_finite: bool
 
+    def __post_init__(self) -> None:
+        """Reject leftover seed/bool/measurement identities before acceptance."""
+        if type(self.seeds) is not tuple or not self.seeds:
+            raise ValueError("seeds must be a non-empty exact tuple")
+        seeds = tuple(_require_seed(seed) for seed in self.seeds)
+        if len(set(seeds)) != len(seeds):
+            raise ValueError("seeds must be unique")
+        object.__setattr__(self, "seeds", seeds)
+        for name in (
+            "frozen_prequential_reward",
+            "learner_only_prequential_reward",
+            "joint_adaptive_prequential_reward",
+            "reward_uplift_over_frozen",
+            "partner_uplift",
+            "recurrent_a_probe_reward",
+            "mean_forgetting",
+            "max_forgetting",
+            "mean_interference_forgetting",
+            "recurrence_recovery_fraction",
+            "mean_recurrence_recovery_steps",
+            "mean_stability_gap",
+            "maximum_update_latency_ms",
+        ):
+            # real_number rejects leftover bools and still records non-finite
+            # recovery means the factory emits when no seed recovered.
+            object.__setattr__(self, name, real_number(name, getattr(self, name)))
+        if type(self.reward_uplift_interval) is not BootstrapInterval:
+            raise ValueError("reward_uplift_interval must be a BootstrapInterval")
+        if type(self.partner_uplift_interval) is not BootstrapInterval:
+            raise ValueError("partner_uplift_interval must be a BootstrapInterval")
+        phase_rewards = _require_ndarray(
+            "joint_adaptive_phase_rewards",
+            self.joint_adaptive_phase_rewards,
+            dtype=np.dtype(np.float64),
+            ndim=1,
+        )
+        performance = _require_ndarray(
+            "joint_adaptive_performance_matrix",
+            self.joint_adaptive_performance_matrix,
+            dtype=np.dtype(np.float64),
+            ndim=2,
+        )
+        object.__setattr__(self, "joint_adaptive_phase_rewards", _freeze_ndarray(phase_rewards))
+        object.__setattr__(
+            self, "joint_adaptive_performance_matrix", _freeze_ndarray(performance)
+        )
+        object.__setattr__(
+            self, "state_scalars", _require_int32("state_scalars", self.state_scalars, minimum=0)
+        )
+        object.__setattr__(
+            self, "state_bytes", _require_int32("state_bytes", self.state_bytes, minimum=0)
+        )
+        object.__setattr__(
+            self,
+            "action_scalars_per_step",
+            _require_int32("action_scalars_per_step", self.action_scalars_per_step, minimum=0),
+        )
+        if type(self.budgets_identical) is not bool:
+            raise ValueError("budgets_identical must be an exact bool")
+        if type(self.all_values_finite) is not bool:
+            raise ValueError("all_values_finite must be an exact bool")
+
 
 @dataclass(frozen=True)
 class AcceptanceEvidence:

--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -575,6 +575,10 @@ class AggregateEvidence:
         """Reject leftover seed/bool/measurement identities before acceptance."""
         if type(self.seeds) is not tuple or not self.seeds:
             raise ValueError("seeds must be a non-empty exact tuple")
+        _require_resource_limit(
+            "aggregate seed identities",
+            len(self.seeds) * np.dtype(np.int64).itemsize,
+        )
         seeds = tuple(_require_seed(seed) for seed in self.seeds)
         if len(set(seeds)) != len(seeds):
             raise ValueError("seeds must be unique")
@@ -590,17 +594,52 @@ class AggregateEvidence:
             "max_forgetting",
             "mean_interference_forgetting",
             "recurrence_recovery_fraction",
-            "mean_recurrence_recovery_steps",
             "mean_stability_gap",
             "maximum_update_latency_ms",
         ):
-            # real_number rejects leftover bools and still records non-finite
-            # recovery means the factory emits when no seed recovered.
-            object.__setattr__(self, name, real_number(name, getattr(self, name)))
+            object.__setattr__(self, name, finite_real(name, getattr(self, name)))
+        mean_recovery = real_number(
+            "mean_recurrence_recovery_steps",
+            self.mean_recurrence_recovery_steps,
+        )
+        if mean_recovery < 0.0 or mean_recovery == float("-inf"):
+            raise ValueError("mean_recurrence_recovery_steps must be nonnegative")
+        object.__setattr__(self, "mean_recurrence_recovery_steps", mean_recovery)
+        for name in (
+            "mean_forgetting",
+            "max_forgetting",
+            "mean_interference_forgetting",
+            "mean_stability_gap",
+            "maximum_update_latency_ms",
+        ):
+            if getattr(self, name) < 0.0:
+                raise ValueError(f"{name} must be nonnegative")
+        if not 0.0 <= self.recurrence_recovery_fraction <= 1.0:
+            raise ValueError("recurrence_recovery_fraction must lie in [0, 1]")
         if type(self.reward_uplift_interval) is not BootstrapInterval:
             raise ValueError("reward_uplift_interval must be a BootstrapInterval")
         if type(self.partner_uplift_interval) is not BootstrapInterval:
             raise ValueError("partner_uplift_interval must be a BootstrapInterval")
+        reward_interval = BootstrapInterval(
+            **{
+                field.name: getattr(self.reward_uplift_interval, field.name)
+                for field in fields(BootstrapInterval)
+            }
+        )
+        partner_interval = BootstrapInterval(
+            **{
+                field.name: getattr(self.partner_uplift_interval, field.name)
+                for field in fields(BootstrapInterval)
+            }
+        )
+        if reward_interval.sample_size != len(seeds) or partner_interval.sample_size != len(seeds):
+            raise ValueError("bootstrap interval sample_size must match seeds")
+        if reward_interval.estimate != self.reward_uplift_over_frozen:
+            raise ValueError("reward interval estimate must match reward_uplift_over_frozen")
+        if partner_interval.estimate != self.partner_uplift:
+            raise ValueError("partner interval estimate must match partner_uplift")
+        object.__setattr__(self, "reward_uplift_interval", reward_interval)
+        object.__setattr__(self, "partner_uplift_interval", partner_interval)
         phase_rewards = _require_ndarray(
             "joint_adaptive_phase_rewards",
             self.joint_adaptive_phase_rewards,
@@ -613,6 +652,16 @@ class AggregateEvidence:
             dtype=np.dtype(np.float64),
             ndim=2,
         )
+        if phase_rewards.shape != (3,):
+            raise ValueError("joint_adaptive_phase_rewards must have shape (3,)")
+        if performance.shape != (3, 2):
+            raise ValueError("joint_adaptive_performance_matrix must have shape (3, 2)")
+        if not np.all(np.isfinite(phase_rewards)) or not np.all(np.isfinite(performance)):
+            raise ValueError("aggregate arrays must contain only finite values")
+        if self.recurrent_a_probe_reward != float(performance[-1, MEET_CONTEXT]):
+            raise ValueError(
+                "recurrent_a_probe_reward must match joint_adaptive_performance_matrix"
+            )
         object.__setattr__(self, "joint_adaptive_phase_rewards", _freeze_ndarray(phase_rewards))
         object.__setattr__(
             self, "joint_adaptive_performance_matrix", _freeze_ndarray(performance)
@@ -626,12 +675,14 @@ class AggregateEvidence:
         object.__setattr__(
             self,
             "action_scalars_per_step",
-            _require_int32("action_scalars_per_step", self.action_scalars_per_step, minimum=0),
+            _require_int32("action_scalars_per_step", self.action_scalars_per_step, minimum=1),
         )
         if type(self.budgets_identical) is not bool:
             raise ValueError("budgets_identical must be an exact bool")
         if type(self.all_values_finite) is not bool:
             raise ValueError("all_values_finite must be an exact bool")
+        if not self.all_values_finite:
+            raise ValueError("all_values_finite must match validated finite aggregate payloads")
 
 
 @dataclass(frozen=True)

--- a/tests/test_multiagent_aggregate_leftover_identities.py
+++ b/tests/test_multiagent_aggregate_leftover_identities.py
@@ -1,0 +1,78 @@
+"""Leftover-identity gates for multiagent AggregateEvidence records."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.evaluation.continual_multiagent import (
+    AggregateEvidence,
+    BootstrapInterval,
+)
+
+
+def _interval() -> BootstrapInterval:
+    return BootstrapInterval(
+        estimate=0.1,
+        lower=0.0,
+        upper=0.2,
+        confidence_level=0.95,
+        resamples=10,
+        sample_size=2,
+    )
+
+
+def _legal(**overrides: object) -> AggregateEvidence:
+    payload: dict[str, object] = {
+        "seeds": (1, 2),
+        "frozen_prequential_reward": 0.1,
+        "learner_only_prequential_reward": 0.2,
+        "joint_adaptive_prequential_reward": 0.3,
+        "reward_uplift_over_frozen": 0.1,
+        "reward_uplift_interval": _interval(),
+        "partner_uplift": 0.05,
+        "partner_uplift_interval": _interval(),
+        "joint_adaptive_phase_rewards": np.zeros(3, dtype=np.float64),
+        "joint_adaptive_performance_matrix": np.zeros((3, 2), dtype=np.float64),
+        "recurrent_a_probe_reward": 0.1,
+        "mean_forgetting": 0.0,
+        "max_forgetting": 0.0,
+        "mean_interference_forgetting": 0.0,
+        "recurrence_recovery_fraction": 1.0,
+        "mean_recurrence_recovery_steps": 0.0,
+        "mean_stability_gap": 0.0,
+        "maximum_update_latency_ms": 1.0,
+        "state_scalars": 4,
+        "state_bytes": 16,
+        "action_scalars_per_step": 2,
+        "budgets_identical": True,
+        "all_values_finite": True,
+    }
+    payload.update(overrides)
+    return AggregateEvidence(**payload)  # type: ignore[arg-type]
+
+
+def test_aggregate_evidence_rejects_leftover_identities() -> None:
+    """Public aggregate records must not keep leftover bool/seed identities."""
+
+    with pytest.raises(ValueError, match="frozen_prequential_reward"):
+        _legal(frozen_prequential_reward=True)
+    with pytest.raises(ValueError, match="mean_forgetting"):
+        _legal(mean_forgetting=True)
+    with pytest.raises(ValueError, match="seeds"):
+        _legal(seeds=(True, 2))
+    with pytest.raises(ValueError, match="budgets_identical"):
+        _legal(budgets_identical=1)
+    with pytest.raises(ValueError, match="all_values_finite"):
+        _legal(all_values_finite=0)
+    with pytest.raises(ValueError, match="state_scalars"):
+        _legal(state_scalars=True)
+
+    legal = _legal()
+    assert legal.seeds == (1, 2)
+    assert type(legal.frozen_prequential_reward) is float
+    assert type(legal.budgets_identical) is bool
+    assert type(legal.all_values_finite) is bool
+    assert legal.budgets_identical is True
+    unrecovered = _legal(mean_recurrence_recovery_steps=float("inf"))
+    assert unrecovered.mean_recurrence_recovery_steps == float("inf")

--- a/tests/test_multiagent_aggregate_leftover_identities.py
+++ b/tests/test_multiagent_aggregate_leftover_identities.py
@@ -11,9 +11,9 @@ from alberta_framework.evaluation.continual_multiagent import (
 )
 
 
-def _interval() -> BootstrapInterval:
+def _interval(estimate: float = 0.1) -> BootstrapInterval:
     return BootstrapInterval(
-        estimate=0.1,
+        estimate=estimate,
         lower=0.0,
         upper=0.2,
         confidence_level=0.95,
@@ -31,10 +31,10 @@ def _legal(**overrides: object) -> AggregateEvidence:
         "reward_uplift_over_frozen": 0.1,
         "reward_uplift_interval": _interval(),
         "partner_uplift": 0.05,
-        "partner_uplift_interval": _interval(),
+        "partner_uplift_interval": _interval(0.05),
         "joint_adaptive_phase_rewards": np.zeros(3, dtype=np.float64),
         "joint_adaptive_performance_matrix": np.zeros((3, 2), dtype=np.float64),
-        "recurrent_a_probe_reward": 0.1,
+        "recurrent_a_probe_reward": 0.0,
         "mean_forgetting": 0.0,
         "max_forgetting": 0.0,
         "mean_interference_forgetting": 0.0,
@@ -76,3 +76,40 @@ def test_aggregate_evidence_rejects_leftover_identities() -> None:
     assert legal.budgets_identical is True
     unrecovered = _legal(mean_recurrence_recovery_steps=float("inf"))
     assert unrecovered.mean_recurrence_recovery_steps == float("inf")
+
+
+def test_aggregate_evidence_binds_nested_intervals_arrays_and_flags() -> None:
+    with pytest.raises(ValueError, match="sample_size must match seeds"):
+        _legal(seeds=(1,))
+    with pytest.raises(ValueError, match="reward interval estimate"):
+        _legal(reward_uplift_interval=_interval(0.2))
+    with pytest.raises(ValueError, match="partner interval estimate"):
+        _legal(partner_uplift_interval=_interval(0.2))
+    with pytest.raises(ValueError, match=r"shape \(3,\)"):
+        _legal(joint_adaptive_phase_rewards=np.zeros(2, dtype=np.float64))
+    with pytest.raises(ValueError, match=r"shape \(3, 2\)"):
+        _legal(joint_adaptive_performance_matrix=np.zeros((2, 2), dtype=np.float64))
+    with pytest.raises(ValueError, match="only finite"):
+        _legal(joint_adaptive_phase_rewards=np.full(3, np.nan, dtype=np.float64))
+    with pytest.raises(ValueError, match="must match joint_adaptive"):
+        _legal(recurrent_a_probe_reward=0.2)
+    with pytest.raises(ValueError, match="all_values_finite must match"):
+        _legal(all_values_finite=False)
+
+
+def test_aggregate_evidence_revalidates_replaced_interval_before_attribute_hooks() -> None:
+    class HostileInterval:
+        def __getattribute__(self, name: str) -> object:  # pragma: no cover - must not run
+            raise AssertionError(f"untrusted attribute hook executed: {name}")
+
+    with pytest.raises(ValueError, match="reward_uplift_interval"):
+        _legal(reward_uplift_interval=HostileInterval())
+
+
+def test_aggregate_evidence_owns_read_only_array_snapshots() -> None:
+    phase_rewards = np.zeros(3, dtype=np.float64)
+    result = _legal(joint_adaptive_phase_rewards=phase_rewards)
+    phase_rewards[0] = 1.0
+    assert result.joint_adaptive_phase_rewards[0] == 0.0
+    assert not result.joint_adaptive_phase_rewards.flags.writeable
+    assert not result.joint_adaptive_performance_matrix.flags.writeable


### PR DESCRIPTION
Contributor-preserving successor to #1736. Retains ss251 original hostile-identity commit and adds bounded seed preflight, exact nested interval revalidation, sample/estimate cross-binding, fixed array shapes/finiteness/ownership, reconstructed probe identity, nonnegative/range domains, exact resource minima, and finite-verdict binding.\n\nVerification: 242 passed, 2 skipped focused multiagent tests; Ruff and mypy passed; diff-check clean. No benchmark execution or output mutation.