### PR TITLE
fix(ceiling): report across-seed spread with the sample estimator

### DIFF
--- a/outputs/ipmnist_screening/ceiling/ceiling_analyze.py
+++ b/outputs/ipmnist_screening/ceiling/ceiling_analyze.py
@@ -29,6 +29,21 @@ def smooth(x: np.ndarray, w: int) -> np.ndarray:
     return np.convolve(x, np.ones(w) / w, mode="valid")
 
 
+def across_seed_spread(values: object) -> float:
+    """Sample standard deviation across seeds, matching the campaign convention.
+
+    Issue #33 unified across-seed spread on the sample estimator (``ddof=1``),
+    which the screening merge and ``compute_statistics`` both use. ``np.std``
+    defaults to the population estimator, understating the spread of a seed
+    sample by ``sqrt(n / (n - 1))`` — 22% at n=3, 41% at n=2. A single seed has
+    no spread rather than a zero-width interval implying one.
+    """
+    array = np.asarray(values, dtype=np.float64).ravel()
+    if array.size < 2:
+        return 0.0
+    return float(array.std(ddof=1))
+
+
 def main() -> None:
     report: dict = {}
 
@@ -44,7 +59,7 @@ def main() -> None:
         mc = curves.mean(axis=0)
         late = mc[LATE_LO:LATE_HI].mean()
         print(f"  {spec:20s} avg-online={np.mean(means):.5f} (seeds {sorted(runs)}, "
-              f"sd {np.std(means):.5f})  late-window(4000-5000)={late:.5f}")
+              f"sd {across_seed_spread(means):.5f})  late-window(4000-5000)={late:.5f}")
         bucket_acc = {f"{a}-{b}": round(float(mc[a:b].mean()), 5) for a, b in BUCKETS}
         print(f"      within-task buckets: {bucket_acc}")
         report[f"stationary_{spec}"] = {
@@ -77,7 +92,7 @@ def main() -> None:
               f"t10={pt[:, 9].mean():.4f} t20={pt[:, 19].mean():.4f} "
               f"t40={pt[:, 39].mean():.4f} t60={pt[:, -1].mean():.4f}")
         print(f"      late-task (last 10 tasks) avg-online = {late_tasks.mean():.5f} "
-              f"(sd {late_tasks.std():.5f})")
+              f"(sd {across_seed_spread(late_tasks):.5f})")
         print(f"      late-task late-window (steps 4000-5000) = {last_task_late.mean():.5f}")
         report[f"carried_{spec}"] = {
             "per_task_mean_curve": [round(float(v), 5) for v in pt.mean(axis=0)],

--- a/tests/test_ceiling_analyze.py
+++ b/tests/test_ceiling_analyze.py
@@ -1,0 +1,63 @@
+"""Spread-estimator contract for the ceiling analyzer shipped under ``outputs/``.
+
+The analyzer prints the ``sd`` values quoted in
+``outputs/ipmnist_screening/CEILING_ANALYSIS.md``. Issue #33 unified
+across-seed spread on the sample estimator, but that unification covered
+``alberta_framework`` only, so this script kept NumPy's population default.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ANALYZER = (
+    Path(__file__).resolve().parents[1]
+    / "outputs"
+    / "ipmnist_screening"
+    / "ceiling"
+    / "ceiling_analyze.py"
+)
+
+
+def _load_analyzer() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("ceiling_analyze", _ANALYZER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_across_seed_spread_is_the_sample_estimator() -> None:
+    """Across-seed spread must use ddof=1, matching the screening merge."""
+    module = _load_analyzer()
+    values = [0.7814, 0.7842, 0.7870]
+
+    expected = float(np.asarray(values, dtype=np.float64).std(ddof=1))
+    assert module.across_seed_spread(values) == pytest.approx(expected)
+
+    population = float(np.asarray(values, dtype=np.float64).std())
+    assert module.across_seed_spread(values) > population
+
+
+def test_across_seed_spread_matches_the_screening_merge_convention() -> None:
+    """The helper agrees with the estimator the campaign merge already uses."""
+    module = _load_analyzer()
+    rng = np.random.default_rng(0)
+    for n in (2, 3, 5, 20):
+        sample = rng.normal(size=n)
+        merge_convention = float(sample.std(ddof=1))
+        assert module.across_seed_spread(sample) == pytest.approx(merge_convention)
+
+
+@pytest.mark.parametrize("values", ([], [0.5]))
+def test_across_seed_spread_reports_no_spread_below_two_seeds(values: list[float]) -> None:
+    """One seed has no spread; ddof=1 would be undefined rather than zero."""
+    module = _load_analyzer()
+    assert module.across_seed_spread(values) == 0.0


### PR DESCRIPTION
Fixes #1851.

## What moved

#33 established that across-seed spread uses the **sample** estimator; #40 unified the code on it. That unification covered `alberta_framework` only. `ceiling_analyze.py` under `outputs/` kept NumPy's population default, and its output is what `CEILING_ANALYSIS.md` publishes as `sd`.

Recomputed from the pinned `ceiling/analysis_summary.json` per-seed values at `cc877f78` — the published figures match `ddof=0` exactly:

| `CEILING_ANALYSIS.md` §1a row | published `sd` | `ddof=0` | `ddof=1` | understated |
|---|---|---|---|---|
| `sigma0_ndecay099` (champion) | 0.0028 | **0.00285** | 0.00349 | 1.22x |
| `adamw_control` | 0.0028 | **0.00282** | 0.00345 | 1.22x |
| `sgd_ema_norm` | 0.0027 | **0.00269** | 0.00330 | 1.22x |

So the same quantity is reported two ways depending on which path produced it — the screening merge (`ipmnist_screening.py:10069`, `:10107`) and `compute_statistics` both use `ddof=1`. That is the inconsistency #33 was filed about, surviving in a path #40 did not reach.

## The change

One helper, both across-seed sites routed through it:

```python
def across_seed_spread(values: object) -> float:
    array = np.asarray(values, dtype=np.float64).ravel()
    if array.size < 2:
        return 0.0
    return float(array.std(ddof=1))
```

The sub-two-seed guard mirrors #26/#34: one seed has no spread, rather than `ddof=1` being undefined.

## What this deliberately does **not** do

- **No pinned artifact is rewritten.** `analysis_summary.json` never recorded a spread field — the value existed only in the printed report, so nothing under `outputs/` needed mutating.
- **No headline number changes.** Means, ceilings, the error budget and the ladder are untouched; only the reported spread.
- **`CEILING_ANALYSIS.md` is left alone.** Correcting its three published `sd` values documents a historical run and is a maintainer's call, not mine to make in this PR.

## Tests

`tests/test_ceiling_analyze.py` — the **first test coverage for any of the 35 Python files under `outputs/`**:

- `test_across_seed_spread_is_the_sample_estimator` — matches `ddof=1` and is strictly greater than the population value
- `test_across_seed_spread_matches_the_screening_merge_convention` — agrees with the merge estimator at n = 2, 3, 5, 20
- `test_across_seed_spread_reports_no_spread_below_two_seeds` — n = 0 and n = 1

Verified failing-first by reverting the helper: **4 failed → 4 passed**.

## Verification

Commit `d534cf2a8182cbe9d7db149bf3f07e159a9d860e`, based on `cc877f78`.

```bash
python -m pytest -q -p no:randomly -o addopts= tests/test_ceiling_analyze.py   # 4 passed
python -m ruff check .                                                          # All checks passed!
python -m mypy                                                                  # Success: 190 source files
python -m pytest --collect-only -q -m "not slow and not package"                # 14187 collected, unchanged
```

## What remains open

`ceiling_analyze.py` also hardcodes `/home/shaw/milady/research/alberta/...` for its input paths, so it is not runnable as shipped. That is a separate change and I have not touched it here.

<!-- evidence-head:d534cf2a8182cbe9d7db149bf3f07e159a9d860e -->

---

AI provider/model: anthropic / claude-opus-5 (as reported by the running client)
Client / agent tooling: claude-code
Attribution status: self-reported.
