### PR TITLE
Preflight Pavlovian step working set

### DIFF
--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -101,6 +101,45 @@ def _require_pavlovian_resources(
         raise ValueError("Pavlovian persistent byte count must fit signed int32")
 
 
+def _pavlovian_persistent_bytes(
+    *, n_phases: int, n_cs: int, n_distractors: int
+) -> int:
+    """Named persist already counted inside ``_require_pavlovian_resources``."""
+    static_scalars = n_phases * n_cs + 4 * n_phases
+    state_scalars = n_cs + n_distractors + 6
+    return 4 * (static_scalars + state_scalars)
+
+
+def _pavlovian_step_result_extras_bytes(*, n_cs: int, n_distractors: int) -> int:
+    """Returned ``TimeStep`` extras excluding persist.
+
+    Nested persist is already counted in the simultaneous persist copies.
+    These extras are the published observation and target leaves.
+    """
+    return 4 * (n_cs + n_distractors) + 4
+
+
+def _pavlovian_step_working_set_bytes(
+    *, n_phases: int, n_cs: int, n_distractors: int
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _pavlovian_persistent_bytes(
+        n_phases=n_phases, n_cs=n_cs, n_distractors=n_distractors
+    ) + _pavlovian_step_result_extras_bytes(n_cs=n_cs, n_distractors=n_distractors)
+
+
+def _preflight_pavlovian_step_working_set(
+    *, n_phases: int, n_cs: int, n_distractors: int
+) -> None:
+    """Reject a step envelope the host cannot name in signed int32."""
+    if _pavlovian_step_working_set_bytes(
+        n_phases=n_phases, n_cs=n_cs, n_distractors=n_distractors
+    ) > _INT32_MAX:
+        raise ValueError(
+            "Pavlovian step working set byte count must fit signed int32"
+        )
+
+
 def _require_finite_real(
     value: object,
     *,
@@ -456,6 +495,11 @@ class ClassicalConditioningStream:
         if feature_dim > _INT32_MAX:
             raise ValueError("feature_dim must fit signed int32")
         _require_pavlovian_resources(
+            n_phases=len(phases),
+            n_cs=n_cs,
+            n_distractors=n_distractors,
+        )
+        _preflight_pavlovian_step_working_set(
             n_phases=len(phases),
             n_cs=n_cs,
             n_distractors=n_distractors,

--- a/tests/test_pavlovian_update_working_set.py
+++ b/tests/test_pavlovian_update_working_set.py
@@ -1,0 +1,119 @@
+"""#1383-complete step working-set preflight for Pavlovian streams."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.streams.pavlovian import (
+    ClassicalConditioningStream,
+    PavlovianPhase,
+    _pavlovian_persistent_bytes,
+    _pavlovian_step_working_set_bytes,
+    _preflight_pavlovian_step_working_set,
+    _require_pavlovian_resources,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_N_CS = 80_000_000
+_LAST_FIT_N_CS = 76_695_840
+_FIRST_OVERFLOW_N_CS = 76_695_841
+
+
+def _unit_phase() -> PavlovianPhase:
+    return PavlovianPhase(
+        name="acq",
+        n_steps=10,
+        cs_us_contingency=1.0,
+        cs_active=(0,),
+    )
+
+
+def _unit_stream(n_cs: int, n_distractors: int = 0) -> ClassicalConditioningStream:
+    return ClassicalConditioningStream(
+        phases=(_unit_phase(),),
+        n_cs=n_cs,
+        n_distractors=n_distractors,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _pavlovian_persistent_bytes(
+        n_phases=1, n_cs=_OVERFLOW_N_CS, n_distractors=0
+    )
+    working_set_bytes = _pavlovian_step_working_set_bytes(
+        n_phases=1, n_cs=_OVERFLOW_N_CS, n_distractors=0
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 640_000_040
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_N_CS <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        _unit_stream(_OVERFLOW_N_CS)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for n_cs in range(_LAST_FIT_N_CS, _FIRST_OVERFLOW_N_CS + 2):
+        persist_bytes = _pavlovian_persistent_bytes(
+            n_phases=1, n_cs=n_cs, n_distractors=0
+        )
+        working_set_bytes = _pavlovian_step_working_set_bytes(
+            n_phases=1, n_cs=n_cs, n_distractors=0
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * n_cs <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = n_cs
+        elif first_overflow is None:
+            first_overflow = n_cs
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_N_CS
+    _preflight_pavlovian_step_working_set(
+        n_phases=1, n_cs=last_fit, n_distractors=0
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        _preflight_pavlovian_step_working_set(
+            n_phases=1, n_cs=first_overflow, n_distractors=0
+        )
+    with pytest.raises(ValueError, match="working set byte count"):
+        _unit_stream(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="working set byte count"):
+        _preflight_pavlovian_step_working_set(
+            n_phases=1, n_cs=_OVERFLOW_N_CS, n_distractors=0
+        )
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    _require_pavlovian_resources(n_phases=1, n_cs=1, n_distractors=0)
+    with pytest.raises(ValueError, match="byte count must fit signed int32"):
+        _unit_stream(_INT32_MAX // 4)
+
+
+def test_legal_small_pavlovian_still_steps() -> None:
+    persist_bytes = _pavlovian_persistent_bytes(n_phases=1, n_cs=3, n_distractors=2)
+    assert persist_bytes == 72
+    stream = _unit_stream(3, n_distractors=2)
+    state = stream.init(jr.key(0))
+    stream.step(state, jnp.asarray(0, dtype=jnp.int32))


### PR DESCRIPTION
Closes #1835.

## What changed

`ClassicalConditioningStream.__init__` now preflights the simultaneous `step` working set (`3 × persist + extras`) after the existing persist check. `_require_pavlovian_resources` stays persist-only. Extras are the published observation and target leaves (`4 * (n_cs + n_distractors) + 4`).

On origin/main `cc877f78`, unit `n_cs=80_000_000` accepted persist. Named persist `640000040`, persist+extras, and `4 × n_cs` still fit. The step envelope overflows signed int32. Adjacent last-fit / first-overflow at `76695840` / `76695841`. Legal small streams still step. Persist overflow still fires first. Named persist matches JIT leaves.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816` / `#1818` / `#1820` / `#1822` / `#1824` / `#1826` / `#1828` / `#1830` / `#1832` / `#1834`. `actor_critic.py` is a different file.

## Scope

- `alberta_framework/streams/pavlovian.py`
- `tests/test_pavlovian_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `pavlovian.py`. Factory `HARD_SKIP_PATHS` does not include this host. Leftover-tax hosts already name update envelopes and were skipped.

## Verification

Exact candidate head: `f5115c03b579d849ad1e8608f8c2c16e78f25b19`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: persist helper accepted `n_cs=80_000_000`; persist, persist+extras, and `4 × n_cs` fit; step working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused Pavlovian pytest family including `tests/test_pavlovian_update_working_set.py`: 136 passed (2 pre-existing `longdouble` stream tests on origin/main deselected)
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_pavlovian_update_working_set.py tests/test_pavlovian_validation.py tests/test_pavlovian_phase_hostile_validation.py tests/test_pavlovian_learning.py tests/test_pavlovian_stream.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `640000040` at the overflow dim; persist+extras still fit; last-fit helpers accept; first-overflow construct rejects; persist overflow still fails persist first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f5115c03b579d849ad1e8608f8c2c16e78f25b19 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
