### PR TITLE
fix(ipmnist): retain analytic L2-ER critical value

### DIFF
--- a/alberta_framework/benchmarks/l2er_matched_development.py
+++ b/alberta_framework/benchmarks/l2er_matched_development.py
@@ -44,7 +44,7 @@ ARMS = (
 SEEDS = (1711, 1712, 1713)
 CONFIG = IPMNISTConfig(n_tasks=2, task_length=500)
 CONSUMED_AUDIT_SEEDS = (1701,)
-_T95_DF2 = 4.302652729696142
+_T95_DF2 = math.sqrt(1.805 / 0.0975)
 _MAX_REPORT_RECORDS = 32
 _MAX_REPORT_BYTES = 16 * 1024 * 1024
 _PATH_TYPE = type(Path())
@@ -116,6 +116,9 @@ def frozen_plan() -> dict[str, object]:
         "confidence_level": 0.95,
         "confidence_degrees_of_freedom": 2,
         "confidence_critical": _T95_DF2,
+        "statistical_correction_seed_policy": (
+            "a pre-execution statistical correction does not authorize seed churn"
+        ),
         "allowed_boundary_information": [],
         "allowed_task_information": ["current_example_label"],
         "development_only": True,
@@ -246,6 +249,7 @@ def _validated_plan(value: object) -> dict[str, object]:
         "control_arm",
         "paired_direction",
         "confidence_method",
+        "statistical_correction_seed_policy",
         "consumed_preplan_audit_note",
         "arm_specific_charged_axis",
     ):

--- a/tests/test_l2er_matched_development.py
+++ b/tests/test_l2er_matched_development.py
@@ -235,9 +235,9 @@ def test_three_seed_interval_uses_student_t_not_normal_critical_value() -> None:
     assert outcome == "inconclusive"
     assert matched.frozen_plan()["confidence_method"] == "two_sided_student_t"
     critical = matched.frozen_plan()["confidence_critical"]
-    assert critical == 4.302652729696142
+    assert critical == 4.302652729749464
     assert isinstance(critical, float)
-    assert critical.hex() == "0x1.135ea98e05c38p+2"
+    assert critical.hex() == "0x1.135ea98e146bbp+2"
 
 
 def test_validator_rejects_obsolete_v1_report_identity(
@@ -275,6 +275,12 @@ def test_output_namespace_is_one_new_development_path() -> None:
         "outputs/l2er_matched_development/report.v2.json"
     )
     assert matched.SEEDS == (1711, 1712, 1713)
+    critical = matched.frozen_plan()["confidence_critical"]
+    assert isinstance(critical, float)
+    assert critical.hex() == "0x1.135ea98e146bbp+2"
+    assert matched.frozen_plan()["statistical_correction_seed_policy"] == (
+        "a pre-execution statistical correction does not authorize seed churn"
+    )
     assert matched.frozen_plan()["consumed_preplan_audit_seeds"] == [1701]
     invalid = matched.frozen_plan()["invalid_execution_history"]
     assert invalid[1]["seeds"] == [1721, 1722, 1723]


### PR DESCRIPTION
Immediate narrow corrective to merged #1747. Preserves its authoritative unconsumed seeds 1711-1713 and both invalid-attempt audit records, while restoring the exact analytic binary64 t(df=2,.975) critical as `math.sqrt(1.805 / 0.0975)` (`0x1.135ea98e146bbp+2`). The frozen plan explicitly states that a pre-execution statistical correction does not authorize seed churn.\n\nNo benchmark execution and no output changes. Focused: 28 passed. Ruff clean. mypy clean. Diff check clean.\n\nRefs #1559.