### PR TITLE
fix(steps): validate exact schema fields and subtask entries in Step 11 from_config

### DIFF
--- a/alberta_framework/steps/step11.py
+++ b/alberta_framework/steps/step11.py
@@ -138,37 +138,40 @@ class Step11OaKConfig:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> Step11OaKConfig:
         """Reconstruct from :meth:`to_config` output."""
-        if cls is not Step11OaKConfig:
-            raise ValueError("cls must be Step11OaKConfig")
-        if type(payload) is not dict:
-            raise ValueError("payload must be an actual dict")
-        if any(type(key) is not str for key in payload):
-            raise ValueError("payload keys must be exact strings")
-        if payload.keys() != _STEP11_CONFIG_FIELDS:
-            raise ValueError("payload must contain the exact Step11OaKConfig fields")
-        if type(payload["type"]) is not str or payload["type"] != "Step11OaKConfig":
-            raise ValueError("payload type must be Step11OaKConfig")
-        specs_raw = payload["subtask_specs"]
-        if type(specs_raw) is not list:
-            raise ValueError("subtask_specs must be an actual list")
-        if len(specs_raw) > _MAX_SUBTASK_SPECS:
-            raise ValueError(
-                f"subtask_specs must contain at most {_MAX_SUBTASK_SPECS} elements"
-            )
+        data = _require_payload(
+            payload,
+            name="Step11OaKConfig payload",
+            fields=_STEP11_CONFIG_FIELDS,
+        )
+        if type(data["type"]) is not str or data["type"] != "Step11OaKConfig":
+            raise ValueError("Step11OaKConfig payload type must be 'Step11OaKConfig'")
+        raw_specs = data.pop("subtask_specs")
+        if type(specs_raw := raw_specs) is not list:
+            raise ValueError("subtask_specs payload must be an exact list")
+        values = cast(list[object], specs_raw)
+        _require_subtask_count(len(values))
         specs: list[SubtaskSpec] = []
-        for raw in specs_raw:
-            if type(raw) is not dict:
-                raise ValueError("subtask_specs entries must be actual dicts")
-            if any(type(key) is not str for key in raw):
-                raise ValueError("subtask_specs entry keys must be exact strings")
-            if raw.keys() != _SUBTASK_SPEC_FIELDS:
-                raise ValueError("subtask_specs entries must contain the exact fields")
-            specs.append(SubtaskSpec(**raw))
-        data = {
-            key: value
-            for key, value in payload.items()
-            if key not in {"type", "subtask_specs"}
-        }
+        for index in range(len(values)):
+            raw = _require_payload(
+                values[index],
+                name=f"subtask_specs[{index}]",
+                fields=_SUBTASK_SPEC_FIELDS,
+            )
+            specs.append(
+                SubtaskSpec(
+                    feature_index=_require_int(
+                        "feature_index", raw["feature_index"], minimum=0, maximum=_INT32_MAX
+                    ),
+                    threshold=_require_positive_real("threshold", raw["threshold"]),
+                    pseudo_reward_scale=_require_positive_real(
+                        "pseudo_reward_scale", raw["pseudo_reward_scale"]
+                    ),
+                    max_option_steps=_require_int(
+                        "max_option_steps", raw["max_option_steps"], minimum=1, maximum=_INT32_MAX
+                    ),
+                )
+            )
+        data.pop("type")
         return cls(subtask_specs=tuple(specs), **data)
 
     def to_oak_config(self) -> OaKConfig:
@@ -299,6 +302,24 @@ def _require_bool(name: str, value: object) -> bool:
     return value
 
 
+def _require_payload(
+    value: object, *, name: str, fields: frozenset[str]
+) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise ValueError(f"{name} must be an exact dictionary")
+    raw = cast(dict[object, object], value)
+    if any(type(key) is not str for key in raw):
+        raise ValueError(f"{name} keys must be exact strings")
+    if cast(set[str], set(raw)) != fields:
+        raise ValueError(f"{name} fields do not match the schema")
+    return cast(dict[str, Any], dict(raw))
+
+
+def _require_subtask_count(count: int) -> None:
+    if count > _MAX_SUBTASK_SPECS:
+        raise ValueError(f"subtask_specs must contain at most {_MAX_SUBTASK_SPECS} values")
+
+
 def _trusted_array(
     name: str,
     value: object,
@@ -421,10 +442,7 @@ def _validate_oak_facade_config(config: Step11OaKConfig) -> None:
     )
     if type(config.subtask_specs) is not tuple:
         raise ValueError("subtask_specs must be a tuple of SubtaskSpec")
-    if len(config.subtask_specs) > _MAX_SUBTASK_SPECS:
-        raise ValueError(
-            f"subtask_specs must contain at most {_MAX_SUBTASK_SPECS} elements"
-        )
+    _require_subtask_count(len(config.subtask_specs))
     canonical_specs: list[SubtaskSpec] = []
     for spec in config.subtask_specs:
         if type(spec) is not SubtaskSpec:

--- a/tests/test_step11_hostile_validation.py
+++ b/tests/test_step11_hostile_validation.py
@@ -239,29 +239,77 @@ def test_config_subclass_is_rejected_before_attribute_hooks() -> None:
     assert HostileConfig.calls == 0
 
 
-def test_from_config_requires_exact_closed_json_schema() -> None:
+def test_from_config_requires_complete_exact_schema_without_mapping_hooks() -> None:
+    class HostileDict(dict[object, object]):
+        calls = 0
+
+        def __iter__(self):  # pragma: no cover - must not run
+            type(self).calls += 1
+            raise AssertionError("mapping hook must not run")
+
+    with pytest.raises(ValueError, match="exact dictionary"):
+        Step11OaKConfig.from_config(cast(Any, HostileDict()))
+    assert HostileDict.calls == 0
+
     payload = Step11OaKConfig().to_config()
-    for altered in (
-        {key: value for key, value in payload.items() if key != "type"},
-        {**payload, "type": "Wrong"},
-        {**payload, "extra": 1},
+    for mutation in (
+        lambda value: value.pop("type"),
+        lambda value: value.__setitem__("extra", 1),
+        lambda value: value.__setitem__("type", "wrong"),
     ):
-        with pytest.raises(ValueError):
-            Step11OaKConfig.from_config(altered)
-
-    class DictSubclass(dict[str, Any]):
-        pass
-
-    with pytest.raises(ValueError, match="actual dict"):
-        Step11OaKConfig.from_config(DictSubclass(payload))
+        malformed = dict(payload)
+        mutation(malformed)
+        with pytest.raises(ValueError, match="(schema|payload type)"):
+            Step11OaKConfig.from_config(malformed)
 
 
-def test_from_config_rejects_hostile_or_open_subtask_entries() -> None:
+def test_from_config_requires_exact_nested_records_before_hooks() -> None:
+    class HostileRecord(dict[object, object]):
+        calls = 0
+
+        def __iter__(self):  # pragma: no cover - must not run
+            type(self).calls += 1
+            raise AssertionError("record hook must not run")
+
+    payload = Step11OaKConfig().to_config()
+    payload["subtask_specs"] = [HostileRecord()]
+    with pytest.raises(ValueError, match="exact dictionary"):
+        Step11OaKConfig.from_config(payload)
+    assert HostileRecord.calls == 0
+
     payload = Step11OaKConfig(
         subtask_specs=(SubtaskSpec(feature_index=0),)
     ).to_config()
     payload["subtask_specs"] = [{**payload["subtask_specs"][0], "extra": 1}]
-    with pytest.raises(ValueError, match="exact fields"):
+    with pytest.raises(ValueError, match="fields do not match"):
+        Step11OaKConfig.from_config(payload)
+
+
+def test_from_config_and_direct_paths_have_matching_canonical_values() -> None:
+    direct = Step11OaKConfig(
+        observation_dim=np.int32(4),  # type: ignore[arg-type]
+        base_step_size=np.float64(0.05),  # type: ignore[arg-type]
+        subtask_specs=(SubtaskSpec(feature_index=0, threshold=Fraction(1, 2)),),
+    )
+    parsed = Step11OaKConfig.from_config(direct.to_config())
+    assert parsed == direct
+    assert parsed.to_config() == direct.to_config()
+
+
+def test_subtask_validation_work_is_bounded_before_iteration() -> None:
+    spec = SubtaskSpec(feature_index=0)
+    with pytest.raises(ValueError, match="at most 4096"):
+        Step11OaKConfig(subtask_specs=(spec,) * 4_097)
+
+    payload = Step11OaKConfig().to_config()
+    raw_spec = {
+        "feature_index": 0,
+        "threshold": 0.5,
+        "pseudo_reward_scale": 1.0,
+        "max_option_steps": 8,
+    }
+    payload["subtask_specs"] = [raw_spec] * 4_097
+    with pytest.raises(ValueError, match="at most 4096"):
         Step11OaKConfig.from_config(payload)
 
 


### PR DESCRIPTION
### Summary
This PR hardens deserialization in `Step11OaKConfig.from_config`:
1. Uses `_require_payload` to validate that the top-level payload is an exact dictionary, keys are exact strings, and fields match `_STEP11_CONFIG_FIELDS`.
2. Validates subtask sequence size using `_require_subtask_count(len(values))`.
3. Validates each subtask spec entry via `_require_payload` against `_SUBTASK_SPEC_FIELDS`, ensuring exact dictionary types and preventing mapping/attribute hooks.
4. Validates each field of `SubtaskSpec` (`feature_index`, `threshold`, `pseudo_reward_scale`, `max_option_steps`) with range/type checks (`_require_int`, `_require_positive_real`) consistent with Step 10 and Step 12.
5. Replaces ad-hoc sequence bound in `_validate_oak_facade_config` with `_require_subtask_count`.
6. Adds focused regression tests in `tests/test_step11_hostile_validation.py` covering mapping hooks, nested records, exact schema, subtask iteration bounds, and direct/deserialized canonical equality.

### Verification
- `pytest tests/test_step11_*.py tests/test_step10_*.py tests/test_step12_*.py`: 63+ passed
- `ruff check`: clean
- `mypy alberta_framework/steps/step11.py`: clean
- `git diff --check`: clean

## Measured project receipt
Post-hoc receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F8S4RKAE1QEMT8MB6Y79TF","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T09:42:04.307Z","completed_at":"2026-08-20T09:48:48.838Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T09:42:04.743Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"8e58ac0cf97fa1254459de578ab6ada0b51885c908e15343d706055f4fc34b7d","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"1867ff9b-30df-47d1-9f9c-dad14fa17512","object_id":"sha256:8e58ac0cf97fa1254459de578ab6ada0b51885c908e15343d706055f4fc34b7d","sha256":"8e58ac0cf97fa1254459de578ab6ada0b51885c908e15343d706055f4fc34b7d"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"rbRej2e8SjOGtgIU6FO7tiYY5bnUExhYuTE3f9hCJqmA6biM0LQqh0WcXIyLqKw-mb6Zj1DXSEethijVKvbKBg"}} -->
