### PR TITLE
fix(streams): cap gauntlet scan lengths before arange hang

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -72,6 +72,9 @@ from alberta_framework.core.types import TimeStep
 from alberta_framework.streams.base import ScanStream
 
 NUM_SEGMENTS = 9
+# Documented last-fit is the default nine-segment program
+# (``segment_length=3000``). Origin handed ``10**12`` to ``jnp.arange``.
+_GAUNTLET_LOOP_MAX_STEPS = NUM_SEGMENTS * 3000
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
@@ -98,6 +101,13 @@ def _require_int(
         raise ValueError(f"{name} must be an integer")
     if value < minimum or value > maximum:
         raise ValueError(f"{name} must lie in [{minimum}, {maximum}]")
+    return value
+
+
+def _require_gauntlet_loop_steps(name: str, value: object) -> int:
+    """Reject scan lengths above the documented program before ``jnp.arange``."""
+    if type(value) is not int or value < 1 or value > _GAUNTLET_LOOP_MAX_STEPS:
+        raise ValueError(f"{name} must be an integer in [1, {_GAUNTLET_LOOP_MAX_STEPS}]")
     return value
 
 
@@ -1113,7 +1123,12 @@ def run_gauntlet(
     Returns:
         ``(final_learner_state, squared_errors)`` with squared_errors of
         shape ``(num_steps,)``.
+
+    Raises:
+        ValueError: If ``num_steps`` exceeds the documented program ceiling
+            (``27_000``).
     """
+    num_steps = _require_gauntlet_loop_steps("num_steps", num_steps)
     if reinit_each_segment and segment_length is None:
         raise ValueError("segment_length is required when reinit_each_segment=True")
     resolved_segment_length = 1 if segment_length is None else segment_length
@@ -1167,6 +1182,7 @@ def run_gauntlet_batched(
     Returns:
         Squared errors of shape ``(n_seeds, num_steps)``.
     """
+    num_steps = _require_gauntlet_loop_steps("num_steps", num_steps)
 
     def one_seed(key: Array) -> Array:
         _, sq = run_gauntlet(

--- a/tests/test_gauntlet_loop_steps.py
+++ b/tests/test_gauntlet_loop_steps.py
@@ -1,0 +1,103 @@
+"""Protocol step ceilings for public gauntlet scans.
+
+Documented last-fit is the default nine-segment program (``9 * 3000``).
+Origin handed ``10**12`` to ``jnp.arange`` with no reject — hang/OOM, not
+an INT32 leftover.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.streams.gauntlet import (
+    _GAUNTLET_LOOP_MAX_STEPS,
+    NUM_SEGMENTS,
+    _require_gauntlet_loop_steps,
+    run_gauntlet,
+    run_gauntlet_batched,
+)
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:  # pragma: no cover
+        raise AssertionError("index hook executed")
+
+    def __int__(self) -> int:  # pragma: no cover
+        raise AssertionError("int hook executed")
+
+
+def _spy_arange(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    seen: list[object] = []
+
+    def spy(*args: object, **kwargs: object) -> Any:
+        seen.append((args, kwargs))
+        raise AssertionError(f"jnp.arange must not run: {args} {kwargs}")
+
+    monkeypatch.setattr("alberta_framework.streams.gauntlet.jnp.arange", spy)
+    return seen
+
+
+def test_documented_protocol_ceiling_matches_default_program() -> None:
+    assert NUM_SEGMENTS == 9
+    assert _GAUNTLET_LOOP_MAX_STEPS == 27_000
+
+
+def test_last_fit_protocol_step_count_is_accepted() -> None:
+    assert _require_gauntlet_loop_steps("num_steps", _GAUNTLET_LOOP_MAX_STEPS) == 27_000
+
+
+def test_trillion_steps_rejected_before_arange(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        run_gauntlet(cast(Any, object()), cast(Any, object()), 10**12, jr.key(0))
+    assert seen == []
+
+
+def test_int32_max_steps_rejected_before_arange(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        run_gauntlet(cast(Any, object()), cast(Any, object()), 2**31 - 1, jr.key(0))
+    assert seen == []
+
+
+def test_first_overflow_rejected_before_arange(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match=r"num_steps must be an integer in \[1, 27000\]"):
+        run_gauntlet(
+            cast(Any, object()),
+            cast(Any, object()),
+            _GAUNTLET_LOOP_MAX_STEPS + 1,
+            jr.key(0),
+        )
+    assert seen == []
+
+
+def test_batched_trillion_steps_rejected_before_arange(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        run_gauntlet_batched(
+            cast(Any, object()),
+            cast(Any, object()),
+            10**12,
+            cast(Any, object()),
+        )
+    assert seen == []
+
+
+@pytest.mark.parametrize("value", [True, False, 0, -1, 1.0, 27_000.0])
+def test_rejects_non_exact_or_non_positive_step_counts(value: object) -> None:
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_gauntlet_loop_steps("num_steps", value)
+
+
+def test_rejects_numpy_and_subclass_step_counts_without_index_hooks() -> None:
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_gauntlet_loop_steps("num_steps", np.int64(10))
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_gauntlet_loop_steps("num_steps", _HostileInt(10))


### PR DESCRIPTION
## Summary
- `run_gauntlet` / `run_gauntlet_batched` passed `num_steps` straight to `jnp.arange`.
- `10**12` or `2**31-1` could hang or OOM before any diagnostic ran.
- Both now reject non-exact ints and lengths above the documented last-fit (`9 * 3000 = 27_000`) before `arange`.

This is a validator Fix, not a hill-climb: no shard, seed, or threshold was changed.

## Test plan
- [x] `python -m pytest tests/test_gauntlet_loop_steps.py tests/test_gauntlet_hostile.py tests/test_gauntlet_window_hostile.py -q -o addopts=""` → **18 passed**
- [x] `ruff check` on the two touched files → clean
- [ ] maintainer CI on `ubuntu-latest`

`JAX_PLATFORMS=cpu` Python 3.12, jax 0.11.1. No IPMNIST shard was launched.

AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi

Source HEAD: `0d66934e2ad1ad77399c1421532c5e4270ec30da`

<!-- evidence-head:0d66934e2ad1ad77399c1421532c5e4270ec30da -->
<!-- evidence-row:logs -->
- [x] logs: N/A - pytest/ruff stdout recorded in this body; no separate log artifact
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - validator-only Fix; no campaign shard or summary was written

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DJRW0NTPN6R5W35V6QC8TT","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T17:58:12.245Z","completed_at":"2026-08-20T02:48:22.048Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T17:58:13.481Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2fc6a0928864cd0cab45a51d680487fcdd2538c2519c3b73c3b6737a530f23c8","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"af61af92-31ad-4ba4-9ef9-fd6121d8a58d","object_id":"sha256:2fc6a0928864cd0cab45a51d680487fcdd2538c2519c3b73c3b6737a530f23c8","sha256":"2fc6a0928864cd0cab45a51d680487fcdd2538c2519c3b73c3b6737a530f23c8"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"ucdIpIVKAmmcOKFaRM1y3K0gi1Vq4ot_bV6fDVM4WauKXU-2WeKW-SpPaRa76FetKJzl7vYDFqRe0kQ25fewCw"}} -->
