### PR TITLE
fix: close remaining timing and lifetime-clock gaps

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -41,6 +41,7 @@ from alberta_framework.core.behavior_model import (
     floor_and_renormalize_probabilities,
     selected_action_probabilities,
 )
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.world_model import (
     ActionConditionedWorldModel,
     ActionConditionedWorldModelState,
@@ -75,9 +76,7 @@ _ACTUAL_FLOAT_TYPES: frozenset[type] = frozenset(
 _ALLOWED_REAL_TYPES: frozenset[type] = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
 
 
-def _require_int(
-    name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX
-) -> int:
+def _require_int(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
         raise ValueError(f"{name} must be an integer")
     canonical = operator.index(cast(SupportsIndex, value))
@@ -110,9 +109,7 @@ def _validated_config_float(
     return stored
 
 
-def _require_float32_resource(
-    name: str, *, vector_scalars: int, fixed_scalars: int = 0
-) -> None:
+def _require_float32_resource(name: str, *, vector_scalars: int, fixed_scalars: int = 0) -> None:
     total = vector_scalars + fixed_scalars
     if total > _INT32_MAX:
         raise ValueError(f"{name} scalar count must fit signed int32")
@@ -131,8 +128,6 @@ def _copy_mapping(payload: object, *, name: str) -> dict[str, object]:
         if type(key) is not str:
             raise ValueError(f"{name} payload has exact strings as keys")
     return data
-
-
 
 
 def _require_bool(value: object, name: str) -> bool:
@@ -194,9 +189,7 @@ class DreamingConfig:
             object.__setattr__(
                 self,
                 "max_discount",
-                _validated_config_float(
-                    "max_discount", self.max_discount, lower=0.0
-                ),
+                _validated_config_float("max_discount", self.max_discount, lower=0.0),
             )
         object.__setattr__(
             self,
@@ -291,9 +284,7 @@ class DreamSelectionConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar configuration, rejecting NaN and type stand-ins."""
-        object.__setattr__(
-            self, "max_items", _require_int("max_items", self.max_items, minimum=1)
-        )
+        object.__setattr__(self, "max_items", _require_int("max_items", self.max_items, minimum=1))
         for name in (
             "surprise_weight",
             "utility_weight",
@@ -302,9 +293,7 @@ class DreamSelectionConfig:
             "min_surprise",
             "min_utility",
         ):
-            object.__setattr__(
-                self, name, _validated_config_float(name, getattr(self, name))
-            )
+            object.__setattr__(self, name, _validated_config_float(name, getattr(self, name)))
         for name in ("min_confidence", "max_model_error"):
             object.__setattr__(
                 self,
@@ -324,9 +313,7 @@ class DreamSelectionConfig:
         data = _copy_mapping(config, name="DreamSelectionConfig")
         config_type = data.pop("type", None)
         if type(config_type) is not str or config_type != "DreamSelectionConfig":
-            raise ValueError(
-                "DreamSelectionConfig payload type must be DreamSelectionConfig"
-            )
+            raise ValueError("DreamSelectionConfig payload type must be DreamSelectionConfig")
         allowed = {
             "max_items",
             "surprise_weight",
@@ -371,27 +358,17 @@ class GuardedDreamer:
         # so instances mutated through object.__setattr__ (or crafted subclasses)
         # cannot smuggle NaN or type stand-ins past the guard.
         _require_int("warmup_steps", self._config.warmup_steps, minimum=0)
-        _validated_config_float(
-            "max_model_error_ema", self._config.max_model_error_ema, lower=0.0
-        )
-        _validated_config_float(
-            "max_uncertainty", self._config.max_uncertainty, lower=0.0
-        )
+        _validated_config_float("max_model_error_ema", self._config.max_model_error_ema, lower=0.0)
+        _validated_config_float("max_uncertainty", self._config.max_uncertainty, lower=0.0)
         _validated_config_float("min_discount", self._config.min_discount, lower=0.0)
         if self._config.max_discount is not None:
-            _validated_config_float(
-                "max_discount", self._config.max_discount, lower=0.0
-            )
+            _validated_config_float("max_discount", self._config.max_discount, lower=0.0)
         _require_int("rollout_horizon", self._config.rollout_horizon, minimum=1)
         _validated_config_float(
             "confidence_threshold", self._config.confidence_threshold, lower=0.0
         )
-        _validated_config_float(
-            "max_model_error", self._config.max_model_error, lower=0.0
-        )
-        _validated_config_float(
-            "discount_floor", self._config.discount_floor, lower=0.0
-        )
+        _validated_config_float("max_model_error", self._config.max_model_error, lower=0.0)
+        _validated_config_float("discount_floor", self._config.discount_floor, lower=0.0)
         _require_bool(self._config.stop_on_terminal, "stop_on_terminal")
 
     @property
@@ -436,9 +413,7 @@ class GuardedDreamer:
         uncertainty_arr = jnp.asarray(uncertainty, dtype=jnp.float32)
         prediction = model.predict(model_state, observation, action)
         max_discount = (
-            model.config.gamma
-            if self._config.max_discount is None
-            else self._config.max_discount
+            model.config.gamma if self._config.max_discount is None else self._config.max_discount
         )
         discount = jnp.clip(
             prediction.discount,
@@ -580,6 +555,7 @@ def score_dream_candidates(
         & (confidence_arr >= jnp.asarray(cfg.min_confidence, dtype=jnp.float32))
         & (error_arr <= jnp.asarray(cfg.max_model_error, dtype=jnp.float32))
     )
+
     def weighted_term(weight: float, values: Array) -> Array:
         weight_arr = jnp.asarray(weight, dtype=jnp.float32)
         return jnp.where(
@@ -613,9 +589,7 @@ class RecentObservationBuffer:
     def __init__(self, capacity: int, observation_dim: int):
         """Initialize the buffer shape."""
         self._capacity = _require_int("capacity", capacity, minimum=1)
-        self._observation_dim = _require_int(
-            "observation_dim", observation_dim, minimum=1
-        )
+        self._observation_dim = _require_int("observation_dim", observation_dim, minimum=1)
         _require_float32_resource(
             "RecentObservationBuffer",
             vector_scalars=self._capacity * self._observation_dim,
@@ -653,9 +627,7 @@ class RecentObservationBuffer:
         observation: Array,
     ) -> RecentObservationBufferState:
         """Insert one observation into the ring buffer."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._observation_dim,)
-        )
+        obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._observation_dim,))
         next_observations = state.observations.at[state.index].set(obs)
         return RecentObservationBufferState(
             observations=next_observations,
@@ -749,9 +721,7 @@ class DreamRolloutConfig:
         data = _copy_mapping(config, name="DreamRolloutConfig")
         config_type = data.pop("type", None)
         if type(config_type) is not str or config_type != "DreamRolloutConfig":
-            raise ValueError(
-                "DreamRolloutConfig payload type must be DreamRolloutConfig"
-            )
+            raise ValueError("DreamRolloutConfig payload type must be DreamRolloutConfig")
         allowed = {
             "rollout_horizon",
             "confidence_threshold",
@@ -979,7 +949,7 @@ def dream_one_step(
             rollout_state.cumulative_confidence * world_prediction.confidence,
             rollout_state.cumulative_confidence,
         ),
-        step_count=rollout_state.step_count + 1,
+        step_count=_saturating_int32_counter_increment(rollout_state.step_count),
     )
     transition = ImaginedTransition(
         observation=rollout_state.observation,
@@ -1067,9 +1037,7 @@ def imagined_transition_to_supervised_item(
     transition: ImaginedTransition,
     *,
     n_actions: int | None = None,
-    target: Literal["next_observation", "reward", "reward_next_observation"] = (
-        "next_observation"
-    ),
+    target: Literal["next_observation", "reward", "reward_next_observation"] = ("next_observation"),
 ) -> DreamSupervisedTrainingItem:
     """Convert one imagined transition to a supervised model-learning item."""
     inputs = jnp.concatenate(
@@ -1080,9 +1048,7 @@ def imagined_transition_to_supervised_item(
         axis=0,
     )
     reward = jnp.reshape(jnp.asarray(transition.reward, dtype=jnp.float32), (1,))
-    next_observation = jnp.ravel(
-        jnp.asarray(transition.next_observation, dtype=jnp.float32)
-    )
+    next_observation = jnp.ravel(jnp.asarray(transition.next_observation, dtype=jnp.float32))
     if type(target) is not str or target not in {
         "next_observation",
         "reward",
@@ -1138,9 +1104,7 @@ def imagined_rollout_to_gvf_items(
     return DreamGVFTrainingItem(
         observations=_neutralize_invalid(transitions.observation, transitions.valid),
         cumulants=_neutralize_invalid(cumulant_array, transitions.valid),
-        next_observations=_neutralize_invalid(
-            transitions.next_observation, transitions.valid
-        ),
+        next_observations=_neutralize_invalid(transitions.next_observation, transitions.valid),
         discounts=_neutralize_invalid(
             jnp.asarray(transitions.discount, dtype=jnp.float32), transitions.valid
         ),
@@ -1169,9 +1133,7 @@ def imagined_rollout_to_sarsa_items(
         rewards=_neutralize_invalid(
             jnp.asarray(transitions.reward, dtype=jnp.float32), transitions.valid
         ),
-        next_observations=_neutralize_invalid(
-            transitions.next_observation, transitions.valid
-        ),
+        next_observations=_neutralize_invalid(transitions.next_observation, transitions.valid),
         discounts=_neutralize_invalid(
             jnp.asarray(transitions.discount, dtype=jnp.float32), transitions.valid
         ),

--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -76,7 +76,9 @@ _ACTUAL_FLOAT_TYPES: frozenset[type] = frozenset(
 _ALLOWED_REAL_TYPES: frozenset[type] = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
 
 
-def _require_int(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+def _require_int(
+    name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX
+) -> int:
     if type(value) not in _ACTUAL_INT_TYPES:
         raise ValueError(f"{name} must be an integer")
     canonical = operator.index(cast(SupportsIndex, value))
@@ -109,7 +111,9 @@ def _validated_config_float(
     return stored
 
 
-def _require_float32_resource(name: str, *, vector_scalars: int, fixed_scalars: int = 0) -> None:
+def _require_float32_resource(
+    name: str, *, vector_scalars: int, fixed_scalars: int = 0
+) -> None:
     total = vector_scalars + fixed_scalars
     if total > _INT32_MAX:
         raise ValueError(f"{name} scalar count must fit signed int32")
@@ -128,6 +132,8 @@ def _copy_mapping(payload: object, *, name: str) -> dict[str, object]:
         if type(key) is not str:
             raise ValueError(f"{name} payload has exact strings as keys")
     return data
+
+
 
 
 def _require_bool(value: object, name: str) -> bool:
@@ -189,7 +195,9 @@ class DreamingConfig:
             object.__setattr__(
                 self,
                 "max_discount",
-                _validated_config_float("max_discount", self.max_discount, lower=0.0),
+                _validated_config_float(
+                    "max_discount", self.max_discount, lower=0.0
+                ),
             )
         object.__setattr__(
             self,
@@ -284,7 +292,9 @@ class DreamSelectionConfig:
 
     def __post_init__(self) -> None:
         """Validate scalar configuration, rejecting NaN and type stand-ins."""
-        object.__setattr__(self, "max_items", _require_int("max_items", self.max_items, minimum=1))
+        object.__setattr__(
+            self, "max_items", _require_int("max_items", self.max_items, minimum=1)
+        )
         for name in (
             "surprise_weight",
             "utility_weight",
@@ -293,7 +303,9 @@ class DreamSelectionConfig:
             "min_surprise",
             "min_utility",
         ):
-            object.__setattr__(self, name, _validated_config_float(name, getattr(self, name)))
+            object.__setattr__(
+                self, name, _validated_config_float(name, getattr(self, name))
+            )
         for name in ("min_confidence", "max_model_error"):
             object.__setattr__(
                 self,
@@ -313,7 +325,9 @@ class DreamSelectionConfig:
         data = _copy_mapping(config, name="DreamSelectionConfig")
         config_type = data.pop("type", None)
         if type(config_type) is not str or config_type != "DreamSelectionConfig":
-            raise ValueError("DreamSelectionConfig payload type must be DreamSelectionConfig")
+            raise ValueError(
+                "DreamSelectionConfig payload type must be DreamSelectionConfig"
+            )
         allowed = {
             "max_items",
             "surprise_weight",
@@ -358,17 +372,27 @@ class GuardedDreamer:
         # so instances mutated through object.__setattr__ (or crafted subclasses)
         # cannot smuggle NaN or type stand-ins past the guard.
         _require_int("warmup_steps", self._config.warmup_steps, minimum=0)
-        _validated_config_float("max_model_error_ema", self._config.max_model_error_ema, lower=0.0)
-        _validated_config_float("max_uncertainty", self._config.max_uncertainty, lower=0.0)
+        _validated_config_float(
+            "max_model_error_ema", self._config.max_model_error_ema, lower=0.0
+        )
+        _validated_config_float(
+            "max_uncertainty", self._config.max_uncertainty, lower=0.0
+        )
         _validated_config_float("min_discount", self._config.min_discount, lower=0.0)
         if self._config.max_discount is not None:
-            _validated_config_float("max_discount", self._config.max_discount, lower=0.0)
+            _validated_config_float(
+                "max_discount", self._config.max_discount, lower=0.0
+            )
         _require_int("rollout_horizon", self._config.rollout_horizon, minimum=1)
         _validated_config_float(
             "confidence_threshold", self._config.confidence_threshold, lower=0.0
         )
-        _validated_config_float("max_model_error", self._config.max_model_error, lower=0.0)
-        _validated_config_float("discount_floor", self._config.discount_floor, lower=0.0)
+        _validated_config_float(
+            "max_model_error", self._config.max_model_error, lower=0.0
+        )
+        _validated_config_float(
+            "discount_floor", self._config.discount_floor, lower=0.0
+        )
         _require_bool(self._config.stop_on_terminal, "stop_on_terminal")
 
     @property
@@ -413,7 +437,9 @@ class GuardedDreamer:
         uncertainty_arr = jnp.asarray(uncertainty, dtype=jnp.float32)
         prediction = model.predict(model_state, observation, action)
         max_discount = (
-            model.config.gamma if self._config.max_discount is None else self._config.max_discount
+            model.config.gamma
+            if self._config.max_discount is None
+            else self._config.max_discount
         )
         discount = jnp.clip(
             prediction.discount,
@@ -555,7 +581,6 @@ def score_dream_candidates(
         & (confidence_arr >= jnp.asarray(cfg.min_confidence, dtype=jnp.float32))
         & (error_arr <= jnp.asarray(cfg.max_model_error, dtype=jnp.float32))
     )
-
     def weighted_term(weight: float, values: Array) -> Array:
         weight_arr = jnp.asarray(weight, dtype=jnp.float32)
         return jnp.where(
@@ -589,7 +614,9 @@ class RecentObservationBuffer:
     def __init__(self, capacity: int, observation_dim: int):
         """Initialize the buffer shape."""
         self._capacity = _require_int("capacity", capacity, minimum=1)
-        self._observation_dim = _require_int("observation_dim", observation_dim, minimum=1)
+        self._observation_dim = _require_int(
+            "observation_dim", observation_dim, minimum=1
+        )
         _require_float32_resource(
             "RecentObservationBuffer",
             vector_scalars=self._capacity * self._observation_dim,
@@ -627,7 +654,9 @@ class RecentObservationBuffer:
         observation: Array,
     ) -> RecentObservationBufferState:
         """Insert one observation into the ring buffer."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._observation_dim,))
+        obs = jnp.asarray(observation, dtype=jnp.float32).reshape(
+            (self._observation_dim,)
+        )
         next_observations = state.observations.at[state.index].set(obs)
         return RecentObservationBufferState(
             observations=next_observations,
@@ -721,7 +750,9 @@ class DreamRolloutConfig:
         data = _copy_mapping(config, name="DreamRolloutConfig")
         config_type = data.pop("type", None)
         if type(config_type) is not str or config_type != "DreamRolloutConfig":
-            raise ValueError("DreamRolloutConfig payload type must be DreamRolloutConfig")
+            raise ValueError(
+                "DreamRolloutConfig payload type must be DreamRolloutConfig"
+            )
         allowed = {
             "rollout_horizon",
             "confidence_threshold",
@@ -1037,7 +1068,9 @@ def imagined_transition_to_supervised_item(
     transition: ImaginedTransition,
     *,
     n_actions: int | None = None,
-    target: Literal["next_observation", "reward", "reward_next_observation"] = ("next_observation"),
+    target: Literal["next_observation", "reward", "reward_next_observation"] = (
+        "next_observation"
+    ),
 ) -> DreamSupervisedTrainingItem:
     """Convert one imagined transition to a supervised model-learning item."""
     inputs = jnp.concatenate(
@@ -1048,7 +1081,9 @@ def imagined_transition_to_supervised_item(
         axis=0,
     )
     reward = jnp.reshape(jnp.asarray(transition.reward, dtype=jnp.float32), (1,))
-    next_observation = jnp.ravel(jnp.asarray(transition.next_observation, dtype=jnp.float32))
+    next_observation = jnp.ravel(
+        jnp.asarray(transition.next_observation, dtype=jnp.float32)
+    )
     if type(target) is not str or target not in {
         "next_observation",
         "reward",
@@ -1104,7 +1139,9 @@ def imagined_rollout_to_gvf_items(
     return DreamGVFTrainingItem(
         observations=_neutralize_invalid(transitions.observation, transitions.valid),
         cumulants=_neutralize_invalid(cumulant_array, transitions.valid),
-        next_observations=_neutralize_invalid(transitions.next_observation, transitions.valid),
+        next_observations=_neutralize_invalid(
+            transitions.next_observation, transitions.valid
+        ),
         discounts=_neutralize_invalid(
             jnp.asarray(transitions.discount, dtype=jnp.float32), transitions.valid
         ),
@@ -1133,7 +1170,9 @@ def imagined_rollout_to_sarsa_items(
         rewards=_neutralize_invalid(
             jnp.asarray(transitions.reward, dtype=jnp.float32), transitions.valid
         ),
-        next_observations=_neutralize_invalid(transitions.next_observation, transitions.valid),
+        next_observations=_neutralize_invalid(
+            transitions.next_observation, transitions.valid
+        ),
         discounts=_neutralize_invalid(
             jnp.asarray(transitions.discount, dtype=jnp.float32), transitions.valid
         ),

--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -103,7 +103,9 @@ class Step7DynaConfig:
     fixed number of model-generated one-step backups, gated by model warmup.
     """
 
-    control: Step6DifferentialSARSAConfig = field(default_factory=Step6DifferentialSARSAConfig)
+    control: Step6DifferentialSARSAConfig = field(
+        default_factory=Step6DifferentialSARSAConfig
+    )
     world_model: Step8WorldModelConfig = field(default_factory=Step8WorldModelConfig)
     planning_steps: int = 1
     planning_rollout_depth: int = 1
@@ -342,7 +344,9 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
     ):
         raise ValueError("derived Step 7 planning output bytes must fit signed int32")
     memory_scalars = (
-        2 * planning_memory_size * config.world_model.observation_dim + 4 * planning_memory_size + 3
+        2 * planning_memory_size * config.world_model.observation_dim
+        + 4 * planning_memory_size
+        + 3
     )
     if memory_scalars > _INT32_MAX or 4 * memory_scalars > _INT32_MAX:
         raise ValueError("derived Step 7 planning-memory bytes must fit signed int32")
@@ -492,8 +496,12 @@ class Step7SmokeResult:
         payload["real_td_errors_shape"] = list(self.real_td_errors_shape)
         payload["planning_td_errors_shape"] = list(self.planning_td_errors_shape)
         payload["planning_priorities_shape"] = list(self.planning_priorities_shape)
-        payload["planning_anchor_indices_shape"] = list(self.planning_anchor_indices_shape)
-        payload["planning_importance_ratios_shape"] = list(self.planning_importance_ratios_shape)
+        payload["planning_anchor_indices_shape"] = list(
+            self.planning_anchor_indices_shape
+        )
+        payload["planning_importance_ratios_shape"] = list(
+            self.planning_importance_ratios_shape
+        )
         payload["actions_shape"] = list(self.actions_shape)
         return payload
 
@@ -619,7 +627,9 @@ def init_step7_state(
         raise TypeError("agent must be an actual DifferentialSARSAAgent")
     if type(model) is not OneStepWorldModel:
         raise TypeError("model must be an actual OneStepWorldModel")
-    memory_size = _require_int("memory_size", memory_size, minimum=1, maximum=_INT32_MAX - 1)
+    memory_size = _require_int(
+        "memory_size", memory_size, minimum=1, maximum=_INT32_MAX - 1
+    )
     feature_dim = model.config.observation_dim
     if model.config.n_actions != agent.config.n_actions:
         raise ValueError("model and agent action counts must match")
@@ -716,7 +726,11 @@ def _score_planning_actions(
             jnp.mean((prediction.next_observation - anchor_observation) ** 2)
         )
         reward_priority = jnp.abs(prediction.reward)
-        return reward_priority if strategy == "reward" else reward_priority + transition_magnitude
+        return (
+            reward_priority
+            if strategy == "reward"
+            else reward_priority + transition_magnitude
+        )
 
     priorities = jax.vmap(predict_action)(actions)
     selected = jnp.argmax(priorities).astype(jnp.int32)
@@ -735,7 +749,9 @@ def _store_real_transition(
     index = state.memory_position
     memory_size = state.memory_actions.shape[0]
     observations = state.memory_observations.at[index].set(
-        jnp.asarray(observation, dtype=jnp.float32).reshape((state.memory_observations.shape[1],))
+        jnp.asarray(observation, dtype=jnp.float32).reshape(
+            (state.memory_observations.shape[1],)
+        )
     )
     actions = state.memory_actions.at[index].set(action.astype(jnp.int32))
     rewards = state.memory_rewards.at[index].set(jnp.asarray(reward, dtype=jnp.float32))
@@ -744,8 +760,12 @@ def _store_real_transition(
             (state.memory_next_observations.shape[1],)
         )
     )
-    priorities = state.memory_priorities.at[index].set(jnp.asarray(priority, dtype=jnp.float32))
-    utilities = state.memory_utilities.at[index].set(jnp.asarray(priority, dtype=jnp.float32))
+    priorities = state.memory_priorities.at[index].set(
+        jnp.asarray(priority, dtype=jnp.float32)
+    )
+    utilities = state.memory_utilities.at[index].set(
+        jnp.asarray(priority, dtype=jnp.float32)
+    )
     count = jnp.minimum(state.memory_count + 1, memory_size)
     position = (state.memory_position + 1) % memory_size
     return (
@@ -914,7 +934,8 @@ def _apply_planning_importance_correction(
     return cast(
         DifferentialSARSAState,
         planned_state.replace(  # type: ignore[attr-defined]
-            q_weights=old_state.q_weights + rho * (planned_state.q_weights - old_state.q_weights),
+            q_weights=old_state.q_weights
+            + rho * (planned_state.q_weights - old_state.q_weights),
             q_bias=old_state.q_bias + rho * (planned_state.q_bias - old_state.q_bias),
             q_trace_weights=old_state.q_trace_weights
             + rho * (planned_state.q_trace_weights - old_state.q_trace_weights),
@@ -1043,7 +1064,9 @@ def step7_update(
             model,
             model_state,
             anchor_observation,
-            config.planning_strategy if config.planning_strategy != "random" else "surprise",
+            config.planning_strategy
+            if config.planning_strategy != "random"
+            else "surprise",
             config.control.n_actions,
         )
         action = jnp.where(
@@ -1074,12 +1097,13 @@ def step7_update(
             anchor_priority,
             anchor_priority + priority,
         )
-
         def rollout_step(
             rollout_carry: tuple[DifferentialSARSAState, Array, Array, Array],
             _: Array,
         ) -> tuple[tuple[DifferentialSARSAState, Array, Array, Array], tuple[Array, Array]]:
-            rollout_state, rollout_observation, rollout_action, rollout_key = rollout_carry
+            rollout_state, rollout_observation, rollout_action, rollout_key = (
+                rollout_carry
+            )
             prediction = model.predict(
                 model_state,
                 rollout_observation,
@@ -1286,23 +1310,20 @@ def run_step7_scan(
             result.planning_accepted,
         )
 
-    (
-        final_state,
-        (
-            real_td_errors,
-            average_rewards,
-            actions,
-            model_reward_errors,
-            model_next_observation_errors,
-            model_updates_applied,
-            planning_td_errors,
-            planning_priorities,
-            planning_anchor_indices,
-            planning_behavior_probs,
-            planning_target_probs,
-            planning_importance_ratios,
-            planning_accepted,
-        ),
+    final_state, (
+        real_td_errors,
+        average_rewards,
+        actions,
+        model_reward_errors,
+        model_next_observation_errors,
+        model_updates_applied,
+        planning_td_errors,
+        planning_priorities,
+        planning_anchor_indices,
+        planning_behavior_probs,
+        planning_target_probs,
+        planning_importance_ratios,
+        planning_accepted,
     ) = jax.lax.scan(scan_step, state, (rewards, next_observations))
     return Step7DynaArrayResult(
         state=final_state,
@@ -1343,7 +1364,9 @@ def run_step7_smoke(
     real_output_bytes = steps * (17 + 4 * observation_dim)
     planning_output_bytes = steps * cfg.planning_steps * 25
     memory_scalars = (
-        2 * cfg.planning_memory_size * observation_dim + 4 * cfg.planning_memory_size + 3
+        2 * cfg.planning_memory_size * observation_dim
+        + 4 * cfg.planning_memory_size
+        + 3
     )
     memory_bytes = 4 * memory_scalars
     total_bytes = input_bytes + real_output_bytes + planning_output_bytes + memory_bytes
@@ -1393,7 +1416,9 @@ def run_step7_smoke(
         seed=seed,
         real_td_errors_shape=tuple(int(dim) for dim in result.real_td_errors.shape),
         planning_td_errors_shape=tuple(int(dim) for dim in result.planning_td_errors.shape),
-        planning_priorities_shape=tuple(int(dim) for dim in result.planning_priorities.shape),
+        planning_priorities_shape=tuple(
+            int(dim) for dim in result.planning_priorities.shape
+        ),
         planning_anchor_indices_shape=tuple(
             int(dim) for dim in result.planning_anchor_indices.shape
         ),

--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -65,6 +65,7 @@ from alberta_framework.core.average_reward import (
     DifferentialSARSAState,
     DifferentialSARSAUpdateResult,
 )
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.world_model import (
     OneStepWorldModel,
     WorldModelState,
@@ -102,9 +103,7 @@ class Step7DynaConfig:
     fixed number of model-generated one-step backups, gated by model warmup.
     """
 
-    control: Step6DifferentialSARSAConfig = field(
-        default_factory=Step6DifferentialSARSAConfig
-    )
+    control: Step6DifferentialSARSAConfig = field(default_factory=Step6DifferentialSARSAConfig)
     world_model: Step8WorldModelConfig = field(default_factory=Step8WorldModelConfig)
     planning_steps: int = 1
     planning_rollout_depth: int = 1
@@ -343,9 +342,7 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
     ):
         raise ValueError("derived Step 7 planning output bytes must fit signed int32")
     memory_scalars = (
-        2 * planning_memory_size * config.world_model.observation_dim
-        + 4 * planning_memory_size
-        + 3
+        2 * planning_memory_size * config.world_model.observation_dim + 4 * planning_memory_size + 3
     )
     if memory_scalars > _INT32_MAX or 4 * memory_scalars > _INT32_MAX:
         raise ValueError("derived Step 7 planning-memory bytes must fit signed int32")
@@ -495,12 +492,8 @@ class Step7SmokeResult:
         payload["real_td_errors_shape"] = list(self.real_td_errors_shape)
         payload["planning_td_errors_shape"] = list(self.planning_td_errors_shape)
         payload["planning_priorities_shape"] = list(self.planning_priorities_shape)
-        payload["planning_anchor_indices_shape"] = list(
-            self.planning_anchor_indices_shape
-        )
-        payload["planning_importance_ratios_shape"] = list(
-            self.planning_importance_ratios_shape
-        )
+        payload["planning_anchor_indices_shape"] = list(self.planning_anchor_indices_shape)
+        payload["planning_importance_ratios_shape"] = list(self.planning_importance_ratios_shape)
         payload["actions_shape"] = list(self.actions_shape)
         return payload
 
@@ -626,9 +619,7 @@ def init_step7_state(
         raise TypeError("agent must be an actual DifferentialSARSAAgent")
     if type(model) is not OneStepWorldModel:
         raise TypeError("model must be an actual OneStepWorldModel")
-    memory_size = _require_int(
-        "memory_size", memory_size, minimum=1, maximum=_INT32_MAX - 1
-    )
+    memory_size = _require_int("memory_size", memory_size, minimum=1, maximum=_INT32_MAX - 1)
     feature_dim = model.config.observation_dim
     if model.config.n_actions != agent.config.n_actions:
         raise ValueError("model and agent action counts must match")
@@ -725,11 +716,7 @@ def _score_planning_actions(
             jnp.mean((prediction.next_observation - anchor_observation) ** 2)
         )
         reward_priority = jnp.abs(prediction.reward)
-        return (
-            reward_priority
-            if strategy == "reward"
-            else reward_priority + transition_magnitude
-        )
+        return reward_priority if strategy == "reward" else reward_priority + transition_magnitude
 
     priorities = jax.vmap(predict_action)(actions)
     selected = jnp.argmax(priorities).astype(jnp.int32)
@@ -748,9 +735,7 @@ def _store_real_transition(
     index = state.memory_position
     memory_size = state.memory_actions.shape[0]
     observations = state.memory_observations.at[index].set(
-        jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (state.memory_observations.shape[1],)
-        )
+        jnp.asarray(observation, dtype=jnp.float32).reshape((state.memory_observations.shape[1],))
     )
     actions = state.memory_actions.at[index].set(action.astype(jnp.int32))
     rewards = state.memory_rewards.at[index].set(jnp.asarray(reward, dtype=jnp.float32))
@@ -759,12 +744,8 @@ def _store_real_transition(
             (state.memory_next_observations.shape[1],)
         )
     )
-    priorities = state.memory_priorities.at[index].set(
-        jnp.asarray(priority, dtype=jnp.float32)
-    )
-    utilities = state.memory_utilities.at[index].set(
-        jnp.asarray(priority, dtype=jnp.float32)
-    )
+    priorities = state.memory_priorities.at[index].set(jnp.asarray(priority, dtype=jnp.float32))
+    utilities = state.memory_utilities.at[index].set(jnp.asarray(priority, dtype=jnp.float32))
     count = jnp.minimum(state.memory_count + 1, memory_size)
     position = (state.memory_position + 1) % memory_size
     return (
@@ -933,8 +914,7 @@ def _apply_planning_importance_correction(
     return cast(
         DifferentialSARSAState,
         planned_state.replace(  # type: ignore[attr-defined]
-            q_weights=old_state.q_weights
-            + rho * (planned_state.q_weights - old_state.q_weights),
+            q_weights=old_state.q_weights + rho * (planned_state.q_weights - old_state.q_weights),
             q_bias=old_state.q_bias + rho * (planned_state.q_bias - old_state.q_bias),
             q_trace_weights=old_state.q_trace_weights
             + rho * (planned_state.q_trace_weights - old_state.q_trace_weights),
@@ -1063,9 +1043,7 @@ def step7_update(
             model,
             model_state,
             anchor_observation,
-            config.planning_strategy
-            if config.planning_strategy != "random"
-            else "surprise",
+            config.planning_strategy if config.planning_strategy != "random" else "surprise",
             config.control.n_actions,
         )
         action = jnp.where(
@@ -1096,13 +1074,12 @@ def step7_update(
             anchor_priority,
             anchor_priority + priority,
         )
+
         def rollout_step(
             rollout_carry: tuple[DifferentialSARSAState, Array, Array, Array],
             _: Array,
         ) -> tuple[tuple[DifferentialSARSAState, Array, Array, Array], tuple[Array, Array]]:
-            rollout_state, rollout_observation, rollout_action, rollout_key = (
-                rollout_carry
-            )
+            rollout_state, rollout_observation, rollout_action, rollout_key = rollout_carry
             prediction = model.predict(
                 model_state,
                 rollout_observation,
@@ -1235,7 +1212,7 @@ def step7_update(
         memory_utilities=planned_memory_utilities,
         memory_count=memory_count,
         memory_position=memory_position,
-        step_count=state.step_count + 1,
+        step_count=_saturating_int32_counter_increment(state.step_count),
     )
     return Step7DynaUpdateResult(
         state=new_state,
@@ -1309,20 +1286,23 @@ def run_step7_scan(
             result.planning_accepted,
         )
 
-    final_state, (
-        real_td_errors,
-        average_rewards,
-        actions,
-        model_reward_errors,
-        model_next_observation_errors,
-        model_updates_applied,
-        planning_td_errors,
-        planning_priorities,
-        planning_anchor_indices,
-        planning_behavior_probs,
-        planning_target_probs,
-        planning_importance_ratios,
-        planning_accepted,
+    (
+        final_state,
+        (
+            real_td_errors,
+            average_rewards,
+            actions,
+            model_reward_errors,
+            model_next_observation_errors,
+            model_updates_applied,
+            planning_td_errors,
+            planning_priorities,
+            planning_anchor_indices,
+            planning_behavior_probs,
+            planning_target_probs,
+            planning_importance_ratios,
+            planning_accepted,
+        ),
     ) = jax.lax.scan(scan_step, state, (rewards, next_observations))
     return Step7DynaArrayResult(
         state=final_state,
@@ -1363,9 +1343,7 @@ def run_step7_smoke(
     real_output_bytes = steps * (17 + 4 * observation_dim)
     planning_output_bytes = steps * cfg.planning_steps * 25
     memory_scalars = (
-        2 * cfg.planning_memory_size * observation_dim
-        + 4 * cfg.planning_memory_size
-        + 3
+        2 * cfg.planning_memory_size * observation_dim + 4 * cfg.planning_memory_size + 3
     )
     memory_bytes = 4 * memory_scalars
     total_bytes = input_bytes + real_output_bytes + planning_output_bytes + memory_bytes
@@ -1415,9 +1393,7 @@ def run_step7_smoke(
         seed=seed,
         real_td_errors_shape=tuple(int(dim) for dim in result.real_td_errors.shape),
         planning_td_errors_shape=tuple(int(dim) for dim in result.planning_td_errors.shape),
-        planning_priorities_shape=tuple(
-            int(dim) for dim in result.planning_priorities.shape
-        ),
+        planning_priorities_shape=tuple(int(dim) for dim in result.planning_priorities.shape),
         planning_anchor_indices_shape=tuple(
             int(dim) for dim in result.planning_anchor_indices.shape
         ),

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -53,6 +53,7 @@ from alberta_framework.core.dreaming import (
     RecentObservationBufferState,
     score_dream_candidates,
 )
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.world_model import (
     ActionConditionedWorldModel,
     ActionConditionedWorldModelConfig,
@@ -904,7 +905,7 @@ def step9_update(
         world_model_state=model_state,
         behavior_model_state=final_behavior,
         buffer_state=buffer_state,
-        step_count=state.step_count + 1,
+        step_count=_saturating_int32_counter_increment(state.step_count),
     )
     return Step9DreamingUpdateResult(
         state=new_state,

--- a/tests/test_continual_ia_timing_identities.py
+++ b/tests/test_continual_ia_timing_identities.py
@@ -1,0 +1,58 @@
+"""Host-boundary identities for continual-IA operational timings."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_ia_artifact import _validate_operational
+
+pytestmark = pytest.mark.unit
+
+_ENV = {
+    "python": {"implementation": "CPython", "version": "3.12.0"},
+    "platform": {"system": "Linux", "release": "1", "machine": "x86_64"},
+    "packages": {"jax": "0", "jaxlib": "0", "numpy": "0"},
+    "jax_default_backend": "cpu",
+    "jax_devices": [{"platform": "cpu", "device_kind": "cpu"}],
+}
+
+
+def _operational(seed: object, condition: object = "baseline") -> dict[str, object]:
+    return {
+        "digest_exclusion_reason": (
+            "host environment and wall-clock timing are non-deterministic"
+        ),
+        "environment": _ENV,
+        "condition_timings": [
+            {
+                "seed": seed,
+                "condition": condition,
+                "wall_seconds": 1.0,
+                "mean_step_latency_ms": 1.0,
+            }
+        ],
+        "overall_acceptance_passed": False,
+    }
+
+
+@pytest.mark.parametrize("seed", [True, False, 1.0, "1"])
+def test_condition_timing_rejects_noncanonical_seed(seed: object) -> None:
+    errors: list[str] = []
+    _validate_operational(
+        _operational(seed),
+        expected_results=None,
+        expected_acceptance=False,
+        errors=errors,
+    )
+    assert any("invalid identity" in error for error in errors)
+
+
+def test_condition_timing_accepts_builtin_int_seed() -> None:
+    errors: list[str] = []
+    _validate_operational(
+        _operational(7),
+        expected_results=None,
+        expected_acceptance=False,
+        errors=errors,
+    )
+    assert not any("invalid identity" in error for error in errors)

--- a/tests/test_dreaming_lifetime_clock.py
+++ b/tests/test_dreaming_lifetime_clock.py
@@ -1,0 +1,92 @@
+# mypy: disable-error-code="call-arg"
+"""Saturating lifetime clock keeps DreamRolloutState.step_count non-negative."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import jax.numpy as jnp
+import jax.random as jr
+from jax import Array
+
+from alberta_framework.core.dreaming import (
+    DreamBehaviorModelPrediction,
+    DreamRolloutState,
+    DreamWorldModelPrediction,
+    dream_one_step,
+    init_dream_rollout_state,
+)
+
+_INT32_MAX = 2**31 - 1
+
+
+@dataclasses.dataclass(frozen=True)
+class MockWorldModel:
+    def predict(
+        self, state: Any, observation: Array, action: Array, key: Array
+    ) -> DreamWorldModelPrediction:
+        return DreamWorldModelPrediction(
+            next_observation=observation + 0.1,
+            reward=jnp.asarray(1.0, dtype=jnp.float32),
+            discount=jnp.asarray(0.9, dtype=jnp.float32),
+            terminated=jnp.asarray(False, dtype=jnp.bool_),
+            confidence=jnp.asarray(1.0, dtype=jnp.float32),
+            model_error=jnp.asarray(0.0, dtype=jnp.float32),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class MockBehaviorModel:
+    def sample_action(
+        self, state: Any, observation: Array, key: Array
+    ) -> DreamBehaviorModelPrediction:
+        return DreamBehaviorModelPrediction(
+            action=jnp.asarray(1, dtype=jnp.int32),
+            action_probability=jnp.asarray(1.0, dtype=jnp.float32),
+            log_probability=jnp.asarray(0.0, dtype=jnp.float32),
+        )
+
+
+def test_dream_one_step_step_count_saturates_at_int32_max() -> None:
+    world = MockWorldModel()
+    behavior = MockBehaviorModel()
+    initial = init_dream_rollout_state(
+        jnp.asarray([1.0, 2.0], dtype=jnp.float32),
+        jr.key(13),
+    )
+    near_max = DreamRolloutState(
+        observation=initial.observation,
+        rng_key=initial.rng_key,
+        active=initial.active,
+        cumulative_confidence=initial.cumulative_confidence,
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32),
+    )
+
+    next_state, _ = dream_one_step(
+        world_model=world,
+        world_state=None,
+        behavior_model=behavior,
+        behavior_state=None,
+        rollout_state=near_max,
+    )
+    assert int(next_state.step_count) == _INT32_MAX
+    assert int(next_state.step_count) >= 0
+
+
+def test_dream_one_step_step_count_increments_below_max() -> None:
+    world = MockWorldModel()
+    behavior = MockBehaviorModel()
+    initial = init_dream_rollout_state(
+        jnp.asarray([1.0, 2.0], dtype=jnp.float32),
+        jr.key(13),
+    )
+
+    next_state, _ = dream_one_step(
+        world_model=world,
+        world_state=None,
+        behavior_model=behavior,
+        behavior_state=None,
+        rollout_state=initial,
+    )
+    assert int(next_state.step_count) == 1

--- a/tests/test_step7_lifetime_clock.py
+++ b/tests/test_step7_lifetime_clock.py
@@ -1,0 +1,93 @@
+"""Saturating lifetime clock keeps Step7DynaState.step_count non-negative."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.steps.step6 import Step6DifferentialSARSAConfig
+from alberta_framework.steps.step7 import (
+    Step7DynaConfig,
+    Step7DynaState,
+    init_step7_state,
+    make_step7_components,
+    step7_update,
+)
+from alberta_framework.steps.step8 import Step8WorldModelConfig
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def _cfg() -> Step7DynaConfig:
+    return Step7DynaConfig(
+        control=Step6DifferentialSARSAConfig(n_actions=2),
+        world_model=Step8WorldModelConfig(observation_dim=2, n_actions=2),
+        planning_steps=1,
+        planning_warmup_steps=0,
+        planning_memory_size=16,
+    )
+
+
+def test_bare_int32_increment_wraps_negative() -> None:
+    wrap = jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    assert int(wrap) == _INT32_MIN
+
+
+def test_step7_step_count_saturates_at_int32_max() -> None:
+    cfg = _cfg()
+    agent, model = make_step7_components(cfg)
+    state = init_step7_state(
+        agent,
+        model,
+        key=jr.key(0),
+        initial_observation=jnp.zeros(2),
+        memory_size=cfg.planning_memory_size,
+    )
+    near_max: Step7DynaState = state.replace(  # type: ignore[attr-defined]
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+
+    result = step7_update(
+        cfg,
+        agent,
+        model,
+        near_max,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+
+    assert int(result.state.step_count) == _INT32_MAX
+    assert int(result.state.step_count) >= 0
+
+    again = step7_update(
+        cfg,
+        agent,
+        model,
+        result.state,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+    assert int(again.state.step_count) == _INT32_MAX
+    assert int(again.state.step_count) >= 0
+
+
+def test_step7_step_count_increments_below_max() -> None:
+    cfg = _cfg()
+    agent, model = make_step7_components(cfg)
+    state = init_step7_state(
+        agent,
+        model,
+        key=jr.key(1),
+        initial_observation=jnp.zeros(2),
+        memory_size=cfg.planning_memory_size,
+    )
+    result = step7_update(
+        cfg,
+        agent,
+        model,
+        state,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == 1

--- a/tests/test_step9_lifetime_clock.py
+++ b/tests/test_step9_lifetime_clock.py
@@ -1,0 +1,91 @@
+"""Saturating lifetime clock keeps Step9DreamingState.step_count non-negative.
+
+Before this fix, ``step9_update`` advanced ``Step9DreamingState.step_count``
+with a bare ``+ 1`` on an int32 array. At ``INT32_MAX`` that wraps to
+``INT32_MIN``, silently corrupting a counter every external caller (tests,
+checkpoints, telemetry) treats as monotonically non-negative. This mirrors
+the already-fixed lifetime-clock defects in
+``alberta_framework.streams.{alberta_plan_step1,feature_discovery}`` and the
+open siblings tracked for ``GauntletStream``/``UPGDLearner``/``MixedHorde``.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.steps.step9 import (
+    Step9DreamingConfig,
+    Step9DreamingState,
+    init_step9_state,
+    make_step9_components,
+    step9_update,
+)
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def _cfg() -> Step9DreamingConfig:
+    return Step9DreamingConfig(
+        observation_dim=2,
+        n_actions=2,
+        model_hidden_sizes=(),
+        model_sparsity=0.0,
+        planning_budget=1,
+        dreaming_warmup_steps=0,
+        dreaming_max_model_error=1e30,
+    )
+
+
+def test_bare_int32_increment_wraps_negative() -> None:
+    """Document the raw JAX behaviour the old ``state.step_count + 1`` relied on."""
+    wrap = jnp.asarray(_INT32_MAX, dtype=jnp.int32) + jnp.asarray(1, dtype=jnp.int32)
+    assert int(wrap) == _INT32_MIN
+
+
+def test_step9_step_count_saturates_at_int32_max() -> None:
+    """A facade clock already at INT32_MAX must saturate, not wrap negative."""
+    cfg = _cfg()
+    agent, model, buffer = make_step9_components(cfg)
+    state = init_step9_state(
+        agent, model, buffer, key=jr.key(0), initial_observation=jnp.zeros(2)
+    )
+    near_max: Step9DreamingState = state.replace(  # type: ignore[attr-defined]
+        step_count=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+
+    result = step9_update(
+        cfg, agent, model, buffer,
+        near_max,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+
+    assert int(result.state.step_count) == _INT32_MAX
+    assert int(result.state.step_count) >= 0
+
+    again = step9_update(
+        cfg, agent, model, buffer,
+        result.state,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+    assert int(again.state.step_count) == _INT32_MAX
+    assert int(again.state.step_count) >= 0
+
+
+def test_step9_step_count_still_increments_below_max() -> None:
+    """The saturating clock is a no-op change for ordinary, unsaturated counts."""
+    cfg = _cfg()
+    agent, model, buffer = make_step9_components(cfg)
+    state = init_step9_state(
+        agent, model, buffer, key=jr.key(1), initial_observation=jnp.zeros(2)
+    )
+    result = step9_update(
+        cfg, agent, model, buffer,
+        state,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.1, 0.2], dtype=jnp.float32),
+    )
+    assert int(result.state.step_count) == 1


### PR DESCRIPTION
## Outcome

Consolidates the four remaining small correctness PRs after #1874 advanced `main`, preserving contributor commits while removing unrelated formatter churn from the Dreaming and Step 7 patches.

Incorporates and supersedes:

- #1899 — exact bool rejection for continual-IA condition-timing seed identities (closes #1898)
- #1906 — saturating `Step9DreamingState.step_count` (closes #1905)
- #1908 — saturating `DreamRolloutState.step_count`
- #1909 — saturating `Step7DynaState.step_count`

## Integration details

The original #1908/#1909 heads reformatted large portions of their source files. This branch retains only the semantic import and counter-increment changes plus their regression tests, keeping the production diff focused.

## Validation

- 13 focused tests passed
- Ruff passed on all touched production/test files
- Focused strict mypy passed on 4 production files
- `git diff --check` passed
- No `outputs/**` or evidence artifact changes

This is L0 correctness hardening only; it makes no performance or scientific claim.
