### PR TITLE
fix(benchmarks): reject hostile string identities before membership at OCI launch entrypoints

### DIFF
--- a/alberta_framework/benchmarks/official_foragax_oci.py
+++ b/alberta_framework/benchmarks/official_foragax_oci.py
@@ -1450,7 +1450,10 @@ def emit_launch_command(
         raise OfficialForagaxOciError(
             "launch image must be a sha256 image-config digest"
         )
-    if entrypoint not in {"src/continuing_main.py", "src/rtu_ppo.py"}:
+    if type(entrypoint) is not str or entrypoint not in {
+        "src/continuing_main.py",
+        "src/rtu_ppo.py",
+    }:
         raise OfficialForagaxOciError("launch entrypoint is not allowlisted")
     config = PurePosixPath(config_path)
     if (
@@ -2996,7 +2999,7 @@ def qualify_v4_runs(
     environment_profile_sha256: str,
 ) -> dict[str, Any]:
     """Seal exact two-run deterministic evidence without granting endorsement."""
-    if backend not in {"cpu", "gpu"}:
+    if type(backend) is not str or backend not in {"cpu", "gpu"}:
         raise OfficialForagaxOciError(
             "qualification backend must be exactly cpu or gpu"
         )

--- a/tests/test_official_foragax_oci.py
+++ b/tests/test_official_foragax_oci.py
@@ -995,3 +995,81 @@ def test_gpu_launch_uses_explicit_devices_and_read_only_driver_bind() -> None:
         "--env=XLA_FLAGS=--xla_gpu_enable_triton_gemm=false "
         "--xla_gpu_deterministic_ops=true"
     ) in command
+
+
+class _HostileStr(str):
+    """A str subclass whose dunders raise, to prove they never run."""
+
+    calls = 0
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile eq must not run")
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile hash must not run")
+
+    def __bool__(self) -> bool:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile bool must not run")
+
+    def __str__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile str must not run")
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile repr must not run")
+
+
+def test_emit_launch_command_rejects_hostile_entrypoint_before_membership() -> None:
+    """A hostile str-subclass entrypoint must not run its __eq__/__hash__ hooks.
+
+    ``emit_launch_command`` gates its entrypoint allowlist with
+    ``entrypoint not in {...}`` against an untrusted ``entrypoint: str``
+    parameter. Before the fix, a hostile object reached that membership test
+    before its type was confirmed, letting a hostile ``__eq__``/``__hash__``
+    run.
+    """
+    hostile = _HostileStr("src/continuing_main.py")
+    _HostileStr.calls = 0
+    with pytest.raises(oci.OfficialForagaxOciError, match="entrypoint is not allowlisted"):
+        oci.emit_launch_command(
+            image_id="sha256:" + "1" * 64,
+            entrypoint=hostile,  # type: ignore[arg-type]
+            config_path="/opt/continual-foragax-agents/config.json",
+            index_expression="0",
+            gpu=False,
+        )
+    assert _HostileStr.calls == 0
+
+
+def test_qualify_v4_runs_rejects_hostile_backend_before_membership(tmp_path: Path) -> None:
+    """A hostile str-subclass backend must not run its __eq__/__hash__ hooks.
+
+    ``qualify_v4_runs`` gates its backend allowlist with
+    ``backend not in {...}`` as the very first check, before either archive
+    is touched. Before the fix, a hostile object reached that membership test
+    before its type was confirmed, letting a hostile ``__eq__``/``__hash__``
+    run.
+    """
+    hostile = _HostileStr("cpu")
+    _HostileStr.calls = 0
+    with pytest.raises(
+        oci.OfficialForagaxOciError, match="backend must be exactly cpu or gpu"
+    ):
+        oci.qualify_v4_runs(
+            tmp_path / "first.tar",
+            tmp_path / "second.tar",
+            backend=hostile,  # type: ignore[arg-type]
+            image_id="sha256:" + "1" * 64,
+            runtime_profile_id="fixture",
+            effective_seed=7,
+            steps=12,
+            config_sha256="2" * 64,
+            source_archive_sha256="3" * 64,
+            workload_identity={},
+            environment_profile_sha256="5" * 64,
+        )
+    assert _HostileStr.calls == 0


### PR DESCRIPTION
## Summary

`emit_launch_command` and `qualify_v4_runs` in
`alberta_framework/benchmarks/official_foragax_oci.py` gate their allowlists
with `entrypoint not in {"src/continuing_main.py", "src/rtu_ppo.py"}` and
`backend not in {"cpu", "gpu"}` against untrusted `entrypoint: str` /
`backend: str` parameters, without first confirming their runtime type. A
hostile `str` subclass whose `__eq__`/`__hash__` raises or has side effects
reaches that membership test *before* any type check, so a benign-looking
call can execute attacker-controlled code.

Both are public module-level functions (importable and callable directly, not
gated behind JSON-only parsing), so this is a real entry point, not just dead
defense-in-depth. `qualify_v4_runs`'s `backend` check is literally the first
statement in the function body, ahead of any archive access.

Same vulnerability class as #2018 (`interaction_features.py`), #2020
(`compositional_features.py`), #2021 (`foragax_open_screen.py`), and #2023
(`future_utility.py`) — checking `value in some_set` / `value not in allowed`
before confirming `value`'s type is safe.

I grepped `alberta_framework/core/`, `benchmarks/`, `evaluation/`, and
`utils/` for the same `in {...}` / `not in {...}` pattern (245 hits) and
manually traced each hit's provenance. The large majority either already had
a preceding `type(x) is not str` guard, or reused an internal attribute that
was already validated as `str` at construction time (e.g. dataclass
`__post_init__` guards in `horde_actor_critic.py`, `canonical_upgd.py`,
`prototype_agent.py`, `representation_gradient_mixer.py`, `feature_discovery.py`).
Two more unguarded hits in this same file — the Debian-package `architecture`
field and the qualification workload's `entrypoint_family` field — are reached
only through `_strict_json_file` (standard `json.loads`, which never produces
`str` subclasses), so they are dead defense-in-depth rather than a reachable
gap; left unchanged to keep this PR to genuinely reachable entry points.

## Fix

- `emit_launch_command`: `entrypoint not in {...}` → `type(entrypoint) is not
  str or entrypoint not in {...}`.
- `qualify_v4_runs`: `backend not in {...}` → `type(backend) is not str or
  backend not in {...}`.

Both preserve existing behavior for every legitimate string input — only the
hostile-object code path changes, from "runs attacker code" to "treated as no
match, raises the existing error."

## Evidence (failing-test-first)

Added two tests to `tests/test_official_foragax_oci.py` using a `_HostileStr`
str subclass whose `__eq__`, `__hash__`, `__bool__`, `__str__`, and `__repr__`
all raise `AssertionError`, asserting zero hook calls and the existing
rejection error:
- `test_emit_launch_command_rejects_hostile_entrypoint_before_membership`
- `test_qualify_v4_runs_rejects_hostile_backend_before_membership`

Both tests fail against pre-fix code (the hostile `__hash__` fires and raises
`AssertionError` inside the membership check, before the intended
`OfficialForagaxOciError` is ever raised) and pass against this branch.
Verified by stashing the source fix and confirming both new tests fail with
the hostile `__hash__`/`__repr__` `AssertionError`, then restoring the fix
and confirming they pass.

Commands run at head `04b9f43c58972425b19d8dfebd08402257139143`:

```
$ .venv/bin/python -m pytest tests/test_official_foragax_oci.py -q -o addopts=""
23 passed in 2.07s

$ .venv/bin/python -m ruff check alberta_framework/benchmarks/official_foragax_oci.py tests/test_official_foragax_oci.py
All checks passed!

$ .venv/bin/python -m mypy alberta_framework/benchmarks/official_foragax_oci.py
Success: no issues found in 1 source file
```

## Scope

This is a correctness/robustness fix, not a benchmark measurement — no
`outputs/` artifacts are written or touched, and no benchmark number moves.
Only `alberta_framework/benchmarks/official_foragax_oci.py` and
`tests/test_official_foragax_oci.py` are changed.

## What remains open

The two dead-defense-in-depth hits noted above
(`official_foragax_oci.py`'s Debian `architecture` and qualification
`entrypoint_family` fields) are not fixed here since they are unreachable
through their only current callers. The broader pattern may still exist in
`alberta_framework/streams/`, `alberta_framework/steps/`, or outside my
assigned territory — not audited here.

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DSTWVQ69XM2RMHRNR2ZZ81","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T20:01:38.680Z","completed_at":"2026-08-19T20:02:20.656Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T20:01:40.027Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"bc0f5ec7306e7e4c4c711219bfd466765c72074e0fd6f0ea2d20b0cd8c84b7c7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b7125dbb-0c10-4d46-b5bb-dec78ce81500","object_id":"sha256:bc0f5ec7306e7e4c4c711219bfd466765c72074e0fd6f0ea2d20b0cd8c84b7c7","sha256":"bc0f5ec7306e7e4c4c711219bfd466765c72074e0fd6f0ea2d20b0cd8c84b7c7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"cFyRADsutREaIuCNm2JA_dEpeaM0y87Cxw6La_NUfWzWQO7yGejHVNB2r6MAopLwRmJyu0wcwV47CHo3RMooAQ"}} -->
