### PR TITLE
fix(steps): cap Step 8 smoke steps before unbounded allocation

### DIFF
--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -389,8 +389,7 @@ def run_step8_smoke(
     seed: int = 0,
 ) -> Step8SmokeResult:
     """Run a tiny deterministic Step 8 environment-prediction probe."""
-    if steps < 1:
-        raise ValueError("steps must be positive")
+    steps = _require_int("steps", steps, minimum=1, maximum=_INT32_MAX)
 
     cfg = config or Step8WorldModelConfig()
     if cfg.n_actions is None:

--- a/tests/test_step8_hostile_validation.py
+++ b/tests/test_step8_hostile_validation.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 import numpy as np
 import pytest
 
-from alberta_framework.steps.step8 import Step8WorldModelConfig
+from alberta_framework.steps.step8 import Step8WorldModelConfig, run_step8_smoke
 
 
 class _EvilStr(str):
@@ -167,3 +167,75 @@ def test_float_subclass_with_lying_ratio_is_rejected() -> None:
     with pytest.raises(ValueError, match="must be finite"):
         Step8WorldModelConfig(step_size=RatioFloat(0.05))
     assert RatioFloat.calls == 0
+
+
+def test_step8_smoke_zero_steps_raises() -> None:
+    with pytest.raises(ValueError, match="steps must be positive"):
+        run_step8_smoke(steps=0)
+
+
+@pytest.mark.parametrize("steps", [True, False, 1.5])
+def test_step8_smoke_rejects_non_integer_steps(steps: object) -> None:
+    with pytest.raises(ValueError, match="steps must be an integer"):
+        run_step8_smoke(steps=cast(Any, steps))
+
+
+def test_step8_smoke_rejects_class_spoofed_integer_steps() -> None:
+    class _SpoofedInt:
+        """Mimics ``int`` via ``__class__`` to defeat ``isinstance`` checks."""
+
+        @property
+        def __class__(self) -> type:  # type: ignore[override]
+            return int
+
+        def __int__(self) -> int:  # pragma: no cover
+            raise AssertionError("SpoofedInt.__int__ must not be called")
+
+        def __index__(self) -> int:  # pragma: no cover
+            raise AssertionError("SpoofedInt.__index__ must not be called")
+
+    with pytest.raises(ValueError, match="steps must be an integer"):
+        run_step8_smoke(steps=cast(Any, _SpoofedInt()))
+
+
+def test_step8_smoke_rejects_oversized_steps_before_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hostile/mistaken huge ``steps`` must be rejected before any array is
+    allocated. Origin only checked ``steps < 1`` with no upper bound, so a
+    caller-supplied ``steps=2**31`` (or larger) reached ``jr.normal``/
+    ``jnp.arange`` uncapped -- unbounded allocation, hang/OOM.
+    """
+
+    def _spy(*args: object, **kwargs: object) -> Any:
+        raise AssertionError(f"jr.normal must not run: {args} {kwargs}")
+
+    monkeypatch.setattr("alberta_framework.steps.step8.jr.normal", _spy)
+    with pytest.raises(ValueError, match="steps must be at most int32 max"):
+        run_step8_smoke(steps=2**31)
+
+
+def test_step8_smoke_rejects_trillion_steps_before_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _spy(*args: object, **kwargs: object) -> Any:
+        raise AssertionError(f"jr.normal must not run: {args} {kwargs}")
+
+    monkeypatch.setattr("alberta_framework.steps.step8.jr.normal", _spy)
+    with pytest.raises(ValueError, match="steps must be at most int32 max"):
+        run_step8_smoke(steps=10**12)
+
+
+def test_step8_smoke_accepts_int32_max_steps_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The documented boundary (int32 max) must still pass the gate itself;
+    only the value fed forward is checked here, not a real huge allocation.
+    """
+
+    def _spy(*args: object, **kwargs: object) -> Any:
+        raise AssertionError(f"jr.normal must not run: {args} {kwargs}")
+
+    monkeypatch.setattr("alberta_framework.steps.step8.jr.normal", _spy)
+    with pytest.raises(AssertionError, match="jr.normal must not run"):
+        run_step8_smoke(steps=2**31 - 1)


### PR DESCRIPTION
## Summary

`run_step8_smoke` in `alberta_framework/steps/step8.py` only checked `steps < 1`
before feeding `steps` straight into `jr.normal(...)` and `jnp.arange(...)`:

```python
if steps < 1:
    raise ValueError("steps must be positive")
```

No type check and no upper bound. Every sibling smoke entrypoint in this
package (`run_step1_smoke`, `run_step2_smoke`, `run_step2_associative_smoke`,
`run_step3_smoke`, `run_step5_smoke`, `run_step6_smoke`, `run_step7_smoke`,
`run_step9_smoke`, `run_step10_smoke`, `run_step11_smoke`, `run_step12_smoke`)
already gates `steps` through `_require_int("steps", steps, minimum=1,
maximum=_INT32_MAX)` — `run_step8_smoke` was the one outlier still on the weak
`< 1` check.

Two concrete problems on `origin/main` `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`:

1. **Unbounded allocation / hang-OOM.** `run_step8_smoke(steps=2**31)` or
   `run_step8_smoke(steps=10**12)` reaches `jr.normal(data_key, (steps,
   cfg.observation_dim), ...)` uncapped — the same hang/OOM class already
   fixed for every other Step N smoke function in this file family (see
   `_require_int(..., maximum=_INT32_MAX)` in step1/2/3/5/6/7/9/10/11/12).
2. **Hostile-bool bypass.** `steps=True` silently passes `True < 1 == False`
   instead of being rejected as non-integer, unlike `_require_int`'s exact
   `type(value) not in _ACTUAL_INT_TYPES` gate.

## Expected behavior

`steps` in `[1, 2**31-1]` (exact `int`/numpy-int types) still runs the probe.
A non-positive, non-integer (including `bool`), or oversized `steps` raises
`ValueError` ("steps must be positive" / "steps must be an integer" / "steps
must be at most int32 max") before any array is allocated.

## Scope

- `alberta_framework/steps/step8.py`
- `tests/test_step8_hostile_validation.py`

Does not touch `Step8WorldModelConfig.from_dict` (separately covered by the
open PR on schema-field validation) — this change is only `run_step8_smoke`'s
`steps` gate.

## Verification

```text
# red on origin/main ec035f73ad8e1e0545155e94c3e689d4b8d5d82b:
# run_step8_smoke(steps=2**31) and steps=10**12 reach jr.normal(shape=(steps, obs_dim))
# uncapped; steps=False / steps=1.5 / a __class__-spoofed int all pass the bare `< 1` check.

.venv/bin/python -m pytest tests/test_step8_hostile_validation.py tests/test_step8_production.py -q -o addopts=""
# 105 passed

.venv/bin/python -m pytest tests/test_step5_step6_production.py tests/test_step7_hostile_validation.py \
  tests/test_step7_lifetime_clock.py tests/test_step7_production.py tests/test_step7_rng.py \
  tests/test_step_float32_validation.py tests/test_step_smoke_record_shapes.py -q -o addopts=""
# 454 passed

.venv/bin/python -m ruff check alberta_framework/steps/step8.py tests/test_step8_hostile_validation.py
# All checks passed!

.venv/bin/python -m mypy alberta_framework/steps/step8.py
# Success: no issues found in 1 source file
```

New tests added in `tests/test_step8_hostile_validation.py` (`test_step8_smoke_rejects_oversized_steps_before_allocation`,
`test_step8_smoke_rejects_trillion_steps_before_allocation`) monkeypatch
`jr.normal` to assert it is never called, proving the guard fires before any
allocation rather than actually performing a multi-gigabyte allocation in CI.

<!-- evidence-head:30eec4458cf62c3ef35ca304071777135ceb04c9 -->
<!-- evidence-row:logs -->
- [x] logs: see the Verification block above (full pytest/ruff/mypy command output reproduced inline; this is a local unit-test fix, not a benchmark run, so no external log artifact applies)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A — validator hardening, no IPMNIST/benchmark shard produced

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0DT4EV6RMV9DN08X1E3RFEV","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-19T20:06:52.006Z","completed_at":"2026-08-19T20:07:26.011Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-19T20:06:52.850Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"9ce28826a143def563b741e6a9e92deb23535b8dc891eb757731b29badc23f90","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a6255ed7-6a5d-4822-a5c5-b6373b17c099","object_id":"sha256:9ce28826a143def563b741e6a9e92deb23535b8dc891eb757731b29badc23f90","sha256":"9ce28826a143def563b741e6a9e92deb23535b8dc891eb757731b29badc23f90"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"riM84GvC90tVb3JSFzKIpToDW8N64YfwplWH6PlN0fEGf10NvmCga-X8drUHuzAFWo_JvoBW_3WloovydQNgAw"}} -->
