### PR TITLE
fix(streams): cap feature-discovery collector scan length before hang

### DIFF
--- a/alberta_framework/streams/feature_discovery.py
+++ b/alberta_framework/streams/feature_discovery.py
@@ -34,6 +34,17 @@ from alberta_framework.core.normalizers import _saturating_int32_counter_increme
 from alberta_framework.core.types import TimeStep
 
 _INT32_MAX = 2**31 - 1
+# ``collect_feature_discovery_stream`` hands ``num_steps`` straight to
+# ``jnp.arange``/``jax.lax.scan`` with no bound tighter than ``_INT32_MAX``.
+# Bounding only by ``_INT32_MAX`` still lets a caller force JAX to
+# trace/compile a scan of up to ~2 billion steps (or, for narrow streams,
+# hundreds of millions -- the int32-overflow resource preflight below only
+# catches wide rows, not long-but-narrow ones), hanging the process well
+# before any step executes. Matches the ceiling convention adopted this
+# session for sibling scan-driven array loops (``steps.step9``,
+# ``streams.gauntlet``, ``core.sarsa``, ``core.average_reward``,
+# ``core.horde_actor_critic``).
+_FEATURE_DISCOVERY_LOOP_MAX_STEPS = 10_000
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -471,6 +482,12 @@ def collect_feature_discovery_stream(
     This helper is for controlled experiments where multiple learners should
     see the exact same stream.  It still uses the one-step stream interface and
     ``jax.lax.scan``; it does not imply experience replay inside a learner.
+
+    Raises:
+        ValueError: If ``num_steps`` is out of range, the output resource
+            total would overflow signed int32, or ``num_steps`` exceeds the
+            documented scan-length ceiling
+            (``_FEATURE_DISCOVERY_LOOP_MAX_STEPS``).
     """
     num_steps = _require_int("num_steps", num_steps, minimum=1, maximum=_INT32_MAX)
     if type(stream) not in (NonlinearFeatureDiscoveryStream, InteractionFeatureDiscoveryStream):
@@ -484,6 +501,10 @@ def collect_feature_discovery_stream(
         _checked_sum("collected row width", stream.feature_dim, stream.target_dim),
     )
     _checked_product("collected feature-discovery output bytes", 4, output_cells)
+    if num_steps > _FEATURE_DISCOVERY_LOOP_MAX_STEPS:
+        raise ValueError(
+            f"num_steps must be <= {_FEATURE_DISCOVERY_LOOP_MAX_STEPS}"
+        )
 
     state = stream.init(key)
 

--- a/tests/test_feature_discovery_hostile_validation.py
+++ b/tests/test_feature_discovery_hostile_validation.py
@@ -255,6 +255,89 @@ def test_collect_preflights_output_resource_total() -> None:
         collect_feature_discovery_stream(stream, _INT32_MAX, jr.key(0))
 
 
+# =============================================================================
+# collect_feature_discovery_stream scan-length ceiling (hang guard)
+# =============================================================================
+#
+# ``collect_feature_discovery_stream`` hands ``num_steps`` straight to
+# ``jnp.arange``/``jax.lax.scan`` bounded only by ``_INT32_MAX``. A caller
+# supplying a long-but-narrow stream (small row width) can pass the int32
+# overflow preflight above while still forcing JAX to trace/compile a scan of
+# hundreds of millions of steps, hanging the process well before any step
+# executes -- the same hang class fixed this session for other scan-driven
+# array/loop runners in ``steps/step9.py``, ``streams/gauntlet.py``,
+# ``core/sarsa.py``, ``core/average_reward.py``, and
+# ``core/horde_actor_critic.py``.
+
+
+def _spy_scan(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    seen: list[int] = []
+
+    def spy(fn, init, xs, **kwargs):  # type: ignore[no-untyped-def]
+        seen.append(int(xs.shape[0]))
+        raise AssertionError(f"jax.lax.scan must not run: T={xs.shape[0]}")
+
+    monkeypatch.setattr("alberta_framework.streams.feature_discovery.jax.lax.scan", spy)
+    return seen
+
+
+def test_feature_discovery_loop_ceiling_is_documented() -> None:
+    from alberta_framework.streams.feature_discovery import (
+        _FEATURE_DISCOVERY_LOOP_MAX_STEPS,
+    )
+
+    assert _FEATURE_DISCOVERY_LOOP_MAX_STEPS == 10_000
+
+
+def test_collect_rejects_narrow_overflow_length_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A long-but-narrow request that would clear the int32 resource
+    preflight is still rejected before ``jax.lax.scan`` ever runs."""
+    from alberta_framework.streams.feature_discovery import (
+        _FEATURE_DISCOVERY_LOOP_MAX_STEPS,
+        collect_feature_discovery_stream,
+    )
+
+    seen = _spy_scan(monkeypatch)
+    stream = NonlinearFeatureDiscoveryStream(feature_dim=1, n_tasks=1, n_latents=1)
+    with pytest.raises(
+        ValueError, match=rf"num_steps must be <= {_FEATURE_DISCOVERY_LOOP_MAX_STEPS}"
+    ):
+        collect_feature_discovery_stream(
+            stream, _FEATURE_DISCOVERY_LOOP_MAX_STEPS + 1, jr.key(0)
+        )
+    assert seen == []
+
+
+def test_collect_rejects_origin_hang_class_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A far larger narrow request -- the actual hang class, still well
+    under the int32 resource preflight -- is also rejected before scan."""
+    from alberta_framework.streams.feature_discovery import collect_feature_discovery_stream
+
+    seen = _spy_scan(monkeypatch)
+    stream = NonlinearFeatureDiscoveryStream(feature_dim=1, n_tasks=1, n_latents=1)
+    with pytest.raises(ValueError, match="num_steps must be <="):
+        collect_feature_discovery_stream(stream, 50_000_000, jr.key(0))
+    assert seen == []
+
+
+def test_collect_ceiling_length_still_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    from alberta_framework.streams.feature_discovery import (
+        _FEATURE_DISCOVERY_LOOP_MAX_STEPS,
+        collect_feature_discovery_stream,
+    )
+
+    stream = NonlinearFeatureDiscoveryStream(feature_dim=2, n_tasks=1, n_latents=1)
+    observations, targets = collect_feature_discovery_stream(
+        stream, _FEATURE_DISCOVERY_LOOP_MAX_STEPS, jr.key(0)
+    )
+    assert observations.shape[0] == _FEATURE_DISCOVERY_LOOP_MAX_STEPS
+    assert targets.shape[0] == _FEATURE_DISCOVERY_LOOP_MAX_STEPS
+
+
 @pytest.mark.parametrize(
     "factory", [NonlinearFeatureDiscoveryStream, InteractionFeatureDiscoveryStream]
 )


### PR DESCRIPTION
## Problem

`collect_feature_discovery_stream` in `alberta_framework/streams/feature_discovery.py`
hands a caller-supplied `num_steps` straight to `jnp.arange`/`jax.lax.scan`,
bounded only by `_INT32_MAX` (`2**31 - 1`). The existing int32-overflow
resource preflight (`_checked_product` on `num_steps * row_width * 4`) only
catches *wide* requests — a long-but-narrow stream (small
`feature_dim + target_dim`) can pass that check with `num_steps` in the
hundreds of millions while still forcing JAX to trace/compile a scan of
that length, hanging the process well before any step executes.

This is the same hang class fixed this session in sibling scan-driven
array/loop runners: `alberta_framework/steps/step9.py` (#2014),
`alberta_framework/streams/gauntlet.py` (#2008), `core/sarsa.py` (#1996),
`core/average_reward.py` (#1999), and `core/horde_actor_critic.py` (#2009).

## Fix

Add `_FEATURE_DISCOVERY_LOOP_MAX_STEPS = 10_000`, matching the ceiling
convention used by the sibling fixes above (all existing call sites in
this repository use `num_steps` in the 10-12 range). The new check runs
*after* the existing resource preflight so the pre-existing
`test_collect_preflights_output_resource_total` test (which exercises
the `_INT32_MAX` int32-overflow path) keeps its original assertion
unchanged.

## Evidence

Commands run at head `5e171ba1c5485ec0061d3d56589a93190f8f8129`:

```
.venv/bin/python -m pytest tests/test_feature_discovery_hostile_validation.py -q -o addopts=""
# 37 passed in 8.57s

.venv/bin/python -m pytest tests/test_feature_discovery.py -q -o addopts=""
# 148 passed in 95.96s

.venv/bin/python -m ruff check alberta_framework/streams/feature_discovery.py tests/test_feature_discovery_hostile_validation.py
# All checks passed!

.venv/bin/python -m mypy alberta_framework/streams/feature_discovery.py
# Success: no issues found in 1 source file
```

`mypy` on the test file reports 19 pre-existing errors unrelated to this
change (verified identical count/lines via `git stash` against the
unmodified file) — none in the new code added by this PR.

New tests added in `tests/test_feature_discovery_hostile_validation.py`:
- `test_feature_discovery_loop_ceiling_is_documented` — pins the constant.
- `test_collect_rejects_narrow_overflow_length_before_scan` — a
  long-but-narrow request just over the ceiling is rejected before
  `jax.lax.scan` runs (spies on `jax.lax.scan` to prove it).
- `test_collect_rejects_origin_hang_class_before_scan` — a
  50,000,000-step narrow request (the actual hang class, well under the
  int32 resource preflight) is also rejected before scan.
- `test_collect_ceiling_length_still_succeeds` — the ceiling itself still
  produces a correct real scan.

## Scope

Single file, single variable (the new step-ceiling gate). No other
behavior changed. Territory: `alberta_framework/streams/`.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DQPPT9NFT3HY49BQ9EXJ9B","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T19:24:24.266Z","completed_at":"2026-08-19T19:24:59.310Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T19:24:25.879Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a704fdce17710773918424d641681f01e18786564e2aee83acbaccb4744749a5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ae4509aa-6c12-467f-bcd3-9cfa276e7e49","object_id":"sha256:a704fdce17710773918424d641681f01e18786564e2aee83acbaccb4744749a5","sha256":"a704fdce17710773918424d641681f01e18786564e2aee83acbaccb4744749a5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"MxF4m4az9cepK3s28j_kWAfovDUQNpl9-h2NPxz9YvL0OssQ2aS8I3Gj_2eFmk0JSIHhieAelvboDxqPbH9eBw"}} -->
