### PR TITLE
fix(step7): saturate Step7DynaState.step_count at int32 max

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -65,6 +65,7 @@ from alberta_framework.core.average_reward import (
     DifferentialSARSAState,
     DifferentialSARSAUpdateResult,
 )
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.world_model import (
     OneStepWorldModel,
     WorldModelState,
@@ -102,9 +103,7 @@ class Step7DynaConfig:
     fixed number of model-generated one-step backups, gated by model warmup.
     """
 
-    control: Step6DifferentialSARSAConfig = field(
-        default_factory=Step6DifferentialSARSAConfig
-    )
+    control: Step6DifferentialSARSAConfig = field(default_factory=Step6DifferentialSARSAConfig)
     world_model: Step8WorldModelConfig = field(default_factory=Step8WorldModelConfig)
     planning_steps: int = 1
     planning_rollout_depth: int = 1
@@ -343,9 +342,7 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
     ):
         raise ValueError("derived Step 7 planning output bytes must fit signed int32")
     memory_scalars = (
-        2 * planning_memory_size * config.world_model.observation_dim
-        + 4 * planning_memory_size
-        + 3
+        2 * planning_memory_size * config.world_model.observation_dim + 4 * planning_memory_size + 3
     )
     if memory_scalars > _INT32_MAX or 4 * memory_scalars > _INT32_MAX:
         raise ValueError("derived Step 7 planning-memory bytes must fit signed int32")
@@ -495,12 +492,8 @@ class Step7SmokeResult:
         payload["real_td_errors_shape"] = list(self.real_td_errors_shape)
         payload["planning_td_errors_shape"] = list(self.planning_td_errors_shape)
         payload["planning_priorities_shape"] = list(self.planning_priorities_shape)
-        payload["planning_anchor_indices_shape"] = list(
-            self.planning_anchor_indices_shape
-        )
-        payload["planning_importance_ratios_shape"] = list(
-            self.planning_importance_ratios_shape
-        )
+        payload["planning_anchor_indices_shape"] = list(self.planning_anchor_indices_shape)
+        payload["planning_importance_ratios_shape"] = list(self.planning_importance_ratios_shape)
         payload["actions_shape"] = list(self.actions_shape)
         return payload
 
@@ -626,9 +619,7 @@ def init_step7_state(
         raise TypeError("agent must be an actual DifferentialSARSAAgent")
     if type(model) is not OneStepWorldModel:
         raise TypeError("model must be an actual OneStepWorldModel")
-    memory_size = _require_int(
-        "memory_size", memory_size, minimum=1, maximum=_INT32_MAX - 1
-    )
+    memory_size = _require_int("memory_size", memory_size, minimum=1, maximum=_INT32_MAX - 1)
     feature_dim = model.config.observation_dim
     if model.config.n_actions != agent.config.n_actions:
         raise ValueError("model and agent action counts must match")
@@ -725,11 +716,7 @@ def _score_planning_actions(
             jnp.mean((prediction.next_observation - anchor_observation) ** 2)
         )
         reward_priority = jnp.abs(prediction.reward)
-        return (
-            reward_priority
-            if strategy == "reward"
-            else reward_priority + transition_magnitude
-        )
+        return reward_priority if strategy == "reward" else reward_priority + transition_magnitude
 
     priorities = jax.vmap(predict_action)(actions)
     selected = jnp.argmax(priorities).astype(jnp.int32)
@@ -748,9 +735,7 @@ def _store_real_transition(
     index = state.memory_position
     memory_size = state.memory_actions.shape[0]
     observations = state.memory_observations.at[index].set(
-        jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (state.memory_observations.shape[1],)
-        )
+        jnp.asarray(observation, dtype=jnp.float32).reshape((state.memory_observations.shape[1],))
     )
     actions = state.memory_actions.at[index].set(action.astype(jnp.int32))
     rewards = state.memory_rewards.at[index].set(jnp.asarray(reward, dtype=jnp.float32))
@@ -759,12 +744,8 @@ def _store_real_transition(
             (state.memory_next_observations.shape[1],)
         )
     )
-    priorities = state.memory_priorities.at[index].set(
-        jnp.asarray(priority, dtype=jnp.float32)
-    )
-    utilities = state.memory_utilities.at[index].set(
-        jnp.asarray(priority, dtype=jnp.float32)
-    )
+    priorities = state.memory_priorities.at[index].set(jnp.asarray(priority, dtype=jnp.float32))
+    utilities = state.memory_utilities.at[index].set(jnp.asarray(priority, dtype=jnp.float32))
     count = jnp.minimum(state.memory_count + 1, memory_size)
     position = (state.memory_position + 1) % memory_size
     return (
@@ -933,8 +914,7 @@ def _apply_planning_importance_correction(
     return cast(
         DifferentialSARSAState,
         planned_state.replace(  # type: ignore[attr-defined]
-            q_weights=old_state.q_weights
-            + rho * (planned_state.q_weights - old_state.q_weights),
+            q_weights=old_state.q_weights + rho * (planned_state.q_weights - old_state.q_weights),
             q_bias=old_state.q_bias + rho * (planned_state.q_bias - old_state.q_bias),
             q_trace_weights=old_state.q_trace_weights
             + rho * (planned_state.q_trace_weights - old_state.q_trace_weights),
@@ -1063,9 +1043,7 @@ def step7_update(
             model,
             model_state,
             anchor_observation,
-            config.planning_strategy
-            if config.planning_strategy != "random"
-            else "surprise",
+            config.planning_strategy if config.planning_strategy != "random" else "surprise",
             config.control.n_actions,
         )
         action = jnp.where(
@@ -1096,13 +1074,12 @@ def step7_update(
             anchor_priority,
             anchor_priority + priority,
         )
+
         def rollout_step(
             rollout_carry: tuple[DifferentialSARSAState, Array, Array, Array],
             _: Array,
         ) -> tuple[tuple[DifferentialSARSAState, Array, Array, Array], tuple[Array, Array]]:
-            rollout_state, rollout_observation, rollout_action, rollout_key = (
-                rollout_carry
-            )
+            rollout_state, rollout_observation, rollout_action, rollout_key = rollout_carry
             prediction = model.predict(
                 model_state,
                 rollout_observation,
@@ -1235,7 +1212,7 @@ def step7_update(
         memory_utilities=planned_memory_utilities,
         memory_count=memory_count,
         memory_position=memory_position,
-        step_count=state.step_count + 1,
+        step_count=_saturating_int32_counter_increment(state.step_count),
     )
     return Step7DynaUpdateResult(
         state=new_state,
@@ -1309,20 +1286,23 @@ def run_step7_scan(
             result.planning_accepted,
         )
 
-    final_state, (
-        real_td_errors,
-        average_rewards,
-        actions,
-        model_reward_errors,
-        model_next_observation_errors,
-        model_updates_applied,
-        planning_td_errors,
-        planning_priorities,
-        planning_anchor_indices,
-        planning_behavior_probs,
-        planning_target_probs,
-        planning_importance_ratios,
-        planning_accepted,
+    (
+        final_state,
+        (
+            real_td_errors,
+            average_rewards,
+            actions,
+            model_reward_errors,
+            model_next_observation_errors,
+            model_updates_applied,
+            planning_td_errors,
+            planning_priorities,
+            planning_anchor_indices,
+            planning_behavior_probs,
+            planning_target_probs,
+            planning_importance_ratios,
+            planning_accepted,
+        ),
     ) = jax.lax.scan(scan_step, state, (rewards, next_observations))
     return Step7DynaArrayResult(
         state=final_state,
@@ -1363,9 +1343,7 @@ def run_step7_smoke(
     real_output_bytes = steps * (17 + 4 * observation_dim)
     planning_output_bytes = steps * cfg.planning_steps * 25
     memory_scalars = (
-        2 * cfg.planning_memory_size * observation_dim
-        + 4 * cfg.planning_memory_size
-        + 3
+        2 * cfg.planning_memory_size * observation_dim + 4 * cfg.planning_memory_size + 3
     )
     memory_bytes = 4 * memory_scalars
     total_bytes = input_bytes + real_output_bytes + planning_output_bytes + memory_bytes
@@ -1415,9 +1393,7 @@ def run_step7_smoke(
         seed=seed,
         real_td_errors_shape=tuple(int(dim) for dim in result.real_td_errors.shape),
         planning_td_errors_shape=tuple(int(dim) for dim in result.planning_td_errors.shape),
-        planning_priorities_shape=tuple(
-            int(dim) for dim in result.planning_priorities.shape
-        ),
+        planning_priorities_shape=tuple(int(dim) for dim in result.planning_priorities.shape),
         planning_anchor_indices_shape=tuple(
             int(dim) for dim in result.planning_anchor_indices.shape
         ),

--- a/tests/test_step7_lifetime_clock.py
+++ b/tests/test_step7_lifetime_clock.py
@@ -1,0 +1,93 @@
+"""Saturating lifetime clock keeps Step7DynaState.step_count non-negative."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.steps.step6 import Step6DifferentialSARSAConfig
+from alberta_framework.steps.step7 import (
+    Step7DynaConfig,
+    Step7DynaState,
+    init_step7_state,
+    make_step7_components,
+    step7_update,
+)
+from alberta_framework.steps.step8 import Step8WorldModelConfig
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def _cfg() -> Step7DynaConfig:
+    return Step7DynaConfig(
+        control=Step6DifferentialSARSAConfig(n_actions=2),
+        world_model=Step8WorldModelConfig(observation_dim=2, n_actions=2),
+        planning_steps=1,
+        planning_warmup_steps=0,
+        planning_memory_size=16,
+    )
+
+
+def test_bare_int32_increment_wraps_negative() -> None:
+    wrap = jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    assert int(wrap) == _INT32_MIN
+
+
+def test_step7_step_count_saturates_at_int32_max() -> None:
+    cfg = _cfg()
+    agent, model = make_step7_components(cfg)
+    state = init_step7_state(
+        agent,
+        model,
+        key=jr.key(0),
+        initial_observation=jnp.zeros(2),
+        memory_size=cfg.planning_memory_size,
+    )
+    near_max: Step7DynaState = state.replace(  # type: ignore[attr-defined]
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+
+    result = step7_update(
+        cfg,
+        agent,
+        model,
+        near_max,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+
+    assert int(result.state.step_count) == _INT32_MAX
+    assert int(result.state.step_count) >= 0
+
+    again = step7_update(
+        cfg,
+        agent,
+        model,
+        result.state,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+    assert int(again.state.step_count) == _INT32_MAX
+    assert int(again.state.step_count) >= 0
+
+
+def test_step7_step_count_increments_below_max() -> None:
+    cfg = _cfg()
+    agent, model = make_step7_components(cfg)
+    state = init_step7_state(
+        agent,
+        model,
+        key=jr.key(1),
+        initial_observation=jnp.zeros(2),
+        memory_size=cfg.planning_memory_size,
+    )
+    result = step7_update(
+        cfg,
+        agent,
+        model,
+        state,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == 1


### PR DESCRIPTION
Saturating lifetime clock keeps `Step7DynaState.step_count` non-negative:

- In `step7_update` (`alberta_framework/steps/step7.py`), `step_count` was advanced with a bare `+ 1` on an `int32` array.
- At `INT32_MAX`, bare addition wraps to negative (`INT32_MIN`), breaking downstream monotonicity assumptions in checkpoints, telemetry, and evaluation gates.
- Uses `_saturating_int32_counter_increment` to clamp at `INT32_MAX`.

Validation: ruff 0, mypy PASS, pytest 3 passed (`tests/test_step7_lifetime_clock.py`). Evidence-safe (unpinned).
