### PR TITLE
fix(core): gate _positive_float32_scalar's sign check by exact type before comparison

### DIFF
--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -167,8 +167,6 @@ def _positive_float32_scalar(name: str, value: object) -> float:
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(message)
     try:
-        if value <= 0:
-            raise ValueError
         narrowed = round_real_to_float32(value)
     except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
         raise ValueError(message) from error

--- a/tests/test_intelligence_amplification_positive_scalar_hostile.py
+++ b/tests/test_intelligence_amplification_positive_scalar_hostile.py
@@ -1,0 +1,171 @@
+# mypy: disable-error-code="attr-defined,call-arg,override"
+"""``_positive_float32_scalar`` must gate by exact type before any comparison.
+
+``ExoCerebellumConfig.step_size`` is validated through
+``_positive_float32_scalar``, which historically ran ``value <= 0`` on the
+caller-supplied object *before* ``round_real_to_float32`` narrowed it through
+its own exact-type gate (see ``alberta_framework/_float32.py::_real_ratio``,
+which checks ``type(value)`` against an allow-list before touching any
+instance dunder). A ``numbers.Real`` subclass overriding ``__le__``,
+``__lt__``, ``__gt__``, ``__ge__``, or ``__bool__`` therefore had its hostile
+dunder invoked during "trusted" validation, before the value's type was ever
+confirmed safe -- the same class of defect closed file-by-file elsewhere in
+this repository's evidence and stream validators (e.g. commit ``a81e159f``,
+which hardened ``continual_ia_artifact.py``'s ``_number`` to gate on
+``type(value) is int or type(value) is float`` before any conversion).
+"""
+
+from __future__ import annotations
+
+from numbers import Real
+from typing import Any
+
+import pytest
+
+from alberta_framework.core.intelligence_amplification import ExoCerebellumConfig
+
+
+class _HostileReal(Real):
+    """A ``numbers.Real`` whose comparison/conversion dunders must never run."""
+
+    calls: list[str] = []
+
+    def __init__(self, magnitude: float) -> None:
+        self._magnitude = magnitude
+
+    def _record(self, name: str) -> None:
+        type(self).calls.append(name)
+
+    def __le__(self, other: object) -> bool:
+        self._record("__le__")
+        raise AssertionError("hostile __le__ ran")
+
+    def __lt__(self, other: object) -> bool:
+        self._record("__lt__")
+        raise AssertionError("hostile __lt__ ran")
+
+    def __gt__(self, other: object) -> bool:
+        self._record("__gt__")
+        raise AssertionError("hostile __gt__ ran")
+
+    def __ge__(self, other: object) -> bool:
+        self._record("__ge__")
+        raise AssertionError("hostile __ge__ ran")
+
+    def __bool__(self) -> bool:
+        self._record("__bool__")
+        raise AssertionError("hostile __bool__ ran")
+
+    def __float__(self) -> float:
+        self._record("__float__")
+        raise AssertionError("hostile __float__ ran")
+
+    def __eq__(self, other: object) -> bool:
+        self._record("__eq__")
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return 0
+
+    # Remaining abstract members of numbers.Real -- unused by the validator,
+    # but required for the ABC to instantiate. Each records and raises too,
+    # so *any* touch of the hostile instance's numeric protocol is caught.
+    def __abs__(self) -> Any:
+        self._record("__abs__")
+        raise AssertionError("hostile __abs__ ran")
+
+    def __add__(self, other: object) -> Any:
+        self._record("__add__")
+        raise AssertionError("hostile __add__ ran")
+
+    def __radd__(self, other: object) -> Any:
+        self._record("__radd__")
+        raise AssertionError("hostile __radd__ ran")
+
+    def __neg__(self) -> Any:
+        self._record("__neg__")
+        raise AssertionError("hostile __neg__ ran")
+
+    def __pos__(self) -> Any:
+        self._record("__pos__")
+        raise AssertionError("hostile __pos__ ran")
+
+    def __mul__(self, other: object) -> Any:
+        self._record("__mul__")
+        raise AssertionError("hostile __mul__ ran")
+
+    def __rmul__(self, other: object) -> Any:
+        self._record("__rmul__")
+        raise AssertionError("hostile __rmul__ ran")
+
+    def __truediv__(self, other: object) -> Any:
+        self._record("__truediv__")
+        raise AssertionError("hostile __truediv__ ran")
+
+    def __rtruediv__(self, other: object) -> Any:
+        self._record("__rtruediv__")
+        raise AssertionError("hostile __rtruediv__ ran")
+
+    def __floordiv__(self, other: object) -> Any:
+        self._record("__floordiv__")
+        raise AssertionError("hostile __floordiv__ ran")
+
+    def __rfloordiv__(self, other: object) -> Any:
+        self._record("__rfloordiv__")
+        raise AssertionError("hostile __rfloordiv__ ran")
+
+    def __mod__(self, other: object) -> Any:
+        self._record("__mod__")
+        raise AssertionError("hostile __mod__ ran")
+
+    def __rmod__(self, other: object) -> Any:
+        self._record("__rmod__")
+        raise AssertionError("hostile __rmod__ ran")
+
+    def __pow__(self, other: object) -> Any:
+        self._record("__pow__")
+        raise AssertionError("hostile __pow__ ran")
+
+    def __rpow__(self, other: object) -> Any:
+        self._record("__rpow__")
+        raise AssertionError("hostile __rpow__ ran")
+
+    def __trunc__(self) -> Any:
+        self._record("__trunc__")
+        raise AssertionError("hostile __trunc__ ran")
+
+    def __floor__(self) -> Any:
+        self._record("__floor__")
+        raise AssertionError("hostile __floor__ ran")
+
+    def __ceil__(self) -> Any:
+        self._record("__ceil__")
+        raise AssertionError("hostile __ceil__ ran")
+
+    def __round__(self, ndigits: int | None = None) -> Any:
+        self._record("__round__")
+        raise AssertionError("hostile __round__ ran")
+
+
+def test_cerebellum_config_rejects_hostile_real_without_touching_its_dunders() -> None:
+    _HostileReal.calls.clear()
+    with pytest.raises(ValueError, match="step_size"):
+        ExoCerebellumConfig(step_size=_HostileReal(0.05))  # type: ignore[arg-type]
+    assert _HostileReal.calls == []
+
+
+def test_cerebellum_config_rejects_hostile_real_reporting_as_positive() -> None:
+    """A hostile instance cannot bypass the gate merely by "looking" positive."""
+    _HostileReal.calls.clear()
+    with pytest.raises(ValueError, match="step_size"):
+        ExoCerebellumConfig(step_size=_HostileReal(1.0))  # type: ignore[arg-type]
+    assert _HostileReal.calls == []
+
+
+def test_cerebellum_config_rejects_plain_negative_and_zero_step_size() -> None:
+    with pytest.raises(ValueError, match="step_size"):
+        ExoCerebellumConfig(step_size=-0.05)
+    with pytest.raises(ValueError, match="step_size"):
+        ExoCerebellumConfig(step_size=0.0)
+    with pytest.raises(ValueError, match="step_size"):
+        ExoCerebellumConfig(step_size=-0.0)


### PR DESCRIPTION
Fixes #1955.

## What's wrong

`_positive_float32_scalar` in `alberta_framework/core/intelligence_amplification.py`
gates its input with `isinstance(value, bool) or not isinstance(value, Real)` —
which accepts any `numbers.Real` subclass — and then evaluated `value <= 0`
**directly on the untrusted instance** before `round_real_to_float32` ever
narrows it through its own exact-type allow-list
(`alberta_framework/_float32.py::_real_ratio`, which checks `type(value)`
against `{int, float, Fraction, np.float16/32/64/128, ...}` *before* touching
any instance dunder). A hostile `numbers.Real` subclass overriding `__le__`
therefore had that dunder invoked during "trusted" validation before the
value's type was ever confirmed safe — the same class of defect this
repository has been closing file-by-file elsewhere (e.g. `a81e159f`, which
hardened `continual_ia_artifact.py`'s `_number` helper to gate on
`type(value) is int or type(value) is float` before any conversion runs).

This is directly reachable, unlike a dead-code preflight gap:
`ExoCerebellumConfig.__post_init__` calls
`_positive_float32_scalar("step_size", self.step_size)`, and `step_size` is a
plain constructible dataclass field — `ExoCerebellumConfig(step_size=<hostile>)`
runs the hostile dunder immediately, no other setup required.

## The fix

Drop the premature `if value <= 0: raise ValueError` line and defer the
sign/finiteness check to `narrowed <= 0.0` on the plain `float` that
`round_real_to_float32` returns — the exact pattern already used safely by
the sibling `_require_positive_float32` in
`alberta_framework/streams/out_of_class.py`. No change to accepted
magnitudes or the float32 rounding contract: `round_real_to_float32` still
rejects non-allow-listed types with `TypeError` (caught and re-raised as the
same `ValueError`), and the post-rounding `narrowed <= 0.0` check still
rejects zero/negative/subnormal-underflowing values exactly as before. Only
the order of operations changes, so that no dunder of an untyped `value` ever
runs before its type is confirmed to be in the exact allow-list.

```diff
     if isinstance(value, bool) or not isinstance(value, Real):
         raise ValueError(message)
     try:
-        if value <= 0:
-            raise ValueError
         narrowed = round_real_to_float32(value)
     except (FloatingPointError, OverflowError, TypeError, ValueError) as error:
         raise ValueError(message) from error
```

## Reachability / severity

Reachable through public API surface (`ExoCerebellumConfig(step_size=...)`),
not gated behind an internal-only code path. A hostile `numbers.Real`
subclass supplied as `step_size` (e.g. from a deserialized/untrusted config
payload routed through this constructor) gets its `__le__`/other numeric
dunders executed during construction instead of being cleanly rejected —
exactly the arbitrary-code-during-validation class of bug the repository's
hostile-identity hardening series targets.

## Evidence

`gh gist create` / `gh api gists` is blocked by this session's local
auto-mode classifier (publishing content publicly is treated as sensitive),
so I could not attach a gist. Full command output is inlined below instead,
per the operator's disclosed workaround for this limitation.

### Repro against pre-fix code (hostile dunder runs)

```
$ .venv/bin/python -c "
import numbers
class HostileReal(numbers.Real):
    def __le__(self, other): raise AssertionError('hostile __le__ ran')
    def __float__(self): raise AssertionError('hostile __float__ ran')
    # (remaining numbers.Real abstract dunders each defined similarly)
    ...
from alberta_framework.core.intelligence_amplification import ExoCerebellumConfig
try:
    cfg = ExoCerebellumConfig(step_size=HostileReal(0.05))
    print('NO ERROR - config constructed:', cfg)
except AssertionError as e:
    print('HOSTILE DUNDER RAN:', e)
except ValueError as e:
    print('Rejected cleanly with ValueError:', e)
"
HOSTILE DUNDER RAN: hostile __le__ ran
```

### Failing-test-first (new test file against pre-fix code)

```
$ .venv/bin/python -m pytest tests/test_intelligence_amplification_positive_scalar_hostile.py -q -o addopts=""
...
alberta_framework/core/intelligence_amplification.py:170: in _positive_float32_scalar
    if value <= 0:
       ^^^^^^^^^^
tests/test_intelligence_amplification_positive_scalar_hostile.py:41: in __le__
    raise AssertionError("hostile __le__ ran")
E   AssertionError: hostile __le__ ran
FAILED tests/test_intelligence_amplification_positive_scalar_hostile.py::test_cerebellum_config_rejects_hostile_real_without_touching_its_dunders
FAILED tests/test_intelligence_amplification_positive_scalar_hostile.py::test_cerebellum_config_rejects_hostile_real_reporting_as_positive
2 failed, 1 passed in 1.28s
```

### Same test file, post-fix

```
$ .venv/bin/python -m pytest tests/test_intelligence_amplification_positive_scalar_hostile.py -q -o addopts=""
...
3 passed in 1.09s
```

### Full targeted regression surface, post-fix (all IA-module consumers + hostile-identity siblings)

```
$ .venv/bin/python -m pytest \
    tests/test_ia_amplification.py \
    tests/test_ia_cerebellum_overflow_preflight.py \
    tests/test_ia_crediting.py \
    tests/test_ia_recommendation_intervention.py \
    tests/test_ia_transition_discounts.py \
    tests/test_intelligence_amplification_horizon.py \
    tests/test_intelligence_amplification_positive_scalar_hostile.py \
    tests/test_prototype_agent.py \
    tests/test_prototype_ia_action_credit.py \
    tests/test_step12_production.py \
    tests/test_wave_1383_1397_hostile_type_identity.py \
    tests/test_ia_condition_result_hostile.py \
    -q -o addopts=""
........................................................................ [ 18%]
........................................................................ [ 36%]
........................................................................ [ 54%]
........................................................................ [ 72%]
.......................................................
[exited with code 0]
```

(399 tests collected across these 12 files per `--collect-only`; the run
above completed with exit code 0, i.e. all passed. This includes
`test_cerebellum_config_rejects_values_outside_its_float32_sink` (nan/inf/1e100/1e-100/bool/np.bool_/np.ndarray
still rejected) and `test_cerebellum_config_rounds_exact_reals_once_and_updates_with_that_sink`
(legitimate `Fraction` step sizes still round and update correctly), proving the
reordering preserves all prior accept/reject behavior for trusted types.)

### Lint / types / whitespace

```
$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy alberta_framework/core/intelligence_amplification.py tests/test_intelligence_amplification_positive_scalar_hostile.py
Success: no issues found in 2 source files

$ git diff --check
(no output — clean)
```

## Collision check

Checked live open PR file lists (`gh pr list --repo elizaOS/asi --state open
--json number,title,headRefName,files`) immediately before committing: no
open PR touches `alberta_framework/core/intelligence_amplification.py`.
Searched `gh issue list --search intelligence_amplification/ExoCerebellum` —
no open or prior issue on this file's hostile-identity gate.

## Scope

One lane, one variable: reorder the sign check in `_positive_float32_scalar`
so it runs on the type-gated, converted output instead of the raw untrusted
input. No formula, threshold, or accepted-magnitude change.

<!-- evidence-head:a457322fd184e5ecba44540fdcd1edb8beec20e3 -->
<!-- evidence-row:logs -->
- [x] logs: inlined above (gist/gh-api-gists blocked by this session's local auto-mode classifier; full command output included in the PR body per the operator's disclosed workaround, no attachment URL available)

---

**Client/provider/model disclosure:** `--client claude-code --provider anthropic --model claude-sonnet-5`, lane `rama0x1-asi-claude-worker`.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0D5X3XQFTCTBNJDW9RYA26S","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T14:13:19.928Z","completed_at":"2026-08-19T14:13:56.789Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T14:13:20.494Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"421513c4e4fe00390993fec9118f7c5dce7a734a5567dfe44560cfda34e05295","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"6389d9bc-c59d-4009-83aa-dbe88c1adca8","object_id":"sha256:421513c4e4fe00390993fec9118f7c5dce7a734a5567dfe44560cfda34e05295","sha256":"421513c4e4fe00390993fec9118f7c5dce7a734a5567dfe44560cfda34e05295"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"r6erL1FYq0IVWw7MXQc_00itqf1kp-1hjs08qGnCPlLW1Jxz6ViLvBvwyHJ3qYd8jcLwzO2p8pJHiIPrDwXZBA"}} -->
