### PR TITLE
fix(reference-life): reject hostile int/float identities in RiverSwim oracle gate (#1968)

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -1413,6 +1413,17 @@ class RiverSwimReferenceEnvironment:
             )
 
 
+def _validate_riverswim_oracle(oracle_value: object) -> float:
+    if type(oracle_value) is bool or (
+        type(oracle_value) is not int and type(oracle_value) is not float
+    ):
+        raise DecisionOwnershipError("checkpoint RiverSwim oracle is invalid")
+    oracle_reward = float(oracle_value)
+    if not math.isfinite(oracle_reward):
+        raise DecisionOwnershipError("checkpoint RiverSwim oracle is invalid")
+    return oracle_reward
+
+
 def _agent_descriptor(
     manifest: AgentManifest,
     *,
@@ -2154,11 +2165,7 @@ class ReferenceLifeRunner:
             if metrics_mode != "stationary":
                 raise DecisionOwnershipError("checkpoint RiverSwim metrics mode is invalid")
             oracle_value = environment_config.get("oracle_average_reward")
-            if isinstance(oracle_value, bool) or not isinstance(oracle_value, (int, float)):
-                raise DecisionOwnershipError("checkpoint RiverSwim oracle is invalid")
-            oracle_reward = float(oracle_value)
-            if not math.isfinite(oracle_reward):
-                raise DecisionOwnershipError("checkpoint RiverSwim oracle is invalid")
+            oracle_reward = _validate_riverswim_oracle(oracle_value)
             expected_phase_counts = (accepted, 0)
             expected_current_phase = 0
             expected_phase_switches = 0

--- a/tests/test_reference_life_hostile_oracle_gate.py
+++ b/tests/test_reference_life_hostile_oracle_gate.py
@@ -1,0 +1,95 @@
+"""Hostile int/float identity gate for the reference-life RiverSwim checkpoint
+oracle before float() conversion.
+
+reference_life.validate_checkpoint_state reads oracle_average_reward from the
+environment manifest with an isinstance gate before float(oracle_value); a
+hostile subclass passes the gate and its overridden __float__ runs during
+checkpoint validation.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from alberta_framework.reference_life import (
+    DecisionOwnershipError,
+    _validate_riverswim_oracle,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileFloat(float):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __float__(self) -> float:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile float must not run")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+def _reset() -> None:
+    _HostileFloat.calls = 0
+    _HostileInt.calls = 0
+
+
+def test_oracle_rejects_hostile_float_before_float() -> None:
+    _reset()
+    with pytest.raises(DecisionOwnershipError, match="RiverSwim oracle"):
+        _validate_riverswim_oracle(_HostileFloat(1.0))
+    assert _HostileFloat.calls == 0
+
+
+def test_oracle_rejects_hostile_int_before_float() -> None:
+    _reset()
+    with pytest.raises(DecisionOwnershipError, match="RiverSwim oracle"):
+        _validate_riverswim_oracle(_HostileInt(1))
+    assert _HostileInt.calls == 0
+
+
+def test_oracle_rejects_non_finite_and_non_numeric() -> None:
+    _reset()
+    for bad in (True, False, None, "1.0", math.inf, math.nan):
+        with pytest.raises(DecisionOwnershipError, match="RiverSwim oracle"):
+            _validate_riverswim_oracle(bad)  # type: ignore[arg-type]
+    assert _HostileFloat.calls == 0
+
+
+def test_oracle_accepts_benign_numeric() -> None:
+    _reset()
+    assert _validate_riverswim_oracle(1) == 1.0
+    assert _validate_riverswim_oracle(0.5) == 0.5
+    assert _HostileFloat.calls == 0


### PR DESCRIPTION
## Fix

`validate_checkpoint_state` read `oracle_average_reward` from the environment manifest with an `isinstance` gate before `float(oracle_value)`, so a hostile `int`/`float` subclass passed the gate and its overridden `__float__` ran during checkpoint validation. The gate is now a module-level `_validate_riverswim_oracle` helper using the exact-type form used across this bug class:

```python
if type(oracle_value) is bool or (
    type(oracle_value) is not int and type(oracle_value) is not float
):
    raise DecisionOwnershipError("checkpoint RiverSwim oracle is invalid")
oracle_reward = float(oracle_value)
if not math.isfinite(oracle_reward):
    raise DecisionOwnershipError("checkpoint RiverSwim oracle is invalid")
```

No checkpoint-schema, digest, or behavior change.

## Verification

- Failing-test-first: `tests/test_reference_life_hostile_oracle_gate.py` (4 tests) — hostile `float`/`int` oracles rejected with the existing `DecisionOwnershipError` while proving no dunder runs; bool/None/str/inf/nan still rejected; benign numerics unchanged.
- `tests/test_reference_life_riverswim_checkpoint.py`, `test_reference_life_checkpoint.py`, `test_reference_life.py`, hostile gate: 62 passed. ruff + strict mypy clean.

Source HEAD: `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`

<!-- slop-contribution-attribution:v1 {"provider":"nvidia","model":"nemotron-3.5-lightning-30b-a3b","client":"pi","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0CGP8A57X91W4RW84XD0NCQ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T08:02:34.949Z","completed_at":"2026-08-19T08:30:57.159Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T08:02:36.742Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f95b0f483eda3f1cd757902f3cf473fa36589d4c82c74d4102d0d00608804825","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"63d8d85f-8b01-4b00-8b6a-b791b8f80483","object_id":"sha256:f95b0f483eda3f1cd757902f3cf473fa36589d4c82c74d4102d0d00608804825","sha256":"f95b0f483eda3f1cd757902f3cf473fa36589d4c82c74d4102d0d00608804825"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA7Xc3RKhR1QPS51q691BsKWyOxxZO4963EemNA5AUWt0","device_key_id":"5a97a3056057521cbc90fa44e9e53c57f81babbea5e549e3c8ddb787030c540a","device_signature":"l1NEzodMCBF_dFj08VwLUaoXuyR5Y5ulFWqmwJYxIhxaO3Im78XWpw-X0OclQ3DCBQEYfye6ONrJ5fkrNh_sBg"}} -->
