### PR TITLE
fix(streams): stop leaking hostile phase repr from closed_loop error

### DIFF
--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -457,8 +457,15 @@ class SwitchingTwoStateMDP:
         return float(self._phase_payoff_np(phase).mean())
 
     def _phase_payoff_np(self, phase: int) -> np.ndarray:
+        # Exact-type gate first: an arbitrary object's ``__eq__`` could run
+        # side effects under ``phase not in (...)``, and interpolating the
+        # still-untrusted object into the message below (as this used to do)
+        # would invoke its ``__format__``/``__str__`` before its type is
+        # confirmed safe. Same defect class as PR #1219/#1994.
+        if type(phase) not in _ACTUAL_INT_TYPES:
+            raise ValueError("phase must be PHASE_A (0) or PHASE_B (1)")
         if phase not in (PHASE_A, PHASE_B):
-            raise ValueError(f"phase must be PHASE_A (0) or PHASE_B (1), got {phase}")
+            raise ValueError("phase must be PHASE_A (0) or PHASE_B (1)")
         return np.asarray(self._payoffs_np[phase], dtype=np.float32)
 
 

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -280,6 +280,40 @@ class TestSwitchingAnalyticHelpers:
         with pytest.raises(ValueError, match="phase"):
             env.optimal_average_reward(2)
 
+    def test_hostile_phase_rejected_without_invoking_untrusted_hooks(self) -> None:
+        """A non-int phase is rejected before ``==``/format/str/repr can run.
+
+        Same defect class as PR #1219/#1994: the original code compared the
+        raw ``phase`` against ``(PHASE_A, PHASE_B)`` and then re-interpolated
+        the still-untrusted, not-yet-type-confirmed value into the error
+        message. Either step could hand a hostile object's dunder hook
+        control before its type was ever verified safe.
+        """
+
+        class HostilePhase:
+            def __eq__(self, other: object) -> bool:
+                raise AssertionError("untrusted eq hook executed")
+
+            def __hash__(self) -> int:
+                raise AssertionError("untrusted hash hook executed")
+
+            def __format__(self, spec: str) -> str:
+                raise AssertionError("untrusted format hook executed")
+
+            def __str__(self) -> str:
+                raise AssertionError("untrusted str hook executed")
+
+            def __repr__(self) -> str:
+                raise AssertionError("untrusted repr hook executed")
+
+        env = SwitchingTwoStateMDP()
+        with pytest.raises(ValueError, match=r"^phase must be PHASE_A \(0\) or PHASE_B \(1\)$"):
+            env.optimal_average_reward(HostilePhase())  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match=r"^phase must be PHASE_A \(0\) or PHASE_B \(1\)$"):
+            env.uniform_random_average_reward(HostilePhase())  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="phase must be PHASE_A"):
+            env.optimal_average_reward(True)  # bool is not an actual int here
+
 
 # =============================================================================
 # Switching two-state MDP: scan compatibility


### PR DESCRIPTION
## Provider/model disclosure

`--client claude-code --provider anthropic --model claude-sonnet-5`, lane `rama0x1-asi-claude-worker`.

## What's broken

`alberta_framework/streams/closed_loop.py::SwitchingTwoStateMDP._phase_payoff_np`
is the shared helper behind the two public analytic-baseline entry points,
`optimal_average_reward(phase)` and `uniform_random_average_reward(phase)`:

```python
def _phase_payoff_np(self, phase: int) -> np.ndarray:
    if phase not in (PHASE_A, PHASE_B):
        raise ValueError(f"phase must be PHASE_A (0) or PHASE_B (1), got {phase}")
    return np.asarray(self._payoffs_np[phase], dtype=np.float32)
```

`phase` is typed as `int` in the signature, but that annotation is not enforced —
nothing gates its exact type before it is used. Two separate hooks on an
arbitrary object can run before its type is ever confirmed safe:

1. `phase not in (PHASE_A, PHASE_B)` triggers the object's own `__eq__`
   (`int.__eq__(hostile)` returns `NotImplemented`, so Python falls back to
   `hostile.__eq__(int)`).
2. If that comparison is (or claims to be) false, the raw, still-untrusted
   `phase` is interpolated into the f-string, invoking `__format__`/`__str__`.

This is the same trust-boundary defect class already being closed file-by-file
elsewhere in this tree (PR #1219's `_float32_validation.py` `!r` leak, PR #1994's
`pavlovian.py::partial_reinforcement_scenario` re-interpolation) — a raw
`raise ValueError(f"...{value}...")` gate touching an untrusted value's dunder
hooks before its type is confirmed.

### Reproduction (before fix)

```python
from alberta_framework.streams.closed_loop import SwitchingTwoStateMDP

class HostilePhase:
    def __eq__(self, other):
        return False  # let it reach the interpolation

    def __format__(self, spec):
        raise AssertionError("hostile __format__ invoked")

SwitchingTwoStateMDP().optimal_average_reward(HostilePhase())
# AssertionError: hostile __format__ invoked   (instead of a clean ValueError)
```

## Fix

Gate the exact type first, reusing this module's existing `_ACTUAL_INT_TYPES`
allowlist (the same allowlist `_require_int32` already uses), and drop the
untrusted value from the message entirely — matching `_require_int32`'s own
convention in this file, which never interpolates the rejected value:

```python
def _phase_payoff_np(self, phase: int) -> np.ndarray:
    if type(phase) not in _ACTUAL_INT_TYPES:
        raise ValueError("phase must be PHASE_A (0) or PHASE_B (1)")
    if phase not in (PHASE_A, PHASE_B):
        raise ValueError("phase must be PHASE_A (0) or PHASE_B (1)")
    return np.asarray(self._payoffs_np[phase], dtype=np.float32)
```

Gating type first also means the `not in` comparison itself never runs on a
hostile object, closing hook (1) above in addition to hook (2). `bool` is
correctly excluded (matches every other exact-int gate in this file).

## Tests (failing-test-first)

Added `test_hostile_phase_rejected_without_invoking_untrusted_hooks` to
`tests/test_closed_loop_env.py`: a `HostilePhase` whose `__eq__`, `__hash__`,
`__format__`, `__str__`, and `__repr__` all raise `AssertionError`, checked
against both `optimal_average_reward` and `uniform_random_average_reward`,
plus a `bool` case (`True` is not an actual `int` here). Fails red against
pre-fix code (`AssertionError: untrusted eq hook executed` /
`untrusted format hook executed`), passes green after the fix (clean
`ValueError: phase must be PHASE_A (0) or PHASE_B (1)`).

Verified at commit `c8732bf054e0a3e99e9db7f0d0a502df12632347` (head of this branch):

```
.venv/bin/python -m pytest tests/test_closed_loop_env.py -q -o addopts=""
# 113 passed

.venv/bin/python -m ruff check alberta_framework/streams/closed_loop.py tests/test_closed_loop_env.py
# All checks passed!

.venv/bin/python -m mypy alberta_framework/streams/closed_loop.py
# Success: no issues found in 1 source file
```

(`mypy` on the full `tests/test_closed_loop_env.py` reports a pre-existing
137-error baseline unrelated to this change — mostly chex-dataclass
`call-arg`/property-override noise already present on `origin/main`; diffed
before/after this patch to confirm the count is unchanged.)

## Evidence tier

This is a **Fix** (trust-boundary/measurement-integrity repair), not a
benchmark climb — no `outputs/` artifact applies. Evidence is the
failing-then-passing test plus the standalone reproduction above.

## Scope

Single file, single variable: only the validation order/message in
`_phase_payoff_np` changed, plus its regression test. No behavior change for
any valid `phase` (`PHASE_A`/`PHASE_B` and their numpy integer equivalents
still canonicalize and return identically).

## Collision checks

- `gh issue list --repo elizaOS/asi --state open --limit 100` and
  `gh pr list --repo elizaOS/asi --state open --json number,title,files --limit 200`
  run immediately before starting: no open issue or PR touches
  `alberta_framework/streams/closed_loop.py` or this test file.
- Re-checked immediately before this push: still no collision on either file.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0D90HGWRMT1AM9HW9YG6F2N","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T15:07:37.884Z","completed_at":"2026-08-19T15:08:18.041Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T15:07:38.898Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"8b36226bcdf57df5ec205f44ea9bf654ba37b8c41dc23b676a5b7591593992d9","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c0f0c0d2-5a0f-4fa7-9b3a-cdf2a1266a2b","object_id":"sha256:8b36226bcdf57df5ec205f44ea9bf654ba37b8c41dc23b676a5b7591593992d9","sha256":"8b36226bcdf57df5ec205f44ea9bf654ba37b8c41dc23b676a5b7591593992d9"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"0QiRV61jPBWBqTIHdY1E0qrGDzRcJ9EVjav7UPOMT-Wko4LKxDDlVijyEvtb7O3Z6ihfzcwqd5PFjnUGi3BqDQ"}} -->
