### PR TITLE
fix(benchmarks): close trust-boundary residuals in forager_matched_qualification sink

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_qualification.py
+++ b/alberta_framework/benchmarks/forager_matched_qualification.py
@@ -525,23 +525,37 @@ def _freeze_json(value: Any) -> Any:
     return value
 
 
+def _require_exact_str(name: object, value: object) -> str:
+    if type(name) is not str:
+        raise ForagerMatchedQualificationError("name must be an exact string")
+    if type(value) is not str:
+        raise ForagerMatchedQualificationError(f"{name} must be an exact string")
+    return value
+
+
 def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in pairs:
-        if key in result:
-            raise ForagerMatchedQualificationError(f"duplicate JSON key {key!r}")
-        result[key] = value
+        host_key = _require_exact_str("key", key)
+        if host_key in result:
+            raise ForagerMatchedQualificationError(f"duplicate JSON key '{host_key}'")
+        result[host_key] = value
     return result
 
 
 def _reject_nonfinite(value: str) -> NoReturn:
-    raise ForagerMatchedQualificationError(f"non-finite JSON number {value!r}")
+    host_value = _require_exact_str("value", value)
+    raise ForagerMatchedQualificationError(f"non-finite JSON number '{host_value}'")
 
 
 def _parse_finite_json_float(value: str) -> float:
-    parsed = float(value)
+    host_value = _require_exact_str("value", value)
+    try:
+        parsed = float(host_value)
+    except (OverflowError, ValueError) as exc:
+        raise ForagerMatchedQualificationError(f"invalid JSON number '{host_value}'") from exc
     if not math.isfinite(parsed):
-        raise ForagerMatchedQualificationError(f"non-finite JSON number {value!r}")
+        raise ForagerMatchedQualificationError(f"non-finite JSON number '{host_value}'")
     return parsed
 
 

--- a/tests/test_forager_matched_qualification_trust_hostile_validation.py
+++ b/tests/test_forager_matched_qualification_trust_hostile_validation.py
@@ -1,0 +1,112 @@
+"""Trust-boundary validation for forager_matched_qualification sanitized errors."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_qualification import (
+    ForagerMatchedQualificationError,
+    _parse_finite_json_float,
+    _reject_duplicate_keys,
+    _reject_nonfinite,
+    _require_exact_str,
+)
+
+
+class _EvilStr(str):
+    def __str__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__str__ must not be called")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__repr__ must not be called")
+
+    def __hash__(self) -> int:
+        raise AssertionError("EvilStr.__hash__ must not be called")
+
+
+class _StringSubclass(str):
+    pass
+
+
+def test_require_exact_str_rejects_subclass() -> None:
+    with pytest.raises(ForagerMatchedQualificationError, match="must be an exact string"):
+        _require_exact_str("key", _StringSubclass("x"))
+    with pytest.raises(ForagerMatchedQualificationError, match="must be an exact string"):
+        _require_exact_str("value", _StringSubclass("x"))
+    with pytest.raises(ForagerMatchedQualificationError, match="must be an exact string"):
+        _require_exact_str("name", _StringSubclass("x"))
+
+
+def test_require_exact_str_hostile_without_repr_leak() -> None:
+    evil = _EvilStr("evil")
+    with pytest.raises(ForagerMatchedQualificationError, match="must be an exact string") as exc:
+        _require_exact_str("key", evil)
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+    evil2 = _EvilStr("val")
+    with pytest.raises(ForagerMatchedQualificationError, match="must be an exact string") as exc2:
+        _require_exact_str("value", evil2)
+    assert "EvilStr" not in str(exc2.value)
+
+
+def test_duplicate_key_sanitized() -> None:
+    with pytest.raises(ForagerMatchedQualificationError, match="duplicate JSON key") as exc:
+        _reject_duplicate_keys([("evil_key", 1), ("evil_key", 2)])
+    msg = str(exc.value)
+    assert "!r" not in msg
+    assert "'evil_key'" in msg
+
+
+def test_duplicate_key_hostile_blocked_before_hash() -> None:
+    evil = _EvilStr("evil")
+    with pytest.raises(ForagerMatchedQualificationError, match="must be an exact string") as exc:
+        _reject_duplicate_keys([(evil, 1)])
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+    with pytest.raises(ForagerMatchedQualificationError, match="must be an exact string"):
+        _reject_duplicate_keys([(_StringSubclass("evil"), 1)])
+
+
+def test_nonfinite_sanitized() -> None:
+    with pytest.raises(ForagerMatchedQualificationError, match="non-finite JSON number") as exc:
+        _reject_nonfinite("NaN")
+    msg = str(exc.value)
+    assert "!r" not in msg
+    assert "'NaN'" in msg
+    with pytest.raises(ForagerMatchedQualificationError, match="non-finite JSON number") as exc2:
+        _parse_finite_json_float("Infinity")
+    msg2 = str(exc2.value)
+    assert "!r" not in msg2
+    assert "'Infinity'" in msg2
+
+
+def test_nonfinite_hostile() -> None:
+    evil = _EvilStr("Infinity")
+    with pytest.raises(ForagerMatchedQualificationError, match="must be an exact string") as exc:
+        _reject_nonfinite(evil)
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+    evil2 = _EvilStr("NaN")
+    with pytest.raises(ForagerMatchedQualificationError, match="must be an exact string"):
+        _parse_finite_json_float(evil2)
+    with pytest.raises(ForagerMatchedQualificationError, match="must be an exact string"):
+        _parse_finite_json_float(_StringSubclass("Infinity"))
+
+
+def test_source_contains_no_repr_leak() -> None:
+    p = pathlib.Path("alberta_framework/benchmarks/forager_matched_qualification.py")
+    text = p.read_text(encoding="utf-8")
+    assert "duplicate JSON key {key!r}" not in text
+    assert "non-finite JSON number {value!r}" not in text
+    assert "duplicate JSON key '{host_key}'" in text
+    assert "non-finite JSON number '{host_value}'" in text
+
+
+def test_valid_still_passes() -> None:
+    assert _require_exact_str("key", "ok") == "ok"
+    assert _reject_duplicate_keys([("a", 1), ("b", 2)]) == {"a": 1, "b": 2}
+    assert _parse_finite_json_float("1.5") == 1.5
+    with pytest.raises(ForagerMatchedQualificationError):
+        _reject_nonfinite("x")


### PR DESCRIPTION
Closes 3 trust-boundary residuals in `forager_matched_qualification.py` (2234 lines, evidence-safe, 3 leaks):

- Adds `_require_exact_str` host gate before duplicate key checks and non-finite float parsing
- Sanitizes duplicate JSON object key: `host_key` before membership test and `f"duplicate JSON key '{host_key}'"`
- Sanitizes non-finite JSON constant and invalid/non-finite JSON number: `host_value` before `float()` and quoted `'{host_value}'`
- Errors now use quoted `'{host}'` (no repr), hostile `_EvilStr`/`_StringSubclass` never reaches `__str__`/`__repr__`/`__hash__`

Validation: ruff 0, mypy PASS, grep -c '!r' 0 (was 3), pytest 8 passed (hostile trust). Evidence-safe (not in evidence_manifest.py).
