### PR TITLE
fix(horde): saturate MixedHorde step_count at int32 max

### DIFF
--- a/alberta_framework/core/horde.py
+++ b/alberta_framework/core/horde.py
@@ -42,6 +42,7 @@ from alberta_framework.core.normalizers import (
     EMANormalizerState,
     Normalizer,
     WelfordNormalizerState,
+    _saturating_int32_counter_increment,
 )
 from alberta_framework.core.optimizers import Bounder
 from alberta_framework.core.types import HordeSpec, TraceMode
@@ -91,6 +92,7 @@ def _canonical_horde_host_scalars(
         _require_float32("leaky_relu_slope", leaky_relu_slope, lower=0.0),
         _require_exact_bool("use_layer_norm", use_layer_norm),
     )
+
 
 # =============================================================================
 # Types
@@ -284,8 +286,7 @@ class HordeLearner:
         # learner's exact-nonzero guard sees the value that will actually
         # be used (0.0 trace decay), not an unrepresentable exact product.
         per_head_gl = tuple(
-            float(np.float32(d.gamma) * np.float32(d.lamda))
-            for d in horde_spec.demons
+            float(np.float32(d.gamma) * np.float32(d.lamda)) for d in horde_spec.demons
         )
 
         self._learner = MultiHeadMLPLearner(
@@ -363,22 +364,16 @@ class HordeLearner:
         state_schema = config.pop("state_schema", MULTI_HEAD_MLP_STATE_SCHEMA)
         host_state_schema = _require_exact_str("state_schema", state_schema)
         if host_state_schema != MULTI_HEAD_MLP_STATE_SCHEMA:
-            raise ValueError(
-                f"unsupported Horde state schema: '{MULTI_HEAD_MLP_STATE_SCHEMA}'"
-            )
+            raise ValueError(f"unsupported Horde state schema: '{MULTI_HEAD_MLP_STATE_SCHEMA}'")
 
         horde_spec = HordeSpec.from_config(config.pop("horde_spec"))
         optimizer = optimizer_from_config(config.pop("optimizer"))
         bounder_cfg = config.pop("bounder", None)
         bounder = bounder_from_config(bounder_cfg) if bounder_cfg is not None else None
         normalizer_cfg = config.pop("normalizer", None)
-        normalizer = (
-            normalizer_from_config(normalizer_cfg) if normalizer_cfg is not None else None
-        )
+        normalizer = normalizer_from_config(normalizer_cfg) if normalizer_cfg is not None else None
         head_opt_cfg = config.pop("head_optimizer", None)
-        head_optimizer = (
-            optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
-        )
+        head_optimizer = optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
 
         trace_mode_str = config.pop("trace_mode", None)
         trace_mode = (
@@ -451,9 +446,7 @@ class HordeLearner:
         cumulants = jnp.asarray(cumulants)
         expected_shape = (self.n_demons,)
         if cumulants.shape != expected_shape:
-            raise ValueError(
-                f"cumulants must have shape {expected_shape}, got {cumulants.shape}"
-            )
+            raise ValueError(f"cumulants must have shape {expected_shape}, got {cumulants.shape}")
 
         # 1. Compute V(s') for bootstrapping
         next_preds = self._learner.predict(state, next_observation)
@@ -488,9 +481,7 @@ class HordeLearner:
                 ),
                 jnp.zeros_like(result.predictions),
             ),
-            td_errors=_report_head_values(
-                result.errors, requested, head_updates_applied
-            ),
+            td_errors=_report_head_values(result.errors, requested, head_updates_applied),
             td_targets=_report_head_values(targets, requested, head_updates_applied),
             per_demon_metrics=_report_head_values(
                 result.per_head_metrics, requested, head_updates_applied
@@ -536,13 +527,9 @@ class HordeLearner:
         discounts = jnp.asarray(discounts, dtype=jnp.float32)
         expected_shape = (self.n_demons,)
         if cumulants.shape != expected_shape:
-            raise ValueError(
-                f"cumulants must have shape {expected_shape}, got {cumulants.shape}"
-            )
+            raise ValueError(f"cumulants must have shape {expected_shape}, got {cumulants.shape}")
         if discounts.shape != expected_shape:
-            raise ValueError(
-                f"discounts must have shape {expected_shape}, got {discounts.shape}"
-            )
+            raise ValueError(f"discounts must have shape {expected_shape}, got {discounts.shape}")
 
         next_preds = self._learner.predict(state, next_observation)
         bootstrap = jnp.where(discounts == 0.0, 0.0, discounts * next_preds)
@@ -579,9 +566,7 @@ class HordeLearner:
                 ),
                 jnp.zeros_like(result.predictions),
             ),
-            td_errors=_report_head_values(
-                result.errors, requested, head_updates_applied
-            ),
+            td_errors=_report_head_values(result.errors, requested, head_updates_applied),
             td_targets=_report_head_values(targets, requested, head_updates_applied),
             per_demon_metrics=_report_head_values(
                 result.per_head_metrics, requested, head_updates_applied
@@ -725,19 +710,11 @@ class MixedHorde:
             "type": "MixedHorde",
             "horde_spec": self._horde_spec.to_config(),
             "hidden_sizes": list(self._hidden_sizes),
-            "optimizer": (
-                self._optimizer.to_config() if self._optimizer is not None else None
-            ),
-            "bounder": (
-                self._bounder.to_config() if self._bounder is not None else None
-            ),
-            "normalizer": (
-                self._normalizer.to_config() if self._normalizer is not None else None
-            ),
+            "optimizer": (self._optimizer.to_config() if self._optimizer is not None else None),
+            "bounder": (self._bounder.to_config() if self._bounder is not None else None),
+            "normalizer": (self._normalizer.to_config() if self._normalizer is not None else None),
             "head_optimizer": (
-                self._head_optimizer.to_config()
-                if self._head_optimizer is not None
-                else None
+                self._head_optimizer.to_config() if self._head_optimizer is not None else None
             ),
             "step_size": self._step_size,
             "sparsity": self._sparsity,
@@ -763,13 +740,9 @@ class MixedHorde:
         bounder_cfg = config.pop("bounder", None)
         bounder = bounder_from_config(bounder_cfg) if bounder_cfg is not None else None
         normalizer_cfg = config.pop("normalizer", None)
-        normalizer = (
-            normalizer_from_config(normalizer_cfg) if normalizer_cfg is not None else None
-        )
+        normalizer = normalizer_from_config(normalizer_cfg) if normalizer_cfg is not None else None
         head_opt_cfg = config.pop("head_optimizer", None)
-        head_optimizer = (
-            optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
-        )
+        head_optimizer = optimizer_from_config(head_opt_cfg) if head_opt_cfg is not None else None
         trace_mode_str = config.pop("trace_mode", None)
         trace_mode = (
             TraceMode(trace_mode_str) if trace_mode_str is not None else TraceMode.ACCUMULATING
@@ -815,16 +788,14 @@ class MixedHorde:
         if self._shared_horde is not None:
             shared_state = cast(MultiHeadMLPState, state.shared_state)
             shared_preds = self._shared_horde.predict(shared_state, observation)
-            preds = preds.at[jnp.asarray(self._shared_indices, dtype=jnp.int32)].set(
-                shared_preds
-            )
+            preds = preds.at[jnp.asarray(self._shared_indices, dtype=jnp.int32)].set(shared_preds)
         if self._independent_horde is not None:
             independent_preds = self._independent_horde.predict(
                 state.independent_state, observation
             )
-            preds = preds.at[
-                jnp.asarray(self._independent_indices, dtype=jnp.int32)
-            ].set(independent_preds)
+            preds = preds.at[jnp.asarray(self._independent_indices, dtype=jnp.int32)].set(
+                independent_preds
+            )
         return preds
 
     def update(
@@ -857,9 +828,7 @@ class MixedHorde:
             predictions = predictions.at[idx].set(shared_result.predictions)
             td_errors = td_errors.at[idx].set(shared_result.td_errors)
             td_targets = td_targets.at[idx].set(shared_result.td_targets)
-            per_demon_metrics = per_demon_metrics.at[idx].set(
-                shared_result.per_demon_metrics
-            )
+            per_demon_metrics = per_demon_metrics.at[idx].set(shared_result.per_demon_metrics)
             head_updates_applied = head_updates_applied.at[idx].set(
                 shared_result.head_updates_applied
             )
@@ -878,9 +847,7 @@ class MixedHorde:
             predictions = predictions.at[idx].set(independent_result.predictions)
             td_errors = td_errors.at[idx].set(independent_result.td_errors)
             td_targets = td_targets.at[idx].set(independent_result.td_targets)
-            per_demon_metrics = per_demon_metrics.at[idx].set(
-                independent_result.per_demon_metrics
-            )
+            per_demon_metrics = per_demon_metrics.at[idx].set(independent_result.per_demon_metrics)
             head_updates_applied = head_updates_applied.at[idx].set(
                 independent_result.head_updates_applied
             )
@@ -889,7 +856,7 @@ class MixedHorde:
         proposed_state = MixedHordeState(
             shared_state=new_shared_state,
             independent_state=new_independent_state,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )
@@ -957,11 +924,14 @@ def run_horde_learning_loop(
         )
 
     t0 = time.time()
-    final_state, (
-        per_demon_metrics,
-        td_errors,
-        head_updates_applied,
-        updates_applied,
+    (
+        final_state,
+        (
+            per_demon_metrics,
+            td_errors,
+            head_updates_applied,
+            updates_applied,
+        ),
     ) = jax.lax.scan(step_fn, state, (observations, cumulants, next_observations))
     elapsed = time.time() - t0
     final_state = final_state.replace(uptime_s=final_state.uptime_s + elapsed)  # type: ignore[attr-defined]
@@ -998,11 +968,14 @@ def run_mixed_horde_learning_loop(
         )
 
     t0 = time.time()
-    final_state, (
-        per_demon_metrics,
-        td_errors,
-        head_updates_applied,
-        updates_applied,
+    (
+        final_state,
+        (
+            per_demon_metrics,
+            td_errors,
+            head_updates_applied,
+            updates_applied,
+        ),
     ) = jax.lax.scan(step_fn, state, (observations, cumulants, next_observations))
     elapsed = time.time() - t0
     final_state = final_state.replace(  # type: ignore[attr-defined]

--- a/tests/test_mixed_horde.py
+++ b/tests/test_mixed_horde.py
@@ -13,6 +13,8 @@ configs run without trunk-trace assertion errors, and that
 ``to_config`` / ``from_config`` round-trip preserves all settings.
 """
 
+import dataclasses
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -71,9 +73,7 @@ def _random_walk_arrays(
     k1, k2 = jr.split(key)
     observations = jr.normal(k1, (num_steps, feature_dim))
     cumulants = jr.normal(k2, (num_steps, n_demons))
-    next_observations = jnp.concatenate(
-        [observations[1:], observations[:1]], axis=0
-    )
+    next_observations = jnp.concatenate([observations[1:], observations[:1]], axis=0)
     return observations, cumulants, next_observations
 
 
@@ -95,9 +95,7 @@ class TestRouting:
         assert horde.independent_horde is None
 
     def test_all_independent_when_gamma_lamda_positive(self) -> None:
-        demons = [
-            _temporal_demon(f"d{i}", i, gamma=0.9, lamda=0.5) for i in range(3)
-        ]
+        demons = [_temporal_demon(f"d{i}", i, gamma=0.9, lamda=0.5) for i in range(3)]
         spec = create_horde_spec(demons)
         horde = MixedHorde(horde_spec=spec, hidden_sizes=(8,), sparsity=0.0)
         assert horde.shared_indices == ()
@@ -190,9 +188,7 @@ class TestAllSharedEqualsHordeLearner:
         chex.assert_trees_all_close(
             m_result.per_demon_metrics, s_result.per_demon_metrics, rtol=1e-5
         )
-        chex.assert_trees_all_close(
-            m_result.td_errors, s_result.td_errors, rtol=1e-5
-        )
+        chex.assert_trees_all_close(m_result.td_errors, s_result.td_errors, rtol=1e-5)
 
 
 # =============================================================================
@@ -204,9 +200,7 @@ class TestAllIndependentEqualsIndependentDemonHorde:
     """All-independent MixedHorde matches IndependentDemonHorde exactly."""
 
     def test_predictions_match(self) -> None:
-        demons = [
-            _temporal_demon(f"d{i}", i, gamma=0.9, lamda=0.5) for i in range(2)
-        ]
+        demons = [_temporal_demon(f"d{i}", i, gamma=0.9, lamda=0.5) for i in range(2)]
         spec = create_horde_spec(demons)
 
         common_kwargs = {
@@ -233,10 +227,7 @@ class TestAllIndependentEqualsIndependentDemonHorde:
         n_demons = 2
         feature_dim = 5
         num_steps = 200
-        demons = [
-            _temporal_demon(f"d{i}", i, gamma=0.9, lamda=0.5)
-            for i in range(n_demons)
-        ]
+        demons = [_temporal_demon(f"d{i}", i, gamma=0.9, lamda=0.5) for i in range(n_demons)]
         spec = create_horde_spec(demons)
 
         common_kwargs = {
@@ -270,17 +261,13 @@ class TestAllIndependentEqualsIndependentDemonHorde:
         chex.assert_trees_all_close(
             m_result.per_demon_metrics, i_result.per_demon_metrics, rtol=1e-5
         )
-        chex.assert_trees_all_close(
-            m_result.td_errors, i_result.td_errors, rtol=1e-5
-        )
+        chex.assert_trees_all_close(m_result.td_errors, i_result.td_errors, rtol=1e-5)
 
     def test_rejected_update_has_neutral_trunk_metric_and_recovers_under_jit(
         self,
     ) -> None:
         """An all-independent refusal must not report a successful bound."""
-        spec = create_horde_spec(
-            [_temporal_demon("temporal", 0, gamma=0.9, lamda=0.5)]
-        )
+        spec = create_horde_spec([_temporal_demon("temporal", 0, gamma=0.9, lamda=0.5)])
         horde = MixedHorde(
             horde_spec=spec,
             hidden_sizes=(),
@@ -424,12 +411,8 @@ class TestOriginalDemonOrder:
         chex.assert_trees_all_close(result.td_targets[0], cumulants[0])
         chex.assert_trees_all_close(result.td_targets[2], cumulants[2])
         # temporal demons: target == cumulant + gamma * V(s')
-        chex.assert_trees_all_close(
-            result.td_targets[1], cumulants[1] + 0.9 * v_next[1], atol=1e-5
-        )
-        chex.assert_trees_all_close(
-            result.td_targets[3], cumulants[3] + 0.5 * v_next[3], atol=1e-5
-        )
+        chex.assert_trees_all_close(result.td_targets[1], cumulants[1] + 0.9 * v_next[1], atol=1e-5)
+        chex.assert_trees_all_close(result.td_targets[3], cumulants[3] + 0.5 * v_next[3], atol=1e-5)
 
 
 # =============================================================================
@@ -492,9 +475,7 @@ class TestConfigRoundtrip:
         assert restored.shared_horde is not None
 
     def test_config_roundtrip_all_independent(self) -> None:
-        demons = [
-            _temporal_demon(f"d{i}", i, gamma=0.9, lamda=0.5) for i in range(2)
-        ]
+        demons = [_temporal_demon(f"d{i}", i, gamma=0.9, lamda=0.5) for i in range(2)]
         spec = create_horde_spec(demons)
         original = MixedHorde(
             horde_spec=spec,
@@ -547,9 +528,7 @@ class TestRunMixedHordeLearningLoop:
             horde, state, observations, cumulants, next_observations
         )
         assert isinstance(result, MixedHordeLearningResult)
-        chex.assert_shape(
-            result.per_demon_metrics, (num_steps, n_demons, 3)
-        )
+        chex.assert_shape(result.per_demon_metrics, (num_steps, n_demons, 3))
         chex.assert_shape(result.td_errors, (num_steps, n_demons))
 
 
@@ -588,3 +567,43 @@ class TestStep3RoutingDispatch:
         cfg = Step3HordeConfig(routing="mixed")
         restored = Step3HordeConfig.from_dict(cfg.to_dict())
         assert restored.routing == "mixed"
+
+
+class TestMixedHordeLifetimeClock:
+    """Saturating lifetime clock keeps MixedHordeState.step_count non-negative."""
+
+    def test_mixed_horde_step_count_saturates_at_int32_max(self) -> None:
+        spec = create_horde_spec([_gamma0_demon("imm", 0)])
+        horde = MixedHorde(
+            horde_spec=spec,
+            hidden_sizes=(),
+            step_size=0.05,
+            sparsity=0.0,
+        )
+        state = horde.init(2, jr.key(23))
+        near_max = dataclasses.replace(state, step_count=jnp.array(2147483647, dtype=jnp.int32))
+        res = horde.update(
+            near_max,
+            jnp.ones(2, dtype=jnp.float32),
+            jnp.array([1.0], dtype=jnp.float32),
+            jnp.zeros(2, dtype=jnp.float32),
+        )
+        assert int(res.state.step_count) == 2147483647
+        assert int(res.state.step_count) >= 0
+
+    def test_mixed_horde_step_count_increments_below_max(self) -> None:
+        spec = create_horde_spec([_gamma0_demon("imm", 0)])
+        horde = MixedHorde(
+            horde_spec=spec,
+            hidden_sizes=(),
+            step_size=0.05,
+            sparsity=0.0,
+        )
+        state = horde.init(2, jr.key(23))
+        res = horde.update(
+            state,
+            jnp.ones(2, dtype=jnp.float32),
+            jnp.array([1.0], dtype=jnp.float32),
+            jnp.zeros(2, dtype=jnp.float32),
+        )
+        assert int(res.state.step_count) == 1


### PR DESCRIPTION
Saturating lifetime clock keeps `MixedHordeState.step_count` non-negative:

- In `MixedHorde.update` (`alberta_framework/core/horde.py`), `step_count` was advanced with a bare `+ 1` on an `int32` array leaf.
- At `INT32_MAX`, bare addition wraps to negative (`INT32_MIN`), breaking downstream monotonicity assumptions in checkpoints, telemetry, and evaluation gates.
- Uses `_saturating_int32_counter_increment` to clamp at `INT32_MAX`.

Validation: ruff 0, mypy PASS, pytest 21 passed (`tests/test_mixed_horde.py`). Evidence-safe (unpinned).
