### PR TITLE
fix(streams): stop leaking hostile p through partial_reinforcement_scenario error

### DIFF
--- a/alberta_framework/streams/pavlovian.py
+++ b/alberta_framework/streams/pavlovian.py
@@ -1083,7 +1083,11 @@ def partial_reinforcement_scenario(
     try:
         p = _require_unit_interval(p, name="p")
     except ValueError as error:
-        raise ValueError(f"p must be in [0, 1], got {p}") from error
+        # ``_require_unit_interval`` never touches ``p`` in its own message
+        # (it is exact-type-gated before any format/str hook could run) —
+        # do not undo that guarantee by re-interpolating the still-untrusted
+        # original object here.
+        raise ValueError("p must be in [0, 1]") from error
     phases = (
         PavlovianPhase(
             name="partial_reinforcement",

--- a/tests/test_pavlovian_phase_hostile_validation.py
+++ b/tests/test_pavlovian_phase_hostile_validation.py
@@ -7,7 +7,10 @@ from typing import Any
 
 import pytest
 
-from alberta_framework.streams.pavlovian import PavlovianPhase
+from alberta_framework.streams.pavlovian import (
+    PavlovianPhase,
+    partial_reinforcement_scenario,
+)
 
 
 def _phase(**overrides: Any) -> PavlovianPhase:
@@ -57,3 +60,28 @@ def test_phase_preserves_supported_exact_fraction_probability() -> None:
 def test_phase_rejects_noncanonical_fields(field: str, value: object) -> None:
     with pytest.raises(ValueError):
         _phase(**{field: value})
+
+
+class _HostileFormatReal:
+    """A ``numbers.Real`` registrant whose format/str hooks must never run.
+
+    ``partial_reinforcement_scenario`` rejects this in
+    ``_require_unit_interval`` (it is not an exact allow-listed real type),
+    which itself never touches the value in its error message. The
+    surrounding ``except ValueError`` handler must preserve that guarantee
+    instead of re-interpolating the still-untrusted original object.
+    """
+
+    def __format__(self, spec: str) -> str:  # pragma: no cover
+        raise AssertionError("hostile __format__ must not run")
+
+    def __str__(self) -> str:  # pragma: no cover
+        raise AssertionError("hostile __str__ must not run")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        raise AssertionError("hostile __repr__ must not run")
+
+
+def test_partial_reinforcement_scenario_rejects_hostile_p_without_format_hook() -> None:
+    with pytest.raises(ValueError, match=r"p must be in \[0, 1\]"):
+        partial_reinforcement_scenario(p=_HostileFormatReal())


### PR DESCRIPTION
## Provider/model disclosure

`--client claude-code --provider anthropic --model claude-sonnet-5`, lane `rama0x1-asi-claude-worker`.

## What's broken

`alberta_framework/streams/pavlovian.py::partial_reinforcement_scenario` validates its
`p` argument through `_require_unit_interval`, which is itself hostile-safe: it
exact-type-gates `value` against the allow-listed real types before any numeric
conversion, and its own `ValueError` message never touches `value`. But the caller's
wrapping handler undoes that guarantee:

```python
try:
    p = _require_unit_interval(p, name="p")
except ValueError as error:
    raise ValueError(f"p must be in [0, 1], got {p}") from error
```

Because the assignment `p = _require_unit_interval(...)` never completes when the
exception fires, `p` in the `except` block still refers to the **original, untrusted**
object. Interpolating it into the f-string calls `format()`/`str()` on it, invoking a
hostile `__format__`/`__str__` before the value's type has ever been confirmed safe —
the same trust-boundary defect class this repository has been closing file-by-file
elsewhere (e.g. PR #1219 removing `!r` leaks from
`alberta_framework/steps/_float32_validation.py`).

### Reproduction (before fix)

```python
from alberta_framework.streams.pavlovian import partial_reinforcement_scenario

class HostileP:
    def __format__(self, spec):
        raise AssertionError("hostile __format__ invoked")

partial_reinforcement_scenario(p=HostileP())
# AssertionError: hostile __format__ invoked   (instead of a clean ValueError)
```

## Fix

Drop the untrusted re-interpolation and keep the safe generic message, preserving the
original error via `from error` for traceback context.

## Tests (failing-test-first)

Added `test_partial_reinforcement_scenario_rejects_hostile_p_without_format_hook` to
`tests/test_pavlovian_phase_hostile_validation.py`: a `_HostileFormatReal` whose
`__format__`/`__str__`/`__repr__` each raise `AssertionError` if invoked. Fails red
against pre-fix code (`AssertionError: hostile __format__ must not run`), passes green
after the fix (clean `ValueError: p must be in [0, 1]`).

Verified at commit `eaf7332921f6bda12e70255d64d75c9c53c7de6` (head of this branch):

```
.venv/bin/python -m pytest tests/test_pavlovian_phase_hostile_validation.py -q -o addopts=""
# 13 passed

.venv/bin/python -m pytest tests/test_pavlovian_learning.py tests/test_pavlovian_validation.py \
  tests/test_pavlovian_update_working_set.py tests/test_pavlovian_stream.py \
  tests/test_pavlovian_phase_hostile_validation.py -q -o addopts=""
# 139 passed

.venv/bin/python -m ruff check alberta_framework/streams/pavlovian.py tests/test_pavlovian_phase_hostile_validation.py
# All checks passed!

.venv/bin/python -m mypy alberta_framework/streams/pavlovian.py
# Success: no issues found in 1 source file
```

## Evidence tier

This is a **Fix** (trust-boundary/measurement-integrity repair), not a benchmark
climb — no `outputs/` artifact applies. Evidence is the failing-then-passing test plus
the standalone reproduction above.

## Scope

Single file, single variable: only the error-formatting line in
`partial_reinforcement_scenario` changed, plus its regression test. No behavior change
for any valid `p`.

## Collision checks

- `gh issue list --repo elizaOS/asi --state open --limit 100` and
  `gh pr list --repo elizaOS/asi --state open --json number,title,files --limit 100`
  run immediately before starting: no open issue or PR touches
  `alberta_framework/streams/pavlovian.py` or this test file.
- Re-checked immediately before this push: still no collision on either file.
- `gh issue list --repo elizaOS/asi --state all --search pavlovian`: all matches are
  historical and closed; none describe this specific defect.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0D89MD6FPYPX7W2WDABN8AW","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T14:55:07.174Z","completed_at":"2026-08-19T14:55:48.221Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T14:55:08.436Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"89d1494b33d83c27cb98f33660681b1a4ee12bf78a6517813d51dd12a4972006","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a2e56c0b-c4b8-481e-a543-7444f4818f9c","object_id":"sha256:89d1494b33d83c27cb98f33660681b1a4ee12bf78a6517813d51dd12a4972006","sha256":"89d1494b33d83c27cb98f33660681b1a4ee12bf78a6517813d51dd12a4972006"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"3dVf8JsSUfJSL5AXJKXpYRyfJNN86ijHfx7hyH9vB9ofootkir-sHUCuh5zO_Qh_RIIbMWtnFosOUrgzTSvrBw"}} -->
