### PR TITLE
fix(streams): saturate partial-observation periodic clock at int32 max

### DIFF
--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -30,6 +30,7 @@ from jax import Array
 from jaxtyping import Bool, PRNGKeyArray
 
 from alberta_framework.core._float32_scalars import validated_float32_scalar
+from alberta_framework.core.normalizers import _saturating_int32_counter_increment
 from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream
 
@@ -212,7 +213,7 @@ class PartialObservationWrapper[InnerStateT]:
         else:  # PERIODIC
             assert self._schedule is not None
             mask = self._schedule[state.period_index % self._schedule.shape[0]]
-            new_period_index = state.period_index + 1
+            new_period_index = _saturating_int32_counter_increment(state.period_index)
 
         masked_obs = jnp.where(
             mask,

--- a/tests/test_partial_observation_periodic_clock.py
+++ b/tests/test_partial_observation_periodic_clock.py
@@ -1,0 +1,78 @@
+"""Saturating periodic clock keeps schedule-phase identity at int32 exhaustion.
+
+``PartialObservationWrapper`` under ``MaskMode.PERIODIC`` tracks
+``period_index`` as an int32 JAX scalar and indexes the mask schedule with
+``period_index % len(schedule)``. Incrementing that counter with plain
+``+ 1`` silently wraps ``INT32_MAX`` to ``INT32_MIN`` (signed int32
+overflow), which desyncs the observed schedule phase from the true
+(unbounded) step count: ``2**31 % 3 == 2`` but ``(-2**31) % 3 == 1``. A run
+long enough to exhaust int32 would silently start masking the wrong
+channels forever after, with no error. This mirrors the already-fixed
+lifetime/step counters elsewhere in ``alberta_framework.streams`` (Step 1,
+gauntlet, feature discovery, synthetic, out-of-class): saturate instead of
+wrapping.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from alberta_framework.streams.partial_observation import (
+    MaskMode,
+    PartialObservationWrapper,
+)
+from alberta_framework.streams.synthetic import RandomWalkStream
+
+_INT32_MAX = 2**31 - 1
+_INT32_MIN = -(2**31)
+
+
+def test_unsaturated_wraparound_would_desync_the_schedule_phase() -> None:
+    """Document the corruption a plain ``+ 1`` would cause at exhaustion.
+
+    This is a static arithmetic fact about int32 wraparound, independent of
+    the fix: the wrapped (negative) counter reduces to a different residue
+    than the true, unbounded step count would.
+    """
+    schedule_length = 3
+    true_next_step_count = 2**31  # INT32_MAX + 1, in unbounded arithmetic
+    wrapped_step_count = _INT32_MIN  # what a signed int32 `+ 1` overflow stores
+
+    true_phase = true_next_step_count % schedule_length
+    wrapped_phase = wrapped_step_count % schedule_length
+
+    assert true_phase != wrapped_phase
+
+
+def test_periodic_period_index_saturates_at_int32_max() -> None:
+    """The counter must not overflow to a negative int32 value."""
+    inner = RandomWalkStream(feature_dim=3, drift_rate=0.0, noise_std=0.0)
+    schedule = (
+        jnp.array([True, False, False]),
+        jnp.array([False, True, False]),
+        jnp.array([False, False, True]),
+    )
+    wrapper = PartialObservationWrapper(inner, mode=MaskMode.PERIODIC, schedule=schedule)
+
+    planted = wrapper.init(jr.key(0)).replace(
+        period_index=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    _, advanced = wrapper.step(planted, jnp.asarray(0, dtype=jnp.int32))
+
+    assert int(advanced.period_index) == _INT32_MAX
+    assert int(advanced.period_index) >= 0
+
+
+def test_periodic_period_index_stays_nonnegative_across_repeated_saturation() -> None:
+    """Once saturated, further steps must keep the counter pinned, not wrap."""
+    inner = RandomWalkStream(feature_dim=2, drift_rate=0.0, noise_std=0.0)
+    schedule = (jnp.array([True, False]), jnp.array([False, True]))
+    wrapper = PartialObservationWrapper(inner, mode=MaskMode.PERIODIC, schedule=schedule)
+
+    state = wrapper.init(jr.key(1)).replace(
+        period_index=jnp.asarray(_INT32_MAX, dtype=jnp.int32)
+    )
+    for step in range(3):
+        _, state = wrapper.step(state, jnp.asarray(step, dtype=jnp.int32))
+        assert int(state.period_index) == _INT32_MAX


### PR DESCRIPTION
### Summary

`PartialObservationWrapper` (`alberta_framework/streams/partial_observation.py`) under `MaskMode.PERIODIC` tracks `period_index` as an int32 JAX scalar and indexes the mask schedule with `period_index % len(schedule)`. The counter was incremented with a plain `state.period_index + 1`, unlike every other lifetime/step counter in `alberta_framework.streams` (Step 1, gauntlet, feature discovery, synthetic, out-of-class — all already fixed in prior merged PRs), which use the shared `core.normalizers._saturating_int32_counter_increment` helper.

A plain `+ 1` silently overflows a signed int32 at `INT32_MAX` to `INT32_MIN`, and that wraparound desyncs the observed schedule phase from the true (unbounded) step count:

```
2**31 % 3        == 2   # true next phase
(-2**31) % 3     == 1   # what the wrapped counter produces
```

A run long enough to exhaust int32 would silently start masking the wrong observation channels forever after, with no error raised — a measurement-corrupting bug in the sense the wraparound convention elsewhere in this codebase already treats as unacceptable.

Fix: use `_saturating_int32_counter_increment` for `period_index`, matching the established convention (pins the counter at `INT32_MAX` instead of wrapping negative).

### Evidence

Commit under review: `cd107e78d5c784b7fda896e810fda8da95c2a123`

New test file `tests/test_partial_observation_periodic_clock.py`:
- `test_unsaturated_wraparound_would_desync_the_schedule_phase` — static arithmetic proof of the residue mismatch above.
- `test_periodic_period_index_saturates_at_int32_max` and `test_periodic_period_index_stays_nonnegative_across_repeated_saturation` — plant `period_index = INT32_MAX`, step the wrapper, assert the counter does not go negative.

Verified failing-then-passing directly (`git stash` the one-line fix, rerun, `git stash pop`, rerun):

```
# pre-fix (state.period_index + 1):
.venv/bin/python -m pytest tests/test_partial_observation_periodic_clock.py -q -o addopts=""
  -> 2 failed, 1 passed  (period_index went to -2147483648)

# post-fix (_saturating_int32_counter_increment):
.venv/bin/python -m pytest tests/test_partial_observation_periodic_clock.py tests/test_partial_observation.py tests/test_partial_observation_leftover_mode.py -q -o addopts=""
  -> 35 passed in 9.93s
```

- `.venv/bin/python -m ruff check .` — all checks passed.
- `.venv/bin/python -m mypy` (project config, `alberta_framework/` only) — same 2 pre-existing unrelated errors in `alberta_framework/benchmarks/ipmnist_ceiling.py` as on `origin/main` before this change; nothing new introduced.

This is a narrow, single-file library correctness fix (no benchmark run involved), so there is no `outputs/` artifact to attach; evidence is the test file plus the before/after pytest output above.

Declared identity: Claude Code (claude-code) + Anthropic claude-sonnet-5 (unattended worker for rama0x1).

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0D7345XMKY06H19ZESQR3PH","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T14:34:05.373Z","completed_at":"2026-08-19T14:34:47.707Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T14:34:06.781Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"92c307a1fea8e09b7ac6dbdfe770ca94e90912eec2cb3d88535e84d24080c06b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ad910e58-9352-4a62-9e00-99c4fa5636d8","object_id":"sha256:92c307a1fea8e09b7ac6dbdfe770ca94e90912eec2cb3d88535e84d24080c06b","sha256":"92c307a1fea8e09b7ac6dbdfe770ca94e90912eec2cb3d88535e84d24080c06b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"y0ynLG3xTZuBf-vuia1itINEFwnYXyCIrdMWx6NSqO5lApd_mw-TcJ6Z_RCUQHkPPNleM4rhBAc--cNeJDDuAA"}} -->
