### PR TITLE
fix(core): cap average-reward array-loop sequence length before scan hang

### DIFF
--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -77,6 +77,47 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+# Matches the class of ceiling already established for other scan-driven
+# array-loop runners in ``core`` (e.g. ``sarsa._SARSA_SEQUENCE_MAX_STEPS``,
+# ``learners._LEARNING_LOOP_MAX_STEPS``). Set with headroom above this
+# module's largest exercised sequence (20,000 steps, see
+# ``test_differential_gtd_scan_learns_average_reward_cycle``) while still
+# bounding the leading axis that every ``run_*_from_arrays`` runner below
+# hands straight to ``jax.lax.scan``.
+_AVERAGE_REWARD_SEQUENCE_MAX_STEPS = 50_000
+
+
+def _require_avg_reward_sequence_length(name: str, value: object) -> int:
+    """Reject an oversized or malformed leading axis before it drives a scan.
+
+    The array-loop runners in this module (``run_differential_td_from_arrays``,
+    ``run_differential_gtd_from_arrays``, ``run_differential_sarsa_from_arrays``,
+    ``run_average_reward_horde_actor_critic_from_arrays``) hand their step
+    arrays straight to ``jax.lax.scan`` with no bound on the leading (step)
+    axis. A hostile or mistaken caller supplying a huge leading length forces
+    JAX to materialize per-step outputs (and, for large enough arrays, the
+    inputs) at that length, exhausting memory or hanging the process well
+    before any step executes.
+    """
+    if not isinstance(value, jax.Array):
+        raise TypeError(f"{name} must be a JAX array")
+    if value.ndim < 1:
+        raise ValueError(f"{name} must have a leading step axis")
+    length = int(value.shape[0])
+    if length < 1 or length > _AVERAGE_REWARD_SEQUENCE_MAX_STEPS:
+        raise ValueError(
+            f"{name} length must be an integer in [1, {_AVERAGE_REWARD_SEQUENCE_MAX_STEPS}]"
+        )
+    return length
+
+
+def _require_avg_reward_matching_length(name: str, value: object, *, expected: int) -> None:
+    if not isinstance(value, jax.Array):
+        raise TypeError(f"{name} must be a JAX array")
+    if value.ndim < 1 or int(value.shape[0]) != expected:
+        raise ValueError(f"{name} must share the same leading length as the primary sequence")
+
+
 def _validate_hidden_sizes(hidden_sizes: object) -> tuple[int, ...]:
     if type(hidden_sizes) is not tuple:
         raise ValueError("hidden_sizes must be an actual tuple")
@@ -1563,7 +1604,19 @@ def run_differential_td_from_arrays(
     rewards: Float[Array, " num_steps"],
     next_observations: Float[Array, "num_steps feature_dim"],
 ) -> DifferentialTDArrayResult:
-    """Run differential TD updates over transition arrays with ``lax.scan``."""
+    """Run differential TD updates over transition arrays with ``lax.scan``.
+
+    Raises:
+        TypeError: If an input is not a JAX array.
+        ValueError: If ``observations`` is empty, exceeds the documented
+            scan-length ceiling (``_AVERAGE_REWARD_SEQUENCE_MAX_STEPS``), or
+            the other step arrays do not share its leading length.
+    """
+    num_steps = _require_avg_reward_sequence_length("observations", observations)
+    _require_avg_reward_matching_length("rewards", rewards, expected=num_steps)
+    _require_avg_reward_matching_length(
+        "next_observations", next_observations, expected=num_steps
+    )
     start = time.time()
 
     def _scan_fn(
@@ -1605,7 +1658,20 @@ def run_differential_gtd_from_arrays(
     next_observations: Float[Array, "num_steps feature_dim"],
     rhos: Float[Array, " num_steps"],
 ) -> DifferentialGTDArrayResult:
-    """Run differential GTD/TDC updates over transition arrays with ``lax.scan``."""
+    """Run differential GTD/TDC updates over transition arrays with ``lax.scan``.
+
+    Raises:
+        TypeError: If an input is not a JAX array.
+        ValueError: If ``observations`` is empty, exceeds the documented
+            scan-length ceiling (``_AVERAGE_REWARD_SEQUENCE_MAX_STEPS``), or
+            the other step arrays do not share its leading length.
+    """
+    num_steps = _require_avg_reward_sequence_length("observations", observations)
+    _require_avg_reward_matching_length("rewards", rewards, expected=num_steps)
+    _require_avg_reward_matching_length(
+        "next_observations", next_observations, expected=num_steps
+    )
+    _require_avg_reward_matching_length("rhos", rhos, expected=num_steps)
     start = time.time()
 
     def _scan_fn(
@@ -1684,6 +1750,12 @@ def run_average_reward_horde_from_arrays(
         raise ValueError(
             f"cumulants must have shape {expected_cumulant_shape}, got {cumulants.shape}"
         )
+    num_steps = observations.shape[0]
+    if num_steps < 1 or num_steps > _AVERAGE_REWARD_SEQUENCE_MAX_STEPS:
+        raise ValueError(
+            "observations length must be an integer in "
+            f"[1, {_AVERAGE_REWARD_SEQUENCE_MAX_STEPS}]"
+        )
     start = time.time()
 
     def _scan_fn(
@@ -1732,7 +1804,18 @@ def run_average_reward_horde_actor_critic_from_arrays(
     rewards: Float[Array, " num_steps"],
     next_observations: Float[Array, "num_steps observation_dim"],
 ) -> AverageRewardHordeActorCriticArrayResult:
-    """Run average-reward Horde actor-critic over transition arrays."""
+    """Run average-reward Horde actor-critic over transition arrays.
+
+    Raises:
+        TypeError: If an input is not a JAX array.
+        ValueError: If ``rewards`` is empty, exceeds the documented
+            scan-length ceiling (``_AVERAGE_REWARD_SEQUENCE_MAX_STEPS``), or
+            ``next_observations`` does not share its leading length.
+    """
+    num_steps = _require_avg_reward_sequence_length("rewards", rewards)
+    _require_avg_reward_matching_length(
+        "next_observations", next_observations, expected=num_steps
+    )
     start = time.time()
 
     def _scan_fn(
@@ -2364,7 +2447,20 @@ def run_differential_sarsa_from_arrays(
     transitions from the stored `(S_t, A_t)` to each ``next_observations[t]``.
     When ``discounts`` is omitted, every transition uses ``1.0`` for backward
     compatibility with the original continuing-task runner.
+
+    Raises:
+        TypeError: If an input is not a JAX array.
+        ValueError: If ``rewards`` is empty, exceeds the documented
+            scan-length ceiling (``_AVERAGE_REWARD_SEQUENCE_MAX_STEPS``), or
+            ``next_observations``/``discounts`` do not share its leading
+            length.
     """
+    num_steps = _require_avg_reward_sequence_length("rewards", rewards)
+    _require_avg_reward_matching_length(
+        "next_observations", next_observations, expected=num_steps
+    )
+    if discounts is not None:
+        _require_avg_reward_matching_length("discounts", discounts, expected=num_steps)
     start = time.time()
     if discounts is None:
         discounts = jnp.ones_like(rewards, dtype=jnp.float32)

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -12,6 +12,7 @@ from alberta_framework import (
 )
 from alberta_framework.core import DifferentialTDLearner as CoreDifferentialTDLearner
 from alberta_framework.core.average_reward import (
+    _AVERAGE_REWARD_SEQUENCE_MAX_STEPS,
     AverageRewardHordeActorCriticAgent,
     AverageRewardHordeActorCriticConfig,
     AverageRewardHordeLearner,
@@ -21,6 +22,8 @@ from alberta_framework.core.average_reward import (
     DifferentialSARSAConfig,
     DifferentialTDConfig,
     DifferentialTDLearner,
+    _require_avg_reward_matching_length,
+    _require_avg_reward_sequence_length,
     run_average_reward_horde_actor_critic_from_arrays,
     run_average_reward_horde_from_arrays,
     run_differential_gtd_from_arrays,
@@ -1159,3 +1162,207 @@ def test_differential_td_and_gtd_configs_reject_invalid_scalars() -> None:
         AverageRewardHordeLearner(1, sparsity=float("nan"))
     with pytest.raises(ValueError, match="use_layer_norm"):
         AverageRewardHordeLearner(1, use_layer_norm=1)  # type: ignore[arg-type]
+
+
+# =============================================================================
+# Scan sequence-length ceiling (hang guard)
+# =============================================================================
+#
+# ``run_differential_td_from_arrays``, ``run_differential_gtd_from_arrays``,
+# ``run_average_reward_horde_from_arrays``,
+# ``run_average_reward_horde_actor_critic_from_arrays``, and
+# ``run_differential_sarsa_from_arrays`` hand their step arrays straight to
+# ``jax.lax.scan`` with no bound on the leading (step) axis. A hostile or
+# mistaken caller supplying a huge array forces JAX to materialize per-step
+# outputs at that length, hanging the process well before any step executes
+# -- the same hang class already fixed for other scan-driven array loops in
+# ``core`` and ``utils``.
+
+
+def _spy_scan(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    seen: list[int] = []
+
+    def spy(fn, init, xs, **kwargs):  # type: ignore[no-untyped-def]
+        first = xs[0] if isinstance(xs, tuple) else xs
+        seen.append(int(first.shape[0]))
+        raise AssertionError(f"jax.lax.scan must not run: T={first.shape[0]}")
+
+    monkeypatch.setattr("alberta_framework.core.average_reward.jax.lax.scan", spy)
+    return seen
+
+
+class TestAverageRewardSequenceCeiling:
+    def test_documented_protocol_ceiling(self) -> None:
+        assert _AVERAGE_REWARD_SEQUENCE_MAX_STEPS == 50_000
+
+    def test_last_fit_length_is_accepted(self) -> None:
+        vector = jnp.zeros((_AVERAGE_REWARD_SEQUENCE_MAX_STEPS,))
+        assert (
+            _require_avg_reward_sequence_length("rewards", vector)
+            == _AVERAGE_REWARD_SEQUENCE_MAX_STEPS
+        )
+
+    def test_first_overflow_length_is_rejected(self) -> None:
+        vector = jnp.zeros((_AVERAGE_REWARD_SEQUENCE_MAX_STEPS + 1,))
+        with pytest.raises(
+            ValueError, match=r"rewards length must be an integer in \[1, 50000\]"
+        ):
+            _require_avg_reward_sequence_length("rewards", vector)
+
+    def test_empty_length_is_rejected(self) -> None:
+        vector = jnp.zeros((0,))
+        with pytest.raises(ValueError, match=r"rewards length must be an integer in"):
+            _require_avg_reward_sequence_length("rewards", vector)
+
+    def test_scalar_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="leading step axis"):
+            _require_avg_reward_sequence_length("rewards", jnp.array(1.0))
+
+    def test_non_array_is_rejected(self) -> None:
+        with pytest.raises(TypeError, match="must be a JAX array"):
+            _require_avg_reward_sequence_length("rewards", [1.0, 2.0, 3.0])
+
+        class _HostileArrayLike:
+            shape = (3,)
+            ndim = 1
+
+        with pytest.raises(TypeError, match="must be a JAX array"):
+            _require_avg_reward_sequence_length("rewards", _HostileArrayLike())
+
+    def test_mismatched_length_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="same leading length"):
+            _require_avg_reward_matching_length("rewards", jnp.zeros((3,)), expected=4)
+
+    def test_matching_length_non_array_is_rejected(self) -> None:
+        with pytest.raises(TypeError, match="must be a JAX array"):
+            _require_avg_reward_matching_length("rewards", [1.0, 2.0], expected=2)
+
+    def test_run_differential_td_from_arrays_rejects_overflow_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        learner = DifferentialTDLearner(DifferentialTDConfig())
+        state = learner.init(2)
+        n = _AVERAGE_REWARD_SEQUENCE_MAX_STEPS + 1
+        observations = jnp.ones((n, 2), dtype=jnp.float32)
+        rewards = jnp.ones((n,), dtype=jnp.float32)
+        next_observations = jnp.ones((n, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="observations length must be an integer in"):
+            run_differential_td_from_arrays(
+                learner, state, observations, rewards, next_observations
+            )
+        assert seen == []
+
+    def test_run_differential_td_from_arrays_rejects_mismatched_length_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        learner = DifferentialTDLearner(DifferentialTDConfig())
+        state = learner.init(2)
+        observations = jnp.ones((10, 2), dtype=jnp.float32)
+        rewards = jnp.ones((5,), dtype=jnp.float32)
+        next_observations = jnp.ones((10, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="same leading length"):
+            run_differential_td_from_arrays(
+                learner, state, observations, rewards, next_observations
+            )
+        assert seen == []
+
+    def test_run_differential_gtd_from_arrays_rejects_overflow_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        learner = DifferentialGTDLearner(DifferentialGTDConfig())
+        state = learner.init(2)
+        n = _AVERAGE_REWARD_SEQUENCE_MAX_STEPS + 1
+        observations = jnp.ones((n, 2), dtype=jnp.float32)
+        rewards = jnp.ones((n,), dtype=jnp.float32)
+        next_observations = jnp.ones((n, 2), dtype=jnp.float32)
+        rhos = jnp.ones((n,), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="observations length must be an integer in"):
+            run_differential_gtd_from_arrays(
+                learner, state, observations, rewards, next_observations, rhos
+            )
+        assert seen == []
+
+    def test_run_average_reward_horde_from_arrays_rejects_overflow_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        learner = AverageRewardHordeLearner(n_demons=1, hidden_sizes=())
+        state = learner.init(2, jr.key(0))
+        n = _AVERAGE_REWARD_SEQUENCE_MAX_STEPS + 1
+        observations = jnp.ones((n, 2), dtype=jnp.float32)
+        cumulants = jnp.ones((n, 1), dtype=jnp.float32)
+        next_observations = jnp.ones((n, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="observations length must be an integer in"):
+            run_average_reward_horde_from_arrays(
+                learner, state, observations, cumulants, next_observations
+            )
+        assert seen == []
+
+    def test_run_average_reward_horde_actor_critic_from_arrays_rejects_overflow_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        agent = AverageRewardHordeActorCriticAgent(
+            AverageRewardHordeActorCriticConfig(n_actions=2, hidden_sizes=())
+        )
+        state = agent.init(2, jr.key(0))
+        state, _ = agent.start(state, jnp.array([1.0, 0.0], dtype=jnp.float32))
+        n = _AVERAGE_REWARD_SEQUENCE_MAX_STEPS + 1
+        rewards = jnp.ones((n,), dtype=jnp.float32)
+        next_observations = jnp.ones((n, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="rewards length must be an integer in"):
+            run_average_reward_horde_actor_critic_from_arrays(
+                agent, state, rewards, next_observations
+            )
+        assert seen == []
+
+    def test_run_differential_sarsa_from_arrays_rejects_overflow_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        agent = DifferentialSARSAAgent(DifferentialSARSAConfig(n_actions=2))
+        state = agent.init(2, jr.key(0))
+        state, _ = agent.start(state, jnp.array([1.0, 0.0], dtype=jnp.float32))
+        n = _AVERAGE_REWARD_SEQUENCE_MAX_STEPS + 1
+        rewards = jnp.ones((n,), dtype=jnp.float32)
+        next_observations = jnp.ones((n, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="rewards length must be an integer in"):
+            run_differential_sarsa_from_arrays(agent, state, rewards, next_observations)
+        assert seen == []
+
+    def test_run_differential_sarsa_from_arrays_rejects_mismatched_discounts_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        agent = DifferentialSARSAAgent(DifferentialSARSAConfig(n_actions=2))
+        state = agent.init(2, jr.key(0))
+        state, _ = agent.start(state, jnp.array([1.0, 0.0], dtype=jnp.float32))
+        rewards = jnp.ones((5,), dtype=jnp.float32)
+        next_observations = jnp.ones((5, 2), dtype=jnp.float32)
+        discounts = jnp.ones((3,), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="same leading length"):
+            run_differential_sarsa_from_arrays(
+                agent, state, rewards, next_observations, discounts
+            )
+        assert seen == []
+
+    def test_origin_hang_class_is_rejected_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A far larger sequence length -- the actual hang class -- is also
+        rejected before ``jax.lax.scan`` is ever called."""
+        seen = _spy_scan(monkeypatch)
+        learner = DifferentialTDLearner(DifferentialTDConfig())
+        state = learner.init(2)
+        n = 2_000_000
+        observations = jnp.ones((n, 2), dtype=jnp.float32)
+        rewards = jnp.ones((n,), dtype=jnp.float32)
+        next_observations = jnp.ones((n, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="observations length must be an integer in"):
+            run_differential_td_from_arrays(
+                learner, state, observations, rewards, next_observations
+            )
+        assert seen == []


### PR DESCRIPTION
## Summary

`alberta_framework/core/average_reward.py`'s five `run_*_from_arrays` runners
(`run_differential_td_from_arrays`, `run_differential_gtd_from_arrays`,
`run_average_reward_horde_from_arrays`,
`run_average_reward_horde_actor_critic_from_arrays`,
`run_differential_sarsa_from_arrays`) hand their caller-supplied step arrays
(`observations`, `rewards`, `next_observations`, `cumulants`, `rhos`,
`discounts`) straight to `jax.lax.scan` with **no bound on the leading
(step) axis** and, for four of the five, no length-matching check at all. A
hostile or mistaken caller supplying a huge array forces JAX to materialize
per-step outputs (and stacked inputs) at that length, hanging the process or
exhausting memory well before any step executes.

This is the same hang class already fixed for other scan-driven array loops
in this repo (`core/sarsa.py` #1996, `core/partner_policy_fusion.py` #1991,
`utils/nexting.py` #1992, `core/learners.py` #1989) — `average_reward.py`
was not covered by any of those. All five functions are exported public API
(`alberta_framework.__init__` and `alberta_framework.core.__init__`), and
two of them (`run_differential_td_from_arrays`,
`run_differential_sarsa_from_arrays`) are the runners the Step 5/6 library
facades (`alberta_framework/steps/step5.py`, `step6.py`) call into.

## Fix

Adds `_require_avg_reward_sequence_length` (exact-type JAX-array + shape
gate, rejects a leading length outside `[1, 50_000]` before any scan) and
`_require_avg_reward_matching_length` (checks companion arrays share the
primary sequence's leading length). Applied at the top of all five
`run_*_from_arrays` functions, before `jax.lax.scan` is called.

The `50_000` ceiling is set with headroom above this module's largest
already-exercised sequence (20,000 steps, in
`test_differential_gtd_scan_learns_average_reward_cycle`) while still
bounding the previously-unbounded leading axis. `run_average_reward_horde_from_arrays`
already had per-argument shape-matching validation; this PR adds only the
missing absolute-length cap there, preserving its existing tolerant
`jnp.asarray`-based input handling.

## Scope

- `alberta_framework/core/average_reward.py`
- `tests/test_average_reward.py`

## Verification

Commit under test: `161f13a90514ae4e91bfdfdb36a822e86839437f`

```text
# On origin/main ec035f73 (pre-fix): no cap exists on any of the five
# run_*_from_arrays functions; jax.lax.scan is called unconditionally with
# the caller-supplied leading length. Confirmed by reading the pre-fix
# source (no _require_* call before jax.lax.scan in any of them).

# At this head: oversized (50_001), origin-hang-class-sized (2,000,000),
# and length-mismatched inputs are rejected with a ValueError for all five
# functions, and a monkeypatch spy proves
# alberta_framework.core.average_reward.jax.lax.scan is never invoked on a
# rejected input. Pre-existing behavior (including the 20,000-step
# in-bound GTD test) is unchanged.

.venv/bin/python -m pytest tests/test_average_reward.py -q -o addopts=""
# 114 tests passed (98 before this change, +16 new)

.venv/bin/python -m pytest tests/test_differential_sarsa_horizon.py \
  tests/test_differential_sarsa_discounts.py tests/test_step5_step6_production.py \
  tests/test_step5_hostile_validation.py -q -o addopts=""
# 226 passed -- downstream Step 5/6 callers and discount/horizon coverage unaffected

.venv/bin/python -m ruff check alberta_framework/core/average_reward.py tests/test_average_reward.py
# All checks passed!

.venv/bin/python -m mypy alberta_framework/core/average_reward.py
# Success: no issues found in 1 source file
.venv/bin/python -m mypy tests/test_average_reward.py
# 34 errors, all pre-existing on origin/main before this change (verified by
# diffing mypy output before/after; same 34 errors, none in the newly added
# test class); this PR introduces zero new mypy errors.

python -c "import alberta_framework"  # import surface stays intact
```

<!-- evidence-head:161f13a90514ae4e91bfdfdb36a822e86839437f -->
<!-- evidence-row:logs -->
- [x] logs: local pytest/ruff/mypy output above; 114 collected/passed in tests/test_average_reward.py (+16 new), 226 passed in downstream Step 5/6 + discount/horizon suites, zero new mypy errors vs. origin/main baseline
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - scan sequence-length hang guard, no IPMNIST/benchmark shard produced

<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: anthropic/claude-sonnet-5
- Agent tooling: Claude Code
- Skill path: contribute-to-asi (local skill copy)
- Provenance status: self-reported

AI provider/model: Anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Attribution status: self-reported

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DA5AXVEDNKM87P7XJMGJRR","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T15:27:43.548Z","completed_at":"2026-08-19T15:28:17.371Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T15:27:44.188Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"8bf4a2cf13c96c71d6b654de10556813b072d9a7ba39e87f98b0b6932a165d0f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b6c1bf46-29ef-4d15-9bf4-fc157f0de32e","object_id":"sha256:8bf4a2cf13c96c71d6b654de10556813b072d9a7ba39e87f98b0b6932a165d0f","sha256":"8bf4a2cf13c96c71d6b654de10556813b072d9a7ba39e87f98b0b6932a165d0f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"0QURCAnu4wS81p3aF5OizlTgxqyyCLLOLToQjzdxV8jfDa8NKitK4zBGZW_zjR2CgV0ra5mXHYYyGOh7t_kgBw"}} -->
