### PR TITLE
fix(evidence): bound recurring consumer snapshots

### DIFF
--- a/alberta_framework/recurring_feature_gate.py
+++ b/alberta_framework/recurring_feature_gate.py
@@ -635,10 +635,7 @@ class RecurringFeatureGateResult:
         criteria: RecurringFeatureGateCriteria | None = None,
     ) -> RecurringFeatureGateDecision:
         """Evaluate this result without trusting a cached pass flag."""
-        return evaluate_recurring_feature_gate(
-            self,
-            criteria=criteria or RecurringFeatureGateCriteria(),
-        )
+        return evaluate_recurring_feature_gate(self, criteria=criteria)
 
     def require_pass(
         self,
@@ -692,9 +689,9 @@ def _validated_task_recovery(value: object) -> TaskRecoveryEvidence:
 def _validated_seed_evidence(value: object) -> RecurringFeatureSeedEvidence:
     if type(value) is not RecurringFeatureSeedEvidence:
         raise ValueError("seeds must contain exact RecurringFeatureSeedEvidence records")
-    if type(value.phase_evidence) is not tuple:
+    if type(value.phase_evidence) is not tuple or len(value.phase_evidence) > 4096:
         raise ValueError("phase_evidence must be a bounded exact tuple")
-    if type(value.task_recovery) is not tuple:
+    if type(value.task_recovery) is not tuple or len(value.task_recovery) > 4096:
         raise ValueError("task_recovery must be a bounded exact tuple")
     return RecurringFeatureSeedEvidence(
         seed=value.seed,
@@ -710,7 +707,7 @@ def _validated_seed_evidence(value: object) -> RecurringFeatureSeedEvidence:
 def _validated_variant_evidence(value: object) -> RecurringFeatureVariantEvidence:
     if type(value) is not RecurringFeatureVariantEvidence:
         raise ValueError("variants must be exact RecurringFeatureVariantEvidence records")
-    if type(value.seeds) is not tuple:
+    if type(value.seeds) is not tuple or len(value.seeds) > 4096:
         raise ValueError("seeds must be a bounded exact tuple")
     return RecurringFeatureVariantEvidence(
         name=value.name,
@@ -745,6 +742,16 @@ def _validated_gate_result(value: object) -> RecurringFeatureGateResult:
         no_retention=_validated_variant_evidence(value.no_retention),
         scope=value.scope,
     )
+
+
+def _validated_gate_criteria(value: object) -> RecurringFeatureGateCriteria:
+    if value is None:
+        return RecurringFeatureGateCriteria()
+    if type(value) is not RecurringFeatureGateCriteria:
+        raise ValueError("criteria must be an exact RecurringFeatureGateCriteria")
+    checked = replace(value)
+    checked.validate()
+    return checked
 
 
 @dataclass(frozen=True, slots=True)
@@ -1147,8 +1154,7 @@ def evaluate_recurring_feature_gate(
 ) -> RecurringFeatureGateDecision:
     """Recompute a fail-closed decision from raw per-seed evidence."""
     result = _validated_gate_result(result)
-    chosen = criteria or RecurringFeatureGateCriteria()
-    chosen.validate()
+    chosen = _validated_gate_criteria(criteria)
     failures = _canonical_protocol_failures(result.protocol)
     failures.extend(_seed_failures(result))
 

--- a/tests/test_recurring_feature_evidence_leftover_identities.py
+++ b/tests/test_recurring_feature_evidence_leftover_identities.py
@@ -170,3 +170,24 @@ def test_decision_revalidates_and_cross_binds_memory_budget() -> None:
     )
     with pytest.raises(ValueError, match="capacities must match"):
         mismatched.decision()
+
+
+def test_decision_preflights_forged_nested_lengths_before_snapshot() -> None:
+    result = _decision_result()
+    seed = result.retained.seeds[0]
+    object.__setattr__(seed, "phase_evidence", seed.phase_evidence * 4097)
+    with pytest.raises(ValueError, match="bounded exact tuple"):
+        result.decision()
+
+
+def test_decision_rejects_hostile_criteria_without_truthiness_dispatch() -> None:
+    class HostileCriteria:
+        calls = 0
+
+        def __bool__(self) -> bool:
+            type(self).calls += 1
+            raise AssertionError("hostile truthiness")
+
+    with pytest.raises(ValueError, match="criteria must be an exact"):
+        _decision_result().decision(HostileCriteria())  # type: ignore[arg-type]
+    assert HostileCriteria.calls == 0


### PR DESCRIPTION
Post-merge audit corrective for #1766. Its reconstruction/canonicalization and memory-budget cross-bind are sound, but forged exact tuples could exceed the 4096-record contract and be fully copied before constructor rejection. This patch preflights phase, recovery, and seed tuple lengths before snapshot iteration. It also removes pre-validation criteria truthiness dispatch and reconstructs/revalidates exact criteria.\n\nTests include a forged 4097-phase record and hostile criteria `__bool__` zero-dispatch case. No outputs changed. Focused 39 passed; Ruff clean; mypy clean; diff check clean.