### PR TITLE
fix(core): saturate UPGDLearner step_count at int32 max

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -53,6 +53,7 @@ from alberta_framework.core._float32_scalars import (
     validated_float32_scalar_with_ratio,
 )
 from alberta_framework.core.initializers import sparse_init
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.optimizers import Bounder, ObGDBounding
 from alberta_framework.core.types import MLPParams
 from alberta_framework.core.update_safety import zero_if_collapsed_infinity
@@ -3327,7 +3328,7 @@ class UPGDLearner:
             previous_head_weight_grads=next_previous_head_weight_grads,
             previous_head_bias_grads=next_previous_head_bias_grads,
             key=new_key,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )

--- a/tests/test_upgd_lifetime_clock.py
+++ b/tests/test_upgd_lifetime_clock.py
@@ -1,0 +1,68 @@
+"""Saturating lifetime clocks keep the UPGD learner update identity at int32 exhaustion."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.core.upgd import UPGDLearner
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def _make_learner() -> UPGDLearner:
+    return UPGDLearner(
+        n_heads=2,
+        hidden_sizes=(4,),
+        sparsity=0.0,
+        perturbation_sigma=0.0,
+    )
+
+
+def test_upgd_clock_wraps_without_saturation_at_int32_max() -> None:
+    """The old bare increment wraps INT32_MAX + 1 to INT32_MIN."""
+
+    wrap = jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    assert int(wrap) == _INT32_MIN
+
+
+def test_upgd_clock_saturates_and_keeps_update_identity() -> None:
+    """A planted INT32_MAX clock saturates instead of wrapping negative."""
+
+    learner = _make_learner()
+    predecessor = learner.init(feature_dim=4, key=jr.key(0)).replace(  # type: ignore[attr-defined]
+        step_count=jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
+    )
+    result = learner.update(
+        predecessor,
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == _INT32_MAX
+    assert int(result.state.step_count) >= 0
+
+    exhausted = learner.update(
+        result.state,
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32),
+    )
+    assert int(exhausted.state.step_count) == _INT32_MAX
+    assert int(exhausted.state.step_count) >= 0
+    assert int(exhausted.state.step_count) == int(result.state.step_count)
+
+
+def test_upgd_clock_at_int32_max_does_not_wrap_negative() -> None:
+    """One more update from the saturated clock stays at INT32_MAX, never INT32_MIN."""
+
+    learner = _make_learner()
+    state = learner.init(feature_dim=4, key=jr.key(0)).replace(  # type: ignore[attr-defined]
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    result = learner.update(
+        state,
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == _INT32_MAX
+    assert int(result.state.step_count) != _INT32_MIN


### PR DESCRIPTION
Closes #1841

## Problem

`UPGDLearner.update` advanced the lifetime `step_count` with a bare `state.step_count + 1` (`alberta_framework/core/upgd.py:3330`). The counter is declared `dtype=jnp.int32` and has no saturating increment. At `step_count == 2**31 - 1` the next update wraps the clock to `INT32_MIN`.

The wrapped negative clock flips the warm-up, meta-warm, and perturbation-schedule branches inside `update` (`upgd.py:2393`, `2418`, `2873-2876`, `3207`, `3242`) to `False` permanently, so an exhausted learner no longer reproduces its pre-wrap update behavior.

## Fix

Replace the bare increment with the tree-wide saturating int32 counter increment (`normalizers._saturating_int32_counter_increment`), matching the existing lifetime-clock fixes in learners, synthetic streams, feature discovery, horde, and reward_model.

## Tests

Adds `tests/test_upgd_lifetime_clock.py`: plants the exhausted clock and asserts the counter saturates at `INT32_MAX` and never wraps negative.

- `pytest tests/test_upgd.py tests/test_upgd_lifetime_clock.py`: 94 passed
- `ruff check`: clean
- `mypy`: clean