### PR TITLE
Preflight normalizer update working set

### DIFF
--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -515,6 +515,11 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
         feature_dim = _require_int(
             "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
         )
+        _preflight_normalizer_update_working_set(
+            "EMANormalizer",
+            normalizer_state_nbytes_formula("EMANormalizer", feature_dim),
+            feature_dim,
+        )
         return EMANormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),
@@ -663,6 +668,11 @@ class WelfordNormalizer(Normalizer[WelfordNormalizerState]):
         feature_dim = _require_int(
             "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
         )
+        _preflight_normalizer_update_working_set(
+            "WelfordNormalizer",
+            normalizer_state_nbytes_formula("WelfordNormalizer", feature_dim),
+            feature_dim,
+        )
         return WelfordNormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),
@@ -803,6 +813,11 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
         feature_dim = _require_int(
             "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
         )
+        _preflight_normalizer_update_working_set(
+            "StreamingBatchNormalizer",
+            normalizer_state_nbytes_formula("StreamingBatchNormalizer", feature_dim),
+            feature_dim,
+        )
         return StreamingBatchNormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),
@@ -917,6 +932,31 @@ def normalizer_state_nbytes_formula(
     if host_type == "WelfordNormalizer":
         return 12 * feature_dim + 12
     raise ValueError(f"Unknown normalizer type: '{host_type}'")
+
+
+def _normalizer_update_result_extras_bytes(feature_dim: int) -> int:
+    """Returned ``NormalizerUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published normalized observation,
+    sample-count words, and availability leaves.
+    """
+    return 4 * feature_dim + 20
+
+
+def _normalizer_update_working_set_bytes(persist_bytes: int, feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * persist_bytes + _normalizer_update_result_extras_bytes(feature_dim)
+
+
+def _preflight_normalizer_update_working_set(
+    name: str, persist_bytes: int, feature_dim: int
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _normalizer_update_working_set_bytes(persist_bytes, feature_dim) > _INT32_MAX:
+        raise ValueError(
+            f"{name} update working set byte count must fit signed int32"
+        )
 
 
 def measure_normalizer_state_nbytes(state: AnyNormalizerState) -> int:

--- a/tests/test_normalizers_update_working_set.py
+++ b/tests/test_normalizers_update_working_set.py
@@ -1,0 +1,146 @@
+"""#1383-complete update working-set preflight for online normalizers."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.normalizers import (
+    EMANormalizer,
+    StreamingBatchNormalizer,
+    WelfordNormalizer,
+    _normalizer_update_working_set_bytes,
+    _preflight_normalizer_update_working_set,
+    normalizer_state_nbytes_formula,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_EMA_OVERFLOW_FEATURE_DIM = 80_000_000
+_EMA_LAST_FIT = 76_695_842
+_EMA_FIRST_OVERFLOW = 76_695_843
+_WELFORD_OVERFLOW_FEATURE_DIM = 60_000_000
+_WELFORD_LAST_FIT = 53_687_089
+_WELFORD_FIRST_OVERFLOW = 53_687_090
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_ema_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = normalizer_state_nbytes_formula(
+        "EMANormalizer", _EMA_OVERFLOW_FEATURE_DIM
+    )
+    working_set_bytes = _normalizer_update_working_set_bytes(
+        persist_bytes, _EMA_OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 640_000_016
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _EMA_OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        EMANormalizer().init(_EMA_OVERFLOW_FEATURE_DIM)
+    with pytest.raises(ValueError, match="working set byte count"):
+        StreamingBatchNormalizer().init(_EMA_OVERFLOW_FEATURE_DIM)
+
+
+def test_ema_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_EMA_LAST_FIT, _EMA_FIRST_OVERFLOW + 2):
+        persist_bytes = normalizer_state_nbytes_formula("EMANormalizer", feature_dim)
+        working_set_bytes = _normalizer_update_working_set_bytes(
+            persist_bytes, feature_dim
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _EMA_LAST_FIT
+    _preflight_normalizer_update_working_set(
+        "EMANormalizer",
+        normalizer_state_nbytes_formula("EMANormalizer", last_fit),
+        last_fit,
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        EMANormalizer().init(first_overflow)
+    with pytest.raises(ValueError, match="working set byte count"):
+        StreamingBatchNormalizer().init(first_overflow)
+
+
+def test_welford_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = normalizer_state_nbytes_formula(
+        "WelfordNormalizer", _WELFORD_OVERFLOW_FEATURE_DIM
+    )
+    working_set_bytes = _normalizer_update_working_set_bytes(
+        persist_bytes, _WELFORD_OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 720_000_012
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _WELFORD_OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        WelfordNormalizer().init(_WELFORD_OVERFLOW_FEATURE_DIM)
+
+
+def test_welford_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_WELFORD_LAST_FIT, _WELFORD_FIRST_OVERFLOW + 2):
+        persist_bytes = normalizer_state_nbytes_formula("WelfordNormalizer", feature_dim)
+        working_set_bytes = _normalizer_update_working_set_bytes(
+            persist_bytes, feature_dim
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _WELFORD_LAST_FIT
+    _preflight_normalizer_update_working_set(
+        "WelfordNormalizer",
+        normalizer_state_nbytes_formula("WelfordNormalizer", last_fit),
+        last_fit,
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        WelfordNormalizer().init(first_overflow)
+
+
+def test_persist_formula_still_names_int32_max() -> None:
+    persist_bytes = normalizer_state_nbytes_formula("EMANormalizer", _INT32_MAX)
+    assert persist_bytes == 8 * _INT32_MAX + 16
+    assert persist_bytes > _INT32_MAX
+
+
+def test_legal_small_normalizers_still_update() -> None:
+    observation = jnp.ones((5,), dtype=jnp.float32)
+    ema = EMANormalizer()
+    assert normalizer_state_nbytes_formula("EMANormalizer", 5) == 56
+    ema.normalize_with_diagnostics(ema.init(5), observation)
+    welford = WelfordNormalizer()
+    assert normalizer_state_nbytes_formula("WelfordNormalizer", 5) == 72
+    welford.normalize_with_diagnostics(welford.init(5), observation)
+    streaming = StreamingBatchNormalizer()
+    streaming.normalize_with_diagnostics(streaming.init(5), observation)


### PR DESCRIPTION
Closes #1839.

## What changed

`EMANormalizer.init`, `WelfordNormalizer.init`, and `StreamingBatchNormalizer.init` now preflight the simultaneous update working set (`3 × persist + extras`) after the existing feature-dim check and before zeros allocation. `normalizer_state_nbytes_formula` stays persist-only. Extras are the published normalized observation, sample-count words, and availability leaves (`4F + 20`).

On origin/main `cc877f78`, unit `feature_dim=80_000_000` (EMA / StreamingBatch) accepted persist `640000016`. Persist+extras and `4 × feature_dim` still fit. The update envelope overflows signed int32. Welford unit `feature_dim=60_000_000` persist `720000012` fits; `3 × persist + extras` overflows. Adjacent last-fit / first-overflow at `76695842` / `76695843` (EMA / StreamingBatch) and `53687089` / `53687090` (Welford). Legal small normalizers still `normalize_with_diagnostics`. Named persist matches JIT leaves.

This matches the `#1383` complete-aggregate bar. It does not remine leftover-id or stack `#1771` / `#1777` / `#1779` / `#1785` / `#1807` / `#1809` / `#1812` / `#1814` / `#1816` / `#1818` / `#1820` / `#1822` / `#1824` / `#1826` / `#1828` / `#1830` / `#1832` / `#1834` / `#1836` / `#1838`. `gymnasium.py` leftover-tax was skipped.

## Scope

- `alberta_framework/core/normalizers.py`
- `tests/test_normalizers_update_working_set.py`

## Why this is unowned

Live occupancy at publish time: no open PR touches `normalizers.py`. Factory `HARD_SKIP_PATHS` does not include this host. Leftover-tax hosts already name update envelopes and were skipped.

## Verification

Exact candidate head: `c9b22e8eaf19f042d17986207128dc4bf2595bd6`
Base: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

- Red on base: persist formula accepted `80_000_000` / `60_000_000`; persist, persist+extras, and `4 × feature_dim` fit; update working-set bytes overflow; int32 wrap stores `INT32_MIN`
- Focused normalizer pytest family including `tests/test_normalizers_update_working_set.py`: 166 passed
- `ruff check` on the two changed files: clean
- `scope-check.sh --max-files 2`: PASS

## Scientific integrity

This is fail-closed host-boundary overflow preflight only. It does not change kernel math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

<!-- evidence-row:logs -->
- [x] logs: N/A - host-boundary unit tests only; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact is claimed
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - no agent trajectory artifact is attached; reproduction is the unit tests above
<!-- evidence-row:reproduction -->
- [x] reproduction: `PYTHONPATH=. python -m pytest tests/test_normalizers_update_working_set.py tests/test_normalizers.py tests/test_normalizers_hostile_validation.py -q`
<!-- evidence-row:negative-controls -->
- [x] negative-controls: named persist is `640000016` (EMA) / `720000012` (Welford) at the overflow dims; persist+extras still fit; last-fit helpers accept; first-overflow `init` rejects; persist formula still names `INT32_MAX`
<!-- evidence-row:compute-receipt -->
- [x] compute-receipt: N/A - no official run-receipt was minted

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:c9b22e8eaf19f042d17986207128dc4bf2595bd6 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-asi"} -->
