### PR TITLE
fix(evaluation): reject bool IA timing seed identities

### DIFF
--- a/alberta_framework/evaluation/continual_ia_artifact.py
+++ b/alberta_framework/evaluation/continual_ia_artifact.py
@@ -1071,7 +1071,7 @@ def _validate_operational(
             condition = timing.get("condition")
             wall = _number(timing.get("wall_seconds"))
             latency = _number(timing.get("mean_step_latency_ms"))
-            if not isinstance(seed, int) or not isinstance(condition, str):
+            if type(seed) is not int or type(condition) is not str:
                 errors.append(f"condition_timings[{index}] has invalid identity")
             else:
                 observed_pairs.append((seed, condition))

--- a/tests/test_continual_ia_timing_identities.py
+++ b/tests/test_continual_ia_timing_identities.py
@@ -1,0 +1,58 @@
+"""Host-boundary identities for continual-IA operational timings."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_ia_artifact import _validate_operational
+
+pytestmark = pytest.mark.unit
+
+_ENV = {
+    "python": {"implementation": "CPython", "version": "3.12.0"},
+    "platform": {"system": "Linux", "release": "1", "machine": "x86_64"},
+    "packages": {"jax": "0", "jaxlib": "0", "numpy": "0"},
+    "jax_default_backend": "cpu",
+    "jax_devices": [{"platform": "cpu", "device_kind": "cpu"}],
+}
+
+
+def _operational(seed: object, condition: object = "baseline") -> dict[str, object]:
+    return {
+        "digest_exclusion_reason": (
+            "host environment and wall-clock timing are non-deterministic"
+        ),
+        "environment": _ENV,
+        "condition_timings": [
+            {
+                "seed": seed,
+                "condition": condition,
+                "wall_seconds": 1.0,
+                "mean_step_latency_ms": 1.0,
+            }
+        ],
+        "overall_acceptance_passed": False,
+    }
+
+
+@pytest.mark.parametrize("seed", [True, False, 1.0, "1"])
+def test_condition_timing_rejects_noncanonical_seed(seed: object) -> None:
+    errors: list[str] = []
+    _validate_operational(
+        _operational(seed),
+        expected_results=None,
+        expected_acceptance=False,
+        errors=errors,
+    )
+    assert any("invalid identity" in error for error in errors)
+
+
+def test_condition_timing_accepts_builtin_int_seed() -> None:
+    errors: list[str] = []
+    _validate_operational(
+        _operational(7),
+        expected_results=None,
+        expected_acceptance=False,
+        errors=errors,
+    )
+    assert not any("invalid identity" in error for error in errors)


### PR DESCRIPTION
Closes #1898

## What changed

`_validate_operational` used `isinstance(seed, int)`, so `True` was a legal timing-seed identity and could publish JSON `true` as seed `1`.

On `origin/main`:

- `condition_timings: [{seed: True, ...}]` did not report `invalid identity`
- legal `seed=7` still validates

## Scope

- `alberta_framework/evaluation/continual_ia_artifact.py`
- `tests/test_continual_ia_timing_identities.py`

## Known gaps

Did not run `pytest` on this Windows host (ASI deps `chex`/`jax` not installed). Please treat CI as first execution.

<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"hermes-agent","skill_revision":"local:slop-eliza/skills/slop-cash-contribute"} -->
