### PR TITLE
Preflight interaction-feature update working set

### DIFF
--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -119,6 +119,95 @@ def _require_state_resources(
     _require_resource("interaction-feature state", scalars=scalars, nbytes=nbytes)
 
 
+def _interaction_persistent_bytes(
+    *,
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    scale_robust: bool,
+) -> int:
+    """Named persist already preflighted by ``FixedBudgetInteractionLearner``."""
+    normalizer = int(scale_robust)
+    return (
+        8 * n_tasks * n_features
+        + 4 * n_tasks * candidate_count
+        + (37 + 4 * normalizer) * n_features
+        + (33 + 4 * normalizer) * candidate_count
+        + (12 + 4 * normalizer) * n_tasks
+        + 32
+    )
+
+
+def _interaction_update_result_extras_bytes(
+    *,
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    scale_robust: bool,
+) -> int:
+    """Returned ``InteractionFeatureUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. ``pre_curation_state`` and the published diagnostic leaves
+    are extras.
+    """
+    return (
+        _interaction_persistent_bytes(
+            n_features=n_features,
+            n_tasks=n_tasks,
+            candidate_count=candidate_count,
+            scale_robust=scale_robust,
+        )
+        + (7 + 4 * n_tasks) * n_features
+        + 18 * candidate_count
+        + 8 * n_tasks
+        + 98
+    )
+
+
+def _interaction_update_working_set_bytes(
+    *,
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    scale_robust: bool,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _interaction_persistent_bytes(
+        n_features=n_features,
+        n_tasks=n_tasks,
+        candidate_count=candidate_count,
+        scale_robust=scale_robust,
+    ) + _interaction_update_result_extras_bytes(
+        n_features=n_features,
+        n_tasks=n_tasks,
+        candidate_count=candidate_count,
+        scale_robust=scale_robust,
+    )
+
+
+def _preflight_interaction_update_working_set(
+    *,
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    scale_robust: bool,
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if (
+        _interaction_update_working_set_bytes(
+            n_features=n_features,
+            n_tasks=n_tasks,
+            candidate_count=candidate_count,
+            scale_robust=scale_robust,
+        )
+        > _INT32_MAX
+    ):
+        raise ValueError(
+            "interaction-feature update working set byte count must fit signed int32"
+        )
+
+
 def _require_serialized_scalars(payload: Mapping[str, Any], owner: type[Any]) -> None:
     """Require the canonical JSON scalar types emitted by ``to_config``."""
     annotations = get_type_hints(owner.__init__)
@@ -592,6 +681,12 @@ class FixedBudgetInteractionLearner:
         )
 
         _require_state_resources(
+            n_features=n_features,
+            n_tasks=n_tasks,
+            candidate_count=candidate_count,
+            scale_robust=scale_robust,
+        )
+        _preflight_interaction_update_working_set(
             n_features=n_features,
             n_tasks=n_tasks,
             candidate_count=candidate_count,

--- a/tests/test_interaction_feature_validation.py
+++ b/tests/test_interaction_feature_validation.py
@@ -128,8 +128,8 @@ def test_boolean_fields_require_exact_bool(field: str) -> None:
 def test_persistent_state_resources_are_preflighted_without_allocation() -> None:
     # With one task, no candidates, and no normalizers, state bytes are 45F + 44.
     last_legal = (_INT32_MAX - 44) // 45
-    legal = _construct(n_features=last_legal, n_tasks=1, candidate_count=0)
-    assert legal.n_features == last_legal
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _construct(n_features=last_legal, n_tasks=1, candidate_count=0)
     with pytest.raises(ValueError, match="state byte count"):
         _construct(n_features=last_legal + 1, n_tasks=1, candidate_count=0)
     with pytest.raises(ValueError, match="state (scalar|byte) count"):

--- a/tests/test_interaction_features_update_working_set.py
+++ b/tests/test_interaction_features_update_working_set.py
@@ -1,0 +1,106 @@
+"""#1383-complete update working-set preflight for interaction features."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.interaction_features import (
+    FixedBudgetInteractionLearner,
+    _interaction_persistent_bytes,
+    _interaction_update_working_set_bytes,
+    _preflight_interaction_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURES = 20_000_000
+_LAST_FIT_FEATURES = 11_243_368
+_FIRST_OVERFLOW_FEATURES = 11_243_369
+_UNIT = {"n_tasks": 1, "candidate_count": 0, "scale_robust": False}
+
+
+def _unit_persist_bytes(n_features: int) -> int:
+    return _interaction_persistent_bytes(n_features=n_features, **_UNIT)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _unit_persist_bytes(_OVERFLOW_FEATURES)
+    working_set_bytes = _interaction_update_working_set_bytes(
+        n_features=_OVERFLOW_FEATURES,
+        **_UNIT,
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 900_000_044
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURES <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        FixedBudgetInteractionLearner(n_features=_OVERFLOW_FEATURES, **_UNIT)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for n_features in range(_LAST_FIT_FEATURES, _FIRST_OVERFLOW_FEATURES + 2):
+        persist_bytes = _unit_persist_bytes(n_features)
+        working_set_bytes = _interaction_update_working_set_bytes(
+            n_features=n_features,
+            **_UNIT,
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * n_features <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = n_features
+        elif first_overflow is None:
+            first_overflow = n_features
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURES
+    learner = FixedBudgetInteractionLearner(n_features=last_fit, **_UNIT)
+    assert learner.n_features == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        FixedBudgetInteractionLearner(n_features=first_overflow, **_UNIT)
+    _preflight_interaction_update_working_set(n_features=last_fit, **_UNIT)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_interaction_update_working_set(n_features=first_overflow, **_UNIT)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_interaction_update_working_set(
+            n_features=_OVERFLOW_FEATURES,
+            **_UNIT,
+        )
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (_INT32_MAX - 44) // 45
+    with pytest.raises(ValueError, match="state byte count"):
+        FixedBudgetInteractionLearner(n_features=last_legal + 1, **_UNIT)
+
+
+def test_legal_small_interaction_learner_still_updates() -> None:
+    persist_bytes = _unit_persist_bytes(4)
+    assert persist_bytes == 224
+    learner = FixedBudgetInteractionLearner(n_features=4, **_UNIT)
+    state = learner.init(2, jr.key(0))
+    learner.update(
+        state,
+        jnp.asarray((0.5, -0.25), dtype=jnp.float32),
+        jnp.asarray((0.75,), dtype=jnp.float32),
+    )


### PR DESCRIPTION
Closes #1825.

## What changed

`FixedBudgetInteractionLearner.__init__` now preflights the simultaneous `update` working set (`3 × persist + extras`) after the existing persist check. `_require_state_resources` stays persist-only. Extras are `pre_curation_state` plus the published diagnostic leaves (`56F + 150` on the unit fixture).

On origin/main `cc877f78`, `n_features=20_000_000` constructed. Named persist `900000044` and persist+extras still fit. `4 × n_features` still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `11243368` / `11243369`. Legal small learners still update. Persist overflow still fires first. Named persist matches measured JIT leaves.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816` / `#1818` / `#1820` / `#1822` / `#1824`. `history_features.py` is a different file.

## Scope

- `alberta_framework/core/interaction_features.py`
- `tests/test_interaction_features_update_working_set.py`
- `tests/test_interaction_feature_validation.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `interaction_features.py`. Factory `HARD_SKIP_PATHS` does not include this host. Leftover-tax hosts already name update envelopes and were skipped.

## Verification

Exact candidate head: `1027f99297ec5bd54cbba1ec36093f91b3585960`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `FixedBudgetInteractionLearner(n_features=20_000_000, n_tasks=1, candidate_count=0)` constructed; persist and persist+extras fit; `4 × n_features` fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused interaction-feature pytest family including `tests/test_interaction_features_update_working_set.py`: 87 passed
- `ruff check` on the three changed files: clean
- `scope-check.sh --max-files 4`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_interaction_features_update_working_set.py tests/test_interaction_feature_validation.py tests/test_interaction_feature_horizon.py tests/test_interaction_task_utility_weights.py tests/test_interaction_retirement_throughput.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `900000044` at the overflow dim; persist+extras and `4 × n_features` still fit; last-fit `11243368` constructs; first-overflow `11243369` rejects; persist overflow still fails persist first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1027f99297ec5bd54cbba1ec36093f91b3585960 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
