### PR TITLE
fix(benchmarks): revalidate Forager comparison consumers

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -3833,6 +3833,57 @@ class ForagerBenchmarkSummary:
     confidence: float
     runs: tuple[ForagerRunResult, ...]
 
+    def __post_init__(self) -> None:
+        if type(self.agent) is not str or not self.agent:
+            raise ValueError("agent must be a non-empty string")
+        if type(self.privileged) is not bool:
+            raise ValueError("privileged must be an exact boolean")
+        if type(self.metric) is not str or self.metric not in (
+            "mean_reward",
+            "final_window_mean_reward",
+            "final_ewm_reward",
+            "mean_ewm_reward",
+            "fov_last_10pct_ema_auc",
+        ):
+            raise ValueError("metric is not a valid Forager summary metric")
+        if type(self.runs) is not tuple or not self.runs:
+            raise ValueError("runs must be a non-empty exact tuple")
+        if any(type(run) is not ForagerRunResult for run in self.runs):
+            raise ValueError("runs must contain exact ForagerRunResult records")
+        runs = tuple(
+            ForagerRunResult(
+                **{field.name: getattr(run, field.name) for field in dataclasses.fields(run)}
+            )
+            for run in self.runs
+        )
+        if type(self.seeds) is not tuple:
+            raise ValueError("seeds must be an exact tuple")
+        seeds = tuple(
+            _validated_seed(seed, name=f"seeds[{index}]")
+            for index, seed in enumerate(self.seeds)
+        )
+        if seeds != tuple(run.seed for run in runs) or len(set(seeds)) != len(seeds):
+            raise ValueError("seeds must exactly match the unique ordered runs")
+        if any(run.agent != self.agent or run.privileged is not self.privileged for run in runs):
+            raise ValueError("runs must match the named agent and privilege identity")
+        mean = _require_result_scalar(self.mean, name="mean")
+        ci_low = _require_result_scalar(self.ci_low, name="ci_low")
+        ci_high = _require_result_scalar(self.ci_high, name="ci_high")
+        confidence = _require_result_scalar(self.confidence, name="confidence")
+        if ci_low > ci_high:
+            raise ValueError("ci_low must not exceed ci_high")
+        if not 0.0 < confidence < 1.0:
+            raise ValueError("confidence must lie in (0, 1)")
+        expected_mean = float(np.mean([getattr(run, self.metric) for run in runs]))
+        if mean != expected_mean:
+            raise ValueError("mean must reconstruct from the selected run metric")
+        object.__setattr__(self, "runs", runs)
+        object.__setattr__(self, "seeds", seeds)
+        object.__setattr__(self, "mean", mean)
+        object.__setattr__(self, "ci_low", ci_low)
+        object.__setattr__(self, "ci_high", ci_high)
+        object.__setattr__(self, "confidence", confidence)
+
     def to_dict(self) -> dict[str, Any]:
         data = dataclasses.asdict(self)
         data["seeds"] = list(self.seeds)
@@ -3855,8 +3906,6 @@ def summarize_forager_runs(
     bootstrap_seed: int = 0,
 ) -> ForagerBenchmarkSummary:
     """Summarize same-agent runs without mixing privileged controls."""
-    if len(runs) == 0:
-        raise ValueError("at least one run is required")
     supported_metrics = {
         "mean_reward",
         "final_window_mean_reward",
@@ -3868,6 +3917,8 @@ def summarize_forager_runs(
         raise ValueError("unsupported Forager summary metric")
     if type(runs) not in (list, tuple):
         raise TypeError("runs must be an actual list or tuple")
+    if len(runs) == 0:
+        raise ValueError("at least one run is required")
     if any(type(run) is not ForagerRunResult for run in runs):
         raise TypeError("runs must contain only ForagerRunResult values")
     names = {run.agent for run in runs}

--- a/alberta_framework/benchmarks/forager_results.py
+++ b/alberta_framework/benchmarks/forager_results.py
@@ -2322,18 +2322,20 @@ class ForagerPairedComparison:
         if not self.seeds:
             raise ValueError("seeds must not be empty")
         for seed in self.seeds:
-            if type(seed) is not int or isinstance(seed, bool):
-                raise TypeError("seeds must contain integers")
+            if type(seed) is not int or seed < 0:
+                raise TypeError("seeds must contain nonnegative exact integers")
         if len(set(self.seeds)) != len(self.seeds):
             raise ValueError("seeds must be unique")
         for name in ("mean_difference", "ci_low", "ci_high"):
             val = getattr(self, name)
             if type(val) not in (int, float) or not math.isfinite(val):
                 raise ValueError(f"{name} must be a finite float")
-        if type(self.confidence) not in (int, float) or not (
-            0.0 < self.confidence < 1.0
-        ):
+            object.__setattr__(self, name, float(val))
+        if self.ci_low > self.ci_high:
+            raise ValueError("ci_low must not exceed ci_high")
+        if type(self.confidence) not in (int, float) or not 0.0 < self.confidence < 1.0:
             raise ValueError("confidence must be a probability in (0, 1)")
+        object.__setattr__(self, "confidence", float(self.confidence))
 
     def to_dict(self) -> dict[str, Any]:
         data = dataclasses.asdict(self)
@@ -2351,8 +2353,36 @@ def paired_forager_comparison(
     bootstrap_seed: int = 0,
 ) -> ForagerPairedComparison:
     """Compare methods using identical seeds and environment contracts."""
+    if type(metric) is not str or metric not in (
+        "mean_reward",
+        "final_window_mean_reward",
+        "final_ewm_reward",
+        "mean_ewm_reward",
+        "fov_last_10pct_ema_auc",
+    ):
+        raise ValueError("metric is not a valid ForagerMetric")
+    if type(candidate_runs) not in (list, tuple) or type(baseline_runs) not in (list, tuple):
+        raise TypeError("candidate_runs and baseline_runs must be exact lists or tuples")
     if not candidate_runs or not baseline_runs:
         raise ValueError("both candidate_runs and baseline_runs are required")
+    if any(type(run) is not ForagerRunResult for run in (*candidate_runs, *baseline_runs)):
+        raise TypeError("comparison inputs must contain exact ForagerRunResult records")
+    candidate_summary = summarize_forager_runs(
+        candidate_runs,
+        metric=metric,
+        confidence=confidence,
+        bootstrap_resamples=1,
+        bootstrap_seed=bootstrap_seed,
+    )
+    baseline_summary = summarize_forager_runs(
+        baseline_runs,
+        metric=metric,
+        confidence=confidence,
+        bootstrap_resamples=1,
+        bootstrap_seed=bootstrap_seed,
+    )
+    candidate_runs = candidate_summary.runs
+    baseline_runs = baseline_summary.runs
     candidate_legacy = {
         run.agent_metadata.get("result_source") == "official_fov_sqlite" for run in candidate_runs
     }
@@ -2382,20 +2412,6 @@ def paired_forager_comparison(
                         f"{label} contains an official archive without "
                         "reverified protocol attestation evidence"
                     ) from exc
-    summarize_forager_runs(
-        candidate_runs,
-        metric=metric,
-        confidence=confidence,
-        bootstrap_resamples=1,
-        bootstrap_seed=bootstrap_seed,
-    )
-    summarize_forager_runs(
-        baseline_runs,
-        metric=metric,
-        confidence=confidence,
-        bootstrap_resamples=1,
-        bootstrap_seed=bootstrap_seed,
-    )
     candidate_by_seed = {run.seed: run for run in candidate_runs}
     baseline_by_seed = {run.seed: run for run in baseline_runs}
     if len(candidate_by_seed) != len(candidate_runs) or len(baseline_by_seed) != len(baseline_runs):
@@ -2490,20 +2506,59 @@ class ForagerComparisonReport:
             raise ValueError("metric is not a valid ForagerMetric")
         if type(self.summaries) is not dict:
             raise TypeError("summaries must be an exact dictionary")
+        if type(self.paired_comparisons) is not tuple:
+            raise TypeError("paired_comparisons must be an exact tuple")
+        if type(self.unpaired_methods) is not tuple:
+            raise TypeError("unpaired_methods must be an exact tuple")
+        summaries: dict[str, ForagerBenchmarkSummary] = {}
         for name, summary in self.summaries.items():
             if type(name) is not str or not name:
                 raise ValueError("summary names must be non-empty strings")
             if type(summary) is not ForagerBenchmarkSummary:
                 raise TypeError("summaries must contain ForagerBenchmarkSummary instances")
-        if type(self.paired_comparisons) is not tuple:
-            raise TypeError("paired_comparisons must be an exact tuple")
+            validated_summary = ForagerBenchmarkSummary(
+                **{
+                    field.name: getattr(summary, field.name)
+                    for field in dataclasses.fields(summary)
+                }
+            )
+            if name != validated_summary.agent or validated_summary.metric != self.metric:
+                raise ValueError("summary keys and metrics must match the report")
+            summaries[name] = validated_summary
+        if self.candidate not in summaries:
+            raise ValueError("candidate must name one report summary")
         if any(type(comp) is not ForagerPairedComparison for comp in self.paired_comparisons):
             raise TypeError("paired_comparisons must contain ForagerPairedComparison instances")
-        if type(self.unpaired_methods) is not tuple:
-            raise TypeError("unpaired_methods must be an exact tuple")
+        comparisons = tuple(
+            ForagerPairedComparison(
+                **{field.name: getattr(comp, field.name) for field in dataclasses.fields(comp)}
+            )
+            for comp in self.paired_comparisons
+        )
+        for comparison in comparisons:
+            if (
+                comparison.candidate != self.candidate
+                or comparison.metric != self.metric
+                or comparison.baseline not in summaries
+            ):
+                raise ValueError("paired comparisons must match report identities")
+            if comparison.seeds != summaries[self.candidate].seeds:
+                raise ValueError("paired comparison seeds must match the candidate summary")
+            if comparison.seeds != summaries[comparison.baseline].seeds:
+                raise ValueError("paired comparison seeds must match the baseline summary")
         for method in self.unpaired_methods:
             if type(method) is not str or not method:
                 raise ValueError("unpaired_methods must contain non-empty strings")
+        unpaired = tuple(self.unpaired_methods)
+        if len(set(unpaired)) != len(unpaired) or tuple(sorted(unpaired)) != unpaired:
+            raise ValueError("unpaired_methods must be unique and sorted")
+        compared = {comparison.baseline for comparison in comparisons}
+        expected_others = set(summaries) - {self.candidate}
+        if compared & set(unpaired) or compared | set(unpaired) != expected_others:
+            raise ValueError("paired and unpaired methods must partition non-candidates")
+        object.__setattr__(self, "summaries", summaries)
+        object.__setattr__(self, "paired_comparisons", comparisons)
+        object.__setattr__(self, "unpaired_methods", unpaired)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -2526,11 +2581,21 @@ def build_forager_comparison_report(
     bootstrap_seed: int = 0,
 ) -> ForagerComparisonReport:
     """Group seed runs and compare every exactly paired method to Alberta."""
+    if type(candidate) is not str:
+        raise ValueError("candidate must be an exact string")
+    if type(runs) not in (list, tuple):
+        raise TypeError("runs must be an exact list or tuple")
+    if any(type(run) is not ForagerRunResult for run in runs):
+        raise TypeError("runs must contain exact ForagerRunResult records")
+    runs = tuple(
+        ForagerRunResult(
+            **{field.name: getattr(run, field.name) for field in dataclasses.fields(run)}
+        )
+        for run in runs
+    )
     grouped: dict[str, list[ForagerRunResult]] = {}
     for run in runs:
         grouped.setdefault(run.agent, []).append(run)
-    if type(candidate) is not str:
-        raise ValueError("candidate must be an exact string")
     if candidate not in grouped:
         raise ValueError("candidate is absent from runs")
     summaries = {

--- a/tests/test_forager_candidate_hostile_strings.py
+++ b/tests/test_forager_candidate_hostile_strings.py
@@ -69,3 +69,20 @@ def test_candidate_rejects_hostile_before_membership() -> None:
 
     report = build_forager_comparison_report(runs, candidate="toy")
     assert report.candidate == "toy"
+
+
+def test_candidate_and_runs_are_admitted_before_traversal() -> None:
+    class HostileRuns(list[ForagerRunResult]):
+        def __iter__(self):  # type: ignore[no-untyped-def]  # pragma: no cover
+            raise AssertionError("hostile run traversal")
+
+    hostile = _HostileStr("toy")
+    with pytest.raises(ValueError, match="exact string"):
+        build_forager_comparison_report(HostileRuns(), candidate=hostile)  # type: ignore[arg-type]
+
+    run = _run()
+    object.__setattr__(run, "agent", hostile)
+    _HostileStr.calls = 0
+    with pytest.raises(ValueError, match="agent must be a non-empty string"):
+        build_forager_comparison_report([run], candidate="toy")
+    assert _HostileStr.calls == 0

--- a/tests/test_forager_results_comparison_hostile_validation.py
+++ b/tests/test_forager_results_comparison_hostile_validation.py
@@ -4,10 +4,51 @@ from __future__ import annotations
 
 import pytest
 
+from alberta_framework.benchmarks.forager import ForagerBenchmarkSummary, ForagerRunResult
 from alberta_framework.benchmarks.forager_results import (
     ForagerComparisonReport,
     ForagerPairedComparison,
 )
+
+
+def _run(*, agent: str, seed: int, reward: float) -> ForagerRunResult:
+    return ForagerRunResult(
+        agent=agent,
+        privileged=False,
+        seed=seed,
+        steps=1,
+        total_reward=reward,
+        mean_reward=reward,
+        final_window_mean_reward=reward,
+        final_ewm_reward=reward,
+        mean_ewm_reward=reward,
+        fov_last_10pct_ema_auc=reward,
+        mean_biome_regret=0.0,
+        final_biome_regret=0.0,
+        curve_steps=(1,),
+        curve_ewm_reward=(reward,),
+        curve_window_reward=(reward,),
+        duration_s=1.0,
+        frames_per_second=1.0,
+        environment={"kind": "toy"},
+        metric_contract={"metric": "mean_reward"},
+        agent_metadata={"name": agent},
+    )
+
+
+def _summary(agent: str, reward: float) -> ForagerBenchmarkSummary:
+    runs = (_run(agent=agent, seed=1, reward=reward),)
+    return ForagerBenchmarkSummary(
+        agent=agent,
+        privileged=False,
+        seeds=(1,),
+        metric="mean_reward",
+        mean=reward,
+        ci_low=reward,
+        ci_high=reward,
+        confidence=0.95,
+        runs=runs,
+    )
 
 
 def test_forager_paired_comparison_valid_construction() -> None:
@@ -39,6 +80,20 @@ def test_forager_paired_comparison_rejects_invalid_inputs() -> None:
             mean_difference=0.5,
             ci_low=0.2,
             ci_high=0.8,
+            confidence=0.95,
+        )
+
+    with pytest.raises(ValueError, match="ci_low must not exceed ci_high"):
+        ForagerPairedComparison(
+            candidate="cand_1",
+            baseline="base_1",
+            candidate_privileged=False,
+            baseline_privileged=False,
+            metric="mean_reward",
+            seeds=(1,),
+            mean_difference=0.5,
+            ci_low=0.8,
+            ci_high=0.2,
             confidence=0.95,
         )
 
@@ -131,5 +186,40 @@ def test_forager_comparison_literals_reject_before_hooks() -> None:
             metric="mean_reward",
             summaries={},
             paired_comparisons=[],  # type: ignore[arg-type]
+            unpaired_methods=(),
+        )
+
+
+def test_report_revalidates_nested_summaries_and_comparisons() -> None:
+    candidate = _summary("candidate", 1.0)
+    baseline = _summary("baseline", 0.0)
+    comparison = ForagerPairedComparison(
+        candidate="candidate",
+        baseline="baseline",
+        candidate_privileged=False,
+        baseline_privileged=False,
+        metric="mean_reward",
+        seeds=(1,),
+        mean_difference=1.0,
+        ci_low=1.0,
+        ci_high=1.0,
+        confidence=0.95,
+    )
+    report = ForagerComparisonReport(
+        candidate="candidate",
+        metric="mean_reward",
+        summaries={"candidate": candidate, "baseline": baseline},
+        paired_comparisons=(comparison,),
+        unpaired_methods=(),
+    )
+    assert report.paired_comparisons[0].mean_difference == 1.0
+
+    object.__setattr__(candidate, "mean", 2.0)
+    with pytest.raises(ValueError, match="mean must reconstruct"):
+        ForagerComparisonReport(
+            candidate="candidate",
+            metric="mean_reward",
+            summaries={"candidate": candidate, "baseline": baseline},
+            paired_comparisons=(comparison,),
             unpaired_methods=(),
         )


### PR DESCRIPTION
Summary:
- admit exact candidate, metric, run containers, and run records before traversal
- reconstruct Forager run and summary records at public consumption boundaries
- validate summary means, ordered confidence bounds, comparison identities, and report partitions
- revalidate nested summaries/comparisons before report serialization

Verification:
- focused comparator/result panel: 121 passed
- expanded all-Forager run before interruption: 452 passed; its one real compatibility failure was corrected and rerun green (the second reported failure was caused by the requested KeyboardInterrupt)
- full Ruff passed
- strict mypy passed for 189 source files
- diff check passed

Source/tests only; no benchmark was launched and no output artifact was changed.