### PR TITLE
fix(adamo): reject non-finite isometry_gradient output

### DIFF
--- a/alberta_framework/core/adamo.py
+++ b/alberta_framework/core/adamo.py
@@ -171,9 +171,16 @@ def isometry_gradient(weight: Array) -> Array:
     _gram_bytes(rows, columns, matrix.dtype.itemsize)
     if rows >= columns:
         identity = jnp.eye(columns, dtype=matrix.dtype)
-        return 4.0 * matrix @ (matrix.T @ matrix - identity)
-    identity = jnp.eye(rows, dtype=matrix.dtype)
-    return 4.0 * (matrix @ matrix.T - identity) @ matrix
+        candidate = 4.0 * matrix @ (matrix.T @ matrix - identity)
+    else:
+        identity = jnp.eye(rows, dtype=matrix.dtype)
+        candidate = 4.0 * (matrix @ matrix.T - identity) @ matrix
+    valid = jnp.all(jnp.isfinite(candidate))
+    if isinstance(valid, jax.core.Tracer):
+        return jnp.where(valid, candidate, jnp.full_like(candidate, jnp.nan))
+    if not bool(valid):
+        raise ValueError("isometry gradient must be finite")
+    return candidate
 
 
 def state_persistent_bytes(state: AdamOState) -> int:

--- a/tests/test_adamo.py
+++ b/tests/test_adamo.py
@@ -48,6 +48,18 @@ def test_penalty_preserves_invalidity_in_eager_and_traced_calls(weight: jax.Arra
     assert float(traced) != 0.0
 
 
+@pytest.mark.parametrize("shape", [(2, 2), (2, 3)])
+def test_gradient_preserves_invalidity_in_eager_and_traced_calls(
+    shape: tuple[int, int],
+) -> None:
+    weight = jnp.full(shape, jnp.finfo(jnp.float32).max)
+    with pytest.raises(ValueError, match="isometry gradient must be finite"):
+        isometry_gradient(weight)
+
+    traced = jax.jit(isometry_gradient)(weight)
+    assert bool(jnp.all(jnp.isnan(traced)))
+
+
 def test_zero_strength_reduces_exactly_to_adam_task_step() -> None:
     config = AdamOConfig(
         step_size=1e-3, beta1=0.9, beta2=0.99, eps=1e-8, isometry_strength=0.0


### PR DESCRIPTION
Closes #1794.

## What changed

`isometry_gradient` (the closed-form gradient of `isometry_penalty`, paper equation 16) had no finite-output guard, unlike its sibling `isometry_penalty` which already validates its own output.

## Fix

Compute the branch result once, then apply the same tracer-aware finite check `isometry_penalty` already uses: raise `ValueError` under eager execution, return `NaN` under `jax.jit` (since a traced value can't raise). No change to the gradient formula itself.

## Reachability

`AdamO`/`isometry_gradient` are not re-exported from `alberta_framework.__init__` or `alberta_framework.core.__init__`, so reachability is module-level rather than package-root. The caller is a real, non-test optimizer step method in the same module (`AdamO`'s update method, `isometry_step = isometry_step_size * isometry_strength * isometry_gradient(parameter)` when `regularize=True` and `isometry_strength != 0.0`), not dead code.

## Verification

Live reproduction against the unpatched tree:

```text
result: [[inf inf]
 [inf inf]]
all finite: False
```

The regression test (`test_gradient_preserves_invalidity_in_eager_and_traced_calls`, parametrized over two shapes) asserts eager raises `ValueError` and jitted returns all-NaN.

Mutation check (source fix reverted, test kept):

```text
FAILED tests/test_adamo.py::test_gradient_preserves_invalidity_in_eager_and_traced_calls[shape0]
FAILED tests/test_adamo.py::test_gradient_preserves_invalidity_in_eager_and_traced_calls[shape1]
Failed: DID NOT RAISE ValueError
2 failed, 18 deselected
```

Fix restored: `2 passed, 18 deselected`.

Full `tests/test_adamo.py`: `20 passed`.

`ruff check` and `mypy` both clean on the touched files.

## Provenance

AI-assisted, with a real correction. The bug was first identified by OpenAI Codex (`gpt-5.6-sol`, via AgentRouter) running in a sandboxed worktree, but that session's AgentRouter quota was exhausted mid-edit (a multi-location patch), leaving the actual source change broken: the finite-check logic ended up duplicated as dead code inside the *wrong* function (`isometry_penalty`, which already had its own correct check) with the wrong error message, while `isometry_gradient` itself — the function that actually needed the fix — was left completely unguarded. I independently reproduced the underlying bug from scratch, discarded the broken source edit, and wrote the correct fix myself, mirroring `isometry_penalty`'s already-established, already-shipped pattern exactly. The regression test the crashed session had already written was correct and is unchanged. Full mutation check, lint, mypy, and the reachability trace above were run against my corrected fix, not the crashed session's report (which never completed).

Attribution status: self-reported.
