### PR TITLE
fix: consolidate hostile boundary gates

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -3865,7 +3865,7 @@ def summarize_forager_runs(
         "fov_last_10pct_ema_auc",
     }
     if type(metric) is not str or metric not in supported_metrics:
-        raise ValueError(f"unsupported Forager summary metric {metric!r}")
+        raise ValueError("unsupported Forager summary metric")
     if type(runs) not in (list, tuple):
         raise TypeError("runs must be an actual list or tuple")
     if any(type(run) is not ForagerRunResult for run in runs):

--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -2529,8 +2529,10 @@ def build_forager_comparison_report(
     grouped: dict[str, list[ForagerRunResult]] = {}
     for run in runs:
         grouped.setdefault(run.agent, []).append(run)
+    if type(candidate) is not str:
+        raise ValueError("candidate must be an exact string")
     if candidate not in grouped:
-        raise ValueError(f"candidate {candidate!r} is absent from runs")
+        raise ValueError("candidate is absent from runs")
     summaries = {
         name: summarize_forager_runs(
             method_runs,

--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -1247,8 +1247,10 @@ def early_window_mse(
         raise ValueError("segment must be a non-negative integer")
     if type(segment_length) is not int or segment_length < 1:
         raise ValueError("segment_length must be a positive integer")
-    if type(window) is not int or window < 1 or window > segment_length:
-        raise ValueError(f"window must be an integer in [1, {segment_length}], got {window!r}")
+    if type(window) is not int:
+        raise ValueError("window must be an integer")
+    if not 1 <= window <= segment_length:
+        raise ValueError(f"window must be an integer in [1, {segment_length}]")
     seg = segment_slice(sq_errors, segment, segment_length)
     return jnp.mean(seg[..., :window], axis=-1)
 

--- a/tests/test_forager_candidate_hostile_strings.py
+++ b/tests/test_forager_candidate_hostile_strings.py
@@ -1,0 +1,80 @@
+"""Hostile string gate for forager comparison candidate."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager import ForagerRunResult
+from alberta_framework.benchmarks.forager_results import build_forager_comparison_report
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+    def __str__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile str must not run")
+
+
+def _run(*, agent: str = "toy", seed: int = 0) -> ForagerRunResult:
+    return ForagerRunResult(
+        agent=agent,
+        privileged=False,
+        seed=seed,
+        steps=2,
+        total_reward=0.0,
+        mean_reward=0.0,
+        final_window_mean_reward=0.0,
+        final_ewm_reward=0.0,
+        mean_ewm_reward=0.0,
+        fov_last_10pct_ema_auc=0.0,
+        mean_biome_regret=0.0,
+        final_biome_regret=0.0,
+        curve_steps=(1, 2),
+        curve_ewm_reward=(0.0, 0.0),
+        curve_window_reward=(0.0, 0.0),
+        duration_s=1.0,
+        frames_per_second=1.0,
+        environment={"kind": "toy"},
+        metric_contract={"metric": "mean_reward"},
+        agent_metadata={"name": agent, "privileged": False},
+    )
+
+
+def test_candidate_rejects_hostile_before_membership() -> None:
+    runs = [_run(agent="toy", seed=0), _run(agent="toy", seed=1)]
+    hostile = _HostileStr("evil")
+    _HostileStr.calls = 0
+    with pytest.raises(ValueError, match="exact string"):
+        build_forager_comparison_report(runs, candidate=hostile)  # type: ignore[arg-type]
+    assert _HostileStr.calls == 0
+
+    with pytest.raises(ValueError, match="candidate is absent"):
+        build_forager_comparison_report(runs, candidate="missing")
+    assert _HostileStr.calls == 0
+
+    report = build_forager_comparison_report(runs, candidate="toy")
+    assert report.candidate == "toy"
+
+
+def test_candidate_rejects_hostile_hash_without_repr() -> None:
+    runs = [_run(agent="a", seed=0), _run(agent="a", seed=1)]
+    hostile = _HostileStr("a")
+    _HostileStr.calls = 0
+    with pytest.raises(ValueError, match="exact string"):
+        build_forager_comparison_report(runs, candidate=hostile)  # type: ignore[arg-type]
+    assert _HostileStr.calls == 0

--- a/tests/test_forager_candidate_hostile_strings.py
+++ b/tests/test_forager_candidate_hostile_strings.py
@@ -69,12 +69,3 @@ def test_candidate_rejects_hostile_before_membership() -> None:
 
     report = build_forager_comparison_report(runs, candidate="toy")
     assert report.candidate == "toy"
-
-
-def test_candidate_rejects_hostile_hash_without_repr() -> None:
-    runs = [_run(agent="a", seed=0), _run(agent="a", seed=1)]
-    hostile = _HostileStr("a")
-    _HostileStr.calls = 0
-    with pytest.raises(ValueError, match="exact string"):
-        build_forager_comparison_report(runs, candidate=hostile)  # type: ignore[arg-type]
-    assert _HostileStr.calls == 0

--- a/tests/test_forager_summary_metric_hostile.py
+++ b/tests/test_forager_summary_metric_hostile.py
@@ -1,0 +1,66 @@
+"""Hostile string gate for Forager summary metric."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager import ForagerRunResult, summarize_forager_runs
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+def _run(*, seed: int = 0) -> ForagerRunResult:
+    return ForagerRunResult(
+        agent="toy",
+        privileged=False,
+        seed=seed,
+        steps=2,
+        total_reward=0.0,
+        mean_reward=0.0,
+        final_window_mean_reward=0.0,
+        final_ewm_reward=0.0,
+        mean_ewm_reward=0.0,
+        fov_last_10pct_ema_auc=0.0,
+        mean_biome_regret=0.0,
+        final_biome_regret=0.0,
+        curve_steps=(1, 2),
+        curve_ewm_reward=(0.0, 0.0),
+        curve_window_reward=(0.0, 0.0),
+        duration_s=1.0,
+        frames_per_second=1.0,
+        environment={"kind": "toy"},
+        metric_contract={"metric": "mean_reward"},
+        agent_metadata={"name": "toy", "privileged": False},
+    )
+
+
+def test_summarize_rejects_hostile_metric_before_in_and_repr() -> None:
+    runs = [_run(seed=0), _run(seed=1)]
+    hostile = _HostileStr("evil_metric")
+    _HostileStr.calls = 0
+    with pytest.raises(ValueError, match="unsupported Forager summary metric"):
+        summarize_forager_runs(runs, metric=hostile)  # type: ignore[arg-type]
+    assert _HostileStr.calls == 0
+
+    with pytest.raises(ValueError, match="unsupported Forager summary metric"):
+        summarize_forager_runs(runs, metric="unknown_metric")  # type: ignore[arg-type]
+
+    # valid still works
+    summary = summarize_forager_runs(runs, metric="mean_reward")
+    assert summary.metric == "mean_reward"

--- a/tests/test_gauntlet_window_hostile.py
+++ b/tests/test_gauntlet_window_hostile.py
@@ -1,0 +1,66 @@
+"""Hostile integer gate for gauntlet early_window_mse."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.streams.gauntlet import early_window_mse
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+    def __str__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile str must not run")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __lt__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile lt must not run")
+
+    def __le__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile le must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __int__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile int must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        return int.__hash__(self)
+
+
+def test_early_window_mse_rejects_hostile_before_repr() -> None:
+    errors = jnp.ones((10,), dtype=jnp.float32)
+    hostile = _HostileInt(5)
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="window must be an integer"):
+        early_window_mse(errors, segment=0, segment_length=10, window=hostile)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+
+    # bool is subclass of int but must be rejected
+    with pytest.raises(ValueError, match="window must be an integer"):
+        early_window_mse(errors, segment=0, segment_length=10, window=True)  # type: ignore[arg-type]
+
+    # valid still works
+    result = early_window_mse(errors, segment=0, segment_length=10, window=5)
+    assert float(result) == pytest.approx(1.0)
+
+    # out of range without hostile still generic message
+    with pytest.raises(ValueError, match="window must be an integer in"):
+        early_window_mse(errors, segment=0, segment_length=10, window=20)


### PR DESCRIPTION
Consolidates the exact production commits from #1725, #1730, and #1733 on current main, preserving contributor authorship and resolving their stale-base merge failures. Removes one duplicate candidate test that repeated the same hostile object, production call, rejection, and zero-hook assertion.

Validation: 25 focused Forager/gauntlet tests passed; scoped Ruff passed; strict mypy passed for the three source modules; diff check passed. No benchmark run or artifact.