### PR TITLE
fix(benchmarks): reject hostile int/float identities in upgd_ipmnist shard loader

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -1591,11 +1591,9 @@ def _validated_partial_payload(
     for name, value in hyperparameters.items():
         if (
             type(name) is not str
-            or isinstance(value, bool)
-            or not isinstance(value, (int, float))
+            or (type(value) is not int and type(value) is not float)
+            or not math.isfinite(float(value))
         ):
-            raise ValueError(f"{path}: hyperparameters must be finite named numbers")
-        if not math.isfinite(float(value)):
             raise ValueError(f"{path}: hyperparameters must be finite named numbers")
     try:
         resolved_hyperparameters = resolve_hyperparameters(
@@ -1662,14 +1660,13 @@ def _validated_partial_payload(
         lower_ok = matrix >= lower if inclusive else matrix > lower
         if not bool(np.all(lower_ok)) or (upper is not None and not bool(np.all(matrix <= upper))):
             raise ValueError(f"{path}: {field} values are outside the allowed range")
-    wall_clock = payload.get("wall_clock_seconds")
-    if (
-        isinstance(wall_clock, bool)
-        or not isinstance(wall_clock, (int, float))
-        or not math.isfinite(float(wall_clock))
-        or float(wall_clock) <= 0.0
-    ):
+    try:
+        wall_clock = _require_finite_real("wall_clock_seconds", payload.get("wall_clock_seconds"))
+    except ValueError as exc:
+        raise ValueError(f"{path}: wall_clock_seconds must be finite and positive") from exc
+    if wall_clock <= 0.0:
         raise ValueError(f"{path}: wall_clock_seconds must be finite and positive")
+    payload["wall_clock_seconds"] = wall_clock
     return payload
 
 

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -1061,6 +1061,81 @@ class TestPartialMerge:
 
         assert _HostileString.calls == 0
 
+    def test_partial_validation_rejects_hostile_hyperparameter_value_before_float_hook(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A hostile int/float subclass hyperparameter value must be rejected by an
+        exact-type check before its ``__float__`` hook ever runs, matching the
+        already-hardened ``IPMNISTRunResult.__post_init__`` convention in this module.
+        """
+
+        class HostileFloat(float):
+            def __float__(self) -> float:
+                raise AssertionError("hostile float conversion must not run")
+
+        payload = self._minimal_v2_payload()
+        payload["hyperparameters"] = {"step_size": HostileFloat(0.001)}
+        monkeypatch.setattr(upgd_ipmnist, "_strict_json_object", lambda _path: payload)
+
+        with pytest.raises(ValueError, match="finite named numbers"):
+            upgd_ipmnist._validated_partial_payload(
+                tmp_path / "hostile.json", schema=PARTIAL_SCHEMA, seed_field="seed_id"
+            )
+
+    def test_partial_validation_rejects_hostile_wall_clock_before_float_hook(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A hostile int/float subclass ``wall_clock_seconds`` must be rejected before
+        its ``__float__``/``__add__`` hooks run; otherwise it survives validation and
+        ``_merge_partial_results`` later calls the unguarded builtin ``sum()`` over it.
+
+        Uses a fully valid shard payload (from a real run) so the function actually
+        reaches the ``wall_clock_seconds`` gate instead of failing earlier on the
+        deliberately-incomplete minimal fixture's hyperparameters.
+        """
+
+        class HostileFloat(float):
+            def __float__(self) -> float:
+                raise AssertionError("hostile float conversion must not run")
+
+            def __add__(self, other: object) -> float:
+                raise AssertionError("hostile addition must not run")
+
+            __radd__ = __add__
+
+        data_x, data_y = _synthetic_dataset(6, N_TRAIN, TINY.input_dim, TINY.n_classes)
+        shard = run_ipmnist(data_x, data_y, "upgd_w", seeds=(0,), config=TINY)
+        payload = partial_payload(shard)
+        payload["wall_clock_seconds"] = HostileFloat(1.0)
+        monkeypatch.setattr(upgd_ipmnist, "_strict_json_object", lambda _path: payload)
+
+        with pytest.raises(ValueError, match="wall_clock_seconds"):
+            upgd_ipmnist._validated_partial_payload(
+                tmp_path / "hostile.json", schema=PARTIAL_SCHEMA, seed_field="seed_id"
+            )
+
+    def test_partial_validation_normalizes_integer_wall_clock_seconds(
+        self, tmp_path: Path
+    ) -> None:
+        """An integer ``wall_clock_seconds`` is a legitimate finite real value (the
+        v1 legacy schema and hand-built shards may supply one) and must be accepted
+        and coerced to a builtin ``float`` via ``_require_finite_real``, matching the
+        already-hardened convention used for the live-run result dataclass.
+        """
+        data_x, data_y = _synthetic_dataset(6, N_TRAIN, TINY.input_dim, TINY.n_classes)
+        shard = run_ipmnist(data_x, data_y, "upgd_w", seeds=(0,), config=TINY)
+        payload = partial_payload(shard)
+        payload["wall_clock_seconds"] = 3
+        path = tmp_path / "integer-wall-clock.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        validated = upgd_ipmnist._validated_partial_payload(
+            path, schema=PARTIAL_SCHEMA, seed_field="seed_id"
+        )
+
+        assert validated["wall_clock_seconds"] == 3.0
+        assert type(validated["wall_clock_seconds"]) is float
+
     def test_v2_partial_manifest_binds_identity_and_digest_to_one_read(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
Closes #1959.

<!-- evidence-head:844143f08cf71f388dcd8e2fdd0a1c00dcc0fb82 -->

## Provider/model disclosure

`--client claude-code --provider anthropic --model claude-sonnet-5`, lane `rama0x1-asi-claude-worker-2`.

## What's broken

`_validated_partial_payload` in `alberta_framework/benchmarks/upgd_ipmnist.py`
reads untrusted UPGD-IPMNIST shard JSON from disk — it's the boundary between
"on-disk shard content" and a trusted `IPMNISTRunResult`. Two of its numeric
gates still used the spoofable `isinstance` form:

```python
for name, value in hyperparameters.items():
    if (
        type(name) is not str
        or isinstance(value, bool)
        or not isinstance(value, (int, float))
    ):
        raise ValueError(f"{path}: hyperparameters must be finite named numbers")
    if not math.isfinite(float(value)):
        raise ValueError(f"{path}: hyperparameters must be finite named numbers")
...
wall_clock = payload.get("wall_clock_seconds")
if (
    isinstance(wall_clock, bool)
    or not isinstance(wall_clock, (int, float))
    or not math.isfinite(float(wall_clock))
    or float(wall_clock) <= 0.0
):
    raise ValueError(f"{path}: wall_clock_seconds must be finite and positive")
```

`isinstance` accepts subclasses, so a hostile `int`/`float` subclass overriding
`__float__`/`__add__`/`__radd__` passes the gate and its overridden dunder then
runs during "trusted" numeric conversion, before the type is confirmed safe.

This same module already carries the hardened convention elsewhere:
`_require_finite_real` (defined line 306, used line 911 for
`IPMNISTRunResult.wall_clock_seconds` on the trusted live-run path) and the
equivalent inline `(type(value) is not int and type(value) is not float)` gate
in `IPMNISTRunResult.__post_init__` (line 831) for `hyperparameters`. The two
shard-loader sites fixed here were the boundary functions that missed it.

**Concrete downstream exploitation, not just theoretical.** The
`hyperparameters` value happens to get re-validated later by
`resolve_hyperparameters` (already hardened — see
`test_resolve_hyperparameters_rejects_hostile_numeric_subclass`), so its
exposure was the `float(value)` call inside this function's own loop. But a
hostile `wall_clock_seconds` that survived this gate was stored **unchanged**
in the returned `payload` dict and flowed straight into
`_merge_partial_results`'s `sum(shard["wall_clock_seconds"] for shard in
shards)` — an unguarded builtin `sum()` over attacker-controlled shard
content, invoking `__radd__`/`__add__` with no type check in between.

## Fix

- `hyperparameters` value loop: exact-type gate matching
  `IPMNISTRunResult.__post_init__`'s convention, folded into one condition
  (behavior for legitimate `int`/`float` values, including the deliberate
  "integer alias of a float field must fail the complete-configuration check"
  case in `test_merge_rejects_integer_alias_of_float_hyperparameter`, is
  unchanged — only the type gate is hardened, the dict is not renormalized).
- `wall_clock_seconds`: reuse the module's own `_require_finite_real` helper
  (DRY with the `IPMNISTRunResult` site) and write the coerced `float` back
  onto `payload["wall_clock_seconds"]` so the hostile object never survives
  into `_merge_partial_results`'s `sum()`.

## Tests (failing-test-first)

Three new cases in `tests/test_upgd_ipmnist.py::TestPartialMerge`:

- `test_partial_validation_rejects_hostile_hyperparameter_value_before_float_hook`
- `test_partial_validation_rejects_hostile_wall_clock_before_float_hook`
- `test_partial_validation_normalizes_integer_wall_clock_seconds`

The two hostile-subclass tests assert `ValueError` is raised with the hostile
`__float__`/`__add__`/`__radd__` never invoked (they raise `AssertionError` if
called); the third builds a full valid shard from a real `run_ipmnist` run and
checks an integer `wall_clock_seconds` is accepted and coerced to a builtin
`float`.

Verified red-then-green: reverted only the production file
(`git stash push -- alberta_framework/benchmarks/upgd_ipmnist.py`) and reran
the three new tests — all three failed (two with the hostile dunder's
`AssertionError` actually propagating, one with the raw `int` surviving
uncoerced), then restored the fix and reran green.

<!-- evidence-row:logs -->
- [x] logs: pasted below (this is a validator-correctness fix with no
  benchmark run or `outputs/` artifact; `gh gist create`/`gh api gists` are
  blocked by this session's local classifier, so there is no attachment-URL
  host available — full command output is inlined verbatim instead, per the
  skill's disclosure fallback)

Pre-fix (production file reverted, new tests only):
```
$ .venv/bin/python -m pytest tests/test_upgd_ipmnist.py -q -o addopts="" -k "hostile_hyperparameter_value or hostile_wall_clock or normalizes_integer_wall_clock"
FAILED tests/test_upgd_ipmnist.py::TestPartialMerge::test_partial_validation_rejects_hostile_hyperparameter_value_before_float_hook
FAILED tests/test_upgd_ipmnist.py::TestPartialMerge::test_partial_validation_rejects_hostile_wall_clock_before_float_hook
FAILED tests/test_upgd_ipmnist.py::TestPartialMerge::test_partial_validation_normalizes_integer_wall_clock_seconds
3 failed, 121 deselected in 13.80s
```

Post-fix, at head `844143f08cf71f388dcd8e2fdd0a1c00dcc0fb82`:
```
$ .venv/bin/python -m pytest tests/test_upgd_ipmnist.py -q -o addopts=""
124 passed in 266.61s (0:04:26)

$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 197 source files

$ git diff --check
(clean, no output)
```

## Collision check

Immediately before committing, `gh pr list --repo elizaOS/asi --state open
--json number,title,files --limit 100` showed no open PR touching
`alberta_framework/benchmarks/upgd_ipmnist.py`. Re-checked again after commit,
before this push — still clean.

## What remains open

`upgd_ipmnist.py` may have other adjacent numeric gates worth a future audit
pass; this PR is scoped to the two sites in `_validated_partial_payload`
identified above, one variable (the type gate) at a time.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0D36EQEEWV9J5FE6YPBXTZ0","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T13:26:00.174Z","completed_at":"2026-08-19T14:07:26.649Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T13:26:01.929Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"483ba0b71fd8510434d52e0d443cc0e9809f8955927397788d540d6aa3254c7e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"721f7d91-cbce-42b9-8945-e260abe80be4","object_id":"sha256:483ba0b71fd8510434d52e0d443cc0e9809f8955927397788d540d6aa3254c7e","sha256":"483ba0b71fd8510434d52e0d443cc0e9809f8955927397788d540d6aa3254c7e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"2tF2AMghS80_629mWtT1Pufq4Opw91LNa0K58eG6tImzkBelZLE-tcUUcCk7rhz-wwapc-pc6Zqzi9V8JrXMBQ"}} -->
