### PR TITLE
fix(reference-life): reject deep checkpoint JSON before RecursionError

### DIFF
--- a/alberta_framework/reference_life_checkpoint.py
+++ b/alberta_framework/reference_life_checkpoint.py
@@ -177,6 +177,8 @@ def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
             ).encode("ascii")
             + b"\n"
         )
+    except RecursionError as exc:
+        raise ValueError("checkpoint value exceeds the JSON nesting limit") from exc
     except (TypeError, ValueError) as exc:
         raise ValueError("checkpoint value is not canonical finite JSON") from exc
 
@@ -200,10 +202,42 @@ def _read_bounded_json_file(path: Path) -> bytes:
     return raw
 
 
+def _require_json_text_depth(raw: bytes, *, name: str) -> None:
+    """Reject JSON nests deeper than ``_MAX_TREE_DEPTH`` before RecursionError."""
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{name} is not canonical JSON") from exc
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            if depth > _MAX_TREE_DEPTH:
+                raise ValueError(f"{name} exceeds the JSON nesting limit")
+        elif character in "]}":
+            depth -= 1
+
+
 def _load_canonical_json(path: Path) -> dict[str, Any]:
     raw = _read_bounded_json_file(path)
     try:
+        _require_json_text_depth(raw, name=path.name)
         value = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+    except RecursionError as exc:
+        raise ValueError(f"{path.name} exceeds the JSON nesting limit") from exc
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError(f"{path.name} is not canonical JSON") from exc
     if type(value) is not dict or raw != _canonical_json_bytes(value):
@@ -1514,8 +1548,11 @@ def _load_raw_prototype_metadata(path: Path) -> dict[str, Any]:
 
     raw = _read_bounded_json_file(path)
     try:
+        _require_json_text_depth(raw, name="prototype.metadata")
         value = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
-    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+    except RecursionError as exc:
+        raise ValueError("prototype.metadata exceeds the JSON nesting limit") from exc
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError("nested Prototype metadata is not valid bounded JSON") from exc
     data = _require_keys(
         value,

--- a/tests/test_reference_life_checkpoint_json_depth.py
+++ b/tests/test_reference_life_checkpoint_json_depth.py
@@ -1,0 +1,68 @@
+"""Depth ceiling for reference-life checkpoint JSON loads.
+
+Origin ``json.loads`` RecursionError'd a 10_000-deep object nest that still
+fit ``_MAX_JSON_BYTES``. The codec now uses the directory-tree depth bound
+(32) and raises ``ValueError`` before the CPython decoder blows the stack.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.reference_life_checkpoint import (
+    _MAX_TREE_DEPTH,
+    _canonical_json_bytes,
+    _load_canonical_json,
+    _require_json_text_depth,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _nested_dict(depth: int) -> dict[str, object]:
+    nest: object = True
+    for _ in range(depth):
+        nest = {"k": nest}
+    assert type(nest) is dict
+    return nest
+
+
+def _nested_json_bytes(depth: int) -> bytes:
+    return ('{"k":' * depth + "true" + "}" * depth).encode("ascii")
+
+
+def test_protocol_ceiling_matches_directory_tree_bound() -> None:
+    assert _MAX_TREE_DEPTH == 32
+
+
+def test_last_fit_nest_is_accepted(tmp_path: Path) -> None:
+    encoded = _canonical_json_bytes(_nested_dict(_MAX_TREE_DEPTH))
+    path = tmp_path / "manifest.json"
+    path.write_bytes(encoded)
+    loaded = _load_canonical_json(path)
+    assert loaded == _nested_dict(_MAX_TREE_DEPTH)
+
+
+def test_first_overflow_nest_is_value_error_not_recursion_error() -> None:
+    with pytest.raises(ValueError, match="nesting limit"):
+        _require_json_text_depth(
+            _nested_json_bytes(_MAX_TREE_DEPTH + 1), name="manifest.json"
+        )
+
+
+def test_origin_hang_class_10000_is_value_error_not_recursion_error(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "manifest.json"
+    path.write_bytes(_nested_json_bytes(10_000))
+    with pytest.raises(ValueError, match="nesting limit"):
+        _load_canonical_json(path)
+
+
+def test_load_rejects_overflow_nest_without_recursion_error(tmp_path: Path) -> None:
+    path = tmp_path / "life_state.json"
+    path.write_bytes(_nested_json_bytes(_MAX_TREE_DEPTH + 1))
+    with pytest.raises(ValueError, match="nesting limit"):
+        _load_canonical_json(path)


### PR DESCRIPTION
## Summary

Occupancy-FREE complete RecursionError hang on `origin/main` `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`.

`_load_canonical_json` called `json.loads` and caught only `UnicodeDecodeError`/`JSONDecodeError`. A 10_000-deep object nest still fit `_MAX_JSON_BYTES` (60_004 bytes < 16 MiB) and RecursionError'd:

```text
json.loads(10000-deep {"k": ...}) -> RecursionError
_load_canonical_json(manifest.json with that nest) -> RecursionError
```

`load_reference_life_checkpoint` reads `manifest.json` and `life_state.json` through this helper. The file already bounds directory trees at `_MAX_TREE_DEPTH = 32` but the JSON decoder had no depth ceiling.

This is the same complete class as `#1919` / `#1997` (RecursionError on a deep nest), not leftover persist / 256 MiB / INT32 / scan-T. Scan JSON text with that 32 ceiling and raise `ValueError` before CPython blows the stack.

Not `#1874`. Not clocks / forager / IA / FTL / `optimizers.py`. Not `#1989` `learners.py` / `#1991` fusion / `#1992` nexting / `#1997` `checkpoints.py` (those hosts stay occupied).

## Expected behavior

JSON nests of depth `<= 32` still load when canonically encoded. Depth `33` and the origin hang-class `10_000` raise `ValueError` matching `nesting limit`, never `RecursionError`.

## Scope

- `alberta_framework/reference_life_checkpoint.py`
- `tests/test_reference_life_checkpoint_json_depth.py`

## Verification

```text
# red on origin/main ec035f73
_load_canonical_json(10000-deep {"k":...} nest) -> RecursionError

# green at this head
.venv/bin/python -m pytest tests/test_reference_life_checkpoint_json_depth.py -q -o addopts=""
# 5 passed
.venv/bin/python -m ruff check alberta_framework/reference_life_checkpoint.py tests/test_reference_life_checkpoint_json_depth.py
.venv/bin/python -m mypy alberta_framework/reference_life_checkpoint.py tests/test_reference_life_checkpoint_json_depth.py
```

<!-- evidence-head:825e34be8837343184c4702e44c6bbcaca1b4e7d -->
<!-- evidence-row:logs -->
- [x] logs: origin `ec035f73` RecursionError'd 10_000-deep checkpoint JSON; this head raises ValueError at 33 and 10_000; 5 focused tests passed
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - checkpoint JSON RecursionError preflight, no IPMNIST shard
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - local fail-before-RecursionError proof, no model-trajectory artifact

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
