### PR TITLE
fix(utils): ensure positive bar annotation offset for negative metrics in visualization

### DIFF
--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -292,8 +292,10 @@ def plot_final_performance_bars(
     # Add significance markers if provided
     if show_significance and significance_results:
         best_name = names[best_idx]
-        y_max = max(m + s for m, s in zip(means, stds, strict=False))
-        y_offset = y_max * 0.05
+        y_top = max(m + s for m, s in zip(means, stds, strict=False))
+        y_bot = min(min(0.0, m - s) for m, s in zip(means, stds, strict=False))
+        y_span = max(y_top - y_bot, max(abs(y_top), 1.0))
+        y_offset = max(y_span * 0.05, 1e-4)
 
         for i, name in enumerate(names):
             if name == best_name:
@@ -357,7 +359,7 @@ def plot_hyperparameter_heatmap(
     for i, p1 in enumerate(param1_values):
         for j, p2 in enumerate(param2_values):
             name = name_pattern.format(p1=p1, p2=p2)
-            if name in results:
+            if name in results and metric in results[name].summary:
                 data[i, j] = results[name].summary[metric].mean
             else:
                 data[i, j] = np.nan

--- a/tests/test_utils_smoke.py
+++ b/tests/test_utils_smoke.py
@@ -395,3 +395,69 @@ def test_set_publication_style_keeps_legal_hosts() -> None:
         assert plt.rcParams["text.usetex"] is False
     finally:
         plt.rcParams.update(before)
+
+
+def test_plot_final_performance_bars_significance_offset_on_negative_metrics() -> None:
+    """Significance markers must sit strictly above the error bar for negative metrics."""
+    from alberta_framework.utils.statistics import SignificanceResult
+
+    results = {
+        "best": _aggregated_from_error("best", np.full((2, 4), -100.0)),
+        "suboptimal": _aggregated_from_error("suboptimal", np.full((2, 4), -150.0)),
+    }
+    # For squared_error, override the summary with negative means and positive stds
+    summary_best = MetricSummary(
+        mean=-100.0, std=5.0, min=-110.0, max=-90.0, n_seeds=2, values=np.array([-105.0, -95.0])
+    )
+    summary_sub = MetricSummary(
+        mean=-150.0, std=10.0, min=-165.0, max=-135.0, n_seeds=2, values=np.array([-160.0, -140.0])
+    )
+    results["best"] = results["best"]._replace(summary={"squared_error": summary_best})
+    results["suboptimal"] = results["suboptimal"]._replace(summary={"squared_error": summary_sub})
+
+    sig_results = {
+        ("suboptimal", "best"): SignificanceResult(
+            test_name="t_test",
+            statistic=-5.0,
+            p_value=0.0005,
+            significant=True,
+            alpha=0.05,
+            effect_size=2.0,
+            method_a="suboptimal",
+            method_b="best",
+        )
+    }
+
+    fig, ax = plot_final_performance_bars(
+        results,
+        metric="squared_error",
+        show_significance=True,
+        significance_results=sig_results,
+        lower_is_better=False,  # -100 is better than -150
+    )
+    assert isinstance(fig, plt.Figure)
+    annotations = [t for t in ax.texts if t.get_text() == "***"]
+    assert len(annotations) == 1
+    ann = annotations[0]
+    # Bar top + std for suboptimal is -150.0 + 10.0 = -140.0.
+    # The annotation position y must be strictly above -140.0.
+    bar_top = -150.0 + 10.0
+    ann_x, ann_y = ann.xy
+    assert ann_x == 1  # suboptimal is second bar
+    assert ann_y > bar_top, f"Annotation y ({ann_y}) must be above bar top ({bar_top})"
+
+
+def test_plot_hyperparameter_heatmap_handles_missing_metric_in_summary(results) -> None:
+    """Heatmap sets nan without KeyError when requested metric is missing in summary."""
+    fig, ax = plot_hyperparameter_heatmap(
+        results,
+        param1_name="optimizer",
+        param1_values=["lms", "idbd"],
+        param2_name="suffix",
+        param2_values=[""],
+        name_pattern="{p1}{p2}",
+        metric="nonexistent_metric",
+    )
+    assert isinstance(fig, plt.Figure)
+    data = np.ma.filled(np.asarray(ax.images[0].get_array(), dtype=float), np.nan)
+    assert np.isnan(data).all()


### PR DESCRIPTION
### Summary
In `plot_final_performance_bars` (`alberta_framework/utils/visualization.py`), significance marker annotations previously computed vertical offset as `y_offset = y_max * 0.05` where `y_max = max(m + s)`. When evaluating methods on negative-valued metrics (such as cumulative rewards, log returns, or loss), `y_max` is negative, causing `y_offset` to become negative and rendering the annotation markers downward inside or below the error bar instead of floating above the bar.

This fix:
1. Computes `y_offset` from the visible vertical data span (`max(y_top - y_bot, max(abs(y_top), 1.0)) * 0.05`), ensuring `y_offset > 0` strictly for positive, zero, and negative metric distributions.
2. In `plot_hyperparameter_heatmap`, guards `metric in results[name].summary` lookup to prevent raw `KeyError` on missing metrics (matching `plot_step_size_evolution`).
3. Adds unit test coverage in `tests/test_utils_smoke.py` verifying marker annotation placement strictly above the error bar for negative metrics and graceful handling of missing metrics in heatmaps.

### Verification
- `.venv/bin/python -m pytest tests/test_utils_smoke.py tests/test_visualization_int_hostile.py -v` (31/31 passed)
- `.venv/bin/python -m ruff check alberta_framework/utils/visualization.py tests/test_utils_smoke.py` (All checks passed)
- `.venv/bin/python -m mypy alberta_framework/utils/visualization.py` (Success: no issues found)
- `git diff --check` (clean)

## Measured project receipt
Post-hoc receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F8YZZ17QV77ET526W6ZT6X","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T09:45:16.002Z","completed_at":"2026-08-20T09:46:11.579Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T09:45:17.187Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"720bae342d58fbb19e364fb613ae479e4a7106330da76a8a3f7577c9831a23f5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4b7a195f-3d8b-452b-8322-e3f4747965a6","object_id":"sha256:720bae342d58fbb19e364fb613ae479e4a7106330da76a8a3f7577c9831a23f5","sha256":"720bae342d58fbb19e364fb613ae479e4a7106330da76a8a3f7577c9831a23f5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"B07-5VMnpaw1lfOhFAJZF4geBoPrXljvZ9-8x3NX3NlPLiG02VI9DyIoNOTZC_gkI2tGvXPlKyjKFgaT6ySLCQ"}} -->
