### PR TITLE
fix(screening): require exact config keys before reconstructing IPMNISTConfig

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -143,7 +143,7 @@ import platform
 import subprocess
 import time
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 from types import FunctionType, MappingProxyType
 from typing import Any, cast
@@ -9251,6 +9251,12 @@ def run_screening_config(
 # =============================================================================
 
 
+# Derived from the dataclass itself so a new protocol field cannot silently
+# reopen the gap this closes: every IPMNISTConfig field has a published
+# default, so a shard whose config omits one reconstructs at that default
+# instead of what actually ran.
+_IPMNIST_CONFIG_FIELDS = frozenset(field.name for field in fields(IPMNISTConfig))
+
 _V2_SHARD_FIELDS = frozenset(
     {
         "schema",
@@ -9717,6 +9723,9 @@ def load_shard(
         payload["environment"] = _validated_runtime_environment(
             payload["environment"], context=str(path)
         )
+    _require_exact_keys(
+        payload["config"], _IPMNIST_CONFIG_FIELDS, context=f"{path}: config"
+    )
     config = IPMNISTConfig(**payload["config"])
     if is_v2:
         _validate_dataset_config_binding(

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -1134,6 +1134,25 @@ class TestShardsAndMerge:
         with pytest.raises(ValueError, match="seed.*uint32"):
             load_shard(path)
 
+    @pytest.mark.parametrize(
+        "omitted", ["hidden1", "hidden2", "task_length", "input_dim", "n_classes"]
+    )
+    def test_load_shard_rejects_config_missing_a_protocol_field(
+        self, tmp_path, small_data, omitted: str
+    ) -> None:
+        """Every IPMNISTConfig field carries a published default, so a shard
+        whose config omits one reconstructs at that default instead of what
+        actually ran -- silently misreporting the protocol the curves came
+        from. The top-level payload already gets _require_exact_keys; the
+        nested config dict must too."""
+        path = self._make_shard(tmp_path, small_data, "upgd_w_control", 0)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        del payload["config"][omitted]
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(ValueError, match=rf"config: missing field\(s\) \['{omitted}'\]"):
+            load_shard(path)
+
     @pytest.mark.parametrize("location", ["top-level", "nested"])
     def test_load_shard_rejects_duplicate_top_level_and_nested_keys(
         self, tmp_path: Path, location: str


### PR DESCRIPTION
Closes #1927.

## What changed

`load_shard` reconstructed the protocol config with `IPMNISTConfig(**payload["config"])` and no key check. Every field of that frozen dataclass has a published default, so a shard omitting one loaded at the default instead of what actually ran — misreporting the protocol in the summary's `protocol_config` with no error. The nested `config` mapping was the one payload object reconstructed without the exact-keys gate the repo already applies to the top-level shard (`_V2_SHARD_FIELDS`), `hyperparameters`, `evidence_policy`, `source_provenance`, and `dataset_provenance`.

This applies that same existing helper to `payload["config"]`, with the expected field set derived from `dataclasses.fields(IPMNISTConfig)` rather than hand-listed — a future protocol field joins the contract automatically instead of silently reopening the gap.

Before, on `main` `4797603`:

```text
actual run config:       IPMNISTConfig(n_tasks=3, task_length=5, input_dim=4, hidden1=8, hidden2=6, n_classes=3)
shard missing 'hidden1': IPMNISTConfig(n_tasks=3, task_length=5, input_dim=4, hidden1=300, hidden2=6, n_classes=3)
hidden1 silently became: 300 (published default) instead of 8
parameter_count differs: 115 vs 3327 — no exception raised
```

After:

```text
ValueError: <path>: config: missing field(s) ['hidden1']
```

Applied to v1 and v2 shards alike: the historical scan below shows the legacy corpus already satisfies it, so there is no reason to leave the older format ungated.

Failing-test-first in `TestShardsAndMerge`: `test_load_shard_rejects_config_missing_a_protocol_field`, parametrized over `hidden1`, `hidden2`, `task_length`, `input_dim`, `n_classes` — red on `main` (5 failed, `DID NOT RAISE`), green at head. (`n_tasks` is deliberately not parametrized: it is already caught indirectly by the per-task curve-length assertion, so it would not have been a red.)

## Evidence

Lane: deterministic unit tests, non-promoting; no benchmark runs, no `outputs/` artifacts touched. Environment: macOS arm64, CPU, Python 3.12.14, jax 0.11.0. Commit measured: `1790dcc8c0de11dda5fdeb2e25c9b81edb63f8c3`.

<!-- evidence-head:1790dcc8c0de11dda5fdeb2e25c9b81edb63f8c3 -->
<!-- evidence-row:logs -->
- [x] logs: inline transcripts below.

```text
# RED (guard reverted, tests present)
$ .venv/bin/python -m pytest tests/test_ipmnist_screening.py -k "config_missing_a_protocol_field" -q -o addopts=""
FAILED ...[hidden1]  FAILED ...[hidden2]  FAILED ...[task_length]
FAILED ...[input_dim]  FAILED ...[n_classes]
5 failed, 335 deselected in 6.00s

# GREEN
5 passed, 335 deselected in 4.77s

# full touched file
340 passed in 83.59s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/ipmnist_screening.py tests/test_ipmnist_screening.py
All checks passed!
$ .venv/bin/python -m mypy alberta_framework/benchmarks/ipmnist_screening.py
Success: no issues found in 1 source file
```

**Historical safety:** all **471** pinned shards under `outputs/ipmnist_screening/**` matching the screening shard schema were scanned for their `config` key shape. Exactly **one** distinct shape exists across the entire corpus — the six expected fields — so **zero** historical shards would be refused by this guard. This is a complete census of the pinned corpus, not a sample: config key-shape is a per-shard property, checkable independently of which summary a shard fed.

No schema bump: this narrows which payloads are accepted for an existing field, and adds no new field to shard or summary.

## Provenance

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/slopdotcash@a99f2e649ecadc35896c9d65c8d5136e947333ce:skills/contribute-to-asi
Attribution status: self-reported
— [nxn-claude-code]
