### PR TITLE
fix(core): reject hostile mode identities before membership in future-utility helpers

### DIFF
--- a/alberta_framework/core/future_utility.py
+++ b/alberta_framework/core/future_utility.py
@@ -480,7 +480,7 @@ def normalize_future_utility_signal(
     )
     normalized = signal
 
-    if mode in {"uncertainty", "uncertainty_age"}:
+    if type(mode) is str and mode in {"uncertainty", "uncertainty_age"}:
         normalized = normalized / jnp.sqrt(new_second_moment + 1e-6)
 
     return normalized, new_second_moment
@@ -501,7 +501,7 @@ def bias_correct_future_utility(
     checkpoint schemas.  Age-zero slots have no observations and retain their
     raw value (normally zero).
     """
-    if mode not in {"age", "uncertainty_age"}:
+    if type(mode) is not str or mode not in {"age", "uncertainty_age"}:
         return utilities
 
     age_count = jnp.maximum(ages.astype(jnp.float32), 0.0)

--- a/tests/test_future_utility.py
+++ b/tests/test_future_utility.py
@@ -565,6 +565,71 @@ def test_compositional_future_utility_metrics_remain_finite_with_variants() -> N
     chex.assert_tree_all_finite(result.state.candidate_utilities)
 
 
+class _HostileStr(str):
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __str__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile str must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+def test_normalize_future_utility_signal_skips_hostile_mode_before_membership() -> None:
+    """A hostile str-subclass mode must not run its __eq__/__hash__ hooks.
+
+    ``normalize_future_utility_signal`` gates ``"uncertainty"``/
+    ``"uncertainty_age"`` normalization with ``mode in {...}``. Before the
+    fix, an untrusted ``mode`` object reached that membership test before its
+    type was confirmed, letting a hostile ``__eq__``/``__hash__`` run.
+    """
+    hostile = _HostileStr("uncertainty")
+    _HostileStr.calls = 0
+    signal = jnp.array([2.0, 3.0], dtype=jnp.float32)
+    normalized, second_moment = normalize_future_utility_signal(
+        signal=signal,
+        ages=jnp.array([0, 0], dtype=jnp.int32),
+        second_moment=jnp.zeros(2, dtype=jnp.float32),
+        moment_decay=0.9,
+        utility_decay=0.99,
+        mode=hostile,  # type: ignore[arg-type]
+    )
+    assert _HostileStr.calls == 0
+    # A non-str mode never matches the normalization set, so the signal
+    # passes through unnormalized (the same fallback as an unrecognized
+    # plain-string mode).
+    chex.assert_trees_all_close(normalized, signal)
+
+
+def test_bias_correct_future_utility_skips_hostile_mode_before_membership() -> None:
+    """A hostile str-subclass mode must not run its __eq__/__hash__ hooks."""
+    hostile = _HostileStr("age")
+    _HostileStr.calls = 0
+    utilities = jnp.array([0.5, 0.25], dtype=jnp.float32)
+    corrected = bias_correct_future_utility(
+        utilities,
+        ages=jnp.array([3, 5], dtype=jnp.int32),
+        utility_decay=0.9,
+        mode=hostile,  # type: ignore[arg-type]
+    )
+    assert _HostileStr.calls == 0
+    chex.assert_trees_all_close(corrected, utilities)
+
+
 def test_inf_error_silent_feature_scores_zero_not_nan() -> None:
     """Inf error * a silent feature is 0*inf = NaN in the LMS counterfactual.
 


### PR DESCRIPTION
## Summary

`normalize_future_utility_signal` and `bias_correct_future_utility` in
`alberta_framework/core/future_utility.py` gate their normalization branches
with `mode in {"uncertainty", "uncertainty_age"}` / `mode not in {"age",
"uncertainty_age"}` against an untrusted `mode: str` parameter, without first
confirming its runtime type. A hostile `str` subclass whose `__eq__`/`__hash__`
raises or has side effects reaches that membership test *before* any type
check, so a benign-looking call can execute attacker-controlled code.

Both functions are public module-level helpers (imported and called directly
from `compositional_features.py` and `feature_discovery.py`), so this is a
real entry point, not just dead defense-in-depth.

Same vulnerability class as #2018 (`interaction_features.py`) and #2020
(`compositional_features.py`) — checking `value in some_set` / `value not in
allowed` before confirming `value`'s type is safe. Grepped the rest of my
territory (`alberta_framework/core/`, `benchmarks/`, `evaluation/`, `utils/`)
for the same `not in {...}` / `in {...}` pattern; the other hits I found
(`associative_memory.py`, `upgd_memory.py`, `prototype_agent.py`) already have
a preceding `type(x) is not str` guard, so `future_utility.py` was the
remaining unguarded surface.

## Fix

- `normalize_future_utility_signal`: `mode in {...}` → `type(mode) is str and
  mode in {...}` (short-circuits before any dunder call on a non-str mode).
- `bias_correct_future_utility`: `mode not in {...}` → `type(mode) is not str
  or mode not in {...}`.

Both preserve existing behavior for every legitimate string input (including
unrecognized-but-plain-string modes, which already fell through unnormalized) —
only the hostile-object code path changes, from "runs attacker code" to
"treated as no match."

## Evidence (failing-test-first)

Added two tests to `tests/test_future_utility.py` using a `_HostileStr` str
subclass whose `__eq__`, `__hash__`, `__bool__`, `__str__`, and `__repr__` all
raise `AssertionError`, asserting zero hook calls and unchanged
pass-through output:
- `test_normalize_future_utility_signal_skips_hostile_mode_before_membership`
- `test_bias_correct_future_utility_skips_hostile_mode_before_membership`

Both tests fail against pre-fix `main` (the hostile `__eq__`/`__hash__` fires
and raises `AssertionError` inside the membership check) and pass against this
branch.

Commands run at head `d5aa1f991c4659fcc6f5c2e817f5d3c48227bd12`:

```
$ .venv/bin/python -m pytest tests/test_future_utility.py -q -o addopts=""
............................................                             [100%]
44 passed in 9.94s

$ .venv/bin/python -m ruff check alberta_framework/core/future_utility.py tests/test_future_utility.py
All checks passed!

$ .venv/bin/python -m mypy alberta_framework/core/future_utility.py
Success: no issues found in 1 source file

$ .venv/bin/python -m pytest tests/test_compositional_features.py tests/test_feature_discovery.py \
    -q -o addopts="" -m "not slow and not package"
........................................................................ [ 72%]
......................................................                   [100%]
198 passed in 163.27s (0:02:43)
```

The last run covers the two callers of these helpers end to end, confirming
no behavior regression for legitimate `mode` values.

## Scope

This is a correctness/robustness fix, not a benchmark measurement — no
`outputs/` artifacts are written or touched, and no benchmark number moves.
Only `alberta_framework/core/future_utility.py` and
`tests/test_future_utility.py` are changed.

## What remains open

None for this specific gap. The broader hostile-string-membership pattern may
still exist in `alberta_framework/streams/`, `alberta_framework/steps/`, or
outside my assigned territory — not audited here.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DS1GN8JV77A3641BE6ER6X","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T19:47:46.984Z","completed_at":"2026-08-19T19:48:21.382Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T19:47:47.591Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"9f909f635ba91d53c0e7ebfdda5cb3a9c2c5d6aaee730a8ad35bb8ac7ab6b3d4","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"dfb70549-e9f0-4bf3-abef-135f8e291e16","object_id":"sha256:9f909f635ba91d53c0e7ebfdda5cb3a9c2c5d6aaee730a8ad35bb8ac7ab6b3d4","sha256":"9f909f635ba91d53c0e7ebfdda5cb3a9c2c5d6aaee730a8ad35bb8ac7ab6b3d4"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"JUdnqZDHsduUyKCKEDTKwb8rPOhkqcGG_ZhjJAql6lxalcjzapHo2_OkaofSgGd7hA-VilslGgTyWaTndvZmBw"}} -->
