### PR TITLE
Preflight synthetic step working set

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -78,6 +78,43 @@ def _require_float32_resource(
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
+def _hidden_state_ar2_persistent_bytes(feature_dim: int) -> int:
+    """Named persist already counted inside ``_require_float32_resource``."""
+    return 4 * (2 * feature_dim + 2)
+
+
+def _sutton_experiment1_persistent_bytes(feature_dim: int) -> int:
+    """Named persist already counted inside ``_require_float32_resource``."""
+    return 4 * (feature_dim + 3)
+
+
+def _scale_stream_persistent_bytes(feature_dim: int) -> int:
+    """Named persist already counted inside ``_require_float32_resource``."""
+    return 4 * (2 * feature_dim + 3)
+
+
+def _synthetic_step_result_extras_bytes(feature_dim: int) -> int:
+    """Returned ``TimeStep`` extras excluding persist.
+
+    Nested persist is already counted in the simultaneous persist copies.
+    These extras are the published observation and target leaves.
+    """
+    return 4 * feature_dim + 4
+
+
+def _synthetic_step_working_set_bytes(persist_bytes: int, feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * persist_bytes + _synthetic_step_result_extras_bytes(feature_dim)
+
+
+def _preflight_synthetic_step_working_set(
+    name: str, persist_bytes: int, feature_dim: int
+) -> None:
+    """Reject a step envelope the host cannot name in signed int32."""
+    if _synthetic_step_working_set_bytes(persist_bytes, feature_dim) > _INT32_MAX:
+        raise ValueError(f"{name} step working set byte count must fit signed int32")
+
+
 def _narrow_real_to_float32(name: str, value: object, message: str) -> tuple[int, int, float]:
     """Return one trusted exact ratio together with its binary32 rounding."""
     actual_type = type(value)
@@ -280,6 +317,11 @@ class HiddenStateAR2Stream:
             "HiddenStateAR2Stream state",
             vector_scalars=2 * feature_dim,
             fixed_scalars=2,
+        )
+        _preflight_synthetic_step_working_set(
+            "HiddenStateAR2Stream",
+            _hidden_state_ar2_persistent_bytes(feature_dim),
+            feature_dim,
         )
         phi1 = _require_finite_float32("phi1", phi1)
         phi2 = _require_finite_float32("phi2", phi2)
@@ -531,6 +573,11 @@ class SuttonExperiment1Stream:
             "SuttonExperiment1Stream state",
             vector_scalars=feature_dim,
             fixed_scalars=3,
+        )
+        _preflight_synthetic_step_working_set(
+            "SuttonExperiment1Stream",
+            _sutton_experiment1_persistent_bytes(feature_dim),
+            feature_dim,
         )
         self._change_interval = _require_positive_int("change_interval", change_interval)
         self._noise_std = _require_finite_nonnegative_float32("noise_std", noise_std)
@@ -1082,6 +1129,11 @@ class DynamicScaleShiftStream:
             vector_scalars=2 * self._feature_dim,
             fixed_scalars=3,
         )
+        _preflight_synthetic_step_working_set(
+            "DynamicScaleShiftStream",
+            _scale_stream_persistent_bytes(self._feature_dim),
+            self._feature_dim,
+        )
         self._scale_change_interval = _require_positive_int(
             "scale_change_interval", scale_change_interval
         )
@@ -1237,6 +1289,11 @@ class ScaleDriftStream:
             "ScaleDriftStream state",
             vector_scalars=2 * self._feature_dim,
             fixed_scalars=3,
+        )
+        _preflight_synthetic_step_working_set(
+            "ScaleDriftStream",
+            _scale_stream_persistent_bytes(self._feature_dim),
+            self._feature_dim,
         )
         self._weight_drift_rate = _require_finite_nonnegative_float32(
             "weight_drift_rate", weight_drift_rate

--- a/tests/test_synthetic_stream_validation.py
+++ b/tests/test_synthetic_stream_validation.py
@@ -10,6 +10,7 @@ from alberta_framework.streams.synthetic import (
     HiddenStateAR2Stream,
     ScaleDriftStream,
     SuttonExperiment1Stream,
+    _require_float32_resource,
     make_scale_range,
 )
 
@@ -170,15 +171,27 @@ def test_make_scale_range_rejects_invalid_feature_dim_hostile() -> None:
 def test_hidden_and_scale_streams_preflight_state_bytes_without_allocation() -> None:
     last_legal = (2**29 - 1 - 3) // 2
 
-    DynamicScaleShiftStream(feature_dim=last_legal)
-    ScaleDriftStream(feature_dim=last_legal)
+    _require_float32_resource(
+        "DynamicScaleShiftStream state",
+        vector_scalars=2 * last_legal,
+        fixed_scalars=3,
+    )
+    _require_float32_resource(
+        "ScaleDriftStream state",
+        vector_scalars=2 * last_legal,
+        fixed_scalars=3,
+    )
     with pytest.raises(ValueError, match="byte count"):
         DynamicScaleShiftStream(feature_dim=last_legal + 1)
     with pytest.raises(ValueError, match="byte count"):
         ScaleDriftStream(feature_dim=last_legal + 1)
 
     hidden_last_legal = (2**29 - 1 - 2) // 2
-    HiddenStateAR2Stream(feature_dim=hidden_last_legal, visible_dim=2)
+    _require_float32_resource(
+        "HiddenStateAR2Stream state",
+        vector_scalars=2 * hidden_last_legal,
+        fixed_scalars=2,
+    )
     with pytest.raises(ValueError, match="byte count"):
         HiddenStateAR2Stream(feature_dim=hidden_last_legal + 1, visible_dim=2)
 
@@ -186,7 +199,11 @@ def test_hidden_and_scale_streams_preflight_state_bytes_without_allocation() -> 
 def test_sutton_stream_preflights_derived_feature_and_state_bytes() -> None:
     last_legal_total = 2**29 - 1 - 3
 
-    SuttonExperiment1Stream(num_relevant=1, num_irrelevant=last_legal_total - 1)
+    _require_float32_resource(
+        "SuttonExperiment1Stream state",
+        vector_scalars=last_legal_total,
+        fixed_scalars=3,
+    )
     with pytest.raises(ValueError, match="byte count"):
         SuttonExperiment1Stream(num_relevant=1, num_irrelevant=last_legal_total)
     with pytest.raises(ValueError, match="feature_dim"):

--- a/tests/test_synthetic_update_working_set.py
+++ b/tests/test_synthetic_update_working_set.py
@@ -1,0 +1,211 @@
+"""#1383-complete step working-set preflight for synthetic streams."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.streams.synthetic import (
+    DynamicScaleShiftStream,
+    HiddenStateAR2Stream,
+    ScaleDriftStream,
+    SuttonExperiment1Stream,
+    _hidden_state_ar2_persistent_bytes,
+    _preflight_synthetic_step_working_set,
+    _require_float32_resource,
+    _scale_stream_persistent_bytes,
+    _sutton_experiment1_persistent_bytes,
+    _synthetic_step_working_set_bytes,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURE_DIM = 80_000_000
+_HIDDEN_LAST_FIT = 76_695_843
+_HIDDEN_FIRST_OVERFLOW = 76_695_844
+_SCALE_LAST_FIT = 76_695_843
+_SCALE_FIRST_OVERFLOW = 76_695_844
+_SUTTON_OVERFLOW_FEATURE_DIM = 200_000_000
+_SUTTON_LAST_FIT = 134_217_725
+_SUTTON_FIRST_OVERFLOW = 134_217_726
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_hidden_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _hidden_state_ar2_persistent_bytes(_OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _synthetic_step_working_set_bytes(
+        persist_bytes, _OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 640_000_008
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        HiddenStateAR2Stream(_OVERFLOW_FEATURE_DIM, visible_dim=1)
+
+
+def test_hidden_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_HIDDEN_LAST_FIT, _HIDDEN_FIRST_OVERFLOW + 2):
+        persist_bytes = _hidden_state_ar2_persistent_bytes(feature_dim)
+        working_set_bytes = _synthetic_step_working_set_bytes(persist_bytes, feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _HIDDEN_LAST_FIT
+    _preflight_synthetic_step_working_set(
+        "HiddenStateAR2Stream",
+        _hidden_state_ar2_persistent_bytes(last_fit),
+        last_fit,
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        HiddenStateAR2Stream(first_overflow, visible_dim=1)
+
+
+def test_scale_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _scale_stream_persistent_bytes(_OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _synthetic_step_working_set_bytes(
+        persist_bytes, _OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 640_000_012
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        DynamicScaleShiftStream(_OVERFLOW_FEATURE_DIM)
+    with pytest.raises(ValueError, match="working set byte count"):
+        ScaleDriftStream(_OVERFLOW_FEATURE_DIM)
+
+
+def test_scale_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_SCALE_LAST_FIT, _SCALE_FIRST_OVERFLOW + 2):
+        persist_bytes = _scale_stream_persistent_bytes(feature_dim)
+        working_set_bytes = _synthetic_step_working_set_bytes(persist_bytes, feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _SCALE_LAST_FIT
+    _preflight_synthetic_step_working_set(
+        "DynamicScaleShiftStream",
+        _scale_stream_persistent_bytes(last_fit),
+        last_fit,
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        DynamicScaleShiftStream(first_overflow)
+    with pytest.raises(ValueError, match="working set byte count"):
+        ScaleDriftStream(first_overflow)
+
+
+def test_sutton_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _sutton_experiment1_persistent_bytes(_SUTTON_OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _synthetic_step_working_set_bytes(
+        persist_bytes, _SUTTON_OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 800_000_012
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _SUTTON_OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        SuttonExperiment1Stream(
+            num_relevant=1, num_irrelevant=_SUTTON_OVERFLOW_FEATURE_DIM - 1
+        )
+
+
+def test_sutton_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_SUTTON_LAST_FIT, _SUTTON_FIRST_OVERFLOW + 2):
+        persist_bytes = _sutton_experiment1_persistent_bytes(feature_dim)
+        working_set_bytes = _synthetic_step_working_set_bytes(persist_bytes, feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _SUTTON_LAST_FIT
+    _preflight_synthetic_step_working_set(
+        "SuttonExperiment1Stream",
+        _sutton_experiment1_persistent_bytes(last_fit),
+        last_fit,
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        SuttonExperiment1Stream(num_relevant=1, num_irrelevant=first_overflow - 1)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (2**29 - 1 - 3) // 2
+    _require_float32_resource(
+        "DynamicScaleShiftStream state",
+        vector_scalars=2 * last_legal,
+        fixed_scalars=3,
+    )
+    with pytest.raises(ValueError, match="byte count"):
+        DynamicScaleShiftStream(feature_dim=last_legal + 1)
+    hidden_last_legal = (2**29 - 1 - 2) // 2
+    _require_float32_resource(
+        "HiddenStateAR2Stream state",
+        vector_scalars=2 * hidden_last_legal,
+        fixed_scalars=2,
+    )
+    with pytest.raises(ValueError, match="byte count"):
+        HiddenStateAR2Stream(feature_dim=hidden_last_legal + 1, visible_dim=2)
+    last_legal_total = 2**29 - 1 - 3
+    _require_float32_resource(
+        "SuttonExperiment1Stream state",
+        vector_scalars=last_legal_total,
+        fixed_scalars=3,
+    )
+    with pytest.raises(ValueError, match="byte count"):
+        SuttonExperiment1Stream(num_relevant=1, num_irrelevant=last_legal_total)
+
+
+def test_legal_small_synthetic_streams_still_step() -> None:
+    assert _hidden_state_ar2_persistent_bytes(8) == 72
+    hidden = HiddenStateAR2Stream(8, visible_dim=2)
+    hidden.step(hidden.init(jr.key(0)), jnp.asarray(0, dtype=jnp.int32))
+    assert _scale_stream_persistent_bytes(4) == 44
+    dynamic = DynamicScaleShiftStream(4)
+    dynamic.step(dynamic.init(jr.key(1)), jnp.asarray(0, dtype=jnp.int32))
+    drift = ScaleDriftStream(4)
+    drift.step(drift.init(jr.key(2)), jnp.asarray(0, dtype=jnp.int32))
+    assert _sutton_experiment1_persistent_bytes(5) == 32
+    sutton = SuttonExperiment1Stream(num_relevant=2, num_irrelevant=3)
+    sutton.step(sutton.init(jr.key(3)), jnp.asarray(0, dtype=jnp.int32))


### PR DESCRIPTION
Closes #1837.

## What changed

The persist-named synthetic stream constructors now preflight the simultaneous `step` working set (`3 × persist + extras`) after the existing persist check. `_require_float32_resource` stays persist-only. Extras are the published observation and target leaves (`4 * feature_dim + 4`). Covered hosts: `HiddenStateAR2Stream`, `SuttonExperiment1Stream`, `DynamicScaleShiftStream`, `ScaleDriftStream`. `make_scale_range` stays persist-only.

On origin/main `cc877f78`, unit overflow dims constructed. Named persist `640000008` / `640000012` / `800000012`, persist+extras, and `4 × feature_dim` still fit. The step envelope overflows signed int32. Adjacent last-fit / first-overflow at `76695843` / `76695844` (hidden and scale) and `134217725` / `134217726` (Sutton). Legal small streams still step. Persist overflow still fires first. Named persist matches JIT leaves.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816` / `#1818` / `#1820` / `#1822` / `#1824` / `#1826` / `#1828` / `#1830` / `#1832` / `#1834` / `#1836`. `pavlovian.py` is a different file.

## Scope

- `alberta_framework/streams/synthetic.py`
- `tests/test_synthetic_update_working_set.py`
- `tests/test_synthetic_stream_validation.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `synthetic.py`. Factory `HARD_SKIP_PATHS` does not include this host. Leftover-tax hosts already name update envelopes and were skipped.

## Verification

Exact candidate head: `27ccabc929309d5a63b5d9dadc3ed501a10133ab`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: persist-named constructors accepted overflow dims; persist, persist+extras, and `4 × feature_dim` fit; step working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused synthetic pytest family including `tests/test_synthetic_update_working_set.py`: 90 passed
- `ruff check` on the three changed files: clean
- `scope-check.sh --max-files 4`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_synthetic_update_working_set.py tests/test_synthetic_stream_validation.py tests/test_synthetic_streams_extra.py tests/test_synthetic_lifetime_clock.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist still fits at the overflow dims; persist+extras still fit; last-fit helpers accept; first-overflow construct rejects; persist overflow still fails persist first
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:27ccabc929309d5a63b5d9dadc3ed501a10133ab -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
