### PR TITLE
fix(evaluation): bind IA and multiagent aggregate consumption

### DIFF
--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -509,8 +509,8 @@ class IAConditionResult:
         for name, array in zip(
             (
                 "rewards",
-                "credited_actions",
                 "executed_actions",
+                "credited_actions",
                 "recommendations",
                 "partner_proposals",
                 "accepted_recommendations",

--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -1352,6 +1352,36 @@ def aggregate_ia_evidence(
         )
         if result.rewards.size != config.num_steps:
             raise ValueError("result length does not match config.num_steps")
+        if result.condition in RECOMMENDATION_CONDITIONS:
+            expected_actions = np.where(
+                result.accepted_recommendations,
+                result.recommendations,
+                result.partner_proposals,
+            )
+            if not np.array_equal(result.executed_actions, expected_actions):
+                raise ValueError("executed actions violate the recommendation protocol")
+            if bool(result.accepted_recommendations[0]):
+                raise ValueError("the first transition cannot have a prior acceptance")
+            if (
+                result.recommendations[0] != result.executed_actions[0]
+                or result.partner_proposals[0] != result.executed_actions[0]
+            ):
+                raise ValueError("first-transition provenance must equal the initial action")
+            if result.nominal_recommendation_decisions != config.num_steps:
+                raise ValueError("nominal recommendation decisions must equal config.num_steps")
+            executed_accepted = result.executed_accepted_recommendations
+            if result.nominal_accepted_recommendations not in {
+                executed_accepted,
+                executed_accepted + 1,
+            }:
+                raise ValueError("nominal accepted count is not bound to executed primitives")
+            if result.condition == "observe_only" and result.nominal_accepted_recommendations != 0:
+                raise ValueError("observe-only nominal accepts must be zero")
+            if (
+                result.condition == "accept_always"
+                and result.nominal_accepted_recommendations != config.num_steps
+            ):
+                raise ValueError("accept-always must accept every decision")
         expected_phase_means = _phase_means(result.rewards, config)
         if not np.array_equal(result.phase_mean_rewards, expected_phase_means):
             raise ValueError("phase_mean_rewards do not match rewards and config")
@@ -1362,6 +1392,10 @@ def aggregate_ia_evidence(
     if len(validated) % len(CONDITION_NAMES) != 0:
         raise ValueError("results must contain complete IA condition tuples")
     results = tuple(validated)
+    expected_budgets = _condition_budgets(config, _make_partner(config), _make_ia(config))
+    for result in results:
+        if result.controller_budget != expected_budgets[result.condition]:
+            raise ValueError("controller budget does not match the live configured components")
     groups = {condition: _condition_group(results, condition) for condition in CONDITION_NAMES}
     seed_sets = {
         condition: tuple(result.seed for result in group) for condition, group in groups.items()

--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -1052,6 +1052,9 @@ def aggregate_evidence(
 
     if type(config) is not ContinualMultiAgentConfig:
         raise ValueError("config must be a ContinualMultiAgentConfig")
+    config = ContinualMultiAgentConfig(
+        **{field.name: getattr(config, field.name) for field in fields(ContinualMultiAgentConfig)}
+    )
     if type(results) not in (list, tuple):
         raise ValueError("results must be an exact list or tuple")
     if not results:

--- a/tests/test_ia_condition_result_hostile.py
+++ b/tests/test_ia_condition_result_hostile.py
@@ -153,6 +153,18 @@ def test_ia_condition_result_owns_read_only_array_snapshots() -> None:
         result.rewards[0] = 1.0
 
 
+def test_ia_condition_result_preserves_executed_and_credited_array_roles() -> None:
+    executed = np.asarray([0, 1], dtype=np.int64)
+    credited = np.asarray([1, 1], dtype=np.int64)
+    result = _legal(
+        executed_actions=executed,
+        credited_actions=credited,
+        executed_action_credit_mismatches=1,
+    )
+    np.testing.assert_array_equal(result.executed_actions, executed)
+    np.testing.assert_array_equal(result.credited_actions, credited)
+
+
 def test_ia_condition_result_rejects_nested_subclasses() -> None:
     class BudgetSubclass(ControllerBudget):
         pass

--- a/tests/test_ia_condition_result_hostile.py
+++ b/tests/test_ia_condition_result_hostile.py
@@ -197,6 +197,48 @@ def test_ia_aggregation_revalidates_config_at_consumption() -> None:
         aggregate_ia_evidence([_legal()], config=config)
 
 
+def test_ia_aggregation_binds_recommendation_protocol() -> None:
+    recommendation = {
+        "condition": "observe_only",
+        "recommendations": np.zeros(2, dtype=np.int64),
+        "partner_proposals": np.zeros(2, dtype=np.int64),
+        "nominal_recommendation_decisions": 2,
+    }
+    config = ContinualIAConfig(num_steps=2, phase_length=2, recovery_window=1)
+    invalid_actions = _legal(
+        **recommendation,
+        executed_actions=np.ones(2, dtype=np.int64),
+        credited_actions=np.ones(2, dtype=np.int64),
+    )
+    with pytest.raises(ValueError, match="executed actions violate"):
+        aggregate_ia_evidence([invalid_actions], config=config)
+    invalid_count = _legal(**(recommendation | {"nominal_recommendation_decisions": 1}))
+    with pytest.raises(ValueError, match="decisions must equal"):
+        aggregate_ia_evidence([invalid_count], config=config)
+
+
+def test_ia_aggregation_binds_live_component_budget() -> None:
+    results = []
+    for condition in CONDITION_NAMES:
+        overrides: dict[str, object] = {"condition": condition}
+        if condition in {"observe_only", "recommendation_p05", "accept_always"}:
+            accepted = np.array([False, condition == "accept_always"], dtype=np.bool_)
+            overrides.update(
+                recommendations=np.zeros(2, dtype=np.int64),
+                partner_proposals=np.zeros(2, dtype=np.int64),
+                accepted_recommendations=accepted,
+                nominal_recommendation_decisions=2,
+                nominal_accepted_recommendations=2 if condition == "accept_always" else 0,
+                executed_accepted_recommendations=int(np.count_nonzero(accepted)),
+            )
+        results.append(_legal(**overrides))
+    with pytest.raises(ValueError, match="live configured components"):
+        aggregate_ia_evidence(
+            results,
+            config=ContinualIAConfig(num_steps=2, phase_length=2, recovery_window=1),
+        )
+
+
 def test_ia_result_preflights_retained_bytes_before_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_multiagent_condition_result_hostile.py
+++ b/tests/test_multiagent_condition_result_hostile.py
@@ -200,6 +200,14 @@ def test_aggregation_revalidates_nested_records_at_consumption() -> None:
         )
 
 
+def test_aggregation_revalidates_config_at_consumption() -> None:
+    config = ContinualMultiAgentConfig()
+    object.__setattr__(config, "phase_steps", True)
+
+    with pytest.raises(ValueError, match="phase_steps must be an integer"):
+        aggregate_evidence([_legal()], config=config)
+
+
 def test_aggregation_rejects_hostile_outer_container_before_hooks() -> None:
     class HostileList(list[ConditionResult]):
         def __len__(self) -> int:  # pragma: no cover - must not run
@@ -252,7 +260,7 @@ def test_aggregation_preflights_retained_arrays_before_record_iteration(
         1,
     )
 
-    with pytest.raises(ValueError, match="aggregate condition result arrays requires"):
+    with pytest.raises(ValueError, match="bootstrap_resamples"):
         aggregate_evidence(
             [result],
             config=config,


### PR DESCRIPTION
Summary:
- preserve the contributor-authored IA action-role correction from #1739
- revalidate IA recommendation execution, provenance, counters, and live configured budgets at aggregate consumption
- reconstruct exact multiagent configuration before any aggregate resource or cross-field use

Verification:
- IA panel: 171 passed, 9 skipped
- multiagent panel: 251 passed, 2 skipped
- full Ruff passed
- strict mypy passed for 189 source files
- diff check passed

Source-only corrective. No immutable output was changed; registered evidence remains invalid pending separately authorized frozen reruns.

Supersedes #1739 with its contributor commit preserved as the first commit.