### PR TITLE
fix(benchmarks): noise_curvature_step_size fails closed on warming overflow (#1774)

### DIFF
--- a/alberta_framework/benchmarks/plasticity_comparators.py
+++ b/alberta_framework/benchmarks/plasticity_comparators.py
@@ -683,7 +683,11 @@ def noise_curvature_step_size(
     if not enabled:
         return base
     if effective > bound and effective > 0.12:
-        return base * (1.0 - rate)
-    if early_training and effective < 0.1 * bound:
-        return base * (1.0 + rate)
-    return base
+        result = base * (1.0 - rate)
+    elif early_training and effective < 0.1 * bound:
+        result = base * (1.0 + rate)
+    else:
+        result = base
+    if not math.isfinite(result):
+        raise ValueError("noise_curvature step size overflowed its finite scalar domain")
+    return result

--- a/tests/test_plasticity_comparators.py
+++ b/tests/test_plasticity_comparators.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import jax
 import jax.numpy as jnp
 import jax.random as jr
@@ -180,6 +182,31 @@ def test_noise_curvature_scheduler_and_off_reduction() -> None:
         early_training=False,
         enabled=False,
     ) == 0.1
+
+
+def test_noise_curvature_step_size_fails_closed_on_warming_overflow() -> None:
+    base = float("1.79e308")
+    with pytest.raises(ValueError, match="overflowed its finite scalar domain"):
+        noise_curvature_step_size(
+            base,
+            effective_step_size=0.01,
+            safe_bound=1.0,
+            early_training=True,
+        )
+    unchanged = noise_curvature_step_size(
+        base,
+        effective_step_size=0.5,
+        safe_bound=1.0,
+        early_training=True,
+    )
+    assert unchanged == base
+    cooled = noise_curvature_step_size(
+        base,
+        effective_step_size=0.2,
+        safe_bound=0.15,
+        early_training=False,
+    )
+    assert math.isfinite(cooled)
 
 
 def test_exact_resource_accounting_and_hostile_protocol_scalars() -> None:


### PR DESCRIPTION
## Fix

`noise_curvature_step_size` in `alberta_framework/benchmarks/plasticity_comparators.py` could return `inf`: a finite `base_step_size` near the float64 max overflows on the warming branch (`base * (1 + rate)`), violating the function's own finite-scalar contract instead of failing closed.

As specified in issue #1774: compute the cooling/warming/unchanged result once, then require `math.isfinite` before returning, raising `ValueError` otherwise. **No change to the cooling/warming formula or thresholds.**

## Verification

- New test `test_noise_curvature_step_size_fails_closed_on_warming_overflow` covers:
  - warming branch with `base = 1.79e308` raises `ValueError` (overflow failed closed)
  - unchanged branch still returns the finite base exactly
  - cooling branch stays finite
- `tests/test_plasticity_comparators.py`: 14 passed
- `ruff check` + strict `mypy`: clean

Defense-in-depth per issue scope: the function has no non-test caller today; the fix restores its documented finite-output contract.

Source HEAD: `cc877f78566675214e2f356bd797f0f3c5ec1bb0`

— [asi-climb-aug]
<!-- slop-contribution-attribution:v1 {"provider":"nvidia","model":"nemotron-3.5-lightning-30b-a3b","client":"pi","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0C8FZE378ASQH47DKKBJEGZ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T05:39:20.644Z","completed_at":"2026-08-19T06:30:34.337Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T05:39:21.769Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"7090c5d2051b2de496bc8a374aa7251ed243deea9aa1c6851ef9cb9e2556c3d3","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5da4da32-e1fb-40ae-96e9-ea258d98870a","object_id":"sha256:7090c5d2051b2de496bc8a374aa7251ed243deea9aa1c6851ef9cb9e2556c3d3","sha256":"7090c5d2051b2de496bc8a374aa7251ed243deea9aa1c6851ef9cb9e2556c3d3"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA7Xc3RKhR1QPS51q691BsKWyOxxZO4963EemNA5AUWt0","device_key_id":"5a97a3056057521cbc90fa44e9e53c57f81babbea5e549e3c8ddb787030c540a","device_signature":"xw-aGRPjRMsr1H1EVoC88rZxfROySCXum2j1XYqcQ4AI0nXEx0OklQo4YS6SnFrHV-mKQC6Ox8P47xQYekeQCg"}} -->
