### PR TITLE
fix(ipmnist): pin gradual report schedule RNG

### DIFF
--- a/alberta_framework/evaluation/gradual_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/gradual_ipmnist_nonpromoting.py
@@ -433,7 +433,7 @@ def _direction(delta: float) -> str:
 
 
 def _schedule_identities(seed: int, config: IPMNISTConfig, n_train: int) -> tuple[str, str]:
-    _, key_schedule, _ = jr.split(jr.key(np.uint32(seed)), 3)
+    _, key_schedule, _ = jr.split(jr.key(seed, impl="threefry2x32"), 3)
     schedule = build_schedule(key_schedule, config, n_train)
 
     def digest(domain: bytes, value: jax.Array) -> str:

--- a/tests/test_gradual_ipmnist_nonpromoting.py
+++ b/tests/test_gradual_ipmnist_nonpromoting.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import copy
+import json
 from pathlib import Path
 from typing import Any, cast
 
+import jax
 import numpy as np
 import pytest
 
@@ -149,3 +151,44 @@ def test_gradual_report_retention_is_exclusive_and_reload_validated(
     )
     with pytest.raises(FileExistsError):
         retain_frozen_gradual_input_development_report(report, x, y, repository_root=tmp_path)
+
+
+def test_retained_v2_exactly_derives_from_v1_independent_of_default_prng(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository_root = Path(__file__).resolve().parents[1]
+    parent = json.loads(
+        (
+            repository_root
+            / "outputs/ipmnist_gradual/development.v1"
+            / "result.7b2bf6c0f73b9fae20fcde53445f5f81656976ea4d042641772501e0108c6561.json"
+        ).read_bytes()
+    )
+    retained = json.loads(
+        (
+            repository_root
+            / "outputs/ipmnist_gradual/development.v2"
+            / "result.9ff58ac51163004208b94e325f9539037cb8cfb3540024da95c847f50154b483.json"
+        ).read_bytes()
+    )
+    monkeypatch.setattr(
+        gradual_report,
+        "_dataset_identity",
+        lambda _x, _y, _config: copy.deepcopy(parent["dataset"]),
+    )
+    monkeypatch.setattr(
+        gradual_report,
+        "_runtime_identity",
+        lambda: copy.deepcopy(parent["identity"]["runtime"]),
+    )
+    monkeypatch.setattr(
+        gradual_report,
+        "_source_identity",
+        lambda: copy.deepcopy(retained["identity"]["derivation_source_sha256"]),
+    )
+
+    with jax.default_prng_impl("rbg"):
+        derived = gradual_report.derive_gradual_input_resource_correction(
+            parent, object(), object()
+        )
+    assert derived == retained


### PR DESCRIPTION
## Summary
- pin gradual report schedule re-derivation to explicit `threefry2x32`, matching the runner receipt contract
- load the retained v1 and v2 reports in a focused test and require exact v1→v2 correction derivation under an `rbg` global default
- avoid rematerializing MNIST by using the identities already frozen in the two append-only artifacts

## Context
Merged #1751 correctly reports the v2 payload as a resource-only correction of historical v1, not a rerun. Its execution schedule hashes recompute exactly under Threefry and not under RBG. The validator helper still inherited `jax_default_prng_impl`, however, so validation was accidentally coupled to mutable process configuration.

The source change makes the existing derivation-source identity historical by design; this PR does not rewrite either retained artifact or claim a new execution.

## Verification
- `.venv/bin/python -m pytest tests/test_ipmnist_gradual.py tests/test_gradual_ipmnist_nonpromoting.py -q` (27 passed)
- `.venv/bin/python -m ruff check alberta_framework/evaluation/gradual_ipmnist_nonpromoting.py tests/test_gradual_ipmnist_nonpromoting.py`
- `.venv/bin/python -m mypy alberta_framework/evaluation/gradual_ipmnist_nonpromoting.py`
- `git diff --check`