### PR TITLE
Preflight experiential memory update working set

### DIFF
--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -291,6 +291,78 @@ def _require_float32_allocation(name: str, scalars: int) -> None:
         raise ValueError(f"{name} scalar and byte counts must fit signed int32")
 
 
+def _experiential_persistent_bytes(
+    *,
+    capacity: int,
+    observation_dim: int,
+    key_dim: int,
+    action_dim: int,
+    outcome_dim: int,
+) -> int:
+    """Named persist already preflighted by ``_validate_config``."""
+    vector_values = observation_dim + key_dim + action_dim + outcome_dim
+    return capacity * (4 * (vector_values + 11) + 4) + 32
+
+
+def _experiential_step_result_extras_bytes(
+    *,
+    observation_dim: int,
+    action_dim: int,
+    outcome_dim: int,
+    top_k: int,
+) -> int:
+    """Returned ``ExperientialMemoryStepResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published retrieval and write
+    diagnostic leaves.
+    """
+    payload_values = observation_dim + action_dim + outcome_dim
+    return 36 + 4 * payload_values + 25 * top_k
+
+
+def _experiential_update_working_set_bytes(
+    *,
+    capacity: int,
+    observation_dim: int,
+    key_dim: int,
+    action_dim: int,
+    outcome_dim: int,
+    top_k: int,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    persist_bytes = _experiential_persistent_bytes(
+        capacity=capacity,
+        observation_dim=observation_dim,
+        key_dim=key_dim,
+        action_dim=action_dim,
+        outcome_dim=outcome_dim,
+    )
+    extras_bytes = _experiential_step_result_extras_bytes(
+        observation_dim=observation_dim,
+        action_dim=action_dim,
+        outcome_dim=outcome_dim,
+        top_k=top_k,
+    )
+    return 3 * persist_bytes + extras_bytes
+
+
+def _preflight_experiential_update_working_set(config: ExperientialMemoryConfig) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    working_set_bytes = _experiential_update_working_set_bytes(
+        capacity=config.capacity,
+        observation_dim=config.observation_dim,
+        key_dim=config.key_dim,
+        action_dim=config.action_dim,
+        outcome_dim=config.outcome_dim,
+        top_k=config.top_k,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "experiential memory update working set byte count must fit signed int32"
+        )
+
+
 def _validate_config(config: ExperientialMemoryConfig) -> None:
     for name in (
         "capacity",
@@ -356,6 +428,7 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
             "ExperientialMemoryConfig aggregate query working-set bytes "
             "must fit signed int32"
         )
+    _preflight_experiential_update_working_set(config)
 
     object.__setattr__(
         config,

--- a/tests/test_experiential_memory_update_working_set.py
+++ b/tests/test_experiential_memory_update_working_set.py
@@ -1,0 +1,161 @@
+"""#1383-complete update working-set preflight for experiential memory."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.experiential_memory import (
+    ExperientialMemory,
+    ExperientialMemoryConfig,
+    ExperientialMemoryEntry,
+    _experiential_persistent_bytes,
+    _experiential_update_working_set_bytes,
+    _preflight_experiential_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_CAPACITY = 11_200_000
+_LAST_FIT_CAPACITY = 11_184_809
+_FIRST_OVERFLOW_CAPACITY = 11_184_810
+_UNIT = {
+    "observation_dim": 1,
+    "key_dim": 1,
+    "action_dim": 1,
+    "outcome_dim": 1,
+    "top_k": 1,
+}
+
+
+def _unit_persist_bytes(capacity: int) -> int:
+    return _experiential_persistent_bytes(
+        capacity=capacity,
+        observation_dim=1,
+        key_dim=1,
+        action_dim=1,
+        outcome_dim=1,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _unit_persist_bytes(_OVERFLOW_CAPACITY)
+    working_set_bytes = _experiential_update_working_set_bytes(
+        capacity=_OVERFLOW_CAPACITY,
+        **_UNIT,
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 716_800_032
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_CAPACITY <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        ExperientialMemoryConfig(capacity=_OVERFLOW_CAPACITY, **_UNIT)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for capacity in range(_LAST_FIT_CAPACITY, _FIRST_OVERFLOW_CAPACITY + 2):
+        persist_bytes = _unit_persist_bytes(capacity)
+        working_set_bytes = _experiential_update_working_set_bytes(
+            capacity=capacity,
+            **_UNIT,
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * capacity <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = capacity
+        elif first_overflow is None:
+            first_overflow = capacity
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_CAPACITY
+    config = ExperientialMemoryConfig(capacity=last_fit, **_UNIT)
+    assert config.capacity == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        ExperientialMemoryConfig(capacity=first_overflow, **_UNIT)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    overflow = ExperientialMemoryConfig(capacity=4, **_UNIT)
+    object.__setattr__(overflow, "capacity", _OVERFLOW_CAPACITY)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_experiential_update_working_set(overflow)
+
+
+def test_query_envelope_still_fires_before_working_set_when_it_overflows_first() -> None:
+    with pytest.raises(ValueError, match="aggregate query working-set bytes"):
+        ExperientialMemoryConfig(capacity=12_000_000, **_UNIT)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (2**31 - 1 - 32) // 64
+    with pytest.raises(ValueError, match="state byte count"):
+        ExperientialMemoryConfig(capacity=last_legal + 1, **_UNIT)
+
+
+def test_existing_query_last_legal_capacity_still_constructs() -> None:
+    persist_bytes = _unit_persist_bytes(11_000_000)
+    working_set_bytes = _experiential_update_working_set_bytes(
+        capacity=11_000_000,
+        **_UNIT,
+    )
+    assert persist_bytes == 704_000_032
+    assert working_set_bytes <= _INT32_MAX
+    config = ExperientialMemoryConfig(capacity=11_000_000, **_UNIT)
+    assert config.capacity == 11_000_000
+
+
+def test_legal_small_experiential_memory_still_steps() -> None:
+    persist_bytes = _experiential_persistent_bytes(
+        capacity=4,
+        observation_dim=1,
+        key_dim=1,
+        action_dim=1,
+        outcome_dim=1,
+    )
+    assert persist_bytes == 288
+    config = ExperientialMemoryConfig(capacity=4, **_UNIT)
+    memory = ExperientialMemory(config)
+    state = memory.init()
+    entry = ExperientialMemoryEntry(
+        observation=jnp.zeros((1,), dtype=jnp.float32),
+        key=jnp.zeros((1,), dtype=jnp.float32),
+        action=jnp.zeros((1,), dtype=jnp.float32),
+        outcome=jnp.zeros((1,), dtype=jnp.float32),
+        reward=jnp.asarray(0.0, dtype=jnp.float32),
+        uncertainty=jnp.asarray(0.1, dtype=jnp.float32),
+        uncertainty_available=jnp.asarray(True),
+        safety_cost=jnp.asarray(0.0, dtype=jnp.float32),
+        safety_cost_available=jnp.asarray(True),
+        reliability=jnp.asarray(1.0, dtype=jnp.float32),
+        utility=jnp.asarray(0.0, dtype=jnp.float32),
+        utility_available=jnp.asarray(True),
+        representation_version=jnp.asarray(1, dtype=jnp.int32),
+        valid=jnp.asarray(True),
+        age=jnp.asarray(0, dtype=jnp.int32),
+        provenance_id=jnp.asarray(1, dtype=jnp.int32),
+        source_id=jnp.asarray(1, dtype=jnp.int32),
+    )
+    memory.step(
+        state,
+        entry.key,
+        jnp.asarray(1, dtype=jnp.int32),
+        jnp.asarray(0.1, dtype=jnp.float32),
+        jnp.asarray(True),
+        entry,
+    )


### PR DESCRIPTION
Closes #1819.

## What changed

`ExperientialMemoryConfig` validation now preflights the simultaneous `step` working set (`3 × persist + extras`) after the existing persist and persist+query checks.

On origin/main `cc877f78`, unit-width `capacity=11_200_000` constructed. Named persist, persist+extras, and the query envelope still fit. `4 × capacity` still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `11184809` / `11184810`. Existing query last-legal `11_000_000` still constructs. Legal small configs are unchanged. Persist and query overflows still fire first.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id, the query envelope, or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816` / `#1818`.

## Scope

- `alberta_framework/core/experiential_memory.py`
- `tests/test_experiential_memory_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `experiential_memory.py`. Factory `HARD_SKIP_PATHS` does not include this host.

## Verification

Exact candidate head: `ce09b179630f34e898cbc42e16285aa29bd5f004`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `ExperientialMemoryConfig(..., capacity=11_200_000)` constructed; persist, persist+extras, and query envelope fit; `4 × capacity` fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused experiential pytest family including `tests/test_experiential_memory_update_working_set.py`: 193 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_experiential_memory_update_working_set.py tests/test_experiential_memory.py tests/test_experiential_memory_validation.py tests/test_experiential_memory_policy.py tests/test_experiential_memory_policy_validation.py tests/test_experiential_memory_policy_resource_declaration.py tests/test_prototype_experiential_memory_resource_declaration.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `716800032` at the overflow capacity; persist+extras and `4 × capacity` still fit; last-fit `11184809` constructs; first-overflow `11184810` rejects; `11_000_000` still constructs; `12_000_000` still fails the query envelope first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:ce09b179630f34e898cbc42e16285aa29bd5f004 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
