### PR TITLE
fix(delight): reject non-boolean rare_mask in stratify_delight_outcomes

### DIFF
--- a/alberta_framework/core/delight.py
+++ b/alberta_framework/core/delight.py
@@ -2116,7 +2116,10 @@ def stratify_delight_outcomes(
     but belong to neither success nor failure stratum.
     """
     advantages = jnp.ravel(jnp.asarray(result.advantage, dtype=jnp.float32))
-    rare = jnp.ravel(jnp.asarray(rare_mask, dtype=jnp.bool_))
+    rare_input = jnp.asarray(rare_mask)
+    if rare_input.dtype != jnp.bool_:
+        raise ValueError("rare_mask must have boolean dtype")
+    rare = jnp.ravel(rare_input)
     if rare.shape != advantages.shape:
         raise ValueError("rare_mask must match the flattened advantage shape")
     common = ~rare

--- a/tests/test_delight.py
+++ b/tests/test_delight.py
@@ -2136,3 +2136,23 @@ def test_paper_specific_dg_rejects_shape_mismatch_and_empty_batches() -> None:
     )
     with pytest.raises(ValueError, match="rare_mask"):
         stratify_delight_outcomes(result, jnp.zeros((3,), dtype=jnp.bool_))
+
+
+@pytest.mark.parametrize(
+    "rare_mask",
+    (
+        jnp.array([0.0, 0.5], dtype=jnp.float32),
+        jnp.array([0.0, jnp.nan], dtype=jnp.float32),
+        jnp.array([0, 1], dtype=jnp.int32),
+    ),
+)
+def test_delight_stratification_rejects_non_boolean_rare_masks(rare_mask: Array) -> None:
+    result = discrete_delightful_policy_gradient(
+        jnp.log(jnp.array([0.5, 0.5], dtype=jnp.float32)),
+        jnp.array([1.0, -1.0], dtype=jnp.float32),
+    )
+
+    with pytest.raises(ValueError, match="rare_mask must have boolean dtype"):
+        stratify_delight_outcomes(result, rare_mask)
+    with pytest.raises(ValueError, match="rare_mask must have boolean dtype"):
+        jax.jit(stratify_delight_outcomes)(result, rare_mask)


### PR DESCRIPTION
Closes #1772.

## What changed

`stratify_delight_outcomes` cast `rare_mask` to `jnp.bool_` unconditionally via `jnp.asarray(rare_mask, dtype=jnp.bool_)`, silently accepting any numeric array instead of requiring an actual boolean mask.

## Fix

Convert without narrowing first, require `dtype == jnp.bool_`, then flatten. Works under `jax.jit` since dtype is static during tracing.

## Reachability

`stratify_delight_outcomes` is directly exported from both `alberta_framework/core/__init__.py` and the package root `alberta_framework/__init__.py`, and accepts caller-provided runtime `rare_mask` arrays — reachable through the public API with non-hardcoded inputs.

## Verification

Live reproduction against the unpatched tree:

```text
[0.  0.5] rare_success= 0 rare_failure= 1
[ 0. nan] rare_success= 0 rare_failure= 1
```

Added `test_delight_stratification_rejects_non_boolean_rare_masks`, parametrized over a fractional float32 mask, a NaN-containing float32 mask, and an int32 0/1 mask, in both eager and `jax.jit` calls.

Mutation check (source fix reverted, test kept):

```text
FAILED tests/test_delight.py::test_delight_stratification_rejects_non_boolean_rare_masks[rare_mask0]
FAILED tests/test_delight.py::test_delight_stratification_rejects_non_boolean_rare_masks[rare_mask1]
FAILED tests/test_delight.py::test_delight_stratification_rejects_non_boolean_rare_masks[rare_mask2]
3 failed, 79 deselected
```

Fix restored: `3 passed, 79 deselected`.

Full `tests/test_delight.py`: `82 passed`.

`ruff check` and `mypy` both clean on the touched files.

## Provenance

AI-assisted: drafted by OpenAI Codex (`gpt-5.6-sol`, via AgentRouter), independently re-verified end to end before this PR was opened — reproduction, mutation check (both directions), full test file, lint, mypy, and the reachability trace above were all re-run and re-confirmed by hand, not taken from the draft's own report.

Attribution status: self-reported.
