### PR TITLE
fix(benchmarks): close trust-boundary residuals in forager_matched_final_analysis sink

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_final_analysis.py
+++ b/alberta_framework/benchmarks/forager_matched_final_analysis.py
@@ -1128,7 +1128,8 @@ def _validate_inventory_payload(payload: Any, *, label: str) -> str:
 
 
 def _expected_entrypoint_binding(candidate_id: str) -> dict[str, Any]:
-    if candidate_id in open_protocol.MATCHED_CURRENT_ALBERTA_CANDIDATE_IDS:
+    host_candidate_id = _require_identifier(candidate_id, "candidate_id")
+    if host_candidate_id in open_protocol.MATCHED_CURRENT_ALBERTA_CANDIDATE_IDS:
         source_key = "alberta"
         entrypoint_path = "alberta_framework/benchmarks/_forager_matched_alberta_worker.py"
         invocation_style = "alberta_single_seed_v1"
@@ -1136,11 +1137,11 @@ def _expected_entrypoint_binding(candidate_id: str) -> dict[str, Any]:
     else:
         try:
             raw_source, entrypoint_path, invocation_style, result_root, _agent = (
-                qualification._EXTERNAL_EXECUTION[candidate_id]
+                qualification._EXTERNAL_EXECUTION[host_candidate_id]
             )
         except KeyError as exc:
             raise ForagerMatchedFinalAnalysisError(
-                f"candidate {candidate_id!r} has no frozen entrypoint binding"
+                f"candidate '{host_candidate_id}' has no frozen entrypoint binding"
             ) from exc
         source_key = str(raw_source)
     return {
@@ -1851,8 +1852,9 @@ def _validate_plan_and_manifests(
             f"evaluation source manifest candidate {index}",
         )
         if candidate_id not in sealed_protocol.candidate_index:
+            host_candidate_id = _require_identifier(candidate_id, "candidate_id")
             raise ForagerMatchedFinalAnalysisError(
-                f"evaluation source manifest names unknown candidate {candidate_id!r}"
+                f"evaluation source manifest names unknown candidate '{host_candidate_id}'"
             )
         frozen_candidate = sealed_protocol.candidate_index[candidate_id]
         expected_entrypoint = _expected_entrypoint_binding(candidate_id)
@@ -2014,8 +2016,9 @@ def _validate_plan_and_manifests(
             f"evaluation candidate command template {index}",
         )
         if candidate_id not in sealed_protocol.candidate_index:
+            host_candidate_id = _require_identifier(candidate_id, "candidate_id")
             raise ForagerMatchedFinalAnalysisError(
-                f"evaluation command template names unknown candidate {candidate_id!r}"
+                f"evaluation command template names unknown candidate '{host_candidate_id}'"
             )
         expected_argv = _expected_candidate_command_template(
             sealed_protocol,

--- a/tests/test_forager_matched_final_analysis_trust_hostile_validation.py
+++ b/tests/test_forager_matched_final_analysis_trust_hostile_validation.py
@@ -1,0 +1,71 @@
+"""Trust-boundary validation for forager_matched_final_analysis sanitized errors."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_final_analysis import (
+    ForagerMatchedFinalAnalysisError,
+    _expected_entrypoint_binding,
+    _require_identifier,
+)
+
+
+class _EvilStr(str):
+    def __str__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__str__ must not be called")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__repr__ must not be called")
+
+    def __hash__(self) -> int:
+        raise AssertionError("EvilStr.__hash__ must not be called")
+
+
+class _StringSubclass(str):
+    pass
+
+
+def test_require_identifier_rejects_subclass() -> None:
+    with pytest.raises(ForagerMatchedFinalAnalysisError, match="must be a non-empty string"):
+        _require_identifier(_StringSubclass("x"), "candidate_id")
+
+
+def test_require_identifier_hostile_without_repr_leak() -> None:
+    evil = _EvilStr("evil")
+    with pytest.raises(ForagerMatchedFinalAnalysisError, match="must be a non-empty string") as exc:
+        _require_identifier(evil, "candidate_id")
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+
+
+def test_expected_entrypoint_binding_unknown_sanitized() -> None:
+    with pytest.raises(
+        ForagerMatchedFinalAnalysisError, match="has no frozen entrypoint binding"
+    ) as exc:
+        _expected_entrypoint_binding("evil_cand")
+    msg = str(exc.value)
+    assert "!r" not in msg
+    assert "'evil_cand'" in msg
+
+
+def test_expected_entrypoint_binding_hostile() -> None:
+    evil = _EvilStr("evil")
+    with pytest.raises(ForagerMatchedFinalAnalysisError, match="must be a non-empty string"):
+        _expected_entrypoint_binding(evil)
+
+
+def test_source_contains_no_repr_leak() -> None:
+    p = pathlib.Path("alberta_framework/benchmarks/forager_matched_final_analysis.py")
+    text = p.read_text(encoding="utf-8")
+    assert "candidate {candidate_id!r}" not in text
+    assert "unknown candidate {candidate_id!r}" not in text
+    assert "candidate '{host_candidate_id}' has no frozen entrypoint binding" in text
+    assert "evaluation source manifest names unknown candidate '{host_candidate_id}'" in text
+    assert "evaluation command template names unknown candidate '{host_candidate_id}'" in text
+
+
+def test_valid_still_passes() -> None:
+    assert _require_identifier("valid_cand", "candidate_id") == "valid_cand"


### PR DESCRIPTION
Closes 3 trust-boundary residuals in `forager_matched_final_analysis.py` (2822 lines, evidence-safe, 3 leaks):

- Adds host gate via `_require_identifier` before entrypoint lookup and unknown candidate error formatting
- Sanitizes frozen entrypoint binding and unknown candidate errors: `host_candidate_id` before lookup/membership test and quoted `'{host_candidate_id}'`
- Errors now use quoted `'{host}'` (no repr), hostile `_EvilStr`/`_StringSubclass` never reaches `__str__`/`__repr__`/`__hash__`

Validation: ruff 0, mypy PASS, grep -c '!r' 0 (was 3), pytest 6 passed (hostile trust). Evidence-safe (not in evidence_manifest.py).
