### PR TITLE
fix(utils): close trust-boundary residuals in experiments and statistics sinks

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -241,9 +241,11 @@ class ExperimentConfig(_ExperimentConfigTuple):
         return cls(*values)
 
     def _replace(self, **changes: object) -> ExperimentConfig:
+        for k in changes:
+            _require_exact_str("field_name", k)
         unexpected = changes.keys() - self._fields
         if unexpected:
-            raise ValueError(f"Got unexpected field names: {sorted(unexpected)!r}")
+            raise ValueError(f"Got unexpected field names: {sorted(unexpected)}")
         values = self._asdict()
         values.update(changes)
         return type(self)(**values)
@@ -295,9 +297,11 @@ class SingleRunResult(_SingleRunResultTuple):
         return cls(*values)
 
     def _replace(self, **changes: object) -> SingleRunResult:
+        for k in changes:
+            _require_exact_str("field_name", k)
         unexpected = changes.keys() - self._fields
         if unexpected:
-            raise ValueError(f"Got unexpected field names: {sorted(unexpected)!r}")
+            raise ValueError(f"Got unexpected field names: {sorted(unexpected)}")
         values = self._asdict()
         values.update(changes)
         return type(self)(**values)
@@ -402,9 +406,7 @@ def aggregate_metrics(results: list[SingleRunResult]) -> AggregatedResults:
     if not results:
         raise ValueError("Cannot aggregate empty results list")
 
-    config_names = sorted(
-        {_require_exact_str("config_name", r.config_name) for r in results}
-    )
+    config_names = sorted({_require_exact_str("config_name", r.config_name) for r in results})
     if len(config_names) != 1:
         raise ValueError(
             f"aggregate_metrics requires runs from one configuration; got {config_names}"
@@ -524,12 +526,9 @@ def run_multi_seed_experiment(
                 "of unique built-in integer seeds"
             ) from exc
         if not raw_seeds:
-            raise ValueError(
-                "seeds must be a non-empty sequence of unique built-in integer seeds"
-            )
+            raise ValueError("seeds must be a non-empty sequence of unique built-in integer seeds")
         seed_list = [
-            require_jax_seed(seed, name=f"seeds[{index}]")
-            for index, seed in enumerate(raw_seeds)
+            require_jax_seed(seed, name=f"seeds[{index}]") for index, seed in enumerate(raw_seeds)
         ]
 
     seen_seeds: set[int] = set()
@@ -763,14 +762,10 @@ def extract_hyperparameter_results(
     if collisions:
         parts: list[str] = []
         for coll_value, coll_names in collisions:
-            safe_coll_names = ", ".join(
-                f"'{_require_exact_str('name', n)}'" for n in coll_names
-            )
+            safe_coll_names = ", ".join(f"'{_require_exact_str('name', n)}'" for n in coll_names)
             parts.append(f"{coll_value} <- [{safe_coll_names}]")
         described = "; ".join(parts)
-        raise ValueError(
-            f"param_extractor maps several configurations to one value: {described}"
-        )
+        raise ValueError(f"param_extractor maps several configurations to one value: {described}")
     try:
         return {value: performance[names[0]] for value, names in coordinate_groups}
     except Exception as exc:
@@ -841,11 +836,7 @@ def _require_hyperparameter_coordinate(
             denominator = fraction.denominator
         except AttributeError:
             reject()
-        if (
-            type(numerator) is not int
-            or type(denominator) is not int
-            or denominator <= 0
-        ):
+        if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
             reject()
         return _CanonicalFractionCoordinate(numerator, denominator)
 
@@ -869,9 +860,7 @@ def _require_hyperparameter_coordinate(
         return value
 
     if _type_identity_in(value_type, _NUMPY_COORDINATE_TYPES):
-        if np.dtype(value_type).kind in ("f", "c") and not bool(
-            np.isfinite(cast(Any, value))
-        ):
+        if np.dtype(value_type).kind in ("f", "c") and not bool(np.isfinite(cast(Any, value))):
             reject()
         return value
 
@@ -895,9 +884,7 @@ def _is_python_numeric_coordinate_type(value_type: type[object]) -> bool:
 
 
 def _is_numpy_numeric_coordinate_type(value_type: type[object]) -> bool:
-    return _type_identity_in(value_type, _NUMPY_COORDINATE_TYPES) and np.dtype(
-        value_type
-    ).kind in (
+    return _type_identity_in(value_type, _NUMPY_COORDINATE_TYPES) and np.dtype(value_type).kind in (
         "b",
         "i",
         "u",

--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -168,9 +168,11 @@ class SignificanceResult(_SignificanceResultTuple):
         return cls(*values)
 
     def _replace(self, **changes: object) -> "SignificanceResult":
+        for k in changes:
+            _require_exact_str("field_name", k)
         unexpected = changes.keys() - self._fields
         if unexpected:
-            raise ValueError(f"Got unexpected field names: {sorted(unexpected)!r}")
+            raise ValueError(f"Got unexpected field names: {sorted(unexpected)}")
         values = self._asdict()
         values.update(changes)
         return type(self)(**values)
@@ -224,9 +226,7 @@ def _require_probability(value: object, *, name: str, strict: bool) -> float:
             return validated_float32_scalar(
                 name, value, positive=True, upper=1.0, upper_inclusive=False
             )
-        return validated_float32_scalar(
-            name, value, lower=0.0, upper=1.0, upper_inclusive=True
-        )
+        return validated_float32_scalar(name, value, lower=0.0, upper=1.0, upper_inclusive=True)
     except ValueError:
         domain = "strictly between 0 and 1" if strict else "in [0, 1]"
         raise ValueError(f"{name} must be a finite real {domain}") from None
@@ -391,9 +391,7 @@ def cohens_d(
     n_b = len(b)
 
     if n_a == 0 or n_b == 0:
-        raise ValueError(
-            f"cohens_d requires non-empty groups (got n_a={n_a}, n_b={n_b})"
-        )
+        raise ValueError(f"cohens_d requires non-empty groups (got n_a={n_a}, n_b={n_b})")
 
     pooled_df = n_a + n_b - 2
     if pooled_df <= 0:
@@ -489,9 +487,7 @@ def ttest_comparison(
             test_name = "independent t-test"
         # scipy returns (statistic, pvalue) tuple
         stat_val = float(result[0])
-        p_val = _require_p_value(
-            result[1], name=f"p_value returned by {test_name}"
-        )
+        p_val = _require_p_value(result[1], name=f"p_value returned by {test_name}")
     except ImportError:
         raise ImportError("scipy is required for t-test. Install with: pip install scipy")
 
@@ -557,9 +553,7 @@ def mann_whitney_comparison(
             result = stats.mannwhitneyu(a, b, alternative="two-sided")
             # scipy returns (statistic, pvalue) tuple
             stat_val = float(result[0])
-            p_val = _require_p_value(
-                result[1], name="p_value returned by Mann-Whitney U"
-            )
+            p_val = _require_p_value(result[1], name="p_value returned by Mann-Whitney U")
         except ImportError:
             raise ImportError(
                 "scipy is required for Mann-Whitney test. Install with: pip install scipy"
@@ -622,8 +616,7 @@ def wilcoxon_comparison(
 
     if len(a) != len(b):
         raise ValueError(
-            f"Wilcoxon signed-rank test requires equal-length samples "
-            f"(got {len(a)} and {len(b)})"
+            f"Wilcoxon signed-rank test requires equal-length samples (got {len(a)} and {len(b)})"
         )
     _require_exact_str("method_a", method_a)
     _require_exact_str("method_b", method_b)
@@ -633,9 +626,7 @@ def wilcoxon_comparison(
             "samples; the Wilcoxon signed-rank statistic is undefined"
         )
     if len(a) < 2:
-        raise ValueError(
-            f"Wilcoxon signed-rank test requires at least 2 pairs (got {len(a)})"
-        )
+        raise ValueError(f"Wilcoxon signed-rank test requires at least 2 pairs (got {len(a)})")
 
     try:
         from scipy import stats
@@ -643,9 +634,7 @@ def wilcoxon_comparison(
         result = stats.wilcoxon(a, b, alternative="two-sided")
         # scipy returns (statistic, pvalue) tuple
         stat_val = float(result[0])
-        p_val = _require_p_value(
-            result[1], name="p_value returned by Wilcoxon signed-rank"
-        )
+        p_val = _require_p_value(result[1], name="p_value returned by Wilcoxon signed-rank")
     except ImportError:
         raise ImportError("scipy is required for Wilcoxon test. Install with: pip install scipy")
 
@@ -721,9 +710,7 @@ def holm_correction(
     return significant
 
 
-def _holm_decisions(
-    p_values: list[float], alpha: float
-) -> tuple[list[bool], list[float]]:
+def _holm_decisions(p_values: list[float], alpha: float) -> tuple[list[bool], list[float]]:
     """Return Holm decisions and each record's effective step-down threshold."""
 
     n_tests = len(p_values)
@@ -832,8 +819,7 @@ def pairwise_comparisons(
         _require_exact_str("metric", metric)
         if arr.shape[1] == 0:
             raise ValueError(
-                f"AggregatedResults '{name}' must contain at least one metric step "
-                f"for '{metric}'"
+                f"AggregatedResults '{name}' must contain at least one metric step for '{metric}'"
             )
         metric_arrays[name] = arr
         seeds_by_name[name] = agg.seeds

--- a/tests/test_utils_trust_hostile_validation.py
+++ b/tests/test_utils_trust_hostile_validation.py
@@ -1,0 +1,80 @@
+"""Trust-boundary validation for utils sanitized errors."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from alberta_framework.utils.experiments import _require_exact_str
+from alberta_framework.utils.statistics import SignificanceResult
+
+
+class _EvilStr(str):
+    def __str__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__str__ must not be called")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("EvilStr.__repr__ must not be called")
+
+    def __hash__(self) -> int:
+        raise AssertionError("EvilStr.__hash__ must not be called")
+
+
+class _StringSubclass(str):
+    pass
+
+
+def test_require_exact_str_rejects_subclass() -> None:
+    with pytest.raises(ValueError, match="must be an exact string"):
+        _require_exact_str("key", _StringSubclass("x"))
+    with pytest.raises(ValueError, match="must be an exact string"):
+        _require_exact_str("value", _StringSubclass("x"))
+    with pytest.raises(ValueError, match="must be an exact string"):
+        _require_exact_str("name", _StringSubclass("x"))
+
+
+def test_require_exact_str_hostile_without_repr_leak() -> None:
+    evil = _EvilStr("evil")
+    with pytest.raises(ValueError, match="must be an exact string") as exc:
+        _require_exact_str("key", evil)
+    assert "EvilStr" not in str(exc.value)
+    assert "!r" not in str(exc.value)
+    evil2 = _EvilStr("val")
+    with pytest.raises(ValueError, match="must be an exact string") as exc2:
+        _require_exact_str("value", evil2)
+    assert "EvilStr" not in str(exc2.value)
+
+
+def test_significance_result_replace_unexpected_sanitized() -> None:
+    res = SignificanceResult(
+        test_name="paired_t",
+        statistic=1.5,
+        p_value=0.01,
+        significant=True,
+        alpha=0.05,
+        effect_size=0.8,
+        method_a="A",
+        method_b="B",
+    )
+    with pytest.raises(ValueError, match="Got unexpected field names") as exc:
+        res._replace(unknown_field=1)
+    msg = str(exc.value)
+    assert "!r" not in msg
+    assert "unknown_field" in msg
+
+
+def test_source_contains_no_repr_leak() -> None:
+    p1 = pathlib.Path("alberta_framework/utils/experiments.py")
+    text1 = p1.read_text(encoding="utf-8")
+    assert "Got unexpected field names: {sorted(unexpected)!r}" not in text1
+    assert "Got unexpected field names: {sorted(unexpected)}" in text1
+
+    p2 = pathlib.Path("alberta_framework/utils/statistics.py")
+    text2 = p2.read_text(encoding="utf-8")
+    assert "Got unexpected field names: {sorted(unexpected)!r}" not in text2
+    assert "Got unexpected field names: {sorted(unexpected)}" in text2
+
+
+def test_valid_still_passes() -> None:
+    assert _require_exact_str("key", "ok") == "ok"


### PR DESCRIPTION
Closes 3 trust-boundary residuals in `utils/experiments.py` and `utils/statistics.py` (evidence-safe, 3 leaks):

- Adds `_require_exact_str` host gate before keyword verification in `_replace`
- Sanitizes unexpected field name errors: unquoted list representation without `!r`
- Errors now use clean formatting (no repr), hostile `_EvilStr`/`_StringSubclass` never reaches `__str__`/`__repr__`/`__hash__`

Validation: ruff 0, mypy PASS, grep -c '!r' 0 (was 3), pytest 5 passed (hostile trust). Evidence-safe (not in evidence_manifest.py).
