### PR TITLE
fix(evaluation): bind exact condition-timing identities

### DIFF
--- a/alberta_framework/evaluation/continual_ia_artifact.py
+++ b/alberta_framework/evaluation/continual_ia_artifact.py
@@ -1071,7 +1071,7 @@ def _validate_operational(
             condition = timing.get("condition")
             wall = _number(timing.get("wall_seconds"))
             latency = _number(timing.get("mean_step_latency_ms"))
-            if not isinstance(seed, int) or not isinstance(condition, str):
+            if type(seed) is not int or type(condition) is not str:
                 errors.append(f"condition_timings[{index}] has invalid identity")
             else:
                 observed_pairs.append((seed, condition))

--- a/tests/test_continual_ia_timing_identity_hostile.py
+++ b/tests/test_continual_ia_timing_identity_hostile.py
@@ -1,0 +1,109 @@
+"""Hostile identity gates for operational condition-timing validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_ia_artifact import _validate_operational
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile int equality hook executed")
+
+    def __hash__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile int hash hook executed")
+
+
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile str equality hook executed")
+
+    def __hash__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile str hash hook executed")
+
+
+def _operational(timings: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "digest_exclusion_reason": (
+            "host environment and wall-clock timing are non-deterministic"
+        ),
+        "environment": None,
+        "condition_timings": timings,
+        "overall_acceptance_passed": True,
+    }
+
+
+def _timing(seed: object, condition: object) -> dict[str, object]:
+    return {
+        "seed": seed,
+        "condition": condition,
+        "wall_seconds": 1.0,
+        "mean_step_latency_ms": 1.0,
+    }
+
+
+def _identity_errors(errors: list[str]) -> list[str]:
+    return [error for error in errors if "has invalid identity" in error]
+
+
+class TestConditionTimingIdentity:
+    def test_exact_int_seed_and_exact_str_condition_pass(self) -> None:
+        errors: list[str] = []
+        _validate_operational(
+            _operational([_timing(30, "current")]),
+            expected_results=None,
+            expected_acceptance=True,
+            errors=errors,
+        )
+        assert _identity_errors(errors) == []
+
+    def test_bool_seed_is_rejected(self) -> None:
+        errors: list[str] = []
+        _validate_operational(
+            _operational([_timing(True, "current")]),
+            expected_results=None,
+            expected_acceptance=True,
+            errors=errors,
+        )
+        assert _identity_errors(errors) == [
+            "condition_timings[0] has invalid identity"
+        ]
+
+    def test_int_subclass_seed_is_rejected_without_hooks(self) -> None:
+        _HostileInt.calls = 0
+        errors: list[str] = []
+        _validate_operational(
+            _operational([_timing(_HostileInt(30), "current")]),
+            expected_results=None,
+            expected_acceptance=True,
+            errors=errors,
+        )
+        assert _identity_errors(errors) == [
+            "condition_timings[0] has invalid identity"
+        ]
+        assert _HostileInt.calls == 0
+
+    def test_str_subclass_condition_is_rejected_without_hooks(self) -> None:
+        _HostileStr.calls = 0
+        errors: list[str] = []
+        _validate_operational(
+            _operational([_timing(30, _HostileStr("current"))]),
+            expected_results=None,
+            expected_acceptance=True,
+            errors=errors,
+        )
+        assert _identity_errors(errors) == [
+            "condition_timings[0] has invalid identity"
+        ]
+        assert _HostileStr.calls == 0


### PR DESCRIPTION
Fix-lane follow-up to the hostile-identity wave (#1693 / #1722 / #1725): the operational condition-timing validator in `continual_ia_artifact.py` was the remaining identity gate still using bare `isinstance`.

## The spoof

`_validate_operational` accepted `"seed": true` from a JSON artifact — `isinstance(True, int)` passes, and `(True, cond) == (1, cond)` in the observed/expected pair comparison, so a bool seed silently binds to seed 1. Similarly, `str`-subclass conditions pass `isinstance` and execute their `__eq__/__hash__` hooks inside `observed_pairs != expected_pairs`. The same file already guards every other boundary (`_integer`, `_number`, 6 bool guards) — this line was the miss.

## Fix

One line, matching the wave's exact-type convention:
```python
- if not isinstance(seed, int) or not isinstance(condition, str):
+ if type(seed) is not int or type(condition) is not str:
```

**Production-path safety:** genuine artifacts are unaffected — seeds are canonicalized to exact `int` via `operator.index` in `_require_integer` (continual_ia.py) before reaching `IAConditionResult`, and JSON parsing yields exact types on the read path.

## Tests (failing-test-first)

New `tests/test_continual_ia_timing_identity_hostile.py` — 4 tests: exact-identity pass, bool-seed rejection, hostile-int-subclass rejection with zero hook executions, hostile-str-subclass rejection with zero hook executions. 3 fail on main before the fix; 4 pass after.

## Verification

Commit measured: `82c2a49120e31a3719905a2ed04abe8584141069`
```
pytest tests/test_continual_ia_timing_identity_hostile.py -q -o addopts=""  # 4 passed
pytest tests/test_continual_ia_cli.py -q -o addopts=""                      # 5 passed
ruff check (both touched files)   # All checks passed
mypy (both touched files)         # Success: no issues in 2 source files
```
**Honest limitation:** `tests/test_continual_ia_evidence.py` (141 tests) exceeds my runner's memory (2 vCPU / 4 GB container; the artifact fixtures OOM) — I could not complete it locally. Static analysis of the seed path (above) says it passes; CI should confirm. If anything there fails, treat this PR as not verified and I'll rework.

## Disclosure

Client `claude-code`, provider `anthropic`, model `claude-fable-5`. No Slop run receipt: project policy is `paused`/`pending-authority-activation` at submission — unscored contribution.

---
🤖 Built with [Emblem:build](https://emblem.build)
