### PR TITLE
fix(off-policy-td): ETD follow-on trace uses previous-step rho, not current

### DIFF
--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -289,6 +289,10 @@ class ETDState:
         bias_eligibility_trace: Emphatic eligibility trace for the bias
         follow_on_trace: Scalar follow-on trace ``F_t``
         emphasis: Scalar emphasis ``M_t`` from the latest update
+        previous_rho: Importance ratio from the prior update call, carried
+            forward so the *next* call can advance ``F_t`` on ``rho_{t-1}``
+            (Sutton, Mahmood & White 2016, eq. 20) rather than on the ratio
+            of the transition it is currently processing.
         step_count: Number of updates applied
         birth_timestamp: Wall-clock seconds at init
         uptime_s: Cumulative wall-clock seconds spent in update calls
@@ -300,6 +304,7 @@ class ETDState:
     bias_eligibility_trace: Float[Array, ""]
     follow_on_trace: Float[Array, ""]
     emphasis: Float[Array, ""]
+    previous_rho: Float[Array, ""] = None  # type: ignore[assignment]
     step_count: Int[Array, ""] = None  # type: ignore[assignment]
     birth_timestamp: float = 0.0
     uptime_s: float = 0.0
@@ -402,7 +407,7 @@ def _etd_state_contract(state: object) -> tuple[ETDState, int]:
     _array_metadata("state.weights", checked.weights, (feature_dim,))
     _array_metadata("state.bias", checked.bias, ())
     _array_metadata("state.eligibility_traces", checked.eligibility_traces, (feature_dim,))
-    for name in ("bias_eligibility_trace", "follow_on_trace", "emphasis"):
+    for name in ("bias_eligibility_trace", "follow_on_trace", "emphasis", "previous_rho"):
         _array_metadata(f"state.{name}", getattr(checked, name), ())
     try:
         step_shape = tuple(checked.step_count.shape)
@@ -673,9 +678,12 @@ class ETDLinearLearner:
     """Off-policy linear emphatic TD(lambda).
 
     Unlike the clipped per-decision learner above, ETD(lambda) uses a
-    follow-on trace and scalar emphasis:
+    follow-on trace and scalar emphasis. Per Sutton, Mahmood & White (2016),
+    eqs. 17-20, the follow-on trace advances on the *previous* step's ratio
+    while the eligibility trace uses the *current* one -- this offset is
+    deliberate, not a typo:
 
-    ``F_t = rho_t * gamma_t * F_{t-1} + i_t``
+    ``F_t = rho_{t-1} * gamma_t * F_{t-1} + i_t``
     ``M_t = lambda * i_t + (1 - lambda) * F_t``
     ``e_t = rho_t * (gamma_t * lambda * e_{t-1} + M_t * phi_t)``
     ``w_{t+1} = w_t + alpha * delta_t * e_t``
@@ -718,7 +726,7 @@ class ETDLinearLearner:
     def init(self, feature_dim: int) -> ETDState:
         """Initialize learner state with zero weights and zero traces."""
         feature_dim = _require_feature_dim(
-            feature_dim, vectors=2, fixed_scalars=5, update_vectors=9
+            feature_dim, vectors=2, fixed_scalars=6, update_vectors=9
         )
         return ETDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
@@ -727,6 +735,7 @@ class ETDLinearLearner:
             bias_eligibility_trace=jnp.array(0.0, dtype=jnp.float32),
             follow_on_trace=jnp.array(0.0, dtype=jnp.float32),
             emphasis=jnp.array(0.0, dtype=jnp.float32),
+            previous_rho=jnp.array(1.0, dtype=jnp.float32),
             step_count=jnp.array(0, dtype=jnp.int32),
             birth_timestamp=time.time(),
             uptime_s=0.0,
@@ -809,7 +818,12 @@ class ETDLinearLearner:
         v_next = jnp.dot(state.weights, next_observation) + state.bias
         td_error = reward_s + _skip_zero_scale(gamma_s, v_next) - v_t
 
-        follow_on = rho_s * _skip_zero_scale(gamma_s, state.follow_on_trace) + interest_s
+        # F_t = rho_{t-1} * gamma_t * F_{t-1} + i_t (Sutton, Mahmood & White
+        # 2016, eq. 20): the follow-on trace advances on the PRIOR call's
+        # ratio (state.previous_rho), not rho_s -- only e_t below uses rho_s.
+        follow_on = (
+            _skip_zero_scale(gamma_s, state.previous_rho * state.follow_on_trace) + interest_s
+        )
         emphasis = _skip_zero_scale(lam, interest_s) + _skip_zero_scale(1.0 - lam, follow_on)
 
         trace_decay = gamma_s * lam
@@ -825,6 +839,7 @@ class ETDLinearLearner:
             bias_eligibility_trace=new_e_b,
             follow_on_trace=follow_on,
             emphasis=emphasis,
+            previous_rho=rho_s,
             step_count=jnp.minimum(state.step_count, _INT32_MAX - 1) + 1,
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
@@ -842,6 +857,7 @@ class ETDLinearLearner:
             eligibility_traces=_zero_if_unused(trace_decay, state.eligibility_traces),
             bias_eligibility_trace=_zero_if_unused(trace_decay, state.bias_eligibility_trace),
             follow_on_trace=_zero_if_unused(gamma_s, state.follow_on_trace),
+            previous_rho=_zero_if_unused(gamma_s, state.previous_rho),
         )
         squared_td = td_error**2
         mean_e = jnp.mean(jnp.abs(proposed_state.eligibility_traces))

--- a/tests/test_baird.py
+++ b/tests/test_baird.py
@@ -271,12 +271,19 @@ class TestRhoZeroInvariance:
         # The canonical per-decision trace z = rho * (...) vanishes.
         chex.assert_trees_all_close(result.state.eligibility_traces, jnp.zeros(N_FEATURES))
 
-    def test_etd_weights_invariant_and_follow_on_resets(self) -> None:
+    def test_etd_weights_invariant_and_follow_on_uses_previous_rho(self) -> None:
+        """A dashed (rho=0) transition must not move the primary weights or
+        contaminate the eligibility trace. But F_t = rho_{t-1} * gamma_t *
+        F_{t-1} + i_t (Sutton, Mahmood & White 2016, eq. 20) only depends on
+        the PRIOR transition's ratio -- it must not collapse just because
+        the CURRENT transition happens to be dashed.
+        """
         learner = ETDLinearLearner(step_size=0.1, trace_decay=0.0)
         state = learner.init(N_FEATURES).replace(
             weights=jnp.asarray(W_INIT),
             bias=jnp.float32(0.5),
             follow_on_trace=jnp.float32(3.0),
+            previous_rho=jnp.float32(RHO_SOLID),
         )
         result = learner.update(
             state,
@@ -288,9 +295,13 @@ class TestRhoZeroInvariance:
         )
         chex.assert_trees_all_equal(result.state.weights, state.weights)
         chex.assert_trees_all_equal(result.state.bias, state.bias)
-        # The follow-on recursion F = rho * gamma * F_prev + i resets to interest.
-        chex.assert_trees_all_close(result.state.follow_on_trace, jnp.float32(1.0))
-        # e = rho * (...) vanishes, so nothing can leak into the next update.
+        # F = previous_rho(=RHO_SOLID) * gamma * F_prev + i -- unaffected by
+        # the current call's dashed (rho=0) transition.
+        expected_follow_on = RHO_SOLID * GAMMA * 3.0 + 1.0
+        chex.assert_trees_all_close(
+            result.state.follow_on_trace, jnp.float32(expected_follow_on)
+        )
+        # e = rho_t * (...) vanishes when the CURRENT transition is dashed.
         chex.assert_trees_all_close(result.state.eligibility_traces, jnp.zeros(N_FEATURES))
 
     def test_gradient_td_primary_weights_invariant(self) -> None:

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -406,17 +406,48 @@ class TestETDLambda:
             jnp.float32(0.5),
         )
 
-        # F_1 = 2 * 0.9 * 0 + 1 = 1
-        # F_2 = 0.5 * 0.8 * 1 + 1 = 1.4
-        # M_2 = lambda * i + (1 - lambda) * F_2 = 0.4 + 0.6 * 1.4 = 1.24
+        # F_t = rho_{t-1} * gamma_t * F_{t-1} + i_t (Sutton, Mahmood & White
+        # 2016, eq. 20): F advances on the PRIOR step's rho, not the current
+        # one. init()'s previous_rho=1.0 is irrelevant here since F_0=0.
+        # F_1 = 1.0 * 0.9 * 0 + 1 = 1
+        # F_2 = rho_1 * 0.8 * 1 + 1 = 2.0 * 0.8 * 1 + 1 = 2.6
+        # M_2 = lambda * i + (1 - lambda) * F_2 = 0.4 + 0.6 * 2.6 = 1.96
         chex.assert_trees_all_close(first.state.follow_on_trace, jnp.float32(1.0))
-        chex.assert_trees_all_close(second.state.follow_on_trace, jnp.float32(1.4))
-        chex.assert_trees_all_close(second.state.emphasis, jnp.float32(1.24))
+        chex.assert_trees_all_close(second.state.follow_on_trace, jnp.float32(2.6))
+        chex.assert_trees_all_close(second.state.emphasis, jnp.float32(1.96))
         chex.assert_trees_all_close(
             second.state.eligibility_traces,
-            jnp.array([0.32, 0.62], dtype=jnp.float32),
+            jnp.array([0.32, 0.98], dtype=jnp.float32),
             atol=1e-6,
         )
+
+    def test_follow_on_trace_advances_on_previous_step_rho_not_current(self) -> None:
+        """F_t = rho_{t-1} * gamma_t * F_{t-1} + i_t (Sutton, Mahmood & White
+        2016, eq. 20): the follow-on trace must advance on the PRIOR step's
+        importance ratio. rho_t (the ratio of the transition currently being
+        processed) only governs e_t, the eligibility trace, not F_t. This
+        test isolates F_t (lambda=0 so M_t == F_t exactly) across three
+        steps with sharply different rho each step, so a same-step-rho bug
+        produces a visibly different trajectory than the correct one.
+        """
+        learner = ETDLinearLearner(step_size=0.05, trace_decay=0.0)
+        state = learner.init(1)
+        for gamma, rho in ((0.5, 3.0), (0.9, 0.1), (0.7, 4.0)):
+            result = learner.update(
+                state,
+                jnp.ones(1, dtype=jnp.float32),
+                jnp.float32(0.0),
+                jnp.zeros(1, dtype=jnp.float32),
+                jnp.float32(gamma),
+                jnp.float32(rho),
+            )
+            state = result.state
+
+        # F_1 = previous_rho(init=1.0) * 0.5 * F_0(=0) + 1 = 1.0
+        # F_2 = rho_1(=3.0) * 0.9 * F_1(=1.0) + 1 = 3.7
+        # F_3 = rho_2(=0.1) * 0.7 * F_2(=3.7) + 1 = 1.259
+        # (using rho_t instead of rho_{t-1} at each step gives F_3 = 4.052)
+        chex.assert_trees_all_close(state.follow_on_trace, jnp.float32(1.259), atol=1e-5)
 
     def test_update_is_jit_compatible(self) -> None:
         learner = ETDLinearLearner(step_size=0.05, trace_decay=0.5)


### PR DESCRIPTION
## No Slop run receipt

This session ran as `claude-sonnet-5`, not `claude-fable-5`, so this is not a Slop-compliant
measured run (no `run-receipt.mjs start/finish`). Flagged honestly per this track's
established convention.

## What's wrong

`ETDLinearLearner._update_jit` in `alberta_framework/core/off_policy_td.py` advanced the
follow-on trace using the **current** call's importance ratio (`rho_s`) — the same ratio
used for the eligibility trace — instead of the **previous** call's ratio:

```python
follow_on = rho_s * _skip_zero_scale(gamma_s, state.follow_on_trace) + interest_s
```

Per Sutton, Mahmood & White (2016), *An Emphatic Approach to the Problem of Off-policy
Temporal-Difference Learning* (eqs. 17-20), the two traces deliberately use different time
indices for rho:

- `e_t = rho_t * (gamma_t * lambda_t * e_{t-1} + M_t * phi_t)` — eligibility trace uses the
  **current** step's ratio.
- `F_t = rho_{t-1} * gamma_t * F_{t-1} + i_t` — follow-on trace uses the **previous** step's
  ratio.

This offset is deliberate: `F_t` is meant to depend only on history up to `S_t`, not on the
ratio of the action about to be taken there. Using the same `rho_s` for both collapses `F_t`'s
memory whenever the *current* transition happens to be off-support (`rho=0`), and otherwise
scales its history term by the wrong step's ratio on every update — corrupting the emphasis
`M_t` and every downstream weight update.

Verified against the primary source directly (not from memory — see the repo's own #131
lesson about "fixing" a cited formula from recollection) before treating this as a bug.

## Fix

Adds `ETDState.previous_rho`, carried across calls so `F_t` advances on the prior call's
ratio while `e_t` keeps using the current one. `init()` seeds it to `1.0`, which is provably
inert on the first call since `F_0 = 0` (multiplied away regardless of the seed value).

## Verification

- Reproduced live: a 3-step scenario with sharply different per-step `rho` produces
  `F_3 = 4.052` under the buggy formula vs. `F_3 = 1.259` under the correct one.
- Two existing tests (`test_off_policy_td.py::test_follow_on_and_emphasis_evolve_under_off_policy_rho`,
  `test_baird.py::TestRhoZeroInvariance::test_etd_weights_invariant_and_follow_on_resets`) had
  encoded the buggy formula's output as "expected" — corrected both, and renamed the latter
  since its old name/comment ("follow-on resets") described a bug side-effect, not a real
  invariant.
- Added a dedicated regression test (`test_follow_on_trace_advances_on_previous_step_rho_not_current`)
  isolating just this mechanism.
- Mutation-resistance: reverted only the source fix, confirmed both corrected tests fail with
  exactly the predicted buggy values, restored the fix.
- 133/133 relevant tests pass (`test_baird.py`, `test_off_policy_td.py`,
  `test_off_policy_td_update_working_set.py`), ruff and mypy clean on changed files.
- Grepped the repo: `ETDState`/`ETDLinearLearner` are not referenced outside this file and its
  two test files, so no external checkpoint/serialization compatibility concerns.
- Ran the full repo test suite; the only failures were two pre-existing, unrelated,
  environment-specific issues confirmed present on unmodified `origin/main` too (an
  `np.longdouble("1e400")` overflow test and an `os.O_TMPFILE`-requires-Linux test, neither of
  which exists/behaves the same on macOS).

Fixes #1974.
