### PR TITLE
Preflight STOMP update working set

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -118,6 +118,32 @@ def _stomp_direct_array_scalars(config: STOMPConfig) -> int:
     )
 
 
+def _stomp_direct_state_bytes(config: STOMPConfig) -> int:
+    """Named persist already preflighted by ``STOMPConfig.__post_init__``."""
+    return 4 * _stomp_direct_array_scalars(config)
+
+
+def _stomp_update_result_extras_bytes() -> int:
+    """Returned ``STOMPUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published diagnostic, clock-word,
+    and nested-update leaves.
+    """
+    return 64
+
+
+def _stomp_update_working_set_bytes(config: STOMPConfig) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _stomp_direct_state_bytes(config) + _stomp_update_result_extras_bytes()
+
+
+def _preflight_stomp_update_working_set(config: STOMPConfig) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _stomp_update_working_set_bytes(config) > _INT32_MAX:
+        raise ValueError("STOMP update working set byte count must fit signed int32")
+
+
 # ---------------------------------------------------------------------------
 # Subtask specification (Python-level; JAX arrays extracted for scan use)
 # ---------------------------------------------------------------------------
@@ -1549,6 +1575,7 @@ class STOMPConfig:
         direct_scalars = _stomp_direct_array_scalars(self)
         if direct_scalars > _INT32_MAX or 4 * direct_scalars > _INT32_MAX:
             raise ValueError("derived STOMP direct array bytes must fit signed int32")
+        _preflight_stomp_update_working_set(self)
 
     @property
     def n_options(self) -> int:

--- a/tests/test_oak_prototype_fixes.py
+++ b/tests/test_oak_prototype_fixes.py
@@ -373,9 +373,8 @@ def test_oak_and_keyboard_close_schema_float32_and_resource_boundaries() -> None
         )
 
     stomp_only_limit = (2**29 - 1 - 22) // 4
-    stomp = STOMPConfig(observation_dim=stomp_only_limit, n_primitive_actions=1)
-    with pytest.raises(ValueError, match="OaK direct array bytes"):
-        OaKConfig(stomp=stomp)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        STOMPConfig(observation_dim=stomp_only_limit, n_primitive_actions=1)
 
     last_legal_keyboard_options = (2**31 - 1) // 4 - 2
     KeyboardChordLearnerConfig(n_options=last_legal_keyboard_options)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -453,7 +453,8 @@ def test_stomp_closes_float32_schema_and_direct_resource_boundaries() -> None:
         SubtaskSpec(feature_index=0, threshold=1.0e100)
 
     last_legal_observation_dim = (2**29 - 1 - 22) // 4
-    STOMPConfig(observation_dim=last_legal_observation_dim, n_primitive_actions=1)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        STOMPConfig(observation_dim=last_legal_observation_dim, n_primitive_actions=1)
     with pytest.raises(ValueError, match="direct array bytes"):
         STOMPConfig(observation_dim=last_legal_observation_dim + 1, n_primitive_actions=1)
 

--- a/tests/test_stomp_update_working_set.py
+++ b/tests/test_stomp_update_working_set.py
@@ -1,0 +1,117 @@
+"""#1383-complete update working-set preflight for STOMP."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.options import (
+    STOMPAgent,
+    STOMPConfig,
+    SubtaskSpec,
+    _preflight_stomp_update_working_set,
+    _stomp_direct_state_bytes,
+    _stomp_update_working_set_bytes,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_OBS = 20_000
+_LAST_FIT_OBS = 13_373
+_FIRST_OVERFLOW_OBS = 13_374
+_UNIT = {
+    "n_primitive_actions": 1,
+    "base_hidden_sizes": (),
+}
+
+
+def _unit_stomp(observation_dim: int) -> STOMPConfig:
+    return STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=observation_dim,
+        **_UNIT,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def _unit_persist_bytes(observation_dim: int) -> int:
+    return 4 * (observation_dim * observation_dim + 8 * observation_dim + 37)
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _unit_persist_bytes(_OVERFLOW_OBS)
+    working_set_bytes = 3 * persist_bytes + 64
+    extras_bytes = 64
+    assert persist_bytes == 1_600_640_148
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_OBS <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_stomp(_OVERFLOW_OBS)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for observation_dim in range(_LAST_FIT_OBS, _FIRST_OVERFLOW_OBS + 2):
+        persist_bytes = _unit_persist_bytes(observation_dim)
+        working_set_bytes = 3 * persist_bytes + 64
+        extras_bytes = 64
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * observation_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = observation_dim
+        elif first_overflow is None:
+            first_overflow = observation_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_OBS
+    last_stomp = _unit_stomp(last_fit)
+    assert last_stomp.observation_dim == last_fit
+    assert _stomp_direct_state_bytes(last_stomp) == _unit_persist_bytes(last_fit)
+    assert _stomp_update_working_set_bytes(last_stomp) <= _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_stomp(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    last_fit = _unit_stomp(_LAST_FIT_OBS)
+    object.__setattr__(last_fit, "observation_dim", _OVERFLOW_OBS)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_stomp_update_working_set(last_fit)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (2**29 - 1 - 22) // 4
+    with pytest.raises(ValueError, match="direct array bytes"):
+        STOMPConfig(observation_dim=last_legal + 1, n_primitive_actions=1)
+
+
+def test_legal_small_stomp_still_constructs() -> None:
+    stomp = STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=4,
+        n_primitive_actions=2,
+        base_hidden_sizes=(),
+    )
+    persist_bytes = _stomp_direct_state_bytes(stomp)
+    assert persist_bytes == 420
+    agent = STOMPAgent(stomp)
+    state = agent.init(jr.key(0))
+    agent.update(
+        state,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.zeros((4,), dtype=jnp.float32),
+    )


### PR DESCRIPTION
Closes #1821.

## What changed

`STOMPConfig.__post_init__` now preflights the simultaneous `update` working set (`3 × persist + extras`) after the existing persist check. `_stomp_direct_array_scalars` stays persist-only.

On origin/main `cc877f78`, `observation_dim=20_000` on the unit 1-option/1-action fixture constructed. Named persist and persist+extras still fit. `4 × observation_dim` still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `13373` / `13374`. Legal small configs are unchanged. Persist overflow still fires first.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816` / `#1818` / `#1820`. `option_search_control.py` is a different file.

## Scope

- `alberta_framework/core/options.py`
- `tests/test_stomp_update_working_set.py`
- `tests/test_options.py`
- `tests/test_oak_prototype_fixes.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `options.py`. Factory `HARD_SKIP_PATHS` does not include this host. `prototype_memory.py` and `off_policy_td.py` already name update envelopes and were leftover-tax skipped.

## Verification

Exact candidate head: `87d0cb5d75527d7bb70aec8fb8ad1cff0b3198a0`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `STOMPConfig(..., observation_dim=20_000)` constructed; persist and persist+extras fit; `4 × observation_dim` fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused STOMP/options pytest family including `tests/test_stomp_update_working_set.py`: 155 passed
- `ruff check` on the four changed files: clean
- `scope-check.sh --max-files 4`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_stomp_update_working_set.py tests/test_options.py tests/test_oak_prototype_fixes.py tests/test_stomp_startup_semantics.py tests/test_stomp_reward_semantics.py tests/test_stomp_degeneracy.py tests/test_stomp_option_planning.py tests/test_step10_production.py::test_step10_stomp_int_dimensions_stay_within_int32 -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `1600640148` at the overflow dim; persist+extras and `4 × observation_dim` still fit; last-fit `13373` constructs; first-overflow `13374` rejects; empty-options persist limit still fails persist first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:87d0cb5d75527d7bb70aec8fb8ad1cff0b3198a0 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
