### PR TITLE
test(scorecard): declare the Linux-only publication requirement

### DIFF
--- a/tests/test_reference_life_scorecard.py
+++ b/tests/test_reference_life_scorecard.py
@@ -378,6 +378,10 @@ def test_summary_retains_failures_and_reports_valid_baseline_failure() -> None:
     assert summary["status"] == "valid_baseline_failure"
 
 
+@pytest.mark.skipif(
+    not hasattr(os, "O_TMPFILE"),
+    reason="write_new_json publishes through Linux O_TMPFILE and linkat(AT_EMPTY_PATH)",
+)
 def test_new_json_publication_is_canonical_and_refuses_overwrite(tmp_path: Path) -> None:
     destination = tmp_path / "plan.json"
     payload = build_development_plan().to_payload()
@@ -391,6 +395,17 @@ def test_new_json_publication_is_canonical_and_refuses_overwrite(tmp_path: Path)
     ).encode("utf-8") + b"\n"
     with pytest.raises(FileExistsError, match="refusing to overwrite"):
         write_new_json(destination, {"different": math.pi})
+
+
+@pytest.mark.skipif(
+    hasattr(os, "O_TMPFILE"),
+    reason="Linux publishes the document instead of refusing",
+)
+def test_new_json_publication_fails_closed_without_o_tmpfile(tmp_path: Path) -> None:
+    destination = tmp_path / "plan.json"
+    with pytest.raises(OSError, match="requires Linux O_TMPFILE support"):
+        write_new_json(destination, build_development_plan().to_payload())
+    assert not destination.exists()
 
 
 def test_new_json_publication_rejects_a_symlinked_parent(tmp_path: Path) -> None:
@@ -994,7 +1009,8 @@ def test_validate_cli_accepts_the_canonical_plan(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     path = tmp_path / "plan.json"
-    scorecard.write_new_json(path, scorecard.build_development_plan().to_payload())
+    payload = scorecard.build_development_plan().to_payload()
+    path.write_text(json.dumps(payload), encoding="utf-8")
 
     assert scorecard.main(["validate", str(path)]) == 0
     result = json.loads(capsys.readouterr().out)


### PR DESCRIPTION

Fixes #1980.


## Root cause

`reference_life_scorecard.write_new_json` publishes immutably through Linux `O_TMPFILE` + `linkat(AT_EMPTY_PATH)` and fails closed everywhere else (`alberta_framework/benchmarks/reference_life_scorecard.py:1536-1537`):

```python
if not hasattr(os, "O_TMPFILE"):
    raise OSError("immutable publication requires Linux O_TMPFILE support")
```

Two tests introduced alongside it in `563a8aaf` ("feat(reference): integrate preview1 life development stack") call that publisher without declaring the requirement, so they have failed on every non-Linux platform since the day they landed:

```console
$ git log --oneline -S "def write_new_json" -- alberta_framework/benchmarks/reference_life_scorecard.py
563a8aaf feat(reference): integrate preview1 life development stack
$ git log --oneline -S "test_new_json_publication_is_canonical_and_refuses_overwrite" -- tests/test_reference_life_scorecard.py
563a8aaf feat(reference): integrate preview1 life development stack
```

It stayed invisible because `.github/workflows/ci.yml` runs the full suite only on `ubuntu-latest` (job `test`, line 312 / `runs-on:` line 316). The single non-Linux job, `portability` (line 180, matrix `[macos-14, windows-latest]`), runs a panel of seven explicitly named tests, none of which is in this file.

## The Linux guarantee is deliberate and is untouched

I did **not** add a portable fallback, and this PR changes no library source. Filling an unnamed inode and only then `linkat`-ing it is what makes "no reachable partial file, never an overwrite" true; an `O_EXCL` + `rename` substitute would weaken that under a green suite. The repo says the binding is intended in four places:

- `reference_life_scorecard.py:1656-1658` — "Whole-life checkpoint publication is intentionally Linux-only. Keep that dependency behind the artifact-construction boundary so the portable scorecard CLI, help, and deterministic plan remain importable elsewhere."
- `alberta_framework/reference_life_checkpoint.py:1663-1664` — same gate for `renameat2`.
- `alberta_framework/benchmarks/forager_matched_campaign.py:662-663` — same gate for `O_TMPFILE`.
- `.github/workflows/reference-life-scorecard-dev.yml` — the real campaign is `runs-on: ubuntu-latest` at both lines 22 and 99.

## The change

One test file, +17 / -1.

1. `test_new_json_publication_is_canonical_and_refuses_overwrite` gains `@pytest.mark.skipif(not hasattr(os, "O_TMPFILE"), ...)`. Its whole body depends on a published inode — the canonical-bytes assertion reads the file back, and the refuse-to-overwrite assertion needs that file to exist — so there is no portable remainder to keep running. The predicate mirrors the production guard exactly rather than testing `sys.platform`.
2. New `test_new_json_publication_fails_closed_without_o_tmpfile`, gated on the exact complement (`hasattr(os, "O_TMPFILE")` → skip). It asserts publication raises with the documented message and leaves no partial file behind. Off Linux this positively pins the fail-closed contract instead of merely skipping, which is the guard against a future "portability fix" that silently degrades the immutability guarantee.
3. `test_validate_cli_accepts_the_canonical_plan` keeps running on every platform. Its subject is the portable `validate` CLI, not the publisher — at base it died in its fixture line before `scorecard.main(["validate", ...])` was ever reached. It now lays its input down with the same plain canonical write the sibling test directly above it (`test_validate_cli_accepts_valid_completed_inputs`) already uses:

```python
path.write_text(json.dumps(payload), encoding="utf-8")
```

`test_new_json_publication_rejects_a_symlinked_parent` is left alone: it already passes on macOS because `_open_output_parent` raises before the `O_TMPFILE` check.

## Red proof (base `47976036`, macOS arm64, project venv)

```console
$ .venv/bin/python -m pytest tests/test_reference_life_scorecard.py -q
...
            if not hasattr(os, "O_TMPFILE"):
>               raise OSError("immutable publication requires Linux O_TMPFILE support")
E               OSError: immutable publication requires Linux O_TMPFILE support

alberta_framework/benchmarks/reference_life_scorecard.py:1537: OSError
=========================== short test summary info ============================
FAILED tests/test_reference_life_scorecard.py::test_new_json_publication_is_canonical_and_refuses_overwrite
FAILED tests/test_reference_life_scorecard.py::test_validate_cli_accepts_the_canonical_plan
2 failed, 62 passed in 33.72s
```

## Green proof

```console
$ .venv/bin/python -m pytest tests/test_reference_life_scorecard.py -q -rs
....................s............................................        [100%]
=========================== short test summary info ============================
SKIPPED [1] tests/test_reference_life_scorecard.py:381: write_new_json publishes through Linux O_TMPFILE and linkat(AT_EMPTY_PATH)
64 passed, 1 skipped in 49.28s
```

Neighbouring modules that import the scorecard — `test_reference_scorecard_int_hostile.py`, `test_benchmark_hostile_identity_boundaries.py`, `test_scorecard_arm_hostile_strings.py`, `test_scorecard_run_spec_hostile.py`, `test_reference_life_scorecard_workflow.py`, `test_console_entrypoints.py` — `33 passed in 7.98s`.

**Linux behaviour is preserved.** I have no Linux runner here, so I verified the gating structurally by simulating the constant at collection time and reading the resolved marks:

```
test_new_json_publication_is_canonical_and_refuses_overwrite: would_skip_on_linux=False
test_new_json_publication_fails_closed_without_o_tmpfile:     would_skip_on_linux=True
test_validate_cli_accepts_the_canonical_plan:                 would_skip_on_linux=False
```

The two `skipif` conditions are exact complements, so exactly one of the two publication tests runs on any platform, and on Linux the `O_TMPFILE` contract test executes with its body unchanged. That is a claim about test selection, not a Linux execution — please treat CI's Linux run as the confirming evidence.

## Gates

```console
$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 190 source files
```

`pyproject.toml` sets `files = ["alberta_framework"]` for mypy, and this PR touches nothing there, so its input is byte-identical to base.

## Evidence discipline

**No registered evidence source is touched.** The only changed file is `tests/test_reference_life_scorecard.py`. Checking it against the five-claim inventory in `alberta_framework/evaluation/evidence_manifest.py`:

```
'tests/test_reference_life_scorecard.py'                      registered? False
'alberta_framework/benchmarks/reference_life_scorecard.py'    registered? False
```

The 25 registered sources all live under `alberta_framework/core/`, `alberta_framework/evaluation/`, `alberta_framework/streams/`, plus `utils/metrics.py` and `recurring_feature_gate.py`. Nothing under `outputs/` is written, edited, or deleted, and no `docs/` file is changed. Because no file under `alberta_framework/` changed, no persisted artifact's source hashes can move.

## Scope and non-goals

- **Not** making scorecard publication portable. If cross-platform publication is ever wanted, it needs its own change with its own contract tests and an explicit decision about what the weaker guarantee costs.
- **Not** touching any library source, the frozen plan, the schema, the seed roster, or any workflow.
- **Not** auditing the other Linux-only publishers in the tree (`forager_matched_campaign._publish_bytes`, `reference_life_checkpoint`'s `renameat2` path). Their tests may have the same undeclared-requirement problem on macOS; that is a separate change.
- **Not** widening CI's cross-platform panel. That is a reasonable follow-up — the panel is why this sat unnoticed — but it is a CI-policy decision, not part of this fix.
- No benchmark was executed and no performance or evidence claim is made or implied.

## Known reviewer objection

On Linux, `test_validate_cli_accepts_the_canonical_plan` no longer calls `write_new_json`. That publisher's canonical-bytes and refuse-to-overwrite contract is still covered on Linux by `test_new_json_publication_is_canonical_and_refuses_overwrite`, and its symlinked-parent rejection by `test_new_json_publication_rejects_a_symlinked_parent` (which runs on all platforms). The plain-write fixture is the convention the adjacent test in the same file already follows for the same CLI. If you would rather Linux keep exercising the publisher there, the alternative is a platform branch inside the test body; I judged that less readable, and can change it on request.

---

## Whole-suite re-measurement (macOS 15 / Darwin 25.2.0, arm64)

Re-measured on `47976036c254ac895e896c8244714eebd345b6bb` with a 6-way sharded sweep of the full `tests/` tree (`-q -p no:randomly -m "not slow"`), comparing pristine `origin/main` against a branch merging this fix together with its three sibling platform fixes:

| | failing/erroring node ids |
|---|---|
| pristine `origin/main` | **68** |
| main + the four platform fixes | **3** |

Set-differencing the sorted node-id lists: **65 reds cleared, zero regressions** — `comm -13` between the two lists is empty, so no test that passed on main fails with these changes.

The 3 residuals are all pre-existing on main and untouched by this work: `test_open_campaign_v2_golden_byte_contract` (a separate, filed architecture-reproducibility defect), `test_schema_23_real_tiny_rtu_run_captures_and_recomputes_raw_trace` (needs the `forager`/`gymnasium` extras, which this review venv lacks and CI installs), and `test_wheel_and_sdist_are_complete_and_hard_link_safe`.
