### PR TITLE
Preflight stacked Horde update working set

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -191,6 +191,36 @@ def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
         raise ValueError("stacked Horde aggregate bytes must fit signed int32")
 
 
+def _stacked_horde_persistent_bytes(n_demons: int, feature_dim: int) -> int:
+    """Named persist already counted inside ``_preflight_horde_resources``."""
+    return 8 * n_demons * feature_dim + 4
+
+
+def _stacked_horde_update_result_extras_bytes(n_demons: int) -> int:
+    """Returned ``StackedHordeUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published prediction, TD-error,
+    per-head, and diagnostic leaves.
+    """
+    return 9 * n_demons + 1
+
+
+def _stacked_horde_update_working_set_bytes(n_demons: int, feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _stacked_horde_persistent_bytes(
+        n_demons, feature_dim
+    ) + _stacked_horde_update_result_extras_bytes(n_demons)
+
+
+def _preflight_stacked_horde_update_working_set(n_demons: int, feature_dim: int) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _stacked_horde_update_working_set_bytes(n_demons, feature_dim) > _INT32_MAX:
+        raise ValueError(
+            "stacked Horde update working set byte count must fit signed int32"
+        )
+
+
 def _require_scan_result_resources(num_updates: int, n_demons: int) -> None:
     result_scalars = num_updates * n_demons
     if result_scalars > _INT32_MAX or 4 * result_scalars > _INT32_MAX:
@@ -260,6 +290,7 @@ class StackedHordeConfig:
         )
 
         _preflight_horde_resources(n_demons, feature_dim)
+        _preflight_stacked_horde_update_working_set(n_demons, feature_dim)
 
         object.__setattr__(self, "n_demons", n_demons)
         object.__setattr__(self, "feature_dim", feature_dim)
@@ -337,6 +368,7 @@ def nexting_spec(
     if n_demons < 1 or n_demons > _INT32_MAX:
         raise ValueError("derived n_demons must be in the signed int32 domain")
     _preflight_horde_resources(n_demons, feature_dim)
+    _preflight_stacked_horde_update_working_set(n_demons, feature_dim)
     idxs: list[int] = []
     gs: list[float] = []
     for c in canonical_indices:

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -862,13 +862,14 @@ def test_stacked_horde_from_config_accepts_only_exact_list_or_tuple_sequences() 
 
 def test_stacked_horde_preflights_aggregate_resources_before_allocation() -> None:
     last_feature_dim = (2**31 - 1 - 26) // 8
-    StackedHordeConfig(
-        n_demons=1,
-        feature_dim=last_feature_dim,
-        gammas=(0.9,),
-        lamdas=(0.8,),
-        cumulant_indices=(0,),
-    )
+    with pytest.raises(ValueError, match="update working set byte count"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=last_feature_dim,
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
     with pytest.raises(ValueError, match="aggregate bytes"):
         StackedHordeConfig(
             n_demons=1,

--- a/tests/test_stacked_horde_update_working_set.py
+++ b/tests/test_stacked_horde_update_working_set.py
@@ -1,0 +1,103 @@
+"""#1383-complete update working-set preflight for stacked Horde."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.stacked_horde import (
+    StackedHordeConfig,
+    StackedLinearHorde,
+    _preflight_stacked_horde_update_working_set,
+    _stacked_horde_persistent_bytes,
+    _stacked_horde_update_working_set_bytes,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURE_DIM = 90_000_000
+_LAST_FIT_FEATURE_DIM = 89_478_484
+_FIRST_OVERFLOW_FEATURE_DIM = 89_478_485
+
+
+def _unit_config(feature_dim: int) -> StackedHordeConfig:
+    return StackedHordeConfig(
+        n_demons=1,
+        feature_dim=feature_dim,
+        gammas=(0.9,),
+        lamdas=(0.8,),
+        cumulant_indices=(0,),
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _stacked_horde_persistent_bytes(1, _OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _stacked_horde_update_working_set_bytes(1, _OVERFLOW_FEATURE_DIM)
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 720_000_004
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_config(_OVERFLOW_FEATURE_DIM)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_LAST_FIT_FEATURE_DIM, _FIRST_OVERFLOW_FEATURE_DIM + 2):
+        persist_bytes = _stacked_horde_persistent_bytes(1, feature_dim)
+        working_set_bytes = _stacked_horde_update_working_set_bytes(1, feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURE_DIM
+    cfg = _unit_config(last_fit)
+    assert cfg.feature_dim == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_config(first_overflow)
+    _preflight_stacked_horde_update_working_set(1, last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_stacked_horde_update_working_set(1, first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_stacked_horde_update_working_set(1, _OVERFLOW_FEATURE_DIM)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (_INT32_MAX - 26) // 8
+    with pytest.raises(ValueError, match="aggregate bytes"):
+        _unit_config(last_legal + 1)
+
+
+def test_legal_small_stacked_horde_still_updates() -> None:
+    persist_bytes = _stacked_horde_persistent_bytes(1, 4)
+    assert persist_bytes == 36
+    horde = StackedLinearHorde(_unit_config(4))
+    state = horde.init()
+    horde.update(
+        state,
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.ones(1, dtype=jnp.float32),
+    )


### PR DESCRIPTION
Closes #1831.

## What changed

`StackedHordeConfig.__post_init__` and `nexting_spec` now preflight the simultaneous `update` working set (`3 × persist + extras`) after the existing persist+extras aggregate check. `_preflight_horde_resources` stays persist+extras. Extras are the published prediction, TD-error, per-head, and diagnostic leaves (`9 * n_demons + 1`).

On origin/main `cc877f78`, `feature_dim=90_000_000` on the unit 1-demon fixture constructed. Named persist `720000004`, persist+extras, and the named aggregate still fit. `4 × feature_dim` still fits. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `89478484` / `89478485`. Legal small configs still update. Aggregate overflow still fires first. Named persist matches JIT leaves.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816` / `#1818` / `#1820` / `#1822` / `#1824` / `#1826` / `#1828` / `#1830`. `horde.py` is a different file.

## Scope

- `alberta_framework/core/stacked_horde.py`
- `tests/test_stacked_horde_update_working_set.py`
- `tests/test_stacked_horde.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `stacked_horde.py`. Factory `HARD_SKIP_PATHS` does not include this host. Leftover-tax hosts already name update envelopes and were skipped.

## Verification

Exact candidate head: `8a1e0139ef373098927e1b5096aab37478e4e8fb`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: `StackedHordeConfig(n_demons=1, feature_dim=90_000_000, ...)` constructed; persist, persist+extras, and named aggregate fit; `4 × feature_dim` fits; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused stacked Horde pytest family including `tests/test_stacked_horde_update_working_set.py`: 100 passed
- `ruff check` on the three changed files: clean
- `scope-check.sh --max-files 4`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_stacked_horde_update_working_set.py tests/test_stacked_horde.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `720000004` at the overflow dim; persist+extras and the named aggregate still fit; last-fit `89478484` constructs; first-overflow `89478485` rejects; aggregate overflow still fails aggregate first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8a1e0139ef373098927e1b5096aab37478e4e8fb -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
