### PR TITLE
test(forager-matched): declare the Linux-only publication requirements

### DIFF
--- a/tests/_forager_matched_platform.py
+++ b/tests/_forager_matched_platform.py
@@ -1,0 +1,60 @@
+"""Platform predicates for the Linux-only matched-current publication primitives.
+
+Matched-current publication deliberately depends on kernel primitives that only
+Linux provides, and every call site fails closed elsewhere:
+
+* ``open(O_TMPFILE)`` + ``linkat(AT_EMPTY_PATH)`` fill an inode that has no
+  directory entry until it is complete.  ``forager_matched_campaign._publish_bytes``
+  refuses with "O_TMPFILE is required for crash-safe publication".
+* ``renameat2(RENAME_NOREPLACE)`` publishes a directory without ever replacing an
+  existing destination.  ``forager_matched_seal._publish_verified_no_replace``
+  refuses with "renameat2 is required for seal publication",
+  ``forager_matched_campaign._rename_no_replace`` with "renameat2 is required for
+  exclusive publication", and
+  ``forager_matched_qualification._publish_directory_no_replace`` with "atomic
+  no-replace publication is unavailable on this platform".
+* ``/proc/self/fd`` names open descriptors, which the descriptor-leak censuses and
+  the fsync-order tests read back.  Unlike the other two this can also be missing
+  on Linux, so it is probed independently rather than inferred from the platform.
+
+Each predicate runs the same probe as the guard it stands in for, so a gated test
+skips exactly when the library would refuse and runs wherever the library
+succeeds.  ``test_forager_matched_container_hardening`` already uses the
+equivalent runtime skip for its procfs descriptor census.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _probe_renameat2() -> bool:
+    """Repeat the publication guards' own ``dlsym`` lookup for ``renameat2``."""
+
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+    except OSError:  # dlopen(NULL) is unavailable off POSIX; treat it as absent
+        return False
+    return getattr(libc, "renameat2", None) is not None
+
+
+HAS_O_TMPFILE = bool(getattr(os, "O_TMPFILE", 0))
+HAS_RENAMEAT2 = _probe_renameat2()
+HAS_PROCFS_DESCRIPTORS = Path("/proc/self/fd").is_dir()
+
+requires_o_tmpfile = pytest.mark.skipif(
+    not HAS_O_TMPFILE,
+    reason="crash-safe artifact publication requires Linux O_TMPFILE",
+)
+requires_renameat2 = pytest.mark.skipif(
+    not HAS_RENAMEAT2,
+    reason="atomic no-replace publication requires Linux renameat2",
+)
+requires_procfs_descriptors = pytest.mark.skipif(
+    not HAS_PROCFS_DESCRIPTORS,
+    reason="descriptor-path readback requires procfs",
+)

--- a/tests/test_forager_matched_campaign.py
+++ b/tests/test_forager_matched_campaign.py
@@ -34,6 +34,7 @@ from alberta_framework.benchmarks import forager_matched_open_protocol as open_p
 from alberta_framework.benchmarks import forager_matched_qualification as qualification
 from tests import test_forager_matched_executor as executor_fixtures
 from tests import test_forager_matched_open_protocol as protocol_fixtures
+from tests._forager_matched_platform import HAS_O_TMPFILE, requires_o_tmpfile
 
 pytestmark = pytest.mark.integration
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -366,6 +367,7 @@ def test_campaign_manifest_rejects_each_qualification_digest_carrier_drift(
         )
 
 
+@requires_o_tmpfile
 @pytest.mark.parametrize("carrier", ("payload", "sidecar"))
 def test_load_context_rejects_persisted_qualification_manifest_drift(
     tmp_path: Path,
@@ -408,6 +410,7 @@ def test_load_context_rejects_persisted_qualification_manifest_drift(
     assert context.rebuilt.bundle.manifest_sha256 == _QUALIFICATION_MANIFEST_SHA256
 
 
+@requires_o_tmpfile
 def test_load_context_rejects_literal_v1_open_campaign_manifest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -629,6 +632,7 @@ def test_cell_bindings_derive_stage_from_context_protocol(tmp_path: Path) -> Non
     assert pointer["stage"] == "sealed_evaluation"
 
 
+@requires_o_tmpfile
 def test_custom_completion_summary_builder_flows_through_resume_and_replay(
     tmp_path: Path,
 ) -> None:
@@ -701,6 +705,7 @@ def test_custom_completion_summary_builder_flows_through_resume_and_replay(
         campaign._derive_status(context, scans)
 
 
+@requires_o_tmpfile
 def test_completed_campaign_loader_returns_exact_immutable_bundle(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -739,6 +744,7 @@ def test_completed_campaign_loader_returns_exact_immutable_bundle(
         cast(dict[str, str], bundle.final_file_sha256)["mutated"] = "0" * 64
 
 
+@requires_o_tmpfile
 def test_completed_campaign_loader_rejects_incomplete_campaign(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -758,6 +764,7 @@ def test_completed_campaign_loader_rejects_incomplete_campaign(
         )
 
 
+@requires_o_tmpfile
 @pytest.mark.parametrize("artifact_name", campaign._FINAL_ARTIFACTS)
 def test_completed_campaign_loader_rejects_each_self_consistent_final_tamper(
     tmp_path: Path,
@@ -787,6 +794,7 @@ def test_completed_campaign_loader_rejects_each_self_consistent_final_tamper(
         )
 
 
+@requires_o_tmpfile
 def test_completed_campaign_loader_is_read_only(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -816,6 +824,7 @@ def test_completed_campaign_loader_is_read_only(
     assert snapshot() == before
 
 
+@requires_o_tmpfile
 def test_completed_campaign_bundle_preserves_plan_candidate_seed_and_final_order(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -862,6 +871,7 @@ def test_prepare_rejects_an_existing_output_root(tmp_path: Path) -> None:
         )
 
 
+@requires_o_tmpfile
 def test_scorer_failure_resumes_bound_raw_without_rerunning_candidate(
     tmp_path: Path,
 ) -> None:
@@ -903,6 +913,7 @@ def test_scorer_failure_resumes_bound_raw_without_rerunning_candidate(
     assert (failed.resumable_attempt / "failures" / "failure-000001.json").is_file()
 
 
+@requires_o_tmpfile
 def test_raw_only_orphan_starts_a_new_attempt_and_is_never_resumed(tmp_path: Path) -> None:
     context = _context(tmp_path)
     candidate_id = context.rebuilt.candidate_ids[0]
@@ -931,6 +942,7 @@ def test_raw_only_orphan_starts_a_new_attempt_and_is_never_resumed(tmp_path: Pat
     assert (run_cell / "attempt-000002" / "bundle.json").is_file()
 
 
+@requires_o_tmpfile
 def test_bound_raw_corruption_fails_before_any_oci_call(tmp_path: Path) -> None:
     context = _context(tmp_path)
     candidate_id = context.rebuilt.candidate_ids[0]
@@ -995,6 +1007,7 @@ def test_raw_binding_rejects_equal_valued_float_size_alias(tmp_path: Path) -> No
         campaign._validate_raw_binding(context, candidate_id, seed, attempt)
 
 
+@requires_o_tmpfile
 def test_completed_bundle_without_pointer_repairs_only_the_pointer(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1033,6 +1046,7 @@ def test_completed_bundle_without_pointer_repairs_only_the_pointer(
     assert campaign._scan_cell(context, candidate_id, seed).pointer_present is True
 
 
+@requires_o_tmpfile
 def test_duplicate_completed_and_resumable_attempts_fail_closed(tmp_path: Path) -> None:
     context = _context(tmp_path)
     candidate_id = context.rebuilt.candidate_ids[0]
@@ -1055,6 +1069,7 @@ def test_duplicate_completed_and_resumable_attempts_fail_closed(tmp_path: Path) 
         campaign._scan_cell(context, candidate_id, seed)
 
 
+@requires_o_tmpfile
 def test_unknown_symlink_and_hardlinked_dynamic_artifacts_fail_closed(
     tmp_path: Path,
 ) -> None:
@@ -1102,6 +1117,7 @@ def test_unknown_symlink_and_hardlinked_dynamic_artifacts_fail_closed(
         campaign._scan_cell(hardlink_context, hard_candidate, hard_seed)
 
 
+@requires_o_tmpfile
 def test_final_artifacts_are_forbidden_early_and_exact_after_complete_block(
     tmp_path: Path,
 ) -> None:
@@ -1157,6 +1173,7 @@ def test_final_artifacts_are_forbidden_early_and_exact_after_complete_block(
     campaign._finalize_or_validate(context, scans, create=False)
 
 
+@requires_o_tmpfile
 def test_self_consistent_execution_receipt_index_tamper_fails_replay(
     tmp_path: Path,
 ) -> None:
@@ -1195,6 +1212,7 @@ def test_self_consistent_execution_receipt_index_tamper_fails_replay(
         campaign._finalize_or_validate(context, scans, create=False)
 
 
+@requires_o_tmpfile
 def test_run_mode_repairs_payload_first_sidecar_interruption(tmp_path: Path) -> None:
     context = _context(tmp_path)
     candidate_id = context.rebuilt.candidate_ids[0]
@@ -1221,6 +1239,7 @@ def test_run_mode_repairs_payload_first_sidecar_interruption(tmp_path: Path) -> 
     assert sidecar.is_file()
 
 
+@requires_o_tmpfile
 def test_persisted_live_runtime_identity_drift_fails_closed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1336,6 +1355,7 @@ def test_prepare_rejects_parent_symlink_redirection_before_qualification_write(
     assert not (safe_parent / "nested-parent" / "campaign").exists()
 
 
+@requires_o_tmpfile
 def test_anonymous_publication_failure_leaves_no_visible_partial(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1350,6 +1370,18 @@ def test_anonymous_publication_failure_leaves_no_visible_partial(
     assert list(tmp_path.iterdir()) == []
 
 
+@pytest.mark.skipif(HAS_O_TMPFILE, reason="Linux publishes the artifact instead of refusing")
+def test_publication_fails_closed_without_o_tmpfile(tmp_path: Path) -> None:
+    with pytest.raises(
+        campaign.ForagerMatchedCampaignError,
+        match="O_TMPFILE is required for crash-safe publication",
+    ):
+        campaign._publish_bytes(tmp_path / "artifact.json", b"{}")
+
+    assert list(tmp_path.iterdir()) == []
+
+
+@requires_o_tmpfile
 def test_campaign_lock_rejects_a_concurrent_writer(tmp_path: Path) -> None:
     root = tmp_path / "locked-campaign"
     root.mkdir()

--- a/tests/test_forager_matched_fd_cleanup.py
+++ b/tests/test_forager_matched_fd_cleanup.py
@@ -17,11 +17,14 @@ import pytest
 
 from alberta_framework.benchmarks import forager_matched_executor as executor
 from alberta_framework.benchmarks import forager_matched_qualification as qualification
+from tests._forager_matched_platform import HAS_PROCFS_DESCRIPTORS
 
 pytestmark = pytest.mark.unit
 
 
 def _open_fd_count() -> int:
+    if not HAS_PROCFS_DESCRIPTORS:
+        pytest.skip("descriptor-count regression requires procfs")
     return len(list(Path("/proc/self/fd").iterdir()))
 
 

--- a/tests/test_forager_matched_qualification.py
+++ b/tests/test_forager_matched_qualification.py
@@ -38,6 +38,12 @@ from alberta_framework.benchmarks import forager_matched_executor as executor
 from alberta_framework.benchmarks import forager_matched_open_protocol as builder
 from alberta_framework.benchmarks import forager_matched_qualification as qualification
 from alberta_framework.benchmarks.forager_matched_protocol import SourceBinding
+from tests._forager_matched_platform import (
+    HAS_PROCFS_DESCRIPTORS,
+    HAS_RENAMEAT2,
+    requires_procfs_descriptors,
+    requires_renameat2,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -2440,6 +2446,7 @@ def test_public_api_allows_intended_outputs_forager_sibling(
     assert not output.exists()
 
 
+@requires_renameat2
 def test_publication_is_atomic_and_never_replaces_existing_directory(tmp_path: Path) -> None:
     source = tmp_path / "partial"
     source.mkdir()
@@ -2468,6 +2475,27 @@ def test_publication_is_atomic_and_never_replaces_existing_directory(tmp_path: P
     assert (destination / "manifest.json").read_bytes() == b"{}"
 
 
+@pytest.mark.skipif(HAS_RENAMEAT2, reason="Linux publishes the directory instead of refusing")
+def test_publication_fails_closed_without_renameat2(tmp_path: Path) -> None:
+    source = tmp_path / "partial"
+    source.mkdir()
+    (source / "manifest.json").write_bytes(b"{}")
+    destination = tmp_path / "final"
+
+    with pytest.raises(
+        qualification.ForagerMatchedQualificationError,
+        match="atomic no-replace publication is unavailable on this platform",
+    ):
+        qualification._publish_directory_no_replace(  # noqa: SLF001
+            source,
+            destination,
+            tmp_path,
+        )
+    assert not destination.exists()
+    assert (source / "manifest.json").read_bytes() == b"{}"
+
+
+@requires_renameat2
 def test_publication_parent_fsync_failure_is_published_uncertain(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2555,6 +2583,7 @@ def test_publication_rejects_parent_or_staging_inode_substitution(tmp_path: Path
     assert not (stable_parent / "final").exists()
 
 
+@requires_renameat2
 def test_publication_detects_destination_inode_substitution_after_rename(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2591,6 +2620,7 @@ def test_publication_detects_destination_inode_substitution_after_rename(
     assert (tmp_path / "displaced-final/manifest.json").read_bytes() == b"{}"
 
 
+@requires_renameat2
 def test_publication_detects_destination_replacement_inside_validator(
     tmp_path: Path,
 ) -> None:
@@ -2622,6 +2652,7 @@ def test_publication_detects_destination_replacement_inside_validator(
     assert (displaced / "manifest.json").read_bytes() == b"{}"
 
 
+@requires_procfs_descriptors
 def test_verified_tree_fsyncs_files_and_directories_bottom_up(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2699,6 +2730,8 @@ def test_verified_tree_rejects_link_and_detects_replacement_during_fsync(
     ):
         qualification._durably_sync_verified_tree(linked_root)  # noqa: SLF001
 
+    if not HAS_PROCFS_DESCRIPTORS:
+        pytest.skip("the replacement race reads descriptor paths back through procfs")
     race_root = tmp_path / "race"
     race_root.mkdir()
     payload = race_root / "payload"
@@ -2934,6 +2967,7 @@ def test_qualification_fresh_replay_failure_cleans_before_publication(
     assert not output.exists()
 
 
+@requires_renameat2
 def test_qualification_final_loader_failure_is_published_uncertain(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2975,6 +3009,7 @@ def test_qualification_final_loader_failure_is_published_uncertain(
     assert not list(tmp_path.glob(f".{output.name}.partial-*"))
 
 
+@requires_renameat2
 def test_qualification_post_publish_replay_failure_is_published_uncertain(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3029,6 +3064,7 @@ def test_qualification_post_publish_replay_failure_is_published_uncertain(
     assert not list(tmp_path.glob(f".{output.name}.partial-*"))
 
 
+@requires_renameat2
 def test_qualification_post_publish_returned_closure_mismatch_is_uncertain(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_forager_matched_seal.py
+++ b/tests/test_forager_matched_seal.py
@@ -33,6 +33,11 @@ from alberta_framework.benchmarks import forager_matched_executor as executor
 from alberta_framework.benchmarks import forager_matched_protocol as protocol
 from alberta_framework.benchmarks import forager_matched_seal as seal
 from tests import test_forager_matched_evidence as evidence_fixtures
+from tests._forager_matched_platform import (
+    HAS_RENAMEAT2,
+    requires_procfs_descriptors,
+    requires_renameat2,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -370,6 +375,7 @@ def _roots(tmp_path: Path) -> tuple[Path, Path, Path]:
     return qualification_root, campaign_root, tmp_path / "seal"
 
 
+@requires_renameat2
 def test_atomic_seal_round_trip_keeps_content_and_external_trust_separate(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -590,6 +596,7 @@ def test_execution_plan_rejects_non_integer_horizon(
         )
 
 
+@requires_renameat2
 def test_literal_v1_qualification_carriers_and_seal_manifest_are_rejected(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -654,6 +661,7 @@ def test_literal_v1_qualification_carriers_and_seal_manifest_are_rejected(
         seal._validate_manifest_shape(legacy_manifest)
 
 
+@requires_renameat2
 def test_content_valid_cache_cannot_authenticate_itself(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -682,6 +690,7 @@ def test_content_valid_cache_cannot_authenticate_itself(
         )
 
 
+@requires_renameat2
 def test_no_authenticated_wrapper_is_exposed_and_authentication_returns_plain_bindings(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -741,6 +750,7 @@ def test_create_rejects_anchor_and_subject_pins_before_resolver(
     assert not output_root.exists()
 
 
+@requires_renameat2
 def test_authentication_rejects_all_pin_mismatches_before_resolver(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -849,6 +859,31 @@ def test_resolver_failure_creates_no_output_or_parent(
     assert not output_root.parent.exists()
 
 
+@pytest.mark.skipif(HAS_RENAMEAT2, reason="Linux publishes the bundle instead of refusing")
+def test_publication_fails_closed_without_renameat2(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    completed, bindings = _completed_campaign(tmp_path)
+    _install_completed_loader(monkeypatch, completed)
+    qualification_root, campaign_root, output_root = _roots(tmp_path)
+
+    with pytest.raises(
+        seal.ForagerMatchedSealError,
+        match="renameat2 is required for seal publication",
+    ):
+        seal.create_forager_matched_seal_bundle(
+            qualification_root,
+            campaign_root,
+            output_root,
+            resolver=lambda _request: bindings,
+            expected_trust_anchor_identity=bindings.trust_anchor_identity,
+        )
+    assert not output_root.exists()
+    assert not tuple(output_root.parent.glob(".seal-partial-*"))
+
+
+@requires_renameat2
 def test_create_replays_then_fsyncs_then_publishes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -953,6 +988,7 @@ def test_existing_output_is_never_replaced_or_resolved(
     assert marker.read_text(encoding="utf-8") == "existing"
 
 
+@requires_renameat2
 def test_publish_loses_a_concurrent_create_without_replacing_it(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1067,6 +1103,7 @@ def test_parent_inode_substitution_is_rejected_without_touching_replacement(
     assert not tuple(moved_parent.glob(".seal-partial-*"))
 
 
+@requires_renameat2
 def test_parent_fsync_failure_reports_published_destination_as_uncertain(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1093,6 +1130,7 @@ def test_parent_fsync_failure_reports_published_destination_as_uncertain(
     assert seal.load_forager_matched_seal_bundle_content(output_root).output_root == output_root
 
 
+@requires_renameat2
 def test_post_publish_replay_failure_reports_destination_as_uncertain(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1132,6 +1170,7 @@ def test_post_publish_replay_failure_reports_destination_as_uncertain(
     assert (output_root / "seal.json").is_file()
 
 
+@requires_renameat2
 def test_loader_rejects_unknown_links_and_artifact_tampering(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1163,6 +1202,7 @@ def test_loader_rejects_unknown_links_and_artifact_tampering(
         seal.load_forager_matched_seal_bundle_content(output_root)
 
 
+@requires_renameat2
 def test_seal_closes_over_canonical_plan_and_live_runtime_artifacts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1283,6 +1323,7 @@ def test_frozen_selection_replay_cap_rejects_before_resolver(
     assert not output_root.exists()
 
 
+@requires_renameat2
 def test_loader_detects_inventory_mutation_after_all_artifact_reads(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1324,6 +1365,7 @@ def test_loader_detects_inventory_mutation_after_all_artifact_reads(
     assert injected is True
 
 
+@requires_renameat2
 def test_loader_holds_original_root_inode_and_rejects_path_swap(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1364,6 +1406,8 @@ def test_loader_holds_original_root_inode_and_rejects_path_swap(
     assert not (output_root / "seal.json").exists()
 
 
+@requires_renameat2
+@requires_procfs_descriptors
 def test_fsync_walk_visits_all_files_before_root_directory(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_forager_matched_sealed_evaluation_campaign.py
+++ b/tests/test_forager_matched_sealed_evaluation_campaign.py
@@ -41,6 +41,7 @@ from alberta_framework.benchmarks import forager_matched_trust as trust
 from tests import test_forager_matched_executor as executor_fixtures
 from tests import test_forager_matched_final_analysis as final_analysis_fixtures
 from tests import test_forager_matched_open_protocol as protocol_fixtures
+from tests._forager_matched_platform import HAS_RENAMEAT2, requires_renameat2
 
 pytestmark = pytest.mark.integration
 
@@ -421,6 +422,8 @@ def test_exact_six_by_thirty_manifest_and_initial_inventory(tmp_path: Path) -> N
             "c563582c1c40176af9eadf3a98475e99ea2851a36a8aad6ab14571f5198b1cd1"
         ),
     }
+    if not HAS_RENAMEAT2:
+        pytest.skip("the published inventory half requires Linux renameat2")
     _publish_context(context)
     expected = {
         "runs",
@@ -567,6 +570,7 @@ def test_postpublication_verify_failure_is_uncertain_and_preserves_destination(
     assert (output / "preserved").read_bytes() == b"published"
 
 
+@requires_renameat2
 def test_read_only_verification_never_authenticates_or_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -611,6 +615,7 @@ def test_read_only_verification_never_authenticates_or_writes(
     assert after == before
 
 
+@requires_renameat2
 def test_run_recovers_bound_raw_then_repairs_missing_completion_pointer(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -699,6 +704,7 @@ def test_run_recovers_bound_raw_then_repairs_missing_completion_pointer(
     assert len(auth_calls) == 3
 
 
+@requires_renameat2
 @pytest.mark.slow
 def test_full_evaluation_finalizes_stage_specific_unresolved_content(
     tmp_path: Path,

--- a/tests/test_forager_matched_sealed_evaluation_campaign_adversarial.py
+++ b/tests/test_forager_matched_sealed_evaluation_campaign_adversarial.py
@@ -39,6 +39,11 @@ from alberta_framework.benchmarks import (
 )
 from tests import test_forager_matched_evidence as evidence_fixtures
 from tests import test_forager_matched_seal as seal_fixtures
+from tests._forager_matched_platform import (
+    HAS_RENAMEAT2,
+    requires_o_tmpfile,
+    requires_renameat2,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -314,6 +319,8 @@ def _tree_snapshot(root: Path) -> tuple[tuple[str, str, str], ...]:
 
 @pytest.fixture(scope="module")
 def real_seal_bundle(tmp_path_factory: pytest.TempPathFactory) -> Any:
+    if not HAS_RENAMEAT2:
+        pytest.skip("a real seal bundle can only be published with Linux renameat2")
     root = tmp_path_factory.mktemp("sealed-campaign-real-auth")
     _manifest, _raw, qualification_digest = _qualification_material()
     patcher = pytest.MonkeyPatch()
@@ -488,6 +495,7 @@ def test_exact_six_by_thirty_rebuild_and_seed_major_schedule(
     assert [cell["ordinal"] for cell in schedule["cells"]] == list(range(180))
 
 
+@requires_renameat2
 def test_initial_publication_has_exact_immutable_inventory(tmp_path: Path) -> None:
     inputs = _synthetic_inputs(tmp_path)
     live = _fake_live()
@@ -554,6 +562,7 @@ def test_publication_rejects_changed_qualification_bytes_before_writing(
     assert not output_root.parent.exists()
 
 
+@requires_renameat2
 def test_v1_campaign_manifest_is_rejected_as_nonexact(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -884,6 +893,7 @@ def test_run_auth_failure_does_not_repair_and_resolver_precedes_engine(
     assert events == ["load", "resolver", "engine"]
 
 
+@requires_o_tmpfile
 def test_read_only_entry_points_never_resolve_authority(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -986,6 +996,7 @@ def test_completion_summary_rejects_false_authority_and_closure(tmp_path: Path) 
         validator(context, receipt, scores, request, numeric_alias)
 
 
+@requires_o_tmpfile
 def test_partial_final_artifacts_fail_closed_without_repair(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1026,6 +1037,7 @@ def test_partial_final_artifacts_fail_closed_without_repair(
     assert not partial.with_name(f"{partial.name}.sha256").exists()
 
 
+@requires_o_tmpfile
 def test_root_and_dynamic_root_substitution_are_rejected(tmp_path: Path) -> None:
     root = tmp_path / "root-swap" / "evaluation"
     _minimal_locked_root(root)


### PR DESCRIPTION

Fixes #1981.


Declares the Linux-only platform requirement on the 62 `forager_matched` tests that have failed on macOS since they landed, without weakening a single library guard.

Test-only. No file under `alberta_framework/` is modified. `git diff --stat 47976036c254ac895e896c8244714eebd345b6bb` is 7 files, **193 insertions, 0 deletions**.

## The defect

Matched-current publication deliberately depends on three Linux-only kernel primitives and every library call site fails closed elsewhere:

| Primitive | Guard site | Message |
|---|---|---|
| `os.O_TMPFILE` | `forager_matched_campaign.py:663` | `O_TMPFILE is required for crash-safe publication` |
| `renameat2` | `forager_matched_seal.py:1568` | `renameat2 is required for seal publication` |
| `renameat2` | `forager_matched_qualification.py:3904` | `atomic no-replace publication is unavailable on this platform` |
| `renameat2` | `forager_matched_campaign.py:558` | `renameat2 is required for exclusive publication` |
| `/proc/self/fd` | read directly by the descriptor-leak and fsync-order tests | — |

Sixty-two tests were written against those publishers in `6df2fbe4` without declaring the requirement. On darwin `hasattr(os, "O_TMPFILE")` is `False` and `dlsym(RTLD_DEFAULT, "renameat2")` raises, so all the refusals are correct; the downstream symptoms (`Regex pattern did not match`, `assert None is not None`, four fixture ERRORs) are consequences of the same three refusals, not separate defects.

CI runs the full suite on `ubuntu-latest` only (`ci.yml` ~312-380); the `macos-14`/`windows-latest` `portability` job (`ci.yml` ~180-230) runs a fixed 7-test panel containing none of these files. The failure is structurally invisible.

## The fix, grouped by primitive

The commit is deliberately separable into three groups.

**Shared predicates.** New `tests/_forager_matched_platform.py` (60 lines) runs *each guard's own probe* rather than a platform string: `getattr(os, "O_TMPFILE", 0)`, the same `ctypes` `dlsym` lookup the guards use, and `Path("/proc/self/fd").is_dir()`. It exposes three `skipif` marks plus their booleans. procfs is probed independently of the other two because, unlike them, it can also be missing on Linux — which is exactly why `test_forager_matched_container_hardening` already guards it at runtime.

**O_TMPFILE** — `@requires_o_tmpfile` on 23 functions: 20 in `test_forager_matched_campaign.py` (24 node ids) and 3 in `..._sealed_evaluation_campaign_adversarial.py`.

**renameat2** — `@requires_renameat2` on 26 functions: 14 in `test_forager_matched_seal.py`, 7 in `test_forager_matched_qualification.py`, 3 in `..._sealed_evaluation_campaign.py` (one of which is `slow` and therefore deselected in this lane), 2 in the adversarial file. The adversarial module-scoped `real_seal_bundle` fixture now skips rather than erroring, which covers its 4 dependants and any future one in a single place.

**procfs** — `@requires_procfs_descriptors` on the two fsync-order tests, and `test_forager_matched_fd_cleanup._open_fd_count` now skips exactly like `test_forager_matched_container_hardening._descriptor_count`.

### Tighter guards where a test is only partly platform-bound

Two tests are **not** blanket-skipped, so their portable halves still execute off Linux:

- `test_verified_tree_rejects_link_and_detects_replacement_during_fsync` still asserts symlink/special-file rejection, and skips only at the procfs replacement race.
- `test_exact_six_by_thirty_manifest_and_initial_inventory` still asserts the entire 6x30 manifest shape, candidate ordering, and threat-boundary block, and skips only at the published-inventory half.

### Positive fail-closed assertions, not just skips

Three mirrored cases pin the platform contract instead of merely stepping around it, one per guard site — each asserts the documented message *and* that no partial artifact is left behind:

- `test_publication_fails_closed_without_o_tmpfile` (`_publish_bytes`)
- `test_publication_fails_closed_without_renameat2` (`create_forager_matched_seal_bundle`)
- `test_publication_fails_closed_without_renameat2` (`_publish_directory_no_replace`)

All three pass on macOS and skip on Linux.

## Verification (Darwin 25.2.0, arm64, Python 3.13.5, pytest 9.1.1)

Per file, `-m "not slow and not package" -p no:randomly`:

| File | Before | After |
|---|---|---|
| `test_forager_matched_campaign.py` | 25 failed, 18 passed | **1 failed, 19 passed, 24 skipped** |
| `test_forager_matched_seal.py` | 14 failed, 19 passed | **20 passed, 14 skipped** |
| `test_forager_matched_qualification.py` | 9 failed, 108 passed | **109 passed, 9 skipped** |
| `..._sealed_evaluation_campaign.py` | 3 failed, 12 passed, 1 desel. | **12 passed, 3 skipped, 1 desel.** |
| `..._sealed_evaluation_campaign_adversarial.py` | 5 failed, 13 passed, 4 errors | **13 passed, 9 skipped** |
| `test_forager_matched_fd_cleanup.py` | 2 failed | **2 skipped** |

**Reconciliation: 62 red (58 failed + 4 errors) -> 61 skipped + 1 still failing.** The `+3` in passed counts (18->19, 19->20, 108->109) are the three new mirrored contract tests.

Whole forager family (58 files, `tests/test_forager*.py`), same flags:

- before: **60 failed, 941 passed, 4 skipped, 140 deselected, 4 errors**
- after: **3 failed, 944 passed, 65 skipped, 140 deselected**
- delta: +61 skips, +3 passes, -61 red. The 2 residual non-golden failures (`test_forager_matched_qualification_integration.py::test_builtin_git_tar_ignores_repository_local_archive_commands` and `test_forager_matrix.py::test_schema_23_real_tiny_rtu_run_captures_and_recomputes_raw_trace`) reproduce identically at the base commit and are untouched by this change.

Suite collection: **15369 -> 15372**, exactly the three new cases. The helper module is not collected (it does not match `test_*.py`), and `grep -rl _forager_matched_platform` returns exactly the six modified files, so no other test can be affected.

**Whole non-slow, non-package suite** (443 files split across 4 parallel processes; `pytest-xdist` is not installed here, so this is 4 plain `pytest` runs over disjoint file sets, ~35 min each):

```
shard0  4 failed, 3904 passed, 13 skipped, 149 deselected
shard1  2 failed, 2576 passed, 30 skipped, 388 deselected
shard2  1 failed, 3859 passed, 20 skipped, 425 deselected
shard3  5 failed, 3690 passed, 18 skipped, 289 deselected
-----   12 failed, 14029 passed, 81 skipped, 1251 deselected
```

All 12 residual failures are accounted for and none is a regression from this change:

| Failure | Owner |
|---|---|
| `test_forager_matched_campaign.py::test_open_campaign_v2_golden_byte_contract` | deliberately out of scope (below) |
| `test_off_policy_td.py::test_config_scalars_canonicalize_reals_and_preserve_infinity_clip_sentinel` | separate `np.longdouble` aarch64 defect |
| `test_reference_life_scorecard.py` x2 | separate O_TMPFILE scorecard defect |
| `test_ipmnist_local_prereg.py` x3 | separate prereg-config defect |
| `test_step_smoke_record_shapes.py` x2 | separate stale-fixture defect |
| `test_package_import_boundaries.py::test_gymnasium_adapter_runtime_annotations_remain_resolvable` | separate `package`-lane `NameError` |
| `test_forager_matched_qualification_integration.py::test_builtin_git_tar_ignores_repository_local_archive_commands` | pre-existing, unrelated, reproduces at base |
| `test_forager_matrix.py::test_schema_23_real_tiny_rtu_run_captures_and_recomputes_raw_trace` | pre-existing, unrelated, reproduces at base |

Zero failures remain in the six files this PR touches, apart from the one deliberately left red.

Gates: `ruff check .` -> *All checks passed!*; `mypy` -> *Success: no issues found in 190 source files*.

## Linux behaviour is unchanged — how that was checked

No Linux box or container is available here (Docker daemon not running), so Linux was **not** executed. Instead the three predicates were forced `True` at collection time on this same macOS box via a throwaway pytest plugin that rebinds `tests._forager_matched_platform` before any test module imports it, then the six files were run:

```
58 failed, 170 passed, 3 skipped, 1 deselected, 4 errors
SKIPPED [1] test_forager_matched_campaign.py:1373: Linux publishes the artifact instead of refusing
SKIPPED [1] test_forager_matched_seal.py:862: Linux publishes the bundle instead of refusing
SKIPPED [1] test_forager_matched_qualification.py:2478: Linux publishes the directory instead of refusing
```

That is **the pristine baseline outcome distribution exactly** — 58 failed + 4 errors + 170 passed — with the only skips being the three new non-Linux contract cases. So when the predicates are true, every test that ran before still runs, still executes the same body, and still asserts the same thing; the two inline mid-test guards also do not fire; and the three new tests correctly stand down.

What this does **not** prove: that the predicates evaluate `True` on a real Linux kernel. That rests on reading the code — the predicates run the identical probes the library guards run (`getattr(os, "O_TMPFILE", 0)`, `getattr(ctypes.CDLL(None), "renameat2", None)`, `Path("/proc/self/fd").is_dir()`), so a predicate can only be `False` where the corresponding guard would itself refuse. A Linux CI run is the confirming evidence and I could not produce one.

## Deliberately left failing

`test_open_campaign_v2_golden_byte_contract` is **not** touched and still fails on macOS. It needs no platform primitive; it fails on a real digest divergence in 3 of 9 frozen golden payloads (`open-protocol.json`, `execution-schedule.json`, `campaign.json`) at `tests/test_forager_matched_campaign.py:476`. Re-pinning a frozen golden from the failing side is forbidden by `CLAUDE.md`, and the macOS/Linux byte divergence is a separate open question. It stays red on purpose.

## Other limitations I want to be explicit about

- The `slow`-marked `test_full_evaluation_finalizes_stage_specific_unresolved_content` was outside the measured 62 (it is deselected by `-m "not slow"`). I ran it explicitly, measured the same `renameat2 is required for seal publication` refusal, and gated it on that measurement. It is the one test in this diff whose gate comes from a targeted run rather than the sweep.
- Each test carries the mark for the primitive whose refusal I **measured**. Some campaign tests reach `_publish_initial_root`, which uses `O_TMPFILE` first and `renameat2` afterwards; they carry only `@requires_o_tmpfile` because that is where they actually stop. On every platform in the support matrix the two are co-present, so this is precise in practice, but I did not add a second mark I could not exercise.
- Windows was not tested. `_probe_renameat2` catches `OSError` from `ctypes.CDLL(None)` so that a Windows collection would skip rather than error at import, but I could not verify that path.
- Two tests now report as SKIPPED on macOS even though a portable prefix executed (the two tighter guards above). That is intentional and matches the existing container-hardening idiom, but skip counts alone will not show that the portable halves ran.

## Evidence-promotion impact

None. No path under `tests/` appears in the five-claim registered-source inventory in `alberta_framework/evaluation/evidence_manifest.py` (`grep` for `forager` or `tests/` there returns 0 hits; the registered paths are all under `alberta_framework/core`, `alberta_framework/evaluation`, and `alberta_framework/streams`). `alberta-evidence-status` output is byte-identical before and after this change apart from its `validation_timestamp_utc` fields, exiting `2` in both cases — a pre-existing state at the base commit, not something this change introduces. Nothing under `outputs/` is read or written.
---

## Whole-suite re-measurement (macOS 15 / Darwin 25.2.0, arm64)

Re-measured on `47976036c254ac895e896c8244714eebd345b6bb` with a 6-way sharded sweep of the full `tests/` tree (`-q -p no:randomly -m "not slow"`), comparing pristine `origin/main` against a branch merging this fix together with its three sibling platform fixes:

| | failing/erroring node ids |
|---|---|
| pristine `origin/main` | **68** |
| main + the four platform fixes | **3** |

Set-differencing the sorted node-id lists: **65 reds cleared, zero regressions** — `comm -13` between the two lists is empty, so no test that passed on main fails with these changes.

The 3 residuals are all pre-existing on main and untouched by this work: `test_open_campaign_v2_golden_byte_contract` (a separate, filed architecture-reproducibility defect), `test_schema_23_real_tiny_rtu_run_captures_and_recomputes_raw_trace` (needs the `forager`/`gymnasium` extras, which this review venv lacks and CI installs), and `test_wheel_and_sdist_are_complete_and_hard_link_safe`.
