### PR TITLE
fix(step9): saturate Step9DreamingState.step_count at int32 max

### DIFF
--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -53,6 +53,7 @@ from alberta_framework.core.dreaming import (
     RecentObservationBufferState,
     score_dream_candidates,
 )
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.world_model import (
     ActionConditionedWorldModel,
     ActionConditionedWorldModelConfig,
@@ -904,7 +905,7 @@ def step9_update(
         world_model_state=model_state,
         behavior_model_state=final_behavior,
         buffer_state=buffer_state,
-        step_count=state.step_count + 1,
+        step_count=_saturating_int32_counter_increment(state.step_count),
     )
     return Step9DreamingUpdateResult(
         state=new_state,

--- a/tests/test_step9_lifetime_clock.py
+++ b/tests/test_step9_lifetime_clock.py
@@ -1,0 +1,91 @@
+"""Saturating lifetime clock keeps Step9DreamingState.step_count non-negative.
+
+Before this fix, ``step9_update`` advanced ``Step9DreamingState.step_count``
+with a bare ``+ 1`` on an int32 array. At ``INT32_MAX`` that wraps to
+``INT32_MIN``, silently corrupting a counter every external caller (tests,
+checkpoints, telemetry) treats as monotonically non-negative. This mirrors
+the already-fixed lifetime-clock defects in
+``alberta_framework.streams.{alberta_plan_step1,feature_discovery}`` and the
+open siblings tracked for ``GauntletStream``/``UPGDLearner``/``MixedHorde``.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.steps.step9 import (
+    Step9DreamingConfig,
+    Step9DreamingState,
+    init_step9_state,
+    make_step9_components,
+    step9_update,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def _cfg() -> Step9DreamingConfig:
+    return Step9DreamingConfig(
+        observation_dim=2,
+        n_actions=2,
+        model_hidden_sizes=(),
+        model_sparsity=0.0,
+        planning_budget=1,
+        dreaming_warmup_steps=0,
+        dreaming_max_model_error=1e30,
+    )
+
+
+def test_bare_int32_increment_wraps_negative() -> None:
+    """Document the raw JAX behaviour the old ``state.step_count + 1`` relied on."""
+    wrap = jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    assert int(wrap) == _INT32_MIN
+
+
+def test_step9_step_count_saturates_at_int32_max() -> None:
+    """A facade clock already at INT32_MAX must saturate, not wrap negative."""
+    cfg = _cfg()
+    agent, model, buffer = make_step9_components(cfg)
+    state = init_step9_state(
+        agent, model, buffer, key=jr.key(0), initial_observation=jnp.zeros(2)
+    )
+    near_max: Step9DreamingState = state.replace(  # type: ignore[attr-defined]
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+
+    result = step9_update(
+        cfg, agent, model, buffer,
+        near_max,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+
+    assert int(result.state.step_count) == _INT32_MAX
+    assert int(result.state.step_count) >= 0
+
+    again = step9_update(
+        cfg, agent, model, buffer,
+        result.state,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+    assert int(again.state.step_count) == _INT32_MAX
+    assert int(again.state.step_count) >= 0
+
+
+def test_step9_step_count_still_increments_below_max() -> None:
+    """The saturating clock is a no-op change for ordinary, unsaturated counts."""
+    cfg = _cfg()
+    agent, model, buffer = make_step9_components(cfg)
+    state = init_step9_state(
+        agent, model, buffer, key=jr.key(1), initial_observation=jnp.zeros(2)
+    )
+    result = step9_update(
+        cfg, agent, model, buffer,
+        state,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == 1


### PR DESCRIPTION
Fixes #1905.

## What

`step9_update` in `alberta_framework/steps/step9.py` advanced the Step 9
guarded-dreaming facade's own lifetime clock with a bare
`state.step_count + 1` on an int32 array. JAX/NumPy int32 addition wraps
silently on overflow: at `INT32_MAX` (`2**31 - 1`), `+ 1` produces
`INT32_MIN` instead of saturating or raising.

`Step9DreamingState` is exported public library surface
(`alberta_framework.steps.Step9DreamingState`). External callers that treat
`state.step_count` as a monotonically non-negative counter (checkpoint
cadence, logging, telemetry) would see it silently go negative after ~2.1
billion real transitions.

This mirrors the already-fixed lifetime-clock defects in
`alberta_framework.streams.{alberta_plan_step1,feature_discovery,out_of_class,synthetic}`
(#1369, #1367, #1434, #1365) and the still-open siblings tracked for
`GauntletStream` (#1843), `UPGDLearner` (#1841), and `MixedHorde` (#1787).

Note: `model_state.step_count` (the world model's own internal counter,
already gated separately at `config.dreaming_warmup_steps`) is a different
field on a different object and was never affected by this bug — only the
Step 9 facade's own `state.step_count` was.

## Fix

Reuse the existing
`alberta_framework.core.normalizers._saturating_int32_counter_increment`
helper, matching the pattern already used in the streams modules listed
above.

## Deliberately out of scope

`alberta_framework/steps/step7.py`'s `Step7DynaState.step_count` has the
identical bare-`+ 1` pattern in `step7_update`. Left unfixed here to keep
this PR to one file/one variable per the repo's contribution norms; flagged
as a follow-up in the linked issue.

## Verification

Head SHA: `df7fe617e62d1810ebb27042de6e325e8345f979` (branch off
`origin/main` at `cc877f78566675214e2f356bd797f0f3c5ec1bb0`, no other
commits in between).

Failing-test-first: `tests/test_step9_lifetime_clock.py` was written and
confirmed to fail against the unpatched function (`git stash` on
`step9.py` reproduces `int(result.state.step_count) == -2147483648` instead
of `INT32_MAX`) before the one-line fix was applied.

```
.venv/bin/python -m pytest tests/test_step9_lifetime_clock.py -q -o addopts=""
3 passed

.venv/bin/python -m pytest tests/test_step9_production.py tests/test_step9_rng.py \
  tests/test_step9_lifetime_clock.py -q -o addopts=""
195 passed

.venv/bin/python -m pytest tests/test_pipeline.py tests/test_pipeline_hostile_validation.py \
  tests/test_step9_hostile_validation.py tests/test_steps_float32_validation_hostile.py \
  -q -o addopts=""
230 passed

.venv/bin/python -m pytest tests/test_normalizers.py tests/test_normalizers_hostile_validation.py \
  -q -o addopts=""
159 passed

.venv/bin/python -m ruff check alberta_framework/steps/step9.py tests/test_step9_lifetime_clock.py
All checks passed!

.venv/bin/python -m mypy
Success: no issues found in 190 source files

git diff --check
(clean)
```

This is a mechanism-level correctness fix (L0), not a benchmark result — no
`outputs/` artifact or evidence-registry claim is affected.

## Provenance

Client: `claude-code`, provider: `anthropic`, model: `claude-sonnet-5`,
lane: `rama0x1-asi-claude-worker`.