### PR TITLE
fix(core): gate actor-critic array-runner terminated dtype

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -198,6 +198,13 @@ def _trusted_shape(name: str, value: object) -> tuple[int, ...]:
     return tuple(value.shape)
 
 
+def _checked_terminated(name: str, value: Array) -> Array:
+    """Validate a ``terminated`` flag array dtype before boolean coercion."""
+    if value.dtype not in (jnp.dtype(jnp.bool_), jnp.dtype(jnp.float32)):
+        raise TypeError(f"{name} must have dtype bool or float32")
+    return value
+
+
 def _validated_bounder_result(
     name: str,
     result: object,
@@ -896,7 +903,9 @@ def run_actor_critic_from_arrays(
     next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
     rewards = jnp.asarray(rewards, dtype=jnp.float32)
     if terminated is not None:
-        terminated = jnp.asarray(terminated, dtype=jnp.bool_)
+        terminated = jnp.asarray(
+            _checked_terminated("terminated", jnp.asarray(terminated)), dtype=jnp.bool_
+        )
     if discounts is not None:
         discounts = jnp.asarray(discounts, dtype=jnp.float32)
     if terminated is None:
@@ -1720,7 +1729,9 @@ def run_continuous_actor_critic_from_arrays(
     next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
     rewards = jnp.asarray(rewards, dtype=jnp.float32)
     if terminated is not None:
-        terminated = jnp.asarray(terminated, dtype=jnp.bool_)
+        terminated = jnp.asarray(
+            _checked_terminated("terminated", jnp.asarray(terminated)), dtype=jnp.bool_
+        )
     if discounts is not None:
         discounts = jnp.asarray(discounts, dtype=jnp.float32)
     if terminated is None:

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -546,6 +546,38 @@ def test_actor_critic_rejects_wrong_observation_shapes(shape: tuple[int, ...]) -
         agent.update(state, jnp.asarray(0.0), malformed)
 
 
+@pytest.mark.parametrize("dtype", [jnp.int32, jnp.uint8, jnp.int64])
+def test_run_actor_critic_from_arrays_rejects_integer_terminated(dtype: object) -> None:
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+    state = agent.init(2, jr.key(0))
+    observations = jnp.zeros((2, 2), dtype=jnp.float32)
+    rewards = jnp.zeros((2,), dtype=jnp.float32)
+    with pytest.raises(TypeError, match="terminated must have dtype bool or float32"):
+        run_actor_critic_from_arrays(
+            agent,
+            state,
+            observations,
+            rewards,
+            jnp.array([0, 1], dtype=dtype),
+            observations,
+        )
+
+
+def test_run_actor_critic_from_arrays_accepts_bool_and_float32_terminated() -> None:
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+    state = agent.init(2, jr.key(0))
+    observations = jnp.zeros((2, 2), dtype=jnp.float32)
+    rewards = jnp.zeros((2,), dtype=jnp.float32)
+    for flags in (
+        jnp.array([False, True], dtype=jnp.bool_),
+        jnp.array([0.0, 1.0], dtype=jnp.float32),
+    ):
+        result = run_actor_critic_from_arrays(
+            agent, state, observations, rewards, flags, observations
+        )
+        assert result.td_errors.shape == (2,)
+
+
 def test_actor_critic_state_contract_and_counter_saturation() -> None:
     agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
     state = agent.init(2, jr.key(0))

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -618,6 +618,40 @@ def test_continuous_actor_critic_rejects_wrong_observation_shapes(
         agent.update(state, jnp.asarray(0.0), malformed)
 
 
+@pytest.mark.parametrize("dtype", [jnp.int32, jnp.uint8, jnp.int64])
+def test_run_continuous_actor_critic_from_arrays_rejects_integer_terminated(
+    dtype: object,
+) -> None:
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
+    state = agent.init(2, jr.key(0))
+    observations = jnp.zeros((2, 2), dtype=jnp.float32)
+    rewards = jnp.zeros((2,), dtype=jnp.float32)
+    with pytest.raises(TypeError, match="terminated must have dtype bool or float32"):
+        run_continuous_actor_critic_from_arrays(
+            agent,
+            state,
+            observations,
+            rewards,
+            jnp.array([0, 1], dtype=dtype),
+            observations,
+        )
+
+
+def test_run_continuous_actor_critic_from_arrays_accepts_bool_and_float32_terminated() -> None:
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
+    state = agent.init(2, jr.key(0))
+    observations = jnp.zeros((2, 2), dtype=jnp.float32)
+    rewards = jnp.zeros((2,), dtype=jnp.float32)
+    for flags in (
+        jnp.array([False, True], dtype=jnp.bool_),
+        jnp.array([0.0, 1.0], dtype=jnp.float32),
+    ):
+        result = run_continuous_actor_critic_from_arrays(
+            agent, state, observations, rewards, flags, observations
+        )
+        assert result.td_errors.shape == (2,)
+
+
 def test_continuous_actor_critic_state_contract_and_counter_saturation() -> None:
     agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
     state = agent.init(2, jr.key(0))


### PR DESCRIPTION
Closes #1845

## Problem

`run_actor_critic_from_arrays` and `run_continuous_actor_critic_from_arrays` silently coerced any `terminated` array to boolean via `jnp.asarray(terminated, dtype=jnp.bool_)` (`actor_critic.py:899`, `:1723`). Hostile dtypes (`int32`, `uint8`) and mistyped float values (e.g. `0.5` → `True`, turning a non-terminal transition terminal) were accepted without a dtype gate. The per-transition `update` path already requires exact bool dtype (`_array`, `actor_critic.py:654`), and `SARSA` gates `terminated` to bool/float32 (`sarsa.py:861-862`).

## Fix

Add a `_checked_terminated` gate and call it at both array runners before the boolean coercion: raise `TypeError` on any dtype other than bool or float32, matching the SARSA contract.

## Tests

Regression tests in `tests/test_actor_critic.py` and `tests/test_continuous_actor_critic.py`: int32/uint8/int64 `terminated` arrays are rejected with the dtype message; bool and float32 flag arrays still run for both runners.

- `pytest tests/test_actor_critic.py tests/test_continuous_actor_critic.py tests/test_actor_critic_merged_runtime_residuals.py`: 104 passed
- `ruff check`: clean
- `mypy` (authoritative scope `alberta_framework`): clean