### PR TITLE
fix(core): preflight behavior-model update working sets

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -88,6 +88,46 @@ def _resource_counts(n_actions: int, feature_dim: int) -> tuple[int, int]:
     return trainable, state_nbytes
 
 
+def _behavior_model_update_working_set_bytes(n_actions: int, feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras.
+
+    ``update`` keeps the source state, the proposed state, and the
+    transaction-selected result simultaneously live.  The worst-case path
+    also materializes a weight/bias gradient plus an L2 or clip copy,
+    logits / probabilities / one-hot / logit-error, the observation, and
+    neutralized returned logits/probabilities beside the committed state.
+    """
+
+    trainable = n_actions * feature_dim + n_actions
+    persist_scalars = trainable + 6
+    update_scalars = (
+        3 * persist_scalars
+        + 2 * n_actions * feature_dim
+        + 2 * n_actions
+        + 4 * n_actions
+        + feature_dim
+        + 2 * n_actions
+        + 16
+    )
+    return 4 * update_scalars
+
+
+def _preflight_behavior_model_update_working_set(
+    n_actions: int,
+    feature_dim: int,
+) -> None:
+    """Reject an update envelope the behavior model cannot name."""
+
+    working_set_bytes = _behavior_model_update_working_set_bytes(
+        n_actions,
+        feature_dim,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "behavior-model update working set byte count must fit signed int32"
+        )
+
+
 def _saturating_int32_increment(value: Array) -> Array:
     maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
     counter = jnp.asarray(value, dtype=jnp.int32)
@@ -564,6 +604,10 @@ class BehaviorModel:
         """Initialize parameters and diagnostics."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _resource_counts(self._config.n_actions, feature_dim)
+        _preflight_behavior_model_update_working_set(
+            self._config.n_actions,
+            feature_dim,
+        )
         return BehaviorModelState(
             weights=jnp.zeros(
                 (self._config.n_actions, feature_dim),
@@ -586,6 +630,10 @@ class BehaviorModel:
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         trainable, state_nbytes = _resource_counts(self._config.n_actions, feature_dim)
+        _preflight_behavior_model_update_working_set(
+            self._config.n_actions,
+            feature_dim,
+        )
         diagnostics = 3
         administrative = 1
         rng_words = 2

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -11,6 +11,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from jax import tree_util
 
 
 class _HostileFloat(float):
@@ -26,6 +27,9 @@ try:
     from alberta_framework.core.behavior_model import (
         BehaviorModel,
         BehaviorModelConfig,
+        _behavior_model_update_working_set_bytes,
+        _preflight_behavior_model_update_working_set,
+        _resource_counts,
         action_log_likelihoods,
         clipped_importance_ratios,
         epsilon_greedy_probabilities,
@@ -60,6 +64,13 @@ except ImportError:
     floor_and_renormalize_probabilities = behavior_model_module.floor_and_renormalize_probabilities
     run_behavior_model_from_arrays = behavior_model_module.run_behavior_model_from_arrays
     selected_action_probabilities = behavior_model_module.selected_action_probabilities
+    _behavior_model_update_working_set_bytes = (
+        behavior_model_module._behavior_model_update_working_set_bytes
+    )
+    _preflight_behavior_model_update_working_set = (
+        behavior_model_module._preflight_behavior_model_update_working_set
+    )
+    _resource_counts = behavior_model_module._resource_counts
 
 
 def _assert_behavior_update_finite(result: Any) -> None:
@@ -613,11 +624,14 @@ def test_behavior_model_preflights_resource_bytes_before_allocation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     model = BehaviorModel(BehaviorModelConfig(n_actions=2))
-    max_feature_dim = ((2**31 - 1) - 32) // 8
-    budget = model.resource_budget(max_feature_dim)
-    assert budget.state_nbytes <= 2**31 - 1
+    persist_last_legal = ((2**31 - 1) - 32) // 8
+    update_last_legal = 48_806_441
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.resource_budget(persist_last_legal)
     with pytest.raises(ValueError, match="state_nbytes"):
-        model.resource_budget(max_feature_dim + 1)
+        model.resource_budget(persist_last_legal + 1)
+    budget = model.resource_budget(update_last_legal)
+    assert budget.state_nbytes <= 2**31 - 1
 
     calls = 0
 
@@ -628,10 +642,13 @@ def test_behavior_model_preflights_resource_bytes_before_allocation(
 
     monkeypatch.setattr("alberta_framework.core.behavior_model.jnp.zeros", forbidden_zeros)
     with pytest.raises(ValueError, match="state_nbytes"):
-        model.init(max_feature_dim + 1, jax.random.key(0))
+        model.init(persist_last_legal + 1, jax.random.key(0))
+    assert calls == 0
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.init(persist_last_legal, jax.random.key(0))
     assert calls == 0
     with pytest.raises(AssertionError, match="allocator reached"):
-        model.init(max_feature_dim, jax.random.key(0))
+        model.init(update_last_legal, jax.random.key(0))
     assert calls == 1
 
 
@@ -674,3 +691,74 @@ def test_action_ids_still_accept_trusted_hosts_and_tracers() -> None:
         jnp.asarray(3, dtype=jnp.int32)
     )
     chex.assert_tree_all_finite(traced)
+
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_behavior_model_persist_matches_jit_materialized_leaves() -> None:
+    model = BehaviorModel(BehaviorModelConfig(n_actions=2))
+    state = model.init(4, jax.random.key(0))
+    actual = sum(
+        int(leaf.size) * int(leaf.dtype.itemsize)
+        for leaf in tree_util.tree_leaves(state)
+    )
+    assert actual == model.resource_budget(4).state_nbytes
+    _, persist_bytes = _resource_counts(2, 4)
+    assert actual == persist_bytes
+
+
+def test_behavior_model_persist_fits_while_update_working_set_does_not() -> None:
+    feature_dim = 180_000_000
+    _, persist_bytes = _resource_counts(1, feature_dim)
+    working_set_bytes = _behavior_model_update_working_set_bytes(1, feature_dim)
+    assert persist_bytes <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    model = BehaviorModel(BehaviorModelConfig(n_actions=1))
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.resource_budget(feature_dim)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.init(feature_dim, jax.random.key(0))
+
+
+def test_behavior_model_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(89_478_476, 89_478_480):
+        working_set_bytes = _behavior_model_update_working_set_bytes(1, feature_dim)
+        _, persist_bytes = _resource_counts(1, feature_dim)
+        assert persist_bytes <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    model = BehaviorModel(BehaviorModelConfig(n_actions=1))
+    model.resource_budget(last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.resource_budget(first_overflow)
+
+
+def test_behavior_model_persistent_byte_bound_still_fires_first() -> None:
+    feature_dim = 536_870_905
+    with pytest.raises(ValueError, match="state_nbytes"):
+        _resource_counts(1, feature_dim)
+    model = BehaviorModel(BehaviorModelConfig(n_actions=1))
+    with pytest.raises(ValueError, match="state_nbytes"):
+        model.init(feature_dim, jax.random.key(0))
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_behavior_model_update_working_set(1, 180_000_000)


### PR DESCRIPTION
Closes #1776.

## What changed

`BehaviorModel.init()` and `resource_budget()` now preflight the simultaneous update working set after the existing persistent `state_nbytes` check.

On origin/main `cc877f78`, `n_actions = 1` / `feature_dim = 180_000_000` keeps persist nameable (720000028 bytes, matching JIT `init()` leaves on a legal width). Source + proposed + committed persist, weight/bias gradient and L2/clip copies, logits/probabilities/one-hot/logit-error, observation, and neutralized returned leaves overflow signed int32. Existing persist-bound tests still fire first (`state_nbytes` at `feature_dim=536870905`). Adjacent last-fit / first-overflow at `89478477` / `89478478`. Legal small inits are unchanged.

This matches the `#1383` complete-aggregate bar. It does not remine `#1174`, `#1749`, fusion leftover-tax, or touch `intelligence_amplification.py`. `#1771` still owns `state_builder.py`.

## Scope

- `alberta_framework/core/behavior_model.py`
- `tests/test_behavior_model.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `behavior_model.py`. Factory `HARD_SKIP_PATHS` does not include this host. `#1174` stay-off is leftover-identity only.

## Verification

Exact candidate head: `1594b8ed1532561aa03a8a0384ec8a7c15371794`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `resource_budget(180_000_000)` constructed; persist 720000028 fits and matches JIT leaves; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_behavior_model.py` plus `tests/test_behavior_model_resource_budget.py`: 70 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_behavior_model.py tests/test_behavior_model_resource_budget.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: persist still matches JIT leaves on a small config; persist `state_nbytes` still fires first at `536870905`; last-fit `89478477` constructs; first-overflow `89478478` rejects
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1594b8ed1532561aa03a8a0384ec8a7c15371794 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
