### PR TITLE
fix(core): make PrototypeMemory hit counts int32 and saturating

### DIFF
--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -27,7 +27,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
-from jaxtyping import Bool, Float
+from jaxtyping import Bool, Float, Int
 
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.update_safety import (
@@ -243,7 +243,7 @@ class PrototypeMemoryState:
     """State for :class:`PrototypeMemoryLearner`."""
 
     means: Float[Array, "n_classes slots_per_class feature_dim"]
-    counts: Float[Array, "n_classes slots_per_class"]
+    counts: Int[Array, "n_classes slots_per_class"]
     last_update: Array
     step_count: Array
 
@@ -357,7 +357,7 @@ class PrototypeMemoryLearner:
             state.counts,
             name="state.counts",
             shape=slot_shape,
-            dtype=jnp.float32,
+            dtype=jnp.int32,
         )
         _require_array(
             state.last_update,
@@ -390,7 +390,7 @@ class PrototypeMemoryLearner:
                 (c.n_classes, c.slots_per_class, c.feature_dim),
                 dtype=jnp.float32,
             ),
-            counts=jnp.zeros((c.n_classes, c.slots_per_class), dtype=jnp.float32),
+            counts=jnp.zeros((c.n_classes, c.slots_per_class), dtype=jnp.int32),
             last_update=jnp.zeros((c.n_classes, c.slots_per_class), dtype=jnp.int32),
             step_count=jnp.array(0, dtype=jnp.int32),
         )
@@ -571,7 +571,11 @@ class PrototypeMemoryLearner:
                 safe_observation,
                 old_mean + eta * (safe_observation - old_mean),
             )
-            new_count = jnp.where(novel, 1.0, current.counts[head, slot] + 1.0)
+            new_count = jnp.where(
+                novel,
+                jnp.asarray(1, dtype=jnp.int32),
+                _saturating_increment(current.counts[head, slot]),
+            )
             next_step = _saturating_increment(current.step_count)
             next_state = PrototypeMemoryState(
                 means=current.means.at[head, slot].set(new_mean),

--- a/tests/test_prototype_memory.py
+++ b/tests/test_prototype_memory.py
@@ -28,6 +28,29 @@ def test_prototype_memory_init_shapes() -> None:
     chex.assert_tree_all_finite(state)
 
 
+def test_prototype_memory_hit_count_is_int32_and_saturates() -> None:
+    """Hit counts must be exact past 2**24 and saturate instead of stalling."""
+
+    config = PrototypeMemoryConfig(feature_dim=2, n_classes=2, slots_per_class=1)
+    learner = PrototypeMemoryLearner(config)
+    state = learner.init()
+    assert state.counts.dtype == jnp.dtype(jnp.int32)
+    target = jnp.asarray([1.0, 0.0], dtype=jnp.float32)
+
+    planted = state.replace(
+        counts=jnp.array([[16777216], [0]], dtype=jnp.int32),
+        means=jnp.array([[[1.0, 1.0]], [[0.0, 0.0]]], dtype=jnp.float32),
+    )
+    result = learner.update(planted, jnp.ones((2,), dtype=jnp.float32), target)
+    assert int(result.state.counts[0, 0]) == 16777217
+
+    exhausted = result.state.replace(
+        counts=result.state.counts.at[0, 0].set(2**31 - 1)
+    )
+    final = learner.update(exhausted, jnp.ones((2,), dtype=jnp.float32), target)
+    assert int(final.state.counts[0, 0]) == 2**31 - 1
+
+
 def test_empty_memory_predicts_uniformly() -> None:
     """With no prototypes, softmax logits should be neutral."""
     learner = PrototypeMemoryLearner(


### PR DESCRIPTION
Closes #1847

## Problem

`PrototypeMemoryLearner.update` stored slot hit counts as `dtype=jnp.float32` and incremented them with a bare `+1.0` (`prototype_memory.py:574`). float32 has only 24 mantissa bits, so a count at `2**24` silently stalls forever — the next matched update is absorbed by rounding. The stalled count corrupts the least-used replacement selection (`_replacement_slot`: `min_count`/tied, `prototype_memory.py:465-476`) and the active-slot telemetry for the rest of the life.

## Fix

Store `counts` as `dtype=jnp.int32` and increment with the tree-wide saturating increment (`_saturating_increment`, same helper already used for `step_count` in this module). Counts are now exact past `2**24` and monotone up to int32 exhaustion. Updated the state annotation, the `_require_array` dtype gate, and `init`.

## Tests

Adds a regression test asserting counts are int32, a planted `2**24` count advances to `2**24 + 1` on a matched update, and the count saturates at `INT32_MAX`.

- `pytest tests/test_prototype_memory.py tests/test_prototype_memory_validation.py tests/test_late_wave_transactions.py`: 196 passed
- `ruff check`: clean
- `mypy`: clean