### PR TITLE
Preflight actor-critic update working set

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -106,11 +106,75 @@ def _require_discrete_state_resources(n_actions: int, feature_dim: int) -> None:
         raise ValueError("derived actor-critic state exceeds the signed-int32 budget")
 
 
+def _actor_critic_persistent_bytes(n_actions: int, feature_dim: int) -> int:
+    """Named persist already counted inside ``_require_discrete_state_resources``."""
+    return 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 24
+
+
+def _actor_critic_update_result_extras_bytes(n_actions: int) -> int:
+    """Returned ``ActorCriticUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published action, policy, value,
+    next-value, TD-error, bounder, and acceptance leaves.
+    """
+    return 4 * n_actions + 21
+
+
+def _actor_critic_update_working_set_bytes(n_actions: int, feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _actor_critic_persistent_bytes(
+        n_actions, feature_dim
+    ) + _actor_critic_update_result_extras_bytes(n_actions)
+
+
+def _preflight_actor_critic_update_working_set(n_actions: int, feature_dim: int) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _actor_critic_update_working_set_bytes(n_actions, feature_dim) > _INT32_MAX:
+        raise ValueError(
+            "actor-critic update working set byte count must fit signed int32"
+        )
+
+
 def _require_continuous_state_resources(action_dim: int, feature_dim: int) -> None:
     state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 5
     state_bytes = 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 20
     if state_scalars > _INT32_MAX or state_bytes > _INT32_MAX:
         raise ValueError("derived continuous actor-critic state exceeds the signed-int32 budget")
+
+
+def _continuous_actor_critic_persistent_bytes(action_dim: int, feature_dim: int) -> int:
+    """Named persist already counted inside ``_require_continuous_state_resources``."""
+    return 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 20
+
+
+def _continuous_actor_critic_update_result_extras_bytes(action_dim: int) -> int:
+    """Returned ``ContinuousActorCriticUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published action, mean, sigma, value,
+    next-value, TD-error, bounder, and acceptance leaves.
+    """
+    return 12 * action_dim + 17
+
+
+def _continuous_actor_critic_update_working_set_bytes(
+    action_dim: int, feature_dim: int
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _continuous_actor_critic_persistent_bytes(
+        action_dim, feature_dim
+    ) + _continuous_actor_critic_update_result_extras_bytes(action_dim)
+
+
+def _preflight_continuous_actor_critic_update_working_set(
+    action_dim: int, feature_dim: int
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _continuous_actor_critic_update_working_set_bytes(action_dim, feature_dim) > _INT32_MAX:
+        raise ValueError(
+            "continuous actor-critic update working set byte count must fit signed int32"
+        )
 
 
 def _require_discrete_scan_resources(
@@ -511,6 +575,7 @@ class ActorCriticAgent:
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_discrete_state_resources(self._config.n_actions, feature_dim)
+        _preflight_actor_critic_update_working_set(self._config.n_actions, feature_dim)
         key = _require_key(key)
         zeros_actor = jnp.zeros((self._config.n_actions, feature_dim), dtype=jnp.float32)
         zeros_policy_bias = jnp.zeros((self._config.n_actions,), dtype=jnp.float32)
@@ -1287,6 +1352,7 @@ class ContinuousActorCriticAgent:
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         cfg = self._config
         _require_continuous_state_resources(cfg.action_dim, feature_dim)
+        _preflight_continuous_actor_critic_update_working_set(cfg.action_dim, feature_dim)
         key = _require_key(key)
         zeros_mean = jnp.zeros((cfg.action_dim, feature_dim), dtype=jnp.float32)
         zeros_mean_bias = jnp.zeros((cfg.action_dim,), dtype=jnp.float32)

--- a/tests/test_actor_critic_update_working_set.py
+++ b/tests/test_actor_critic_update_working_set.py
@@ -1,0 +1,174 @@
+"""#1383-complete update working-set preflight for actor-critic."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.actor_critic import (
+    ActorCriticAgent,
+    ActorCriticConfig,
+    ContinuousActorCriticAgent,
+    ContinuousActorCriticConfig,
+    _actor_critic_persistent_bytes,
+    _actor_critic_update_working_set_bytes,
+    _continuous_actor_critic_persistent_bytes,
+    _continuous_actor_critic_update_working_set_bytes,
+    _preflight_actor_critic_update_working_set,
+    _preflight_continuous_actor_critic_update_working_set,
+    _require_continuous_state_resources,
+    _require_discrete_state_resources,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURE_DIM = 40_000_000
+_LAST_FIT_FEATURE_DIM = 35_791_392
+_FIRST_OVERFLOW_FEATURE_DIM = 35_791_393
+_CONTINUOUS_LAST_FIT_FEATURE_DIM = 35_791_391
+_CONTINUOUS_FIRST_OVERFLOW_FEATURE_DIM = 35_791_392
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _actor_critic_persistent_bytes(1, _OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _actor_critic_update_working_set_bytes(1, _OVERFLOW_FEATURE_DIM)
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 800_000_032
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
+    with pytest.raises(ValueError, match="update working set byte count"):
+        agent.init(_OVERFLOW_FEATURE_DIM, jr.key(0))
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_LAST_FIT_FEATURE_DIM, _FIRST_OVERFLOW_FEATURE_DIM + 2):
+        persist_bytes = _actor_critic_persistent_bytes(1, feature_dim)
+        working_set_bytes = _actor_critic_update_working_set_bytes(1, feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURE_DIM
+    _preflight_actor_critic_update_working_set(1, last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_actor_critic_update_working_set(1, first_overflow)
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
+    with pytest.raises(ValueError, match="update working set byte count"):
+        agent.init(first_overflow, jr.key(0))
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_actor_critic_update_working_set(1, _OVERFLOW_FEATURE_DIM)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    _require_discrete_state_resources(1, 107_374_180)
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
+    with pytest.raises(ValueError, match="state exceeds"):
+        agent.init(107_374_181, jr.key(0))
+
+
+def test_legal_small_actor_critic_still_updates() -> None:
+    persist_bytes = _actor_critic_persistent_bytes(1, 4)
+    assert persist_bytes == 112
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
+    state = agent.init(4, jr.key(0))
+    observation = jnp.zeros((4,), dtype=jnp.float32)
+    state, _, _ = agent.start(state, observation)
+    agent.update(
+        state,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        observation,
+        jnp.asarray(False),
+    )
+
+
+def test_continuous_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _continuous_actor_critic_persistent_bytes(1, _OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _continuous_actor_critic_update_working_set_bytes(
+        1, _OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 800_000_040
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
+    with pytest.raises(ValueError, match="update working set byte count"):
+        agent.init(_OVERFLOW_FEATURE_DIM, jr.key(0))
+
+
+def test_continuous_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(
+        _CONTINUOUS_LAST_FIT_FEATURE_DIM, _CONTINUOUS_FIRST_OVERFLOW_FEATURE_DIM + 2
+    ):
+        persist_bytes = _continuous_actor_critic_persistent_bytes(1, feature_dim)
+        working_set_bytes = _continuous_actor_critic_update_working_set_bytes(
+            1, feature_dim
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _CONTINUOUS_LAST_FIT_FEATURE_DIM
+    _preflight_continuous_actor_critic_update_working_set(1, last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_continuous_actor_critic_update_working_set(1, first_overflow)
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
+    with pytest.raises(ValueError, match="update working set byte count"):
+        agent.init(first_overflow, jr.key(0))
+
+
+def test_continuous_persist_bound_still_fires_before_working_set() -> None:
+    _require_continuous_state_resources(1, 107_374_180)
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
+    with pytest.raises(ValueError, match="state exceeds"):
+        agent.init(107_374_181, jr.key(0))
+
+
+def test_legal_small_continuous_actor_critic_still_updates() -> None:
+    persist_bytes = _continuous_actor_critic_persistent_bytes(1, 5)
+    assert persist_bytes == 140
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
+    state = agent.init(5, jr.key(0))
+    observation = jnp.zeros((5,), dtype=jnp.float32)
+    state, _, _, _ = agent.start(state, observation)
+    agent.update(
+        state,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        observation,
+        jnp.asarray(False),
+    )


### PR DESCRIPTION
Closes #1833.

## What changed

`ActorCriticAgent.init` and `ContinuousActorCriticAgent.init` now preflight the simultaneous `update` working set (`3 × persist + extras`) after the existing persist check. `_require_discrete_state_resources` and `_require_continuous_state_resources` stay persist-only. Discrete extras are the published action, policy, value, next-value, TD-error, bounder, and acceptance leaves (`4 * n_actions + 21`). Continuous extras are the published action, mean, sigma, value, next-value, TD-error, bounder, and acceptance leaves (`12 * action_dim + 17`).

On origin/main `cc877f78`, unit `feature_dim=40_000_000` accepted persist. Named persist `800000032` / `800000040`, persist+extras, and `4 × feature_dim` still fit. The update envelope overflows signed int32. Adjacent last-fit / first-overflow at `35791392` / `35791393` (discrete) and `35791391` / `35791392` (continuous). Legal small agents still update. Persist overflow still fires first. Named persist matches JIT leaves. The scan envelope was not remined.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816` / `#1818` / `#1820` / `#1822` / `#1824` / `#1826` / `#1828` / `#1830` / `#1832`. `recurrent_trace_actor_critic.py` is a different file.

## Scope

- `alberta_framework/core/actor_critic.py`
- `tests/test_actor_critic_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `actor_critic.py`. Factory `HARD_SKIP_PATHS` does not include this host. Leftover-tax hosts already name update envelopes and were skipped.

## Verification

Exact candidate head: `9ead2df4c775019c9acacf10eedf793e610d4948`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: unit `init(40_000_000)` was not required; persist helpers accepted `feature_dim=40_000_000`; persist, persist+extras, and `4 × feature_dim` fit; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused actor-critic pytest family including `tests/test_actor_critic_update_working_set.py`: 81 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_actor_critic_update_working_set.py tests/test_actor_critic.py tests/test_continuous_actor_critic.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `800000032` / `800000040` at the overflow dim; persist+extras still fit; last-fit helpers accept; first-overflow `init` rejects; persist overflow still fails persist first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9ead2df4c775019c9acacf10eedf793e610d4948 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
