### PR TITLE
fix(core): cap Horde learning-loop sequence length before scan hang

### DIFF
--- a/alberta_framework/core/horde.py
+++ b/alberta_framework/core/horde.py
@@ -51,6 +51,13 @@ _ACTUAL_INT_TYPES = frozenset({int, *(np.dtype(code).type for code in "bBhHiIlLq
 _ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
     {float, *(np.dtype(code).type for code in "efdg")}
 )
+# Matches the documented learning-loop step ceiling established for
+# scan-driven array loops elsewhere in the codebase (see
+# ``learners._LEARNING_LOOP_MAX_STEPS`` and ``sarsa._SARSA_SEQUENCE_MAX_STEPS``).
+# The Horde learning loops below hand caller-supplied ``observations``,
+# ``cumulants``, and ``next_observations`` straight to ``jax.lax.scan`` with
+# no other cap on the scanned sequence length.
+_HORDE_SEQUENCE_MAX_STEPS = 10_000
 
 
 def _require_float32(
@@ -69,6 +76,34 @@ def _require_exact_bool(name: str, value: object) -> bool:
     if type(value) is not bool:
         raise ValueError(f"{name} must be an exact bool")
     return value
+
+
+def _require_horde_sequence_length(name: str, value: object) -> int:
+    """Reject an oversized or malformed leading axis before it drives a scan.
+
+    ``run_horde_learning_loop``, ``run_mixed_horde_learning_loop``, and
+    ``run_horde_learning_loop_final_state`` hand their step arrays straight to
+    ``jax.lax.scan`` with no bound on the leading (step) dimension. A hostile
+    or mistaken caller supplying a huge array can force JAX to trace/compile a
+    scan of that length, hanging the process well before any step executes.
+    """
+    if not isinstance(value, jax.Array):
+        raise TypeError(f"{name} must be a JAX array")
+    if value.ndim < 1:
+        raise ValueError(f"{name} must have a leading step axis")
+    length = int(value.shape[0])
+    if length < 1 or length > _HORDE_SEQUENCE_MAX_STEPS:
+        raise ValueError(
+            f"{name} length must be an integer in [1, {_HORDE_SEQUENCE_MAX_STEPS}]"
+        )
+    return length
+
+
+def _require_horde_matching_length(name: str, value: object, *, expected: int) -> None:
+    if not isinstance(value, jax.Array):
+        raise TypeError(f"{name} must be a JAX array")
+    if value.ndim < 1 or int(value.shape[0]) != expected:
+        raise ValueError(f"{name} must share the same leading length as observations")
 
 
 def _require_exact_str(name: object, value: object) -> str:
@@ -941,7 +976,18 @@ def run_horde_learning_loop(
 
     Returns:
         HordeLearningResult with final state, per-demon metrics, and TD errors
+
+    Raises:
+        TypeError: If an input is not a JAX array.
+        ValueError: If ``observations`` is empty, exceeds the documented
+            scan-length ceiling (``_HORDE_SEQUENCE_MAX_STEPS``), or the other
+            step arrays do not share its leading length.
     """
+    num_steps = _require_horde_sequence_length("observations", observations)
+    _require_horde_matching_length("cumulants", cumulants, expected=num_steps)
+    _require_horde_matching_length(
+        "next_observations", next_observations, expected=num_steps
+    )
 
     def step_fn(
         carry: MultiHeadMLPState,
@@ -983,7 +1029,19 @@ def run_mixed_horde_learning_loop(
     cumulants: Array,
     next_observations: Array,
 ) -> MixedHordeLearningResult:
-    """Run a mixed Horde learning loop using ``jax.lax.scan``."""
+    """Run a mixed Horde learning loop using ``jax.lax.scan``.
+
+    Raises:
+        TypeError: If an input is not a JAX array.
+        ValueError: If ``observations`` is empty, exceeds the documented
+            scan-length ceiling (``_HORDE_SEQUENCE_MAX_STEPS``), or the other
+            step arrays do not share its leading length.
+    """
+    num_steps = _require_horde_sequence_length("observations", observations)
+    _require_horde_matching_length("cumulants", cumulants, expected=num_steps)
+    _require_horde_matching_length(
+        "next_observations", next_observations, expected=num_steps
+    )
 
     def step_fn(
         carry: MixedHordeState,
@@ -1029,7 +1087,18 @@ def run_horde_learning_loop_final_state(
 
     Throughput benchmarks use this helper to avoid materializing the full
     metrics trace when only the final state is needed.
+
+    Raises:
+        TypeError: If an input is not a JAX array.
+        ValueError: If ``observations`` is empty, exceeds the documented
+            scan-length ceiling (``_HORDE_SEQUENCE_MAX_STEPS``), or the other
+            step arrays do not share its leading length.
     """
+    num_steps = _require_horde_sequence_length("observations", observations)
+    _require_horde_matching_length("cumulants", cumulants, expected=num_steps)
+    _require_horde_matching_length(
+        "next_observations", next_observations, expected=num_steps
+    )
 
     def step_fn(
         carry: MultiHeadMLPState,

--- a/tests/test_horde_learning_loop_scan_hang.py
+++ b/tests/test_horde_learning_loop_scan_hang.py
@@ -1,0 +1,234 @@
+"""Scan sequence-length ceiling for public Horde learning-loop scans (hang guard).
+
+``run_horde_learning_loop``, ``run_mixed_horde_learning_loop``, and
+``run_horde_learning_loop_final_state`` hand their caller-supplied step arrays
+(``observations``, ``cumulants``, ``next_observations``) straight to
+``jax.lax.scan`` with no bound on the leading (step) axis and no check that
+the three arrays share a length. A hostile or mistaken caller supplying a huge
+array forces JAX to trace/compile a scan of that length, hanging the process
+well before any step executes -- the same hang class already fixed for other
+scan-driven array loops elsewhere in this repository (``core/sarsa.py``,
+``core/partner_policy_fusion.py``, ``core/learners.py``, ``utils/nexting.py``).
+
+All three functions are exported public API (``alberta_framework.__init__``).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax import Array
+
+from alberta_framework import (
+    DemonType,
+    GVFSpec,
+    HordeLearner,
+    MixedHorde,
+    ObGDBounding,
+    create_horde_spec,
+    run_horde_learning_loop,
+    run_horde_learning_loop_final_state,
+    run_mixed_horde_learning_loop,
+)
+from alberta_framework.core.horde import (
+    _HORDE_SEQUENCE_MAX_STEPS,
+    MixedHordeState,
+    _require_horde_matching_length,
+    _require_horde_sequence_length,
+)
+from alberta_framework.core.multi_head_learner import MultiHeadMLPState
+
+
+def _make_all_gamma0_spec(n: int) -> list[GVFSpec]:
+    return [
+        GVFSpec(
+            name=f"d{i}", demon_type=DemonType.PREDICTION, gamma=0.0, lamda=0.0, cumulant_index=i
+        )
+        for i in range(n)
+    ]
+
+
+def _shared_horde(
+    n_demons: int = 2, feature_dim: int = 5
+) -> tuple[HordeLearner, MultiHeadMLPState]:
+    horde = HordeLearner(
+        horde_spec=create_horde_spec(_make_all_gamma0_spec(n_demons)),
+        hidden_sizes=(4,),
+        sparsity=0.0,
+        bounder=ObGDBounding(kappa=2.0),
+    )
+    return horde, horde.init(feature_dim, jr.key(0))
+
+
+def _mixed_horde(n_demons: int = 2, feature_dim: int = 5) -> tuple[MixedHorde, MixedHordeState]:
+    mixed = MixedHorde(
+        horde_spec=create_horde_spec(_make_all_gamma0_spec(n_demons)),
+        hidden_sizes=(4,),
+        sparsity=0.0,
+        bounder=ObGDBounding(kappa=2.0),
+    )
+    return mixed, mixed.init(feature_dim, jr.key(0))
+
+
+def _arrays(num_steps: int, feature_dim: int = 5, n_demons: int = 2) -> tuple[Array, Array, Array]:
+    key = jr.key(42)
+    k1, k2 = jr.split(key)
+    observations = jr.normal(k1, (num_steps, feature_dim))
+    cumulants = jr.normal(k2, (num_steps, n_demons))
+    next_observations = jnp.zeros((num_steps, feature_dim))
+    return observations, cumulants, next_observations
+
+
+def _spy_scan(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    seen: list[int] = []
+
+    def spy(fn, init, xs, **kwargs):  # type: ignore[no-untyped-def]
+        first = xs[0] if isinstance(xs, tuple) else xs
+        seen.append(int(first.shape[0]))
+        raise AssertionError(f"jax.lax.scan must not run: T={first.shape[0]}")
+
+    monkeypatch.setattr("alberta_framework.core.horde.jax.lax.scan", spy)
+    return seen
+
+
+# =============================================================================
+# _require_horde_sequence_length / _require_horde_matching_length unit tests
+# =============================================================================
+
+
+class TestRequireHordeSequenceLength:
+    def test_rejects_non_array(self) -> None:
+        with pytest.raises(TypeError, match="must be a JAX array"):
+            _require_horde_sequence_length("observations", [1.0, 2.0, 3.0])
+
+    def test_rejects_scalar(self) -> None:
+        with pytest.raises(ValueError, match="leading step axis"):
+            _require_horde_sequence_length("observations", jnp.asarray(1.0))
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            _require_horde_sequence_length("observations", jnp.zeros((0, 5)))
+
+    def test_rejects_oversized(self) -> None:
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            _require_horde_sequence_length(
+                "observations", jnp.zeros((_HORDE_SEQUENCE_MAX_STEPS + 1, 5))
+            )
+
+    def test_accepts_last_fit_length(self) -> None:
+        length = _require_horde_sequence_length(
+            "observations", jnp.zeros((_HORDE_SEQUENCE_MAX_STEPS, 5))
+        )
+        assert length == _HORDE_SEQUENCE_MAX_STEPS
+
+    def test_rejects_origin_hang_class_sized(self) -> None:
+        # Mirrors the hang class this guard closes: a caller-supplied huge
+        # leading axis must be rejected long before it reaches lax.scan.
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            _require_horde_sequence_length("observations", jnp.zeros((200_000, 5)))
+
+
+class TestRequireHordeMatchingLength:
+    def test_rejects_non_array(self) -> None:
+        with pytest.raises(TypeError, match="must be a JAX array"):
+            _require_horde_matching_length("cumulants", [1.0, 2.0], expected=2)
+
+    def test_rejects_mismatched_length(self) -> None:
+        with pytest.raises(ValueError, match="must share the same leading length"):
+            _require_horde_matching_length("cumulants", jnp.zeros((3, 2)), expected=5)
+
+    def test_accepts_matching_length(self) -> None:
+        _require_horde_matching_length("cumulants", jnp.zeros((5, 2)), expected=5)
+
+
+# =============================================================================
+# run_horde_learning_loop
+# =============================================================================
+
+
+class TestRunHordeLearningLoopSequenceLengthGuard:
+    def test_oversized_rejected_before_scan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen = _spy_scan(monkeypatch)
+        horde, state = _shared_horde()
+        observations, cumulants, next_observations = _arrays(_HORDE_SEQUENCE_MAX_STEPS + 1)
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            run_horde_learning_loop(horde, state, observations, cumulants, next_observations)
+        assert seen == []
+
+    def test_origin_hang_class_sized_rejected_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        horde, state = _shared_horde()
+        observations, cumulants, next_observations = _arrays(200_000)
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            run_horde_learning_loop(horde, state, observations, cumulants, next_observations)
+        assert seen == []
+
+    def test_mismatched_length_rejected_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        horde, state = _shared_horde()
+        observations, cumulants, _ = _arrays(10)
+        _, _, next_observations = _arrays(9)
+        with pytest.raises(ValueError, match="must share the same leading length"):
+            run_horde_learning_loop(horde, state, observations, cumulants, next_observations)
+        assert seen == []
+
+    def test_last_fit_length_still_runs(self) -> None:
+        horde, state = _shared_horde()
+        observations, cumulants, next_observations = _arrays(16)
+        result = run_horde_learning_loop(horde, state, observations, cumulants, next_observations)
+        assert result.td_errors.shape[0] == 16
+
+
+# =============================================================================
+# run_mixed_horde_learning_loop
+# =============================================================================
+
+
+class TestRunMixedHordeLearningLoopSequenceLengthGuard:
+    def test_oversized_rejected_before_scan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen = _spy_scan(monkeypatch)
+        mixed, state = _mixed_horde()
+        observations, cumulants, next_observations = _arrays(_HORDE_SEQUENCE_MAX_STEPS + 1)
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            run_mixed_horde_learning_loop(
+                mixed, state, observations, cumulants, next_observations
+            )
+        assert seen == []
+
+    def test_last_fit_length_still_runs(self) -> None:
+        mixed, state = _mixed_horde()
+        observations, cumulants, next_observations = _arrays(16)
+        result = run_mixed_horde_learning_loop(
+            mixed, state, observations, cumulants, next_observations
+        )
+        assert result.td_errors.shape[0] == 16
+
+
+# =============================================================================
+# run_horde_learning_loop_final_state
+# =============================================================================
+
+
+class TestRunHordeLearningLoopFinalStateSequenceLengthGuard:
+    def test_oversized_rejected_before_scan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen = _spy_scan(monkeypatch)
+        horde, state = _shared_horde()
+        observations, cumulants, next_observations = _arrays(_HORDE_SEQUENCE_MAX_STEPS + 1)
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            run_horde_learning_loop_final_state(
+                horde, state, observations, cumulants, next_observations
+            )
+        assert seen == []
+
+    def test_last_fit_length_still_runs(self) -> None:
+        horde, state = _shared_horde()
+        observations, cumulants, next_observations = _arrays(16)
+        final_state = run_horde_learning_loop_final_state(
+            horde, state, observations, cumulants, next_observations
+        )
+        assert final_state is not None


### PR DESCRIPTION
## Summary

`alberta_framework/core/horde.py`'s `run_horde_learning_loop`,
`run_mixed_horde_learning_loop`, and `run_horde_learning_loop_final_state`
hand their caller-supplied step arrays (`observations`, `cumulants`,
`next_observations`) straight to `jax.lax.scan` with no bound on the leading
(step) axis and no check that the three arrays share a length. A hostile or
mistaken caller supplying a huge array forces JAX to trace/compile a scan of
that length, hanging the process well before any step executes.

This is the same hang class already fixed for other scan-driven array loops
in this repo (`core/sarsa.py` #1996, `core/partner_policy_fusion.py` #1991,
`core/learners.py` #1989, `utils/nexting.py` #1992) — `horde.py` was not
covered by any of those PRs. All three functions are exported public API
(`alberta_framework.__init__`), and `horde.py` is imported by several other
`core` modules (`sarsa.py`, `horde_actor_critic.py`), so this is real
in-repo surface, not just an internal helper.

## Fix

Adds `_require_horde_sequence_length` (exact-type JAX-array + shape gate,
rejects length outside `[1, 10_000]` before any scan) and
`_require_horde_matching_length` (checks `cumulants`/`next_observations`
share `observations`' leading length). The `10_000` ceiling matches the
documented learning-loop step ceiling already established elsewhere in
`core` (`learners._LEARNING_LOOP_MAX_STEPS`, `sarsa._SARSA_SEQUENCE_MAX_STEPS`).

`run_horde_learning_loop_batched` is not directly touched — it calls
`run_horde_learning_loop` internally with the same three arrays, so it
inherits the guard transitively.

## Scope

- `alberta_framework/core/horde.py`
- `tests/test_horde_learning_loop_scan_hang.py` (new)

## Verification

Commit under test: `6ebcff7533352304e9a6cf91424ce9ead4f8bfd4`

```text
# On origin/main ec035f73 (pre-fix): no cap exists, jax.lax.scan is called
# unconditionally with the caller-supplied leading length in all three
# functions -- confirmed by reading the pre-fix source (no _require_* call
# before jax.lax.scan in any of the three).

# At this head: oversized (10_001), origin-hang-class-sized (200_000), and
# length-mismatched inputs are rejected with a ValueError/TypeError and a
# monkeypatch spy proves alberta_framework.core.horde.jax.lax.scan is never
# invoked. The documented last-fit length still runs end-to-end for all
# three functions.

.venv/bin/python -m pytest tests/test_horde_learning_loop_scan_hang.py -q -o addopts=""
# 17 tests collected, 17 passed

.venv/bin/python -m pytest tests/test_horde.py tests/test_mixed_horde.py \
  tests/test_horde_actor_critic.py tests/test_baird_horde.py \
  tests/test_horde_schema_hostile_validation.py tests/test_sarsa.py -q -o addopts=""
# 290 passed, 2 skipped -- no regression in existing Horde/SARSA suites

.venv/bin/python -m ruff check alberta_framework/core/horde.py tests/test_horde_learning_loop_scan_hang.py
# All checks passed!

.venv/bin/python -m mypy alberta_framework/core/horde.py
# Success: no issues found in 1 source file

.venv/bin/python -m mypy tests/test_horde_learning_loop_scan_hang.py
# 5 errors, all the same pre-existing `GVFSpec` chex-dataclass call-arg quirk
# present in unmodified tests/test_horde.py on origin/main (133 errors there
# using the identical GVFSpec(...) call pattern); this PR introduces zero new
# mypy error classes.

.venv/bin/python -m ruff check .
# All checks passed! (full repo)

.venv/bin/python -c "import alberta_framework"  # import surface stays intact
```

<!-- evidence-head:6ebcff7533352304e9a6cf91424ce9ead4f8bfd4 -->
<!-- evidence-row:logs -->
- [x] logs: local pytest/ruff/mypy output above; 17/17 new tests passed, 290 passed / 2 skipped across the existing Horde/SARSA suites, zero new mypy error classes vs. origin/main baseline
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - scan sequence-length hang guard, no IPMNIST/benchmark shard produced

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-sonnet-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: contribute-to-asi (local skill copy)
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: Anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Attribution status: self-reported

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DQFZYA7YTX2EBHK19C175P","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T19:20:44.234Z","completed_at":"2026-08-19T19:21:18.739Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T19:20:44.841Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"7e575398b6d9b06d913b66d1671b72ac791d5eec0fdbad996e8766b1d908585f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"23547f5c-7d30-47aa-829e-575e9d8589b0","object_id":"sha256:7e575398b6d9b06d913b66d1671b72ac791d5eec0fdbad996e8766b1d908585f","sha256":"7e575398b6d9b06d913b66d1671b72ac791d5eec0fdbad996e8766b1d908585f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"S5Ys2yUic4DuRL19zUtK4lGwaHJa-FgFB9aVa8tb3aAgzCrM6ynV3dGkv8DY1p-A9ArnlX5tjwDLOJ_aG440Aw"}} -->
