### PR TITLE
Preflight OaK update working set

### DIFF
--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -130,6 +130,35 @@ def _default_stomp_config() -> STOMPConfig:
     return STOMPConfig(subtask_specs=(SubtaskSpec(feature_index=0),))
 
 
+def _oak_direct_state_bytes(stomp: STOMPConfig) -> int:
+    """Named persist already preflighted by ``OaKConfig.__post_init__``."""
+    n_options = len(stomp.subtask_specs)
+    return 4 * (_stomp_direct_array_scalars(stomp) + 3 * n_options + 3)
+
+
+def _oak_update_result_extras_bytes(n_options: int) -> int:
+    """Returned ``OaKUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published diagnostic, clock-word,
+    and per-option utility leaves.
+    """
+    return 52 + 4 * n_options
+
+
+def _oak_update_working_set_bytes(stomp: STOMPConfig) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _oak_direct_state_bytes(stomp) + _oak_update_result_extras_bytes(
+        len(stomp.subtask_specs)
+    )
+
+
+def _preflight_oak_update_working_set(stomp: STOMPConfig) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _oak_update_working_set_bytes(stomp) > _INT32_MAX:
+        raise ValueError("OaK update working set byte count must fit signed int32")
+
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -187,6 +216,7 @@ class OaKConfig:
         combined_scalars = _stomp_direct_array_scalars(self.stomp) + 3 * self.n_options + 3
         if combined_scalars > _INT32_MAX or 4 * combined_scalars > _INT32_MAX:
             raise ValueError("derived OaK direct array bytes must fit signed int32")
+        _preflight_oak_update_working_set(self.stomp)
 
     @property
     def n_options(self) -> int:

--- a/tests/test_oak_update_working_set.py
+++ b/tests/test_oak_update_working_set.py
@@ -1,0 +1,112 @@
+"""#1383-complete update working-set preflight for the OaK host."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.oak import (
+    OaKAgent,
+    OaKConfig,
+    _oak_direct_state_bytes,
+    _oak_update_working_set_bytes,
+    _preflight_oak_update_working_set,
+)
+from alberta_framework.core.options import STOMPConfig, SubtaskSpec
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_OBS = 20_000
+_LAST_FIT_OBS = 13_373
+_FIRST_OVERFLOW_OBS = 13_374
+_UNIT_STOMP = {
+    "n_primitive_actions": 1,
+    "base_hidden_sizes": (),
+}
+
+
+def _unit_stomp(observation_dim: int) -> STOMPConfig:
+    return STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=observation_dim,
+        **_UNIT_STOMP,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    stomp = _unit_stomp(_OVERFLOW_OBS)
+    persist_bytes = _oak_direct_state_bytes(stomp)
+    working_set_bytes = _oak_update_working_set_bytes(stomp)
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 1_600_640_172
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_OBS <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        OaKConfig(stomp=stomp)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for observation_dim in range(_LAST_FIT_OBS, _FIRST_OVERFLOW_OBS + 2):
+        stomp = _unit_stomp(observation_dim)
+        persist_bytes = _oak_direct_state_bytes(stomp)
+        working_set_bytes = _oak_update_working_set_bytes(stomp)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * observation_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = observation_dim
+        elif first_overflow is None:
+            first_overflow = observation_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_OBS
+    config = OaKConfig(stomp=_unit_stomp(last_fit))
+    assert config.observation_dim == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        OaKConfig(stomp=_unit_stomp(first_overflow))
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_oak_update_working_set(_unit_stomp(_OVERFLOW_OBS))
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    stomp_only_limit = (2**29 - 1 - 22) // 4
+    stomp = STOMPConfig(observation_dim=stomp_only_limit, n_primitive_actions=1)
+    with pytest.raises(ValueError, match="OaK direct array bytes"):
+        OaKConfig(stomp=stomp)
+
+
+def test_legal_small_oak_still_constructs() -> None:
+    stomp = STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=4,
+        n_primitive_actions=2,
+        base_hidden_sizes=(),
+    )
+    persist_bytes = _oak_direct_state_bytes(stomp)
+    assert persist_bytes == 444
+    agent = OaKAgent(OaKConfig(stomp=stomp))
+    state = agent.init(jr.key(0))
+    agent.update(
+        state,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.zeros((4,), dtype=jnp.float32),
+    )


### PR DESCRIPTION
Closes #1817.

## What changed

`OaKConfig.__post_init__` now preflights the simultaneous `update` working set (`3 × persist + extras`) after the existing persist checks. `_stomp_direct_array_scalars` stays persist-only.

On origin/main `cc877f78`, `observation_dim=20_000` on the unit 1-option/1-action fixture constructed. Named persist and persist+extras still fit. `4 × observation_dim` still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `13373` / `13374`. Legal small configs are unchanged. Persist overflow still fires first.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816`.

## Scope

- `alberta_framework/core/oak.py`
- `tests/test_oak_update_working_set.py`

## Why this is unowned

Live occupancy at claim time: no open PR touches `oak.py`. Factory `HARD_SKIP_PATHS` does not include this host.

## Verification

Exact candidate head: `02b897e80e486717b7dec427c14e07b16a1fdeaa`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `OaKConfig(..., observation_dim=20_000)` constructed; persist and persist+extras fit; `4 × observation_dim` fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused oak pytest family including `tests/test_oak_update_working_set.py`: 94 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_oak_update_working_set.py tests/test_oak_prototype_fixes.py tests/test_oak_transition_accounting.py tests/test_oak_keyboard_dispatch.py tests/test_oak_authoritative_stomp_adoption.py tests/test_oak_stomp_adoption_resource_budget.py tests/test_stomp_oak_horizon.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `1600640172` at the overflow dim; persist+extras and `4 × observation_dim` still fit; last-fit `13373` constructs; first-overflow `13374` rejects; STOMP-only persist limit still fails persist first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:02b897e80e486717b7dec427c14e07b16a1fdeaa -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
