### PR TITLE
fix(benchmarks): bind exact string identities in causal-map state gates

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -2484,9 +2484,11 @@ def causal_map_state_from_dict(
     }
     if set(payload) != expected_top_level:
         raise ValueError("serialized state top-level fields do not match the schema")
-    if payload.get("schema") != CAUSAL_MAP_STATE_SCHEMA:
+    raw_schema = payload.get("schema")
+    if type(raw_schema) is not str or raw_schema != CAUSAL_MAP_STATE_SCHEMA:
         raise ValueError("unsupported causal-map state schema")
-    if payload.get("prng_impl") != _CAUSAL_MAP_PRNG_IMPL:
+    raw_prng_impl = payload.get("prng_impl")
+    if type(raw_prng_impl) is not str or raw_prng_impl != _CAUSAL_MAP_PRNG_IMPL:
         raise ValueError("serialized state PRNG implementation does not match")
     checkpoint_partitionable = payload.get("jax_threefry_partitionable")
     if type(checkpoint_partitionable) is not bool:
@@ -2526,7 +2528,11 @@ def causal_map_state_from_dict(
     except (TypeError, ValueError) as exc:
         raise ValueError("serialized state config is not canonical JSON") from exc
     declared_config_sha256 = hashlib.sha256(declared_config.encode()).hexdigest()
-    declared_hash_matches = payload.get("config_sha256") == declared_config_sha256
+    raw_config_sha256 = payload.get("config_sha256")
+    declared_hash_matches = (
+        type(raw_config_sha256) is str
+        and raw_config_sha256 == declared_config_sha256
+    )
     current_config_matches = (
         declared_config == expected_config
         and declared_config_sha256 == config.fingerprint()

--- a/tests/test_causal_map_state_string_identity_hostile.py
+++ b/tests/test_causal_map_state_string_identity_hostile.py
@@ -1,0 +1,98 @@
+"""Hostile string identity gates for causal-map serialized state validation."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.benchmarks.causal_map_forager import (
+    CausalMapForagerConfig,
+    causal_map_start,
+    causal_map_state_from_dict,
+    causal_map_state_to_dict,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile str equality hook executed")
+
+    def __ne__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile str inequality hook executed")
+
+    def __hash__(self) -> int:
+        return str.__hash__(self)
+
+
+class _LyingStr(str):
+    """Claims equality with everything without raising."""
+
+    def __eq__(self, other: object) -> bool:
+        return True
+
+    def __ne__(self, other: object) -> bool:
+        return False
+
+    def __hash__(self) -> int:
+        return str.__hash__(self)
+
+
+def _observation() -> jnp.ndarray:
+    image = jnp.zeros((9, 9, 3), dtype=jnp.float32)
+    return image.at[4, 4, 1].set(1.0)
+
+
+def _valid_payload(config: CausalMapForagerConfig) -> dict[str, object]:
+    state, _ = causal_map_start(_observation(), config, 19)
+    return causal_map_state_to_dict(state, config)
+
+
+class TestSerializedStateStringIdentity:
+    def test_valid_payload_round_trips(self) -> None:
+        config = CausalMapForagerConfig()
+        payload = _valid_payload(config)
+        causal_map_state_from_dict(payload, config)
+
+    def test_schema_subclass_is_rejected_without_hooks(self) -> None:
+        config = CausalMapForagerConfig()
+        payload = _valid_payload(config)
+        _HostileStr.calls = 0
+        payload["schema"] = _HostileStr(payload["schema"])
+        with pytest.raises(ValueError, match="unsupported causal-map state schema"):
+            causal_map_state_from_dict(payload, config)
+        assert _HostileStr.calls == 0
+
+    def test_lying_schema_subclass_cannot_spoof_the_gate(self) -> None:
+        config = CausalMapForagerConfig()
+        payload = _valid_payload(config)
+        payload["schema"] = _LyingStr("alberta.wrong_schema.v0")
+        with pytest.raises(ValueError, match="unsupported causal-map state schema"):
+            causal_map_state_from_dict(payload, config)
+
+    def test_prng_impl_subclass_is_rejected_without_hooks(self) -> None:
+        config = CausalMapForagerConfig()
+        payload = _valid_payload(config)
+        _HostileStr.calls = 0
+        payload["prng_impl"] = _HostileStr(payload["prng_impl"])
+        with pytest.raises(
+            ValueError, match="PRNG implementation does not match"
+        ):
+            causal_map_state_from_dict(payload, config)
+        assert _HostileStr.calls == 0
+
+    def test_config_sha256_subclass_is_rejected_without_hooks(self) -> None:
+        config = CausalMapForagerConfig()
+        payload = _valid_payload(config)
+        _HostileStr.calls = 0
+        payload["config_sha256"] = _HostileStr(payload["config_sha256"])
+        with pytest.raises(
+            ValueError, match="embeds a different configuration"
+        ):
+            causal_map_state_from_dict(payload, config)
+        assert _HostileStr.calls == 0


### PR DESCRIPTION
Fix-lane follow-up to the hostile-identity wave (#1722 / #1725 precedent): the causal-map serialized-state validator still had three string gates using bare `==`/`!=` on untrusted checkpoint payload values.

## The spoof

In `causal_map_state_from_dict` (untrusted checkpoint restore path):
- `payload.get("schema") != CAUSAL_MAP_STATE_SCHEMA` — a hostile `str` subclass's `__ne__` executes inside the validator, and a **lying subclass (`__ne__` → False) passes the schema gate with a wrong schema string**;
- same for `prng_impl`;
- `payload.get("config_sha256") == declared_config_sha256` — subclass `__eq__` executes and can claim a hash match it doesn't have.

The same function already uses exact-type discipline for its newer field (`type(checkpoint_partitionable) is not bool`), and the module ships `_require_exact_str` — these three gates predate the convention.

## Fix

Exact-type gates preserving the existing error messages:
```python
raw_schema = payload.get("schema")
if type(raw_schema) is not str or raw_schema != CAUSAL_MAP_STATE_SCHEMA: ...
raw_prng_impl = payload.get("prng_impl")
if type(raw_prng_impl) is not str or raw_prng_impl != _CAUSAL_MAP_PRNG_IMPL: ...
declared_hash_matches = type(raw_config_sha256) is str and raw_config_sha256 == declared_config_sha256
```

## Tests (failing-test-first)

New `tests/test_causal_map_state_string_identity_hostile.py` — 5 tests over a REAL `causal_map_start` → `causal_map_state_to_dict` round-trip payload: valid round-trip, raising-hostile schema (zero hooks), **lying schema spoof**, raising prng_impl (zero hooks), raising config_sha256 (zero hooks). 4 fail on main before the fix; 5 pass after.

## Verification

Commit measured: `0d7b93b447d261190d6df5614fad63e0dc10e204`
```
pytest tests/test_causal_map_state_string_identity_hostile.py -q  # 5 passed
pytest tests/test_causal_map_hostile_validation.py tests/test_causal_map_int_hostile.py -q  # 8 passed
pytest tests/test_causal_map_forager.py::test_state_serialization_round_trip_and_validation \
       ::test_field_absent_v5_checkpoint_requires_explicit_legacy_readiness_policy \
       ::test_checkpoint_rejects_cross_mode_threefry_partitionable_restore  # 3 passed (run individually)
ruff check / mypy (both touched files)  # clean
```
**Honest limitation:** the full `test_causal_map_forager.py` suite exceeds my runner's memory (2 vCPU / 4 GB) — serialization-relevant tests were run individually instead; CI should confirm the rest.

## Disclosure

Client `claude-code`, provider `anthropic`, model `claude-fable-5`. No Slop run receipt: policy `paused`/`pending-authority-activation` — unscored contribution.

---
🤖 Built with [Emblem:build](https://emblem.build)
