### PR TITLE
fix(core): cap feature-discovery loop steps before arange hang

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -53,6 +53,9 @@ from alberta_framework.core.update_safety import (
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
 _MAX_STATE_NBYTES = 256 * 1024 * 1024
+# README / package-init public scan last-fit. Origin handed ``10**12`` to
+# ``jnp.arange`` with no reject — hang/OOM, not an INT32 leftover.
+_FEATURE_DISCOVERY_LOOP_MAX_STEPS = 10_000
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -78,6 +81,15 @@ def _require_int32(name: str, value: object, *, minimum: int) -> int:
     if not minimum <= canonical <= _INT32_MAX:
         raise ValueError(f"{name} must be an integer in [{minimum}, {_INT32_MAX}]")
     return canonical
+
+
+def _require_feature_discovery_loop_steps(name: str, value: object) -> int:
+    """Reject scan lengths above the public last-fit before ``jnp.arange``."""
+    if type(value) is not int or value < 1 or value > _FEATURE_DISCOVERY_LOOP_MAX_STEPS:
+        raise ValueError(
+            f"{name} must be an integer in [1, {_FEATURE_DISCOVERY_LOOP_MAX_STEPS}]"
+        )
+    return value
 
 
 def _saturating_int32_increment(value: Array) -> Array:
@@ -1978,6 +1990,7 @@ def run_feature_discovery_loop(
     learner_state: FeatureDiscoveryState | None = None,
 ) -> FeatureDiscoveryLearningResult:
     """Run feature discovery directly from a scan-compatible stream."""
+    num_steps = _require_feature_discovery_loop_steps("num_steps", num_steps)
     stream_key, learner_key = jr.split(key)
     stream_state = stream.init(stream_key)
     if learner_state is None:

--- a/tests/test_feature_discovery_loop_steps.py
+++ b/tests/test_feature_discovery_loop_steps.py
@@ -1,0 +1,106 @@
+"""Protocol step ceiling for public feature-discovery scans.
+
+Documented last-fit is README / package-init ``num_steps=10_000``. Origin handed
+``10**12`` and ``2**31-1`` to ``jnp.arange`` with no reject — hang/OOM, not an
+INT32 leftover.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.feature_discovery import (
+    _FEATURE_DISCOVERY_LOOP_MAX_STEPS,
+    _require_feature_discovery_loop_steps,
+    run_feature_discovery_loop,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:  # pragma: no cover
+        raise AssertionError("index hook executed")
+
+    def __int__(self) -> int:  # pragma: no cover
+        raise AssertionError("int hook executed")
+
+
+def _spy_arange(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    seen: list[object] = []
+
+    def spy(*args: object, **kwargs: object) -> Any:
+        seen.append((args, kwargs))
+        raise AssertionError(f"jnp.arange must not run: {args} {kwargs}")
+
+    monkeypatch.setattr("alberta_framework.core.feature_discovery.jnp.arange", spy)
+    return seen
+
+
+def test_documented_protocol_ceiling_matches_public_scan_example() -> None:
+    assert _FEATURE_DISCOVERY_LOOP_MAX_STEPS == 10_000
+
+
+def test_last_fit_protocol_step_count_is_accepted() -> None:
+    assert (
+        _require_feature_discovery_loop_steps(
+            "num_steps", _FEATURE_DISCOVERY_LOOP_MAX_STEPS
+        )
+        == 10_000
+    )
+
+
+def test_first_overflow_protocol_step_count_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match=r"num_steps must be an integer in \[1, 10000\]"):
+        run_feature_discovery_loop(
+            object(),  # type: ignore[arg-type]
+            object(),
+            _FEATURE_DISCOVERY_LOOP_MAX_STEPS + 1,
+            object(),  # type: ignore[arg-type]
+        )
+    assert seen == []
+
+
+def test_trillion_steps_rejected_before_arange(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        run_feature_discovery_loop(
+            object(),  # type: ignore[arg-type]
+            object(),
+            10**12,
+            object(),  # type: ignore[arg-type]
+        )
+    assert seen == []
+
+
+def test_int32_max_steps_rejected_before_arange(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        run_feature_discovery_loop(
+            object(),  # type: ignore[arg-type]
+            object(),
+            2**31 - 1,
+            object(),  # type: ignore[arg-type]
+        )
+    assert seen == []
+
+
+@pytest.mark.parametrize("value", [True, False, 0, -1, 1.0, 10_000.0])
+def test_rejects_non_exact_or_non_positive_step_counts(value: object) -> None:
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_feature_discovery_loop_steps("num_steps", value)
+
+
+def test_rejects_numpy_and_subclass_step_counts_without_index_hooks() -> None:
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_feature_discovery_loop_steps("num_steps", np.int64(10))
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_feature_discovery_loop_steps("num_steps", _HostileInt(10))


### PR DESCRIPTION
## Summary

Occupancy-FREE complete hang on `origin/main` `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`.

`run_feature_discovery_loop` passed caller `num_steps` straight to `jnp.arange` with no reject. `_require_int32` already gates constructor scalars in this file and is unused on the public scan length:

```text
run_feature_discovery_loop(..., num_steps=10**12, ...) -> jnp.arange(10**12)
run_feature_discovery_loop(..., num_steps=2**31-1, ...) -> jnp.arange(2147483647)
```

That is the hang/OOM class, not leftover INT32 (this PR rejects `2**31-1` rather than blessing it). Public last-fit is README / `alberta_framework/__init__.py` `num_steps=10_000`. In-file scan test uses 15 and still fits.

Not `#1874`. Not clocks / forager / IA / FTL / `optimizers.py`. Not `#1989` `learners.py` / `#1991` fusion / `#1992` nexting / `#1997` / `#2002` (those hosts stay occupied). Occupancy-FREE `feature_discovery.py`.

## Expected behavior

`num_steps` in `[1, 10000]` still scans. `10001`, `10**12`, and `2**31-1` raise `ValueError` matching `num_steps must be an integer in [1, 10000]` before `jnp.arange`.

## Scope

- `alberta_framework/core/feature_discovery.py`
- `tests/test_feature_discovery_loop_steps.py`

## Verification

```text
# red on origin/main ec035f73
run_feature_discovery_loop(..., 10**12, ...) reaches jnp.arange(num_steps)

# green at this head
.venv/bin/python -m pytest tests/test_feature_discovery_loop_steps.py tests/test_feature_discovery.py -q -o addopts=""
# 160 passed
.venv/bin/python -m ruff check alberta_framework/core/feature_discovery.py tests/test_feature_discovery_loop_steps.py
.venv/bin/python -m mypy alberta_framework/core/feature_discovery.py tests/test_feature_discovery_loop_steps.py
```

<!-- evidence-head:cbf8f91f1d9de4895bf91e85c677b466325edafa -->
<!-- evidence-row:logs -->
- [x] logs: origin `ec035f73` handed `10**12` to `jnp.arange`; this head rejects 10001 / 10**12 / 2**31-1 before arange; 12 focused + 160 including existing feature-discovery tests passed
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - scan-length hang preflight, no IPMNIST shard
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - local fail-before-arange proof, no model-trajectory artifact

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
