### PR TITLE
fix: resolve complete open PR audit with deep integrations

### DIFF
--- a/.github/scripts/ipmnist_local_prereg.py
+++ b/.github/scripts/ipmnist_local_prereg.py
@@ -27,7 +27,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import asdict, dataclass, is_dataclass
+from dataclasses import asdict, dataclass, is_dataclass, replace
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Final, cast
@@ -2153,6 +2153,22 @@ def _validate_collection(
 ) -> dict[str, Any]:
     import alberta_framework.benchmarks.ipmnist_screening as screening
 
+    spec_registry = dict(screening.SCREENING_REGISTRY)
+    if protocol.key == "issue184":
+        # Issue 184 is concluded and deliberately absent from the live runnable
+        # registry. Historical validation must nevertheless retain its exact
+        # arm identity and hyperparameters instead of mutating the live global
+        # registry or failing to validate its immutable result bundle.
+        incumbent = screening.screening_spec(protocol.control)
+        spec_registry[protocol.candidate] = replace(
+            incumbent,
+            name=protocol.candidate,
+            hyperparameters={
+                **incumbent.hyperparameters,
+                "rls_reset_frac": 2.0,
+            },
+        )
+
     expected_pairs = {
         (arm, seed)
         for arm in (protocol.control, protocol.candidate)
@@ -2163,7 +2179,9 @@ def _validate_collection(
     }
     if len(paths) != len(expected_pairs) or {path.name for path in paths} != expected_names:
         raise ValueError("shard filename coverage is not exact")
-    shards = [screening.load_shard(path) for path in paths]
+    shards = [
+        screening.load_shard(path, spec_registry=spec_registry) for path in paths
+    ]
     initial_manifest = _expected_manifest(paths, shards, root=root)
     observed_pairs: set[tuple[str, int]] = set()
     first_dataset: Mapping[str, Any] | None = None
@@ -2233,6 +2251,7 @@ def _validate_collection(
         paths,
         control_name=protocol.control,
         slope_window=15,
+        spec_registry=spec_registry,
     )
     final_manifest = _expected_manifest(paths, shards, root=root)
     if _canonical_json(final_manifest) != _canonical_json(initial_manifest):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ name: ci
 # Benchmarks never execute in CI. The runtime lane collects only tests selected
 # by `not slow and not package`, balances their files by collected-node count,
 # and caps xdist at two workers so JAX compilation remains inside hosted-runner
-# memory limits.
+# memory limits. Ten partitions also keep file-level runtime skew inside the
+# hosted-runner execution envelope; collected-node count alone underestimates
+# several integration-heavy files.
 "on":
   push:
     branches: [main]
@@ -20,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  SHARD_COUNT: "8"
+  SHARD_COUNT: "10"
   XLA_PYTHON_CLIENT_PREALLOCATE: "false"
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: ci
 # Benchmarks never execute in CI. The runtime lane collects only tests selected
 # by `not slow and not package`, balances their files by collected-node count,
 # and caps xdist at two workers so JAX compilation remains inside hosted-runner
-# memory limits. Ten partitions also keep file-level runtime skew inside the
+# memory limits. Sixteen partitions also keep file-level runtime skew inside the
 # hosted-runner execution envelope; collected-node count alone underestimates
 # several integration-heavy files.
 "on":
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  SHARD_COUNT: "10"
+  SHARD_COUNT: "16"
   XLA_PYTHON_CLIENT_PREALLOCATE: "false"
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ The console scripts are grouped by responsibility; every command supports `--hel
 |---|---|
 | `alberta-step1-smoke`, `alberta-step2-smoke` | Nonpromoting mechanism smoke checks |
 | `asi-reference-life-scorecard` | Run or validate the permanently nonpromoting reference-life development scorecard |
+| `asi-ipmnist-ceiling` | Produce new, atomic no-replace stationary/carried/full or batch ceiling diagnostics |
+| `asi-ipmnist-campaign` | Recompute paired frontiers or ceiling summaries from explicit input directories |
+| `asi-rule-discovery-summary` | Rebuild the nonpromoting rule-discovery comparison from explicit inputs |
 | `alberta-evidence-status` | Validate the complete five-claim evidence registry |
 | `alberta-recurring-feature-evidence`, `alberta-scale-robust-evidence`, `alberta-ftl-evidence`, `alberta-multiagent-evidence`, `alberta-ia-evidence` | Validate or build one claim's versioned artifact under its strict protocol |
 | `alberta-forager-benchmark`, `alberta-historical-forager` | Run development Forager comparisons or inspect reconstructed historical families |
@@ -250,6 +253,10 @@ The console scripts are grouped by responsibility; every command supports `--hel
 Benchmark commands are not shortcuts around the evidence rules. Read
 [`FORAGER_BENCHMARK.md`](FORAGER_BENCHMARK.md) and the
 [`foragax-open-screen` runbook](docs/runbooks/foragax-open-screen.md) before using them.
+Use the [maintained IPMNIST campaign tools](docs/runbooks/ipmnist-maintained-tools.md) for
+ceiling, frontier, and rule-discovery reproduction. Programs stored under `outputs/` remain
+historical provenance, not the maintained implementation; existing bytes follow their pinned
+immutable or active-campaign append-only policy.
 
 ## Package layout
 
@@ -401,6 +408,7 @@ consumed seeds, or modify immutable `outputs/` records. See
 ### Runbooks
 
 - [Foragax open development screen](docs/runbooks/foragax-open-screen.md)
+- [Maintained IPMNIST campaign tools](docs/runbooks/ipmnist-maintained-tools.md)
 
 ### Research and historical audits
 

--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -2484,9 +2484,11 @@ def causal_map_state_from_dict(
     }
     if set(payload) != expected_top_level:
         raise ValueError("serialized state top-level fields do not match the schema")
-    if payload.get("schema") != CAUSAL_MAP_STATE_SCHEMA:
+    raw_schema = payload.get("schema")
+    if type(raw_schema) is not str or raw_schema != CAUSAL_MAP_STATE_SCHEMA:
         raise ValueError("unsupported causal-map state schema")
-    if payload.get("prng_impl") != _CAUSAL_MAP_PRNG_IMPL:
+    raw_prng_impl = payload.get("prng_impl")
+    if type(raw_prng_impl) is not str or raw_prng_impl != _CAUSAL_MAP_PRNG_IMPL:
         raise ValueError("serialized state PRNG implementation does not match")
     checkpoint_partitionable = payload.get("jax_threefry_partitionable")
     if type(checkpoint_partitionable) is not bool:
@@ -2526,7 +2528,11 @@ def causal_map_state_from_dict(
     except (TypeError, ValueError) as exc:
         raise ValueError("serialized state config is not canonical JSON") from exc
     declared_config_sha256 = hashlib.sha256(declared_config.encode()).hexdigest()
-    declared_hash_matches = payload.get("config_sha256") == declared_config_sha256
+    raw_config_sha256 = payload.get("config_sha256")
+    declared_hash_matches = (
+        type(raw_config_sha256) is str
+        and raw_config_sha256 == declared_config_sha256
+    )
     current_config_matches = (
         declared_config == expected_config
         and declared_config_sha256 == config.fingerprint()

--- a/alberta_framework/benchmarks/ipmnist_campaign_tools.py
+++ b/alberta_framework/benchmarks/ipmnist_campaign_tools.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
+import re
 import statistics
 import time
 from collections.abc import Sequence
@@ -17,6 +19,7 @@ from typing import Any, cast
 
 import numpy as np
 
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.benchmarks.ipmnist_provenance import analysis_provenance
 
 DEFAULT_BASE = "upgd_ema_norm_sigma0"
@@ -43,6 +46,37 @@ BUCKETS = (
     (2000, 3500),
     (3500, 5000),
 )
+_IDENTIFIER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*\Z")
+
+
+def _safe_identifier(value: object, *, name: str) -> str:
+    if type(value) is not str or _IDENTIFIER_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a safe exact identifier")
+    return value
+
+
+def _finite_scalar(value: object, *, name: str) -> float:
+    if type(value) not in (int, float):
+        raise ValueError(f"{name} must be a finite built-in number")
+    number = float(cast(int | float, value))
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be a finite built-in number")
+    return number
+
+
+def _frontier_arms(value: object, *, base: str) -> tuple[str, ...]:
+    if type(value) not in (list, tuple):
+        raise ValueError("arms must be a non-empty exact list or tuple")
+    raw = cast(list[object] | tuple[object, ...], value)
+    if len(raw) == 0:
+        raise ValueError("arms must be a non-empty exact list or tuple")
+    arms = tuple(
+        _safe_identifier(raw[index], name=f"arms[{index}]")
+        for index in range(len(raw))
+    )
+    if len(set(arms)) != len(arms) or base in arms:
+        raise ValueError("arms must be unique and distinct from base")
+    return arms
 
 
 def across_seed_spread(values: Sequence[float] | np.ndarray[Any, Any]) -> float:
@@ -62,15 +96,23 @@ def _json_object(path: Path) -> dict[str, Any]:
 
 def seed_means(root: Path, config_name: str) -> dict[int, float]:
     """Read mean per-task accuracy by seed for one campaign arm."""
+    config_name = _safe_identifier(config_name, name="config_name")
     result: dict[int, float] = {}
     for path in sorted(root.glob(f"{config_name}_seed*.json")):
         payload = _json_object(path)
-        seed = payload.get("seed")
+        raw_seed = payload.get("seed")
         accuracies = payload.get("per_task_accuracy")
-        if type(seed) is not int or type(accuracies) is not list or not accuracies:
+        if type(accuracies) is not list or not accuracies:
             raise ValueError(f"{path} lacks a valid seed or per_task_accuracy")
+        seed = require_jax_seed(raw_seed, name=f"{path} seed")
+        if path.name != f"{config_name}_seed{seed}.json":
+            raise ValueError(f"{path} filename disagrees with payload seed")
         values = np.asarray(accuracies, dtype=np.float64)
-        if values.ndim != 1 or not bool(np.all(np.isfinite(values))):
+        if (
+            values.ndim != 1
+            or not bool(np.all(np.isfinite(values)))
+            or not bool(np.all((0.0 <= values) & (values <= 1.0)))
+        ):
             raise ValueError(f"{path} has invalid per_task_accuracy")
         if seed in result:
             raise ValueError(f"duplicate seed {seed} for {config_name}")
@@ -88,12 +130,21 @@ def build_frontier(
     created_unix: float | None = None,
 ) -> dict[str, Any]:
     """Build a paired-seed development frontier without mixing seed sets."""
+    if screen_dir.resolve() == confirm_dir.resolve():
+        raise ValueError("screen_dir and confirm_dir must resolve to distinct paths")
+    base = _safe_identifier(base, name="base")
+    checked_arms = _frontier_arms(arms, base=base)
+    threshold = _finite_scalar(threshold, name="threshold")
+    if created_unix is not None:
+        created_unix = _finite_scalar(created_unix, name="created_unix")
+        if created_unix < 0:
+            raise ValueError("created_unix must be nonnegative")
     screen_base = seed_means(screen_dir, base)
     confirm_base = seed_means(confirm_dir, base)
     if not screen_base:
         raise ValueError(f"screen base {base!r} has no seeds")
     rows: list[dict[str, Any]] = []
-    for arm in arms:
+    for arm in checked_arms:
         screen = seed_means(screen_dir, arm)
         confirm = seed_means(confirm_dir, arm)
         if screen.keys() != screen_base.keys():
@@ -133,7 +184,7 @@ def build_frontier(
     input_paths = [
         path
         for directory in (screen_dir, confirm_dir)
-        for name in (base, *arms)
+        for name in (base, *checked_arms)
         for path in directory.glob(f"{name}_seed*.json")
     ]
     return {
@@ -166,15 +217,24 @@ def _ceiling_runs(
     *,
     input_paths: list[Path] | None = None,
 ) -> dict[int, dict[str, Any]]:
+    prefix = _safe_identifier(prefix, name="prefix")
     runs: dict[int, dict[str, Any]] = {}
     for path in sorted(ceiling_dir.glob(f"{prefix}_seed*.json")):
         payload = _json_object(path)
-        seed = payload.get("seed")
+        raw_seed = payload.get("seed")
         tag = payload.get("tag")
-        if type(seed) is not int or type(tag) is not str:
-            raise ValueError(f"{path} lacks a valid seed or tag")
+        seed = require_jax_seed(raw_seed, name=f"{path} seed")
+        tag = _safe_identifier(tag, name=f"{path} tag")
+        if tag != prefix:
+            raise ValueError(f"{path} tag disagrees with requested prefix")
+        if seed in runs:
+            raise ValueError(f"duplicate ceiling seed {seed} for {prefix}")
+        if path.name != f"{prefix}_seed{seed}.json":
+            raise ValueError(f"{path} filename disagrees with payload seed")
         per_step_path = ceiling_dir / f"{tag}_seed{seed}_per_step.npy"
-        payload["per_step"] = np.load(per_step_path, allow_pickle=False)
+        payload["per_step"] = _validated_ceiling_run(
+            payload, np.load(per_step_path, allow_pickle=False), path=path
+        )
         if input_paths is not None:
             input_paths.extend((path, per_step_path))
         runs[seed] = payload
@@ -186,23 +246,98 @@ def _ceiling_runs(
             raise ValueError(f"{path} metadata must be a JSON object")
         if payload.get("schema") != "asi.ipmnist_ceiling.run.v2":
             raise ValueError(f"{path} has an unsupported maintained run schema")
-        if type(payload.get("provenance")) is not dict:
+        if (
+            payload.get("evidence_class")
+            != "development_screening_diagnostic"
+            or payload.get("development_only") is not True
+            or payload.get("scientific_promotion_allowed") is not False
+        ):
+            raise ValueError(f"{path} violates the permanently nonpromoting policy")
+        wall_seconds = _finite_scalar(
+            payload.get("wall_clock_seconds"), name=f"{path} wall_clock_seconds"
+        )
+        if wall_seconds < 0:
+            raise ValueError(f"{path} wall_clock_seconds must be nonnegative")
+        provenance = payload.get("provenance")
+        if (
+            type(provenance) is not dict
+            or provenance.get("schema") != "asi.ipmnist.ceiling_run_provenance.v1"
+        ):
             raise ValueError(f"{path} lacks maintained run provenance")
-        seed = payload.get("seed")
-        if type(seed) is not int:
-            raise ValueError(f"{path} lacks a valid seed")
+        seed = require_jax_seed(payload.get("seed"), name=f"{path} seed")
         if seed in runs:
             raise ValueError(f"duplicate ceiling seed {seed} for {prefix}")
-        if per_step.ndim != 2 or list(per_step.shape) != [
-            payload.get("n_tasks"),
-            payload.get("task_length"),
-        ]:
-            raise ValueError(f"{path} per_step shape disagrees with metadata")
-        payload["per_step"] = per_step
+        if path.name != f"{prefix}_seed{seed}.npz":
+            raise ValueError(f"{path} filename disagrees with payload seed")
+        tag = _safe_identifier(payload.get("tag"), name=f"{path} tag")
+        if tag != prefix:
+            raise ValueError(f"{path} tag disagrees with requested prefix")
+        payload["per_step"] = _validated_ceiling_run(payload, per_step, path=path)
         if input_paths is not None:
             input_paths.append(path)
         runs[seed] = payload
     return runs
+
+
+def _validated_ceiling_run(
+    payload: dict[str, Any], per_step: object, *, path: Path
+) -> np.ndarray[Any, Any]:
+    n_tasks = payload.get("n_tasks")
+    task_length = payload.get("task_length")
+    if type(n_tasks) is not int or n_tasks <= 0:
+        raise ValueError(f"{path} has invalid n_tasks")
+    if type(task_length) is not int or task_length != 5_000:
+        raise ValueError(f"{path} task_length must equal 5000")
+    tag = _safe_identifier(payload.get("tag"), name=f"{path} tag")
+    spec_name = _safe_identifier(payload.get("spec_name"), name=f"{path} spec_name")
+    permutation_mode = payload.get("perm_mode")
+    if type(permutation_mode) is not str:
+        raise ValueError(f"{path} perm_mode must be an exact string")
+    if tag == f"stationary_{spec_name}":
+        expected_mode, expected_tasks = "identity", 1
+    elif tag == f"carried_{spec_name}":
+        expected_mode, expected_tasks = "same", None
+    elif tag == f"full_{spec_name}":
+        expected_mode, expected_tasks = "protocol", 200
+    else:
+        raise ValueError(f"{path} tag does not bind its spec_name")
+    if permutation_mode != expected_mode:
+        raise ValueError(f"{path} perm_mode disagrees with tag family")
+    if expected_tasks is not None and n_tasks != expected_tasks:
+        raise ValueError(f"{path} n_tasks disagrees with tag family")
+    if expected_tasks is None and n_tasks < 10:
+        raise ValueError(f"{path} carried runs require at least ten tasks")
+    array = np.asarray(per_step)
+    if array.shape != (n_tasks, task_length):
+        raise ValueError(f"{path} per_step shape disagrees with metadata")
+    if array.dtype != np.dtype(np.uint8) or not bool(np.all((array == 0) | (array == 1))):
+        raise ValueError(f"{path} per_step must be a uint8 binary matrix")
+    raw_per_task = payload.get("per_task_accuracy")
+    if type(raw_per_task) is not list:
+        raise ValueError(f"{path} per_task_accuracy must be an exact list")
+    per_task = _finite_vector(raw_per_task, name="per_task_accuracy")
+    if per_task.shape != (n_tasks,) or not bool(np.all((0.0 <= per_task) & (per_task <= 1.0))):
+        raise ValueError(f"{path} per_task_accuracy has invalid shape or domain")
+    observed_means = array.astype(np.float64).mean(axis=1)
+    if not bool(
+        np.allclose(
+            per_task,
+            observed_means,
+            rtol=0.0,
+            atol=CONFIRM_ALIGNMENT_ATOL,
+            equal_nan=False,
+        )
+    ):
+        raise ValueError(f"{path} per_task_accuracy disagrees with per_step means")
+    mean_accuracy = _finite_scalar(payload.get("mean_accuracy"), name="mean_accuracy")
+    if not 0.0 <= mean_accuracy <= 1.0 or not math.isclose(
+        mean_accuracy,
+        float(per_task.mean()),
+        rel_tol=0.0,
+        abs_tol=CONFIRM_ALIGNMENT_ATOL,
+    ):
+        raise ValueError(f"{path} mean_accuracy disagrees with per_task_accuracy")
+    return array
 
 
 def _finite_vector(value: object, *, name: str) -> np.ndarray[Any, np.dtype[np.float64]]:
@@ -231,6 +366,11 @@ def validate_confirm_alignment(
         seed = cast(int, run["seed"])
         reference_path = confirm_dir / f"sigma0_ndecay099_seed{seed}.json"
         reference = _json_object(reference_path)
+        reference_seed = require_jax_seed(
+            reference.get("seed"), name=f"{reference_path} seed"
+        )
+        if reference_seed != seed:
+            raise ValueError(f"{reference_path} seed does not match ceiling seed {seed}")
         if input_paths is not None:
             input_paths.append(reference_path)
         observed = _finite_vector(run["per_task_accuracy"], name="per_task_accuracy")
@@ -320,17 +460,30 @@ def build_ceiling_summary(ceiling_dir: Path, confirm_dir: Path) -> dict[str, Any
             "late_task_late_window": float(last_task_late.mean()),
         }
 
-    batch = [
-        _json_object(path)
-        for path in sorted(ceiling_dir.glob("batch_reference_seed*.json"))
-    ]
-    input_paths.extend(sorted(ceiling_dir.glob("batch_reference_seed*.json")))
+    batch_paths = sorted(ceiling_dir.glob("batch_reference_seed*.json"))
+    batch = []
+    batch_seeds: set[int] = set()
+    for path in batch_paths:
+        run = _json_object(path)
+        seed = require_jax_seed(run.get("seed"), name=f"{path} seed")
+        if seed in batch_seeds:
+            raise ValueError(f"{path} has a duplicate seed")
+        if path.name != f"batch_reference_seed{seed}.json":
+            raise ValueError(f"{path} filename disagrees with payload seed")
+        batch_seeds.add(seed)
+        best_score = _finite_scalar(
+            run.get("test_accuracy_best"), name="test_accuracy_best"
+        )
+        if not 0.0 <= best_score <= 1.0:
+            raise ValueError(f"{path} test_accuracy_best is outside [0, 1]")
+        batch.append(run)
+    input_paths.extend(batch_paths)
     if batch:
-        best = [float(run["test_accuracy_best"]) for run in batch]
+        best_scores = [float(run["test_accuracy_best"]) for run in batch]
         report["batch_reference"] = {
-            "test_best_mean": float(np.mean(best)),
-            "test_best_sample_standard_deviation": across_seed_spread(best),
-            "per_seed": best,
+            "test_best_mean": float(np.mean(best_scores)),
+            "test_best_sample_standard_deviation": across_seed_spread(best_scores),
+            "per_seed": best_scores,
         }
 
     full = _ceiling_runs(
@@ -418,7 +571,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
     else:
         result = build_ceiling_summary(args.ceiling_dir, args.confirm_dir)
-    print(json.dumps(result, indent=2, sort_keys=True))
+    print(json.dumps(result, indent=2, sort_keys=True, allow_nan=False))
     return 0
 
 

--- a/alberta_framework/benchmarks/ipmnist_campaign_tools.py
+++ b/alberta_framework/benchmarks/ipmnist_campaign_tools.py
@@ -1,0 +1,426 @@
+"""Maintained, nonpromoting IPMNIST campaign analysis tools.
+
+Historical programs stored below ``outputs/`` are immutable run records.  This
+module owns the live analysis contracts and takes every input path explicitly,
+so reproduction never depends on a contributor's home directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+
+from alberta_framework.benchmarks.ipmnist_provenance import analysis_provenance
+
+DEFAULT_BASE = "upgd_ema_norm_sigma0"
+DEFAULT_ARMS = (
+    "sigma0_hidden_norm",
+    "sigma0_localgate",
+    "sigma0_ndecay099",
+    "sigma0_ndecay09999",
+    "sigma0_eps1e6",
+    "sigma0_eps1e4",
+    "sigma0_gate_beta05",
+    "sigma0_gate_beta2",
+)
+DEFAULT_THRESHOLD = 0.002
+CONFIRM_ALIGNMENT_ATOL = 1e-7
+LATE_LO, LATE_HI = 4000, 5000
+BUCKETS = (
+    (0, 50),
+    (50, 100),
+    (100, 250),
+    (250, 500),
+    (500, 1000),
+    (1000, 2000),
+    (2000, 3500),
+    (3500, 5000),
+)
+
+
+def across_seed_spread(values: Sequence[float] | np.ndarray[Any, Any]) -> float:
+    """Return sample standard deviation, or zero below two observations."""
+    array = np.asarray(values, dtype=np.float64).ravel()
+    if array.size < 2:
+        return 0.0
+    return float(array.std(ddof=1))
+
+
+def _json_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if type(payload) is not dict:
+        raise ValueError(f"{path} must contain a JSON object")
+    return cast(dict[str, Any], payload)
+
+
+def seed_means(root: Path, config_name: str) -> dict[int, float]:
+    """Read mean per-task accuracy by seed for one campaign arm."""
+    result: dict[int, float] = {}
+    for path in sorted(root.glob(f"{config_name}_seed*.json")):
+        payload = _json_object(path)
+        seed = payload.get("seed")
+        accuracies = payload.get("per_task_accuracy")
+        if type(seed) is not int or type(accuracies) is not list or not accuracies:
+            raise ValueError(f"{path} lacks a valid seed or per_task_accuracy")
+        values = np.asarray(accuracies, dtype=np.float64)
+        if values.ndim != 1 or not bool(np.all(np.isfinite(values))):
+            raise ValueError(f"{path} has invalid per_task_accuracy")
+        if seed in result:
+            raise ValueError(f"duplicate seed {seed} for {config_name}")
+        result[seed] = statistics.mean(float(value) for value in values)
+    return result
+
+
+def build_frontier(
+    screen_dir: Path,
+    confirm_dir: Path,
+    *,
+    base: str = DEFAULT_BASE,
+    arms: Sequence[str] = DEFAULT_ARMS,
+    threshold: float = DEFAULT_THRESHOLD,
+    created_unix: float | None = None,
+) -> dict[str, Any]:
+    """Build a paired-seed development frontier without mixing seed sets."""
+    screen_base = seed_means(screen_dir, base)
+    confirm_base = seed_means(confirm_dir, base)
+    if not screen_base:
+        raise ValueError(f"screen base {base!r} has no seeds")
+    rows: list[dict[str, Any]] = []
+    for arm in arms:
+        screen = seed_means(screen_dir, arm)
+        confirm = seed_means(confirm_dir, arm)
+        if screen.keys() != screen_base.keys():
+            raise ValueError(
+                f"screen seed sets differ for {arm!r} and base {base!r}: "
+                f"{sorted(screen)} != {sorted(screen_base)}"
+            )
+        paired_seeds = sorted(screen)
+        row: dict[str, Any] = {
+            "config_name": arm,
+            "n_screen_seeds": len(paired_seeds),
+            "screen_mean": statistics.mean(screen[seed] for seed in paired_seeds),
+            "screen_paired_delta_vs_base": statistics.mean(
+                screen[seed] - screen_base[seed] for seed in paired_seeds
+            ),
+            "screen_per_seed_delta": [
+                round(screen[seed] - screen_base[seed], 6) for seed in paired_seeds
+            ],
+        }
+        row["confirmation_candidate"] = row["screen_paired_delta_vs_base"] > threshold
+        if confirm:
+            if confirm.keys() != confirm_base.keys():
+                raise ValueError(
+                    f"confirm seed sets differ for {arm!r} and base {base!r}: "
+                    f"{sorted(confirm)} != {sorted(confirm_base)}"
+                )
+            confirm_seeds = sorted(confirm)
+            row["confirm_mean"] = statistics.mean(
+                confirm[seed] for seed in confirm_seeds
+            )
+            row["n_confirm_seeds"] = len(confirm_seeds)
+            row["confirm_paired_delta_vs_base"] = statistics.mean(
+                confirm[seed] - confirm_base[seed] for seed in confirm_seeds
+            )
+        rows.append(row)
+    rows.sort(key=lambda row: -float(row.get("screen_mean", 0.0)))
+    input_paths = [
+        path
+        for directory in (screen_dir, confirm_dir)
+        for name in (base, *arms)
+        for path in directory.glob(f"{name}_seed*.json")
+    ]
+    return {
+        "schema": "asi.ipmnist.frontier.v2",
+        "base": base,
+        "base_screen_mean": statistics.mean(screen_base.values()) if screen_base else None,
+        "base_confirm_mean": (
+            statistics.mean(confirm_base.values()) if confirm_base else None
+        ),
+        "confirmation_threshold": threshold,
+        "created_unix": time.time() if created_unix is None else created_unix,
+        "evidence_policy": {
+            "development_only": True,
+            "evidence_class": "development_screening_diagnostic",
+            "scientific_promotion_allowed": False,
+        },
+        "provenance": analysis_provenance(
+            command="frontier",
+            input_paths=input_paths,
+            sources={"campaign_tools": Path(__file__)},
+            repository_root=Path(__file__).resolve().parents[2],
+        ),
+        "results": rows,
+    }
+
+
+def _ceiling_runs(
+    ceiling_dir: Path,
+    prefix: str,
+    *,
+    input_paths: list[Path] | None = None,
+) -> dict[int, dict[str, Any]]:
+    runs: dict[int, dict[str, Any]] = {}
+    for path in sorted(ceiling_dir.glob(f"{prefix}_seed*.json")):
+        payload = _json_object(path)
+        seed = payload.get("seed")
+        tag = payload.get("tag")
+        if type(seed) is not int or type(tag) is not str:
+            raise ValueError(f"{path} lacks a valid seed or tag")
+        per_step_path = ceiling_dir / f"{tag}_seed{seed}_per_step.npy"
+        payload["per_step"] = np.load(per_step_path, allow_pickle=False)
+        if input_paths is not None:
+            input_paths.extend((path, per_step_path))
+        runs[seed] = payload
+    for path in sorted(ceiling_dir.glob(f"{prefix}_seed*.npz")):
+        with np.load(path, allow_pickle=False) as archive:
+            payload = json.loads(str(archive["metadata"].item()))
+            per_step = np.asarray(archive["per_step"])
+        if type(payload) is not dict:
+            raise ValueError(f"{path} metadata must be a JSON object")
+        if payload.get("schema") != "asi.ipmnist_ceiling.run.v2":
+            raise ValueError(f"{path} has an unsupported maintained run schema")
+        if type(payload.get("provenance")) is not dict:
+            raise ValueError(f"{path} lacks maintained run provenance")
+        seed = payload.get("seed")
+        if type(seed) is not int:
+            raise ValueError(f"{path} lacks a valid seed")
+        if seed in runs:
+            raise ValueError(f"duplicate ceiling seed {seed} for {prefix}")
+        if per_step.ndim != 2 or list(per_step.shape) != [
+            payload.get("n_tasks"),
+            payload.get("task_length"),
+        ]:
+            raise ValueError(f"{path} per_step shape disagrees with metadata")
+        payload["per_step"] = per_step
+        if input_paths is not None:
+            input_paths.append(path)
+        runs[seed] = payload
+    return runs
+
+
+def _finite_vector(value: object, *, name: str) -> np.ndarray[Any, np.dtype[np.float64]]:
+    array = np.asarray(value, dtype=np.float64)
+    if array.ndim != 1 or not bool(np.all(np.isfinite(array))):
+        raise ValueError(f"{name} must be a finite vector")
+    return array
+
+
+def validate_confirm_alignment(
+    runs: Sequence[dict[str, Any]],
+    confirm_dir: Path,
+    *,
+    input_paths: list[Path] | None = None,
+) -> dict[str, Any]:
+    """Validate rounded ceiling JSON against confirmation shards.
+
+    Both files store decimal JSON derived from independently rounded floating
+    computations.  The fixed absolute tolerance admits the observed encoding
+    delta while rejecting a score-relevant disagreement; relative tolerance is
+    deliberately zero so the gate does not widen with accuracy magnitude.
+    """
+    per_seed: dict[str, Any] = {}
+    maximum = 0.0
+    for run in runs:
+        seed = cast(int, run["seed"])
+        reference_path = confirm_dir / f"sigma0_ndecay099_seed{seed}.json"
+        reference = _json_object(reference_path)
+        if input_paths is not None:
+            input_paths.append(reference_path)
+        observed = _finite_vector(run["per_task_accuracy"], name="per_task_accuracy")
+        expected = _finite_vector(reference["per_task_accuracy"], name="reference")
+        if observed.shape != expected.shape:
+            raise ValueError(f"ceiling and confirm shapes differ for seed {seed}")
+        max_delta = float(np.max(np.abs(observed - expected), initial=0.0))
+        if not bool(
+            np.allclose(
+                observed,
+                expected,
+                rtol=0.0,
+                atol=CONFIRM_ALIGNMENT_ATOL,
+                equal_nan=False,
+            )
+        ):
+            raise ValueError(
+                f"ceiling and confirm per-task values differ for seed {seed}: "
+                f"max_abs_delta={max_delta:.17g} exceeds atol={CONFIRM_ALIGNMENT_ATOL}"
+            )
+        maximum = max(maximum, max_delta)
+        per_seed[str(seed)] = {
+            "n_values": int(observed.size),
+            "max_abs_delta": max_delta,
+        }
+    return {
+        "absolute_tolerance": CONFIRM_ALIGNMENT_ATOL,
+        "relative_tolerance": 0.0,
+        "max_abs_delta": maximum,
+        "per_seed": per_seed,
+    }
+
+
+def build_ceiling_summary(ceiling_dir: Path, confirm_dir: Path) -> dict[str, Any]:
+    """Recompute the maintained ceiling/error-budget summary from raw runs."""
+    input_paths: list[Path] = []
+    report: dict[str, Any] = {
+        "schema": "asi.ipmnist.ceiling_summary.v2",
+        "evidence_policy": {
+            "development_only": True,
+            "scientific_promotion_allowed": False,
+        }
+    }
+    for spec in ("sigma0_ndecay099", "adamw_control", "sgd_ema_norm"):
+        runs = _ceiling_runs(
+            ceiling_dir, f"stationary_{spec}", input_paths=input_paths
+        )
+        if not runs:
+            continue
+        means = [float(run["mean_accuracy"]) for run in runs.values()]
+        curves = np.stack(
+            [np.asarray(run["per_step"])[0].astype(np.float64) for run in runs.values()]
+        )
+        mean_curve = curves.mean(axis=0)
+        report[f"stationary_{spec}"] = {
+            "avg_online_mean": float(np.mean(means)),
+            "avg_online_per_seed": means,
+            "sample_standard_deviation": across_seed_spread(means),
+            "late_window": float(mean_curve[LATE_LO:LATE_HI].mean()),
+            "buckets": {
+                f"{start}-{end}": round(float(mean_curve[start:end].mean()), 5)
+                for start, end in BUCKETS
+            },
+        }
+
+    for spec in ("sigma0_ndecay099", "adamw_control"):
+        runs = _ceiling_runs(ceiling_dir, f"carried_{spec}", input_paths=input_paths)
+        if not runs:
+            continue
+        per_task = np.stack(
+            [
+                _finite_vector(run["per_task_accuracy"], name="per_task_accuracy")
+                for run in runs.values()
+            ]
+        )
+        late_tasks = per_task[:, -10:].mean(axis=1)
+        last_task_late = np.stack(
+            [
+                np.asarray(run["per_step"], dtype=np.float64)[-10:, LATE_LO:LATE_HI].mean()
+                for run in runs.values()
+            ]
+        )
+        report[f"carried_{spec}"] = {
+            "per_task_mean_curve": [round(float(value), 5) for value in per_task.mean(axis=0)],
+            "late_task_avg_online": float(late_tasks.mean()),
+            "late_task_sample_standard_deviation": across_seed_spread(late_tasks),
+            "late_task_late_window": float(last_task_late.mean()),
+        }
+
+    batch = [
+        _json_object(path)
+        for path in sorted(ceiling_dir.glob("batch_reference_seed*.json"))
+    ]
+    input_paths.extend(sorted(ceiling_dir.glob("batch_reference_seed*.json")))
+    if batch:
+        best = [float(run["test_accuracy_best"]) for run in batch]
+        report["batch_reference"] = {
+            "test_best_mean": float(np.mean(best)),
+            "test_best_sample_standard_deviation": across_seed_spread(best),
+            "per_seed": best,
+        }
+
+    full = _ceiling_runs(
+        ceiling_dir, "full_sigma0_ndecay099", input_paths=input_paths
+    )
+    if full:
+        ordered = [full[seed] for seed in sorted(full)]
+        alignment = validate_confirm_alignment(
+            ordered, confirm_dir, input_paths=input_paths
+        )
+        array = np.stack(
+            [np.asarray(run["per_step"], dtype=np.float64) for run in ordered]
+        )
+        overall = float(array.mean())
+        plateau_by_task = array[:, :, LATE_LO:LATE_HI].mean(axis=2)
+        asymptotic_error = float((1.0 - plateau_by_task).mean())
+        total_error = 1.0 - overall
+        curve = array.mean(axis=(0, 1))
+        bucket_rows = []
+        for start, end in BUCKETS:
+            accuracy = float(curve[start:end].mean())
+            excess = float(
+                (plateau_by_task[:, :, None] - array[:, :, start:end]).mean()
+            )
+            contribution = excess * (end - start) / array.shape[2]
+            bucket_rows.append(
+                [
+                    f"{start}-{end}",
+                    round(accuracy, 5),
+                    round(excess, 5),
+                    round(contribution, 5),
+                ]
+            )
+        task_plateau = plateau_by_task.mean(axis=0)
+        task_index = np.arange(task_plateau.size)
+        late_mask = task_index >= 20
+        slope = float(np.polyfit(task_index[late_mask], task_plateau[late_mask], 1)[0])
+        report["error_budget"] = {
+            "overall": overall,
+            "total_error": total_error,
+            "asymptotic_error": asymptotic_error,
+            "transient_excess": total_error - asymptotic_error,
+            "plateau_mean": float(plateau_by_task.mean()),
+            "first500": float(array[:, :, :500].mean()),
+            "buckets": bucket_rows,
+            "plateau_tasks_20_60": float(task_plateau[20:60].mean()),
+            "plateau_tasks_160_200": float(task_plateau[160:200].mean()),
+            "drift_slope_per_task": slope,
+            "confirm_alignment": alignment,
+        }
+    report["provenance"] = analysis_provenance(
+        command="ceiling",
+        input_paths=input_paths,
+        sources={"campaign_tools": Path(__file__)},
+        repository_root=Path(__file__).resolve().parents[2],
+    )
+    return report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    frontier = subparsers.add_parser("frontier", help="build a paired-seed frontier")
+    frontier.add_argument("--screen-dir", type=Path, required=True)
+    frontier.add_argument("--confirm-dir", type=Path, required=True)
+    frontier.add_argument("--base", default=DEFAULT_BASE)
+    frontier.add_argument("--arms", nargs="+", default=list(DEFAULT_ARMS))
+    frontier.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    ceiling = subparsers.add_parser("ceiling", help="recompute the ceiling summary")
+    ceiling.add_argument("--ceiling-dir", type=Path, required=True)
+    ceiling.add_argument("--confirm-dir", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run a maintained analyzer and emit JSON to stdout only."""
+    args = _parser().parse_args(argv)
+    if args.command == "frontier":
+        result = build_frontier(
+            args.screen_dir,
+            args.confirm_dir,
+            base=args.base,
+            arms=args.arms,
+            threshold=args.threshold,
+        )
+    else:
+        result = build_ceiling_summary(args.ceiling_dir, args.confirm_dir)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/alberta_framework/benchmarks/ipmnist_ceiling.py
+++ b/alberta_framework/benchmarks/ipmnist_ceiling.py
@@ -1,0 +1,448 @@
+"""Maintained IPMNIST ceiling-run producer.
+
+The scripts preserved under ``outputs/`` describe historical executions and
+must not be edited.  This module is their maintained replacement: destinations
+are explicit, publication is no-replace, and every result remains permanently
+development-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+import time
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any, BinaryIO
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+
+import alberta_framework.benchmarks.ipmnist_provenance as ipmnist_provenance_module
+import alberta_framework.benchmarks.ipmnist_screening as ipmnist_screening_module
+import alberta_framework.benchmarks.upgd_ipmnist as upgd_ipmnist_module
+from alberta_framework.benchmarks.ipmnist_provenance import (
+    array_identity,
+    repository_specification_identities,
+    runtime_identity,
+    source_identities,
+)
+from alberta_framework.benchmarks.ipmnist_screening import screening_spec
+from alberta_framework.benchmarks.upgd_ipmnist import (
+    IPMNISTConfig,
+    build_schedule,
+    default_openml_data_home,
+    init_mlp_params,
+    load_mnist_train,
+)
+
+
+def _load_train() -> tuple[np.ndarray[Any, Any], np.ndarray[Any, Any]]:
+    return load_mnist_train(default_openml_data_home())
+
+
+def run_arm_per_step(
+    spec_name: str,
+    seed: int,
+    n_tasks: int,
+    permutation_mode: str,
+    *,
+    progress_every: int = 20,
+) -> tuple[np.ndarray[Any, Any], np.ndarray[Any, Any], float, dict[str, Any]]:
+    """Run one screening arm while retaining per-step online accuracy."""
+    config = IPMNISTConfig(n_tasks=n_tasks)
+    spec = screening_spec(spec_name)
+    init_fn, step_fn = spec.factory(spec.hyperparameters)
+    data_x_numpy, data_y_numpy = _load_train()
+    data_x = jnp.asarray(data_x_numpy, dtype=jnp.float32)
+    data_y = jnp.asarray(data_y_numpy, dtype=jnp.int32)
+    root = jr.key(jnp.uint32(seed))
+    key_init, key_schedule, key_noise = jr.split(root, 3)
+    params = init_mlp_params(key_init, config)
+    schedule = build_schedule(key_schedule, config, int(data_x.shape[0]))
+    if permutation_mode == "same":
+        permutations = jnp.tile(schedule.permutations[0][None, :], (n_tasks, 1))
+    elif permutation_mode == "identity":
+        permutations = jnp.tile(
+            jnp.arange(config.input_dim, dtype=jnp.int32)[None, :], (n_tasks, 1)
+        )
+    elif permutation_mode == "protocol":
+        permutations = schedule.permutations
+    else:
+        raise ValueError("permutation_mode must be identity, same, or protocol")
+    state = init_fn(params)
+
+    def run_task(
+        task_params: Any,
+        task_state: Any,
+        task_key: Any,
+        permutation: Any,
+        examples: Any,
+    ) -> tuple[Any, Any, Any, Any]:
+        def one_step(carry: tuple[Any, Any, Any], example: Any) -> tuple[Any, Any]:
+            step_params, step_state, key = carry
+            observation = data_x[example][permutation]
+            target = data_y[example]
+            key, step_key = jr.split(key)
+            next_params, next_state, metrics = step_fn(
+                step_params, step_state, observation, target, step_key
+            )
+            return (next_params, next_state, key), metrics
+
+        (next_params, next_state, next_key), metrics = jax.lax.scan(
+            one_step, (task_params, task_state, task_key), examples
+        )
+        accuracies, _, _ = metrics
+        return next_params, next_state, next_key, accuracies
+
+    run_task_jit = jax.jit(run_task)
+    per_step = np.zeros((n_tasks, config.task_length), dtype=np.uint8)
+    per_task = np.zeros(n_tasks, dtype=np.float64)
+    started = time.monotonic()
+    for task in range(n_tasks):
+        params, state, key_noise, accuracies = run_task_jit(
+            params,
+            state,
+            key_noise,
+            permutations[task],
+            schedule.example_indices[task],
+        )
+        accuracy_array = np.asarray(accuracies)
+        per_step[task] = accuracy_array.astype(np.uint8)
+        per_task[task] = float(accuracy_array.mean())
+        if progress_every > 0 and (task + 1) % progress_every == 0:
+            print(
+                f"{spec_name} seed={seed} mode={permutation_mode} "
+                f"task={task + 1}/{n_tasks} accuracy={per_task[task]:.4f}",
+                flush=True,
+            )
+    provenance = {
+        "schema": "asi.ipmnist.ceiling_run_provenance.v1",
+        "runtime": runtime_identity(dependencies=("jax", "jaxlib", "numpy")),
+        "sources": source_identities(
+            {
+                "ceiling_runner": Path(__file__),
+                "ipmnist_screening": Path(ipmnist_screening_module.__file__),
+                "ipmnist_provenance": Path(ipmnist_provenance_module.__file__),
+                "upgd_ipmnist": Path(upgd_ipmnist_module.__file__),
+            },
+            repository_root=Path(__file__).resolve().parents[2],
+        ),
+        "environment_specifications": repository_specification_identities(
+            Path(__file__).resolve().parents[2]
+        ),
+        "dataset": {
+            "name": "mnist_784",
+            "version": 1,
+            "train_observations": array_identity(data_x_numpy),
+            "train_labels": array_identity(data_y_numpy),
+        },
+        "schedule": {
+            "derivation": "jr.split(root,3)[1]; per-task fold_in permutations/samples",
+            "permutations": array_identity(np.asarray(permutations)),
+            "example_indices": array_identity(np.asarray(schedule.example_indices)),
+        },
+        "inputs": {
+            "spec_name": spec.name,
+            "base_learner": spec.base_learner,
+            "mechanism": spec.mechanism,
+            "hyperparameters": dict(sorted(spec.hyperparameters.items())),
+            "seed": seed,
+            "permutation_mode": permutation_mode,
+            "config": config.to_config(),
+        },
+    }
+    return per_step, per_task, time.monotonic() - started, provenance
+
+
+def _publish_run(
+    output_dir: Path,
+    *,
+    tag: str,
+    spec_name: str,
+    seed: int,
+    permutation_mode: str,
+    n_tasks: int,
+    per_step: np.ndarray[Any, Any],
+    per_task: np.ndarray[Any, Any],
+    wall_seconds: float,
+    provenance: dict[str, Any],
+) -> Path:
+    """Atomically publish one self-contained run without replacement."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = output_dir / f"{tag}_seed{seed}.npz"
+    if artifact_path.exists():
+        raise FileExistsError(f"refusing to replace {tag} seed {seed} in {output_dir}")
+    payload = {
+        "schema": "asi.ipmnist_ceiling.run.v2",
+        "evidence_class": "development_screening_diagnostic",
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "tag": tag,
+        "spec_name": spec_name,
+        "seed": seed,
+        "perm_mode": permutation_mode,
+        "n_tasks": n_tasks,
+        "task_length": int(per_step.shape[1]),
+        "per_task_accuracy": [round(float(value), 8) for value in per_task],
+        "mean_accuracy": round(float(per_task.mean()), 8),
+        "wall_clock_seconds": round(wall_seconds, 2),
+        "jax": jax.__version__,
+        "provenance": provenance,
+    }
+    metadata = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+    def write_archive(stream: BinaryIO) -> None:
+        np.savez_compressed(
+            stream,
+            metadata=np.asarray(metadata),
+            per_step=per_step,
+        )
+
+    _atomic_publish(artifact_path, write_archive)
+    return artifact_path
+
+
+def _atomic_publish(path: Path, writer: Callable[[BinaryIO], None]) -> None:
+    """Publish one file by durable temp write plus atomic no-replace link."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    temporary = Path(temporary_name)
+    published = False
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            writer(stream)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, path)
+        published = True
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    except BaseException:
+        if published:
+            path.unlink(missing_ok=True)
+        raise
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def run_and_publish(
+    output_dir: Path,
+    *,
+    mode: str,
+    spec_name: str,
+    seed: int,
+    n_tasks: int | None = None,
+) -> Path:
+    """Run one stationary, carried, or full ceiling shard."""
+    if mode == "stationary":
+        tasks, permutation_mode, tag = 1, "identity", f"stationary_{spec_name}"
+    elif mode == "carried":
+        tasks = 60 if n_tasks is None else n_tasks
+        permutation_mode, tag = "same", f"carried_{spec_name}"
+    elif mode == "full":
+        tasks, permutation_mode, tag = 200, "protocol", f"full_{spec_name}"
+    else:
+        raise ValueError("mode must be stationary, carried, or full")
+    if tasks <= 0:
+        raise ValueError("n_tasks must be positive")
+    per_step, per_task, wall_seconds, provenance = run_arm_per_step(
+        spec_name, seed, tasks, permutation_mode
+    )
+    return _publish_run(
+        output_dir,
+        tag=tag,
+        spec_name=spec_name,
+        seed=seed,
+        permutation_mode=permutation_mode,
+        n_tasks=tasks,
+        per_step=per_step,
+        per_task=per_task,
+        wall_seconds=wall_seconds,
+        provenance=provenance,
+    )
+
+
+def run_batch_reference(
+    output_dir: Path,
+    *,
+    seed: int,
+    epochs: int = 30,
+    batch_size: int = 128,
+) -> Path:
+    """Run the converged minibatch-Adam architecture reference."""
+    import optax  # type: ignore[import-not-found]
+    from sklearn.datasets import fetch_openml  # type: ignore[import-untyped]
+
+    if epochs <= 0 or batch_size <= 0:
+        raise ValueError("epochs and batch_size must be positive")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"batch_reference_seed{seed}.json"
+    if output_path.exists():
+        raise FileExistsError(f"refusing to replace {output_path}")
+
+    raw = fetch_openml(
+        "mnist_784",
+        version=1,
+        as_frame=False,
+        data_home=str(default_openml_data_home()),
+        n_retries=3,
+        delay=2.0,
+    )
+    observations = np.asarray(raw.data, dtype=np.float32)
+    labels = np.asarray(raw.target, dtype=np.int32)
+    observations = (observations / 255.0 - 0.5) / 0.5
+    train_x = jnp.asarray(observations[:60_000])
+    train_y = jnp.asarray(labels[:60_000])
+    test_x = jnp.asarray(observations[60_000:])
+    test_y = jnp.asarray(labels[60_000:])
+    config = IPMNISTConfig(n_tasks=1)
+    params = init_mlp_params(jr.key(jnp.uint32(seed)), config)
+
+    def loss_fn(model: Any, batch_x: Any, batch_y: Any) -> Any:
+        hidden1 = jax.nn.relu(batch_x @ model["w1"] + model["b1"])
+        hidden2 = jax.nn.relu(hidden1 @ model["w2"] + model["b2"])
+        logits = hidden2 @ model["w3"] + model["b3"]
+        return -jnp.mean(
+            jnp.take_along_axis(jax.nn.log_softmax(logits), batch_y[:, None], axis=1)
+        )
+
+    def accuracy_fn(model: Any, batch_x: Any, batch_y: Any) -> Any:
+        hidden1 = jax.nn.relu(batch_x @ model["w1"] + model["b1"])
+        hidden2 = jax.nn.relu(hidden1 @ model["w2"] + model["b2"])
+        logits = hidden2 @ model["w3"] + model["b3"]
+        return jnp.mean((jnp.argmax(logits, axis=1) == batch_y).astype(jnp.float32))
+
+    optimizer = optax.adam(1e-3)
+    optimizer_state = optimizer.init(params)
+
+    @jax.jit
+    def train_step(
+        model: Any, state: Any, batch_x: Any, batch_y: Any
+    ) -> tuple[Any, Any]:
+        _, gradients = jax.value_and_grad(loss_fn)(model, batch_x, batch_y)
+        updates, next_state = optimizer.update(gradients, state)
+        return optax.apply_updates(model, updates), next_state
+
+    accuracy_jit = jax.jit(accuracy_fn)
+    rng = np.random.default_rng(seed)
+    history: list[float] = []
+    started = time.monotonic()
+    for epoch in range(epochs):
+        order = rng.permutation(60_000)
+        for start in range(0, 60_000 - batch_size + 1, batch_size):
+            indices = order[start : start + batch_size]
+            params, optimizer_state = train_step(
+                params, optimizer_state, train_x[indices], train_y[indices]
+            )
+        test_accuracy = float(accuracy_jit(params, test_x, test_y))
+        history.append(test_accuracy)
+        print(
+            f"batch seed={seed} epoch={epoch + 1}/{epochs} "
+            f"test_accuracy={test_accuracy:.4f}",
+            flush=True,
+        )
+    train_accuracy = float(accuracy_jit(params, train_x[:20_000], train_y[:20_000]))
+    payload = {
+        "schema": "asi.ipmnist_ceiling.batch_reference.v2",
+        "evidence_class": "development_screening_diagnostic",
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "seed": seed,
+        "epochs": epochs,
+        "batch_size": batch_size,
+        "optimizer": "adam(1e-3)",
+        "architecture": "784-300-150-10 ReLU (protocol init)",
+        "test_accuracy_final": round(history[-1], 5),
+        "test_accuracy_best": round(max(history), 5),
+        "train_accuracy_20k": round(train_accuracy, 5),
+        "test_curve": [round(value, 5) for value in history],
+        "wall_clock_seconds": round(time.monotonic() - started, 1),
+        "provenance": {
+            "schema": "asi.ipmnist.ceiling_batch_provenance.v1",
+            "runtime": runtime_identity(
+                dependencies=("jax", "jaxlib", "numpy", "optax", "scikit-learn")
+            ),
+            "sources": source_identities(
+                {
+                    "ceiling_runner": Path(__file__),
+                    "ipmnist_provenance": Path(ipmnist_provenance_module.__file__),
+                    "upgd_ipmnist": Path(upgd_ipmnist_module.__file__),
+                },
+                repository_root=Path(__file__).resolve().parents[2],
+            ),
+            "environment_specifications": repository_specification_identities(
+                Path(__file__).resolve().parents[2]
+            ),
+            "dataset": {
+                "name": "mnist_784",
+                "version": 1,
+                "observations": array_identity(observations),
+                "labels": array_identity(labels),
+                "split": {"train_rows": 60_000, "test_rows": 10_000},
+            },
+            "schedule": {
+                "kind": "numpy.default_rng epoch permutation",
+                "seed": seed,
+                "epochs": epochs,
+                "batch_size": batch_size,
+            },
+            "inputs": {"config": config.to_config(), "optimizer": "adam(1e-3)"},
+        },
+    }
+    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode()
+
+    def write_payload(stream: BinaryIO) -> None:
+        stream.write(encoded)
+
+    _atomic_publish(output_path, write_payload)
+    return output_path
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("stationary", "carried", "full", "batch"))
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument("--spec", default="sigma0_ndecay099")
+    parser.add_argument("--n-tasks", type=int)
+    parser.add_argument("--epochs", type=int, default=30)
+    parser.add_argument("--batch-size", type=int, default=128)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one explicitly addressed, permanently nonpromoting ceiling shard."""
+    args = _parser().parse_args(argv)
+    if args.mode == "batch":
+        print(
+            run_batch_reference(
+                args.output_dir,
+                seed=args.seed,
+                epochs=args.epochs,
+                batch_size=args.batch_size,
+            )
+        )
+    else:
+        path = run_and_publish(
+            args.output_dir,
+            mode=args.mode,
+            spec_name=args.spec,
+            seed=args.seed,
+            n_tasks=args.n_tasks,
+        )
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/alberta_framework/benchmarks/ipmnist_ceiling.py
+++ b/alberta_framework/benchmarks/ipmnist_ceiling.py
@@ -9,6 +9,7 @@ development-only.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import tempfile
@@ -335,10 +336,12 @@ def run_batch_reference(
 
     accuracy_jit = jax.jit(accuracy_fn)
     rng = np.random.default_rng(seed)
+    schedule_digest = hashlib.sha256()
     history: list[float] = []
     started = time.monotonic()
     for epoch in range(epochs):
         order = rng.permutation(60_000)
+        schedule_digest.update(memoryview(np.ascontiguousarray(order)).cast("B"))
         for start in range(0, 60_000 - batch_size + 1, batch_size):
             indices = order[start : start + batch_size]
             params, optimizer_state = train_step(
@@ -395,6 +398,7 @@ def run_batch_reference(
                 "seed": seed,
                 "epochs": epochs,
                 "batch_size": batch_size,
+                "epoch_order_sha256": schedule_digest.hexdigest(),
             },
             "inputs": {"config": config.to_config(), "optimizer": "adam(1e-3)"},
         },

--- a/alberta_framework/benchmarks/ipmnist_ceiling.py
+++ b/alberta_framework/benchmarks/ipmnist_ceiling.py
@@ -42,6 +42,11 @@ from alberta_framework.benchmarks.upgd_ipmnist import (
     load_mnist_train,
 )
 
+_BATCH_TRAIN_SIZE = 60_000
+_MIN_BATCH_SIZE = 32
+_MAX_BATCH_EPOCHS = 30
+_MAX_BATCH_UPDATES = 50_000
+
 
 def _load_train() -> tuple[np.ndarray[Any, Any], np.ndarray[Any, Any]]:
     return load_mnist_train(default_openml_data_home())
@@ -176,6 +181,45 @@ def _publish_run(
     provenance: dict[str, Any],
 ) -> Path:
     """Atomically publish one self-contained run without replacement."""
+    tag = _safe_output_tag(tag)
+    spec_name = _safe_output_tag(spec_name)
+    if type(permutation_mode) is not str:
+        raise ValueError("permutation_mode must be an exact string")
+    seed = require_jax_seed(seed)
+    if type(n_tasks) is not int or n_tasks <= 0:
+        raise ValueError("n_tasks must be a positive built-in integer")
+    _validate_run_identity(tag, spec_name, permutation_mode, n_tasks)
+    if type(wall_seconds) not in (int, float) or not np.isfinite(wall_seconds):
+        raise ValueError("wall_seconds must be a finite built-in number")
+    if wall_seconds < 0:
+        raise ValueError("wall_seconds must be nonnegative")
+    if type(per_step) is not np.ndarray or per_step.dtype != np.dtype(np.uint8):
+        raise ValueError("per_step must be an exact uint8 numpy array")
+    if per_step.ndim != 2 or per_step.shape != (n_tasks, 5_000):
+        raise ValueError("per_step shape must be (n_tasks, 5000)")
+    if not bool(np.all((per_step == 0) | (per_step == 1))):
+        raise ValueError("per_step must contain only binary correctness values")
+    if type(per_task) is not np.ndarray or per_task.dtype != np.dtype(np.float64):
+        raise ValueError("per_task must be an exact float64 numpy array")
+    if per_task.shape != (n_tasks,) or not bool(np.all(np.isfinite(per_task))):
+        raise ValueError("per_task must be a finite vector with one value per task")
+    if not bool(np.all((0.0 <= per_task) & (per_task <= 1.0))):
+        raise ValueError("per_task values must be in [0, 1]")
+    if not bool(
+        np.allclose(
+            per_task,
+            per_step.astype(np.float64).mean(axis=1),
+            rtol=0.0,
+            atol=1e-7,
+            equal_nan=False,
+        )
+    ):
+        raise ValueError("per_task must match the per_step task means")
+    if (
+        type(provenance) is not dict
+        or provenance.get("schema") != "asi.ipmnist.ceiling_run_provenance.v1"
+    ):
+        raise ValueError("provenance must use the maintained ceiling-run schema")
     output_dir.mkdir(parents=True, exist_ok=True)
     artifact_path = output_dir / f"{tag}_seed{seed}.npz"
     if artifact_path.exists():
@@ -197,7 +241,9 @@ def _publish_run(
         "jax": jax.__version__,
         "provenance": provenance,
     }
-    metadata = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    metadata = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), allow_nan=False
+    )
 
     def write_archive(stream: BinaryIO) -> None:
         np.savez_compressed(
@@ -208,6 +254,38 @@ def _publish_run(
 
     _atomic_publish(artifact_path, write_archive)
     return artifact_path
+
+
+def _safe_output_tag(value: object) -> str:
+    if type(value) is not str or not value:
+        raise ValueError("tag must be a non-empty safe exact identifier")
+    alphanumeric = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    if value[0] not in alphanumeric or not all(
+        character in alphanumeric or character in "_-" for character in value
+    ):
+        raise ValueError("tag must be a non-empty safe exact identifier")
+    return value
+
+
+def _validate_run_identity(
+    tag: str, spec_name: str, permutation_mode: str, n_tasks: int
+) -> None:
+    expected: tuple[str, int | None]
+    if tag == f"stationary_{spec_name}":
+        expected = ("identity", 1)
+    elif tag == f"carried_{spec_name}":
+        expected = ("same", None)
+    elif tag == f"full_{spec_name}":
+        expected = ("protocol", 200)
+    else:
+        raise ValueError("tag must bind its run family and spec_name")
+    expected_mode, expected_tasks = expected
+    if permutation_mode != expected_mode:
+        raise ValueError("permutation_mode disagrees with tag family")
+    if expected_tasks is not None and n_tasks != expected_tasks:
+        raise ValueError("n_tasks disagrees with tag family")
+    if expected_tasks is None and n_tasks < 10:
+        raise ValueError("carried runs require at least ten tasks")
 
 
 def _atomic_publish(path: Path, writer: Callable[[BinaryIO], None]) -> None:
@@ -284,11 +362,26 @@ def run_batch_reference(
 ) -> Path:
     """Run the converged minibatch-Adam architecture reference."""
     seed = require_jax_seed(seed)
+    if type(epochs) is not int or not 1 <= epochs <= _MAX_BATCH_EPOCHS:
+        raise ValueError(
+            f"epochs must be a built-in integer in [1, {_MAX_BATCH_EPOCHS}]"
+        )
+    if (
+        type(batch_size) is not int
+        or not _MIN_BATCH_SIZE <= batch_size <= _BATCH_TRAIN_SIZE
+    ):
+        raise ValueError(
+            "batch_size must be a built-in integer in "
+            f"[{_MIN_BATCH_SIZE}, {_BATCH_TRAIN_SIZE}]"
+        )
+    update_count = epochs * (_BATCH_TRAIN_SIZE // batch_size)
+    if update_count > _MAX_BATCH_UPDATES:
+        raise ValueError(
+            f"batch run exceeds the {_MAX_BATCH_UPDATES} optimizer-update bound"
+        )
     import optax  # type: ignore[import-not-found]
     from sklearn.datasets import fetch_openml  # type: ignore[import-untyped]
 
-    if epochs <= 0 or batch_size <= 0:
-        raise ValueError("epochs and batch_size must be positive")
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / f"batch_reference_seed{seed}.json"
     if output_path.exists():
@@ -343,9 +436,11 @@ def run_batch_reference(
     history: list[float] = []
     started = time.monotonic()
     for epoch in range(epochs):
-        order = rng.permutation(60_000)
+        order = rng.permutation(_BATCH_TRAIN_SIZE)
         schedule_digest.update(memoryview(np.ascontiguousarray(order)).cast("B"))
-        for start in range(0, 60_000 - batch_size + 1, batch_size):
+        for start in range(
+            0, _BATCH_TRAIN_SIZE - batch_size + 1, batch_size
+        ):
             indices = order[start : start + batch_size]
             params, optimizer_state = train_step(
                 params, optimizer_state, train_x[indices], train_y[indices]
@@ -406,7 +501,9 @@ def run_batch_reference(
             "inputs": {"config": config.to_config(), "optimizer": "adam(1e-3)"},
         },
     }
-    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode()
+    encoded = (
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode()
 
     def write_payload(stream: BinaryIO) -> None:
         stream.write(encoded)

--- a/alberta_framework/benchmarks/ipmnist_ceiling.py
+++ b/alberta_framework/benchmarks/ipmnist_ceiling.py
@@ -26,6 +26,7 @@ import numpy as np
 import alberta_framework.benchmarks.ipmnist_provenance as ipmnist_provenance_module
 import alberta_framework.benchmarks.ipmnist_screening as ipmnist_screening_module
 import alberta_framework.benchmarks.upgd_ipmnist as upgd_ipmnist_module
+from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.benchmarks.ipmnist_provenance import (
     array_identity,
     repository_specification_identities,
@@ -55,6 +56,7 @@ def run_arm_per_step(
     progress_every: int = 20,
 ) -> tuple[np.ndarray[Any, Any], np.ndarray[Any, Any], float, dict[str, Any]]:
     """Run one screening arm while retaining per-step online accuracy."""
+    seed = require_jax_seed(seed)
     config = IPMNISTConfig(n_tasks=n_tasks)
     spec = screening_spec(spec_name)
     init_fn, step_fn = spec.factory(spec.hyperparameters)
@@ -281,6 +283,7 @@ def run_batch_reference(
     batch_size: int = 128,
 ) -> Path:
     """Run the converged minibatch-Adam architecture reference."""
+    seed = require_jax_seed(seed)
     import optax  # type: ignore[import-not-found]
     from sklearn.datasets import fetch_openml  # type: ignore[import-untyped]
 

--- a/alberta_framework/benchmarks/ipmnist_provenance.py
+++ b/alberta_framework/benchmarks/ipmnist_provenance.py
@@ -1,0 +1,121 @@
+"""Canonical provenance helpers for maintained IPMNIST diagnostics."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import platform
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def sha256_file(path: Path) -> str:
+    """Hash one regular input file without loading it all at once."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def file_identity(path: Path, *, relative_to: Path | None = None) -> dict[str, Any]:
+    """Return stable byte identity and size for one consumed file."""
+    resolved = path.resolve(strict=True)
+    name = str(resolved)
+    if relative_to is not None:
+        try:
+            name = str(resolved.relative_to(relative_to.resolve(strict=True)))
+        except ValueError:
+            pass
+    metadata = resolved.stat()
+    if not resolved.is_file():
+        raise ValueError(f"provenance input is not a regular file: {resolved}")
+    return {"path": name, "bytes": metadata.st_size, "sha256": sha256_file(resolved)}
+
+
+def input_file_identities(
+    paths: Iterable[Path], *, relative_to: Path | None = None
+) -> list[dict[str, Any]]:
+    """Return sorted, duplicate-free identities for every consumed input."""
+    resolved = sorted({path.resolve(strict=True) for path in paths})
+    return [file_identity(path, relative_to=relative_to) for path in resolved]
+
+
+def array_identity(array: np.ndarray[Any, Any]) -> dict[str, Any]:
+    """Bind shape, dtype, and canonical C-order bytes of one array."""
+    contiguous = np.ascontiguousarray(array)
+    return {
+        "shape": list(contiguous.shape),
+        "dtype": contiguous.dtype.str,
+        "sha256": hashlib.sha256(memoryview(contiguous).cast("B")).hexdigest(),
+    }
+
+
+def dependency_versions(distributions: Sequence[str]) -> dict[str, str | None]:
+    """Record installed versions, explicitly naming absent optional dependencies."""
+    result: dict[str, str | None] = {}
+    for distribution in distributions:
+        try:
+            result[distribution] = importlib.metadata.version(distribution)
+        except importlib.metadata.PackageNotFoundError:
+            result[distribution] = None
+    return result
+
+
+def runtime_identity(*, dependencies: Sequence[str]) -> dict[str, Any]:
+    """Describe the interpreter, platform, and relevant installed distributions."""
+    return {
+        "python": platform.python_version(),
+        "implementation": platform.python_implementation(),
+        "executable": sys.executable,
+        "platform": platform.platform(),
+        "dependencies": dependency_versions(dependencies),
+    }
+
+
+def source_identities(
+    sources: Mapping[str, Path], *, repository_root: Path | None = None
+) -> dict[str, dict[str, Any]]:
+    """Bind every maintained source file that defines an execution path."""
+    return {
+        name: file_identity(path, relative_to=repository_root)
+        for name, path in sorted(sources.items())
+    }
+
+
+def repository_specification_identities(repository_root: Path) -> list[dict[str, Any]]:
+    """Bind the project metadata and resolved lock used by the checkout."""
+    candidates = (repository_root / "pyproject.toml", repository_root / "uv.lock")
+    return input_file_identities(
+        (path for path in candidates if path.is_file()), relative_to=repository_root
+    )
+
+
+def analysis_provenance(
+    *,
+    command: str,
+    input_paths: Iterable[Path],
+    sources: Mapping[str, Path],
+    repository_root: Path | None = None,
+    dependencies: Sequence[str] = ("numpy",),
+) -> dict[str, Any]:
+    """Build complete provenance for one analysis execution and its input bytes."""
+    provenance_source = Path(__file__)
+    bound_sources = dict(sources)
+    bound_sources["ipmnist_provenance"] = provenance_source
+    return {
+        "schema": "asi.ipmnist.analysis_provenance.v1",
+        "command": command,
+        "runtime": runtime_identity(dependencies=dependencies),
+        "sources": source_identities(bound_sources, repository_root=repository_root),
+        "environment_specifications": (
+            repository_specification_identities(repository_root)
+            if repository_root is not None
+            else []
+        ),
+        "inputs": input_file_identities(input_paths, relative_to=repository_root),
+    }

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -9677,8 +9677,13 @@ def shard_payload(
     return payload
 
 
-def load_shard(path: Path) -> dict[str, Any]:
+def load_shard(
+    path: Path,
+    *,
+    spec_registry: Mapping[str, ScreeningSpec] | None = None,
+) -> dict[str, Any]:
     """Load legacy v1 or strictly validate a source-bound v2 screening shard."""
+    registry = SCREENING_REGISTRY if spec_registry is None else spec_registry
     payload = load_strict_json_object(path)
     schema = payload.get("schema")
     if schema not in {LEGACY_SHARD_SCHEMA, SHARD_SCHEMA}:
@@ -9743,9 +9748,9 @@ def load_shard(path: Path) -> dict[str, Any]:
     config_name = _required_nonempty_string(
         payload.get("config_name"), context=f"{path}: config_name"
     )
-    if config_name not in SCREENING_REGISTRY:
+    if config_name not in registry:
         raise ValueError(f"{path}: unknown config_name")
-    spec = SCREENING_REGISTRY[config_name]
+    spec = registry[config_name]
     base_learner = _required_nonempty_string(
         payload.get("base_learner"), context=f"{path}: base_learner"
     )
@@ -9950,6 +9955,8 @@ def merge_shards(
     paths: Sequence[Path],
     control_name: str = "upgd_w_control",
     slope_window: int = 15,
+    *,
+    spec_registry: Mapping[str, ScreeningSpec] | None = None,
 ) -> dict[str, Any]:
     """Merge shards into a ranked screening summary with paired comparisons.
 
@@ -9961,7 +9968,9 @@ def merge_shards(
     input_bindings = _artifact_file_bindings(
         normalized_paths, context="screening shard input"
     )
-    shards = [load_shard(path) for path in normalized_paths]
+    shards = [
+        load_shard(path, spec_registry=spec_registry) for path in normalized_paths
+    ]
     if not shards:
         raise ValueError("no shards given")
     shard_schemas = {shard["schema"] for shard in shards}

--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -595,7 +595,7 @@ class StreamingRunSummary:
         late_window: int | None,
         post_switch_window: int | None,
     ) -> None:
-        if environment_kind not in ENVIRONMENT_ROSTER:
+        if type(environment_kind) is not str or environment_kind not in ENVIRONMENT_ROSTER:
             raise ValueError("unsupported streaming-summary environment")
         if type(horizon) is not int or horizon <= 0:
             raise ValueError("horizon must be a positive integer")

--- a/alberta_framework/benchmarks/rule_discovery_summary.py
+++ b/alberta_framework/benchmarks/rule_discovery_summary.py
@@ -1,0 +1,161 @@
+"""Maintained rule-discovery summary builder for explicit campaign inputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+import alberta_framework.benchmarks.rule_discovery as rule_discovery_module
+from alberta_framework.benchmarks.ipmnist_provenance import analysis_provenance
+from alberta_framework.benchmarks.rule_discovery import NONPROMOTING_POLICY
+
+SCREEN_ARMS = (
+    "disc_r1",
+    "disc_r2",
+    "disc_r3",
+    "disc_r1_pscale",
+    "disc_r1_pscale_norms",
+    "sigma0_shiftnorm_d099",
+    "sgd_ema_norm_d099",
+    "upgd_w_control",
+)
+DISCOVERY_ARMS = (
+    "disc_r1",
+    "disc_r2",
+    "disc_r3",
+    "disc_r1_pscale",
+    "disc_r1_pscale_norms",
+)
+CHAMPION = "sigma0_shiftnorm_d099"
+
+
+def _arm(directory: Path, name: str, seeds: Sequence[int]) -> dict[str, Any]:
+    values = []
+    for seed in seeds:
+        path = directory / f"{name}_seed{seed}.json"
+        if not path.exists():
+            raise ValueError(f"{name} is missing seed {seed} in {directory}")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if type(payload) is not dict or type(payload.get("per_task_accuracy")) is not list:
+            raise ValueError(f"{path} lacks per_task_accuracy")
+        accuracy = np.asarray(payload["per_task_accuracy"], dtype=np.float64)
+        if accuracy.ndim != 1 or not bool(np.all(np.isfinite(accuracy))):
+            raise ValueError(f"{path} has invalid per_task_accuracy")
+        values.append(float(np.mean(accuracy)))
+    return {"per_seed": values, "mean": float(np.mean(values))}
+
+
+def build_legacy_rule_discovery_summary(
+    screen_dir: Path,
+    confirm_dir: Path,
+    *,
+    seeds: Sequence[int] = (0, 1, 2),
+) -> dict[str, Any]:
+    """Reconstruct the exact legacy v1 payload for compatibility checks."""
+    screen = {name: _arm(screen_dir, name, seeds) for name in SCREEN_ARMS}
+    full = {
+        name: _arm(confirm_dir, name, seeds)
+        for name in ("disc_r1_pscale_norms", CHAMPION)
+        if all((confirm_dir / f"{name}_seed{seed}.json").exists() for seed in seeds)
+    }
+    champion = np.asarray(screen[CHAMPION]["per_seed"], dtype=np.float64)
+    paired: dict[str, Any] = {}
+    for name in DISCOVERY_ARMS:
+        values = np.asarray(screen[name]["per_seed"], dtype=np.float64)
+        differences = values - champion
+        paired[name] = {
+            "per_seed": [float(value) for value in differences],
+            "mean": float(np.mean(values) - np.mean(champion)),
+        }
+    return {
+        "schema": "alberta.rule_discovery.real_screen.v1",
+        "evidence_policy": dict(NONPROMOTING_POLICY),
+        "bar": 0.8640,
+        "seeds": list(seeds),
+        "screen_60_task": screen,
+        "paired_vs_champion_60_task": paired,
+        "confirm_200_task": full,
+        "verdicts": {
+            "disc_r1_verbatim": (
+                "below bar (0.78372); beats published UPGD-W control +0.006, no gate"
+            ),
+            "disc_r2_verbatim": "below bar (0.72313)",
+            "disc_r3_verbatim": "below bar (0.77339)",
+            "disc_r1_pscale": (
+                "hidden RMS at protocol scale costs ~-0.051 (transfer-killer isolated)"
+            ),
+            "disc_r1_pscale_norms": (
+                "discovered structure (surprise budget replaces utility gate) at champion "
+                "constants beats the champion on the 60-task screen (+0.00173, 3/3 seeds) "
+                "and ties-to-slightly-beats at 200 tasks (+0.00066 paired, 2/3 seeds; "
+                "screening claims nothing by itself)"
+            ),
+        },
+    }
+
+
+def build_rule_discovery_summary(
+    screen_dir: Path,
+    confirm_dir: Path,
+    *,
+    seeds: Sequence[int] = (0, 1, 2),
+) -> dict[str, Any]:
+    """Build the maintained v2 summary with explicit legacy compatibility."""
+    legacy = build_legacy_rule_discovery_summary(
+        screen_dir, confirm_dir, seeds=seeds
+    )
+    legacy_canonical = json.dumps(
+        legacy, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode()
+    maintained = dict(legacy)
+    maintained["schema"] = "asi.rule_discovery.real_screen.v2"
+    maintained["legacy_compatibility"] = {
+        "schema": legacy["schema"],
+        "canonical_sha256": hashlib.sha256(legacy_canonical).hexdigest(),
+    }
+    maintained["provenance"] = analysis_provenance(
+        command="rule-discovery-summary",
+        input_paths=[
+            directory / f"{name}_seed{seed}.json"
+            for directory, names in (
+                (screen_dir, SCREEN_ARMS),
+                (confirm_dir, tuple(legacy["confirm_200_task"])),
+            )
+            for name in names
+            for seed in seeds
+        ],
+        sources={
+            "rule_discovery": Path(rule_discovery_module.__file__),
+            "rule_discovery_summary": Path(__file__),
+        },
+        repository_root=Path(__file__).resolve().parents[2],
+    )
+    return maintained
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--screen-dir", type=Path, required=True)
+    parser.add_argument("--confirm-dir", type=Path, required=True)
+    parser.add_argument("--seeds", type=int, nargs="+", default=[0, 1, 2])
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Emit a nonpromoting summary to stdout without modifying artifacts."""
+    args = _parser().parse_args(argv)
+    result = build_rule_discovery_summary(
+        args.screen_dir, args.confirm_dir, seeds=args.seeds
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/alberta_framework/benchmarks/rule_discovery_summary.py
+++ b/alberta_framework/benchmarks/rule_discovery_summary.py
@@ -12,6 +12,7 @@ from typing import Any
 import numpy as np
 
 import alberta_framework.benchmarks.rule_discovery as rule_discovery_module
+from alberta_framework._seed_validation import require_jax_seed, require_unique_jax_seeds
 from alberta_framework.benchmarks.ipmnist_provenance import analysis_provenance
 from alberta_framework.benchmarks.rule_discovery import NONPROMOTING_POLICY
 
@@ -42,10 +43,21 @@ def _arm(directory: Path, name: str, seeds: Sequence[int]) -> dict[str, Any]:
         if not path.exists():
             raise ValueError(f"{name} is missing seed {seed} in {directory}")
         payload = json.loads(path.read_text(encoding="utf-8"))
-        if type(payload) is not dict or type(payload.get("per_task_accuracy")) is not list:
+        if (
+            type(payload) is not dict
+            or type(payload.get("per_task_accuracy")) is not list
+            or not payload["per_task_accuracy"]
+        ):
             raise ValueError(f"{path} lacks per_task_accuracy")
+        payload_seed = require_jax_seed(payload.get("seed"), name=f"{path} seed")
+        if payload_seed != seed:
+            raise ValueError(f"{path} seed does not match requested seed {seed}")
         accuracy = np.asarray(payload["per_task_accuracy"], dtype=np.float64)
-        if accuracy.ndim != 1 or not bool(np.all(np.isfinite(accuracy))):
+        if (
+            accuracy.ndim != 1
+            or not bool(np.all(np.isfinite(accuracy)))
+            or not bool(np.all((0.0 <= accuracy) & (accuracy <= 1.0)))
+        ):
             raise ValueError(f"{path} has invalid per_task_accuracy")
         values.append(float(np.mean(accuracy)))
     return {"per_seed": values, "mean": float(np.mean(values))}
@@ -58,12 +70,21 @@ def build_legacy_rule_discovery_summary(
     seeds: Sequence[int] = (0, 1, 2),
 ) -> dict[str, Any]:
     """Reconstruct the exact legacy v1 payload for compatibility checks."""
+    seeds = require_unique_jax_seeds(seeds)
     screen = {name: _arm(screen_dir, name, seeds) for name in SCREEN_ARMS}
-    full = {
-        name: _arm(confirm_dir, name, seeds)
-        for name in ("disc_r1_pscale_norms", CHAMPION)
-        if all((confirm_dir / f"{name}_seed{seed}.json").exists() for seed in seeds)
-    }
+    confirm_names = ("disc_r1_pscale_norms", CHAMPION)
+    present = [
+        (confirm_dir / f"{name}_seed{seed}.json").exists()
+        for name in confirm_names
+        for seed in seeds
+    ]
+    if any(present) and not all(present):
+        raise ValueError("rule-discovery confirmation seeds are incomplete")
+    full = (
+        {name: _arm(confirm_dir, name, seeds) for name in confirm_names}
+        if all(present)
+        else {}
+    )
     champion = np.asarray(screen[CHAMPION]["per_seed"], dtype=np.float64)
     paired: dict[str, Any] = {}
     for name in DISCOVERY_ARMS:
@@ -107,6 +128,7 @@ def build_rule_discovery_summary(
     seeds: Sequence[int] = (0, 1, 2),
 ) -> dict[str, Any]:
     """Build the maintained v2 summary with explicit legacy compatibility."""
+    seeds = require_unique_jax_seeds(seeds)
     legacy = build_legacy_rule_discovery_summary(
         screen_dir, confirm_dir, seeds=seeds
     )
@@ -153,7 +175,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     result = build_rule_discovery_summary(
         args.screen_dir, args.confirm_dir, seeds=args.seeds
     )
-    print(json.dumps(result, indent=2, sort_keys=True))
+    print(json.dumps(result, indent=2, sort_keys=True, allow_nan=False))
     return 0
 
 

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -198,6 +198,13 @@ def _trusted_shape(name: str, value: object) -> tuple[int, ...]:
     return tuple(value.shape)
 
 
+def _checked_terminated(name: str, value: Array) -> Array:
+    """Validate a ``terminated`` flag array dtype before boolean coercion."""
+    if value.dtype not in (jnp.dtype(jnp.bool_), jnp.dtype(jnp.float32)):
+        raise TypeError(f"{name} must have dtype bool or float32")
+    return value
+
+
 def _validated_bounder_result(
     name: str,
     result: object,
@@ -896,7 +903,9 @@ def run_actor_critic_from_arrays(
     next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
     rewards = jnp.asarray(rewards, dtype=jnp.float32)
     if terminated is not None:
-        terminated = jnp.asarray(terminated, dtype=jnp.bool_)
+        terminated = jnp.asarray(
+            _checked_terminated("terminated", jnp.asarray(terminated)), dtype=jnp.bool_
+        )
     if discounts is not None:
         discounts = jnp.asarray(discounts, dtype=jnp.float32)
     if terminated is None:
@@ -1720,7 +1729,9 @@ def run_continuous_actor_critic_from_arrays(
     next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
     rewards = jnp.asarray(rewards, dtype=jnp.float32)
     if terminated is not None:
-        terminated = jnp.asarray(terminated, dtype=jnp.bool_)
+        terminated = jnp.asarray(
+            _checked_terminated("terminated", jnp.asarray(terminated)), dtype=jnp.bool_
+        )
     if discounts is not None:
         discounts = jnp.asarray(discounts, dtype=jnp.float32)
     if terminated is None:

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -198,11 +198,13 @@ def _trusted_shape(name: str, value: object) -> tuple[int, ...]:
     return tuple(value.shape)
 
 
-def _checked_terminated(name: str, value: Array) -> Array:
+def _checked_terminated(name: str, value: object) -> Array:
     """Validate a ``terminated`` flag array dtype before boolean coercion."""
+    if not (type(value) is np.ndarray or isinstance(value, jax.Array)):
+        raise ValueError(f"{name} must expose trusted array metadata")
     if value.dtype not in (jnp.dtype(jnp.bool_), jnp.dtype(jnp.float32)):
         raise TypeError(f"{name} must have dtype bool or float32")
-    return value
+    return cast(Array, value)
 
 
 def _validated_bounder_result(
@@ -903,9 +905,7 @@ def run_actor_critic_from_arrays(
     next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
     rewards = jnp.asarray(rewards, dtype=jnp.float32)
     if terminated is not None:
-        terminated = jnp.asarray(
-            _checked_terminated("terminated", jnp.asarray(terminated)), dtype=jnp.bool_
-        )
+        terminated = jnp.asarray(_checked_terminated("terminated", terminated), dtype=jnp.bool_)
     if discounts is not None:
         discounts = jnp.asarray(discounts, dtype=jnp.float32)
     if terminated is None:
@@ -1729,9 +1729,7 @@ def run_continuous_actor_critic_from_arrays(
     next_observations = jnp.asarray(next_observations, dtype=jnp.float32)
     rewards = jnp.asarray(rewards, dtype=jnp.float32)
     if terminated is not None:
-        terminated = jnp.asarray(
-            _checked_terminated("terminated", jnp.asarray(terminated)), dtype=jnp.bool_
-        )
+        terminated = jnp.asarray(_checked_terminated("terminated", terminated), dtype=jnp.bool_)
     if discounts is not None:
         discounts = jnp.asarray(discounts, dtype=jnp.float32)
     if terminated is None:

--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -106,11 +106,75 @@ def _require_discrete_state_resources(n_actions: int, feature_dim: int) -> None:
         raise ValueError("derived actor-critic state exceeds the signed-int32 budget")
 
 
+def _actor_critic_persistent_bytes(n_actions: int, feature_dim: int) -> int:
+    """Named persist already counted inside ``_require_discrete_state_resources``."""
+    return 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 24
+
+
+def _actor_critic_update_result_extras_bytes(n_actions: int) -> int:
+    """Returned ``ActorCriticUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published action, policy, value,
+    next-value, TD-error, bounder, and acceptance leaves.
+    """
+    return 4 * n_actions + 21
+
+
+def _actor_critic_update_working_set_bytes(n_actions: int, feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _actor_critic_persistent_bytes(
+        n_actions, feature_dim
+    ) + _actor_critic_update_result_extras_bytes(n_actions)
+
+
+def _preflight_actor_critic_update_working_set(n_actions: int, feature_dim: int) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _actor_critic_update_working_set_bytes(n_actions, feature_dim) > _INT32_MAX:
+        raise ValueError(
+            "actor-critic update working set byte count must fit signed int32"
+        )
+
+
 def _require_continuous_state_resources(action_dim: int, feature_dim: int) -> None:
     state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 5
     state_bytes = 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 20
     if state_scalars > _INT32_MAX or state_bytes > _INT32_MAX:
         raise ValueError("derived continuous actor-critic state exceeds the signed-int32 budget")
+
+
+def _continuous_actor_critic_persistent_bytes(action_dim: int, feature_dim: int) -> int:
+    """Named persist already counted inside ``_require_continuous_state_resources``."""
+    return 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 20
+
+
+def _continuous_actor_critic_update_result_extras_bytes(action_dim: int) -> int:
+    """Returned ``ContinuousActorCriticUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published action, mean, sigma, value,
+    next-value, TD-error, bounder, and acceptance leaves.
+    """
+    return 12 * action_dim + 17
+
+
+def _continuous_actor_critic_update_working_set_bytes(
+    action_dim: int, feature_dim: int
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _continuous_actor_critic_persistent_bytes(
+        action_dim, feature_dim
+    ) + _continuous_actor_critic_update_result_extras_bytes(action_dim)
+
+
+def _preflight_continuous_actor_critic_update_working_set(
+    action_dim: int, feature_dim: int
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _continuous_actor_critic_update_working_set_bytes(action_dim, feature_dim) > _INT32_MAX:
+        raise ValueError(
+            "continuous actor-critic update working set byte count must fit signed int32"
+        )
 
 
 def _require_discrete_scan_resources(
@@ -520,6 +584,7 @@ class ActorCriticAgent:
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _require_discrete_state_resources(self._config.n_actions, feature_dim)
+        _preflight_actor_critic_update_working_set(self._config.n_actions, feature_dim)
         key = _require_key(key)
         zeros_actor = jnp.zeros((self._config.n_actions, feature_dim), dtype=jnp.float32)
         zeros_policy_bias = jnp.zeros((self._config.n_actions,), dtype=jnp.float32)
@@ -1296,6 +1361,7 @@ class ContinuousActorCriticAgent:
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         cfg = self._config
         _require_continuous_state_resources(cfg.action_dim, feature_dim)
+        _preflight_continuous_actor_critic_update_working_set(cfg.action_dim, feature_dim)
         key = _require_key(key)
         zeros_mean = jnp.zeros((cfg.action_dim, feature_dim), dtype=jnp.float32)
         zeros_mean_bias = jnp.zeros((cfg.action_dim,), dtype=jnp.float32)

--- a/alberta_framework/core/adamo.py
+++ b/alberta_framework/core/adamo.py
@@ -171,9 +171,16 @@ def isometry_gradient(weight: Array) -> Array:
     _gram_bytes(rows, columns, matrix.dtype.itemsize)
     if rows >= columns:
         identity = jnp.eye(columns, dtype=matrix.dtype)
-        return 4.0 * matrix @ (matrix.T @ matrix - identity)
-    identity = jnp.eye(rows, dtype=matrix.dtype)
-    return 4.0 * (matrix @ matrix.T - identity) @ matrix
+        candidate = 4.0 * matrix @ (matrix.T @ matrix - identity)
+    else:
+        identity = jnp.eye(rows, dtype=matrix.dtype)
+        candidate = 4.0 * (matrix @ matrix.T - identity) @ matrix
+    valid = jnp.all(jnp.isfinite(candidate))
+    if isinstance(valid, jax.core.Tracer):
+        return jnp.where(valid, candidate, jnp.full_like(candidate, jnp.nan))
+    if not bool(valid):
+        raise ValueError("isometry gradient must be finite")
+    return candidate
 
 
 def state_persistent_bytes(state: AdamOState) -> int:

--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -188,6 +188,36 @@ def _preflight_differential_td_state(feature_dim: int) -> None:
     )
 
 
+def _differential_td_persistent_bytes(feature_dim: int) -> int:
+    """Named persist already preflighted by ``DifferentialTDLearner.init``."""
+    return 4 * (2 * feature_dim + 4)
+
+
+def _differential_td_update_result_extras_bytes() -> int:
+    """Returned ``DifferentialTDUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published prediction, TD-error,
+    reward-rate, metric, and diagnostic leaves.
+    """
+    return 33
+
+
+def _differential_td_update_working_set_bytes(feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _differential_td_persistent_bytes(
+        feature_dim
+    ) + _differential_td_update_result_extras_bytes()
+
+
+def _preflight_differential_td_update_working_set(feature_dim: int) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _differential_td_update_working_set_bytes(feature_dim) > _INT32_MAX:
+        raise ValueError(
+            "differential TD update working set byte count must fit signed int32"
+        )
+
+
 def _preflight_differential_gtd_state(feature_dim: int) -> None:
     scalar_count = 3 * feature_dim + 5
     _require_state_resources(
@@ -1417,6 +1447,7 @@ class DifferentialTDLearner:
         """Initialize value weights, traces, and reward-rate estimate."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _preflight_differential_td_state(feature_dim)
+        _preflight_differential_td_update_working_set(feature_dim)
         average_reward = _validated_float32_scalar_preserving_nonzero(
             "average_reward", average_reward
         )

--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -88,6 +88,46 @@ def _resource_counts(n_actions: int, feature_dim: int) -> tuple[int, int]:
     return trainable, state_nbytes
 
 
+def _behavior_model_update_working_set_bytes(n_actions: int, feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras.
+
+    ``update`` keeps the source state, the proposed state, and the
+    transaction-selected result simultaneously live.  The worst-case path
+    also materializes a weight/bias gradient plus an L2 or clip copy,
+    logits / probabilities / one-hot / logit-error, the observation, and
+    neutralized returned logits/probabilities beside the committed state.
+    """
+
+    trainable = n_actions * feature_dim + n_actions
+    persist_scalars = trainable + 6
+    update_scalars = (
+        3 * persist_scalars
+        + 2 * n_actions * feature_dim
+        + 2 * n_actions
+        + 4 * n_actions
+        + feature_dim
+        + 2 * n_actions
+        + 16
+    )
+    return 4 * update_scalars
+
+
+def _preflight_behavior_model_update_working_set(
+    n_actions: int,
+    feature_dim: int,
+) -> None:
+    """Reject an update envelope the behavior model cannot name."""
+
+    working_set_bytes = _behavior_model_update_working_set_bytes(
+        n_actions,
+        feature_dim,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "behavior-model update working set byte count must fit signed int32"
+        )
+
+
 def _saturating_int32_increment(value: Array) -> Array:
     maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
     counter = jnp.asarray(value, dtype=jnp.int32)
@@ -564,6 +604,10 @@ class BehaviorModel:
         """Initialize parameters and diagnostics."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         _resource_counts(self._config.n_actions, feature_dim)
+        _preflight_behavior_model_update_working_set(
+            self._config.n_actions,
+            feature_dim,
+        )
         return BehaviorModelState(
             weights=jnp.zeros(
                 (self._config.n_actions, feature_dim),
@@ -586,6 +630,10 @@ class BehaviorModel:
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         trainable, state_nbytes = _resource_counts(self._config.n_actions, feature_dim)
+        _preflight_behavior_model_update_working_set(
+            self._config.n_actions,
+            feature_dim,
+        )
         diagnostics = 3
         administrative = 1
         rng_words = 2

--- a/alberta_framework/core/delight.py
+++ b/alberta_framework/core/delight.py
@@ -2116,7 +2116,10 @@ def stratify_delight_outcomes(
     but belong to neither success nor failure stratum.
     """
     advantages = jnp.ravel(jnp.asarray(result.advantage, dtype=jnp.float32))
-    rare = jnp.ravel(jnp.asarray(rare_mask, dtype=jnp.bool_))
+    rare_input = jnp.asarray(rare_mask)
+    if rare_input.dtype != jnp.bool_:
+        raise ValueError("rare_mask must have boolean dtype")
+    rare = jnp.ravel(rare_input)
     if rare.shape != advantages.shape:
         raise ValueError("rare_mask must match the flattened advantage shape")
     common = ~rare

--- a/alberta_framework/core/dual_replay.py
+++ b/alberta_framework/core/dual_replay.py
@@ -537,6 +537,63 @@ def _allocation_sizes(config: DualReplayConfig) -> tuple[int, int]:
     return slot_bytes, persistent_bytes
 
 
+def _dual_replay_record_extras_bytes(observation_dim: int, action_dim: int) -> int:
+    """Prediction, outcome, and ``ReplayWriteResult`` extras excluding persist."""
+    prediction_bytes = 4 * observation_dim + 4 * action_dim + 38
+    outcome_bytes = 4 * observation_dim + 21
+    write_result_extras = 55
+    return prediction_bytes + outcome_bytes + write_result_extras
+
+
+def _dual_replay_sample_extras_bytes(batch_size: int, slot_bytes: int) -> int:
+    """Returned ``ReplaySampleResult`` extras excluding persist."""
+    return batch_size * (slot_bytes + 13) + 28
+
+
+def _dual_replay_update_working_set_bytes(
+    *,
+    total_capacity: int,
+    observation_dim: int,
+    action_dim: int,
+    batch_size: int,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras.
+
+    ``record`` keeps the source state, the candidate persist, and the
+    transaction-selected result live together with the prediction, outcome, and
+    write-result extras.  ``sample`` keeps the same three persist copies live
+    with the returned batch and sample diagnostics.  The host names the larger
+    envelope.
+    """
+    slot_bytes = 4 * (2 * observation_dim + action_dim + 14) + 11
+    persist_bytes = total_capacity * slot_bytes + 60
+    extras = max(
+        _dual_replay_record_extras_bytes(observation_dim, action_dim),
+        _dual_replay_sample_extras_bytes(batch_size, slot_bytes),
+    )
+    return 3 * persist_bytes + extras
+
+
+def _preflight_dual_replay_update_working_set(
+    *,
+    total_capacity: int,
+    observation_dim: int,
+    action_dim: int,
+    batch_size: int,
+) -> None:
+    """Reject a record/sample envelope the host cannot name in signed int32."""
+    working_set_bytes = _dual_replay_update_working_set_bytes(
+        total_capacity=total_capacity,
+        observation_dim=observation_dim,
+        action_dim=action_dim,
+        batch_size=batch_size,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "dual replay update working set byte count must fit signed int32"
+        )
+
+
 def _validate_config(config: DualReplayConfig) -> None:
     for name in (
         "total_capacity",
@@ -594,6 +651,12 @@ def _validate_config(config: DualReplayConfig) -> None:
             ),
         )
     _allocation_sizes(config)
+    _preflight_dual_replay_update_working_set(
+        total_capacity=config.total_capacity,
+        observation_dim=config.observation_dim,
+        action_dim=config.action_dim,
+        batch_size=config.batch_size,
+    )
 
 
 def _require_array(

--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -291,6 +291,78 @@ def _require_float32_allocation(name: str, scalars: int) -> None:
         raise ValueError(f"{name} scalar and byte counts must fit signed int32")
 
 
+def _experiential_persistent_bytes(
+    *,
+    capacity: int,
+    observation_dim: int,
+    key_dim: int,
+    action_dim: int,
+    outcome_dim: int,
+) -> int:
+    """Named persist already preflighted by ``_validate_config``."""
+    vector_values = observation_dim + key_dim + action_dim + outcome_dim
+    return capacity * (4 * (vector_values + 11) + 4) + 32
+
+
+def _experiential_step_result_extras_bytes(
+    *,
+    observation_dim: int,
+    action_dim: int,
+    outcome_dim: int,
+    top_k: int,
+) -> int:
+    """Returned ``ExperientialMemoryStepResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published retrieval and write
+    diagnostic leaves.
+    """
+    payload_values = observation_dim + action_dim + outcome_dim
+    return 36 + 4 * payload_values + 25 * top_k
+
+
+def _experiential_update_working_set_bytes(
+    *,
+    capacity: int,
+    observation_dim: int,
+    key_dim: int,
+    action_dim: int,
+    outcome_dim: int,
+    top_k: int,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    persist_bytes = _experiential_persistent_bytes(
+        capacity=capacity,
+        observation_dim=observation_dim,
+        key_dim=key_dim,
+        action_dim=action_dim,
+        outcome_dim=outcome_dim,
+    )
+    extras_bytes = _experiential_step_result_extras_bytes(
+        observation_dim=observation_dim,
+        action_dim=action_dim,
+        outcome_dim=outcome_dim,
+        top_k=top_k,
+    )
+    return 3 * persist_bytes + extras_bytes
+
+
+def _preflight_experiential_update_working_set(config: ExperientialMemoryConfig) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    working_set_bytes = _experiential_update_working_set_bytes(
+        capacity=config.capacity,
+        observation_dim=config.observation_dim,
+        key_dim=config.key_dim,
+        action_dim=config.action_dim,
+        outcome_dim=config.outcome_dim,
+        top_k=config.top_k,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "experiential memory update working set byte count must fit signed int32"
+        )
+
+
 def _validate_config(config: ExperientialMemoryConfig) -> None:
     for name in (
         "capacity",
@@ -356,6 +428,7 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
             "ExperientialMemoryConfig aggregate query working-set bytes "
             "must fit signed int32"
         )
+    _preflight_experiential_update_working_set(config)
 
     object.__setattr__(
         config,

--- a/alberta_framework/core/horde.py
+++ b/alberta_framework/core/horde.py
@@ -42,6 +42,7 @@ from alberta_framework.core.normalizers import (
     EMANormalizerState,
     Normalizer,
     WelfordNormalizerState,
+    _saturating_int32_counter_increment,
 )
 from alberta_framework.core.optimizers import Bounder
 from alberta_framework.core.types import HordeSpec, TraceMode
@@ -889,7 +890,7 @@ class MixedHorde:
         proposed_state = MixedHordeState(
             shared_state=new_shared_state,
             independent_state=new_independent_state,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )

--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -354,6 +354,19 @@ class IndependentDemonHorde:
             optimizer if optimizer is not None else LMS(step_size=step_size)
         )
         self._head_optimizer: AnyOptimizer | None = head_optimizer
+        if self._optimizer.supported_for_mlp() is not True:
+            raise ValueError(
+                f"optimizer {type(self._optimizer).__name__} does not support the MLP "
+                "shape-generic update API"
+            )
+        if (
+            self._head_optimizer is not None
+            and self._head_optimizer.supported_for_mlp() is not True
+        ):
+            raise ValueError(
+                f"head_optimizer {type(self._head_optimizer).__name__} does not support the MLP "
+                "shape-generic update API"
+            )
         self._step_size = step_size
         self._bounder = bounder
         self._normalizer = normalizer

--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -119,6 +119,95 @@ def _require_state_resources(
     _require_resource("interaction-feature state", scalars=scalars, nbytes=nbytes)
 
 
+def _interaction_persistent_bytes(
+    *,
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    scale_robust: bool,
+) -> int:
+    """Named persist already preflighted by ``FixedBudgetInteractionLearner``."""
+    normalizer = int(scale_robust)
+    return (
+        8 * n_tasks * n_features
+        + 4 * n_tasks * candidate_count
+        + (37 + 4 * normalizer) * n_features
+        + (33 + 4 * normalizer) * candidate_count
+        + (12 + 4 * normalizer) * n_tasks
+        + 32
+    )
+
+
+def _interaction_update_result_extras_bytes(
+    *,
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    scale_robust: bool,
+) -> int:
+    """Returned ``InteractionFeatureUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. ``pre_curation_state`` and the published diagnostic leaves
+    are extras.
+    """
+    return (
+        _interaction_persistent_bytes(
+            n_features=n_features,
+            n_tasks=n_tasks,
+            candidate_count=candidate_count,
+            scale_robust=scale_robust,
+        )
+        + (7 + 4 * n_tasks) * n_features
+        + 18 * candidate_count
+        + 8 * n_tasks
+        + 98
+    )
+
+
+def _interaction_update_working_set_bytes(
+    *,
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    scale_robust: bool,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _interaction_persistent_bytes(
+        n_features=n_features,
+        n_tasks=n_tasks,
+        candidate_count=candidate_count,
+        scale_robust=scale_robust,
+    ) + _interaction_update_result_extras_bytes(
+        n_features=n_features,
+        n_tasks=n_tasks,
+        candidate_count=candidate_count,
+        scale_robust=scale_robust,
+    )
+
+
+def _preflight_interaction_update_working_set(
+    *,
+    n_features: int,
+    n_tasks: int,
+    candidate_count: int,
+    scale_robust: bool,
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if (
+        _interaction_update_working_set_bytes(
+            n_features=n_features,
+            n_tasks=n_tasks,
+            candidate_count=candidate_count,
+            scale_robust=scale_robust,
+        )
+        > _INT32_MAX
+    ):
+        raise ValueError(
+            "interaction-feature update working set byte count must fit signed int32"
+        )
+
+
 def _require_serialized_scalars(payload: Mapping[str, Any], owner: type[Any]) -> None:
     """Require the canonical JSON scalar types emitted by ``to_config``."""
     annotations = get_type_hints(owner.__init__)
@@ -592,6 +681,12 @@ class FixedBudgetInteractionLearner:
         )
 
         _require_state_resources(
+            n_features=n_features,
+            n_tasks=n_tasks,
+            candidate_count=candidate_count,
+            scale_robust=scale_robust,
+        )
+        _preflight_interaction_update_working_set(
             n_features=n_features,
             n_tasks=n_tasks,
             candidate_count=candidate_count,

--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -131,6 +131,86 @@ def _saturating_int32_increment(value: Array) -> Array:
     return jnp.where(value < maximum, value + jnp.asarray(1, dtype=jnp.int32), maximum)
 
 
+def _latent_direct_state_scalars(
+    *,
+    observation_dim: int,
+    n_actions: int,
+    latent_dim: int,
+    hidden_sizes: tuple[int, ...],
+    include_action_interactions: bool,
+) -> int:
+    """Named persist scalars already preflighted by ``LatentWorldModelConfig``."""
+    input_dim = latent_dim + n_actions
+    if include_action_interactions:
+        input_dim += latent_dim * n_actions
+    layer_sizes = (input_dim, *hidden_sizes)
+    trunk_parameters = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    n_heads = latent_dim + 2
+    head_input = hidden_sizes[-1] if hidden_sizes else input_dim
+    head_parameters = n_heads * (head_input + 1)
+    learner_direct_scalars = (
+        2 * (trunk_parameters + head_parameters) + sum(hidden_sizes) + 3
+    )
+    outer_state_scalars = observation_dim * latent_dim + 3 * latent_dim + 4
+    return learner_direct_scalars + outer_state_scalars
+
+
+def _latent_update_result_extras_bytes(*, latent_dim: int) -> int:
+    """Returned ``LatentWorldModelUpdateResult`` extras excluding persist.
+
+    Nested ``learner_result.state`` is callee persist and is already counted
+    in the simultaneous persist copies.  These extras are the published
+    prediction, target, error, metric, and learner-result diagnostic leaves.
+    """
+    n_heads = latent_dim + 2
+    return 12 * latent_dim + 44 * n_heads + 64
+
+
+def _latent_update_working_set_bytes(
+    *,
+    observation_dim: int,
+    n_actions: int,
+    latent_dim: int,
+    hidden_sizes: tuple[int, ...],
+    include_action_interactions: bool,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    persist_bytes = 4 * _latent_direct_state_scalars(
+        observation_dim=observation_dim,
+        n_actions=n_actions,
+        latent_dim=latent_dim,
+        hidden_sizes=hidden_sizes,
+        include_action_interactions=include_action_interactions,
+    )
+    extras_bytes = _latent_update_result_extras_bytes(latent_dim=latent_dim)
+    return 3 * persist_bytes + extras_bytes
+
+
+def _preflight_latent_update_working_set(
+    *,
+    observation_dim: int,
+    n_actions: int,
+    latent_dim: int,
+    hidden_sizes: tuple[int, ...],
+    include_action_interactions: bool,
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    working_set_bytes = _latent_update_working_set_bytes(
+        observation_dim=observation_dim,
+        n_actions=n_actions,
+        latent_dim=latent_dim,
+        hidden_sizes=hidden_sizes,
+        include_action_interactions=include_action_interactions,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "latent world-model update working set byte count must fit signed int32"
+        )
+
+
 @dataclasses.dataclass(frozen=True)
 class LatentWorldModelConfig:
     """Configuration for :class:`LatentWorldModel`.
@@ -263,25 +343,26 @@ class LatentWorldModelConfig:
             _require_int32_product(f"hidden_layer[{index}]_scalars", fan_in, fan_out)
         head_input = self.hidden_sizes[-1] if self.hidden_sizes else input_dim
         _require_int32_product("head_weight_scalars", n_heads, head_input)
-        layer_sizes = (input_dim, *self.hidden_sizes)
-        trunk_parameters = sum(
-            fan_out * (fan_in + 1)
-            for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+        combined_direct_state_scalars = _latent_direct_state_scalars(
+            observation_dim=self.observation_dim,
+            n_actions=self.n_actions,
+            latent_dim=self.latent_dim,
+            hidden_sizes=self.hidden_sizes,
+            include_action_interactions=self.include_action_interactions,
         )
-        head_parameters = n_heads * (head_input + 1)
-        learner_direct_scalars = (
-            2 * (trunk_parameters + head_parameters) + sum(self.hidden_sizes) + 3
-        )
-        outer_state_scalars = (
-            self.observation_dim * self.latent_dim + 3 * self.latent_dim + 4
-        )
-        combined_direct_state_scalars = learner_direct_scalars + outer_state_scalars
         for name, value in (
             ("combined_direct_state_scalars", combined_direct_state_scalars),
             ("combined_direct_state_bytes", 4 * combined_direct_state_scalars),
         ):
             if value > _INT32_MAX:
                 raise ValueError(f"derived {name} must fit in signed int32")
+        _preflight_latent_update_working_set(
+            observation_dim=self.observation_dim,
+            n_actions=self.n_actions,
+            latent_dim=self.latent_dim,
+            hidden_sizes=self.hidden_sizes,
+            include_action_interactions=self.include_action_interactions,
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""

--- a/alberta_framework/core/learning_signals.py
+++ b/alberta_framework/core/learning_signals.py
@@ -84,6 +84,46 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _learning_signal_observe_working_set_bytes(
+    ensemble_size: int,
+    target_dim: int,
+) -> int:
+    """Source persist, proposed persist, inputs, sanitized copies, and returned leaves.
+
+    ``observe`` keeps the source state, the valid-path proposal, and the
+    invalid-path proposal live together with the raw ensemble inputs, their
+    sanitized copies, member residual squares, per-dimension temps, and the
+    returned signal / availability leaves.
+    """
+
+    persist_scalars = 9
+    input_scalars = 2 * ensemble_size * target_dim + target_dim + 1
+    observe_scalars = (
+        3 * persist_scalars
+        + 2 * input_scalars
+        + ensemble_size * target_dim
+        + 5 * target_dim
+        + 16
+    )
+    return 4 * observe_scalars
+
+
+def _preflight_learning_signal_observe_working_set(
+    ensemble_size: int,
+    target_dim: int,
+) -> None:
+    """Reject an observe envelope the estimator cannot name."""
+
+    working_set_bytes = _learning_signal_observe_working_set_bytes(
+        ensemble_size,
+        target_dim,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "learning-signal observe working set byte count must fit signed int32"
+        )
+
+
 def _ratio_less(left: tuple[int, int], right: tuple[int, int]) -> bool:
     return left[0] * right[1] < right[0] * left[1]
 
@@ -164,6 +204,10 @@ class LearningSignalEstimatorConfig:
             raise ValueError(
                 "ensemble_size and target_dim input resource budget must fit signed int32"
             )
+        _preflight_learning_signal_observe_working_set(
+            self.ensemble_size,
+            self.target_dim,
+        )
         object.__setattr__(
             self,
             "progress_warmup_steps",

--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -77,7 +77,6 @@ MODEL_REPLAY_REHEARSAL_SCHEMA = "alberta.model_replay_rehearsal.v1"
 MECHANISM_STATUS = "model-only-replay-mechanism-no-scientific-claim"
 _INT32_MAX = 2_147_483_647
 _UINT32_MAX = 4_294_967_295
-_MAX_EXACT_FLOAT32_INTEGER = 16_777_216
 _COMPOSER_ACCOUNTING_BYTES = 7 * 4
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
@@ -201,8 +200,6 @@ class ModelReplayRehearsalConfig:
             raise ValueError("action_encoding must be 'scalar_index' or 'one_hot'")
         if self.ensemble.model.observation_dim != self.replay.observation_dim:
             raise ValueError("ensemble and replay observation dimensions must match")
-        if self.ensemble.model.n_actions > _MAX_EXACT_FLOAT32_INTEGER:
-            raise ValueError("n_actions exceeds exact float32 action-index storage")
         _require_int(
             "ensemble.model.n_actions",
             self.ensemble.model.n_actions,

--- a/alberta_framework/core/model_replay_rehearsal.py
+++ b/alberta_framework/core/model_replay_rehearsal.py
@@ -130,16 +130,18 @@ def _copy_mapping(payload: object, *, name: str) -> dict[str, Any]:
 
 
 def _preflight_model_replay_state_resources(config: ModelReplayRehearsalConfig) -> None:
-    """Reject an oversized combined state before either child allocates arrays."""
+    """Reject an oversized combined update before either child allocates arrays.
+
+    Each child already requires its three-copy update envelope to fit signed
+    int32.  Consequently their combined one-copy persistent state is bounded
+    below two thirds of that limit; a separate composer persistent-state check
+    is unreachable.
+    """
     _, ensemble_bytes = _ensemble_state_resource_counts(
         model=config.ensemble.model,
         ensemble_size=config.ensemble.ensemble_size,
     )
     replay_slot_bytes, replay_bytes = _allocation_sizes(config.replay)
-    persistent_bytes = ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
-    if persistent_bytes > _INT32_MAX:
-        raise ValueError("model replay rehearsal state byte count must fit signed int32")
-
     model = config.ensemble.model
     ensemble_size = config.ensemble.ensemble_size
     target_dim = model.observation_dim + 2

--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -177,6 +177,58 @@ def _validate_direct_state_resources(
             raise ValueError(f"derived {name} must be at most {_INT32_MAX}")
 
 
+def _direct_state_bytes(
+    n_heads: int,
+    hidden_sizes: tuple[int, ...],
+    feature_dim: int,
+) -> int:
+    """Named persist already preflighted by ``_validate_direct_state_resources``."""
+    layer_sizes = (feature_dim, *hidden_sizes)
+    trunk_parameter_count = sum(
+        fan_out * (fan_in + 1)
+        for fan_in, fan_out in zip(layer_sizes, layer_sizes[1:], strict=False)
+    )
+    final_width = hidden_sizes[-1] if hidden_sizes else feature_dim
+    head_parameter_count = n_heads * (final_width + 1)
+    return 4 * (2 * (trunk_parameter_count + head_parameter_count) + sum(hidden_sizes) + 3)
+
+
+def _multi_head_update_result_extras_bytes(n_heads: int) -> int:
+    """Returned ``MultiHeadMLPUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published prediction, error, metric,
+    clock-word, and diagnostic leaves.
+    """
+    return 20 * n_heads + 25
+
+
+def _multi_head_update_working_set_bytes(
+    n_heads: int,
+    hidden_sizes: tuple[int, ...],
+    feature_dim: int,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _direct_state_bytes(
+        n_heads, hidden_sizes, feature_dim
+    ) + _multi_head_update_result_extras_bytes(n_heads)
+
+
+def _preflight_multi_head_update_working_set(
+    n_heads: int,
+    hidden_sizes: tuple[int, ...],
+    feature_dim: int,
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    working_set_bytes = _multi_head_update_working_set_bytes(
+        n_heads, hidden_sizes, feature_dim
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "multi-head learner update working set byte count must fit signed int32"
+        )
+
+
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Return 0 when ``scale`` is 0 so IEEE ``0 * inf`` does not become NaN."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
@@ -491,6 +543,7 @@ class MultiHeadMLPLearner:
         if hidden_sizes:
             _require_int32_product("head_weight_scalars", n_heads, hidden_sizes[-1])
         _validate_direct_state_resources(n_heads, hidden_sizes, feature_dim=1)
+        _preflight_multi_head_update_working_set(n_heads, hidden_sizes, feature_dim=1)
         if per_head_gamma_lamda is not None and type(per_head_gamma_lamda) is not tuple:
             raise ValueError(
                 "per_head_gamma_lamda must be an actual tuple when constructed directly"
@@ -723,6 +776,9 @@ class MultiHeadMLPLearner:
         else:
             _require_int32_product("linear_head_weight_scalars", self._n_heads, feature_dim)
         _validate_direct_state_resources(self._n_heads, self._hidden_sizes, feature_dim)
+        _preflight_multi_head_update_working_set(
+            self._n_heads, self._hidden_sizes, feature_dim
+        )
         # Trunk: [feature_dim, *hidden_sizes] — all hidden layers
         trunk_layer_sizes = [feature_dim, *self._hidden_sizes]
 

--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -515,6 +515,11 @@ class EMANormalizer(Normalizer[EMANormalizerState]):
         feature_dim = _require_int(
             "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
         )
+        _preflight_normalizer_update_working_set(
+            "EMANormalizer",
+            normalizer_state_nbytes_formula("EMANormalizer", feature_dim),
+            feature_dim,
+        )
         return EMANormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),
@@ -663,6 +668,11 @@ class WelfordNormalizer(Normalizer[WelfordNormalizerState]):
         feature_dim = _require_int(
             "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
         )
+        _preflight_normalizer_update_working_set(
+            "WelfordNormalizer",
+            normalizer_state_nbytes_formula("WelfordNormalizer", feature_dim),
+            feature_dim,
+        )
         return WelfordNormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),
@@ -803,6 +813,11 @@ class StreamingBatchNormalizer(Normalizer[StreamingBatchNormalizerState]):
         feature_dim = _require_int(
             "feature_dim", feature_dim, minimum=1, maximum=_INT32_MAX
         )
+        _preflight_normalizer_update_working_set(
+            "StreamingBatchNormalizer",
+            normalizer_state_nbytes_formula("StreamingBatchNormalizer", feature_dim),
+            feature_dim,
+        )
         return StreamingBatchNormalizerState(
             mean=jnp.zeros(feature_dim, dtype=jnp.float32),
             var=jnp.ones(feature_dim, dtype=jnp.float32),
@@ -917,6 +932,31 @@ def normalizer_state_nbytes_formula(
     if host_type == "WelfordNormalizer":
         return 12 * feature_dim + 12
     raise ValueError(f"Unknown normalizer type: '{host_type}'")
+
+
+def _normalizer_update_result_extras_bytes(feature_dim: int) -> int:
+    """Returned ``NormalizerUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published normalized observation,
+    sample-count words, and availability leaves.
+    """
+    return 4 * feature_dim + 20
+
+
+def _normalizer_update_working_set_bytes(persist_bytes: int, feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * persist_bytes + _normalizer_update_result_extras_bytes(feature_dim)
+
+
+def _preflight_normalizer_update_working_set(
+    name: str, persist_bytes: int, feature_dim: int
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _normalizer_update_working_set_bytes(persist_bytes, feature_dim) > _INT32_MAX:
+        raise ValueError(
+            f"{name} update working set byte count must fit signed int32"
+        )
 
 
 def measure_normalizer_state_nbytes(state: AnyNormalizerState) -> int:

--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -130,6 +130,35 @@ def _default_stomp_config() -> STOMPConfig:
     return STOMPConfig(subtask_specs=(SubtaskSpec(feature_index=0),))
 
 
+def _oak_direct_state_bytes(stomp: STOMPConfig) -> int:
+    """Named persist already preflighted by ``OaKConfig.__post_init__``."""
+    n_options = len(stomp.subtask_specs)
+    return 4 * (_stomp_direct_array_scalars(stomp) + 3 * n_options + 3)
+
+
+def _oak_update_result_extras_bytes(n_options: int) -> int:
+    """Returned ``OaKUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published diagnostic, clock-word,
+    and per-option utility leaves.
+    """
+    return 52 + 4 * n_options
+
+
+def _oak_update_working_set_bytes(stomp: STOMPConfig) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _oak_direct_state_bytes(stomp) + _oak_update_result_extras_bytes(
+        len(stomp.subtask_specs)
+    )
+
+
+def _preflight_oak_update_working_set(stomp: STOMPConfig) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _oak_update_working_set_bytes(stomp) > _INT32_MAX:
+        raise ValueError("OaK update working set byte count must fit signed int32")
+
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -187,6 +216,7 @@ class OaKConfig:
         combined_scalars = _stomp_direct_array_scalars(self.stomp) + 3 * self.n_options + 3
         if combined_scalars > _INT32_MAX or 4 * combined_scalars > _INT32_MAX:
             raise ValueError("derived OaK direct array bytes must fit signed int32")
+        _preflight_oak_update_working_set(self.stomp)
 
     @property
     def n_options(self) -> int:

--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -370,12 +370,15 @@ class OptionValueDurationLearner:
         dtype: Any,
     ) -> Array:
         try:
-            array = jnp.asarray(value)
+            actual_shape = tuple(value.shape)
+            actual_dtype = jnp.dtype(value.dtype)
         except Exception as error:
-            raise ValueError(f"{name} must be a readable array") from error
-        if array.shape != shape or array.dtype != dtype:
+            raise TypeError(
+                f"{name} must expose array shape and dtype metadata"
+            ) from error
+        if actual_shape != shape or actual_dtype != jnp.dtype(dtype):
             raise ValueError(f"{name} must have shape {shape} and dtype {dtype}")
-        return array
+        return jnp.asarray(value)
 
     @staticmethod
     def _state_values_valid(state: OptionValueDurationState) -> Array:

--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -369,13 +369,14 @@ class OptionValueDurationLearner:
         shape: tuple[int, ...],
         dtype: Any,
     ) -> Array:
-        try:
-            actual_shape = tuple(value.shape)
-            actual_dtype = jnp.dtype(value.dtype)
-        except Exception as error:
-            raise TypeError(
-                f"{name} must expose array shape and dtype metadata"
-            ) from error
+        actual_type = type(value)
+        if not (
+            actual_type is np.ndarray
+            or issubclass(actual_type, (jax.Array, jax.core.Tracer))
+        ):
+            raise TypeError(f"{name} must expose trusted array metadata")
+        actual_shape = tuple(value.shape)
+        actual_dtype = jnp.dtype(value.dtype)
         if actual_shape != shape or actual_dtype != jnp.dtype(dtype):
             raise ValueError(f"{name} must have shape {shape} and dtype {dtype}")
         return jnp.asarray(value)

--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -118,6 +118,32 @@ def _stomp_direct_array_scalars(config: STOMPConfig) -> int:
     )
 
 
+def _stomp_direct_state_bytes(config: STOMPConfig) -> int:
+    """Named persist already preflighted by ``STOMPConfig.__post_init__``."""
+    return 4 * _stomp_direct_array_scalars(config)
+
+
+def _stomp_update_result_extras_bytes() -> int:
+    """Returned ``STOMPUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published diagnostic, clock-word,
+    and nested-update leaves.
+    """
+    return 64
+
+
+def _stomp_update_working_set_bytes(config: STOMPConfig) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _stomp_direct_state_bytes(config) + _stomp_update_result_extras_bytes()
+
+
+def _preflight_stomp_update_working_set(config: STOMPConfig) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _stomp_update_working_set_bytes(config) > _INT32_MAX:
+        raise ValueError("STOMP update working set byte count must fit signed int32")
+
+
 # ---------------------------------------------------------------------------
 # Subtask specification (Python-level; JAX arrays extracted for scan use)
 # ---------------------------------------------------------------------------
@@ -1549,6 +1575,7 @@ class STOMPConfig:
         direct_scalars = _stomp_direct_array_scalars(self)
         if direct_scalars > _INT32_MAX or 4 * direct_scalars > _INT32_MAX:
             raise ValueError("derived STOMP direct array bytes must fit signed int32")
+        _preflight_stomp_update_working_set(self)
 
     @property
     def n_options(self) -> int:

--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -322,6 +322,44 @@ def _require_float32_resource(
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
+def _gru_perception_persistent_bytes(observation_dim: int, hidden_dim: int) -> int:
+    """Named persist already preflighted by ``GRUPerceptionConfig``."""
+    return 4 * (
+        3 * hidden_dim * observation_dim + 3 * hidden_dim * hidden_dim + 4 * hidden_dim
+    )
+
+
+def _gru_perception_update_result_extras_bytes(
+    observation_dim: int, hidden_dim: int
+) -> int:
+    """Returned ``_gru_step`` extras excluding persist.
+
+    Nested new ``GRUPerceptionState`` is persist and is already counted in the
+    simultaneous persist copies. These extras are the published augmented
+    observation ``[obs, new_hidden]``.
+    """
+    return 4 * (observation_dim + hidden_dim)
+
+
+def _gru_perception_update_working_set_bytes(
+    observation_dim: int, hidden_dim: int
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _gru_perception_persistent_bytes(
+        observation_dim, hidden_dim
+    ) + _gru_perception_update_result_extras_bytes(observation_dim, hidden_dim)
+
+
+def _preflight_gru_perception_update_working_set(
+    observation_dim: int, hidden_dim: int
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _gru_perception_update_working_set_bytes(observation_dim, hidden_dim) > _INT32_MAX:
+        raise ValueError(
+            "GRUPerception update working set byte count must fit signed int32"
+        )
+
+
 def _copy_mapping(payload: object, *, name: str) -> dict[str, Any]:
     if not issubclass(type(payload), Mapping):
         raise ValueError(f"{name} payload must be a mapping")
@@ -383,6 +421,7 @@ class GRUPerceptionConfig:
             vector_scalars=3 * h * obs + 3 * h * h,
             fixed_scalars=4 * h,
         )
+        _preflight_gru_perception_update_working_set(obs, h)
 
     def augmented_dim(self) -> int:
         """Return ``observation_dim + hidden_dim``."""

--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -27,7 +27,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
-from jaxtyping import Bool, Float
+from jaxtyping import Bool, Float, Int
 
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.update_safety import (
@@ -243,7 +243,7 @@ class PrototypeMemoryState:
     """State for :class:`PrototypeMemoryLearner`."""
 
     means: Float[Array, "n_classes slots_per_class feature_dim"]
-    counts: Float[Array, "n_classes slots_per_class"]
+    counts: Int[Array, "n_classes slots_per_class"]
     last_update: Array
     step_count: Array
 
@@ -357,7 +357,7 @@ class PrototypeMemoryLearner:
             state.counts,
             name="state.counts",
             shape=slot_shape,
-            dtype=jnp.float32,
+            dtype=jnp.int32,
         )
         _require_array(
             state.last_update,
@@ -390,7 +390,7 @@ class PrototypeMemoryLearner:
                 (c.n_classes, c.slots_per_class, c.feature_dim),
                 dtype=jnp.float32,
             ),
-            counts=jnp.zeros((c.n_classes, c.slots_per_class), dtype=jnp.float32),
+            counts=jnp.zeros((c.n_classes, c.slots_per_class), dtype=jnp.int32),
             last_update=jnp.zeros((c.n_classes, c.slots_per_class), dtype=jnp.int32),
             step_count=jnp.array(0, dtype=jnp.int32),
         )
@@ -571,7 +571,11 @@ class PrototypeMemoryLearner:
                 safe_observation,
                 old_mean + eta * (safe_observation - old_mean),
             )
-            new_count = jnp.where(novel, 1.0, current.counts[head, slot] + 1.0)
+            new_count = jnp.where(
+                novel,
+                jnp.asarray(1, dtype=jnp.int32),
+                _saturating_increment(current.counts[head, slot]),
+            )
             next_step = _saturating_increment(current.step_count)
             next_state = PrototypeMemoryState(
                 means=current.means.at[head, slot].set(new_mean),

--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -467,7 +467,7 @@ class PrototypeMemoryLearner:
         class_counts = state.counts[head]
         class_last_update = state.last_update[head]
         min_count = jnp.min(class_counts)
-        tied = class_counts <= (min_count + 1e-6)
+        tied = class_counts == min_count
         oldest_among_tied = jnp.where(
             tied,
             class_last_update,

--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -42,6 +42,10 @@ _DIAGNOSTIC_FLOAT32_SCALARS = 12
 _OUTPUT_BOOL_SCALARS = 12
 _FIXED_OUTPUT_BYTES = 4 * _DIAGNOSTIC_FLOAT32_SCALARS + _OUTPUT_BOOL_SCALARS
 _MAX_REPRESENTATION_DIM = (_INT32_MAX - _FIXED_OUTPUT_BYTES) // 4
+# Raw pair, safe pair, prepared pair, per-source normalize/clip temps,
+# zeros, for-use pair, contribution pair, safe-contribution pair,
+# mixed/unclipped, safe mixed, final candidate, and returned gradient.
+_MIX_WORKING_SET_DIM_VECTORS = 21
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -60,6 +64,28 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _mixer_update_working_set_bytes(representation_dim: int) -> int:
+    """Simultaneous two-source mix working set plus returned-leaf bytes.
+
+    Persist is empty.  ``mix_representation_gradients`` keeps the raw,
+    neutralized, prepared, contribution, and returned dim-vectors live
+    together with the fixed diagnostic/bool result payload.
+    """
+
+    return 4 * _MIX_WORKING_SET_DIM_VECTORS * representation_dim + _FIXED_OUTPUT_BYTES
+
+
+def _preflight_mixer_update_working_set(representation_dim: int) -> None:
+    """Reject a mix envelope the host cannot name in signed int32."""
+
+    working_set_bytes = _mixer_update_working_set_bytes(representation_dim)
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "representation-gradient mixer update working set byte count "
+            "must fit signed int32"
+        )
 
 
 def _strict_float32_scalar(
@@ -124,6 +150,7 @@ class RepresentationGradientMixerConfig:
                 maximum=_MAX_REPRESENTATION_DIM,
             ),
         )
+        _preflight_mixer_update_working_set(self.representation_dim)
         if type(self.mode) is not str or self.mode not in _VALID_MODES:
             raise ValueError(
                 "mode must be full, behavior_only, world_only, or discard"

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -191,6 +191,36 @@ def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
         raise ValueError("stacked Horde aggregate bytes must fit signed int32")
 
 
+def _stacked_horde_persistent_bytes(n_demons: int, feature_dim: int) -> int:
+    """Named persist already counted inside ``_preflight_horde_resources``."""
+    return 8 * n_demons * feature_dim + 4
+
+
+def _stacked_horde_update_result_extras_bytes(n_demons: int) -> int:
+    """Returned ``StackedHordeUpdateResult`` extras excluding persist.
+
+    Nested ``state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published prediction, TD-error,
+    per-head, and diagnostic leaves.
+    """
+    return 9 * n_demons + 1
+
+
+def _stacked_horde_update_working_set_bytes(n_demons: int, feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _stacked_horde_persistent_bytes(
+        n_demons, feature_dim
+    ) + _stacked_horde_update_result_extras_bytes(n_demons)
+
+
+def _preflight_stacked_horde_update_working_set(n_demons: int, feature_dim: int) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _stacked_horde_update_working_set_bytes(n_demons, feature_dim) > _INT32_MAX:
+        raise ValueError(
+            "stacked Horde update working set byte count must fit signed int32"
+        )
+
+
 def _require_scan_result_resources(num_updates: int, n_demons: int) -> None:
     result_scalars = num_updates * n_demons
     if result_scalars > _INT32_MAX or 4 * result_scalars > _INT32_MAX:
@@ -260,6 +290,7 @@ class StackedHordeConfig:
         )
 
         _preflight_horde_resources(n_demons, feature_dim)
+        _preflight_stacked_horde_update_working_set(n_demons, feature_dim)
 
         object.__setattr__(self, "n_demons", n_demons)
         object.__setattr__(self, "feature_dim", feature_dim)
@@ -337,6 +368,7 @@ def nexting_spec(
     if n_demons < 1 or n_demons > _INT32_MAX:
         raise ValueError("derived n_demons must be in the signed int32 domain")
     _preflight_horde_resources(n_demons, feature_dim)
+    _preflight_stacked_horde_update_working_set(n_demons, feature_dim)
     idxs: list[int] = []
     gs: list[float] = []
     for c in canonical_indices:

--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -1280,6 +1280,61 @@ class FixedTraceStateBuilder:
         return self.commit_learning_update(state, proposal)
 
 
+def _online_gated_update_working_set_bytes(
+    observation_dim: int,
+    n_actions: int,
+    hidden_dim: int,
+    *,
+    include_raw_observation: bool,
+) -> int:
+    """Source persist, candidate persist, selected persist, and returned extras.
+
+    ``update`` keeps the source state, the candidate state, and the
+    transaction-selected result simultaneously live.  ``jax.jacfwd``
+    materializes another sensitivity matrix, the proposed sensitivity is
+    live before it is stored, and the caller-visible representation plus
+    its neutralized NaN copy are returned beside the selected state.
+    Event / safe-event / gate temporaries are charged as well.
+    """
+
+    event_dim = observation_dim + n_actions + 2
+    feature_dim = hidden_dim + (observation_dim if include_raw_observation else 0)
+    parameter_count = 2 * hidden_dim * (event_dim + 1)
+    persist_scalars = (
+        parameter_count + hidden_dim + hidden_dim * parameter_count + 3
+    )
+    update_scalars = (
+        3 * persist_scalars
+        + 2 * hidden_dim * parameter_count
+        + 2 * feature_dim
+        + 2 * event_dim
+        + hidden_dim
+        + 16
+    )
+    return 4 * update_scalars
+
+
+def _preflight_online_gated_update_working_set(
+    observation_dim: int,
+    n_actions: int,
+    hidden_dim: int,
+    *,
+    include_raw_observation: bool,
+) -> None:
+    """Reject an update envelope the online-gated builder cannot name."""
+
+    working_set_bytes = _online_gated_update_working_set_bytes(
+        observation_dim,
+        n_actions,
+        hidden_dim,
+        include_raw_observation=include_raw_observation,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "online-gated update working set byte count must fit signed int32"
+        )
+
+
 @dataclass(frozen=True)
 class OnlineGatedStateBuilderConfig:
     """Configuration for the online learnable write/hold state builder."""
@@ -1349,6 +1404,12 @@ class OnlineGatedStateBuilderConfig:
         _require_derived_int32("parameter_count", parameter_count, minimum=1)
         _require_derived_int32("state_scalars", state_scalars, minimum=1)
         _require_derived_int32("state_bytes", 4 * state_scalars, minimum=1)
+        _preflight_online_gated_update_working_set(
+            self.observation_dim,
+            self.n_actions,
+            self.hidden_dim,
+            include_raw_observation=self.include_raw_observation,
+        )
 
     def event_dim(self) -> int:
         """Return observation + one-hot action + reward + discount width."""

--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -101,6 +101,34 @@ def _require_float32_resource(name: str, *, float32_scalars: int) -> None:
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
+def _swift_td_persistent_bytes(feature_dim: int) -> int:
+    """Named persist already preflighted by ``SwiftTD.init``."""
+    return 4 * (8 * (feature_dim + 1) + 5)
+
+
+def _swift_td_update_result_extras_bytes(feature_dim: int) -> int:
+    """Returned ``SwiftTDUpdate`` extras excluding persist.
+
+    Nested ``new_state`` is persist and is already counted in the simultaneous
+    persist copies. These extras are the published weight/bias deltas, metric
+    scalars, and diagnostic leaf.
+    """
+    return 4 * feature_dim + 29
+
+
+def _swift_td_update_working_set_bytes(feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _swift_td_persistent_bytes(
+        feature_dim
+    ) + _swift_td_update_result_extras_bytes(feature_dim)
+
+
+def _preflight_swift_td_update_working_set(feature_dim: int) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    if _swift_td_update_working_set_bytes(feature_dim) > _INT32_MAX:
+        raise ValueError("SwiftTD update working set byte count must fit signed int32")
+
+
 _DEFAULT_ETA_MIN = math.exp(-15.0)
 
 _SUPPORTED_CONFIG_REAL_TYPES: tuple[type[object], ...] = (
@@ -319,6 +347,7 @@ class SwiftTD:
             "SwiftTD state",
             float32_scalars=8 * aug_dim + 5,
         )
+        _preflight_swift_td_update_working_set(feature_dim)
         # The dense reference implementation clips beta into
         # [ln(eta_min), ln(eta)] on every pass, including the (otherwise
         # trivial) very first one -- so step-sizes are capped BEFORE the
@@ -366,6 +395,7 @@ class SwiftTD:
         if augmented_dim < 2:
             raise ValueError("state vector length must include a positive feature dimension")
         _require_float32_resource("SwiftTD adopted state", float32_scalars=8 * augmented_dim + 5)
+        _preflight_swift_td_update_working_set(augmented_dim - 1)
         for name, value in vectors:
             if not hasattr(value, "shape") or not hasattr(value, "dtype"):
                 raise TypeError(f"{name} must expose array shape and dtype metadata")

--- a/alberta_framework/core/temporal_context.py
+++ b/alberta_framework/core/temporal_context.py
@@ -156,6 +156,105 @@ def _require_int(
     return number
 
 
+def _temporal_context_persist_bytes(input_dim: int) -> int:
+    """EMA float32 vector plus the signed-int32 step counter."""
+
+    return 4 * input_dim + 4
+
+
+def _temporal_context_output_dim(
+    input_dim: int,
+    *,
+    include_raw: bool,
+    include_ema: bool,
+    include_delta: bool,
+    include_phase_products: bool,
+    n_periods: int,
+) -> int:
+    copies = int(include_raw) + int(include_ema) + int(include_delta)
+    phase_dim = 2 * n_periods
+    product_dim = phase_dim * input_dim * int(include_phase_products and n_periods > 0)
+    return copies * input_dim + phase_dim + product_dim
+
+
+def _temporal_context_update_working_set_bytes(
+    input_dim: int,
+    *,
+    include_raw: bool,
+    include_ema: bool,
+    include_delta: bool,
+    include_phase_products: bool,
+    n_periods: int,
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras.
+
+    ``step`` keeps the source EMA/counter, the proposed EMA/counter, and the
+    transaction-selected result live together with the observation, sanitized
+    copies, optional delta pair, phase code, optional phase×obs products, and
+    the returned feature leaf.
+    """
+
+    persist_bytes = _temporal_context_persist_bytes(input_dim)
+    copies = int(include_raw) + int(include_ema) + int(include_delta)
+    phase_dim = 2 * n_periods
+    product_dim = phase_dim * input_dim * int(include_phase_products and n_periods > 0)
+    output_dim = copies * input_dim + phase_dim + product_dim
+    extra_bytes = (
+        4 * input_dim
+        + 4 * input_dim
+        + 4 * input_dim
+        + 4 * input_dim
+        + 8 * input_dim * int(include_delta)
+        + 4 * phase_dim
+        + 4 * product_dim
+        + 4 * output_dim
+        + 16
+    )
+    return 3 * persist_bytes + extra_bytes
+
+
+def _preflight_temporal_context_update_working_set(
+    input_dim: int,
+    *,
+    include_raw: bool,
+    include_ema: bool,
+    include_delta: bool,
+    include_phase_products: bool,
+    n_periods: int,
+) -> None:
+    """Reject a step envelope the host cannot name in signed int32."""
+
+    persist_bytes = _temporal_context_persist_bytes(input_dim)
+    if persist_bytes > _INT32_MAX:
+        raise ValueError(
+            "temporal-context persistent state byte count must fit signed int32"
+        )
+    output_dim = _temporal_context_output_dim(
+        input_dim,
+        include_raw=include_raw,
+        include_ema=include_ema,
+        include_delta=include_delta,
+        include_phase_products=include_phase_products,
+        n_periods=n_periods,
+    )
+    if output_dim > _INT32_MAX or 4 * output_dim > _INT32_MAX:
+        raise ValueError(
+            "temporal-context returned feature byte count must fit signed int32"
+        )
+    working_set_bytes = _temporal_context_update_working_set_bytes(
+        input_dim,
+        include_raw=include_raw,
+        include_ema=include_ema,
+        include_delta=include_delta,
+        include_phase_products=include_phase_products,
+        n_periods=n_periods,
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "temporal-context update working set byte count must fit signed int32"
+        )
+
+
 @dataclass(frozen=True)
 class TemporalContextConfig:
     """Configuration for :class:`TemporalContextFeaturizer`.
@@ -184,10 +283,14 @@ class TemporalContextConfig:
 
     def output_dim(self) -> int:
         """Return the transformed feature dimensionality."""
-        copies = int(self.include_raw) + int(self.include_ema) + int(self.include_delta)
-        phase_dim = 2 * len(self.periods)
-        product_dim = phase_dim * self.input_dim * int(self.include_phase_products)
-        return copies * self.input_dim + phase_dim + product_dim
+        return _temporal_context_output_dim(
+            self.input_dim,
+            include_raw=self.include_raw,
+            include_ema=self.include_ema,
+            include_delta=self.include_delta,
+            include_phase_products=self.include_phase_products,
+            n_periods=len(self.periods),
+        )
 
     def to_config(self) -> dict[str, Any]:
         """Serialize to a plain dictionary."""
@@ -312,6 +415,14 @@ def _validate_config(config: TemporalContextConfig) -> None:
     )
     object.__setattr__(config, "ema_decay", ema_decay)
     object.__setattr__(config, "periods", canonical_periods)
+    _preflight_temporal_context_update_working_set(
+        input_dim,
+        include_raw=config.include_raw,
+        include_ema=config.include_ema,
+        include_delta=config.include_delta,
+        include_phase_products=config.include_phase_products,
+        n_periods=len(canonical_periods),
+    )
 
 
 class TemporalContextFeaturizer:

--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -53,6 +53,7 @@ from alberta_framework.core._float32_scalars import (
     validated_float32_scalar_with_ratio,
 )
 from alberta_framework.core.initializers import sparse_init
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.optimizers import Bounder, ObGDBounding
 from alberta_framework.core.types import MLPParams
 from alberta_framework.core.update_safety import zero_if_collapsed_infinity
@@ -3327,7 +3328,7 @@ class UPGDLearner:
             previous_head_weight_grads=next_previous_head_weight_grads,
             previous_head_bias_grads=next_previous_head_bias_grads,
             key=new_key,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )

--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -156,17 +156,12 @@ def _ensemble_state_resource_counts(
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived {name} must fit signed int32")
 
-    update_float32_scalars = (
-        2 * ensemble_size * target_dim
-        + 3 * target_dim
-        + ensemble_size * model.observation_dim
-        + 2 * model.observation_dim
-        + 3 * ensemble_size
-        + 13
+    extras_scalars, extras_bytes = _ensemble_update_result_extras(
+        observation_dim=model.observation_dim,
+        ensemble_size=ensemble_size,
     )
-    update_bool_scalars = 2 * ensemble_size + 20
-    update_scalars = logical_scalars + update_float32_scalars + update_bool_scalars
-    update_bytes = logical_bytes + 4 * update_float32_scalars + update_bool_scalars
+    update_scalars = logical_scalars + extras_scalars
+    update_bytes = logical_bytes + extras_bytes
     for name, value in (
         ("ensemble update-result scalars", update_scalars),
         ("ensemble update-result bytes", update_bytes),
@@ -174,6 +169,61 @@ def _ensemble_state_resource_counts(
         if not 1 <= value <= _INT32_MAX:
             raise ValueError(f"derived {name} must fit signed int32")
     return logical_scalars, logical_bytes
+
+
+def _ensemble_update_result_extras(
+    *, observation_dim: int, ensemble_size: int
+) -> tuple[int, int]:
+    """Returned ``WorldModelEnsembleUpdateResult`` extras excluding persist.
+
+    Returns ``(extras_scalars, extras_bytes)``.
+    """
+    target_dim = observation_dim + 2
+    update_float32_scalars = (
+        2 * ensemble_size * target_dim
+        + 3 * target_dim
+        + ensemble_size * observation_dim
+        + 2 * observation_dim
+        + 3 * ensemble_size
+        + 13
+    )
+    update_bool_scalars = 2 * ensemble_size + 20
+    return (
+        update_float32_scalars + update_bool_scalars,
+        4 * update_float32_scalars + update_bool_scalars,
+    )
+
+
+def _ensemble_update_working_set_bytes(
+    *, model: ActionConditionedWorldModelConfig, ensemble_size: int
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras.
+
+    ``update`` keeps the source ensemble state, the candidate persist, and the
+    transaction-selected result live together with the returned prediction,
+    signal, target, and diagnostic leaves.
+    """
+    _, persist_bytes = _ensemble_state_resource_counts(
+        model=model, ensemble_size=ensemble_size
+    )
+    _, extras_bytes = _ensemble_update_result_extras(
+        observation_dim=model.observation_dim,
+        ensemble_size=ensemble_size,
+    )
+    return 3 * persist_bytes + extras_bytes
+
+
+def _preflight_ensemble_update_working_set(
+    *, model: ActionConditionedWorldModelConfig, ensemble_size: int
+) -> None:
+    """Reject an update envelope the host cannot name in signed int32."""
+    working_set_bytes = _ensemble_update_working_set_bytes(
+        model=model, ensemble_size=ensemble_size
+    )
+    if working_set_bytes > _INT32_MAX:
+        raise ValueError(
+            "world-model ensemble update working set byte count must fit signed int32"
+        )
 
 
 def _safe_mean(values: Array, *, axis: int | None = None) -> Array:
@@ -288,6 +338,9 @@ class WorldModelEnsembleConfig:
         )
         object.__setattr__(self, "residual_variance_floor", residual_variance_floor)
         _ensemble_state_resource_counts(model=self.model, ensemble_size=ensemble_size)
+        _preflight_ensemble_update_working_set(
+            model=self.model, ensemble_size=ensemble_size
+        )
 
     @property
     def target_dim(self) -> int:

--- a/alberta_framework/evaluation/continual_ia_artifact.py
+++ b/alberta_framework/evaluation/continual_ia_artifact.py
@@ -1071,7 +1071,7 @@ def _validate_operational(
             condition = timing.get("condition")
             wall = _number(timing.get("wall_seconds"))
             latency = _number(timing.get("mean_step_latency_ms"))
-            if not isinstance(seed, int) or not isinstance(condition, str):
+            if type(seed) is not int or type(condition) is not str:
                 errors.append(f"condition_timings[{index}] has invalid identity")
             else:
                 observed_pairs.append((seed, condition))

--- a/alberta_framework/evaluation/continual_ia_artifact.py
+++ b/alberta_framework/evaluation/continual_ia_artifact.py
@@ -525,7 +525,7 @@ def write_ia_consumed_seed_replay(
 
 
 def _number(value: object) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) is bool or (type(value) is not int and type(value) is not float):
         return None
     numeric = float(value)
     return numeric if np.isfinite(numeric) else None

--- a/alberta_framework/evaluation/continual_multiagent_artifact.py
+++ b/alberta_framework/evaluation/continual_multiagent_artifact.py
@@ -1330,7 +1330,7 @@ def validate_evidence_artifact(
                 "content_digest.canonicalization has an unsupported value"
             )
         recorded = digest.get("sha256")
-        if not isinstance(recorded, str) or len(recorded) != 64:
+        if type(recorded) is not str or len(recorded) != 64:
             errors.append("content_digest.sha256 must be a 64-character string")
         elif content is not None:
             expected = scientific_content_sha256(content)

--- a/alberta_framework/evaluation/ftl_decision_artifact.py
+++ b/alberta_framework/evaluation/ftl_decision_artifact.py
@@ -1015,7 +1015,7 @@ def _validate_source_provenance(
         errors.append(f"{location}.repository_subtree is invalid")
     generation_head = value.get("git_head")
     if (
-        not isinstance(generation_head, str)
+        type(generation_head) is not str
         or len(generation_head) != 40
         or any(character not in "0123456789abcdef" for character in generation_head)
     ):

--- a/alberta_framework/evaluation/recurring_feature_artifact.py
+++ b/alberta_framework/evaluation/recurring_feature_artifact.py
@@ -1444,7 +1444,7 @@ def _validate_checks(
         if (
             actual is None
             or threshold is None
-            or not isinstance(comparator, str)
+            or type(comparator) is not str
             or comparator not in {">=", "<=", ">", "=="}
         ):
             computed = False

--- a/alberta_framework/evaluation/scale_robust_feature_artifact.py
+++ b/alberta_framework/evaluation/scale_robust_feature_artifact.py
@@ -1836,7 +1836,7 @@ def _validate_source_provenance(
         errors.append("source_provenance.repository_subtree is inconsistent")
     git_head = source.get("git_head")
     if (
-        not isinstance(git_head, str)
+        type(git_head) is not str
         or len(git_head) != 40
         or any(character not in "0123456789abcdef" for character in git_head)
     ):
@@ -1856,7 +1856,7 @@ def _validate_source_provenance(
         )
         for path, digest in hashes.items():
             if (
-                not isinstance(digest, str)
+                type(digest) is not str
                 or len(digest) != 64
                 or any(character not in "0123456789abcdef" for character in digest)
             ):

--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -67,6 +67,7 @@ from alberta_framework.core.checkpoints import (
     load_checkpoint_metadata,
     save_checkpoint,
 )
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream
 
@@ -419,7 +420,7 @@ class GauntletStream:
         )
         new_state = GauntletState(
             key=key,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
             drift_weights=new_drift,
             w_a=state.w_a,
             w_c=state.w_c,

--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -233,21 +233,21 @@ class GauntletConfig:
     def __post_init__(self) -> None:
         """Validate the configuration."""
         if (
-            isinstance(self.relevant_dim, bool)
-            or not isinstance(self.relevant_dim, int)
+            type(self.relevant_dim) is bool
+            or type(self.relevant_dim) is not int
             or self.relevant_dim < 2
             or self.relevant_dim % 2 != 0
         ):
             raise ValueError("relevant_dim must be an even integer >= 2")
         if (
-            isinstance(self.irrelevant_dim, bool)
-            or not isinstance(self.irrelevant_dim, int)
+            type(self.irrelevant_dim) is bool
+            or type(self.irrelevant_dim) is not int
             or self.irrelevant_dim < 0
         ):
             raise ValueError("irrelevant_dim must be non-negative")
         if (
-            isinstance(self.segment_length, bool)
-            or not isinstance(self.segment_length, int)
+            type(self.segment_length) is bool
+            or type(self.segment_length) is not int
             or self.segment_length < 1
         ):
             raise ValueError("segment_length must be positive")
@@ -259,7 +259,9 @@ class GauntletConfig:
             "context_noise_std",
         ):
             value = getattr(self, name)
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
+            if type(value) is bool or (
+                type(value) is not int and type(value) is not float
+            ):
                 raise ValueError(f"{name} must be a finite real number")
             if not math.isfinite(float(value)):
                 raise ValueError(f"{name} must be finite")

--- a/alberta_framework/streams/gymnasium.py
+++ b/alberta_framework/streams/gymnasium.py
@@ -36,12 +36,11 @@ from jax import Array
 
 from alberta_framework._seed_validation import JAX_KEY_SEED_MAX, require_jax_seed
 from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core.learners import LinearLearner
 from alberta_framework.core.types import LearnerState, TimeStep
 
 if TYPE_CHECKING:
     import gymnasium
-
-    from alberta_framework.core.learners import LinearLearner
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)

--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -101,6 +101,45 @@ def _require_pavlovian_resources(
         raise ValueError("Pavlovian persistent byte count must fit signed int32")
 
 
+def _pavlovian_persistent_bytes(
+    *, n_phases: int, n_cs: int, n_distractors: int
+) -> int:
+    """Named persist already counted inside ``_require_pavlovian_resources``."""
+    static_scalars = n_phases * n_cs + 4 * n_phases
+    state_scalars = n_cs + n_distractors + 6
+    return 4 * (static_scalars + state_scalars)
+
+
+def _pavlovian_step_result_extras_bytes(*, n_cs: int, n_distractors: int) -> int:
+    """Returned ``TimeStep`` extras excluding persist.
+
+    Nested persist is already counted in the simultaneous persist copies.
+    These extras are the published observation and target leaves.
+    """
+    return 4 * (n_cs + n_distractors) + 4
+
+
+def _pavlovian_step_working_set_bytes(
+    *, n_phases: int, n_cs: int, n_distractors: int
+) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * _pavlovian_persistent_bytes(
+        n_phases=n_phases, n_cs=n_cs, n_distractors=n_distractors
+    ) + _pavlovian_step_result_extras_bytes(n_cs=n_cs, n_distractors=n_distractors)
+
+
+def _preflight_pavlovian_step_working_set(
+    *, n_phases: int, n_cs: int, n_distractors: int
+) -> None:
+    """Reject a step envelope the host cannot name in signed int32."""
+    if _pavlovian_step_working_set_bytes(
+        n_phases=n_phases, n_cs=n_cs, n_distractors=n_distractors
+    ) > _INT32_MAX:
+        raise ValueError(
+            "Pavlovian step working set byte count must fit signed int32"
+        )
+
+
 def _require_finite_real(
     value: object,
     *,
@@ -456,6 +495,11 @@ class ClassicalConditioningStream:
         if feature_dim > _INT32_MAX:
             raise ValueError("feature_dim must fit signed int32")
         _require_pavlovian_resources(
+            n_phases=len(phases),
+            n_cs=n_cs,
+            n_distractors=n_distractors,
+        )
+        _preflight_pavlovian_step_working_set(
             n_phases=len(phases),
             n_cs=n_cs,
             n_distractors=n_distractors,

--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -382,15 +382,15 @@ class RecurringTwoAgentWorld:
         partner_policy: PartnerPolicy | None = None,
     ) -> None:
         if (
-            isinstance(context_length, bool)
-            or not isinstance(context_length, int)
+            type(context_length) is bool
+            or type(context_length) is not int
             or context_length <= 0
         ):
-            raise ValueError(f"context_length must be positive, got {context_length}")
+            raise ValueError("context_length must be positive")
         if context_length > _INT32_MAX // 2:
             raise ValueError("2 * context_length must fit in signed schedule telemetry")
-        if isinstance(nuisance_dim, bool) or not isinstance(nuisance_dim, int) or nuisance_dim < 0:
-            raise ValueError(f"nuisance_dim must be non-negative, got {nuisance_dim}")
+        if type(nuisance_dim) is bool or type(nuisance_dim) is not int or nuisance_dim < 0:
+            raise ValueError("nuisance_dim must be non-negative")
         for name, value in (
             ("nuisance_scale", nuisance_scale),
             ("world_limit", world_limit),
@@ -399,22 +399,24 @@ class RecurringTwoAgentWorld:
             ("time_delta", time_delta),
             ("max_speed", max_speed),
         ):
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
+            if type(value) is bool or (
+                type(value) is not int and type(value) is not float
+            ):
                 raise ValueError(f"{name} must be a finite real number")
             if not math.isfinite(float(value)):
                 raise ValueError(f"{name} must be finite")
         if nuisance_scale < 0.0:
-            raise ValueError(f"nuisance_scale must be non-negative, got {nuisance_scale}")
+            raise ValueError("nuisance_scale must be non-negative")
         if world_limit <= 0.0:
-            raise ValueError(f"world_limit must be positive, got {world_limit}")
+            raise ValueError("world_limit must be positive")
         if not 0.0 <= damping < 1.0:
-            raise ValueError(f"damping must lie in [0, 1), got {damping}")
+            raise ValueError("damping must lie in [0, 1)")
         if acceleration <= 0.0:
-            raise ValueError(f"acceleration must be positive, got {acceleration}")
+            raise ValueError("acceleration must be positive")
         if time_delta <= 0.0:
-            raise ValueError(f"time_delta must be positive, got {time_delta}")
+            raise ValueError("time_delta must be positive")
         if max_speed <= 0.0:
-            raise ValueError(f"max_speed must be positive, got {max_speed}")
+            raise ValueError("max_speed must be positive")
         if type(initial_positions) is not tuple or len(initial_positions) != N_AGENTS:
             raise ValueError(f"initial_positions must be an exact {N_AGENTS}-tuple")
         canonical_positions = tuple(

--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -78,6 +78,43 @@ def _require_float32_resource(
         raise ValueError(f"{name} byte count must fit signed int32")
 
 
+def _hidden_state_ar2_persistent_bytes(feature_dim: int) -> int:
+    """Named persist already counted inside ``_require_float32_resource``."""
+    return 4 * (2 * feature_dim + 2)
+
+
+def _sutton_experiment1_persistent_bytes(feature_dim: int) -> int:
+    """Named persist already counted inside ``_require_float32_resource``."""
+    return 4 * (feature_dim + 3)
+
+
+def _scale_stream_persistent_bytes(feature_dim: int) -> int:
+    """Named persist already counted inside ``_require_float32_resource``."""
+    return 4 * (2 * feature_dim + 3)
+
+
+def _synthetic_step_result_extras_bytes(feature_dim: int) -> int:
+    """Returned ``TimeStep`` extras excluding persist.
+
+    Nested persist is already counted in the simultaneous persist copies.
+    These extras are the published observation and target leaves.
+    """
+    return 4 * feature_dim + 4
+
+
+def _synthetic_step_working_set_bytes(persist_bytes: int, feature_dim: int) -> int:
+    """Source persist, proposed persist, committed persist, and returned extras."""
+    return 3 * persist_bytes + _synthetic_step_result_extras_bytes(feature_dim)
+
+
+def _preflight_synthetic_step_working_set(
+    name: str, persist_bytes: int, feature_dim: int
+) -> None:
+    """Reject a step envelope the host cannot name in signed int32."""
+    if _synthetic_step_working_set_bytes(persist_bytes, feature_dim) > _INT32_MAX:
+        raise ValueError(f"{name} step working set byte count must fit signed int32")
+
+
 def _narrow_real_to_float32(name: str, value: object, message: str) -> tuple[int, int, float]:
     """Return one trusted exact ratio together with its binary32 rounding."""
     actual_type = type(value)
@@ -280,6 +317,11 @@ class HiddenStateAR2Stream:
             "HiddenStateAR2Stream state",
             vector_scalars=2 * feature_dim,
             fixed_scalars=2,
+        )
+        _preflight_synthetic_step_working_set(
+            "HiddenStateAR2Stream",
+            _hidden_state_ar2_persistent_bytes(feature_dim),
+            feature_dim,
         )
         phi1 = _require_finite_float32("phi1", phi1)
         phi2 = _require_finite_float32("phi2", phi2)
@@ -531,6 +573,11 @@ class SuttonExperiment1Stream:
             "SuttonExperiment1Stream state",
             vector_scalars=feature_dim,
             fixed_scalars=3,
+        )
+        _preflight_synthetic_step_working_set(
+            "SuttonExperiment1Stream",
+            _sutton_experiment1_persistent_bytes(feature_dim),
+            feature_dim,
         )
         self._change_interval = _require_positive_int("change_interval", change_interval)
         self._noise_std = _require_finite_nonnegative_float32("noise_std", noise_std)
@@ -1082,6 +1129,11 @@ class DynamicScaleShiftStream:
             vector_scalars=2 * self._feature_dim,
             fixed_scalars=3,
         )
+        _preflight_synthetic_step_working_set(
+            "DynamicScaleShiftStream",
+            _scale_stream_persistent_bytes(self._feature_dim),
+            self._feature_dim,
+        )
         self._scale_change_interval = _require_positive_int(
             "scale_change_interval", scale_change_interval
         )
@@ -1237,6 +1289,11 @@ class ScaleDriftStream:
             "ScaleDriftStream state",
             vector_scalars=2 * self._feature_dim,
             fixed_scalars=3,
+        )
+        _preflight_synthetic_step_working_set(
+            "ScaleDriftStream",
+            _scale_stream_persistent_bytes(self._feature_dim),
+            self._feature_dim,
         )
         self._weight_drift_rate = _require_finite_nonnegative_float32(
             "weight_drift_rate", weight_drift_rate

--- a/docs/research/ipmnist-campaign-index.md
+++ b/docs/research/ipmnist-campaign-index.md
@@ -1,10 +1,17 @@
 # IPMNIST campaign index
 
+Last reconciled: 2026-08-18.
+
 This is the mutable index for the active IPMNIST development-screening and
 development-confirmation campaign. It is **permanently nonpromoting**. It
 tests one plasticity/conditioning subsystem and does not support an integrated
 ASI-agent, robotics, scientific-evidence, state-of-the-art, or Alberta Plan
 completion claim.
+
+Maintained ceiling, frontier, and rule-discovery reproduction commands live in
+the [IPMNIST campaign-tools runbook](../runbooks/ipmnist-maintained-tools.md).
+Programs stored beside historical `outputs/` artifacts remain provenance
+records and are not the maintained implementation.
 
 ## Current stored record
 

--- a/docs/runbooks/ipmnist-maintained-tools.md
+++ b/docs/runbooks/ipmnist-maintained-tools.md
@@ -1,0 +1,102 @@
+# Maintained IPMNIST campaign tools
+
+Programs stored beside existing `outputs/` records are historical provenance,
+not the maintained implementation. Preserve every existing byte: pinned
+evidence artifacts are immutable, while the active IPMNIST and UPGD campaign
+roots are append-only at new paths under their own protocols. The package
+commands below supersede the old programs' analysis and reproduction roles.
+All commands are permanently nonpromoting: they do not create scientific
+evidence or update a reference channel.
+
+Use an explicit new directory outside the repository for every expensive run.
+The runner atomically publishes one self-contained `.npz` artifact per shard
+and refuses to replace an existing path.
+
+## Produce new ceiling shards
+
+Choose a fresh run ID; do not reuse a directory from an earlier execution.
+
+```bash
+ASI_RUN_DIR=../asi-runs/ipmnist-ceiling-001
+
+.venv/bin/asi-ipmnist-ceiling stationary \
+  --output-dir "$ASI_RUN_DIR" \
+  --spec sigma0_ndecay099 --seed 0
+
+.venv/bin/asi-ipmnist-ceiling carried \
+  --output-dir "$ASI_RUN_DIR" \
+  --spec sigma0_ndecay099 --seed 0 --n-tasks 60
+
+.venv/bin/asi-ipmnist-ceiling full \
+  --output-dir "$ASI_RUN_DIR" \
+  --spec sigma0_ndecay099 --seed 0
+
+.venv/bin/asi-ipmnist-ceiling batch \
+  --output-dir "$ASI_RUN_DIR" \
+  --seed 0 --epochs 30 --batch-size 128
+```
+
+Repeat with the declared development seeds and comparator arms required
+by the intended diagnostic. The command retains per-step accuracy and uses the
+same screening specification, schedule construction, initialization, and RNG
+chain as the IPMNIST screening implementation. These are expensive benchmark
+executions and must not run inside pytest. New artifacts bind the maintained
+source files, runtime and dependency versions, dataset arrays, schedule arrays,
+resolved arm configuration, seed, and protocol configuration.
+
+## Recompute a ceiling summary
+
+The analyzer reads paths supplied by the caller and writes JSON to stdout. It
+uses sample standard deviation (`ddof=1`) for across-seed spread.
+
+```bash
+.venv/bin/asi-ipmnist-campaign ceiling \
+  --ceiling-dir "$ASI_RUN_DIR" \
+  --confirm-dir outputs/ipmnist_screening/confirm_full \
+  > "${ASI_RUN_DIR}-summary.json"
+```
+
+The full-mode cross-check freezes `rtol=0` and `atol=1e-7` for the historical
+JSON decimal-encoding difference, reports the maximum observed delta, and
+fails above that tolerance. A summary produced from historical raw runs is a
+new development diagnostic; it does not revise the historical report.
+
+## Rebuild the paired frontier
+
+```bash
+.venv/bin/asi-ipmnist-campaign frontier \
+  --screen-dir outputs/ipmnist_screening/shards \
+  --confirm-dir outputs/ipmnist_screening/confirm_full \
+  > ../asi-runs/ipmnist-frontier-current.json
+```
+
+Every screen comparison requires the candidate and base to have the same
+non-empty seed set. A present confirmation arm must likewise match the base's
+complete confirmation seed set. Mismatched or disjoint sets fail closed rather
+than being silently intersected; an arm with no confirmation shards has no
+confirmation comparison.
+
+## Rebuild the rule-discovery comparison
+
+```bash
+.venv/bin/asi-rule-discovery-summary \
+  --screen-dir outputs/ipmnist_screening/shards \
+  --confirm-dir outputs/ipmnist_screening/confirm_full \
+  > ../asi-runs/rule-discovery-current.json
+```
+
+This command is read-only with respect to its inputs and emits JSON to stdout.
+Keep generated diagnostics outside `outputs/` unless a separately reviewed,
+append-only artifact protocol assigns a new destination and schema.
+
+## Historical provenance
+
+The following files remain useful only as provenance for the runs beside them:
+
+- `outputs/ipmnist_screening/ceiling/ceiling_runs.py`
+- `outputs/ipmnist_screening/ceiling/ceiling_analyze.py`
+- `outputs/ipmnist_screening/frontier_rank.py`
+- `outputs/rule_discovery/write_real_screen_summary.py`
+
+Their machine-specific paths and historical statistical behavior are preserved
+intentionally. Contributor workflows must use the maintained package commands.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ Issues = "https://github.com/elizaOS/asi/issues"
 Upstream = "https://github.com/lalalune/alberta"
 
 [project.scripts]
+asi-ipmnist-campaign = "alberta_framework.benchmarks.ipmnist_campaign_tools:main"
+asi-ipmnist-ceiling = "alberta_framework.benchmarks.ipmnist_ceiling:main"
+asi-rule-discovery-summary = "alberta_framework.benchmarks.rule_discovery_summary:main"
 asi-reference-life-scorecard = "alberta_framework.benchmarks.reference_life_scorecard:main"
 asi-l2er-matched-development = "alberta_framework.benchmarks.l2er_matched_development:main"
 alberta-step1-smoke = "alberta_framework.cli:step1_smoke_main"

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -546,6 +546,38 @@ def test_actor_critic_rejects_wrong_observation_shapes(shape: tuple[int, ...]) -
         agent.update(state, jnp.asarray(0.0), malformed)
 
 
+@pytest.mark.parametrize("dtype", [jnp.int32, jnp.uint8, jnp.int64])
+def test_run_actor_critic_from_arrays_rejects_integer_terminated(dtype: object) -> None:
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+    state = agent.init(2, jr.key(0))
+    observations = jnp.zeros((2, 2), dtype=jnp.float32)
+    rewards = jnp.zeros((2,), dtype=jnp.float32)
+    with pytest.raises(TypeError, match="terminated must have dtype bool or float32"):
+        run_actor_critic_from_arrays(
+            agent,
+            state,
+            observations,
+            rewards,
+            jnp.array([0, 1], dtype=dtype),
+            observations,
+        )
+
+
+def test_run_actor_critic_from_arrays_accepts_bool_and_float32_terminated() -> None:
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+    state = agent.init(2, jr.key(0))
+    observations = jnp.zeros((2, 2), dtype=jnp.float32)
+    rewards = jnp.zeros((2,), dtype=jnp.float32)
+    for flags in (
+        jnp.array([False, True], dtype=jnp.bool_),
+        jnp.array([0.0, 1.0], dtype=jnp.float32),
+    ):
+        result = run_actor_critic_from_arrays(
+            agent, state, observations, rewards, flags, observations
+        )
+        assert result.td_errors.shape == (2,)
+
+
 def test_actor_critic_state_contract_and_counter_saturation() -> None:
     agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
     state = agent.init(2, jr.key(0))

--- a/tests/test_actor_critic_merged_runtime_residuals.py
+++ b/tests/test_actor_critic_merged_runtime_residuals.py
@@ -45,6 +45,14 @@ class _HostileArray:
         raise AssertionError("conversion executed before trusted metadata rejection")
 
 
+class _HostileTerminated:
+    shape = (1,)
+    dtype = np.dtype(np.float32)
+
+    def __jax_array__(self) -> jax.Array:
+        raise AssertionError("hostile terminated conversion executed")
+
+
 class _MalformedBounder(Bounder):
     def to_config(self) -> dict[str, Any]:
         return {"type": "test-only"}
@@ -118,6 +126,67 @@ def test_scan_rejects_hostile_input_before_jax_conversion(continuous: bool) -> N
             jnp.zeros((1, 2), dtype=jnp.float32),
             discounts=jnp.zeros((1,), dtype=jnp.float32),
         )
+
+
+def _terminated_scan_fixture(continuous: bool) -> tuple[Any, Any, Any, Array, Array]:
+    if continuous:
+        agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
+        state = agent.init(1, jr.key(0))
+        runner = run_continuous_actor_critic_from_arrays
+    else:
+        agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
+        state = agent.init(1, jr.key(0))
+        runner = run_actor_critic_from_arrays
+    observations = jnp.zeros((1, 1), dtype=jnp.float32)
+    rewards = jnp.zeros((1,), dtype=jnp.float32)
+    return runner, agent, state, observations, rewards
+
+
+@pytest.mark.parametrize("continuous", [False, True])
+@pytest.mark.parametrize(
+    ("terminated", "error", "message"),
+    [
+        (np.asarray([1.0], dtype=np.float16), TypeError, "dtype bool or float32"),
+        (np.asarray([1.0], dtype=np.float64), TypeError, "dtype bool or float32"),
+        ([False], ValueError, "trusted array metadata"),
+        (_HostileTerminated(), ValueError, "trusted array metadata"),
+    ],
+)
+def test_scan_validates_original_terminated_before_conversion(
+    continuous: bool,
+    terminated: object,
+    error: type[Exception],
+    message: str,
+) -> None:
+    runner, agent, state, observations, rewards = _terminated_scan_fixture(continuous)
+    with pytest.raises(error, match=message):
+        runner(  # type: ignore[arg-type]
+            agent, state, observations, rewards, terminated, observations
+        )
+
+
+@pytest.mark.parametrize("continuous", [False, True])
+@pytest.mark.parametrize("dtype", [np.bool_, np.float32])
+def test_scan_accepts_original_numpy_terminated_contract(
+    continuous: bool, dtype: type[np.generic]
+) -> None:
+    runner, agent, state, observations, rewards = _terminated_scan_fixture(continuous)
+    result = runner(  # type: ignore[arg-type]
+        agent, state, observations, rewards, np.asarray([1], dtype=dtype), observations
+    )
+    assert result.td_errors.shape == (1,)
+
+
+@pytest.mark.parametrize("continuous", [False, True])
+def test_scan_terminated_contract_accepts_jit_tracers(continuous: bool) -> None:
+    runner, agent, state, observations, rewards = _terminated_scan_fixture(continuous)
+    compiled = jax.jit(
+        lambda initial_state, flags: runner(  # type: ignore[arg-type]
+            agent, initial_state, observations, rewards, flags, observations
+        )
+    )
+    result = compiled(state, jnp.asarray([False], dtype=jnp.bool_))
+    assert result.td_errors.shape == (1,)
 
 
 def test_discrete_scan_working_set_formula_has_exact_byte_boundary() -> None:

--- a/tests/test_actor_critic_update_working_set.py
+++ b/tests/test_actor_critic_update_working_set.py
@@ -1,0 +1,174 @@
+"""#1383-complete update working-set preflight for actor-critic."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.actor_critic import (
+    ActorCriticAgent,
+    ActorCriticConfig,
+    ContinuousActorCriticAgent,
+    ContinuousActorCriticConfig,
+    _actor_critic_persistent_bytes,
+    _actor_critic_update_working_set_bytes,
+    _continuous_actor_critic_persistent_bytes,
+    _continuous_actor_critic_update_working_set_bytes,
+    _preflight_actor_critic_update_working_set,
+    _preflight_continuous_actor_critic_update_working_set,
+    _require_continuous_state_resources,
+    _require_discrete_state_resources,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURE_DIM = 40_000_000
+_LAST_FIT_FEATURE_DIM = 35_791_392
+_FIRST_OVERFLOW_FEATURE_DIM = 35_791_393
+_CONTINUOUS_LAST_FIT_FEATURE_DIM = 35_791_391
+_CONTINUOUS_FIRST_OVERFLOW_FEATURE_DIM = 35_791_392
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _actor_critic_persistent_bytes(1, _OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _actor_critic_update_working_set_bytes(1, _OVERFLOW_FEATURE_DIM)
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 800_000_032
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
+    with pytest.raises(ValueError, match="update working set byte count"):
+        agent.init(_OVERFLOW_FEATURE_DIM, jr.key(0))
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_LAST_FIT_FEATURE_DIM, _FIRST_OVERFLOW_FEATURE_DIM + 2):
+        persist_bytes = _actor_critic_persistent_bytes(1, feature_dim)
+        working_set_bytes = _actor_critic_update_working_set_bytes(1, feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURE_DIM
+    _preflight_actor_critic_update_working_set(1, last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_actor_critic_update_working_set(1, first_overflow)
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
+    with pytest.raises(ValueError, match="update working set byte count"):
+        agent.init(first_overflow, jr.key(0))
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_actor_critic_update_working_set(1, _OVERFLOW_FEATURE_DIM)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    _require_discrete_state_resources(1, 107_374_180)
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
+    with pytest.raises(ValueError, match="state exceeds"):
+        agent.init(107_374_181, jr.key(0))
+
+
+def test_legal_small_actor_critic_still_updates() -> None:
+    persist_bytes = _actor_critic_persistent_bytes(1, 4)
+    assert persist_bytes == 112
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
+    state = agent.init(4, jr.key(0))
+    observation = jnp.zeros((4,), dtype=jnp.float32)
+    state, _, _ = agent.start(state, observation)
+    agent.update(
+        state,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        observation,
+        jnp.asarray(False),
+    )
+
+
+def test_continuous_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _continuous_actor_critic_persistent_bytes(1, _OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _continuous_actor_critic_update_working_set_bytes(
+        1, _OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 800_000_040
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
+    with pytest.raises(ValueError, match="update working set byte count"):
+        agent.init(_OVERFLOW_FEATURE_DIM, jr.key(0))
+
+
+def test_continuous_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(
+        _CONTINUOUS_LAST_FIT_FEATURE_DIM, _CONTINUOUS_FIRST_OVERFLOW_FEATURE_DIM + 2
+    ):
+        persist_bytes = _continuous_actor_critic_persistent_bytes(1, feature_dim)
+        working_set_bytes = _continuous_actor_critic_update_working_set_bytes(
+            1, feature_dim
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _CONTINUOUS_LAST_FIT_FEATURE_DIM
+    _preflight_continuous_actor_critic_update_working_set(1, last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_continuous_actor_critic_update_working_set(1, first_overflow)
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
+    with pytest.raises(ValueError, match="update working set byte count"):
+        agent.init(first_overflow, jr.key(0))
+
+
+def test_continuous_persist_bound_still_fires_before_working_set() -> None:
+    _require_continuous_state_resources(1, 107_374_180)
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
+    with pytest.raises(ValueError, match="state exceeds"):
+        agent.init(107_374_181, jr.key(0))
+
+
+def test_legal_small_continuous_actor_critic_still_updates() -> None:
+    persist_bytes = _continuous_actor_critic_persistent_bytes(1, 5)
+    assert persist_bytes == 140
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
+    state = agent.init(5, jr.key(0))
+    observation = jnp.zeros((5,), dtype=jnp.float32)
+    state, _, _, _ = agent.start(state, observation)
+    agent.update(
+        state,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        observation,
+        jnp.asarray(False),
+    )

--- a/tests/test_adamo.py
+++ b/tests/test_adamo.py
@@ -48,6 +48,18 @@ def test_penalty_preserves_invalidity_in_eager_and_traced_calls(weight: jax.Arra
     assert float(traced) != 0.0
 
 
+@pytest.mark.parametrize("shape", [(2, 2), (2, 3)])
+def test_gradient_preserves_invalidity_in_eager_and_traced_calls(
+    shape: tuple[int, int],
+) -> None:
+    weight = jnp.full(shape, jnp.finfo(jnp.float32).max)
+    with pytest.raises(ValueError, match="isometry gradient must be finite"):
+        isometry_gradient(weight)
+
+    traced = jax.jit(isometry_gradient)(weight)
+    assert bool(jnp.all(jnp.isnan(traced)))
+
+
 def test_zero_strength_reduces_exactly_to_adam_task_step() -> None:
     config = AdamOConfig(
         step_size=1e-3, beta1=0.9, beta2=0.99, eps=1e-8, isometry_strength=0.0

--- a/tests/test_average_reward_update_working_set.py
+++ b/tests/test_average_reward_update_working_set.py
@@ -1,0 +1,91 @@
+"""#1383-complete update working-set preflight for differential TD."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.average_reward import (
+    DifferentialTDLearner,
+    _differential_td_persistent_bytes,
+    _differential_td_update_working_set_bytes,
+    _preflight_differential_td_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURE_DIM = 90_000_000
+_LAST_FIT_FEATURE_DIM = 89_478_481
+_FIRST_OVERFLOW_FEATURE_DIM = 89_478_482
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _differential_td_persistent_bytes(_OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _differential_td_update_working_set_bytes(_OVERFLOW_FEATURE_DIM)
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 720_000_016
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        DifferentialTDLearner().init(_OVERFLOW_FEATURE_DIM)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_LAST_FIT_FEATURE_DIM, _FIRST_OVERFLOW_FEATURE_DIM + 2):
+        persist_bytes = _differential_td_persistent_bytes(feature_dim)
+        working_set_bytes = _differential_td_update_working_set_bytes(feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURE_DIM
+    _preflight_differential_td_update_working_set(last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_differential_td_update_working_set(first_overflow)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        DifferentialTDLearner().init(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_differential_td_update_working_set(_OVERFLOW_FEATURE_DIM)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = ((2**31 - 1) // 4 - 4) // 2
+    with pytest.raises(ValueError, match="differential TD state bytes"):
+        DifferentialTDLearner().init(last_legal + 1)
+
+
+def test_legal_small_differential_td_still_updates() -> None:
+    persist_bytes = _differential_td_persistent_bytes(5)
+    assert persist_bytes == 56
+    learner = DifferentialTDLearner()
+    state = learner.init(5)
+    observation = jnp.zeros((5,), dtype=jnp.float32)
+    learner.update(
+        state,
+        observation,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        observation,
+    )

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -11,6 +11,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from jax import tree_util
 
 
 class _HostileFloat(float):
@@ -26,6 +27,9 @@ try:
     from alberta_framework.core.behavior_model import (
         BehaviorModel,
         BehaviorModelConfig,
+        _behavior_model_update_working_set_bytes,
+        _preflight_behavior_model_update_working_set,
+        _resource_counts,
         action_log_likelihoods,
         clipped_importance_ratios,
         epsilon_greedy_probabilities,
@@ -60,6 +64,13 @@ except ImportError:
     floor_and_renormalize_probabilities = behavior_model_module.floor_and_renormalize_probabilities
     run_behavior_model_from_arrays = behavior_model_module.run_behavior_model_from_arrays
     selected_action_probabilities = behavior_model_module.selected_action_probabilities
+    _behavior_model_update_working_set_bytes = (
+        behavior_model_module._behavior_model_update_working_set_bytes
+    )
+    _preflight_behavior_model_update_working_set = (
+        behavior_model_module._preflight_behavior_model_update_working_set
+    )
+    _resource_counts = behavior_model_module._resource_counts
 
 
 def _assert_behavior_update_finite(result: Any) -> None:
@@ -613,11 +624,14 @@ def test_behavior_model_preflights_resource_bytes_before_allocation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     model = BehaviorModel(BehaviorModelConfig(n_actions=2))
-    max_feature_dim = ((2**31 - 1) - 32) // 8
-    budget = model.resource_budget(max_feature_dim)
-    assert budget.state_nbytes <= 2**31 - 1
+    persist_last_legal = ((2**31 - 1) - 32) // 8
+    update_last_legal = 48_806_441
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.resource_budget(persist_last_legal)
     with pytest.raises(ValueError, match="state_nbytes"):
-        model.resource_budget(max_feature_dim + 1)
+        model.resource_budget(persist_last_legal + 1)
+    budget = model.resource_budget(update_last_legal)
+    assert budget.state_nbytes <= 2**31 - 1
 
     calls = 0
 
@@ -628,10 +642,13 @@ def test_behavior_model_preflights_resource_bytes_before_allocation(
 
     monkeypatch.setattr("alberta_framework.core.behavior_model.jnp.zeros", forbidden_zeros)
     with pytest.raises(ValueError, match="state_nbytes"):
-        model.init(max_feature_dim + 1, jax.random.key(0))
+        model.init(persist_last_legal + 1, jax.random.key(0))
+    assert calls == 0
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.init(persist_last_legal, jax.random.key(0))
     assert calls == 0
     with pytest.raises(AssertionError, match="allocator reached"):
-        model.init(max_feature_dim, jax.random.key(0))
+        model.init(update_last_legal, jax.random.key(0))
     assert calls == 1
 
 
@@ -674,3 +691,74 @@ def test_action_ids_still_accept_trusted_hosts_and_tracers() -> None:
         jnp.asarray(3, dtype=jnp.int32)
     )
     chex.assert_tree_all_finite(traced)
+
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_behavior_model_persist_matches_jit_materialized_leaves() -> None:
+    model = BehaviorModel(BehaviorModelConfig(n_actions=2))
+    state = model.init(4, jax.random.key(0))
+    actual = sum(
+        int(leaf.size) * int(leaf.dtype.itemsize)
+        for leaf in tree_util.tree_leaves(state)
+    )
+    assert actual == model.resource_budget(4).state_nbytes
+    _, persist_bytes = _resource_counts(2, 4)
+    assert actual == persist_bytes
+
+
+def test_behavior_model_persist_fits_while_update_working_set_does_not() -> None:
+    feature_dim = 180_000_000
+    _, persist_bytes = _resource_counts(1, feature_dim)
+    working_set_bytes = _behavior_model_update_working_set_bytes(1, feature_dim)
+    assert persist_bytes <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    model = BehaviorModel(BehaviorModelConfig(n_actions=1))
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.resource_budget(feature_dim)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.init(feature_dim, jax.random.key(0))
+
+
+def test_behavior_model_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(89_478_476, 89_478_480):
+        working_set_bytes = _behavior_model_update_working_set_bytes(1, feature_dim)
+        _, persist_bytes = _resource_counts(1, feature_dim)
+        assert persist_bytes <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    model = BehaviorModel(BehaviorModelConfig(n_actions=1))
+    model.resource_budget(last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        model.resource_budget(first_overflow)
+
+
+def test_behavior_model_persistent_byte_bound_still_fires_first() -> None:
+    feature_dim = 536_870_905
+    with pytest.raises(ValueError, match="state_nbytes"):
+        _resource_counts(1, feature_dim)
+    model = BehaviorModel(BehaviorModelConfig(n_actions=1))
+    with pytest.raises(ValueError, match="state_nbytes"):
+        model.init(feature_dim, jax.random.key(0))
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_behavior_model_update_working_set(1, 180_000_000)

--- a/tests/test_causal_map_state_string_identity_hostile.py
+++ b/tests/test_causal_map_state_string_identity_hostile.py
@@ -1,0 +1,98 @@
+"""Hostile string identity gates for causal-map serialized state validation."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.benchmarks.causal_map_forager import (
+    CausalMapForagerConfig,
+    causal_map_start,
+    causal_map_state_from_dict,
+    causal_map_state_to_dict,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile str equality hook executed")
+
+    def __ne__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile str inequality hook executed")
+
+    def __hash__(self) -> int:
+        return str.__hash__(self)
+
+
+class _LyingStr(str):
+    """Claims equality with everything without raising."""
+
+    def __eq__(self, other: object) -> bool:
+        return True
+
+    def __ne__(self, other: object) -> bool:
+        return False
+
+    def __hash__(self) -> int:
+        return str.__hash__(self)
+
+
+def _observation() -> jnp.ndarray:
+    image = jnp.zeros((9, 9, 3), dtype=jnp.float32)
+    return image.at[4, 4, 1].set(1.0)
+
+
+def _valid_payload(config: CausalMapForagerConfig) -> dict[str, object]:
+    state, _ = causal_map_start(_observation(), config, 19)
+    return causal_map_state_to_dict(state, config)
+
+
+class TestSerializedStateStringIdentity:
+    def test_valid_payload_round_trips(self) -> None:
+        config = CausalMapForagerConfig()
+        payload = _valid_payload(config)
+        causal_map_state_from_dict(payload, config)
+
+    def test_schema_subclass_is_rejected_without_hooks(self) -> None:
+        config = CausalMapForagerConfig()
+        payload = _valid_payload(config)
+        _HostileStr.calls = 0
+        payload["schema"] = _HostileStr(payload["schema"])
+        with pytest.raises(ValueError, match="unsupported causal-map state schema"):
+            causal_map_state_from_dict(payload, config)
+        assert _HostileStr.calls == 0
+
+    def test_lying_schema_subclass_cannot_spoof_the_gate(self) -> None:
+        config = CausalMapForagerConfig()
+        payload = _valid_payload(config)
+        payload["schema"] = _LyingStr("alberta.wrong_schema.v0")
+        with pytest.raises(ValueError, match="unsupported causal-map state schema"):
+            causal_map_state_from_dict(payload, config)
+
+    def test_prng_impl_subclass_is_rejected_without_hooks(self) -> None:
+        config = CausalMapForagerConfig()
+        payload = _valid_payload(config)
+        _HostileStr.calls = 0
+        payload["prng_impl"] = _HostileStr(payload["prng_impl"])
+        with pytest.raises(
+            ValueError, match="PRNG implementation does not match"
+        ):
+            causal_map_state_from_dict(payload, config)
+        assert _HostileStr.calls == 0
+
+    def test_config_sha256_subclass_is_rejected_without_hooks(self) -> None:
+        config = CausalMapForagerConfig()
+        payload = _valid_payload(config)
+        _HostileStr.calls = 0
+        payload["config_sha256"] = _HostileStr(payload["config_sha256"])
+        with pytest.raises(
+            ValueError, match="embeds a different configuration"
+        ):
+            causal_map_state_from_dict(payload, config)
+        assert _HostileStr.calls == 0

--- a/tests/test_continual_ia_number_hostile.py
+++ b/tests/test_continual_ia_number_hostile.py
@@ -1,0 +1,86 @@
+"""Hostile int gate for continual_ia _number before float."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_ia_artifact import _number
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+def test_number_rejects_hostile_int_before_float() -> None:
+    hostile = _HostileInt(42)
+    _HostileInt.calls = 0
+    result = _number(hostile)  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileInt.calls == 0
+
+
+def test_number_rejects_hostile_float_before_float() -> None:
+    hostile = _HostileFloat(3.14)
+    _HostileFloat.calls = 0
+    result = _number(hostile)  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileFloat.calls == 0
+
+
+def test_number_rejects_bool() -> None:
+    assert _number(True) is None
+    assert _number(False) is None
+    assert _HostileInt.calls == 0
+
+
+def test_number_benign_still_works() -> None:
+    assert _number(1) == 1.0
+    assert _number(1.5) == 1.5
+    assert _number(0) == 0.0
+    assert _number("bad") is None  # type: ignore[arg-type]
+    assert _number(None) is None  # type: ignore[arg-type]
+    import math
+
+    assert _number(float("inf")) is None  # type: ignore[arg-type]
+    assert _number(math.nan) is None  # type: ignore[arg-type]
+
+
+def test_number_non_finite_rejected() -> None:
+    import math
+
+    assert _number(math.inf) is None
+    assert _number(-math.inf) is None

--- a/tests/test_continual_ia_timing_identity_hostile.py
+++ b/tests/test_continual_ia_timing_identity_hostile.py
@@ -1,0 +1,109 @@
+"""Hostile identity gates for operational condition-timing validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_ia_artifact import _validate_operational
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile int equality hook executed")
+
+    def __hash__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile int hash hook executed")
+
+
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile str equality hook executed")
+
+    def __hash__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile str hash hook executed")
+
+
+def _operational(timings: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "digest_exclusion_reason": (
+            "host environment and wall-clock timing are non-deterministic"
+        ),
+        "environment": None,
+        "condition_timings": timings,
+        "overall_acceptance_passed": True,
+    }
+
+
+def _timing(seed: object, condition: object) -> dict[str, object]:
+    return {
+        "seed": seed,
+        "condition": condition,
+        "wall_seconds": 1.0,
+        "mean_step_latency_ms": 1.0,
+    }
+
+
+def _identity_errors(errors: list[str]) -> list[str]:
+    return [error for error in errors if "has invalid identity" in error]
+
+
+class TestConditionTimingIdentity:
+    def test_exact_int_seed_and_exact_str_condition_pass(self) -> None:
+        errors: list[str] = []
+        _validate_operational(
+            _operational([_timing(30, "current")]),
+            expected_results=None,
+            expected_acceptance=True,
+            errors=errors,
+        )
+        assert _identity_errors(errors) == []
+
+    def test_bool_seed_is_rejected(self) -> None:
+        errors: list[str] = []
+        _validate_operational(
+            _operational([_timing(True, "current")]),
+            expected_results=None,
+            expected_acceptance=True,
+            errors=errors,
+        )
+        assert _identity_errors(errors) == [
+            "condition_timings[0] has invalid identity"
+        ]
+
+    def test_int_subclass_seed_is_rejected_without_hooks(self) -> None:
+        _HostileInt.calls = 0
+        errors: list[str] = []
+        _validate_operational(
+            _operational([_timing(_HostileInt(30), "current")]),
+            expected_results=None,
+            expected_acceptance=True,
+            errors=errors,
+        )
+        assert _identity_errors(errors) == [
+            "condition_timings[0] has invalid identity"
+        ]
+        assert _HostileInt.calls == 0
+
+    def test_str_subclass_condition_is_rejected_without_hooks(self) -> None:
+        _HostileStr.calls = 0
+        errors: list[str] = []
+        _validate_operational(
+            _operational([_timing(30, _HostileStr("current"))]),
+            expected_results=None,
+            expected_acceptance=True,
+            errors=errors,
+        )
+        assert _identity_errors(errors) == [
+            "condition_timings[0] has invalid identity"
+        ]
+        assert _HostileStr.calls == 0

--- a/tests/test_continual_multiagent_sha256_hostile.py
+++ b/tests/test_continual_multiagent_sha256_hostile.py
@@ -1,0 +1,130 @@
+"""Hostile string gate for continual multiagent digest sha256 before len."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_multiagent_artifact import (
+    CANONICALIZATION,
+    DIGEST_ALGORITHM,
+    DIGEST_SCOPE,
+    SCHEMA_VERSION,
+    validate_evidence_artifact,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __len__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile len must not run")
+
+    def __str__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile str must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+def _minimal_artifact_with_digest(hostile_sha: object) -> dict[str, object]:
+    # Minimal artifact that will reach digest validation.
+    # Provide required top-level keys to avoid early returns, but content can be minimal.
+    # The digest sha check is independent of content validity; we just need digest to be hostile.
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "content": {
+            "protocol": {},
+            "configuration": {},
+            "thresholds": {},
+            "seed_summaries": [],
+            "aggregate": {},
+            "acceptance": {},
+            "source_provenance": {},
+        },
+        "content_digest": {
+            "algorithm": DIGEST_ALGORITHM,
+            "scope": DIGEST_SCOPE,
+            "canonicalization": CANONICALIZATION,
+            "sha256": hostile_sha,
+        },
+        "operational_diagnostics": {
+            "digest_exclusion_reason": "test",
+            "environment": "test",
+            "condition_timings": {},
+            "maximum_update_latency_ms": 0,
+            "checks": [],
+            "passed": False,
+            "overall_acceptance_passed": False,
+        },
+    }
+
+
+def test_continual_digest_rejects_hostile_before_len() -> None:
+    hostile = _HostileStr("a" * 64)
+    _HostileStr.calls = 0
+    artifact = _minimal_artifact_with_digest(hostile)  # type: ignore[dict-item]
+    validation = validate_evidence_artifact(artifact)  # type: ignore[arg-type]
+    assert validation.valid is False
+    assert any(
+        "content_digest.sha256 must be a 64-character string" in e
+        for e in validation.errors
+    ) or any("sha256" in e for e in validation.errors)
+    assert _HostileStr.calls == 0
+    # ensure no repr dispatch in errors
+    for err in validation.errors:
+        assert "_HostileStr" not in err
+        assert "hostile" not in err.lower()
+
+
+def test_continual_digest_rejects_hostile_wrong_length_before_len() -> None:
+    hostile = _HostileStr("short")
+    _HostileStr.calls = 0
+    artifact = _minimal_artifact_with_digest(hostile)  # type: ignore[dict-item]
+    validation = validate_evidence_artifact(artifact)  # type: ignore[arg-type]
+    assert validation.valid is False
+    assert _HostileStr.calls == 0
+
+
+def test_continual_digest_accepts_exact_str_still_validates() -> None:
+    # benign exact string with wrong length should be caught without hostile
+    artifact_bad = _minimal_artifact_with_digest("short")  # type: ignore[dict-item]
+    validation_bad = validate_evidence_artifact(artifact_bad)  # type: ignore[arg-type]
+    assert validation_bad.valid is False
+    # benign exact 64-char still goes to digest mismatch path but not crash
+    artifact_ok_len = _minimal_artifact_with_digest("a" * 64)  # type: ignore[dict-item]
+    validation_ok = validate_evidence_artifact(artifact_ok_len)  # type: ignore[arg-type]
+    # It will still be invalid due to other content errors, but must not have crashed on sha check
+    assert validation_ok.valid is False
+    assert _HostileStr.calls == 0
+
+
+def test_continual_digest_rejects_bool_subclass_before_len() -> None:
+    # bool is subclass of int, but for str leaf, passing bool should be rejected without len
+    artifact_bool = _minimal_artifact_with_digest(True)  # type: ignore[dict-item]
+    validation = validate_evidence_artifact(artifact_bool)  # type: ignore[arg-type]
+    assert validation.valid is False
+    assert _HostileStr.calls == 0
+
+
+def test_continual_digest_non_string_types_rejected() -> None:
+    for bad in [123, None, 12.34, b"bytes", ["a"]]:
+        artifact = _minimal_artifact_with_digest(bad)  # type: ignore[dict-item]
+        validation = validate_evidence_artifact(artifact)  # type: ignore[arg-type]
+        assert validation.valid is False

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -618,6 +618,40 @@ def test_continuous_actor_critic_rejects_wrong_observation_shapes(
         agent.update(state, jnp.asarray(0.0), malformed)
 
 
+@pytest.mark.parametrize("dtype", [jnp.int32, jnp.uint8, jnp.int64])
+def test_run_continuous_actor_critic_from_arrays_rejects_integer_terminated(
+    dtype: object,
+) -> None:
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
+    state = agent.init(2, jr.key(0))
+    observations = jnp.zeros((2, 2), dtype=jnp.float32)
+    rewards = jnp.zeros((2,), dtype=jnp.float32)
+    with pytest.raises(TypeError, match="terminated must have dtype bool or float32"):
+        run_continuous_actor_critic_from_arrays(
+            agent,
+            state,
+            observations,
+            rewards,
+            jnp.array([0, 1], dtype=dtype),
+            observations,
+        )
+
+
+def test_run_continuous_actor_critic_from_arrays_accepts_bool_and_float32_terminated() -> None:
+    agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
+    state = agent.init(2, jr.key(0))
+    observations = jnp.zeros((2, 2), dtype=jnp.float32)
+    rewards = jnp.zeros((2,), dtype=jnp.float32)
+    for flags in (
+        jnp.array([False, True], dtype=jnp.bool_),
+        jnp.array([0.0, 1.0], dtype=jnp.float32),
+    ):
+        result = run_continuous_actor_critic_from_arrays(
+            agent, state, observations, rewards, flags, observations
+        )
+        assert result.td_errors.shape == (2,)
+
+
 def test_continuous_actor_critic_state_contract_and_counter_saturation() -> None:
     agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=2))
     state = agent.init(2, jr.key(0))

--- a/tests/test_delight.py
+++ b/tests/test_delight.py
@@ -2136,3 +2136,23 @@ def test_paper_specific_dg_rejects_shape_mismatch_and_empty_batches() -> None:
     )
     with pytest.raises(ValueError, match="rare_mask"):
         stratify_delight_outcomes(result, jnp.zeros((3,), dtype=jnp.bool_))
+
+
+@pytest.mark.parametrize(
+    "rare_mask",
+    (
+        jnp.array([0.0, 0.5], dtype=jnp.float32),
+        jnp.array([0.0, jnp.nan], dtype=jnp.float32),
+        jnp.array([0, 1], dtype=jnp.int32),
+    ),
+)
+def test_delight_stratification_rejects_non_boolean_rare_masks(rare_mask: Array) -> None:
+    result = discrete_delightful_policy_gradient(
+        jnp.log(jnp.array([0.5, 0.5], dtype=jnp.float32)),
+        jnp.array([1.0, -1.0], dtype=jnp.float32),
+    )
+
+    with pytest.raises(ValueError, match="rare_mask must have boolean dtype"):
+        stratify_delight_outcomes(result, rare_mask)
+    with pytest.raises(ValueError, match="rare_mask must have boolean dtype"):
+        jax.jit(stratify_delight_outcomes)(result, rare_mask)

--- a/tests/test_dual_replay_update_working_set.py
+++ b/tests/test_dual_replay_update_working_set.py
@@ -1,0 +1,124 @@
+"""#1383-complete record/sample working-set preflight for dual replay."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax import tree_util
+
+from alberta_framework.core.dual_replay import (
+    DualReplayConfig,
+    DualReplayMemory,
+    _allocation_sizes,
+    _dual_replay_update_working_set_bytes,
+    _preflight_dual_replay_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_CAPACITY = 10_000_000
+_LAST_FIT_CAPACITY = 9_061_110
+_FIRST_OVERFLOW_CAPACITY = 9_061_111
+_UNIT_KWARGS = {
+    "observation_dim": 1,
+    "action_dim": 1,
+    "batch_size": 2,
+}
+
+
+def _unit_config(total_capacity: int) -> DualReplayConfig:
+    return DualReplayConfig(
+        total_capacity=total_capacity,
+        short_term_capacity=1,
+        observation_dim=1,
+        action_dim=1,
+        short_term_sample_size=1,
+        long_term_sample_size=1,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_dual_replay_persist_matches_jit_and_width_still_fits() -> None:
+    config = DualReplayConfig(
+        total_capacity=7,
+        short_term_capacity=3,
+        observation_dim=2,
+        action_dim=2,
+        short_term_sample_size=2,
+        long_term_sample_size=2,
+    )
+    memory = DualReplayMemory(config)
+    state = memory.init(jr.key(3))
+    actual = sum(
+        int(leaf.size) * int(leaf.dtype.itemsize)
+        for leaf in tree_util.tree_leaves(state)
+    )
+    slot_bytes, persist_bytes = _allocation_sizes(config)
+    assert actual == persist_bytes == memory.persistent_bytes == 697
+    assert slot_bytes == memory.slot_bytes == 91
+    overflow_persist = _OVERFLOW_CAPACITY * 79 + 60
+    overflow_sample_extras = 2 * (79 + 13) + 28
+    working_set_bytes = _dual_replay_update_working_set_bytes(
+        total_capacity=_OVERFLOW_CAPACITY,
+        **_UNIT_KWARGS,
+    )
+    assert overflow_persist <= _INT32_MAX
+    assert overflow_persist + overflow_sample_extras <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_config(_OVERFLOW_CAPACITY)
+
+
+def test_dual_replay_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for total_capacity in range(_LAST_FIT_CAPACITY, _FIRST_OVERFLOW_CAPACITY + 2):
+        persist_bytes = total_capacity * 79 + 60
+        working_set_bytes = _dual_replay_update_working_set_bytes(
+            total_capacity=total_capacity,
+            **_UNIT_KWARGS,
+        )
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + (2 * (79 + 13) + 28) <= _INT32_MAX
+        assert 4 * 1 <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = total_capacity
+        elif first_overflow is None:
+            first_overflow = total_capacity
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_CAPACITY
+    constructed = _unit_config(last_fit)
+    assert constructed.total_capacity == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_config(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_dual_replay_update_working_set(
+            total_capacity=_OVERFLOW_CAPACITY,
+            **_UNIT_KWARGS,
+        )
+
+
+def test_legal_small_dual_replay_still_constructs() -> None:
+    config = DualReplayConfig(
+        total_capacity=6,
+        short_term_capacity=3,
+        observation_dim=2,
+        action_dim=2,
+        short_term_sample_size=2,
+        long_term_sample_size=2,
+    )
+    DualReplayMemory(config).init(jr.key(1))

--- a/tests/test_experiential_memory_update_working_set.py
+++ b/tests/test_experiential_memory_update_working_set.py
@@ -1,0 +1,161 @@
+"""#1383-complete update working-set preflight for experiential memory."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.experiential_memory import (
+    ExperientialMemory,
+    ExperientialMemoryConfig,
+    ExperientialMemoryEntry,
+    _experiential_persistent_bytes,
+    _experiential_update_working_set_bytes,
+    _preflight_experiential_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_CAPACITY = 11_200_000
+_LAST_FIT_CAPACITY = 11_184_809
+_FIRST_OVERFLOW_CAPACITY = 11_184_810
+_UNIT = {
+    "observation_dim": 1,
+    "key_dim": 1,
+    "action_dim": 1,
+    "outcome_dim": 1,
+    "top_k": 1,
+}
+
+
+def _unit_persist_bytes(capacity: int) -> int:
+    return _experiential_persistent_bytes(
+        capacity=capacity,
+        observation_dim=1,
+        key_dim=1,
+        action_dim=1,
+        outcome_dim=1,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _unit_persist_bytes(_OVERFLOW_CAPACITY)
+    working_set_bytes = _experiential_update_working_set_bytes(
+        capacity=_OVERFLOW_CAPACITY,
+        **_UNIT,
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 716_800_032
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_CAPACITY <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        ExperientialMemoryConfig(capacity=_OVERFLOW_CAPACITY, **_UNIT)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for capacity in range(_LAST_FIT_CAPACITY, _FIRST_OVERFLOW_CAPACITY + 2):
+        persist_bytes = _unit_persist_bytes(capacity)
+        working_set_bytes = _experiential_update_working_set_bytes(
+            capacity=capacity,
+            **_UNIT,
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * capacity <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = capacity
+        elif first_overflow is None:
+            first_overflow = capacity
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_CAPACITY
+    config = ExperientialMemoryConfig(capacity=last_fit, **_UNIT)
+    assert config.capacity == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        ExperientialMemoryConfig(capacity=first_overflow, **_UNIT)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    overflow = ExperientialMemoryConfig(capacity=4, **_UNIT)
+    object.__setattr__(overflow, "capacity", _OVERFLOW_CAPACITY)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_experiential_update_working_set(overflow)
+
+
+def test_query_envelope_still_fires_before_working_set_when_it_overflows_first() -> None:
+    with pytest.raises(ValueError, match="aggregate query working-set bytes"):
+        ExperientialMemoryConfig(capacity=12_000_000, **_UNIT)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (2**31 - 1 - 32) // 64
+    with pytest.raises(ValueError, match="state byte count"):
+        ExperientialMemoryConfig(capacity=last_legal + 1, **_UNIT)
+
+
+def test_existing_query_last_legal_capacity_still_constructs() -> None:
+    persist_bytes = _unit_persist_bytes(11_000_000)
+    working_set_bytes = _experiential_update_working_set_bytes(
+        capacity=11_000_000,
+        **_UNIT,
+    )
+    assert persist_bytes == 704_000_032
+    assert working_set_bytes <= _INT32_MAX
+    config = ExperientialMemoryConfig(capacity=11_000_000, **_UNIT)
+    assert config.capacity == 11_000_000
+
+
+def test_legal_small_experiential_memory_still_steps() -> None:
+    persist_bytes = _experiential_persistent_bytes(
+        capacity=4,
+        observation_dim=1,
+        key_dim=1,
+        action_dim=1,
+        outcome_dim=1,
+    )
+    assert persist_bytes == 288
+    config = ExperientialMemoryConfig(capacity=4, **_UNIT)
+    memory = ExperientialMemory(config)
+    state = memory.init()
+    entry = ExperientialMemoryEntry(
+        observation=jnp.zeros((1,), dtype=jnp.float32),
+        key=jnp.zeros((1,), dtype=jnp.float32),
+        action=jnp.zeros((1,), dtype=jnp.float32),
+        outcome=jnp.zeros((1,), dtype=jnp.float32),
+        reward=jnp.asarray(0.0, dtype=jnp.float32),
+        uncertainty=jnp.asarray(0.1, dtype=jnp.float32),
+        uncertainty_available=jnp.asarray(True),
+        safety_cost=jnp.asarray(0.0, dtype=jnp.float32),
+        safety_cost_available=jnp.asarray(True),
+        reliability=jnp.asarray(1.0, dtype=jnp.float32),
+        utility=jnp.asarray(0.0, dtype=jnp.float32),
+        utility_available=jnp.asarray(True),
+        representation_version=jnp.asarray(1, dtype=jnp.int32),
+        valid=jnp.asarray(True),
+        age=jnp.asarray(0, dtype=jnp.int32),
+        provenance_id=jnp.asarray(1, dtype=jnp.int32),
+        source_id=jnp.asarray(1, dtype=jnp.int32),
+    )
+    memory.step(
+        state,
+        entry.key,
+        jnp.asarray(1, dtype=jnp.int32),
+        jnp.asarray(0.1, dtype=jnp.float32),
+        jnp.asarray(True),
+        entry,
+    )

--- a/tests/test_ftl_sha_hostile.py
+++ b/tests/test_ftl_sha_hostile.py
@@ -1,0 +1,121 @@
+"""Hostile string gate for FTL generation_head before len."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.ftl_decision_artifact import (
+    DIGEST_ALGORITHM,
+    DIGEST_SCOPE,
+    SCHEMA_VERSION,
+    validate_ftl_decision_artifact,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __len__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile len must not run")
+
+    def __str__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile str must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+def _minimal_ftl_artifact_with_git_head(hostile: object) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scientific_payload": {
+            "protocol": {"kind": "test"},
+            "configuration": {},
+            "thresholds": {},
+            "bootstrap": {},
+            "memory": {},
+            "seed_summaries": [],
+            "aggregate": {},
+            "acceptance": {"passed": False, "checks": []},
+            "source_provenance": {
+                "repository_subtree": "research/alberta",
+                "git_head": hostile,
+                "source_sha256": {},
+                "interpretation": "test",
+            },
+        },
+        "scientific_digest": {
+            "algorithm": DIGEST_ALGORITHM,
+            "scope": DIGEST_SCOPE,
+            "canonicalization": "utf8-json-sort-keys-compact-no-nan",
+            "sha256": "a" * 64,
+        },
+        "operational_metadata": {
+            "gate_wall_seconds": 1.0,
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "git_worktree": {"head": "a" * 40, "dirty": False},
+            "runtime": {"python": "3.12"},
+            "protocol": {},
+        },
+    }
+
+
+def test_ftl_git_head_rejects_hostile_before_len() -> None:
+    hostile = _HostileStr("a" * 40)
+    _HostileStr.calls = 0
+    artifact = _minimal_ftl_artifact_with_git_head(hostile)  # type: ignore[dict-item]
+    validation = validate_ftl_decision_artifact(artifact)  # type: ignore[arg-type]
+    assert validation.valid is False
+    assert _HostileStr.calls == 0
+    for err in validation.errors:
+        assert "_HostileStr" not in err
+
+
+def test_ftl_git_head_rejects_hostile_short_before_len() -> None:
+    hostile = _HostileStr("short")
+    _HostileStr.calls = 0
+    artifact = _minimal_ftl_artifact_with_git_head(hostile)  # type: ignore[dict-item]
+    validation = validate_ftl_decision_artifact(artifact)  # type: ignore[arg-type]
+    assert validation.valid is False
+    assert _HostileStr.calls == 0
+
+
+def test_ftl_git_head_benign_still_validates() -> None:
+    artifact = _minimal_ftl_artifact_with_git_head("b" * 40)  # type: ignore[dict-item]
+    validation = validate_ftl_decision_artifact(artifact)  # type: ignore[arg-type]
+    assert validation.valid is False
+    assert _HostileStr.calls == 0
+
+
+def test_ftl_git_head_non_string_rejected() -> None:
+    for bad in [123, None, True]:
+        artifact = _minimal_ftl_artifact_with_git_head(bad)  # type: ignore[dict-item]
+        validation = validate_ftl_decision_artifact(artifact)  # type: ignore[arg-type]
+        assert validation.valid is False
+
+
+def test_ftl_git_head_hostile_wrong_hex_before_len() -> None:
+    # hostile subclass with valid length but invalid hex should still not call len
+    hostile = _HostileStr("z" * 40)
+    _HostileStr.calls = 0
+    artifact = _minimal_ftl_artifact_with_git_head(hostile)  # type: ignore[dict-item]
+    validation = validate_ftl_decision_artifact(artifact)  # type: ignore[arg-type]
+    assert validation.valid is False
+    assert _HostileStr.calls == 0

--- a/tests/test_gauntlet_hostile.py
+++ b/tests/test_gauntlet_hostile.py
@@ -1,0 +1,118 @@
+"""Hostile int/float gate for GauntletConfig before float/range."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.streams.gauntlet import GauntletConfig
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __lt__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile lt must not run")
+
+    def __mod__(self, other: object) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile mod must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+def test_gauntlet_rejects_hostile_int_before_range() -> None:
+    hostile = _HostileInt(8)
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="relevant_dim must be an even integer"):
+        GauntletConfig(relevant_dim=hostile)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+
+    hostile_seg = _HostileInt(3000)
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="segment_length must be positive"):
+        GauntletConfig(segment_length=hostile_seg)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+
+    # bool must be rejected without dispatch
+    with pytest.raises(ValueError, match="relevant_dim must be an even integer"):
+        GauntletConfig(relevant_dim=True)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+
+
+def test_gauntlet_rejects_hostile_float_before_float() -> None:
+    hostile = _HostileFloat(0.1)
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="noise_std must be a finite real number"):
+        GauntletConfig(noise_std=hostile)  # type: ignore[arg-type]
+    assert _HostileFloat.calls == 0
+
+    hostile_int = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="noise_std must be a finite real number"):
+        GauntletConfig(noise_std=hostile_int)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+
+    # bool subclass
+    with pytest.raises(ValueError, match="noise_std must be a finite real number"):
+        GauntletConfig(noise_std=True)  # type: ignore[arg-type]
+
+
+def test_gauntlet_benign_still_works() -> None:
+    cfg = GauntletConfig()
+    assert cfg.relevant_dim == 8
+    assert cfg.noise_std == 0.1
+    # benign exact int/float
+    cfg2 = GauntletConfig(
+        relevant_dim=4,
+        noise_std=0.2,
+        feature_std=1.0,
+        scale_factor=5.0,
+        drift_rate=0.02,
+        context_noise_std=0.1,
+    )
+    assert cfg2.relevant_dim == 4
+    # finite check
+
+    with pytest.raises(ValueError, match="must be finite"):
+        GauntletConfig(noise_std=float("inf"))  # type: ignore[arg-type]
+
+
+def test_gauntlet_hostile_not_in_repr() -> None:
+    hostile = _HostileInt(8)
+    _HostileInt.calls = 0
+    try:
+        GauntletConfig(relevant_dim=hostile)  # type: ignore[arg-type]
+    except ValueError as exc:
+        assert "_HostileInt" not in str(exc)
+        assert _HostileInt.calls == 0
+    else:
+        raise AssertionError("should have raised")

--- a/tests/test_gauntlet_lifetime_clock.py
+++ b/tests/test_gauntlet_lifetime_clock.py
@@ -1,0 +1,39 @@
+"""Saturating lifetime clocks keep GauntletStream segment identity at int32 exhaustion."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.streams.gauntlet import NUM_SEGMENTS, GauntletStream
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_gauntlet_wrap_forges_a_different_segment() -> None:
+    """The old bare increment wraps INT32_MAX + 1 to INT32_MIN and resets the course."""
+
+    stream = GauntletStream()
+    wrap = jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    assert int(wrap) == _INT32_MIN
+    assert int(stream.segment_of(wrap)) == 0
+    assert int(stream.segment_of(jnp.asarray(_INT32_MAX, dtype=jnp.int32))) == NUM_SEGMENTS - 1
+
+
+def test_gauntlet_clock_saturates_at_int32_max() -> None:
+    """A planted INT32_MAX clock saturates instead of wrapping negative."""
+
+    stream = GauntletStream()
+    predecessor = stream.init(jr.key(0)).replace(  # type: ignore[attr-defined]
+        step_count=jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
+    )
+    _, advanced = stream.step(predecessor, jnp.asarray(0, dtype=jnp.int32))
+    assert int(advanced.step_count) == _INT32_MAX
+    assert int(advanced.step_count) >= 0
+    assert int(stream.segment_of(advanced.step_count)) == NUM_SEGMENTS - 1
+
+    exhausted = stream.step(advanced, jnp.asarray(0, dtype=jnp.int32))
+    assert int(exhausted[1].step_count) == _INT32_MAX
+    assert int(exhausted[1].step_count) >= 0
+    assert int(stream.segment_of(exhausted[1].step_count)) == NUM_SEGMENTS - 1

--- a/tests/test_gru_perception_update_working_set.py
+++ b/tests/test_gru_perception_update_working_set.py
@@ -1,0 +1,116 @@
+"""#1383-complete update working-set preflight for GRU perception."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.prototype_agent import (
+    GRUPerceptionConfig,
+    _gru_perception_persistent_bytes,
+    _gru_perception_update_working_set_bytes,
+    _gru_step,
+    _init_gru_state,
+    _preflight_gru_perception_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_OBSERVATION_DIM = 60_000_000
+_LAST_FIT_OBSERVATION_DIM = 53_687_088
+_FIRST_OVERFLOW_OBSERVATION_DIM = 53_687_089
+_UNIT_HIDDEN_DIM = 1
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _gru_perception_persistent_bytes(
+        _OVERFLOW_OBSERVATION_DIM, _UNIT_HIDDEN_DIM
+    )
+    working_set_bytes = _gru_perception_update_working_set_bytes(
+        _OVERFLOW_OBSERVATION_DIM, _UNIT_HIDDEN_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 720_000_028
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_OBSERVATION_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        GRUPerceptionConfig(
+            observation_dim=_OVERFLOW_OBSERVATION_DIM,
+            hidden_dim=_UNIT_HIDDEN_DIM,
+        )
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for observation_dim in range(
+        _LAST_FIT_OBSERVATION_DIM, _FIRST_OVERFLOW_OBSERVATION_DIM + 2
+    ):
+        persist_bytes = _gru_perception_persistent_bytes(
+            observation_dim, _UNIT_HIDDEN_DIM
+        )
+        working_set_bytes = _gru_perception_update_working_set_bytes(
+            observation_dim, _UNIT_HIDDEN_DIM
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * observation_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = observation_dim
+        elif first_overflow is None:
+            first_overflow = observation_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_OBSERVATION_DIM
+    cfg = GRUPerceptionConfig(
+        observation_dim=last_fit, hidden_dim=_UNIT_HIDDEN_DIM
+    )
+    assert cfg.observation_dim == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        GRUPerceptionConfig(
+            observation_dim=first_overflow, hidden_dim=_UNIT_HIDDEN_DIM
+        )
+    _preflight_gru_perception_update_working_set(last_fit, _UNIT_HIDDEN_DIM)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_gru_perception_update_working_set(
+            first_overflow, _UNIT_HIDDEN_DIM
+        )
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_gru_perception_update_working_set(
+            _OVERFLOW_OBSERVATION_DIM, _UNIT_HIDDEN_DIM
+        )
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (_INT32_MAX - 28) // 12
+    with pytest.raises(ValueError, match="GRUPerception state byte count"):
+        GRUPerceptionConfig(
+            observation_dim=last_legal + 1, hidden_dim=_UNIT_HIDDEN_DIM
+        )
+    with pytest.raises(ValueError, match="fit signed int32"):
+        GRUPerceptionConfig(observation_dim=1_000_000, hidden_dim=1_000_000)
+
+
+def test_legal_small_gru_perception_still_steps() -> None:
+    persist_bytes = _gru_perception_persistent_bytes(4, 1)
+    assert persist_bytes == 76
+    cfg = GRUPerceptionConfig(observation_dim=4, hidden_dim=1)
+    state = _init_gru_state(cfg, jr.key(0))
+    _gru_step(state, jnp.zeros((4,), dtype=jnp.float32))

--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -46,8 +46,11 @@ _WHEEL_FILES = tuple(
     and (path.suffix == ".py" or path.name == "py.typed")
 )
 _EXPECTED_SCRIPT_NAMES = {
+    "asi-ipmnist-campaign",
+    "asi-ipmnist-ceiling",
     "asi-l2er-matched-development",
     "asi-reference-life-scorecard",
+    "asi-rule-discovery-summary",
     "alberta-evidence-status",
     "alberta-forager-benchmark",
     "alberta-forager-matched-campaign",

--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -46,6 +46,7 @@ _WHEEL_FILES = tuple(
     and (path.suffix == ".py" or path.name == "py.typed")
 )
 _EXPECTED_SCRIPT_NAMES = {
+    "asi-l2er-matched-development",
     "asi-reference-life-scorecard",
     "alberta-evidence-status",
     "alberta-forager-benchmark",

--- a/tests/test_interaction_feature_validation.py
+++ b/tests/test_interaction_feature_validation.py
@@ -128,8 +128,8 @@ def test_boolean_fields_require_exact_bool(field: str) -> None:
 def test_persistent_state_resources_are_preflighted_without_allocation() -> None:
     # With one task, no candidates, and no normalizers, state bytes are 45F + 44.
     last_legal = (_INT32_MAX - 44) // 45
-    legal = _construct(n_features=last_legal, n_tasks=1, candidate_count=0)
-    assert legal.n_features == last_legal
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _construct(n_features=last_legal, n_tasks=1, candidate_count=0)
     with pytest.raises(ValueError, match="state byte count"):
         _construct(n_features=last_legal + 1, n_tasks=1, candidate_count=0)
     with pytest.raises(ValueError, match="state (scalar|byte) count"):

--- a/tests/test_interaction_features_update_working_set.py
+++ b/tests/test_interaction_features_update_working_set.py
@@ -1,0 +1,106 @@
+"""#1383-complete update working-set preflight for interaction features."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.interaction_features import (
+    FixedBudgetInteractionLearner,
+    _interaction_persistent_bytes,
+    _interaction_update_working_set_bytes,
+    _preflight_interaction_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURES = 20_000_000
+_LAST_FIT_FEATURES = 11_243_368
+_FIRST_OVERFLOW_FEATURES = 11_243_369
+_UNIT = {"n_tasks": 1, "candidate_count": 0, "scale_robust": False}
+
+
+def _unit_persist_bytes(n_features: int) -> int:
+    return _interaction_persistent_bytes(n_features=n_features, **_UNIT)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _unit_persist_bytes(_OVERFLOW_FEATURES)
+    working_set_bytes = _interaction_update_working_set_bytes(
+        n_features=_OVERFLOW_FEATURES,
+        **_UNIT,
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 900_000_044
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURES <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        FixedBudgetInteractionLearner(n_features=_OVERFLOW_FEATURES, **_UNIT)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for n_features in range(_LAST_FIT_FEATURES, _FIRST_OVERFLOW_FEATURES + 2):
+        persist_bytes = _unit_persist_bytes(n_features)
+        working_set_bytes = _interaction_update_working_set_bytes(
+            n_features=n_features,
+            **_UNIT,
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * n_features <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = n_features
+        elif first_overflow is None:
+            first_overflow = n_features
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURES
+    learner = FixedBudgetInteractionLearner(n_features=last_fit, **_UNIT)
+    assert learner.n_features == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        FixedBudgetInteractionLearner(n_features=first_overflow, **_UNIT)
+    _preflight_interaction_update_working_set(n_features=last_fit, **_UNIT)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_interaction_update_working_set(n_features=first_overflow, **_UNIT)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_interaction_update_working_set(
+            n_features=_OVERFLOW_FEATURES,
+            **_UNIT,
+        )
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (_INT32_MAX - 44) // 45
+    with pytest.raises(ValueError, match="state byte count"):
+        FixedBudgetInteractionLearner(n_features=last_legal + 1, **_UNIT)
+
+
+def test_legal_small_interaction_learner_still_updates() -> None:
+    persist_bytes = _unit_persist_bytes(4)
+    assert persist_bytes == 224
+    learner = FixedBudgetInteractionLearner(n_features=4, **_UNIT)
+    state = learner.init(2, jr.key(0))
+    learner.update(
+        state,
+        jnp.asarray((0.5, -0.25), dtype=jnp.float32),
+        jnp.asarray((0.75,), dtype=jnp.float32),
+    )

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -17,7 +17,12 @@ from alberta_framework.benchmarks.ipmnist_campaign_tools import (
     build_frontier,
     validate_confirm_alignment,
 )
-from alberta_framework.benchmarks.ipmnist_ceiling import _atomic_publish, _publish_run
+from alberta_framework.benchmarks.ipmnist_ceiling import (
+    _atomic_publish,
+    _publish_run,
+    run_arm_per_step,
+    run_batch_reference,
+)
 from alberta_framework.benchmarks.rule_discovery_summary import (
     CHAMPION,
     SCREEN_ARMS,
@@ -27,6 +32,14 @@ from alberta_framework.benchmarks.rule_discovery_summary import (
 
 pytestmark = pytest.mark.unit
 _REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _HostileSeed(int):
+    def __index__(self) -> int:  # pragma: no cover
+        raise AssertionError("seed conversion hook executed")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("seed representation hook executed")
 
 
 def _shard(path: Path, *, seed: int, accuracy: float) -> None:
@@ -62,6 +75,30 @@ def _ceiling_run(
         np.full((tasks, 5000), mean_accuracy, dtype=np.float64),
         allow_pickle=False,
     )
+
+
+@pytest.mark.parametrize(
+    "seed",
+    [True, False, _HostileSeed(1), -1, 2**32],
+    ids=("true", "false", "hostile-int", "negative", "above-uint32"),
+)
+def test_ceiling_runner_rejects_noncanonical_seed_before_work(seed: object) -> None:
+    with pytest.raises(ValueError, match="built-in integer.*uint32"):
+        run_arm_per_step("unused", seed, 1, "identity")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "seed",
+    [True, False, _HostileSeed(1), -1, 2**32],
+    ids=("true", "false", "hostile-int", "negative", "above-uint32"),
+)
+def test_batch_reference_rejects_noncanonical_seed_before_publication(
+    tmp_path: Path, seed: object
+) -> None:
+    output_dir = tmp_path / "must-not-exist"
+    with pytest.raises(ValueError, match="built-in integer.*uint32"):
+        run_batch_reference(output_dir, seed=seed)  # type: ignore[arg-type]
+    assert not output_dir.exists()
 
 
 def test_across_seed_spread_uses_sample_estimator() -> None:

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -133,6 +133,20 @@ def test_frontier_rejects_empty_or_no_overlap_screen_seed_sets(tmp_path: Path) -
         build_frontier(tmp_path / "empty", confirm, base="base", arms=["candidate"])
 
 
+def test_current_frontier_legacy_numeric_payload_reconstructs() -> None:
+    campaign = _REPO_ROOT / "outputs" / "ipmnist_screening"
+    expected = json.loads((campaign / "frontier_results.json").read_text())
+    actual = build_frontier(
+        campaign / "shards",
+        campaign / "confirm_full",
+        created_unix=float(expected["created_unix"]),
+    )
+    actual.pop("schema")
+    actual.pop("provenance")
+
+    assert actual == expected
+
+
 def test_ceiling_summary_records_sample_spread_from_explicit_paths(tmp_path: Path) -> None:
     ceiling = tmp_path / "ceiling"
     confirm = tmp_path / "confirm"

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -1,0 +1,310 @@
+"""Contracts for maintained campaign tools that supersede output-local scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import BinaryIO
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.ipmnist_campaign_tools import (
+    CONFIRM_ALIGNMENT_ATOL,
+    across_seed_spread,
+    build_ceiling_summary,
+    build_frontier,
+    validate_confirm_alignment,
+)
+from alberta_framework.benchmarks.ipmnist_ceiling import _atomic_publish, _publish_run
+from alberta_framework.benchmarks.rule_discovery_summary import (
+    CHAMPION,
+    SCREEN_ARMS,
+    build_legacy_rule_discovery_summary,
+    build_rule_discovery_summary,
+)
+
+pytestmark = pytest.mark.unit
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _shard(path: Path, *, seed: int, accuracy: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"seed": seed, "per_task_accuracy": [accuracy, accuracy]}),
+        encoding="utf-8",
+    )
+
+
+def _ceiling_run(
+    root: Path,
+    *,
+    prefix: str,
+    seed: int,
+    mean_accuracy: float,
+    tasks: int = 1,
+) -> None:
+    tag = prefix
+    (root / f"{prefix}_seed{seed}.json").write_text(
+        json.dumps(
+            {
+                "seed": seed,
+                "tag": tag,
+                "mean_accuracy": mean_accuracy,
+                "per_task_accuracy": [mean_accuracy] * tasks,
+            }
+        ),
+        encoding="utf-8",
+    )
+    np.save(
+        root / f"{tag}_seed{seed}_per_step.npy",
+        np.full((tasks, 5000), mean_accuracy, dtype=np.float64),
+        allow_pickle=False,
+    )
+
+
+def test_across_seed_spread_uses_sample_estimator() -> None:
+    values = [0.7814, 0.7842, 0.7870]
+    assert across_seed_spread(values) == pytest.approx(np.std(values, ddof=1))
+    assert across_seed_spread(values) > float(np.std(values))
+    assert across_seed_spread([]) == 0.0
+    assert across_seed_spread([0.5]) == 0.0
+
+
+def test_frontier_requires_and_uses_exact_paired_seed_sets(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    for seed in (0, 1):
+        _shard(screen / f"base_seed{seed}.json", seed=seed, accuracy=0.80)
+        _shard(screen / f"candidate_seed{seed}.json", seed=seed, accuracy=0.81)
+        _shard(confirm / f"base_seed{seed}.json", seed=seed, accuracy=0.80)
+        _shard(confirm / f"candidate_seed{seed}.json", seed=seed, accuracy=0.82)
+    frontier = build_frontier(
+        screen,
+        confirm,
+        base="base",
+        arms=["candidate"],
+        created_unix=0.0,
+    )
+    row = frontier["results"][0]
+
+    assert row["n_confirm_seeds"] == 2
+    assert row["confirm_mean"] == pytest.approx(0.82)
+    assert row["confirm_paired_delta_vs_base"] == pytest.approx(0.02)
+
+    assert frontier["schema"] == "asi.ipmnist.frontier.v2"
+    assert len(frontier["provenance"]["inputs"]) == 8
+    assert len(frontier["provenance"]["sources"]["campaign_tools"]["sha256"]) == 64
+    assert "ipmnist_provenance" in frontier["provenance"]["sources"]
+    assert {
+        item["path"] for item in frontier["provenance"]["environment_specifications"]
+    } == {"pyproject.toml", "uv.lock"}
+
+
+def test_frontier_rejects_mismatched_confirm_seed_sets(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    _shard(screen / "base_seed0.json", seed=0, accuracy=0.80)
+    _shard(screen / "candidate_seed0.json", seed=0, accuracy=0.81)
+    _shard(confirm / "base_seed0.json", seed=0, accuracy=0.80)
+    _shard(confirm / "candidate_seed7.json", seed=7, accuracy=0.99)
+
+    with pytest.raises(ValueError, match="confirm seed sets differ"):
+        build_frontier(
+            screen,
+            confirm,
+            base="base",
+            arms=["candidate"],
+            created_unix=0.0,
+        )
+
+
+def test_frontier_rejects_empty_or_no_overlap_screen_seed_sets(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    _shard(screen / "base_seed0.json", seed=0, accuracy=0.80)
+    _shard(screen / "candidate_seed7.json", seed=7, accuracy=0.81)
+
+    with pytest.raises(ValueError, match="screen seed sets differ"):
+        build_frontier(screen, confirm, base="base", arms=["candidate"])
+
+    with pytest.raises(ValueError, match="has no seeds"):
+        build_frontier(tmp_path / "empty", confirm, base="base", arms=["candidate"])
+
+
+def test_ceiling_summary_records_sample_spread_from_explicit_paths(tmp_path: Path) -> None:
+    ceiling = tmp_path / "ceiling"
+    confirm = tmp_path / "confirm"
+    ceiling.mkdir()
+    confirm.mkdir()
+    for seed, accuracy in enumerate((0.78, 0.82)):
+        _ceiling_run(
+            ceiling,
+            prefix="stationary_sigma0_ndecay099",
+            seed=seed,
+            mean_accuracy=accuracy,
+        )
+
+    summary = build_ceiling_summary(ceiling, confirm)
+    result = summary["stationary_sigma0_ndecay099"]
+
+    assert result["sample_standard_deviation"] == pytest.approx(
+        np.std([0.78, 0.82], ddof=1)
+    )
+    assert summary["schema"] == "asi.ipmnist.ceiling_summary.v2"
+    assert len(summary["provenance"]["inputs"]) == 4
+    assert summary["provenance"]["runtime"]["dependencies"]["numpy"] is not None
+
+
+def test_current_stored_ceiling_reconstructs_with_rounded_confirmation() -> None:
+    campaign = _REPO_ROOT / "outputs" / "ipmnist_screening"
+
+    summary = build_ceiling_summary(campaign / "ceiling", campaign / "confirm_full")
+    alignment = summary["error_budget"]["confirm_alignment"]
+
+    assert alignment["relative_tolerance"] == 0.0
+    assert alignment["absolute_tolerance"] == CONFIRM_ALIGNMENT_ATOL
+    assert alignment["max_abs_delta"] == pytest.approx(6.000000007944095e-08)
+
+
+def test_ceiling_confirm_alignment_rejects_delta_above_frozen_tolerance(
+    tmp_path: Path,
+) -> None:
+    confirm = tmp_path / "confirm"
+    _shard(confirm / "sigma0_ndecay099_seed0.json", seed=0, accuracy=0.8)
+    run = {"seed": 0, "per_task_accuracy": [0.8, 0.8 + 2 * CONFIRM_ALIGNMENT_ATOL]}
+
+    with pytest.raises(ValueError, match="exceeds atol"):
+        validate_confirm_alignment([run], confirm)
+
+
+def test_ceiling_publication_refuses_to_replace_existing_bytes(tmp_path: Path) -> None:
+    per_step = np.ones((1, 5000), dtype=np.uint8)
+    per_task = np.asarray([1.0], dtype=np.float64)
+    artifact_path = _publish_run(
+        tmp_path,
+        tag="stationary_sigma0_ndecay099",
+        spec_name="test",
+        seed=0,
+        permutation_mode="identity",
+        n_tasks=1,
+        per_step=per_step,
+        per_task=per_task,
+        wall_seconds=1.0,
+        provenance={"schema": "test.provenance.v1"},
+    )
+    before = artifact_path.read_bytes()
+    with np.load(artifact_path, allow_pickle=False) as archive:
+        metadata = json.loads(str(archive["metadata"].item()))
+        assert np.array_equal(archive["per_step"], per_step)
+    assert metadata["schema"] == "asi.ipmnist_ceiling.run.v2"
+    assert metadata["provenance"]["schema"] == "test.provenance.v1"
+    reconstructed = build_ceiling_summary(tmp_path, tmp_path / "confirm")
+    assert reconstructed["stationary_sigma0_ndecay099"]["avg_online_mean"] == 1.0
+
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        _publish_run(
+            tmp_path,
+            tag="stationary_sigma0_ndecay099",
+            spec_name="test",
+            seed=0,
+            permutation_mode="identity",
+            n_tasks=1,
+            per_step=per_step,
+            per_task=per_task,
+            wall_seconds=1.0,
+            provenance={"schema": "test.provenance.v1"},
+        )
+
+    assert artifact_path.read_bytes() == before
+
+
+def test_atomic_publication_cleans_up_writer_failure(tmp_path: Path) -> None:
+    destination = tmp_path / "result.bin"
+
+    def fail_after_write(stream: BinaryIO) -> None:
+        stream.write(b"partial")
+        raise RuntimeError("injected writer fault")
+
+    with pytest.raises(RuntimeError, match="injected writer fault"):
+        _atomic_publish(destination, fail_after_write)
+
+    assert not destination.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_atomic_publication_cleans_up_link_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "result.bin"
+
+    def fail_link(source: object, target: object) -> None:
+        del source, target
+        raise OSError("injected link fault")
+
+    monkeypatch.setattr("alberta_framework.benchmarks.ipmnist_ceiling.os.link", fail_link)
+    with pytest.raises(OSError, match="injected link fault"):
+        _atomic_publish(destination, lambda stream: stream.write(b"complete"))
+
+    assert not destination.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_atomic_publication_rolls_back_directory_sync_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "result.bin"
+    real_fsync = os.fsync
+    calls = 0
+
+    def fail_second_fsync(descriptor: int) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("injected directory sync fault")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr("alberta_framework.benchmarks.ipmnist_ceiling.os.fsync", fail_second_fsync)
+    with pytest.raises(OSError, match="injected directory sync fault"):
+        _atomic_publish(destination, lambda stream: stream.write(b"complete"))
+
+    assert not destination.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_rule_discovery_summary_uses_explicit_directories(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    for name in SCREEN_ARMS:
+        for seed in (0, 1, 2):
+            accuracy = 0.8 if name == CHAMPION else 0.79
+            _shard(screen / f"{name}_seed{seed}.json", seed=seed, accuracy=accuracy)
+
+    summary = build_rule_discovery_summary(screen, confirm)
+
+    assert summary["schema"] == "asi.rule_discovery.real_screen.v2"
+    assert summary["legacy_compatibility"]["schema"] == (
+        "alberta.rule_discovery.real_screen.v1"
+    )
+    assert summary["screen_60_task"][CHAMPION]["mean"] == pytest.approx(0.8)
+    assert summary["paired_vs_champion_60_task"]["disc_r1"]["mean"] == pytest.approx(
+        -0.01
+    )
+    assert summary["provenance"]["schema"] == "asi.ipmnist.analysis_provenance.v1"
+    assert len(summary["provenance"]["inputs"]) == 24
+    assert "rule_discovery" in summary["provenance"]["sources"]
+    assert "ipmnist_provenance" in summary["provenance"]["sources"]
+
+
+def test_current_rule_discovery_legacy_payload_reconstructs_exactly() -> None:
+    campaign = _REPO_ROOT / "outputs" / "ipmnist_screening"
+    expected = json.loads(
+        (_REPO_ROOT / "outputs" / "rule_discovery" / "real_screen_v1.json").read_text()
+    )
+
+    actual = build_legacy_rule_discovery_summary(
+        campaign / "shards", campaign / "confirm_full"
+    )
+
+    assert actual == expected

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -10,6 +10,7 @@ from typing import BinaryIO
 import numpy as np
 import pytest
 
+import alberta_framework.benchmarks.ipmnist_campaign_tools as campaign_tools_module
 from alberta_framework.benchmarks.ipmnist_campaign_tools import (
     CONFIRM_ALIGNMENT_ATOL,
     across_seed_spread,
@@ -42,6 +43,10 @@ class _HostileSeed(int):
         raise AssertionError("seed representation hook executed")
 
 
+class _StringSubclass(str):
+    pass
+
+
 def _shard(path: Path, *, seed: int, accuracy: float) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -59,20 +64,34 @@ def _ceiling_run(
     tasks: int = 1,
 ) -> None:
     tag = prefix
+    family, spec_name = prefix.split("_", 1)
+    permutation_mode = {"stationary": "identity", "carried": "same", "full": "protocol"}[
+        family
+    ]
+    correct = int(round(mean_accuracy * 5000))
+    row = np.concatenate(
+        (np.ones(correct, dtype=np.uint8), np.zeros(5000 - correct, dtype=np.uint8))
+    )
+    per_step = np.tile(row, (tasks, 1))
+    per_task = per_step.astype(np.float64).mean(axis=1).tolist()
     (root / f"{prefix}_seed{seed}.json").write_text(
         json.dumps(
             {
                 "seed": seed,
                 "tag": tag,
-                "mean_accuracy": mean_accuracy,
-                "per_task_accuracy": [mean_accuracy] * tasks,
+                "spec_name": spec_name,
+                "perm_mode": permutation_mode,
+                "n_tasks": tasks,
+                "task_length": 5000,
+                "mean_accuracy": float(np.mean(per_task)),
+                "per_task_accuracy": per_task,
             }
         ),
         encoding="utf-8",
     )
     np.save(
         root / f"{tag}_seed{seed}_per_step.npy",
-        np.full((tasks, 5000), mean_accuracy, dtype=np.float64),
+        per_step,
         allow_pickle=False,
     )
 
@@ -99,6 +118,99 @@ def test_batch_reference_rejects_noncanonical_seed_before_publication(
     with pytest.raises(ValueError, match="built-in integer.*uint32"):
         run_batch_reference(output_dir, seed=seed)  # type: ignore[arg-type]
     assert not output_dir.exists()
+
+
+@pytest.mark.parametrize(
+    ("epochs", "batch_size"),
+    [
+        (True, 128),
+        (0, 128),
+        (31, 128),
+        (1, True),
+        (1, 31),
+        (1, 60_001),
+        (30, 32),
+    ],
+)
+def test_batch_reference_preflights_exact_bounded_work_before_io(
+    tmp_path: Path, epochs: object, batch_size: object
+) -> None:
+    output_dir = tmp_path / "must-not-exist"
+    with pytest.raises(ValueError):
+        run_batch_reference(
+            output_dir,
+            seed=0,
+            epochs=epochs,  # type: ignore[arg-type]
+            batch_size=batch_size,  # type: ignore[arg-type]
+        )
+    assert not output_dir.exists()
+
+
+@pytest.mark.parametrize(
+    ("base", "arms", "threshold", "created_unix"),
+    [
+        ("../base", ("candidate",), 0.0, 0.0),
+        ("base", (), 0.0, 0.0),
+        ("base", ("candidate", "candidate"), 0.0, 0.0),
+        ("base", ("base",), 0.0, 0.0),
+        ("base", (_StringSubclass("candidate"),), 0.0, 0.0),
+        ("base", ("../candidate",), 0.0, 0.0),
+        ("base", ("candidate",), True, 0.0),
+        ("base", ("candidate",), float("nan"), 0.0),
+        ("base", ("candidate",), 0.0, -1.0),
+        ("base", ("candidate",), 0.0, float("inf")),
+    ],
+)
+def test_frontier_rejects_hostile_identifiers_and_nonfinite_controls(
+    tmp_path: Path,
+    base: object,
+    arms: object,
+    threshold: object,
+    created_unix: object,
+) -> None:
+    with pytest.raises(ValueError):
+        build_frontier(
+            tmp_path / "screen",
+            tmp_path / "confirm",
+            base=base,  # type: ignore[arg-type]
+            arms=arms,  # type: ignore[arg-type]
+            threshold=threshold,  # type: ignore[arg-type]
+            created_unix=created_unix,  # type: ignore[arg-type]
+        )
+
+
+def test_frontier_requires_distinct_resolved_directories(tmp_path: Path) -> None:
+    directory = tmp_path / "campaign"
+    with pytest.raises(ValueError, match="distinct paths"):
+        build_frontier(directory, directory, base="base", arms=("candidate",))
+
+
+def test_frontier_seed_filename_must_bind_payload_seed(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    _shard(screen / "base_seed0.json", seed=1, accuracy=0.8)
+    with pytest.raises(ValueError, match="filename disagrees"):
+        build_frontier(screen, confirm, base="base", arms=("candidate",))
+
+
+def test_campaign_cli_uses_strict_json_serialization(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        campaign_tools_module,
+        "build_frontier",
+        lambda *args, **kwargs: {"nonfinite": float("nan")},
+    )
+    with pytest.raises(ValueError, match="Out of range float values"):
+        campaign_tools_module.main(
+            [
+                "frontier",
+                "--screen-dir",
+                str(tmp_path / "screen"),
+                "--confirm-dir",
+                str(tmp_path / "confirm"),
+            ]
+        )
 
 
 def test_across_seed_spread_uses_sample_estimator() -> None:
@@ -236,21 +348,23 @@ def test_ceiling_publication_refuses_to_replace_existing_bytes(tmp_path: Path) -
     artifact_path = _publish_run(
         tmp_path,
         tag="stationary_sigma0_ndecay099",
-        spec_name="test",
+        spec_name="sigma0_ndecay099",
         seed=0,
         permutation_mode="identity",
         n_tasks=1,
         per_step=per_step,
         per_task=per_task,
         wall_seconds=1.0,
-        provenance={"schema": "test.provenance.v1"},
+        provenance={"schema": "asi.ipmnist.ceiling_run_provenance.v1"},
     )
     before = artifact_path.read_bytes()
     with np.load(artifact_path, allow_pickle=False) as archive:
         metadata = json.loads(str(archive["metadata"].item()))
         assert np.array_equal(archive["per_step"], per_step)
     assert metadata["schema"] == "asi.ipmnist_ceiling.run.v2"
-    assert metadata["provenance"]["schema"] == "test.provenance.v1"
+    assert metadata["provenance"]["schema"] == (
+        "asi.ipmnist.ceiling_run_provenance.v1"
+    )
     reconstructed = build_ceiling_summary(tmp_path, tmp_path / "confirm")
     assert reconstructed["stationary_sigma0_ndecay099"]["avg_online_mean"] == 1.0
 
@@ -258,17 +372,202 @@ def test_ceiling_publication_refuses_to_replace_existing_bytes(tmp_path: Path) -
         _publish_run(
             tmp_path,
             tag="stationary_sigma0_ndecay099",
-            spec_name="test",
+            spec_name="sigma0_ndecay099",
             seed=0,
             permutation_mode="identity",
             n_tasks=1,
             per_step=per_step,
             per_task=per_task,
             wall_seconds=1.0,
-            provenance={"schema": "test.provenance.v1"},
+            provenance={"schema": "asi.ipmnist.ceiling_run_provenance.v1"},
         )
 
     assert artifact_path.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"tag": "../escape"},
+        {"tag": _StringSubclass("stationary_sigma0_ndecay099")},
+        {"spec_name": "other"},
+        {"permutation_mode": "protocol"},
+        {"n_tasks": 2},
+        {"wall_seconds": float("nan")},
+        {"provenance": {"schema": "wrong"}},
+    ],
+)
+def test_ceiling_publisher_rejects_hostile_identity_and_scalar_contracts(
+    tmp_path: Path, override: dict[str, object]
+) -> None:
+    arguments: dict[str, object] = {
+        "tag": "stationary_sigma0_ndecay099",
+        "spec_name": "sigma0_ndecay099",
+        "seed": 0,
+        "permutation_mode": "identity",
+        "n_tasks": 1,
+        "per_step": np.ones((1, 5000), dtype=np.uint8),
+        "per_task": np.ones(1, dtype=np.float64),
+        "wall_seconds": 1.0,
+        "provenance": {"schema": "asi.ipmnist.ceiling_run_provenance.v1"},
+    }
+    arguments.update(override)
+    with pytest.raises(ValueError):
+        _publish_run(tmp_path / "out", **arguments)  # type: ignore[arg-type]
+    assert not (tmp_path / "out").exists()
+
+
+@pytest.mark.parametrize(
+    ("per_step", "per_task"),
+    [
+        (np.ones((1, 5000), dtype=np.float32), np.ones(1, dtype=np.float64)),
+        (np.full((1, 5000), 2, dtype=np.uint8), np.ones(1, dtype=np.float64)),
+        (np.ones((1, 4999), dtype=np.uint8), np.ones(1, dtype=np.float64)),
+        (np.ones((1, 5000), dtype=np.uint8), np.asarray([np.nan])),
+        (np.ones((1, 5000), dtype=np.uint8), np.asarray([0.5])),
+    ],
+)
+def test_ceiling_publisher_rejects_invalid_accuracy_arrays(
+    tmp_path: Path, per_step: np.ndarray, per_task: np.ndarray
+) -> None:
+    with pytest.raises(ValueError):
+        _publish_run(
+            tmp_path / "out",
+            tag="stationary_sigma0_ndecay099",
+            spec_name="sigma0_ndecay099",
+            seed=0,
+            permutation_mode="identity",
+            n_tasks=1,
+            per_step=per_step,
+            per_task=per_task,
+            wall_seconds=1.0,
+            provenance={"schema": "asi.ipmnist.ceiling_run_provenance.v1"},
+        )
+    assert not (tmp_path / "out").exists()
+
+
+def _write_legacy_ceiling_run(
+    root: Path,
+    *,
+    filename: str,
+    seed: int = 0,
+    task_length: int = 5000,
+    n_tasks: int = 1,
+) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    tag = "stationary_sigma0_ndecay099"
+    payload = {
+        "tag": tag,
+        "spec_name": "sigma0_ndecay099",
+        "seed": seed,
+        "perm_mode": "identity",
+        "n_tasks": n_tasks,
+        "task_length": task_length,
+        "per_task_accuracy": [1.0] * n_tasks,
+        "mean_accuracy": 1.0,
+    }
+    (root / filename).write_text(json.dumps(payload), encoding="utf-8")
+    np.save(
+        root / f"{tag}_seed{seed}_per_step.npy",
+        np.ones((n_tasks, task_length), dtype=np.uint8),
+        allow_pickle=False,
+    )
+
+
+def test_ceiling_analyzer_rejects_short_task_dimension(tmp_path: Path) -> None:
+    ceiling = tmp_path / "ceiling"
+    _write_legacy_ceiling_run(
+        ceiling,
+        filename="stationary_sigma0_ndecay099_seed0.json",
+        task_length=1,
+    )
+    with pytest.raises(ValueError, match="task_length must equal 5000"):
+        build_ceiling_summary(ceiling, tmp_path / "confirm")
+
+
+def test_ceiling_analyzer_rejects_duplicate_legacy_seed(tmp_path: Path) -> None:
+    ceiling = tmp_path / "ceiling"
+    _write_legacy_ceiling_run(
+        ceiling, filename="stationary_sigma0_ndecay099_seed0.json"
+    )
+    _write_legacy_ceiling_run(
+        ceiling, filename="stationary_sigma0_ndecay099_seed0_duplicate.json"
+    )
+    with pytest.raises(ValueError, match="duplicate ceiling seed"):
+        build_ceiling_summary(ceiling, tmp_path / "confirm")
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"development_only": False},
+        {"scientific_promotion_allowed": True},
+        {"evidence_class": "scientific_evidence"},
+        {"wall_clock_seconds": float("nan")},
+        {"provenance": {"schema": "wrong"}},
+    ],
+)
+def test_ceiling_analyzer_rejects_tampered_maintained_metadata(
+    tmp_path: Path, override: dict[str, object]
+) -> None:
+    ceiling = tmp_path / "ceiling"
+    ceiling.mkdir()
+    payload: dict[str, object] = {
+        "schema": "asi.ipmnist_ceiling.run.v2",
+        "evidence_class": "development_screening_diagnostic",
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "tag": "stationary_sigma0_ndecay099",
+        "spec_name": "sigma0_ndecay099",
+        "seed": 0,
+        "perm_mode": "identity",
+        "n_tasks": 1,
+        "task_length": 5000,
+        "per_task_accuracy": [1.0],
+        "mean_accuracy": 1.0,
+        "wall_clock_seconds": 1.0,
+        "provenance": {"schema": "asi.ipmnist.ceiling_run_provenance.v1"},
+    }
+    payload.update(override)
+    np.savez_compressed(
+        ceiling / "stationary_sigma0_ndecay099_seed0.npz",
+        metadata=np.asarray(json.dumps(payload)),
+        per_step=np.ones((1, 5000), dtype=np.uint8),
+    )
+    with pytest.raises(ValueError):
+        build_ceiling_summary(ceiling, tmp_path / "confirm")
+
+
+def test_confirm_alignment_requires_matching_canonical_reference_seed(
+    tmp_path: Path,
+) -> None:
+    confirm = tmp_path / "confirm"
+    _shard(confirm / "sigma0_ndecay099_seed0.json", seed=1, accuracy=0.8)
+    with pytest.raises(ValueError, match="does not match ceiling seed"):
+        validate_confirm_alignment(
+            [{"seed": 0, "per_task_accuracy": [0.8, 0.8]}], confirm
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"seed": 1, "test_accuracy_best": 0.9},
+        {"seed": -1, "test_accuracy_best": 0.9},
+        {"seed": 0, "test_accuracy_best": float("nan")},
+        {"seed": 0, "test_accuracy_best": 1.1},
+    ],
+)
+def test_ceiling_analyzer_rejects_invalid_batch_summary(
+    tmp_path: Path, payload: dict[str, object]
+) -> None:
+    ceiling = tmp_path / "ceiling"
+    ceiling.mkdir()
+    (ceiling / "batch_reference_seed0.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+    with pytest.raises(ValueError):
+        build_ceiling_summary(ceiling, tmp_path / "confirm")
 
 
 def test_atomic_publication_cleans_up_writer_failure(tmp_path: Path) -> None:
@@ -346,6 +645,58 @@ def test_rule_discovery_summary_uses_explicit_directories(tmp_path: Path) -> Non
     assert len(summary["provenance"]["inputs"]) == 24
     assert "rule_discovery" in summary["provenance"]["sources"]
     assert "ipmnist_provenance" in summary["provenance"]["sources"]
+
+
+@pytest.mark.parametrize("seeds", [(), (0, 0), (True,), (-1,), (2**32,)])
+def test_rule_summary_rejects_noncanonical_or_duplicate_seeds_before_io(
+    tmp_path: Path, seeds: object
+) -> None:
+    with pytest.raises(ValueError):
+        build_legacy_rule_discovery_summary(
+            tmp_path / "screen",
+            tmp_path / "confirm",
+            seeds=seeds,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("accuracy", [[], [float("nan")], [-0.1], [1.1]])
+def test_rule_summary_rejects_invalid_accuracy_payloads(
+    tmp_path: Path, accuracy: list[float]
+) -> None:
+    screen = tmp_path / "screen"
+    path = screen / f"{SCREEN_ARMS[0]}_seed0.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"seed": 0, "per_task_accuracy": accuracy}), encoding="utf-8"
+    )
+    with pytest.raises(ValueError):
+        build_legacy_rule_discovery_summary(
+            screen, tmp_path / "confirm", seeds=(0,)
+        )
+
+
+def test_rule_summary_requires_payload_seed_to_match_requested_seed(
+    tmp_path: Path,
+) -> None:
+    screen = tmp_path / "screen"
+    _shard(screen / f"{SCREEN_ARMS[0]}_seed0.json", seed=1, accuracy=0.8)
+    with pytest.raises(ValueError, match="does not match requested seed"):
+        build_legacy_rule_discovery_summary(
+            screen, tmp_path / "confirm", seeds=(0,)
+        )
+
+
+def test_rule_summary_rejects_partial_confirmation_seed_set(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    for name in SCREEN_ARMS:
+        for seed in (0, 1):
+            _shard(screen / f"{name}_seed{seed}.json", seed=seed, accuracy=0.8)
+    _shard(
+        confirm / "disc_r1_pscale_norms_seed0.json", seed=0, accuracy=0.8
+    )
+    with pytest.raises(ValueError, match="confirmation seeds are incomplete"):
+        build_legacy_rule_discovery_summary(screen, confirm, seeds=(0, 1))
 
 
 def test_current_rule_discovery_legacy_payload_reconstructs_exactly() -> None:

--- a/tests/test_ipmnist_local_prereg.py
+++ b/tests/test_ipmnist_local_prereg.py
@@ -1194,6 +1194,49 @@ def _validate(root: Path, protocol_key: str) -> dict[str, Any]:
         )
 
 
+def _historical_issue184_registry() -> tuple[Any, MappingProxyType[str, Any]]:
+    """Reconstruct the concluded arm only inside historical validation tests."""
+    import alberta_framework.benchmarks.ipmnist_screening as screening_module
+
+    protocol = _PROTOCOLS["issue184"]
+    assert protocol.candidate not in screening_module.SCREENING_REGISTRY
+    incumbent = screening_module.screening_spec(protocol.control)
+    retired = replace(
+        incumbent,
+        name=protocol.candidate,
+        hyperparameters={
+            **incumbent.hyperparameters,
+            "rls_reset_frac": 2.0,
+        },
+    )
+    historical_registry = MappingProxyType(
+        {**screening_module.SCREENING_REGISTRY, protocol.candidate: retired}
+    )
+    return screening_module, historical_registry
+
+
+def _publish_historical_issue184(root: Path) -> dict[str, Any]:
+    """Exercise publication without restoring the retired arm to the live registry."""
+    screening_module, historical_registry = _historical_issue184_registry()
+    protocol = _PROTOCOLS["issue184"]
+    with pytest.MonkeyPatch.context() as registry_patch:
+        registry_patch.setattr(
+            screening_module,
+            "SCREENING_REGISTRY",
+            historical_registry,
+        )
+        return cast(
+            dict[str, Any],
+            _validate_and_publish_result(
+                protocol_key=protocol.key,
+                root=root,
+                repository_identity=_repository_identity(),
+                runner_receipt=_runner_receipt(),
+                verify_cache_file=False,
+            ),
+        )
+
+
 @pytest.mark.parametrize(
     ("difference", "expected"),
     [
@@ -1370,25 +1413,13 @@ def test_issue14_full_bundle_reports_evaluation_and_combined_outcome(
 def test_result_publication_is_one_shot_after_success(tmp_path: Path) -> None:
     namespace = _write_protocol_receipts(tmp_path, "issue184")
     _write_stage(tmp_path, "issue184", "screen_60", differences=(0.003,) * 3)
-    result = _validate_and_publish_result(
-        protocol_key="issue184",
-        root=tmp_path,
-        repository_identity=_repository_identity(),
-        runner_receipt=_runner_receipt(),
-        verify_cache_file=False,
-    )
+    result = _publish_historical_issue184(tmp_path)
     assert result["outcome"] == "no_reset_win"
     assert (namespace / "result-claim.v1.json").is_file()
     assert (namespace / "result.v1.json").is_file()
     assert _validate(tmp_path, "issue184") == result
     with pytest.raises(FileExistsError):
-        _validate_and_publish_result(
-            protocol_key="issue184",
-            root=tmp_path,
-            repository_identity=_repository_identity(),
-            runner_receipt=_runner_receipt(),
-            verify_cache_file=False,
-        )
+        _publish_historical_issue184(tmp_path)
 
 
 def test_failed_result_validation_consumes_the_only_attempt(tmp_path: Path) -> None:
@@ -1424,11 +1455,18 @@ def test_result_validation_rejects_shards_created_before_cache_receipt(
     prior = Path.cwd()
     os.chdir(tmp_path)
     try:
-        summary = merge_shards(
-            [path.relative_to(tmp_path) for path in paths],
-            control_name="rls_head_resid_l1_preset005",
-            slope_window=15,
-        )
+        screening_module, historical_registry = _historical_issue184_registry()
+        with pytest.MonkeyPatch.context() as registry_patch:
+            registry_patch.setattr(
+                screening_module,
+                "SCREENING_REGISTRY",
+                historical_registry,
+            )
+            summary = merge_shards(
+                [path.relative_to(tmp_path) for path in paths],
+                control_name="rls_head_resid_l1_preset005",
+                slope_window=15,
+            )
     finally:
         os.chdir(prior)
     (namespace / "screen_60/summary.json").write_text(
@@ -1654,13 +1692,7 @@ def test_result_validation_rejects_malformed_or_premature_claim(
 def test_published_result_tamper_is_rejected_on_strict_reload(tmp_path: Path) -> None:
     namespace = _write_protocol_receipts(tmp_path, "issue184")
     _write_stage(tmp_path, "issue184", "screen_60", differences=(0.003,) * 3)
-    result = _validate_and_publish_result(
-        protocol_key="issue184",
-        root=tmp_path,
-        repository_identity=_repository_identity(),
-        runner_receipt=_runner_receipt(),
-        verify_cache_file=False,
-    )
+    result = _publish_historical_issue184(tmp_path)
     stored = json.loads((namespace / "result.v1.json").read_text(encoding="utf-8"))
     assert stored == result
     stored["outcome"] = "inconclusive"

--- a/tests/test_ipmnist_local_prereg.py
+++ b/tests/test_ipmnist_local_prereg.py
@@ -1149,53 +1149,20 @@ def _write_combined_summary(root: Path) -> Path:
 
 
 def _validate(root: Path, protocol_key: str) -> dict[str, Any]:
-    if protocol_key != "issue184":
-        return cast(
-            dict[str, Any],
-            _validate_result_bundle(
-                protocol_key=protocol_key,
-                root=root,
-                repository_identity=_repository_identity(),
-                runner_receipt=_runner_receipt(),
-                verify_cache_file=False,
-            ),
-        )
-
-    import alberta_framework.benchmarks.ipmnist_screening as screening_module
-
-    protocol = _PROTOCOLS[protocol_key]
-    incumbent = screening_module.screening_spec(protocol.control)
-    retired = replace(
-        incumbent,
-        name=protocol.candidate,
-        hyperparameters={
-            **incumbent.hyperparameters,
-            "rls_reset_frac": 2.0,
-        },
+    return cast(
+        dict[str, Any],
+        _validate_result_bundle(
+            protocol_key=protocol_key,
+            root=root,
+            repository_identity=_repository_identity(),
+            runner_receipt=_runner_receipt(),
+            verify_cache_file=False,
+        ),
     )
-    historical_registry = MappingProxyType(
-        {**screening_module.SCREENING_REGISTRY, protocol.candidate: retired}
-    )
-    with pytest.MonkeyPatch.context() as registry_patch:
-        registry_patch.setattr(
-            screening_module,
-            "SCREENING_REGISTRY",
-            historical_registry,
-        )
-        return cast(
-            dict[str, Any],
-            _validate_result_bundle(
-                protocol_key=protocol_key,
-                root=root,
-                repository_identity=_repository_identity(),
-                runner_receipt=_runner_receipt(),
-                verify_cache_file=False,
-            ),
-        )
 
 
-def _historical_issue184_registry() -> tuple[Any, MappingProxyType[str, Any]]:
-    """Reconstruct the concluded arm only inside historical validation tests."""
+def _historical_issue184_registry() -> dict[str, Any]:
+    """Build the explicit registry used to reconstruct a historical summary."""
     import alberta_framework.benchmarks.ipmnist_screening as screening_module
 
     protocol = _PROTOCOLS["issue184"]
@@ -1209,32 +1176,22 @@ def _historical_issue184_registry() -> tuple[Any, MappingProxyType[str, Any]]:
             "rls_reset_frac": 2.0,
         },
     )
-    historical_registry = MappingProxyType(
-        {**screening_module.SCREENING_REGISTRY, protocol.candidate: retired}
-    )
-    return screening_module, historical_registry
+    return {**screening_module.SCREENING_REGISTRY, protocol.candidate: retired}
 
 
 def _publish_historical_issue184(root: Path) -> dict[str, Any]:
     """Exercise publication without restoring the retired arm to the live registry."""
-    screening_module, historical_registry = _historical_issue184_registry()
     protocol = _PROTOCOLS["issue184"]
-    with pytest.MonkeyPatch.context() as registry_patch:
-        registry_patch.setattr(
-            screening_module,
-            "SCREENING_REGISTRY",
-            historical_registry,
-        )
-        return cast(
-            dict[str, Any],
-            _validate_and_publish_result(
-                protocol_key=protocol.key,
-                root=root,
-                repository_identity=_repository_identity(),
-                runner_receipt=_runner_receipt(),
-                verify_cache_file=False,
-            ),
-        )
+    return cast(
+        dict[str, Any],
+        _validate_and_publish_result(
+            protocol_key=protocol.key,
+            root=root,
+            repository_identity=_repository_identity(),
+            runner_receipt=_runner_receipt(),
+            verify_cache_file=False,
+        ),
+    )
 
 
 @pytest.mark.parametrize(
@@ -1455,18 +1412,12 @@ def test_result_validation_rejects_shards_created_before_cache_receipt(
     prior = Path.cwd()
     os.chdir(tmp_path)
     try:
-        screening_module, historical_registry = _historical_issue184_registry()
-        with pytest.MonkeyPatch.context() as registry_patch:
-            registry_patch.setattr(
-                screening_module,
-                "SCREENING_REGISTRY",
-                historical_registry,
-            )
-            summary = merge_shards(
-                [path.relative_to(tmp_path) for path in paths],
-                control_name="rls_head_resid_l1_preset005",
-                slope_window=15,
-            )
+        summary = merge_shards(
+            [path.relative_to(tmp_path) for path in paths],
+            control_name="rls_head_resid_l1_preset005",
+            slope_window=15,
+            spec_registry=_historical_issue184_registry(),
+        )
     finally:
         os.chdir(prior)
     (namespace / "screen_60/summary.json").write_text(

--- a/tests/test_latent_world_model_update_working_set.py
+++ b/tests/test_latent_world_model_update_working_set.py
@@ -1,0 +1,134 @@
+"""#1383-complete update working-set preflight for the latent world model."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.latent_world_model import (
+    LatentWorldModel,
+    LatentWorldModelConfig,
+    _latent_direct_state_scalars,
+    _latent_update_working_set_bytes,
+    _preflight_latent_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_LATENT_DIM = 10_000
+_LAST_FIT_LATENT_DIM = 9_454
+_FIRST_OVERFLOW_LATENT_DIM = 9_455
+_LINEAR_KWARGS = {
+    "observation_dim": 1,
+    "n_actions": 2,
+    "hidden_sizes": (),
+    "include_action_interactions": False,
+}
+
+
+def _linear_persist_bytes(latent_dim: int) -> int:
+    return 4 * _latent_direct_state_scalars(
+        observation_dim=1,
+        n_actions=2,
+        latent_dim=latent_dim,
+        hidden_sizes=(),
+        include_action_interactions=False,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_latent_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _linear_persist_bytes(_OVERFLOW_LATENT_DIM)
+    working_set_bytes = _latent_update_working_set_bytes(
+        latent_dim=_OVERFLOW_LATENT_DIM,
+        **_LINEAR_KWARGS,
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 800_560_076
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_LATENT_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        LatentWorldModelConfig(latent_dim=_OVERFLOW_LATENT_DIM, **_LINEAR_KWARGS)
+
+
+def test_latent_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for latent_dim in range(_LAST_FIT_LATENT_DIM, _FIRST_OVERFLOW_LATENT_DIM + 2):
+        persist_bytes = _linear_persist_bytes(latent_dim)
+        working_set_bytes = _latent_update_working_set_bytes(
+            latent_dim=latent_dim,
+            **_LINEAR_KWARGS,
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * latent_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = latent_dim
+        elif first_overflow is None:
+            first_overflow = latent_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_LATENT_DIM
+    config = LatentWorldModelConfig(latent_dim=last_fit, **_LINEAR_KWARGS)
+    assert config.latent_dim == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        LatentWorldModelConfig(latent_dim=first_overflow, **_LINEAR_KWARGS)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_latent_update_working_set(
+            latent_dim=_OVERFLOW_LATENT_DIM,
+            **_LINEAR_KWARGS,
+        )
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    with pytest.raises(ValueError, match="combined_direct_state_bytes"):
+        LatentWorldModelConfig(
+            observation_dim=1,
+            n_actions=1,
+            latent_dim=8,
+            hidden_sizes=(16_384, 16_384),
+        )
+
+
+def test_legal_small_latent_world_model_still_constructs() -> None:
+    config = LatentWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        latent_dim=4,
+        hidden_sizes=(),
+    )
+    persist_bytes = 4 * _latent_direct_state_scalars(
+        observation_dim=2,
+        n_actions=2,
+        latent_dim=4,
+        hidden_sizes=(),
+        include_action_interactions=False,
+    )
+    assert persist_bytes == 444
+    model = LatentWorldModel(config)
+    state = model.init(jr.key(0))
+    model.update(
+        state,
+        jnp.zeros((2,), dtype=jnp.float32),
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(0.99, dtype=jnp.float32),
+        jnp.zeros((2,), dtype=jnp.float32),
+    )

--- a/tests/test_learner_optimizer_fallback_truthiness.py
+++ b/tests/test_learner_optimizer_fallback_truthiness.py
@@ -190,6 +190,23 @@ class TestIndependentDemonHordeOptimizerTruthiness:
         assert horde._optimizer is opt
         assert _HostileLMS.calls == 0
 
+    def test_independent_demon_horde_supported_for_mlp_strict_check(self) -> None:
+        spec = _sample_horde_spec()
+        bad_opt = _MockUnsupportedOptimizer(initial_step_size=0.01)
+        with pytest.raises(ValueError, match="does not support the MLP shape-generic"):
+            IndependentDemonHorde(
+                horde_spec=spec,
+                optimizer=bad_opt,  # type: ignore[arg-type]
+            )
+
+        good_opt = LMS(step_size=0.1)
+        with pytest.raises(ValueError, match="head_optimizer.*does not support the MLP"):
+            IndependentDemonHorde(
+                horde_spec=spec,
+                optimizer=good_opt,
+                head_optimizer=bad_opt,  # type: ignore[arg-type]
+            )
+
 
 class TestOffPolicyHordeLearnerOptimizerTruthiness:
     def test_off_policy_horde_preserves_custom_falsy_optimizer(self) -> None:

--- a/tests/test_learning_signals_resource_budget.py
+++ b/tests/test_learning_signals_resource_budget.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import dataclasses
 import json
 
+import jax.numpy as jnp
 import pytest
+from jax import tree_util
 
 from alberta_framework.core.learning_signals import (
     LearningSignalEstimator,
     LearningSignalEstimatorConfig,
     LearningSignalResourceBudget,
+    _learning_signal_observe_working_set_bytes,
+    _preflight_learning_signal_observe_working_set,
 )
 
 
@@ -118,12 +122,69 @@ def test_learning_signal_budget_rejects_unattainable_input_counts(count: int) ->
 
 
 def test_learning_signal_config_gates_exact_derived_input_budget_bound() -> None:
-    largest = LearningSignalEstimatorConfig(ensemble_size=1_073_741_822, target_dim=1)
-    assert (
-        LearningSignalEstimator(largest).resource_budget().input_float_scalars_per_step
-        == 2_147_483_646
-    )
+    with pytest.raises(ValueError, match="observe working set byte count"):
+        LearningSignalEstimatorConfig(ensemble_size=1_073_741_822, target_dim=1)
     with pytest.raises(ValueError, match="input resource budget"):
         LearningSignalEstimatorConfig(ensemble_size=1_073_741_823, target_dim=1)
     with pytest.raises(ValueError, match="input resource budget"):
         LearningSignalEstimatorConfig(ensemble_size=50_000, target_dim=50_000)
+
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_learning_signal_persist_matches_jit_and_input_bytes_still_fit() -> None:
+    config = LearningSignalEstimatorConfig(ensemble_size=2, target_dim=1)
+    estimator = LearningSignalEstimator(config)
+    state = estimator.init()
+    actual = sum(
+        int(leaf.size) * int(leaf.dtype.itemsize)
+        for leaf in tree_util.tree_leaves(state)
+    )
+    assert actual == estimator.resource_budget().persistent_state_bytes == 36
+    target_dim = 45_000_000
+    input_scalars = 2 * 2 * target_dim + target_dim + 1
+    assert input_scalars <= _INT32_MAX
+    assert 4 * input_scalars <= _INT32_MAX
+    assert _learning_signal_observe_working_set_bytes(2, target_dim) > _INT32_MAX
+    with pytest.raises(ValueError, match="observe working set byte count"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=target_dim)
+
+
+def test_learning_signal_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for target_dim in range(31_580_638, 31_580_642):
+        working_set_bytes = _learning_signal_observe_working_set_bytes(2, target_dim)
+        input_scalars = 2 * 2 * target_dim + target_dim + 1
+        assert input_scalars <= _INT32_MAX
+        assert 4 * input_scalars <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = target_dim
+        elif first_overflow is None:
+            first_overflow = target_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    LearningSignalEstimatorConfig(ensemble_size=2, target_dim=last_fit)
+    with pytest.raises(ValueError, match="observe working set byte count"):
+        LearningSignalEstimatorConfig(ensemble_size=2, target_dim=first_overflow)
+
+
+def test_learning_signal_input_scalar_bound_still_fires_first() -> None:
+    with pytest.raises(ValueError, match="input resource budget"):
+        LearningSignalEstimatorConfig(ensemble_size=1_073_741_823, target_dim=1)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="observe working set byte count"):
+        _preflight_learning_signal_observe_working_set(2, 45_000_000)

--- a/tests/test_mixed_horde.py
+++ b/tests/test_mixed_horde.py
@@ -128,6 +128,23 @@ class TestRouting:
 class TestAllSharedEqualsHordeLearner:
     """All-shared MixedHorde matches HordeLearner exactly."""
 
+    def test_update_saturates_step_count_at_int32_max(self) -> None:
+        spec = create_horde_spec([_gamma0_demon("d0", 0)])
+        horde = MixedHorde(horde_spec=spec, hidden_sizes=(4,), sparsity=0.0)
+        state = horde.init(2, jr.key(0)).replace(
+            step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32)
+        )
+
+        result = horde.update(
+            state,
+            jnp.asarray([1.0, 0.0]),
+            jnp.asarray([1.0]),
+            jnp.asarray([0.0, 1.0]),
+        )
+
+        assert bool(result.update_applied)
+        assert int(result.state.step_count) == 2**31 - 1
+
     def test_predictions_match(self) -> None:
         demons = [_gamma0_demon(f"d{i}", i) for i in range(3)]
         spec = create_horde_spec(demons)

--- a/tests/test_model_replay_rehearsal_update_working_set.py
+++ b/tests/test_model_replay_rehearsal_update_working_set.py
@@ -6,7 +6,11 @@ import jax.numpy as jnp
 import jax.random as jr
 import pytest
 
-from alberta_framework.core.dual_replay import DualReplayConfig, _allocation_sizes
+from alberta_framework.core.dual_replay import (
+    DualReplayConfig,
+    _allocation_sizes,
+    _dual_replay_update_working_set_bytes,
+)
 from alberta_framework.core.learning_signals import LearningSignalEstimatorConfig
 from alberta_framework.core.model_replay_rehearsal import (
     ModelReplayRehearsal,
@@ -17,12 +21,14 @@ from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
 from alberta_framework.core.world_model_ensemble import (
     WorldModelEnsembleConfig,
     _ensemble_state_resource_counts,
+    _ensemble_update_working_set_bytes,
 )
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
-_WORKING_SET_OVERFLOW = 9_000
 _COMPOSER_ACCOUNTING_BYTES = 28
+_LAST_COMPOSER_FIT_CAPACITY = 8_624_421
+_FIRST_COMPOSER_OVERFLOW_CAPACITY = 8_624_422
 
 
 def _ensemble(*, observation_dim: int, n_actions: int = 2, ensemble_size: int = 2):
@@ -109,41 +115,41 @@ def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
     assert wrapped_bytes != published_bytes
 
 
-def test_rehearsal_one_bank_and_persistent_fit_while_update_working_set_does_not() -> None:
-    observation_dim = 6_000
+def test_child_updates_fit_while_combined_update_working_set_does_not() -> None:
+    observation_dim = 1
     ensemble = _ensemble(observation_dim=observation_dim)
-    replay = _replay(observation_dim=observation_dim)
+    replay = _replay(
+        observation_dim=observation_dim,
+        total_capacity=_FIRST_COMPOSER_OVERFLOW_CAPACITY,
+    )
     _, ensemble_bytes = _ensemble_state_resource_counts(
         model=ensemble.model, ensemble_size=ensemble.ensemble_size
     )
     _, replay_bytes = _allocation_sizes(replay)
     persistent_bytes = ensemble_bytes + replay_bytes + 28
-    contributor_bytes = 2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
     config = ModelReplayRehearsalConfig(
         ensemble=ensemble, replay=replay, action_encoding="one_hot"
     )
     update_bytes = _working_bytes(config)
-    assert ensemble_bytes <= _INT32_MAX
     assert persistent_bytes <= _INT32_MAX
-    assert contributor_bytes <= _INT32_MAX
+    assert (
+        _ensemble_update_working_set_bytes(
+            model=ensemble.model,
+            ensemble_size=ensemble.ensemble_size,
+        )
+        <= _INT32_MAX
+    )
+    assert (
+        _dual_replay_update_working_set_bytes(
+            total_capacity=replay.total_capacity,
+            observation_dim=replay.observation_dim,
+            action_dim=replay.action_dim,
+            batch_size=replay.batch_size,
+        )
+        <= _INT32_MAX
+    )
     assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
-        ModelReplayRehearsal(config)
-
-
-def test_rehearsal_persistent_byte_bound_still_fires_first() -> None:
-    ensemble = _ensemble(observation_dim=10_000)
-    replay = _replay(observation_dim=10_000, total_capacity=7_000)
-    _, ensemble_bytes = _ensemble_state_resource_counts(
-        model=ensemble.model, ensemble_size=ensemble.ensemble_size
-    )
-    _, replay_bytes = _allocation_sizes(replay)
-    assert ensemble_bytes <= _INT32_MAX
-    assert ensemble_bytes + replay_bytes + 28 > _INT32_MAX
-    config = ModelReplayRehearsalConfig(
-        ensemble=ensemble, replay=replay, action_encoding="one_hot"
-    )
-    with pytest.raises(ValueError, match="state byte count"):
         ModelReplayRehearsal(config)
 
 
@@ -162,24 +168,15 @@ def test_legal_rehearsal_init_identity_is_unchanged() -> None:
 
 
 def test_rehearsal_exact_last_legal_working_set_and_first_overflow() -> None:
-    def config(observation_dim: int) -> ModelReplayRehearsalConfig:
+    def config(total_capacity: int) -> ModelReplayRehearsalConfig:
         return ModelReplayRehearsalConfig(
-            ensemble=_ensemble(observation_dim=observation_dim),
-            replay=_replay(observation_dim=observation_dim),
+            ensemble=_ensemble(observation_dim=1),
+            replay=_replay(observation_dim=1, total_capacity=total_capacity),
             action_encoding="one_hot",
         )
 
-    low, high = 1, _WORKING_SET_OVERFLOW
-    while low < high:
-        middle = (low + high + 1) // 2
-        candidate = config(middle)
-        if _working_bytes(candidate) <= _INT32_MAX:
-            low = middle
-        else:
-            high = middle - 1
-
-    last_legal = config(low)
-    first_overflowing = config(low + 1)
+    last_legal = config(_LAST_COMPOSER_FIT_CAPACITY)
+    first_overflowing = config(_FIRST_COMPOSER_OVERFLOW_CAPACITY)
     assert _working_bytes(last_legal) <= _INT32_MAX
     assert _working_bytes(first_overflowing) > _INT32_MAX
     _preflight_model_replay_state_resources(last_legal)
@@ -188,12 +185,12 @@ def test_rehearsal_exact_last_legal_working_set_and_first_overflow() -> None:
 
 
 def test_rehearsal_general_shape_formula_preflights_before_child_allocation() -> None:
-    observation_dim = 5_000
+    observation_dim = 2
     ensemble = _ensemble(observation_dim=observation_dim, n_actions=5, ensemble_size=3)
     replay = _replay(
         observation_dim=observation_dim,
         action_dim=5,
-        total_capacity=4,
+        total_capacity=6_949_773,
     )
     config = ModelReplayRehearsalConfig(
         ensemble=ensemble,
@@ -206,10 +203,17 @@ def test_rehearsal_general_shape_formula_preflights_before_child_allocation() ->
     )
     _, replay_bytes = _allocation_sizes(replay)
     persistent_bytes = ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
-    contributor_bytes = 2 * ensemble_bytes + replay_bytes + _COMPOSER_ACCOUNTING_BYTES
     update_bytes = _working_bytes(config)
     assert persistent_bytes <= _INT32_MAX
-    assert contributor_bytes <= _INT32_MAX
+    assert (
+        _dual_replay_update_working_set_bytes(
+            total_capacity=replay.total_capacity,
+            observation_dim=replay.observation_dim,
+            action_dim=replay.action_dim,
+            batch_size=replay.batch_size,
+        )
+        <= _INT32_MAX
+    )
     assert update_bytes > _INT32_MAX
     with pytest.raises(ValueError, match="update working set byte count"):
         ModelReplayRehearsal(config)

--- a/tests/test_model_replay_rehearsal_validation.py
+++ b/tests/test_model_replay_rehearsal_validation.py
@@ -198,16 +198,6 @@ def test_composer_rejects_observation_dim_mismatch() -> None:
         )
 
 
-def test_composer_rejects_n_actions_exceeds_exact_float32() -> None:
-    # _MAX_EXACT_FLOAT32_INTEGER is 16_777_216
-    ensemble = _ensemble(n_actions=16_777_217)
-    replay = _replay(action_dim=16_777_217)
-    with pytest.raises(ValueError, match="exceeds exact float32"):
-        ModelReplayRehearsalConfig(
-            ensemble=ensemble, replay=replay, action_encoding="one_hot"
-        )
-
-
 def test_composer_rejects_action_dim_mismatch_for_encodings() -> None:
     ensemble = _ensemble(n_actions=4)
     # scalar_index requires action_dim == 1

--- a/tests/test_multi_head_learner.py
+++ b/tests/test_multi_head_learner.py
@@ -235,9 +235,14 @@ class TestMultiHeadInit:
             linear.init(2**30, jr.key(0))
         assert calls == 0
 
+        overflow = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(1,))
+        with pytest.raises(ValueError, match="update working set byte count"):
+            overflow.init(268_435_450, jr.key(0))
+        assert calls == 0
+
         boundary = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(1,))
         with pytest.raises(AssertionError, match="allocator reached"):
-            boundary.init(268_435_450, jr.key(0))
+            boundary.init(89_478_436, jr.key(0))
         assert calls == 1
 
     def test_aggregate_direct_state_resources_fail_before_allocation(self):

--- a/tests/test_multi_head_learner_update_working_set.py
+++ b/tests/test_multi_head_learner_update_working_set.py
@@ -1,0 +1,140 @@
+"""#1383-complete update working-set preflight for the multi-head MLP learner."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.multi_head_learner import (
+    MultiHeadMLPLearner,
+    _direct_state_bytes,
+    _multi_head_update_working_set_bytes,
+    _preflight_multi_head_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_HIDDEN = 30_000_000
+_LAST_FIT_HIDDEN = 25_565_280
+_FIRST_OVERFLOW_HIDDEN = 25_565_281
+_OVERFLOW_FEATURE_DIM = 90_000_000
+_LAST_FIT_FEATURE_DIM = 89_478_480
+_FIRST_OVERFLOW_FEATURE_DIM = 89_478_481
+
+
+def _unit_persist_bytes(hidden: int) -> int:
+    return _direct_state_bytes(1, (hidden,), 1)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _unit_persist_bytes(_OVERFLOW_HIDDEN)
+    working_set_bytes = _multi_head_update_working_set_bytes(
+        1, (_OVERFLOW_HIDDEN,), 1
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 840_000_020
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_HIDDEN <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        MultiHeadMLPLearner(n_heads=1, hidden_sizes=(_OVERFLOW_HIDDEN,))
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for hidden in range(_LAST_FIT_HIDDEN, _FIRST_OVERFLOW_HIDDEN + 2):
+        persist_bytes = _unit_persist_bytes(hidden)
+        working_set_bytes = _multi_head_update_working_set_bytes(1, (hidden,), 1)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * hidden <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = hidden
+        elif first_overflow is None:
+            first_overflow = hidden
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_HIDDEN
+    learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(last_fit,))
+    assert learner._hidden_sizes == (last_fit,)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        MultiHeadMLPLearner(n_heads=1, hidden_sizes=(first_overflow,))
+
+
+def test_init_rejects_linear_feature_dim_working_set_before_allocation() -> None:
+    persist_bytes = _direct_state_bytes(1, (), _OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _multi_head_update_working_set_bytes(
+        1, (), _OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 720_000_020
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=())
+    with pytest.raises(ValueError, match="update working set byte count"):
+        learner.init(_OVERFLOW_FEATURE_DIM, jr.key(0))
+
+
+def test_init_last_fit_and_first_overflow_feature_dims_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(
+        _LAST_FIT_FEATURE_DIM, _FIRST_OVERFLOW_FEATURE_DIM + 2
+    ):
+        persist_bytes = _direct_state_bytes(1, (), feature_dim)
+        working_set_bytes = _multi_head_update_working_set_bytes(
+            1, (), feature_dim
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURE_DIM
+    _preflight_multi_head_update_working_set(1, (), last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_multi_head_update_working_set(1, (), first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_multi_head_update_working_set(1, (_OVERFLOW_HIDDEN,), 1)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    with pytest.raises(ValueError, match="direct_state_bytes"):
+        MultiHeadMLPLearner(n_heads=134_217_728, hidden_sizes=())
+
+
+def test_legal_small_multi_head_learner_still_constructs() -> None:
+    persist_bytes = _direct_state_bytes(2, (4,), 3)
+    assert persist_bytes == 236
+    learner = MultiHeadMLPLearner(
+        n_heads=2, hidden_sizes=(4,), sparsity=0.0, use_layer_norm=False
+    )
+    state = learner.init(feature_dim=3, key=jr.key(0))
+    learner.update(
+        state,
+        jnp.zeros((3,), dtype=jnp.float32),
+        jnp.zeros((2,), dtype=jnp.float32),
+    )

--- a/tests/test_normalizers_update_working_set.py
+++ b/tests/test_normalizers_update_working_set.py
@@ -1,0 +1,146 @@
+"""#1383-complete update working-set preflight for online normalizers."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.normalizers import (
+    EMANormalizer,
+    StreamingBatchNormalizer,
+    WelfordNormalizer,
+    _normalizer_update_working_set_bytes,
+    _preflight_normalizer_update_working_set,
+    normalizer_state_nbytes_formula,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_EMA_OVERFLOW_FEATURE_DIM = 80_000_000
+_EMA_LAST_FIT = 76_695_842
+_EMA_FIRST_OVERFLOW = 76_695_843
+_WELFORD_OVERFLOW_FEATURE_DIM = 60_000_000
+_WELFORD_LAST_FIT = 53_687_089
+_WELFORD_FIRST_OVERFLOW = 53_687_090
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_ema_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = normalizer_state_nbytes_formula(
+        "EMANormalizer", _EMA_OVERFLOW_FEATURE_DIM
+    )
+    working_set_bytes = _normalizer_update_working_set_bytes(
+        persist_bytes, _EMA_OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 640_000_016
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _EMA_OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        EMANormalizer().init(_EMA_OVERFLOW_FEATURE_DIM)
+    with pytest.raises(ValueError, match="working set byte count"):
+        StreamingBatchNormalizer().init(_EMA_OVERFLOW_FEATURE_DIM)
+
+
+def test_ema_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_EMA_LAST_FIT, _EMA_FIRST_OVERFLOW + 2):
+        persist_bytes = normalizer_state_nbytes_formula("EMANormalizer", feature_dim)
+        working_set_bytes = _normalizer_update_working_set_bytes(
+            persist_bytes, feature_dim
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _EMA_LAST_FIT
+    _preflight_normalizer_update_working_set(
+        "EMANormalizer",
+        normalizer_state_nbytes_formula("EMANormalizer", last_fit),
+        last_fit,
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        EMANormalizer().init(first_overflow)
+    with pytest.raises(ValueError, match="working set byte count"):
+        StreamingBatchNormalizer().init(first_overflow)
+
+
+def test_welford_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = normalizer_state_nbytes_formula(
+        "WelfordNormalizer", _WELFORD_OVERFLOW_FEATURE_DIM
+    )
+    working_set_bytes = _normalizer_update_working_set_bytes(
+        persist_bytes, _WELFORD_OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 720_000_012
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _WELFORD_OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        WelfordNormalizer().init(_WELFORD_OVERFLOW_FEATURE_DIM)
+
+
+def test_welford_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_WELFORD_LAST_FIT, _WELFORD_FIRST_OVERFLOW + 2):
+        persist_bytes = normalizer_state_nbytes_formula("WelfordNormalizer", feature_dim)
+        working_set_bytes = _normalizer_update_working_set_bytes(
+            persist_bytes, feature_dim
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _WELFORD_LAST_FIT
+    _preflight_normalizer_update_working_set(
+        "WelfordNormalizer",
+        normalizer_state_nbytes_formula("WelfordNormalizer", last_fit),
+        last_fit,
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        WelfordNormalizer().init(first_overflow)
+
+
+def test_persist_formula_still_names_int32_max() -> None:
+    persist_bytes = normalizer_state_nbytes_formula("EMANormalizer", _INT32_MAX)
+    assert persist_bytes == 8 * _INT32_MAX + 16
+    assert persist_bytes > _INT32_MAX
+
+
+def test_legal_small_normalizers_still_update() -> None:
+    observation = jnp.ones((5,), dtype=jnp.float32)
+    ema = EMANormalizer()
+    assert normalizer_state_nbytes_formula("EMANormalizer", 5) == 56
+    ema.normalize_with_diagnostics(ema.init(5), observation)
+    welford = WelfordNormalizer()
+    assert normalizer_state_nbytes_formula("WelfordNormalizer", 5) == 72
+    welford.normalize_with_diagnostics(welford.init(5), observation)
+    streaming = StreamingBatchNormalizer()
+    streaming.normalize_with_diagnostics(streaming.init(5), observation)

--- a/tests/test_oak_prototype_fixes.py
+++ b/tests/test_oak_prototype_fixes.py
@@ -373,9 +373,8 @@ def test_oak_and_keyboard_close_schema_float32_and_resource_boundaries() -> None
         )
 
     stomp_only_limit = (2**29 - 1 - 22) // 4
-    stomp = STOMPConfig(observation_dim=stomp_only_limit, n_primitive_actions=1)
-    with pytest.raises(ValueError, match="OaK direct array bytes"):
-        OaKConfig(stomp=stomp)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        STOMPConfig(observation_dim=stomp_only_limit, n_primitive_actions=1)
 
     last_legal_keyboard_options = (2**31 - 1) // 4 - 2
     KeyboardChordLearnerConfig(n_options=last_legal_keyboard_options)

--- a/tests/test_oak_update_working_set.py
+++ b/tests/test_oak_update_working_set.py
@@ -1,0 +1,112 @@
+"""#1383-complete update working-set preflight for the OaK host."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.oak import (
+    OaKAgent,
+    OaKConfig,
+    _oak_direct_state_bytes,
+    _oak_update_working_set_bytes,
+    _preflight_oak_update_working_set,
+)
+from alberta_framework.core.options import STOMPConfig, SubtaskSpec
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_OBS = 20_000
+_LAST_FIT_OBS = 13_373
+_FIRST_OVERFLOW_OBS = 13_374
+_UNIT_STOMP = {
+    "n_primitive_actions": 1,
+    "base_hidden_sizes": (),
+}
+
+
+def _unit_stomp(observation_dim: int) -> STOMPConfig:
+    return STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=observation_dim,
+        **_UNIT_STOMP,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    stomp = _unit_stomp(_OVERFLOW_OBS)
+    persist_bytes = _oak_direct_state_bytes(stomp)
+    working_set_bytes = _oak_update_working_set_bytes(stomp)
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 1_600_640_172
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_OBS <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        OaKConfig(stomp=stomp)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for observation_dim in range(_LAST_FIT_OBS, _FIRST_OVERFLOW_OBS + 2):
+        stomp = _unit_stomp(observation_dim)
+        persist_bytes = _oak_direct_state_bytes(stomp)
+        working_set_bytes = _oak_update_working_set_bytes(stomp)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * observation_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = observation_dim
+        elif first_overflow is None:
+            first_overflow = observation_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_OBS
+    config = OaKConfig(stomp=_unit_stomp(last_fit))
+    assert config.observation_dim == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        OaKConfig(stomp=_unit_stomp(first_overflow))
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_oak_update_working_set(_unit_stomp(_OVERFLOW_OBS))
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    stomp_only_limit = (2**29 - 1 - 22) // 4
+    stomp = STOMPConfig(observation_dim=stomp_only_limit, n_primitive_actions=1)
+    with pytest.raises(ValueError, match="OaK direct array bytes"):
+        OaKConfig(stomp=stomp)
+
+
+def test_legal_small_oak_still_constructs() -> None:
+    stomp = STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=4,
+        n_primitive_actions=2,
+        base_hidden_sizes=(),
+    )
+    persist_bytes = _oak_direct_state_bytes(stomp)
+    assert persist_bytes == 444
+    agent = OaKAgent(OaKConfig(stomp=stomp))
+    state = agent.init(jr.key(0))
+    agent.update(
+        state,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.zeros((4,), dtype=jnp.float32),
+    )

--- a/tests/test_oak_update_working_set.py
+++ b/tests/test_oak_update_working_set.py
@@ -13,24 +13,26 @@ from alberta_framework.core.oak import (
     _oak_update_working_set_bytes,
     _preflight_oak_update_working_set,
 )
-from alberta_framework.core.options import STOMPConfig, SubtaskSpec
+from alberta_framework.core.options import (
+    STOMPConfig,
+    SubtaskSpec,
+    _stomp_direct_state_bytes,
+    _stomp_update_working_set_bytes,
+)
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
-_OVERFLOW_OBS = 20_000
-_LAST_FIT_OBS = 13_373
-_FIRST_OVERFLOW_OBS = 13_374
-_UNIT_STOMP = {
-    "n_primitive_actions": 1,
-    "base_hidden_sizes": (),
-}
+_LAST_OAK_FIT_HIDDEN = 19_884_101
+_FIRST_OAK_OVERFLOW_HIDDEN = 19_884_102
 
 
-def _unit_stomp(observation_dim: int) -> STOMPConfig:
+def _boundary_stomp(hidden_width: int) -> STOMPConfig:
+    """Return a valid STOMP config tuned to the narrower OaK-only boundary."""
     return STOMPConfig(
         subtask_specs=(SubtaskSpec(feature_index=0),),
-        observation_dim=observation_dim,
-        **_UNIT_STOMP,
+        observation_dim=1,
+        n_primitive_actions=1,
+        base_hidden_sizes=(hidden_width,),
     )
 
 
@@ -43,55 +45,59 @@ def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
     assert wrapped_bytes != published_bytes
 
 
-def test_named_persist_and_width_still_fit_at_overflow() -> None:
-    stomp = _unit_stomp(_OVERFLOW_OBS)
+def test_valid_stomp_reaches_the_oak_only_update_boundary() -> None:
+    stomp = _boundary_stomp(_FIRST_OAK_OVERFLOW_HIDDEN)
+    stomp_persist_bytes = _stomp_direct_state_bytes(stomp)
+    stomp_working_set_bytes = _stomp_update_working_set_bytes(stomp)
     persist_bytes = _oak_direct_state_bytes(stomp)
     working_set_bytes = _oak_update_working_set_bytes(stomp)
     extras_bytes = working_set_bytes - 3 * persist_bytes
-    assert persist_bytes == 1_600_640_172
+
+    assert stomp_persist_bytes == 715_827_848
+    assert stomp_working_set_bytes == 2_147_483_608
+    assert stomp_working_set_bytes <= _INT32_MAX
+    assert persist_bytes == 715_827_872
     assert persist_bytes <= _INT32_MAX
     assert persist_bytes + extras_bytes <= _INT32_MAX
-    assert 4 * _OVERFLOW_OBS <= _INT32_MAX
+    assert 4 * _FIRST_OAK_OVERFLOW_HIDDEN <= _INT32_MAX
     assert 4 * 1 <= _INT32_MAX
-    assert working_set_bytes > _INT32_MAX
+    assert working_set_bytes == 2_147_483_672
     with pytest.raises(ValueError, match="update working set byte count"):
         OaKConfig(stomp=stomp)
 
 
-def test_last_fit_and_first_overflow_are_adjacent() -> None:
-    last_fit = None
-    first_overflow = None
-    for observation_dim in range(_LAST_FIT_OBS, _FIRST_OVERFLOW_OBS + 2):
-        stomp = _unit_stomp(observation_dim)
-        persist_bytes = _oak_direct_state_bytes(stomp)
-        working_set_bytes = _oak_update_working_set_bytes(stomp)
-        extras_bytes = working_set_bytes - 3 * persist_bytes
-        assert persist_bytes <= _INT32_MAX
-        assert persist_bytes + extras_bytes <= _INT32_MAX
-        assert 4 * observation_dim <= _INT32_MAX
-        if working_set_bytes <= _INT32_MAX:
-            last_fit = observation_dim
-        elif first_overflow is None:
-            first_overflow = observation_dim
-            break
-    assert last_fit is not None and first_overflow == last_fit + 1
-    assert last_fit == _LAST_FIT_OBS
-    config = OaKConfig(stomp=_unit_stomp(last_fit))
-    assert config.observation_dim == last_fit
+def test_adjacent_hidden_widths_straddle_only_the_oak_boundary() -> None:
+    assert _FIRST_OAK_OVERFLOW_HIDDEN == _LAST_OAK_FIT_HIDDEN + 1
+    last_stomp = _boundary_stomp(_LAST_OAK_FIT_HIDDEN)
+    first_stomp = _boundary_stomp(_FIRST_OAK_OVERFLOW_HIDDEN)
+
+    assert _stomp_update_working_set_bytes(last_stomp) <= _INT32_MAX
+    assert _stomp_update_working_set_bytes(first_stomp) <= _INT32_MAX
+    assert _oak_update_working_set_bytes(last_stomp) == 2_147_483_564
+    assert _oak_update_working_set_bytes(first_stomp) == 2_147_483_672
+
+    config = OaKConfig(stomp=last_stomp)
+    assert config.stomp.base_hidden_sizes == (_LAST_OAK_FIT_HIDDEN,)
     with pytest.raises(ValueError, match="update working set byte count"):
-        OaKConfig(stomp=_unit_stomp(first_overflow))
+        OaKConfig(stomp=first_stomp)
 
 
 def test_preflight_helper_rejects_the_same_working_set() -> None:
     with pytest.raises(ValueError, match="update working set byte count"):
-        _preflight_oak_update_working_set(_unit_stomp(_OVERFLOW_OBS))
+        _preflight_oak_update_working_set(
+            _boundary_stomp(_FIRST_OAK_OVERFLOW_HIDDEN)
+        )
 
 
-def test_persist_bound_still_fires_before_working_set() -> None:
-    stomp_only_limit = (2**29 - 1 - 22) // 4
-    stomp = STOMPConfig(observation_dim=stomp_only_limit, n_primitive_actions=1)
-    with pytest.raises(ValueError, match="OaK direct array bytes"):
-        OaKConfig(stomp=stomp)
+def test_nested_stomp_overflow_is_not_mislabeled_as_oak_coverage() -> None:
+    """The former observation-width fixture now fails in STOMP, before OaK."""
+    with pytest.raises(ValueError, match="STOMP update working set"):
+        STOMPConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0),),
+            observation_dim=20_000,
+            n_primitive_actions=1,
+            base_hidden_sizes=(),
+        )
 
 
 def test_legal_small_oak_still_constructs() -> None:

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -642,3 +642,66 @@ def test_option_duration_array_runner_requires_exact_shapes() -> None:
             jnp.ones((2, 2), dtype=jnp.float32),
             jnp.zeros((2,), dtype=jnp.float32),
         )
+
+
+def test_array_runner_rejects_untrusted_inputs_without_running_conversion_hooks() -> None:
+    """The array runner must gate on array metadata before any conversion.
+
+    ``_require_array`` reached ``jnp.asarray(value)`` before validating
+    anything, so an untrusted ``__array__`` hook executed ahead of the shape
+    and dtype checks and chose the value they then saw. The public ``update``
+    path is gated by an outer contract check; the array runner called the
+    helper directly.
+    """
+
+    class _HostileArray:
+        def __array__(self, dtype: object = None, copy: object = None) -> np.ndarray:
+            raise AssertionError("array hook must not run")
+
+    learner = OptionValueDurationLearner(3, OptionValueDurationConfig())
+    state = learner.init(2)
+    steps = 2
+    observations = jnp.zeros((steps, 2), dtype=jnp.float32)
+    next_observations = jnp.zeros((steps, 2), dtype=jnp.float32)
+    rewards = jnp.zeros((steps,), dtype=jnp.float32)
+    discounts = jnp.zeros((steps,), dtype=jnp.float32)
+    option_indices = jnp.zeros((steps,), dtype=jnp.int32)
+
+    with pytest.raises(TypeError, match="shape and dtype metadata"):
+        run_option_value_duration_from_arrays(
+            learner,
+            state,
+            observations,
+            _HostileArray(),
+            rewards,
+            next_observations,
+            discounts,
+        )
+
+    with pytest.raises(TypeError, match="shape and dtype metadata"):
+        run_option_value_duration_from_arrays(
+            learner,
+            state,
+            observations,
+            option_indices,
+            _HostileArray(),
+            next_observations,
+            discounts,
+        )
+
+
+def test_array_runner_still_accepts_trusted_arrays() -> None:
+    """The metadata gate must not reject the arrays the runner already supports."""
+    learner = OptionValueDurationLearner(3, OptionValueDurationConfig())
+    state = learner.init(2)
+    steps = 2
+    result = run_option_value_duration_from_arrays(
+        learner,
+        state,
+        jnp.zeros((steps, 2), dtype=jnp.float32),
+        np.zeros((steps,), dtype=np.int32),
+        jnp.zeros((steps,), dtype=jnp.float32),
+        jnp.zeros((steps, 2), dtype=jnp.float32),
+        jnp.zeros((steps,), dtype=jnp.float32),
+    )
+    chex.assert_tree_all_finite(result.predictions)

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -644,19 +644,22 @@ def test_option_duration_array_runner_requires_exact_shapes() -> None:
         )
 
 
-def test_array_runner_rejects_untrusted_inputs_without_running_conversion_hooks() -> None:
-    """The array runner must gate on array metadata before any conversion.
+def test_array_runner_rejects_without_dispatching_hostile_metadata() -> None:
+    """Identity validation must precede even shape and dtype property access."""
 
-    ``_require_array`` reached ``jnp.asarray(value)`` before validating
-    anything, so an untrusted ``__array__`` hook executed ahead of the shape
-    and dtype checks and chose the value they then saw. The public ``update``
-    path is gated by an outer contract check; the array runner called the
-    helper directly.
-    """
+    class _HostileMetadata:
+        shape_reads = 0
+        dtype_reads = 0
 
-    class _HostileArray:
-        def __array__(self, dtype: object = None, copy: object = None) -> np.ndarray:
-            raise AssertionError("array hook must not run")
+        @property
+        def shape(self) -> tuple[int, ...]:
+            type(self).shape_reads += 1
+            raise AssertionError("shape property must not run")
+
+        @property
+        def dtype(self) -> np.dtype[np.int32]:
+            type(self).dtype_reads += 1
+            raise AssertionError("dtype property must not run")
 
     learner = OptionValueDurationLearner(3, OptionValueDurationConfig())
     state = learner.init(2)
@@ -665,29 +668,58 @@ def test_array_runner_rejects_untrusted_inputs_without_running_conversion_hooks(
     next_observations = jnp.zeros((steps, 2), dtype=jnp.float32)
     rewards = jnp.zeros((steps,), dtype=jnp.float32)
     discounts = jnp.zeros((steps,), dtype=jnp.float32)
-    option_indices = jnp.zeros((steps,), dtype=jnp.int32)
 
-    with pytest.raises(TypeError, match="shape and dtype metadata"):
+    with pytest.raises(TypeError, match="trusted array metadata"):
         run_option_value_duration_from_arrays(
             learner,
             state,
             observations,
-            _HostileArray(),
+            _HostileMetadata(),
             rewards,
             next_observations,
             discounts,
         )
+    assert _HostileMetadata.shape_reads == 0
+    assert _HostileMetadata.dtype_reads == 0
 
-    with pytest.raises(TypeError, match="shape and dtype metadata"):
+
+def test_array_runner_rejects_spoofed_metadata_without_conversion() -> None:
+    """Plausible public metadata must not authorize an arbitrary conversion hook."""
+
+    class _SpoofedArray:
+        shape = (2,)
+        dtype = np.dtype(np.float32)
+        class_reads = 0
+        conversions = 0
+
+        @property
+        def __class__(self) -> type[jax.Array]:
+            type(self).class_reads += 1
+            return jax.Array
+
+        def __array__(self, dtype: object = None, copy: object = None) -> np.ndarray:
+            type(self).conversions += 1
+            raise AssertionError("array conversion hook must not run")
+
+    learner = OptionValueDurationLearner(3, OptionValueDurationConfig())
+    state = learner.init(2)
+    observations = jnp.zeros((2, 2), dtype=jnp.float32)
+    option_indices = jnp.zeros((2,), dtype=jnp.int32)
+    next_observations = jnp.zeros((2, 2), dtype=jnp.float32)
+    discounts = jnp.zeros((2,), dtype=jnp.float32)
+
+    with pytest.raises(TypeError, match="trusted array metadata"):
         run_option_value_duration_from_arrays(
             learner,
             state,
             observations,
             option_indices,
-            _HostileArray(),
+            _SpoofedArray(),
             next_observations,
             discounts,
         )
+    assert _SpoofedArray.class_reads == 0
+    assert _SpoofedArray.conversions == 0
 
 
 def test_array_runner_still_accepts_trusted_arrays() -> None:
@@ -704,4 +736,21 @@ def test_array_runner_still_accepts_trusted_arrays() -> None:
         jnp.zeros((steps, 2), dtype=jnp.float32),
         jnp.zeros((steps,), dtype=jnp.float32),
     )
+    chex.assert_tree_all_finite(result.predictions)
+
+
+def test_array_runner_accepts_jax_arrays_under_jit() -> None:
+    learner = OptionValueDurationLearner(3, OptionValueDurationConfig())
+    state = learner.init(2)
+    observations = jnp.zeros((2, 2), dtype=jnp.float32)
+    option_indices = jnp.zeros((2,), dtype=jnp.int32)
+    rewards = jnp.zeros((2,), dtype=jnp.float32)
+    discounts = jnp.zeros((2,), dtype=jnp.float32)
+
+    compiled = jax.jit(
+        lambda obs, indices, rs, next_obs, ds: run_option_value_duration_from_arrays(
+            learner, state, obs, indices, rs, next_obs, ds
+        )
+    )
+    result = compiled(observations, option_indices, rewards, observations, discounts)
     chex.assert_tree_all_finite(result.predictions)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -453,7 +453,8 @@ def test_stomp_closes_float32_schema_and_direct_resource_boundaries() -> None:
         SubtaskSpec(feature_index=0, threshold=1.0e100)
 
     last_legal_observation_dim = (2**29 - 1 - 22) // 4
-    STOMPConfig(observation_dim=last_legal_observation_dim, n_primitive_actions=1)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        STOMPConfig(observation_dim=last_legal_observation_dim, n_primitive_actions=1)
     with pytest.raises(ValueError, match="direct array bytes"):
         STOMPConfig(observation_dim=last_legal_observation_dim + 1, n_primitive_actions=1)
 

--- a/tests/test_pavlovian_update_working_set.py
+++ b/tests/test_pavlovian_update_working_set.py
@@ -1,0 +1,119 @@
+"""#1383-complete step working-set preflight for Pavlovian streams."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.streams.pavlovian import (
+    ClassicalConditioningStream,
+    PavlovianPhase,
+    _pavlovian_persistent_bytes,
+    _pavlovian_step_working_set_bytes,
+    _preflight_pavlovian_step_working_set,
+    _require_pavlovian_resources,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_N_CS = 80_000_000
+_LAST_FIT_N_CS = 76_695_840
+_FIRST_OVERFLOW_N_CS = 76_695_841
+
+
+def _unit_phase() -> PavlovianPhase:
+    return PavlovianPhase(
+        name="acq",
+        n_steps=10,
+        cs_us_contingency=1.0,
+        cs_active=(0,),
+    )
+
+
+def _unit_stream(n_cs: int, n_distractors: int = 0) -> ClassicalConditioningStream:
+    return ClassicalConditioningStream(
+        phases=(_unit_phase(),),
+        n_cs=n_cs,
+        n_distractors=n_distractors,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _pavlovian_persistent_bytes(
+        n_phases=1, n_cs=_OVERFLOW_N_CS, n_distractors=0
+    )
+    working_set_bytes = _pavlovian_step_working_set_bytes(
+        n_phases=1, n_cs=_OVERFLOW_N_CS, n_distractors=0
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 640_000_040
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_N_CS <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        _unit_stream(_OVERFLOW_N_CS)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for n_cs in range(_LAST_FIT_N_CS, _FIRST_OVERFLOW_N_CS + 2):
+        persist_bytes = _pavlovian_persistent_bytes(
+            n_phases=1, n_cs=n_cs, n_distractors=0
+        )
+        working_set_bytes = _pavlovian_step_working_set_bytes(
+            n_phases=1, n_cs=n_cs, n_distractors=0
+        )
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * n_cs <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = n_cs
+        elif first_overflow is None:
+            first_overflow = n_cs
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_N_CS
+    _preflight_pavlovian_step_working_set(
+        n_phases=1, n_cs=last_fit, n_distractors=0
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        _preflight_pavlovian_step_working_set(
+            n_phases=1, n_cs=first_overflow, n_distractors=0
+        )
+    with pytest.raises(ValueError, match="working set byte count"):
+        _unit_stream(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="working set byte count"):
+        _preflight_pavlovian_step_working_set(
+            n_phases=1, n_cs=_OVERFLOW_N_CS, n_distractors=0
+        )
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    _require_pavlovian_resources(n_phases=1, n_cs=1, n_distractors=0)
+    with pytest.raises(ValueError, match="byte count must fit signed int32"):
+        _unit_stream(_INT32_MAX // 4)
+
+
+def test_legal_small_pavlovian_still_steps() -> None:
+    persist_bytes = _pavlovian_persistent_bytes(n_phases=1, n_cs=3, n_distractors=2)
+    assert persist_bytes == 72
+    stream = _unit_stream(3, n_distractors=2)
+    state = stream.init(jr.key(0))
+    stream.step(state, jnp.asarray(0, dtype=jnp.int32))

--- a/tests/test_prototype_memory.py
+++ b/tests/test_prototype_memory.py
@@ -28,6 +28,29 @@ def test_prototype_memory_init_shapes() -> None:
     chex.assert_tree_all_finite(state)
 
 
+def test_prototype_memory_hit_count_is_int32_and_saturates() -> None:
+    """Hit counts must be exact past 2**24 and saturate instead of stalling."""
+
+    config = PrototypeMemoryConfig(feature_dim=2, n_classes=2, slots_per_class=1)
+    learner = PrototypeMemoryLearner(config)
+    state = learner.init()
+    assert state.counts.dtype == jnp.dtype(jnp.int32)
+    target = jnp.asarray([1.0, 0.0], dtype=jnp.float32)
+
+    planted = state.replace(
+        counts=jnp.array([[16777216], [0]], dtype=jnp.int32),
+        means=jnp.array([[[1.0, 1.0]], [[0.0, 0.0]]], dtype=jnp.float32),
+    )
+    result = learner.update(planted, jnp.ones((2,), dtype=jnp.float32), target)
+    assert int(result.state.counts[0, 0]) == 16777217
+
+    exhausted = result.state.replace(
+        counts=result.state.counts.at[0, 0].set(2**31 - 1)
+    )
+    final = learner.update(exhausted, jnp.ones((2,), dtype=jnp.float32), target)
+    assert int(final.state.counts[0, 0]) == 2**31 - 1
+
+
 def test_empty_memory_predicts_uniformly() -> None:
     """With no prototypes, softmax logits should be neutral."""
     learner = PrototypeMemoryLearner(

--- a/tests/test_prototype_memory.py
+++ b/tests/test_prototype_memory.py
@@ -51,6 +51,26 @@ def test_prototype_memory_hit_count_is_int32_and_saturates() -> None:
     assert int(final.state.counts[0, 0]) == 2**31 - 1
 
 
+def test_replacement_uses_exact_integer_minimum_past_float32_precision() -> None:
+    """An older, higher-count slot must not join the least-used tie set."""
+
+    learner = PrototypeMemoryLearner(
+        PrototypeMemoryConfig(feature_dim=2, n_classes=2, slots_per_class=2)
+    )
+    state = learner.init().replace(
+        counts=jnp.asarray([[2**24, 2**24 + 1], [0, 0]], dtype=jnp.int32),
+        last_update=jnp.asarray([[2, 1], [0, 0]], dtype=jnp.int32),
+        step_count=jnp.asarray(2, dtype=jnp.int32),
+    )
+    head = jnp.asarray(0, dtype=jnp.int32)
+
+    eager_slot = learner._replacement_slot(state, head)
+    jitted_slot = jax.jit(learner._replacement_slot)(state, head)
+
+    assert int(eager_slot) == 0
+    assert int(jitted_slot) == 0
+
+
 def test_empty_memory_predicts_uniformly() -> None:
     """With no prototypes, softmax logits should be neutral."""
     learner = PrototypeMemoryLearner(

--- a/tests/test_recurring_comparator_hostile.py
+++ b/tests/test_recurring_comparator_hostile.py
@@ -1,0 +1,136 @@
+"""Hostile comparator gate for recurring feature artifact before hash."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.recurring_feature_artifact import (
+    CANONICALIZATION,
+    DIGEST_ALGORITHM,
+    DIGEST_SCOPE,
+    SCHEMA_VERSION,
+    validate_recurring_feature_artifact,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __len__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile len must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+    def __str__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile str must not run")
+
+
+def _artifact_with_hostile_comparator(hostile: object) -> dict[str, object]:
+    # Minimal artifact that reaches comparator validation
+    # Keep top-level and scientific_payload keys to ensure _validate_checks is called
+    hostile_check = {
+        "name": "canonical_protocol",
+        "passed": True,
+        "actual": 1.0,
+        "comparator": hostile,
+        "threshold": 1.0,
+        "detail": "dummy detail for test",
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scientific_payload": {
+            "protocol": {},
+            "configuration": {},
+            "criteria": {},
+            "bootstrap": {},
+            "memory_budget": {},
+            "seed_summaries": [],
+            "aggregate": {},
+            "acceptance": {
+                "passed": True,
+                "checks": [hostile_check],
+                "upstream_summary": "test",
+                "upstream_failures": [],
+            },
+            "source_provenance": {
+                "repository_subtree": "research/alberta",
+                "git_head": "a" * 40,
+                "source_sha256": {},
+                "interpretation": "test",
+            },
+        },
+        "scientific_digest": {
+            "algorithm": DIGEST_ALGORITHM,
+            "scope": DIGEST_SCOPE,
+            "canonicalization": CANONICALIZATION,
+            "sha256": "a" * 64,
+        },
+        "operational_metadata": {
+            "gate_wall_seconds": 1.0,
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "git_worktree": {"head": "a" * 40, "dirty": False},
+            "runtime": {"python": "3.12", "platform": "test"},
+            "protocol": {},
+            "gate_result": {},
+        },
+    }
+
+
+def test_recurring_comparator_rejects_hostile_before_hash() -> None:
+    hostile = _HostileStr(">=")
+    _HostileStr.calls = 0
+    artifact = _artifact_with_hostile_comparator(hostile)  # type: ignore[dict-item]
+    validation = validate_recurring_feature_artifact(artifact)  # type: ignore[arg-type]
+    # Should not have called hostile hash/eq/bool/len
+    assert _HostileStr.calls == 0
+    assert validation.valid is False
+    # ensure error contains generic message without repr dispatch
+    for err in validation.errors:
+        assert "_HostileStr" not in err
+        assert "hostile" not in err.lower()
+
+
+def test_recurring_comparator_rejects_hostile_unknown_before_hash() -> None:
+    hostile = _HostileStr("evil")
+    _HostileStr.calls = 0
+    artifact = _artifact_with_hostile_comparator(hostile)  # type: ignore[dict-item]
+    validation = validate_recurring_feature_artifact(artifact)  # type: ignore[arg-type]
+    assert _HostileStr.calls == 0
+    assert validation.valid is False
+
+
+def test_recurring_comparator_benign_still_works() -> None:
+    # benign valid comparator should be processed without error about hash
+    artifact = _artifact_with_hostile_comparator(">=")  # type: ignore[dict-item]
+    validation = validate_recurring_feature_artifact(artifact)  # type: ignore[arg-type]
+    # Will be invalid due to dummy payload, but should not crash and hostile count remains 0
+    assert validation.valid is False
+    # also test invalid comparator string
+    artifact2 = _artifact_with_hostile_comparator("invalid_comparator")  # type: ignore[dict-item]
+    validation2 = validate_recurring_feature_artifact(artifact2)  # type: ignore[arg-type]
+    assert validation2.valid is False
+    assert _HostileStr.calls == 0
+
+
+def test_recurring_comparator_bool_subclass_rejected() -> None:
+    artifact = _artifact_with_hostile_comparator(True)  # type: ignore[dict-item]
+    validation = validate_recurring_feature_artifact(artifact)  # type: ignore[arg-type]
+    assert validation.valid is False

--- a/tests/test_recurring_multiagent_hostile.py
+++ b/tests/test_recurring_multiagent_hostile.py
@@ -1,0 +1,102 @@
+"""Hostile int/float gate for RecurringTwoAgentWorld before range/float."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.streams.recurring_multiagent import RecurringTwoAgentWorld
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __lt__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile lt must not run")
+
+    def __le__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile le must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+def test_recurring_world_rejects_hostile_int_before_range() -> None:
+    hostile = _HostileInt(64)
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="context_length must be positive"):
+        RecurringTwoAgentWorld(context_length=hostile)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+
+    hostile2 = _HostileInt(4)
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="nuisance_dim must be non-negative"):
+        RecurringTwoAgentWorld(nuisance_dim=hostile2)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+
+    with pytest.raises(ValueError, match="context_length must be positive"):
+        RecurringTwoAgentWorld(context_length=True)  # type: ignore[arg-type]
+
+
+def test_recurring_world_rejects_hostile_float_before_float() -> None:
+    hostile = _HostileFloat(1.0)
+    _HostileFloat.calls = 0
+    with pytest.raises(ValueError, match="nuisance_scale must be a finite real number"):
+        RecurringTwoAgentWorld(nuisance_scale=hostile)  # type: ignore[arg-type]
+    assert _HostileFloat.calls == 0
+
+    hostile_int = _HostileInt(1)
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="nuisance_scale must be a finite real number"):
+        RecurringTwoAgentWorld(nuisance_scale=hostile_int)  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+
+
+def test_recurring_world_benign_still_works() -> None:
+    world = RecurringTwoAgentWorld()
+    assert world is not None
+    world2 = RecurringTwoAgentWorld(context_length=32, nuisance_dim=2, nuisance_scale=0.5)
+    assert world2 is not None
+
+    with pytest.raises(ValueError, match="must be finite"):
+        RecurringTwoAgentWorld(nuisance_scale=float("inf"))  # type: ignore[arg-type]
+
+
+def test_recurring_world_hostile_not_in_repr() -> None:
+    hostile = _HostileInt(64)
+    _HostileInt.calls = 0
+    try:
+        RecurringTwoAgentWorld(context_length=hostile)  # type: ignore[arg-type]
+    except ValueError as exc:
+        assert "_HostileInt" not in str(exc)
+        assert _HostileInt.calls == 0
+    else:
+        raise AssertionError("should have raised")

--- a/tests/test_representation_gradient_mixer.py
+++ b/tests/test_representation_gradient_mixer.py
@@ -16,9 +16,12 @@ import pytest
 from jax import Array
 
 from alberta_framework.core.representation_gradient_mixer import (
+    _MAX_REPRESENTATION_DIM,
     GradientMixMode,
     RepresentationGradientMixerConfig,
     RepresentationGradientMixResult,
+    _mixer_update_working_set_bytes,
+    _preflight_mixer_update_working_set,
     mix_representation_gradients,
 )
 
@@ -529,23 +532,26 @@ def test_gradient_mixer_rejects_integer_spoofs_without_running_repr() -> None:
 
 def test_gradient_mixer_allocation_contract_endpoints_are_allocation_free() -> None:
     fixed_output_bytes = 12 * 4 + 12
-    last_legal = ((2**31 - 1) - fixed_output_bytes) // 4
-    config = RepresentationGradientMixerConfig(representation_dim=last_legal)
+    output_last_legal = ((2**31 - 1) - fixed_output_bytes) // 4
+    update_last_legal = 25_565_280
+    with pytest.raises(ValueError, match="update working set byte count"):
+        RepresentationGradientMixerConfig(representation_dim=output_last_legal)
+    config = RepresentationGradientMixerConfig(representation_dim=update_last_legal)
     budget = config.resource_budget
 
-    assert budget.representation_dim == last_legal
+    assert budget.representation_dim == update_last_legal
     assert budget.persistent_state_scalars == 0
     assert budget.persistent_state_bytes == 0
-    assert budget.output_float32_scalars == last_legal + 12
+    assert budget.output_float32_scalars == update_last_legal + 12
     assert budget.output_bool_scalars == 12
-    assert budget.output_scalars == last_legal + 24
-    assert budget.output_nbytes == 4 * (last_legal + 12) + 12
+    assert budget.output_scalars == update_last_legal + 24
+    assert budget.output_nbytes == 4 * (update_last_legal + 12) + 12
     assert budget.output_nbytes <= 2**31 - 1
-    assert 4 * (last_legal + 1 + 12) + 12 > 2**31 - 1
+    assert 4 * (output_last_legal + 1 + 12) + 12 > 2**31 - 1
     json.dumps(budget.to_dict(), allow_nan=False)
 
     with pytest.raises(ValueError, match="representation_dim"):
-        RepresentationGradientMixerConfig(representation_dim=last_legal + 1)
+        RepresentationGradientMixerConfig(representation_dim=output_last_legal + 1)
 
 
 @pytest.mark.parametrize(
@@ -728,3 +734,52 @@ def test_gradient_mixer_resource_budget_is_exported_from_public_packages() -> No
     budget = RepresentationGradientMixerConfig(representation_dim=3).resource_budget
     assert isinstance(budget, RootBudget)
     assert RootBudget is CoreBudget
+
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_mixer_persist_is_empty_and_output_fits_at_max_dim() -> None:
+    working_set_bytes = _mixer_update_working_set_bytes(_MAX_REPRESENTATION_DIM)
+    output_nbytes = 4 * (_MAX_REPRESENTATION_DIM + 12) + 12
+    assert output_nbytes <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        RepresentationGradientMixerConfig(representation_dim=_MAX_REPRESENTATION_DIM)
+
+
+def test_mixer_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for representation_dim in range(25_565_279, 25_565_283):
+        working_set_bytes = _mixer_update_working_set_bytes(representation_dim)
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = representation_dim
+        elif first_overflow is None:
+            first_overflow = representation_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    config = RepresentationGradientMixerConfig(representation_dim=last_fit)
+    assert config.resource_budget.persistent_state_bytes == 0
+    with pytest.raises(ValueError, match="update working set byte count"):
+        RepresentationGradientMixerConfig(representation_dim=first_overflow)
+
+
+def test_mixer_output_byte_bound_still_fires_first() -> None:
+    with pytest.raises(ValueError, match="representation_dim"):
+        RepresentationGradientMixerConfig(representation_dim=_MAX_REPRESENTATION_DIM + 1)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_mixer_update_working_set(_MAX_REPRESENTATION_DIM)

--- a/tests/test_scale_robust_sha_hostile.py
+++ b/tests/test_scale_robust_sha_hostile.py
@@ -1,0 +1,168 @@
+"""Hostile string gate for scale robust git_head and digest before len."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.scale_robust_feature_artifact import (
+    DIGEST_ALGORITHM,
+    DIGEST_SCOPE,
+    SCHEMA_VERSION,
+    validate_evidence_artifact,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __len__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile len must not run")
+
+    def __str__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile str must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+def _minimal_artifact_with_git_head(hostile: object) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scientific_payload": {
+            "protocol": {},
+            "configuration": {},
+            "criteria": {},
+            "bootstrap": {},
+            "memory_budget": {},
+            "seed_summaries": [],
+            "aggregate": {},
+            "acceptance": {"passed": False, "checks": [], "retention_ablation_interpretation": ""},
+            "source_provenance": {
+                "repository_subtree": "research/alberta",
+                "git_head": hostile,
+                "source_sha256": {},
+                "interpretation": "test",
+            },
+        },
+        "content_digest": {
+            "algorithm": DIGEST_ALGORITHM,
+            "scope": DIGEST_SCOPE,
+            "canonicalization": "utf8-json-sort-keys-compact-no-nan",
+            "sha256": "a" * 64,
+        },
+        "operational_metadata": {
+            "gate_wall_seconds": 1.0,
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "git_worktree": {"head": "a" * 40, "dirty": False},
+            "runtime": {"python": "3.12"},
+            "protocol": {},
+            "gate_result": {},
+        },
+    }
+
+
+def _minimal_artifact_with_digest(hostile: object) -> dict[str, object]:
+
+    # need at least one valid source path key to trigger digest loop
+    # Use a dummy path that is in _SOURCE_PATHS; we can inspect it
+    # But easiest: provide a mapping with one entry that will be validated
+    # The hashes validation iterates over hashes.items() regardless of expected_paths,
+    # so we can provide any dict with hostile value
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scientific_payload": {
+            "protocol": {},
+            "configuration": {},
+            "criteria": {},
+            "bootstrap": {},
+            "memory_budget": {},
+            "seed_summaries": [],
+            "aggregate": {},
+            "acceptance": {"passed": False, "checks": [], "retention_ablation_interpretation": ""},
+            "source_provenance": {
+                "repository_subtree": "research/alberta",
+                "git_head": "a" * 40,
+                "source_sha256": {
+                    "alberta_framework/evaluation/scale_robust_feature_artifact.py": hostile
+                },
+                "interpretation": "test",
+            },
+        },
+        "content_digest": {
+            "algorithm": DIGEST_ALGORITHM,
+            "scope": DIGEST_SCOPE,
+            "canonicalization": "utf8-json-sort-keys-compact-no-nan",
+            "sha256": "a" * 64,
+        },
+        "operational_metadata": {
+            "gate_wall_seconds": 1.0,
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "git_worktree": {"head": "a" * 40, "dirty": False},
+            "runtime": {"python": "3.12"},
+            "protocol": {},
+            "gate_result": {},
+        },
+    }
+
+
+def test_scale_git_head_rejects_hostile_before_len() -> None:
+    hostile = _HostileStr("a" * 40)
+    _HostileStr.calls = 0
+    artifact = _minimal_artifact_with_git_head(hostile)  # type: ignore[dict-item]
+    validation = validate_evidence_artifact(artifact)  # type: ignore[arg-type]
+    assert validation.valid is False
+    assert _HostileStr.calls == 0
+    for err in validation.errors:
+        assert "_HostileStr" not in err
+
+
+def test_scale_git_head_rejects_hostile_short_before_len() -> None:
+    hostile = _HostileStr("short")
+    _HostileStr.calls = 0
+    artifact = _minimal_artifact_with_git_head(hostile)  # type: ignore[dict-item]
+    validation = validate_evidence_artifact(artifact)  # type: ignore[arg-type]
+    assert validation.valid is False
+    assert _HostileStr.calls == 0
+
+
+def test_scale_digest_rejects_hostile_before_len() -> None:
+    hostile = _HostileStr("b" * 64)
+    _HostileStr.calls = 0
+    artifact = _minimal_artifact_with_digest(hostile)  # type: ignore[dict-item]
+    validation = validate_evidence_artifact(artifact)  # type: ignore[arg-type]
+    assert validation.valid is False
+    assert _HostileStr.calls == 0
+
+
+def test_scale_benign_still_validates() -> None:
+    artifact = _minimal_artifact_with_git_head("c" * 40)  # type: ignore[dict-item]
+    validation = validate_evidence_artifact(artifact)  # type: ignore[arg-type]
+    assert validation.valid is False  # still invalid due to dummy payload but not crash
+    artifact2 = _minimal_artifact_with_digest("d" * 64)  # type: ignore[dict-item]
+    validation2 = validate_evidence_artifact(artifact2)  # type: ignore[arg-type]
+    assert validation2.valid is False
+    assert _HostileStr.calls == 0
+
+
+def test_scale_non_string_rejected() -> None:
+    for bad in [123, None, True, 12.3]:
+        artifact = _minimal_artifact_with_git_head(bad)  # type: ignore[dict-item]
+        validation = validate_evidence_artifact(artifact)  # type: ignore[arg-type]
+        assert validation.valid is False

--- a/tests/test_scorecard_streaming_hostile.py
+++ b/tests/test_scorecard_streaming_hostile.py
@@ -1,0 +1,88 @@
+"""Hostile string gate for streaming summary environment before hash."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.reference_life_scorecard import (
+    ENVIRONMENT_ROSTER,
+    StreamingRunSummary,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __len__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile len must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+    def __str__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile str must not run")
+
+
+def _legal_kwargs(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "environment_kind": ENVIRONMENT_ROSTER[0],
+        "horizon": 10,
+        "phase_length": 2,
+        "n_states": 2,
+        "early_window": 1,
+        "late_window": 1,
+        "post_switch_window": 1,
+    }
+    base.update(overrides)
+    return base  # type: ignore[return-value]
+
+
+def test_streaming_summary_rejects_hostile_env_before_hash() -> None:
+    hostile = _HostileStr(ENVIRONMENT_ROSTER[0])
+    _HostileStr.calls = 0
+    with pytest.raises(ValueError, match="unsupported streaming-summary environment"):
+        StreamingRunSummary(**_legal_kwargs(environment_kind=hostile))  # type: ignore[arg-type]
+    assert _HostileStr.calls == 0
+    # also test unknown env still raises without hostile
+    with pytest.raises(ValueError, match="unsupported streaming-summary environment"):
+        StreamingRunSummary(**_legal_kwargs(environment_kind="unknown_env"))  # type: ignore[arg-type]
+    # benign still works
+    summary = StreamingRunSummary(**_legal_kwargs())  # type: ignore[arg-type]
+    assert summary is not None
+
+
+def test_streaming_summary_rejects_non_str_env() -> None:
+    with pytest.raises(ValueError, match="unsupported streaming-summary environment"):
+        StreamingRunSummary(**_legal_kwargs(environment_kind=True))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="unsupported streaming-summary environment"):
+        StreamingRunSummary(**_legal_kwargs(environment_kind=123))  # type: ignore[arg-type]
+
+
+def test_streaming_summary_hostile_not_in_repr() -> None:
+    hostile = _HostileStr("evil_env")
+    _HostileStr.calls = 0
+    try:
+        StreamingRunSummary(**_legal_kwargs(environment_kind=hostile))  # type: ignore[arg-type]
+    except ValueError as exc:
+        assert "_HostileStr" not in str(exc)
+        assert "evil_env" not in str(exc)
+        assert _HostileStr.calls == 0
+    else:
+        raise AssertionError("should have raised")

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -862,13 +862,14 @@ def test_stacked_horde_from_config_accepts_only_exact_list_or_tuple_sequences() 
 
 def test_stacked_horde_preflights_aggregate_resources_before_allocation() -> None:
     last_feature_dim = (2**31 - 1 - 26) // 8
-    StackedHordeConfig(
-        n_demons=1,
-        feature_dim=last_feature_dim,
-        gammas=(0.9,),
-        lamdas=(0.8,),
-        cumulant_indices=(0,),
-    )
+    with pytest.raises(ValueError, match="update working set byte count"):
+        StackedHordeConfig(
+            n_demons=1,
+            feature_dim=last_feature_dim,
+            gammas=(0.9,),
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
     with pytest.raises(ValueError, match="aggregate bytes"):
         StackedHordeConfig(
             n_demons=1,

--- a/tests/test_stacked_horde_update_working_set.py
+++ b/tests/test_stacked_horde_update_working_set.py
@@ -1,0 +1,103 @@
+"""#1383-complete update working-set preflight for stacked Horde."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.stacked_horde import (
+    StackedHordeConfig,
+    StackedLinearHorde,
+    _preflight_stacked_horde_update_working_set,
+    _stacked_horde_persistent_bytes,
+    _stacked_horde_update_working_set_bytes,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURE_DIM = 90_000_000
+_LAST_FIT_FEATURE_DIM = 89_478_484
+_FIRST_OVERFLOW_FEATURE_DIM = 89_478_485
+
+
+def _unit_config(feature_dim: int) -> StackedHordeConfig:
+    return StackedHordeConfig(
+        n_demons=1,
+        feature_dim=feature_dim,
+        gammas=(0.9,),
+        lamdas=(0.8,),
+        cumulant_indices=(0,),
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _stacked_horde_persistent_bytes(1, _OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _stacked_horde_update_working_set_bytes(1, _OVERFLOW_FEATURE_DIM)
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 720_000_004
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_config(_OVERFLOW_FEATURE_DIM)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_LAST_FIT_FEATURE_DIM, _FIRST_OVERFLOW_FEATURE_DIM + 2):
+        persist_bytes = _stacked_horde_persistent_bytes(1, feature_dim)
+        working_set_bytes = _stacked_horde_update_working_set_bytes(1, feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURE_DIM
+    cfg = _unit_config(last_fit)
+    assert cfg.feature_dim == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_config(first_overflow)
+    _preflight_stacked_horde_update_working_set(1, last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_stacked_horde_update_working_set(1, first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_stacked_horde_update_working_set(1, _OVERFLOW_FEATURE_DIM)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (_INT32_MAX - 26) // 8
+    with pytest.raises(ValueError, match="aggregate bytes"):
+        _unit_config(last_legal + 1)
+
+
+def test_legal_small_stacked_horde_still_updates() -> None:
+    persist_bytes = _stacked_horde_persistent_bytes(1, 4)
+    assert persist_bytes == 36
+    horde = StackedLinearHorde(_unit_config(4))
+    state = horde.init()
+    horde.update(
+        state,
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.ones(1, dtype=jnp.float32),
+    )

--- a/tests/test_state_builder_update_working_set.py
+++ b/tests/test_state_builder_update_working_set.py
@@ -1,0 +1,106 @@
+"""Complete update working-set preflight for the online-gated state builder."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax import tree_util
+
+from alberta_framework.core.state_builder import (
+    OnlineGatedStateBuilder,
+    OnlineGatedStateBuilderConfig,
+    _online_gated_update_working_set_bytes,
+    _preflight_online_gated_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def _persist_bytes(observation_dim: int, hidden_dim: int, n_actions: int = 0) -> int:
+    event_dim = observation_dim + n_actions + 2
+    parameter_count = 2 * hidden_dim * (event_dim + 1)
+    persist_scalars = (
+        parameter_count + hidden_dim + hidden_dim * parameter_count + 3
+    )
+    return 4 * persist_scalars
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_online_gated_persist_matches_jit_materialized_leaves() -> None:
+    config = OnlineGatedStateBuilderConfig(
+        observation_dim=3,
+        hidden_dim=2,
+        n_actions=1,
+    )
+    builder = OnlineGatedStateBuilder(config)
+    state = builder.init(jr.PRNGKey(0))
+    actual = sum(
+        int(leaf.size) * int(leaf.dtype.itemsize)
+        for leaf in tree_util.tree_leaves(state)
+    )
+    assert actual == builder.resource_budget().state_bytes
+    assert actual == _persist_bytes(3, 2, 1)
+
+
+def test_online_gated_persist_fits_while_update_working_set_does_not() -> None:
+    observation_dim = 45_000_000
+    persist_bytes = _persist_bytes(observation_dim, 1)
+    working_set_bytes = _online_gated_update_working_set_bytes(
+        observation_dim,
+        0,
+        1,
+        include_raw_observation=True,
+    )
+    assert persist_bytes <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        OnlineGatedStateBuilderConfig(observation_dim=observation_dim, hidden_dim=1)
+
+
+def test_online_gated_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for observation_dim in range(26_843_540, 26_843_545):
+        working_set_bytes = _online_gated_update_working_set_bytes(
+            observation_dim,
+            0,
+            1,
+            include_raw_observation=True,
+        )
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = observation_dim
+        elif first_overflow is None:
+            first_overflow = observation_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert _persist_bytes(last_fit, 1) <= _INT32_MAX
+    OnlineGatedStateBuilderConfig(observation_dim=last_fit, hidden_dim=1)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        OnlineGatedStateBuilderConfig(observation_dim=first_overflow, hidden_dim=1)
+
+
+def test_online_gated_persistent_byte_bound_still_fires_first() -> None:
+    observation_dim = 134_217_725
+    assert _persist_bytes(observation_dim, 1) > _INT32_MAX
+    with pytest.raises(ValueError, match="state_bytes"):
+        OnlineGatedStateBuilderConfig(observation_dim=observation_dim, hidden_dim=1)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_online_gated_update_working_set(
+            45_000_000,
+            0,
+            1,
+            include_raw_observation=True,
+        )

--- a/tests/test_step1_hostile_validation.py
+++ b/tests/test_step1_hostile_validation.py
@@ -174,7 +174,7 @@ def test_smoke_result_rejects_hostile_shape_without_hooks() -> None:
             steps=2,
             seed=0,
             final_window_mse=0.0,
-            metrics_shape=_HostileTuple((2, 2)),
+            metrics_shape=_HostileTuple((2, 4)),
             finite=True,
         )
     assert _HostileTuple.calls == 0

--- a/tests/test_step_smoke_record_shapes.py
+++ b/tests/test_step_smoke_record_shapes.py
@@ -33,7 +33,7 @@ def test_shared_shape_gate_rejects_noncanonical_or_inconsistent_values(value: ob
 
 def _records_and_shape_fields() -> tuple[tuple[object, tuple[str, ...]], ...]:
     return (
-        (Step1SmokeResult(Step1KernelConfig(), 8, 0, 0.0, (8,), True), ("metrics_shape",)),
+        (Step1SmokeResult(Step1KernelConfig(), 8, 0, 0.0, (8, 4), True), ("metrics_shape",)),
         (
             Step2SmokeResult(Step2KernelConfig(), 8, 0, 0.0, (8,), True, {}),
             ("metrics_shape",),

--- a/tests/test_stomp_update_working_set.py
+++ b/tests/test_stomp_update_working_set.py
@@ -1,0 +1,117 @@
+"""#1383-complete update working-set preflight for STOMP."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.options import (
+    STOMPAgent,
+    STOMPConfig,
+    SubtaskSpec,
+    _preflight_stomp_update_working_set,
+    _stomp_direct_state_bytes,
+    _stomp_update_working_set_bytes,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_OBS = 20_000
+_LAST_FIT_OBS = 13_373
+_FIRST_OVERFLOW_OBS = 13_374
+_UNIT = {
+    "n_primitive_actions": 1,
+    "base_hidden_sizes": (),
+}
+
+
+def _unit_stomp(observation_dim: int) -> STOMPConfig:
+    return STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=observation_dim,
+        **_UNIT,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def _unit_persist_bytes(observation_dim: int) -> int:
+    return 4 * (observation_dim * observation_dim + 8 * observation_dim + 37)
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _unit_persist_bytes(_OVERFLOW_OBS)
+    working_set_bytes = 3 * persist_bytes + 64
+    extras_bytes = 64
+    assert persist_bytes == 1_600_640_148
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_OBS <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_stomp(_OVERFLOW_OBS)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for observation_dim in range(_LAST_FIT_OBS, _FIRST_OVERFLOW_OBS + 2):
+        persist_bytes = _unit_persist_bytes(observation_dim)
+        working_set_bytes = 3 * persist_bytes + 64
+        extras_bytes = 64
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * observation_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = observation_dim
+        elif first_overflow is None:
+            first_overflow = observation_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_OBS
+    last_stomp = _unit_stomp(last_fit)
+    assert last_stomp.observation_dim == last_fit
+    assert _stomp_direct_state_bytes(last_stomp) == _unit_persist_bytes(last_fit)
+    assert _stomp_update_working_set_bytes(last_stomp) <= _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _unit_stomp(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    last_fit = _unit_stomp(_LAST_FIT_OBS)
+    object.__setattr__(last_fit, "observation_dim", _OVERFLOW_OBS)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_stomp_update_working_set(last_fit)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (2**29 - 1 - 22) // 4
+    with pytest.raises(ValueError, match="direct array bytes"):
+        STOMPConfig(observation_dim=last_legal + 1, n_primitive_actions=1)
+
+
+def test_legal_small_stomp_still_constructs() -> None:
+    stomp = STOMPConfig(
+        subtask_specs=(SubtaskSpec(feature_index=0),),
+        observation_dim=4,
+        n_primitive_actions=2,
+        base_hidden_sizes=(),
+    )
+    persist_bytes = _stomp_direct_state_bytes(stomp)
+    assert persist_bytes == 420
+    agent = STOMPAgent(stomp)
+    state = agent.init(jr.key(0))
+    agent.update(
+        state,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.zeros((4,), dtype=jnp.float32),
+    )

--- a/tests/test_swift_td_update_working_set.py
+++ b/tests/test_swift_td_update_working_set.py
@@ -1,0 +1,92 @@
+"""#1383-complete update working-set preflight for SwiftTD."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.swift_td import (
+    SwiftTD,
+    _preflight_swift_td_update_working_set,
+    _swift_td_persistent_bytes,
+    _swift_td_update_working_set_bytes,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURE_DIM = 30_000_000
+_LAST_FIT_FEATURE_DIM = 21_474_834
+_FIRST_OVERFLOW_FEATURE_DIM = 21_474_835
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _swift_td_persistent_bytes(_OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _swift_td_update_working_set_bytes(_OVERFLOW_FEATURE_DIM)
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 960_000_052
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        SwiftTD().init(_OVERFLOW_FEATURE_DIM)
+
+
+def test_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_LAST_FIT_FEATURE_DIM, _FIRST_OVERFLOW_FEATURE_DIM + 2):
+        persist_bytes = _swift_td_persistent_bytes(feature_dim)
+        working_set_bytes = _swift_td_update_working_set_bytes(feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_FEATURE_DIM
+    _preflight_swift_td_update_working_set(last_fit)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_swift_td_update_working_set(first_overflow)
+    with pytest.raises(ValueError, match="update working set byte count"):
+        SwiftTD().init(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_swift_td_update_working_set(_OVERFLOW_FEATURE_DIM)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_feature_dim = (((2**31 - 1) // 4 - 5) // 8) - 1
+    with pytest.raises(ValueError, match="SwiftTD state byte count"):
+        SwiftTD().init(last_feature_dim + 1)
+
+
+def test_legal_small_swift_td_still_updates() -> None:
+    persist_bytes = _swift_td_persistent_bytes(5)
+    assert persist_bytes == 212
+    optimizer = SwiftTD()
+    state = optimizer.init(5)
+    observation = jnp.zeros((5,), dtype=jnp.float32)
+    optimizer.update(
+        state,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        observation,
+        observation,
+        jnp.asarray(0.99, dtype=jnp.float32),
+    )

--- a/tests/test_synthetic_stream_validation.py
+++ b/tests/test_synthetic_stream_validation.py
@@ -10,6 +10,7 @@ from alberta_framework.streams.synthetic import (
     HiddenStateAR2Stream,
     ScaleDriftStream,
     SuttonExperiment1Stream,
+    _require_float32_resource,
     make_scale_range,
 )
 
@@ -170,15 +171,27 @@ def test_make_scale_range_rejects_invalid_feature_dim_hostile() -> None:
 def test_hidden_and_scale_streams_preflight_state_bytes_without_allocation() -> None:
     last_legal = (2**29 - 1 - 3) // 2
 
-    DynamicScaleShiftStream(feature_dim=last_legal)
-    ScaleDriftStream(feature_dim=last_legal)
+    _require_float32_resource(
+        "DynamicScaleShiftStream state",
+        vector_scalars=2 * last_legal,
+        fixed_scalars=3,
+    )
+    _require_float32_resource(
+        "ScaleDriftStream state",
+        vector_scalars=2 * last_legal,
+        fixed_scalars=3,
+    )
     with pytest.raises(ValueError, match="byte count"):
         DynamicScaleShiftStream(feature_dim=last_legal + 1)
     with pytest.raises(ValueError, match="byte count"):
         ScaleDriftStream(feature_dim=last_legal + 1)
 
     hidden_last_legal = (2**29 - 1 - 2) // 2
-    HiddenStateAR2Stream(feature_dim=hidden_last_legal, visible_dim=2)
+    _require_float32_resource(
+        "HiddenStateAR2Stream state",
+        vector_scalars=2 * hidden_last_legal,
+        fixed_scalars=2,
+    )
     with pytest.raises(ValueError, match="byte count"):
         HiddenStateAR2Stream(feature_dim=hidden_last_legal + 1, visible_dim=2)
 
@@ -186,7 +199,11 @@ def test_hidden_and_scale_streams_preflight_state_bytes_without_allocation() -> 
 def test_sutton_stream_preflights_derived_feature_and_state_bytes() -> None:
     last_legal_total = 2**29 - 1 - 3
 
-    SuttonExperiment1Stream(num_relevant=1, num_irrelevant=last_legal_total - 1)
+    _require_float32_resource(
+        "SuttonExperiment1Stream state",
+        vector_scalars=last_legal_total,
+        fixed_scalars=3,
+    )
     with pytest.raises(ValueError, match="byte count"):
         SuttonExperiment1Stream(num_relevant=1, num_irrelevant=last_legal_total)
     with pytest.raises(ValueError, match="feature_dim"):

--- a/tests/test_synthetic_update_working_set.py
+++ b/tests/test_synthetic_update_working_set.py
@@ -1,0 +1,211 @@
+"""#1383-complete step working-set preflight for synthetic streams."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.streams.synthetic import (
+    DynamicScaleShiftStream,
+    HiddenStateAR2Stream,
+    ScaleDriftStream,
+    SuttonExperiment1Stream,
+    _hidden_state_ar2_persistent_bytes,
+    _preflight_synthetic_step_working_set,
+    _require_float32_resource,
+    _scale_stream_persistent_bytes,
+    _sutton_experiment1_persistent_bytes,
+    _synthetic_step_working_set_bytes,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_FEATURE_DIM = 80_000_000
+_HIDDEN_LAST_FIT = 76_695_843
+_HIDDEN_FIRST_OVERFLOW = 76_695_844
+_SCALE_LAST_FIT = 76_695_843
+_SCALE_FIRST_OVERFLOW = 76_695_844
+_SUTTON_OVERFLOW_FEATURE_DIM = 200_000_000
+_SUTTON_LAST_FIT = 134_217_725
+_SUTTON_FIRST_OVERFLOW = 134_217_726
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_hidden_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _hidden_state_ar2_persistent_bytes(_OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _synthetic_step_working_set_bytes(
+        persist_bytes, _OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 640_000_008
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert 4 * 1 <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        HiddenStateAR2Stream(_OVERFLOW_FEATURE_DIM, visible_dim=1)
+
+
+def test_hidden_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_HIDDEN_LAST_FIT, _HIDDEN_FIRST_OVERFLOW + 2):
+        persist_bytes = _hidden_state_ar2_persistent_bytes(feature_dim)
+        working_set_bytes = _synthetic_step_working_set_bytes(persist_bytes, feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _HIDDEN_LAST_FIT
+    _preflight_synthetic_step_working_set(
+        "HiddenStateAR2Stream",
+        _hidden_state_ar2_persistent_bytes(last_fit),
+        last_fit,
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        HiddenStateAR2Stream(first_overflow, visible_dim=1)
+
+
+def test_scale_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _scale_stream_persistent_bytes(_OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _synthetic_step_working_set_bytes(
+        persist_bytes, _OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 640_000_012
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        DynamicScaleShiftStream(_OVERFLOW_FEATURE_DIM)
+    with pytest.raises(ValueError, match="working set byte count"):
+        ScaleDriftStream(_OVERFLOW_FEATURE_DIM)
+
+
+def test_scale_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_SCALE_LAST_FIT, _SCALE_FIRST_OVERFLOW + 2):
+        persist_bytes = _scale_stream_persistent_bytes(feature_dim)
+        working_set_bytes = _synthetic_step_working_set_bytes(persist_bytes, feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _SCALE_LAST_FIT
+    _preflight_synthetic_step_working_set(
+        "DynamicScaleShiftStream",
+        _scale_stream_persistent_bytes(last_fit),
+        last_fit,
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        DynamicScaleShiftStream(first_overflow)
+    with pytest.raises(ValueError, match="working set byte count"):
+        ScaleDriftStream(first_overflow)
+
+
+def test_sutton_named_persist_and_width_still_fit_at_overflow() -> None:
+    persist_bytes = _sutton_experiment1_persistent_bytes(_SUTTON_OVERFLOW_FEATURE_DIM)
+    working_set_bytes = _synthetic_step_working_set_bytes(
+        persist_bytes, _SUTTON_OVERFLOW_FEATURE_DIM
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    assert persist_bytes == 800_000_012
+    assert persist_bytes <= _INT32_MAX
+    assert persist_bytes + extras_bytes <= _INT32_MAX
+    assert 4 * _SUTTON_OVERFLOW_FEATURE_DIM <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="working set byte count"):
+        SuttonExperiment1Stream(
+            num_relevant=1, num_irrelevant=_SUTTON_OVERFLOW_FEATURE_DIM - 1
+        )
+
+
+def test_sutton_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for feature_dim in range(_SUTTON_LAST_FIT, _SUTTON_FIRST_OVERFLOW + 2):
+        persist_bytes = _sutton_experiment1_persistent_bytes(feature_dim)
+        working_set_bytes = _synthetic_step_working_set_bytes(persist_bytes, feature_dim)
+        extras_bytes = working_set_bytes - 3 * persist_bytes
+        assert persist_bytes <= _INT32_MAX
+        assert persist_bytes + extras_bytes <= _INT32_MAX
+        assert 4 * feature_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = feature_dim
+        elif first_overflow is None:
+            first_overflow = feature_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _SUTTON_LAST_FIT
+    _preflight_synthetic_step_working_set(
+        "SuttonExperiment1Stream",
+        _sutton_experiment1_persistent_bytes(last_fit),
+        last_fit,
+    )
+    with pytest.raises(ValueError, match="working set byte count"):
+        SuttonExperiment1Stream(num_relevant=1, num_irrelevant=first_overflow - 1)
+
+
+def test_persist_bound_still_fires_before_working_set() -> None:
+    last_legal = (2**29 - 1 - 3) // 2
+    _require_float32_resource(
+        "DynamicScaleShiftStream state",
+        vector_scalars=2 * last_legal,
+        fixed_scalars=3,
+    )
+    with pytest.raises(ValueError, match="byte count"):
+        DynamicScaleShiftStream(feature_dim=last_legal + 1)
+    hidden_last_legal = (2**29 - 1 - 2) // 2
+    _require_float32_resource(
+        "HiddenStateAR2Stream state",
+        vector_scalars=2 * hidden_last_legal,
+        fixed_scalars=2,
+    )
+    with pytest.raises(ValueError, match="byte count"):
+        HiddenStateAR2Stream(feature_dim=hidden_last_legal + 1, visible_dim=2)
+    last_legal_total = 2**29 - 1 - 3
+    _require_float32_resource(
+        "SuttonExperiment1Stream state",
+        vector_scalars=last_legal_total,
+        fixed_scalars=3,
+    )
+    with pytest.raises(ValueError, match="byte count"):
+        SuttonExperiment1Stream(num_relevant=1, num_irrelevant=last_legal_total)
+
+
+def test_legal_small_synthetic_streams_still_step() -> None:
+    assert _hidden_state_ar2_persistent_bytes(8) == 72
+    hidden = HiddenStateAR2Stream(8, visible_dim=2)
+    hidden.step(hidden.init(jr.key(0)), jnp.asarray(0, dtype=jnp.int32))
+    assert _scale_stream_persistent_bytes(4) == 44
+    dynamic = DynamicScaleShiftStream(4)
+    dynamic.step(dynamic.init(jr.key(1)), jnp.asarray(0, dtype=jnp.int32))
+    drift = ScaleDriftStream(4)
+    drift.step(drift.init(jr.key(2)), jnp.asarray(0, dtype=jnp.int32))
+    assert _sutton_experiment1_persistent_bytes(5) == 32
+    sutton = SuttonExperiment1Stream(num_relevant=2, num_irrelevant=3)
+    sutton.step(sutton.init(jr.key(3)), jnp.asarray(0, dtype=jnp.int32))

--- a/tests/test_temporal_context_update_working_set.py
+++ b/tests/test_temporal_context_update_working_set.py
@@ -1,0 +1,96 @@
+"""#1383-complete step working-set preflight for temporal context."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+from jax import tree_util
+
+from alberta_framework.core.temporal_context import (
+    TemporalContextConfig,
+    TemporalContextFeaturizer,
+    _preflight_temporal_context_update_working_set,
+    _temporal_context_persist_bytes,
+    _temporal_context_update_working_set_bytes,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+_OVERFLOW_INPUT_DIM = 25_000_000
+_PHASE_PRODUCT_KWARGS = {
+    "include_raw": True,
+    "include_ema": True,
+    "include_delta": True,
+    "include_phase_products": True,
+    "n_periods": 3,
+}
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_temporal_context_persist_matches_jit_and_width_still_fits() -> None:
+    config = TemporalContextConfig(input_dim=3, include_phase_products=True)
+    state = TemporalContextFeaturizer(config).init()
+    actual = sum(
+        int(leaf.size) * int(leaf.dtype.itemsize)
+        for leaf in tree_util.tree_leaves(state)
+    )
+    persist_bytes = _temporal_context_persist_bytes(3)
+    assert actual == persist_bytes == 16
+    working_set_bytes = _temporal_context_update_working_set_bytes(
+        _OVERFLOW_INPUT_DIM,
+        **_PHASE_PRODUCT_KWARGS,
+    )
+    persist_at_overflow = _temporal_context_persist_bytes(_OVERFLOW_INPUT_DIM)
+    assert persist_at_overflow <= _INT32_MAX
+    assert 4 * _OVERFLOW_INPUT_DIM <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        TemporalContextConfig(
+            input_dim=_OVERFLOW_INPUT_DIM,
+            include_phase_products=True,
+        )
+
+
+def test_temporal_context_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    for input_dim in range(22_369_618, 22_369_624):
+        working_set_bytes = _temporal_context_update_working_set_bytes(
+            input_dim,
+            **_PHASE_PRODUCT_KWARGS,
+        )
+        persist_bytes = _temporal_context_persist_bytes(input_dim)
+        assert persist_bytes <= _INT32_MAX
+        assert 4 * input_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = input_dim
+        elif first_overflow is None:
+            first_overflow = input_dim
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    config = TemporalContextConfig(input_dim=last_fit, include_phase_products=True)
+    assert config.input_dim == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        TemporalContextConfig(input_dim=first_overflow, include_phase_products=True)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_temporal_context_update_working_set(
+            _OVERFLOW_INPUT_DIM,
+            **_PHASE_PRODUCT_KWARGS,
+        )
+
+
+def test_legal_small_temporal_context_still_constructs() -> None:
+    config = TemporalContextConfig(input_dim=4, include_phase_products=True)
+    assert config.output_dim() == 3 * 4 + 6 + 6 * 4
+    TemporalContextFeaturizer(config).init()

--- a/tests/test_upgd_lifetime_clock.py
+++ b/tests/test_upgd_lifetime_clock.py
@@ -1,0 +1,68 @@
+"""Saturating lifetime clocks keep the UPGD learner update identity at int32 exhaustion."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.core.upgd import UPGDLearner
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def _make_learner() -> UPGDLearner:
+    return UPGDLearner(
+        n_heads=2,
+        hidden_sizes=(4,),
+        sparsity=0.0,
+        perturbation_sigma=0.0,
+    )
+
+
+def test_upgd_clock_wraps_without_saturation_at_int32_max() -> None:
+    """The old bare increment wraps INT32_MAX + 1 to INT32_MIN."""
+
+    wrap = jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    assert int(wrap) == _INT32_MIN
+
+
+def test_upgd_clock_saturates_and_keeps_update_identity() -> None:
+    """A planted INT32_MAX clock saturates instead of wrapping negative."""
+
+    learner = _make_learner()
+    predecessor = learner.init(feature_dim=4, key=jr.key(0)).replace(  # type: ignore[attr-defined]
+        step_count=jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
+    )
+    result = learner.update(
+        predecessor,
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == _INT32_MAX
+    assert int(result.state.step_count) >= 0
+
+    exhausted = learner.update(
+        result.state,
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32),
+    )
+    assert int(exhausted.state.step_count) == _INT32_MAX
+    assert int(exhausted.state.step_count) >= 0
+    assert int(exhausted.state.step_count) == int(result.state.step_count)
+
+
+def test_upgd_clock_at_int32_max_does_not_wrap_negative() -> None:
+    """One more update from the saturated clock stays at INT32_MAX, never INT32_MIN."""
+
+    learner = _make_learner()
+    state = learner.init(feature_dim=4, key=jr.key(0)).replace(  # type: ignore[attr-defined]
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    result = learner.update(
+        state,
+        jnp.ones(4, dtype=jnp.float32),
+        jnp.ones(2, dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == _INT32_MAX
+    assert int(result.state.step_count) != _INT32_MIN

--- a/tests/test_world_model_ensemble.py
+++ b/tests/test_world_model_ensemble.py
@@ -766,10 +766,10 @@ def test_checkpoint_rejects_invalid_state(tmp_path: Path) -> None:
 
 
 def test_config_preflights_complete_update_result_at_exact_boundary() -> None:
-    # Linear 2-observation/2-action fixture: 324 * ensemble_size + 196 bytes.
-    last_legal = (2**31 - 1 - 196) // 324
+    # Linear 2-observation/2-action fixture: 864 * ensemble_size + 316 bytes.
+    last_legal = (2**31 - 1 - 316) // 864
     _config(ensemble_size=last_legal)
-    with pytest.raises(ValueError, match="update-result bytes"):
+    with pytest.raises(ValueError, match="update working set byte count"):
         _config(ensemble_size=last_legal + 1)
 
 

--- a/tests/test_world_model_ensemble_update_working_set.py
+++ b/tests/test_world_model_ensemble_update_working_set.py
@@ -1,0 +1,153 @@
+"""#1383-complete update working-set preflight for world-model ensemble."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax import tree_util
+
+from alberta_framework.core.learning_signals import LearningSignalEstimatorConfig
+from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
+from alberta_framework.core.world_model_ensemble import (
+    WorldModelEnsemble,
+    WorldModelEnsembleConfig,
+    _ensemble_state_resource_counts,
+    _ensemble_update_working_set_bytes,
+    _preflight_ensemble_update_working_set,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+# Persist + extras last-legal N on origin/main: still constructs there, but
+# 3 × persist + extras overflows signed int32.
+_OVERFLOW_ENSEMBLE_SIZE = 6_628_035
+_LAST_FIT_ENSEMBLE_SIZE = 2_485_513
+_FIRST_OVERFLOW_ENSEMBLE_SIZE = 2_485_514
+
+
+def _linear_model() -> ActionConditionedWorldModelConfig:
+    return ActionConditionedWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        gamma=0.95,
+        hidden_sizes=(),
+        step_size=0.05,
+        sparsity=0.0,
+        use_layer_norm=False,
+        error_decay=0.8,
+    )
+
+
+def _config(ensemble_size: int) -> WorldModelEnsembleConfig:
+    return WorldModelEnsembleConfig(
+        model=_linear_model(),
+        signal_estimator=LearningSignalEstimatorConfig(
+            ensemble_size=ensemble_size,
+            target_dim=4,
+            progress_warmup_steps=2,
+            change_calibration_steps=2,
+            fast_loss_decay=0.5,
+            slow_loss_decay=0.9,
+            max_input_magnitude=100.0,
+            max_predicted_variance=10_000.0,
+            max_observed_loss=10_000.0,
+        ),
+        ensemble_size=ensemble_size,
+        bootstrap_probability=0.5,
+        residual_variance_decay=0.8,
+        residual_variance_warmup_steps=1,
+        residual_variance_floor=1.0e-6,
+    )
+
+
+def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
+    published_bytes = _INT32_MAX + 1
+    wrapped_bytes = int(
+        jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    )
+    assert wrapped_bytes == _INT32_MIN
+    assert wrapped_bytes != published_bytes
+
+
+def test_ensemble_persist_matches_jit_and_width_still_fits() -> None:
+    config = _config(2)
+    ensemble = WorldModelEnsemble(config)
+    state = ensemble.init(jr.key(0))
+    actual = 0
+    for leaf in tree_util.tree_leaves(state):
+        dtype = getattr(leaf, "dtype", None)
+        if dtype is not None and jnp.issubdtype(dtype, jax.dtypes.prng_key):
+            array = jr.key_data(leaf)
+        else:
+            array = jnp.asarray(leaf)
+        actual += int(array.size) * int(array.dtype.itemsize)
+    _, persist_bytes = _ensemble_state_resource_counts(
+        model=config.model, ensemble_size=2
+    )
+    assert actual == persist_bytes == 600
+    assert ensemble.resource_budget(state).persistent_state_bytes == persist_bytes
+    working_set_bytes = _ensemble_update_working_set_bytes(
+        model=config.model, ensemble_size=_OVERFLOW_ENSEMBLE_SIZE
+    )
+    persist_at_overflow, extras_fit = _persist_and_update(
+        config.model, _OVERFLOW_ENSEMBLE_SIZE
+    )
+    assert persist_at_overflow <= _INT32_MAX
+    assert extras_fit <= _INT32_MAX
+    assert 4 * config.model.observation_dim <= _INT32_MAX
+    assert working_set_bytes > _INT32_MAX
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _config(_OVERFLOW_ENSEMBLE_SIZE)
+
+
+def _persist_and_update(
+    model: ActionConditionedWorldModelConfig, ensemble_size: int
+) -> tuple[int, int]:
+    _, persist_bytes = _ensemble_state_resource_counts(
+        model=model, ensemble_size=ensemble_size
+    )
+    working_set_bytes = _ensemble_update_working_set_bytes(
+        model=model, ensemble_size=ensemble_size
+    )
+    extras_bytes = working_set_bytes - 3 * persist_bytes
+    return persist_bytes, persist_bytes + extras_bytes
+
+
+def test_ensemble_last_fit_and_first_overflow_are_adjacent() -> None:
+    last_fit = None
+    first_overflow = None
+    model = _linear_model()
+    for ensemble_size in range(_LAST_FIT_ENSEMBLE_SIZE, _FIRST_OVERFLOW_ENSEMBLE_SIZE + 2):
+        persist_bytes, update_bytes = _persist_and_update(model, ensemble_size)
+        working_set_bytes = _ensemble_update_working_set_bytes(
+            model=model, ensemble_size=ensemble_size
+        )
+        assert persist_bytes <= _INT32_MAX
+        assert update_bytes <= _INT32_MAX
+        assert 4 * model.observation_dim <= _INT32_MAX
+        if working_set_bytes <= _INT32_MAX:
+            last_fit = ensemble_size
+        elif first_overflow is None:
+            first_overflow = ensemble_size
+            break
+    assert last_fit is not None and first_overflow == last_fit + 1
+    assert last_fit == _LAST_FIT_ENSEMBLE_SIZE
+    config = _config(last_fit)
+    assert config.ensemble_size == last_fit
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _config(first_overflow)
+
+
+def test_preflight_helper_rejects_the_same_working_set() -> None:
+    with pytest.raises(ValueError, match="update working set byte count"):
+        _preflight_ensemble_update_working_set(
+            model=_linear_model(),
+            ensemble_size=_OVERFLOW_ENSEMBLE_SIZE,
+        )
+
+
+def test_legal_small_ensemble_still_constructs() -> None:
+    config = _config(2)
+    WorldModelEnsemble(config).init(jr.key(1))

--- a/tests/test_world_model_ensemble_validation.py
+++ b/tests/test_world_model_ensemble_validation.py
@@ -213,12 +213,12 @@ def test_wm_ensemble_dimensions_preflight_without_allocation() -> None:
 
 
 def test_wm_ensemble_result_preflight_bytes_without_allocation() -> None:
-    # This base has 61 member-state scalars and target_dim=4. Persistent bytes
-    # are 270*ensemble+60; the complete update result is the stricter
-    # 324*ensemble+196 after the aggregate result contract added in #868.
-    last_legal = (2**31 - 1 - 196) // 324
+    # Linear 2-observation/2-action fixture. Persist + extras is
+    # 324 * ensemble_size + 196. Simultaneous source + proposed + committed
+    # persist plus returned extras is the stricter 864 * ensemble_size + 316.
+    last_legal = (2**31 - 1 - 316) // 864
     _base_cfg(ensemble_size=last_legal)
-    with pytest.raises(ValueError, match="update-result bytes"):
+    with pytest.raises(ValueError, match="update working set byte count"):
         _base_cfg(ensemble_size=last_legal + 1)
     with pytest.raises(ValueError, match="fit signed int32"):
         _base_cfg(ensemble_size=500_000_000)


### PR DESCRIPTION
## Outcome

Consolidates the complete open-PR audit on current `main`, preserving contributor commits for sound changes and replacing shallow patches where the underlying contract required a deeper repair. No pinned or active `outputs/**` artifact is modified.

## Directly incorporated

#1767, #1770, #1771, #1773, #1777, #1779, #1785, #1788, #1795, #1807, #1809, #1810, #1812, #1814, #1816, #1820, #1824, #1826, #1828, #1830, #1832, #1834, #1836, #1838, #1840, #1842, #1844, #1864, #1865, #1866, #1867, #1868, #1869, #1871, #1872.

## Deepened rather than merged verbatim

- #1818/#1822: retain both STOMP and OaK working-set boundaries and add the OaK-only boundary case.
- #1846: validate trusted `terminated` metadata before coercion and retain eager/JIT residual coverage.
- #1848: use saturating int32 hit counts and exact integer comparison semantics.
- #1850: require trusted array identities before conversion, not merely spoofable metadata.
- #1852/#1854/#1856: keep historical `outputs/` immutable; add maintained package CLIs for sample spread, fail-closed paired frontier reconstruction, ceiling analysis/runs, and rule-discovery summaries with repository-relative provenance.
- Retired issue-184 IPMNIST shards validate through an explicit historical spec registry without restoring the arm to the live runnable registry or monkeypatching global state.

## Rejected

#1775 is not incorporated: its target has no non-test caller, so an output guard would add maintenance to an unconsumed surface without closing an end-to-end ASI integration gap.

## Validation

- Prior reconstructed base: 209 focused tests, strict mypy, Ruff.
- #1818/#1822: 134 focused tests.
- #1846: 118 focused tests.
- #1848: 78 focused tests.
- #1850: 67 focused tests.
- Combined contributor stack: Ruff clean and strict mypy clean before the historical-registry correction.
- Focused historical-registry tests and repository CI are running on this head.

This is development infrastructure and validation hardening only; it does not promote evidence or make a scientific/performance claim.