### PR TITLE
fix(plasticity-comparators): reject non-finite noise_curvature_step_size output

### DIFF
--- a/alberta_framework/benchmarks/plasticity_comparators.py
+++ b/alberta_framework/benchmarks/plasticity_comparators.py
@@ -683,7 +683,11 @@ def noise_curvature_step_size(
     if not enabled:
         return base
     if effective > bound and effective > 0.12:
-        return base * (1.0 - rate)
-    if early_training and effective < 0.1 * bound:
-        return base * (1.0 + rate)
-    return base
+        result = base * (1.0 - rate)
+    elif early_training and effective < 0.1 * bound:
+        result = base * (1.0 + rate)
+    else:
+        result = base
+    if not math.isfinite(result):
+        raise ValueError("adjusted step size overflowed its finite scalar domain")
+    return result

--- a/tests/test_plasticity_comparators.py
+++ b/tests/test_plasticity_comparators.py
@@ -180,6 +180,13 @@ def test_noise_curvature_scheduler_and_off_reduction() -> None:
         early_training=False,
         enabled=False,
     ) == 0.1
+    with pytest.raises(ValueError, match="adjusted step size overflowed"):
+        noise_curvature_step_size(
+            float(np.finfo(np.float64).max),
+            effective_step_size=0.0,
+            safe_bound=1.0,
+            early_training=True,
+        )
 
 
 def test_exact_resource_accounting_and_hostile_protocol_scalars() -> None:


### PR DESCRIPTION
Closes #1774.

## What changed

`noise_curvature_step_size` (`arXiv:2509.19698v3` Algorithm 1) could return `inf`: a finite `base_step_size` near the float64 max, multiplied by `(1 + rate)` on the warming branch, overflows past the function's own documented finite-scalar contract.

## Fix

Compute the cooling/warming/unchanged result once, then require `math.isfinite` before returning, raising `ValueError` otherwise. No change to the cooling/warming formula, thresholds, or the disabled-mechanism return path — purely enforces the existing finite-output contract after the formula is evaluated.

## Reachability

The function has no non-test caller anywhere in the codebase currently — not re-exported by `alberta_framework.benchmarks.__init__` or the package root, and not called by any other function in its own module. This is a defense-in-depth fix to the function's own documented finite-output contract, not a currently-reachable production bug.

## Verification

Live reproduction against the unpatched tree:

```text
inf
finite: False
```

After the fix, same inputs:

```text
ValueError: adjusted step size overflowed its finite scalar domain
```

Added a regression case to `test_noise_curvature_scheduler_and_off_reduction`, using `float(np.finfo(np.float64).max)` to reach the warming branch with an exact native float.

Mutation check (source fix reverted, test kept):

```text
FAILED tests/test_plasticity_comparators.py::test_noise_curvature_scheduler_and_off_reduction
Failed: DID NOT RAISE ValueError
1 failed, 12 passed
```

Fix restored: `13 passed`.

`ruff check` and `mypy` both clean on the touched files.

## Provenance

AI-assisted: drafted by OpenAI Codex (`gpt-5.6-sol`, via AgentRouter), independently re-verified end to end before this PR was opened — reproduction, mutation check (both directions), full test file, lint, mypy, and the reachability trace above were all re-run and re-confirmed by hand, not taken from the draft's own report. The draft's own report already disclosed the narrow reachability honestly; I confirmed it myself rather than taking the claim at face value.

Attribution status: self-reported.
