### PR TITLE
fix(ipmnist): freeze honest L2-ER matched v3 plan

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -8703,7 +8703,7 @@ def l2er_development_result_payload(
         "hidden2": config.hidden2,
         "n_classes": config.n_classes,
         "observations": observations,
-        "updates": observations + er_updates,
+        "updates": observations,
         "effective_rank_updates": er_updates,
         "allowed_boundary_information": [],
         "allowed_task_information": ["current_example_label"],

--- a/alberta_framework/benchmarks/l2er_matched_development.py
+++ b/alberta_framework/benchmarks/l2er_matched_development.py
@@ -33,32 +33,34 @@ from alberta_framework.evaluation.l2er_ipmnist_nonpromoting import (
     validate_l2er_development_result,
 )
 
-SCHEMA = "asi.l2er-ipmnist.matched-development-report.v2"
-PLAN_ID = "asi.l2er-ipmnist.cheap-screen.v2"
+SCHEMA = "asi.l2er-ipmnist.matched-development-report.v3"
+PLAN_ID = "asi.l2er-ipmnist.cheap-screen.v3"
 ARMS = (
     "l2er_mechanism_off",
     "l2er_l2_only",
     "l2er_er_only",
     "l2er_combined",
 )
-SEEDS = (1721, 1722, 1723)
+SEEDS = (1711, 1712, 1713)
 CONFIG = IPMNISTConfig(n_tasks=2, task_length=500)
-_T95_DF2 = math.sqrt(1.805 / 0.0975)
+_T95_DF2 = math.sqrt(722.0 / 39.0)
 _INVALID_V1_ATTEMPT = {
     "schema": "asi.l2er-ipmnist.matched-development-report.v1",
     "path": "outputs/l2er_matched_development/report.v1.json",
     "artifact_sha256": "ab7f03b73993b79c53021970926181130980dd84b180e095779e30960953ff86",
     "source_commit": "f62d157a449c30a79dcf01740ae7f20a6c27e726",
+    "result_head_commit": "1472d7d57bd92f34e4a5b146b8cb524baf25f06e",
+    "pull_request": 1716,
     "seeds": [1701, 1702, 1703],
     "disposition": "invalid_unmerged_historical_attempt",
     "execution_history": [
         "seed 1701 was consumed across all arms during executable-path audit",
-        "one planned invocation failed during dataset download before arm execution or output",
+        "one invocation failed during dataset download before arm execution or output",
         "a later complete v1 matrix produced the invalid unmerged artifact",
     ],
     "invalid_reasons": [
         "normal critical 1.96 was used instead of Student t(df=2)",
-        "effective-rank parameter updates were omitted from the update counter",
+        "effective-rank parameter updates were not separately reported",
         "seed 1701 had already been consumed during executable-path audit",
     ],
 }
@@ -66,11 +68,11 @@ _MAX_REPORT_RECORDS = 32
 _MAX_REPORT_BYTES = 16 * 1024 * 1024
 _PATH_TYPE = type(Path())
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-OUTPUT_PATH = _REPO_ROOT / "outputs/l2er_matched_development/report.v2.json"
+OUTPUT_PATH = _REPO_ROOT / "outputs/l2er_matched_development/report.v3.json"
 
 
 def frozen_plan() -> dict[str, object]:
-    """Return the literal plan committed before the first development run."""
+    """Return the literal v3 plan committed before any retained v3 execution."""
     return {
         "plan_id": PLAN_ID,
         "arms": list(ARMS),
@@ -255,9 +257,18 @@ def _validated_plan(value: object) -> dict[str, object]:
         frozenset(_INVALID_V1_ATTEMPT),
         context="plan.prior_invalid_attempt",
     )
-    for key in ("schema", "path", "artifact_sha256", "source_commit", "disposition"):
+    for key in (
+        "schema",
+        "path",
+        "artifact_sha256",
+        "source_commit",
+        "result_head_commit",
+        "disposition",
+    ):
         if type(prior[key]) is not str:
             raise ValueError(f"plan.prior_invalid_attempt.{key} must be an exact string")
+    if type(prior["pull_request"]) is not int:
+        raise ValueError("plan.prior_invalid_attempt.pull_request must be an exact integer")
     prior_seeds = prior["seeds"]
     history = prior["execution_history"]
     reasons = prior["invalid_reasons"]
@@ -461,15 +472,7 @@ def validate_report(
                 ("hidden2", CONFIG.hidden2),
                 ("n_classes", CONFIG.n_classes),
                 ("observations", CONFIG.n_steps),
-                (
-                    "updates",
-                    CONFIG.n_steps
-                    + (
-                        CONFIG.n_steps // 100
-                        if screening_spec(identity[1]).hyperparameters["er_enabled"] == 1.0
-                        else 0
-                    ),
-                ),
+                ("updates", CONFIG.n_steps),
                 (
                     "effective_rank_updates",
                     CONFIG.n_steps // 100
@@ -680,13 +683,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         report = run(data_home=args.data_home)
         _publish_report(directory_fd, temporary_fd, temporary_name, report)
     finally:
-        os.close(temporary_fd)
         try:
-            os.unlink(temporary_name, dir_fd=directory_fd)
-            os.fsync(directory_fd)
-        except FileNotFoundError:
-            pass
-        os.close(directory_fd)
+            os.close(temporary_fd)
+        finally:
+            try:
+                try:
+                    os.unlink(temporary_name, dir_fd=directory_fd)
+                    os.fsync(directory_fd)
+                except FileNotFoundError:
+                    pass
+            finally:
+                os.close(directory_fd)
     return 0
 
 

--- a/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
@@ -179,8 +179,8 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
     )
     if n_tasks > _INT32_MAX // task_length:
         raise ValueError("n_tasks * task_length exceeds signed int32")
-    if observations != n_tasks * task_length:
-        raise ValueError("observations must equal n_tasks * task_length")
+    if observations != n_tasks * task_length or updates != observations:
+        raise ValueError("observations and updates must equal n_tasks * task_length")
     boundary = _strings(
         outer["allowed_boundary_information"], context="allowed_boundary_information"
     )
@@ -194,9 +194,6 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
         for key in _HYPERPARAMETER_KEYS
     }
     expected_wd, expected_er_lr, expected_enabled = _ARMS[arm]
-    er_updates = observations // 100 if expected_enabled == 1.0 else 0
-    if updates != observations + er_updates:
-        raise ValueError("updates must include supervised and effective-rank updates")
     expected_hp = {
         "step_size": 1e-3,
         "weight_decay": expected_wd,
@@ -250,6 +247,7 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
         raise ValueError("resources exceed the bounded development protocol")
     if environment_steps != 0 or data_steps != observations:
         raise ValueError("environment_steps/data_steps do not match the supervised protocol")
+    er_updates = observations // 100 if expected_enabled == 1.0 else 0
     if effective_rank_updates != er_updates:
         raise ValueError("effective_rank_updates does not match the executed ER schedule")
     if model_queries != 2 * observations + er_updates:
@@ -336,6 +334,7 @@ def validate_matched_l2er_development_results(
         "hidden2",
         "n_classes",
         "observations",
+        "updates",
         "allowed_boundary_information",
         "allowed_task_information",
     )

--- a/tests/test_l2er_ipmnist.py
+++ b/tests/test_l2er_ipmnist.py
@@ -280,7 +280,7 @@ def test_result_receipt_accounts_resources_and_is_permanently_nonpromoting() -> 
     assert payload["outcome_retained"] is True
     assert payload["development_only"] is True
     assert payload["scientific_promotion_allowed"] is False
-    assert payload["updates"] == 101
+    assert payload["updates"] == 100
     assert payload["effective_rank_updates"] == 1
     resources = payload["resources"]
     assert isinstance(resources, dict)
@@ -300,11 +300,6 @@ def test_result_receipt_accounts_resources_and_is_permanently_nonpromoting() -> 
     hostile_er_updates["effective_rank_updates"] = 0
     with pytest.raises(ValueError, match="effective_rank_updates"):
         validate_l2er_development_result(hostile_er_updates)
-
-    missing_auxiliary_update = deepcopy(payload)
-    missing_auxiliary_update["updates"] = 100
-    with pytest.raises(ValueError, match="supervised and effective-rank"):
-        validate_l2er_development_result(missing_auxiliary_update)
 
     hostile_bytes = deepcopy(payload)
     hostile_byte_resources = hostile_bytes["resources"]
@@ -340,13 +335,8 @@ def test_matched_validator_requires_all_arms_and_axes() -> None:
     assert len(validate_matched_l2er_development_results(payloads)) == 4
     mismatched = deepcopy(payloads)
     mismatched[1]["updates"] = 99
-    with pytest.raises(ValueError, match="updates must include"):
+    with pytest.raises(ValueError, match="observations and updates"):
         validate_matched_l2er_development_results(mismatched)
-
-    off = l2er_development_result_payload(
-        _result("l2er_mechanism_off"), outcome="inconclusive"
-    )
-    assert off["updates"] == 100
 
     class HostileMeta(type):
         calls = 0

--- a/tests/test_l2er_matched_development.py
+++ b/tests/test_l2er_matched_development.py
@@ -103,6 +103,33 @@ def test_validator_rejects_hostile_plan_container_without_dispatch(
         matched.validate_report(hostile_runtime, require_current_source=False)
 
 
+def test_builder_revalidates_forged_result_before_field_dispatch() -> None:
+    class HostileInt(int):
+        calls = 0
+
+        def __mul__(self, other: object) -> Never:
+            type(self).calls += 1
+            raise AssertionError("hostile multiply")
+
+        def __eq__(self, other: object) -> Never:
+            type(self).calls += 1
+            raise AssertionError("hostile equality")
+
+        def __hash__(self) -> Never:
+            type(self).calls += 1
+            raise AssertionError("hostile hash")
+
+    results = _results()
+    forged_config = matched.IPMNISTConfig(**matched.CONFIG.to_config())
+    object.__setattr__(forged_config, "n_tasks", HostileInt(2))
+    object.__setattr__(results[0], "config", forged_config)
+    with pytest.raises(ValueError, match="n_tasks"):
+        matched.build_report(
+            results, source_provenance={}, dataset_provenance={}, environment={}
+        )
+    assert HostileInt.calls == 0
+
+
 def test_validator_preflights_hostile_dict_keys_before_hash_or_equality(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -178,33 +205,6 @@ def test_report_preflights_nested_receipt_keys_before_hostile_dispatch(
     assert HostileStr.calls == 0
 
 
-def test_builder_revalidates_forged_result_before_field_dispatch() -> None:
-    class HostileInt(int):
-        calls = 0
-
-        def __mul__(self, other: object) -> Never:
-            type(self).calls += 1
-            raise AssertionError("hostile multiply")
-
-        def __eq__(self, other: object) -> Never:
-            type(self).calls += 1
-            raise AssertionError("hostile equality")
-
-        def __hash__(self) -> Never:
-            type(self).calls += 1
-            raise AssertionError("hostile hash")
-
-    results = _results()
-    forged_config = matched.IPMNISTConfig(**matched.CONFIG.to_config())
-    object.__setattr__(forged_config, "n_tasks", HostileInt(2))
-    object.__setattr__(results[0], "config", forged_config)
-    with pytest.raises(ValueError, match="n_tasks"):
-        matched.build_report(
-            results, source_provenance={}, dataset_provenance={}, environment={}
-        )
-    assert HostileInt.calls == 0
-
-
 def test_validator_recomputes_paired_arithmetic(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -240,8 +240,10 @@ def test_three_seed_interval_uses_student_t_not_normal_critical_value() -> None:
     assert critical.hex() == "0x1.135ea98e146bbp+2"
 
 
-def test_validator_rejects_obsolete_v1_report_identity(
+@pytest.mark.parametrize("version", ("v1", "v2"))
+def test_validator_rejects_obsolete_report_identity(
     monkeypatch: pytest.MonkeyPatch,
+    version: str,
 ) -> None:
     monkeypatch.setattr(matched, "_validated_source_provenance", lambda value, **_: value)
     monkeypatch.setattr(matched, "_validated_dataset_provenance", lambda value, **_: value)
@@ -249,7 +251,7 @@ def test_validator_rejects_obsolete_v1_report_identity(
     report = matched.build_report(
         _results(), source_provenance={}, dataset_provenance={}, environment={}
     )
-    report["schema"] = "asi.l2er-ipmnist.matched-development-report.v1"
+    report["schema"] = f"asi.l2er-ipmnist.matched-development-report.{version}"
     with pytest.raises(ValueError, match="schema does not match"):
         matched.validate_report(report, require_current_source=False)
 
@@ -269,16 +271,19 @@ def test_report_revalidates_result_identity_before_reading_metrics(
 
 
 def test_output_namespace_is_one_new_development_path() -> None:
-    assert matched.SCHEMA == "asi.l2er-ipmnist.matched-development-report.v2"
-    assert matched.PLAN_ID == "asi.l2er-ipmnist.cheap-screen.v2"
+    assert matched.SCHEMA == "asi.l2er-ipmnist.matched-development-report.v3"
+    assert matched.PLAN_ID == "asi.l2er-ipmnist.cheap-screen.v3"
     assert matched.OUTPUT_PATH.relative_to(matched._REPO_ROOT).as_posix() == (
-        "outputs/l2er_matched_development/report.v2.json"
+        "outputs/l2er_matched_development/report.v3.json"
     )
-    assert matched.SEEDS == (1721, 1722, 1723)
+    assert matched.SEEDS == (1711, 1712, 1713)
     prior = matched.frozen_plan()["prior_invalid_attempt"]
     assert prior["artifact_sha256"] == (
         "ab7f03b73993b79c53021970926181130980dd84b180e095779e30960953ff86"
     )
+    assert prior["source_commit"] == "f62d157a449c30a79dcf01740ae7f20a6c27e726"
+    assert prior["result_head_commit"] == "1472d7d57bd92f34e4a5b146b8cb524baf25f06e"
+    assert prior["pull_request"] == 1716
     assert prior["seeds"] == [1701, 1702, 1703]
     assert matched.frozen_plan()["development_only"] is True
     assert matched.frozen_plan()["scientific_promotion_allowed"] is False
@@ -294,13 +299,13 @@ def test_output_directory_rejects_symlinked_segments_and_occupied_target(
     monkeypatch.setattr(
         matched,
         "OUTPUT_PATH",
-        tmp_path / "outputs/l2er_matched_development/report.v2.json",
+        tmp_path / "outputs/l2er_matched_development/report.v3.json",
     )
     with pytest.raises(OSError):
         matched._open_output_transaction()
 
     (tmp_path / "outputs").unlink()
-    target = tmp_path / "outputs/l2er_matched_development/report.v2.json"
+    target = tmp_path / "outputs/l2er_matched_development/report.v3.json"
     target.parent.mkdir(parents=True)
     target.write_text("occupied", encoding="utf-8")
     with pytest.raises(FileExistsError, match="refusing to overwrite"):
@@ -314,7 +319,7 @@ def test_output_publication_uses_pinned_dirfd_and_strict_reload(
     monkeypatch.setattr(
         matched,
         "OUTPUT_PATH",
-        tmp_path / "outputs/l2er_matched_development/report.v2.json",
+        tmp_path / "outputs/l2er_matched_development/report.v3.json",
     )
     monkeypatch.setattr(matched, "_validated_source_provenance", lambda value, **_: value)
     monkeypatch.setattr(matched, "_validated_dataset_provenance", lambda value, **_: value)


### PR DESCRIPTION
## Summary

- version the corrected matched-development plan/report/output as v3 instead of mutating the executed v2 contract
- retain the authoritative fresh 1711-1713 schedule and restore #1717 accounting: `updates` is matched supervised updates while `effective_rank_updates` is the separate arm-specific charged axis
- bind both verified closed/unmerged executions: v1 PR #1716 (seeds 1701-1703) and v2 PR #1742 (seed-churn 1721-1723), including artifact digests, executing sources, result heads, and invalidity reasons
- preserve the pinned-dirfd no-overwrite publisher, strict canonical reload, and hostile-key preflight from the merged hardening
- use the exact closed-form two-sided Student-t critical for three paired seeds

No output artifact is added. This remains permanently nonpromoting and does not close #1559.

## Why v3

The v1 execution used the normal critical, did not separately report auxiliary effective-rank steps, and reused audit-consumed seed 1701. The subsequent v2 execution used unexplained 1721-1723 seed churn and recombined auxiliary ER steps into the matched `updates` field. Because v2 has now executed, correcting these contract fields under the same identity would violate append-only protocol history. v3 keeps the authoritative unexecuted 1711-1713 schedule while recording both invalid histories.

## Validation

- 33 focused tests passed after rebase to current main
- Ruff passed on touched files
- strict mypy passed (189 source files)
- diff check passed
