### PR TITLE
fix(benchmarks): parse remaining campaign scores with the shared strict JSON loader

### DIFF
--- a/alberta_framework/_strict_json.py
+++ b/alberta_framework/_strict_json.py
@@ -54,19 +54,7 @@ def _reject_duplicate_object_keys(
     return parsed
 
 
-def _decode_bounded_utf8_json(path: Path) -> str:
-    try:
-        with path.open("rb") as stream:
-            raw = stream.read(_MAX_JSON_BYTES + 1)
-    except OSError:
-        raise
-    if len(raw) > _MAX_JSON_BYTES:
-        raise ValueError("JSON payload exceeds the byte limit")
-    try:
-        text = raw.decode("utf-8", errors="strict")
-    except UnicodeDecodeError as error:
-        raise ValueError("JSON payload must be valid UTF-8") from error
-
+def _scan_json_nesting(text: str) -> None:
     depth = 0
     in_string = False
     escaped = False
@@ -87,7 +75,38 @@ def _decode_bounded_utf8_json(path: Path) -> str:
                 raise ValueError("JSON payload exceeds the nesting-depth limit")
         elif character in "]}":
             depth -= 1
+
+
+def _decode_bounded_utf8_json(path: Path) -> str:
+    try:
+        with path.open("rb") as stream:
+            raw = stream.read(_MAX_JSON_BYTES + 1)
+    except OSError:
+        raise
+    if len(raw) > _MAX_JSON_BYTES:
+        raise ValueError("JSON payload exceeds the byte limit")
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise ValueError("JSON payload must be valid UTF-8") from error
+    _scan_json_nesting(text)
     return text
+
+
+def _loads_strict_json_object(text: str, *, label: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(
+            text,
+            parse_constant=_reject_nonstandard_constant,
+            parse_float=_parse_finite_float,
+            object_pairs_hook=_reject_duplicate_object_keys,
+        )
+    except RecursionError as error:
+        raise ValueError("JSON payload exceeds the parser recursion limit") from error
+    _validate_exact_json_tree(parsed)
+    if type(parsed) is not dict:
+        raise ValueError(f"{label}: payload must contain one JSON object")
+    return parsed
 
 
 def _validate_exact_json_tree(root: object) -> None:
@@ -118,17 +137,21 @@ def load_strict_json_object(path: Path | str) -> dict[str, Any]:
     """Load one finite UTF-8 JSON object, rejecting duplicate keys at every depth."""
 
     resolved = _require_path(path, name="path")
-    text = _decode_bounded_utf8_json(resolved)
-    try:
-        parsed = json.loads(
-            text,
-            parse_constant=_reject_nonstandard_constant,
-            parse_float=_parse_finite_float,
-            object_pairs_hook=_reject_duplicate_object_keys,
-        )
-    except RecursionError as error:
-        raise ValueError("JSON payload exceeds the parser recursion limit") from error
-    _validate_exact_json_tree(parsed)
-    if type(parsed) is not dict:
-        raise ValueError(f"{resolved}: payload must contain one JSON object")
-    return parsed
+    return _loads_strict_json_object(
+        _decode_bounded_utf8_json(resolved),
+        label=str(resolved),
+    )
+
+
+def load_strict_json_object_from_text(text: object, *, label: str) -> dict[str, Any]:
+    """Parse one in-memory JSON object under the same bounds as the file loader."""
+
+    if type(label) is not str or not label:
+        raise ValueError("label must be a non-empty exact string")
+    if type(text) is not str:
+        raise ValueError(f"{label} must be an exact string")
+    encoded = text.encode("utf-8")
+    if len(encoded) > _MAX_JSON_BYTES:
+        raise ValueError("JSON payload exceeds the byte limit")
+    _scan_json_nesting(text)
+    return _loads_strict_json_object(text, label=label)

--- a/alberta_framework/benchmarks/ipmnist_campaign_tools.py
+++ b/alberta_framework/benchmarks/ipmnist_campaign_tools.py
@@ -20,6 +20,10 @@ from typing import Any, cast
 import numpy as np
 
 from alberta_framework._seed_validation import require_jax_seed
+from alberta_framework._strict_json import (
+    load_strict_json_object,
+    load_strict_json_object_from_text,
+)
 from alberta_framework.benchmarks.ipmnist_provenance import analysis_provenance
 
 DEFAULT_BASE = "upgd_ema_norm_sigma0"
@@ -88,10 +92,7 @@ def across_seed_spread(values: Sequence[float] | np.ndarray[Any, Any]) -> float:
 
 
 def _json_object(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if type(payload) is not dict:
-        raise ValueError(f"{path} must contain a JSON object")
-    return cast(dict[str, Any], payload)
+    return load_strict_json_object(path)
 
 
 def seed_means(root: Path, config_name: str) -> dict[int, float]:
@@ -240,10 +241,11 @@ def _ceiling_runs(
         runs[seed] = payload
     for path in sorted(ceiling_dir.glob(f"{prefix}_seed*.npz")):
         with np.load(path, allow_pickle=False) as archive:
-            payload = json.loads(str(archive["metadata"].item()))
+            payload = load_strict_json_object_from_text(
+                archive["metadata"].item(),
+                label=f"{path} metadata",
+            )
             per_step = np.asarray(archive["per_step"])
-        if type(payload) is not dict:
-            raise ValueError(f"{path} metadata must be a JSON object")
         if payload.get("schema") != "asi.ipmnist_ceiling.run.v2":
             raise ValueError(f"{path} has an unsupported maintained run schema")
         if (

--- a/alberta_framework/benchmarks/rule_discovery_summary.py
+++ b/alberta_framework/benchmarks/rule_discovery_summary.py
@@ -13,6 +13,7 @@ import numpy as np
 
 import alberta_framework.benchmarks.rule_discovery as rule_discovery_module
 from alberta_framework._seed_validation import require_jax_seed, require_unique_jax_seeds
+from alberta_framework._strict_json import load_strict_json_object
 from alberta_framework.benchmarks.ipmnist_provenance import analysis_provenance
 from alberta_framework.benchmarks.rule_discovery import NONPROMOTING_POLICY
 
@@ -42,10 +43,9 @@ def _arm(directory: Path, name: str, seeds: Sequence[int]) -> dict[str, Any]:
         path = directory / f"{name}_seed{seed}.json"
         if not path.exists():
             raise ValueError(f"{name} is missing seed {seed} in {directory}")
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = load_strict_json_object(path)
         if (
-            type(payload) is not dict
-            or type(payload.get("per_task_accuracy")) is not list
+            type(payload.get("per_task_accuracy")) is not list
             or not payload["per_task_accuracy"]
         ):
             raise ValueError(f"{path} lacks per_task_accuracy")

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -221,6 +221,54 @@ def test_across_seed_spread_uses_sample_estimator() -> None:
     assert across_seed_spread([0.5]) == 0.0
 
 
+def test_frontier_rejects_duplicate_json_object_keys(tmp_path: Path) -> None:
+    """Plain json.loads kept the last per_task_accuracy and scored a poisoned shard."""
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    screen.mkdir(parents=True)
+    confirm.mkdir(parents=True)
+    (screen / "base_seed0.json").write_text(
+        '{"seed":0,"per_task_accuracy":[0.1,0.1],"per_task_accuracy":[0.9,0.9]}',
+        encoding="utf-8",
+    )
+    _shard(screen / "candidate_seed0.json", seed=0, accuracy=0.81)
+    _shard(confirm / "base_seed0.json", seed=0, accuracy=0.80)
+    _shard(confirm / "candidate_seed0.json", seed=0, accuracy=0.82)
+    with pytest.raises(ValueError, match="duplicate"):
+        build_frontier(screen, confirm, base="base", arms=["candidate"], created_unix=0.0)
+
+
+def test_ceiling_npz_metadata_rejects_duplicate_json_object_keys(tmp_path: Path) -> None:
+    ceiling = tmp_path / "ceiling"
+    ceiling.mkdir()
+    valid_payload: dict[str, object] = {
+        "schema": "asi.ipmnist_ceiling.run.v2",
+        "evidence_class": "development_screening_diagnostic",
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "tag": "stationary_sigma0_ndecay099",
+        "spec_name": "sigma0_ndecay099",
+        "seed": 0,
+        "perm_mode": "identity",
+        "n_tasks": 1,
+        "task_length": 5000,
+        "per_task_accuracy": [1.0],
+        "mean_accuracy": 1.0,
+        "wall_clock_seconds": 1.0,
+        "provenance": {"schema": "asi.ipmnist.ceiling_run_provenance.v1"},
+    }
+    hostile_metadata = json.dumps(valid_payload).replace(
+        "{", '{"evidence_class":"bogus",', 1
+    )
+    np.savez_compressed(
+        ceiling / "stationary_sigma0_ndecay099_seed0.npz",
+        metadata=np.asarray(hostile_metadata),
+        per_step=np.ones((1, 5000), dtype=np.uint8),
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        build_ceiling_summary(ceiling, tmp_path / "confirm")
+
+
 def test_frontier_requires_and_uses_exact_paired_seed_sets(tmp_path: Path) -> None:
     screen = tmp_path / "screen"
     confirm = tmp_path / "confirm"
@@ -657,6 +705,19 @@ def test_rule_summary_rejects_noncanonical_or_duplicate_seeds_before_io(
             tmp_path / "confirm",
             seeds=seeds,  # type: ignore[arg-type]
         )
+
+
+def test_rule_summary_rejects_duplicate_json_object_keys(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    screen.mkdir(parents=True)
+    for name in SCREEN_ARMS[1:]:
+        _shard(screen / f"{name}_seed0.json", seed=0, accuracy=0.8)
+    (screen / f"{SCREEN_ARMS[0]}_seed0.json").write_text(
+        '{"seed":0,"per_task_accuracy":[0.1],"per_task_accuracy":[0.9]}',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        build_legacy_rule_discovery_summary(screen, tmp_path / "confirm", seeds=(0,))
 
 
 @pytest.mark.parametrize("accuracy", [[], [float("nan")], [-0.1], [1.1]])

--- a/tests/test_strict_json_finite_numbers.py
+++ b/tests/test_strict_json_finite_numbers.py
@@ -31,6 +31,7 @@ from alberta_framework.benchmarks import (
     forager_results,
     forager_rng_parity,
     historical_forager,
+    ipmnist_campaign_tools,
     official_foragax,
     official_foragax_oci,
     upgd_ipmnist,
@@ -52,6 +53,7 @@ _PATH_LOADERS: tuple[
     tuple[str, Callable[[Path], object], type[BaseException]], ...
 ] = (
     ("shared", load_strict_json_object, ValueError),
+    ("campaign_tools", ipmnist_campaign_tools._json_object, ValueError),
     ("evidence_manifest", evidence_manifest._load_strict_json_object, ValueError),
     ("upgd_ipmnist", upgd_ipmnist._strict_json_object, ValueError),
     ("upgd_label_emnist", upgd_label_emnist._strict_json_object, ValueError),

--- a/tests/test_strict_json_hostile_validation.py
+++ b/tests/test_strict_json_hostile_validation.py
@@ -12,6 +12,7 @@ from alberta_framework._strict_json import (
     _reject_duplicate_object_keys,
     _validate_exact_json_tree,
     load_strict_json_object,
+    load_strict_json_object_from_text,
 )
 
 
@@ -98,6 +99,22 @@ def test_load_rejects_nonfinite_json(tmp_path: Path) -> None:
     path.write_text('{"a": NaN}', encoding="utf-8")
     with pytest.raises(ValueError, match="non-standard JSON numeric constant"):
         load_strict_json_object(path)
+
+
+def test_load_from_text_rejects_duplicate_keys_and_non_strings() -> None:
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_strict_json_object_from_text('{"a": 1, "a": 2}', label="metadata")
+    with pytest.raises(ValueError, match="must be an exact string"):
+        load_strict_json_object_from_text(_StringSubclass("{}"), label="metadata")
+    with pytest.raises(ValueError, match="must be an exact string"):
+        load_strict_json_object_from_text(b"{}", label="metadata")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="non-empty exact string"):
+        load_strict_json_object_from_text("{}", label="")
+
+
+def test_load_from_text_rejects_overflow_exponent() -> None:
+    with pytest.raises(ValueError, match="non-finite JSON number"):
+        load_strict_json_object_from_text('{"value":1e999}', label="metadata")
 
 
 def test_hostile_path_not_invoke_fspath_on_error() -> None:


### PR DESCRIPTION
## Summary
- Maintained campaign score readers still used `json.loads` for frontier shards (`_json_object`), ceiling `.npz` metadata, and rule-discovery arm files.
- A duplicate object key or `1e999` could therefore change a number the rest of the screening stack would have rejected.
- Those three readers now go through the shared strict JSON loader (file path + in-memory text), including duplicate-key, non-finite, and byte/nesting bounds.

Fixes leftover holes from #1938 and #1946. This is a validator Fix, not a hill-climb: no shard, seed, or threshold was changed.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_strict_json_hostile_validation.py tests/test_ipmnist_campaign_tools.py tests/test_strict_json_finite_numbers.py -q -o addopts=""` â†’ **147 passed**
- [x] `ruff check` on the six touched files â†’ clean
- [ ] maintainer CI on `ubuntu-latest`

Source HEAD: `317d38313e68e7961bf632a2e19f0896e8501d04`

`JAX_PLATFORMS=cpu` Python 3.12, jax 0.11.1. No IPMNIST shard was launched.

<!-- evidence-head:317d38313e68e7961bf632a2e19f0896e8501d04 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - pytest/ruff stdout recorded in this body; no separate log artifact
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - validator-only Fix; no campaign shard or summary was written

AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
ΓÇö [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DFC9KH98RK249VRTDJN9WQ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T16:58:54.450Z","completed_at":"2026-08-19T17:37:06.663Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T16:58:56.027Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"62d0b9db80db216895b1e1fa2877803e9480b19924c7fa1b23041555bdc3be29","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4db00b72-22dd-443a-a5aa-bfc85a6c0788","object_id":"sha256:62d0b9db80db216895b1e1fa2877803e9480b19924c7fa1b23041555bdc3be29","sha256":"62d0b9db80db216895b1e1fa2877803e9480b19924c7fa1b23041555bdc3be29"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"ugljjbXH7iFGmqI626OZs04NqkMMZOqOJVdho-JmkIGRwKkEY4iPIeSO-Cr2nohiBGK4pz-EnpCGtTCUk1H9Cw"}} -->
