### PR TITLE
Preflight dual-replay record/sample working set

### DIFF
--- a/alberta_framework/core/dual_replay.py
+++ b/alberta_framework/core/dual_replay.py
@@ -537,6 +537,63 @@ def _allocation_sizes(config: DualReplayConfig) -> tuple[int, int]:
     return slot_bytes, persistent_bytes
 
 
+def _dual_replay_record_extras_bytes(observation_dim: int, action_dim: int) -> int:
+    """Prediction, outcome, and ``ReplayWriteResult`` extras excluding persist."""
+    prediction_bytes = 4 * observation_dim + 4 * action_dim + 38
+    outcome_bytes = 4 * observation_dim + 21
+    write_result_extras = 55
+    return prediction_bytes + outcome_bytes + write_result_extras
+
+
+def _dual_replay_sample_extras_bytes(batch_size: int, slot_bytes: int) -> int:
+    """Returned ``ReplaySampleResult`` extras excluding persist."""
+    return batch_size * (slot_bytes + 13) + 28
+
+
+def _dual_replay_update_working_set_bytes(
+    *,
+    total_capacity: int,
+    observation_dim: int,
+    action_dim: int,
+    batch_size: int,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras.
+
+    ``record`` keeps the source state, the candidate persist, and the
+    transaction-selected result live together with the prediction, outcome, and
+    write-result extras.  ``sample`` keeps the same three persist copies live
+    with the returned batch and sample diagnostics.  The host names the larger
+    envelope.
+    """
+    slot_bytes = 4 * (2 * observation_dim + action_dim + 14) + 11
+    persist_bytes = total_capacity * slot_bytes + 60
+    extras = max(
+        _dual_replay_record_extras_bytes(observation_dim, action_dim),
+        _dual_replay_sample_extras_bytes(batch_size, slot_bytes),
+    )
+    return 3 * persist_bytes + extras
+
+
+def _preflight_dual_replay_update_working_set(
+    *,
+    total_capacity: int,
+    observation_dim: int,
+    action_dim: int,
+    batch_size: int,
+) -> None:
+    """Reject a record/sample envelope the host cannot name in signed int32."""
+    working_set_bytes = _dual_replay_update_working_set_bytes(
+        total_capacity=total_capacity,
+        observation_dim=observation_dim,
+        action_dim=action_dim,
+        batch_size=batch_size,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "dual replay update working set byte count must fit signed int32"
+        )
+
+
 def _validate_config(config: DualReplayConfig) -> None:
     for name in (
         "total_capacity",
@@ -594,6 +651,12 @@ def _validate_config(config: DualReplayConfig) -> None:
             ),
         )
     _allocation_sizes(config)
+    _preflight_dual_replay_update_working_set(
+        total_capacity=config.total_capacity,
+        observation_dim=config.observation_dim,
+        action_dim=config.action_dim,
+        batch_size=config.batch_size,
+    )
 
 
 def _require_array(

--- a/tests/test_dual_replay_update_working_set.py
+++ b/tests/test_dual_replay_update_working_set.py
@@ -1,0 +1,124 @@
+"""#1383-complete record/sample working-set preflight for dual replay."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax import tree_util
+
+from alberta_framework.core.dual_replay import (
+    DualReplayConfig,
+    DualReplayMemory,
+    _allocation_sizes,
+    _dual_replay_update_working_set_bytes,
+    _preflight_dual_replay_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_CAPACITY = 10_000_000
+_LAST_FIT_CAPACITY = 9_061_110
+_FIRST_OVERFLOW_CAPACITY = 9_061_111
+_UNIT_KWARGS = {
+    "observation_dim": 1,
+    "action_dim": 1,
+    "batch_size": 2,
+}
+
+
+def _unit_config(total_capacity: int) -> DualReplayConfig:
+    return DualReplayConfig(
+        total_capacity=total_capacity,
+        short_term_capacity=1,
+        observation_dim=1,
+        action_dim=1,
+        short_term_sample_size=1,
+        long_term_sample_size=1,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_dual_replay_persist_matches_jit_and_width_still_fits() -> None:
+    config = DualReplayConfig(
+        total_capacity=7,
+        short_term_capacity=3,
+        observation_dim=2,
+        action_dim=2,
+        short_term_sample_size=2,
+        long_term_sample_size=2,
+    )
+    memory = DualReplayMemory(config)
+    state = memory.init(jr.key(3))
+    actual = sum(
+        int(leaf.size) * int(leaf.dtype.itemsize)
+        for leaf in tree_util.tree_leaves(state)
+    )
+    slot_bytes, persist_bytes = _allocation_sizes(config)
+    assert actual == persist_bytes == memory.persistent_bytes == 697
+    assert slot_bytes == memory.slot_bytes == 91
+    overflow_persist = _OVERFLOW_CAPACITY * 79 + 60
+    overflow_sample_extras = 2 * (79 + 13) + 28
+    working_set_bytes = _dual_replay_update_working_set_bytes(
+        total_capacity=_OVERFLOW_CAPACITY,
+        **_UNIT_KWARGS,
+    )
+    assert overflow_persist <= _INT32_MAX
+    assert overflow_persist + overflow_sample_extras <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_config(_OVERFLOW_CAPACITY)
+
+
+def test_dual_replay_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for total_capacity in range(_LAST_FIT_CAPACITY, _FIRST_OVERFLOW_CAPACITY + 2):
+        persist_bytes = total_capacity * 79 + 60
+        working_set_bytes = _dual_replay_update_working_set_bytes(
+            total_capacity=total_capacity,
+            **_UNIT_KWARGS,
+        )
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + (2 * (79 + 13) + 28) <= _INT32_MAX
+        assert 4 * 1 <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = total_capacity
+        elif first_overflow is None:
+            first_overflow = total_capacity
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_CAPACITY
+    constructed = _unit_config(last_fit)
+    assert constructed.total_capacity == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_config(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_dual_replay_update_working_set(
+            total_capacity=_OVERFLOW_CAPACITY,
+            **_UNIT_KWARGS,
+        )
+
+
+def test_legal_small_dual_replay_still_constructs() -> None:
+    config = DualReplayConfig(
+        total_capacity=6,
+        short_term_capacity=3,
+        observation_dim=2,
+        action_dim=2,
+        short_term_sample_size=2,
+        long_term_sample_size=2,
+    )
+    DualReplayMemory(config).init(jr.key(1))


### PR DESCRIPTION
Closes #1811.

## What changed

`DualReplayConfig` validation now preflights the simultaneous `record` / `sample` working set (`3 × persist + extras`) after the existing UINT32 persist check.

On origin/main `cc877f78`, `total_capacity=10_000_000` at unit width constructed. Persist matches JIT. Persist and persist+sample extras still fit signed int32. `4 ×` width still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `9061110` / `9061111`. Legal small configs are unchanged.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id, UINT32 persist identity, or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809`.

## Scope

- `alberta_framework/core/dual_replay.py`
- `tests/test_dual_replay_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `dual_replay.py`. Factory `HARD_SKIP_PATHS` does not include this host.

## Verification

Exact candidate head: `f70fdc2d2801ff6087e21803b6573fcefe1ba19e`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `DualReplayConfig(..., total_capacity=10_000_000)` constructed; persist and persist+sample extras fit; `4 ×` width fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_dual_replay_update_working_set.py` plus `tests/test_dual_replay.py` plus `tests/test_dual_replay_int_hostile.py` plus `tests/test_dual_replay_hostile_digests.py`: 179 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_dual_replay_update_working_set.py tests/test_dual_replay.py tests/test_dual_replay_int_hostile.py tests/test_dual_replay_hostile_digests.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: persist matches JIT at the 7/3/2/2 fixture; persist+sample extras and `4 ×` width still fit at the origin/main overflow capacity; last-fit `9061110` constructs; first-overflow `9061111` rejects
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f70fdc2d2801ff6087e21803b6573fcefe1ba19e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
