### PR TITLE
Preflight latent world-model update working set

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -131,6 +131,86 @@ def _saturating_int32_increment(value: Array) -> Array:
     return jnp.where(value < maximum, value + jnp.asarray(1, dtype=jnp.int32), maximum)
 
 
+def _latent_direct_state_scalars(
+    *,
+    observation_dim: int,
+    n_actions: int,
+    latent_dim: int,
+    hidden_sizes: tuple[int, ...],
+    include_action_interactions: bool,
+) -> int:
+    """Named persist scalars already preflighted by ``LatentWorldModelConfig``."""
+    input_dim = latent_dim + n_actions
+    if include_action_interactions:
+        input_dim += latent_dim * n_actions
+    layer_sizes = (input_dim, *hidden_sizes)
+    trunk_parameters = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    n_heads = latent_dim + 2
+    head_input = hidden_sizes[-1] if hidden_sizes else input_dim
+    head_parameters = n_heads * (head_input + 1)
+    learner_direct_scalars = (
+        2 * (trunk_parameters + head_parameters) + sum(hidden_sizes) + 3
+    )
+    outer_state_scalars = observation_dim * latent_dim + 3 * latent_dim + 4
+    return learner_direct_scalars + outer_state_scalars
+
+
+def _latent_update_result_extras_bytes(*, latent_dim: int) -> int:
+    """Returned ``LatentWorldModelUpdateResult`` extras excluding persist.
+
+    Nested ``learner_result.state`` is callee persist and is already counted
+    in the simultaneous persist copies.  These extras are the published
+    prediction, target, error, metric, and learner-result diagnostic leaves.
+    """
+    n_heads = latent_dim + 2
+    return 12 * latent_dim + 44 * n_heads + 64
+
+
+def _latent_update_working_set_bytes(
+    *,
+    observation_dim: int,
+    n_actions: int,
+    latent_dim: int,
+    hidden_sizes: tuple[int, ...],
+    include_action_interactions: bool,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    persist_bytes = 4 * _latent_direct_state_scalars(
+        observation_dim=observation_dim,
+        n_actions=n_actions,
+        latent_dim=latent_dim,
+        hidden_sizes=hidden_sizes,
+        include_action_interactions=include_action_interactions,
+    )
+    extras_bytes = _latent_update_result_extras_bytes(latent_dim=latent_dim)
+    return 3 * persist_bytes + extras_bytes
+
+
+def _preflight_latent_update_working_set(
+    *,
+    observation_dim: int,
+    n_actions: int,
+    latent_dim: int,
+    hidden_sizes: tuple[int, ...],
+    include_action_interactions: bool,
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    working_set_bytes = _latent_update_working_set_bytes(
+        observation_dim=observation_dim,
+        n_actions=n_actions,
+        latent_dim=latent_dim,
+        hidden_sizes=hidden_sizes,
+        include_action_interactions=include_action_interactions,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "latent world-model update working set byte count must fit signed int32"
+        )
+
+
 @dataclasses.dataclass(frozen=True)
 class LatentWorldModelConfig:
     """Configuration for :class:`LatentWorldModel`.
@@ -263,25 +343,26 @@ class LatentWorldModelConfig:
             _require_int32_product(f"hidden_layer[{index}]_scalars", fan_in, fan_out)
         head_input = self.hidden_sizes[-1] if self.hidden_sizes else input_dim
         _require_int32_product("head_weight_scalars", n_heads, head_input)
-        layer_sizes = (input_dim, *self.hidden_sizes)
-        trunk_parameters = sum(
-            fan_out * (fan_in + 1)
-            for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+        combined_direct_state_scalars = _latent_direct_state_scalars(
+            observation_dim=self.observation_dim,
+            n_actions=self.n_actions,
+            latent_dim=self.latent_dim,
+            hidden_sizes=self.hidden_sizes,
+            include_action_interactions=self.include_action_interactions,
         )
-        head_parameters = n_heads * (head_input + 1)
-        learner_direct_scalars = (
-            2 * (trunk_parameters + head_parameters) + sum(self.hidden_sizes) + 3
-        )
-        outer_state_scalars = (
-            self.observation_dim * self.latent_dim + 3 * self.latent_dim + 4
-        )
-        combined_direct_state_scalars = learner_direct_scalars + outer_state_scalars
         for name, value in (
             ("combined_direct_state_scalars", combined_direct_state_scalars),
             ("combined_direct_state_bytes", 4 * combined_direct_state_scalars),
         ):
             if value > _INT32_MAX:
                 raise ValueError(f"derived {name} must fit in signed int32")
+        _preflight_latent_update_working_set(
+            observation_dim=self.observation_dim,
+            n_actions=self.n_actions,
+            latent_dim=self.latent_dim,
+            hidden_sizes=self.hidden_sizes,
+            include_action_interactions=self.include_action_interactions,
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""

--- a/tests/test_latent_world_model_update_working_set.py
+++ b/tests/test_latent_world_model_update_working_set.py
@@ -1,0 +1,134 @@
+"""#1383-complete update working-set preflight for the latent world model."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.latent_world_model import (
+    LatentWorldModel,
+    LatentWorldModelConfig,
+    _latent_direct_state_scalars,
+    _latent_update_working_set_bytes,
+    _preflight_latent_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_LATENT_DIM = 10_000
+_LAST_FIT_LATENT_DIM = 9_454
+_FIRST_OVERFLOW_LATENT_DIM = 9_455
+_LINEAR_KWARGS = {
+    "observation_dim": 1,
+    "n_actions": 2,
+    "hidden_sizes": (),
+    "include_action_interactions": False,
+}
+
+
+def _linear_persist_bytes(latent_dim: int) -> int:
+    return 4 * _latent_direct_state_scalars(
+        observation_dim=1,
+        n_actions=2,
+        latent_dim=latent_dim,
+        hidden_sizes=(),
+        include_action_interactions=False,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_latent_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _linear_persist_bytes(_OVERFLOW_LATENT_DIM)
+    working_set_bytes = _latent_update_working_set_bytes(
+        latent_dim=_OVERFLOW_LATENT_DIM,
+        **_LINEAR_KWARGS,
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 800_560_076
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_LATENT_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        LatentWorldModelConfig(latent_dim=_OVERFLOW_LATENT_DIM, **_LINEAR_KWARGS)
+
+
+def test_latent_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for latent_dim in range(_LAST_FIT_LATENT_DIM, _FIRST_OVERFLOW_LATENT_DIM + 2):
+        persist_bytes = _linear_persist_bytes(latent_dim)
+        working_set_bytes = _latent_update_working_set_bytes(
+            latent_dim=latent_dim,
+            **_LINEAR_KWARGS,
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * latent_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = latent_dim
+        elif first_overflow is None:
+            first_overflow = latent_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_LATENT_DIM
+    config = LatentWorldModelConfig(latent_dim=last_fit, **_LINEAR_KWARGS)
+    assert config.latent_dim == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        LatentWorldModelConfig(latent_dim=first_overflow, **_LINEAR_KWARGS)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_latent_update_working_set(
+            latent_dim=_OVERFLOW_LATENT_DIM,
+            **_LINEAR_KWARGS,
+        )
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    with pytest.raises(ValueError, match="combined_direct_state_bytes"):
+        LatentWorldModelConfig(
+            observation_dim=1,
+            n_actions=1,
+            latent_dim=8,
+            hidden_sizes=(16_384, 16_384),
+        )
+
+
+def test_legal_small_latent_world_model_still_constructs() -> None:
+    config = LatentWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        latent_dim=4,
+        hidden_sizes=(),
+    )
+    persist_bytes = 4 * _latent_direct_state_scalars(
+        observation_dim=2,
+        n_actions=2,
+        latent_dim=4,
+        hidden_sizes=(),
+        include_action_interactions=False,
+    )
+    assert persist_bytes == 444
+    model = LatentWorldModel(config)
+    state = model.init(jr.key(0))
+    model.update(
+        state,
+        jnp.zeros((2,), dtype=jnp.float32),
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(0.99, dtype=jnp.float32),
+        jnp.zeros((2,), dtype=jnp.float32),
+    )


### PR DESCRIPTION
Closes #1813.

## What changed

`LatentWorldModelConfig.__post_init__` now preflights the simultaneous `update` working set (`3 × persist + extras`) after the existing persist checks.

On origin/main `cc877f78`, `latent_dim=10_000` on the linear 1-obs/2-action fixture constructed. Named persist and persist+extras still fit. `4 × latent_dim` still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `9454` / `9455`. Legal small configs are unchanged. Persist overflow still fires first.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812`. `world_model.py` stays HARD_SKIP; this file is `latent_world_model.py`.

## Scope

- `alberta_framework/core/latent_world_model.py`
- `tests/test_latent_world_model_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `latent_world_model.py`. Factory `HARD_SKIP_PATHS` includes `world_model.py` and does not include this host.

## Verification

Exact candidate head: `75a98f44fb03767fa0bb23f12f2591fe086d485a`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `LatentWorldModelConfig(..., latent_dim=10_000)` constructed; persist and persist+extras fit; `4 × latent_dim` fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_latent_world_model_update_working_set.py` plus `tests/test_latent_world_model.py`: 62 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_latent_world_model_update_working_set.py tests/test_latent_world_model.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `800560076` at the overflow dim; persist+extras and `4 × latent_dim` still fit; last-fit `9454` constructs; first-overflow `9455` rejects; `(16_384, 16_384)` still fails persist first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:75a98f44fb03767fa0bb23f12f2591fe086d485a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
