### PR TITLE
fix(benchmarks): reject duplicate JSON keys in campaign analysis inputs (#1938)

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_campaign_tools.py
+++ b/alberta_framework/benchmarks/ipmnist_campaign_tools.py
@@ -88,7 +88,17 @@ def across_seed_spread(values: Sequence[float] | np.ndarray[Any, Any]) -> float:
 
 
 def _json_object(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    def pairs_hook(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        parsed: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in parsed:
+                raise ValueError(f"duplicate JSON key: {key}")
+            parsed[key] = value
+        return parsed
+
+    payload = json.loads(
+        path.read_text(encoding="utf-8"), object_pairs_hook=pairs_hook
+    )
     if type(payload) is not dict:
         raise ValueError(f"{path} must contain a JSON object")
     return cast(dict[str, Any], payload)

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -221,6 +221,29 @@ def test_across_seed_spread_uses_sample_estimator() -> None:
     assert across_seed_spread([0.5]) == 0.0
 
 
+def test_frontier_rejects_duplicate_json_object_keys(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    screen.mkdir(parents=True, exist_ok=True)
+    confirm.mkdir(parents=True, exist_ok=True)
+    (screen / "base_seed0.json").write_text(
+        '{"seed":0,"per_task_accuracy":[0.1,0.1],"per_task_accuracy":[0.9,0.9]}',
+        encoding="utf-8",
+    )
+    _shard(screen / "candidate_seed0.json", seed=0, accuracy=0.81)
+    _shard(confirm / "base_seed0.json", seed=0, accuracy=0.80)
+    _shard(confirm / "candidate_seed0.json", seed=0, accuracy=0.82)
+
+    with pytest.raises(ValueError, match="duplicate"):
+        build_frontier(
+            screen,
+            confirm,
+            base="base",
+            arms=["candidate"],
+            created_unix=0.0,
+        )
+
+
 def test_frontier_requires_and_uses_exact_paired_seed_sets(tmp_path: Path) -> None:
     screen = tmp_path / "screen"
     confirm = tmp_path / "confirm"


### PR DESCRIPTION
## Fix

`_json_object` in `alberta_framework/benchmarks/ipmnist_campaign_tools.py` used plain `json.loads`, so maintained campaign inputs accepted duplicate object keys and Python silently kept the last value. A doubly-declared `per_task_accuracy` reached `seed_means` as `{0: 0.9}` instead of being rejected; the same ambiguity reached frontier and ceiling inputs through `_json_object`.

Per issue #1938's proposed fix: parse with an `object_pairs_hook` that rejects duplicates, preserving the existing exact-object-type check. No benchmark run, seed reservation, threshold change, or artifact rewrite.

## Verification

- Failing-test-first: `test_frontier_rejects_duplicate_json_object_keys` writes `{"seed":0,"per_task_accuracy":[0.1,0.1],"per_task_accuracy":[0.9,0.9]}` and asserts a frontier build rejects it (previously accepted as `{0: 0.9}`).
- `tests/test_ipmnist_campaign_tools.py`: 80 passed. ruff + strict mypy clean.

Source HEAD: `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`

<!-- slop-contribution-attribution:v1 {"provider":"nvidia","model":"nemotron-3.5-lightning-30b-a3b","client":"pi","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0CBX7YPBR6E6R4XB1XQWXGJ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T06:39:01.079Z","completed_at":"2026-08-19T07:55:09.054Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T06:39:02.239Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2aa5ba03-de27-4735-a93f-afac62507e5a","object_id":"sha256:fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e","sha256":"fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA7Xc3RKhR1QPS51q691BsKWyOxxZO4963EemNA5AUWt0","device_key_id":"5a97a3056057521cbc90fa44e9e53c57f81babbea5e549e3c8ddb787030c540a","device_signature":"0HSaYw4rksC6QwK3AsJfqdCOFxJ1hfF8bnm9ziyEBmrANi7CyPElQ9xjO7KSx2-1EC5byiBcMEUsDUenUED-CA"}} -->
