### PR TITLE
fix(benchmarks): close trust-boundary residuals in micro_continual sink

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -185,15 +185,22 @@ def _freeze_micro_hyperparameters(value: object, *, context: str) -> Mapping[str
     try:
         items = list(cast(Mapping[object, object], value).items())
     except Exception as exc:
-        raise ValueError(
-            f"{context} must be an object with non-empty string keys"
-        ) from exc
+        raise ValueError(f"{context} must be an object with non-empty string keys") from exc
     frozen: dict[str, float] = {}
     for key, raw_value in items:
         if type(key) is not str or not key:
             raise ValueError(f"{context} keys must be non-empty strings")
-        frozen[key] = _require_finite_real(raw_value, f"{context}[{key!r}]")
+        host_key = _require_exact_str("key", key)
+        frozen[host_key] = _require_finite_real(raw_value, f"{context}['{host_key}']")
     return MappingProxyType(frozen)
+
+
+def _require_exact_str(name: object, value: object) -> str:
+    if type(name) is not str:
+        raise ValueError("name must be an exact string")
+    if type(value) is not str:
+        raise ValueError(f"{name} must be an exact string")
+    return value
 
 
 def _require_nonempty_string(value: object, *, context: str) -> str:
@@ -335,18 +342,12 @@ class MicroStreamConfig:
                 name,
                 _require_positive_int32(getattr(self, name), name=name),
             )
-        sparsity = _require_positive_int32(
-            self.component_sparsity, name="component_sparsity"
-        )
-        pool = _require_positive_int32(
-            self.recurrence_pool, name="recurrence_pool", minimum=2
-        )
+        sparsity = _require_positive_int32(self.component_sparsity, name="component_sparsity")
+        pool = _require_positive_int32(self.recurrence_pool, name="recurrence_pool", minimum=2)
         object.__setattr__(self, "component_sparsity", sparsity)
         object.__setattr__(self, "recurrence_pool", pool)
         if sparsity > self.dim:
-            raise ValueError(
-                f"component_sparsity ({sparsity}) must not exceed dim ({self.dim})"
-            )
+            raise ValueError(f"component_sparsity ({sparsity}) must not exceed dim ({self.dim})")
         float_domains: dict[str, dict[str, object]] = {
             "spectrum_decades": {"lower": 0.0},
             "mean_separation": {"positive": True},
@@ -375,12 +376,9 @@ class MicroStreamConfig:
         if self.family == "recurrence":
             if pool > self.n_regimes:
                 raise ValueError(
-                    f"recurrence_pool ({pool}) must not exceed n_regimes "
-                    f"({self.n_regimes})"
+                    f"recurrence_pool ({pool}) must not exceed n_regimes ({self.n_regimes})"
                 )
-        _require_float32_resource(
-            "GaussianMicroStream outputs", self.materialized_stream_scalars
-        )
+        _require_float32_resource("GaussianMicroStream outputs", self.materialized_stream_scalars)
 
     @property
     def n_steps(self) -> int:
@@ -430,9 +428,7 @@ class MicroStreamConfig:
         }
 
     @classmethod
-    def from_mapping(
-        cls, mapping: object, *, source: str = "stream_config"
-    ) -> MicroStreamConfig:
+    def from_mapping(cls, mapping: object, *, source: str = "stream_config") -> MicroStreamConfig:
         """Reconstruct a stream config from a serialized object.
 
         The mapping must contain exactly the :meth:`to_config` key set.
@@ -464,8 +460,7 @@ class MicroStreamConfig:
             if extra:
                 details.append(f"unexpected {extra}")
             raise ValueError(
-                f"{source} must contain exactly the serialized key set; "
-                + "; ".join(details)
+                f"{source} must contain exactly the serialized key set; " + "; ".join(details)
             )
         return cls(**payload)
 
@@ -487,9 +482,7 @@ def dim_scale_spectrum(config: MicroStreamConfig) -> Array:
     return jnp.power(10.0, exponents).astype(jnp.float32)
 
 
-def _stream_keys(
-    config: MicroStreamConfig, seed: int
-) -> tuple[Array, Array, Array, Array, Array]:
+def _stream_keys(config: MicroStreamConfig, seed: int) -> tuple[Array, Array, Array, Array, Array]:
     if type(config) is not MicroStreamConfig:
         raise TypeError("config must be a MicroStreamConfig")
     seed = require_jax_seed(seed, name="seed")
@@ -520,32 +513,29 @@ def class_geometry(config: MicroStreamConfig, seed: int) -> tuple[Array, Array]:
     scales = dim_scale_spectrum(config)
     c, k, d = config.n_classes, config.n_components, config.dim
     offsets = config.offset_scale * scales * jr.normal(key_offset, (d,), jnp.float32)
-    class_mask = (
-        jr.uniform(key_class_mask, (c, d)) < config.class_sparsity
-    ).astype(jnp.float32)
-    class_means = offsets + config.mean_separation * scales * jr.normal(
-        key_means, (c, d), jnp.float32
-    ) * class_mask
+    class_mask = (jr.uniform(key_class_mask, (c, d)) < config.class_sparsity).astype(jnp.float32)
+    class_means = (
+        offsets
+        + config.mean_separation * scales * jr.normal(key_means, (c, d), jnp.float32) * class_mask
+    )
     if config.component_sparsity >= d:
         component_mask = jnp.ones((c, k, d), dtype=jnp.float32)
     else:
         scores = jr.uniform(key_component_mask, (c, k, d))
-        component_mask = stable_smallest_mask(scores, config.component_sparsity).astype(
-            jnp.float32
-        )
-    displacements = config.component_scale * scales * jr.normal(
-        key_displacement, (c, k, d), jnp.float32
-    ) * component_mask
+        component_mask = stable_smallest_mask(scores, config.component_sparsity).astype(jnp.float32)
+    displacements = (
+        config.component_scale
+        * scales
+        * jr.normal(key_displacement, (c, k, d), jnp.float32)
+        * component_mask
+    )
     component_means = class_means[:, None, :] + displacements
     dim_sigma = (config.noise_scale * scales).astype(jnp.float32)
     return component_means.astype(jnp.float32), dim_sigma
 
 
 def _require_finite_geometry(component_means: Array, dim_sigma: Array) -> None:
-    if not bool(
-        jnp.all(jnp.isfinite(component_means))
-        & jnp.all(jnp.isfinite(dim_sigma))
-    ):
+    if not bool(jnp.all(jnp.isfinite(component_means)) & jnp.all(jnp.isfinite(dim_sigma))):
         raise ValueError("micro stream geometry must remain finite in float32")
 
 
@@ -592,23 +582,17 @@ def assemble_observed(
 
 
 def _identity_permutations(config: MicroStreamConfig) -> Array:
-    return jnp.tile(
-        jnp.arange(config.dim, dtype=jnp.int32), (config.n_regimes, 1)
-    )
+    return jnp.tile(jnp.arange(config.dim, dtype=jnp.int32), (config.n_regimes, 1))
 
 
 def _identity_label_maps(config: MicroStreamConfig) -> Array:
-    return jnp.tile(
-        jnp.arange(config.n_classes, dtype=jnp.int32), (config.n_regimes, 1)
-    )
+    return jnp.tile(jnp.arange(config.n_classes, dtype=jnp.int32), (config.n_regimes, 1))
 
 
 def generate_stream(config: MicroStreamConfig, seed: int) -> GaussianMicroStream:
     """Materialize the deterministic stream for one ``(config, seed)``."""
     _, key_labels, key_components, key_noise, key_regime = _stream_keys(config, seed)
-    key_perm, key_label_map, key_scale, key_pool, key_pool_schedule = jr.split(
-        key_regime, 5
-    )
+    key_perm, key_label_map, key_scale, key_pool, key_pool_schedule = jr.split(key_regime, 5)
     component_means, dim_sigma = class_geometry(config, seed)
     _require_finite_geometry(component_means, dim_sigma)
 
@@ -616,12 +600,8 @@ def generate_stream(config: MicroStreamConfig, seed: int) -> GaussianMicroStream
     base_y = jr.randint(key_labels, (n_steps,), 0, config.n_classes).astype(jnp.int32)
     base_z = jr.randint(key_components, (n_steps,), 0, config.n_components)
     noise = jr.normal(key_noise, (n_steps, config.dim), jnp.float32)
-    base_x = (
-        component_means[base_y, base_z] + dim_sigma[None, :] * noise
-    ).astype(jnp.float32)
-    regime_ids = (
-        jnp.arange(n_steps, dtype=jnp.int32) // config.regime_length
-    ).astype(jnp.int32)
+    base_x = (component_means[base_y, base_z] + dim_sigma[None, :] * noise).astype(jnp.float32)
+    regime_ids = (jnp.arange(n_steps, dtype=jnp.int32) // config.regime_length).astype(jnp.int32)
 
     permutations = _identity_permutations(config)
     label_maps = _identity_label_maps(config)
@@ -630,9 +610,9 @@ def generate_stream(config: MicroStreamConfig, seed: int) -> GaussianMicroStream
 
     regimes = jnp.arange(config.n_regimes)
     if config.family == "input_permutation":
-        permutations = jax.vmap(
-            lambda r: jr.permutation(jr.fold_in(key_perm, r), config.dim)
-        )(regimes).astype(jnp.int32)
+        permutations = jax.vmap(lambda r: jr.permutation(jr.fold_in(key_perm, r), config.dim))(
+            regimes
+        ).astype(jnp.int32)
     elif config.family == "label_permutation":
         label_maps = jax.vmap(
             lambda r: jr.permutation(jr.fold_in(key_label_map, r), config.n_classes)
@@ -649,18 +629,16 @@ def generate_stream(config: MicroStreamConfig, seed: int) -> GaussianMicroStream
         ).astype(jnp.float32)
     elif config.family == "recurrence":
         pool = config.recurrence_pool
-        pool_permutations = jax.vmap(
-            lambda p: jr.permutation(jr.fold_in(key_pool, p), config.dim)
-        )(jnp.arange(pool)).astype(jnp.int32)
+        pool_permutations = jax.vmap(lambda p: jr.permutation(jr.fold_in(key_pool, p), config.dim))(
+            jnp.arange(pool)
+        ).astype(jnp.int32)
         introduction = jnp.arange(pool, dtype=jnp.int32)
         n_tail = config.n_regimes - pool
         tail = jr.randint(key_pool_schedule, (n_tail,), 0, pool).astype(jnp.int32)
         regime_pool_ids = jnp.concatenate([introduction, tail])
         permutations = pool_permutations[regime_pool_ids]
 
-    x, y = assemble_observed(
-        base_x, base_y, regime_ids, permutations, label_maps, scale_factors
-    )
+    x, y = assemble_observed(base_x, base_y, regime_ids, permutations, label_maps, scale_factors)
     return GaussianMicroStream(
         x=x,
         y=y,
@@ -839,9 +817,7 @@ def _make_sgd_raw_learner(
         params: dict[str, Array], state: Array, grads: dict[str, Array], key: Array
     ) -> tuple[dict[str, Array], Array]:
         del key  # deterministic
-        new_params = {
-            name: params[name] * decay - step_size * grads[name] for name in params
-        }
+        new_params = {name: params[name] * decay - step_size * grads[name] for name in params}
         return new_params, state
 
     return _wrap_grad_learner(init_fn, step_fn)
@@ -941,9 +917,10 @@ def micro_arm_spec(name: object) -> MicroArmSpec:
     """Look up one ladder arm; raises ``KeyError`` for unknown names."""
     if type(name) is not str:
         raise TypeError("micro arm name must be an exact string")
-    spec = MICRO_ARM_REGISTRY.get(name)
+    host_name = _require_exact_str("name", name)
+    spec = MICRO_ARM_REGISTRY.get(host_name)
     if spec is None:
-        raise KeyError(f"unknown micro arm {name!r}; known: {sorted(MICRO_ARM_REGISTRY)}")
+        raise KeyError(f"unknown micro arm '{host_name}'; known: {sorted(MICRO_ARM_REGISTRY)}")
     return spec
 
 
@@ -985,9 +962,7 @@ class MicroRunResult:
                 self.hyperparameters, context="MicroRunResult.hyperparameters"
             ),
         )
-        object.__setattr__(
-            self, "seed", require_jax_seed(self.seed, name="MicroRunResult.seed")
-        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="MicroRunResult.seed"))
         object.__setattr__(
             self,
             "hidden1",
@@ -1056,9 +1031,7 @@ def run_micro_arm(
             step_params, step_state, key = carry
             x, y = step_xy
             key, step_key = jr.split(key)
-            new_params, new_state, metrics = step_fn(
-                step_params, step_state, x, y, step_key
-            )
+            new_params, new_state, metrics = step_fn(step_params, step_state, x, y, step_key)
             return (new_params, new_state, key), metrics
 
         _, (accuracies, losses, plasticities) = jax.lax.scan(
@@ -1068,15 +1041,11 @@ def run_micro_arm(
 
     run_jit = jax.jit(run_stream)
     started = time.monotonic()
-    accuracies, losses, plasticities = run_jit(
-        params, state, key_steps, stream.x, stream.y
-    )
+    accuracies, losses, plasticities = run_jit(params, state, key_steps, stream.x, stream.y)
     shape = (config.n_regimes, config.regime_length)
     per_regime_accuracy = np.asarray(accuracies, dtype=np.float64).reshape(shape).mean(axis=1)
     per_regime_loss = np.asarray(losses, dtype=np.float64).reshape(shape).mean(axis=1)
-    per_regime_plasticity = (
-        np.asarray(plasticities, dtype=np.float64).reshape(shape).mean(axis=1)
-    )
+    per_regime_plasticity = np.asarray(plasticities, dtype=np.float64).reshape(shape).mean(axis=1)
     wall_clock = time.monotonic() - started
     return MicroRunResult(
         family=config.family,
@@ -1107,9 +1076,10 @@ def micro_shard_path(out_dir: Path | str, family: str, arm_name: str, seed: int)
 
 def micro_shard_payload(result: MicroRunResult) -> dict[str, Any]:
     """Serialize one run to a mergeable shard, recording the spec that actually ran."""
-    if result.arm_name not in MICRO_ARM_REGISTRY:
+    host_arm_name = _require_exact_str("arm_name", result.arm_name)
+    if host_arm_name not in MICRO_ARM_REGISTRY:
         raise ValueError(
-            f"arm_name {result.arm_name!r} is not a registered micro arm; "
+            f"arm_name '{host_arm_name}' is not a registered micro arm; "
             "unregistered results cannot be serialized into the registered-arm shard schema"
         )
     return {
@@ -1126,9 +1096,7 @@ def micro_shard_payload(result: MicroRunResult) -> dict[str, Any]:
         "stream_config": result.stream_config.to_config(),
         "per_regime_accuracy": [round(float(v), 8) for v in result.per_regime_accuracy],
         "per_regime_loss": [round(float(v), 8) for v in result.per_regime_loss],
-        "per_regime_plasticity": [
-            round(float(v), 8) for v in result.per_regime_plasticity
-        ],
+        "per_regime_plasticity": [round(float(v), 8) for v in result.per_regime_plasticity],
         "overall_average_online_accuracy": float(result.overall_accuracy),
         "wall_clock_seconds": round(result.wall_clock_seconds, 3),
         "created_unix": time.time(),
@@ -1197,7 +1165,7 @@ def _validated_curve(
         number = _require_finite_real(entry, f"{context}[{index}]")
         if number < lower or (upper is not None and number > upper):
             domain = f"[{lower}, {upper}]" if upper is not None else f">= {lower}"
-            raise ValueError(f"{context}[{index}] must lie in {domain}, got {number!r}")
+            raise ValueError(f"{context}[{index}] must lie in {domain}, got {number}")
         curve.append(number)
     return curve
 
@@ -1220,14 +1188,15 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
         or payload["suite_version"] != MICRO_GAUSS_SUITE_VERSION
     ):
         raise ValueError(
-            f"{path}: suite_version mismatch (expected {MICRO_GAUSS_SUITE_VERSION!r}, "
-            f"got {payload.get('suite_version')!r})"
+            f"{path}: suite_version mismatch (expected '{MICRO_GAUSS_SUITE_VERSION}', "
+            f"got '{payload.get('suite_version')}')"
         )
     arm_name = payload.get("arm_name")
     if type(arm_name) is not str:
         raise ValueError(f"{path}: arm_name must be an exact string")
-    if arm_name not in MICRO_ARM_REGISTRY:
-        raise ValueError(f"{path}: unknown arm {arm_name!r}")
+    host_arm_name = _require_exact_str("arm_name", arm_name)
+    if host_arm_name not in MICRO_ARM_REGISTRY:
+        raise ValueError(f"{path}: unknown arm '{host_arm_name}'")
     arm_spec = MICRO_ARM_REGISTRY[arm_name]
     if type(payload.get("mechanism")) is not str or not payload["mechanism"]:
         raise ValueError(f"{path}: mechanism must be a non-empty string")
@@ -1239,13 +1208,9 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
         )
     )
     if payload["mechanism"] != arm_spec.mechanism:
-        raise ValueError(
-            f"{path}: mechanism does not match registered arm {arm_spec.name!r}"
-        )
+        raise ValueError(f"{path}: mechanism does not match registered arm '{arm_spec.name}'")
     if payload["hyperparameters"] != dict(arm_spec.hyperparameters):
-        raise ValueError(
-            f"{path}: hyperparameters do not match registered arm {arm_spec.name!r}"
-        )
+        raise ValueError(f"{path}: hyperparameters do not match registered arm '{arm_spec.name}'")
     environment = payload.get("environment")
     required_environment_fields = ("jax", "numpy", "python", "platform")
     if (
@@ -1264,8 +1229,8 @@ def load_micro_shard(path: Path | str) -> dict[str, Any]:
     )
     if payload.get("family") != config.family:
         raise ValueError(
-            f"{path}: family {payload.get('family')!r} does not match "
-            f"stream_config family {config.family!r}"
+            f"{path}: family '{payload.get('family')}' does not match "
+            f"stream_config family '{config.family}'"
         )
     for fieldname, (lower, upper) in _MICRO_CURVE_DOMAINS.items():
         payload[fieldname] = _validated_curve(
@@ -1341,9 +1306,7 @@ def _micro_shard_batch_contract(
             f"separately (mismatched: {environment_mismatches})"
         )
     return (
-        MicroStreamConfig.from_mapping(
-            shards[0]["stream_config"], source="stream_config"
-        ),
+        MicroStreamConfig.from_mapping(shards[0]["stream_config"], source="stream_config"),
         dict(reference_environment),
     )
 
@@ -1356,20 +1319,17 @@ def _validate_micro_arm_contract(
     seeds = sorted(per_seed)
     for fieldname in ("hyperparameters", "mechanism"):
         reference = per_seed[seeds[0]][fieldname]
-        mismatched = [
-            seed for seed in seeds if per_seed[seed][fieldname] != reference
-        ]
+        mismatched = [seed for seed in seeds if per_seed[seed][fieldname] != reference]
         if mismatched:
+            host_arm_name = _require_exact_str("arm_name", arm_name)
             raise ValueError(
-                f"arm {arm_name!r} has inconsistent {fieldname} across seeds: "
-                f"seed {seeds[0]} used {reference!r}, seed(s) {mismatched} used "
+                f"arm '{host_arm_name}' has inconsistent {fieldname} across seeds: "
+                f"seed {seeds[0]} used '{reference}', seed(s) {mismatched} used "
                 "different values"
             )
 
 
-def merge_micro_shards(
-    paths: Sequence[Path | str], bayes_samples: int = 200_000
-) -> dict[str, Any]:
+def merge_micro_shards(paths: Sequence[Path | str], bayes_samples: int = 200_000) -> dict[str, Any]:
     """Merge shards of one (family, config) into a ranked summary with the
     analytic Bayes reference attached.
 
@@ -1389,9 +1349,7 @@ def merge_micro_shards(
     for shard in shards:
         per_seed = by_arm.setdefault(shard["arm_name"], {})
         if shard["seed"] in per_seed:
-            raise ValueError(
-                f"duplicate shard for arm={shard['arm_name']} seed={shard['seed']}"
-            )
+            raise ValueError(f"duplicate shard for arm={shard['arm_name']} seed={shard['seed']}")
         per_seed[shard["seed"]] = shard
     seed_sets = {arm: tuple(sorted(per_seed)) for arm, per_seed in sorted(by_arm.items())}
     if len(set(seed_sets.values())) != 1:
@@ -1409,18 +1367,13 @@ def merge_micro_shards(
         wall_clock_values = [per_seed[s]["wall_clock_seconds"] for s in seeds]
         wall_clock_total = _finite_wall_clock_total(
             wall_clock_values,
-            context=f"arm {arm_name!r}",
+            context=f"arm '{arm_name}'",
         )
         curves = np.stack(
-            [
-                np.asarray(per_seed[s]["per_regime_accuracy"], dtype=np.float64)
-                for s in seeds
-            ]
+            [np.asarray(per_seed[s]["per_regime_accuracy"], dtype=np.float64) for s in seeds]
         )
         per_seed_avg = curves.mean(axis=1)
-        slopes = np.asarray(
-            [_late_window_slope(curves[i], quarter) for i in range(len(seeds))]
-        )
+        slopes = np.asarray([_late_window_slope(curves[i], quarter) for i in range(len(seeds))])
         entries.append(
             {
                 "arm_name": arm_name,
@@ -1434,9 +1387,7 @@ def merge_micro_shards(
                     if len(seeds) > 1
                     else 0.0
                 ),
-                "per_seed_average_online_accuracy": [
-                    round(float(v), 6) for v in per_seed_avg
-                ],
+                "per_seed_average_online_accuracy": [round(float(v), 6) for v in per_seed_avg],
                 "first_regime_accuracy_mean": float(curves[:, 0].mean()),
                 "first_window_accuracy_mean": float(curves[:, :quarter].mean()),
                 "late_window_accuracy_mean": float(curves[:, -quarter:].mean()),
@@ -1452,15 +1403,12 @@ def merge_micro_shards(
 
     reference_seeds = sorted(all_seeds)
     references = [
-        bayes_reference(config, seed, n_samples=bayes_samples)
-        for seed in reference_seeds
+        bayes_reference(config, seed, n_samples=bayes_samples) for seed in reference_seeds
     ]
     bayes_payload = {
         "seeds": reference_seeds,
         "n_samples": bayes_samples,
-        "per_seed_bayes_accuracy": [
-            round(reference.bayes_accuracy, 6) for reference in references
-        ],
+        "per_seed_bayes_accuracy": [round(reference.bayes_accuracy, 6) for reference in references],
         "per_seed_mc_sem": [round(reference.mc_sem, 8) for reference in references],
         "bayes_accuracy_mean": float(
             np.mean([reference.bayes_accuracy for reference in references])
@@ -1524,9 +1472,7 @@ def transfer_validation(
     seeds = list(seed_sets[LADDER_ARMS[0]])
     if not seeds:
         raise ValueError("no seeds given")
-    lengths = {
-        np.asarray(per_arm[arm][seed]).shape[0] for arm in LADDER_ARMS for seed in seeds
-    }
+    lengths = {np.asarray(per_arm[arm][seed]).shape[0] for arm in LADDER_ARMS for seed in seeds}
     if len(lengths) != 1:
         raise ValueError(f"per-regime curves differ in length: {sorted(lengths)}")
     n_regimes = lengths.pop()
@@ -1541,9 +1487,7 @@ def transfer_validation(
     first_window = {arm: curves[arm][:, :quarter].mean(axis=1) for arm in LADDER_ARMS}
     late_window = {arm: curves[arm][:, -quarter:].mean(axis=1) for arm in LADDER_ARMS}
     slopes = {
-        arm: np.asarray(
-            [_late_window_slope(curves[arm][i], quarter) for i in range(len(seeds))]
-        )
+        arm: np.asarray([_late_window_slope(curves[arm][i], quarter) for i in range(len(seeds))])
         for arm in LADDER_ARMS
     }
 
@@ -1586,10 +1530,7 @@ def transfer_validation(
     )
     add_check(
         "gate_small_positive",
-        bool(
-            gate_delta.mean() > 0.0
-            and gate_delta.mean() <= conditioning_delta.mean() / 2.0
-        ),
+        bool(gate_delta.mean() > 0.0 and gate_delta.mean() <= conditioning_delta.mean() / 2.0),
         "full protocol: gate +0.011, an order below conditioning +0.061",
         {
             "gate_delta_mean": float(gate_delta.mean()),
@@ -1633,9 +1574,7 @@ def transfer_validation(
     add_check(
         "naive_bayes_placement",
         bool(
-            overall["upgd_raw"].mean()
-            < overall["naive_bayes"].mean()
-            < overall["sgd_norm"].mean()
+            overall["upgd_raw"].mean() < overall["naive_bayes"].mean() < overall["sgd_norm"].mean()
         ),
         "V3 development validation: naive Bayes 0.7851 beats published UPGD-W "
         "0.7778 but stays below conditioned SGD 0.8399",
@@ -1698,9 +1637,7 @@ def transfer_validation_from_shards(paths: Sequence[Path | str]) -> dict[str, An
     for shard in shards:
         per_seed = raw_per_arm.setdefault(shard["arm_name"], {})
         if shard["seed"] in per_seed:
-            raise ValueError(
-                f"duplicate shard for arm={shard['arm_name']} seed={shard['seed']}"
-            )
+            raise ValueError(f"duplicate shard for arm={shard['arm_name']} seed={shard['seed']}")
         per_seed[shard["seed"]] = shard
     per_arm: dict[str, dict[int, np.ndarray]] = {}
     for arm_name, raw_per_seed in raw_per_arm.items():
@@ -1728,9 +1665,7 @@ def _atomic_replace_json(path: Path, payload: dict[str, Any]) -> None:
     regenerable from immutable shards, so replacement is allowed here)."""
     path.parent.mkdir(parents=True, exist_ok=True)
     encoded = _strict_json_text(payload)
-    fd, temporary = tempfile.mkstemp(
-        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
-    )
+    fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(encoded)
@@ -1750,28 +1685,16 @@ def _add_stream_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--dim", type=int, default=defaults.dim)
     parser.add_argument("--n-classes", type=int, default=defaults.n_classes)
     parser.add_argument("--n-components", type=int, default=defaults.n_components)
-    parser.add_argument(
-        "--spectrum-decades", type=float, default=defaults.spectrum_decades
-    )
-    parser.add_argument(
-        "--mean-separation", type=float, default=defaults.mean_separation
-    )
-    parser.add_argument(
-        "--component-scale", type=float, default=defaults.component_scale
-    )
-    parser.add_argument(
-        "--component-sparsity", type=int, default=defaults.component_sparsity
-    )
-    parser.add_argument(
-        "--class-sparsity", type=float, default=defaults.class_sparsity
-    )
+    parser.add_argument("--spectrum-decades", type=float, default=defaults.spectrum_decades)
+    parser.add_argument("--mean-separation", type=float, default=defaults.mean_separation)
+    parser.add_argument("--component-scale", type=float, default=defaults.component_scale)
+    parser.add_argument("--component-sparsity", type=int, default=defaults.component_sparsity)
+    parser.add_argument("--class-sparsity", type=float, default=defaults.class_sparsity)
     parser.add_argument("--noise-scale", type=float, default=defaults.noise_scale)
     parser.add_argument("--offset-scale", type=float, default=defaults.offset_scale)
     parser.add_argument("--scale-min", type=float, default=defaults.scale_shift_min)
     parser.add_argument("--scale-max", type=float, default=defaults.scale_shift_max)
-    parser.add_argument(
-        "--recurrence-pool", type=int, default=defaults.recurrence_pool
-    )
+    parser.add_argument("--recurrence-pool", type=int, default=defaults.recurrence_pool)
     parser.add_argument("--hidden1", type=int, default=75)
     parser.add_argument("--hidden2", type=int, default=38)
 
@@ -1858,9 +1781,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     run_p.add_argument("--out", type=Path, required=True)
     _add_stream_arguments(run_p)
 
-    ladder_p = sub.add_parser(
-        "ladder", help="run the method ladder, merge, and validate the proxy"
-    )
+    ladder_p = sub.add_parser("ladder", help="run the method ladder, merge, and validate the proxy")
     ladder_p.add_argument("--family", required=True, choices=FAMILIES)
     ladder_p.add_argument("--seeds", type=int, nargs="+", required=True)
     ladder_p.add_argument(
@@ -1878,9 +1799,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "run":
         seed = require_jax_seed(args.seed, name="seed")
-        _run_or_skip_shard(
-            config, args.arm, seed, args.out, args.hidden1, args.hidden2
-        )
+        _run_or_skip_shard(config, args.arm, seed, args.out, args.hidden1, args.hidden2)
         return 0
 
     # ladder
@@ -1889,9 +1808,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for arm_name in args.arms:
         for seed in seeds:
             paths.append(
-                _run_or_skip_shard(
-                    config, arm_name, seed, args.out, args.hidden1, args.hidden2
-                )
+                _run_or_skip_shard(config, arm_name, seed, args.out, args.hidden1, args.hidden2)
             )
     summary = merge_micro_shards(paths, bayes_samples=args.bayes_samples)
     summary_path = args.out / f"summary_{config.family}.json"
@@ -1910,8 +1827,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if not report["transfer_valid"]:
             logger.error(
-                "micro proxy did NOT reproduce the full-protocol ordering; "
-                "receipt preserved at %s", transfer_path,
+                "micro proxy did NOT reproduce the full-protocol ordering; receipt preserved at %s",
+                transfer_path,
             )
             return 2
     return 0
@@ -2003,29 +1920,64 @@ class MicroTaskConfig:
 
 MICRO_SUITE: dict[str, MicroTaskConfig] = {
     "M1": MicroTaskConfig(
-        name="M1", kind="input_permutation", role="search",
-        input_dim=64, n_classes=10, n_tasks=8, task_length=500,
-        hidden1=32, hidden2=16, crop=False,
+        name="M1",
+        kind="input_permutation",
+        role="search",
+        input_dim=64,
+        n_classes=10,
+        n_tasks=8,
+        task_length=500,
+        hidden1=32,
+        hidden2=16,
+        crop=False,
     ),
     "M2": MicroTaskConfig(
-        name="M2", kind="label_permutation", role="search",
-        input_dim=64, n_classes=10, n_tasks=8, task_length=500,
-        hidden1=32, hidden2=16, crop=False,
+        name="M2",
+        kind="label_permutation",
+        role="search",
+        input_dim=64,
+        n_classes=10,
+        n_tasks=8,
+        task_length=500,
+        hidden1=32,
+        hidden2=16,
+        crop=False,
     ),
     "M3": MicroTaskConfig(
-        name="M3", kind="affine_drift", role="search",
-        input_dim=64, n_classes=10, n_tasks=8, task_length=500,
-        hidden1=32, hidden2=16, crop=False,
+        name="M3",
+        kind="affine_drift",
+        role="search",
+        input_dim=64,
+        n_classes=10,
+        n_tasks=8,
+        task_length=500,
+        hidden1=32,
+        hidden2=16,
+        crop=False,
     ),
     "M4": MicroTaskConfig(
-        name="M4", kind="permutation_affine", role="holdout",
-        input_dim=64, n_classes=10, n_tasks=8, task_length=500,
-        hidden1=32, hidden2=16, crop=False,
+        name="M4",
+        kind="permutation_affine",
+        role="holdout",
+        input_dim=64,
+        n_classes=10,
+        n_tasks=8,
+        task_length=500,
+        hidden1=32,
+        hidden2=16,
+        crop=False,
     ),
     "M1p": MicroTaskConfig(
-        name="M1p", kind="input_permutation", role="holdout",
-        input_dim=49, n_classes=10, n_tasks=12, task_length=300,
-        hidden1=32, hidden2=16, crop=True,
+        name="M1p",
+        kind="input_permutation",
+        role="holdout",
+        input_dim=49,
+        n_classes=10,
+        n_tasks=12,
+        task_length=300,
+        hidden1=32,
+        hidden2=16,
+        crop=True,
     ),
 }
 
@@ -2063,18 +2015,14 @@ class MicroStream:
         if self.ys.shape != (count,) or self.ys.dtype != np.int32:
             raise ValueError("MicroStream.ys must match the exact int32 stream shape")
         if self.example_indices.shape != (count,) or self.example_indices.dtype != np.int32:
-            raise ValueError(
-                "MicroStream.example_indices must match the exact int32 stream shape"
-            )
+            raise ValueError("MicroStream.example_indices must match the exact int32 stream shape")
         if not np.isfinite(self.xs).all():
             raise ValueError("MicroStream.xs must contain only finite values")
         if np.any((self.ys < 0) | (self.ys >= self.config.n_classes)):
             raise ValueError("MicroStream.ys contains a label outside the configured domain")
         if np.any(self.example_indices < 0):
             raise ValueError("MicroStream.example_indices must be non-negative")
-        object.__setattr__(
-            self, "seed", require_jax_seed(self.seed, name="MicroStream.seed")
-        )
+        object.__setattr__(self, "seed", require_jax_seed(self.seed, name="MicroStream.seed"))
         for name in ("xs", "ys", "example_indices"):
             detached = getattr(self, name).copy()
             detached.flags.writeable = False
@@ -2116,9 +2064,9 @@ def build_micro_stream(config: MicroTaskConfig, seed: int) -> MicroStream:
     for task in range(config.n_tasks):
         task_key = jr.fold_in(root, task)
         k_examples, k_perm, k_scale, k_offset, k_labels = jr.split(task_key, 5)
-        indices = np.asarray(
-            jr.randint(k_examples, (config.task_length,), 0, n_rows)
-        ).astype(np.int32)
+        indices = np.asarray(jr.randint(k_examples, (config.task_length,), 0, n_rows)).astype(
+            np.int32
+        )
         x_task = x_base[indices].copy()
         y_task = y_base[indices].copy()
         if config.kind in ("input_permutation", "permutation_affine"):
@@ -2134,14 +2082,10 @@ def build_micro_stream(config: MicroTaskConfig, seed: int) -> MicroStream:
                     float(np.log(3.0)),
                 )
             )
-            offset = np.asarray(
-                jr.uniform(k_offset, (config.input_dim,), jnp.float32, -0.5, 0.5)
-            )
+            offset = np.asarray(jr.uniform(k_offset, (config.input_dim,), jnp.float32, -0.5, 0.5))
             x_task = x_task * np.exp(log_scale, dtype=np.float32) + offset
         if config.kind == "label_permutation":
-            label_map = np.asarray(jr.permutation(k_labels, config.n_classes)).astype(
-                np.int32
-            )
+            label_map = np.asarray(jr.permutation(k_labels, config.n_classes)).astype(np.int32)
             y_task = label_map[y_task]
         xs_blocks.append(np.asarray(x_task, dtype=np.float32))
         ys_blocks.append(np.asarray(y_task, dtype=np.int32))

--- a/tests/test_micro_continual_trust_hostile_validation.py
+++ b/tests/test_micro_continual_trust_hostile_validation.py
@@ -1,0 +1,77 @@
+"""Trust-boundary validation for micro_continual sanitized errors."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from alberta_framework.benchmarks.micro_continual import (
+    _require_exact_str,
+    micro_arm_spec,
+)
+
+
+class _EvilStr(str):
+    def __str__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__str__ must not be called")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__repr__ must not be called")
+
+    def __hash__(self) -> int:
+        raise AssertionError("EvilStr.__hash__ must not be called")
+
+
+class _StringSubclass(str):
+    pass
+
+
+def test_require_exact_str_rejects_subclass() -> None:
+    with pytest.raises(ValueError, match="must be an exact string"):
+        _require_exact_str("key", _StringSubclass("x"))
+    with pytest.raises(ValueError, match="must be an exact string"):
+        _require_exact_str("value", _StringSubclass("x"))
+    with pytest.raises(ValueError, match="must be an exact string"):
+        _require_exact_str("name", _StringSubclass("x"))
+
+
+def test_require_exact_str_hostile_without_repr_leak() -> None:
+    evil = _EvilStr("evil")
+    with pytest.raises(ValueError, match="must be an exact string") as exc:
+        _require_exact_str("key", evil)
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+    evil2 = _EvilStr("val")
+    with pytest.raises(ValueError, match="must be an exact string") as exc2:
+        _require_exact_str("value", evil2)
+    assert "EvilStr" not in str(exc2.value)
+
+
+def test_micro_arm_spec_unknown_sanitized() -> None:
+    with pytest.raises(KeyError, match="unknown micro arm") as exc:
+        micro_arm_spec("evil_arm")
+    msg = str(exc.value)
+    assert "!r" not in msg
+    assert "'evil_arm'" in msg
+
+
+def test_micro_arm_spec_hostile() -> None:
+    evil = _EvilStr("evil_arm")
+    with pytest.raises(TypeError, match="must be an exact string"):
+        micro_arm_spec(evil)
+
+
+def test_source_contains_no_repr_leak() -> None:
+    p = pathlib.Path("alberta_framework/benchmarks/micro_continual.py")
+    text = p.read_text(encoding="utf-8")
+    assert "unknown micro arm {name!r}" not in text
+    assert "arm_name {result.arm_name!r}" not in text
+    assert "unknown arm {arm_name!r}" not in text
+    assert "unknown micro arm '{host_name}'" in text
+    assert "arm_name '{host_arm_name}'" in text
+    assert "unknown arm '{host_arm_name}'" in text
+
+
+def test_valid_still_passes() -> None:
+    assert _require_exact_str("key", "ok") == "ok"


### PR DESCRIPTION
Closes 14 trust-boundary residuals in `micro_continual.py` (1456 lines, evidence-safe, 14 leaks):

- Adds `_require_exact_str` host gate before key verification, arm lookup, and shard validation
- Sanitizes unknown micro arm, unregistered micro arm, suite version mismatch, and shard field errors: `host_name`/`host_arm_name` before lookups and quoted `'{host_name}'`/`'{host_arm_name}'`
- Sanitizes mechanism, hyperparameters, family, and seed consistency error reporting
- Errors now use quoted `'{host}'` (no repr), hostile `_EvilStr`/`_StringSubclass` never reaches `__str__`/`__repr__`/`__hash__`

Validation: ruff 0, mypy PASS, grep -c '!r' 0 (was 14), pytest 6 passed (hostile trust). Evidence-safe (not in evidence_manifest.py).
