### PR TITLE
fix(frontier-rank): restrict the confirm mean to seeds shared with the base

### DIFF
--- a/outputs/ipmnist_screening/ceiling/ceiling_analyze.py
+++ b/outputs/ipmnist_screening/ceiling/ceiling_analyze.py
@@ -29,6 +29,21 @@ def smooth(x: np.ndarray, w: int) -> np.ndarray:
     return np.convolve(x, np.ones(w) / w, mode="valid")
 
 
+def across_seed_spread(values: object) -> float:
+    """Sample standard deviation across seeds, matching the campaign convention.
+
+    Issue #33 unified across-seed spread on the sample estimator (``ddof=1``),
+    which the screening merge and ``compute_statistics`` both use. ``np.std``
+    defaults to the population estimator, understating the spread of a seed
+    sample by ``sqrt(n / (n - 1))`` — 22% at n=3, 41% at n=2. A single seed has
+    no spread rather than a zero-width interval implying one.
+    """
+    array = np.asarray(values, dtype=np.float64).ravel()
+    if array.size < 2:
+        return 0.0
+    return float(array.std(ddof=1))
+
+
 def main() -> None:
     report: dict = {}
 
@@ -44,7 +59,7 @@ def main() -> None:
         mc = curves.mean(axis=0)
         late = mc[LATE_LO:LATE_HI].mean()
         print(f"  {spec:20s} avg-online={np.mean(means):.5f} (seeds {sorted(runs)}, "
-              f"sd {np.std(means):.5f})  late-window(4000-5000)={late:.5f}")
+              f"sd {across_seed_spread(means):.5f})  late-window(4000-5000)={late:.5f}")
         bucket_acc = {f"{a}-{b}": round(float(mc[a:b].mean()), 5) for a, b in BUCKETS}
         print(f"      within-task buckets: {bucket_acc}")
         report[f"stationary_{spec}"] = {
@@ -77,7 +92,7 @@ def main() -> None:
               f"t10={pt[:, 9].mean():.4f} t20={pt[:, 19].mean():.4f} "
               f"t40={pt[:, 39].mean():.4f} t60={pt[:, -1].mean():.4f}")
         print(f"      late-task (last 10 tasks) avg-online = {late_tasks.mean():.5f} "
-              f"(sd {late_tasks.std():.5f})")
+              f"(sd {across_seed_spread(late_tasks):.5f})")
         print(f"      late-task late-window (steps 4000-5000) = {last_task_late.mean():.5f}")
         report[f"carried_{spec}"] = {
             "per_task_mean_curve": [round(float(v), 5) for v in pt.mean(axis=0)],

--- a/outputs/ipmnist_screening/frontier_rank.py
+++ b/outputs/ipmnist_screening/frontier_rank.py
@@ -53,13 +53,15 @@ def build() -> dict:
                 row["screen_paired_delta_vs_base"] > THRESHOLD
             )
         cshared = sorted(set(confirm) & set(confirm_base))
-        if confirm:
-            row["confirm_mean"] = statistics.mean(confirm.values())
-            row["n_confirm_seeds"] = len(confirm)
-            if cshared:
-                row["confirm_paired_delta_vs_base"] = statistics.mean(
-                    confirm[s] - confirm_base[s] for s in cshared
-                )
+        if cshared:
+            row["confirm_mean"] = statistics.mean(confirm[s] for s in cshared)
+            row["n_confirm_seeds"] = len(cshared)
+            row["confirm_paired_delta_vs_base"] = statistics.mean(
+                confirm[s] - confirm_base[s] for s in cshared
+            )
+        elif confirm:
+            row["n_confirm_seeds"] = 0
+            row["confirm_unpaired_seeds"] = sorted(confirm)
         rows.append(row)
     rows.sort(key=lambda r: -(r.get("screen_mean") or 0.0))
     return {

--- a/tests/test_ceiling_analyze.py
+++ b/tests/test_ceiling_analyze.py
@@ -1,0 +1,63 @@
+"""Spread-estimator contract for the ceiling analyzer shipped under ``outputs/``.
+
+The analyzer prints the ``sd`` values quoted in
+``outputs/ipmnist_screening/CEILING_ANALYSIS.md``. Issue #33 unified
+across-seed spread on the sample estimator, but that unification covered
+``alberta_framework`` only, so this script kept NumPy's population default.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ANALYZER = (
+    Path(__file__).resolve().parents[1]
+    / "outputs"
+    / "ipmnist_screening"
+    / "ceiling"
+    / "ceiling_analyze.py"
+)
+
+
+def _load_analyzer() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("ceiling_analyze", _ANALYZER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_across_seed_spread_is_the_sample_estimator() -> None:
+    """Across-seed spread must use ddof=1, matching the screening merge."""
+    module = _load_analyzer()
+    values = [0.7814, 0.7842, 0.7870]
+
+    expected = float(np.asarray(values, dtype=np.float64).std(ddof=1))
+    assert module.across_seed_spread(values) == pytest.approx(expected)
+
+    population = float(np.asarray(values, dtype=np.float64).std())
+    assert module.across_seed_spread(values) > population
+
+
+def test_across_seed_spread_matches_the_screening_merge_convention() -> None:
+    """The helper agrees with the estimator the campaign merge already uses."""
+    module = _load_analyzer()
+    rng = np.random.default_rng(0)
+    for n in (2, 3, 5, 20):
+        sample = rng.normal(size=n)
+        merge_convention = float(sample.std(ddof=1))
+        assert module.across_seed_spread(sample) == pytest.approx(merge_convention)
+
+
+@pytest.mark.parametrize("values", ([], [0.5]))
+def test_across_seed_spread_reports_no_spread_below_two_seeds(values: list[float]) -> None:
+    """One seed has no spread; ddof=1 would be undefined rather than zero."""
+    module = _load_analyzer()
+    assert module.across_seed_spread(values) == 0.0

--- a/tests/test_frontier_rank.py
+++ b/tests/test_frontier_rank.py
@@ -1,0 +1,98 @@
+"""Pairing contract for the frontier ranker shipped under ``outputs/``.
+
+``ipmnist_screening.merge_shards`` refuses to rank configs whose seed sets
+differ, because a mean over one seed set printed beside a delta over another
+is not a paired comparison. This ranker's screen path already restricts to
+shared seeds; its confirm path did not.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RANKER = (
+    Path(__file__).resolve().parents[1]
+    / "outputs"
+    / "ipmnist_screening"
+    / "frontier_rank.py"
+)
+
+
+def _load_ranker() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("frontier_rank", _RANKER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_with(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    screen: dict[str, dict[int, float]],
+    confirm: dict[str, dict[int, float]],
+) -> dict[str, Any]:
+    def fake_seed_means(cfg: str, root: str) -> dict[int, float]:
+        table = confirm if root.endswith("confirm_full") else screen
+        return dict(table.get(cfg, {}))
+
+    monkeypatch.setattr(module, "seed_means", fake_seed_means)
+    monkeypatch.setattr(module, "BASE", "base_arm")
+    monkeypatch.setattr(module, "ARMS", ["candidate"])
+    return module.build()
+
+
+def test_confirm_mean_uses_only_seeds_shared_with_the_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unpaired seed must not enter the confirm mean beside a paired delta."""
+    module = _load_ranker()
+    screen = {"base_arm": {0: 0.80, 1: 0.80}, "candidate": {0: 0.81, 1: 0.81}}
+    # Seed 2 exists for the candidate only, and is far from its paired seeds.
+    confirm = {
+        "base_arm": {0: 0.80, 1: 0.80},
+        "candidate": {0: 0.82, 1: 0.82, 2: 0.99},
+    }
+
+    row = _build_with(module, monkeypatch, screen, confirm)["results"][0]
+
+    assert row["n_confirm_seeds"] == 2
+    assert row["confirm_mean"] == pytest.approx(0.82)
+    assert row["confirm_paired_delta_vs_base"] == pytest.approx(0.02)
+
+
+def test_confirm_block_is_omitted_when_no_seed_is_shared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no shared seed there is no paired confirm result to report."""
+    module = _load_ranker()
+    screen = {"base_arm": {0: 0.80}, "candidate": {0: 0.81}}
+    confirm = {"base_arm": {0: 0.80}, "candidate": {7: 0.99}}
+
+    row = _build_with(module, monkeypatch, screen, confirm)["results"][0]
+
+    assert "confirm_mean" not in row
+    assert "confirm_paired_delta_vs_base" not in row
+    assert row["n_confirm_seeds"] == 0
+    assert row["confirm_unpaired_seeds"] == [7]
+
+
+def test_screen_and_confirm_agree_on_the_shared_seed_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both paths restrict to shared seeds, so their seed counts agree."""
+    module = _load_ranker()
+    screen = {"base_arm": {0: 0.80, 1: 0.80}, "candidate": {0: 0.81, 1: 0.83}}
+    confirm = {"base_arm": {0: 0.80, 1: 0.80}, "candidate": {0: 0.81, 1: 0.83}}
+
+    row = _build_with(module, monkeypatch, screen, confirm)["results"][0]
+
+    assert row["n_screen_seeds"] == row["n_confirm_seeds"] == 2
+    assert row["screen_mean"] == pytest.approx(row["confirm_mean"])


### PR DESCRIPTION
Fixes #1853.

## What moved

The ranker's screen path already restricts to seeds shared with the base. Its confirm path did not — `confirm_mean` and `n_confirm_seeds` covered the arm's whole seed set while `confirm_paired_delta_vs_base` beside them covered only the shared subset.

That is the condition `ipmnist_screening.merge_shards` **refuses** to rank:

> `seed sets differ across configs: {...}; merge_shards ranks configs on paired seeds only`

So the analyzer reporting on the campaign was less strict than the merge it reports on — failing open where the framework fails closed.

## This is latent — no published number changes

Stated up front because it bounds the claim: **every arm's confirm seed set is `[0, 1, 2]` and matches the base**, so `cshared == sorted(confirm)` throughout and `frontier_results.json` is byte-identical on a re-run. Verified against the shards, not assumed:

```text
arms whose confirm_mean would change: 0
```

The defect is a missing guard, not a bad number already emitted. It bites the first time a confirm wave lands on a seed the base lacks.

## The change

```python
        cshared = sorted(set(confirm) & set(confirm_base))
        if cshared:
            row["confirm_mean"] = statistics.mean(confirm[s] for s in cshared)
            row["n_confirm_seeds"] = len(cshared)
            row["confirm_paired_delta_vs_base"] = statistics.mean(
                confirm[s] - confirm_base[s] for s in cshared
            )
        elif confirm:
            row["n_confirm_seeds"] = 0
            row["confirm_unpaired_seeds"] = sorted(confirm)
```

With no shared seed the confirm mean is omitted entirely rather than emitted as a number implying a comparison, and the unpaired seeds are named so the omission is diagnosable.

I kept this to matching the screen path's existing behaviour rather than raising the way `merge_shards` does. Raising is arguably more in keeping with the fail-closed contract, but it would change this script's behaviour beyond the inconsistency being fixed — happy to switch if a maintainer prefers that.

## Tests

`tests/test_frontier_rank.py`, injecting through the `seed_means` seam:

- `test_confirm_mean_uses_only_seeds_shared_with_the_base` — a candidate-only seed at 0.99 must not enter the mean
- `test_confirm_block_is_omitted_when_no_seed_is_shared`
- `test_screen_and_confirm_agree_on_the_shared_seed_set`

Verified failing-first by reverting the fix: **2 failed, 1 passed** — the third passes either way because its seed sets already match, which is the latency in miniature.

## Verification

Commit `c8eb91456cf306cf88fde8bc82787f8940a54426`, based on `cc877f78`.

```bash
python -m pytest -q -p no:randomly -o addopts= tests/test_frontier_rank.py tests/test_ceiling_analyze.py
# 7 passed

python -m ruff check .   # All checks passed!
python -m mypy           # Success: no issues found in 190 source files
```

## Context

Second finding in the untested `outputs/` scripts after #1851. Those 35 files had no coverage before these two PRs.

<!-- evidence-head:c8eb91456cf306cf88fde8bc82787f8940a54426 -->

---

AI provider/model: anthropic / claude-opus-5 (as reported by the running client)
Client / agent tooling: claude-code
Attribution status: self-reported.
