### PR TITLE
fix(streams): reject hostile shape metadata before comparing in gymnasium

### DIFF
--- a/alberta_framework/streams/gymnasium.py
+++ b/alberta_framework/streams/gymnasium.py
@@ -214,6 +214,14 @@ def _require_runtime_shape(name: str, value: object, expected: tuple[int, ...]) 
         actual = tuple(metadata) if metadata is not None else tuple(np.shape(cast(Any, value)))
     except Exception as error:
         raise ValueError(f"{name} shape metadata could not be read") from error
+    # Exact-type gate every dimension before comparing or formatting: a
+    # hostile ``.shape`` property (or an object whose ``np.shape`` fallback
+    # yields hostile elements) could otherwise run an attacker-controlled
+    # ``__eq__``/``__ne__`` via ``actual != expected`` below, or
+    # ``__repr__``/``__format__`` via the f-string, before any dimension's
+    # type has been confirmed safe. Same defect class as PR #1219/#1994/#1995.
+    if any(type(dimension) is not int for dimension in actual):
+        raise ValueError(f"{name} shape metadata must be built-in integers")
     if actual != expected:
         raise ValueError(f"{name} must have declared shape {expected}; got {actual}")
 

--- a/tests/test_gymnasium_runtime_shape_hostile_validation.py
+++ b/tests/test_gymnasium_runtime_shape_hostile_validation.py
@@ -1,0 +1,70 @@
+"""Standalone trust-boundary validation for Gymnasium runtime shape checks."""
+
+from __future__ import annotations
+
+import pytest
+
+gymnasium = pytest.importorskip("gymnasium")
+
+from alberta_framework.streams.gymnasium import _require_runtime_shape  # noqa: E402
+
+
+class _HostileDimension:
+    """An object masquerading as a shape dimension with hostile hooks."""
+
+    def __eq__(self, other: object) -> bool:  # pragma: no cover - only if reached
+        raise AssertionError("hostile __eq__ must not run")
+
+    def __ne__(self, other: object) -> bool:  # pragma: no cover - only if reached
+        raise AssertionError("hostile __ne__ must not run")
+
+    def __repr__(self) -> str:  # pragma: no cover - only if reached
+        raise AssertionError("hostile __repr__ must not run")
+
+    def __hash__(self) -> int:
+        return 0
+
+
+class _HostileNonRaisingDimension:
+    """A hostile dimension whose comparison quietly returns False."""
+
+    def __eq__(self, other: object) -> bool:
+        return False
+
+    def __repr__(self) -> str:  # pragma: no cover - only if reached
+        raise AssertionError("hostile __repr__ must not run")
+
+    def __hash__(self) -> int:
+        return 0
+
+
+class _HostileShapeHolder:
+    """Reports a hostile ``.shape`` without being a trusted array type."""
+
+    def __init__(self, dimension: object) -> None:
+        self._dimension = dimension
+
+    @property
+    def shape(self) -> tuple[object, ...]:
+        return (self._dimension,)
+
+
+def test_require_runtime_shape_rejects_hostile_dimension_without_eq_hook() -> None:
+    with pytest.raises(ValueError, match="built-in integers"):
+        _require_runtime_shape("observation", _HostileShapeHolder(_HostileDimension()), (3,))
+
+
+def test_require_runtime_shape_rejects_hostile_dimension_without_repr_hook() -> None:
+    with pytest.raises(ValueError, match="built-in integers"):
+        _require_runtime_shape(
+            "action", _HostileShapeHolder(_HostileNonRaisingDimension()), (3,)
+        )
+
+
+def test_require_runtime_shape_accepts_matching_plain_int_shape() -> None:
+    _require_runtime_shape("observation", _HostileShapeHolder(3), (3,))
+
+
+def test_require_runtime_shape_still_rejects_mismatched_plain_int_shape() -> None:
+    with pytest.raises(ValueError, match="must have declared shape"):
+        _require_runtime_shape("observation", _HostileShapeHolder(4), (3,))


### PR DESCRIPTION
## Provider/model disclosure

`--client claude-code --provider anthropic --model claude-sonnet-5`, lane `rama0x1-asi-claude-worker`.

## What's broken

`alberta_framework/streams/gymnasium.py::_require_runtime_shape` is called by
`_flatten_observation`/`_flatten_action` to check a candidate observation or
action's shape against the space's declared shape before any JAX conversion
runs. It reads shape metadata off the untrusted value with
`getattr(value, "shape", None)` (falling back to `np.shape(value)`), but never
confirms the resulting dimensions are built-in `int`s before either comparing
them or formatting them into the raised message:

```python
def _require_runtime_shape(name: str, value: object, expected: tuple[int, ...]) -> None:
    try:
        metadata = getattr(value, "shape", None)
        actual = tuple(metadata) if metadata is not None else tuple(np.shape(cast(Any, value)))
    except Exception as error:
        raise ValueError(f"{name} shape metadata could not be read") from error
    if actual != expected:
        raise ValueError(f"{name} must have declared shape {expected}; got {actual}")
```

A hostile `obs`/`action` whose `.shape` property returns a tuple containing an
object with adversarial `__eq__` or `__repr__` hooks gets that hook invoked by
`actual != expected` or by the f-string — before the object's type has been
confirmed safe. Same trust-boundary defect class this repository has been
closing file-by-file elsewhere (e.g. PR #1219 removing `!r` leaks from
`alberta_framework/steps/_float32_validation.py`, and my prior PRs #1994/#1995
in `pavlovian.py`/`closed_loop.py`). Contrast with the safe pattern already
used elsewhere in this repo (e.g. `alberta_framework/steps/step7.py::_trusted_array`),
which gates `type(value)` *before* touching `.shape`/`.dtype` at all.

### Reproduction (before fix)

```python
from alberta_framework.streams.gymnasium import _require_runtime_shape

class HostileInt:
    def __eq__(self, other):
        raise AssertionError("hostile __eq__ invoked")
    def __repr__(self):
        raise AssertionError("hostile __repr__ invoked")
    def __hash__(self):
        return 0

class HostileShapeHolder:
    @property
    def shape(self):
        return (HostileInt(),)

_require_runtime_shape("observation", HostileShapeHolder(), (3,))
# AssertionError: hostile __eq__ invoked   (instead of a clean ValueError)
```

A second variant (`__eq__` returns `False` instead of raising) instead reaches
the f-string and invokes the hostile `__repr__` there.

## Fix

Exact-type-gate every extracted dimension (`type(dimension) is int`) before
either the `!=` comparison or the message is built, raising a generic message
that never echoes the untrusted dimensions.

## Tests (failing-test-first)

Added `tests/test_gymnasium_runtime_shape_hostile_validation.py`:
- a hostile dimension whose `__eq__`/`__ne__`/`__repr__` each raise
  `AssertionError` if invoked — fails red pre-fix (`AssertionError: hostile
  __eq__ must not run`), passes green post-fix (clean `ValueError`);
- a variant hostile dimension whose `__eq__` quietly returns `False` (so the
  buggy code reaches the f-string) but whose `__repr__` raises — same
  red/green behavior, isolating the format-time leak;
- two control cases confirming plain-`int` shapes still compare correctly
  (matching and mismatched).

Verified at commit `05b85efcb4c5d50e2ce4ef72213dee2dc333e702` (head of this branch):

```
.venv/bin/python -m pytest tests/test_gymnasium_runtime_shape_hostile_validation.py -q -o addopts=""
# 4 passed

.venv/bin/python -m pytest tests/test_gymnasium_streams.py tests/test_gymnasium_bootstrap.py \
  tests/test_gymnasium_runtime_shape_hostile_validation.py -q -o addopts=""
# 71 passed

.venv/bin/python -m ruff check alberta_framework/streams/gymnasium.py tests/test_gymnasium_runtime_shape_hostile_validation.py
# All checks passed!

.venv/bin/python -m mypy alberta_framework/streams/gymnasium.py
# Success: no issues found in 1 source file
```

## Evidence tier

This is a **Fix** (trust-boundary/measurement-integrity repair), not a
benchmark climb — no `outputs/` artifact applies. Evidence is the
failing-then-passing tests plus the standalone reproduction above.

## Scope

Single file, single variable: only `_require_runtime_shape` in
`alberta_framework/streams/gymnasium.py`, plus its dedicated test file. No
other behavior changes.

## Search for further instances this cycle

Re-ran the hostile-repr/hostile-comparison grep across all of
`alberta_framework/streams/` and `alberta_framework/steps/` this cycle
(`got \{`, `!r\}`, exception-handler re-interpolation patterns), including
files not yet touched by any open PR (`synthetic.py`, `feature_discovery.py`,
`gymnasium.py`, `alberta_plan_step1.py`, `step7.py`, `out_of_class.py`,
`base.py`, and the remaining `step*.py`/`_*_validation.py` files). Every other
hit either interpolates a static `name`/label string (never the untrusted
value) or is already exact-type-gated before the value is touched (e.g.
`step7.py::_trusted_array`, `gauntlet.py::lifetime_scorecard`'s `window`, and
the `_require_array` helpers in `gauntlet.py`/`recurring_multiagent.py`,
which convert through `jnp.asarray` — producing a confirmed real array —
before reading `.shape`/`.dtype`). `gymnasium.py::_require_runtime_shape` was
the one outlier that read shape metadata off the untrusted value before any
type confirmation. No other unfixed instance found in this territory.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0D9PFJTXQ7CJ07AZT33DMFD","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T15:19:36.794Z","completed_at":"2026-08-19T15:20:14.368Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T15:19:37.358Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b844a75514087f7499aa889e01027848a743dfed49d8a13ff3dda44e86a4896e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4cd105cd-ea9a-4c12-94fe-a538b81db0f7","object_id":"sha256:b844a75514087f7499aa889e01027848a743dfed49d8a13ff3dda44e86a4896e","sha256":"b844a75514087f7499aa889e01027848a743dfed49d8a13ff3dda44e86a4896e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"bbaDBv93RxEu51sP1HiZg8mEM_SGyPePGv96X8nU3LxzVeJsE1aE9d0tSbRVONyiZRPUeLIlNkCT119Liz6pBw"}} -->
