### PR TITLE
results(ipmnist): retain authoritative L2-ER v2 outcome

### DIFF
--- a/outputs/l2er_matched_development/report.v2.json
+++ b/outputs/l2er_matched_development/report.v2.json
@@ -1,0 +1,781 @@
+{
+ "dataset_provenance": {
+  "materialization": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
+  "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
+  "source": {
+   "name": "mnist_784",
+   "provider": "openml",
+   "row_start": 0,
+   "row_stop_exclusive": 60000,
+   "version": 1
+  },
+  "x": {
+   "dtype": "<f4",
+   "sha256": "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313",
+   "shape": [
+    60000,
+    784
+   ]
+  },
+  "y": {
+   "dtype": "<i4",
+   "sha256": "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a",
+   "shape": [
+    60000
+   ]
+  }
+ },
+ "environment": {
+  "jax": {
+   "backend": "cpu",
+   "config": {
+    "jax_default_matmul_precision": null,
+    "jax_default_prng_impl": "threefry2x32",
+    "jax_disable_jit": false,
+    "jax_enable_x64": false,
+    "jax_numpy_dtype_promotion": "standard",
+    "jax_numpy_rank_promotion": "allow",
+    "jax_random_seed_offset": 0,
+    "jax_threefry_partitionable": true
+   },
+   "devices": [
+    {
+     "device_kind": "cpu",
+     "id": 0,
+     "platform": "cpu",
+     "process_index": 0
+    }
+   ]
+  },
+  "packages": {
+   "chex": "0.1.92",
+   "jax": "0.11.0",
+   "jaxlib": "0.11.0",
+   "numpy": "2.5.1",
+   "scikit-learn": "1.9.0"
+  },
+  "platform": {
+   "machine": "x86_64",
+   "release": "7.0.0-28-generic",
+   "system": "Linux"
+  },
+  "process_environment": {
+   "CUDA_VISIBLE_DEVICES": null,
+   "JAX_DEFAULT_MATMUL_PRECISION": null,
+   "JAX_ENABLE_X64": null,
+   "JAX_PLATFORMS": null,
+   "JAX_PLATFORM_NAME": null,
+   "OMP_NUM_THREADS": null,
+   "XLA_FLAGS": null
+  },
+  "python": {
+   "implementation": "CPython",
+   "version": "3.12.3"
+  },
+  "schema": "alberta.ipmnist_screening.runtime.v1"
+ },
+ "paired_comparisons": {
+  "l2er_combined": {
+   "ci95_lower": -0.12215228219740261,
+   "ci95_upper": 0.013485608894752157,
+   "deltas": [
+    -0.07900001108646393,
+    -0.02499999850988388,
+    -0.05900000035762787
+   ],
+   "mean_delta": -0.054333336651325226,
+   "outcome": "inconclusive"
+  },
+  "l2er_er_only": {
+   "ci95_lower": -0.11270119820592364,
+   "ci95_upper": 0.012034521247521641,
+   "deltas": [
+    -0.07400000840425491,
+    -0.024000003933906555,
+    -0.05300000309944153
+   ],
+   "mean_delta": -0.050333338479201,
+   "outcome": "inconclusive"
+  },
+  "l2er_l2_only": {
+   "ci95_lower": -0.0034612491011267914,
+   "ci95_upper": 0.004127912151778342,
+   "deltas": [
+    0.001999996602535248,
+    0.0,
+    -0.0010000020265579224
+   ],
+   "mean_delta": 0.00033333152532577515,
+   "outcome": "inconclusive"
+  }
+ },
+ "plan": {
+  "allowed_boundary_information": [],
+  "allowed_task_information": [
+   "current_example_label"
+  ],
+  "arm_specific_charged_axis": "effective_rank_updates",
+  "arms": [
+   "l2er_mechanism_off",
+   "l2er_l2_only",
+   "l2er_er_only",
+   "l2er_combined"
+  ],
+  "confidence_critical": 4.302652729749464,
+  "confidence_degrees_of_freedom": 2,
+  "confidence_level": 0.95,
+  "confidence_method": "two_sided_student_t",
+  "config": {
+   "hidden1": 300,
+   "hidden2": 150,
+   "input_dim": 784,
+   "n_classes": 10,
+   "n_tasks": 2,
+   "task_length": 500
+  },
+  "consumed_preplan_audit_note": "seed 1701 ran once across all four arms during executable-path audit; no complete report was produced",
+  "consumed_preplan_audit_seeds": [
+   1701
+  ],
+  "control_arm": "l2er_mechanism_off",
+  "development_only": true,
+  "invalid_execution_history": [
+   {
+    "artifact_sha256": "ab7f03b73993b79c53021970926181130980dd84b180e095779e30960953ff86",
+    "disposition": "invalid_unmerged_historical_attempt",
+    "invalid_reasons": [
+     "normal critical 1.96 was used instead of the frozen Student t(df=2) rule",
+     "effective-rank parameter updates were omitted from the update counter",
+     "seed 1701 had already been consumed during executable-path audit"
+    ],
+    "path": "outputs/l2er_matched_development/report.v1.json",
+    "schema": "asi.l2er-ipmnist.matched-development-report.v1",
+    "seeds": [
+     1701,
+     1702,
+     1703
+    ],
+    "source_commit": "f62d157a449c30a79dcf01740ae7f20a6c27e726"
+   },
+   {
+    "artifact_sha256": "579c400412d3c50898c16a8fd02fa82e2cd712b5278b5a99974b5e89560707ec",
+    "disposition": "invalid_unmerged_seed_churn_attempt",
+    "invalid_reasons": [
+     "the execution substituted unexplained seeds after the frozen 1711-1713 plan",
+     "the invalid output is not retained and cannot replace the prospective v2 matrix"
+    ],
+    "path": "outputs/l2er_matched_development/report.v2.json",
+    "schema": "asi.l2er-ipmnist.matched-development-report.v2",
+    "seeds": [
+     1721,
+     1722,
+     1723
+    ],
+    "source_commit": "5fc85b69897fc5b74c27389579c3d1bc27931394"
+   }
+  ],
+  "matched_axes": [
+   "example_schedule",
+   "observations",
+   "supervised_updates",
+   "allowed_boundary_information",
+   "allowed_task_information"
+  ],
+  "null_delta": 0.0,
+  "outcome_retention_required": true,
+  "paired_direction": "higher_is_better",
+  "plan_id": "asi.l2er-ipmnist.cheap-screen.v2",
+  "primary_metric": "mean_online_accuracy",
+  "scientific_promotion_allowed": false,
+  "seeds": [
+   1711,
+   1712,
+   1713
+  ],
+  "statistical_correction_seed_policy": "a pre-execution statistical correction does not authorize seed churn"
+ },
+ "policy": {
+  "development_only": true,
+  "outcome_retained": true,
+  "scientific_promotion_allowed": false,
+  "timing_is_telemetry_only": true
+ },
+ "records": [
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_mechanism_off",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.259238123893738,
+    "mean_online_accuracy": 0.22100001573562622,
+    "mean_plasticity": 0.014108987990766764
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 3.3570536949991947
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1711,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_l2_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.259145975112915,
+    "mean_online_accuracy": 0.22300001233816147,
+    "mean_plasticity": 0.01411861227825284
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 3.20202330200118
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1711,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_er_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2920689582824707,
+    "mean_online_accuracy": 0.1470000073313713,
+    "mean_plasticity": 0.007486640242859721
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 4.718998149008257
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1711,
+   "task_length": 500,
+   "updates": 1010
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_combined",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2912063598632812,
+    "mean_online_accuracy": 0.1420000046491623,
+    "mean_plasticity": 0.007549766451120377
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 4.820051439004601
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1711,
+   "task_length": 500,
+   "updates": 1010
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_mechanism_off",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2572710514068604,
+    "mean_online_accuracy": 0.20800001174211502,
+    "mean_plasticity": 0.013928170315921307
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 3.3341978199896403
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1712,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_l2_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2572789192199707,
+    "mean_online_accuracy": 0.20800001174211502,
+    "mean_plasticity": 0.0139249786734581
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 3.1387904370058095
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1712,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_er_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2866902351379395,
+    "mean_online_accuracy": 0.18400000780820847,
+    "mean_plasticity": 0.007578023709356785
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 4.583371678003459
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1712,
+   "task_length": 500,
+   "updates": 1010
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_combined",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.286696434020996,
+    "mean_online_accuracy": 0.18300001323223114,
+    "mean_plasticity": 0.00758819910697639
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 4.632876028001192
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1712,
+   "task_length": 500,
+   "updates": 1010
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_mechanism_off",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2509323358535767,
+    "mean_online_accuracy": 0.19300001114606857,
+    "mean_plasticity": 0.014407008420675993
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 3.179931202001171
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1713,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_l2_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 0,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 0.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.0,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.250966429710388,
+    "mean_online_accuracy": 0.19200000911951065,
+    "mean_plasticity": 0.014402811881154776
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2000,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 3.294180900003994
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1713,
+   "task_length": 500,
+   "updates": 1000
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_er_only",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2851234674453735,
+    "mean_online_accuracy": 0.14000000804662704,
+    "mean_plasticity": 0.007474077632650733
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 4.918892361005419
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1713,
+   "task_length": 500,
+   "updates": 1010
+  },
+  {
+   "allowed_boundary_information": [],
+   "allowed_task_information": [
+    "current_example_label"
+   ],
+   "arm": "l2er_combined",
+   "comparison_id": "asi.l2er-ipmnist.current-runner.v1",
+   "development_only": true,
+   "effective_rank_updates": 10,
+   "hidden1": 300,
+   "hidden2": 150,
+   "hyperparameters": {
+    "er_batch_size": 100.0,
+    "er_enabled": 1.0,
+    "er_epsilon": 1e-08,
+    "er_step_size": 0.001,
+    "er_steps_per_batch": 1.0,
+    "step_size": 0.001,
+    "weight_decay": 0.0001
+   },
+   "input_dim": 784,
+   "metrics": {
+    "mean_loss": 2.2853678464889526,
+    "mean_online_accuracy": 0.1340000107884407,
+    "mean_plasticity": 0.007428917568176985
+   },
+   "n_classes": 10,
+   "n_tasks": 2,
+   "observations": 1000,
+   "official_commit": "52ae3eb0702a9e6923f252c1f7cb29340eb5b3d5",
+   "outcome": "inconclusive",
+   "outcome_retained": true,
+   "paper_revision": "arXiv:2509.22335v3",
+   "resources": {
+    "data_steps": 1000,
+    "environment_steps": 0,
+    "model_queries": 2010,
+    "persistent_bytes": 1442245,
+    "timing_is_telemetry_only": true,
+    "timing_seconds": 4.70147664801334
+   },
+   "schema": "asi.l2er-ipmnist.development-result.v2",
+   "scientific_promotion_allowed": false,
+   "seed": 1713,
+   "task_length": 500,
+   "updates": 1010
+  }
+ ],
+ "schema": "asi.l2er-ipmnist.matched-development-report.v2",
+ "source_provenance": {
+  "git_commit": "072cfee9d061a2e2a370eee21ea901aa9fbad870",
+  "git_object_format": "sha1",
+  "git_tree": "28f2f5b629623fa119a9a23bb084a5a15ed00ab8",
+  "relevant_source_file_count": 195,
+  "relevant_source_scope": "tracked:alberta_framework/**,pyproject.toml,uv.lock",
+  "relevant_source_sha256": "9fc6a0e9fe8e10f1e771e7055e9c9f90181d904ebe1ddcb6d25c15fd4c8bc4af",
+  "schema": "alberta.ipmnist_screening.source_provenance.v1",
+  "uv_lock_sha256": "0fc52a642ba70bd64bfa80049b1efc99c35829d01e44705370994ad818ee82d7",
+  "worktree_clean": true
+ }
+}


### PR DESCRIPTION
Retains the single authoritative v2 matched nonpromoting development execution for #1559.\n\nExecution identity:\n- exact merged source: 072cfee9d061a2e2a370eee21ea901aa9fbad870\n- authoritative unconsumed seeds: 1711, 1712, 1713\n- immutable path/schema: outputs/l2er_matched_development/report.v2.json / asi.l2er-ipmnist.matched-development-report.v2\n- artifact SHA-256: c5a6b8efb050d3c6c05648a46689ca0903389340764f7c20b589bfc4e8b0c6f2\n- exact analytic Student t(df=2) critical: 4.302652729749464 / 0x1.135ea98e146bbp+2\n- ER accounting: 1000 supervised + 10 auxiliary = 1010 total updates and 2010 model queries\n\nRetained paired outcomes (all inconclusive):\n- L2-only mean +0.000333, 95% CI [-0.003461, +0.004128]\n- ER-only mean -0.050333, 95% CI [-0.112701, +0.012035]\n- combined mean -0.054333, 95% CI [-0.122152, +0.013486]\n\nThe report binds both invalid unmerged histories: v1 SHA ab7f03... (bad z/update accounting/preconsumed seed) and churned-seed v2 SHA 579c40... (unauthorized 1721-23 substitution). Neither invalid JSON is included. This PR contains exactly one new JSON artifact and remains development-only/permanently nonpromoting.\n\nKeep #1559 open pending independent artifact audit.