### PR TITLE
fix(label-emnist): require exact plan config fields before reconstructing LabelEMNISTConfig

### DIFF
--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -96,7 +96,7 @@ import math
 import platform
 import time
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -395,6 +395,13 @@ class LabelEMNISTConfig:
             "hidden2": self.hidden2,
             "n_classes": self.n_classes,
         }
+
+
+# Derived from the dataclass rather than from to_config() so a new protocol
+# field joins this contract automatically: every LabelEMNISTConfig field is
+# defaulted to the published ICLR-2024 configuration, so a plan that omits one
+# would otherwise reconstruct at that default instead of what the plan states.
+_LABEL_EMNIST_CONFIG_FIELDS = frozenset(field.name for field in fields(LabelEMNISTConfig))
 
 
 @chex.dataclass(frozen=True)
@@ -1104,6 +1111,13 @@ def load_plan(path: Path) -> dict[str, Any]:
         raise ValueError(f"{path}: plan benchmark is not {BENCHMARK}")
     config_payload = dict(body["config"])
     n_steps = config_payload.pop("n_steps", None)
+    if set(config_payload) != _LABEL_EMNIST_CONFIG_FIELDS:
+        missing = sorted(_LABEL_EMNIST_CONFIG_FIELDS - set(config_payload))
+        unexpected = sorted(set(config_payload) - _LABEL_EMNIST_CONFIG_FIELDS)
+        raise ValueError(
+            f"{path}: plan config fields do not match the protocol contract "
+            f"(missing {missing}; unexpected {unexpected})"
+        )
     config = LabelEMNISTConfig(**config_payload)
     if n_steps != config.n_steps:
         raise ValueError(f"{path}: plan n_steps is inconsistent with config")

--- a/tests/test_upgd_label_emnist.py
+++ b/tests/test_upgd_label_emnist.py
@@ -641,6 +641,31 @@ class TestPlanShardMergeAccounting:
         assert loaded["plan"]["planned_shard_count"] == 4
         assert loaded["plan_sha256"] == payload["plan_sha256"]
 
+    @pytest.mark.parametrize(
+        "omitted",
+        ["n_tasks", "task_length", "input_dim", "hidden1", "hidden2", "n_classes"],
+    )
+    def test_load_plan_rejects_config_missing_a_protocol_field(self, tmp_path, omitted):
+        """Every LabelEMNISTConfig field is defaulted to the published
+        configuration, so a plan omitting one reconstructs at that default
+        instead of what the plan states -- and plan_sha256 then seals the
+        under-specified document rather than detecting it."""
+        from alberta_framework.benchmarks.upgd_ipmnist import atomic_write_new_json
+
+        payload = self._plan()
+        del payload["plan"]["config"][omitted]
+        # Re-seal so the truncation is challenged by the config-field contract
+        # rather than by the hash: any producer writing a plan this way would
+        # emit a matching plan_sha256.
+        payload["plan_sha256"] = upgd_label_emnist.canonical_json_sha256(
+            payload["plan"]
+        )
+        path = tmp_path / "plan.json"
+        atomic_write_new_json(path, payload)
+
+        with pytest.raises(ValueError, match=r"plan config fields do not match"):
+            load_plan(path)
+
     def test_plan_rejects_bad_seed_lists(self):
         with pytest.raises(ValueError, match="unique"):
             build_plan_payload(TINY, [1, 1], DATASET_META)


### PR DESCRIPTION
Closes #1935.

## What changed

`load_plan` rebuilt the protocol config from the plan body with no key-set gate, so a plan omitting a field reconstructed at the published ICLR-2024 default instead of what the plan states — and `plan_sha256`, computed over the truncated body, sealed the under-specified plan rather than detecting it.

This gates `config_payload` against the dataclass's own field set before reconstruction, deriving the expected set from `dataclasses.fields(LabelEMNISTConfig)` so a future protocol field joins the contract automatically instead of silently reopening the gap.

Same fix as #1928 for the sibling `ipmnist_screening.load_shard`, which you merged today; `upgd_ipmnist.py:1617` has long carried the inline form (`set(config_payload) != set(IPMNISTConfig().to_config())`). This module was the remaining lane in the family without the gate — `_require_exact_keys` has zero hits in the file, so the check is written in this module's own `sorted(...)`/`ValueError` idiom rather than importing a foreign helper.

Before, on `main` `ec035f7` — omitting one field at a time and re-sealing `plan_sha256`:

```text
input_dim   -> DID NOT RAISE      (silently reconstructs at 784)
hidden1     -> DID NOT RAISE      (silently reconstructs at 300)
hidden2     -> DID NOT RAISE      (silently reconstructs at 150)
n_classes   -> DID NOT RAISE      (silently reconstructs at 47)
n_tasks     -> raises, but as "plan n_steps is inconsistent with config"
task_length -> raises, but as "plan n_steps is inconsistent with config"
```

Four of six accepted outright; the remaining two caught only incidentally by the `n_steps` product check, with a message that misnames the fault. After, all six:

```text
ValueError: <path>: plan config fields do not match the protocol contract
            (missing ['hidden1']; unexpected [])
```

The tests re-seal `plan_sha256` after truncating, deliberately: without that the plan would fail on the hash check and the test would pass for the wrong reason. Re-sealing reproduces what any producer writing such a plan would actually emit, so the new gate is what does the work.

Failing-test-first in `TestPlanShardMergeAccounting`: `test_load_plan_rejects_config_missing_a_protocol_field`, parametrized over all six fields — red on `main` (6 failed: 4 `DID NOT RAISE`, 2 wrong-message), green at head.

Also closed: an *extra* config key previously escaped as an unhandled `TypeError` from the dataclass constructor rather than this module's path-prefixed `ValueError` contract.

## Evidence

Lane: deterministic unit tests, non-promoting; no campaign runs, no `outputs/` artifacts modified. Environment: macOS arm64, CPU, Python 3.12.14, jax 0.11.0. Commit measured: `98cd0b6651a42ab7157069d919813b1274bf1f9c`.

<!-- evidence-head:98cd0b6651a42ab7157069d919813b1274bf1f9c -->
<!-- evidence-row:logs -->
- [x] logs: inline transcripts below.

```text
# RED (guard reverted, tests present)
$ .venv/bin/python -m pytest tests/test_upgd_label_emnist.py -k "config_missing_a_protocol_field" -q -o addopts=""
6 failed, 87 deselected in 1.85s
  [input_dim] [hidden1] [hidden2] [n_classes] -> Failed: DID NOT RAISE ValueError
  [n_tasks] [task_length]                     -> Regex did not match; actual: "plan n_steps is inconsistent with config"

# GREEN
6 passed, 87 deselected in 1.24s

# full touched file
93 passed in 39.83s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/upgd_label_emnist.py tests/test_upgd_label_emnist.py
All checks passed!
$ .venv/bin/python -m mypy alberta_framework/benchmarks/upgd_label_emnist.py
Success: no issues found in 1 source file
```

**Historical safety — every pinned plan re-loaded through the patched loader, not merely inspected:**

```text
pinned artifacts with schema alberta.upgd_label_emnist.plan.v1: 2
  ACCEPTED outputs/upgd_label_emnist/plan.v1.json
  ACCEPTED outputs/upgd_label_emnist/plan.v2.json
accepted=2 refused=0
```

No schema bump: this narrows which payloads are accepted for existing fields and adds nothing to the plan or artifact shape.

**Collision:** none — no open PR touches `upgd_label_emnist.py` (checked all open PRs at time of writing).

## Provenance

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/slopdotcash@a99f2e649ecadc35896c9d65c8d5136e947333ce:skills/contribute-to-asi
Attribution status: self-reported
— [nxn-claude-code]
