### PR TITLE
fix(streams): validate exact schema and string keys in gauntlet and recurring multiagent configs

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -82,6 +82,27 @@ LIFETIME_GAUNTLET_CHECKPOINT_SCHEMA = "alberta.lifetime-gauntlet-checkpoint.v2"
 _LEGACY_LIFETIME_GAUNTLET_CHECKPOINT_SCHEMA = "alberta.lifetime-gauntlet-checkpoint.v1"
 LIFETIME_GAUNTLET_CLOCK_NBYTES = 12
 LIFETIME_GAUNTLET_CLOCK_DELTA_NBYTES = 8
+_LIFETIME_GAUNTLET_CONFIG_FIELDS = frozenset(
+    {
+        "type",
+        "config_schema",
+        "state_schema",
+        "gauntlet_config",
+        "scale_cycle_period",
+    }
+)
+_GAUNTLET_CONFIG_FIELDS = frozenset(
+    {
+        "relevant_dim",
+        "irrelevant_dim",
+        "segment_length",
+        "noise_std",
+        "feature_std",
+        "scale_factor",
+        "drift_rate",
+        "context_noise_std",
+    }
+)
 
 
 def _require_int(
@@ -714,28 +735,32 @@ class LifetimeGauntletStream:
     @classmethod
     def from_config(cls, config: Mapping[str, Any]) -> LifetimeGauntletStream:
         """Strictly reconstruct a v2 lifetime stream."""
+        if type(config) is not dict:
+            raise ValueError("lifetime-gauntlet config must be an exact dictionary")
+        if any(type(key) is not str for key in config):
+            raise ValueError("lifetime-gauntlet config keys must be exact strings")
         values = dict(config)
-        expected = {
-            "type",
-            "config_schema",
-            "state_schema",
-            "gauntlet_config",
-            "scale_cycle_period",
-        }
-        if set(values) != expected:
+        if set(values) != _LIFETIME_GAUNTLET_CONFIG_FIELDS:
             raise ValueError("lifetime-gauntlet config fields are invalid")
-        if values.pop("type") != cls.__name__:
+        type_name = values.pop("type")
+        if type(type_name) is not str or type_name != cls.__name__:
             raise ValueError("lifetime-gauntlet config type is unsupported")
-        if values.pop("config_schema") != LIFETIME_GAUNTLET_CONFIG_SCHEMA:
+        config_schema = values.pop("config_schema")
+        if type(config_schema) is not str or config_schema != LIFETIME_GAUNTLET_CONFIG_SCHEMA:
             raise ValueError("lifetime-gauntlet config schema is unsupported")
-        if values.pop("state_schema") != LIFETIME_GAUNTLET_STATE_SCHEMA:
+        state_schema = values.pop("state_schema")
+        if type(state_schema) is not str or state_schema != LIFETIME_GAUNTLET_STATE_SCHEMA:
             raise ValueError("lifetime-gauntlet state schema is unsupported")
         raw_gauntlet = values.pop("gauntlet_config")
-        if not isinstance(raw_gauntlet, Mapping):
-            raise ValueError("lifetime-gauntlet nested config is invalid")
-        gauntlet_fields = {field.name for field in dataclasses.fields(GauntletConfig)}
-        if set(raw_gauntlet) != gauntlet_fields:
+        if type(raw_gauntlet) is not dict:
+            raise ValueError("lifetime-gauntlet nested config must be an exact dictionary")
+        if any(type(key) is not str for key in raw_gauntlet):
+            raise ValueError("lifetime-gauntlet nested config keys must be exact strings")
+        if set(raw_gauntlet) != _GAUNTLET_CONFIG_FIELDS:
             raise ValueError("lifetime-gauntlet nested config fields are invalid")
+        scale_period = values.get("scale_cycle_period")
+        if type(scale_period) is bool or type(scale_period) is not int:
+            raise ValueError("scale_cycle_period must be an exact integer")
         return cls(GauntletConfig(**dict(raw_gauntlet)), **values)
 
     def _require_state_contract(self, state: LifetimeState) -> None:

--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -73,6 +73,23 @@ RECURRING_TWO_AGENT_CHECKPOINT_SCHEMA = "alberta.recurring-two-agent-checkpoint.
 _LEGACY_RECURRING_TWO_AGENT_CHECKPOINT_SCHEMA = "alberta.recurring-two-agent-checkpoint.v1"
 RECURRING_TWO_AGENT_CLOCK_NBYTES = 12
 RECURRING_TWO_AGENT_CLOCK_DELTA_NBYTES = 8
+_RECURRING_TWO_AGENT_CONFIG_FIELDS = frozenset(
+    {
+        "type",
+        "config_schema",
+        "state_schema",
+        "context_length",
+        "nuisance_dim",
+        "nuisance_scale",
+        "world_limit",
+        "damping",
+        "acceleration",
+        "time_delta",
+        "max_speed",
+        "initial_positions",
+        "partner_policy",
+    }
+)
 
 type PartnerPolicy = Callable[[Array, Array], Array]
 
@@ -522,21 +539,33 @@ class RecurringTwoAgentWorld:
     @classmethod
     def from_config(cls, config: Mapping[str, Any]) -> RecurringTwoAgentWorld:
         """Strictly reconstruct a default-policy v2 environment."""
+        if type(config) is not dict:
+            raise ValueError("recurring two-agent config must be an exact dictionary")
+        if any(type(key) is not str for key in config):
+            raise ValueError("recurring two-agent config keys must be exact strings")
         values = dict(config)
-        expected = set(cls().to_config())
-        if set(values) != expected:
+        if set(values) != _RECURRING_TWO_AGENT_CONFIG_FIELDS:
             raise ValueError("recurring two-agent config fields are invalid")
-        if values.pop("type") != cls.__name__:
+        type_name = values.pop("type")
+        if type(type_name) is not str or type_name != cls.__name__:
             raise ValueError("recurring two-agent config type is unsupported")
-        if values.pop("config_schema") != RECURRING_TWO_AGENT_CONFIG_SCHEMA:
+        config_schema = values.pop("config_schema")
+        if type(config_schema) is not str or config_schema != RECURRING_TWO_AGENT_CONFIG_SCHEMA:
             raise ValueError("recurring two-agent config schema is unsupported")
-        if values.pop("state_schema") != RECURRING_TWO_AGENT_STATE_SCHEMA:
+        state_schema = values.pop("state_schema")
+        if type(state_schema) is not str or state_schema != RECURRING_TWO_AGENT_STATE_SCHEMA:
             raise ValueError("recurring two-agent state schema is unsupported")
-        if values.pop("partner_policy") != "scripted_meet_avoid_partner_policy":
+        partner_policy = values.pop("partner_policy")
+        if (
+            type(partner_policy) is not str
+            or partner_policy != "scripted_meet_avoid_partner_policy"
+        ):
             raise ValueError("recurring two-agent partner policy is unsupported")
         initial = values.pop("initial_positions")
-        if not isinstance(initial, (list, tuple)):
-            raise ValueError("recurring two-agent initial_positions is invalid")
+        if type(initial) is not list:
+            raise ValueError("recurring two-agent initial_positions must be an exact list")
+        if len(initial) != N_AGENTS:
+            raise ValueError(f"recurring two-agent initial_positions must have length {N_AGENTS}")
         return cls(initial_positions=tuple(initial), **values)
 
     def _require_state_contract(self, state: RecurringTwoAgentState) -> None:

--- a/tests/test_gauntlet_hostile.py
+++ b/tests/test_gauntlet_hostile.py
@@ -1,10 +1,13 @@
-"""Hostile int/float gate for GauntletConfig before float/range."""
-
 from __future__ import annotations
+
+from typing import Any
 
 import pytest
 
-from alberta_framework.streams.gauntlet import GauntletConfig
+from alberta_framework.streams.gauntlet import (
+    GauntletConfig,
+    LifetimeGauntletStream,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -116,3 +119,70 @@ def test_gauntlet_hostile_not_in_repr() -> None:
         assert _HostileInt.calls == 0
     else:
         raise AssertionError("should have raised")
+
+
+def test_lifetime_gauntlet_from_config_roundtrip() -> None:
+    stream = LifetimeGauntletStream(scale_cycle_period=4)
+    cfg = stream.to_config()
+    restored = LifetimeGauntletStream.from_config(cfg)
+    assert restored.scale_cycle_period == 4
+    assert restored.config.relevant_dim == stream.config.relevant_dim
+    assert restored.config.noise_std == stream.config.noise_std
+
+
+def test_lifetime_gauntlet_from_config_rejects_invalid_containers() -> None:
+    with pytest.raises(ValueError, match="exact dictionary"):
+        LifetimeGauntletStream.from_config([("type", "LifetimeGauntletStream")])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="exact dictionary"):
+        LifetimeGauntletStream.from_config("not_a_dict")  # type: ignore[arg-type]
+
+
+def test_lifetime_gauntlet_from_config_rejects_non_string_keys() -> None:
+    valid = LifetimeGauntletStream().to_config()
+    bad_keys: dict[Any, Any] = dict(valid)
+    bad_keys[123] = "invalid_key"
+    with pytest.raises(ValueError, match="keys must be exact strings"):
+        LifetimeGauntletStream.from_config(bad_keys)  # type: ignore[arg-type]
+
+
+def test_lifetime_gauntlet_from_config_rejects_invalid_schema_fields() -> None:
+    valid = LifetimeGauntletStream().to_config()
+    with pytest.raises(ValueError, match="fields are invalid"):
+        LifetimeGauntletStream.from_config({**valid, "extra": 1})
+    missing = dict(valid)
+    del missing["scale_cycle_period"]
+    with pytest.raises(ValueError, match="fields are invalid"):
+        LifetimeGauntletStream.from_config(missing)
+
+
+def test_lifetime_gauntlet_from_config_rejects_unsupported_type_or_schema() -> None:
+    valid = LifetimeGauntletStream().to_config()
+    with pytest.raises(ValueError, match="type is unsupported"):
+        LifetimeGauntletStream.from_config({**valid, "type": "WrongStream"})
+    with pytest.raises(ValueError, match="config schema is unsupported"):
+        LifetimeGauntletStream.from_config({**valid, "config_schema": "wrong.schema"})
+    with pytest.raises(ValueError, match="state schema is unsupported"):
+        LifetimeGauntletStream.from_config({**valid, "state_schema": "wrong.schema"})
+
+
+def test_lifetime_gauntlet_from_config_rejects_invalid_nested_gauntlet_config() -> None:
+    valid = LifetimeGauntletStream().to_config()
+    with pytest.raises(ValueError, match="nested config must be an exact dictionary"):
+        LifetimeGauntletStream.from_config({**valid, "gauntlet_config": "not_a_dict"})
+    raw_gauntlet = dict(valid["gauntlet_config"])
+    raw_gauntlet_bad_keys: dict[Any, Any] = dict(raw_gauntlet)
+    raw_gauntlet_bad_keys[123] = "bad"
+    with pytest.raises(ValueError, match="nested config keys must be exact strings"):
+        LifetimeGauntletStream.from_config({**valid, "gauntlet_config": raw_gauntlet_bad_keys})
+    with pytest.raises(ValueError, match="nested config fields are invalid"):
+        LifetimeGauntletStream.from_config(
+            {**valid, "gauntlet_config": {**raw_gauntlet, "extra": 1}}
+        )
+
+
+def test_lifetime_gauntlet_from_config_rejects_invalid_scale_period_type() -> None:
+    valid = LifetimeGauntletStream().to_config()
+    with pytest.raises(ValueError, match="scale_cycle_period must be an exact integer"):
+        LifetimeGauntletStream.from_config({**valid, "scale_cycle_period": True})
+    with pytest.raises(ValueError, match="scale_cycle_period must be an exact integer"):
+        LifetimeGauntletStream.from_config({**valid, "scale_cycle_period": 3.0})

--- a/tests/test_recurring_multiagent_hostile.py
+++ b/tests/test_recurring_multiagent_hostile.py
@@ -1,6 +1,6 @@
-"""Hostile int/float gate for RecurringTwoAgentWorld before range/float."""
-
 from __future__ import annotations
+
+from typing import Any
 
 import pytest
 
@@ -100,3 +100,65 @@ def test_recurring_world_hostile_not_in_repr() -> None:
         assert _HostileInt.calls == 0
     else:
         raise AssertionError("should have raised")
+
+
+def test_recurring_world_from_config_roundtrip() -> None:
+    world = RecurringTwoAgentWorld(
+        context_length=32,
+        nuisance_dim=2,
+        nuisance_scale=0.5,
+        initial_positions=(-0.25, 0.25),
+    )
+    cfg = world.to_config()
+    restored = RecurringTwoAgentWorld.from_config(cfg)
+    assert restored._context_length == 32
+    assert restored._nuisance_dim == 2
+    assert restored._nuisance_scale == 0.5
+    assert restored._initial_positions_tuple == (-0.25, 0.25)
+
+
+def test_recurring_world_from_config_rejects_invalid_containers() -> None:
+    with pytest.raises(ValueError, match="exact dictionary"):
+        RecurringTwoAgentWorld.from_config([("type", "RecurringTwoAgentWorld")])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="exact dictionary"):
+        RecurringTwoAgentWorld.from_config("not_a_dict")  # type: ignore[arg-type]
+
+
+def test_recurring_world_from_config_rejects_non_string_keys() -> None:
+    valid = RecurringTwoAgentWorld().to_config()
+    bad_keys: dict[Any, Any] = dict(valid)
+    bad_keys[123] = "invalid_key"
+    with pytest.raises(ValueError, match="keys must be exact strings"):
+        RecurringTwoAgentWorld.from_config(bad_keys)  # type: ignore[arg-type]
+
+
+def test_recurring_world_from_config_rejects_invalid_schema_fields() -> None:
+    valid = RecurringTwoAgentWorld().to_config()
+    with pytest.raises(ValueError, match="fields are invalid"):
+        RecurringTwoAgentWorld.from_config({**valid, "extra_field": 1})
+    missing = dict(valid)
+    del missing["context_length"]
+    with pytest.raises(ValueError, match="fields are invalid"):
+        RecurringTwoAgentWorld.from_config(missing)
+
+
+def test_recurring_world_from_config_rejects_unsupported_type_or_schema_or_policy() -> None:
+    valid = RecurringTwoAgentWorld().to_config()
+    with pytest.raises(ValueError, match="type is unsupported"):
+        RecurringTwoAgentWorld.from_config({**valid, "type": "WrongWorld"})
+    with pytest.raises(ValueError, match="config schema is unsupported"):
+        RecurringTwoAgentWorld.from_config({**valid, "config_schema": "wrong.schema"})
+    with pytest.raises(ValueError, match="state schema is unsupported"):
+        RecurringTwoAgentWorld.from_config({**valid, "state_schema": "wrong.schema"})
+    with pytest.raises(ValueError, match="partner policy is unsupported"):
+        RecurringTwoAgentWorld.from_config({**valid, "partner_policy": "custom_policy"})
+
+
+def test_recurring_world_from_config_rejects_invalid_initial_positions() -> None:
+    valid = RecurringTwoAgentWorld().to_config()
+    with pytest.raises(ValueError, match="initial_positions must be an exact list"):
+        RecurringTwoAgentWorld.from_config({**valid, "initial_positions": (-0.5, 0.5)})
+    with pytest.raises(ValueError, match="initial_positions must have length 2"):
+        RecurringTwoAgentWorld.from_config({**valid, "initial_positions": [-0.5]})
+    with pytest.raises(ValueError, match="initial_positions must have length 2"):
+        RecurringTwoAgentWorld.from_config({**valid, "initial_positions": [-0.5, 0.0, 0.5]})


### PR DESCRIPTION
### Summary

Hardens `from_config` deserialization for `LifetimeGauntletStream` in `alberta_framework.streams.gauntlet` and `RecurringTwoAgentWorld` in `alberta_framework.streams.recurring_multiagent`:
- Enforces exact `dict` input type and exact `str` keys for serialized config dictionaries and nested sub-configs.
- Replaces dynamic instantiation (`set(cls().to_config())`) in `RecurringTwoAgentWorld.from_config` with a static frozen constant `_RECURRING_TWO_AGENT_CONFIG_FIELDS`.
- Validates exact schema fields against `_LIFETIME_GAUNTLET_CONFIG_FIELDS` and `_GAUNTLET_CONFIG_FIELDS` in `LifetimeGauntletStream.from_config`.
- Enforces exact integer type for `scale_cycle_period` and exact `list` container of exact length `N_AGENTS` for `initial_positions`.
- Adds comprehensive schema and hostile-key rejection unit tests in `tests/test_gauntlet_hostile.py` and `tests/test_recurring_multiagent_hostile.py`.

### Verification

- Ran pytest unit test suite covering gauntlet and recurring_multiagent tests: 93 passed in 30.11s.
- Ran `ruff check .`: clean.
- Ran `mypy` on modified files: clean.
- Ran `git diff --check`: clean.

Declared identity: Antigravity CLI + Gemini (unattended worker for rama0x1).

## Measured project receipt
Post-hoc receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F8QRBNT506ZP3V9MEBD6KB","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T09:41:18.837Z","completed_at":"2026-08-20T09:41:32.545Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T09:41:19.240Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"1438707dc1e8c3f0c87679f3614b6a18fca18e9da63c1aea9f06467e7b375c3c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"63b4f00f-75f8-4eb8-8f2f-a7c9ee0f95a9","object_id":"sha256:1438707dc1e8c3f0c87679f3614b6a18fca18e9da63c1aea9f06467e7b375c3c","sha256":"1438707dc1e8c3f0c87679f3614b6a18fca18e9da63c1aea9f06467e7b375c3c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"OwoeznWuisblXqtYBYF-rGVnQO-KnDaRdmvfiGYmCY_X-RIY8YLIxfggrC96u3qG0_17FpoKL6uuoU8ESmTVDQ"}} -->
