### PR TITLE
fix(benchmarks): close trust-boundary residuals in forager_matched_campaign sink

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_campaign.py
@@ -344,23 +344,37 @@ def _canonical_sha256(value: Mapping[str, Any]) -> str:
     return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
 
 
+def _require_exact_str(name: object, value: object) -> str:
+    if type(name) is not str:
+        raise ForagerMatchedCampaignError("name must be an exact string")
+    if type(value) is not str:
+        raise ForagerMatchedCampaignError(f"{name} must be an exact string")
+    return value
+
+
 def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in pairs:
-        if key in result:
-            raise ForagerMatchedCampaignError(f"duplicate JSON key {key!r}")
-        result[key] = value
+        host_key = _require_exact_str("key", key)
+        if host_key in result:
+            raise ForagerMatchedCampaignError(f"duplicate JSON key '{host_key}'")
+        result[host_key] = value
     return result
 
 
 def _reject_nonfinite(value: str) -> NoReturn:
-    raise ForagerMatchedCampaignError(f"non-finite JSON number {value!r}")
+    host_value = _require_exact_str("value", value)
+    raise ForagerMatchedCampaignError(f"non-finite JSON number '{host_value}'")
 
 
 def _parse_finite_json_float(value: str) -> float:
-    parsed = float(value)
+    host_value = _require_exact_str("value", value)
+    try:
+        parsed = float(host_value)
+    except (OverflowError, ValueError) as exc:
+        raise ForagerMatchedCampaignError(f"invalid JSON number '{host_value}'") from exc
     if not math.isfinite(parsed):
-        raise ForagerMatchedCampaignError(f"non-finite JSON number {value!r}")
+        raise ForagerMatchedCampaignError(f"non-finite JSON number '{host_value}'")
     return parsed
 
 
@@ -576,8 +590,9 @@ def _rename_no_replace(source: Path, destination: Path) -> None:
         if result != 0:
             error = ctypes.get_errno()
             if error == errno.EEXIST:
+                host_dest = _require_exact_str("destination.name", destination.name)
                 raise ForagerMatchedCampaignError(
-                    f"artifact {destination.name!r} already exists"
+                    f"artifact '{host_dest}' already exists"
                 )
             raise ForagerMatchedCampaignError(
                 f"exclusive publication failed with errno {error}"
@@ -633,8 +648,9 @@ def _link_anonymous_no_replace(
         if result != 0:
             error = ctypes.get_errno()
             if error == errno.EEXIST:
+                host_dest = _require_exact_str("destination_name", destination_name)
                 raise ForagerMatchedCampaignError(
-                    f"artifact {destination_name!r} already exists"
+                    f"artifact '{host_dest}' already exists"
                 )
             raise ForagerMatchedCampaignError(
                 f"anonymous artifact publication failed with errno {error}"

--- a/tests/test_forager_matched_campaign_trust_hostile_validation.py
+++ b/tests/test_forager_matched_campaign_trust_hostile_validation.py
@@ -1,0 +1,115 @@
+"""Trust-boundary validation for forager_matched_campaign sanitized errors."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_campaign import (
+    ForagerMatchedCampaignError,
+    _parse_finite_json_float,
+    _reject_duplicate_keys,
+    _reject_nonfinite,
+    _require_exact_str,
+)
+
+
+class _EvilStr(str):
+    def __str__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__str__ must not be called")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__repr__ must not be called")
+
+    def __hash__(self) -> int:
+        raise AssertionError("EvilStr.__hash__ must not be called")
+
+
+class _StringSubclass(str):
+    pass
+
+
+def test_require_exact_str_rejects_subclass() -> None:
+    with pytest.raises(ForagerMatchedCampaignError, match="must be an exact string"):
+        _require_exact_str("key", _StringSubclass("x"))
+    with pytest.raises(ForagerMatchedCampaignError, match="must be an exact string"):
+        _require_exact_str("value", _StringSubclass("x"))
+    with pytest.raises(ForagerMatchedCampaignError, match="must be an exact string"):
+        _require_exact_str("name", _StringSubclass("x"))
+
+
+def test_require_exact_str_hostile_without_repr_leak() -> None:
+    evil = _EvilStr("evil")
+    with pytest.raises(ForagerMatchedCampaignError, match="must be an exact string") as exc:
+        _require_exact_str("key", evil)
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+    evil2 = _EvilStr("val")
+    with pytest.raises(ForagerMatchedCampaignError, match="must be an exact string") as exc2:
+        _require_exact_str("value", evil2)
+    assert "EvilStr" not in str(exc2.value)
+
+
+def test_duplicate_key_sanitized() -> None:
+    with pytest.raises(ForagerMatchedCampaignError, match="duplicate JSON key") as exc:
+        _reject_duplicate_keys([("evil_key", 1), ("evil_key", 2)])
+    msg = str(exc.value)
+    assert "!r" not in msg
+    assert "'evil_key'" in msg
+
+
+def test_duplicate_key_hostile_blocked_before_hash() -> None:
+    evil = _EvilStr("evil")
+    with pytest.raises(ForagerMatchedCampaignError, match="must be an exact string") as exc:
+        _reject_duplicate_keys([(evil, 1)])
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+    with pytest.raises(ForagerMatchedCampaignError, match="must be an exact string"):
+        _reject_duplicate_keys([(_StringSubclass("evil"), 1)])
+
+
+def test_nonfinite_sanitized() -> None:
+    with pytest.raises(ForagerMatchedCampaignError, match="non-finite JSON number") as exc:
+        _reject_nonfinite("NaN")
+    msg = str(exc.value)
+    assert "!r" not in msg
+    assert "'NaN'" in msg
+    with pytest.raises(ForagerMatchedCampaignError, match="non-finite JSON number") as exc2:
+        _parse_finite_json_float("Infinity")
+    msg2 = str(exc2.value)
+    assert "!r" not in msg2
+    assert "'Infinity'" in msg2
+
+
+def test_nonfinite_hostile() -> None:
+    evil = _EvilStr("Infinity")
+    with pytest.raises(ForagerMatchedCampaignError, match="must be an exact string") as exc:
+        _reject_nonfinite(evil)
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+    evil2 = _EvilStr("NaN")
+    with pytest.raises(ForagerMatchedCampaignError, match="must be an exact string"):
+        _parse_finite_json_float(evil2)
+    with pytest.raises(ForagerMatchedCampaignError, match="must be an exact string"):
+        _parse_finite_json_float(_StringSubclass("Infinity"))
+
+
+def test_source_contains_no_repr_leak() -> None:
+    p = pathlib.Path("alberta_framework/benchmarks/forager_matched_campaign.py")
+    text = p.read_text(encoding="utf-8")
+    assert "duplicate JSON key {key!r}" not in text
+    assert "non-finite JSON number {value!r}" not in text
+    assert "artifact {destination.name!r}" not in text
+    assert "artifact {destination_name!r}" not in text
+    assert "duplicate JSON key '{host_key}'" in text
+    assert "non-finite JSON number '{host_value}'" in text
+    assert "artifact '{host_dest}' already exists" in text
+
+
+def test_valid_still_passes() -> None:
+    assert _require_exact_str("key", "ok") == "ok"
+    assert _reject_duplicate_keys([("a", 1), ("b", 2)]) == {"a": 1, "b": 2}
+    assert _parse_finite_json_float("1.5") == 1.5
+    with pytest.raises(ForagerMatchedCampaignError):
+        _reject_nonfinite("x")


### PR DESCRIPTION
Closes 5 trust-boundary residuals in `forager_matched_campaign.py` (718 lines, evidence-safe, 5 leaks):

- Adds `_require_exact_str` host gate before duplicate key checks, non-finite float parsing, and artifact publishing
- Sanitizes duplicate JSON object key: `host_key` before membership test and `f"duplicate JSON key '{host_key}'"`
- Sanitizes non-finite JSON constant and invalid/non-finite JSON number: `host_value` before `float()` and quoted `'{host_value}'`
- Sanitizes artifact collision errors: `host_dest` before raises and quoted `'{host_dest}'`
- Errors now use quoted `'{host}'` (no repr), hostile `_EvilStr`/`_StringSubclass` never reaches `__str__`/`__repr__`/`__hash__`

Validation: ruff 0, mypy PASS, grep -c '!r' 0 (was 5), pytest 8 passed (hostile trust). Evidence-safe (not in evidence_manifest.py).
