### PR TITLE
fix(core): cap interaction-feature loop steps before arange hang

### DIFF
--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -50,6 +50,9 @@ from alberta_framework.core.future_utility import one_step_output_loss_reduction
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
+# README / package-init public scan last-fit. Origin handed ``10**12`` to
+# ``jnp.arange`` with no reject — hang/OOM, not an INT32 leftover.
+_INTERACTION_FEATURE_LOOP_MAX_STEPS = 10_000
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -81,6 +84,15 @@ def _require_int32(
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _require_interaction_feature_loop_steps(name: str, value: object) -> int:
+    """Reject scan lengths above the public last-fit before ``jnp.arange``."""
+    if type(value) is not int or value < 1 or value > _INTERACTION_FEATURE_LOOP_MAX_STEPS:
+        raise ValueError(
+            f"{name} must be an integer in [1, {_INTERACTION_FEATURE_LOOP_MAX_STEPS}]"
+        )
+    return value
 
 
 def _require_resource(name: str, *, scalars: int, nbytes: int) -> None:
@@ -3892,7 +3904,13 @@ def run_interaction_feature_loop(
     key: Array,
     learner_state: InteractionFeatureState | None = None,
 ) -> InteractionFeatureLearningResult:
-    """Run interaction feature discovery directly from a scan-compatible stream."""
+    """Run interaction feature discovery directly from a scan-compatible stream.
+
+    Raises:
+        ValueError: If ``num_steps`` exceeds the documented protocol ceiling
+            (``10_000``).
+    """
+    num_steps = _require_interaction_feature_loop_steps("num_steps", num_steps)
     stream_key, learner_key = jr.split(key)
     stream_state = stream.init(stream_key)
     if learner_state is None:

--- a/tests/test_interaction_feature_loop_steps.py
+++ b/tests/test_interaction_feature_loop_steps.py
@@ -1,0 +1,97 @@
+"""Protocol step ceilings for public interaction-feature scans.
+
+Origin handed ``10**12`` to ``jnp.arange`` with no reject — that is the
+hang/OOM class, not an INT32 leftover.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.interaction_features import (
+    _INTERACTION_FEATURE_LOOP_MAX_STEPS,
+    _require_interaction_feature_loop_steps,
+    run_interaction_feature_loop,
+)
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:  # pragma: no cover
+        raise AssertionError("index hook executed")
+
+    def __int__(self) -> int:  # pragma: no cover
+        raise AssertionError("int hook executed")
+
+
+def _spy_arange(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    seen: list[object] = []
+
+    def spy(*args: object, **kwargs: object) -> Any:
+        seen.append((args, kwargs))
+        raise AssertionError(f"jnp.arange must not run: {args} {kwargs}")
+
+    monkeypatch.setattr("alberta_framework.core.interaction_features.jnp.arange", spy)
+    return seen
+
+
+def test_documented_protocol_ceiling() -> None:
+    assert _INTERACTION_FEATURE_LOOP_MAX_STEPS == 10_000
+
+
+def test_last_fit_protocol_step_count_is_accepted() -> None:
+    assert _require_interaction_feature_loop_steps(
+        "num_steps", _INTERACTION_FEATURE_LOOP_MAX_STEPS
+    ) == 10_000
+
+
+def test_trillion_steps_rejected_before_arange(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        run_interaction_feature_loop(
+            cast(Any, object()),
+            cast(Any, object()),
+            10**12,
+            jr.key(0),
+        )
+    assert seen == []
+
+
+def test_int32_max_steps_rejected_before_arange(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        run_interaction_feature_loop(
+            cast(Any, object()),
+            cast(Any, object()),
+            2**31 - 1,
+            jr.key(0),
+        )
+    assert seen == []
+
+
+def test_first_overflow_rejected_before_arange(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match=r"num_steps must be an integer in \[1, 10000\]"):
+        run_interaction_feature_loop(
+            cast(Any, object()),
+            cast(Any, object()),
+            _INTERACTION_FEATURE_LOOP_MAX_STEPS + 1,
+            jr.key(0),
+        )
+    assert seen == []
+
+
+@pytest.mark.parametrize("value", [True, False, 0, -1, 1.0, 10_000.0])
+def test_rejects_non_exact_or_non_positive_step_counts(value: object) -> None:
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_interaction_feature_loop_steps("num_steps", value)
+
+
+def test_rejects_numpy_and_subclass_step_counts_without_index_hooks() -> None:
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_interaction_feature_loop_steps("num_steps", np.int64(10))
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_interaction_feature_loop_steps("num_steps", _HostileInt(10))


### PR DESCRIPTION
## Summary
- `run_interaction_feature_loop` passed `num_steps` straight to `jnp.arange`.
- `10**12` or `2**31-1` could hang or OOM before any learning happened.
- The loop now rejects non-exact ints and lengths above the public last-fit (`10_000`) before `arange`.

This is a validator Fix, not a hill-climb: no shard, seed, or threshold was changed.

## Test plan
- [x] `python -m pytest tests/test_interaction_feature_loop_steps.py -q -o addopts=""` → **12 passed**
- [x] `ruff check` on the two touched files → clean
- [ ] maintainer CI on `ubuntu-latest`

`JAX_PLATFORMS=cpu` Python 3.12, jax 0.11.1. No IPMNIST shard was launched.

AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi

Source HEAD: `a5816e0179d20beadf226f60ee23a85de6d2a6c4`

<!-- evidence-head:a5816e0179d20beadf226f60ee23a85de6d2a6c4 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - pytest/ruff stdout recorded in this body; no separate log artifact
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - validator-only Fix; no campaign shard or summary was written

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DJEV8P8W4ZA0SNWYY5VWHV","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T17:52:43.799Z","completed_at":"2026-08-20T02:41:55.168Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T17:52:45.529Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"269a01fb500f04b69fd9763aff570e06897b939cffd8070851f9d2c3572b3604","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"d3beaf82-34b1-44f9-8d0e-96cb4334c28f","object_id":"sha256:269a01fb500f04b69fd9763aff570e06897b939cffd8070851f9d2c3572b3604","sha256":"269a01fb500f04b69fd9763aff570e06897b939cffd8070851f9d2c3572b3604"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"DYRWMRtajz4rnQUh9V863WHbG_Iz2c6x4YFxmMT1kHMs_1thP_9E2jIGYL8Tvs0XlaqUbSHIerGoYXkXrisNBw"}} -->
