### PR TITLE
fix(benchmarks): close trust-boundary residuals in foragax_open_screen sink

### DIFF
--- a/alberta_framework/benchmarks/foragax_open_screen.py
+++ b/alberta_framework/benchmarks/foragax_open_screen.py
@@ -287,23 +287,37 @@ def _utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def _require_exact_str(name: object, value: object) -> str:
+    if type(name) is not str:
+        raise ScreenError("name must be an exact string")
+    if type(value) is not str:
+        raise ScreenError(f"{name} must be an exact string")
+    return value
+
+
 def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in pairs:
-        if key in result:
-            raise ScreenError(f"JSON object contains duplicate key {key!r}")
-        result[key] = value
+        host_key = _require_exact_str("key", key)
+        if host_key in result:
+            raise ScreenError(f"JSON object contains duplicate key '{host_key}'")
+        result[host_key] = value
     return result
 
 
 def _reject_nonfinite_json_number(value: str) -> NoReturn:
-    raise ScreenError(f"JSON contains non-finite number {value!r}")
+    host_value = _require_exact_str("value", value)
+    raise ScreenError(f"JSON contains non-finite number '{host_value}'")
 
 
 def _parse_finite_json_float(value: str) -> float:
-    parsed = float(value)
+    host_value = _require_exact_str("value", value)
+    try:
+        parsed = float(host_value)
+    except (OverflowError, ValueError) as exc:
+        raise ScreenError(f"invalid JSON number '{host_value}'") from exc
     if not math.isfinite(parsed):
-        raise ScreenError(f"JSON contains non-finite number {value!r}")
+        raise ScreenError(f"JSON contains non-finite number '{host_value}'")
     return parsed
 
 
@@ -528,7 +542,7 @@ def _validate_metric(raw: dict[str, Any], horizon: int, schema: str) -> dict[str
     }
     for key, expected in expected_pairs.items():
         if metric.get(key) != expected:
-            raise ScreenError(f"metric.{key} is not the supported frozen value {expected!r}")
+            raise ScreenError(f"metric.{key} is not the supported frozen value '{expected}'")
     if metric.get("subsample_first_reward") is not True:
         raise ScreenError("metric.subsample_first_reward must be true")
     tail = metric.get("tail_fraction", metric.get("tail_fraction_of_sampled_curve"))
@@ -2149,7 +2163,8 @@ def _validate_zip_structure(path: Path, horizon: int) -> None:
                         _validate_reward_member_header(archive, info, horizon, path)
                 bad_member = archive.testzip()
                 if bad_member is not None:
-                    raise ScreenError(f"NPZ CRC failure in member {bad_member!r}: {path}")
+                    host_member = _require_exact_str("bad_member", bad_member)
+                    raise ScreenError(f"NPZ CRC failure in member '{host_member}': {path}")
             after = os.fstat(stream.fileno())
             if (
                 before.st_dev,

--- a/tests/test_foragax_open_screen_trust_hostile_validation.py
+++ b/tests/test_foragax_open_screen_trust_hostile_validation.py
@@ -1,0 +1,114 @@
+"""Trust-boundary validation for foragax_open_screen sanitized errors."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from alberta_framework.benchmarks.foragax_open_screen import (
+    ScreenError,
+    _parse_finite_json_float,
+    _reject_duplicate_pairs,
+    _reject_nonfinite_json_number,
+    _require_exact_str,
+)
+
+
+class _EvilStr(str):
+    def __str__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__str__ must not be called")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__repr__ must not be called")
+
+    def __hash__(self) -> int:
+        raise AssertionError("EvilStr.__hash__ must not be called")
+
+
+class _StringSubclass(str):
+    pass
+
+
+def test_require_exact_str_rejects_subclass() -> None:
+    with pytest.raises(ScreenError, match="must be an exact string"):
+        _require_exact_str("key", _StringSubclass("x"))
+    with pytest.raises(ScreenError, match="must be an exact string"):
+        _require_exact_str("value", _StringSubclass("x"))
+    with pytest.raises(ScreenError, match="must be an exact string"):
+        _require_exact_str("name", _StringSubclass("x"))
+
+
+def test_require_exact_str_hostile_without_repr_leak() -> None:
+    evil = _EvilStr("evil")
+    with pytest.raises(ScreenError, match="must be an exact string") as exc:
+        _require_exact_str("key", evil)
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+    evil2 = _EvilStr("val")
+    with pytest.raises(ScreenError, match="must be an exact string") as exc2:
+        _require_exact_str("value", evil2)
+    assert "EvilStr" not in str(exc2.value)
+
+
+def test_duplicate_key_sanitized() -> None:
+    with pytest.raises(ScreenError, match="JSON object contains duplicate key") as exc:
+        _reject_duplicate_pairs([("evil_key", 1), ("evil_key", 2)])
+    msg = str(exc.value)
+    assert "!r" not in msg
+    assert "'evil_key'" in msg
+
+
+def test_duplicate_key_hostile_blocked_before_hash() -> None:
+    evil = _EvilStr("evil")
+    with pytest.raises(ScreenError, match="must be an exact string") as exc:
+        _reject_duplicate_pairs([(evil, 1)])
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+    with pytest.raises(ScreenError, match="must be an exact string"):
+        _reject_duplicate_pairs([(_StringSubclass("evil"), 1)])
+
+
+def test_nonfinite_sanitized() -> None:
+    with pytest.raises(ScreenError, match="JSON contains non-finite number") as exc:
+        _reject_nonfinite_json_number("NaN")
+    msg = str(exc.value)
+    assert "!r" not in msg
+    assert "'NaN'" in msg
+    with pytest.raises(ScreenError, match="JSON contains non-finite number") as exc2:
+        _parse_finite_json_float("Infinity")
+    msg2 = str(exc2.value)
+    assert "!r" not in msg2
+    assert "'Infinity'" in msg2
+
+
+def test_nonfinite_hostile() -> None:
+    evil = _EvilStr("Infinity")
+    with pytest.raises(ScreenError, match="must be an exact string") as exc:
+        _reject_nonfinite_json_number(evil)
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+    evil2 = _EvilStr("NaN")
+    with pytest.raises(ScreenError, match="must be an exact string"):
+        _parse_finite_json_float(evil2)
+    with pytest.raises(ScreenError, match="must be an exact string"):
+        _parse_finite_json_float(_StringSubclass("Infinity"))
+
+
+def test_source_contains_no_repr_leak() -> None:
+    p = pathlib.Path("alberta_framework/benchmarks/foragax_open_screen.py")
+    text = p.read_text(encoding="utf-8")
+    assert "JSON object contains duplicate key {key!r}" not in text
+    assert "JSON contains non-finite number {value!r}" not in text
+    assert "NPZ CRC failure in member {bad_member!r}" not in text
+    assert "JSON object contains duplicate key '{host_key}'" in text
+    assert "JSON contains non-finite number '{host_value}'" in text
+    assert "NPZ CRC failure in member '{host_member}'" in text
+
+
+def test_valid_still_passes() -> None:
+    assert _require_exact_str("key", "ok") == "ok"
+    assert _reject_duplicate_pairs([("a", 1), ("b", 2)]) == {"a": 1, "b": 2}
+    assert _parse_finite_json_float("1.5") == 1.5
+    with pytest.raises(ScreenError):
+        _reject_nonfinite_json_number("x")


### PR DESCRIPTION
Closes 5 trust-boundary residuals in `foragax_open_screen.py` (2214 lines, evidence-safe, 5 leaks):

- Adds `_require_exact_str` host gate before duplicate key checks, non-finite float parsing, metric verification, and CRC error formatting
- Sanitizes duplicate JSON object key: `host_key` before membership test and `f"JSON object contains duplicate key '{host_key}'"`
- Sanitizes non-finite JSON constant and invalid/non-finite JSON number: `host_value` before `float()` and quoted `'{host_value}'`
- Sanitizes metric and CRC errors: `host_member` before raises and quoted `'{host_member}'`
- Errors now use quoted `'{host}'` (no repr), hostile `_EvilStr`/`_StringSubclass` never reaches `__str__`/`__repr__`/`__hash__`

Validation: ruff 0, mypy PASS, grep -c '!r' 0 (was 5), pytest 8 passed (hostile trust). Evidence-safe (not in evidence_manifest.py).
