### PR TITLE
Preflight SwiftTD update working set

### DIFF
--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -101,6 +101,34 @@ def _require_float32_resource(name: str, *, float32_scalars: int) -> None:
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
+def _swift_td_persistent_bytes(feature_dim: int) -> int:
+    """Named persist already preflighted by ``SwiftTD.init``."""
+    return 4 * (8 * (feature_dim + 1) + 5)
+
+
+def _swift_td_update_result_extras_bytes(feature_dim: int) -> int:
+    """Returned ``SwiftTDUpdate`` extras excluding persist.
+
+    Nested ``new_state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published weight/bias deltas, metric
+    scalars, and diagnostic leaf.
+    """
+    return 4 * feature_dim + 29
+
+
+def _swift_td_update_working_set_bytes(feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _swift_td_persistent_bytes(
+        feature_dim
+    ) + _swift_td_update_result_extras_bytes(feature_dim)
+
+
+def _preflight_swift_td_update_working_set(feature_dim: int) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _swift_td_update_working_set_bytes(feature_dim) > _INT32_MAX:
+        raise ValueError("SwiftTD update working set byte count must fit signed int32")
+
+
 _DEFAULT_ETA_MIN = math.exp(-15.0)
 
 _SUPPORTED_CONFIG_REAL_TYPES: tuple[type[object], ...] = (
@@ -319,6 +347,7 @@ class SwiftTD:
             "SwiftTD state",
             float32_scalars=8 * aug_dim + 5,
         )
+        _preflight_swift_td_update_working_set(feature_dim)
         # The dense reference implementation clips beta into
         # [ln(eta_min), ln(eta)] on every pass, including the (otherwise
         # trivial) very first one -- so step-sizes are capped BEFORE the
@@ -366,6 +395,7 @@ class SwiftTD:
         if augmented_dim < 2:
             raise ValueError("state vector length must include a positive feature dimension")
         _require_float32_resource("SwiftTD adopted state", float32_scalars=8 * augmented_dim + 5)
+        _preflight_swift_td_update_working_set(augmented_dim - 1)
         for name, value in vectors:
             if not hasattr(value, "shape") or not hasattr(value, "dtype"):
                 raise TypeError(f"{name} must expose array shape and dtype metadata")

--- a/tests/test_swift_td_update_working_set.py
+++ b/tests/test_swift_td_update_working_set.py
@@ -1,0 +1,92 @@
+"""#1383-complete update working-set preflight for SwiftTD."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.swift_td import (
+    SwiftTD,
+    _preflight_swift_td_update_working_set,
+    _swift_td_persistent_bytes,
+    _swift_td_update_working_set_bytes,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURE_DIM = 30_000_000
+_LAST_FIT_FEATURE_DIM = 21_474_834
+_FIRST_OVERFLOW_FEATURE_DIM = 21_474_835
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _swift_td_persistent_bytes(_OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _swift_td_update_working_set_bytes(_OVERFLOW_FEATURE_DIM)
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 960_000_052
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        SwiftTD().init(_OVERFLOW_FEATURE_DIM)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_LAST_FIT_FEATURE_DIM, _FIRST_OVERFLOW_FEATURE_DIM + 2):
+        persist_bytes = _swift_td_persistent_bytes(feature_dim)
+        working_set_bytes = _swift_td_update_working_set_bytes(feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURE_DIM
+    _preflight_swift_td_update_working_set(last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_swift_td_update_working_set(first_overflow)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        SwiftTD().init(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_swift_td_update_working_set(_OVERFLOW_FEATURE_DIM)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_feature_dim = (((2**31 - 1) // 4 - 5) // 8) - 1
+    with pytest.raises(ValueError, match="SwiftTD state byte count"):
+        SwiftTD().init(last_feature_dim + 1)
+
+
+def test_legal_small_swift_td_still_updates() -> None:
+    persist_bytes = _swift_td_persistent_bytes(5)
+    assert persist_bytes == 212
+    optimizer = SwiftTD()
+    state = optimizer.init(5)
+    observation = jnp.zeros((5,), dtype=jnp.float32)
+    optimizer.update(
+        state,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        observation,
+        observation,
+        jnp.asarray(0.99, dtype=jnp.float32),
+    )


### PR DESCRIPTION
Closes #1823.

## What changed

`SwiftTD.init` and adopted-state validation now preflight the simultaneous `update` working set (`3 × persist + extras`) after the existing persist check. `_require_float32_resource` stays persist-only. Extras are `4 * feature_dim + 29`.

On origin/main `cc877f78`, persist `_require_float32_resource` accepts `feature_dim=30_000_000`. Named persist `960000052` and persist+extras still fit. `4 × feature_dim` still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `21474834` / `21474835`. Legal small inits still update. Persist overflow still fires first. Named persist matches JIT.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816` / `#1818` / `#1820` / `#1822`. `optimizers.py` is a different file.

## Scope

- `alberta_framework/core/swift_td.py`
- `tests/test_swift_td_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `swift_td.py`. Factory `HARD_SKIP_PATHS` does not include this host. `prototype_memory.py` and `off_policy_td.py` already name update envelopes and were leftover-tax skipped.

## Verification

Exact candidate head: `424ceaa6f3e87bc8f1b3e0d62967f75de36731fa`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: persist accepts `feature_dim=30_000_000`; persist and persist+extras fit; `4 × feature_dim` fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused SwiftTD pytest family including `tests/test_swift_td_update_working_set.py`: 68 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_swift_td_update_working_set.py tests/test_swift_td.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `960000052` at the overflow dim; persist+extras and `4 × feature_dim` still fit; last-fit helper `21474834`; first-overflow `21474835` rejects; persist overflow still fails persist first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:424ceaa6f3e87bc8f1b3e0d62967f75de36731fa -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
