### PR TITLE
fix(core): reject hostile feature_dim identity before comparison at checkpoint gates

### DIFF
--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -3814,8 +3814,7 @@ def save_interaction_feature_checkpoint(
     feature_dim: int,
 ) -> None:
     """Persist state with its explicit probe semantics and resource contract."""
-    if isinstance(feature_dim, bool) or not isinstance(feature_dim, int) or feature_dim < 1:
-        raise ValueError("feature_dim must be a positive integer")
+    feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
     learner._require_state_contract(state, feature_dim=feature_dim)
     if not bool(_lifetime_counter_valid(state.step_words, state.step_count)):
         raise ValueError("interaction-feature checkpoint lifetime counter is invalid")
@@ -3861,9 +3860,10 @@ def load_interaction_feature_checkpoint(
     if not isinstance(config, dict):
         raise ValueError("interaction-feature checkpoint is missing learner_config")
     learner = FixedBudgetInteractionLearner.from_config(config)
-    feature_dim = metadata.get("feature_dim")
-    if isinstance(feature_dim, bool) or not isinstance(feature_dim, int) or feature_dim < 1:
-        raise ValueError("interaction-feature checkpoint feature_dim is invalid")
+    try:
+        feature_dim = _require_int32("feature_dim", metadata.get("feature_dim"), minimum=1)
+    except ValueError as error:
+        raise ValueError("interaction-feature checkpoint feature_dim is invalid") from error
     template = learner.init(feature_dim=feature_dim, key=jr.key(0))
     restored, restored_metadata = load_checkpoint(template, path)
     if restored_metadata != metadata:

--- a/tests/test_interaction_feature_checkpoint_feature_dim_hostile.py
+++ b/tests/test_interaction_feature_checkpoint_feature_dim_hostile.py
@@ -1,0 +1,157 @@
+"""Hostile ``feature_dim`` identity containment at the checkpoint boundary.
+
+``save_interaction_feature_checkpoint`` and ``load_interaction_feature_checkpoint``
+gated ``feature_dim`` with ``isinstance(feature_dim, bool) or not
+isinstance(feature_dim, int) or feature_dim < 1``. ``isinstance`` accepts
+subclasses, so a hostile ``int`` subclass overriding ``__lt__``/``__eq__``/
+``__index__`` passed the gate and its overridden dunder then ran during the
+"trusted" ``feature_dim < 1`` comparison — before the value's type was
+confirmed safe. This is the same spoofable-identity shape already closed at
+other numeric gates across this codebase (e.g. ``_require_int32`` itself,
+used everywhere else in this module).
+
+Both sites now route through the already-hardened ``_require_int32`` helper,
+which rejects on an exact-type membership check (``type(value) not in
+_ACTUAL_INT_TYPES``) before ever calling ``operator.index`` or comparing the
+value, so a hostile subclass's dunders never run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import jax.random as jr
+import pytest
+
+import alberta_framework.core.interaction_features as interaction_features
+from alberta_framework.core.interaction_features import (
+    INTERACTION_FEATURE_CHECKPOINT_SCHEMA,
+    FixedBudgetInteractionLearner,
+    load_interaction_feature_checkpoint,
+    save_interaction_feature_checkpoint,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    """An ``int`` subclass whose comparison/index dunders must never run."""
+
+    calls = 0
+
+    def __lt__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile __lt__ ran")
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile __eq__ ran")
+
+    def __index__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile __index__ ran")
+
+
+def _learner() -> FixedBudgetInteractionLearner:
+    return FixedBudgetInteractionLearner(
+        n_features=1,
+        n_tasks=1,
+        candidate_count=0,
+        replacement_interval=0,
+        min_feature_age=0,
+    )
+
+
+def test_save_checkpoint_rejects_hostile_feature_dim_before_comparison(
+    tmp_path: Path,
+) -> None:
+    learner = _learner()
+    state = learner.init(2, jr.key(0))
+    hostile = _HostileInt(2)
+    _HostileInt.calls = 0
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        save_interaction_feature_checkpoint(
+            learner,
+            state,
+            tmp_path / "hostile_ckpt",
+            feature_dim=hostile,  # type: ignore[arg-type]
+        )
+    assert _HostileInt.calls == 0
+    assert not (tmp_path / "hostile_ckpt").exists()
+
+
+def test_save_checkpoint_rejects_bool_and_nonpositive_feature_dim(
+    tmp_path: Path,
+) -> None:
+    learner = _learner()
+    state = learner.init(2, jr.key(0))
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        save_interaction_feature_checkpoint(
+            learner,
+            state,
+            tmp_path / "bool_ckpt",
+            feature_dim=True,  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="feature_dim"):
+        save_interaction_feature_checkpoint(
+            learner, state, tmp_path / "zero_ckpt", feature_dim=0
+        )
+
+
+def test_save_checkpoint_accepts_genuine_positive_feature_dim(
+    tmp_path: Path,
+) -> None:
+    learner = _learner()
+    state = learner.init(2, jr.key(0))
+
+    save_interaction_feature_checkpoint(
+        learner, state, tmp_path / "good_ckpt", feature_dim=2
+    )
+    loaded_learner, loaded_state = load_interaction_feature_checkpoint(tmp_path / "good_ckpt")
+    assert loaded_learner.to_config() == learner.to_config()
+
+
+def test_load_checkpoint_rejects_hostile_feature_dim_before_comparison(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    learner = _learner()
+    state = learner.init(2, jr.key(0))
+    hostile = _HostileInt(2)
+    _HostileInt.calls = 0
+    fake_metadata = {
+        "schema": INTERACTION_FEATURE_CHECKPOINT_SCHEMA,
+        "learner_config": learner.to_config(),
+        "feature_dim": hostile,
+        "memory_accounting": learner.memory_accounting(state),
+    }
+    monkeypatch.setattr(
+        interaction_features, "load_checkpoint_metadata", lambda path: fake_metadata
+    )
+
+    with pytest.raises(ValueError, match="feature_dim"):
+        load_interaction_feature_checkpoint(tmp_path / "does-not-exist")
+    assert _HostileInt.calls == 0
+
+
+def test_load_checkpoint_rejects_bool_and_nonpositive_feature_dim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    learner = _learner()
+    state = learner.init(2, jr.key(0))
+
+    for bad_feature_dim in (True, 0, -1):
+        fake_metadata = {
+            "schema": INTERACTION_FEATURE_CHECKPOINT_SCHEMA,
+            "learner_config": learner.to_config(),
+            "feature_dim": bad_feature_dim,
+            "memory_accounting": learner.memory_accounting(state),
+        }
+        monkeypatch.setattr(
+            interaction_features, "load_checkpoint_metadata", lambda path: fake_metadata
+        )
+        with pytest.raises(ValueError, match="feature_dim"):
+            load_interaction_feature_checkpoint(tmp_path / "does-not-exist")


### PR DESCRIPTION
<!-- evidence-head:f3f7a98f4e5f83e9a3540fda461010da29ed4c5c -->

Closes #1948.

## Provider/model disclosure

`--client claude-code --provider anthropic --model claude-sonnet-5`, lane `rama0x1-asi-claude-worker-2`.

## What's wrong

`save_interaction_feature_checkpoint` and `load_interaction_feature_checkpoint`
in `alberta_framework/core/interaction_features.py` gated `feature_dim` with:

```python
if isinstance(feature_dim, bool) or not isinstance(feature_dim, int) or feature_dim < 1:
    raise ValueError(...)
```

`isinstance` accepts subclasses, so a hostile `int` subclass overriding
`__lt__` (or `__eq__`/`__index__`) passes the `isinstance(feature_dim, int)`
gate, and its overridden `__lt__` then runs during the "trusted"
`feature_dim < 1` comparison — before the value's type is confirmed safe.
This is the same spoofable-identity shape this codebase has been closing
file-by-file at other numeric gates. The module already carries its own fix
for this exact shape: `_require_int32` (line 70), an exact-type-membership
gate against `_ACTUAL_INT_TYPES` (built-in `int` plus the full NumPy integer
family) followed by `operator.index`, used at every *other* integer field in
this file — including `feature_dim` itself at the
`FixedBudgetInteractionLearner.init` constructor path (line 1353). The two
checkpoint boundary functions duplicated a weaker ad hoc check instead of
calling it.

- `save_interaction_feature_checkpoint` validated its caller-supplied
  `feature_dim: int` parameter with the vulnerable `isinstance` gate.
- `load_interaction_feature_checkpoint` read
  `feature_dim = metadata.get("feature_dim")` from checkpoint metadata and
  validated it the same vulnerable way *before* calling
  `learner.init(feature_dim=feature_dim, ...)`, whose internal
  `_require_int32` call never got a chance to run — the weaker pre-check
  raised (or, worse, ran attacker code) first.

## Reproduction

```python
class _HostileInt(int):
    def __lt__(self, other):
        raise AssertionError("hostile __lt__ ran")

save_interaction_feature_checkpoint(learner, state, path, feature_dim=_HostileInt(2))
# pre-fix: AssertionError from inside the hostile subclass
# post-fix: ValueError, dunder never invoked
```

Same shape for `load_interaction_feature_checkpoint` via a hostile
`feature_dim` in checkpoint metadata.

## Fix

Route both sites through the module's own `_require_int32("feature_dim", value, minimum=1)`
instead of the ad hoc `isinstance` gate — one line at each site, no new
mechanism, no behavior change for legitimate values (it returns the same
canonical `int` via `operator.index`, and also now correctly accepts the
NumPy integer family the same way every other integer field in this file
already does).

## Tests (failing-test-first)

`tests/test_interaction_feature_checkpoint_feature_dim_hostile.py` — new
file, five tests:

- hostile-subclass rejection at `save_interaction_feature_checkpoint`,
  asserting `ValueError` (not `AssertionError`) and the hostile dunder call
  counter stays at `0`;
- hostile-subclass rejection at `load_interaction_feature_checkpoint` (via a
  monkeypatched `load_checkpoint_metadata` returning a hostile `feature_dim`
  in otherwise-valid metadata), same assertions;
- `bool`/zero/negative rejection at both sites;
- a genuine positive `feature_dim` round-trips through save+load unchanged.

Verified red-then-green by stashing the production fix and re-running the new
test file against the unmodified source:

```
$ git stash push -- alberta_framework/core/interaction_features.py
$ .venv/bin/python -m pytest tests/test_interaction_feature_checkpoint_feature_dim_hostile.py -q -o addopts=""
...
AssertionError: hostile __lt__ ran
2 failed, 3 passed in 3.94s
$ git stash pop
$ .venv/bin/python -m pytest tests/test_interaction_feature_checkpoint_feature_dim_hostile.py -q -o addopts=""
5 passed in 4.13s
```

<!-- evidence-row:logs -->
- [x] logs: pasted below (validator-correctness fix, no benchmark run or
  `outputs/` artifact; no attachment-URL host is available in this
  environment, so full command output is inlined verbatim instead)

Full regression, at head `f3f7a98f4e5f83e9a3540fda461010da29ed4c5c`:

```
$ .venv/bin/python -m pytest tests/test_interaction_feature_horizon.py \
    tests/test_interaction_feature_validation.py \
    tests/test_interaction_features_update_working_set.py \
    tests/test_interaction_feature_checkpoint_feature_dim_hostile.py \
    tests/test_interaction_task_utility_weights.py \
    tests/test_feature_discovery.py -q -o addopts=""
234 passed in 140.35s (0:02:20)

$ .venv/bin/python -m ruff check alberta_framework/core/interaction_features.py \
    tests/test_interaction_feature_checkpoint_feature_dim_hostile.py
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 197 source files

$ git diff --check
(no output, exit 0)
```

<!-- evidence-row:domain-artifact -->
- [ ] domain-artifact: not applicable — this is a validator-code correctness
  fix (`Fix` outcome per the contribution skill), not a benchmark
  measurement; it produces no `outputs/` artifact.

## Expected effect on the evidence registry

`alberta_framework/core/interaction_features.py` is not a registered evidence
source for any of the five `alberta-evidence-status` claims
(`recurring_pair_features`, `scale_robust_pair_features`,
`ftl_world_model_decision_fidelity`, `recurring_multiagent_coadaptation`,
`continual_intelligence_amplification`) — checked against
`alberta_framework/evaluation/evidence_manifest.py` before starting. This
change does not invalidate any pinned artifact or registered-source claim.

## Scope note / no collision

Checked all 19 currently open PRs (`gh pr list --state open --json files`)
immediately before committing: none touch
`alberta_framework/core/interaction_features.py`. This file and defect are
outside the concurrently-worked `evaluation/*_artifact.py` numeric-gate issue
(#1944 / PR #1945) and the six open string-identity PRs (#1929-#1934), which
are scoped to a disjoint set of files in `alberta_framework/evaluation/`.

## What remains open

The same spoofable-`isinstance`-before-comparison shape may exist at other
call sites across `alberta_framework/core/` and `alberta_framework/benchmarks/`
that do not yet route through `_require_int32` or an equivalent exact-type
gate; a full audit is out of scope for this narrowly-targeted fix.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0D5SDATH0F7R9TXFS8HY1A8","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T14:11:18.491Z","completed_at":"2026-08-19T14:11:56.364Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T14:11:20.496Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e2f98ec6add44b2df1f13fb40ef1e8d539bd25fc1eb308b8ddcb073e7db6ee7c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"94ebf775-8acb-41dc-ad55-212a40de6fd5","object_id":"sha256:e2f98ec6add44b2df1f13fb40ef1e8d539bd25fc1eb308b8ddcb073e7db6ee7c","sha256":"e2f98ec6add44b2df1f13fb40ef1e8d539bd25fc1eb308b8ddcb073e7db6ee7c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"FvJkr_V3uKTJl_2qj3ZpTsl3WAyDKAx4Ut3mi_3jgCqPL4gBhML9IyNENCz773kwURIbjoG6-l8XMmzXcUWwDw"}} -->
