### PR TITLE
fix(streams): saturate GauntletStream step_count at int32 max

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -67,6 +67,7 @@ from alberta_framework.core.checkpoints import (
     load_checkpoint_metadata,
     save_checkpoint,
 )
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream
 
@@ -419,7 +420,7 @@ class GauntletStream:
         )
         new_state = GauntletState(
             key=key,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
             drift_weights=new_drift,
             w_a=state.w_a,
             w_c=state.w_c,

--- a/tests/test_gauntlet_lifetime_clock.py
+++ b/tests/test_gauntlet_lifetime_clock.py
@@ -1,0 +1,39 @@
+"""Saturating lifetime clocks keep GauntletStream segment identity at int32 exhaustion."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.streams.gauntlet import NUM_SEGMENTS, GauntletStream
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_gauntlet_wrap_forges_a_different_segment() -> None:
+    """The old bare increment wraps INT32_MAX + 1 to INT32_MIN and resets the course."""
+
+    stream = GauntletStream()
+    wrap = jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    assert int(wrap) == _INT32_MIN
+    assert int(stream.segment_of(wrap)) == 0
+    assert int(stream.segment_of(jnp.asarray(_INT32_MAX, dtype=jnp.int32))) == NUM_SEGMENTS - 1
+
+
+def test_gauntlet_clock_saturates_at_int32_max() -> None:
+    """A planted INT32_MAX clock saturates instead of wrapping negative."""
+
+    stream = GauntletStream()
+    predecessor = stream.init(jr.key(0)).replace(  # type: ignore[attr-defined]
+        step_count=jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
+    )
+    _, advanced = stream.step(predecessor, jnp.asarray(0, dtype=jnp.int32))
+    assert int(advanced.step_count) == _INT32_MAX
+    assert int(advanced.step_count) >= 0
+    assert int(stream.segment_of(advanced.step_count)) == NUM_SEGMENTS - 1
+
+    exhausted = stream.step(advanced, jnp.asarray(0, dtype=jnp.int32))
+    assert int(exhausted[1].step_count) == _INT32_MAX
+    assert int(exhausted[1].step_count) >= 0
+    assert int(stream.segment_of(exhausted[1].step_count)) == NUM_SEGMENTS - 1


### PR DESCRIPTION
Closes #1843

## Problem

`GauntletStream.step` advanced the lifetime `step_count` with a bare `state.step_count + 1` (`alberta_framework/streams/gauntlet.py:422`). The counter is declared `dtype=jnp.int32` and has no saturating increment. At `step_count == 2**31 - 1` the next step wraps the clock to `INT32_MIN`.

`step_count` drives the segment schedule via `segment_of` (`step // segment_length` clamped to the last segment). A wrapped negative step makes the segment reset to 0 — the gauntlet silently restarts its course instead of staying on the last segment — which also flips the drift/scale/readout behavior selected per segment.

## Fix

Replace the bare increment with the tree-wide saturating int32 counter increment (`normalizers._saturating_int32_counter_increment`), matching the existing lifetime-clock fixes in learners, synthetic streams, feature discovery, Step 1, horde, reward_model, and upgd.

## Tests

Adds `tests/test_gauntlet_lifetime_clock.py`: plants the exhausted clock and asserts the counter saturates at `INT32_MAX` and the segment stays on the last segment.

- `pytest tests/test_gauntlet_*.py`: 18 passed
- `ruff check`: clean
- `mypy`: clean