### PR TITLE
fix(core): preflight mixer update working sets

### DIFF
--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -42,6 +42,10 @@ _DIAGNOSTIC_FLOAT32_SCALARS = 12
 _OUTPUT_BOOL_SCALARS = 12
 _FIXED_OUTPUT_BYTES = 4 * _DIAGNOSTIC_FLOAT32_SCALARS + _OUTPUT_BOOL_SCALARS
 _MAX_REPRESENTATION_DIM = (_INT32_MAX - _FIXED_OUTPUT_BYTES) // 4
+# Raw pair, safe pair, prepared pair, per-source normalize/clip temps,
+# zeros, for-use pair, contribution pair, safe-contribution pair,
+# mixed/unclipped, safe mixed, final candidate, and returned gradient.
+_MIX_WORKING_SET_DIM_VECTORS = 21
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -60,6 +64,28 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _mixer_update_working_set_bytes(representation_dim: int) -> int:
+    """Simultaneous two-source mix working set plus returned-leaf bytes.
+
+    Persist is empty.  ``mix_representation_gradients`` keeps the raw,
+    neutralized, prepared, contribution, and returned dim-vectors live
+    together with the fixed diagnostic/bool result payload.
+    """
+
+    return 4 * _MIX_WORKING_SET_DIM_VECTORS * representation_dim + _FIXED_OUTPUT_BYTES
+
+
+def _preflight_mixer_update_working_set(representation_dim: int) -> None:
+    """Reject a mix envelope the host cannot name in signed int32."""
+
+    working_set_bytes = _mixer_update_working_set_bytes(representation_dim)
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "representation-gradient mixer update working set byte count "
+            "must fit signed int32"
+        )
 
 
 def _strict_float32_scalar(
@@ -124,6 +150,7 @@ class RepresentationGradientMixerConfig:
                 maximum=_MAX_REPRESENTATION_DIM,
             ),
         )
+        _preflight_mixer_update_working_set(self.representation_dim)
         if type(self.mode) is not str or self.mode not in _VALID_MODES:
             raise ValueError(
                 "mode must be full, behavior_only, world_only, or discard"

--- a/tests/test_representation_gradient_mixer.py
+++ b/tests/test_representation_gradient_mixer.py
@@ -16,9 +16,12 @@ import pytest
 from jax import Array
 
 from alberta_framework.core.representation_gradient_mixer import (
+    _MAX_REPRESENTATION_DIM,
     GradientMixMode,
     RepresentationGradientMixerConfig,
     RepresentationGradientMixResult,
+    _mixer_update_working_set_bytes,
+    _preflight_mixer_update_working_set,
     mix_representation_gradients,
 )
 
@@ -529,23 +532,26 @@ def test_gradient_mixer_rejects_integer_spoofs_without_running_repr() -> None:
 
 def test_gradient_mixer_allocation_contract_endpoints_are_allocation_free() -> None:
     fixed_output_bytes = 12 * 4 + 12
-    last_legal = ((2**31 - 1) - fixed_output_bytes) // 4
-    config = RepresentationGradientMixerConfig(representation_dim=last_legal)
+    output_last_legal = ((2**31 - 1) - fixed_output_bytes) // 4
+    update_last_legal = 25_565_280
+    with pytest.raises(ValueError, match="update working set byte count"):
+        RepresentationGradientMixerConfig(representation_dim=output_last_legal)
+    config = RepresentationGradientMixerConfig(representation_dim=update_last_legal)
     budget = config.resource_budget
 
-    assert budget.representation_dim == last_legal
+    assert budget.representation_dim == update_last_legal
     assert budget.persistent_state_scalars == 0
     assert budget.persistent_state_bytes == 0
-    assert budget.output_float32_scalars == last_legal + 12
+    assert budget.output_float32_scalars == update_last_legal + 12
     assert budget.output_bool_scalars == 12
-    assert budget.output_scalars == last_legal + 24
-    assert budget.output_nbytes == 4 * (last_legal + 12) + 12
+    assert budget.output_scalars == update_last_legal + 24
+    assert budget.output_nbytes == 4 * (update_last_legal + 12) + 12
     assert budget.output_nbytes <= 2**31 - 1
-    assert 4 * (last_legal + 1 + 12) + 12 > 2**31 - 1
+    assert 4 * (output_last_legal + 1 + 12) + 12 > 2**31 - 1
     json.dumps(budget.to_dict(), allow_nan=False)
 
     with pytest.raises(ValueError, match="representation_dim"):
-        RepresentationGradientMixerConfig(representation_dim=last_legal + 1)
+        RepresentationGradientMixerConfig(representation_dim=output_last_legal + 1)
 
 
 @pytest.mark.parametrize(
@@ -728,3 +734,52 @@ def test_gradient_mixer_resource_budget_is_exported_from_public_packages() -> No
     budget = RepresentationGradientMixerConfig(representation_dim=3).resource_budget
     assert isinstance(budget, RootBudget)
     assert RootBudget is CoreBudget
+
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_mixer_persist_is_empty_and_output_fits_at_max_dim() -> None:
+    working_set_bytes = _mixer_update_working_set_bytes(_MAX_REPRESENTATION_DIM)
+    output_nbytes = 4 * (_MAX_REPRESENTATION_DIM + 12) + 12
+    assert output_nbytes <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        RepresentationGradientMixerConfig(representation_dim=_MAX_REPRESENTATION_DIM)
+
+
+def test_mixer_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for representation_dim in range(25_565_279, 25_565_283):
+        working_set_bytes = _mixer_update_working_set_bytes(representation_dim)
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = representation_dim
+        elif first_overflow is None:
+            first_overflow = representation_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    config = RepresentationGradientMixerConfig(representation_dim=last_fit)
+    assert config.resource_budget.persistent_state_bytes == 0
+    with pytest.raises(ValueError, match="update working set byte count"):
+        RepresentationGradientMixerConfig(representation_dim=first_overflow)
+
+
+def test_mixer_output_byte_bound_still_fires_first() -> None:
+    with pytest.raises(ValueError, match="representation_dim"):
+        RepresentationGradientMixerConfig(representation_dim=_MAX_REPRESENTATION_DIM + 1)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_mixer_update_working_set(_MAX_REPRESENTATION_DIM)


### PR DESCRIPTION
Closes #1778.

## What changed

`RepresentationGradientMixerConfig.__post_init__` now preflights the simultaneous two-source mix working set after the existing output-dim / persist-0 contract.

On origin/main `cc877f78`, `_MAX_REPRESENTATION_DIM` keeps persist 0 and `output_nbytes` nameable (2147483644). Raw + safe + prepared + contribution + returned dim-vectors overflow signed int32. Existing output-bound tests still fire first (`representation_dim` at `_MAX_REPRESENTATION_DIM + 1`). Adjacent last-fit / first-overflow at `25565280` / `25565281`. Legal small mixes are unchanged.

This matches the `#1383` complete-aggregate bar. It does not remine `#1173`, `#1749`, fusion leftover-tax, or stack `#1771` / `#1777`.

## Scope

- `alberta_framework/core/representation_gradient_mixer.py`
- `tests/test_representation_gradient_mixer.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `representation_gradient_mixer.py`. Factory `HARD_SKIP_PATHS` does not include this host. `#1173` stay-off is leftover-identity only.

## Verification

Exact candidate head: `71a88584cc62b84fb9a23ad0cfa99837947e8f5f`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `_MAX_REPRESENTATION_DIM` constructed; persist 0; output 2147483644 fits; mix working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_representation_gradient_mixer.py` plus `tests/test_representation_gradient_mixer_resource_budget.py`: 83 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_representation_gradient_mixer.py tests/test_representation_gradient_mixer_resource_budget.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: persist stays 0; output `representation_dim` still fires first at `_MAX_REPRESENTATION_DIM + 1`; last-fit `25565280` constructs; first-overflow `25565281` rejects
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:71a88584cc62b84fb9a23ad0cfa99837947e8f5f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
