### PR TITLE
test(forager-matched): run the Git archive contract through a singly linked wrapper

### DIFF
--- a/tests/test_forager_matched_qualification_integration.py
+++ b/tests/test_forager_matched_qualification_integration.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import hashlib
 import io
 import os
+import shlex
 import shutil
+import stat
 import subprocess
 import sys
 import tarfile
@@ -137,12 +139,57 @@ def test_bounded_process_timeout_leaves_no_live_child_pid() -> None:
         os.kill(pid, 0)
 
 
+def _singly_linked_git(git: str, tmp_path: Path) -> Path:
+    """Return a singly linked path that runs the host Git.
+
+    `_bind_git_runtime` hashes the resolved executable through `_sha256_file`,
+    which admits only a singly linked regular file.  macOS Command Line Tools
+    ships `/usr/bin/git` as one of many hard links to a multi-call shim, so
+    binding the host path directly is refused there.  A `sh` wrapper that
+    `exec`s the host Git is itself a singly linked regular file, is accepted by
+    the bind, and forwards its argv unchanged -- so the archive contract below
+    is exercised on that platform instead of being skipped.
+    """
+
+    resolved = Path(git).resolve(strict=True)
+    metadata = resolved.stat()
+    if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink == 1:
+        return resolved
+    wrapper = tmp_path / "git-wrapper"
+    wrapper.write_text(f'#!/bin/sh\nexec {shlex.quote(resolved.as_posix())} "$@"\n')
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def test_git_binding_refuses_a_multiply_linked_executable(tmp_path: Path) -> None:
+    executable = tmp_path / "git"
+    executable.write_bytes(b"multi-call-shim")
+    executable.chmod(0o755)
+    alias = tmp_path / "git-alias"
+    try:
+        os.link(executable, alias)
+    except OSError as error:  # pragma: no cover - filesystem without hard links
+        pytest.skip(f"filesystem does not support hard links: {error}")
+
+    with pytest.raises(
+        qualification.ForagerMatchedQualificationError,
+        match="is not a bounded regular file",
+    ):
+        qualification._bind_git_runtime(executable)  # noqa: SLF001
+
+    alias.unlink()
+    identity = qualification._bind_git_runtime(executable)  # noqa: SLF001
+    assert identity.executable == executable.resolve()
+    assert identity.executable_sha256 == hashlib.sha256(b"multi-call-shim").hexdigest()
+
+
 def test_builtin_git_tar_ignores_repository_local_archive_commands(
     tmp_path: Path,
 ) -> None:
     git = shutil.which("git", path=os.defpath)
     if git is None:
         pytest.skip("system Git is unavailable")
+    binding = _singly_linked_git(git, tmp_path)
     repository = tmp_path / "repository"
     environment = qualification._git_environment()  # noqa: SLF001
     commands = (
@@ -183,7 +230,7 @@ def test_builtin_git_tar_ignores_repository_local_archive_commands(
             timeout=10,
             env=environment,
         )
-    identity = qualification._bind_git_runtime(Path(git))  # noqa: SLF001
+    identity = qualification._bind_git_runtime(binding)  # noqa: SLF001
     completed = qualification._run_bounded_process(  # noqa: SLF001
         qualification._git_command(  # noqa: SLF001
             identity,


### PR DESCRIPTION

Fixes #1982.

## What was wrong

`_bind_git_runtime` hashes the resolved Git executable through `_sha256_file`, which admits only a singly linked regular file. macOS Command Line Tools ships `/usr/bin/git` as one of many hard links to a multi-call shim (`st_nlink == 78` on the test host), so the bind is refused before any archive runs and `test_builtin_git_tar_ignores_repository_local_archive_commands` is permanently red on that platform. CI does not see it: the full suite is `ubuntu-latest` only, and the macOS/Windows portability job runs a 7-test panel that excludes this file.

The failure is entirely incidental to what the test checks. Its subject is archive-command injection via repository-local git config: it sets `tar.tar.command=false`, runs `git archive --format=tar HEAD`, and asserts the archive still yields exactly `["payload.txt"]`. The link count of the host binary has nothing to do with that contract.

## What this changes

Tests only. One file, +48/-1.

- `_singly_linked_git(git, tmp_path)` returns the resolved host Git when it is already singly linked, and otherwise writes a `#!/bin/sh\nexec <git> "$@"` wrapper and returns that. The wrapper is a singly linked regular file, so `_bind_git_runtime` accepts it unmodified, and `exec` forwards argv unchanged — the contract is exercised rather than skipped.
- `test_git_binding_refuses_a_multiply_linked_executable` covers the refusal path directly: `_bind_git_runtime` must reject a hard-linked executable with `"is not a bounded regular file"`, and must accept the same bytes once the extra link is removed. It skips where the filesystem has no hard links rather than erroring.

**No library change.** The `st_nlink != 1` guard is a deliberate hardlink-tampering defence applied uniformly across all 22 `_sha256_file` call sites, and relaxing it after seeing a red would be retuning a fail-closed guard — which CLAUDE.md forbids. It stays exactly as it is.

## Why a wrapper rather than a skip

`tar.tar.command` appears in exactly one test in the whole repository, so this is the sole guard for that contract, and the contract is not a tautology. Measured against git 2.50.1: a repository-local `tar.evil.command=false` **is** honored for a custom format (`fatal: 'false' filter reported error`, rc 128), while `tar.tar.command` is ignored for the builtin format. Repository-local config is a live command-execution channel during `git archive`; this test is the only canary that the builtin `tar` format sits outside it. Skipping on macOS would disable that canary on a platform where it can in fact run, for the sake of about four lines.

Substituting a fixture executable for the host Git is also the repo's own idiom — `tests/test_forager_matched_qualification.py` already binds a written fixture when exercising `_bind_git_runtime`.

## Measured

macOS 15 / Darwin 25.2.0, arm64, on `47976036c254ac895e896c8244714eebd345b6bb`:

| | `tests/test_forager_matched_qualification_integration.py` |
|---|---|
| base | 1 failed, 7 passed |
| this branch | **8 passed, 0 skipped** |

- `ruff check .` — All checks passed.
- `mypy` — `Found 2 errors in 1 file (checked 194 source files)`, identical to pristine `origin/main`; this branch adds none. (Both are `alberta_framework/benchmarks/ipmnist_ceiling.py` missing `optax` stubs, an environment artifact of the review box.)
- Nothing under `outputs/` touched; no registered evidence source touched.

## Not verified here

No Linux host was available. The Linux side is argued structurally rather than executed: there `/usr/bin/git` already satisfies `st_nlink == 1`, so `_singly_linked_git` returns the resolved host path and the wrapper branch is never taken, leaving the test body byte-for-byte the behaviour it has today.

---

## Whole-suite re-measurement (macOS 15 / Darwin 25.2.0, arm64)

Re-measured on `47976036c254ac895e896c8244714eebd345b6bb` with a 6-way sharded sweep of the full `tests/` tree (`-q -p no:randomly -m "not slow"`), comparing pristine `origin/main` against a branch merging this fix together with its three sibling platform fixes:

| | failing/erroring node ids |
|---|---|
| pristine `origin/main` | **68** |
| main + the four platform fixes | **3** |

Set-differencing the sorted node-id lists: **65 reds cleared, zero regressions** — `comm -13` between the two lists is empty, so no test that passed on main fails with these changes.

The 3 residuals are all pre-existing on main and untouched by this work: `test_open_campaign_v2_golden_byte_contract` (a separate, filed architecture-reproducibility defect), `test_schema_23_real_tiny_rtu_run_captures_and_recomputes_raw_trace` (needs the `forager`/`gymnasium` extras, which this review venv lacks and CI installs), and `test_wheel_and_sdist_are_complete_and_hard_link_safe`.
