### PR TITLE
fix(core): preflight temporal-context step working sets

### DIFF
--- a/alberta_framework/core/temporal_context.py
+++ b/alberta_framework/core/temporal_context.py
@@ -156,6 +156,105 @@ def _require_int(
     return number
 
 
+def _temporal_context_persist_bytes(input_dim: int) -> int:
+    """EMA float32 vector plus the signed-int32 step counter."""
+
+    return 4 * input_dim + 4
+
+
+def _temporal_context_output_dim(
+    input_dim: int,
+    *,
+    include_raw: bool,
+    include_ema: bool,
+    include_delta: bool,
+    include_phase_products: bool,
+    n_periods: int,
+) -> int:
+    copies = int(include_raw) + int(include_ema) + int(include_delta)
+    phase_dim = 2 * n_periods
+    product_dim = phase_dim * input_dim * int(include_phase_products and n_periods > 0)
+    return copies * input_dim + phase_dim + product_dim
+
+
+def _temporal_context_update_working_set_bytes(
+    input_dim: int,
+    *,
+    include_raw: bool,
+    include_ema: bool,
+    include_delta: bool,
+    include_phase_products: bool,
+    n_periods: int,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras.
+
+    ``step`` keeps the source EMA/counter, the proposed EMA/counter, and the
+    transaction-selected result live together with the observation, sanitized
+    copies, optional delta pair, phase code, optional phase×obs products, and
+    the returned feature leaf.
+    """
+
+    persist_bytes = _temporal_context_persist_bytes(input_dim)
+    copies = int(include_raw) + int(include_ema) + int(include_delta)
+    phase_dim = 2 * n_periods
+    product_dim = phase_dim * input_dim * int(include_phase_products and n_periods > 0)
+    output_dim = copies * input_dim + phase_dim + product_dim
+    extra_bytes = (
+        4 * input_dim
+        + 4 * input_dim
+        + 4 * input_dim
+        + 4 * input_dim
+        + 8 * input_dim * int(include_delta)
+        + 4 * phase_dim
+        + 4 * product_dim
+        + 4 * output_dim
+        + 16
+    )
+    return 3 * persist_bytes + extra_bytes
+
+
+def _preflight_temporal_context_update_working_set(
+    input_dim: int,
+    *,
+    include_raw: bool,
+    include_ema: bool,
+    include_delta: bool,
+    include_phase_products: bool,
+    n_periods: int,
+) -> None:
+    """Reject a step envelope the host cannot name in signed int32."""
+
+    persist_bytes = _temporal_context_persist_bytes(input_dim)
+    if persist_bytes > _INT32_MAX:
+        raise ValueError(
+            "temporal-context persistent state byte count must fit signed int32"
+        )
+    output_dim = _temporal_context_output_dim(
+        input_dim,
+        include_raw=include_raw,
+        include_ema=include_ema,
+        include_delta=include_delta,
+        include_phase_products=include_phase_products,
+        n_periods=n_periods,
+    )
+    if output_dim > _INT32_MAX or 4 * output_dim > _INT32_MAX:
+        raise ValueError(
+            "temporal-context returned feature byte count must fit signed int32"
+        )
+    working_set_bytes = _temporal_context_update_working_set_bytes(
+        input_dim,
+        include_raw=include_raw,
+        include_ema=include_ema,
+        include_delta=include_delta,
+        include_phase_products=include_phase_products,
+        n_periods=n_periods,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "temporal-context update working set byte count must fit signed int32"
+        )
+
+
 @dataclass(frozen=True)
 class TemporalContextConfig:
     """Configuration for :class:`TemporalContextFeaturizer`.
@@ -184,10 +283,14 @@ class TemporalContextConfig:
 
     def output_dim(self) -> int:
         """Return the transformed feature dimensionality."""
-        copies = int(self.include_raw) + int(self.include_ema) + int(self.include_delta)
-        phase_dim = 2 * len(self.periods)
-        product_dim = phase_dim * self.input_dim * int(self.include_phase_products)
-        return copies * self.input_dim + phase_dim + product_dim
+        return _temporal_context_output_dim(
+            self.input_dim,
+            include_raw=self.include_raw,
+            include_ema=self.include_ema,
+            include_delta=self.include_delta,
+            include_phase_products=self.include_phase_products,
+            n_periods=len(self.periods),
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a plain dictionary."""
@@ -312,6 +415,14 @@ def _validate_config(config: TemporalContextConfig) -> None:
     )
     object.__setattr__(config, "ema_decay", ema_decay)
     object.__setattr__(config, "periods", canonical_periods)
+    _preflight_temporal_context_update_working_set(
+        input_dim,
+        include_raw=config.include_raw,
+        include_ema=config.include_ema,
+        include_delta=config.include_delta,
+        include_phase_products=config.include_phase_products,
+        n_periods=len(canonical_periods),
+    )
 
 
 class TemporalContextFeaturizer:

--- a/tests/test_temporal_context_update_working_set.py
+++ b/tests/test_temporal_context_update_working_set.py
@@ -1,0 +1,96 @@
+"""#1383-complete step working-set preflight for temporal context."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+from jax import tree_util
+
+from alberta_framework.core.temporal_context import (
+    TemporalContextConfig,
+    TemporalContextFeaturizer,
+    _preflight_temporal_context_update_working_set,
+    _temporal_context_persist_bytes,
+    _temporal_context_update_working_set_bytes,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_INPUT_DIM = 25_000_000
+_PHASE_PRODUCT_KWARGS = {
+    "include_raw": True,
+    "include_ema": True,
+    "include_delta": True,
+    "include_phase_products": True,
+    "n_periods": 3,
+}
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_temporal_context_persist_matches_jit_and_width_still_fits() -> None:
+    config = TemporalContextConfig(input_dim=3, include_phase_products=True)
+    state = TemporalContextFeaturizer(config).init()
+    actual = sum(
+        int(leaf.size) * int(leaf.dtype.itemsize)
+        for leaf in tree_util.tree_leaves(state)
+    )
+    persist_bytes = _temporal_context_persist_bytes(3)
+    assert actual == persist_bytes == 16
+    working_set_bytes = _temporal_context_update_working_set_bytes(
+        _OVERFLOW_INPUT_DIM,
+        **_PHASE_PRODUCT_KWARGS,
+    )
+    persist_at_overflow = _temporal_context_persist_bytes(_OVERFLOW_INPUT_DIM)
+    assert persist_at_overflow <= _INT32_MAX
+    assert 4 * _OVERFLOW_INPUT_DIM <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        TemporalContextConfig(
+            input_dim=_OVERFLOW_INPUT_DIM,
+            include_phase_products=True,
+        )
+
+
+def test_temporal_context_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for input_dim in range(22_369_618, 22_369_624):
+        working_set_bytes = _temporal_context_update_working_set_bytes(
+            input_dim,
+            **_PHASE_PRODUCT_KWARGS,
+        )
+        persist_bytes = _temporal_context_persist_bytes(input_dim)
+        assert persist_bytes <= _INT32_MAX
+        assert 4 * input_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = input_dim
+        elif first_overflow is None:
+            first_overflow = input_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    config = TemporalContextConfig(input_dim=last_fit, include_phase_products=True)
+    assert config.input_dim == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        TemporalContextConfig(input_dim=first_overflow, include_phase_products=True)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_temporal_context_update_working_set(
+            _OVERFLOW_INPUT_DIM,
+            **_PHASE_PRODUCT_KWARGS,
+        )
+
+
+def test_legal_small_temporal_context_still_constructs() -> None:
+    config = TemporalContextConfig(input_dim=4, include_phase_products=True)
+    assert config.output_dim() == 3 * 4 + 6 + 6 * 4
+    TemporalContextFeaturizer(config).init()


### PR DESCRIPTION
Closes #1806.

## What changed

`TemporalContextConfig.__post_init__` now preflights persist bytes, returned feature bytes, and the simultaneous `step` working set.

On origin/main `cc877f78`, `input_dim=25_000_000` with `include_phase_products=True` constructed. Persist matches JIT. `4 × input_dim` still fits. The step envelope overflows signed int32. Adjacent last-fit / first-overflow at `22369620` / `22369621`. Legal small configs are unchanged.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id, fusion leftover-tax, or stack `#1771` / `#1777` / `#1779` / `#1785`. `option_search_control.py` was skipped: no legal-constructor overflow remains there.

## Scope

- `alberta_framework/core/temporal_context.py`
- `tests/test_temporal_context_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `temporal_context.py`. Factory `HARD_SKIP_PATHS` does not include this host.

## Verification

Exact candidate head: `c2c0091e7a0c985f5b662f53a673230476c1c576`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `TemporalContextConfig(input_dim=25_000_000, include_phase_products=True)` constructed; persist and `4 × input_dim` fit; step working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_temporal_context_update_working_set.py` plus `tests/test_temporal_context.py` plus `tests/test_temporal_context_hostile_validation.py`: 68 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_temporal_context_update_working_set.py tests/test_temporal_context.py tests/test_temporal_context_hostile_validation.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: persist matches JIT at `input_dim=3`; `4 × input_dim` still fits at the overflow dim; last-fit `22369620` constructs; first-overflow `22369621` rejects
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- evidence-head:c2c0091e7a0c985f5b662f53a673230476c1c576 -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
