### PR TITLE
fix(security): revalidate oracle records at consumption

### DIFF
--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -128,6 +128,62 @@ def _copy_json_mapping(payload: object, *, name: str) -> dict[str, Any]:
     }
 
 
+def _freeze_json_value(value: Any) -> Any:
+    value_type = type(value)
+    if value_type is list:
+        return tuple(_freeze_json_value(item) for item in value)
+    if value_type is dict:
+        return MappingProxyType(
+            {key: _freeze_json_value(item) for key, item in value.items()}
+        )
+    return value
+
+
+def _freeze_json_mapping(payload: dict[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType(
+        {key: _freeze_json_value(value) for key, value in payload.items()}
+    )
+
+
+def _require_frozen_json_value(
+    value: object,
+    *,
+    name: str,
+    depth: int = 0,
+    budget: list[int] | None = None,
+) -> None:
+    if budget is None:
+        budget = [_JSON_MAX_NODES]
+    budget[0] -= 1
+    if budget[0] < 0:
+        raise ValueError(f"{name} exceeds the JSON value resource limit")
+    if depth > _JSON_MAX_DEPTH:
+        raise ValueError(f"{name} exceeds the JSON nesting limit")
+    value_type = type(value)
+    if (
+        value is None
+        or value_type is bool
+        or value_type is int
+        or value_type is float
+        or value_type is str
+    ):
+        return
+    if value_type is tuple:
+        for item in cast(tuple[object, ...], value):
+            _require_frozen_json_value(
+                item, name=name, depth=depth + 1, budget=budget
+            )
+        return
+    if value_type is MappingProxyType:
+        payload = _copy_mapping(value, name=name)
+        for item in payload.values():
+            _require_frozen_json_value(
+                item, name=name, depth=depth + 1, budget=budget
+            )
+        return
+    raise ValueError(f"{name} must contain immutable exact JSON values")
+
+
 def _require_exact_str(name: str, value: object) -> str:
     if type(value) is not str:
         raise ValueError(f"{name} must be an exact string")
@@ -484,20 +540,23 @@ class SecurityOracleExperience:
                 raise ValueError("security oracle outcome label does not match action metadata")
         object.__setattr__(self, "state", state)
         object.__setattr__(self, "reward", reward)
-        object.__setattr__(self, "outcome", MappingProxyType(outcome))
-        object.__setattr__(self, "policy_metadata", MappingProxyType(policy_metadata))
+        object.__setattr__(self, "outcome", _freeze_json_mapping(outcome))
+        object.__setattr__(self, "policy_metadata", _freeze_json_mapping(policy_metadata))
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable oracle experience mapping."""
+        validated = _require_canonical_oracle_experience(self)
         payload = {
-            "schema": self.schema,
-            "state": list(self.state),
-            "action": int(self.action),
-            "action_name": security_gym_action_name(self.action),
-            "reward": self.reward,
-            "outcome": _copy_json_mapping(self.outcome, name="security oracle outcome"),
+            "schema": validated.schema,
+            "state": list(validated.state),
+            "action": int(validated.action),
+            "action_name": security_gym_action_name(validated.action),
+            "reward": validated.reward,
+            "outcome": _copy_json_mapping(
+                validated.outcome, name="security oracle outcome"
+            ),
             "policy_metadata": _copy_json_mapping(
-                self.policy_metadata, name="policy_metadata"
+                validated.policy_metadata, name="policy_metadata"
             ),
         }
         _require_rfc_json_mapping(payload, name="security oracle experience")
@@ -554,12 +613,45 @@ def validate_security_oracle_experience(
         if type(record) is not SecurityOracleExperience:
             raise ValueError(f"invalid oracle experience {idx}: wrong record type")
         try:
-            schema.validate_observation(record.state)
+            validated = _require_canonical_oracle_experience(record)
         except ValueError as exc:
             raise ValueError(f"invalid oracle experience {idx}: {exc}") from exc
-        label = record.outcome.get("label")
+        try:
+            schema.validate_observation(validated.state)
+        except ValueError as exc:
+            raise ValueError(f"invalid oracle experience {idx}: {exc}") from exc
+        label = validated.outcome.get("label")
         if type(label) is not str or len(label) == 0:
             raise ValueError(f"invalid oracle experience {idx}: missing outcome label")
+
+
+def _require_canonical_oracle_experience(
+    record: SecurityOracleExperience,
+) -> SecurityOracleExperience:
+    if type(record.state) is not tuple or any(
+        type(value) is not float for value in record.state
+    ):
+        raise ValueError("state must contain canonical float values")
+    if type(record.action) is not SecurityAction:
+        raise ValueError("action must be an exact SecurityAction")
+    if type(record.reward) is not float:
+        raise ValueError("reward must be a canonical float")
+    if type(record.schema) is not str or record.schema != _ORACLE_EXPERIENCE_SCHEMA:
+        raise ValueError("schema must identify the oracle-experience v1 contract")
+    if type(record.outcome) is not MappingProxyType:
+        raise ValueError("security oracle outcome must be an immutable mapping")
+    if type(record.policy_metadata) is not MappingProxyType:
+        raise ValueError("policy_metadata must be an immutable mapping")
+    _require_frozen_json_value(record.outcome, name="security oracle outcome")
+    _require_frozen_json_value(record.policy_metadata, name="policy_metadata")
+    return SecurityOracleExperience(
+        state=record.state,
+        action=record.action,
+        reward=record.reward,
+        outcome=record.outcome,
+        policy_metadata=record.policy_metadata,
+        schema=record.schema,
+    )
 
 
 def coerce_security_action(action: object) -> SecurityAction:

--- a/tests/test_security_oracle_leftover_identities.py
+++ b/tests/test_security_oracle_leftover_identities.py
@@ -94,6 +94,8 @@ def test_oracle_experience_snapshots_nested_payloads_on_real_conversion_path() -
     metadata_nested.append("changed")
     assert direct.to_dict()["outcome"]["nested"] == ["source"]
     assert direct.to_dict()["policy_metadata"]["nested"] == ["source"]
+    assert type(direct.outcome["nested"]) is tuple
+    assert type(direct.policy_metadata["nested"]) is tuple
 
 
 def test_oracle_experience_cross_binds_derived_label_to_action_metadata() -> None:
@@ -140,3 +142,58 @@ def test_oracle_validator_rejects_hostile_outer_container_without_hooks() -> Non
         validate_security_oracle_experience(
             _HostileRecords([_legal()]), SecurityFeatureSchema(names=("risk",))
         )
+
+
+@pytest.mark.parametrize("consumer", ["validate", "serialize"])
+def test_oracle_consumers_reject_forged_state_without_hooks(consumer: str) -> None:
+    class _HostileInt(int):
+        calls = 0
+
+        def __int__(self) -> int:  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("integer hook executed")
+
+        def __repr__(self) -> str:
+            type(self).calls += 1
+            raise AssertionError("representation hook executed")
+
+    record = _legal()
+    object.__setattr__(record, "action", _HostileInt(0))
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="action must be an exact SecurityAction"):
+        if consumer == "validate":
+            validate_security_oracle_experience(
+                [record], SecurityFeatureSchema(names=("risk",))
+            )
+        else:
+            record.to_dict()
+    assert _HostileInt.calls == 0
+
+
+def test_oracle_consumers_reject_forged_mutable_nested_alias() -> None:
+    record = _legal()
+    object.__setattr__(
+        record,
+        "outcome",
+        MappingProxyType({"label": "safe", "nested": ["mutable"]}),
+    )
+    with pytest.raises(ValueError, match="immutable exact JSON values"):
+        validate_security_oracle_experience(
+            [record], SecurityFeatureSchema(names=("risk",))
+        )
+    with pytest.raises(ValueError, match="immutable exact JSON values"):
+        record.to_dict()
+
+
+def test_oracle_consumers_bound_forged_immutable_nesting() -> None:
+    nested: object = "leaf"
+    for _ in range(34):
+        nested = (nested,)
+    record = _legal()
+    object.__setattr__(
+        record,
+        "outcome",
+        MappingProxyType({"label": "safe", "nested": nested}),
+    )
+    with pytest.raises(ValueError, match="nesting limit"):
+        record.to_dict()

--- a/tests/test_security_oracle_leftover_identities.py
+++ b/tests/test_security_oracle_leftover_identities.py
@@ -224,8 +224,12 @@ def test_oracle_public_consumers_revalidate_forged_frozen_fields(
 
 def test_oracle_public_consumers_revalidate_forged_label_binding() -> None:
     record = _legal(action=SecurityAction.BLOCK)
-    object.__setattr__(record, "policy_metadata", {"is_malicious": True})
-    object.__setattr__(record, "outcome", {"label": "false_negative"})
+    object.__setattr__(
+        record, "policy_metadata", MappingProxyType({"is_malicious": True})
+    )
+    object.__setattr__(
+        record, "outcome", MappingProxyType({"label": "false_negative"})
+    )
 
     with pytest.raises(ValueError, match="does not match action metadata"):
         record.to_dict()


### PR DESCRIPTION
Follow-up to #1738: seal nested record values transitively and revalidate canonical state at both public consumers.

- freeze nested JSON containers, not only the outer mapping
- reject forged dataclass scalar, container, and resource identities before hooks
- serialize from a fresh validated snapshot to close consumption-time alias drift
- validate schema/action/label/resource cross-fields again at the public validator

Verification: 54 security tests; Ruff; strict mypy (189 files); diff check. No evidence artifacts or workflows touched.