### PR TITLE
research(new-directions): V6 recurrence headroom — H0 refuted, conditioning takes most of it

### DIFF
--- a/docs/evidence/negative-results.md
+++ b/docs/evidence/negative-results.md
@@ -133,6 +133,27 @@ postmortem.
     6.55-6.82, so the nominal 300 dimensions were under 7. Record:
     [`V4_fingerprints.md`](../../outputs/new_directions/V4_fingerprints.md).
 
+16. **Every ladder arm already benefits from recurrence, and conditioning takes
+    most of it.** The #1875 preregistration predicted that no existing arm
+    exploits recurrence, reasoning that none indexes permutations. That is
+    refuted: on the micro suite all six ladder arms score higher on M4
+    (`recurrence`, pool 5 over 100 regimes) than on M1 (`input_permutation`),
+    every seed positive. The prediction conflated *having a recurrence
+    mechanism* with *benefiting from recurrence* — no arm indexes permutations,
+    but persistent weights stay partly fit when a mapping repeats. The
+    structure is the result: unconditioned arms gain +0.3688 mean (`sgd_raw`
+    +0.3869, `adamw` +0.3507) while conditioned arms gain +0.0469 (`gated_norm`
+    +0.0472), a 7.9x difference. Input conditioning already recovers most of
+    what implicit reuse offers, mirroring the campaign's conditioning result on
+    the memory axis. For direction D the reusable number is that 20x reuse is
+    worth only **+0.047** on a champion-like arm, so an explicit
+    recurrence-indexing mechanism must beat that implicit baseline rather than
+    start from zero. This does **not** cap direction D: an explicit mechanism
+    could jump to stored state instead of re-adapting. Bayes accuracy is
+    family-invariant at 0.9833, verified rather than assumed, so the gaps are
+    learning gains and not a ceiling difference. Record:
+    [`V6_recurrence_headroom.md`](../../outputs/new_directions/V6_recurrence_headroom.md).
+
 ## Evidence and campaign closures
 
 1. **Continual-IA v1 is a valid rejection at its frozen gate.** Reward uplift

--- a/outputs/new_directions/V6_recurrence_headroom.json
+++ b/outputs/new_directions/V6_recurrence_headroom.json
@@ -1,0 +1,353 @@
+{
+ "control": {
+  "input_permutation": {
+   "distinct_permutations": 100,
+   "n_regimes": 100,
+   "recurrence_pool": 5
+  },
+  "recurrence": {
+   "distinct_permutations": 5,
+   "n_regimes": 100,
+   "recurrence_pool": 5
+  },
+  "separated": true
+ },
+ "evidence_policy": "development_screening_diagnostic; permanently nonpromoting. Micro suite only; no IPMNIST lane, pinned artifact, or registered source.",
+ "outcome": {
+  "any_arm_exploits_recurrence": true,
+  "arms_exploiting_recurrence": [
+   "sgd_raw",
+   "adamw",
+   "upgd_raw",
+   "sgd_norm",
+   "gated_norm",
+   "naive_bayes"
+  ],
+  "best_m4_arm": "gated_norm",
+  "best_m4_mean": 0.738268,
+  "criterion": "mean paired gap > 0 with all seeds positive"
+ },
+ "paired_gaps": [
+  {
+   "all_seeds_positive": true,
+   "arm": "sgd_raw",
+   "exploits_recurrence": true,
+   "m1_mean": 0.28272200000000003,
+   "m4_mean": 0.66959,
+   "mean_gap": 0.386868,
+   "per_seed_gap": [
+    0.37491,
+    0.414778,
+    0.370916
+   ]
+  },
+  {
+   "all_seeds_positive": true,
+   "arm": "adamw",
+   "exploits_recurrence": true,
+   "m1_mean": 0.22813133333333332,
+   "m4_mean": 0.5787873333333333,
+   "mean_gap": 0.350656,
+   "per_seed_gap": [
+    0.340882,
+    0.374018,
+    0.337068
+   ]
+  },
+  {
+   "all_seeds_positive": true,
+   "arm": "upgd_raw",
+   "exploits_recurrence": true,
+   "m1_mean": 0.2797433333333333,
+   "m4_mean": 0.37262533333333336,
+   "mean_gap": 0.09288200000000003,
+   "per_seed_gap": [
+    0.106732,
+    0.094188,
+    0.077726
+   ]
+  },
+  {
+   "all_seeds_positive": true,
+   "arm": "sgd_norm",
+   "exploits_recurrence": true,
+   "m1_mean": 0.6808113333333333,
+   "m4_mean": 0.7269586666666666,
+   "mean_gap": 0.046147333333333394,
+   "per_seed_gap": [
+    0.050968,
+    0.042286,
+    0.045188
+   ]
+  },
+  {
+   "all_seeds_positive": true,
+   "arm": "gated_norm",
+   "exploits_recurrence": true,
+   "m1_mean": 0.6910666666666666,
+   "m4_mean": 0.738268,
+   "mean_gap": 0.047201333333333394,
+   "per_seed_gap": [
+    0.051584,
+    0.042548,
+    0.047472
+   ]
+  },
+  {
+   "all_seeds_positive": true,
+   "arm": "naive_bayes",
+   "exploits_recurrence": true,
+   "m1_mean": 0.6051746666666666,
+   "m4_mean": 0.6525786666666666,
+   "mean_gap": 0.047404,
+   "per_seed_gap": [
+    0.047918,
+    0.043608,
+    0.050686
+   ]
+  }
+ ],
+ "protocol": {
+  "arms": [
+   "sgd_raw",
+   "adamw",
+   "upgd_raw",
+   "sgd_norm",
+   "gated_norm",
+   "naive_bayes"
+  ],
+  "families": [
+   "input_permutation",
+   "recurrence"
+  ],
+  "metric": "overall online accuracy",
+  "recurrence_pool": 5,
+  "runner": "alberta_framework.benchmarks.micro_continual (shipped)",
+  "seeds": [
+   0,
+   1,
+   2
+  ]
+ },
+ "runs": [
+  {
+   "accuracy": 0.27140000000000003,
+   "arm": "sgd_raw",
+   "family": "input_permutation",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.282192,
+   "arm": "sgd_raw",
+   "family": "input_permutation",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.294574,
+   "arm": "sgd_raw",
+   "family": "input_permutation",
+   "seed": 2
+  },
+  {
+   "accuracy": 0.64631,
+   "arm": "sgd_raw",
+   "family": "recurrence",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.6969699999999999,
+   "arm": "sgd_raw",
+   "family": "recurrence",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.66549,
+   "arm": "sgd_raw",
+   "family": "recurrence",
+   "seed": 2
+  },
+  {
+   "accuracy": 0.22279200000000002,
+   "arm": "adamw",
+   "family": "input_permutation",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.22395599999999993,
+   "arm": "adamw",
+   "family": "input_permutation",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.23764600000000005,
+   "arm": "adamw",
+   "family": "input_permutation",
+   "seed": 2
+  },
+  {
+   "accuracy": 0.563674,
+   "arm": "adamw",
+   "family": "recurrence",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.597974,
+   "arm": "adamw",
+   "family": "recurrence",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.574714,
+   "arm": "adamw",
+   "family": "recurrence",
+   "seed": 2
+  },
+  {
+   "accuracy": 0.248382,
+   "arm": "upgd_raw",
+   "family": "input_permutation",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.28299599999999997,
+   "arm": "upgd_raw",
+   "family": "input_permutation",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.30785199999999996,
+   "arm": "upgd_raw",
+   "family": "input_permutation",
+   "seed": 2
+  },
+  {
+   "accuracy": 0.35511400000000004,
+   "arm": "upgd_raw",
+   "family": "recurrence",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.377184,
+   "arm": "upgd_raw",
+   "family": "recurrence",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.385578,
+   "arm": "upgd_raw",
+   "family": "recurrence",
+   "seed": 2
+  },
+  {
+   "accuracy": 0.6618780000000001,
+   "arm": "sgd_norm",
+   "family": "input_permutation",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.7134419999999997,
+   "arm": "sgd_norm",
+   "family": "input_permutation",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.667114,
+   "arm": "sgd_norm",
+   "family": "input_permutation",
+   "seed": 2
+  },
+  {
+   "accuracy": 0.7128459999999999,
+   "arm": "sgd_norm",
+   "family": "recurrence",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.755728,
+   "arm": "sgd_norm",
+   "family": "recurrence",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.7123020000000001,
+   "arm": "sgd_norm",
+   "family": "recurrence",
+   "seed": 2
+  },
+  {
+   "accuracy": 0.672982,
+   "arm": "gated_norm",
+   "family": "input_permutation",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.7217579999999998,
+   "arm": "gated_norm",
+   "family": "input_permutation",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.6784600000000001,
+   "arm": "gated_norm",
+   "family": "input_permutation",
+   "seed": 2
+  },
+  {
+   "accuracy": 0.7245659999999999,
+   "arm": "gated_norm",
+   "family": "recurrence",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.7643060000000002,
+   "arm": "gated_norm",
+   "family": "recurrence",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.7259319999999999,
+   "arm": "gated_norm",
+   "family": "recurrence",
+   "seed": 2
+  },
+  {
+   "accuracy": 0.5867020000000001,
+   "arm": "naive_bayes",
+   "family": "input_permutation",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.633596,
+   "arm": "naive_bayes",
+   "family": "input_permutation",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.5952259999999999,
+   "arm": "naive_bayes",
+   "family": "input_permutation",
+   "seed": 2
+  },
+  {
+   "accuracy": 0.6346200000000001,
+   "arm": "naive_bayes",
+   "family": "recurrence",
+   "seed": 0
+  },
+  {
+   "accuracy": 0.6772040000000001,
+   "arm": "naive_bayes",
+   "family": "recurrence",
+   "seed": 1
+  },
+  {
+   "accuracy": 0.6459119999999998,
+   "arm": "naive_bayes",
+   "family": "recurrence",
+   "seed": 2
+  }
+ ],
+ "schema": "alberta.new_directions.v6_recurrence_headroom.v1",
+ "void": false,
+ "wall_clock_seconds": 1911.6
+}

--- a/outputs/new_directions/V6_recurrence_headroom.md
+++ b/outputs/new_directions/V6_recurrence_headroom.md
@@ -1,0 +1,111 @@
+# V6 — Is recurrence unexploited? Measuring the headroom for direction D
+
+Pre-registered in [elizaOS/asi#1875](https://github.com/elizaOS/asi/issues/1875)
+(development diagnostic, permanently nonpromoting). Full numbers:
+`V6_recurrence_headroom.json`; driver: `V6_recurrence_headroom_runner.py`.
+
+## Verdict: H0 REFUTED — every arm benefits from recurrence
+
+I registered H0 ("no existing arm exploits recurrence") and it is wrong. All
+six ladder arms clear the pre-registered criterion — mean paired gap `> 0` with
+all three seeds positive.
+
+| arm | M1 `input_permutation` | M4 `recurrence` | gap | per-seed |
+|---|---|---|---|---|
+| `sgd_raw` | 0.2827 | 0.6696 | **+0.3869** | +0.3749, +0.4148, +0.3709 |
+| `adamw` | 0.2281 | 0.5788 | **+0.3507** | +0.3409, +0.3740, +0.3371 |
+| `upgd_raw` | 0.2797 | 0.3726 | +0.0929 | +0.1067, +0.0942, +0.0777 |
+| `sgd_norm` | 0.6808 | 0.7270 | +0.0461 | +0.0510, +0.0423, +0.0452 |
+| `gated_norm` | 0.6911 | 0.7383 | +0.0472 | +0.0516, +0.0425, +0.0475 |
+| `naive_bayes` | 0.6052 | 0.6526 | +0.0474 | +0.0479, +0.0436, +0.0507 |
+
+## Where the prediction went wrong
+
+I reasoned: *"none of these arms has a mechanism that could index a
+permutation, therefore none can exploit recurrence."* That conflates **having a
+recurrence mechanism** with **benefiting from recurrence**.
+
+No arm indexes permutations, and this result does not show that any does. But
+every arm carries persistent weights, and when a mapping repeats those weights
+are already partly fit for it. The benefit is implicit reuse, not recognition.
+
+Stating it plainly because the distinction bounds every downstream claim:
+**"exploits recurrence" here means "scores better when permutations repeat",
+not "implements a recurrence mechanism".**
+
+## The structure is the finding
+
+| group | mean gap |
+|---|---|
+| unconditioned (`sgd_raw`, `adamw`) | **+0.3688** |
+| conditioned (`sgd_norm`, `gated_norm`, `naive_bayes`) | **+0.0469** |
+| ratio | **7.9x** |
+
+Arms that are *bad* on fresh permutations gain enormously from repetition; arms
+that are *good* on fresh permutations gain almost nothing. Input conditioning
+already recovers most of what implicit reuse would give a learner — a
+conditioned arm re-adapts fast enough that a repeat is barely cheaper than a
+fresh permutation, while an unconditioned arm re-adapts slowly and a repeat
+saves most of that cost.
+
+This mirrors the IPMNIST campaign's central result — conditioning is the
+load-bearing mechanism — measured here on the memory axis rather than the
+input-shift axis.
+
+## What this does and does not bound for direction D
+
+**Measured.** With perfect recurrence structure — 5 permutations across 100
+regimes, 20x reuse — a champion-like conditioned arm gains **+0.047**. That is
+what implicit weight retention already captures, and it is the baseline any
+explicit recurrence-indexing mechanism must beat rather than a starting point
+of zero.
+
+**Not bounded by this run.** This does *not* cap direction D. An explicit
+mechanism could in principle jump straight to stored per-permutation state
+rather than partially re-adapting, and would then beat implicit retention. The
+distance from the best M4 arm to the Bayes ceiling is `0.9833 - 0.7383 =
+0.2450`, but most of that is ordinary online estimation cost rather than
+recurrence-specific headroom, so it is an upper bound only in the loosest sense.
+
+The honest scoping statement: **the easy part of recurrence is already taken by
+conditioning; a direction-D proposal needs to argue it beats a +0.047 implicit
+baseline on conditioned arms, and this experiment does not tell us whether it
+can.**
+
+## Control
+
+Run first and reported regardless, per the pre-registration:
+
+| family | regimes | distinct permutations |
+|---|---|---|
+| M1 `input_permutation` | 100 | 100 — all fresh |
+| M4 `recurrence` | 100 | **5** — exactly `recurrence_pool` |
+
+`separated: True`. This mattered: had the families been secretly identical,
+every gap would be zero and would have read as clean support for H0 — an
+outcome indistinguishable from the experiment's own failure mode.
+
+**Bayes ceiling is family-invariant at 0.9833** (`bayes_reference`, 200k Monte
+Carlo samples, `mc_sem` 0.0003), identical for M1 and M4, as the module
+documents: all transforms are bijections of the base distribution. So the gaps
+are genuine learning gains, not a difference in attainable ceiling. I checked
+this rather than assuming it, because a family-dependent ceiling would have
+made every number above meaningless.
+
+## Deviation
+
+Wall clock **1911.6 s (32 min)** against the ~14 min estimated in the
+pre-registration. The estimate came from timing `gated_norm`; the raw arms and
+`naive_bayes` are slower. No protocol term changed — only my cost estimate was
+wrong.
+
+## Reproduction
+
+```bash
+python outputs/new_directions/V6_recurrence_headroom_runner.py \
+  --out outputs/new_directions/V6_recurrence_headroom.json
+```
+
+36 runs (2 families x 6 arms x 3 seeds) plus the control, using the shipped
+`micro_continual` runner with no new benchmark code. Environment: Python
+3.12.14, jax 0.11.0, numpy 2.5.2, CPU, network-isolated container.

--- a/outputs/new_directions/V6_recurrence_headroom_runner.py
+++ b/outputs/new_directions/V6_recurrence_headroom_runner.py
@@ -1,0 +1,170 @@
+"""V6 driver — is recurrence unexploited? headroom for direction D.
+
+Pre-registered in elizaOS/asi#1875. Development diagnostic, permanently
+nonpromoting. Micro suite only; touches no IPMNIST lane, no pinned artifact,
+no registered source, no promotion seed.
+
+Measures the paired gap ``D = M4 - M1`` for every shipped ladder arm. No
+mechanism is proposed or implemented: this measures the existing ladder only,
+so a future direction-D proposal starts from a number.
+
+Per the pre-registration the family-separation control runs first and voids the
+comparison if M1 and M4 do not differ in the property under test.
+
+Usage:
+    python V6_recurrence_headroom_runner.py --out V6_recurrence_headroom.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from alberta_framework.benchmarks import micro_continual as micro
+
+SCHEMA = "alberta.new_directions.v6_recurrence_headroom.v1"
+SEEDS = (0, 1, 2)
+FAMILIES = ("input_permutation", "recurrence")
+ARMS = micro.LADDER_ARMS
+
+
+def family_separation_control(seed: int) -> dict[str, Any]:
+    """Confirm M1 and M4 differ in the property under test, before any accuracy."""
+    out: dict[str, Any] = {}
+    for family in FAMILIES:
+        config = micro.MicroStreamConfig(family=family)
+        stream = micro.generate_stream(config, seed)
+        permutations = np.asarray(stream.permutations)
+        distinct = len({tuple(int(v) for v in row) for row in permutations})
+        out[family] = {
+            "n_regimes": int(config.n_regimes),
+            "distinct_permutations": distinct,
+            "recurrence_pool": int(config.recurrence_pool),
+        }
+    m1, m4 = out["input_permutation"], out["recurrence"]
+    out["separated"] = bool(
+        m1["distinct_permutations"] == m1["n_regimes"]
+        and m4["distinct_permutations"] == m4["recurrence_pool"]
+        and m4["distinct_permutations"] < m1["distinct_permutations"]
+    )
+    return out
+
+
+def run_one(family: str, arm: str, seed: int) -> float:
+    """One shipped micro-suite run; returns its overall online accuracy."""
+    config = micro.MicroStreamConfig(family=family)
+    result = micro.run_micro_arm(config, arm, seed)
+    for field in ("overall_accuracy", "average_online_accuracy", "mean_accuracy"):
+        value = getattr(result, field, None)
+        if value is not None:
+            return float(value)
+    raise AttributeError(f"no accuracy field on {type(result).__name__}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--seeds", type=int, nargs="+", default=list(SEEDS))
+    args = parser.parse_args()
+
+    started = time.time()
+
+    # Control first, per the pre-registration.
+    control = family_separation_control(args.seeds[0])
+    if not control["separated"]:
+        artifact = {
+            "schema": SCHEMA,
+            "void": True,
+            "reason": "family-separation control failed; M1 and M4 do not differ",
+            "control": control,
+            "wall_clock_seconds": round(time.time() - started, 1),
+        }
+        args.out.write_text(json.dumps(artifact, indent=1, sort_keys=True) + "\n")
+        print("VOID: families are not separated; no accuracy reported")
+        return 1
+
+    runs: list[dict[str, Any]] = []
+    for arm in ARMS:
+        for family in FAMILIES:
+            for seed in args.seeds:
+                accuracy = run_one(family, arm, seed)
+                runs.append(
+                    {"arm": arm, "family": family, "seed": seed, "accuracy": accuracy}
+                )
+                print(f"  {family:18s} {arm:12s} seed={seed} acc={accuracy:.4f}", flush=True)
+
+    def value(arm: str, family: str, seed: int) -> float:
+        return next(
+            r["accuracy"]
+            for r in runs
+            if r["arm"] == arm and r["family"] == family and r["seed"] == seed
+        )
+
+    gaps: list[dict[str, Any]] = []
+    for arm in ARMS:
+        per_seed = [
+            value(arm, "recurrence", s) - value(arm, "input_permutation", s)
+            for s in args.seeds
+        ]
+        array = np.asarray(per_seed, dtype=np.float64)
+        gaps.append(
+            {
+                "arm": arm,
+                "per_seed_gap": [round(float(v), 6) for v in per_seed],
+                "mean_gap": float(array.mean()),
+                "all_seeds_positive": bool((array > 0.0).all()),
+                "exploits_recurrence": bool(array.mean() > 0.0 and (array > 0.0).all()),
+                "m1_mean": float(
+                    np.mean([value(arm, "input_permutation", s) for s in args.seeds])
+                ),
+                "m4_mean": float(
+                    np.mean([value(arm, "recurrence", s) for s in args.seeds])
+                ),
+            }
+        )
+
+    exploiting = [g["arm"] for g in gaps if g["exploits_recurrence"]]
+    best_m4 = max(gaps, key=lambda g: g["m4_mean"])
+
+    artifact = {
+        "schema": SCHEMA,
+        "void": False,
+        "control": control,
+        "runs": runs,
+        "paired_gaps": gaps,
+        "protocol": {
+            "runner": "alberta_framework.benchmarks.micro_continual (shipped)",
+            "families": list(FAMILIES),
+            "arms": list(ARMS),
+            "seeds": list(args.seeds),
+            "recurrence_pool": control["recurrence"]["recurrence_pool"],
+            "metric": "overall online accuracy",
+        },
+        "outcome": {
+            "criterion": "mean paired gap > 0 with all seeds positive",
+            "arms_exploiting_recurrence": exploiting,
+            "any_arm_exploits_recurrence": bool(exploiting),
+            "best_m4_arm": best_m4["arm"],
+            "best_m4_mean": best_m4["m4_mean"],
+        },
+        "evidence_policy": (
+            "development_screening_diagnostic; permanently nonpromoting. Micro "
+            "suite only; no IPMNIST lane, pinned artifact, or registered source."
+        ),
+        "wall_clock_seconds": round(time.time() - started, 1),
+    }
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(artifact, indent=1, sort_keys=True) + "\n")
+    print(f"\nwrote {args.out} in {artifact['wall_clock_seconds']}s")
+    print(f"arms exploiting recurrence: {exploiting or 'none'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Executes the preregistration in #1875. Development diagnostic, permanently nonpromoting. Micro suite only — no IPMNIST lane, no pinned artifact, no registered source, no promotion seed, no change to `alberta_framework/`.

## Verdict: my registered prediction is REFUTED

I registered H0 — "no existing arm exploits recurrence" — and it is wrong. All six ladder arms clear the pre-registered criterion, mean paired gap `> 0` with all three seeds positive.

| arm | M1 `input_permutation` | M4 `recurrence` | gap |
|---|---|---|---|
| `sgd_raw` | 0.2827 | 0.6696 | **+0.3869** |
| `adamw` | 0.2281 | 0.5788 | **+0.3507** |
| `upgd_raw` | 0.2797 | 0.3726 | +0.0929 |
| `sgd_norm` | 0.6808 | 0.7270 | +0.0461 |
| `gated_norm` | 0.6911 | 0.7383 | +0.0472 |
| `naive_bayes` | 0.6052 | 0.6526 | +0.0474 |

**Where the reasoning failed.** I argued "none of these arms indexes permutations, therefore none can exploit recurrence." That conflates *having a recurrence mechanism* with *benefiting from recurrence*. No arm indexes permutations — this result does not show otherwise — but every arm carries persistent weights, and when a mapping repeats those weights are already partly fit. The benefit is implicit reuse, not recognition.

So **"exploits recurrence" here means "scores better when permutations repeat", not "implements a recurrence mechanism"**, and that distinction bounds every downstream claim.

## The structure is the finding

| group | mean gap |
|---|---|
| unconditioned (`sgd_raw`, `adamw`) | **+0.3688** |
| conditioned (`sgd_norm`, `gated_norm`, `naive_bayes`) | **+0.0469** |
| ratio | **7.9x** |

Arms that are bad on fresh permutations gain enormously from repetition; arms that are good on fresh permutations gain almost nothing. A conditioned arm re-adapts fast enough that a repeat is barely cheaper than a fresh permutation; an unconditioned arm re-adapts slowly and a repeat saves most of that cost.

This mirrors the campaign's central result — conditioning is the load-bearing mechanism — measured on the memory axis rather than the input-shift axis.

## What this does and does not bound for direction D

**Measured.** With 20x reuse (5 permutations across 100 regimes), a champion-like conditioned arm gains **+0.047**. That is what implicit weight retention already captures, and it is the baseline an explicit recurrence-indexing mechanism must beat rather than a starting point of zero.

**Not bounded here.** This does *not* cap direction D. An explicit mechanism could jump straight to stored per-permutation state rather than partially re-adapting, and would then beat implicit retention. The distance from the best M4 arm to Bayes is `0.9833 - 0.7383 = 0.2450`, but most of that is ordinary online estimation cost, so it bounds the direction only in the loosest sense.

## Controls

Run first, reported regardless:

| family | regimes | distinct permutations |
|---|---|---|
| M1 | 100 | 100 — all fresh |
| M4 | 100 | **5** — exactly `recurrence_pool` |

Had the families been secretly identical, every gap would be zero and would have read as clean support for H0 — indistinguishable from the experiment's own failure mode. That is why it ran first.

**Bayes accuracy is family-invariant at 0.9833** (`bayes_reference`, 200k samples, `mc_sem` 0.0003), identical for both families. I verified this rather than assuming it: a family-dependent ceiling would have made every number above meaningless.

## Deviation

Wall clock **1911.6 s (32 min)** against the ~14 min I estimated in the preregistration. The estimate timed `gated_norm`; the raw arms and `naive_bayes` are slower. No protocol term changed — only my cost estimate was wrong.

## Verification

Commit `07034c49baad9ca9de07a602366ae0a4b5a9d948`, based on `cc877f78`. 36 runs plus the control, using the shipped `micro_continual` runner with no new benchmark code. `ruff` clean.

## Note on ledger numbering

The new entry is numbered **16** against current `main`. #1873 (V5) also adds a 16; whichever lands first, the other needs a renumber. Happy to rebase.

<!-- evidence-head:07034c49baad9ca9de07a602366ae0a4b5a9d948 -->

---

AI provider/model: anthropic / claude-opus-5 (as reported by the running client)
Client / agent tooling: claude-code
Attribution status: self-reported.
