### PR TITLE
Preflight GRU perception update working set

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -322,6 +322,44 @@ def _require_float32_resource(
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
+def _gru_perception_persistent_bytes(observation_dim: int, hidden_dim: int) -> int:
+    """Named persist already preflighted by ``GRUPerceptionConfig``."""
+    return 4 * (
+        3 * hidden_dim * observation_dim + 3 * hidden_dim * hidden_dim + 4 * hidden_dim
+    )
+
+
+def _gru_perception_update_result_extras_bytes(
+    observation_dim: int, hidden_dim: int
+) -> int:
+    """Returned ``_gru_step`` extras excluding persist.
+
+    Nested new ``GRUPerceptionState`` is persist and is already counted in the
+    simultaneous persist copies. These extras are the published augmented
+    observation ``[obs, new_hidden]``.
+    """
+    return 4 * (observation_dim + hidden_dim)
+
+
+def _gru_perception_update_working_set_bytes(
+    observation_dim: int, hidden_dim: int
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _gru_perception_persistent_bytes(
+        observation_dim, hidden_dim
+    ) + _gru_perception_update_result_extras_bytes(observation_dim, hidden_dim)
+
+
+def _preflight_gru_perception_update_working_set(
+    observation_dim: int, hidden_dim: int
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _gru_perception_update_working_set_bytes(observation_dim, hidden_dim) > _INT32_MAX:
+        raise ValueError(
+            "GRUPerception update working set byte count must fit signed int32"
+        )
+
+
 def _copy_mapping(payload: object, *, name: str) -> dict[str, Any]:
     if not issubclass(type(payload), Mapping):
         raise ValueError(f"{name} payload must be a mapping")
@@ -383,6 +421,7 @@ class GRUPerceptionConfig:
             vector_scalars=3 * h * obs + 3 * h * h,
             fixed_scalars=4 * h,
         )
+        _preflight_gru_perception_update_working_set(obs, h)
 
     def augmented_dim(self) -> int:
         """Return ``observation_dim + hidden_dim``."""

--- a/tests/test_gru_perception_update_working_set.py
+++ b/tests/test_gru_perception_update_working_set.py
@@ -1,0 +1,116 @@
+"""#1383-complete update working-set preflight for GRU perception."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.prototype_agent import (
+    GRUPerceptionConfig,
+    _gru_perception_persistent_bytes,
+    _gru_perception_update_working_set_bytes,
+    _gru_step,
+    _init_gru_state,
+    _preflight_gru_perception_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_OBSERVATION_DIM = 60_000_000
+_LAST_FIT_OBSERVATION_DIM = 53_687_088
+_FIRST_OVERFLOW_OBSERVATION_DIM = 53_687_089
+_UNIT_HIDDEN_DIM = 1
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _gru_perception_persistent_bytes(
+        _OVERFLOW_OBSERVATION_DIM, _UNIT_HIDDEN_DIM
+    )
+    working_set_bytes = _gru_perception_update_working_set_bytes(
+        _OVERFLOW_OBSERVATION_DIM, _UNIT_HIDDEN_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 720_000_028
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_OBSERVATION_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        GRUPerceptionConfig(
+            observation_dim=_OVERFLOW_OBSERVATION_DIM,
+            hidden_dim=_UNIT_HIDDEN_DIM,
+        )
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for observation_dim in range(
+        _LAST_FIT_OBSERVATION_DIM, _FIRST_OVERFLOW_OBSERVATION_DIM + 2
+    ):
+        persist_bytes = _gru_perception_persistent_bytes(
+            observation_dim, _UNIT_HIDDEN_DIM
+        )
+        working_set_bytes = _gru_perception_update_working_set_bytes(
+            observation_dim, _UNIT_HIDDEN_DIM
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * observation_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = observation_dim
+        elif first_overflow is None:
+            first_overflow = observation_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_OBSERVATION_DIM
+    cfg = GRUPerceptionConfig(
+        observation_dim=last_fit, hidden_dim=_UNIT_HIDDEN_DIM
+    )
+    assert cfg.observation_dim == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        GRUPerceptionConfig(
+            observation_dim=first_overflow, hidden_dim=_UNIT_HIDDEN_DIM
+        )
+    _preflight_gru_perception_update_working_set(last_fit, _UNIT_HIDDEN_DIM)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_gru_perception_update_working_set(
+            first_overflow, _UNIT_HIDDEN_DIM
+        )
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_gru_perception_update_working_set(
+            _OVERFLOW_OBSERVATION_DIM, _UNIT_HIDDEN_DIM
+        )
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (_INT32_MAX - 28) // 12
+    with pytest.raises(ValueError, match="GRUPerception state byte count"):
+        GRUPerceptionConfig(
+            observation_dim=last_legal + 1, hidden_dim=_UNIT_HIDDEN_DIM
+        )
+    with pytest.raises(ValueError, match="fit signed int32"):
+        GRUPerceptionConfig(observation_dim=1_000_000, hidden_dim=1_000_000)
+
+
+def test_legal_small_gru_perception_still_steps() -> None:
+    persist_bytes = _gru_perception_persistent_bytes(4, 1)
+    assert persist_bytes == 76
+    cfg = GRUPerceptionConfig(observation_dim=4, hidden_dim=1)
+    state = _init_gru_state(cfg, jr.key(0))
+    _gru_step(state, jnp.zeros((4,), dtype=jnp.float32))


### PR DESCRIPTION
Closes #1829.

## What changed

`GRUPerceptionConfig.__post_init__` now preflights the simultaneous `_gru_step` working set (`3 × persist + extras`) after the existing persist check. `_require_float32_resource` stays persist-only. Extras are the published augmented observation (`4 * (observation_dim + hidden_dim)`).

On origin/main `cc877f78`, `observation_dim=60_000_000` on the unit `hidden_dim=1` fixture constructed. Named persist `720000028` and persist+extras still fit. `4 × observation_dim` still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `53687088` / `53687089`. Legal small configs still step. Persist overflow still fires first. Named persist matches JIT leaves.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816` / `#1818` / `#1820` / `#1822` / `#1824` / `#1826` / `#1828`. `oak.py` is a different file.

## Scope

- `alberta_framework/core/prototype_agent.py`
- `tests/test_gru_perception_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `prototype_agent.py`. Factory `HARD_SKIP_PATHS` does not include this host. Leftover-tax hosts already name update envelopes and were skipped.

## Verification

Exact candidate head: `d8fc389e481b34a5cfea802295fd4bdd09e19835`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `GRUPerceptionConfig(observation_dim=60_000_000, hidden_dim=1)` constructed; persist and persist+extras fit; `4 × observation_dim` fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused GRU perception pytest family including `tests/test_gru_perception_update_working_set.py`: 42 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_gru_perception_update_working_set.py tests/test_prototype_agent_validation.py tests/test_prototype_agent.py::TestGRUPerceptionConfig tests/test_prototype_agent.py::TestGRUPerceptionStateInit tests/test_prototype_agent.py::TestGRUPerceptionUpdate -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `720000028` at the overflow dim; persist+extras and `4 × observation_dim` still fit; last-fit `53687088` constructs; first-overflow `53687089` rejects; persist overflow still fails persist first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:d8fc389e481b34a5cfea802295fd4bdd09e19835 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
