### PR TITLE
Reject unsupported optimizers at construction in IndependentDemonHorde

### DIFF
--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -354,6 +354,19 @@ class IndependentDemonHorde:
             optimizer if optimizer is not None else LMS(step_size=step_size)
         )
         self._head_optimizer: AnyOptimizer | None = head_optimizer
+        if self._optimizer.supported_for_mlp() is not True:
+            raise ValueError(
+                f"optimizer {type(self._optimizer).__name__} does not support the MLP "
+                "shape-generic update API"
+            )
+        if (
+            self._head_optimizer is not None
+            and self._head_optimizer.supported_for_mlp() is not True
+        ):
+            raise ValueError(
+                f"head_optimizer {type(self._head_optimizer).__name__} does not support the MLP "
+                "shape-generic update API"
+            )
         self._step_size = step_size
         self._bounder = bounder
         self._normalizer = normalizer

--- a/tests/test_learner_optimizer_fallback_truthiness.py
+++ b/tests/test_learner_optimizer_fallback_truthiness.py
@@ -190,6 +190,23 @@ class TestIndependentDemonHordeOptimizerTruthiness:
         assert horde._optimizer is opt
         assert _HostileLMS.calls == 0
 
+    def test_independent_demon_horde_supported_for_mlp_strict_check(self) -> None:
+        spec = _sample_horde_spec()
+        bad_opt = _MockUnsupportedOptimizer(initial_step_size=0.01)
+        with pytest.raises(ValueError, match="does not support the MLP shape-generic"):
+            IndependentDemonHorde(
+                horde_spec=spec,
+                optimizer=bad_opt,  # type: ignore[arg-type]
+            )
+
+        good_opt = LMS(step_size=0.1)
+        with pytest.raises(ValueError, match="head_optimizer.*does not support the MLP"):
+            IndependentDemonHorde(
+                horde_spec=spec,
+                optimizer=good_opt,
+                head_optimizer=bad_opt,  # type: ignore[arg-type]
+            )
+
 
 class TestOffPolicyHordeLearnerOptimizerTruthiness:
     def test_off_policy_horde_preserves_custom_falsy_optimizer(self) -> None:


### PR DESCRIPTION
## Problem

`IndependentDemonHorde.__init__` stored `optimizer` / `head_optimizer` without checking `supported_for_mlp()`, unlike its sibling MLP learners (`MultiHeadMLPLearner`, `MLPLearner`) and the nonlinear Horde actor-critic agents (guarded in #1129). An unsupported optimizer — e.g. `ObGD`, `AutostepGTDLambda`, `AdaGain`, `NADALINE` — was therefore accepted at construction and only failed much later, deep inside `.init()`:

```
NotImplementedError: ObGD does not support init_for_shape. Only LMS, IDBD, and Autostep currently implement this.
```

`MixedHorde` routes trace demons (`gamma * lamda != 0`) through `IndependentDemonHorde`, so today a bad optimizer is caught early only when shared demons are present, and slips through to `.init()` when only trace demons exist.

## Fix

Mirror the existing sibling guard (`MultiHeadMLPLearner.__init__`): reject an `optimizer` / `head_optimizer` whose `supported_for_mlp()` is not `True` at construction, using the same message. `IndependentDemonHorde` (and therefore `MixedHorde`) now fail fast with a clear `ValueError` instead of a deep `NotImplementedError`.

Follows the same pattern as #1129.

## Tests

Failing-test-first. Added `test_independent_demon_horde_supported_for_mlp_strict_check` to the existing `TestIndependentDemonHordeOptimizerTruthiness` class, mirroring `test_multi_head_mlp_supported_for_mlp_strict_check`, so the `IndependentDemonHorde` truthiness suite now matches its siblings. The existing `preserves_custom_falsy_optimizer` / `does_not_invoke_truthiness` tests still pass — the guard compares the return value of `supported_for_mlp()` with `is not True` and never invokes `bool(optimizer)`.

- `pytest tests/test_learner_optimizer_fallback_truthiness.py` — pass
- `pytest tests/test_independent_demon_horde.py` — pass
- `ruff check .` — clean
- `mypy` — clean (strict, py312)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
