### PR TITLE
fix(core): validate exact schema and string keys for state builder configs

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -138,6 +138,22 @@ def _require_derived_int32(name: str, value: int, *, minimum: int = 0) -> int:
     return value
 
 
+def _require_payload(
+    payload: object,
+    *,
+    name: str,
+    expected_fields: frozenset[str],
+) -> dict[str, Any]:
+    if type(payload) is not dict:
+        raise ValueError(f"{name} payload must be an exact dictionary")
+    raw = cast(dict[object, object], payload)
+    if any(type(key) is not str for key in raw):
+        raise ValueError(f"{name} payload keys must be exact strings")
+    if cast(set[str], set(raw)) != expected_fields:
+        raise ValueError(f"{name} payload fields do not match the schema")
+    return cast(dict[str, Any], dict(raw))
+
+
 _FLOAT32_MAX = 3.4028234663852886e38
 
 
@@ -708,6 +724,9 @@ def _fixed_learning_commit_diagnostics(
     )
 
 
+_IDENTITY_CONFIG_FIELDS = frozenset({"type", "observation_dim"})
+
+
 @dataclass(frozen=True)
 class IdentityStateBuilderConfig:
     """Configuration for the observation-only state baseline."""
@@ -731,8 +750,15 @@ class IdentityStateBuilderConfig:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> IdentityStateBuilderConfig:
         """Reconstruct from :meth:`to_config` output."""
-        data = dict(payload)
-        data.pop("type", None)
+        data = _require_payload(
+            payload,
+            name="IdentityStateBuilderConfig",
+            expected_fields=_IDENTITY_CONFIG_FIELDS,
+        )
+        if type(data["type"]) is not str or data["type"] != "IdentityStateBuilder":
+            raise ValueError(
+                "IdentityStateBuilderConfig payload type must be 'IdentityStateBuilder'"
+            )
         return cls(observation_dim=data["observation_dim"])
 
 
@@ -998,16 +1024,45 @@ class FixedTraceStateBuilderConfig:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> FixedTraceStateBuilderConfig:
         """Reconstruct from :meth:`to_config` output."""
-        data = dict(payload)
-        data.pop("type", None)
+        data = _require_payload(
+            payload,
+            name="FixedTraceStateBuilderConfig",
+            expected_fields=_FIXED_TRACE_CONFIG_FIELDS,
+        )
+        if type(data["type"]) is not str or data["type"] != "FixedTraceStateBuilder":
+            raise ValueError(
+                "FixedTraceStateBuilderConfig payload type must be 'FixedTraceStateBuilder'"
+            )
+        obs_decays = data["observation_decay_rates"]
+        act_decays = data["action_decay_rates"]
+        out_decays = data["outcome_decay_rates"]
+        if (
+            not isinstance(obs_decays, (list, tuple))
+            or not isinstance(act_decays, (list, tuple))
+            or not isinstance(out_decays, (list, tuple))
+        ):
+            raise ValueError("decay rates must be lists or tuples")
         return cls(
             observation_dim=data["observation_dim"],
-            n_actions=data.get("n_actions", 0),
-            observation_decay_rates=tuple(data.get("observation_decay_rates", ())),
-            action_decay_rates=tuple(data.get("action_decay_rates", ())),
-            outcome_decay_rates=tuple(data.get("outcome_decay_rates", ())),
-            include_raw_observation=data.get("include_raw_observation", True),
+            n_actions=data["n_actions"],
+            observation_decay_rates=tuple(obs_decays),
+            action_decay_rates=tuple(act_decays),
+            outcome_decay_rates=tuple(out_decays),
+            include_raw_observation=data["include_raw_observation"],
         )
+
+
+_FIXED_TRACE_CONFIG_FIELDS = frozenset(
+    {
+        "type",
+        "observation_dim",
+        "n_actions",
+        "observation_decay_rates",
+        "action_decay_rates",
+        "outcome_decay_rates",
+        "include_raw_observation",
+    }
+)
 
 
 class FixedTraceStateBuilder:
@@ -1432,9 +1487,22 @@ class OnlineGatedStateBuilderConfig:
     @classmethod
     def from_config(cls, payload: dict[str, Any]) -> OnlineGatedStateBuilderConfig:
         """Reconstruct from :meth:`to_config` output."""
-        data = dict(payload)
-        data.pop("type", None)
+        data = _require_payload(
+            payload,
+            name="OnlineGatedStateBuilderConfig",
+            expected_fields=_ONLINE_GATED_CONFIG_FIELDS,
+        )
+        if type(data["type"]) is not str or data["type"] != "OnlineGatedStateBuilder":
+            raise ValueError(
+                "OnlineGatedStateBuilderConfig payload type must be 'OnlineGatedStateBuilder'"
+            )
+        data.pop("type")
         return cls(**data)
+
+
+_ONLINE_GATED_CONFIG_FIELDS = frozenset(
+    {"type", *OnlineGatedStateBuilderConfig.__dataclass_fields__}
+)
 
 
 @chex.dataclass(frozen=True)
@@ -2053,6 +2121,8 @@ def state_builder_config_from_config(payload: dict[str, Any]) -> StateBuilderCon
     """Parse one known state-builder configuration without creating state."""
     if type(payload) is not dict:
         raise ValueError("state builder payload must be an exact dict")
+    if any(type(key) is not str for key in payload):
+        raise ValueError("state builder payload keys must be exact strings")
     builder_type = payload.get("type")
     host_builder_type = _require_exact_str("payload.type", builder_type)
     if host_builder_type == "IdentityStateBuilder":

--- a/tests/test_state_builder.py
+++ b/tests/test_state_builder.py
@@ -1065,7 +1065,7 @@ def test_state_builder_checkpoint_config_digest_rejects_behavior_tampering(
     noncanonical_path = tmp_path / "noncanonical"
     save_checkpoint(identity_state, noncanonical_path, metadata=noncanonical_metadata)
 
-    with pytest.raises(ValueError, match="config is not canonical"):
+    with pytest.raises(ValueError, match="config is not canonical|fields do not match the schema"):
         load_state_builder_checkpoint(noncanonical_path)
 
 

--- a/tests/test_state_builder_hostile_validation.py
+++ b/tests/test_state_builder_hostile_validation.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
 from alberta_framework.core.state_builder import (
+    FixedTraceStateBuilderConfig,
+    IdentityStateBuilderConfig,
+    OnlineGatedStateBuilderConfig,
     _require_exact_str,
     state_builder_config_from_config,
+    state_builder_from_config,
 )
 
 
@@ -30,7 +36,7 @@ def test_require_exact_str_rejects_evil() -> None:
     evil = _EvilStr("v")
     _EvilStr.calls = 0
     with pytest.raises(ValueError, match="exact string") as exc:
-        _require_exact_str("payload.type", evil)  # type: ignore[arg-type]
+        _require_exact_str("payload.type", evil)
     assert _EvilStr.calls == 0
     assert "!r" not in str(exc.value)
 
@@ -39,7 +45,7 @@ def test_state_builder_rejects_evil_without_hooks() -> None:
     evil = _EvilStr("IdentityStateBuilder")
     _EvilStr.calls = 0
     with pytest.raises(ValueError, match="exact string") as exc:
-        state_builder_config_from_config({"type": evil})  # type: ignore[arg-type]
+        state_builder_config_from_config({"type": evil})
     assert _EvilStr.calls == 0
     assert "!r" not in str(exc.value)
     assert "EvilStr" not in str(exc.value)
@@ -47,7 +53,7 @@ def test_state_builder_rejects_evil_without_hooks() -> None:
 
 def test_state_builder_rejects_subclass() -> None:
     with pytest.raises(ValueError, match="exact string"):
-        state_builder_config_from_config({"type": _StringSubclass("IdentityStateBuilder")})  # type: ignore[arg-type]
+        state_builder_config_from_config({"type": _StringSubclass("IdentityStateBuilder")})
 
 
 def test_state_builder_mismatch_sanitized() -> None:
@@ -63,3 +69,111 @@ def test_state_builder_mismatch_sanitized() -> None:
 def test_state_builder_valid_passes() -> None:
     cfg = state_builder_config_from_config({"type": "IdentityStateBuilder", "observation_dim": 2})
     assert cfg is not None
+
+
+class _HostileMapping(dict[object, object]):
+    calls = 0
+
+    def __iter__(self) -> Any:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("HostileMapping.__iter__ must not be called")
+
+
+def test_state_builder_from_config_rejects_non_dict_payload() -> None:
+    for factory in (
+        state_builder_config_from_config,
+        state_builder_from_config,
+        IdentityStateBuilderConfig.from_config,
+        FixedTraceStateBuilderConfig.from_config,
+        OnlineGatedStateBuilderConfig.from_config,
+    ):
+        with pytest.raises(ValueError, match="exact dict"):
+            factory(cast(Any, _HostileMapping()))
+        with pytest.raises(ValueError, match="exact dict"):
+            factory(cast(Any, [("type", "IdentityStateBuilder")]))
+        with pytest.raises(ValueError, match="exact dict"):
+            factory(cast(Any, "IdentityStateBuilder"))
+
+
+def test_state_builder_from_config_rejects_non_string_keys() -> None:
+    payload_bad_keys = {1: "IdentityStateBuilder", "observation_dim": 2}
+    with pytest.raises(ValueError, match="exact strings"):
+        state_builder_config_from_config(cast(Any, payload_bad_keys))
+    with pytest.raises(ValueError, match="exact strings"):
+        IdentityStateBuilderConfig.from_config(cast(Any, payload_bad_keys))
+
+
+def test_identity_state_builder_from_config_schema_validation() -> None:
+    # Missing observation_dim
+    with pytest.raises(ValueError, match="fields do not match the schema"):
+        IdentityStateBuilderConfig.from_config({"type": "IdentityStateBuilder"})
+    # Extra field
+    with pytest.raises(ValueError, match="fields do not match the schema"):
+        IdentityStateBuilderConfig.from_config(
+            {"type": "IdentityStateBuilder", "observation_dim": 2, "extra": 1}
+        )
+    # Type mismatch
+    with pytest.raises(ValueError, match="payload type must be 'IdentityStateBuilder'"):
+        IdentityStateBuilderConfig.from_config(
+            {"type": "FixedTraceStateBuilder", "observation_dim": 2}
+        )
+
+
+def test_fixed_trace_state_builder_from_config_schema_validation() -> None:
+    base = FixedTraceStateBuilderConfig(observation_dim=2).to_config()
+    # Missing field
+    missing = dict(base)
+    del missing["n_actions"]
+    with pytest.raises(ValueError, match="fields do not match the schema"):
+        FixedTraceStateBuilderConfig.from_config(missing)
+    # Extra field
+    extra = {**base, "extra": 1}
+    with pytest.raises(ValueError, match="fields do not match the schema"):
+        FixedTraceStateBuilderConfig.from_config(extra)
+    # Type mismatch
+    wrong_type = {**base, "type": "Wrong"}
+    with pytest.raises(ValueError, match="payload type must be 'FixedTraceStateBuilder'"):
+        FixedTraceStateBuilderConfig.from_config(wrong_type)
+    # Non-sequence decay rates
+    bad_decays = {**base, "observation_decay_rates": 123}
+    with pytest.raises(ValueError, match="decay rates must be lists or tuples"):
+        FixedTraceStateBuilderConfig.from_config(bad_decays)
+
+
+def test_online_gated_state_builder_from_config_schema_validation() -> None:
+    base = OnlineGatedStateBuilderConfig(observation_dim=2).to_config()
+    # Missing field
+    missing = dict(base)
+    del missing["hidden_dim"]
+    with pytest.raises(ValueError, match="fields do not match the schema"):
+        OnlineGatedStateBuilderConfig.from_config(missing)
+    # Extra field
+    extra = {**base, "extra": 1}
+    with pytest.raises(ValueError, match="fields do not match the schema"):
+        OnlineGatedStateBuilderConfig.from_config(extra)
+    # Type mismatch
+    wrong_type = {**base, "type": "Wrong"}
+    with pytest.raises(ValueError, match="payload type must be 'OnlineGatedStateBuilder'"):
+        OnlineGatedStateBuilderConfig.from_config(wrong_type)
+
+
+def test_state_builder_roundtrips() -> None:
+    c1 = IdentityStateBuilderConfig(observation_dim=4)
+    assert IdentityStateBuilderConfig.from_config(c1.to_config()) == c1
+    c2 = FixedTraceStateBuilderConfig(
+        observation_dim=4,
+        n_actions=2,
+        observation_decay_rates=(0.9,),
+        action_decay_rates=(0.8,),
+        outcome_decay_rates=(0.5,),
+        include_raw_observation=True,
+    )
+    assert FixedTraceStateBuilderConfig.from_config(c2.to_config()) == c2
+    c3 = OnlineGatedStateBuilderConfig(
+        observation_dim=4,
+        n_actions=2,
+        hidden_dim=8,
+        step_size=0.01,
+        include_raw_observation=True,
+    )
+    assert OnlineGatedStateBuilderConfig.from_config(c3.to_config()) == c3


### PR DESCRIPTION
### Summary
In `alberta_framework/core/state_builder.py`, `IdentityStateBuilderConfig.from_config`, `FixedTraceStateBuilderConfig.from_config`, and `OnlineGatedStateBuilderConfig.from_config` previously converted inputs with `dict(payload)` and popped `"type"` without validating that the payload is an exact `dict` with exact string keys matching their respective serialization schemas, or verifying that the payload `"type"` matched the expected config class name.

This fix:
1. Adds `_require_payload` helper in `state_builder.py` to strictly enforce that config deserialization payloads are exact dictionaries with exact string keys and matching schema fields.
2. Updates `IdentityStateBuilderConfig.from_config`, `FixedTraceStateBuilderConfig.from_config`, `OnlineGatedStateBuilderConfig.from_config`, and `state_builder_config_from_config` to strictly validate payload dictionary identity, string keys, matching schema fields, and expected type tags.
3. Adds comprehensive hostile validation tests in `tests/test_state_builder_hostile_validation.py` covering non-dict payloads, non-string keys, missing/extra schema fields, invalid type tags, and config round-trips.

### Verification
- `.venv/bin/python -m pytest tests/test_state_builder_hostile_validation.py tests/test_state_builder_update_working_set.py tests/test_state_builder.py -v` (97/97 passed)
- `.venv/bin/python -m ruff check alberta_framework/core/state_builder.py tests/test_state_builder.py tests/test_state_builder_hostile_validation.py` (All checks passed)
- `.venv/bin/python -m mypy alberta_framework/core/state_builder.py tests/test_state_builder_hostile_validation.py` (Success: no issues found)
- `git diff --check` (clean)

## Measured project receipt
Post-hoc receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F8RQ5NC3ZCKTVC8CRS5MVE","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T09:41:50.390Z","completed_at":"2026-08-20T09:42:00.081Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T09:41:50.789Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3c6d4382dd256c60df73c73ea7ae898bdcad2ca12937015f8ba68cc17fdc998d","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7d005155-dea0-49d6-8e25-8029df2dba33","object_id":"sha256:3c6d4382dd256c60df73c73ea7ae898bdcad2ca12937015f8ba68cc17fdc998d","sha256":"3c6d4382dd256c60df73c73ea7ae898bdcad2ca12937015f8ba68cc17fdc998d"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"R3XOteiBRYLbihVKECJPXent3d3ZC1UkRLdsBJS6PjtQwIxe4YrtazeUjZink6hdFNTvUBR7DoR6duzvdwbWCw"}} -->
