### PR TITLE
fix(causal-map): evaluate the respawn quantile without FMA contraction

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -24,7 +24,6 @@ import math
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from statistics import NormalDist
 from typing import Any, NamedTuple, cast
 
 import jax
@@ -141,6 +140,219 @@ def _causal_map_environment_key(seed: int | Array) -> Array:
     if _prng_impl_name(key) != _CAUSAL_MAP_ENVIRONMENT_PRNG_IMPL:
         raise RuntimeError("causal-map environment PRNG implementation mismatch")
     return key
+
+
+def _deterministic_inv_cdf(p: float) -> float:
+    """Return the standard-normal inverse CDF without relying on contraction.
+
+    Wichura's AS241, evaluated in Python rather than through
+    :meth:`statistics.NormalDist.inv_cdf`.  The C accelerator behind that
+    method is compiled with floating-point contraction enabled, so on a target
+    with a fused multiply-add it fuses multiply-add pairs that the reference
+    rounds separately.  Two sites contract: the ``0.180625 - q * q`` step and
+    the ``x * r + c`` Horner chains; reproducing this host's accelerator output
+    across the central branch requires contracting *both*, so neither site
+    alone is a complete account of the difference.  At ``p == 0.9`` the Horner
+    contraction happens to be a no-op and the ``r`` step alone shifts the
+    result down by one ULP -- ``0x1.4813c36e26d34p+0`` where an accelerator
+    without FMA returns it, against ``0x1.4813c36e26d33p+0`` on aarch64.
+
+    That single ULP is not cosmetic here: the value reaches
+    :meth:`CausalMapForagerConfig.fingerprint` and therefore the published
+    ``protocol_sha256`` and ``schedule_sha256`` of a sealed campaign, so the
+    accelerator makes a frozen protocol identity depend on the host CPU.
+    CPython cannot contract across bytecode boundaries -- every operation
+    below is rounded exactly once, as the algorithm specifies -- so this
+    reproduces the recorded values bit-for-bit without altering a single
+    published byte.
+
+    Host-independence is unconditional on the central branch
+    (``|p - 0.5| <= 0.425``), which uses only correctly rounded arithmetic and
+    covers every quantile in the published protocol.  The tail branches
+    additionally call ``log``, which IEEE-754 does not require to be correctly
+    rounded, so those remain libm-dependent; ``sqrt`` is correctly rounded and
+    is not a concern.
+    """
+
+    q = p - 0.5
+    if math.fabs(q) <= 0.425:
+        r = 0.180625 - q * q
+        num = (
+            (
+                (
+                    (
+                        (
+                            (
+                                (
+                                    2.5090809287301226727e3 * r
+                                    + 3.3430575583588128105e4
+                                )
+                                * r
+                                + 6.7265770927008700853e4
+                            )
+                            * r
+                            + 4.5921953931549871457e4
+                        )
+                        * r
+                        + 1.3731693765509461125e4
+                    )
+                    * r
+                    + 1.9715909503065514427e3
+                )
+                * r
+                + 1.3314166789178437745e2
+            )
+            * r
+            + 3.3871328727963666080e0
+        ) * q
+        den = (
+            (
+                (
+                    (
+                        (
+                            (
+                                (5.2264952788528545610e3 * r + 2.8729085735721942674e4)
+                                * r
+                                + 3.9307895800092710610e4
+                            )
+                            * r
+                            + 2.1213794301586595867e4
+                        )
+                        * r
+                        + 5.3941960214247511077e3
+                    )
+                    * r
+                    + 6.8718700749205790830e2
+                )
+                * r
+                + 4.2313330701600911252e1
+            )
+            * r
+            + 1.0
+        )
+        return num / den
+    r = p if q <= 0.0 else 1.0 - p
+    r = math.sqrt(-math.log(r))
+    if r <= 5.0:
+        r = r - 1.6
+        num = (
+            (
+                (
+                    (
+                        (
+                            (
+                                (
+                                    7.74545014278341407640e-4 * r
+                                    + 2.27238449892691845833e-2
+                                )
+                                * r
+                                + 2.41780725177450611770e-1
+                            )
+                            * r
+                            + 1.27045825245236838258e0
+                        )
+                        * r
+                        + 3.64784832476320460504e0
+                    )
+                    * r
+                    + 5.76949722146069140550e0
+                )
+                * r
+                + 4.63033784615654529590e0
+            )
+            * r
+            + 1.42343711074968357734e0
+        )
+        den = (
+            (
+                (
+                    (
+                        (
+                            (
+                                (
+                                    1.05075007164441684324e-9 * r
+                                    + 5.47593808499534494600e-4
+                                )
+                                * r
+                                + 1.51986665636164571966e-2
+                            )
+                            * r
+                            + 1.48103976427480074590e-1
+                        )
+                        * r
+                        + 6.89767334985100004550e-1
+                    )
+                    * r
+                    + 1.67638483018380384940e0
+                )
+                * r
+                + 2.05319162663775882187e0
+            )
+            * r
+            + 1.0
+        )
+    else:
+        r = r - 5.0
+        num = (
+            (
+                (
+                    (
+                        (
+                            (
+                                (
+                                    2.01033439929228813265e-7 * r
+                                    + 2.71155556874348757815e-5
+                                )
+                                * r
+                                + 1.24266094738807843860e-3
+                            )
+                            * r
+                            + 2.65321895265761230930e-2
+                        )
+                        * r
+                        + 2.96560571828504891230e-1
+                    )
+                    * r
+                    + 1.78482653991729133580e0
+                )
+                * r
+                + 5.46378491116411436990e0
+            )
+            * r
+            + 6.65790464350110377720e0
+        )
+        den = (
+            (
+                (
+                    (
+                        (
+                            (
+                                (
+                                    2.04426310338993978564e-15 * r
+                                    + 1.42151175831644588870e-7
+                                )
+                                * r
+                                + 1.84631831751005468180e-5
+                            )
+                            * r
+                            + 7.86869131145613259100e-4
+                        )
+                        * r
+                        + 1.48753612908506148525e-2
+                    )
+                    * r
+                    + 1.36929880922735805310e-1
+                )
+                * r
+                + 5.99832206555887937690e-1
+            )
+            * r
+            + 1.0
+        )
+    x = num / den
+    if q < 0.0:
+        x = -x
+    return x
 
 
 @dataclass(frozen=True)
@@ -401,7 +613,7 @@ class CausalMapForagerConfig:
     @property
     def respawn_quantile_z(self) -> float:
         """One-sided normal quantile used with online Welford statistics."""
-        return float(NormalDist().inv_cdf(self.respawn_safety_quantile))
+        return _deterministic_inv_cdf(self.respawn_safety_quantile)
 
     def to_dict(self) -> dict[str, Any]:
         """Return a fully explicit JSON-compatible configuration."""

--- a/tests/test_causal_map_forager.py
+++ b/tests/test_causal_map_forager.py
@@ -18,15 +18,19 @@ renaming module internals is expected to require touching this file.
 
 from __future__ import annotations
 
+import ast
 import copy
 import dataclasses
 import hashlib
 import heapq
+import inspect
 import json
 import math
 import pickle
+import textwrap
 from collections.abc import Mapping
-from typing import Any, cast
+from statistics import NormalDist
+from typing import Any, Final, cast
 
 import chex
 import jax
@@ -2879,3 +2883,206 @@ def test_seed_batch_validation(monkeypatch: pytest.MonkeyPatch) -> None:
     unsafe = dataclasses.replace(benchmark, steps=np.iinfo(np.int32).max)
     with pytest.raises(ValueError, match="steps must be"):
         run_causal_map_forager_seeds(config, unsafe, (1,))
+
+
+# ---------------------------------------------------------------------------
+# Architecture-independent respawn quantile
+# ---------------------------------------------------------------------------
+
+# The exact ``respawn_quantile_z`` for every quantile the published
+# matched-current protocol uses.  These are the values the sealed campaign was
+# built from -- they appear in plaintext in the sealed configuration payloads
+# under ``outputs/forager/matched_current_qualification_2c3b214c_v1`` -- and are
+# pinned in hex so that a one-ULP drift cannot hide behind repr rounding.
+_REFERENCE_RESPAWN_QUANTILE_Z: Final = {
+    0.5: "0x0.0p+0",
+    0.75: "0x1.5956b87528a49p-1",
+    0.9: "0x1.4813c36e26d34p+0",
+}
+
+
+@pytest.mark.parametrize("quantile", sorted(_REFERENCE_RESPAWN_QUANTILE_Z))
+def test_respawn_quantile_z_matches_the_published_reference_bits(
+    quantile: float,
+) -> None:
+    """``respawn_quantile_z`` must be bit-exact on every host architecture.
+
+    The value feeds ``fingerprint()``, hence ``protocol_sha256`` and
+    ``schedule_sha256``, so a single ULP of drift changes the published
+    identity of a sealed campaign.  ``statistics.NormalDist().inv_cdf`` is a C
+    accelerator compiled with floating-point contraction enabled, which makes
+    that identity depend on whether the host has a fused multiply-add.  Pin the
+    bits, not the repr.
+    """
+
+    config = CausalMapForagerConfig(respawn_safety_quantile=quantile)
+    assert config.respawn_quantile_z.hex() == _REFERENCE_RESPAWN_QUANTILE_Z[quantile]
+
+
+def test_respawn_quantile_z_is_not_the_contracted_neighbour() -> None:
+    """Pin the drift direction, so a near-miss cannot pass as close enough.
+
+    A contracted evaluation lands on the adjacent representable double rather
+    than somewhere far away, so any assertion phrased as closeness would accept
+    the defect.  Name the wrong value explicitly instead.
+    """
+
+    reference = float.fromhex(_REFERENCE_RESPAWN_QUANTILE_Z[0.9])
+    contracted = math.nextafter(reference, 0.0)
+    assert reference != contracted
+
+    observed = CausalMapForagerConfig(respawn_safety_quantile=0.9).respawn_quantile_z
+    assert observed == reference
+    assert observed != contracted
+
+
+@pytest.mark.parametrize(
+    "quantile",
+    [
+        0.5,
+        0.6,
+        0.6886660381825473,  # measured worst-case divergence, 9 ULP
+        0.75,
+        0.837392,
+        0.9,
+        0.925,
+        0.95,
+        0.99,
+        0.999,
+        0.999999,
+        1.0 - 2.0**-40,
+    ],
+)
+def test_deterministic_inv_cdf_tracks_the_standard_library_structurally(
+    quantile: float,
+) -> None:
+    """Catch structural divergence across the whole admissible domain.
+
+    ``respawn_safety_quantile`` is validated into ``[0.5, 1.0)``, so the AS241
+    tail branches are reachable even though the published protocol only uses
+    the central one.  This holds the reimplementation to the shape of the
+    reference across that range -- a wrong branch cut, a transposed
+    numerator/denominator, or a mistyped exponent all show up here.
+
+    The tolerance is deliberately loose and is calibrated, not guessed: the
+    accelerator contracts and this implementation does not, so the two
+    legitimately disagree.  Enumerating five million consecutive doubles
+    through the worst region puts the maximum at **9 ULP** (at ``p =
+    0.6886660381825473``; the divergence histogram there is
+    ``{0: 1769290, ..., 7: 3272, 8: 315, 9: 4}``), so the bound below carries
+    the project's ``>=2x`` margin over the measured worst case.  A tight bound
+    is therefore impossible against this reference, which is exactly why
+    fine-grained coefficient integrity is pinned separately in
+    :func:`test_deterministic_inv_cdf_coefficients_are_pinned` rather than
+    inferred from agreement here.
+    """
+
+    observed = causal_map_module._deterministic_inv_cdf(quantile)  # noqa: SLF001
+    expected = NormalDist().inv_cdf(quantile)
+    assert observed == pytest.approx(expected, abs=20.0 * math.ulp(abs(expected) or 1.0))
+
+
+def test_deterministic_inv_cdf_negates_below_the_median() -> None:
+    """Cover the ``q < 0`` sign flip, which no other test reaches.
+
+    This pins branch structure, not the coefficients.  Oddness holds
+    bit-exactly for *any* coefficient values, so it cannot detect a
+    transcription error -- on the central branch it follows from the trailing
+    ``* q`` factor, and on the tail branches from the explicit ``x = -x`` sign
+    flip over a ``p``-symmetric intermediate.  Only the ``0.99``/``0.01`` pair
+    below reaches that flip; it is here because the negative-``q`` path is
+    otherwise unexecuted.
+    """
+
+    for quantile in (0.6, 0.75, 0.9, 0.99):
+        upper = causal_map_module._deterministic_inv_cdf(quantile)  # noqa: SLF001
+        lower = causal_map_module._deterministic_inv_cdf(1.0 - quantile)  # noqa: SLF001
+        assert lower == -upper
+
+
+_AS241_SOURCE_CONSTANTS: Final = (
+    0.5,
+    0.425,
+    5.0,
+    0.0,
+    0.180625,
+    1.0,
+    0.0,
+    1.0,
+    1.6,
+    1.4234371107496835,
+    1.0,
+    5.0,
+    6.657904643501103,
+    1.0,
+    3.3871328727963665,
+    42.31333070160091,
+    4.630337846156546,
+    2.053191626637759,
+    5.463784911164114,
+    0.599832206555888,
+    133.14166789178438,
+    687.1870074920579,
+    5.769497221460691,
+    1.6763848301838038,
+    1.7848265399172913,
+    0.1369298809227358,
+    1971.5909503065513,
+    5394.196021424751,
+    3.6478483247632045,
+    0.6897673349851,
+    0.29656057182850487,
+    0.014875361290850615,
+    13731.69376550946,
+    21213.794301586597,
+    1.2704582524523684,
+    0.14810397642748008,
+    0.026532189526576124,
+    0.0007868691311456133,
+    45921.95393154987,
+    39307.89580009271,
+    0.2417807251774506,
+    0.015198666563616457,
+    0.0012426609473880784,
+    1.8463183175100548e-05,
+    67265.7709270087,
+    28729.085735721943,
+    0.022723844989269184,
+    0.0005475938084995345,
+    2.7115555687434876e-05,
+    1.421511758316446e-07,
+    33430.57558358813,
+    5226.495278852854,
+    0.0007745450142783414,
+    1.0507500716444169e-09,
+    2.0103343992922881e-07,
+    2.0442631033899397e-15,
+    2509.0809287301227,
+)
+
+
+def test_deterministic_inv_cdf_coefficients_are_pinned() -> None:
+    """Freeze every literal in the quantile, to the bit.
+
+    The differential test above cannot resolve small coefficient drift,
+    because the accelerator it compares against is itself up to 7 ULP away.
+    Most single-ULP perturbations of these constants do change the function's
+    output somewhere in ``[0.5, 1.0)`` -- the exact count rises with probe
+    density, so no single figure is meaningful -- and every one of them stays
+    inside any tolerance loose enough to accommodate the accelerator.  So
+    agreement with the standard library is not sufficient evidence that the
+    transcription is intact.
+
+    Read the literals straight out of the source and compare them against a
+    frozen tuple.  The values were established by fuzzing this implementation
+    against CPython's own pure-Python ``_normal_dist_inv_cdf`` over 1,999,999
+    points with zero mismatches; this test's job is to keep them that way.
+    """
+
+    source = textwrap.dedent(inspect.getsource(causal_map_module._deterministic_inv_cdf))  # noqa: SLF001
+    observed = tuple(
+        node.value
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Constant) and isinstance(node.value, float)
+    )
+    assert observed == _AS241_SOURCE_CONSTANTS

--- a/tests/test_forager_matched_open_protocol.py
+++ b/tests/test_forager_matched_open_protocol.py
@@ -35,6 +35,7 @@ from alberta_framework.benchmarks.forager_matched_evidence import (
     MATCHED_SELECTION_BOOTSTRAP_RNG_IMPLEMENTATION_SHA256,
     MATCHED_SELECTION_STATISTIC_IMPLEMENTATION_SHA256,
 )
+from alberta_framework.benchmarks.forager_matched_executor import canonical_json_bytes
 from alberta_framework.benchmarks.forager_matched_protocol import (
     AllowedTransform,
     ConfigurationBinding,
@@ -696,3 +697,40 @@ def test_resource_accounting_semantics_fail_closed() -> None:
         builder.build_forager_matched_open_protocol(
             runtime=_runtime(), candidate_qualifications=qualifications
         )
+
+
+_SEALED_CONFIGURATIONS: Final = (
+    Path(__file__).resolve().parents[1]
+    / "outputs/forager/matched_current_qualification_2c3b214c_v1/configurations"
+)
+
+
+@pytest.mark.skipif(
+    not _SEALED_CONFIGURATIONS.is_dir(),
+    reason="sealed matched-current qualification root is not present in this tree",
+)
+def test_rebuilt_alberta_configurations_reproduce_the_sealed_bytes() -> None:
+    """Every locally built Alberta configuration must rebuild the sealed bytes.
+
+    ``matched_current_qualification_2c3b214c_v1`` is immutable, and the
+    campaign's published identity is derived from exactly these payloads.  A
+    build that no longer reproduces them byte-for-byte has changed the identity
+    of a frozen campaign, whatever the cause -- a renamed field, a reordered
+    key, or a derived float that came out one ULP different on this host.
+
+    This is the guard that was missing when
+    ``CausalMapForagerConfig.respawn_quantile_z`` silently became
+    architecture-dependent: nothing in the suite compared a rebuild against the
+    sealed root, so three causal cells drifted without any test noticing.
+    """
+
+    configurations = builder.matched_current_alberta_configurations()
+    assert configurations, "expected a non-empty Alberta configuration set"
+
+    drifted = sorted(
+        candidate_id
+        for candidate_id, configuration in configurations.items()
+        if canonical_json_bytes(configuration)
+        != (_SEALED_CONFIGURATIONS / candidate_id / "original.json").read_bytes()
+    )
+    assert not drifted, f"rebuild no longer reproduces the sealed payloads: {drifted}"


### PR DESCRIPTION

Fixes #1987.

## What was wrong

`CausalMapForagerConfig.respawn_quantile_z` derived its value through `statistics.NormalDist().inv_cdf`. That method is backed by the `_statistics` C accelerator, which is compiled with floating-point contraction enabled, so on a target with a fused multiply-add it fuses multiply-add pairs that the reference rounds separately. At `p = 0.90` the result lands one ULP low on aarch64: `0x1.4813c36e26d33p+0` against the recorded `0x1.4813c36e26d34p+0`.

That value is serialized into the payload `fingerprint()` hashes, so it reaches `protocol_sha256` and `schedule_sha256`. **The published identity of a sealed campaign depended on the host CPU.**

## The fix, and what it does to the sealed bytes

Evaluate AS241 in Python. CPython cannot contract across bytecode boundaries, so each operation is rounded exactly once as the algorithm specifies. This **restores** the recorded values rather than changing them.

Rebuilding every local Alberta configuration and comparing `canonical_json_bytes(...)` against the immutable `outputs/forager/matched_current_qualification_2c3b214c_v1/configurations/<id>/original.json`:

| | sealed payloads reproduced byte-for-byte | fingerprint mismatches vs the published protocol root |
|---|---|---|
| `origin/main` on aarch64 | **11 / 14** | **3** — `causal_e025_q090`, `causal_e050_q090`, `causal_e100_q090` |
| this branch on aarch64 | **14 / 14** | **0** |

The entire divergence is a single JSON field: sealed `"respawn_quantile_z":1.2815515655446008` against rebuilt `...446006`.

No new campaign root, no schema version bump, and **no published byte is altered** — nothing under `outputs/` is written or modified.

## The mechanism, stated accurately

Two sites in AS241 contract on this host: the `0.180625 - q * q` step and the `x * r + c` Horner chains. Measured over 200,000 central-branch points against the accelerator, agreement is 45.16% with neither contracted, 49.06% with the `r` step alone, 89.16% with the Horner chains alone, and 100.00% with both. **So neither site alone is a complete account of the difference.** At `p = 0.90` specifically the Horner contraction happens to be a no-op and the `r` step alone moves the result, which is why that one point tells a simpler story than the general case.

## Correctness of the replacement

`_deterministic_inv_cdf` transcribes the same Wichura AS241 that CPython itself uses. All 57 coefficients are bit-identical to `statistics._normal_dist_inv_cdf` and appear in identical source order. Fuzzed against CPython's own pure-Python reference (read from `Lib/statistics.py`, since the C accelerator shadows it at import) over 1,999,999 points spanning the open interval and all three branches:

```
mismatching points out of 1,999,999: 0
EXACT MATCH against CPython's pure-Python AS241 across the whole open interval.
```

**Scope of the host-independence guarantee, stated precisely:** it is unconditional on the central branch (`|p - 0.5| <= 0.425`), which uses only correctly rounded arithmetic and covers every quantile the published protocol uses (`_RESPAWN_QUANTILES = (0.5, 0.75, 0.9)`). The tail branches additionally call `log`, which IEEE-754 does not require to be correctly rounded, so a configuration with `respawn_safety_quantile > 0.925` would remain libm-dependent. `sqrt` is correctly rounded and is not a concern. This PR does not claim to fix that residual, and no configuration in the repository reaches it.

## Tests

Written failing-first. Red on unmodified `main` (aarch64) at exactly the `q = 0.90` assertions, which is the defect.

- `test_respawn_quantile_z_matches_the_published_reference_bits` — pins `respawn_quantile_z` in hex for each quantile the protocol uses. The pinned values are **not** circular: they appear in plaintext in the sealed qualification payloads, independently of the code that now produces them.
- `test_respawn_quantile_z_is_not_the_contracted_neighbour` — names the wrong value explicitly, because a contracted evaluation lands on the *adjacent* double and any assertion phrased as closeness would accept the defect.
- `test_deterministic_inv_cdf_tracks_the_standard_library_structurally` — parametrized across the admissible `[0.5, 1.0)` domain including both tail branches, which the published protocol never reaches but configuration validation admits. **The tolerance is calibrated, not guessed:** the accelerator contracts and this implementation does not, so the two legitimately disagree. Enumerating five million consecutive doubles through the worst region puts the maximum at **9 ULP** at `p = 0.6886660381825473` (histogram there: `{0: 1769290, …, 7: 3272, 8: 315, 9: 4}`). The assertion is set at 20 ULP — a **2.22× margin** over the measured worst case, satisfying this project's `>=2x` rule — and the parametrization includes both that 9-ULP point and an 8-ULP one, so the bound is actually exercised rather than merely asserted.
- `test_deterministic_inv_cdf_negates_below_the_median` — covers the `q < 0` sign-flip branch, which nothing else executes. Its docstring says plainly that it pins the *branch*, not the coefficients: the flip is applied to a `q`-symmetric intermediate, so oddness holds bit-exactly for any coefficient values and has no transcription-detection power.
- `test_deterministic_inv_cdf_coefficients_are_pinned` — reads all 57 float literals straight out of the function's source via `ast` and compares them against a frozen tuple.
- `test_rebuilt_alberta_configurations_reproduce_the_sealed_bytes` (in `tests/test_forager_matched_open_protocol.py`) — **the guard whose absence let this drift go unnoticed.** Nothing in the suite compared a rebuild against the sealed root. It is red on pristine `main`, naming exactly the three drifted cells, and green here.

### Why coefficient integrity is pinned rather than inferred

A differential test against `statistics.NormalDist().inv_cdf` **cannot** resolve small coefficient drift, because the reference it compares against is itself up to 9 ULP away. Most single-ULP perturbations of these constants do change the function's output somewhere in `[0.5, 1.0)` — the exact count rises with probe density, so no single figure is meaningful — and every one of them stays inside any tolerance loose enough to accommodate the accelerator. Agreement with the standard library is therefore not sufficient evidence that the transcription is intact.

The frozen-constant test closes that exhaustively. Perturbing every one of the 57 float constants by one ULP in each direction, via AST rewriting so that docstring text cannot be hit by accident:

```
1-ULP mutations attempted:       114
CAUGHT by the coefficient pin:   112
no-op (nextafter == value):        2
ESCAPED:                           0
```

The two no-ops are `nextafter(0.0, ...)` at the sign-flip and branch-cut sentinels. The pinned values themselves were established independently of this test, by fuzzing the implementation against CPython's own pure-Python `_normal_dist_inv_cdf` over 1,999,999 points with zero mismatches.

## Measured

macOS 15 / Darwin 25.2.0, arm64, CPython 3.13.5:

- `tests/test_causal_map_forager.py`, `test_forager_matched_open_protocol.py`, `test_forager_matched_open_protocol_hostile_validation.py`, `test_causal_map_hostile_validation.py`, `test_causal_map_int_hostile.py`, `test_causal_map_state_string_identity_hostile.py` — **218 passed, 4 skipped**.
- `ruff check .` — All checks passed.
- `mypy` — `Found 2 errors in 1 file (checked 197 source files)`, identical to pristine `origin/main`; this branch adds none. (Both are `ipmnist_ceiling.py` missing `optax` stubs, an environment artifact of the review box.)
- No API newer than the declared `requires-python = ">=3.12"` floor is used.
- `causal_map_forager.py` is not in the registered evidence-source inventory.
- Nothing under `outputs/` touched.

## Not verified here

No x86-64 host was available, so the claim that this reproduces the reference architecture's values is supported indirectly but tightly: the sealed payloads were produced on that architecture, and this implementation reproduces all 14 of them byte-for-byte.

`tests/test_forager_matched_campaign.py::test_open_campaign_v2_golden_byte_contract` remains red on macOS after this change, for an unrelated reason — it publishes through Linux-only `O_TMPFILE`, which is the subject of a separate chain. This PR fixes the architecture-reproducibility defect; it does not claim to make that test pass on macOS.
