### PR TITLE
fix(streams): cap OutOfClassPolynomialStream triple enumeration before hang

### DIFF
--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -26,6 +26,7 @@ or tanh feature bank:
   compositional DAG that builds features-of-features can.
 """
 
+import math
 from fractions import Fraction
 from numbers import Real
 from typing import cast
@@ -105,6 +106,43 @@ def _compositional_state_budget(
         "component_scalars": component_scalars,
         **budget,
     }
+
+
+def _polynomial_state_budget(
+    *,
+    feature_dim: int,
+    n_contexts: int,
+    n_tasks: int,
+    include_squares: bool,
+) -> dict[str, int]:
+    """Preflight the oracle-triple enumeration before it ever runs.
+
+    ``OutOfClassPolynomialStream._triples()`` enumerates all (i, j, l) triples
+    in plain Python -- O(feature_dim ** 3) work and memory for the strict
+    ``i < j < l`` case (``i <= j <= l`` with ``include_squares`` is the same
+    order). A caller-supplied ``feature_dim`` well inside the int32 domain
+    (e.g. a few thousand) already makes that enumeration run for an
+    unbounded amount of time before any JAX array exists, let alone before
+    the sibling classes' own ``_require_state_budget`` gate would catch the
+    resulting tensor size. Compute the exact triple count analytically via
+    ``math.comb`` -- O(1), no enumeration -- and apply the same 64 MiB
+    resident-state budget the sibling ``FrequencyMismatchStream`` and
+    ``CompositionalStream`` constructors already enforce, before
+    ``_triples()`` is ever invoked from ``init()``.
+    """
+    n_triples = math.comb(feature_dim + 2, 3) if include_squares else math.comb(feature_dim, 3)
+    tensor_scalars = n_contexts * n_tasks * n_triples
+    # Resident OutOfClassPolynomialState holds one (n_contexts, n_tasks,
+    # n_triples) ``context_weights`` tensor, 3 * n_triples int32 indices
+    # (triples_left/middle/right), n_tasks * feature_dim ``linear_weights``
+    # scalars, and a scalar step_count; ``_require_state_budget`` adds the
+    # 2-word PRNG key. ``init()`` also transiently allocates a same-shaped
+    # ``dense_context_weights``/``mask_scores``/``mask`` working set, which
+    # is smaller than or comparable to this resident bound and is caught by
+    # the same gate in practice.
+    state_scalars = tensor_scalars + 3 * n_triples + n_tasks * feature_dim + 1
+    budget = _require_state_budget("out-of-class-polynomial", state_scalars)
+    return {"n_triples": n_triples, "tensor_scalars": tensor_scalars, **budget}
 
 
 def _saturating_step_count(step_count: Array) -> Array:
@@ -325,6 +363,12 @@ class OutOfClassPolynomialStream:
         )
         if type(include_squares) is not bool:
             raise ValueError("include_squares must be a built-in bool")
+        resource_budget = _polynomial_state_budget(
+            feature_dim=feature_dim,
+            n_contexts=n_contexts,
+            n_tasks=n_tasks,
+            include_squares=include_squares,
+        )
 
         self._feature_dim = feature_dim
         self._n_tasks = n_tasks
@@ -335,11 +379,17 @@ class OutOfClassPolynomialStream:
         self._linear_scale = linear_scale
         self._noise_std = noise_std
         self._include_squares = include_squares
+        self._resource_budget = resource_budget
 
     @property
     def feature_dim(self) -> int:
         """Return the raw observation dimension."""
         return self._feature_dim
+
+    @property
+    def resource_budget(self) -> dict[str, int]:
+        """Complete resident state payload accounting."""
+        return dict(self._resource_budget)
 
     @property
     def target_dim(self) -> int:

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -9,6 +9,7 @@ out-of-class structural properties that motivate each stream.
 
 import json
 import math
+import time
 from decimal import Decimal
 from fractions import Fraction
 from numbers import Real
@@ -1289,6 +1290,19 @@ class TestCompositionalStream:
 @pytest.mark.parametrize(
     "stream",
     [
+        OutOfClassPolynomialStream(
+            feature_dim=6,
+            n_tasks=3,
+            n_contexts=2,
+            active_triples_per_context=4,
+        ),
+        OutOfClassPolynomialStream(
+            feature_dim=6,
+            n_tasks=3,
+            n_contexts=2,
+            active_triples_per_context=4,
+            include_squares=True,
+        ),
         FrequencyMismatchStream(
             feature_dim=3,
             n_tasks=2,
@@ -1328,6 +1342,36 @@ def test_out_of_class_derived_state_budgets_fail_at_construction() -> None:
             outer_components=100,
             n_contexts=1,
         )
+    with pytest.raises(ValueError, match="out-of-class-polynomial.*64 MiB"):
+        OutOfClassPolynomialStream(
+            feature_dim=274,
+            n_tasks=1,
+            n_contexts=2,
+            active_triples_per_context=1,
+        )
+
+
+def test_out_of_class_polynomial_rejects_hang_inducing_feature_dim_before_enumeration() -> None:
+    """A ``feature_dim`` well inside the int32 domain must not reach ``_triples()``.
+
+    ``_triples()`` enumerates all oracle triples in plain Python --
+    O(feature_dim ** 3) work -- before any JAX array is built. Before this
+    fix, ``feature_dim`` was only bounded by int32 max, so a caller-supplied
+    value of a few thousand (let alone 100_000) would hang the process for an
+    effectively unbounded amount of time; independently timed, the pure
+    enumeration alone already takes several seconds at ``feature_dim=500``
+    and grows cubically from there. The analytic ``math.comb`` precheck in
+    ``_polynomial_state_budget`` must reject this immediately, without ever
+    calling ``_triples()``.
+    """
+    start = time.monotonic()
+    with pytest.raises(ValueError, match="out-of-class-polynomial"):
+        OutOfClassPolynomialStream(feature_dim=100_000, n_tasks=3, n_contexts=4)
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.0, (
+        f"rejection took {elapsed:.3f}s; expected an O(1) analytic precheck, "
+        "not an attempt to enumerate feature_dim**3 triples"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`OutOfClassPolynomialStream.__init__` bounds `feature_dim`, `n_tasks`, and
`n_contexts` only by int32 max, matching the other numeric dimensions in
this file. But `_triples()`, invoked eagerly from `init()`, enumerates every
`(i, j, l)` oracle triple in a plain Python triple-nested loop —
`O(feature_dim ** 3)` work and memory — before any JAX array exists.

A caller-supplied `feature_dim` well inside the int32 domain therefore hangs
the process. Independently timed (see Evidence below), the bare enumeration
alone already takes ~3.4s at `feature_dim=500` and grows cubically:
`feature_dim=100_000` is `math.comb(100_000, 3) ≈ 1.7e14` triples, i.e.
effectively never finishes.

This stream is reachable from an untrusted-JSON path: `Step2KernelConfig`
only bounds `feature_dim` by int32 max (`step2.py::_validate_step2_kernel_config`),
and `Step2KernelConfig.from_dict(...)` → `make_step2_stream(cfg)` →
`OutOfClassPolynomialStream(feature_dim=cfg.feature_dim, ...)` for
`stream="polynomial"`.

The sibling classes in this same file, `FrequencyMismatchStream` and
`CompositionalStream`, already guard their own constructors with
`_require_state_budget` (a 64 MiB resident-state cap) before touching any
caller-controlled shape — see `_frequency_state_budget` /
`_compositional_state_budget`. `OutOfClassPolynomialStream` had no
equivalent guard, and was also conspicuously absent from both
`test_out_of_class_resource_budget_matches_resident_state` and
`test_out_of_class_derived_state_budgets_fail_at_construction`.

## Fix

Adds `_polynomial_state_budget`, which computes the exact triple count
analytically via `math.comb` (`math.comb(feature_dim, 3)`, or
`math.comb(feature_dim + 2, 3)` for `include_squares=True`, matching the
counts already documented in `_triples()`'s own docstring) — O(1), no
enumeration — and applies the same `_require_state_budget` gate the sibling
classes already use. It is called from `__init__` before `_triples()` can
ever run. Also adds the `resource_budget` property the siblings already
expose, matched byte-for-byte against the real resident
`OutOfClassPolynomialState` (`context_weights`, `triples_left/middle/right`,
`linear_weights`, `step_count`, plus the PRNG key `_require_state_budget`
already accounts for).

## Evidence

Commands run at head `05ef9f3cb7dcfc67cfd1d7c4ac7d3e73dd740acd`:

```
.venv/bin/python -m pytest tests/test_out_of_class_streams.py -q -o addopts=""
# 325 passed in 62.31s

.venv/bin/python -m pytest tests/test_out_of_class_lifetime_clock.py tests/test_production_steps.py tests/test_step2_boundary_validation.py -q -o addopts=""
# 401 passed in 31.65s

.venv/bin/python -m ruff check alberta_framework/streams/out_of_class.py tests/test_out_of_class_streams.py
# All checks passed!

.venv/bin/python -m mypy alberta_framework/streams/out_of_class.py
# Success: no issues found in 1 source file
```

Manual reproduction of the underlying risk (not part of the test suite —
timed separately to bound the demonstration):

```
>>> import time
>>> t0 = time.time()
>>> triples = []
>>> feature_dim = 500
>>> for i in range(feature_dim):
...     for j in range(i + 1, feature_dim):
...         for l in range(j + 1, feature_dim):
...             triples.append((i, j, l))
>>> len(triples), time.time() - t0
(20708500, 3.40)   # seconds, pure Python enumeration only, no JAX array yet
```

Post-fix, the same class of caller-supplied value is rejected in under a
millisecond instead of attempting the enumeration:

```
>>> import time
>>> t0 = time.time()
>>> OutOfClassPolynomialStream(feature_dim=100_000, n_tasks=3, n_contexts=4)
ValueError: out-of-class-polynomial state scalar count must fit signed int32
>>> time.time() - t0
0.0002
```

New tests added in `tests/test_out_of_class_streams.py`:
- `OutOfClassPolynomialStream` (both `include_squares=False` and `=True`)
  added to `test_out_of_class_resource_budget_matches_resident_state`,
  asserting `resource_budget` matches the real resident state byte-for-byte.
- `test_out_of_class_derived_state_budgets_fail_at_construction` extended
  with a `feature_dim=274, n_tasks=1, n_contexts=2` case that crosses the
  64 MiB budget (verified `feature_dim=273` with the same shape is still
  accepted).
- `test_out_of_class_polynomial_rejects_hang_inducing_feature_dim_before_enumeration` —
  asserts `feature_dim=100_000` is rejected in under 1 second (an O(1)
  analytic precheck), proving `_triples()` is never reached.

## Scope

Single file (`alberta_framework/streams/out_of_class.py`), single new gate
plus its accompanying `resource_budget` property, mirroring the exact
pattern the two sibling classes in the same file already use. No other
behavior changed. Territory: `alberta_framework/streams/`.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DRQWQ1JVPVQVFHQTKH0WDE","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T19:42:31.649Z","completed_at":"2026-08-19T19:43:43.989Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T19:42:32.592Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ab68aaa28a08bb12e2598586b30e532b6879bde0a36964dbae335a02ddce8958","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ae0a20f2-e2b8-4656-956a-4b81ae780dfc","object_id":"sha256:ab68aaa28a08bb12e2598586b30e532b6879bde0a36964dbae335a02ddce8958","sha256":"ab68aaa28a08bb12e2598586b30e532b6879bde0a36964dbae335a02ddce8958"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"GrB6N4dLldEL3uS6i9pu6zAE6OzXpxr-2Ny-vzKJdOfEnbzQhj4wwYalfdDIkWh5LlbpjdrEDt95j55rirxHDw"}} -->
