### PR TITLE
results(ipmnist): retain matched L2-ER v2 outcome

### DIFF
--- a/outputs/l2er_matched_development/report.v2.json
+++ b/outputs/l2er_matched_development/report.v2.json
@@ -1,0 +1,763 @@
+{
+ "dataset_provenance": {
+  "materialization": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
+  "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
+  "source": {
+   "name": "mnist_784",
+   "provider": "openml",
+   "row_start": 0,
+   "row_stop_exclusive": 60000,
+   "version": 1
+  },
+  "x": {
+   "dtype": "<f4",
+   "sha256": "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313",
+   "shape": [
+    60000,
+    784
+   ]
+  },
+  "y": {
+   "dtype": "<i4",
+   "sha256": "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a",
+   "shape": [
+    60000
+   ]
+  }
+ },
+ "environment": {
+  "jax": {
+   "backend": "cpu",
+   "config": {
+    "jax_default_matmul_precision": null,
+    "jax_default_prng_impl": "threefry2x32",
+    "jax_disable_jit": false,
+    "jax_enable_x64": false,
+    "jax_numpy_dtype_promotion": "standard",
+    "jax_numpy_rank_promotion": "allow",
+    "jax_random_seed_offset": 0,
+    "jax_threefry_partitionable": true
+   },
+   "devices": [
+    {
+     "device_kind": "cpu",
+     "id": 0,
+     "platform": "cpu",
+     "process_index": 0
+    }
+   ]
+  },
+  "packages": {
+   "chex": "0.1.92",
+   "jax": "0.11.0",
+   "jaxlib": "0.11.0",
+   "numpy": "2.5.1",
+   "scikit-learn": "1.9.0"
+  },
+  "platform": {
+   "machine": "x86_64",
+   "release": "7.0.0-28-generic",
+   "system": "Linux"
+  },
+  "process_environment": {
+   "CUDA_VISIBLE_DEVICES": null,
+   "JAX_DEFAULT_MATMUL_PRECISION": null,
+   "JAX_ENABLE_X64": null,
+   "JAX_PLATFORMS": null,
+   "JAX_PLATFORM_NAME": null,
+   "OMP_NUM_THREADS": null,
+   "XLA_FLAGS": null
+  },
+  "python": {
+   "implementation": "CPython",
+   "version": "3.12.3"
+  },
+  "schema": "alberta.ipmnist_screening.runtime.v1"
+ },
+ "paired_comparisons": {
+  "l2er_combined": {
+   "ci95_lower": -0.12322830772941276,
+   "ci95_upper": 0.047894970740327884,
+   "deltas": [
+    -0.05500000715255737,
+    -0.06000000238418579,
+    0.0020000040531158447
+   ],
+   "mean_delta": -0.03766666849454244,
+   "outcome": "inconclusive"
+  },
+  "l2er_er_only": {
+   "ci95_lower": -0.11850805704478798,
+   "ci95_upper": 0.03784139081522205,
+   "deltas": [
+    -0.057999998331069946,
+    -0.05900000035762787,
+    -0.0040000006556510925
+   ],
+   "mean_delta": -0.04033333311478297,
+   "outcome": "inconclusive"
+  },
+  "l2er_l2_only": {
+   "ci95_lower": -0.002100888500813429,
+   "ci95_upper": 0.0007675524654028656,
+   "deltas": [
+    0.0,
+    -0.0010000020265579224,
+    -0.0010000020265579224
+   ],
+   "mean_delta": -0.0006666680177052816,
+   "outcome": "inconclusive"
+  }
+ },
+ "plan": {
+  "allowed_boundary_information": [],
+  "allowed_task_information": [
+   "current_example_label"
+  ],
+  "arm_specific_charged_axis": "effective_rank_updates",
+  "arms": [
+   "l2er_mechanism_off",
+   "l2er_l2_only",
+   "l2er_er_only",
+   "l2er_combined"
+  ],
+  "confidence_critical": 4.302652729749464,
+  "confidence_degrees_of_freedom": 2,
+  "confidence_level": 0.95,
+  "confidence_method": "two_sided_student_t",
+  "config": {
+   "hidden1": 300,
+   "hidden2": 150,
+   "input_dim": 784,
+   "n_classes": 10,
+   "n_tasks": 2,
+   "task_length": 500
+  },
+  "control_arm": "l2er_mechanism_off",
+  "development_only": true,
+  "matched_axes": [
+   "example_schedule",
+   "observations",
+   "supervised_updates",
+   "allowed_boundary_information",
+   "allowed_task_information"
+  ],
+  "null_delta": 0.0,
+  "outcome_retention_required": true,
+  "paired_direction": "higher_is_better",
+  "plan_id": "asi.l2er-ipmnist.cheap-screen.v2",
+  "primary_metric": "mean_online_accuracy",
+  "prior_invalid_attempt": {
+   "artifact_sha256": "ab7f03b73993b79c53021970926181130980dd84b180e095779e30960953ff86",
+   "disposition": "invalid_unmerged_historical_attempt",
+   "execution_history": [
+    "seed 1701 was consumed across all arms during executable-path audit",
+    "one planned invocation failed during dataset download before arm execution or output",
+    "a later complete v1 matrix produced the invalid unmerged artifact"
+   ],
+   "invalid_reasons": [
+    "normal critical 1.96 was used instead of Student t(df=2)",
+    "effective-rank parameter updates were omitted from the update counter",
+    "seed 1701 had already been consumed during executable-path audit"
+   ],
+   "path": "outputs/l2er_matched_development/report.v1.json",
+   "schema": "asi.l2er-ipmnist.matched-development-report.v1",
+   "seeds": [
+    1701,
+    1702,
+    1703
+   ],
+   "source_commit": "f62d157a449c30a79dcf01740ae7f20a6c27e726"
+  },
+  "scientific_promotion_allowed": false,
+  "seeds": [
+   1721,
+   1722,
+   1723
+  ]
+ },
+ "policy": {
+  "development_only": true,
+  "outcome_retained": true,
+  "scientific_promotion_allowed": false,
+  "timing_is_telemetry_only": true
+ },
+ "records": [
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_mechanism_off",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.254384398460388,
+    "mean_online_accuracy": 0.2070000097155571,
+    "mean_plasticity": 0.013753071893006563
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 3.3673553970002104
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1721,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_l2_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2543952465057373,
+    "mean_online_accuracy": 0.2070000097155571,
+    "mean_plasticity": 0.013750141020864248
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 3.588875444009318
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1721,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_er_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2892420291900635,
+    "mean_online_accuracy": 0.14900001138448715,
+    "mean_plasticity": 0.007210403215140104
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 5.5848684619995765
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1721,
+   "task_length": 500,
+   "updates": 1010
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_combined",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.28957998752594,
+    "mean_online_accuracy": 0.15200000256299973,
+    "mean_plasticity": 0.007161461282521486
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 8.241787507999106
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1721,
+   "task_length": 500,
+   "updates": 1010
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_mechanism_off",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2442744970321655,
+    "mean_online_accuracy": 0.23400001227855682,
+    "mean_plasticity": 0.01569659123197198
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 4.406133989003138
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1722,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_l2_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2443476915359497,
+    "mean_online_accuracy": 0.2330000102519989,
+    "mean_plasticity": 0.01569724828004837
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 3.4129400590027217
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1722,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_er_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.28236186504364,
+    "mean_online_accuracy": 0.17500001192092896,
+    "mean_plasticity": 0.008172750007361174
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 5.539075195993064
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1722,
+   "task_length": 500,
+   "updates": 1010
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_combined",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.282277226448059,
+    "mean_online_accuracy": 0.17400000989437103,
+    "mean_plasticity": 0.008188816020265222
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 6.8295831640134566
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1722,
+   "task_length": 500,
+   "updates": 1010
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_mechanism_off",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2481058835983276,
+    "mean_online_accuracy": 0.18700000643730164,
+    "mean_plasticity": 0.01647464046254754
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 3.2980545309983427
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1723,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_l2_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.248107433319092,
+    "mean_online_accuracy": 0.1860000044107437,
+    "mean_plasticity": 0.016433547250926495
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 3.2920129019912565
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1723,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_er_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2818440198898315,
+    "mean_online_accuracy": 0.18300000578165054,
+    "mean_plasticity": 0.008501031436026096
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 6.841531527999905
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1723,
+   "task_length": 500,
+   "updates": 1010
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_combined",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.281873345375061,
+    "mean_online_accuracy": 0.18900001049041748,
+    "mean_plasticity": 0.008445029612630606
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 5.164324241006398
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1723,
+   "task_length": 500,
+   "updates": 1010
+  }
+ ],
+ "schema": "asi.l2er-ipmnist.matched-development-report.v2",
+ "source_provenance": {
+  "git_commit": "5fc85b69897fc5b74c27389579c3d1bc27931394",
+  "git_object_format": "sha1",
+  "git_tree": "a0e43ce47184a15c118c95a7211f8dc6cbee74fd",
+  "relevant_source_file_count": 195,
+  "relevant_source_scope": "tracked:alberta_framework/**,pyproject.toml,uv.lock",
+  "relevant_source_sha256": "dea82e87ff0415ea87ca3ae8dca12760149cc221b297e7971214d3294c9fcf90",
+  "schema": "alberta.ipmnist_screening.source_provenance.v1",
+  "uv_lock_sha256": "0fc52a642ba70bd64bfa80049b1efc99c35829d01e44705370994ad818ee82d7",
+  "worktree_clean": true
+ }
+}


### PR DESCRIPTION
Retains the single corrected v2 matched nonpromoting development execution for #1559.\n\nExecution identity:\n- exact merged source: 5fc85b69897fc5b74c27389579c3d1bc27931394\n- fresh seeds: 1721, 1722, 1723\n- new immutable path/schema: outputs/l2er_matched_development/report.v2.json / asi.l2er-ipmnist.matched-development-report.v2\n- artifact SHA-256: 579c400412d3c50898c16a8fd02fa82e2cd712b5278b5a99974b5e89560707ec\n- Student t(df=2) critical derived as sqrt(1.805/0.0975), binary64 0x1.135ea98e146bbp+2\n- corrected ER accounting: 1000 supervised + 10 auxiliary = 1010 total updates, 2010 model queries\n\nAll three candidate comparisons are retained as inconclusive under the corrected interval. This is development-only and permanently nonpromoting.\n\nHistorical disclosure: invalid unmerged v1 result PR #1716 used seeds 1701-1703 and artifact SHA ab7f03b73993b79c53021970926181130980dd84b180e095779e30960953ff86. It used z=1.96, omitted ER auxiliary updates from total updates, and reused pre-consumed seed 1701. That v1 JSON is not included here and must not be merged.\n\nThis PR contains exactly one new v2 JSON artifact. Keep #1559 open pending independent audit.