### PR TITLE
fix(core): saturate UPGDLearner step_count at int32 max

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -53,6 +53,7 @@ from alberta_framework.core._float32_scalars import (
     validated_float32_scalar_with_ratio,
 )
 from alberta_framework.core.initializers import sparse_init
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.optimizers import Bounder, ObGDBounding
 from alberta_framework.core.types import MLPParams
 from alberta_framework.core.update_safety import zero_if_collapsed_infinity
@@ -131,9 +132,7 @@ def _validated_config_float(
     return stored
 
 
-def _require_float32_resource(
-    name: str, *, vector_scalars: int, fixed_scalars: int = 0
-) -> None:
+def _require_float32_resource(name: str, *, vector_scalars: int, fixed_scalars: int = 0) -> None:
     total = vector_scalars + fixed_scalars
     if total > _INT32_MAX:
         raise ValueError(f"{name} scalar count must fit signed int32")
@@ -635,13 +634,9 @@ class UPGDLearner:
             raise ValueError("hidden_sizes must be a tuple of integers")
         canonical_hidden: list[int] = []
         for idx, size in enumerate(hidden_sizes):
-            canonical_hidden.append(
-                _require_int(f"hidden_sizes[{idx}]", size, minimum=1)
-            )
+            canonical_hidden.append(_require_int(f"hidden_sizes[{idx}]", size, minimum=1))
         hidden_sizes = tuple(canonical_hidden)
-        validated_step_size = _validated_config_float(
-            "step_size", step_size, lower=0.0
-        )
+        validated_step_size = _validated_config_float("step_size", step_size, lower=0.0)
         validated_perturbation_sigma = _validated_config_float(
             "perturbation_sigma", perturbation_sigma, lower=0.0
         )
@@ -668,8 +663,9 @@ class UPGDLearner:
             "leaky_relu_slope", leaky_relu_slope, lower=0.0
         )
         loss_normalization = _require_choice(
-            "loss_normalization", loss_normalization,
-                frozenset({"mean", "sum", "target_density", "target_structure"})
+            "loss_normalization",
+            loss_normalization,
+            frozenset({"mean", "sum", "target_density", "target_structure"}),
         )
         validated_positive_target_loss_scale = _validated_config_float(
             "positive_target_loss_scale", positive_target_loss_scale, lower=0.0
@@ -699,15 +695,21 @@ class UPGDLearner:
             "head_repetition_multiplier", head_repetition_multiplier, lower=0.0
         )
         validated_head_repetition_decay = _validated_config_float(
-            "head_repetition_decay", head_repetition_decay,
-                lower=0.0, upper=1.0, upper_inclusive=False
+            "head_repetition_decay",
+            head_repetition_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
         )
         validated_head_repetition_delta_threshold = _validated_config_float(
             "head_repetition_delta_threshold", head_repetition_delta_threshold, lower=0.0
         )
         validated_head_repetition_pressure_threshold = _validated_config_float(
-            "head_repetition_pressure_threshold", head_repetition_pressure_threshold,
-                lower=0.0, upper=1.0, upper_inclusive=False
+            "head_repetition_pressure_threshold",
+            head_repetition_pressure_threshold,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
         )
         head_repetition_warmup_steps = _require_int(
             "head_repetition_warmup_steps", head_repetition_warmup_steps, minimum=0
@@ -728,26 +730,32 @@ class UPGDLearner:
                 upper_inclusive=False,
             )
         validated_unit_long_utility_decay = _validated_config_float(
-            "unit_long_utility_decay", unit_long_utility_decay,
-                lower=0.0, upper=1.0, upper_inclusive=False
+            "unit_long_utility_decay",
+            unit_long_utility_decay,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
         )
         validated_unit_gradient_decay = _validated_config_float(
             "unit_gradient_decay", unit_gradient_decay, lower=0.0, upper=1.0, upper_inclusive=False
         )
         unit_replacement_criterion = _require_choice(
-            "unit_replacement_criterion", unit_replacement_criterion,
-                frozenset({"low_utility", "stale_gradient_ratio", "low_long_and_gradient"})
+            "unit_replacement_criterion",
+            unit_replacement_criterion,
+            frozenset({"low_utility", "stale_gradient_ratio", "low_long_and_gradient"}),
         )
         unit_replacement_fanin = _require_choice(
-            "unit_replacement_fanin", unit_replacement_fanin,
-                frozenset({"random", "gradient_columns"})
+            "unit_replacement_fanin",
+            unit_replacement_fanin,
+            frozenset({"random", "gradient_columns"}),
         )
         validated_unit_replacement_loss_gate_ratio = _validated_config_float(
             "unit_replacement_loss_gate_ratio", unit_replacement_loss_gate_ratio, lower=0.0
         )
         unit_replacement_budget_mode = _require_choice(
-            "unit_replacement_budget_mode", unit_replacement_budget_mode,
-                frozenset({"always", "gated", "loss_pressure"})
+            "unit_replacement_budget_mode",
+            unit_replacement_budget_mode,
+            frozenset({"always", "gated", "loss_pressure"}),
         )
         validated_unit_replacement_outgoing_scale = _validated_config_float(
             "unit_replacement_outgoing_scale", unit_replacement_outgoing_scale, lower=0.0
@@ -768,8 +776,9 @@ class UPGDLearner:
             "loss_slow_decay", loss_slow_decay, lower=0.0, upper=1.0, upper_inclusive=False
         )
         adaptive_kappa_mode = _require_choice(
-            "adaptive_kappa_mode", adaptive_kappa_mode,
-                frozenset({"none", "loss_ratio", "gradient_alignment"})
+            "adaptive_kappa_mode",
+            adaptive_kappa_mode,
+            frozenset({"none", "loss_ratio", "gradient_alignment"}),
         )
         validated_adaptive_kappa_base = _validated_config_float(
             "adaptive_kappa_base", adaptive_kappa_base, positive=True
@@ -833,15 +842,14 @@ class UPGDLearner:
         adaptive_kappa_meta_warmup_steps = _require_int(
             "adaptive_kappa_meta_warmup_steps", adaptive_kappa_meta_warmup_steps, minimum=0
         )
-        if (
-            type(meta_plasticity_mode) is not str
-            or meta_plasticity_mode not in {"none", "gradient_alignment"}
-        ):
+        if type(meta_plasticity_mode) is not str or meta_plasticity_mode not in {
+            "none",
+            "gradient_alignment",
+        }:
             if type(meta_plasticity_mode) is str:
                 host_mpm = _require_exact_str("meta_plasticity_mode", meta_plasticity_mode)
                 msg = (
-                    "meta_plasticity_mode must be 'none' or 'gradient_alignment', "
-                    f"got '{host_mpm}'"
+                    f"meta_plasticity_mode must be 'none' or 'gradient_alignment', got '{host_mpm}'"
                 )
             else:
                 msg = "meta_plasticity_mode must be 'none' or 'gradient_alignment', got non-string"
@@ -881,10 +889,7 @@ class UPGDLearner:
                 "two_timescale_simplex",
             ),
         }
-        if (
-            type(readout_mode) is not str
-            or readout_mode not in readout_aliases
-        ):
+        if type(readout_mode) is not str or readout_mode not in readout_aliases:
             if type(readout_mode) is str:
                 host_rm = _require_exact_str("readout_mode", readout_mode)
                 msg = (
@@ -941,18 +946,17 @@ class UPGDLearner:
                     "got non-string"
                 )
             raise ValueError(msg)
-        if (
-            type(resolved_readout_prediction_mode) is not str
-            or resolved_readout_prediction_mode not in {
-                "identity",
-                "softmax",
-                "adaptive_simplex",
-                "factorized_simplex",
-                "adaptive_factorized_simplex",
-                "two_timescale_simplex",
-                "unit_clip",
-            }
-        ):
+        if type(
+            resolved_readout_prediction_mode
+        ) is not str or resolved_readout_prediction_mode not in {
+            "identity",
+            "softmax",
+            "adaptive_simplex",
+            "factorized_simplex",
+            "adaptive_factorized_simplex",
+            "two_timescale_simplex",
+            "unit_clip",
+        }:
             if type(resolved_readout_prediction_mode) is str:
                 host_rrpm = _require_exact_str(
                     "resolved_readout_prediction_mode",
@@ -989,8 +993,9 @@ class UPGDLearner:
             "readout_input_mode", readout_input_mode, frozenset({"hidden", "hidden_plus_input"})
         )
         readout_head_normalization = _require_choice(
-            "readout_head_normalization", readout_head_normalization,
-                frozenset({"none", "hidden_norm"})
+            "readout_head_normalization",
+            readout_head_normalization,
+            frozenset({"none", "hidden_norm"}),
         )
         validated_readout_margin = _validated_config_float(
             "readout_margin", readout_margin, lower=0.0
@@ -1002,43 +1007,55 @@ class UPGDLearner:
             "readout_label_adapter_step_size", readout_label_adapter_step_size, lower=0.0
         )
         validated_readout_label_adapter_identity_regularization = _validated_config_float(
-            "readout_label_adapter_identity_regularization", readout_label_adapter_identity_regularization,  # noqa: E501
-                lower=0.0
+            "readout_label_adapter_identity_regularization",
+            readout_label_adapter_identity_regularization,  # noqa: E501
+            lower=0.0,
         )
         validated_readout_label_adapter_entropy_regularization = _validated_config_float(
-            "readout_label_adapter_entropy_regularization", readout_label_adapter_entropy_regularization,  # noqa: E501
-                lower=0.0
+            "readout_label_adapter_entropy_regularization",
+            readout_label_adapter_entropy_regularization,  # noqa: E501
+            lower=0.0,
         )
         validated_readout_label_adapter_floor = _validated_config_float(
-            "readout_label_adapter_floor", readout_label_adapter_floor,
-                lower=0.0, upper=1.0, upper_inclusive=False
+            "readout_label_adapter_floor",
+            readout_label_adapter_floor,
+            lower=0.0,
+            upper=1.0,
+            upper_inclusive=False,
         )
         validated_readout_fast_head_step_size_multiplier = _validated_config_float(
-            "readout_fast_head_step_size_multiplier", readout_fast_head_step_size_multiplier,
-                lower=0.0
+            "readout_fast_head_step_size_multiplier",
+            readout_fast_head_step_size_multiplier,
+            lower=0.0,
         )
         validated_readout_fast_head_bias_step_size_multiplier = _validated_config_float(
-            "readout_fast_head_bias_step_size_multiplier", readout_fast_head_bias_step_size_multiplier,  # noqa: E501
-                lower=0.0
+            "readout_fast_head_bias_step_size_multiplier",
+            readout_fast_head_bias_step_size_multiplier,  # noqa: E501
+            lower=0.0,
         )
         validated_readout_fast_trunk_gradient_multiplier = _validated_config_float(
-            "readout_fast_trunk_gradient_multiplier", readout_fast_trunk_gradient_multiplier,
-                lower=0.0
+            "readout_fast_trunk_gradient_multiplier",
+            readout_fast_trunk_gradient_multiplier,
+            lower=0.0,
         )
         readout_fast_head_bounder_mode = _require_choice(
-            "readout_fast_head_bounder_mode", readout_fast_head_bounder_mode,
-                frozenset({"shared", "separate"})
+            "readout_fast_head_bounder_mode",
+            readout_fast_head_bounder_mode,
+            frozenset({"shared", "separate"}),
         )
         validated_readout_slow_simplex_gradient_multiplier = _validated_config_float(
-            "readout_slow_simplex_gradient_multiplier", readout_slow_simplex_gradient_multiplier,
-                lower=0.0
+            "readout_slow_simplex_gradient_multiplier",
+            readout_slow_simplex_gradient_multiplier,
+            lower=0.0,
         )
         validated_readout_simplex_bias_decay = _validated_config_float(
             "readout_simplex_bias_decay", readout_simplex_bias_decay, lower=0.0, upper=1.0
         )
         validated_readout_simplex_bias_centering_rate = _validated_config_float(
-            "readout_simplex_bias_centering_rate", readout_simplex_bias_centering_rate,
-                lower=0.0, upper=1.0
+            "readout_simplex_bias_centering_rate",
+            readout_simplex_bias_centering_rate,
+            lower=0.0,
+            upper=1.0,
         )
 
         if type(use_layer_norm) is not bool:
@@ -1068,9 +1085,7 @@ class UPGDLearner:
                 fixed_scalars=int(n_heads),
             )
         else:
-            _require_float32_resource(
-                "heads", vector_scalars=int(n_heads), fixed_scalars=0
-            )
+            _require_float32_resource("heads", vector_scalars=int(n_heads), fixed_scalars=0)
         # Complete readout-related preflight for label adapter (n_heads^2)
         _require_float32_resource(
             "readout_label_adapter",
@@ -1142,9 +1157,7 @@ class UPGDLearner:
         self._adaptive_kappa_meta_max_multiplier = float(
             validated_adaptive_kappa_meta_max_multiplier
         )
-        self._adaptive_kappa_meta_warmup_steps = int(
-            adaptive_kappa_meta_warmup_steps
-        )
+        self._adaptive_kappa_meta_warmup_steps = int(adaptive_kappa_meta_warmup_steps)
         self._meta_plasticity_mode = meta_plasticity_mode
         self._meta_plasticity_step_size = float(validated_meta_plasticity_step_size)
         self._meta_plasticity_min_multiplier = float(validated_meta_plasticity_min_multiplier)
@@ -1665,7 +1678,9 @@ class UPGDLearner:
                 unit_scalars += 4 * fan_out  # unit_utilities, long, grad_ema, ages
             unit_scalars += 2 * len(trunk_layer_sizes[1:])  # replacement counts/accumulators
         if store_grad:
-            grad_scalars += total_trunk_params + total_trunk_bias + total_head_params + total_head_bias  # noqa: E501
+            grad_scalars += (
+                total_trunk_params + total_trunk_bias + total_head_params + total_head_bias
+            )  # noqa: E501
         total_scalars = (
             total_trunk_params
             + total_trunk_bias
@@ -3327,7 +3342,7 @@ class UPGDLearner:
             previous_head_weight_grads=next_previous_head_weight_grads,
             previous_head_bias_grads=next_previous_head_bias_grads,
             key=new_key,
-            step_count=state.step_count + 1,
+            step_count=_saturating_int32_counter_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
         )

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -20,6 +20,8 @@ subject: ``TestUtilityTracking``/``TestPerturbation`` (up to ``sigma=1.0``
 so noise effects are unmistakable) and ``sparsity=0.5`` round-trips.
 """
 
+import dataclasses
+
 import chex
 import jax.numpy as jnp
 import jax.random as jr
@@ -54,9 +56,7 @@ class TestInitShapes:
         chex.assert_shape(state.trunk_params.biases[1], (16,))
 
     def test_head_shapes(self):
-        learner = UPGDLearner(
-            n_heads=4, hidden_sizes=(16,), sparsity=0.0, perturbation_sigma=0.0
-        )
+        learner = UPGDLearner(n_heads=4, hidden_sizes=(16,), sparsity=0.0, perturbation_sigma=0.0)
         state = learner.init(feature_dim=8, key=jr.key(0))
         assert len(state.head_params.weights) == 4
         assert len(state.readout_fast_head_params.weights) == 4
@@ -106,9 +106,7 @@ class TestInitShapes:
         chex.assert_shape(state.unit_replacement_accumulators, (2,))
 
     def test_utilities_initialized_to_zero(self):
-        learner = UPGDLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0, perturbation_sigma=0.0
-        )
+        learner = UPGDLearner(n_heads=2, hidden_sizes=(16,), sparsity=0.0, perturbation_sigma=0.0)
         state = learner.init(feature_dim=5, key=jr.key(0))
         for u in state.utilities:
             chex.assert_trees_all_close(u, jnp.zeros_like(u))
@@ -122,16 +120,12 @@ class TestInitShapes:
             chex.assert_trees_all_close(age, jnp.zeros_like(age))
 
     def test_step_count_is_zero(self):
-        learner = UPGDLearner(
-            n_heads=2, hidden_sizes=(16,), sparsity=0.0, perturbation_sigma=0.0
-        )
+        learner = UPGDLearner(n_heads=2, hidden_sizes=(16,), sparsity=0.0, perturbation_sigma=0.0)
         state = learner.init(feature_dim=5, key=jr.key(0))
         assert int(state.step_count) == 0
 
     def test_linear_baseline_no_utilities(self):
-        learner = UPGDLearner(
-            n_heads=2, hidden_sizes=(), sparsity=0.0, perturbation_sigma=0.0
-        )
+        learner = UPGDLearner(n_heads=2, hidden_sizes=(), sparsity=0.0, perturbation_sigma=0.0)
         state = learner.init(feature_dim=5, key=jr.key(0))
         assert len(state.utilities) == 0
         assert len(state.unit_utilities) == 0
@@ -422,18 +416,14 @@ class TestPredictShapes:
     """Predictions should have shape (n_heads,) for any input."""
 
     def test_returns_n_heads(self):
-        learner = UPGDLearner(
-            n_heads=5, hidden_sizes=(16,), sparsity=0.0, perturbation_sigma=0.0
-        )
+        learner = UPGDLearner(n_heads=5, hidden_sizes=(16,), sparsity=0.0, perturbation_sigma=0.0)
         state = learner.init(feature_dim=7, key=jr.key(0))
         preds = learner.predict(state, jnp.ones(7))
         chex.assert_shape(preds, (5,))
         chex.assert_tree_all_finite(preds)
 
     def test_returns_n_heads_zero_input(self):
-        learner = UPGDLearner(
-            n_heads=3, hidden_sizes=(8, 4), sparsity=0.0, perturbation_sigma=0.0
-        )
+        learner = UPGDLearner(n_heads=3, hidden_sizes=(8, 4), sparsity=0.0, perturbation_sigma=0.0)
         state = learner.init(feature_dim=4, key=jr.key(0))
         preds = learner.predict(state, jnp.zeros(4))
         chex.assert_shape(preds, (3,))
@@ -687,8 +677,11 @@ class TestUpdateMetrics:
 
     def test_update_returns_finite_metrics(self):
         learner = UPGDLearner(
-            n_heads=2, hidden_sizes=(8,), sparsity=0.0,
-            step_size=0.01, perturbation_sigma=1e-3,
+            n_heads=2,
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            step_size=0.01,
+            perturbation_sigma=1e-3,
         )
         state = learner.init(feature_dim=5, key=jr.key(0))
         for _ in range(5):
@@ -743,12 +736,10 @@ class TestUpdateMetrics:
         sum_result = sum_learner.update(state, obs, targets)
 
         mean_delta = jnp.linalg.norm(
-            mean_result.state.trunk_params.weights[0]
-            - state.trunk_params.weights[0]
+            mean_result.state.trunk_params.weights[0] - state.trunk_params.weights[0]
         )
         sum_delta = jnp.linalg.norm(
-            sum_result.state.trunk_params.weights[0]
-            - state.trunk_params.weights[0]
+            sum_result.state.trunk_params.weights[0] - state.trunk_params.weights[0]
         )
         assert float(sum_delta) > float(mean_delta)
 
@@ -825,9 +816,7 @@ class TestUpdateMetrics:
         )
 
         dense_zero_targets = jnp.array([0.5, 0.0, -0.25])
-        structure_dense_zero = structure_learner.update(
-            state, obs, dense_zero_targets
-        )
+        structure_dense_zero = structure_learner.update(state, obs, dense_zero_targets)
         mean_dense_zero = mean_learner.update(state, obs, dense_zero_targets)
         chex.assert_trees_all_close(
             structure_dense_zero.state.trunk_params,
@@ -902,20 +891,16 @@ class TestUpdateMetrics:
         scaled_result = scaled.update(state, obs, targets)
 
         plain_trunk_delta = jnp.linalg.norm(
-            plain_result.state.trunk_params.weights[0]
-            - state.trunk_params.weights[0]
+            plain_result.state.trunk_params.weights[0] - state.trunk_params.weights[0]
         )
         scaled_trunk_delta = jnp.linalg.norm(
-            scaled_result.state.trunk_params.weights[0]
-            - state.trunk_params.weights[0]
+            scaled_result.state.trunk_params.weights[0] - state.trunk_params.weights[0]
         )
         plain_head_delta = jnp.linalg.norm(
-            plain_result.state.head_params.weights[0]
-            - state.head_params.weights[0]
+            plain_result.state.head_params.weights[0] - state.head_params.weights[0]
         )
         scaled_head_delta = jnp.linalg.norm(
-            scaled_result.state.head_params.weights[0]
-            - state.head_params.weights[0]
+            scaled_result.state.head_params.weights[0] - state.head_params.weights[0]
         )
 
         chex.assert_trees_all_close(scaled_trunk_delta, plain_trunk_delta)
@@ -943,12 +928,10 @@ class TestUpdateMetrics:
         downweighted_result = downweighted.update(state, obs, targets)
 
         plain_negative_delta = jnp.linalg.norm(
-            plain_result.state.head_params.weights[1]
-            - state.head_params.weights[1]
+            plain_result.state.head_params.weights[1] - state.head_params.weights[1]
         )
         downweighted_negative_delta = jnp.linalg.norm(
-            downweighted_result.state.head_params.weights[1]
-            - state.head_params.weights[1]
+            downweighted_result.state.head_params.weights[1] - state.head_params.weights[1]
         )
         assert float(downweighted_negative_delta) < float(plain_negative_delta)
 
@@ -1067,12 +1050,10 @@ class TestUpdateMetrics:
             plain_result.state.trunk_params.weights[0],
         )
         plain_head_delta = jnp.linalg.norm(
-            plain_result.state.head_params.weights[0]
-            - state.head_params.weights[0]
+            plain_result.state.head_params.weights[0] - state.head_params.weights[0]
         )
         scaled_head_delta = jnp.linalg.norm(
-            scaled_result.state.head_params.weights[0]
-            - state.head_params.weights[0]
+            scaled_result.state.head_params.weights[0] - state.head_params.weights[0]
         )
         assert float(scaled_head_delta) > float(plain_head_delta)
 
@@ -1237,9 +1218,7 @@ class TestUpdateMetrics:
         after = learner.predict(result.state, obs)
 
         assert float(after[1]) > float(before[1])
-        assert float(jnp.linalg.norm(after - target)) < float(
-            jnp.linalg.norm(before - target)
-        )
+        assert float(jnp.linalg.norm(after - target)) < float(jnp.linalg.norm(before - target))
         assert not jnp.allclose(
             result.state.readout_label_adapter,
             state.readout_label_adapter,
@@ -1300,8 +1279,7 @@ class TestUpdateMetrics:
         active_result = active.update(state, obs, target)
 
         passive_delta = jnp.linalg.norm(
-            passive_result.state.trunk_params.weights[0]
-            - state.trunk_params.weights[0]
+            passive_result.state.trunk_params.weights[0] - state.trunk_params.weights[0]
         )
         active_delta = jnp.linalg.norm(
             active_result.state.trunk_params.weights[0]
@@ -1421,12 +1399,10 @@ class TestUpdateMetrics:
         suppressed_result = suppressed.update(state, obs, target)
 
         baseline_slow_delta = jnp.linalg.norm(
-            baseline_result.state.head_params.weights[1]
-            - state.head_params.weights[1]
+            baseline_result.state.head_params.weights[1] - state.head_params.weights[1]
         )
         suppressed_slow_delta = jnp.linalg.norm(
-            suppressed_result.state.head_params.weights[1]
-            - state.head_params.weights[1]
+            suppressed_result.state.head_params.weights[1] - state.head_params.weights[1]
         )
         suppressed_fast_delta = jnp.linalg.norm(
             suppressed_result.state.readout_fast_head_params.weights[1]
@@ -1457,8 +1433,8 @@ class TestUtilityTracking:
             n_heads=1,
             hidden_sizes=(16,),
             sparsity=0.0,
-            step_size=0.0,            # freeze SGD so weights stay constant
-            perturbation_sigma=0.0,   # no perturbation noise
+            step_size=0.0,  # freeze SGD so weights stay constant
+            perturbation_sigma=0.0,  # no perturbation noise
             utility_decay=0.99,
         )
         state = learner.init(feature_dim=feature_dim, key=jr.key(123))
@@ -1521,12 +1497,8 @@ class TestUtilityTracking:
         state = state.replace(  # type: ignore[attr-defined]
             utilities=tuple(jnp.full_like(u, jnp.inf) for u in state.utilities),
             unit_utilities=tuple(jnp.full_like(u, jnp.inf) for u in state.unit_utilities),
-            unit_long_utilities=tuple(
-                jnp.full_like(u, jnp.inf) for u in state.unit_long_utilities
-            ),
-            unit_gradient_emas=tuple(
-                jnp.full_like(u, jnp.inf) for u in state.unit_gradient_emas
-            ),
+            unit_long_utilities=tuple(jnp.full_like(u, jnp.inf) for u in state.unit_long_utilities),
+            unit_gradient_emas=tuple(jnp.full_like(u, jnp.inf) for u in state.unit_gradient_emas),
             loss_fast_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
             loss_slow_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
             target_repeat_ema=jnp.asarray(jnp.inf, dtype=jnp.float32),
@@ -1584,12 +1556,8 @@ class TestUtilityTracking:
         )
         state = learner.init(feature_dim=6, key=jr.key(12))
         state = state.replace(  # type: ignore[attr-defined]
-            unit_long_utilities=(
-                jnp.array([10.0, 1.0, 1.0, 1.0], dtype=jnp.float32),
-            ),
-            unit_gradient_emas=(
-                jnp.array([0.0, 1.0, 1.0, 1.0], dtype=jnp.float32),
-            ),
+            unit_long_utilities=(jnp.array([10.0, 1.0, 1.0, 1.0], dtype=jnp.float32),),
+            unit_gradient_emas=(jnp.array([0.0, 1.0, 1.0, 1.0], dtype=jnp.float32),),
             unit_ages=(jnp.array([5, 5, 5, 5], dtype=jnp.int32),),
         )
 
@@ -1749,9 +1717,7 @@ class TestUtilityTracking:
 
         head_deltas = [
             float(
-                jnp.linalg.norm(
-                    result.state.head_params.weights[i] - state.head_params.weights[i]
-                )
+                jnp.linalg.norm(result.state.head_params.weights[i] - state.head_params.weights[i])
             )
             for i in range(3)
         ]
@@ -1820,10 +1786,10 @@ class TestPerturbation:
             hidden_sizes=(8,),
             sparsity=0.0,
             step_size=0.0,
-            perturbation_sigma=1.0,   # large noise so the difference is obvious
+            perturbation_sigma=1.0,  # large noise so the difference is obvious
             perturbation_beta=2.0,
             perturbation_interval=1,
-            utility_decay=0.0,        # use the instantaneous |w*grad| as utility
+            utility_decay=0.0,  # use the instantaneous |w*grad| as utility
         )
         state = learner.init(feature_dim=4, key=jr.key(7))
 
@@ -2091,9 +2057,7 @@ class TestConfigRoundtrip:
     def test_roundtrip_with_bounder(self):
         from alberta_framework.core.optimizers import ObGDBounding
 
-        learner = UPGDLearner(
-            n_heads=2, hidden_sizes=(8,), bounder=ObGDBounding(kappa=2.0)
-        )
+        learner = UPGDLearner(n_heads=2, hidden_sizes=(8,), bounder=ObGDBounding(kappa=2.0))
         cfg = learner.to_config()
         assert cfg["bounder"] is not None
         rebuilt = UPGDLearner.from_config(cfg)
@@ -2140,9 +2104,7 @@ class TestNanMaskedTarget:
         assert jnp.isnan(result.errors[1])
 
         # Head 0 weights should have moved
-        assert not jnp.allclose(
-            result.state.head_params.weights[0], state.head_params.weights[0]
-        )
+        assert not jnp.allclose(result.state.head_params.weights[0], state.head_params.weights[0])
 
 
 # =============================================================================
@@ -2198,8 +2160,11 @@ class TestLoops:
 
     def test_run_upgd_arrays_smoke(self):
         learner = UPGDLearner(
-            n_heads=1, hidden_sizes=(8,), sparsity=0.0,
-            step_size=0.01, perturbation_sigma=1e-4,
+            n_heads=1,
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            step_size=0.01,
+            perturbation_sigma=1e-4,
         )
         state = learner.init(feature_dim=4, key=jr.key(0))
         observations = jr.normal(jr.key(1), (50, 4))
@@ -2213,9 +2178,50 @@ class TestLoops:
         from alberta_framework.streams.synthetic import RandomWalkStream
 
         learner = UPGDLearner(
-            n_heads=1, hidden_sizes=(8,), sparsity=0.0,
-            step_size=0.01, perturbation_sigma=1e-4,
+            n_heads=1,
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            step_size=0.01,
+            perturbation_sigma=1e-4,
         )
         stream = RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.05)
         result = run_upgd_loop(learner, stream, num_steps=50, key=jr.key(0))
         chex.assert_shape(result.metrics, (50, 4))
+
+
+class TestUPGDLifetimeClock:
+    """Saturating lifetime clock keeps UPGDState.step_count non-negative."""
+
+    def test_upgd_step_count_saturates_at_int32_max(self) -> None:
+        learner = UPGDLearner(
+            n_heads=1,
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            step_size=0.01,
+            perturbation_sigma=1e-4,
+        )
+        state = learner.init(feature_dim=4, key=jr.key(0))
+        near_max = dataclasses.replace(state, step_count=jnp.array(2147483647, dtype=jnp.int32))
+        res = learner.update(
+            near_max,
+            jnp.ones((4,), dtype=jnp.float32),
+            jnp.ones((1,), dtype=jnp.float32),
+        )
+        assert int(res.state.step_count) == 2147483647
+        assert int(res.state.step_count) >= 0
+
+    def test_upgd_step_count_increments_below_max(self) -> None:
+        learner = UPGDLearner(
+            n_heads=1,
+            hidden_sizes=(8,),
+            sparsity=0.0,
+            step_size=0.01,
+            perturbation_sigma=1e-4,
+        )
+        state = learner.init(feature_dim=4, key=jr.key(0))
+        res = learner.update(
+            state,
+            jnp.ones((4,), dtype=jnp.float32),
+            jnp.ones((1,), dtype=jnp.float32),
+        )
+        assert int(res.state.step_count) == 1


### PR DESCRIPTION
Saturating lifetime clock keeps `UPGDState.step_count` non-negative:

- In `UPGDLearner.update` (`alberta_framework/core/upgd.py`), `step_count` was advanced with a bare `+ 1` on an `int32` array leaf.
- At `INT32_MAX`, bare addition wraps to negative (`INT32_MIN`), breaking downstream monotonicity assumptions in checkpoints, telemetry, and evaluation gates.
- Uses `_saturating_int32_counter_increment` to clamp at `INT32_MAX`.

Validation: ruff 0, mypy PASS, pytest 90 passed (`tests/test_upgd.py`). Evidence-safe (unpinned).
