### PR TITLE
fix(security): revalidate oracle records at consumers

### DIFF
--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -487,17 +487,31 @@ class SecurityOracleExperience:
         object.__setattr__(self, "outcome", MappingProxyType(outcome))
         object.__setattr__(self, "policy_metadata", MappingProxyType(policy_metadata))
 
+    def _revalidated_copy(self) -> SecurityOracleExperience:
+        """Reconstruct the record before a public consumer trusts frozen fields."""
+        return SecurityOracleExperience(
+            state=self.state,
+            action=self.action,
+            reward=self.reward,
+            outcome=self.outcome,
+            policy_metadata=self.policy_metadata,
+            schema=self.schema,
+        )
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable oracle experience mapping."""
+        checked = self._revalidated_copy()
         payload = {
-            "schema": self.schema,
-            "state": list(self.state),
-            "action": int(self.action),
-            "action_name": security_gym_action_name(self.action),
-            "reward": self.reward,
-            "outcome": _copy_json_mapping(self.outcome, name="security oracle outcome"),
+            "schema": checked.schema,
+            "state": list(checked.state),
+            "action": int(checked.action),
+            "action_name": security_gym_action_name(checked.action),
+            "reward": checked.reward,
+            "outcome": _copy_json_mapping(
+                checked.outcome, name="security oracle outcome"
+            ),
             "policy_metadata": _copy_json_mapping(
-                self.policy_metadata, name="policy_metadata"
+                checked.policy_metadata, name="policy_metadata"
             ),
         }
         _require_rfc_json_mapping(payload, name="security oracle experience")
@@ -554,10 +568,14 @@ def validate_security_oracle_experience(
         if type(record) is not SecurityOracleExperience:
             raise ValueError(f"invalid oracle experience {idx}: wrong record type")
         try:
-            schema.validate_observation(record.state)
+            checked = record._revalidated_copy()
         except ValueError as exc:
             raise ValueError(f"invalid oracle experience {idx}: {exc}") from exc
-        label = record.outcome.get("label")
+        try:
+            schema.validate_observation(checked.state)
+        except ValueError as exc:
+            raise ValueError(f"invalid oracle experience {idx}: {exc}") from exc
+        label = checked.outcome.get("label")
         if type(label) is not str or len(label) == 0:
             raise ValueError(f"invalid oracle experience {idx}: missing outcome label")
 

--- a/tests/test_security_oracle_leftover_identities.py
+++ b/tests/test_security_oracle_leftover_identities.py
@@ -140,3 +140,39 @@ def test_oracle_validator_rejects_hostile_outer_container_without_hooks() -> Non
         validate_security_oracle_experience(
             _HostileRecords([_legal()]), SecurityFeatureSchema(names=("risk",))
         )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    (
+        ("action", True, "action"),
+        ("reward", float("nan"), "reward"),
+        ("schema", "not-the-v1-schema", "schema"),
+        ("state", [0.5], "state"),
+    ),
+)
+def test_oracle_public_consumers_revalidate_forged_frozen_fields(
+    field: str, value: object, error: str
+) -> None:
+    record = _legal()
+    object.__setattr__(record, field, value)
+
+    with pytest.raises(ValueError, match=error):
+        record.to_dict()
+    with pytest.raises(ValueError, match=error):
+        validate_security_oracle_experience(
+            [record], SecurityFeatureSchema(names=("risk",))
+        )
+
+
+def test_oracle_public_consumers_revalidate_forged_label_binding() -> None:
+    record = _legal(action=SecurityAction.BLOCK)
+    object.__setattr__(record, "policy_metadata", {"is_malicious": True})
+    object.__setattr__(record, "outcome", {"label": "false_negative"})
+
+    with pytest.raises(ValueError, match="does not match action metadata"):
+        record.to_dict()
+    with pytest.raises(ValueError, match="does not match action metadata"):
+        validate_security_oracle_experience(
+            [record], SecurityFeatureSchema(names=("risk",))
+        )


### PR DESCRIPTION
## Summary
- reconstruct `SecurityOracleExperience` before `to_dict()` trusts frozen fields
- reconstruct exact records again in `validate_security_oracle_experience` before schema/label consumption
- cover forged action, reward, schema, state, and action/metadata label binding

## Context
#1723 is closed and superseded by merged #1738. That repair correctly validates and snapshots ordinary construction, but the public validator still trusted constructor history: `object.__setattr__` could forge action/reward/schema and the record passed validation. This follow-up preserves the public field order and positional/keyword constructor surface while making both public consumers fail closed.

`to_dict()` remains the supported serialization surface. The nested payload aliases are copied at construction and copied again for output; timing/JAX/evidence paths are untouched.

## Verification
- `.venv/bin/python -m pytest tests/test_security_integration.py tests/test_security_oracle_leftover_identities.py tests/test_security_oracle_label_hostile.py -q` (33 passed)
- `.venv/bin/python -m ruff check alberta_framework/security.py tests/test_security_oracle_leftover_identities.py tests/test_security_oracle_label_hostile.py`
- `.venv/bin/python -m mypy alberta_framework/security.py`
- `git diff --check`