### PR TITLE
fix(core): reject deep pytrees before jax.tree.leaves SystemError

### DIFF
--- a/alberta_framework/core/update_safety.py
+++ b/alberta_framework/core/update_safety.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import operator
-from typing import SupportsIndex, cast
+from typing import Any, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -27,6 +27,8 @@ _ACTUAL_INT_TYPES = frozenset(
     }
 )
 _INT32_MAX = int(np.iinfo(np.int32).max)
+# Origin ``jax.tree.leaves`` still returns at depth 8000 and SystemErrors at 10_000.
+_MAX_PYTREE_NESTING_DEPTH = 4096
 
 
 def _require_exact_bool(name: str, value: object) -> bool:
@@ -121,11 +123,66 @@ def checked_integer_action_array(
     return safe, valid
 
 
+def _pytree_container_children(node: object) -> tuple[object, ...] | None:
+    node_type = type(node)
+    if node_type is dict:
+        return tuple(cast(dict[Any, Any], node).values())
+    if node_type is list:
+        return tuple(cast(list[Any], node))
+    if node_type is tuple:
+        return cast(tuple[object, ...], node)
+    if isinstance(node, tuple) and getattr(node_type, "_fields", None) is not None:
+        return tuple(node)
+    return None
+
+
+def _require_pytree_nesting(tree: object, *, name: str = "tree") -> None:
+    """Reject cycles and nesting that SystemError ``jax.tree.leaves``."""
+    children = _pytree_container_children(tree)
+    if children is None:
+        return
+    frames: list[tuple[object, tuple[object, ...], int, int]] = [
+        (tree, children, 1, 0)
+    ]
+    ancestors = {id(tree)}
+    while frames:
+        node, kids, depth, index = frames[-1]
+        if depth > _MAX_PYTREE_NESTING_DEPTH:
+            raise ValueError(f"{name} exceeds the maximum pytree nesting depth")
+        if index >= len(kids):
+            frames.pop()
+            ancestors.discard(id(node))
+            continue
+        child = kids[index]
+        frames[-1] = (node, kids, depth, index + 1)
+        child_kids = _pytree_container_children(child)
+        if child_kids is None:
+            continue
+        child_id = id(child)
+        if child_id in ancestors:
+            raise ValueError(f"{name} contains a cyclic pytree")
+        child_depth = depth + 1
+        if child_depth > _MAX_PYTREE_NESTING_DEPTH:
+            raise ValueError(f"{name} exceeds the maximum pytree nesting depth")
+        ancestors.add(child_id)
+        frames.append((child, child_kids, child_depth, 0))
+
+
+def _tree_leaves(tree: object) -> list[Any]:
+    _require_pytree_nesting(tree, name="tree")
+    try:
+        return jax.tree.leaves(tree)
+    except RecursionError as exc:
+        raise ValueError("tree exceeds the maximum pytree nesting depth") from exc
+    except SystemError as exc:
+        raise ValueError("tree exceeds the maximum pytree nesting depth") from exc
+
+
 def floating_tree_is_finite(tree: object) -> Bool[Array, ""]:
     """Return whether every floating or complex leaf in ``tree`` is finite."""
 
     valid = jnp.asarray(True, dtype=jnp.bool_)
-    for leaf in jax.tree.leaves(tree):
+    for leaf in _tree_leaves(tree):
         array = jnp.asarray(leaf)
         if jnp.issubdtype(array.dtype, jnp.inexact):
             valid = valid & jnp.all(jnp.isfinite(array))

--- a/tests/test_update_safety_tree_depth.py
+++ b/tests/test_update_safety_tree_depth.py
@@ -1,0 +1,118 @@
+"""Reject deep or cyclic pytrees before jax.tree.leaves SystemError."""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.update_safety import (
+    _MAX_PYTREE_NESTING_DEPTH,
+    _tree_leaves,
+    floating_tree_is_finite,
+)
+
+
+def _nested_list(depth: int, leaf: Any = 1.0) -> Any:
+    value: Any = leaf
+    for _ in range(depth):
+        value = [value]
+    return value
+
+
+def _nested_tuple(depth: int, leaf: Any = 1.0) -> Any:
+    value: Any = leaf
+    for _ in range(depth):
+        value = (value,)
+    return value
+
+
+def _nested_dict(depth: int, leaf: Any = 1.0) -> Any:
+    value: Any = leaf
+    for _ in range(depth):
+        value = {"k": value}
+    return value
+
+
+def test_deep_list_never_reaches_tree_leaves(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def spy(tree: object) -> list[Any]:
+        calls.append(1)
+        raise AssertionError("jax.tree.leaves must not run on overflow nests")
+
+    monkeypatch.setattr("alberta_framework.core.update_safety.jax.tree.leaves", spy)
+    with pytest.raises(ValueError, match="nesting depth"):
+        floating_tree_is_finite(_nested_list(10_000))
+    assert calls == []
+
+
+def test_last_fit_list_nesting_still_walks() -> None:
+    tree = _nested_list(_MAX_PYTREE_NESTING_DEPTH)
+    assert _tree_leaves(tree) == [1.0]
+    assert bool(floating_tree_is_finite(tree))
+
+
+def test_first_overflow_list_rejects_before_leaves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int] = []
+
+    def spy(tree: object) -> list[Any]:
+        calls.append(1)
+        raise AssertionError("jax.tree.leaves must not run on overflow nests")
+
+    monkeypatch.setattr("alberta_framework.core.update_safety.jax.tree.leaves", spy)
+    with pytest.raises(ValueError, match="nesting depth"):
+        floating_tree_is_finite(_nested_list(_MAX_PYTREE_NESTING_DEPTH + 1))
+    assert calls == []
+
+
+def test_last_fit_tuple_and_dict_nests_still_walk() -> None:
+    assert bool(floating_tree_is_finite(_nested_tuple(_MAX_PYTREE_NESTING_DEPTH)))
+    assert bool(floating_tree_is_finite(_nested_dict(_MAX_PYTREE_NESTING_DEPTH)))
+
+
+def test_cyclic_list_rejects_before_leaves(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def spy(tree: object) -> list[Any]:
+        calls.append(1)
+        raise AssertionError("jax.tree.leaves must not run on cyclic trees")
+
+    monkeypatch.setattr("alberta_framework.core.update_safety.jax.tree.leaves", spy)
+    cyclic: list[Any] = []
+    cyclic.append(cyclic)
+    with pytest.raises(ValueError, match="cyclic pytree"):
+        floating_tree_is_finite(cyclic)
+    assert calls == []
+
+
+def test_shared_subtree_is_not_cyclic() -> None:
+    inner = [jnp.asarray(1.0)]
+    assert bool(floating_tree_is_finite([inner, inner]))
+
+
+class _Pair(NamedTuple):
+    left: Any
+    right: Any
+
+
+def test_namedtuple_container_is_walked() -> None:
+    tree = _Pair(jnp.asarray(1.0), jnp.asarray(2.0))
+    assert bool(floating_tree_is_finite(tree))
+
+
+def test_finite_array_leaf_still_reports_nonfinite() -> None:
+    assert not bool(floating_tree_is_finite(jnp.asarray([1.0, jnp.nan])))
+
+
+def test_systemerror_from_leaves_is_valueerror(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(tree: object) -> list[Any]:
+        del tree
+        raise SystemError("simulated pytree overflow")
+
+    monkeypatch.setattr("alberta_framework.core.update_safety.jax.tree.leaves", boom)
+    with pytest.raises(ValueError, match="nesting depth"):
+        floating_tree_is_finite(1.0)


### PR DESCRIPTION
## Summary

Occupancy-FREE complete overflow on `origin/main` `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`.

`floating_tree_is_finite` called `jax.tree.leaves` with no nesting or cycle guard. Default list/tuple/dict containers still flatten at depth 8000 and **SystemError** at 10_000. A cyclic list SystemErrors immediately:

```text
floating_tree_is_finite([[[[... 1.0 ...]]]] * 10000) -> SystemError
floating_tree_is_finite(cyclic list) -> SystemError
```

Non-scan (not `jax.lax.scan` / `jnp.arange` T). Non-leftover persist/INT32/256 MiB. Not `#2005` option-duration scan T. Not `#1874` / forager / clocks / IA / FTL. Not JSON `json.loads` nest (`#1997` / `#2002` / `#2036` stay on those hosts).

## Expected behavior

Default-container pytrees of depth `<= 4096` still walk. Depth `4097`, the origin crash-class `10_000`, and cyclic lists raise `ValueError` (`nesting depth` / `cyclic pytree`) and never call `jax.tree.leaves`. Shared (diamond) subtrees remain legal. Finite-array leaves still report nonfinite values.

## Scope

- `alberta_framework/core/update_safety.py`
- `tests/test_update_safety_tree_depth.py`

## Verification

```text
# red on origin/main ec035f73
floating_tree_is_finite(10000-deep list) -> SystemError
floating_tree_is_finite(cyclic list) -> SystemError

# green at this head
.venv/bin/python -m pytest tests/test_update_safety_tree_depth.py tests/test_update_safety.py tests/test_feature_discovery.py -q
# 175 passed
.venv/bin/python -m ruff check alberta_framework/core/update_safety.py tests/test_update_safety_tree_depth.py
.venv/bin/python -m mypy alberta_framework/core/update_safety.py tests/test_update_safety_tree_depth.py
```

<!-- evidence-head:4ce752f3e2d955bff8667552d11899055e6acd24 -->
<!-- evidence-row:logs -->
- [x] logs: origin `ec035f73` SystemError'd 10_000-deep and cyclic pytrees in `floating_tree_is_finite`; this head raises ValueError before `jax.tree.leaves`; 175 focused tests passed
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - protocol pytree overflow preflight, no IPMNIST shard
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - local fail-before-SystemError proof, no model-trajectory artifact

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
