### PR TITLE
fix(core): cap SARSA array-loop sequence length before scan hang

### DIFF
--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -62,6 +62,11 @@ from alberta_framework.core.update_safety import (
 
 
 _INT32_MAX = 2**31 - 1
+# Matches the documented learning-loop step ceiling established for
+# scan-driven array loops elsewhere in ``core`` (see
+# ``learners._LEARNING_LOOP_MAX_STEPS`` and ``utils.nexting``). SARSA's
+# array-based loops below have no other cap on the scanned sequence length.
+_SARSA_SEQUENCE_MAX_STEPS = 10_000
 _SARSA_CONFIG_FIELDS = {
     "n_actions",
     "gamma",
@@ -119,6 +124,34 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _require_sarsa_sequence_length(name: str, value: object) -> int:
+    """Reject an oversized or malformed leading axis before it drives a scan.
+
+    ``run_sarsa_from_arrays`` and ``run_sarsa_from_arrays_final_state`` hand
+    their step arrays straight to ``jax.lax.scan`` with no bound on the
+    leading (step) dimension. A hostile or mistaken caller supplying a huge
+    ``num_steps`` can force JAX to trace/compile a scan of that length,
+    hanging the process well before any step executes.
+    """
+    if not isinstance(value, jax.Array):
+        raise TypeError(f"{name} must be a JAX array")
+    if value.ndim < 1:
+        raise ValueError(f"{name} must have a leading step axis")
+    length = int(value.shape[0])
+    if length < 1 or length > _SARSA_SEQUENCE_MAX_STEPS:
+        raise ValueError(
+            f"{name} length must be an integer in [1, {_SARSA_SEQUENCE_MAX_STEPS}]"
+        )
+    return length
+
+
+def _require_sarsa_matching_length(name: str, value: object, *, expected: int) -> None:
+    if not isinstance(value, jax.Array):
+        raise TypeError(f"{name} must be a JAX array")
+    if value.ndim < 1 or int(value.shape[0]) != expected:
+        raise ValueError(f"{name} must share the same leading length as observations")
 
 
 def _validated_config_float_with_ratio(
@@ -1205,7 +1238,19 @@ def run_sarsa_from_arrays(
 
     Returns:
         SARSAArrayResult with per-step Q-values, TD errors, and actions
+
+    Raises:
+        TypeError: If an input is not a JAX array.
+        ValueError: If ``observations`` is empty, exceeds the documented
+            scan-length ceiling (``_SARSA_SEQUENCE_MAX_STEPS``), or the other
+            step arrays do not share its leading length.
     """
+    num_steps = _require_sarsa_sequence_length("observations", observations)
+    _require_sarsa_matching_length("rewards", rewards, expected=num_steps)
+    _require_sarsa_matching_length("terminated", terminated, expected=num_steps)
+    _require_sarsa_matching_length(
+        "next_observations", next_observations, expected=num_steps
+    )
 
     @jax.jit
     def _scan_fn(
@@ -1256,7 +1301,19 @@ def run_sarsa_from_arrays_final_state(
 
     Throughput benchmarks use this helper to avoid materializing per-step
     Q-values, TD errors, and actions.
+
+    Raises:
+        TypeError: If an input is not a JAX array.
+        ValueError: If ``observations`` is empty, exceeds the documented
+            scan-length ceiling (``_SARSA_SEQUENCE_MAX_STEPS``), or the other
+            step arrays do not share its leading length.
     """
+    num_steps = _require_sarsa_sequence_length("observations", observations)
+    _require_sarsa_matching_length("rewards", rewards, expected=num_steps)
+    _require_sarsa_matching_length("terminated", terminated, expected=num_steps)
+    _require_sarsa_matching_length(
+        "next_observations", next_observations, expected=num_steps
+    )
 
     @jax.jit
     def _scan_fn(

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -16,8 +16,15 @@ from alberta_framework import (
     SARSAAgent,
     SARSAArrayResult,
     SARSAConfig,
+    SARSAState,
     SARSAUpdateResult,
     run_sarsa_from_arrays,
+    run_sarsa_from_arrays_final_state,
+)
+from alberta_framework.core.sarsa import (
+    _SARSA_SEQUENCE_MAX_STEPS,
+    _require_sarsa_matching_length,
+    _require_sarsa_sequence_length,
 )
 
 
@@ -989,6 +996,117 @@ class TestSARSAScan:
 
         # Should run without error and produce finite results
         assert jnp.all(jnp.isfinite(result.td_errors))
+
+
+# =============================================================================
+# Scan sequence-length ceiling (hang guard)
+# =============================================================================
+#
+# ``run_sarsa_from_arrays`` and ``run_sarsa_from_arrays_final_state`` hand
+# their step arrays straight to ``jax.lax.scan`` with no bound on the leading
+# (step) axis. A hostile or mistaken caller supplying a huge array forces JAX
+# to trace/compile a scan of that length, hanging the process well before any
+# step executes -- the same hang class fixed for other scan-driven array
+# loops elsewhere in ``core`` and ``utils``.
+
+
+def _spy_scan(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    seen: list[int] = []
+
+    def spy(fn, init, xs, **kwargs):  # type: ignore[no-untyped-def]
+        first = xs[0] if isinstance(xs, tuple) else xs
+        seen.append(int(first.shape[0]))
+        raise AssertionError(f"jax.lax.scan must not run: T={first.shape[0]}")
+
+    monkeypatch.setattr("alberta_framework.core.sarsa.jax.lax.scan", spy)
+    return seen
+
+
+def _sarsa_arrays(
+    n_steps: int,
+) -> tuple[SARSAAgent, SARSAState, jax.Array, jax.Array, jax.Array, jax.Array]:
+    agent = _make_agent(n_actions=2, hidden_sizes=(8,))
+    state = agent.init(feature_dim=4, key=jr.key(42))
+    obs = jnp.ones((n_steps, 4))
+    next_obs = jnp.ones((n_steps, 4))
+    rewards = jnp.ones(n_steps)
+    terminated = jnp.zeros(n_steps)
+    action, new_key = agent.select_action(state, obs[0])
+    state = state.replace(  # type: ignore[attr-defined]
+        last_action=action,
+        last_observation=obs[0],
+        rng_key=new_key,
+    )
+    return agent, state, obs, rewards, terminated, next_obs
+
+
+class TestSARSASequenceCeiling:
+    def test_documented_protocol_ceiling(self) -> None:
+        assert _SARSA_SEQUENCE_MAX_STEPS == 10_000
+
+    def test_last_fit_length_is_accepted(self) -> None:
+        vector = jnp.zeros((_SARSA_SEQUENCE_MAX_STEPS,))
+        assert (
+            _require_sarsa_sequence_length("observations", vector)
+            == _SARSA_SEQUENCE_MAX_STEPS
+        )
+
+    def test_first_overflow_length_is_rejected(self) -> None:
+        vector = jnp.zeros((_SARSA_SEQUENCE_MAX_STEPS + 1,))
+        with pytest.raises(
+            ValueError, match=r"observations length must be an integer in \[1, 10000\]"
+        ):
+            _require_sarsa_sequence_length("observations", vector)
+
+    def test_mismatched_length_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="same leading length"):
+            _require_sarsa_matching_length(
+                "rewards", jnp.zeros((3,)), expected=4
+            )
+
+    def test_run_sarsa_from_arrays_rejects_overflow_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        agent, state, obs, rewards, terminated, next_obs = _sarsa_arrays(
+            _SARSA_SEQUENCE_MAX_STEPS + 1
+        )
+        with pytest.raises(ValueError, match="observations length must be an integer in"):
+            run_sarsa_from_arrays(agent, state, obs, rewards, terminated, next_obs)
+        assert seen == []
+
+    def test_run_sarsa_from_arrays_final_state_rejects_overflow_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        agent, state, obs, rewards, terminated, next_obs = _sarsa_arrays(
+            _SARSA_SEQUENCE_MAX_STEPS + 1
+        )
+        with pytest.raises(ValueError, match="observations length must be an integer in"):
+            run_sarsa_from_arrays_final_state(
+                agent, state, obs, rewards, terminated, next_obs
+            )
+        assert seen == []
+
+    def test_origin_hang_class_is_rejected_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A far larger sequence length -- the actual hang class -- is also
+        rejected before ``jax.lax.scan`` is ever called."""
+        seen = _spy_scan(monkeypatch)
+        agent, state, obs, rewards, terminated, next_obs = _sarsa_arrays(200_000)
+        with pytest.raises(ValueError, match="observations length must be an integer in"):
+            run_sarsa_from_arrays(agent, state, obs, rewards, terminated, next_obs)
+        assert seen == []
+
+    def test_mismatched_step_arrays_are_rejected_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        agent, state, obs, rewards, terminated, next_obs = _sarsa_arrays(10)
+        with pytest.raises(ValueError, match="same leading length"):
+            run_sarsa_from_arrays(agent, state, obs, rewards[:5], terminated, next_obs)
+        assert seen == []
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

`alberta_framework/core/sarsa.py`'s `run_sarsa_from_arrays` and
`run_sarsa_from_arrays_final_state` hand their pre-collected step arrays
(`observations`, `rewards`, `terminated`, `next_observations`) straight to
`jax.lax.scan` with no bound on the leading (step) axis and no check that
the four arrays share a length. A hostile or mistaken caller supplying a
huge array forces JAX to trace/compile a scan of that length, hanging the
process well before any step executes.

This is the same hang class just fixed for other scan-driven array loops in
this repo (`core/partner_policy_fusion.py` #1991, `utils/nexting.py` #1992,
`core/learners.py` #1989) — `sarsa.py` was not covered by any of those PRs.
It is also one of the modules the elizaOS robot track imports in-process
(`core/{actor_critic,continual_backprop,initializers,normalizers,optimizers,
sarsa}`, per this repo's `CLAUDE.md`), so this is real external-facing
surface, not just an internal helper.

Both functions are exported public API (`alberta_framework.__init__`).

## Fix

Adds `_require_sarsa_sequence_length` (exact-type JAX-array + shape gate,
rejects length outside `[1, 10_000]` before any scan) and
`_require_sarsa_matching_length` (checks `rewards`/`terminated`/
`next_observations` share `observations`' leading length). The `10_000`
ceiling matches the documented learning-loop step ceiling already
established elsewhere in `core` (`learners._LEARNING_LOOP_MAX_STEPS`).

## Scope

- `alberta_framework/core/sarsa.py`
- `tests/test_sarsa.py`

## Verification

Commit under test: `1c564d2ba912a12dfab41add00ab4a8c8dbbe242`

```text
# On origin/main ec035f73 (pre-fix): no cap exists, jax.lax.scan is called
# unconditionally with the caller-supplied leading length -- confirmed by
# reading the pre-fix source (no _require_* call before jax.lax.scan in
# either function).

# At this head: oversized (10_001), origin-hang-class-sized (200_000), and
# length-mismatched inputs are rejected with a ValueError and a monkeypatch
# spy proves alberta_framework.core.sarsa.jax.lax.scan is never invoked.
# The documented last-fit length (10_000) still runs end-to-end.

.venv/bin/python -m pytest tests/test_sarsa.py -q -o addopts=""
# 149 tests collected (141 before this change, +8 new), 147 passed, 2 skipped

.venv/bin/python -m ruff check alberta_framework/core/sarsa.py tests/test_sarsa.py
# All checks passed!

.venv/bin/python -m mypy alberta_framework/core/sarsa.py
# Success: no issues found in 1 source file
.venv/bin/python -m mypy tests/test_sarsa.py
# 192 errors, all pre-existing on origin/main before this change (verified by
# diffing mypy output before/after with line numbers normalized); this PR
# introduces zero new mypy errors.

python -c "import alberta_framework"  # import surface stays intact
```

<!-- evidence-head:1c564d2ba912a12dfab41add00ab4a8c8dbbe242 -->
<!-- evidence-row:logs -->
- [x] logs: local pytest/ruff/mypy output above; 149 collected / 147 passed / 2 skipped in tests/test_sarsa.py, zero new mypy errors vs. origin/main baseline
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - scan sequence-length hang guard, no IPMNIST/benchmark shard produced

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-sonnet-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: contribute-to-asi (local skill copy)
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: Anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Attribution status: self-reported

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0D957BWS5FE17A8P8DCMXSP","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T15:10:11.324Z","completed_at":"2026-08-19T15:10:51.487Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T15:10:12.867Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"04e5f7e108a872f7ce0c9a7aa14c495512b1fdc16e511f3dd4580054d895ddcb","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5ee6bbe0-2175-4572-ba4a-94d2e7d9a562","object_id":"sha256:04e5f7e108a872f7ce0c9a7aa14c495512b1fdc16e511f3dd4580054d895ddcb","sha256":"04e5f7e108a872f7ce0c9a7aa14c495512b1fdc16e511f3dd4580054d895ddcb"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"KbzuaApV8diufQYLEwrcXZmIw0zdiZ7Nkj63E9hYGkr1-d_nqAK0n6ghOjuhR0rEn95LpWLpAylKqUFTJ3rnAA"}} -->
