### PR TITLE
fix(benchmarks): reject hostile int/float subclasses in upgd_ipmnist validator (#1961)

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -1591,8 +1591,8 @@ def _validated_partial_payload(
     for name, value in hyperparameters.items():
         if (
             type(name) is not str
-            or isinstance(value, bool)
-            or not isinstance(value, (int, float))
+            or type(value) is bool
+            or (type(value) is not int and type(value) is not float)
         ):
             raise ValueError(f"{path}: hyperparameters must be finite named numbers")
         if not math.isfinite(float(value)):
@@ -1664,8 +1664,8 @@ def _validated_partial_payload(
             raise ValueError(f"{path}: {field} values are outside the allowed range")
     wall_clock = payload.get("wall_clock_seconds")
     if (
-        isinstance(wall_clock, bool)
-        or not isinstance(wall_clock, (int, float))
+        type(wall_clock) is bool
+        or (type(wall_clock) is not int and type(wall_clock) is not float)
         or not math.isfinite(float(wall_clock))
         or float(wall_clock) <= 0.0
     ):

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -59,6 +59,50 @@ class _HostileString(str):
     __hash__ = str.__hash__
 
 
+class _HostileFloat(float):
+    """A float facade whose dunders must not run during trusted validation."""
+
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("untrusted __float__ hook executed")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("untrusted __eq__ hook executed")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("untrusted __bool__ hook executed")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("untrusted __repr__ hook executed")
+
+
+class _HostileInt(int):
+    """An int facade whose dunders must not run during trusted validation."""
+
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("untrusted __float__ hook executed")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("untrusted __eq__ hook executed")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("untrusted __bool__ hook executed")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("untrusted __repr__ hook executed")
+
+
 def _synthetic_dataset(
     seed: int, n_train: int, input_dim: int, n_classes: int
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -1060,6 +1104,65 @@ class TestPartialMerge:
             )
 
         assert _HostileString.calls == 0
+
+    def test_partial_validation_rejects_hostile_hyperparameter_number_before_float(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = self._minimal_v2_payload()
+        payload["hyperparameters"] = {"step_size": _HostileFloat(0.001)}
+        _HostileFloat.calls = 0
+        monkeypatch.setattr(upgd_ipmnist, "_strict_json_object", lambda _path: payload)
+
+        with pytest.raises(ValueError, match="hyperparameters"):
+            upgd_ipmnist._validated_partial_payload(
+                tmp_path / "hostile.json", schema=PARTIAL_SCHEMA, seed_field="seed_id"
+            )
+
+        assert _HostileFloat.calls == 0
+
+    def test_partial_validation_rejects_hostile_hyperparameter_int_before_float(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = self._minimal_v2_payload()
+        payload["hyperparameters"] = {"step_size": _HostileInt(1)}
+        _HostileInt.calls = 0
+        monkeypatch.setattr(upgd_ipmnist, "_strict_json_object", lambda _path: payload)
+
+        with pytest.raises(ValueError, match="hyperparameters"):
+            upgd_ipmnist._validated_partial_payload(
+                tmp_path / "hostile.json", schema=PARTIAL_SCHEMA, seed_field="seed_id"
+            )
+
+        assert _HostileInt.calls == 0
+
+    def test_partial_validation_rejects_hostile_wall_clock_before_float(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = self._minimal_v2_payload()
+        payload["hyperparameters"] = dict(upgd_ipmnist.ADAMW_PROTOCOL_HYPERPARAMETERS)
+        config = upgd_ipmnist.IPMNISTConfig()
+        payload["config"] = dict(config.to_config())
+        payload["matches_selected_publication_configuration"] = (
+            config.matches_selected_publication_configuration
+        )
+        payload["selected_publication_configuration_match_scope"] = (
+            "network_task_shape_and_horizon_only"
+        )
+        payload["seed_id"] = 7
+        payload["seed_count"] = 1
+        payload["per_task_accuracy"] = [[0.5] * config.n_tasks]
+        payload["per_task_loss"] = [[1e-6] * config.n_tasks]
+        payload["per_task_plasticity"] = [[0.5] * config.n_tasks]
+        payload["wall_clock_seconds"] = _HostileFloat(1.0)
+        _HostileFloat.calls = 0
+        monkeypatch.setattr(upgd_ipmnist, "_strict_json_object", lambda _path: payload)
+
+        with pytest.raises(ValueError, match="wall_clock_seconds"):
+            upgd_ipmnist._validated_partial_payload(
+                tmp_path / "hostile.json", schema=PARTIAL_SCHEMA, seed_field="seed_id"
+            )
+
+        assert _HostileFloat.calls == 0
 
     def test_v2_partial_manifest_binds_identity_and_digest_to_one_read(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
## Fix

`_validated_partial_payload` in `alberta_framework/benchmarks/upgd_ipmnist.py` carried two numeric gates of the #1944 class: an `isinstance` acceptance check followed by a trusted `float()` conversion, so a hostile `int`/`float` subclass passed the gate and its overridden `__float__` ran during trusted validation.

- Hyperparameter values (~line 1595): `isinstance(value, bool) or not isinstance(value, (int, float))` then `math.isfinite(float(value))`.
- `wall_clock_seconds` (~line 1667): same pattern then `float(wall_clock) <= 0.0`.

Both now use the exact-type gate used by the rest of this bug class (#1944, `upgd_ipmnist_nonpromoting._finite_number`, `forager_matrix._finite_number`): `type(value) is bool or (type(value) is not int and type(value) is not float)`. No benchmark run, no seed reservation, no threshold change, no artifact rewrite.

## Verification

- Failing-test-first: 3 new tests in `tests/test_upgd_ipmnist.py` — hostile `float` and `int` through `hyperparameters`, and hostile `float` through `wall_clock_seconds` (reaching it past learner/config/seed/matrix checks), each rejected with the existing `ValueError` while proving no dunder runs.
- `tests/test_upgd_ipmnist.py`: 124 passed. ruff + strict mypy clean.

Source HEAD: `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`

<!-- slop-contribution-attribution:v1 {"provider":"nvidia","model":"nemotron-3.5-lightning-30b-a3b","client":"pi","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0CBX7YPBR6E6R4XB1XQWXGJ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T06:39:01.079Z","completed_at":"2026-08-19T07:55:09.054Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T06:39:02.239Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2aa5ba03-de27-4735-a93f-afac62507e5a","object_id":"sha256:fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e","sha256":"fb364f769559289191a072afd2bcdf1b290488dcb60554a4887fcf6b6996822e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA7Xc3RKhR1QPS51q691BsKWyOxxZO4963EemNA5AUWt0","device_key_id":"5a97a3056057521cbc90fa44e9e53c57f81babbea5e549e3c8ddb787030c540a","device_signature":"0HSaYw4rksC6QwK3AsJfqdCOFxJ1hfF8bnm9ziyEBmrANi7CyPElQ9xjO7KSx2-1EC5byiBcMEUsDUenUED-CA"}} -->
