### PR TITLE
Preflight world-model ensemble update working set

### DIFF
--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -156,17 +156,12 @@ def _ensemble_state_resource_counts(
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived {name} must fit signed int32")
 
-    update_float32_scalars = (
-        2 * ensemble_size * target_dim
-        + 3 * target_dim
-        + ensemble_size * model.observation_dim
-        + 2 * model.observation_dim
-        + 3 * ensemble_size
-        + 13
+    extras_scalars, extras_bytes = _ensemble_update_result_extras(
+        observation_dim=model.observation_dim,
+        ensemble_size=ensemble_size,
     )
-    update_bool_scalars = 2 * ensemble_size + 20
-    update_scalars = logical_scalars + update_float32_scalars + update_bool_scalars
-    update_bytes = logical_bytes + 4 * update_float32_scalars + update_bool_scalars
+    update_scalars = logical_scalars + extras_scalars
+    update_bytes = logical_bytes + extras_bytes
     for name, value in (
         ("ensemble update-result scalars", update_scalars),
         ("ensemble update-result bytes", update_bytes),
@@ -174,6 +169,61 @@ def _ensemble_state_resource_counts(
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived {name} must fit signed int32")
     return logical_scalars, logical_bytes
+
+
+def _ensemble_update_result_extras(
+    *, observation_dim: int, ensemble_size: int
+) -> tuple[int, int]:
+    """Returned ``WorldModelEnsembleUpdateResult`` extras excluding persist.
+
+    Returns ``(extras_scalars, extras_bytes)``.
+    """
+    target_dim = observation_dim + 2
+    update_float32_scalars = (
+        2 * ensemble_size * target_dim
+        + 3 * target_dim
+        + ensemble_size * observation_dim
+        + 2 * observation_dim
+        + 3 * ensemble_size
+        + 13
+    )
+    update_bool_scalars = 2 * ensemble_size + 20
+    return (
+        update_float32_scalars + update_bool_scalars,
+        4 * update_float32_scalars + update_bool_scalars,
+    )
+
+
+def _ensemble_update_working_set_bytes(
+    *, model: ActionConditionedWorldModelConfig, ensemble_size: int
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras.
+
+    ``update`` keeps the source ensemble state, the candidate persist, and the
+    transaction-selected result live together with the returned prediction,
+    signal, target, and diagnostic leaves.
+    """
+    _, persist_bytes = _ensemble_state_resource_counts(
+        model=model, ensemble_size=ensemble_size
+    )
+    _, extras_bytes = _ensemble_update_result_extras(
+        observation_dim=model.observation_dim,
+        ensemble_size=ensemble_size,
+    )
+    return 3 * persist_bytes + extras_bytes
+
+
+def _preflight_ensemble_update_working_set(
+    *, model: ActionConditionedWorldModelConfig, ensemble_size: int
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    working_set_bytes = _ensemble_update_working_set_bytes(
+        model=model, ensemble_size=ensemble_size
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "world-model ensemble update working set byte count must fit signed int32"
+        )
 
 
 def _safe_mean(values: Array, *, axis: int | None = None) -> Array:
@@ -288,6 +338,9 @@ class WorldModelEnsembleConfig:
         )
         object.__setattr__(self, "residual_variance_floor", residual_variance_floor)
         _ensemble_state_resource_counts(model=self.model, ensemble_size=ensemble_size)
+        _preflight_ensemble_update_working_set(
+            model=self.model, ensemble_size=ensemble_size
+        )
 
     @property
     def target_dim(self) -> int:

--- a/tests/test_world_model_ensemble.py
+++ b/tests/test_world_model_ensemble.py
@@ -766,10 +766,10 @@ def test_checkpoint_rejects_invalid_state(tmp_path: Path) -> None:
 
 
 def test_config_preflights_complete_update_result_at_exact_boundary() -> None:
-    # Linear 2-observation/2-action fixture: 324 * ensemble_size + 196 bytes.
-    last_legal = (2**31 - 1 - 196) // 324
+    # Linear 2-observation/2-action fixture: 864 * ensemble_size + 316 bytes.
+    last_legal = (2**31 - 1 - 316) // 864
     _config(ensemble_size=last_legal)
-    with pytest.raises(ValueError, match="update-result bytes"):
+    with pytest.raises(ValueError, match="update working set byte count"):
         _config(ensemble_size=last_legal + 1)
 
 

--- a/tests/test_world_model_ensemble_update_working_set.py
+++ b/tests/test_world_model_ensemble_update_working_set.py
@@ -1,0 +1,153 @@
+"""#1383-complete update working-set preflight for world-model ensemble."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax import tree_util
+
+from alberta_framework.core.learning_signals import LearningSignalEstimatorConfig
+from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
+from alberta_framework.core.world_model_ensemble import (
+    WorldModelEnsemble,
+    WorldModelEnsembleConfig,
+    _ensemble_state_resource_counts,
+    _ensemble_update_working_set_bytes,
+    _preflight_ensemble_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+# Persist + extras last-legal N on origin/main: still constructs there, but
+# 3 × persist + extras overflows signed int32.
+_OVERFLOW_ENSEMBLE_SIZE = 6_628_035
+_LAST_FIT_ENSEMBLE_SIZE = 2_485_513
+_FIRST_OVERFLOW_ENSEMBLE_SIZE = 2_485_514
+
+
+def _linear_model() -> ActionConditionedWorldModelConfig:
+    return ActionConditionedWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        gamma=0.95,
+        hidden_sizes=(),
+        step_size=0.05,
+        sparsity=0.0,
+        use_layer_norm=False,
+        error_decay=0.8,
+    )
+
+
+def _config(ensemble_size: int) -> WorldModelEnsembleConfig:
+    return WorldModelEnsembleConfig(
+        model=_linear_model(),
+        signal_estimator=LearningSignalEstimatorConfig(
+            ensemble_size=ensemble_size,
+            target_dim=4,
+            progress_warmup_steps=2,
+            change_calibration_steps=2,
+            fast_loss_decay=0.5,
+            slow_loss_decay=0.9,
+            max_input_magnitude=100.0,
+            max_predicted_variance=10_000.0,
+            max_observed_loss=10_000.0,
+        ),
+        ensemble_size=ensemble_size,
+        bootstrap_probability=0.5,
+        residual_variance_decay=0.8,
+        residual_variance_warmup_steps=1,
+        residual_variance_floor=1.0e-6,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_ensemble_persist_matches_jit_and_width_still_fits() -> None:
+    config = _config(2)
+    ensemble = WorldModelEnsemble(config)
+    state = ensemble.init(jr.key(0))
+    actual = 0
+    for leaf in tree_util.tree_leaves(state):
+        dtype = getattr(leaf, "dtype", None)
+        if dtype is not None and jnp.issubdtype(dtype, jax.dtypes.prng_key):
+            array = jr.key_data(leaf)
+        else:
+            array = jnp.asarray(leaf)
+        actual += int(array.size) * int(array.dtype.itemsize)
+    _, persist_bytes = _ensemble_state_resource_counts(
+        model=config.model, ensemble_size=2
+    )
+    assert actual == persist_bytes == 600
+    assert ensemble.resource_budget(state).persistent_state_bytes == persist_bytes
+    working_set_bytes = _ensemble_update_working_set_bytes(
+        model=config.model, ensemble_size=_OVERFLOW_ENSEMBLE_SIZE
+    )
+    persist_at_overflow, extras_fit = _persist_and_update(
+        config.model, _OVERFLOW_ENSEMBLE_SIZE
+    )
+    assert persist_at_overflow <= _INT32_MAX
+    assert extras_fit <= _INT32_MAX
+    assert 4 * config.model.observation_dim <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _config(_OVERFLOW_ENSEMBLE_SIZE)
+
+
+def _persist_and_update(
+    model: ActionConditionedWorldModelConfig, ensemble_size: int
+) -> tuple[int, int]:
+    _, persist_bytes = _ensemble_state_resource_counts(
+        model=model, ensemble_size=ensemble_size
+    )
+    working_set_bytes = _ensemble_update_working_set_bytes(
+        model=model, ensemble_size=ensemble_size
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    return persist_bytes, persist_bytes + extras_bytes
+
+
+def test_ensemble_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    model = _linear_model()
+    for ensemble_size in range(_LAST_FIT_ENSEMBLE_SIZE, _FIRST_OVERFLOW_ENSEMBLE_SIZE + 2):
+        persist_bytes, update_bytes = _persist_and_update(model, ensemble_size)
+        working_set_bytes = _ensemble_update_working_set_bytes(
+            model=model, ensemble_size=ensemble_size
+        )
+        assert persist_bytes <= _INT32_MAX
+        assert update_bytes <= _INT32_MAX
+        assert 4 * model.observation_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = ensemble_size
+        elif first_overflow is None:
+            first_overflow = ensemble_size
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_ENSEMBLE_SIZE
+    config = _config(last_fit)
+    assert config.ensemble_size == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _config(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_ensemble_update_working_set(
+            model=_linear_model(),
+            ensemble_size=_OVERFLOW_ENSEMBLE_SIZE,
+        )
+
+
+def test_legal_small_ensemble_still_constructs() -> None:
+    config = _config(2)
+    WorldModelEnsemble(config).init(jr.key(1))

--- a/tests/test_world_model_ensemble_validation.py
+++ b/tests/test_world_model_ensemble_validation.py
@@ -213,12 +213,12 @@ def test_wm_ensemble_dimensions_preflight_without_allocation() -> None:
 
 
 def test_wm_ensemble_result_preflight_bytes_without_allocation() -> None:
-    # This base has 61 member-state scalars and target_dim=4. Persistent bytes
-    # are 270*ensemble+60; the complete update result is the stricter
-    # 324*ensemble+196 after the aggregate result contract added in #868.
-    last_legal = (2**31 - 1 - 196) // 324
+    # Linear 2-observation/2-action fixture. Persist + extras is
+    # 324 * ensemble_size + 196. Simultaneous source + proposed + committed
+    # persist plus returned extras is the stricter 864 * ensemble_size + 316.
+    last_legal = (2**31 - 1 - 316) // 864
     _base_cfg(ensemble_size=last_legal)
-    with pytest.raises(ValueError, match="update-result bytes"):
+    with pytest.raises(ValueError, match="update working set byte count"):
         _base_cfg(ensemble_size=last_legal + 1)
     with pytest.raises(ValueError, match="fit signed int32"):
         _base_cfg(ensemble_size=500_000_000)


### PR DESCRIPTION
Closes #1808.

## What changed

`WorldModelEnsembleConfig.__post_init__` now preflights the simultaneous `update` working set (`3 × persist + extras`) after the existing persist and persist+extras checks.

On origin/main `cc877f78`, `ensemble_size=6628035` on the linear 2-obs/2-action fixture constructed. Persist matches JIT (`600==600` at `ensemble_size=2`). Persist and persist+extras still fit. `4 × observation_dim` still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `2485513` / `2485514`. Legal small configs are unchanged.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id, fusion leftover-tax, or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807`. `world_model.py` stays HARD_SKIP; this file is `world_model_ensemble.py`.

## Scope

- `alberta_framework/core/world_model_ensemble.py`
- `tests/test_world_model_ensemble_update_working_set.py`
- `tests/test_world_model_ensemble_validation.py`
- `tests/test_world_model_ensemble.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `world_model_ensemble.py`. Factory `HARD_SKIP_PATHS` includes `world_model.py` and does not include this host.

## Verification

Exact candidate head: `21a50fddd830912746035f13bff3bb96ed62779f`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `WorldModelEnsembleConfig(..., ensemble_size=6628035)` constructed; persist and persist+extras fit; `4 × observation_dim` fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_world_model_ensemble_update_working_set.py` plus `tests/test_world_model_ensemble_validation.py` plus `tests/test_world_model_ensemble.py` plus `tests/test_world_model_ensemble_resource_budget.py`: 117 passed
- `ruff check` on the changed files: clean

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_world_model_ensemble_update_working_set.py tests/test_world_model_ensemble_validation.py tests/test_world_model_ensemble.py tests/test_world_model_ensemble_resource_budget.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: persist matches JIT at `ensemble_size=2`; persist+extras and `4 × observation_dim` still fit at the origin/main overflow N; last-fit `2485513` constructs; first-overflow `2485514` rejects
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:21a50fddd830912746035f13bff3bb96ed62779f -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
