### PR TITLE
fix(option-duration): gate array inputs on metadata before conversion

### DIFF
--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -370,12 +370,15 @@ class OptionValueDurationLearner:
         dtype: Any,
     ) -> Array:
         try:
-            array = jnp.asarray(value)
+            actual_shape = tuple(value.shape)
+            actual_dtype = jnp.dtype(value.dtype)
         except Exception as error:
-            raise ValueError(f"{name} must be a readable array") from error
-        if array.shape != shape or array.dtype != dtype:
+            raise TypeError(
+                f"{name} must expose array shape and dtype metadata"
+            ) from error
+        if actual_shape != shape or actual_dtype != jnp.dtype(dtype):
             raise ValueError(f"{name} must have shape {shape} and dtype {dtype}")
-        return array
+        return jnp.asarray(value)
 
     @staticmethod
     def _state_values_valid(state: OptionValueDurationState) -> Array:

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -642,3 +642,66 @@ def test_option_duration_array_runner_requires_exact_shapes() -> None:
             jnp.ones((2, 2), dtype=jnp.float32),
             jnp.zeros((2,), dtype=jnp.float32),
         )
+
+
+def test_array_runner_rejects_untrusted_inputs_without_running_conversion_hooks() -> None:
+    """The array runner must gate on array metadata before any conversion.
+
+    ``_require_array`` reached ``jnp.asarray(value)`` before validating
+    anything, so an untrusted ``__array__`` hook executed ahead of the shape
+    and dtype checks and chose the value they then saw. The public ``update``
+    path is gated by an outer contract check; the array runner called the
+    helper directly.
+    """
+
+    class _HostileArray:
+        def __array__(self, dtype: object = None, copy: object = None) -> np.ndarray:
+            raise AssertionError("array hook must not run")
+
+    learner = OptionValueDurationLearner(3, OptionValueDurationConfig())
+    state = learner.init(2)
+    steps = 2
+    observations = jnp.zeros((steps, 2), dtype=jnp.float32)
+    next_observations = jnp.zeros((steps, 2), dtype=jnp.float32)
+    rewards = jnp.zeros((steps,), dtype=jnp.float32)
+    discounts = jnp.zeros((steps,), dtype=jnp.float32)
+    option_indices = jnp.zeros((steps,), dtype=jnp.int32)
+
+    with pytest.raises(TypeError, match="shape and dtype metadata"):
+        run_option_value_duration_from_arrays(
+            learner,
+            state,
+            observations,
+            _HostileArray(),
+            rewards,
+            next_observations,
+            discounts,
+        )
+
+    with pytest.raises(TypeError, match="shape and dtype metadata"):
+        run_option_value_duration_from_arrays(
+            learner,
+            state,
+            observations,
+            option_indices,
+            _HostileArray(),
+            next_observations,
+            discounts,
+        )
+
+
+def test_array_runner_still_accepts_trusted_arrays() -> None:
+    """The metadata gate must not reject the arrays the runner already supports."""
+    learner = OptionValueDurationLearner(3, OptionValueDurationConfig())
+    state = learner.init(2)
+    steps = 2
+    result = run_option_value_duration_from_arrays(
+        learner,
+        state,
+        jnp.zeros((steps, 2), dtype=jnp.float32),
+        np.zeros((steps,), dtype=np.int32),
+        jnp.zeros((steps,), dtype=jnp.float32),
+        jnp.zeros((steps, 2), dtype=jnp.float32),
+        jnp.zeros((steps,), dtype=jnp.float32),
+    )
+    chex.assert_tree_all_finite(result.predictions)


### PR DESCRIPTION
Fixes #1849.

## What moved

`OptionValueDurationLearner._require_array` reached `jnp.asarray(value)` before validating anything, so an untrusted `__array__` hook executed ahead of the shape and dtype checks and chose the value they then saw. The `except Exception` also wrapped whatever the hook raised into a generic `"must be a readable array"` ValueError — reporting a failure inside untrusted code as malformed input.

Confirmed on `cc877f78` before the fix:

```text
run_from_arrays(option_indices=Hostile()) -> ACCEPTED   hook_ran=True
run_from_arrays(rewards=Hostile())        -> ValueError hook_ran=True
update(observation=Hostile())             -> TypeError  hook_ran=False   (outer gate catches it)
```

The public `update()` path is gated by an outer contract check. `run_option_value_duration_from_arrays` calls the helper directly and accepted the object outright.

## Scope — an outlier, not a sweep

I checked every `_require_array`-style helper in the tree: **14 of 18 already gate on metadata before converting**. I empirically probed the four that looked ungated — `gauntlet` and `recurring_multiagent` reject without running the hook, so my static heuristic over-flagged them. `option_value_duration` is the reachable one, and this PR is scoped to it.

`interaction_features._require_array_contract` also runs the hook when called directly, but I could not establish a public-API path reaching it with an untrusted object, so it is **not** claimed here.

## The change

Read metadata first, convert only after both checks pass — the same shape as `working_memory._require_array` and the other 13 gated helpers:

```python
        try:
            actual_shape = tuple(value.shape)
            actual_dtype = jnp.dtype(value.dtype)
        except Exception as error:
            raise TypeError(f"{name} must expose array shape and dtype metadata") from error
        if actual_shape != shape or actual_dtype != jnp.dtype(dtype):
            raise ValueError(f"{name} must have shape {shape} and dtype {dtype}")
        return jnp.asarray(value)
```

The existing shape/dtype `ValueError` message is unchanged, so callers relying on it are unaffected.

## Tests

Added to `tests/test_option_value_duration.py`:

- `test_array_runner_rejects_untrusted_inputs_without_running_conversion_hooks` — a `__array__` that raises if invoked, through both `option_indices` and `rewards`
- `test_array_runner_still_accepts_trusted_arrays` — positive control over `jnp` and `np.ndarray` inputs

Verified failing-first by reverting only the helper: **1 failed, 1 passed**, the failure being `ValueError: option_indices must be a readable array` — i.e. the hook ran and its `AssertionError` was swallowed by the `except`, which is exactly the defect.

## Verification

Commit `7624397d36296a8b73dcd273316abe837b27793a`, based on `cc877f78`.

```bash
python -m pytest -q -p no:randomly -o addopts= tests/test_option_value_duration.py
# 65 passed

python -m ruff check .   # All checks passed!
python -m mypy           # Success: no issues found in 190 source files
```

Environment: Python 3.12.14, jax 0.11.0, numpy 2.5.2, CPU, network-isolated container.

<!-- evidence-head:7624397d36296a8b73dcd273316abe837b27793a -->

---

AI provider/model: anthropic / claude-opus-5 (as reported by the running client)
Client / agent tooling: claude-code
Attribution status: self-reported.
