### PR TITLE
fix(statistics): raise instead of silently mislabeling CI on missing scipy

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -284,23 +284,18 @@ def compute_statistics(
     # Compute confidence interval
     try:
         from scipy import stats
-
-        if n > 1:
-            t_value = float(stats.t.ppf((1 + confidence_level) / 2, n - 1))
-            margin = t_value * sem
-            ci_lower = mean - margin
-            ci_upper = mean + margin
-        else:
-            ci_lower = ci_upper = mean
     except ImportError:
-        # Fallback without scipy: normal approximation.  Only two quantiles
-        # are wired in — 0.95 -> z=1.96; every other confidence level silently
-        # gets the 99% quantile z=2.576.  The normal approximation also
-        # understates the t-based interval width at small n.
-        z_value = 1.96 if confidence_level == 0.95 else 2.576  # 95% or 99%
-        margin = z_value * sem
+        raise ImportError(
+            "scipy is required for compute_statistics. Install with: pip install scipy"
+        )
+
+    if n > 1:
+        t_value = float(stats.t.ppf((1 + confidence_level) / 2, n - 1))
+        margin = t_value * sem
         ci_lower = mean - margin
         ci_upper = mean + margin
+    else:
+        ci_lower = ci_upper = mean
 
     return StatisticalSummary(
         mean=mean,
@@ -349,13 +344,12 @@ def compute_timeseries_statistics(
 
     try:
         from scipy import stats
-
-        t_value = stats.t.ppf((1 + confidence_level) / 2, n_seeds - 1)
     except ImportError:
-        # Same limitation as compute_statistics: 0.95 -> z=1.96, any other
-        # level silently gets the 99% quantile z=2.576.
-        t_value = 1.96 if confidence_level == 0.95 else 2.576
+        raise ImportError(
+            "scipy is required for compute_timeseries_statistics. Install with: pip install scipy"
+        )
 
+    t_value = stats.t.ppf((1 + confidence_level) / 2, n_seeds - 1)
     margin = t_value * sem
     ci_lower = mean - margin
     ci_upper = mean + margin

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -26,6 +26,7 @@ Calibration (measured on this machine, scripts in the session scratchpad):
   superset always and strictness on >= 50 draws.
 """
 
+import sys
 import warnings
 from typing import Any
 
@@ -131,6 +132,19 @@ class TestComputeStatistics:
             warnings.simplefilter("error")
             with pytest.raises(ValueError, match="confidence_level.*strictly between 0 and 1"):
                 compute_statistics([4.2], confidence_level=confidence_level)
+
+    def test_missing_scipy_raises_instead_of_silently_wrong_ci(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without scipy, compute_statistics must fail loudly (matching
+        ttest_comparison/mann_whitney_comparison/wilcoxon_comparison's own
+        established convention in this file), not silently substitute the
+        99% z-quantile for every confidence_level != 0.95.
+        """
+        monkeypatch.setitem(sys.modules, "scipy", None)
+        monkeypatch.setitem(sys.modules, "scipy.stats", None)
+        with pytest.raises(ImportError, match="scipy is required for compute_statistics"):
+            compute_statistics([1.0, 2.0, 3.0, 4.0, 5.0], confidence_level=0.90)
 
 
 class TestSampleVectorContract:
@@ -411,6 +425,21 @@ class TestTimeseriesStatistics:
             warnings.simplefilter("error")
             with pytest.raises(ValueError, match="confidence_level.*strictly between 0 and 1"):
                 compute_timeseries_statistics(arr, confidence_level=confidence_level)
+
+    def test_missing_scipy_raises_instead_of_silently_wrong_ci(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same contract as compute_statistics: without scipy this must fail
+        loudly rather than silently substitute the 99% z-quantile for every
+        confidence_level != 0.95.
+        """
+        monkeypatch.setitem(sys.modules, "scipy", None)
+        monkeypatch.setitem(sys.modules, "scipy.stats", None)
+        arr = np.asarray([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+        with pytest.raises(
+            ImportError, match="scipy is required for compute_timeseries_statistics"
+        ):
+            compute_timeseries_statistics(arr, confidence_level=0.90)
 
 
 class TestBootstrapCI:


### PR DESCRIPTION
Fixes #1977.

`compute_statistics` and `compute_timeseries_statistics` fell back, on `ImportError`
importing scipy, to a hardcoded two-point z-value lookup that returned the **99% quantile
(z=2.576)** for any `confidence_level != 0.95` — silently mislabeling a requested 90%, 80%,
97.5%, etc. interval.

Three sibling functions in this same file (`ttest_comparison`, `mann_whitney_comparison`,
`wilcoxon_comparison`) already establish the correct convention here: raise `ImportError`
with an install hint rather than silently degrade. These two functions were the only ones
that deviated from it. `scipy>=1.11` is a mandatory dependency, so this branch is unreachable
today — but it's still incorrect, misleading, and a latent silent-corruption risk if that
ever changes.

**Reproduced**: confirmed the buggy branch returns `z=2.576` (99% quantile) for
`confidence_level=0.90` by exercising it directly.

**Fix**: remove the broken lookup, match the file's own `raise ImportError(...)` convention
used three other places in the same file.

**Regression tests**: one per function, using `monkeypatch.setitem(sys.modules, "scipy", None)`
to actually exercise the scipy-unavailable path (can't otherwise trigger it since scipy is
always installed in this environment) — confirms both now raise `ImportError` instead of
returning a mislabeled interval.

**Verification**:
- `pytest tests/test_statistics_validation.py tests/test_statistics_hostile_validation.py tests/test_forager_matched_statistics.py`: 303 passed
- ruff, mypy: clean on both changed files
- Checked all other callers of both functions (`alberta_framework/utils/visualization.py`) — all use the default `confidence_level=0.95`, unaffected either way
- Mutation-resistance: reverted just the source fix, confirmed both new regression tests fail (silently pass instead of raising) for the right reason, restored the fix, confirmed green again

No Slop run receipt (this session is not running as `claude-fable-5`).
