### PR TITLE
fix(core): reject deep checkpoint metadata before RecursionError

### DIFF
--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -53,6 +53,10 @@ _FORMAT_VERSION = 2
 # Internal metadata key — stripped from user-facing metadata
 _VERSION_KEY = "_format_version"
 _EMPTY_ARRAYS_KEY = "_empty_array_leaves"
+# Same ceiling as security._JSON_MAX_DEPTH. Origin json.dumps RecursionErrors
+# on a 10_000-deep metadata nest and cannot reject it as ValueError.
+_JSON_MAX_DEPTH = 32
+_JSON_MAX_NODES = 4096
 
 
 def _is_empty_array(value: object) -> bool:
@@ -148,10 +152,42 @@ def _require_path(value: object, *, name: str = "checkpoint path") -> Path:
     raise ValueError(f"{name} must be an exact str or Path")
 
 
+def _require_json_nest(
+    value: object, *, name: str, depth: int, budget: list[int]
+) -> None:
+    """Reject unbounded metadata nests before ``json.dumps`` RecursionError."""
+    budget[0] -= 1
+    if budget[0] < 0:
+        raise ValueError(f"{name} exceeds the JSON value resource limit")
+    if depth > _JSON_MAX_DEPTH:
+        raise ValueError(f"{name} exceeds the JSON nesting limit")
+    value_type = type(value)
+    if value is None or value_type is bool or value_type is int or value_type is str:
+        return
+    if value_type is float:
+        return
+    if value_type is list:
+        for item in cast(list[object], value):
+            _require_json_nest(item, name=name, depth=depth + 1, budget=budget)
+        return
+    if value_type is dict:
+        for item in cast(dict[object, object], value).values():
+            _require_json_nest(item, name=name, depth=depth + 1, budget=budget)
+        return
+
+
 def _require_json_safe_metadata(metadata: dict[str, Any]) -> None:
     """Reject metadata that cannot round-trip as finite JSON."""
     try:
+        _require_json_nest(
+            metadata, name="checkpoint metadata", depth=0, budget=[_JSON_MAX_NODES]
+        )
+    except RecursionError as exc:
+        raise ValueError("checkpoint metadata exceeds the JSON nesting limit") from exc
+    try:
         json.dumps(metadata, allow_nan=False)
+    except RecursionError as exc:
+        raise ValueError("checkpoint metadata exceeds the JSON nesting limit") from exc
     except (TypeError, ValueError) as exc:
         raise ValueError("checkpoint metadata must be JSON-safe and finite") from exc
 

--- a/tests/test_checkpoints_metadata_depth.py
+++ b/tests/test_checkpoints_metadata_depth.py
@@ -1,0 +1,53 @@
+"""Depth ceiling for checkpoint metadata JSON walks.
+
+Origin ``json.dumps`` RecursionError'd a 10_000-deep metadata nest. The
+protocol ceiling matches ``security._JSON_MAX_DEPTH`` (32).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework import LinearLearner
+from alberta_framework.core.checkpoints import (
+    _JSON_MAX_DEPTH,
+    _require_json_safe_metadata,
+    save_checkpoint,
+)
+
+
+def _nested_dict(depth: int) -> dict[str, object]:
+    nest: object = True
+    for _ in range(depth):
+        nest = {"k": nest}
+    assert type(nest) is dict
+    return nest
+
+
+def test_protocol_ceiling_matches_json_depth_bound() -> None:
+    assert _JSON_MAX_DEPTH == 32
+
+
+def test_last_fit_nest_is_accepted() -> None:
+    _require_json_safe_metadata(_nested_dict(_JSON_MAX_DEPTH))
+
+
+def test_first_overflow_nest_is_value_error_not_recursion_error() -> None:
+    with pytest.raises(ValueError, match="nesting limit"):
+        _require_json_safe_metadata(_nested_dict(_JSON_MAX_DEPTH + 1))
+
+
+def test_origin_hang_class_10000_is_value_error_not_recursion_error() -> None:
+    with pytest.raises(ValueError, match="nesting limit"):
+        _require_json_safe_metadata(_nested_dict(10_000))
+
+
+def test_save_checkpoint_rejects_overflow_nest_without_writing(tmp_path: Path) -> None:
+    learner = LinearLearner()
+    state = learner.init(3)
+    path = tmp_path / "deep"
+    with pytest.raises(ValueError, match="nesting limit"):
+        save_checkpoint(state, path, metadata=_nested_dict(_JSON_MAX_DEPTH + 1))
+    assert not path.exists()


### PR DESCRIPTION
## Summary

Occupancy-FREE complete RecursionError hang on `origin/main` `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`.

`save_checkpoint` / `_require_json_safe_metadata` called `json.dumps(metadata)` and caught only `TypeError`/`ValueError`. A 10_000-deep dict nest RecursionError'd:

```text
_require_json_safe_metadata(10000-deep {"k": ...}) -> RecursionError
save_checkpoint(..., metadata=that nest) -> RecursionError
```

This is the same complete class as `#1919` (boolean-trace RecursionError), not leftover persist / 256 MiB / INT32 / scan-T. Walk metadata with the protocol JSON depth ceiling (`security._JSON_MAX_DEPTH` = 32) and raise `ValueError` before the encoder blows the stack.

Not `#1874`. Not clocks / forager / IA / FTL / `optimizers.py`. Not `#1989` `learners.py` / `#1991` fusion / `#1992` nexting (those are scan-T).

## Expected behavior

Metadata nests of depth `<= 32` still serialize. Depth `33` and the origin hang-class `10_000` raise `ValueError` matching `nesting limit`, never `RecursionError`. `save_checkpoint` writes nothing on overflow.

## Scope

- `alberta_framework/core/checkpoints.py`
- `tests/test_checkpoints_metadata_depth.py`

## Verification

```text
# red on origin/main ec035f73
save_checkpoint(..., metadata=10000-deep dict nest) -> RecursionError

# green at this head
.venv/bin/python -m pytest tests/test_checkpoints_metadata_depth.py tests/test_checkpoints_validation.py tests/test_checkpoints.py -q -o addopts=""
# 49 passed
.venv/bin/python -m ruff check alberta_framework/core/checkpoints.py tests/test_checkpoints_metadata_depth.py
.venv/bin/python -m mypy alberta_framework/core/checkpoints.py tests/test_checkpoints_metadata_depth.py
```

<!-- evidence-head:342e37e7ef79b103c1557a1d8a63841821e2e01b -->
<!-- evidence-row:logs -->
- [x] logs: origin `ec035f73` RecursionError'd 10_000-deep metadata; this head raises ValueError at 33 and 10_000; 49 focused tests passed
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - checkpoint metadata RecursionError preflight, no IPMNIST shard
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - local fail-before-RecursionError proof, no model-trajectory artifact

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
