### PR TITLE
fix(outputs): resolve shipped script paths from the repository

### DIFF
--- a/outputs/ipmnist_screening/ceiling/ceiling_analyze.py
+++ b/outputs/ipmnist_screening/ceiling/ceiling_analyze.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 import numpy as np
 
-OUT = Path("/home/shaw/milady/research/alberta/outputs/ipmnist_screening/ceiling")
-CONFIRM = Path("/home/shaw/milady/research/alberta/outputs/ipmnist_screening/confirm_full")
+OUT = Path(__file__).resolve().parent
+CONFIRM = OUT.parent / "confirm_full"
 
 LATE_LO, LATE_HI = 4000, 5000  # within-task plateau window
 BUCKETS = [(0, 50), (50, 100), (100, 250), (250, 500), (500, 1000),

--- a/outputs/ipmnist_screening/ceiling/ceiling_runs.py
+++ b/outputs/ipmnist_screening/ceiling/ceiling_runs.py
@@ -41,7 +41,7 @@ from alberta_framework.benchmarks.upgd_ipmnist import (
     load_mnist_train,
 )
 
-OUT = Path("/home/shaw/milady/research/alberta/outputs/ipmnist_screening/ceiling")
+OUT = Path(__file__).resolve().parent
 
 
 def _load_train() -> tuple[np.ndarray, np.ndarray]:

--- a/outputs/rule_discovery/write_real_screen_summary.py
+++ b/outputs/rule_discovery/write_real_screen_summary.py
@@ -16,8 +16,9 @@ import numpy as np
 from alberta_framework.benchmarks.ipmnist_screening import _atomic_write_json
 from alberta_framework.benchmarks.rule_discovery import NONPROMOTING_POLICY
 
-BASE = Path("/home/shaw/milady/research/alberta/outputs/ipmnist_screening")
-OUT = Path("/home/shaw/milady/research/alberta/outputs/rule_discovery/real_screen_v1.json")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASE = REPO_ROOT / "outputs" / "ipmnist_screening"
+OUT = REPO_ROOT / "outputs" / "rule_discovery" / "real_screen_v1.json"
 SEEDS = (0, 1, 2)
 
 

--- a/tests/test_outputs_script_paths.py
+++ b/tests/test_outputs_script_paths.py
@@ -1,0 +1,73 @@
+"""Reproducibility contract for the scripts shipped under ``outputs/``.
+
+Reports cite these scripts as the way to reproduce their numbers — for example
+``CEILING_ANALYSIS.md`` names ``ceiling_runs.py`` as its runner and
+``ceiling_analyze.py`` as its analyzer. A script that resolves its inputs
+through one machine's absolute home directory cannot serve that purpose.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_OUTPUTS = _REPO_ROOT / "outputs"
+_ABSOLUTE_HOME = re.compile(r"""["'](/home/|/Users/)""")
+
+
+def _load(relative: str) -> ModuleType:
+    path = _REPO_ROOT / relative
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except SystemExit:  # pragma: no cover - argparse-driven scripts
+        pass
+    return module
+
+
+def test_no_outputs_script_hardcodes_an_absolute_home_directory() -> None:
+    """Shipped scripts must not resolve inputs through a developer's home."""
+    offenders = [
+        str(path.relative_to(_REPO_ROOT))
+        for path in sorted(_OUTPUTS.rglob("*.py"))
+        if _ABSOLUTE_HOME.search(path.read_text(encoding="utf-8"))
+    ]
+    assert offenders == []
+
+
+@pytest.mark.parametrize(
+    ("relative", "attribute"),
+    (
+        ("outputs/ipmnist_screening/ceiling/ceiling_runs.py", "OUT"),
+        ("outputs/ipmnist_screening/ceiling/ceiling_analyze.py", "OUT"),
+        ("outputs/ipmnist_screening/ceiling/ceiling_analyze.py", "CONFIRM"),
+        ("outputs/rule_discovery/write_real_screen_summary.py", "BASE"),
+    ),
+)
+def test_ceiling_and_screen_scripts_resolve_inside_the_repository(
+    relative: str,
+    attribute: str,
+) -> None:
+    """The directories these scripts read must exist in a fresh checkout."""
+    resolved = Path(getattr(_load(relative), attribute))
+
+    assert resolved.is_dir()
+    assert resolved.is_relative_to(_REPO_ROOT)
+
+
+def test_write_real_screen_summary_targets_its_own_output_directory() -> None:
+    """The summary writer's output path must land in the repository."""
+    out = Path(_load("outputs/rule_discovery/write_real_screen_summary.py").OUT)
+
+    assert out.parent.is_dir()
+    assert out.parent.is_relative_to(_REPO_ROOT)
+    assert out.name == "real_screen_v1.json"


### PR DESCRIPTION
Fixes #1855.

## What moved

Three scripts under `outputs/` resolved their inputs through `/home/shaw/milady/research/alberta/...`, so none could run in a fresh checkout.

`CEILING_ANALYSIS.md` cites two of them as *the* reproduction path:

> - Runner: `outputs/ipmnist_screening/ceiling/ceiling_runs.py`
> - Analyzer: `outputs/ipmnist_screening/ceiling/ceiling_analyze.py` → `analysis_summary.json`

So the stated way to reproduce the ceiling ladder, the oracle bounds and the error budget was a pair of scripts that exit before reading anything.

## The change

Resolve from `__file__`, matching the sibling that already does it right:

```python
# outputs/ipmnist_screening/nb_ensemble/nb_ensemble_analyze.py:31  (unchanged, the precedent)
OUT = Path(__file__).resolve().parent
```

| script | before | after |
|---|---|---|
| `ceiling_runs.py` | `/home/shaw/.../ceiling` | `Path(__file__).resolve().parent` |
| `ceiling_analyze.py` | `/home/shaw/.../ceiling`, `.../confirm_full` | same, plus `OUT.parent / "confirm_full"` |
| `write_real_screen_summary.py` | two `/home/shaw/...` roots | resolved from `parents[2]` |

Verified each resolved root lands on the directory the script already expected.

## Scope

- **No artifact is read, written or rewritten** — only the constants naming where to look.
- **No number changes.** The scripts were not runnable, so nothing was producing different output.
- 32 of the 35 files under `outputs/` were already clean.

## Tests

`tests/test_outputs_script_paths.py`:

- `test_no_outputs_script_hardcodes_an_absolute_home_directory` — repository-wide guard over all 35 scripts, so this cannot regress
- resolution checks for the four affected roots, asserting each is a real directory inside the repo
- `test_write_real_screen_summary_targets_its_own_output_directory`

Verified failing-first by restoring the hardcoded paths: **6 failed → 6 passed**.

## Verification

Commit `60bbed69c7dfa8d36beb9672ecbbba6a7230caf9`, based on `cc877f78`.

```bash
python -m pytest -q -p no:randomly -o addopts= tests/test_outputs_script_paths.py   # 6 passed
python -m ruff check .                                                              # All checks passed!
python -m mypy                                                                      # Success: 190 source files
python -m pytest --collect-only -q -m "not slow and not package"                    # 14189 collected
```

## Note on overlap

This touches `ceiling_analyze.py`, which #1852 also modifies. The hunks are far apart — module constants at the top versus the spread helper below — and should merge cleanly in either order. Happy to rebase if they conflict.

Third finding in the untested `outputs/` scripts after #1851 and #1853.

<!-- evidence-head:60bbed69c7dfa8d36beb9672ecbbba6a7230caf9 -->

---

AI provider/model: anthropic / claude-opus-5 (as reported by the running client)
Client / agent tooling: claude-code
Attribution status: self-reported.
