### PR TITLE
Preflight multi-head learner update working set

### DIFF
--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -177,6 +177,58 @@ def _validate_direct_state_resources(
             raise ValueError(f"derived {name} must be at most {_INT32_MAX}")
 
 
+def _direct_state_bytes(
+    n_heads: int,
+    hidden_sizes: tuple[int, ...],
+    feature_dim: int,
+) -> int:
+    """Named persist already preflighted by ``_validate_direct_state_resources``."""
+    layer_sizes = (feature_dim, *hidden_sizes)
+    trunk_parameter_count = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    final_width = hidden_sizes[-1] if hidden_sizes else feature_dim
+    head_parameter_count = n_heads * (final_width + 1)
+    return 4 * (2 * (trunk_parameter_count + head_parameter_count) + sum(hidden_sizes) + 3)
+
+
+def _multi_head_update_result_extras_bytes(n_heads: int) -> int:
+    """Returned ``MultiHeadMLPUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published prediction, error, metric,
+    clock-word, and diagnostic leaves.
+    """
+    return 20 * n_heads + 25
+
+
+def _multi_head_update_working_set_bytes(
+    n_heads: int,
+    hidden_sizes: tuple[int, ...],
+    feature_dim: int,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _direct_state_bytes(
+        n_heads, hidden_sizes, feature_dim
+    ) + _multi_head_update_result_extras_bytes(n_heads)
+
+
+def _preflight_multi_head_update_working_set(
+    n_heads: int,
+    hidden_sizes: tuple[int, ...],
+    feature_dim: int,
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    working_set_bytes = _multi_head_update_working_set_bytes(
+        n_heads, hidden_sizes, feature_dim
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "multi-head learner update working set byte count must fit signed int32"
+        )
+
+
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
@@ -491,6 +543,7 @@ class MultiHeadMLPLearner:
         if hidden_sizes:
             _require_int32_product("head_weight_scalars", n_heads, hidden_sizes[-1])
         _validate_direct_state_resources(n_heads, hidden_sizes, feature_dim=1)
+        _preflight_multi_head_update_working_set(n_heads, hidden_sizes, feature_dim=1)
         if per_head_gamma_lamda is not None and type(per_head_gamma_lamda) is not tuple:
             raise ValueError(
                 "per_head_gamma_lamda must be an actual tuple when constructed directly"
@@ -723,6 +776,9 @@ class MultiHeadMLPLearner:
         else:
             _require_int32_product("linear_head_weight_scalars", self._n_heads, feature_dim)
         _validate_direct_state_resources(self._n_heads, self._hidden_sizes, feature_dim)
+        _preflight_multi_head_update_working_set(
+            self._n_heads, self._hidden_sizes, feature_dim
+        )
         # Trunk: [feature_dim, *hidden_sizes] — all hidden layers
         trunk_layer_sizes = [feature_dim, *self._hidden_sizes]
 

--- a/tests/test_multi_head_learner.py
+++ b/tests/test_multi_head_learner.py
@@ -235,9 +235,14 @@ class TestMultiHeadInit:
             linear.init(2**30, jr.key(0))
         assert calls == 0
 
+        overflow = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(1,))
+        with pytest.raises(ValueError, match="update working set byte count"):
+            overflow.init(268_435_450, jr.key(0))
+        assert calls == 0
+
         boundary = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(1,))
         with pytest.raises(AssertionError, match="allocator reached"):
-            boundary.init(268_435_450, jr.key(0))
+            boundary.init(89_478_436, jr.key(0))
         assert calls == 1
 
     def test_aggregate_direct_state_resources_fail_before_allocation(self):

--- a/tests/test_multi_head_learner_update_working_set.py
+++ b/tests/test_multi_head_learner_update_working_set.py
@@ -1,0 +1,140 @@
+"""#1383-complete update working-set preflight for the multi-head MLP learner."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.multi_head_learner import (
+    MultiHeadMLPLearner,
+    _direct_state_bytes,
+    _multi_head_update_working_set_bytes,
+    _preflight_multi_head_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_HIDDEN = 30_000_000
+_LAST_FIT_HIDDEN = 25_565_280
+_FIRST_OVERFLOW_HIDDEN = 25_565_281
+_OVERFLOW_FEATURE_DIM = 90_000_000
+_LAST_FIT_FEATURE_DIM = 89_478_480
+_FIRST_OVERFLOW_FEATURE_DIM = 89_478_481
+
+
+def _unit_persist_bytes(hidden: int) -> int:
+    return _direct_state_bytes(1, (hidden,), 1)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _unit_persist_bytes(_OVERFLOW_HIDDEN)
+    working_set_bytes = _multi_head_update_working_set_bytes(
+        1, (_OVERFLOW_HIDDEN,), 1
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 840_000_020
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_HIDDEN <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        MultiHeadMLPLearner(n_heads=1, hidden_sizes=(_OVERFLOW_HIDDEN,))
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for hidden in range(_LAST_FIT_HIDDEN, _FIRST_OVERFLOW_HIDDEN + 2):
+        persist_bytes = _unit_persist_bytes(hidden)
+        working_set_bytes = _multi_head_update_working_set_bytes(1, (hidden,), 1)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * hidden <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = hidden
+        elif first_overflow is None:
+            first_overflow = hidden
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_HIDDEN
+    learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(last_fit,))
+    assert learner._hidden_sizes == (last_fit,)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        MultiHeadMLPLearner(n_heads=1, hidden_sizes=(first_overflow,))
+
+
+def test_init_rejects_linear_feature_dim_working_set_before_allocation() -> None:
+    persist_bytes = _direct_state_bytes(1, (), _OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _multi_head_update_working_set_bytes(
+        1, (), _OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 720_000_020
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=())
+    with pytest.raises(ValueError, match="update working set byte count"):
+        learner.init(_OVERFLOW_FEATURE_DIM, jr.key(0))
+
+
+def test_init_last_fit_and_first_overflow_feature_dims_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(
+        _LAST_FIT_FEATURE_DIM, _FIRST_OVERFLOW_FEATURE_DIM + 2
+    ):
+        persist_bytes = _direct_state_bytes(1, (), feature_dim)
+        working_set_bytes = _multi_head_update_working_set_bytes(
+            1, (), feature_dim
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURE_DIM
+    _preflight_multi_head_update_working_set(1, (), last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_multi_head_update_working_set(1, (), first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_multi_head_update_working_set(1, (_OVERFLOW_HIDDEN,), 1)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    with pytest.raises(ValueError, match="direct_state_bytes"):
+        MultiHeadMLPLearner(n_heads=134_217_728, hidden_sizes=())
+
+
+def test_legal_small_multi_head_learner_still_constructs() -> None:
+    persist_bytes = _direct_state_bytes(2, (4,), 3)
+    assert persist_bytes == 236
+    learner = MultiHeadMLPLearner(
+        n_heads=2, hidden_sizes=(4,), sparsity=0.0, use_layer_norm=False
+    )
+    state = learner.init(feature_dim=3, key=jr.key(0))
+    learner.update(
+        state,
+        jnp.zeros((3,), dtype=jnp.float32),
+        jnp.zeros((2,), dtype=jnp.float32),
+    )


### PR DESCRIPTION
Closes #1815.

## What changed

`MultiHeadMLPLearner.__init__` and `init` now preflight the simultaneous `update` working set (`3 × persist + extras`) after the existing persist checks. `_validate_direct_state_resources` stays persist-only because `prototype_agent.py` imports it for persist bytes.

On origin/main `cc877f78`, `n_heads=1` / `hidden_sizes=(30_000_000,)` constructed. Named persist and persist+extras still fit. `4 × hidden` still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `25565280` / `25565281`. Linear `init(90_000_000)` overflows the same envelope after construct-time persist at `feature_dim=1` has passed. Legal small configs are unchanged. Persist overflow still fires first.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814`. `learners.py` stays stay-off; this file is `multi_head_learner.py`.

## Scope

- `alberta_framework/core/multi_head_learner.py`
- `tests/test_multi_head_learner.py`
- `tests/test_multi_head_learner_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `multi_head_learner.py`. Factory `HARD_SKIP_PATHS` does not include this host.

## Verification

Exact candidate head: `f64f39fbd0d237888ebfbdfd3341f6a9e70d55b6`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `MultiHeadMLPLearner(n_heads=1, hidden_sizes=(30_000_000,))` constructed; persist and persist+extras fit; `4 × hidden` fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused pytest `tests/test_multi_head_learner_update_working_set.py` plus `tests/test_multi_head_learner.py`: 168 passed
- `ruff check` on the three changed files: clean
- `scope-check.sh --max-files 4`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_multi_head_learner_update_working_set.py tests/test_multi_head_learner.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `840000020` at the overflow hidden; persist+extras and `4 × hidden` still fit; last-fit `25565280` constructs; first-overflow `25565281` rejects; `n_heads=134_217_728` still fails persist first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f64f39fbd0d237888ebfbdfd3341f6a9e70d55b6 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
