### PR TITLE
Preflight differential TD update working set

### DIFF
--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -188,6 +188,36 @@ def _preflight_differential_td_state(feature_dim: int) -> None:
     )
 
 
+def _differential_td_persistent_bytes(feature_dim: int) -> int:
+    """Named persist already preflighted by ``DifferentialTDLearner.init``."""
+    return 4 * (2 * feature_dim + 4)
+
+
+def _differential_td_update_result_extras_bytes() -> int:
+    """Returned ``DifferentialTDUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published prediction, TD-error,
+    reward-rate, metric, and diagnostic leaves.
+    """
+    return 33
+
+
+def _differential_td_update_working_set_bytes(feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _differential_td_persistent_bytes(
+        feature_dim
+    ) + _differential_td_update_result_extras_bytes()
+
+
+def _preflight_differential_td_update_working_set(feature_dim: int) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _differential_td_update_working_set_bytes(feature_dim) > _INT32_MAX:
+        raise ValueError(
+            "differential TD update working set byte count must fit signed int32"
+        )
+
+
 def _preflight_differential_gtd_state(feature_dim: int) -> None:
     scalar_count = 3 * feature_dim + 5
     _require_state_resources(
@@ -1417,6 +1447,7 @@ class DifferentialTDLearner:
         """Initialize value weights, traces, and reward-rate estimate."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _preflight_differential_td_state(feature_dim)
+        _preflight_differential_td_update_working_set(feature_dim)
         average_reward = _validated_float32_scalar_preserving_nonzero(
             "average_reward", average_reward
         )

--- a/tests/test_average_reward_update_working_set.py
+++ b/tests/test_average_reward_update_working_set.py
@@ -1,0 +1,91 @@
+"""#1383-complete update working-set preflight for differential TD."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.average_reward import (
+    DifferentialTDLearner,
+    _differential_td_persistent_bytes,
+    _differential_td_update_working_set_bytes,
+    _preflight_differential_td_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURE_DIM = 90_000_000
+_LAST_FIT_FEATURE_DIM = 89_478_481
+_FIRST_OVERFLOW_FEATURE_DIM = 89_478_482
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _differential_td_persistent_bytes(_OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _differential_td_update_working_set_bytes(_OVERFLOW_FEATURE_DIM)
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 720_000_016
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        DifferentialTDLearner().init(_OVERFLOW_FEATURE_DIM)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_LAST_FIT_FEATURE_DIM, _FIRST_OVERFLOW_FEATURE_DIM + 2):
+        persist_bytes = _differential_td_persistent_bytes(feature_dim)
+        working_set_bytes = _differential_td_update_working_set_bytes(feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURE_DIM
+    _preflight_differential_td_update_working_set(last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_differential_td_update_working_set(first_overflow)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        DifferentialTDLearner().init(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_differential_td_update_working_set(_OVERFLOW_FEATURE_DIM)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = ((2**31 - 1) // 4 - 4) // 2
+    with pytest.raises(ValueError, match="differential TD state bytes"):
+        DifferentialTDLearner().init(last_legal + 1)
+
+
+def test_legal_small_differential_td_still_updates() -> None:
+    persist_bytes = _differential_td_persistent_bytes(5)
+    assert persist_bytes == 56
+    learner = DifferentialTDLearner()
+    state = learner.init(5)
+    observation = jnp.zeros((5,), dtype=jnp.float32)
+    learner.update(
+        state,
+        observation,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        observation,
+    )


### PR DESCRIPTION
Closes #1827.

## What changed

`DifferentialTDLearner.init` now preflights the simultaneous `update` working set (`3 × persist + extras`) after the existing persist check. `_preflight_differential_td_state` stays persist-only. Extras are the published prediction, TD-error, reward-rate, metric, and diagnostic leaves (`33` bytes).

On origin/main `cc877f78`, persist `_preflight_differential_td_state` accepts `feature_dim=90_000_000`. Named persist `720000016` and persist+extras still fit. `4 × feature_dim` still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `89478481` / `89478482`. Legal small inits still update. Persist overflow still fires first. Named persist matches JIT leaves at init.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816` / `#1818` / `#1820` / `#1822` / `#1824` / `#1826`. `learners.py` is a different file.

## Scope

- `alberta_framework/core/average_reward.py`
- `tests/test_average_reward_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `average_reward.py`. Factory `HARD_SKIP_PATHS` does not include this host. Leftover-tax hosts already name update envelopes and were skipped.

## Verification

Exact candidate head: `9219c6eaa9e936aec6b93aafcd1babae6cbb054e`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: persist accepts `feature_dim=90_000_000`; persist and persist+extras fit; `4 × feature_dim` fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused average-reward pytest family including `tests/test_average_reward_update_working_set.py`: 104 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_average_reward_update_working_set.py tests/test_average_reward.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `720000016` at the overflow dim; persist+extras and `4 × feature_dim` still fit; last-fit helper `89478481`; first-overflow `89478482` rejects; persist overflow still fails persist first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9219c6eaa9e936aec6b93aafcd1babae6cbb054e -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
