### PR TITLE
test(off-policy-td): make the huge-finite clip fixture platform-honest

### DIFF
--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -1096,7 +1096,12 @@ def test_config_scalars_canonicalize_reals_and_preserve_infinity_clip_sentinel()
             gradient.trace_decay,
         )
     )
-    huge_finite = np.longdouble("1e400")
+    # The widest finite value the platform's longdouble can hold. A literal such
+    # as ``np.longdouble("1e400")`` is only finite where longdouble is wider than
+    # float64; on aarch64 (macOS arm64) longdouble *is* float64, so it overflows
+    # to inf at parse and would be accepted as the documented infinity sentinel
+    # instead of exercising the finite-value float32 overflow rejection.
+    huge_finite = np.finfo(np.longdouble).max
     with pytest.raises(ValueError, match="retrace_clip"):
         OffPolicyTDLinearLearner(retrace_clip=huge_finite)
     with pytest.raises(ValueError, match="ratio_clip"):


### PR DESCRIPTION

Fixes #1979.

Fixes the aarch64-only failure in `tests/test_off_policy_td.py::test_config_scalars_canonicalize_reals_and_preserve_infinity_clip_sentinel`.

## Root cause

The test's "finite value that overflows float32" fixture was the literal `np.longdouble("1e400")` (`tests/test_off_policy_td.py:1099`, added by `c503f1fa551217160f68c7db1f88a0b54521dd8c`). That literal is finite only where C `long double` is wider than binary64. On aarch64 — including the macOS arm64 dev platform — `np.finfo(np.longdouble).bits == 64` and `max == 1.7976931348623157e+308`, so numpy parses `1e400` to `inf` and emits `RuntimeWarning: overflow encountered in conversion from string`.

`_positive_float32_or_infinity` (`alberta_framework/core/off_policy_td.py:123`) deliberately accepts positive infinity — it is the documented "no clipping" sentinel, and the same test asserts that at line 1084 (`assert off_policy.retrace_clip == float("inf")`). So the fixture was silently accepted, `pytest.raises` reported `Failed: DID NOT RAISE ValueError`, and the assertion the test exists to make — that a *finite* host value which narrows to `inf` in binary32 is rejected by `validated_float32_scalar` (`alberta_framework/core/_float32_scalars.py:139`) — was never exercised on that platform. Both the `retrace_clip` and the `ratio_clip` case were affected.

This is the identical defect that #937 reported for `tests/test_experiments_validation.py` and #939 (`4ce71d8a`) fixed one day after the literal landed here.

## The change

One fixture line in one test file, plus a comment matching the merged precedent's house style:

```diff
-    huge_finite = np.longdouble("1e400")
+    # The widest finite value the platform's longdouble can hold. A literal such
+    # as ``np.longdouble("1e400")`` is only finite where longdouble is wider than
+    # float64; on aarch64 (macOS arm64) longdouble *is* float64, so it overflows
+    # to inf at parse and would be accepted as the documented infinity sentinel
+    # instead of exercising the finite-value float32 overflow rejection.
+    huge_finite = np.finfo(np.longdouble).max
```

`np.finfo(np.longdouble).max` is finite on both longdouble widths and far above float32 max on both, so the intended rejection path is now exercised everywhere.

I used a local comment rather than extracting a shared helper. `tests/test_experiments_validation.py` still needs its own `_platform_longdouble_1e4000()` helper for a genuinely different case (a value that is deliberately inf-or-finite depending on platform), so there is no clean shared abstraction between the two files, and a new cross-module test helper would be more churn than a one-line fixture correction warrants.

## Both platforms

**aarch64 (measured on this box, numpy 2.5.2):** `np.finfo(np.longdouble).max` is `1.7976931348623157e+308`, returned as a `numpy.float64` instance. `np.float64` is in `_TRUSTED_REAL_TYPES` (`off_policy_td.py:87-91`) and in `_float32._ACTUAL_FLOAT_TYPES` via `np.dtype("d").type`, so the exact-type gate passes; the value is finite so the `_INFINITY_TYPES`/`np.isinf` sentinel branch is skipped; `validated_float32_scalar` narrows it to `inf` in binary32 and raises. Verified directly:

```
retrace_clip ValueError: retrace_clip must remain finite once narrowed to float32
ratio_clip   ValueError: ratio_clip must remain finite once narrowed to float32
```

**x86-64 (by code reading — I do not have an x86-64 machine to measure on):** `np.finfo(np.longdouble).max` is a `np.longdouble` instance, ~1.1897e4932. `np.longdouble` is in `_TRUSTED_REAL_TYPES` and reachable in `_float32._ACTUAL_FLOAT_TYPES` via `np.dtype("g").type`, so the exact-type gate passes there too. It is finite, so the `np.isinf` sentinel branch is again skipped. `_real_ratio` reads an exact ratio through `np.longdouble.as_integer_ratio`, and `_float32_from_ratio` computes `exponent == 16383 > 127`, producing `+inf`; `validated_float32_scalar_with_ratio` then hits `if not math.isfinite(narrowed)` and raises `"<name> must remain finite once narrowed to float32"`. The `pytest.raises` match is on the field name only, so it matches on both platforms.

The fixture assumes `finfo(longdouble).max > finfo(float32).max`, which holds on every platform numpy supports (binary32 max 3.4e38 < binary64 max 1.8e308 <= longdouble max).

## Red proof (at base `47976036c254ac895e896c8244714eebd345b6bb`)

```
$ .venv/bin/python -m pytest \
    tests/test_off_policy_td.py::test_config_scalars_canonicalize_reals_and_preserve_infinity_clip_sentinel -q

    huge_finite = np.longdouble("1e400")
>   with pytest.raises(ValueError, match="retrace_clip"):
E   Failed: DID NOT RAISE ValueError

tests/test_off_policy_td.py:1100: Failed
tests/test_off_policy_td.py:1099: RuntimeWarning: overflow encountered in conversion from string
FAILED ...::test_config_scalars_canonicalize_reals_and_preserve_infinity_clip_sentinel
1 failed, 1 warning in 1.05s

$ .venv/bin/python -m pytest tests/test_off_policy_td.py -q
1 failed, 98 passed, 1 warning in 8.09s
```

## Green proof

```
$ .venv/bin/python -m pytest \
    tests/test_off_policy_td.py::test_config_scalars_canonicalize_reals_and_preserve_infinity_clip_sentinel -q
1 passed in 0.53s

$ .venv/bin/python -m pytest tests/test_off_policy_td.py -q
99 passed in 7.83s

# every other test file that references off_policy_td
$ .venv/bin/python -m pytest tests/test_off_policy_td_update_working_set.py \
    tests/test_wave_1383_1397_hostile_type_identity.py tests/test_baird_horde.py tests/test_baird.py -q
42 passed in 7.84s

# neighbouring float32 / longdouble validation files, incl. the precedent file
$ .venv/bin/python -m pytest tests/test_experiments_validation.py tests/test_float32.py \
    tests/test_float32_hostile_validation.py -q
193 passed, 1 warning in 1.94s
```

## Gates

```
$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 190 source files

$ git diff --stat 47976036c254ac895e896c8244714eebd345b6bb
 tests/test_off_policy_td.py | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```

Collection is unchanged at 15369 tests (the edit adds no test).

## Why CI did not catch this

`.github/workflows/ci.yml` runs the full suite on `ubuntu-latest` only. The `portability` job (`macos-14`, `windows-latest`) runs a fixed 7-test cross-platform regression panel that does not include this test, so an aarch64-only failure here is structurally invisible to CI. Same blind spot as #937.

## Scope and non-goals

- Test-only. No production module is touched; `alberta_framework/core/off_policy_td.py` and `alberta_framework/core/_float32_scalars.py` behave exactly as before, and the infinity sentinel semantics are unchanged and still asserted by the same test.
- Not attempted here: widening the `portability` panel so longdouble-width-sensitive tests run on macOS CI, and auditing the remaining platform-sensitive longdouble literals in the suite (e.g. `tests/test_upgd_memory_validation.py:291` uses `np.longdouble("1e-500")`, which is an underflow-direction case I did not investigate). Both are separate changes.
- I did not run the full 15369-test suite; `main` is independently red at this base commit for unrelated reasons, so a full-suite number would not be attributable to this change.

## Evidence discipline

**No registered evidence source is touched.** The only modified file is `tests/test_off_policy_td.py`. The five-claim inventory in `alberta_framework/evaluation/evidence_manifest.py` registers 25 paths, all under `alberta_framework/`; no `tests/` path appears in it, and `grep -rn "off_policy_td" alberta_framework/evaluation/evidence_manifest.py` returns nothing. Nothing under `outputs/` or `docs/` is modified, so no pinned artifact and no source hash is invalidated.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
---

## Whole-suite re-measurement (macOS 15 / Darwin 25.2.0, arm64)

Re-measured on `47976036c254ac895e896c8244714eebd345b6bb` with a 6-way sharded sweep of the full `tests/` tree (`-q -p no:randomly -m "not slow"`), comparing pristine `origin/main` against a branch merging this fix together with its three sibling platform fixes:

| | failing/erroring node ids |
|---|---|
| pristine `origin/main` | **68** |
| main + the four platform fixes | **3** |

Set-differencing the sorted node-id lists: **65 reds cleared, zero regressions** — `comm -13` between the two lists is empty, so no test that passed on main fails with these changes.

The 3 residuals are all pre-existing on main and untouched by this work: `test_open_campaign_v2_golden_byte_contract` (a separate, filed architecture-reproducibility defect), `test_schema_23_real_tiny_rtu_run_captures_and_recomputes_raw_trace` (needs the `forager`/`gymnasium` extras, which this review venv lacks and CI installs), and `test_wheel_and_sdist_are_complete_and_hard_link_safe`.
