### PR TITLE
fix(step9): cap dreaming array-loop sequence length before scan hang

### DIFF
--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -73,6 +73,17 @@ from alberta_framework.steps.step6 import (
 _INT32_MAX = 2**31 - 1
 _MAX_CONFIG_SEQUENCE_LENGTH = 4_096
 _MAX_DREAM_WORK_PER_REAL_STEP = 4_096
+# Matches the established ceiling for other scan-driven array-loop runners
+# fixed this session (``core.sarsa._SARSA_SEQUENCE_MAX_STEPS``,
+# ``core.average_reward._AVERAGE_REWARD_SEQUENCE_MAX_STEPS``,
+# ``core.horde_actor_critic._HORDE_AC_SEQUENCE_MAX_STEPS``). ``run_step9_scan``
+# hands ``rewards``/``next_observations`` straight to ``jax.lax.scan`` with no
+# bound on the leading (step) axis; bounding only by ``_INT32_MAX`` still
+# permits a caller to force JAX to trace/compile a scan of ~2 billion steps,
+# hanging the process well before any step executes. Step 9's per-step work
+# additionally includes model-based dreaming rollouts, so this module is at
+# least as exposed to the hang as its siblings.
+_STEP9_SEQUENCE_MAX_STEPS = 10_000
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -916,6 +927,36 @@ def step9_update(
     )
 
 
+def _has_step9_trusted_array_type(value: object) -> bool:
+    actual_type = type(value)
+    return (
+        actual_type is np.ndarray
+        or issubclass(actual_type, jax.Array)
+        or issubclass(actual_type, jax.core.Tracer)
+    )
+
+
+def _require_step9_trusted_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: Any,
+) -> Array:
+    if not _has_step9_trusted_array_type(value):
+        raise TypeError(f"{name} must be a trusted array")
+    try:
+        actual_shape = tuple(value.shape)
+        actual_dtype = jnp.dtype(value.dtype)
+    except (AttributeError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape and dtype metadata") from error
+    if actual_shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if actual_dtype != jnp.dtype(dtype):
+        raise TypeError(f"{name} must have dtype {jnp.dtype(dtype)}")
+    return cast(Array, value)
+
+
 def run_step9_scan(
     config: Step9DreamingConfig,
     agent: DifferentialSARSAAgent,
@@ -925,7 +966,35 @@ def run_step9_scan(
     rewards: Array,
     next_observations: Array,
 ) -> Step9ArrayResult:
-    """Run Step 9 dreaming over real continuing transition arrays."""
+    """Run Step 9 dreaming over real continuing transition arrays.
+
+    Raises:
+        TypeError: If ``config`` is not an actual :class:`Step9DreamingConfig`,
+            or ``rewards``/``next_observations`` are not trusted arrays with
+            the expected dtype.
+        ValueError: If ``rewards`` is empty, exceeds the documented
+            scan-length ceiling (``_STEP9_SEQUENCE_MAX_STEPS``), or
+            ``next_observations`` does not share its leading length.
+    """
+    if type(config) is not Step9DreamingConfig:
+        raise TypeError("config must be an actual Step9DreamingConfig")
+    if not _has_step9_trusted_array_type(rewards):
+        raise TypeError("rewards must be a trusted array")
+    try:
+        steps = int(rewards.shape[0])
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("rewards must expose trusted shape metadata") from error
+    if not 1 <= steps <= _STEP9_SEQUENCE_MAX_STEPS:
+        raise ValueError(
+            f"rewards length must be an integer in [1, {_STEP9_SEQUENCE_MAX_STEPS}]"
+        )
+    rewards = _require_step9_trusted_array("rewards", rewards, shape=(steps,), dtype=jnp.float32)
+    next_observations = _require_step9_trusted_array(
+        "next_observations",
+        next_observations,
+        shape=(steps, config.observation_dim),
+        dtype=jnp.float32,
+    )
 
     def scan_step(
         carry: Step9DreamingState,

--- a/tests/test_step9_hostile_validation.py
+++ b/tests/test_step9_hostile_validation.py
@@ -3,12 +3,19 @@
 from fractions import Fraction
 from typing import Any, cast
 
+import jax
+import jax.numpy as jnp
+import jax.random as jr
 import numpy as np
 import pytest
 
 from alberta_framework.steps.step9 import (
+    _STEP9_SEQUENCE_MAX_STEPS,
     Step9DreamingConfig,
+    _require_step9_trusted_array,
+    init_step9_state,
     make_step9_components,
+    run_step9_scan,
     run_step9_smoke,
 )
 
@@ -244,3 +251,161 @@ def test_runtime_entry_points_require_exact_config_without_truthiness_hooks() ->
 def test_smoke_preflights_complete_output_shape_before_allocation() -> None:
     with pytest.raises(ValueError, match="observation row count"):
         run_step9_smoke(steps=2**31 - 1)
+
+
+# =============================================================================
+# run_step9_scan sequence-length ceiling (hang guard)
+# =============================================================================
+#
+# ``run_step9_scan`` hands ``rewards``/``next_observations`` straight to
+# ``jax.lax.scan`` with no bound on the leading (step) axis. A hostile or
+# mistaken caller supplying a huge array forces JAX to trace/compile a scan
+# of that length, hanging the process well before any step executes -- the
+# same hang class fixed this session for other scan-driven array loops in
+# ``core/sarsa.py``, ``core/average_reward.py``, and
+# ``core/horde_actor_critic.py``.
+
+
+def _step9_scan_components(
+    steps: int,
+) -> tuple[Step9DreamingConfig, Any, Any, Any, Any, jax.Array, jax.Array]:
+    cfg = Step9DreamingConfig(
+        observation_dim=3,
+        n_actions=2,
+        model_hidden_sizes=(),
+        model_sparsity=0.0,
+        planning_budget=0,
+        dreaming_warmup_steps=0,
+        dreaming_max_model_error=1e30,
+    )
+    agent, model, buffer = make_step9_components(cfg)
+    state = init_step9_state(
+        agent,
+        model,
+        buffer,
+        key=jr.key(0),
+        initial_observation=jnp.zeros((3,), dtype=jnp.float32),
+    )
+    rewards = jnp.zeros((steps,), dtype=jnp.float32)
+    next_observations = jnp.zeros((steps, 3), dtype=jnp.float32)
+    return cfg, agent, model, buffer, state, rewards, next_observations
+
+
+def _spy_scan(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    seen: list[int] = []
+
+    def spy(fn, init, xs, **kwargs):  # type: ignore[no-untyped-def]
+        first = xs[0] if isinstance(xs, tuple) else xs
+        seen.append(int(first.shape[0]))
+        raise AssertionError(f"jax.lax.scan must not run: T={first.shape[0]}")
+
+    monkeypatch.setattr("alberta_framework.steps.step9.jax.lax.scan", spy)
+    return seen
+
+
+def test_step9_sequence_ceiling_is_documented() -> None:
+    assert _STEP9_SEQUENCE_MAX_STEPS == 10_000
+
+
+def test_step9_ceiling_length_array_still_passes_the_trusted_array_gate() -> None:
+    rewards = jnp.zeros((_STEP9_SEQUENCE_MAX_STEPS,), dtype=jnp.float32)
+    checked = _require_step9_trusted_array(
+        "rewards", rewards, shape=(_STEP9_SEQUENCE_MAX_STEPS,), dtype=jnp.float32
+    )
+    assert checked.shape == (_STEP9_SEQUENCE_MAX_STEPS,)
+
+
+def test_run_step9_scan_rejects_overflow_length_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _spy_scan(monkeypatch)
+    cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(
+        _STEP9_SEQUENCE_MAX_STEPS + 1
+    )
+    with pytest.raises(ValueError, match=r"rewards length must be an integer in \[1, 10000\]"):
+        run_step9_scan(cfg, agent, model, buffer, state, rewards, next_observations)
+    assert seen == []
+
+
+def test_run_step9_scan_rejects_origin_hang_class_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A far larger sequence length -- the actual hang class -- is also
+    rejected before ``jax.lax.scan`` is ever called."""
+    seen = _spy_scan(monkeypatch)
+    cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(
+        200_000
+    )
+    with pytest.raises(ValueError, match="rewards length must be an integer in"):
+        run_step9_scan(cfg, agent, model, buffer, state, rewards, next_observations)
+    assert seen == []
+
+
+def test_run_step9_scan_rejects_mismatched_next_observations_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _spy_scan(monkeypatch)
+    cfg, agent, model, buffer, state, rewards, _next_observations = _step9_scan_components(5)
+    mismatched = jnp.zeros((6, 3), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="next_observations must have shape"):
+        run_step9_scan(cfg, agent, model, buffer, state, rewards, mismatched)
+    assert seen == []
+
+
+def test_run_step9_scan_rejects_non_config_type_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _spy_scan(monkeypatch)
+    _cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(5)
+    with pytest.raises(TypeError, match="actual Step9DreamingConfig"):
+        run_step9_scan(
+            cast(Any, object()), agent, model, buffer, state, rewards, next_observations
+        )
+    assert seen == []
+
+
+def test_run_step9_scan_rejects_wrong_dtype_rewards_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _spy_scan(monkeypatch)
+    cfg, agent, model, buffer, state, _rewards, next_observations = _step9_scan_components(5)
+    int_rewards = jnp.zeros((5,), dtype=jnp.int32)
+    with pytest.raises(TypeError, match="rewards must have dtype"):
+        run_step9_scan(cfg, agent, model, buffer, state, int_rewards, next_observations)
+    assert seen == []
+
+
+class _HostileArray:
+    """Duck-types ``.shape``/``.dtype`` but is not a trusted array type."""
+
+    calls = 0
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        type(self).calls += 1
+        raise AssertionError("shape hook must not run")
+
+    @property
+    def dtype(self) -> np.dtype[Any]:
+        type(self).calls += 1
+        raise AssertionError("dtype hook must not run")
+
+
+def test_run_step9_scan_rejects_hostile_rewards_without_touching_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _spy_scan(monkeypatch)
+    cfg, agent, model, buffer, state, _rewards, next_observations = _step9_scan_components(5)
+    _HostileArray.calls = 0
+    with pytest.raises(TypeError, match="rewards must be a trusted array"):
+        run_step9_scan(
+            cfg, agent, model, buffer, state, cast(Any, _HostileArray()), next_observations
+        )
+    assert _HostileArray.calls == 0
+    assert seen == []
+
+
+def test_run_step9_scan_accepts_a_small_in_bounds_sequence() -> None:
+    cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(4)
+    result = run_step9_scan(cfg, agent, model, buffer, state, rewards, next_observations)
+    assert result.real_td_errors.shape == (4,)


### PR DESCRIPTION
## Provider/model disclosure

`--client claude-code --provider anthropic --model claude-sonnet-5`, lane `rama0x1-asi-claude-worker`.

## What's broken

`alberta_framework/steps/step9.py::run_step9_scan` hands its caller-supplied
`rewards`/`next_observations` step arrays straight to `jax.lax.scan` with no
real bound on the leading (step) axis. This is the same "unbounded scan hang"
defect class already fixed this session for other scan-driven array-loop
runners: `core/sarsa.py`, `core/average_reward.py`, and
`core/horde_actor_critic.py`. A hostile or mistaken caller supplying a huge
`rewards`/`next_observations` array forces JAX to trace/compile a scan of that
length, hanging the process well before any step executes. Step 9's per-step
work additionally drives model-based dreaming rollouts (`planning_budget`
candidates per real step), so it is at least as exposed to the hang as its
siblings.

The facade also had no exact-type gate on its inputs: a duck-typed object
whose `.shape`/`.dtype` raised or lied could reach comparisons or the scan
build before its type was confirmed safe.

## Fix

- Adds `_has_step9_trusted_array_type` / `_require_step9_trusted_array`: an
  exact-type gate (`np.ndarray`, `jax.Array`, or `jax.core.Tracer` only,
  checked via `type()` before any attribute access) plus shape/dtype
  validation, matching the established `_trusted_array` convention already
  used in this module family (`alberta_framework/steps/step11.py`,
  `step5.py`).
- Adds a real `_STEP9_SEQUENCE_MAX_STEPS = 10_000` ceiling on `rewards`'
  leading length, matching the ceiling convention established this session in
  `core/sarsa.py::_SARSA_SEQUENCE_MAX_STEPS` and
  `core/horde_actor_critic.py::_HORDE_AC_SEQUENCE_MAX_STEPS` (both `10_000`).
  `config`, `rewards`, and `next_observations` are all validated — type,
  length ceiling, and exact shape/dtype — before `jax.lax.scan` is ever
  constructed.

## Tests (failing-test-first)

Added to `tests/test_step9_hostile_validation.py` (new
`run_step9_scan`-specific section): a `monkeypatch` spy replacing
`alberta_framework.steps.step9.jax.lax.scan` with a function that raises if
called, proving `jax.lax.scan` never runs for:

- a `rewards` array one step over the ceiling (`10_001`);
- a `rewards` array far over the ceiling (`200_000`, the actual hang class);
- a `next_observations` array whose length doesn't match `rewards`;
- a non-exact `config` type;
- a wrong-dtype (`int32`) `rewards` array;
- a hostile duck-typed `rewards` object whose `.shape`/`.dtype` properties
  raise `AssertionError` if touched (proving the type gate runs first, `calls
  == 0`).

Plus a boundary check that a `rewards` array of exactly
`_STEP9_SEQUENCE_MAX_STEPS` still passes the trusted-array gate, and a
control test that a small in-bounds sequence still runs `run_step9_scan`
correctly end to end.

Verified at commit `7e5dafd9a22cbfd3198ecabebe0b8394f54b4ac2` (head of this
branch):

```
uv run pytest tests/test_step9_hostile_validation.py -q -o addopts=""
# 27 passed

uv run pytest tests/test_step9*.py -q -o addopts=""
# 222 passed

uv run ruff check alberta_framework/steps/step9.py tests/test_step9_hostile_validation.py
# All checks passed!

uv run python -m mypy
# step9.py: no errors (2 pre-existing, unrelated errors remain in
# alberta_framework/benchmarks/ipmnist_ceiling.py, not touched by this PR)
```

## Evidence tier

This is a **Fix** (measurement-integrity / hang-guard repair on a scan-driven
array-loop facade), not a benchmark climb — no `outputs/` artifact applies.
Evidence is the failing-then-passing tests plus the verification commands
above.

## Scope

Single file plus its dedicated test file: `alberta_framework/steps/step9.py`
(`_has_step9_trusted_array_type`, `_require_step9_trusted_array`,
`_STEP9_SEQUENCE_MAX_STEPS`, and `run_step9_scan`'s validation) and
`tests/test_step9_hostile_validation.py`. No other behavior changes; no
existing test, threshold, or validator was weakened.

## Collision check

Re-ran `gh pr list --repo elizaOS/asi --state open --json number,title,files
--limit 200` filtered on `step9` immediately before starting work and again
immediately before pushing this branch — no other open PR touches
`alberta_framework/steps/step9.py` either time.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DPZ51691P58GJKC1BZ7V3A","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T19:11:32.390Z","completed_at":"2026-08-19T19:12:06.584Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T19:11:33.401Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"84529b53fcb3d4204af5013a5ca047bafeb3e57e2bedcad6d8287948d4531ca7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"6a697e4e-5a27-4925-bdc1-a4e1d942ea9e","object_id":"sha256:84529b53fcb3d4204af5013a5ca047bafeb3e57e2bedcad6d8287948d4531ca7","sha256":"84529b53fcb3d4204af5013a5ca047bafeb3e57e2bedcad6d8287948d4531ca7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"-Uo2ttJ8dEBh4m31a4DNji7udcb9Y5_4_aUhSnLDhp-IiUljUUCZ18eY43UY7GHoe2BC-P0wxgC3UYhYoDABAw"}} -->
