### PR TITLE
fix(evaluation): reject hostile seed/recovery identities before comparison at continual-multiagent gate

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent_artifact.py
+++ b/alberta_framework/evaluation/continual_multiagent_artifact.py
@@ -817,7 +817,7 @@ def _validate_seed_and_aggregate_consistency(
             errors.append(f"{location} must be an object")
             continue
         seed = raw_seed.get("seed")
-        if isinstance(seed, bool) or not isinstance(seed, int):
+        if type(seed) is not int:
             errors.append(f"{location}.seed must be an integer")
         else:
             observed_seeds.append(seed)
@@ -859,7 +859,7 @@ def _validate_seed_and_aggregate_consistency(
                 prequential[condition].append(reward)
             if condition == "joint_adaptive":
                 recovery = result.get("recurrence_recovery_steps")
-                if isinstance(recovery, bool) or not isinstance(recovery, int):
+                if type(recovery) is not int:
                     errors.append(
                         f"{result_location}.recurrence_recovery_steps "
                         "must be an integer"

--- a/tests/test_continual_multiagent_seed_recovery_hostile.py
+++ b/tests/test_continual_multiagent_seed_recovery_hostile.py
@@ -1,0 +1,187 @@
+"""Hostile ``int`` identity containment at the seed/recovery consistency gate.
+
+``_validate_seed_and_aggregate_consistency`` gated ``seed`` and
+``recurrence_recovery_steps`` with ``isinstance(x, bool) or not isinstance(x,
+int)``. ``isinstance`` accepts subclasses, so a hostile ``int`` subclass with
+an overridden ``__eq__``/``__ge__`` passed the gate, was appended into
+``observed_seeds``/``recurrence_steps``, and its overridden dunder then ran
+during a later "trusted" comparison — ``tuple(observed_seeds) !=
+_EXPECTED_EVIDENCE_SEEDS``, ``aggregate_seeds != observed_seeds``, or
+``value >= 0`` over ``recurrence_steps`` — before the value's type was ever
+confirmed safe. This is the same spoofable-identity shape already closed at
+other gates in this exact file (e.g. the ``check.name`` gate in
+``_validate_checks``, and the numeric artifact gates fixed elsewhere in this
+module), just missed at this particular boundary.
+
+Both sites now gate on an exact-type membership check (``type(value) is not
+int``), which rejects both ``bool`` (``type(True) is bool``, never ``int``)
+and any hostile ``int`` subclass before any dunder of the value is ever
+invoked, and before the value is ever appended into a list that later feeds a
+rich comparison.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_multiagent_artifact import (
+    _validate_seed_and_aggregate_consistency,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    """An ``int`` subclass whose comparison dunders must never run."""
+
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile __eq__ ran")
+
+    def __ne__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile __ne__ ran")
+
+    def __ge__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile __ge__ ran")
+
+    def __lt__(self, other: object) -> bool:
+        type(self).calls += 1
+        raise AssertionError("hostile __lt__ ran")
+
+    def __hash__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile __hash__ ran")
+
+
+def _joint_adaptive_condition(recovery: object) -> dict[str, object]:
+    return {
+        "learning_mask": [True, True],
+        "prequential_reward": 0.0,
+        "recurrence_recovery_steps": recovery,
+    }
+
+
+def test_seed_gate_rejects_hostile_int_before_comparison() -> None:
+    hostile = _HostileInt(30)
+    _HostileInt.calls = 0
+    content = {
+        "seed_summaries": [{"seed": hostile, "conditions": {}}],
+        "aggregate": {},
+        "configuration": {},
+    }
+    errors: list[str] = []
+
+    _validate_seed_and_aggregate_consistency(content, errors)
+
+    assert _HostileInt.calls == 0
+    assert any("seed must be an integer" in error for error in errors)
+
+
+def test_seed_gate_rejects_bool() -> None:
+    content = {
+        "seed_summaries": [{"seed": True, "conditions": {}}],
+        "aggregate": {},
+        "configuration": {},
+    }
+    errors: list[str] = []
+
+    _validate_seed_and_aggregate_consistency(content, errors)
+
+    assert any("seed must be an integer" in error for error in errors)
+
+
+def test_seed_gate_accepts_genuine_int() -> None:
+    content = {
+        "seed_summaries": [{"seed": 30, "conditions": {}}],
+        "aggregate": {},
+        "configuration": {},
+    }
+    errors: list[str] = []
+
+    _validate_seed_and_aggregate_consistency(content, errors)
+
+    assert not any("seed must be an integer" in error for error in errors)
+
+
+def test_recovery_gate_rejects_hostile_int_before_comparison() -> None:
+    hostile = _HostileInt(3)
+    _HostileInt.calls = 0
+    content = {
+        "seed_summaries": [
+            {
+                "seed": 30,
+                "conditions": {
+                    "frozen": {"learning_mask": [False, False], "prequential_reward": 0.0},
+                    "learner_only": {
+                        "learning_mask": [True, False],
+                        "prequential_reward": 0.0,
+                    },
+                    "joint_adaptive": _joint_adaptive_condition(hostile),
+                },
+            }
+        ],
+        "aggregate": {},
+        "configuration": {},
+    }
+    errors: list[str] = []
+
+    _validate_seed_and_aggregate_consistency(content, errors)
+
+    assert _HostileInt.calls == 0
+    assert any("recurrence_recovery_steps must be an integer" in error for error in errors)
+
+
+def test_recovery_gate_rejects_bool() -> None:
+    content = {
+        "seed_summaries": [
+            {
+                "seed": 30,
+                "conditions": {
+                    "frozen": {"learning_mask": [False, False], "prequential_reward": 0.0},
+                    "learner_only": {
+                        "learning_mask": [True, False],
+                        "prequential_reward": 0.0,
+                    },
+                    "joint_adaptive": _joint_adaptive_condition(True),
+                },
+            }
+        ],
+        "aggregate": {},
+        "configuration": {},
+    }
+    errors: list[str] = []
+
+    _validate_seed_and_aggregate_consistency(content, errors)
+
+    assert any("recurrence_recovery_steps must be an integer" in error for error in errors)
+
+
+def test_recovery_gate_accepts_genuine_int() -> None:
+    content = {
+        "seed_summaries": [
+            {
+                "seed": 30,
+                "conditions": {
+                    "frozen": {"learning_mask": [False, False], "prequential_reward": 0.0},
+                    "learner_only": {
+                        "learning_mask": [True, False],
+                        "prequential_reward": 0.0,
+                    },
+                    "joint_adaptive": _joint_adaptive_condition(3),
+                },
+            }
+        ],
+        "aggregate": {},
+        "configuration": {},
+    }
+    errors: list[str] = []
+
+    _validate_seed_and_aggregate_consistency(content, errors)
+
+    assert not any(
+        "recurrence_recovery_steps must be an integer" in error for error in errors
+    )


### PR DESCRIPTION
Fixes #1953.

<!-- evidence-head:add14855f1e0e6b853ec48450deac09f69926d9b -->

## What's broken

`_validate_seed_and_aggregate_consistency` in
`alberta_framework/evaluation/continual_multiagent_artifact.py` gated
`seed_summaries[i].seed` and
`seed_summaries[i].conditions.joint_adaptive.recurrence_recovery_steps` with:

```python
if isinstance(seed, bool) or not isinstance(seed, int):
    errors.append(...)
else:
    observed_seeds.append(seed)
```

(and the analogous shape for `recovery`). `isinstance` accepts subclasses, so
a hostile `int` subclass overriding `__eq__`/`__ge__`/`__lt__` passes the
gate, is appended into `observed_seeds` / `recurrence_steps`, and its
overridden dunder then runs during a later "trusted" comparison further down
the same function:

- `tuple(observed_seeds) != _EXPECTED_EVIDENCE_SEEDS`
- `aggregate_seeds != observed_seeds`
- `sum(value >= 0 for value in recurrence_steps)` / `value >= 0` filtering

— all before the value's type was ever confirmed safe.

This is the same spoofable-identity shape already closed at other gates in
this exact file (`check.name` in `_validate_checks`, fixed in #1934; the
numeric artifact gates fixed by #1945/#1952 in sibling artifact modules) and
in `interaction_features.py` (#1950 — same pipeline, prior fix) — just missed
at this particular boundary. `ArtifactValidation.__post_init__` in this same
file already uses the exact-type idiom (`type(self.valid) is not bool`), so
the fix here is bringing this one boundary in line with the rest of the file
rather than introducing a new pattern.

## Fix

Both gates now use `type(value) is not int` instead of the `isinstance` pair.
This rejects `bool` (`type(True) is bool`, never `int`) and any hostile `int`
subclass via an exact-type identity check before any dunder of the value is
ever invoked, and before the value is ever appended into a list that later
feeds a rich comparison. No behavior change for genuine `int` values or for
`numpy` integer scalars (which were already rejected under the old
`isinstance` check too, since they are not subclasses of the builtin `int`).

## Evidence

Commit under test: `add14855f1e0e6b853ec48450deac09f69926d9b`.

`gh gist create` / `gh api gists` are blocked by this session's local
classifier, so evidence is inlined below rather than attached as a gist URL.

**Mutation test — confirms the bug is real.** Stashing the fix and running
the new tests against the pre-fix code:

```
$ git stash && .venv/bin/python -m pytest tests/test_continual_multiagent_seed_recovery_hostile.py -q -o addopts=""
...
E       raise AssertionError("hostile __eq__ ran")
E       AssertionError: hostile __eq__ ran
...
FAILED tests/test_continual_multiagent_seed_recovery_hostile.py::test_seed_gate_rejects_hostile_int_before_comparison
FAILED tests/test_continual_multiagent_seed_recovery_hostile.py::test_recovery_gate_rejects_hostile_int_before_comparison
2 failed, 4 passed in 1.54s
$ git stash pop
```

Both new hostile tests fail before the fix (the hostile `__eq__` genuinely
runs), and pass after (`git stash pop` restores the fix).

**New tests, post-fix:**

```
$ .venv/bin/python -m pytest tests/test_continual_multiagent_seed_recovery_hostile.py -q -o addopts=""
......                                                                   [100%]
6 passed in 2.15s
```

**Full module regression** (all `continual_multiagent`-scoped tests):

```
$ .venv/bin/python -m pytest tests/ -q -o addopts="" -k "continual_multiagent"
........................................................s............... [ 29%]
............s........................................................... [ 58%]
........................................................................ [ 87%]
..............................                                           [100%]
244 passed, 3 skipped, 15492 deselected in 88.87s (0:01:28)
```

**Lint / types:**

```
$ .venv/bin/python -m ruff check .
All checks passed!
$ .venv/bin/python -m mypy
Success: no issues found in 197 source files
$ git diff --check
(no output)
```

**Evidence registry (`alberta-evidence-status`):** exit code `2` both before
and after this change on a fresh `origin/main` checkout, with byte-identical
per-claim `accepted`/`valid` fields before vs. after — this is a pre-existing
environment/runtime-provenance condition on this sandbox unrelated to this
change (confirmed by diffing `alberta-evidence-status` output on the
unmodified tree via `git stash` against the patched tree). Not something this
PR touches or should touch.

## Scope

Single file, single defect pattern, two call sites in one function. No
benchmark number is claimed or moved — this is a `Fix` (measurement/
correctness) contribution per the `contribute-to-asi` skill's four outcome
types, closing a hostile-input containment gap in an evaluation-artifact
validator.

## Deviations from pre-registration

None — this is a narrow correctness fix, not a benchmark comparison; no
seeds, thresholds, or screening protocol are involved.

## What remains open

Two related, out-of-scope patterns in the same function were left untouched
to keep this change to one variable:
- `result.get("learning_mask") != _EXPECTED_LEARNING_MASKS[condition]` and
  the `aggregate_seeds`/`seed_count` comparisons compare raw artifact values
  with no type gate at all (a different, broader pattern than the
  isinstance-vs-exact-type gap fixed here).
- These are flagged for a possible separate, narrowly-scoped follow-up but
  are not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0D5TZXKPWXT3WN37C9D6SB6","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T14:12:10.292Z","completed_at":"2026-08-19T14:13:05.805Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T14:12:11.002Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e1769c90669f8284c7bb938afa6517339d64bc139122e2cda2da596a5746d9f9","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"eb3e5ad6-2976-4eba-a470-ff045e2d395d","object_id":"sha256:e1769c90669f8284c7bb938afa6517339d64bc139122e2cda2da596a5746d9f9","sha256":"e1769c90669f8284c7bb938afa6517339d64bc139122e2cda2da596a5746d9f9"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"GN9rMa1iRqJjsry1yfDrKVQz7gUP5AJAeherWy4Ffjjts1HVC_OWQeZ4K_9aB6Ecqn9tUKhYnUQtYIO6PenMBw"}} -->
