### PR TITLE
fix(core): cap off-policy Horde scan sequence length before scan hang

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -44,6 +44,13 @@ from alberta_framework.core.update_safety import (
 )
 
 _INT32_MAX = 2**31 - 1
+# Matches the documented learning-loop step ceiling established for
+# scan-driven array loops elsewhere in the codebase (see
+# ``horde._HORDE_SEQUENCE_MAX_STEPS``, ``learners._LEARNING_LOOP_MAX_STEPS``,
+# and ``sarsa._SARSA_SEQUENCE_MAX_STEPS``).  ``run_off_policy_horde_learning_loop``
+# hands its caller-supplied step arrays straight to ``jax.lax.scan`` with no
+# other cap on the scanned sequence length.
+_OFF_POLICY_HORDE_SEQUENCE_MAX_STEPS = 10_000
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -156,6 +163,33 @@ def _require_typed_threefry_key(name: str, value: object) -> Array:
     if implementation != "threefry2x32" or tuple(words.shape) != (2,):
         raise ValueError(f"{name} must be a typed scalar threefry2x32 key")
     return value
+
+
+def _require_off_policy_horde_sequence_length(name: str, value: object) -> int:
+    """Reject an oversized or malformed leading axis before it drives a scan.
+
+    ``run_off_policy_horde_learning_loop`` hands its step arrays straight to
+    ``jax.lax.scan`` with no bound on the leading (step) dimension. A hostile
+    or mistaken caller supplying a huge array can force JAX to trace/compile a
+    scan of that length, hanging the process well before any step executes.
+    """
+    if not isinstance(value, jax.Array):
+        raise TypeError(f"{name} must be a JAX array")
+    if value.ndim < 1:
+        raise ValueError(f"{name} must have a leading step axis")
+    length = int(value.shape[0])
+    if length < 1 or length > _OFF_POLICY_HORDE_SEQUENCE_MAX_STEPS:
+        raise ValueError(
+            f"{name} length must be an integer in [1, {_OFF_POLICY_HORDE_SEQUENCE_MAX_STEPS}]"
+        )
+    return length
+
+
+def _require_off_policy_horde_matching_length(name: str, value: object, *, expected: int) -> None:
+    if not isinstance(value, jax.Array):
+        raise TypeError(f"{name} must be a JAX array")
+    if value.ndim < 1 or int(value.shape[0]) != expected:
+        raise ValueError(f"{name} must share the same leading length as observations")
 
 
 def _stable_l2_norm(*values: Array) -> Array:
@@ -1505,9 +1539,24 @@ def run_off_policy_horde_learning_loop(
     rhos: Array,
     discounts: Array | None = None,
 ) -> OffPolicyHordeLearningResult:
-    """Run an off-policy Horde scan over transition arrays."""
+    """Run an off-policy Horde scan over transition arrays.
+
+    Raises:
+        TypeError: If an input is not a JAX array.
+        ValueError: If ``observations`` is empty, exceeds the documented
+            scan-length ceiling (``_OFF_POLICY_HORDE_SEQUENCE_MAX_STEPS``), or
+            the other step arrays do not share its leading length.
+    """
+    num_steps = _require_off_policy_horde_sequence_length("observations", observations)
+    _require_off_policy_horde_matching_length("cumulants", cumulants, expected=num_steps)
+    _require_off_policy_horde_matching_length(
+        "next_observations", next_observations, expected=num_steps
+    )
+    _require_off_policy_horde_matching_length("rhos", rhos, expected=num_steps)
     if discounts is None:
         discounts = jnp.broadcast_to(learner.horde_spec.gammas, cumulants.shape)
+    else:
+        _require_off_policy_horde_matching_length("discounts", discounts, expected=num_steps)
 
     def step_fn(
         carry: MultiHeadMLPState,

--- a/tests/test_off_policy_horde_learning_loop_scan_hang.py
+++ b/tests/test_off_policy_horde_learning_loop_scan_hang.py
@@ -1,0 +1,238 @@
+"""Scan sequence-length ceiling for the off-policy Horde learning loop (hang guard).
+
+``run_off_policy_horde_learning_loop`` hands its caller-supplied step arrays
+(``observations``, ``cumulants``, ``next_observations``, ``rhos``, and
+optionally ``discounts``) straight to ``jax.lax.scan`` with no bound on the
+leading (step) axis and no check that the arrays share a length. A hostile or
+mistaken caller supplying a huge array forces JAX to trace/compile a scan of
+that length, hanging the process well before any step executes -- the same
+hang class already fixed for other scan-driven array loops elsewhere in this
+repository (``core/horde.py``, ``core/sarsa.py``,
+``core/partner_policy_fusion.py``, ``core/learners.py``, ``utils/nexting.py``).
+
+``run_off_policy_horde_learning_loop`` and
+``run_off_policy_horde_learning_loop_batched`` are exported public API
+(``alberta_framework.__init__``); the batched variant calls the guarded
+function internally and inherits the guard transitively.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax import Array
+
+from alberta_framework.core.multi_head_learner import MultiHeadMLPState
+from alberta_framework.core.off_policy_horde import (
+    _OFF_POLICY_HORDE_SEQUENCE_MAX_STEPS,
+    OffPolicyHordeLearner,
+    _require_off_policy_horde_matching_length,
+    _require_off_policy_horde_sequence_length,
+    run_off_policy_horde_learning_loop,
+)
+from alberta_framework.core.optimizers import LMS
+from alberta_framework.core.types import DemonType, GVFSpec, HordeSpec, create_horde_spec
+
+
+def _spec(
+    gammas: tuple[float, ...] = (0.0, 0.5), lamdas: tuple[float, ...] = (0.0, 0.4)
+) -> HordeSpec:
+    demons = tuple(
+        GVFSpec(
+            name=f"demon_{i}",
+            demon_type=DemonType.PREDICTION,
+            gamma=gamma,
+            lamda=lamdas[i],
+            cumulant_index=i,
+        )  # type: ignore[call-arg]
+        for i, gamma in enumerate(gammas)
+    )
+    return create_horde_spec(demons)
+
+
+def _learner_and_state(
+    n_demons: int = 2, feature_dim: int = 3
+) -> tuple[OffPolicyHordeLearner, MultiHeadMLPState]:
+    learner = OffPolicyHordeLearner(
+        _spec(),
+        hidden_sizes=(5,),
+        optimizer=LMS(step_size=0.01),
+        ratio_clip=2.0,
+    )
+    state = learner.init(feature_dim, jr.key(4))
+    return learner, state
+
+
+def _arrays(
+    num_steps: int, feature_dim: int = 3, n_demons: int = 2
+) -> tuple[Array, Array, Array, Array]:
+    key = jr.key(42)
+    k1, k2, k3 = jr.split(key, 3)
+    observations = jr.normal(k1, (num_steps, feature_dim))
+    cumulants = jr.normal(k2, (num_steps, n_demons))
+    next_observations = jr.normal(k3, (num_steps, feature_dim))
+    rhos = jnp.ones((num_steps, n_demons), dtype=jnp.float32)
+    return observations, cumulants, next_observations, rhos
+
+
+def _spy_scan(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    seen: list[int] = []
+
+    def spy(fn, init, xs, **kwargs):  # type: ignore[no-untyped-def]
+        first = xs[0] if isinstance(xs, tuple) else xs
+        seen.append(int(first.shape[0]))
+        raise AssertionError(f"jax.lax.scan must not run: T={first.shape[0]}")
+
+    monkeypatch.setattr("alberta_framework.core.off_policy_horde.jax.lax.scan", spy)
+    return seen
+
+
+# =============================================================================
+# _require_off_policy_horde_sequence_length / _require_off_policy_horde_matching_length
+# =============================================================================
+
+
+class TestRequireOffPolicyHordeSequenceLength:
+    def test_rejects_non_array(self) -> None:
+        with pytest.raises(TypeError, match="must be a JAX array"):
+            _require_off_policy_horde_sequence_length("observations", [1.0, 2.0, 3.0])
+
+    def test_rejects_scalar(self) -> None:
+        with pytest.raises(ValueError, match="leading step axis"):
+            _require_off_policy_horde_sequence_length("observations", jnp.asarray(1.0))
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            _require_off_policy_horde_sequence_length("observations", jnp.zeros((0, 3)))
+
+    def test_rejects_oversized(self) -> None:
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            _require_off_policy_horde_sequence_length(
+                "observations",
+                jnp.zeros((_OFF_POLICY_HORDE_SEQUENCE_MAX_STEPS + 1, 3)),
+            )
+
+    def test_accepts_last_fit_length(self) -> None:
+        length = _require_off_policy_horde_sequence_length(
+            "observations", jnp.zeros((_OFF_POLICY_HORDE_SEQUENCE_MAX_STEPS, 3))
+        )
+        assert length == _OFF_POLICY_HORDE_SEQUENCE_MAX_STEPS
+
+    def test_rejects_origin_hang_class_sized(self) -> None:
+        # Mirrors the hang class this guard closes: a caller-supplied huge
+        # leading axis must be rejected long before it reaches lax.scan.
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            _require_off_policy_horde_sequence_length("observations", jnp.zeros((200_000, 3)))
+
+
+class TestRequireOffPolicyHordeMatchingLength:
+    def test_rejects_non_array(self) -> None:
+        with pytest.raises(TypeError, match="must be a JAX array"):
+            _require_off_policy_horde_matching_length("cumulants", [1.0, 2.0], expected=2)
+
+    def test_rejects_mismatched_length(self) -> None:
+        with pytest.raises(ValueError, match="must share the same leading length"):
+            _require_off_policy_horde_matching_length("cumulants", jnp.zeros((3, 2)), expected=5)
+
+    def test_accepts_matching_length(self) -> None:
+        _require_off_policy_horde_matching_length("cumulants", jnp.zeros((5, 2)), expected=5)
+
+
+# =============================================================================
+# run_off_policy_horde_learning_loop
+# =============================================================================
+
+
+class TestRunOffPolicyHordeLearningLoopSequenceLengthGuard:
+    def test_oversized_rejected_before_scan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen = _spy_scan(monkeypatch)
+        learner, state = _learner_and_state()
+        observations, cumulants, next_observations, rhos = _arrays(
+            _OFF_POLICY_HORDE_SEQUENCE_MAX_STEPS + 1
+        )
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            run_off_policy_horde_learning_loop(
+                learner, state, observations, cumulants, next_observations, rhos
+            )
+        assert seen == []
+
+    def test_origin_hang_class_sized_rejected_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        learner, state = _learner_and_state()
+        observations, cumulants, next_observations, rhos = _arrays(200_000)
+        with pytest.raises(ValueError, match=r"length must be an integer in \[1,"):
+            run_off_policy_horde_learning_loop(
+                learner, state, observations, cumulants, next_observations, rhos
+            )
+        assert seen == []
+
+    def test_mismatched_cumulants_length_rejected_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        learner, state = _learner_and_state()
+        observations, _, next_observations, rhos = _arrays(10)
+        _, cumulants, _, _ = _arrays(9)
+        with pytest.raises(ValueError, match="must share the same leading length"):
+            run_off_policy_horde_learning_loop(
+                learner, state, observations, cumulants, next_observations, rhos
+            )
+        assert seen == []
+
+    def test_mismatched_rhos_length_rejected_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        learner, state = _learner_and_state()
+        observations, cumulants, next_observations, _ = _arrays(10)
+        _, _, _, rhos = _arrays(9)
+        with pytest.raises(ValueError, match="must share the same leading length"):
+            run_off_policy_horde_learning_loop(
+                learner, state, observations, cumulants, next_observations, rhos
+            )
+        assert seen == []
+
+    def test_mismatched_discounts_length_rejected_before_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = _spy_scan(monkeypatch)
+        learner, state = _learner_and_state()
+        observations, cumulants, next_observations, rhos = _arrays(10)
+        discounts = jnp.zeros((9, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="must share the same leading length"):
+            run_off_policy_horde_learning_loop(
+                learner,
+                state,
+                observations,
+                cumulants,
+                next_observations,
+                rhos,
+                discounts,
+            )
+        assert seen == []
+
+    def test_last_fit_length_still_runs(self) -> None:
+        learner, state = _learner_and_state()
+        observations, cumulants, next_observations, rhos = _arrays(16)
+        result = run_off_policy_horde_learning_loop(
+            learner, state, observations, cumulants, next_observations, rhos
+        )
+        assert result.td_errors.shape[0] == 16
+
+    def test_explicit_discounts_still_runs(self) -> None:
+        learner, state = _learner_and_state()
+        observations, cumulants, next_observations, rhos = _arrays(8)
+        discounts = jnp.full((8, 2), 0.5, dtype=jnp.float32)
+        result = run_off_policy_horde_learning_loop(
+            learner,
+            state,
+            observations,
+            cumulants,
+            next_observations,
+            rhos,
+            discounts,
+        )
+        assert result.td_errors.shape[0] == 8


### PR DESCRIPTION
## Summary

`alberta_framework/core/off_policy_horde.py`'s `run_off_policy_horde_learning_loop`
hands its caller-supplied step arrays (`observations`, `cumulants`,
`next_observations`, `rhos`, and optionally `discounts`) straight to
`jax.lax.scan` with **no validation whatsoever** — no bound on the leading
(step) axis, no type check, and no check that the arrays share a length. A
hostile or mistaken caller supplying a huge array forces JAX to trace/compile
a scan of that length, hanging the process well before any step executes.

This is the same hang class already fixed for other scan-driven array loops
in this repo (`core/horde.py` #2016, `core/sarsa.py` #1996,
`core/partner_policy_fusion.py` #1991, `core/learners.py` #1989,
`utils/nexting.py` #1992) — `off_policy_horde.py` was not covered by any of
those PRs, and unlike some sibling Horde variants (e.g.
`independent_demon_horde.py`, `stacked_horde.py`), it had **no int32-budget
guard either**: the scan was completely unguarded.

`run_off_policy_horde_learning_loop` is exported public API
(`alberta_framework.__init__`); `run_off_policy_horde_learning_loop_batched`
calls it internally and inherits the guard transitively, so it is not
directly touched.

## Fix

Adds `_require_off_policy_horde_sequence_length` (exact-type JAX-array +
shape gate, rejects length outside `[1, 10_000]` before any scan) and
`_require_off_policy_horde_matching_length` (checks `cumulants`,
`next_observations`, `rhos`, and — when explicitly supplied — `discounts`
share `observations`' leading length). The `10_000` ceiling matches the
documented learning-loop step ceiling already established elsewhere in
`core` (`horde._HORDE_SEQUENCE_MAX_STEPS`,
`learners._LEARNING_LOOP_MAX_STEPS`, `sarsa._SARSA_SEQUENCE_MAX_STEPS`).

## Scope

- `alberta_framework/core/off_policy_horde.py`
- `tests/test_off_policy_horde_learning_loop_scan_hang.py` (new)

## Verification

Commit under test: `dff98896e926b2a989510391f4680bfdf5664bbe`

```text
# On origin/main ec035f73 (pre-fix): no validation exists at all in
# run_off_policy_horde_learning_loop -- confirmed by reading the pre-fix
# source (jax.lax.scan is called unconditionally on line 1546 with the
# caller-supplied leading length, no _require_* call anywhere above it).

# At this head: oversized (10_001), origin-hang-class-sized (200_000), and
# length-mismatched inputs (cumulants/rhos/discounts) are rejected with a
# ValueError/TypeError, and a monkeypatch spy proves
# alberta_framework.core.off_policy_horde.jax.lax.scan is never invoked.
# The documented last-fit length (10_000) and ordinary lengths still run
# end-to-end, including with an explicit discounts array.

.venv/bin/python -m pytest tests/test_off_policy_horde_learning_loop_scan_hang.py -q -o addopts=""
# 16 tests collected, 16 passed

.venv/bin/python -m pytest tests/test_off_policy_horde.py tests/test_off_policy_horde_update_working_set.py -q -o addopts=""
# 33 passed -- no regression in the existing off-policy Horde suite

.venv/bin/python -m ruff check alberta_framework/core/off_policy_horde.py tests/test_off_policy_horde_learning_loop_scan_hang.py
# All checks passed!

.venv/bin/python -m ruff check .
# All checks passed! (full repo)

.venv/bin/python -m mypy alberta_framework/core/off_policy_horde.py
# Success: no issues found in 1 source file

.venv/bin/python -m mypy tests/test_off_policy_horde_learning_loop_scan_hang.py
# Success: no issues found in 1 source file

.venv/bin/python -m mypy
# Success: no issues found in 197 source files (full repo, strict)

.venv/bin/python -c "import alberta_framework"  # import surface stays intact
```

<!-- evidence-head:dff98896e926b2a989510391f4680bfdf5664bbe -->
<!-- evidence-row:logs -->
- [x] logs: local pytest/ruff/mypy output above; 16/16 new tests passed, 33 passed across the existing off-policy Horde suite, zero mypy errors full-repo (197 files)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - scan sequence-length hang guard, no IPMNIST/benchmark shard produced

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-sonnet-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: contribute-to-asi (local skill copy)
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: Anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Attribution status: self-reported

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DR7T7QE5X43ED8C34DQD6C","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T19:33:44.824Z","completed_at":"2026-08-19T19:34:19.623Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T19:33:45.547Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"be5b51f8e80202f3f7871f5e8ee8b7d440ee77fffe0fa3947e65e43a90d0dadc","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ad919e29-01ad-4f97-b848-40f0e28f3d20","object_id":"sha256:be5b51f8e80202f3f7871f5e8ee8b7d440ee77fffe0fa3947e65e43a90d0dadc","sha256":"be5b51f8e80202f3f7871f5e8ee8b7d440ee77fffe0fa3947e65e43a90d0dadc"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"cRJVad6Dn_XLj8UtjIg3WzHQracqs7Flz3IlQ0dqwXehoFZUvs52Qe4KrrBniBA5714OE0wtsqSCHFYpI2jEBA"}} -->
