### PR TITLE
fix(evaluation): reject hostile int/float identities before numeric conversion (#1944)

### DIFF
--- a/alberta_framework/evaluation/continual_ia_artifact.py
+++ b/alberta_framework/evaluation/continual_ia_artifact.py
@@ -600,7 +600,7 @@ def _integer(
     location: str,
     errors: list[str],
 ) -> int | None:
-    if isinstance(value, bool) or not isinstance(value, int):
+    if type(value) is bool or type(value) is not int:
         errors.append(f"{location} must be an integer")
         return None
     return value

--- a/alberta_framework/evaluation/continual_multiagent_artifact.py
+++ b/alberta_framework/evaluation/continual_multiagent_artifact.py
@@ -693,7 +693,7 @@ def _required_mapping(
 
 
 def _finite_number(value: object) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) is bool or (type(value) is not int and type(value) is not float):
         return None
     numeric = float(value)
     return numeric if np.isfinite(numeric) else None

--- a/alberta_framework/evaluation/ftl_decision_artifact.py
+++ b/alberta_framework/evaluation/ftl_decision_artifact.py
@@ -173,7 +173,7 @@ def _finite_float(value: float) -> float | None:
 
 
 def _finite_number(value: object) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) is bool or (type(value) is not int and type(value) is not float):
         return None
     numeric = float(value)
     return numeric if math.isfinite(numeric) else None

--- a/alberta_framework/evaluation/recurring_feature_artifact.py
+++ b/alberta_framework/evaluation/recurring_feature_artifact.py
@@ -887,7 +887,7 @@ def _mapping(
 
 
 def _finite_number(value: object) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) is bool or (type(value) is not int and type(value) is not float):
         return None
     numeric = float(value)
     return numeric if math.isfinite(numeric) else None

--- a/alberta_framework/evaluation/scale_robust_feature_artifact.py
+++ b/alberta_framework/evaluation/scale_robust_feature_artifact.py
@@ -1599,14 +1599,14 @@ def load_evidence_artifact(path: Path) -> dict[str, object]:
 
 
 def _finite_number(value: object) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if type(value) is bool or (type(value) is not int and type(value) is not float):
         return None
     numeric = float(value)
     return numeric if math.isfinite(numeric) else None
 
 
 def _strict_int(value: object) -> int | None:
-    if isinstance(value, bool) or not isinstance(value, int):
+    if type(value) is bool or type(value) is not int:
         return None
     return value
 

--- a/tests/test_artifact_numeric_gates_hostile.py
+++ b/tests/test_artifact_numeric_gates_hostile.py
@@ -1,0 +1,154 @@
+"""Hostile int/float identity gates for the remaining artifact numeric helpers.
+
+Mirrors tests/test_continual_ia_number_hostile.py, which covers the already
+hardened continual_ia _number. The gates here still used isinstance before
+#1944; a hostile subclass passes the gate and its overridden dunder then runs
+during trusted numeric conversion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_ia_artifact import _integer
+from alberta_framework.evaluation.continual_multiagent_artifact import (
+    _finite_number as _ma_finite_number,
+)
+from alberta_framework.evaluation.ftl_decision_artifact import _finite_number as _ftl_finite_number
+from alberta_framework.evaluation.recurring_feature_artifact import (
+    _finite_number as _rf_finite_number,
+)
+from alberta_framework.evaluation.scale_robust_feature_artifact import (
+    _finite_number as _srf_finite_number,
+)
+from alberta_framework.evaluation.scale_robust_feature_artifact import _strict_int
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+def _reset() -> None:
+    _HostileInt.calls = 0
+    _HostileFloat.calls = 0
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        _ma_finite_number,
+        _ftl_finite_number,
+        _rf_finite_number,
+        _srf_finite_number,
+    ],
+)
+def test_finite_number_rejects_hostile_int_before_float(gate) -> None:
+    _reset()
+    result = gate(_HostileInt(42))  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileInt.calls == 0
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        _ma_finite_number,
+        _ftl_finite_number,
+        _rf_finite_number,
+        _srf_finite_number,
+    ],
+)
+def test_finite_number_rejects_hostile_float_before_float(gate) -> None:
+    _reset()
+    result = gate(_HostileFloat(3.14))  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileFloat.calls == 0
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        _ma_finite_number,
+        _ftl_finite_number,
+        _rf_finite_number,
+        _srf_finite_number,
+    ],
+)
+def test_finite_number_rejects_bool_and_accepts_benign(gate) -> None:
+    _reset()
+    assert gate(True) is None
+    assert gate(False) is None
+    assert gate(1) == 1.0
+    assert gate(1.5) == 1.5
+    assert gate("bad") is None  # type: ignore[arg-type]
+    assert gate(None) is None  # type: ignore[arg-type]
+    import math
+
+    assert gate(math.inf) is None
+    assert gate(math.nan) is None
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        lambda v: _strict_int(v),
+        lambda v: _integer(v, location="x", errors=[]),
+    ],
+)
+def test_integer_gate_rejects_hostile_int(gate) -> None:
+    _reset()
+    result = gate(_HostileInt(42))  # type: ignore[arg-type]
+    assert result is None
+    assert _HostileInt.calls == 0
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        lambda v: _strict_int(v),
+        lambda v: _integer(v, location="x", errors=[]),
+    ],
+)
+def test_integer_gate_rejects_bool_and_accepts_benign(gate) -> None:
+    _reset()
+    assert gate(True) is None
+    assert gate(False) is None
+    assert gate(0) == 0
+    assert gate(42) == 42
+    assert gate(1.5) is None  # type: ignore[arg-type]
+    assert gate("bad") is None  # type: ignore[arg-type]
+    assert gate(None) is None  # type: ignore[arg-type]


### PR DESCRIPTION
## Fix

Five artifact numeric gates still used `isinstance`, so a hostile subclass of `int`/`float` passed the gate and its overridden dunder (`__float__`, `__eq__`, `__hash__`, `__bool__`, `__repr__`) ran during trusted numeric conversion. Per issue #1944:

- `continual_multiagent_artifact._finite_number`
- `ftl_decision_artifact._finite_number`
- `recurring_feature_artifact._finite_number`
- `scale_robust_feature_artifact._finite_number` and `_strict_int`
- `continual_ia_artifact._integer`

Apply the same exact-type gate already used by the hardened `continual_ia _number`:
`type(value) is bool or (type(value) is not int and type(value) is not float)`
for the finite-number helpers, and `type(value) is bool or type(value) is not int`
for the int-only sites. No gate semantics change for benign values.

## Verification

- Failing-test-first: `tests/test_artifact_numeric_gates_hostile.py` (16 tests) — hostile int/float subclass per site proves no dunder runs and the value is rejected; bool rejected; benign values unchanged.
- Affected artifact suites: 395 passed (10 files: continual_multiagent, continual_ia, recurring_feature, scale_robust, ftl/scale_robust hostile chains, number-hostile, validation records, timing identities).
- ruff + strict mypy clean.

Source HEAD: `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`

<!-- slop-contribution-attribution:v1 {"provider":"nvidia","model":"nemotron-3.5-lightning-30b-a3b","client":"pi","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0CBX7YPBR6E6R4XB1XQWXGJ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T06:39:01.079Z","completed_at":"2026-08-19T07:55:09.054Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T06:39:02.239Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2aa5ba03-de27-4735-a93f-afac62507e5a","object_id":"sha256:fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e","sha256":"fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA7Xc3RKhR1QPS51q691BsKWyOxxZO4963EemNA5AUWt0","device_key_id":"5a97a3056057521cbc90fa44e9e53c57f81babbea5e549e3c8ddb787030c540a","device_signature":"0HSaYw4rksC6QwK3AsJfqdCOFxJ1hfF8bnm9ziyEBmrANi7CyPElQ9xjO7KSx2-1EC5byiBcMEUsDUenUED-CA"}} -->
