### PR TITLE
fix(core): validate scan sequence bounds and array dimensions across FTL, latent WM, CBP, and Step 4

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -1341,6 +1341,27 @@ class CBPLearningResult:
     replacements_made: Array
 
 
+def _require_scan_array_metadata(name: str, array: object) -> tuple[int, ...]:
+    actual_type = type(array)
+    if not (
+        actual_type is np.ndarray
+        or issubclass(actual_type, jax.Array)
+        or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise TypeError(f"{name} must be a trusted array")
+    try:
+        shape = tuple(int(dim) for dim in array.shape)  # type: ignore[attr-defined]
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape metadata") from error
+    return shape
+
+
+def _require_scan_resource(num_steps: int, n_heads: int, n_hidden_layers: int) -> None:
+    output_scalars = num_steps * (3 * n_heads + n_hidden_layers)
+    if output_scalars > _INT32_MAX or 4 * output_scalars > _INT32_MAX:
+        raise ValueError("CBP learning loop scan result bytes must fit signed int32")
+
+
 def run_cbp_learning_loop(
     learner: CBPMultiHeadMLPLearner,
     state: CBPMultiHeadMLPState,
@@ -1359,6 +1380,24 @@ def run_cbp_learning_loop(
         :class:`CBPLearningResult` with the final state, per-step
         per-head metrics, and per-step per-layer replacement flags.
     """
+    if type(learner) is not CBPMultiHeadMLPLearner:
+        raise TypeError("learner must be an exact CBPMultiHeadMLPLearner")
+    if type(state) is not CBPMultiHeadMLPState:
+        raise TypeError("state must be an exact CBPMultiHeadMLPState")
+
+    obs_shape = _require_scan_array_metadata("observations", observations)
+    if len(obs_shape) != 2:
+        raise ValueError("observations must have shape (num_steps, feature_dim)")
+    num_steps = _require_int("scan sequence length", obs_shape[0], minimum=1)
+
+    tgt_shape = _require_scan_array_metadata("targets", targets)
+    if tgt_shape != (num_steps, learner.n_heads):
+        raise ValueError(f"targets must have shape ({num_steps}, {learner.n_heads})")
+
+    _require_scan_resource(num_steps, learner.n_heads, len(learner.hidden_sizes))
+
+    obs_array = jnp.asarray(observations, dtype=jnp.float32)
+    tgt_array = jnp.asarray(targets, dtype=jnp.float32)
 
     def step_fn(
         carry: CBPMultiHeadMLPState, inputs: tuple[Array, Array]
@@ -1369,7 +1408,7 @@ def run_cbp_learning_loop(
 
     t0 = time.time()
     final_state, (per_head_metrics, replacements_made) = jax.lax.scan(
-        step_fn, state, (observations, targets)
+        step_fn, state, (obs_array, tgt_array)
     )
     elapsed = time.time() - t0
     final_mlp = final_state.mlp_state.replace(  # type: ignore[attr-defined]

--- a/alberta_framework/core/ftl_world_model.py
+++ b/alberta_framework/core/ftl_world_model.py
@@ -531,6 +531,27 @@ class SparseFTLWorldModel:
         )
 
 
+def _require_scan_array_metadata(name: str, array: object) -> tuple[int, ...]:
+    actual_type = type(array)
+    if not (
+        actual_type is np.ndarray
+        or issubclass(actual_type, jax.Array)
+        or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise TypeError(f"{name} must be a trusted array")
+    try:
+        shape = tuple(int(dim) for dim in array.shape)  # type: ignore[attr-defined]
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape metadata") from error
+    return shape
+
+
+def _require_scan_resource(num_steps: int, observation_dim: int) -> None:
+    output_scalars = num_steps * (3 * observation_dim + 1)
+    if output_scalars > _INT32_MAX or 4 * output_scalars > _INT32_MAX:
+        raise ValueError("sparse FTL world model scan result bytes must fit signed int32")
+
+
 def run_sparse_ftl_world_model(
     model: SparseFTLWorldModel,
     state: SparseFTLWorldModelState,
@@ -539,6 +560,40 @@ def run_sparse_ftl_world_model(
     next_observations: Array,
 ) -> SparseFTLWorldModelLearningResult:
     """Run one uninterrupted, predict-before-update transition stream."""
+    if type(model) is not SparseFTLWorldModel:
+        raise TypeError("model must be an exact SparseFTLWorldModel")
+    if type(state) is not SparseFTLWorldModelState:
+        raise TypeError("state must be an exact SparseFTLWorldModelState")
+
+    obs_shape = _require_scan_array_metadata("observations", observations)
+    if len(obs_shape) != 2 or obs_shape[1] != model.config.observation_dim:
+        raise ValueError(
+            f"observations must have shape (num_steps, {model.config.observation_dim})"
+        )
+    num_steps = _require_int32("scan sequence length", obs_shape[0], minimum=1)
+
+    next_obs_shape = _require_scan_array_metadata("next_observations", next_observations)
+    if next_obs_shape != (num_steps, model.config.observation_dim):
+        raise ValueError(
+            f"next_observations must have shape ({num_steps}, {model.config.observation_dim})"
+        )
+
+    act_shape = _require_scan_array_metadata("actions", actions)
+    expected_act_shape = (
+        (num_steps,)
+        if model.config.action_dim == 1 and len(act_shape) == 1
+        else (num_steps, model.config.action_dim)
+    )
+    if act_shape != expected_act_shape:
+        raise ValueError(
+            f"actions must have shape ({num_steps},) or ({num_steps}, {model.config.action_dim})"
+        )
+
+    _require_scan_resource(num_steps, model.config.observation_dim)
+
+    obs_array = jnp.asarray(observations, dtype=jnp.float32)
+    next_obs_array = jnp.asarray(next_observations, dtype=jnp.float32)
+    act_array = jnp.asarray(actions, dtype=jnp.float32)
 
     def step_fn(
         carry: SparseFTLWorldModelState,
@@ -556,7 +611,7 @@ def run_sparse_ftl_world_model(
     final_state, outputs = jax.lax.scan(
         step_fn,
         state,
-        (observations, actions, next_observations),
+        (obs_array, act_array, next_obs_array),
     )
     predictions, targets, errors, squared_errors = outputs
     return SparseFTLWorldModelLearningResult(

--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -1075,6 +1075,27 @@ class LatentWorldModel:
         return config
 
 
+def _require_scan_array_metadata(name: str, array: object) -> tuple[int, ...]:
+    actual_type = type(array)
+    if not (
+        actual_type is np.ndarray
+        or issubclass(actual_type, jax.Array)
+        or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise TypeError(f"{name} must be a trusted array")
+    try:
+        shape = tuple(int(dim) for dim in array.shape)  # type: ignore[attr-defined]
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape metadata") from error
+    return shape
+
+
+def _require_scan_resource(num_steps: int, latent_dim: int, n_heads: int) -> None:
+    output_scalars = num_steps * (3 * latent_dim + 3 * n_heads + 12)
+    if output_scalars > _INT32_MAX or 4 * output_scalars > _INT32_MAX:
+        raise ValueError("latent world model scan result bytes must fit signed int32")
+
+
 def run_latent_world_model_learning_loop(
     model: LatentWorldModel,
     state: LatentWorldModelState,
@@ -1085,12 +1106,58 @@ def run_latent_world_model_learning_loop(
     discounts: Float[Array, " num_steps"] | None = None,
 ) -> LatentWorldModelLearningResult:
     """Run online latent world-model learning over transition arrays."""
+    if type(model) is not LatentWorldModel:
+        raise TypeError("model must be an exact LatentWorldModel")
+    if type(state) is not LatentWorldModelState:
+        raise TypeError("state must be an exact LatentWorldModelState")
+
+    obs_shape = _require_scan_array_metadata("observations", observations)
+    if len(obs_shape) != 2 or obs_shape[1] != model.config.observation_dim:
+        raise ValueError(
+            f"observations must have shape (num_steps, {model.config.observation_dim})"
+        )
+    num_steps = _require_int32("scan sequence length", obs_shape[0], minimum=1)
+
+    next_obs_shape = _require_scan_array_metadata("next_observations", next_observations)
+    if next_obs_shape != (num_steps, model.config.observation_dim):
+        raise ValueError(
+            f"next_observations must have shape ({num_steps}, {model.config.observation_dim})"
+        )
+
+    act_shape = _require_scan_array_metadata("actions", actions)
+    if model.config.n_actions is not None:
+        if act_shape != (num_steps,):
+            raise ValueError(f"actions must have shape ({num_steps},)")
+    else:
+        if act_shape != (num_steps, model.config.action_dim):
+            raise ValueError(f"actions must have shape ({num_steps}, {model.config.action_dim})")
+
+    rew_shape = _require_scan_array_metadata("rewards", rewards)
+    if rew_shape != (num_steps,):
+        raise ValueError(f"rewards must have shape ({num_steps},)")
+
     if discounts is None:
-        discounts = jnp.full(
-            jnp.shape(rewards),
+        discounts_array = jnp.full(
+            (num_steps,),
             jnp.asarray(model.config.gamma, dtype=jnp.float32),
             dtype=jnp.float32,
         )
+    else:
+        disc_shape = _require_scan_array_metadata("discounts", discounts)
+        if disc_shape != (num_steps,):
+            raise ValueError(f"discounts must have shape ({num_steps},)")
+        discounts_array = jnp.asarray(discounts, dtype=jnp.float32)
+
+    _require_scan_resource(num_steps, model.config.latent_dim, model.config.latent_dim + 2)
+
+    obs_array = jnp.asarray(observations, dtype=jnp.float32)
+    next_obs_array = jnp.asarray(next_observations, dtype=jnp.float32)
+    rew_array = jnp.asarray(rewards, dtype=jnp.float32)
+    act_array = (
+        jnp.asarray(actions, dtype=jnp.int32)
+        if model.config.n_actions is not None
+        else jnp.asarray(actions, dtype=jnp.float32)
+    )
 
     def _scan_fn(
         carry: LatentWorldModelState,
@@ -1140,7 +1207,7 @@ def run_latent_world_model_learning_loop(
     ) = jax.lax.scan(
         _scan_fn,
         state,
-        (observations, actions, rewards, discounts, next_observations),
+        (obs_array, act_array, rew_array, discounts_array, next_obs_array),
     )
     return LatentWorldModelLearningResult(
         state=final_state,

--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -524,6 +524,9 @@ def run_learning_loop[StreamStateT](
     Raises:
         ValueError: If tracking interval is invalid
     """
+    num_steps = _require_int32("num_steps", num_steps, minimum=1)
+    _preflight_float32_resources("learning loop scan result", num_steps * 4)
+
     # Validate tracking configs
     if step_size_tracking is not None:
         if step_size_tracking.interval < 1:
@@ -837,6 +840,7 @@ def run_learning_loop_batched[StreamStateT](
     mean_error = result.metrics[:, :, 0].mean(axis=0)  # Average over seeds
     ```
     """
+    num_steps = _require_int32("num_steps", num_steps, minimum=1)
 
     # Define single-seed function that returns consistent structure
     def single_seed_run(
@@ -1673,6 +1677,9 @@ def run_mlp_learning_loop[StreamStateT](
     Raises:
         ValueError: If normalizer_tracking.interval is invalid
     """
+    num_steps = _require_int32("num_steps", num_steps, minimum=1)
+    _preflight_float32_resources("MLP learning loop scan result", num_steps * 4)
+
     # Validate tracking config
     if normalizer_tracking is not None:
         if normalizer_tracking.interval < 1:
@@ -1823,6 +1830,7 @@ def run_mlp_learning_loop_batched[StreamStateT](
     mean_error = result.metrics[:, :, 0].mean(axis=0)  # Average over seeds
     ```
     """
+    num_steps = _require_int32("num_steps", num_steps, minimum=1)
 
     def single_seed_run(
         key: Array,
@@ -2275,6 +2283,9 @@ def run_td_learning_loop[StreamStateT](
         (num_steps, 4) with columns [squared_td_error, td_error, mean_step_size,
         mean_eligibility_trace]
     """
+    num_steps = _require_int32("num_steps", num_steps, minimum=1)
+    _preflight_float32_resources("TD learning loop scan result", num_steps * 4)
+
     # Initialize states
     if learner_state is None:
         learner_state = learner.init(stream.feature_dim)
@@ -2312,6 +2323,9 @@ def run_true_online_td_loop[StreamStateT](
     learner_state: TrueOnlineTDState | None = None,
 ) -> tuple[TrueOnlineTDState, Array]:
     """Run True Online TD(lambda) over a TD stream with ``jax.lax.scan``."""
+    num_steps = _require_int32("num_steps", num_steps, minimum=1)
+    _preflight_float32_resources("true online TD learning loop scan result", num_steps * 4)
+
     if learner_state is None:
         learner_state = learner.init(stream.feature_dim)
     stream_state = stream.init(key)

--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -575,7 +575,10 @@ def run_option_value_duration_from_arrays(
         raise ValueError("observations have an incompatible shape")
     if observations.dtype != jnp.float32:
         raise ValueError("observations must have dtype float32")
-    num_steps = observations.shape[0]
+    num_steps = _require_int32("scan sequence length", observations.shape[0], minimum=1)
+    output_scalars = num_steps * (4 * learner.n_options + 3)
+    if output_scalars > _INT32_MAX or 4 * output_scalars > _INT32_MAX:
+        raise ValueError("option value duration scan result bytes must fit signed int32")
     next_observations = learner._require_array(
         "next_observations",
         next_observations,

--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -385,6 +385,21 @@ def step4_update(
     )
 
 
+def _require_trusted_array_metadata(name: str, array: object) -> tuple[int, ...]:
+    actual_type = type(array)
+    if not (
+        actual_type is np.ndarray
+        or issubclass(actual_type, jax.Array)
+        or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise TypeError(f"{name} must be a trusted array")
+    try:
+        shape = tuple(int(dim) for dim in cast(Any, array).shape)
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape metadata") from error
+    return shape
+
+
 def run_step4_scan(
     agent: SARSAAgent,
     state: SARSAState,
@@ -393,6 +408,31 @@ def run_step4_scan(
     terminated: Array,
 ) -> SARSAArrayResult:
     """Run Step 4 SARSA over pre-collected transition arrays."""
+    if type(agent) is not SARSAAgent:
+        raise TypeError("agent must be an exact SARSAAgent")
+    if type(state) is not SARSAState:
+        raise TypeError("state must be an exact SARSAState")
+
+    features_shape = _require_trusted_array_metadata("next_features", next_features)
+    if len(features_shape) != 2:
+        raise ValueError("next_features must have shape (num_steps, feature_dim)")
+    num_steps = _require_positive_int("scan sequence length", features_shape[0])
+
+    rewards_shape = _require_trusted_array_metadata("rewards", rewards)
+    if rewards_shape != (num_steps,):
+        raise ValueError(f"rewards must have shape ({num_steps},)")
+
+    terminated_shape = _require_trusted_array_metadata("terminated", terminated)
+    if terminated_shape != (num_steps,):
+        raise ValueError(f"terminated must have shape ({num_steps},)")
+
+    output_scalars = num_steps * (agent.n_actions + 2)
+    if output_scalars > _INT32_MAX or 4 * output_scalars > _INT32_MAX:
+        raise ValueError("step 4 scan result bytes must fit signed int32")
+
+    features_array = jnp.asarray(next_features, dtype=jnp.float32)
+    rewards_array = jnp.asarray(rewards, dtype=jnp.float32)
+    terminated_array = jnp.asarray(terminated, dtype=jnp.float32)
 
     def step_fn(
         carry: SARSAState,
@@ -406,7 +446,7 @@ def run_step4_scan(
     final_state, (q_values, td_errors, actions) = jax.lax.scan(
         step_fn,
         state,
-        (next_features, rewards, terminated),
+        (features_array, rewards_array, terminated_array),
     )
     return SARSAArrayResult(
         state=final_state,

--- a/tests/test_scan_sequence_bounds_validation.py
+++ b/tests/test_scan_sequence_bounds_validation.py
@@ -1,0 +1,353 @@
+"""Tests for scan sequence bounds and array validation across FTL, Latent WM, CBP, OVD, Step 4."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax import Array
+
+from alberta_framework.core.continual_backprop import (
+    CBPMultiHeadMLPLearner,
+    ContinualBackpropConfig,
+    run_cbp_learning_loop,
+)
+from alberta_framework.core.ftl_world_model import (
+    SparseFTLWorldModel,
+    SparseFTLWorldModelConfig,
+    run_sparse_ftl_world_model,
+)
+from alberta_framework.core.latent_world_model import (
+    LatentWorldModel,
+    LatentWorldModelConfig,
+    run_latent_world_model_learning_loop,
+)
+from alberta_framework.core.learners import (
+    LinearLearner,
+    MLPLearner,
+    TDLinearLearner,
+    TrueOnlineTDLearner,
+    run_learning_loop,
+    run_learning_loop_batched,
+    run_mlp_learning_loop,
+    run_mlp_learning_loop_batched,
+    run_td_learning_loop,
+    run_true_online_td_loop,
+)
+from alberta_framework.core.optimizers import LMS
+from alberta_framework.core.option_value_duration import (
+    OptionValueDurationLearner,
+    run_option_value_duration_from_arrays,
+)
+from alberta_framework.core.types import TDTimeStep
+from alberta_framework.steps.step4 import (
+    init_step4_state,
+    make_step4_sarsa_agent,
+    run_step4_scan,
+)
+from alberta_framework.streams.synthetic import RandomWalkStream
+
+
+class SimpleTDStream:
+    def __init__(self, feature_dim: int = 4, gamma: float = 0.99) -> None:
+        self.feature_dim = feature_dim
+        self._gamma = gamma
+
+    def init(self, key: Array) -> dict[str, Any]:
+        return {"key": key, "step": 0}
+
+    def step(self, state: dict[str, Any], idx: Array) -> tuple[TDTimeStep, dict[str, Any]]:
+        key = state["key"]
+        key, obs_key, next_key, reward_key = jr.split(key, 4)
+        observation = jr.normal(obs_key, (self.feature_dim,), dtype=jnp.float32)
+        next_observation = jr.normal(next_key, (self.feature_dim,), dtype=jnp.float32)
+        reward = jr.normal(reward_key, (), dtype=jnp.float32)
+        gamma = jnp.array(self._gamma, dtype=jnp.float32)
+        timestep = TDTimeStep(  # type: ignore[call-arg]
+            observation=observation,
+            reward=reward,
+            next_observation=next_observation,
+            gamma=gamma,
+        )
+        return timestep, {"key": key, "step": state["step"] + 1}
+
+
+# ---------------------------------------------------------------------------
+# Sparse FTL World Model Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_sparse_ftl_world_model_scan_validation() -> None:
+    config = SparseFTLWorldModelConfig(observation_dim=3, action_dim=1, projection_dim=4, bins=4)
+    model = SparseFTLWorldModel(config)
+    key = jr.key(0)
+    state = model.init(key)
+
+    obs = jnp.zeros((5, 3), dtype=jnp.float32)
+    next_obs = jnp.zeros((5, 3), dtype=jnp.float32)
+    actions_1d = jnp.zeros((5,), dtype=jnp.float32)
+    actions_2d = jnp.zeros((5, 1), dtype=jnp.float32)
+
+    # Valid run with 1D action
+    res1 = run_sparse_ftl_world_model(model, state, obs, actions_1d, next_obs)
+    assert res1.predicted_next_observations.shape == (5, 3)
+
+    # Valid run with 2D action
+    res2 = run_sparse_ftl_world_model(model, state, obs, actions_2d, next_obs)
+    assert res2.predicted_next_observations.shape == (5, 3)
+
+    # Invalid model / state
+    with pytest.raises(TypeError, match="model must be an exact"):
+        run_sparse_ftl_world_model(None, state, obs, actions_1d, next_obs)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="state must be an exact"):
+        run_sparse_ftl_world_model(model, None, obs, actions_1d, next_obs)  # type: ignore[arg-type]
+
+    # Untrusted array / invalid shape
+    with pytest.raises(TypeError, match="must be a trusted array"):
+        run_sparse_ftl_world_model(model, state, [[0.0, 0.0, 0.0]], actions_1d, next_obs)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="observations must have shape"):
+        run_sparse_ftl_world_model(model, state, jnp.zeros((5, 2)), actions_1d, next_obs)
+    with pytest.raises(ValueError, match="next_observations must have shape"):
+        run_sparse_ftl_world_model(model, state, obs, actions_1d, jnp.zeros((5, 4)))
+    with pytest.raises(ValueError, match="actions must have shape"):
+        run_sparse_ftl_world_model(model, state, obs, jnp.zeros((5, 2)), next_obs)
+    with pytest.raises(ValueError, match="scan sequence length"):
+        run_sparse_ftl_world_model(
+            model, state, jnp.zeros((0, 3)), jnp.zeros((0,)), jnp.zeros((0, 3))
+        )
+
+
+# ---------------------------------------------------------------------------
+# Latent World Model Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_latent_world_model_scan_validation() -> None:
+    # Discrete actions
+    config_discrete = LatentWorldModelConfig(
+        observation_dim=4,
+        n_actions=2,
+        latent_dim=4,
+        hidden_sizes=(8,),
+    )
+    model_d = LatentWorldModel(config_discrete)
+    state_d = model_d.init(jr.key(1))
+
+    obs = jnp.zeros((6, 4), dtype=jnp.float32)
+    next_obs = jnp.zeros((6, 4), dtype=jnp.float32)
+    actions_d = jnp.zeros((6,), dtype=jnp.int32)
+    rewards = jnp.zeros((6,), dtype=jnp.float32)
+    discounts = jnp.ones((6,), dtype=jnp.float32)
+
+    # Valid run
+    res_d = run_latent_world_model_learning_loop(
+        model_d, state_d, obs, actions_d, rewards, next_obs, discounts
+    )
+    assert res_d.latent_predictions.shape == (6, 4)
+
+    # Invalid types
+    with pytest.raises(TypeError, match="model must be an exact"):
+        run_latent_world_model_learning_loop(
+            None,
+            state_d,
+            obs,
+            actions_d,
+            rewards,
+            next_obs,  # type: ignore[arg-type]
+        )
+    with pytest.raises(TypeError, match="state must be an exact"):
+        run_latent_world_model_learning_loop(
+            model_d,
+            None,
+            obs,
+            actions_d,
+            rewards,
+            next_obs,  # type: ignore[arg-type]
+        )
+
+    # Shape errors
+    with pytest.raises(ValueError, match="observations must have shape"):
+        run_latent_world_model_learning_loop(
+            model_d, state_d, jnp.zeros((6, 5)), actions_d, rewards, next_obs
+        )
+    with pytest.raises(ValueError, match="next_observations must have shape"):
+        run_latent_world_model_learning_loop(
+            model_d, state_d, obs, actions_d, rewards, jnp.zeros((6, 3))
+        )
+    with pytest.raises(ValueError, match="actions must have shape"):
+        run_latent_world_model_learning_loop(
+            model_d, state_d, obs, jnp.zeros((6, 2)), rewards, next_obs
+        )
+    with pytest.raises(ValueError, match="rewards must have shape"):
+        run_latent_world_model_learning_loop(
+            model_d, state_d, obs, actions_d, jnp.zeros((5,)), next_obs
+        )
+    with pytest.raises(ValueError, match="discounts must have shape"):
+        run_latent_world_model_learning_loop(
+            model_d, state_d, obs, actions_d, rewards, next_obs, discounts=jnp.zeros((5,))
+        )
+    with pytest.raises(ValueError, match="scan sequence length"):
+        run_latent_world_model_learning_loop(
+            model_d,
+            state_d,
+            jnp.zeros((0, 4)),
+            jnp.zeros((0,), dtype=jnp.int32),
+            jnp.zeros((0,)),
+            jnp.zeros((0, 4)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Continual Backprop Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_cbp_scan_validation() -> None:
+    learner = CBPMultiHeadMLPLearner(
+        n_heads=2,
+        hidden_sizes=(8,),
+        cbp_config=ContinualBackpropConfig(),
+    )
+    state = learner.init(feature_dim=4, key=jr.key(2))
+
+    obs = jnp.zeros((5, 4), dtype=jnp.float32)
+    targets = jnp.zeros((5, 2), dtype=jnp.float32)
+
+    # Valid run
+    res = run_cbp_learning_loop(learner, state, obs, targets)
+    assert res.per_head_metrics.shape == (5, 2, 3)
+
+    # Invalid types
+    with pytest.raises(TypeError, match="learner must be an exact"):
+        run_cbp_learning_loop(None, state, obs, targets)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="state must be an exact"):
+        run_cbp_learning_loop(learner, None, obs, targets)  # type: ignore[arg-type]
+
+    # Shape errors
+    with pytest.raises(ValueError, match="observations must have shape"):
+        run_cbp_learning_loop(learner, state, jnp.zeros((5,)), targets)
+    with pytest.raises(ValueError, match="targets must have shape"):
+        run_cbp_learning_loop(learner, state, obs, jnp.zeros((5, 3)))
+    with pytest.raises(ValueError, match="scan sequence length"):
+        run_cbp_learning_loop(learner, state, jnp.zeros((0, 4)), jnp.zeros((0, 2)))
+
+
+# ---------------------------------------------------------------------------
+# Option Value Duration Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_option_value_duration_scan_validation() -> None:
+    learner = OptionValueDurationLearner(n_options=2)
+    state = learner.init(feature_dim=4)
+
+    obs = jnp.zeros((4, 4), dtype=jnp.float32)
+    options = jnp.zeros((4,), dtype=jnp.int32)
+    rewards = jnp.zeros((4,), dtype=jnp.float32)
+    next_obs = jnp.zeros((4, 4), dtype=jnp.float32)
+    discounts = jnp.ones((4,), dtype=jnp.float32)
+
+    # Valid run
+    res = run_option_value_duration_from_arrays(
+        learner, state, obs, options, rewards, next_obs, discounts
+    )
+    assert res.predictions.shape == (4, 2)
+
+    # Invalid sequence length
+    with pytest.raises(ValueError, match="scan sequence length"):
+        run_option_value_duration_from_arrays(
+            learner,
+            state,
+            jnp.zeros((0, 4), dtype=jnp.float32),
+            jnp.zeros((0,), dtype=jnp.int32),
+            jnp.zeros((0,), dtype=jnp.float32),
+            jnp.zeros((0, 4), dtype=jnp.float32),
+            jnp.zeros((0,), dtype=jnp.float32),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 4 SARSA Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_step4_scan_validation() -> None:
+    agent = make_step4_sarsa_agent()
+    state = init_step4_state(
+        agent,
+        feature_dim=4,
+        key=jr.key(3),
+        initial_features=jnp.zeros((4,), dtype=jnp.float32),
+    )
+
+    next_features = jnp.zeros((5, 4), dtype=jnp.float32)
+    rewards = jnp.zeros((5,), dtype=jnp.float32)
+    terminated = jnp.zeros((5,), dtype=jnp.float32)
+
+    # Valid run
+    res = run_step4_scan(agent, state, next_features, rewards, terminated)
+    assert res.q_values.shape[0] == 5
+
+    # Invalid types
+    with pytest.raises(TypeError, match="agent must be an exact"):
+        run_step4_scan(None, state, next_features, rewards, terminated)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="state must be an exact"):
+        run_step4_scan(agent, None, next_features, rewards, terminated)  # type: ignore[arg-type]
+
+    # Shape errors
+    with pytest.raises(ValueError, match="next_features must have shape"):
+        run_step4_scan(agent, state, jnp.zeros((5,)), rewards, terminated)
+    with pytest.raises(ValueError, match="rewards must have shape"):
+        run_step4_scan(agent, state, next_features, jnp.zeros((4,)), terminated)
+    with pytest.raises(ValueError, match="terminated must have shape"):
+        run_step4_scan(agent, state, next_features, rewards, jnp.zeros((4,)))
+    with pytest.raises(ValueError, match="positive"):
+        run_step4_scan(
+            agent,
+            state,
+            jnp.zeros((0, 4), dtype=jnp.float32),
+            jnp.zeros((0,), dtype=jnp.float32),
+            jnp.zeros((0,), dtype=jnp.float32),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core Learners num_steps Tests
+# ---------------------------------------------------------------------------
+
+
+def test_core_learners_num_steps_validation() -> None:
+    stream = RandomWalkStream(feature_dim=4)
+    td_stream = SimpleTDStream(feature_dim=4)
+
+    # LinearLearner
+    linear = LinearLearner(optimizer=LMS(step_size=0.01))
+    with pytest.raises(ValueError, match="num_steps must be an integer"):
+        run_learning_loop(linear, stream, num_steps=0, key=jr.key(0))
+    with pytest.raises(ValueError, match="num_steps must be an integer"):
+        run_learning_loop(linear, stream, num_steps=cast(int, True), key=jr.key(0))
+    with pytest.raises(ValueError, match="num_steps must be an integer"):
+        run_learning_loop_batched(linear, stream, num_steps=-1, keys=jr.split(jr.key(0), 2))
+
+    # MLPLearner
+    mlp = MLPLearner(hidden_sizes=(8,))
+    with pytest.raises(ValueError, match="num_steps must be an integer"):
+        run_mlp_learning_loop(mlp, stream, num_steps=0, key=jr.key(0))
+    with pytest.raises(ValueError, match="num_steps must be an integer"):
+        run_mlp_learning_loop_batched(mlp, stream, num_steps=-5, keys=jr.split(jr.key(0), 2))
+
+    # TDLinearLearner
+    td = TDLinearLearner()
+    with pytest.raises(ValueError, match="num_steps must be an integer"):
+        run_td_learning_loop(td, td_stream, num_steps=0, key=jr.key(0))
+    with pytest.raises(ValueError, match="num_steps must be an integer"):
+        run_td_learning_loop(td, td_stream, num_steps=cast(int, False), key=jr.key(0))
+
+    # TrueOnlineTDLearner
+    true_td = TrueOnlineTDLearner()
+    with pytest.raises(ValueError, match="num_steps must be an integer"):
+        run_true_online_td_loop(true_td, td_stream, num_steps=0, key=jr.key(0))
+    with pytest.raises(ValueError, match="num_steps must be an integer"):
+        run_true_online_td_loop(true_td, td_stream, num_steps=-1, key=jr.key(0))


### PR DESCRIPTION
## Summary
Hardens array-based transition scanning and learning loop routines against untrusted array types, incompatible array dimensions/ranks, invalid sequence lengths (`num_steps < 1` or overflow), and potential signed-int32 scalar/byte allocation overflows across:
1. `alberta_framework.core.ftl_world_model.run_sparse_ftl_world_model`
2. `alberta_framework.core.latent_world_model.run_latent_world_model_learning_loop`
3. `alberta_framework.core.continual_backprop.run_cbp_learning_loop`
4. `alberta_framework.core.option_value_duration.run_option_value_duration_from_arrays`
5. `alberta_framework.steps.step4.run_step4_scan`
6. `alberta_framework.core.learners` (`run_learning_loop`, `run_learning_loop_batched`, `run_mlp_learning_loop`, `run_mlp_learning_loop_batched`, `run_td_learning_loop`, `run_true_online_td_loop`)

## Key Changes
- **Exact component/state type verification**: Checks model/learner and state objects to prevent silent state mismatches.
- **Array metadata enforcement**: Verifies input transitions are trusted `np.ndarray`, `jax.Array`, or `jax.core.Tracer` instances with conforming shapes.
- **Sequence bounds validation**: Ensures `1 <= num_steps <= 2**31 - 1` with canonical int index coercion rejecting boolean/float scalar aliases.
- **Resource preflight**: Validates that output scalar/byte sizes fit signed int32 bounds prior to scanning.
- **Test coverage**: Added `tests/test_scan_sequence_bounds_validation.py` covering positive evaluation and negative invalid type/shape/length error paths.

## Validation
- `pytest tests/test_scan_sequence_bounds_validation.py` -> 6/6 passed
- `pytest tests/test_ftl_world_model.py tests/test_latent_world_model.py tests/test_continual_backprop.py tests/test_option_value_duration.py tests/test_step4_production.py tests/test_td_learners.py tests/test_scan_sequence_bounds_validation.py` -> 371/371 passed
- `ruff check .` -> passed
- `mypy` -> passed

## Measured project receipt
Post-hoc receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F8PNB34Q786KF5Z9NYX34P","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T09:40:42.979Z","completed_at":"2026-08-20T09:40:57.510Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T09:40:43.199Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f067613864bafbb0b67c6013f0c42621b2572d9bdb487933ba1604848da3255e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3fd60abe-0681-413a-a54a-0d3cbf353a50","object_id":"sha256:f067613864bafbb0b67c6013f0c42621b2572d9bdb487933ba1604848da3255e","sha256":"f067613864bafbb0b67c6013f0c42621b2572d9bdb487933ba1604848da3255e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"4lHLTd8wYff-VMag3NRMalpfB4SQumIwTjuXpXa-eh1oq7uDyOZZwOtmT_YcJX_0xWVjiEOlU8xODgIhLSCFBQ"}} -->
