### PR TITLE
fix(core): preflight online-gated state-builder update working sets

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -1280,6 +1280,61 @@ class FixedTraceStateBuilder:
         return self.commit_learning_update(state, proposal)
 
 
+def _online_gated_update_working_set_bytes(
+    observation_dim: int,
+    n_actions: int,
+    hidden_dim: int,
+    *,
+    include_raw_observation: bool,
+) -> int:
+    """Source persist, candidate persist, selected persist, and returned extras.
+
+    ``update`` keeps the source state, the candidate state, and the
+    transaction-selected result simultaneously live.  ``jax.jacfwd``
+    materializes another sensitivity matrix, the proposed sensitivity is
+    live before it is stored, and the caller-visible representation plus
+    its neutralized NaN copy are returned beside the selected state.
+    Event / safe-event / gate temporaries are charged as well.
+    """
+
+    event_dim = observation_dim + n_actions + 2
+    feature_dim = hidden_dim + (observation_dim if include_raw_observation else 0)
+    parameter_count = 2 * hidden_dim * (event_dim + 1)
+    persist_scalars = (
+        parameter_count + hidden_dim + hidden_dim * parameter_count + 3
+    )
+    update_scalars = (
+        3 * persist_scalars
+        + 2 * hidden_dim * parameter_count
+        + 2 * feature_dim
+        + 2 * event_dim
+        + hidden_dim
+        + 16
+    )
+    return 4 * update_scalars
+
+
+def _preflight_online_gated_update_working_set(
+    observation_dim: int,
+    n_actions: int,
+    hidden_dim: int,
+    *,
+    include_raw_observation: bool,
+) -> None:
+    """Reject an update envelope the online-gated builder cannot name."""
+
+    working_set_bytes = _online_gated_update_working_set_bytes(
+        observation_dim,
+        n_actions,
+        hidden_dim,
+        include_raw_observation=include_raw_observation,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "online-gated update working set byte count must fit signed int32"
+        )
+
+
 @dataclass(frozen=True)
 class OnlineGatedStateBuilderConfig:
     """Configuration for the online learnable write/hold state builder."""
@@ -1349,6 +1404,12 @@ class OnlineGatedStateBuilderConfig:
         _require_derived_int32("parameter_count", parameter_count, minimum=1)
         _require_derived_int32("state_scalars", state_scalars, minimum=1)
         _require_derived_int32("state_bytes", 4 * state_scalars, minimum=1)
+        _preflight_online_gated_update_working_set(
+            self.observation_dim,
+            self.n_actions,
+            self.hidden_dim,
+            include_raw_observation=self.include_raw_observation,
+        )
 
     def event_dim(self) -> int:
         """Return observation + one-hot action + reward + discount width."""

--- a/tests/test_state_builder_update_working_set.py
+++ b/tests/test_state_builder_update_working_set.py
@@ -1,0 +1,106 @@
+"""Complete update working-set preflight for the online-gated state builder."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax import tree_util
+
+from alberta_framework.core.state_builder import (
+    OnlineGatedStateBuilder,
+    OnlineGatedStateBuilderConfig,
+    _online_gated_update_working_set_bytes,
+    _preflight_online_gated_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def _persist_bytes(observation_dim: int, hidden_dim: int, n_actions: int = 0) -> int:
+    event_dim = observation_dim + n_actions + 2
+    parameter_count = 2 * hidden_dim * (event_dim + 1)
+    persist_scalars = (
+        parameter_count + hidden_dim + hidden_dim * parameter_count + 3
+    )
+    return 4 * persist_scalars
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_online_gated_persist_matches_jit_materialized_leaves() -> None:
+    config = OnlineGatedStateBuilderConfig(
+        observation_dim=3,
+        hidden_dim=2,
+        n_actions=1,
+    )
+    builder = OnlineGatedStateBuilder(config)
+    state = builder.init(jr.PRNGKey(0))
+    actual = sum(
+        int(leaf.size) * int(leaf.dtype.itemsize)
+        for leaf in tree_util.tree_leaves(state)
+    )
+    assert actual == builder.resource_budget().state_bytes
+    assert actual == _persist_bytes(3, 2, 1)
+
+
+def test_online_gated_persist_fits_while_update_working_set_does_not() -> None:
+    observation_dim = 45_000_000
+    persist_bytes = _persist_bytes(observation_dim, 1)
+    working_set_bytes = _online_gated_update_working_set_bytes(
+        observation_dim,
+        0,
+        1,
+        include_raw_observation=True,
+    )
+    assert persist_bytes <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        OnlineGatedStateBuilderConfig(observation_dim=observation_dim, hidden_dim=1)
+
+
+def test_online_gated_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for observation_dim in range(26_843_540, 26_843_545):
+        working_set_bytes = _online_gated_update_working_set_bytes(
+            observation_dim,
+            0,
+            1,
+            include_raw_observation=True,
+        )
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = observation_dim
+        elif first_overflow is None:
+            first_overflow = observation_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert _persist_bytes(last_fit, 1) <= _INT32_MAX
+    OnlineGatedStateBuilderConfig(observation_dim=last_fit, hidden_dim=1)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        OnlineGatedStateBuilderConfig(observation_dim=first_overflow, hidden_dim=1)
+
+
+def test_online_gated_persistent_byte_bound_still_fires_first() -> None:
+    observation_dim = 134_217_725
+    assert _persist_bytes(observation_dim, 1) > _INT32_MAX
+    with pytest.raises(ValueError, match="state_bytes"):
+        OnlineGatedStateBuilderConfig(observation_dim=observation_dim, hidden_dim=1)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_online_gated_update_working_set(
+            45_000_000,
+            0,
+            1,
+            include_raw_observation=True,
+        )


### PR DESCRIPTION
Closes #1769.

## What changed

`OnlineGatedStateBuilderConfig.__post_init__` now preflights the simultaneous update working set after the existing persistent `state_bytes` check.

On origin/main `a87eb067`, `observation_dim = 45_000_000` / `hidden_dim = 1` keeps persist nameable (720000064 bytes, matching JIT `init()` leaves). Source + candidate + selected persist, jacfwd + proposed sensitivities, two representations, and event/gate temps overflow signed int32. Existing persist-bound tests still fire first (`state_bytes` at `observation_dim=134217725`). Adjacent last-fit / first-overflow at `26843541` / `26843542`. Legal small configs are unchanged.

This matches the `#1383` complete-aggregate bar. It does not reopen `#1378`, remine `#1749`, touch `intelligence_amplification.py`, or reprint fusion leftover identities.

## Scope

- `alberta_framework/core/state_builder.py`
- `tests/test_state_builder_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `state_builder.py`.

## Verification

Exact candidate head: `c053209f870a21b8bec182601e9298ddaaa619d6`
Base: `a87eb0671f0026fa9625a990dbfc5a4225451a27`

- Red on base: `OnlineGatedStateBuilderConfig(observation_dim=45_000_000, hidden_dim=1)` constructed; persist 720000064 fits and matches JIT leaves; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_state_builder_update_working_set.py` plus `tests/test_state_builder.py` plus `tests/test_state_builder_hostile_validation.py`: 91 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_state_builder_update_working_set.py tests/test_state_builder.py tests/test_state_builder_hostile_validation.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: persist still matches JIT leaves on a small config; persist `state_bytes` still fires first at `134217725`; last-fit `26843541` constructs; first-overflow `26843542` rejects
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c053209f870a21b8bec182601e9298ddaaa619d6 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
