### PR TITLE
fix(benchmarks): gate LabelEMNISTConfig key set in load_plan (#1935)

### DIFF
--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -96,7 +96,7 @@ import math
 import platform
 import time
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -395,6 +395,26 @@ class LabelEMNISTConfig:
             "hidden2": self.hidden2,
             "n_classes": self.n_classes,
         }
+
+
+_LABEL_EMNIST_CONFIG_FIELDS: frozenset[str] = frozenset(
+    field.name for field in fields(LabelEMNISTConfig)
+)
+
+
+def _require_exact_config_fields(
+    config_payload: Mapping[str, Any], *, context: str
+) -> None:
+    actual = set(config_payload)
+    missing = sorted(_LABEL_EMNIST_CONFIG_FIELDS.difference(actual))
+    unexpected = sorted(actual.difference(_LABEL_EMNIST_CONFIG_FIELDS))
+    if missing or unexpected:
+        parts: list[str] = []
+        if missing:
+            parts.append(f"missing field(s) {missing}")
+        if unexpected:
+            parts.append(f"unexpected field(s) {unexpected}")
+        raise ValueError(f"{context}: {'; '.join(parts)}")
 
 
 @chex.dataclass(frozen=True)
@@ -1102,8 +1122,12 @@ def load_plan(path: Path) -> dict[str, Any]:
         raise ValueError(f"{path}: plan_sha256 does not match the plan body")
     if body.get("benchmark") != BENCHMARK:
         raise ValueError(f"{path}: plan benchmark is not {BENCHMARK}")
-    config_payload = dict(body["config"])
+    raw_config = body.get("config")
+    if not isinstance(raw_config, Mapping):
+        raise ValueError(f"{path}: plan config must be an object")
+    config_payload = dict(raw_config)
     n_steps = config_payload.pop("n_steps", None)
+    _require_exact_config_fields(config_payload, context=f"{path}: config")
     config = LabelEMNISTConfig(**config_payload)
     if n_steps != config.n_steps:
         raise ValueError(f"{path}: plan n_steps is inconsistent with config")

--- a/tests/test_upgd_label_emnist.py
+++ b/tests/test_upgd_label_emnist.py
@@ -641,6 +641,36 @@ class TestPlanShardMergeAccounting:
         assert loaded["plan"]["planned_shard_count"] == 4
         assert loaded["plan_sha256"] == payload["plan_sha256"]
 
+    def test_load_plan_rejects_truncated_or_extra_config_keys(self, tmp_path):
+        from alberta_framework.benchmarks.upgd_ipmnist import atomic_write_new_json
+        from alberta_framework.benchmarks.upgd_label_emnist import canonical_json_sha256
+
+        protocol_fields = ("n_tasks", "task_length", "input_dim", "hidden1", "hidden2", "n_classes")
+        for dropped in protocol_fields:
+            payload = self._plan()
+            body = dict(payload["plan"])
+            config = dict(body["config"])
+            del config[dropped]
+            body["config"] = config
+            payload["plan"] = body
+            payload["plan_sha256"] = canonical_json_sha256(body)
+            path = tmp_path / f"plan_missing_{dropped}.json"
+            atomic_write_new_json(path, payload)
+            with pytest.raises(ValueError, match="config"):
+                load_plan(path)
+
+        payload = self._plan()
+        body = dict(payload["plan"])
+        config = dict(body["config"])
+        config["extra_field"] = 1
+        body["config"] = config
+        payload["plan"] = body
+        payload["plan_sha256"] = canonical_json_sha256(body)
+        path = tmp_path / "plan_extra.json"
+        atomic_write_new_json(path, payload)
+        with pytest.raises(ValueError, match="config"):
+            load_plan(path)
+
     def test_plan_rejects_bad_seed_lists(self):
         with pytest.raises(ValueError, match="unique"):
             build_plan_payload(TINY, [1, 1], DATASET_META)


### PR DESCRIPTION
## Fix

`load_plan` in `alberta_framework/benchmarks/upgd_label_emnist.py` rebuilt the protocol config from the plan body with no key-set gate, so an omitted field silently reconstructed at its published ICLR-2024 default (`input_dim` 784, `hidden1` 300, `hidden2` 150, `n_classes` 47), and an extra key escaped as an unhandled `TypeError`. The preregistration hash sealed the under-specified plan.

Per issue #1935's proposed fix: gate the popped config dict against `dataclasses.fields(LabelEMNISTConfig)`, deriving the expected set from the dataclass itself so a future protocol field joins the contract automatically. Missing or unexpected fields fail with the module's path-prefixed `ValueError`; a non-object config is rejected. No formula, schema, or artifact change.

## Verification

- Failing-test-first: `test_load_plan_rejects_truncated_or_extra_config_keys` drops each of the six protocol fields and adds an extra key, each re-sealed with `plan_sha256`, all rejected (previously four of six accepted outright).
- Both pinned plan artifacts still load through the patched loader (`outputs/upgd_label_emnist/plan.v1.json`, `plan.v2.json`).
- `tests/test_upgd_label_emnist.py`: 88 passed. ruff + strict mypy clean.

Source HEAD: `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`

<!-- slop-contribution-attribution:v1 {"provider":"nvidia","model":"nemotron-3.5-lightning-30b-a3b","client":"pi","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0CBX7YPBR6E6R4XB1XQWXGJ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T06:39:01.079Z","completed_at":"2026-08-19T07:55:09.054Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T06:39:02.239Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2aa5ba03-de27-4735-a93f-afac62507e5a","object_id":"sha256:fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e","sha256":"fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA7Xc3RKhR1QPS51q691BsKWyOxxZO4963EemNA5AUWt0","device_key_id":"5a97a3056057521cbc90fa44e9e53c57f81babbea5e549e3c8ddb787030c540a","device_signature":"0HSaYw4rksC6QwK3AsJfqdCOFxJ1hfF8bnm9ziyEBmrANi7CyPElQ9xjO7KSx2-1EC5byiBcMEUsDUenUED-CA"}} -->
