### PR TITLE
fix(steps): validate exact schema fields and container types in Step 4 and Step 8 from_dict

### DIFF
--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -21,7 +21,7 @@ References:
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from numbers import Integral
 from typing import Any, Literal, cast
 
@@ -108,8 +108,18 @@ class Step4SARSAConfig:
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step4SARSAConfig:
         """Reconstruct from :meth:`to_dict` output."""
-        config = dict(payload)
-        config["hidden_sizes"] = tuple(cast(list[int], config["hidden_sizes"]))
+        if type(payload) is not dict:
+            raise ValueError("Step4SARSAConfig payload must be an exact dictionary")
+        raw = cast(dict[object, object], payload)
+        if any(type(key) is not str for key in raw):
+            raise ValueError("Step4SARSAConfig payload keys must be exact strings")
+        expected = {field.name for field in fields(cls)}
+        if set(raw) != expected:
+            raise ValueError("Step4SARSAConfig payload fields do not match the schema")
+        if type(raw["hidden_sizes"]) is not list:
+            raise ValueError("hidden_sizes must be an exact list")
+        config = dict(raw)
+        config["hidden_sizes"] = tuple(cast(list[object], config["hidden_sizes"]))
         return cls(**cast(Any, config))
 
     def to_sarsa_config(self) -> SARSAConfig:

--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -26,7 +26,7 @@ via Disagreement."
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from numbers import Integral
 from typing import Any, cast
 
@@ -87,10 +87,18 @@ class Step8WorldModelConfig:
     @classmethod
     def from_dict(cls, payload: dict[str, object]) -> Step8WorldModelConfig:
         """Reconstruct from :meth:`to_dict` output."""
-        data = dict(payload)
-        hidden_sizes = data.get("hidden_sizes", (64,))
-        if isinstance(hidden_sizes, list):
-            data["hidden_sizes"] = tuple(hidden_sizes)
+        if type(payload) is not dict:
+            raise ValueError("Step8WorldModelConfig payload must be an exact dictionary")
+        raw = cast(dict[object, object], payload)
+        if any(type(key) is not str for key in raw):
+            raise ValueError("Step8WorldModelConfig payload keys must be exact strings")
+        expected = {field.name for field in fields(cls)}
+        if set(raw) != expected:
+            raise ValueError("Step8WorldModelConfig payload fields do not match the schema")
+        if type(raw["hidden_sizes"]) is not list:
+            raise ValueError("hidden_sizes must be an exact list")
+        data = dict(raw)
+        data["hidden_sizes"] = tuple(cast(list[object], data["hidden_sizes"]))
         return cls(**cast(Any, data))
 
     def to_core_config(self) -> WorldModelConfig:

--- a/tests/test_step4_hostile_validation.py
+++ b/tests/test_step4_hostile_validation.py
@@ -177,3 +177,19 @@ def test_float_subclass_with_lying_ratio_is_rejected() -> None:
     with pytest.raises(ValueError, match="must be finite"):
         Step4SARSAConfig(gamma=RatioFloat(0.99))
     assert RatioFloat.calls == 0
+
+
+def test_from_dict_rejects_hostile_mapping_and_keys() -> None:
+    class _HostileDict(dict[str, object]):
+        pass
+
+    with pytest.raises(ValueError, match="must be an exact dictionary"):
+        Step4SARSAConfig.from_dict(_HostileDict())
+
+    payload = Step4SARSAConfig().to_dict()
+    bad_keys: dict[Any, Any] = dict(payload)
+    bad_keys[_EvilStr("extra")] = 1
+    with pytest.raises(ValueError, match="keys must be exact strings"):
+        Step4SARSAConfig.from_dict(cast(Any, bad_keys))
+
+

--- a/tests/test_step4_production.py
+++ b/tests/test_step4_production.py
@@ -6,7 +6,7 @@ the facade rejects them. Legal endpoints stay constructible.
 """
 
 import json
-from typing import Any
+from typing import Any, cast
 
 import chex
 import jax.numpy as jnp
@@ -378,3 +378,34 @@ def test_step4_smoke_result_rejects_leftover_identities() -> None:
     assert '"steps": true' not in dumped
     assert '"seed": true' not in dumped
     assert '"finite": 1' not in dumped
+
+
+def test_step4_from_dict_schema_validation() -> None:
+    config = Step4SARSAConfig()
+    payload = config.to_dict()
+
+    with pytest.raises(ValueError, match="must be an exact dictionary"):
+        Step4SARSAConfig.from_dict(["not", "a", "dict"])  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="keys must be exact strings"):
+        bad_keys: dict[Any, Any] = dict(payload)
+        bad_keys[1] = "bad"
+        Step4SARSAConfig.from_dict(cast(Any, bad_keys))
+
+    for key in payload:
+        missing = dict(payload)
+        del missing[key]
+        with pytest.raises(ValueError, match="fields do not match the schema"):
+            Step4SARSAConfig.from_dict(missing)
+
+    extra = dict(payload)
+    extra["unexpected_field"] = 123
+    with pytest.raises(ValueError, match="fields do not match the schema"):
+        Step4SARSAConfig.from_dict(extra)
+
+    bad_hidden = dict(payload)
+    bad_hidden["hidden_sizes"] = (16,)
+    with pytest.raises(ValueError, match="hidden_sizes must be an exact list"):
+        Step4SARSAConfig.from_dict(bad_hidden)
+
+

--- a/tests/test_step8_hostile_validation.py
+++ b/tests/test_step8_hostile_validation.py
@@ -167,3 +167,19 @@ def test_float_subclass_with_lying_ratio_is_rejected() -> None:
     with pytest.raises(ValueError, match="must be finite"):
         Step8WorldModelConfig(step_size=RatioFloat(0.05))
     assert RatioFloat.calls == 0
+
+
+def test_from_dict_rejects_hostile_mapping_and_keys() -> None:
+    class _HostileDict(dict[str, object]):
+        pass
+
+    with pytest.raises(ValueError, match="must be an exact dictionary"):
+        Step8WorldModelConfig.from_dict(_HostileDict())
+
+    payload = Step8WorldModelConfig().to_dict()
+    bad_keys: dict[Any, Any] = dict(payload)
+    bad_keys[_EvilStr("extra")] = 1
+    with pytest.raises(ValueError, match="keys must be exact strings"):
+        Step8WorldModelConfig.from_dict(cast(Any, bad_keys))
+
+

--- a/tests/test_step8_production.py
+++ b/tests/test_step8_production.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from fractions import Fraction
-from typing import Any
+from typing import Any, cast
 
 import chex
 import jax.numpy as jnp
@@ -470,3 +470,34 @@ def test_step8_smoke_result_rejects_leftover_identities() -> None:
     assert '"steps": true' not in dumped
     assert '"seed": true' not in dumped
     assert '"finite": 1' not in dumped
+
+
+def test_step8_from_dict_schema_validation() -> None:
+    config = Step8WorldModelConfig()
+    payload = config.to_dict()
+
+    with pytest.raises(ValueError, match="must be an exact dictionary"):
+        Step8WorldModelConfig.from_dict(["not", "a", "dict"])  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="keys must be exact strings"):
+        bad_keys: dict[Any, Any] = dict(payload)
+        bad_keys[1] = "bad"
+        Step8WorldModelConfig.from_dict(cast(Any, bad_keys))
+
+    for key in payload:
+        missing = dict(payload)
+        del missing[key]
+        with pytest.raises(ValueError, match="fields do not match the schema"):
+            Step8WorldModelConfig.from_dict(missing)
+
+    extra = dict(payload)
+    extra["unexpected_field"] = 123
+    with pytest.raises(ValueError, match="fields do not match the schema"):
+        Step8WorldModelConfig.from_dict(extra)
+
+    bad_hidden = dict(payload)
+    bad_hidden["hidden_sizes"] = (64,)
+    with pytest.raises(ValueError, match="hidden_sizes must be an exact list"):
+        Step8WorldModelConfig.from_dict(bad_hidden)
+
+


### PR DESCRIPTION
## Provider/model disclosure

Provider: Google Antigravity CLI (agy) / Gemini.

## Description

In `alberta_framework.steps.step4::Step4SARSAConfig.from_dict` and `alberta_framework.steps.step8::Step8WorldModelConfig.from_dict`:
- Serialized dictionary inputs were previously deserialized with unconstrained `dict(payload)` or unchecked dictionary access without verifying that the payload is an exact `dict` with exact string keys matching the dataclass field schema.
- Because `Step4SARSAConfig` and `Step8WorldModelConfig` specify dataclass defaults for all fields, omitted keys in serialized configs silently defaulted to published baseline parameters rather than failing closed with `ValueError` on schema mismatch / field omission.
- Nested `hidden_sizes` payloads were converted to tuples without checking that the incoming serialized value was an exact `list`.

This PR brings `Step4SARSAConfig.from_dict` and `Step8WorldModelConfig.from_dict` into alignment with the rest of the Step facade configs (Step 1, 2, 3, 5, 6, 7, 9, 10, 11, 12):
1. Verifies payload is an exact `dict` with string keys.
2. Enforces exact schema completeness (`set(raw) == {field.name for field in fields(cls)}`) so omitted fields or injected fields fail closed.
3. Enforces `type(raw["hidden_sizes"]) is list` before tuple conversion.

## Testing

Added unit and hostile tests in:
- `tests/test_step4_production.py` (`test_step4_from_dict_schema_validation`)
- `tests/test_step4_hostile_validation.py` (`test_from_dict_rejects_hostile_mapping_and_keys`)
- `tests/test_step8_production.py` (`test_step8_from_dict_schema_validation`)
- `tests/test_step8_hostile_validation.py` (`test_from_dict_rejects_hostile_mapping_and_keys`)

All test suites pass cleanly with 0 failures, and `ruff check .` / `mypy` pass with 0 warnings.

## Measured project receipt
Post-hoc receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F8W1JHPTWBJ31HHKM420MK","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T09:43:39.346Z","completed_at":"2026-08-20T09:49:57.702Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T09:43:40.692Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e3d249a26ecbc540a5dcf6df1496ca4c713d0226273fb68d3aff8ec3b4b4525b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"65c3e380-e32b-454e-87ce-882be01f5a98","object_id":"sha256:e3d249a26ecbc540a5dcf6df1496ca4c713d0226273fb68d3aff8ec3b4b4525b","sha256":"e3d249a26ecbc540a5dcf6df1496ca4c713d0226273fb68d3aff8ec3b4b4525b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"LJcRa67UwROYG9d_sx6RHZaX3ZaNsD0Q9L4HxkjEKPZasgoDSqKWmXygjjU7HzX4kKpgRdfAL7hkBFjnKZMPAw"}} -->
