### PR TITLE
fix(core): preflight learning-signal observe working sets

### DIFF
--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -84,6 +84,46 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _learning_signal_observe_working_set_bytes(
+    ensemble_size: int,
+    target_dim: int,
+) -> int:
+    """Source persist, proposed persist, inputs, sanitized copies, and returned leaves.
+
+    ``observe`` keeps the source state, the valid-path proposal, and the
+    invalid-path proposal live together with the raw ensemble inputs, their
+    sanitized copies, member residual squares, per-dimension temps, and the
+    returned signal / availability leaves.
+    """
+
+    persist_scalars = 9
+    input_scalars = 2 * ensemble_size * target_dim + target_dim + 1
+    observe_scalars = (
+        3 * persist_scalars
+        + 2 * input_scalars
+        + ensemble_size * target_dim
+        + 5 * target_dim
+        + 16
+    )
+    return 4 * observe_scalars
+
+
+def _preflight_learning_signal_observe_working_set(
+    ensemble_size: int,
+    target_dim: int,
+) -> None:
+    """Reject an observe envelope the estimator cannot name."""
+
+    working_set_bytes = _learning_signal_observe_working_set_bytes(
+        ensemble_size,
+        target_dim,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "learning-signal observe working set byte count must fit signed int32"
+        )
+
+
 def _ratio_less(left: tuple[int, int], right: tuple[int, int]) -> bool:
     return left[0] * right[1] < right[0] * left[1]
 
@@ -164,6 +204,10 @@ class LearningSignalEstimatorConfig:
             raise ValueError(
                 "ensemble_size and target_dim input resource budget must fit signed int32"
             )
+        _preflight_learning_signal_observe_working_set(
+            self.ensemble_size,
+            self.target_dim,
+        )
         object.__setattr__(
             self,
             "progress_warmup_steps",

--- a/tests/test_learning_signals_resource_budget.py
+++ b/tests/test_learning_signals_resource_budget.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import dataclasses
 import json
 
+import jax.numpy as jnp
 import pytest
+from jax import tree_util
 
 from alberta_framework.core.learning_signals import (
     LearningSignalEstimator,
     LearningSignalEstimatorConfig,
     LearningSignalResourceBudget,
+    _learning_signal_observe_working_set_bytes,
+    _preflight_learning_signal_observe_working_set,
 )
 
 
@@ -118,12 +122,69 @@ def test_learning_signal_budget_rejects_unattainable_input_counts(count: int) ->
 
 
 def test_learning_signal_config_gates_exact_derived_input_budget_bound() -> None:
-    largest = LearningSignalEstimatorConfig(ensemble_size=1_073_741_822, target_dim=1)
-    assert (
-        LearningSignalEstimator(largest).resource_budget().input_float_scalars_per_step
-        == 2_147_483_646
-    )
+    with pytest.raises(ValueError, match="observe working set byte count"):
+        LearningSignalEstimatorConfig(ensemble_size=1_073_741_822, target_dim=1)
     with pytest.raises(ValueError, match="input resource budget"):
         LearningSignalEstimatorConfig(ensemble_size=1_073_741_823, target_dim=1)
     with pytest.raises(ValueError, match="input resource budget"):
         LearningSignalEstimatorConfig(ensemble_size=50_000, target_dim=50_000)
+
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_learning_signal_persist_matches_jit_and_input_bytes_still_fit() -> None:
+    config = LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1)
+    estimator = LearningSignalEstimator(config)
+    state = estimator.init()
+    actual = sum(
+        int(leaf.size) * int(leaf.dtype.itemsize)
+        for leaf in tree_util.tree_leaves(state)
+    )
+    assert actual == estimator.resource_budget().persistent_state_bytes == 36
+    target_dim = 45_000_000
+    input_scalars = 2 * 2 * target_dim + target_dim + 1
+    assert input_scalars <= _INT32_MAX
+    assert 4 * input_scalars <= _INT32_MAX
+    assert _learning_signal_observe_working_set_bytes(2, target_dim) > _INT32_MAX
+    with pytest.raises(ValueError, match="observe working set byte count"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=target_dim)
+
+
+def test_learning_signal_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for target_dim in range(31_580_638, 31_580_642):
+        working_set_bytes = _learning_signal_observe_working_set_bytes(2, target_dim)
+        input_scalars = 2 * 2 * target_dim + target_dim + 1
+        assert input_scalars <= _INT32_MAX
+        assert 4 * input_scalars <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = target_dim
+        elif first_overflow is None:
+            first_overflow = target_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    LearningSignalEstimatorConfig(ensemble_size=2, target_dim=last_fit)
+    with pytest.raises(ValueError, match="observe working set byte count"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=first_overflow)
+
+
+def test_learning_signal_input_scalar_bound_still_fires_first() -> None:
+    with pytest.raises(ValueError, match="input resource budget"):
+        LearningSignalEstimatorConfig(ensemble_size=1_073_741_823, target_dim=1)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="observe working set byte count"):
+        _preflight_learning_signal_observe_working_set(2, 45_000_000)


### PR DESCRIPTION
Closes #1784.

## What changed

`LearningSignalEstimatorConfig.__post_init__` now preflights the simultaneous observe working set after the existing input-scalar bound.

On origin/main `cc877f78`, `ensemble_size=2` / `target_dim=45_000_000` keeps persist nameable (36 bytes, JIT-matched) and `4 × input_scalars` nameable. Source + proposed persist, raw + sanitized inputs, residual/per-dimension temps, and returned leaves overflow signed int32. Existing input-scalar tests still fire first (`input resource budget` at `ensemble_size=1073741823`). Adjacent last-fit / first-overflow at `31580639` / `31580640`. Legal small estimators are unchanged.

This matches the `#1383` complete-aggregate bar. It does not remine `#1181`/`#1186`, `#1173`, `#1749`, or stack `#1771` / `#1777` / `#1779`.

## Scope

- `alberta_framework/core/learning_signals.py`
- `tests/test_learning_signals_resource_budget.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `learning_signals.py`. Factory `HARD_SKIP_PATHS` does not include this host. `#1181`/`#1186` stay-off is leftover-identity only.

## Verification

Exact candidate head: `9f5f70ca1ba7834440dd76c5e884fb42caa8c4dc`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `target_dim=45_000_000` constructed; persist 36 matches JIT; `4 × input_scalars` fits; observe working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_learning_signals_resource_budget.py` plus `tests/test_learning_signals.py`: 82 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_learning_signals_resource_budget.py tests/test_learning_signals.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: persist still matches JIT leaves; input-scalar bound still fires first at `ensemble_size=1073741823`; last-fit `31580639` constructs; first-overflow `31580640` rejects; leftover-id budget tests unchanged
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9f5f70ca1ba7834440dd76c5e884fb42caa8c4dc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
