### PR TITLE
fix(ipmnist): name merged L2-ER quarantine honestly

### DIFF
--- a/alberta_framework/benchmarks/l2er_matched_development.py
+++ b/alberta_framework/benchmarks/l2er_matched_development.py
@@ -101,7 +101,9 @@ def _invalid_execution_history() -> list[dict[str, object]]:
             "merge_commit": "ee6d8949fa3ffc267297f2e7ced7f83f589835e1",
             "pull_request": 1753,
             "seeds": [1711, 1712, 1713],
-            "disposition": "invalid_unmerged_consumed_accounting_ambiguous_attempt",
+            "disposition": (
+                "invalid_merged_quarantined_consumed_accounting_ambiguous_attempt"
+            ),
             "paired_outcomes_exposed": {
                 "l2er_l2_only": {
                     "mean_delta": 0.00033333152532577515,
@@ -125,7 +127,8 @@ def _invalid_execution_history() -> list[dict[str, object]]:
             "invalid_reasons": [
                 "the v2 updates field ambiguously combined supervised and auxiliary steps",
                 "all planned 1711-1713 outcomes were exposed before the v3 contract was final",
-                "the unmerged v2 artifact cannot authorize a prospective same-seed v3 rerun",
+                "the merged quarantined v2 artifact cannot authorize a prospective "
+                "same-seed v3 rerun",
             ],
         },
     ]

--- a/tests/test_l2er_matched_development.py
+++ b/tests/test_l2er_matched_development.py
@@ -317,6 +317,10 @@ def test_output_namespace_is_one_new_development_path() -> None:
         "c5a6b8efb050d3c6c05648a46689ca0903389340764f7c20b589bfc4e8b0c6f2"
     )
     assert invalid[2]["seeds"] == [1711, 1712, 1713]
+    assert invalid[2]["disposition"] == (
+        "invalid_merged_quarantined_consumed_accounting_ambiguous_attempt"
+    )
+    assert "merged quarantined v2 artifact" in invalid[2]["invalid_reasons"][-1]
     assert {
         item["outcome"] for item in invalid[2]["paired_outcomes_exposed"].values()
     } == {"inconclusive"}


### PR DESCRIPTION
Follow-up to #1759. The quarantine record already binds #1753 merge commit `ee6d8949`, but two strings still called that artifact unmerged. This changes only those identities to `invalid_merged_quarantined_consumed_accounting_ambiguous_attempt` and “merged quarantined v2 artifact,” with regression assertions.

Verification: 30 focused L2-ER tests passed; Ruff passed; diff check passed. No artifact bytes or execution authorization change.