### PR TITLE
fix(ipmnist): retain exact historical L2-ER loader

### DIFF
--- a/alberta_framework/benchmarks/l2er_matched_development.py
+++ b/alberta_framework/benchmarks/l2er_matched_development.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import os
@@ -50,6 +51,11 @@ _MAX_REPORT_BYTES = 16 * 1024 * 1024
 _PATH_TYPE = type(Path())
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 OUTPUT_PATH = _REPO_ROOT / "outputs/l2er_matched_development/report.v3.json"
+HISTORICAL_V2_PATH = _REPO_ROOT / "outputs/l2er_matched_development/report.v2.json"
+HISTORICAL_V2_SCHEMA = "asi.l2er-ipmnist.matched-development-report.v2"
+HISTORICAL_V2_SHA256 = (
+    "c5a6b8efb050d3c6c05648a46689ca0903389340764f7c20b589bfc4e8b0c6f2"
+)
 _V3_EXECUTION_AUTHORIZED = False
 
 
@@ -507,6 +513,11 @@ def validate_report(
         ),
         context="report",
     )
+    if type(report["schema"]) is str and report["schema"] == HISTORICAL_V2_SCHEMA:
+        historical = load_historical_v2_report()
+        if _bounded_json(report, context="historical_v2_report") != historical:
+            raise ValueError("historical v2 report does not match the exact retained artifact")
+        return historical
     if type(report["schema"]) is not str or report["schema"] != SCHEMA:
         raise ValueError("report schema does not match the frozen protocol")
     plan = _validated_plan(report["plan"])
@@ -641,6 +652,45 @@ def validate_report(
     }
 
 
+def load_historical_v2_report(
+    path: Path = HISTORICAL_V2_PATH,
+) -> dict[str, object]:
+    """Load only the exact immutable, historically validated v2 development result."""
+    if type(path) is not _PATH_TYPE or path != HISTORICAL_V2_PATH:
+        raise ValueError("historical v2 report path must be the exact retained artifact path")
+    try:
+        encoded = path.read_bytes()
+    except OSError as error:
+        raise ValueError("unable to read the retained historical v2 report") from error
+    if len(encoded) > _MAX_REPORT_BYTES:
+        raise ValueError("historical v2 report exceeds the output byte limit")
+    if hashlib.sha256(encoded).hexdigest() != HISTORICAL_V2_SHA256:
+        raise ValueError("historical v2 report does not match its retained artifact SHA-256")
+    try:
+        payload = json.loads(encoded)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("historical v2 report is not exact JSON") from error
+    report = _object(
+        payload,
+        frozenset(
+            {
+                "schema",
+                "plan",
+                "source_provenance",
+                "dataset_provenance",
+                "environment",
+                "records",
+                "paired_comparisons",
+                "policy",
+            }
+        ),
+        context="historical_v2_report",
+    )
+    if type(report["schema"]) is not str or report["schema"] != HISTORICAL_V2_SCHEMA:
+        raise ValueError("historical v2 report schema does not match its retained contract")
+    return cast(dict[str, object], _bounded_json(report, context="historical_v2_report"))
+
+
 def run(*, data_home: Path) -> dict[str, object]:
     """Execute only after a separate methodological disposition authorizes v3."""
     if type(data_home) is not _PATH_TYPE:
@@ -734,6 +784,7 @@ def _publish_report(
     report: dict[str, object],
 ) -> None:
     """Publish and reload one report through a pinned directory descriptor."""
+    _require_execution_authorized()
     normalized = validate_report(report)
     encoded = (
         json.dumps(normalized, allow_nan=False, indent=1, sort_keys=True) + "\n"

--- a/tests/test_l2er_matched_development.py
+++ b/tests/test_l2er_matched_development.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import os
 from copy import deepcopy
 from pathlib import Path
@@ -240,7 +241,7 @@ def test_three_seed_interval_uses_student_t_not_normal_critical_value() -> None:
     assert critical.hex() == "0x1.135ea98e146bbp+2"
 
 
-@pytest.mark.parametrize("version", ("v1", "v2"))
+@pytest.mark.parametrize("version", ("v1",))
 def test_validator_rejects_obsolete_report_identity(
     monkeypatch: pytest.MonkeyPatch,
     version: str,
@@ -254,6 +255,24 @@ def test_validator_rejects_obsolete_report_identity(
     report["schema"] = f"asi.l2er-ipmnist.matched-development-report.{version}"
     with pytest.raises(ValueError, match="schema does not match"):
         matched.validate_report(report, require_current_source=False)
+
+
+def test_historical_v2_loader_accepts_only_exact_retained_artifact(tmp_path: Path) -> None:
+    encoded = matched.HISTORICAL_V2_PATH.read_bytes()
+    assert hashlib.sha256(encoded).hexdigest() == matched.HISTORICAL_V2_SHA256
+    loaded = matched.load_historical_v2_report()
+    assert loaded["schema"] == matched.HISTORICAL_V2_SCHEMA
+    assert matched.validate_report(loaded) == loaded
+
+    copied = tmp_path / "report.v2.json"
+    copied.write_bytes(encoded)
+    with pytest.raises(ValueError, match="exact retained artifact path"):
+        matched.load_historical_v2_report(copied)
+
+    tampered = deepcopy(loaded)
+    tampered["policy"]["scientific_promotion_allowed"] = True
+    with pytest.raises(ValueError, match="exact retained artifact"):
+        matched.validate_report(tampered)
 
 
 def test_report_revalidates_result_identity_before_reading_metrics(
@@ -378,6 +397,7 @@ def test_output_publication_uses_pinned_dirfd_and_strict_reload(
     monkeypatch.setattr(matched, "_validated_runtime_environment", lambda value, **_: value)
     monkeypatch.setattr(matched, "_screening_source_provenance", lambda: {})
     monkeypatch.setattr(matched, "_screening_runtime_environment", lambda: {})
+    monkeypatch.setattr(matched, "_V3_EXECUTION_AUTHORIZED", True)
     report = matched.build_report(
         _results(), source_provenance={}, dataset_provenance={}, environment={}
     )
@@ -393,3 +413,15 @@ def test_output_publication_uses_pinned_dirfd_and_strict_reload(
     assert matched.OUTPUT_PATH.is_file()
     with pytest.raises(FileExistsError, match="refusing to overwrite"):
         matched._open_output_transaction()
+
+
+def test_direct_publication_is_blocked_before_validation_or_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        matched,
+        "validate_report",
+        lambda *_args, **_kwargs: pytest.fail("blocked publication must not validate"),
+    )
+    with pytest.raises(RuntimeError, match="planned seeds were already consumed"):
+        matched._publish_report(-1, -1, "unused", {})


### PR DESCRIPTION
Corrects the residual historical-compatibility and publication-boundary gaps after #1762.

- dispatches the exact retained v2 schema through a canonical-path/file-SHA loader
- accepts only the immutable #1753 artifact bytes and preflights the parsed JSON tree
- leaves the generic v3 validator and its current-source/runtime checks unchanged
- blocks direct `_publish_report` calls before validation or any write while v3 remains unauthorized
- preserves the valid consumed v2 history and the non-runnable prospective v3 plan

No output artifact was edited and no execution was launched.

Verification: 31 focused L2-ER tests passed; Ruff full clean; strict mypy clean (189 source files); diff check clean; retained v2 SHA-256 remains `c5a6b8efb050d3c6c05648a46689ca0903389340764f7c20b589bfc4e8b0c6f2`.

Refs #1559.