### PR TITLE
fix(utils): bound boolean-trace walk before RecursionError

### DIFF
--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -1,7 +1,9 @@
 """Metrics and analysis utilities for continual learning experiments.
 
 Provides functions for computing tracking error, learning curves,
-and other metrics useful for evaluating continual learners.
+and other metrics useful for evaluating continual learners. Nested
+boolean-trace walks stop at ``_BOOLEAN_TRACE_MAX_DEPTH`` so a hostile nest
+raises ``ValueError`` instead of ``RecursionError``.
 
 The task-matrix metrics in this module use a common convention: rows are
 evaluation checkpoints and columns are tasks or regimes. ``first_exposure[j]``
@@ -25,6 +27,9 @@ import numpy as np
 from numpy.typing import NDArray
 
 _INT32_MAX: int = 2**31 - 1
+# Same ceiling as security._JSON_MAX_DEPTH. An unbounded list/tuple walk
+# RecursionErrors on a ~1200-deep nest and cannot reject the boolean.
+_BOOLEAN_TRACE_MAX_DEPTH: int = 32
 
 _ACTUAL_INT_TYPES = frozenset(
     {
@@ -90,7 +95,11 @@ def _require_finite_real(name: str, value: object) -> float:
     return number
 
 
-def _reject_boolean_numeric_trace(values: object, *, name: str) -> None:
+def _reject_boolean_numeric_trace(
+    values: object, *, name: str, depth: int = 0
+) -> None:
+    if depth > _BOOLEAN_TRACE_MAX_DEPTH:
+        raise ValueError(f"{name} exceeds the boolean-trace depth limit")
     if _is_bool(values):
         raise ValueError(f"{name} must not be a boolean")
     if type(values) in _ALLOWED_REAL_TYPES:
@@ -98,14 +107,18 @@ def _reject_boolean_numeric_trace(values: object, *, name: str) -> None:
     if type(values) in (list, tuple):
         sequence = cast(list[object] | tuple[object, ...], values)
         for index, item in enumerate(sequence):
-            _reject_boolean_numeric_trace(item, name=f"{name}[{index}]")
+            _reject_boolean_numeric_trace(
+                item, name=f"{name}[{index}]", depth=depth + 1
+            )
         return
     if type(values) is np.ndarray:
         if values.dtype.kind == "b":
             raise ValueError(f"{name} must not be a boolean array")
         if values.dtype.kind == "O":
             for index, item in enumerate(values.flat):
-                _reject_boolean_numeric_trace(item, name=f"{name}[{index}]")
+                _reject_boolean_numeric_trace(
+                    item, name=f"{name}[{index}]", depth=depth + 1
+                )
         elif values.dtype.kind not in "iuf":
             raise ValueError(f"{name} must contain real numeric values")
         return

--- a/tests/test_metrics_hostile_validation.py
+++ b/tests/test_metrics_hostile_validation.py
@@ -1,4 +1,8 @@
-"""Hostile-safe validation for metrics utilities."""
+"""Hostile-safe validation for metrics utilities.
+
+Includes the boolean-trace depth ceiling: a 2000-deep nest must raise
+ValueError rather than RecursionError.
+"""
 
 from __future__ import annotations
 
@@ -85,6 +89,14 @@ def test_rejects_hostile_int_change_points() -> None:
 def test_rejects_bool_threshold() -> None:
     with pytest.raises(ValueError, match="threshold"):
         compute_recovery_lengths([0.1, 0.9], [0], True, window_size=1)
+
+
+def test_rejects_deeply_nested_boolean_trace_without_recursion_error() -> None:
+    nest: object = True
+    for _ in range(2000):
+        nest = [nest]
+    with pytest.raises(ValueError, match="depth"):
+        compute_stability_gap(nest, 0.0)  # type: ignore[arg-type]
 
 
 def test_rejects_hostile_float_reference_performance() -> None:


### PR DESCRIPTION
# Summary

Occupancy-FREE RecursionError on `alberta_framework/utils/metrics.py` `_reject_boolean_numeric_trace`. No issue filed.
Stayed off `#1874` files (`upgd`/`horde`/`delight`/preflight cores), clocks, forager, IA/FTL, constructor-scalars, `optimizers.py`, and the dirty ASI primary `fix/life-runner-source-clock-atomicity`.

`_reject_boolean_numeric_trace` walked list/tuple/object-array nests with no depth cap. On origin/main `32adb75b`:

```text
depth=900  ValueError (boolean)
depth=1200 RecursionError
depth=2000 RecursionError
```

A 2000-deep `[True]` nest therefore cannot be rejected as a boolean. `compute_stability_gap` and every other caller hang/crash instead of raising `ValueError`.

This PR caps the walk at 32 (same ceiling as `security._JSON_MAX_DEPTH`) and raises `ValueError` (`exceeds the boolean-trace depth limit`). Depth 10 still rejects the boolean. Depth 2000 is now ValueError, not RecursionError.

Not leftover-tax. Not width-only preflight. Not clocks. Not `#1874`.

## Expected behavior

Hostile or malformed nested traces raise `ValueError`. They must not `RecursionError`.

## Scope

- `alberta_framework/utils/metrics.py` — `_reject_boolean_numeric_trace` depth cap
- `tests/test_metrics_hostile_validation.py` — 2000-deep nest → ValueError

## Verification

```text
# red on origin
python3 -c '...'  # depth=1200 RecursionError

# green at this head
.venv/bin/python -m pytest tests/test_metrics_hostile_validation.py -q -o addopts=""
# 18 passed
```

<!-- evidence-head:3b277238346de911eb97d08f57646ca389d9e4bf -->
<!-- evidence-row:logs -->
- [x] logs: red RecursionError at depth 1200/2000; green 18-pass pytest at this head (proof-run recorded).
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - measurement-validator hang, no IPMNIST shard. Focused hostile test is the artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
