### PR TITLE
fix(evaluation): reject hostile int/float identities before float/return at remaining artifact numeric gates

### DIFF
--- a/alberta_framework/evaluation/continual_ia_artifact.py
+++ b/alberta_framework/evaluation/continual_ia_artifact.py
@@ -600,7 +600,7 @@ def _integer(
     location: str,
     errors: list[str],
 ) -> int | None:
-    if isinstance(value, bool) or not isinstance(value, int):
+    if type(value) is bool or type(value) is not int:
         errors.append(f"{location} must be an integer")
         return None
     return value

--- a/alberta_framework/evaluation/continual_multiagent_artifact.py
+++ b/alberta_framework/evaluation/continual_multiagent_artifact.py
@@ -693,7 +693,7 @@ def _required_mapping(
 
 
 def _finite_number(value: object) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) is bool or (type(value) is not int and type(value) is not float):
         return None
     numeric = float(value)
     return numeric if np.isfinite(numeric) else None

--- a/alberta_framework/evaluation/ftl_decision_artifact.py
+++ b/alberta_framework/evaluation/ftl_decision_artifact.py
@@ -173,7 +173,7 @@ def _finite_float(value: float) -> float | None:
 
 
 def _finite_number(value: object) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) is bool or (type(value) is not int and type(value) is not float):
         return None
     numeric = float(value)
     return numeric if math.isfinite(numeric) else None

--- a/alberta_framework/evaluation/recurring_feature_artifact.py
+++ b/alberta_framework/evaluation/recurring_feature_artifact.py
@@ -887,7 +887,7 @@ def _mapping(
 
 
 def _finite_number(value: object) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) is bool or (type(value) is not int and type(value) is not float):
         return None
     numeric = float(value)
     return numeric if math.isfinite(numeric) else None

--- a/alberta_framework/evaluation/scale_robust_feature_artifact.py
+++ b/alberta_framework/evaluation/scale_robust_feature_artifact.py
@@ -1599,14 +1599,14 @@ def load_evidence_artifact(path: Path) -> dict[str, object]:
 
 
 def _finite_number(value: object) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) is bool or (type(value) is not int and type(value) is not float):
         return None
     numeric = float(value)
     return numeric if math.isfinite(numeric) else None
 
 
 def _strict_int(value: object) -> int | None:
-    if isinstance(value, bool) or not isinstance(value, int):
+    if type(value) is bool or type(value) is not int:
         return None
     return value
 

--- a/tests/test_continual_ia_integer_hostile.py
+++ b/tests/test_continual_ia_integer_hostile.py
@@ -1,0 +1,54 @@
+"""Hostile int gate for continual_ia _integer before returning the value."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_ia_artifact import _integer
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+
+def test_integer_rejects_hostile_int_identity() -> None:
+    hostile = _HostileInt(9)
+    _HostileInt.calls = 0
+    errors: list[str] = []
+    result = _integer(hostile, location="field", errors=errors)  # type: ignore[arg-type]
+    assert result is None
+    assert errors == ["field must be an integer"]
+    assert _HostileInt.calls == 0
+
+
+def test_integer_rejects_bool() -> None:
+    errors: list[str] = []
+    assert _integer(True, location="field", errors=errors) is None
+    assert errors == ["field must be an integer"]
+
+
+def test_integer_benign_still_works() -> None:
+    errors: list[str] = []
+    assert _integer(5, location="field", errors=errors) == 5
+    assert errors == []
+    errors = []
+    assert _integer("bad", location="field", errors=errors) is None  # type: ignore[arg-type]
+    assert errors == ["field must be an integer"]

--- a/tests/test_continual_multiagent_finite_number_hostile.py
+++ b/tests/test_continual_multiagent_finite_number_hostile.py
@@ -1,0 +1,71 @@
+"""Hostile int/float gate for continual_multiagent _finite_number before float."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from alberta_framework.evaluation.continual_multiagent_artifact import _finite_number
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+
+def test_finite_number_rejects_hostile_int_before_float() -> None:
+    hostile = _HostileInt(42)
+    _HostileInt.calls = 0
+    result = _finite_number(hostile)  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileInt.calls == 0
+
+
+def test_finite_number_rejects_hostile_float_before_float() -> None:
+    hostile = _HostileFloat(3.14)
+    _HostileFloat.calls = 0
+    result = _finite_number(hostile)  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileFloat.calls == 0
+
+
+def test_finite_number_rejects_bool() -> None:
+    assert _finite_number(True) is None
+    assert _finite_number(False) is None
+
+
+def test_finite_number_benign_still_works() -> None:
+    assert _finite_number(1) == 1.0
+    assert _finite_number(1.5) == 1.5
+    assert _finite_number(0) == 0.0
+    assert _finite_number("bad") is None  # type: ignore[arg-type]
+    assert _finite_number(None) is None  # type: ignore[arg-type]
+    assert _finite_number(math.inf) is None
+    assert _finite_number(-math.inf) is None
+    assert _finite_number(math.nan) is None

--- a/tests/test_ftl_decision_finite_number_hostile.py
+++ b/tests/test_ftl_decision_finite_number_hostile.py
@@ -1,0 +1,71 @@
+"""Hostile int/float gate for ftl_decision _finite_number before float."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from alberta_framework.evaluation.ftl_decision_artifact import _finite_number
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+
+def test_finite_number_rejects_hostile_int_before_float() -> None:
+    hostile = _HostileInt(42)
+    _HostileInt.calls = 0
+    result = _finite_number(hostile)  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileInt.calls == 0
+
+
+def test_finite_number_rejects_hostile_float_before_float() -> None:
+    hostile = _HostileFloat(3.14)
+    _HostileFloat.calls = 0
+    result = _finite_number(hostile)  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileFloat.calls == 0
+
+
+def test_finite_number_rejects_bool() -> None:
+    assert _finite_number(True) is None
+    assert _finite_number(False) is None
+
+
+def test_finite_number_benign_still_works() -> None:
+    assert _finite_number(1) == 1.0
+    assert _finite_number(1.5) == 1.5
+    assert _finite_number(0) == 0.0
+    assert _finite_number("bad") is None  # type: ignore[arg-type]
+    assert _finite_number(None) is None  # type: ignore[arg-type]
+    assert _finite_number(math.inf) is None
+    assert _finite_number(-math.inf) is None
+    assert _finite_number(math.nan) is None

--- a/tests/test_recurring_feature_finite_number_hostile.py
+++ b/tests/test_recurring_feature_finite_number_hostile.py
@@ -1,0 +1,71 @@
+"""Hostile int/float gate for recurring_feature _finite_number before float."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from alberta_framework.evaluation.recurring_feature_artifact import _finite_number
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+
+def test_finite_number_rejects_hostile_int_before_float() -> None:
+    hostile = _HostileInt(42)
+    _HostileInt.calls = 0
+    result = _finite_number(hostile)  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileInt.calls == 0
+
+
+def test_finite_number_rejects_hostile_float_before_float() -> None:
+    hostile = _HostileFloat(3.14)
+    _HostileFloat.calls = 0
+    result = _finite_number(hostile)  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileFloat.calls == 0
+
+
+def test_finite_number_rejects_bool() -> None:
+    assert _finite_number(True) is None
+    assert _finite_number(False) is None
+
+
+def test_finite_number_benign_still_works() -> None:
+    assert _finite_number(1) == 1.0
+    assert _finite_number(1.5) == 1.5
+    assert _finite_number(0) == 0.0
+    assert _finite_number("bad") is None  # type: ignore[arg-type]
+    assert _finite_number(None) is None  # type: ignore[arg-type]
+    assert _finite_number(math.inf) is None
+    assert _finite_number(-math.inf) is None
+    assert _finite_number(math.nan) is None

--- a/tests/test_scale_robust_feature_finite_number_hostile.py
+++ b/tests/test_scale_robust_feature_finite_number_hostile.py
@@ -1,0 +1,96 @@
+"""Hostile int/float gate for scale_robust_feature _finite_number/_strict_int."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from alberta_framework.evaluation.scale_robust_feature_artifact import (
+    _finite_number,
+    _strict_int,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+
+def test_finite_number_rejects_hostile_int_before_float() -> None:
+    hostile = _HostileInt(42)
+    _HostileInt.calls = 0
+    result = _finite_number(hostile)  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileInt.calls == 0
+
+
+def test_finite_number_rejects_hostile_float_before_float() -> None:
+    hostile = _HostileFloat(3.14)
+    _HostileFloat.calls = 0
+    result = _finite_number(hostile)  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileFloat.calls == 0
+
+
+def test_finite_number_rejects_bool() -> None:
+    assert _finite_number(True) is None
+    assert _finite_number(False) is None
+
+
+def test_finite_number_benign_still_works() -> None:
+    assert _finite_number(1) == 1.0
+    assert _finite_number(1.5) == 1.5
+    assert _finite_number(0) == 0.0
+    assert _finite_number("bad") is None  # type: ignore[arg-type]
+    assert _finite_number(None) is None  # type: ignore[arg-type]
+    assert _finite_number(math.inf) is None
+    assert _finite_number(-math.inf) is None
+    assert _finite_number(math.nan) is None
+
+
+def test_strict_int_rejects_hostile_int_before_return() -> None:
+    hostile = _HostileInt(7)
+    _HostileInt.calls = 0
+    result = _strict_int(hostile)  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileInt.calls == 0
+
+
+def test_strict_int_rejects_bool() -> None:
+    assert _strict_int(True) is None
+    assert _strict_int(False) is None
+
+
+def test_strict_int_benign_still_works() -> None:
+    assert _strict_int(7) == 7
+    assert _strict_int(0) == 0
+    assert _strict_int(-3) == -3
+    assert _strict_int("bad") is None  # type: ignore[arg-type]
+    assert _strict_int(1.5) is None  # type: ignore[arg-type]
+    assert _strict_int(None) is None  # type: ignore[arg-type]


### PR DESCRIPTION
<!-- evidence-head:0bf71656ff3afcec2a724d502e518ca6eb48f54b -->

Closes #1944.

## Provider/model disclosure

`--client claude-code --provider anthropic --model claude-sonnet-5`, lane `rama0x1-asi-claude-worker-2`.

## What's wrong

`continual_ia_artifact.py`'s `_number` helper was hardened in `a81e159f`
("fix(evaluation): reject hostile int identities before float at continual
ia") from `isinstance(value, bool) or not isinstance(value, (int, float))` to
an exact-type gate, because `isinstance` accepts subclasses: a hostile
`int`/`float` subclass overriding `__float__`, `__eq__`, `__hash__`, or
`__bool__` passes the `isinstance` gate and its overridden dunder then runs
during "trusted" numeric conversion inside an evidence-artifact validator.

Five sibling sites carry the identical pattern and were not covered by that
fix:

- `alberta_framework/evaluation/continual_multiagent_artifact.py::_finite_number`
- `alberta_framework/evaluation/ftl_decision_artifact.py::_finite_number`
- `alberta_framework/evaluation/recurring_feature_artifact.py::_finite_number`
- `alberta_framework/evaluation/scale_robust_feature_artifact.py::_finite_number`
  and `::_strict_int`
- `alberta_framework/evaluation/continual_ia_artifact.py::_integer` (the
  int-only sibling of the already-fixed `_number` in the same file)

## Fix

Same exact-type gate at all six sites:

```python
if type(value) is bool or (type(value) is not int and type(value) is not float):
    return None
```

int-only sites (`_strict_int`, `_integer`):

```python
if type(value) is bool or type(value) is not int:
    return None
```

## Tests (failing-test-first)

One hostile-subclass test file per production module, mirroring the existing
`tests/test_continual_ia_number_hostile.py` pattern: a hostile `int`/`float`
subclass whose `__float__`/`__eq__`/`__hash__`/`__bool__` raise
`AssertionError` if invoked, asserting the validator returns `None` (or, for
`_integer`, appends its error and returns `None`) with the hostile dunders'
call counters left at `0`. Plus a `bool`-rejection case and a benign-value
case per site.

- `tests/test_continual_multiagent_finite_number_hostile.py`
- `tests/test_ftl_decision_finite_number_hostile.py`
- `tests/test_recurring_feature_finite_number_hostile.py`
- `tests/test_scale_robust_feature_finite_number_hostile.py` (covers both
  `_finite_number` and `_strict_int`)
- `tests/test_continual_ia_integer_hostile.py`

Verified red-then-green: all 10 new hostile-case tests failed against the
pre-fix code (AssertionError from the hostile dunder, or a hostile value
passing through unrejected), then passed after the fix.

<!-- evidence-row:logs -->
- [x] logs: pasted below (this is a validator-correctness fix with no
  benchmark run or `outputs/` artifact; no attachment-URL host is available in
  this environment, so full command output is inlined verbatim instead)

Failing-test-first (pre-fix, on head prior to this commit):
```
$ .venv/bin/python -m pytest tests/test_continual_multiagent_finite_number_hostile.py tests/test_ftl_decision_finite_number_hostile.py tests/test_recurring_feature_finite_number_hostile.py tests/test_scale_robust_feature_finite_number_hostile.py tests/test_continual_ia_integer_hostile.py -q -o addopts=""
...
FAILED tests/test_continual_multiagent_finite_number_hostile.py::test_finite_number_rejects_hostile_int_before_float
FAILED tests/test_continual_multiagent_finite_number_hostile.py::test_finite_number_rejects_hostile_float_before_float
FAILED tests/test_ftl_decision_finite_number_hostile.py::test_finite_number_rejects_hostile_int_before_float
FAILED tests/test_ftl_decision_finite_number_hostile.py::test_finite_number_rejects_hostile_float_before_float
FAILED tests/test_recurring_feature_finite_number_hostile.py::test_finite_number_rejects_hostile_int_before_float
FAILED tests/test_recurring_feature_finite_number_hostile.py::test_finite_number_rejects_hostile_float_before_float
FAILED tests/test_scale_robust_feature_finite_number_hostile.py::test_finite_number_rejects_hostile_int_before_float
FAILED tests/test_scale_robust_feature_finite_number_hostile.py::test_finite_number_rejects_hostile_float_before_float
FAILED tests/test_scale_robust_feature_finite_number_hostile.py::test_strict_int_rejects_hostile_int_before_return
FAILED tests/test_continual_ia_integer_hostile.py::test_integer_rejects_hostile_int_identity
10 failed, 12 passed in 2.30s
```

Post-fix, at head `0bf71656ff3afcec2a724d502e518ca6eb48f54b`:
```
$ .venv/bin/python -m pytest tests/test_continual_multiagent_finite_number_hostile.py tests/test_ftl_decision_finite_number_hostile.py tests/test_recurring_feature_finite_number_hostile.py tests/test_scale_robust_feature_finite_number_hostile.py tests/test_continual_ia_integer_hostile.py -q -o addopts=""
22 passed in 1.39s

$ .venv/bin/python -m pytest tests/test_continual_ia_number_hostile.py tests/test_continual_ia_evidence.py tests/test_continual_ia_cli.py tests/test_continual_multiagent_benchmark.py tests/test_continual_multiagent_validation.py tests/test_continual_multiagent_cli.py tests/test_continual_multiagent_sha256_hostile.py tests/test_ftl_decision_artifact.py tests/test_ftl_decision_fidelity.py tests/test_ftl_decision_fidelity_hostile_validation.py tests/test_ftl_decision_cli.py tests/test_recurring_feature_artifact.py tests/test_recurring_feature_evidence_leftover_identities.py tests/test_recurring_feature_protocol_validation.py tests/test_scale_robust_feature_artifact.py tests/test_scale_robust_feature.py tests/test_scale_robust_feature_cli.py tests/test_scale_robust_sha_hostile.py -q -o addopts=""
775 passed, 18 skipped in 181.15s (0:03:01)

$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 197 source files

$ git diff --check
(no output, exit 0)
```

<!-- evidence-row:domain-artifact -->
- [ ] domain-artifact: not applicable — this is a validator-code correctness
  fix (`Fix` outcome per the contribution skill), not a benchmark measurement;
  it produces no `outputs/` artifact.

## Expected effect on the evidence registry

Editing these five registered validator source files invalidates the five
pinned evidence-registry claims (`.venv/bin/alberta-evidence-status` now
reports `invalid`, exit `2`) until a maintainer reruns each frozen protocol.
This is the documented fail-closed design ("Registered source hashes are
load-bearing... that is working-as-designed, not a bug to silence" —
`CLAUDE.md`), the same effect the precedent commit `a81e159f` and the
currently open string-identity PRs (#1929–#1934) on these same files already
have. No pinned artifact under `outputs/` was edited, moved, or deleted.

## Scope note / no collision

Six other open PRs (#1929, #1930, #1931, #1932, #1933, #1934) are
concurrently hardening *string*-typed identity gates (`name`, `detail`,
`provenance_head`, `git_head`, `recorded`/digest fields) in these same five
files. Checked each of their diffs before starting: none touch
`_finite_number`, `_strict_int`, or `_integer` — this PR is scoped strictly to
the *numeric* gates, which none of those PRs touch.

## What remains open

The same spoofable-`isinstance` shape may exist in the streams/steps modules
of this evidence-artifact family; those are outside this PR's territory and
this issue's scope (see #1944). `_finite_number`/`_strict_int`/`_integer`
callers elsewhere in the artifact modules that already use `type(...) is`
checks (found by grepping each file) were left untouched — only the six
sites named above still had the vulnerable `isinstance` idiom.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0D5PBY772Q3F81NZ26D41X5","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T14:09:38.760Z","completed_at":"2026-08-19T14:10:14.185Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T14:09:39.538Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f8d027ba29bcce2e2bc0e91aefd8184065a12863cd1823868007fcb50240a7a7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"de986485-fb84-4683-a384-08efc8cd12ff","object_id":"sha256:f8d027ba29bcce2e2bc0e91aefd8184065a12863cd1823868007fcb50240a7a7","sha256":"f8d027ba29bcce2e2bc0e91aefd8184065a12863cd1823868007fcb50240a7a7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"up1xmbEER94x7lm34QtPDZFF4BN5r2KyXVpDt4O-fcI4a1NUe1eNsUvPlVxd1KNElu1h6tfOs8AwxLRsyQ1ZAw"}} -->
