### PR TITLE
fix(ipmnist): reject duplicate campaign JSON keys

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_campaign_tools.py
+++ b/alberta_framework/benchmarks/ipmnist_campaign_tools.py
@@ -87,8 +87,22 @@ def across_seed_spread(values: Sequence[float] | np.ndarray[Any, Any]) -> float:
     return float(array.std(ddof=1))
 
 
+def _object_without_duplicate_keys(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key {key!r} is forbidden")
+        result[key] = value
+    return result
+
+
 def _json_object(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = json.loads(
+        path.read_text(encoding="utf-8"),
+        object_pairs_hook=_object_without_duplicate_keys,
+    )
     if type(payload) is not dict:
         raise ValueError(f"{path} must contain a JSON object")
     return cast(dict[str, Any], payload)

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -16,6 +16,7 @@ from alberta_framework.benchmarks.ipmnist_campaign_tools import (
     across_seed_spread,
     build_ceiling_summary,
     build_frontier,
+    seed_means,
     validate_confirm_alignment,
 )
 from alberta_framework.benchmarks.ipmnist_ceiling import (
@@ -191,6 +192,18 @@ def test_frontier_seed_filename_must_bind_payload_seed(tmp_path: Path) -> None:
     _shard(screen / "base_seed0.json", seed=1, accuracy=0.8)
     with pytest.raises(ValueError, match="filename disagrees"):
         build_frontier(screen, confirm, base="base", arms=("candidate",))
+
+
+def test_seed_means_rejects_duplicate_json_object_keys(tmp_path: Path) -> None:
+    path = tmp_path / "base_seed0.json"
+    path.write_text(
+        '{"seed":0,"per_task_accuracy":[0.1,0.1],'
+        '"per_task_accuracy":[0.9,0.9]}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        seed_means(tmp_path, "base")
 
 
 def test_campaign_cli_uses_strict_json_serialization(


### PR DESCRIPTION
Closes #1938.

The maintained IPMNIST campaign analyzers now reject duplicate JSON object keys before a shard can influence a frontier or ceiling score. Previously, Python silently selected the last declaration, so one file could state both `0.1` and `0.9` accuracy curves while the analyzer reported `0.9`.

<!-- evidence-head:5c5f0fde3847661a498eea4e25397cbb6f7f914a -->
<!-- evidence-row:logs -->
- [x] logs: https://gist.githubusercontent.com/ngngocnhan1997-hub/333038f65913ab177795ca93f842989d/raw/ef6d9849944eb313cfd0ac326d1d5864f8a45114/asi-1938-verification.log
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://gist.githubusercontent.com/ngngocnhan1997-hub/333038f65913ab177795ca93f842989d/raw/af67e2670714c19d854e009e2323eabf05106956/asi-1938-domain-artifact.json

## Measurement contract

- Lane: maintained IPMNIST campaign analysis (`ipmnist_campaign_tools`)
- Measured head: `5c5f0fde3847661a498eea4e25397cbb6f7f914a`
- Metric impact: measurement integrity; no benchmark score is claimed
- Before: a duplicate `per_task_accuracy` key was accepted and the last curve determined the score
- After: duplicate keys at any JSON object depth fail closed before analysis
- Seeds: none; no benchmark run or seed reservation was required
- Threshold: unchanged
- Stored artifacts: none modified

## Verification

```text
.venv/bin/python -m pytest tests/test_ipmnist_campaign_tools.py -q -o addopts=
80 passed in 2.75s

.venv/bin/python -m ruff check alberta_framework/benchmarks/ipmnist_campaign_tools.py tests/test_ipmnist_campaign_tools.py
All checks passed!

.venv/bin/python -m mypy
Success: no issues found in 197 source files
```

Verification was run in a clean native Ubuntu checkout at the measured head. The focused regression independently passed with `1 passed, 79 deselected`.

## Scope

- Adds one duplicate-key rejecting `object_pairs_hook` to the maintained analyzer boundary
- Adds one failing-test-first regression through public `seed_means`
- Preserves reconstruction of current stored frontier and ceiling artifacts
- No deviations from the issue preregistration

## Provenance

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: 9routerr / 9routerr/cx/gpt-5.6-sol
Client / agent tooling: opencode
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [ipmnist-campaign-tools]
<!-- slop-contribution-attribution:v1 {"provider":"9routerr","model":"9routerr/cx/gpt-5.6-sol","client":"opencode","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0CBMG60BWTNHN7NAMDCZ5H9","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T06:34:14.593Z","completed_at":"2026-08-19T06:48:03.937Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T06:34:15.950Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ec85f6d65d4befdf0c9f5eaa9e711bfd68ab871321757b9ec5599277618167de","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"6da5bf54-1565-460a-b1c9-3204b3761495","object_id":"sha256:ec85f6d65d4befdf0c9f5eaa9e711bfd68ab871321757b9ec5599277618167de","sha256":"ec85f6d65d4befdf0c9f5eaa9e711bfd68ab871321757b9ec5599277618167de"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAIdIgImG5XXCP_aNHtSB7xOcrrja65EJcbl34PUJk-Gw","device_key_id":"6cde8f7e56fcfad0bd758fb48b6968efe9c85559bdd12abb7d9b0003e3c3a054","device_signature":"kT_O7Fm-UOb2k777rtj0OKh1UVWgL4sckhxqy5kvVUL1MfsnqXqD_El7OBVOhn3vJM6RJUNY511XRT86kmJ4Aw"}} -->
