### PR TITLE
fix(core): cap behavior-model scan sequence length before scan hang

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -88,6 +88,39 @@ def _resource_counts(n_actions: int, feature_dim: int) -> tuple[int, int]:
     return trainable, state_nbytes
 
 
+# Matches the class of ceiling already established for other scan-driven
+# array-loop runners in ``core`` (e.g. ``average_reward._AVERAGE_REWARD_SEQUENCE_MAX_STEPS``,
+# ``learners._LEARNING_LOOP_MAX_STEPS``). Set with generous headroom above
+# this module's largest exercised sequence (12 steps, see
+# ``test_scan_loop_and_jit_compatibility``) while still bounding the leading
+# axis that ``run_behavior_model_from_arrays`` hands straight to
+# ``jax.lax.scan``.
+_BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS = 50_000
+
+
+def _require_behavior_model_sequence_length(name: str, value: object) -> int:
+    """Reject an oversized or malformed leading axis before it drives a scan.
+
+    ``run_behavior_model_from_arrays`` hands ``observations`` straight to
+    ``jax.lax.scan`` with no bound on the leading (step) axis. A hostile or
+    mistaken caller supplying a huge leading length forces JAX to materialize
+    per-step outputs (and, for large enough arrays, the inputs) at that
+    length, exhausting memory or hanging the process well before any step
+    executes.
+    """
+    if not (type(value) is np.ndarray or isinstance(value, jax.Array)):
+        raise TypeError(f"{name} must be a trusted array")
+    array = np.asarray(value) if type(value) is np.ndarray else value
+    if array.ndim < 1:
+        raise ValueError(f"{name} must have a leading step axis")
+    length = int(array.shape[0])
+    if length < 1 or length > _BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS:
+        raise ValueError(
+            f"{name} length must be an integer in [1, {_BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS}]"
+        )
+    return length
+
+
 def _behavior_model_update_working_set_bytes(n_actions: int, feature_dim: int) -> int:
     """Source persist, proposed persist, committed persist, and returned extras.
 
@@ -981,10 +1014,19 @@ def run_behavior_model_from_arrays(
     observations: Float[Array, "num_steps feature_dim"],
     actions: Int[Array, " num_steps"],
 ) -> BehaviorModelArrayResult:
-    """Run online behavior prediction over arrays with ``jax.lax.scan``."""
+    """Run online behavior prediction over arrays with ``jax.lax.scan``.
+
+    Raises:
+        TypeError: If ``observations`` is not a trusted array.
+        ValueError: If ``observations`` does not have shape
+            ``(num_steps, feature_dim)``, is empty, or its leading (step)
+            length exceeds the documented scan-length ceiling
+            (``_BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS``).
+    """
 
     if len(observations.shape) != 2:
         raise ValueError("observations must have shape (num_steps, feature_dim)")
+    _require_behavior_model_sequence_length("observations", observations)
     _, _ = _integer_action_ids(
         actions,
         n_actions=model.config.n_actions,

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -25,10 +25,12 @@ class _HostileDict(dict[str, Any]):
 
 try:
     from alberta_framework.core.behavior_model import (
+        _BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS,
         BehaviorModel,
         BehaviorModelConfig,
         _behavior_model_update_working_set_bytes,
         _preflight_behavior_model_update_working_set,
+        _require_behavior_model_sequence_length,
         _resource_counts,
         action_log_likelihoods,
         clipped_importance_ratios,
@@ -71,6 +73,12 @@ except ImportError:
         behavior_model_module._preflight_behavior_model_update_working_set
     )
     _resource_counts = behavior_model_module._resource_counts
+    _BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS = (
+        behavior_model_module._BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS
+    )
+    _require_behavior_model_sequence_length = (
+        behavior_model_module._require_behavior_model_sequence_length
+    )
 
 
 def _assert_behavior_update_finite(result: Any) -> None:
@@ -762,3 +770,101 @@ def test_behavior_model_persistent_byte_bound_still_fires_first() -> None:
 def test_preflight_helper_rejects_the_same_working_set() -> None:
     with pytest.raises(ValueError, match="update working set byte count"):
         _preflight_behavior_model_update_working_set(1, 180_000_000)
+
+
+# =============================================================================
+# Scan sequence-length ceiling (hang guard)
+# =============================================================================
+#
+# ``run_behavior_model_from_arrays`` hands ``observations``/``actions``
+# straight to ``jax.lax.scan`` with no bound on the leading (step) axis. A
+# hostile or mistaken caller supplying a huge array forces JAX to materialize
+# per-step outputs at that length, hanging the process well before any step
+# executes -- the same hang class already fixed for other scan-driven array
+# loops in ``core`` and ``utils`` (e.g. ``core/sarsa.py``,
+# ``core/average_reward.py``, ``core/learners.py``, ``utils/nexting.py``).
+
+
+def _spy_scan(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    seen: list[int] = []
+
+    def spy(fn, init, xs, **kwargs):  # type: ignore[no-untyped-def]
+        first = xs[0] if isinstance(xs, tuple) else xs
+        seen.append(int(first.shape[0]))
+        raise AssertionError(f"jax.lax.scan must not run: T={first.shape[0]}")
+
+    monkeypatch.setattr("alberta_framework.core.behavior_model.jax.lax.scan", spy)
+    return seen
+
+
+class TestBehaviorModelSequenceCeiling:
+    def test_documented_protocol_ceiling(self) -> None:
+        assert _BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS == 50_000
+
+    def test_last_fit_length_is_accepted(self) -> None:
+        matrix = jnp.zeros((_BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS, 2))
+        assert (
+            _require_behavior_model_sequence_length("observations", matrix)
+            == _BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS
+        )
+
+    def test_first_overflow_length_is_rejected(self) -> None:
+        matrix = jnp.zeros((_BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS + 1, 2))
+        with pytest.raises(
+            ValueError, match=r"observations length must be an integer in \[1, 50000\]"
+        ):
+            _require_behavior_model_sequence_length("observations", matrix)
+
+    def test_empty_length_is_rejected(self) -> None:
+        matrix = jnp.zeros((0, 2))
+        with pytest.raises(ValueError, match=r"observations length must be an integer in"):
+            _require_behavior_model_sequence_length("observations", matrix)
+
+    def test_scalar_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="leading step axis"):
+            _require_behavior_model_sequence_length("observations", jnp.array(1.0))
+
+    def test_non_array_is_rejected(self) -> None:
+        with pytest.raises(TypeError, match="must be a trusted array"):
+            _require_behavior_model_sequence_length("observations", [[1.0, 2.0]])
+
+        class _HostileArrayLike:
+            shape = (3, 2)
+            ndim = 2
+
+        with pytest.raises(TypeError, match="must be a trusted array"):
+            _require_behavior_model_sequence_length("observations", _HostileArrayLike())
+
+    def test_run_behavior_model_from_arrays_rejects_overflow_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        model = BehaviorModel(BehaviorModelConfig(n_actions=3, step_size=0.05))
+        state = model.init(feature_dim=3, key=jax.random.key(5))
+        n = _BEHAVIOR_MODEL_SEQUENCE_MAX_STEPS + 1
+        observations = jnp.zeros((n, 3), dtype=jnp.float32)
+        actions = jnp.zeros((n,), dtype=jnp.int32)
+        with pytest.raises(ValueError, match="observations length must be an integer in"):
+            run_behavior_model_from_arrays(model, state, observations, actions)
+        assert seen == []
+
+    def test_run_behavior_model_from_arrays_rejects_mismatched_actions_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        model = BehaviorModel(BehaviorModelConfig(n_actions=3, step_size=0.05))
+        state = model.init(feature_dim=3, key=jax.random.key(6))
+        observations = jnp.zeros((5, 3), dtype=jnp.float32)
+        actions = jnp.zeros((4,), dtype=jnp.int32)
+        with pytest.raises(ValueError, match="actions must broadcast"):
+            run_behavior_model_from_arrays(model, state, observations, actions)
+        assert seen == []
+
+    def test_run_behavior_model_from_arrays_still_runs_inside_the_ceiling(self) -> None:
+        model = BehaviorModel(BehaviorModelConfig(n_actions=3, step_size=0.05))
+        state = model.init(feature_dim=3, key=jax.random.key(7))
+        observations = jnp.eye(3, dtype=jnp.float32).repeat(4, axis=0)
+        actions = jnp.array([0, 1, 2] * 4, dtype=jnp.int32)
+        result = run_behavior_model_from_arrays(model, state, observations, actions)
+        chex.assert_shape(result.probabilities, (12, 3))
+        assert int(result.state.step_count) == 12


### PR DESCRIPTION
## Summary

`alberta_framework/core/behavior_model.py`'s `run_behavior_model_from_arrays`
hands its caller-supplied `observations`/`actions` step arrays straight to
`jax.lax.scan` with **no bound on the leading (step) axis**. A hostile or
mistaken caller supplying a huge array forces JAX to materialize per-step
outputs (and stacked inputs) at that length, hanging the process or
exhausting memory well before any step executes.

This is the same hang class already fixed for other scan-driven array loops
in this repo (`core/sarsa.py` #1996, `core/partner_policy_fusion.py` #1991,
`utils/nexting.py` #1992, `core/learners.py` #1989,
`core/average_reward.py` #1999) — `behavior_model.py`'s array runner was not
covered by any of those. `run_behavior_model_from_arrays` is exported public
API (`alberta_framework.__init__` and `alberta_framework.core.__init__`).

The existing per-call preflight in this file
(`_preflight_behavior_model_update_working_set`, from a prior fix) only
bounds the working set of a *single* `update`/`init` call by `n_actions` /
`feature_dim`; it says nothing about the `num_steps` leading axis that
`run_behavior_model_from_arrays` feeds to `jax.lax.scan`, so this is a
distinct gap.

## Fix

Adds `_require_behavior_model_sequence_length` (exact-type trusted-array +
shape gate, rejects a leading length outside `[1, 50_000]` before any scan)
and calls it at the top of `run_behavior_model_from_arrays`, before
`_integer_action_ids` and `jax.lax.scan` run. The `50_000` ceiling matches
the convention already established in `average_reward.py`
(`_AVERAGE_REWARD_SEQUENCE_MAX_STEPS`) and `learners.py`
(`_LEARNING_LOOP_MAX_STEPS`), with generous headroom above this module's
largest currently-exercised sequence (12 steps, in
`test_scan_loop_and_jit_compatibility`).

## Scope

- `alberta_framework/core/behavior_model.py`
- `tests/test_behavior_model.py`

## Verification

Commit under test: `8e75dbe7065e68ccb99a4d9609c10e7880c711cc`

```text
# On origin/main ec035f73 (pre-fix): no cap exists on
# run_behavior_model_from_arrays; jax.lax.scan is called unconditionally
# with the caller-supplied leading length. Confirmed by reading the
# pre-fix source (no _require_* length gate before jax.lax.scan).

# At this head: a monkeypatch spy on
# alberta_framework.core.behavior_model.jax.lax.scan proves it is never
# invoked for an oversized (50_001-step) or mismatched-length input;
# both are rejected with a ValueError before the scan runs. The
# 50_000-step boundary is exercised exactly (accepted at 50_000,
# rejected at 50_001), and the existing 12-step
# test_scan_loop_and_jit_compatibility / test_run_behavior_model_from_arrays_
# still_runs_inside_the_ceiling continue to pass unchanged.

.venv/bin/python -m pytest tests/test_behavior_model.py -q -o addopts=""
................................................................         [100%]
64 passed in 14.66s   # 55 pre-existing + 9 new

.venv/bin/python -m ruff check alberta_framework/core/behavior_model.py tests/test_behavior_model.py
All checks passed!

.venv/bin/python -m mypy
Success: no issues found in 197 source files

python -c "import alberta_framework; from alberta_framework import run_behavior_model_from_arrays"
import OK
```

<!-- evidence-head:8e75dbe7065e68ccb99a4d9609c10e7880c711cc -->
<!-- evidence-row:logs -->
- [x] logs: local pytest/ruff/mypy output above; 64 passed in tests/test_behavior_model.py (+9 new), full-project mypy strict clean (197 files), package import surface intact
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - scan sequence-length hang guard, no IPMNIST/benchmark shard produced

## Deviations from pre-registration

None — this is a Fix (repairs a measurement-corrupting/hang-inducing gap),
not a benchmark climb, so no pre-registered comparison applies.

## Open / unexplained

None known. The `50_000` ceiling is a documented-protocol convention shared
with sibling fixes, not a hard resource-derived bound; if a legitimate
caller needs more steps, that ceiling should be raised deliberately alongside
new evidence of the larger workload, not silently.

<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: anthropic/claude-sonnet-5
- Agent tooling: Claude Code
- Skill path: contribute-to-asi (local skill copy)
- Provenance status: self-reported

AI provider/model: Anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Attribution status: self-reported

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DPM7QTVMNBP31XWXSR9864","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T19:05:34.714Z","completed_at":"2026-08-19T19:06:06.976Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T19:05:35.592Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0652668614469c908891922b70f5e6275b844f26c7089627ce02e51a830449ce","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"66e2c3ff-1b46-4133-8c60-eb65b39c70db","object_id":"sha256:0652668614469c908891922b70f5e6275b844f26c7089627ce02e51a830449ce","sha256":"0652668614469c908891922b70f5e6275b844f26c7089627ce02e51a830449ce"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"wbpmKKxBbVdIdvH_VxVHC_hGyTV_tG_ATkF7DgpckNttRvNA8wl96CWLP9-OFcaZEuqdJbiZT3SotMfkQ4ESDg"}} -->
