### PR TITLE
reject leftover recurring-feature evidence-record identities

### DIFF
--- a/alberta_framework/recurring_feature_gate.py
+++ b/alberta_framework/recurring_feature_gate.py
@@ -30,7 +30,7 @@ import numpy as np
 import numpy.typing as npt
 from jax import Array
 
-from alberta_framework._seed_validation import require_unique_jax_seeds
+from alberta_framework._seed_validation import require_jax_seed, require_unique_jax_seeds
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.interaction_features import (
     FixedBudgetInteractionLearner,
@@ -87,6 +87,32 @@ def _require_exact_bool(name: str, value: object) -> bool:
     if type(value) is not bool:
         raise ValueError(f"{name} must be boolean")
     return value
+
+
+def _require_real(name: str, value: object) -> float:
+    if type(value) is not int and type(value) is not float:
+        raise ValueError(f"{name} must be a real number")
+    return float(value)
+
+
+def _require_task(name: str, value: object) -> TaskName:
+    if type(value) is not str or value not in TASK_NAMES:
+        raise ValueError(f"{name} must be an exact task name")
+    return value
+
+
+def _require_optional_int(name: str, value: object) -> int | None:
+    if value is None:
+        return None
+    return _require_builtin_int(name, value, minimum=0)
+
+
+def _require_pair(name: str, value: object) -> Pair:
+    if type(value) is not tuple or len(value) != 2:
+        raise ValueError(f"{name} must be an exact pair")
+    left = _require_builtin_int(f"{name}[0]", value[0], minimum=0)
+    right = _require_builtin_int(f"{name}[1]", value[1], minimum=0)
+    return (left, right)
 
 
 def _preflight_seed_array_resources(
@@ -276,6 +302,22 @@ class PhaseEvidence:
     prequential_nmse: float
     recovery_steps: int | None
 
+    def __post_init__(self) -> None:
+        """Reject leftover phase/task/nmse identities before they become evidence."""
+        object.__setattr__(
+            self, "phase_index", _require_builtin_int("phase_index", self.phase_index, minimum=0)
+        )
+        object.__setattr__(self, "task", _require_task("task", self.task))
+        object.__setattr__(
+            self, "occurrence", _require_builtin_int("occurrence", self.occurrence, minimum=1)
+        )
+        object.__setattr__(
+            self, "prequential_nmse", _require_real("prequential_nmse", self.prequential_nmse)
+        )
+        object.__setattr__(
+            self, "recovery_steps", _require_optional_int("recovery_steps", self.recovery_steps)
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class TaskRecoveryEvidence:
@@ -284,6 +326,25 @@ class TaskRecoveryEvidence:
     task: TaskName
     acquisition_steps: int | None
     recurrence_steps: tuple[int | None, ...]
+
+    def __post_init__(self) -> None:
+        """Reject leftover task/recovery-step identities before they become evidence."""
+        object.__setattr__(self, "task", _require_task("task", self.task))
+        object.__setattr__(
+            self,
+            "acquisition_steps",
+            _require_optional_int("acquisition_steps", self.acquisition_steps),
+        )
+        if type(self.recurrence_steps) is not tuple:
+            raise ValueError("recurrence_steps must be an exact tuple")
+        object.__setattr__(
+            self,
+            "recurrence_steps",
+            tuple(
+                _require_optional_int(f"recurrence_steps[{index}]", step)
+                for index, step in enumerate(self.recurrence_steps)
+            ),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -297,6 +358,51 @@ class RecurringFeatureSeedEvidence:
     phase_evidence: tuple[PhaseEvidence, ...]
     task_recovery: tuple[TaskRecoveryEvidence, ...]
     steps_seen: int
+
+    def __post_init__(self) -> None:
+        """Reject leftover seed/nmse/pair identities before they become evidence."""
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="seed"))
+        if type(self.final_heldout_nmse) is not tuple or not self.final_heldout_nmse:
+            raise ValueError("final_heldout_nmse must be a non-empty exact tuple")
+        object.__setattr__(
+            self,
+            "final_heldout_nmse",
+            tuple(
+                _require_real(f"final_heldout_nmse[{index}]", value)
+                for index, value in enumerate(self.final_heldout_nmse)
+            ),
+        )
+        if type(self.active_pairs) is not tuple:
+            raise ValueError("active_pairs must be an exact tuple")
+        object.__setattr__(
+            self,
+            "active_pairs",
+            tuple(
+                _require_pair(f"active_pairs[{index}]", pair)
+                for index, pair in enumerate(self.active_pairs)
+            ),
+        )
+        if type(self.candidate_pairs) is not tuple:
+            raise ValueError("candidate_pairs must be an exact tuple")
+        object.__setattr__(
+            self,
+            "candidate_pairs",
+            tuple(
+                _require_pair(f"candidate_pairs[{index}]", pair)
+                for index, pair in enumerate(self.candidate_pairs)
+            ),
+        )
+        if type(self.phase_evidence) is not tuple or not all(
+            type(item) is PhaseEvidence for item in self.phase_evidence
+        ):
+            raise ValueError("phase_evidence must be a tuple of PhaseEvidence")
+        if type(self.task_recovery) is not tuple or not all(
+            type(item) is TaskRecoveryEvidence for item in self.task_recovery
+        ):
+            raise ValueError("task_recovery must be a tuple of TaskRecoveryEvidence")
+        object.__setattr__(
+            self, "steps_seen", _require_builtin_int("steps_seen", self.steps_seen, minimum=0)
+        )
 
     @property
     def critical_pairs_retained(self) -> tuple[bool, bool, bool]:
@@ -322,6 +428,21 @@ class RecurringFeatureVariantEvidence:
     name: VariantName
     utility_retention_decay: float | None
     seeds: tuple[RecurringFeatureSeedEvidence, ...]
+
+    def __post_init__(self) -> None:
+        """Reject leftover variant/decay identities before they become evidence."""
+        if type(self.name) is not str or self.name not in ("retained", "no_retention"):
+            raise ValueError("name must be an exact variant name")
+        decay: float | None
+        if self.utility_retention_decay is None:
+            decay = None
+        else:
+            decay = _require_real("utility_retention_decay", self.utility_retention_decay)
+        object.__setattr__(self, "utility_retention_decay", decay)
+        if type(self.seeds) is not tuple or not all(
+            type(item) is RecurringFeatureSeedEvidence for item in self.seeds
+        ):
+            raise ValueError("seeds must be a tuple of RecurringFeatureSeedEvidence")
 
     @property
     def all_critical_retention_rate(self) -> float:
@@ -509,6 +630,19 @@ class RecurringFeatureGateResult:
     retained: RecurringFeatureVariantEvidence
     no_retention: RecurringFeatureVariantEvidence
     scope: str = PAIRWISE_PROBE_SCOPE
+
+    def __post_init__(self) -> None:
+        """Reject leftover scope identities before they become a public result."""
+        if type(self.protocol) is not RecurringFeatureProtocol:
+            raise ValueError("protocol must be a RecurringFeatureProtocol")
+        if type(self.memory_budget) is not FeatureMemoryBudget:
+            raise ValueError("memory_budget must be a FeatureMemoryBudget")
+        if type(self.retained) is not RecurringFeatureVariantEvidence:
+            raise ValueError("retained must be RecurringFeatureVariantEvidence")
+        if type(self.no_retention) is not RecurringFeatureVariantEvidence:
+            raise ValueError("no_retention must be RecurringFeatureVariantEvidence")
+        if type(self.scope) is not str or not self.scope:
+            raise ValueError("scope must be a non-empty exact string")
 
     def decision(
         self,

--- a/tests/test_recurring_feature_evidence_leftover_identities.py
+++ b/tests/test_recurring_feature_evidence_leftover_identities.py
@@ -1,0 +1,129 @@
+"""Leftover-identity gates for recurring-feature evidence records."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from alberta_framework.recurring_feature_gate import (
+    FeatureMemoryBudget,
+    PhaseEvidence,
+    RecurringFeatureGateResult,
+    RecurringFeatureProtocol,
+    RecurringFeatureSeedEvidence,
+    RecurringFeatureVariantEvidence,
+    TaskRecoveryEvidence,
+)
+
+
+def _phase(**overrides: object) -> PhaseEvidence:
+    payload: dict[str, object] = {
+        "phase_index": 0,
+        "task": "A",
+        "occurrence": 1,
+        "prequential_nmse": 0.1,
+        "recovery_steps": None,
+    }
+    payload.update(overrides)
+    return PhaseEvidence(**payload)  # type: ignore[arg-type]
+
+
+def _recovery(**overrides: object) -> TaskRecoveryEvidence:
+    payload: dict[str, object] = {
+        "task": "A",
+        "acquisition_steps": None,
+        "recurrence_steps": (None,),
+    }
+    payload.update(overrides)
+    return TaskRecoveryEvidence(**payload)  # type: ignore[arg-type]
+
+
+def _seed(**overrides: object) -> RecurringFeatureSeedEvidence:
+    payload: dict[str, object] = {
+        "seed": 30,
+        "final_heldout_nmse": (0.1, 0.2, 0.3, math.inf),
+        "active_pairs": ((0, 1), (2, 3)),
+        "candidate_pairs": ((4, 5),),
+        "phase_evidence": (_phase(),),
+        "task_recovery": (_recovery(),),
+        "steps_seen": 9,
+    }
+    payload.update(overrides)
+    return RecurringFeatureSeedEvidence(**payload)  # type: ignore[arg-type]
+
+
+def test_phase_evidence_rejects_leftover_identities() -> None:
+    """Public phase records must not keep leftover index/task/nmse identities."""
+
+    with pytest.raises(ValueError, match="prequential_nmse"):
+        _phase(prequential_nmse=True)
+    with pytest.raises(ValueError, match="phase_index"):
+        _phase(phase_index=True)
+    with pytest.raises(ValueError, match="occurrence"):
+        _phase(occurrence=True)
+    with pytest.raises(ValueError, match="recovery_steps"):
+        _phase(recovery_steps=True)
+    with pytest.raises(ValueError, match="task"):
+        _phase(task=True)
+
+    legal = _phase(prequential_nmse=math.inf)
+    assert type(legal.prequential_nmse) is float
+    assert legal.prequential_nmse == math.inf
+    assert legal.recovery_steps is None
+
+
+def test_task_recovery_and_seed_evidence_reject_leftover_identities() -> None:
+    """Public seed records must not keep leftover seed/pair/recovery identities."""
+
+    with pytest.raises(ValueError, match="acquisition_steps"):
+        _recovery(acquisition_steps=True)
+    with pytest.raises(ValueError, match="recurrence_steps"):
+        _recovery(recurrence_steps=(True,))
+    with pytest.raises(ValueError, match="seed"):
+        _seed(seed=True)
+    with pytest.raises(ValueError, match="final_heldout_nmse"):
+        _seed(final_heldout_nmse=(True,))
+    with pytest.raises(ValueError, match="active_pairs"):
+        _seed(active_pairs=((True, 1),))
+    with pytest.raises(ValueError, match="steps_seen"):
+        _seed(steps_seen=True)
+
+    legal = _seed()
+    assert legal.seed == 30
+    assert type(legal.final_heldout_nmse[-1]) is float
+    assert legal.final_heldout_nmse[-1] == math.inf
+
+
+def test_variant_and_result_reject_leftover_identities() -> None:
+    """Public variant/result records must not keep leftover name/decay/scope identities."""
+
+    with pytest.raises(ValueError, match="name"):
+        RecurringFeatureVariantEvidence(name=True, utility_retention_decay=None, seeds=())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="utility_retention_decay"):
+        RecurringFeatureVariantEvidence(
+            name="retained",
+            utility_retention_decay=True,
+            seeds=(),
+        )
+
+    retained = RecurringFeatureVariantEvidence("retained", 0.999, ())
+    baseline = RecurringFeatureVariantEvidence("no_retention", None, ())
+    with pytest.raises(ValueError, match="scope"):
+        RecurringFeatureGateResult(
+            protocol=RecurringFeatureProtocol(),
+            memory_budget=FeatureMemoryBudget(3, 15, 4),
+            retained=retained,
+            no_retention=baseline,
+            scope=True,  # type: ignore[arg-type]
+        )
+
+    legal = RecurringFeatureGateResult(
+        protocol=RecurringFeatureProtocol(),
+        memory_budget=FeatureMemoryBudget(3, 15, 4),
+        retained=retained,
+        no_retention=baseline,
+    )
+    assert type(legal.scope) is str
+    assert type(retained.utility_retention_decay) is float
+    assert baseline.utility_retention_decay is None


### PR DESCRIPTION
Closes #1748.

## What changed

Recurring-feature evidence records now fail-close leftover `prequential_nmse=True`, leftover `seed=True`, leftover pair indexes, leftover variant `name=True` / `utility_retention_decay=True`, and leftover `scope=True` before they can become public evidence. Exact tasks, real NMSE (including unrecovered `inf`), optional recovery `None`, and exact variant names stay legal.

On `origin/main` `f4eaf335`, leftover identities constructed. Sibling `RecurringFeatureGateDecision` leftover is already gated (`#1480` / `#1488`). `FeatureMemoryBudget` leftover slots are resource leftover-tax and are not gated here. `#1354` stream family is dry.

File was FREE at occupancy.

## Scope

- `alberta_framework/recurring_feature_gate.py`
- `tests/test_recurring_feature_evidence_leftover_identities.py`

## Occupancy

Open ASI PRs at publish (`scannedAt=2026-08-18T06:25:23.160Z` plus later scan): Shaw `#1743` `security.py`, `#1742` L2-ER output. No open PR on `recurring_feature_gate.py`.

## Verification

Exact candidate head: `a609bda9ddb028811c964f16a78ae1f87d270571`

- Red on base: `PhaseEvidence(..., prequential_nmse=True)` and `RecurringFeatureSeedEvidence(..., seed=True)` constructed
- Leftover + sibling recurring-feature suites: 164 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

Fail-closed host-boundary leftover-identity validation only. No kernel math, lifetime clocks, `CHANGELOG.md`, or `outputs/**` change.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is produced by this harness fix
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:a609bda9ddb028811c964f16a78ae1f87d270571 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
