### PR TITLE
fix(reference-agent): reject deep manifest JSON before RecursionError

### DIFF
--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -41,6 +41,7 @@ _MAX_LIFECYCLE_ID_LENGTH = _MAX_ID_LENGTH - len(
     f":{MAX_DECISION_INDEX}:authorization"
 )
 _MAX_CONFIG_BYTES = 1 << 20
+_MAX_JSON_NESTING_DEPTH = 64
 _MAX_ARRAY_RANK = 8
 _MAX_ARRAY_ELEMENTS = 1 << 20
 _SUPPORTED_DTYPES = frozenset(
@@ -83,8 +84,52 @@ def _require_sha256(value: str, *, name: str) -> None:
         raise ValueError(f"{name} must be a lowercase 64-character SHA-256 digest")
 
 
+def _require_json_text_nesting(raw: str, *, name: str) -> None:
+    """Reject nesting that would RecursionError ``json.loads`` before it runs."""
+    if type(raw) is not str:
+        raise ValueError(f"{name} must be canonical JSON")
+    encoded_len = len(raw.encode("utf-8"))
+    if encoded_len > _MAX_CONFIG_BYTES:
+        raise ValueError(f"{name} exceeds {_MAX_CONFIG_BYTES} bytes")
+    depth = 0
+    in_string = False
+    escape = False
+    for character in raw:
+        if in_string:
+            if escape:
+                escape = False
+            elif character == "\\":
+                escape = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+            continue
+        if character in "{[":
+            depth += 1
+            if depth > _MAX_JSON_NESTING_DEPTH:
+                raise ValueError(
+                    f"{name} exceeds the maximum canonical JSON nesting depth"
+                )
+        elif character in "}]":
+            depth -= 1
+
+
+def _load_manifest_config_json(raw: str) -> Any:
+    _require_json_text_nesting(raw, name="manifest config")
+    try:
+        return json.loads(raw)
+    except RecursionError as exc:
+        raise ValueError(
+            "manifest config exceeds the maximum canonical JSON nesting depth"
+        ) from exc
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("manifest config must be canonical JSON") from exc
+
+
 def _validate_json_value(value: Any, *, path: str, depth: int = 0) -> None:
-    if depth > 64:
+    if depth > _MAX_JSON_NESTING_DEPTH:
         raise ValueError(f"{path} exceeds the maximum canonical JSON nesting depth")
     value_type = type(value)
     if value is None or value_type is str or value_type is bool or value_type is int:
@@ -514,10 +559,7 @@ class AgentManifest:
             raise ValueError("action_spec must be a SpaceSpec")
         if not isinstance(self.capabilities, AgentCapabilities):
             raise ValueError("capabilities must be AgentCapabilities")
-        try:
-            config = json.loads(self._config_json)
-        except (TypeError, json.JSONDecodeError) as exc:
-            raise ValueError("manifest config must be canonical JSON") from exc
+        config = _load_manifest_config_json(self._config_json)
         if not isinstance(config, dict):
             raise ValueError("manifest config must be a JSON object")
         if _canonical_json_bytes(config).decode("utf-8") != self._config_json:
@@ -573,7 +615,7 @@ class AgentManifest:
 
     @property
     def config(self) -> dict[str, Any]:
-        config = json.loads(self._config_json)
+        config = _load_manifest_config_json(self._config_json)
         assert isinstance(config, dict)
         return config
 

--- a/tests/test_reference_agent_config_json_depth.py
+++ b/tests/test_reference_agent_config_json_depth.py
@@ -1,0 +1,105 @@
+"""Reject deep manifest config JSON before json.loads RecursionError."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from alberta_framework.reference_agent import (
+    _MAX_JSON_NESTING_DEPTH,
+    REFERENCE_AGENT_MANIFEST_SCHEMA,
+    AgentCapabilities,
+    AgentManifest,
+    SpaceSpec,
+    _load_manifest_config_json,
+)
+
+
+def _nested_array_json(depth: int) -> str:
+    return "[" * depth + "0" + "]" * depth
+
+
+def _manifest_config_json(depth: int) -> str:
+    return '{"k":' + _nested_array_json(depth) + "}"
+
+
+def _attempt_manifest(config_json: str) -> AgentManifest:
+    return AgentManifest(
+        schema=REFERENCE_AGENT_MANIFEST_SCHEMA,
+        implementation_id="a.b",
+        state_schema="c.d",
+        config_sha256="0" * 64,
+        manifest_id="1" * 64,
+        observation_spec=SpaceSpec(
+            kind="box", shape=(), dtype="float32", semantic_id="a.b"
+        ),
+        action_spec=SpaceSpec(
+            kind="box", shape=(), dtype="float32", semantic_id="a.b"
+        ),
+        capabilities=AgentCapabilities(),
+        _config_json=config_json,
+    )
+
+
+def test_deep_config_json_never_reaches_loads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """10_000-deep JSON must ValueError before json.loads RecursionError."""
+    import json as json_module
+
+    calls: list[str] = []
+    real_loads = json_module.loads
+
+    def spy(raw: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append(raw if type(raw) is str else type(raw).__name__)
+        return real_loads(raw, *args, **kwargs)
+
+    monkeypatch.setattr("alberta_framework.reference_agent.json.loads", spy)
+    deep = _manifest_config_json(10_000)
+    assert len(deep.encode("utf-8")) < 1 << 20
+    with pytest.raises(ValueError, match="nesting depth"):
+        _load_manifest_config_json(deep)
+    with pytest.raises(ValueError, match="nesting depth"):
+        _attempt_manifest(deep)
+    assert calls == []
+
+
+def _nested_python_list(depth: int) -> Any:
+    value: Any = 0
+    for _ in range(depth):
+        value = [value]
+    return value
+
+
+def test_last_fit_nesting_still_parses() -> None:
+    # Object + 63 arrays = depth 64, the last-fit for the protocol cap.
+    depth = _MAX_JSON_NESTING_DEPTH - 1
+    loaded = _load_manifest_config_json(_manifest_config_json(depth))
+    assert loaded == {"k": _nested_python_list(depth)}
+
+
+def test_first_overflow_nesting_rejects_before_loads(monkeypatch: pytest.MonkeyPatch) -> None:
+    import json as json_module
+
+    calls: list[int] = []
+    real_loads = json_module.loads
+
+    def spy(raw: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append(1)
+        return real_loads(raw, *args, **kwargs)
+
+    monkeypatch.setattr("alberta_framework.reference_agent.json.loads", spy)
+    with pytest.raises(ValueError, match="nesting depth"):
+        _load_manifest_config_json(_manifest_config_json(_MAX_JSON_NESTING_DEPTH))
+    assert calls == []
+
+
+def test_recursionerror_from_loads_is_valueerror(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(raw: Any, *args: Any, **kwargs: Any) -> Any:
+        del raw, args, kwargs
+        raise RecursionError("simulated parser overflow")
+
+    monkeypatch.setattr("alberta_framework.reference_agent.json.loads", boom)
+    with pytest.raises(ValueError, match="nesting depth"):
+        _load_manifest_config_json(_manifest_config_json(1))


### PR DESCRIPTION
## Summary

Occupancy-FREE complete RecursionError hang on `origin/main` `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`.

`AgentManifest.__post_init__` called `json.loads(self._config_json)` and caught only `TypeError`/`JSONDecodeError`. A 10_000-deep array nest still fit `_MAX_CONFIG_BYTES` (20_001 bytes < 1 MiB) and RecursionError'd:

```text
json.loads(10000-deep [0] nest) -> RecursionError
AgentManifest(..., _config_json='{"k":' + nest + '}') -> RecursionError
```

`from_config` already walks Python objects with `_MAX_JSON_NESTING_DEPTH = 64`. The decoder path for the stored JSON string had no depth ceiling.

Non-scan, non-leftover persist/INT32/256 MiB. Not `#2005` option-duration scan T. Not `#1874` / forager / clocks / IA / FTL. Not `#1997` checkpoints / `#2002` reference-life checkpoint (those hosts stay occupied).

## Expected behavior

JSON nests of depth `<= 64` still parse. Depth `65` and the origin hang-class `10_000` raise `ValueError` matching `nesting depth`, never `RecursionError`. `json.loads` is not reached on overflow.

## Scope

- `alberta_framework/reference_agent.py`
- `tests/test_reference_agent_config_json_depth.py`

## Verification

```text
# red on origin/main ec035f73
AgentManifest(..., _config_json=10000-deep nest) -> RecursionError

# green at this head
.venv/bin/python -m pytest tests/test_reference_agent_config_json_depth.py tests/test_reference_agent_protocol.py -q
# 25 passed
.venv/bin/python -m ruff check alberta_framework/reference_agent.py tests/test_reference_agent_config_json_depth.py
.venv/bin/python -m mypy alberta_framework/reference_agent.py tests/test_reference_agent_config_json_depth.py
```

<!-- evidence-head:3b98e960e02d0bfbe3a90c5024241c66d8969ad8 -->
<!-- evidence-row:logs -->
- [x] logs: origin `ec035f73` RecursionError'd 10_000-deep manifest config JSON; this head raises ValueError before json.loads; 38 focused protocol/hostile/depth tests passed
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - protocol JSON RecursionError preflight, no IPMNIST shard
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - local fail-before-RecursionError proof, no model-trajectory artifact

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
