### PR TITLE
fix(forager-cli): reject hostile int identities in evaluation-seed interval gate (#1970)

### DIFF
--- a/alberta_framework/forager_cli.py
+++ b/alberta_framework/forager_cli.py
@@ -286,11 +286,11 @@ def _protocol_evaluation_seeds(protocol: Any) -> tuple[int, ...]:
     start = protocol.evaluation_seed_start
     count = protocol.evaluation_seeds
     if (
-        isinstance(start, bool)
-        or not isinstance(start, int)
+        type(start) is bool
+        or type(start) is not int
         or start < 0
-        or isinstance(count, bool)
-        or not isinstance(count, int)
+        or type(count) is bool
+        or type(count) is not int
         or count < 1
     ):
         raise ValueError("paper protocol declares an invalid evaluation seed interval")

--- a/tests/test_forager_cli_hostile_seed_gate.py
+++ b/tests/test_forager_cli_hostile_seed_gate.py
@@ -1,0 +1,82 @@
+"""Hostile int identity gates for the forager CLI evaluation-seed interval
+before comparison.
+
+_protocol_evaluation_seeds gates evaluation_seed_start / evaluation_seeds with
+isinstance before the trusted `start < 0` / `count < 1` comparisons, so a
+hostile int subclass passes the gate and its overridden __lt__ runs during
+validation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.forager_cli import _protocol_evaluation_seeds
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __lt__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile lt must not run")
+
+    def __le__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile le must not run")
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __add__(self, other: object) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile add must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+class _Protocol:
+    def __init__(self, start: object, count: object) -> None:
+        self.evaluation_seed_start = start
+        self.evaluation_seeds = count
+
+
+def test_seed_interval_rejects_hostile_start_before_lt() -> None:
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="invalid evaluation seed interval"):
+        _protocol_evaluation_seeds(_Protocol(_HostileInt(100), 3))
+    assert _HostileInt.calls == 0
+
+
+def test_seed_interval_rejects_hostile_count_before_lt() -> None:
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="invalid evaluation seed interval"):
+        _protocol_evaluation_seeds(_Protocol(100, _HostileInt(3)))
+    assert _HostileInt.calls == 0
+
+
+def test_seed_interval_rejects_bool_and_accepts_benign() -> None:
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="invalid evaluation seed interval"):
+        _protocol_evaluation_seeds(_Protocol(True, 3))
+    with pytest.raises(ValueError, match="invalid evaluation seed interval"):
+        _protocol_evaluation_seeds(_Protocol(100, False))
+    with pytest.raises(ValueError, match="invalid evaluation seed interval"):
+        _protocol_evaluation_seeds(_Protocol(-1, 3))
+    with pytest.raises(ValueError, match="invalid evaluation seed interval"):
+        _protocol_evaluation_seeds(_Protocol(100, 0))
+    assert _protocol_evaluation_seeds(_Protocol(100, 3)) == (100, 101, 102)
+    assert _HostileInt.calls == 0


### PR DESCRIPTION
## Fix

`_protocol_evaluation_seeds` gated `evaluation_seed_start` and `evaluation_seeds` with `isinstance` before the trusted `start < 0` / `count < 1` comparisons, so a hostile `int` subclass passed the gate and its overridden `__lt__` ran during validation. Both fields now use the exact-type gate used across this bug class:

```python
if (
    type(start) is bool
    or type(start) is not int
    or start < 0
    or type(count) is bool
    or type(count) is not int
    or count < 1
):
```

No CLI behavior change.

## Verification

- Failing-test-first: `tests/test_forager_cli_hostile_seed_gate.py` (3 tests) — hostile `int` `start` and `count` rejected with the existing `ValueError` while proving no dunder runs; bool/negative/zero still rejected; benign `(100, 3) -> (100, 101, 102)` unchanged.
- `tests/test_forager_cli.py` + hostile gate: 13 passed. ruff + strict mypy clean.

Source HEAD: `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`

<!-- slop-contribution-attribution:v1 {"provider":"nvidia","model":"nemotron-3.5-lightning-30b-a3b","client":"pi","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0CGP8A57X91W4RW84XD0NCQ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T08:02:34.949Z","completed_at":"2026-08-19T08:30:57.159Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T08:02:36.742Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f95b0f483eda3f1cd757902f3cf473fa36589d4c82c74d4102d0d00608804825","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"63d8d85f-8b01-4b00-8b6a-b791b8f80483","object_id":"sha256:f95b0f483eda3f1cd757902f3cf473fa36589d4c82c74d4102d0d00608804825","sha256":"f95b0f483eda3f1cd757902f3cf473fa36589d4c82c74d4102d0d00608804825"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA7Xc3RKhR1QPS51q691BsKWyOxxZO4963EemNA5AUWt0","device_key_id":"5a97a3056057521cbc90fa44e9e53c57f81babbea5e549e3c8ddb787030c540a","device_signature":"l1NEzodMCBF_dFj08VwLUaoXuyR5Y5ulFWqmwJYxIhxaO3Im78XWpw-X0OclQ3DCBQEYfye6ONrJ5fkrNh_sBg"}} -->
