### PR TITLE
fix(core): validate scan sequence bounds and array dimensions in Steps 6, 8, 10, 12, Hordes, Actor-Critic, and UPGD

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -257,18 +257,33 @@ def _array(name: str, value: object, shape: tuple[int, ...], dtype: Any) -> Arra
 
 
 def _trusted_shape(name: str, value: object) -> tuple[int, ...]:
-    if not (type(value) is np.ndarray or isinstance(value, jax.Array)):
+    actual_type = type(value)
+    if not (
+        actual_type is np.ndarray
+        or issubclass(
+            actual_type,
+            (jax.Array, jax.core.Tracer, jax.ShapeDtypeStruct, jax.core.ShapedArray),
+        )
+    ):
         raise ValueError(f"{name} must expose trusted array metadata")
-    return tuple(value.shape)
+    return tuple(cast(Array, value).shape)
 
 
 def _checked_terminated(name: str, value: object) -> Array:
     """Validate a ``terminated`` flag array dtype before boolean coercion."""
-    if not (type(value) is np.ndarray or isinstance(value, jax.Array)):
+    actual_type = type(value)
+    if not (
+        actual_type is np.ndarray
+        or issubclass(
+            actual_type,
+            (jax.Array, jax.core.Tracer, jax.ShapeDtypeStruct, jax.core.ShapedArray),
+        )
+    ):
         raise ValueError(f"{name} must expose trusted array metadata")
-    if value.dtype not in (jnp.dtype(jnp.bool_), jnp.dtype(jnp.float32)):
+    trusted = cast(Array, value)
+    if trusted.dtype not in (jnp.dtype(jnp.bool_), jnp.dtype(jnp.float32)):
         raise TypeError(f"{name} must have dtype bool or float32")
-    return cast(Array, value)
+    return trusted
 
 
 def _validated_bounder_result(
@@ -941,9 +956,14 @@ def run_actor_critic_from_arrays(
     Returns:
         ``ActorCriticArrayResult`` with final state and per-step metrics.
     """
+    if type(agent) is not ActorCriticAgent:
+        raise TypeError("agent must be an exact ActorCriticAgent")
+    if type(state) is not ActorCriticState:
+        raise TypeError("state must be an exact ActorCriticState")
+
     feature_dim = agent._feature_dim(state)
     observations_shape = _trusted_shape("observations", observations)
-    if len(observations_shape) != 2 or observations_shape[0] < 1:
+    if len(observations_shape) != 2 or not 1 <= observations_shape[0] <= _INT32_MAX:
         raise ValueError("observations must have shape (num_steps, feature_dim)")
     num_steps = observations_shape[0]
     expected_observations_shape = (num_steps, feature_dim)
@@ -1765,9 +1785,14 @@ def run_continuous_actor_critic_from_arrays(
     Returns:
         ``ContinuousActorCriticArrayResult`` with final state and per-step metrics.
     """
+    if type(agent) is not ContinuousActorCriticAgent:
+        raise TypeError("agent must be an exact ContinuousActorCriticAgent")
+    if type(state) is not ContinuousActorCriticState:
+        raise TypeError("state must be an exact ContinuousActorCriticState")
+
     feature_dim = agent._feature_dim(state)
     observations_shape = _trusted_shape("observations", observations)
-    if len(observations_shape) != 2 or observations_shape[0] < 1:
+    if len(observations_shape) != 2 or not 1 <= observations_shape[0] <= _INT32_MAX:
         raise ValueError("observations must have shape (num_steps, feature_dim)")
     num_steps = observations_shape[0]
     expected_observations_shape = (num_steps, feature_dim)

--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -147,22 +147,71 @@ def _require_loop_output_resources(num_steps: int, n_demons: int, n_seeds: int =
         raise ValueError("derived learning-loop outputs exceed the signed-int32 budget")
 
 
+def _has_trusted_array_type(value: object) -> bool:
+    actual_type = type(value)
+    return (
+        actual_type is np.ndarray
+        or issubclass(
+            actual_type,
+            (
+                jax.Array,
+                jax.core.Tracer,
+                jax.ShapeDtypeStruct,
+                jax.core.ShapedArray,
+            ),
+        )
+    )
+
+
+def _trusted_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: Any,
+) -> Array:
+    """Validate static array metadata without dispatching on hostile objects."""
+    if not _has_trusted_array_type(value):
+        raise TypeError(f"{name} must be a trusted array")
+    trusted = cast(Array, value)
+    try:
+        actual_shape = tuple(trusted.shape)
+        actual_dtype = np.dtype(trusted.dtype)
+    except (AttributeError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape and dtype metadata") from error
+    if actual_shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if actual_dtype != np.dtype(dtype):
+        raise TypeError(f"{name} must have dtype {np.dtype(dtype)}")
+    return trusted
+
+
 def _require_learning_arrays(
     observations: object,
     cumulants: object,
     next_observations: object,
     n_demons: int,
 ) -> tuple[Array, Array, Array, int, int]:
-    obs = jnp.asarray(observations, dtype=jnp.float32)
-    cums = jnp.asarray(cumulants, dtype=jnp.float32)
-    next_obs = jnp.asarray(next_observations, dtype=jnp.float32)
-    if obs.ndim != 2 or obs.shape[0] < 1 or obs.shape[1] < 1:
+    if not _has_trusted_array_type(observations):
+        raise TypeError("observations must be a trusted array")
+    try:
+        obs_shape = tuple(int(dim) for dim in cast(Any, observations).shape)
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("observations must expose trusted shape metadata") from error
+    if len(obs_shape) != 2 or obs_shape[0] < 1 or obs_shape[1] < 1:
         raise ValueError("observations must have shape (num_steps, feature_dim)")
-    if next_obs.shape != obs.shape:
-        raise ValueError("next_observations must match observations shape")
-    if cums.shape != (obs.shape[0], n_demons):
-        raise ValueError("cumulants must have shape (num_steps, n_demons)")
-    return obs, cums, next_obs, obs.shape[0], obs.shape[1]
+    num_steps, feature_dim = obs_shape
+    if not 1 <= num_steps <= _INT32_MAX or not 1 <= feature_dim <= _INT32_MAX:
+        raise ValueError("observations must contain between 1 and signed-int32 dimensions")
+
+    obs = _trusted_array("observations", observations, shape=obs_shape, dtype=jnp.float32)
+    next_obs = _trusted_array(
+        "next_observations", next_observations, shape=obs_shape, dtype=jnp.float32
+    )
+    cums = _trusted_array(
+        "cumulants", cumulants, shape=(num_steps, n_demons), dtype=jnp.float32
+    )
+    return obs, cums, next_obs, num_steps, feature_dim
 
 
 @chex.dataclass(frozen=True)
@@ -1082,6 +1131,10 @@ def run_independent_horde_learning_loop(
         ``IndependentDemonHordeLearningResult`` with final state,
         per-demon metrics, and TD errors over time.
     """
+    if type(horde) is not IndependentDemonHorde:
+        raise TypeError("horde must be an exact IndependentDemonHorde")
+    if type(state) is not IndependentDemonHordeState:
+        raise TypeError("state must be an exact IndependentDemonHordeState")
 
     observations, cumulants, next_observations, num_steps, feature_dim = (
         _require_learning_arrays(observations, cumulants, next_observations, horde.n_demons)
@@ -1150,6 +1203,8 @@ def run_independent_horde_learning_loop_batched(
         ``BatchedIndependentDemonHordeResult`` with batched states,
         per-demon metrics, and TD errors.
     """
+    if type(horde) is not IndependentDemonHorde:
+        raise TypeError("horde must be an exact IndependentDemonHorde")
     observations, cumulants, next_observations, num_steps, feature_dim = (
         _require_learning_arrays(observations, cumulants, next_observations, horde.n_demons)
     )

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -623,6 +623,45 @@ class StackedLinearHorde:
         )
 
 
+def _has_trusted_array_type(value: object) -> bool:
+    actual_type = type(value)
+    return (
+        actual_type is np.ndarray
+        or issubclass(
+            actual_type,
+            (
+                jax.Array,
+                jax.core.Tracer,
+                jax.ShapeDtypeStruct,
+                jax.core.ShapedArray,
+            ),
+        )
+    )
+
+
+def _trusted_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: Any,
+) -> Array:
+    """Validate static array metadata without dispatching on hostile objects."""
+    if not _has_trusted_array_type(value):
+        raise TypeError(f"{name} must be a trusted array")
+    trusted = cast(Array, value)
+    try:
+        actual_shape = tuple(trusted.shape)
+        actual_dtype = np.dtype(trusted.dtype)
+    except (AttributeError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape and dtype metadata") from error
+    if actual_shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if actual_dtype != np.dtype(dtype):
+        raise TypeError(f"{name} must have dtype {np.dtype(dtype)}")
+    return trusted
+
+
 def run_stacked_horde_scan(
     horde: StackedLinearHorde,
     state: StackedHordeState,
@@ -648,31 +687,54 @@ def run_stacked_horde_scan(
         ``(final_state, td_errors)`` with td_errors of shape
         ``(num_steps - 1, n_demons)``.
     """
-    if features.ndim != 2:
+    if type(horde) is not StackedLinearHorde:
+        raise TypeError("horde must be an exact StackedLinearHorde")
+    if type(state) is not StackedHordeState:
+        raise TypeError("state must be an exact StackedHordeState")
+
+    if not _has_trusted_array_type(features):
+        raise TypeError("features must be a trusted array")
+    try:
+        features_shape = tuple(int(dim) for dim in features.shape)
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("features must expose trusted shape metadata") from error
+    if len(features_shape) != 2:
         raise ValueError("features must be rank-two")
-    if features.dtype != jnp.dtype(jnp.float32):
-        raise TypeError("features must have dtype float32")
-    if features.shape[1] != horde.config.feature_dim:
-        raise ValueError("features must match configured feature_dim")
-    sources_shape = jnp.shape(cumulant_sources)
+    num_steps = features_shape[0]
+    if not 2 <= num_steps <= _INT32_MAX:
+        raise ValueError("features must contain between 2 and signed-int32 steps")
+    _require_scan_result_resources(num_steps - 1, horde.config.n_demons)
+
+    checked_features = _trusted_array(
+        "features", features, shape=(num_steps, horde.config.feature_dim), dtype=jnp.float32
+    )
+
+    if not _has_trusted_array_type(cumulant_sources):
+        raise TypeError("cumulant_sources must be a trusted array")
+    try:
+        sources_shape = tuple(int(dim) for dim in cumulant_sources.shape)
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("cumulant_sources must expose trusted shape metadata") from error
     if len(sources_shape) != 2:
         raise ValueError(f"cumulant_sources must be rank-two, got shape {sources_shape}")
+    if sources_shape[0] != num_steps:
+        raise ValueError("features and cumulant_sources must have the same number of rows")
     max_index = max(horde.config.cumulant_indices)
     if sources_shape[-1] <= max_index:
         raise ValueError(
             f"cumulant_sources has {sources_shape[-1]} channels but "
             f"config.cumulant_indices requires index {max_index}"
         )
-    num_steps = features.shape[0]
-    if sources_shape[0] != num_steps:
-        raise ValueError("features and cumulant_sources must have the same number of rows")
-    if cumulant_sources.dtype != jnp.dtype(jnp.float32):
-        raise TypeError("cumulant_sources must have dtype float32")
-    _require_scan_result_resources(max(num_steps - 1, 0), horde.config.n_demons)
+    checked_sources = _trusted_array(
+        "cumulant_sources", cumulant_sources, shape=sources_shape, dtype=jnp.float32
+    )
+
     if rhos is None:
-        rhos = jnp.ones((num_steps,), dtype=jnp.float32)
-    elif rhos.shape != (num_steps,):
-        raise ValueError("rhos must have shape (num_steps,)")
+        checked_rhos = jnp.ones((num_steps,), dtype=jnp.float32)
+    else:
+        checked_rhos = _trusted_array(
+            "rhos", rhos, shape=(num_steps,), dtype=jnp.float32
+        )
 
     def step_fn(
         carry: StackedHordeState,
@@ -685,6 +747,6 @@ def run_stacked_horde_scan(
     final_state, td_errors = jax.lax.scan(
         step_fn,
         state,
-        (features[:-1], features[1:], cumulant_sources[:-1], rhos[:-1]),
+        (checked_features[:-1], checked_features[1:], checked_sources[:-1], checked_rhos[:-1]),
     )
     return final_state, td_errors

--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -3348,6 +3348,45 @@ class UPGDLearner:
 # =============================================================================
 
 
+def _has_trusted_array_type(value: object) -> bool:
+    actual_type = type(value)
+    return (
+        actual_type is np.ndarray
+        or issubclass(
+            actual_type,
+            (
+                jax.Array,
+                jax.core.Tracer,
+                jax.ShapeDtypeStruct,
+                jax.core.ShapedArray,
+            ),
+        )
+    )
+
+
+def _trusted_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: Any,
+) -> Array:
+    """Validate static array metadata without dispatching on hostile objects."""
+    if not _has_trusted_array_type(value):
+        raise TypeError(f"{name} must be a trusted array")
+    trusted = cast(Array, value)
+    try:
+        actual_shape = tuple(trusted.shape)
+        actual_dtype = np.dtype(trusted.dtype)
+    except (AttributeError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape and dtype metadata") from error
+    if actual_shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if actual_dtype != np.dtype(dtype):
+        raise TypeError(f"{name} must have dtype {np.dtype(dtype)}")
+    return trusted
+
+
 def run_upgd_arrays(
     learner: UPGDLearner,
     state: UPGDState,
@@ -3367,6 +3406,36 @@ def run_upgd_arrays(
         :class:`UPGDLearningResult` with the final state and the per-step
         4-column metrics array.
     """
+    if type(learner) is not UPGDLearner:
+        raise TypeError("learner must be an exact UPGDLearner")
+    if type(state) is not UPGDState:
+        raise TypeError("state must be an exact UPGDState")
+
+    if not _has_trusted_array_type(observations):
+        raise TypeError("observations must be a trusted array")
+    try:
+        obs_shape = tuple(int(dim) for dim in observations.shape)
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("observations must expose trusted shape metadata") from error
+    if len(obs_shape) != 2:
+        raise ValueError("observations must have shape (num_steps, feature_dim)")
+    num_steps = obs_shape[0]
+    if not 1 <= num_steps <= _INT32_MAX:
+        raise ValueError("observations must contain between 1 and signed-int32 steps")
+
+    feature_dim = (
+        state.trunk_params.weights[0].shape[1]
+        if state.trunk_params.weights
+        else state.head_params.weights[0].shape[1]
+    )
+    checked_obs = _trusted_array(
+        "observations", observations, shape=(num_steps, feature_dim), dtype=jnp.float32
+    )
+    checked_targets = _trusted_array(
+        "targets", targets, shape=(num_steps, learner.n_heads), dtype=jnp.float32
+    )
+
+    _require_float32_resource("upgd array metrics", vector_scalars=4 * num_steps)
 
     def step_fn(carry: UPGDState, inputs: tuple[Array, Array]) -> tuple[UPGDState, Array]:
         obs, tgt = inputs
@@ -3374,7 +3443,7 @@ def run_upgd_arrays(
         return result.state, result.metrics
 
     t0 = time.time()
-    final_state, metrics = jax.lax.scan(step_fn, state, (observations, targets))
+    final_state, metrics = jax.lax.scan(step_fn, state, (checked_obs, checked_targets))
     elapsed = time.time() - t0
     final_state = final_state.replace(uptime_s=final_state.uptime_s + elapsed)  # type: ignore[attr-defined]  # noqa: E501
     return UPGDLearningResult(state=final_state, metrics=metrics)  # type: ignore[call-arg]
@@ -3406,6 +3475,13 @@ def run_upgd_loop[StreamStateT](
         :class:`UPGDLearningResult` with the final state and the per-step
         4-column metrics array.
     """
+    if type(learner) is not UPGDLearner:
+        raise TypeError("learner must be an exact UPGDLearner")
+    if learner_state is not None and type(learner_state) is not UPGDState:
+        raise TypeError("learner_state must be an exact UPGDState")
+    num_steps = _require_int("num_steps", num_steps, minimum=1, maximum=_INT32_MAX)
+    _require_float32_resource("upgd loop metrics", vector_scalars=4 * num_steps)
+
     stream_key, init_key = jax.random.split(key)
     if learner_state is None:
         learner_state = learner.init(stream.feature_dim, init_key)

--- a/alberta_framework/steps/step10.py
+++ b/alberta_framework/steps/step10.py
@@ -41,6 +41,7 @@ from fractions import Fraction
 from numbers import Integral
 from typing import Any, cast
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -621,6 +622,45 @@ def step10_update(
     return cast(STOMPUpdateResult, agent.update(state, env_reward, next_observation))
 
 
+def _has_trusted_array_type(value: object) -> bool:
+    actual_type = type(value)
+    return (
+        actual_type is np.ndarray
+        or issubclass(
+            actual_type,
+            (
+                jax.Array,
+                jax.core.Tracer,
+                jax.ShapeDtypeStruct,
+                jax.core.ShapedArray,
+            ),
+        )
+    )
+
+
+def _trusted_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: Any,
+) -> Array:
+    """Validate static array metadata without dispatching on hostile objects."""
+    if not _has_trusted_array_type(value):
+        raise TypeError(f"{name} must be a trusted array")
+    trusted = cast(Array, value)
+    try:
+        actual_shape = tuple(trusted.shape)
+        actual_dtype = np.dtype(trusted.dtype)
+    except (AttributeError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape and dtype metadata") from error
+    if actual_shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if actual_dtype != np.dtype(dtype):
+        raise TypeError(f"{name} must have dtype {np.dtype(dtype)}")
+    return trusted
+
+
 def run_step10_scan(
     agent: STOMPAgent,
     state: STOMPState,
@@ -640,7 +680,28 @@ def run_step10_scan(
     Returns:
         :class:`STOMPArrayResult` with per-step diagnostics arrays.
     """
-    return agent.scan(state, rewards, next_observations)
+    if type(agent) is not STOMPAgent:
+        raise TypeError("agent must be an exact STOMPAgent")
+    if type(state) is not STOMPState:
+        raise TypeError("state must be an exact STOMPState")
+
+    if not _has_trusted_array_type(rewards):
+        raise TypeError("rewards must be a trusted array")
+    try:
+        steps = int(rewards.shape[0])
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("rewards must expose trusted shape metadata") from error
+    if not 1 <= steps <= _INT32_MAX:
+        raise ValueError("rewards must contain between 1 and signed-int32 steps")
+
+    checked_rewards = _trusted_array("rewards", rewards, shape=(steps,), dtype=jnp.float32)
+    checked_next_obs = _trusted_array(
+        "next_observations",
+        next_observations,
+        shape=(steps, agent.config.observation_dim),
+        dtype=jnp.float32,
+    )
+    return agent.scan(state, checked_rewards, checked_next_obs)
 
 
 def run_step10_smoke(

--- a/alberta_framework/steps/step12.py
+++ b/alberta_framework/steps/step12.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass
 from numbers import Integral
 from typing import Any, cast
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -599,6 +600,45 @@ def step12_update(
     return agent.update(state, partner_obs, partner_reward, partner_next_obs)
 
 
+def _has_trusted_array_type(value: object) -> bool:
+    actual_type = type(value)
+    return (
+        actual_type is np.ndarray
+        or issubclass(
+            actual_type,
+            (
+                jax.Array,
+                jax.core.Tracer,
+                jax.ShapeDtypeStruct,
+                jax.core.ShapedArray,
+            ),
+        )
+    )
+
+
+def _trusted_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: Any,
+) -> Array:
+    """Validate static array metadata without dispatching on hostile objects."""
+    if not _has_trusted_array_type(value):
+        raise TypeError(f"{name} must be a trusted array")
+    trusted = cast(Array, value)
+    try:
+        actual_shape = tuple(trusted.shape)
+        actual_dtype = np.dtype(trusted.dtype)
+    except (AttributeError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape and dtype metadata") from error
+    if actual_shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if actual_dtype != np.dtype(dtype):
+        raise TypeError(f"{name} must have dtype {np.dtype(dtype)}")
+    return trusted
+
+
 def run_step12_scan(
     agent: IAAgent,
     state: IAState,
@@ -618,7 +658,31 @@ def run_step12_scan(
     Returns:
         :class:`IAArrayResult` with per-step diagnostics.
     """
-    return agent.scan(state, partner_obs, partner_rewards, partner_next_obs)
+    if type(agent) is not IAAgent:
+        raise TypeError("agent must be an exact IAAgent")
+    if type(state) is not IAState:
+        raise TypeError("state must be an exact IAState")
+
+    if not _has_trusted_array_type(partner_rewards):
+        raise TypeError("partner_rewards must be a trusted array")
+    try:
+        steps = int(partner_rewards.shape[0])
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("partner_rewards must expose trusted shape metadata") from error
+    if not 1 <= steps <= _INT32_MAX:
+        raise ValueError("partner_rewards must contain between 1 and signed-int32 steps")
+
+    obs_dim = agent.config.cerebellum.obs_dim
+    checked_partner_obs = _trusted_array(
+        "partner_obs", partner_obs, shape=(steps, obs_dim), dtype=jnp.float32
+    )
+    checked_partner_rewards = _trusted_array(
+        "partner_rewards", partner_rewards, shape=(steps,), dtype=jnp.float32
+    )
+    checked_partner_next_obs = _trusted_array(
+        "partner_next_obs", partner_next_obs, shape=(steps, obs_dim), dtype=jnp.float32
+    )
+    return agent.scan(state, checked_partner_obs, checked_partner_rewards, checked_partner_next_obs)
 
 
 def run_step12_smoke(

--- a/alberta_framework/steps/step6.py
+++ b/alberta_framework/steps/step6.py
@@ -22,6 +22,7 @@ from dataclasses import asdict, dataclass
 from numbers import Integral
 from typing import Any, cast
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -318,6 +319,45 @@ def init_step6_state(
     return cast(DifferentialSARSAState, state)
 
 
+def _has_trusted_array_type(value: object) -> bool:
+    actual_type = type(value)
+    return (
+        actual_type is np.ndarray
+        or issubclass(
+            actual_type,
+            (
+                jax.Array,
+                jax.core.Tracer,
+                jax.ShapeDtypeStruct,
+                jax.core.ShapedArray,
+            ),
+        )
+    )
+
+
+def _trusted_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: Any,
+) -> Array:
+    """Validate static array metadata without dispatching on hostile objects."""
+    if not _has_trusted_array_type(value):
+        raise TypeError(f"{name} must be a trusted array")
+    trusted = cast(Array, value)
+    try:
+        actual_shape = tuple(trusted.shape)
+        actual_dtype = np.dtype(trusted.dtype)
+    except (AttributeError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape and dtype metadata") from error
+    if actual_shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if actual_dtype != np.dtype(dtype):
+        raise TypeError(f"{name} must have dtype {np.dtype(dtype)}")
+    return trusted
+
+
 def step6_update(
     agent: DifferentialSARSAAgent,
     state: DifferentialSARSAState,
@@ -335,7 +375,33 @@ def run_step6_scan(
     next_features: Array,
 ) -> DifferentialSARSAArrayResult:
     """Run Step 6 differential SARSA over pre-collected transition arrays."""
-    return run_differential_sarsa_from_arrays(agent, state, rewards, next_features)
+    if type(agent) is not DifferentialSARSAAgent:
+        raise TypeError("agent must be an exact DifferentialSARSAAgent")
+    if type(state) is not DifferentialSARSAState:
+        raise TypeError("state must be an exact DifferentialSARSAState")
+
+    if not _has_trusted_array_type(rewards):
+        raise TypeError("rewards must be a trusted array")
+    try:
+        steps = int(rewards.shape[0])
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("rewards must expose trusted shape metadata") from error
+    if not 1 <= steps <= _INT32_MAX:
+        raise ValueError("rewards must contain between 1 and signed-int32 steps")
+
+    feature_dim = state.q_weights.shape[1]
+    checked_rewards = _trusted_array("rewards", rewards, shape=(steps,), dtype=jnp.float32)
+    checked_next_features = _trusted_array(
+        "next_features", next_features, shape=(steps, feature_dim), dtype=jnp.float32
+    )
+
+    _checked_sum(
+        "Step 6 scan output bytes",
+        _checked_product("q_values bytes", 4, steps, agent.config.n_actions),
+        _checked_product("scalar output bytes", 17, steps),
+    )
+
+    return run_differential_sarsa_from_arrays(agent, state, checked_rewards, checked_next_features)
 
 
 def run_step6_smoke(

--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -30,6 +30,7 @@ from dataclasses import asdict, dataclass
 from numbers import Integral
 from typing import Any, cast
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -363,6 +364,49 @@ def step8_ensemble_predict(
     )
 
 
+def _has_trusted_array_type(value: object) -> bool:
+    actual_type = type(value)
+    return (
+        actual_type is np.ndarray
+        or issubclass(
+            actual_type,
+            (
+                jax.Array,
+                jax.core.Tracer,
+                jax.ShapeDtypeStruct,
+                jax.core.ShapedArray,
+            ),
+        )
+    )
+
+
+def _trusted_array(
+    name: str,
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    dtype: Any = None,
+) -> Array:
+    """Validate static array metadata without dispatching on hostile objects."""
+    if not _has_trusted_array_type(value):
+        raise TypeError(f"{name} must be a trusted array")
+    trusted = cast(Array, value)
+    try:
+        actual_shape = tuple(trusted.shape)
+        actual_dtype = np.dtype(trusted.dtype)
+    except (AttributeError, TypeError, ValueError) as error:
+        raise TypeError(f"{name} must expose trusted shape and dtype metadata") from error
+    if actual_shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if dtype is not None:
+        if actual_dtype != np.dtype(dtype):
+            raise TypeError(f"{name} must have dtype {np.dtype(dtype)}")
+    else:
+        if actual_dtype.kind not in "biuf":
+            raise TypeError(f"{name} must have numeric dtype")
+    return trusted
+
+
 def run_step8_scan(
     model: OneStepWorldModel,
     state: WorldModelState,
@@ -372,13 +416,41 @@ def run_step8_scan(
     next_observations: Array,
 ) -> WorldModelLearningResult:
     """Run Step 8 world-model learning over transition arrays."""
+    if type(model) is not OneStepWorldModel:
+        raise TypeError("model must be an exact OneStepWorldModel")
+    if type(state) is not WorldModelState:
+        raise TypeError("state must be an exact WorldModelState")
+
+    if not _has_trusted_array_type(observations):
+        raise TypeError("observations must be a trusted array")
+    try:
+        steps = int(observations.shape[0])
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("observations must expose trusted shape metadata") from error
+    if not 1 <= steps <= _INT32_MAX:
+        raise ValueError("observations must contain between 1 and signed-int32 steps")
+
+    obs_dim = model.config.observation_dim
+    action_shape = (
+        (steps,) if model.config.n_actions is not None else (steps, model.config.action_dim)
+    )
+
+    checked_obs = _trusted_array(
+        "observations", observations, shape=(steps, obs_dim), dtype=jnp.float32
+    )
+    checked_actions = _trusted_array("actions", actions, shape=action_shape)
+    checked_rewards = _trusted_array("rewards", rewards, shape=(steps,), dtype=jnp.float32)
+    checked_next_obs = _trusted_array(
+        "next_observations", next_observations, shape=(steps, obs_dim), dtype=jnp.float32
+    )
+
     return run_world_model_learning_loop(
         model,
         state,
-        observations,
-        actions,
-        rewards,
-        next_observations,
+        checked_obs,
+        checked_actions,
+        checked_rewards,
+        checked_next_obs,
     )
 
 

--- a/tests/test_step_scan_bounds_validation.py
+++ b/tests/test_step_scan_bounds_validation.py
@@ -1,0 +1,416 @@
+"""Tests for scan sequence bounds and array validation across Steps 6, 8, 10, 12, Stacked Horde,
+Independent Demon Horde, Actor-Critic, and UPGD.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework import DemonType, GVFSpec, create_horde_spec
+from alberta_framework.core.actor_critic import (
+    ActorCriticAgent,
+    ActorCriticConfig,
+    ContinuousActorCriticAgent,
+    ContinuousActorCriticConfig,
+    run_actor_critic_from_arrays,
+    run_continuous_actor_critic_from_arrays,
+)
+from alberta_framework.core.independent_demon_horde import (
+    IndependentDemonHorde,
+    run_independent_horde_learning_loop,
+    run_independent_horde_learning_loop_batched,
+)
+from alberta_framework.core.options import SubtaskSpec
+from alberta_framework.core.stacked_horde import (
+    StackedHordeConfig,
+    StackedLinearHorde,
+    run_stacked_horde_scan,
+)
+from alberta_framework.core.upgd import (
+    UPGDLearner,
+    run_upgd_arrays,
+    run_upgd_loop,
+)
+from alberta_framework.steps.step6 import (
+    Step6DifferentialSARSAConfig,
+    init_step6_state,
+    make_step6_differential_sarsa_agent,
+    run_step6_scan,
+)
+from alberta_framework.steps.step8 import (
+    Step8WorldModelConfig,
+    init_step8_state,
+    make_step8_world_model,
+    run_step8_scan,
+)
+from alberta_framework.steps.step10 import (
+    Step10STOMPConfig,
+    init_step10_state,
+    make_step10_stomp_agent,
+    run_step10_scan,
+)
+from alberta_framework.steps.step12 import (
+    Step12IAConfig,
+    init_step12_state,
+    make_step12_ia_agent,
+    run_step12_scan,
+)
+from alberta_framework.streams.synthetic import RandomWalkStream
+
+# ---------------------------------------------------------------------------
+# Step 6 Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_step6_scan_validation() -> None:
+    cfg = Step6DifferentialSARSAConfig(n_actions=2)
+    agent = make_step6_differential_sarsa_agent(cfg)
+    key = jr.key(0)
+    state = init_step6_state(agent, feature_dim=4, key=key, initial_features=jnp.zeros((4,)))
+
+    rewards = jnp.zeros((5,), dtype=jnp.float32)
+    next_features = jnp.zeros((5, 4), dtype=jnp.float32)
+
+    # Valid run
+    res = run_step6_scan(agent, state, rewards, next_features)
+    assert res.q_values.shape == (5, 2)
+    assert res.td_errors.shape == (5,)
+
+    # Invalid agent / state
+    with pytest.raises(TypeError, match="agent must be an exact"):
+        run_step6_scan(None, state, rewards, next_features)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="state must be an exact"):
+        run_step6_scan(agent, None, rewards, next_features)  # type: ignore[arg-type]
+
+    # Untrusted array / invalid shape
+    with pytest.raises(TypeError, match="rewards must be a trusted array"):
+        run_step6_scan(agent, state, [0.0] * 5, next_features)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="rewards must contain between 1"):
+        run_step6_scan(agent, state, jnp.zeros((0,)), jnp.zeros((0, 4)))
+    with pytest.raises(ValueError, match="next_features must have shape"):
+        run_step6_scan(agent, state, rewards, jnp.zeros((5, 3)))
+
+
+# ---------------------------------------------------------------------------
+# Step 8 Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_step8_scan_validation() -> None:
+    cfg = Step8WorldModelConfig(observation_dim=3, n_actions=2)
+    model = make_step8_world_model(cfg)
+    key = jr.key(0)
+    state = init_step8_state(model, key=key)
+
+    obs = jnp.zeros((5, 3), dtype=jnp.float32)
+    actions = jnp.zeros((5,), dtype=jnp.float32)
+    rewards = jnp.zeros((5,), dtype=jnp.float32)
+    next_obs = jnp.zeros((5, 3), dtype=jnp.float32)
+
+    # Valid run
+    res = run_step8_scan(model, state, obs, actions, rewards, next_obs)
+    assert res.reward_predictions.shape == (5,)
+    assert res.next_observation_predictions.shape == (5, 3)
+
+    # Invalid model / state
+    with pytest.raises(TypeError, match="model must be an exact"):
+        run_step8_scan(None, state, obs, actions, rewards, next_obs)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="state must be an exact"):
+        run_step8_scan(model, None, obs, actions, rewards, next_obs)  # type: ignore[arg-type]
+
+    # Untrusted array / invalid shape
+    with pytest.raises(TypeError, match="observations must be a trusted array"):
+        run_step8_scan(model, state, [[0.0, 0.0, 0.0]], actions, rewards, next_obs)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="observations must contain between 1"):
+        run_step8_scan(
+            model, state, jnp.zeros((0, 3)), jnp.zeros((0,)), jnp.zeros((0,)), jnp.zeros((0, 3))
+        )
+    with pytest.raises(ValueError, match="next_observations must have shape"):
+        run_step8_scan(model, state, obs, actions, rewards, jnp.zeros((5, 4)))
+
+
+# ---------------------------------------------------------------------------
+# Step 10 Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_step10_scan_validation() -> None:
+    spec = SubtaskSpec(feature_index=0, threshold=1.0)
+    cfg = Step10STOMPConfig(observation_dim=3, n_primitive_actions=2, subtask_specs=(spec,))
+    agent = make_step10_stomp_agent(cfg)
+    key = jr.key(0)
+    state = init_step10_state(agent, key=key, initial_observation=jnp.zeros((3,)))
+
+    rewards = jnp.zeros((5,), dtype=jnp.float32)
+    next_obs = jnp.zeros((5, 3), dtype=jnp.float32)
+
+    # Valid run
+    res = run_step10_scan(agent, state, rewards, next_obs)
+    assert res.primitive_actions.shape == (5,)
+
+    # Invalid agent / state
+    with pytest.raises(TypeError, match="agent must be an exact"):
+        run_step10_scan(None, state, rewards, next_obs)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="state must be an exact"):
+        run_step10_scan(agent, None, rewards, next_obs)  # type: ignore[arg-type]
+
+    # Untrusted array / invalid shape
+    with pytest.raises(TypeError, match="rewards must be a trusted array"):
+        run_step10_scan(agent, state, [0.0] * 5, next_obs)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="rewards must contain between 1"):
+        run_step10_scan(agent, state, jnp.zeros((0,)), jnp.zeros((0, 3)))
+    with pytest.raises(ValueError, match="next_observations must have shape"):
+        run_step10_scan(agent, state, rewards, jnp.zeros((5, 4)))
+
+
+# ---------------------------------------------------------------------------
+# Step 12 Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_step12_scan_validation() -> None:
+    spec = SubtaskSpec(feature_index=0, threshold=1.0)
+    cfg = Step12IAConfig(
+        observation_dim=3,
+        n_primitive_actions=2,
+        n_demons=2,
+        subtask_specs=(spec,),
+    )
+    agent = make_step12_ia_agent(cfg)
+    key = jr.key(0)
+    state = init_step12_state(agent, key=key, initial_observation=jnp.zeros((3,)))
+
+    partner_obs = jnp.zeros((5, 3), dtype=jnp.float32)
+    partner_rewards = jnp.zeros((5,), dtype=jnp.float32)
+    partner_next_obs = jnp.zeros((5, 3), dtype=jnp.float32)
+
+    # Valid run
+    res = run_step12_scan(agent, state, partner_obs, partner_rewards, partner_next_obs)
+    assert res.predictions.shape == (5, 2)
+    assert res.recommendations.shape == (5,)
+
+    # Invalid agent / state
+    with pytest.raises(TypeError, match="agent must be an exact"):
+        run_step12_scan(None, state, partner_obs, partner_rewards, partner_next_obs)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="state must be an exact"):
+        run_step12_scan(agent, None, partner_obs, partner_rewards, partner_next_obs)  # type: ignore[arg-type]
+
+    # Untrusted array / invalid shape
+    with pytest.raises(TypeError, match="partner_rewards must be a trusted array"):
+        run_step12_scan(agent, state, partner_obs, [0.0] * 5, partner_next_obs)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="partner_rewards must contain between 1"):
+        run_step12_scan(
+            agent, state, partner_obs, jnp.zeros((0,)), partner_next_obs
+        )
+    with pytest.raises(ValueError, match="partner_next_obs must have shape"):
+        run_step12_scan(agent, state, partner_obs, partner_rewards, jnp.zeros((5, 4)))
+
+
+# ---------------------------------------------------------------------------
+# Stacked Linear Horde Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_stacked_horde_scan_validation() -> None:
+    config = StackedHordeConfig(
+        n_demons=2,
+        feature_dim=3,
+        gammas=(0.9, 0.95),
+        lamdas=(0.8, 0.8),
+        cumulant_indices=(0, 1),
+    )
+    horde = StackedLinearHorde(config)
+    state = horde.init()
+
+    features = jnp.zeros((6, 3), dtype=jnp.float32)
+    cumulant_sources = jnp.zeros((6, 2), dtype=jnp.float32)
+
+    # Valid run
+    final_state, td_errors = run_stacked_horde_scan(horde, state, features, cumulant_sources)
+    assert td_errors.shape == (5, 2)
+
+    # Invalid horde / state
+    with pytest.raises(TypeError, match="horde must be an exact"):
+        run_stacked_horde_scan(None, state, features, cumulant_sources)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="state must be an exact"):
+        run_stacked_horde_scan(horde, None, features, cumulant_sources)  # type: ignore[arg-type]
+
+    # Untrusted array / invalid shape
+    with pytest.raises(TypeError, match="features must be a trusted array"):
+        run_stacked_horde_scan(horde, state, [[0.0, 0.0, 0.0]] * 6, cumulant_sources)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="features must contain between 2"):
+        run_stacked_horde_scan(horde, state, jnp.zeros((1, 3)), jnp.zeros((1, 2)))
+    with pytest.raises(ValueError, match="features must have shape"):
+        run_stacked_horde_scan(horde, state, jnp.zeros((6, 4)), cumulant_sources)
+
+
+# ---------------------------------------------------------------------------
+# Independent Demon Horde Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_independent_demon_horde_scan_validation() -> None:
+    specs = [
+        GVFSpec(  # type: ignore[call-arg]
+            name=f"d{i}",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=i,
+        )
+        for i in range(2)
+    ]
+    horde = IndependentDemonHorde(horde_spec=create_horde_spec(specs), hidden_sizes=(8,))
+    key = jr.key(0)
+    state = horde.init(feature_dim=3, key=key)
+
+    obs = jnp.zeros((5, 3), dtype=jnp.float32)
+    cums = jnp.zeros((5, 2), dtype=jnp.float32)
+    next_obs = jnp.zeros((5, 3), dtype=jnp.float32)
+
+    # Valid run
+    res = run_independent_horde_learning_loop(horde, state, obs, cums, next_obs)
+    assert res.td_errors.shape == (5, 2)
+
+    # Valid batched run
+    keys = jr.split(key, 3)
+    res_b = run_independent_horde_learning_loop_batched(horde, obs, cums, next_obs, keys)
+    assert res_b.td_errors.shape == (3, 5, 2)
+
+    # Invalid horde / state
+    with pytest.raises(TypeError, match="horde must be an exact"):
+        run_independent_horde_learning_loop(None, state, obs, cums, next_obs)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="state must be an exact"):
+        run_independent_horde_learning_loop(horde, None, obs, cums, next_obs)  # type: ignore[arg-type]
+
+    # Untrusted array / invalid shape
+    with pytest.raises(TypeError, match="observations must be a trusted array"):
+        run_independent_horde_learning_loop(horde, state, [[0.0, 0.0, 0.0]], cums, next_obs)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="observations must have shape"):
+        run_independent_horde_learning_loop(horde, state, jnp.zeros((0, 3)), cums, next_obs)
+
+
+# ---------------------------------------------------------------------------
+# Actor-Critic Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_actor_critic_scan_validation() -> None:
+    # Discrete
+    disc_cfg = ActorCriticConfig(n_actions=2)
+    disc_agent = ActorCriticAgent(disc_cfg)
+    key = jr.key(0)
+    disc_state = disc_agent.init(feature_dim=3, key=key)
+
+    obs = jnp.zeros((5, 3), dtype=jnp.float32)
+    rewards = jnp.zeros((5,), dtype=jnp.float32)
+    next_obs = jnp.zeros((5, 3), dtype=jnp.float32)
+    discounts = jnp.ones((5,), dtype=jnp.float32)
+
+    res_d = run_actor_critic_from_arrays(
+        disc_agent,
+        disc_state,
+        obs,
+        rewards,
+        terminated=None,
+        next_observations=next_obs,
+        discounts=discounts,
+    )
+    assert res_d.actions.shape == (5,)
+
+    with pytest.raises(TypeError, match="agent must be an exact ActorCriticAgent"):
+        run_actor_critic_from_arrays(
+            None,  # type: ignore[arg-type]
+            disc_state,
+            obs,
+            rewards,
+            terminated=None,
+            next_observations=next_obs,
+            discounts=discounts,
+        )
+    with pytest.raises(TypeError, match="state must be an exact ActorCriticState"):
+        run_actor_critic_from_arrays(
+            disc_agent,
+            None,  # type: ignore[arg-type]
+            obs,
+            rewards,
+            terminated=None,
+            next_observations=next_obs,
+            discounts=discounts,
+        )
+
+    # Continuous
+    cont_cfg = ContinuousActorCriticConfig(action_dim=2)
+    cont_agent = ContinuousActorCriticAgent(cont_cfg)
+    cont_state = cont_agent.init(feature_dim=3, key=key)
+
+    res_c = run_continuous_actor_critic_from_arrays(
+        cont_agent,
+        cont_state,
+        obs,
+        rewards,
+        terminated=None,
+        next_observations=next_obs,
+        discounts=discounts,
+    )
+    assert res_c.actions.shape == (5, 2)
+
+    with pytest.raises(TypeError, match="agent must be an exact ContinuousActorCriticAgent"):
+        run_continuous_actor_critic_from_arrays(
+            None,  # type: ignore[arg-type]
+            cont_state,
+            obs,
+            rewards,
+            terminated=None,
+            next_observations=next_obs,
+            discounts=discounts,
+        )
+    with pytest.raises(TypeError, match="state must be an exact ContinuousActorCriticState"):
+        run_continuous_actor_critic_from_arrays(
+            cont_agent,
+            None,  # type: ignore[arg-type]
+            obs,
+            rewards,
+            terminated=None,
+            next_observations=next_obs,
+            discounts=discounts,
+        )
+
+
+# ---------------------------------------------------------------------------
+# UPGD Scan Tests
+# ---------------------------------------------------------------------------
+
+
+def test_upgd_scan_validation() -> None:
+    learner = UPGDLearner(n_heads=2, hidden_sizes=(16,))
+    key = jr.key(0)
+    state = learner.init(3, key)
+
+    obs = jnp.zeros((5, 3), dtype=jnp.float32)
+    targets = jnp.zeros((5, 2), dtype=jnp.float32)
+
+    # Valid array run
+    res_arr = run_upgd_arrays(learner, state, obs, targets)
+    assert res_arr.metrics.shape == (5, 4)
+
+    # Valid stream loop run
+    stream = RandomWalkStream(feature_dim=3)
+    res_loop = run_upgd_loop(learner, stream, num_steps=5, key=key, learner_state=state)
+    assert res_loop.metrics.shape == (5, 4)
+
+    # Invalid learner / state
+    with pytest.raises(TypeError, match="learner must be an exact UPGDLearner"):
+        run_upgd_arrays(None, state, obs, targets)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="state must be an exact UPGDState"):
+        run_upgd_arrays(learner, None, obs, targets)  # type: ignore[arg-type]
+
+    # Untrusted array / invalid shape
+    with pytest.raises(TypeError, match="observations must be a trusted array"):
+        run_upgd_arrays(learner, state, [[0.0, 0.0, 0.0]], targets)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="observations must have shape"):
+        run_upgd_arrays(learner, state, jnp.zeros((5, 2)), targets)
+    with pytest.raises(ValueError, match="targets must have shape"):
+        run_upgd_arrays(learner, state, obs, jnp.zeros((5, 3)))


### PR DESCRIPTION
### Summary

Enforces exact container and agent/state types, trusted array metadata, non-empty and bounded `1 <= steps <= INT32_MAX` sequence lengths, and exact array shape/dtype compatibility across remaining scan and learning-loop entrypoints in:

- **Step 6**: `run_step6_scan` (Differential SARSA arrays)
- **Step 8**: `run_step8_scan` (OneStepWorldModel transition arrays)
- **Step 10**: `run_step10_scan` (STOMPAgent arrays)
- **Step 12**: `run_step12_scan` (IAAgent partner interaction arrays)
- **Stacked Linear Horde**: `run_stacked_horde_scan`
- **Independent Demon Horde**: `run_independent_horde_learning_loop` and `run_independent_horde_learning_loop_batched`
- **Actor-Critic**: `run_actor_critic_from_arrays` and `run_continuous_actor_critic_from_arrays`
- **UPGD**: `run_upgd_arrays`

### Validation & Testing
- Unit tests added in `tests/test_step_scan_bounds_validation.py` covering agent/state type gating, trusted array validation, sequence length bounds, and shape/dtype mismatches across all 8 modules.
- Existing tests verified: 250 passed across `test_actor_critic.py`, `test_sarsa.py`, `test_canonical_upgd.py`, and `test_step_scan_bounds_validation.py`.
- `ruff` check, `mypy` strict type checking, and `git diff --check` pass cleanly.

Declared identity: Antigravity CLI + Gemini (Google DeepMind).

## Measured project receipt
Post-hoc receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F8P3VADM697JSY9ZGWPNNB","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T09:40:25.066Z","completed_at":"2026-08-20T09:40:39.686Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T09:40:25.361Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a4980ecac57a6828d012381f0101a0a07a072ab0aa05757f8296610257387384","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"762e0010-7849-415a-acdc-fa6ba16a43e2","object_id":"sha256:a4980ecac57a6828d012381f0101a0a07a072ab0aa05757f8296610257387384","sha256":"a4980ecac57a6828d012381f0101a0a07a072ab0aa05757f8296610257387384"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"fEDC6ErH-S7bO5Bt5wA8luu_4tdkyZY76D2DVM8U1mMHhmWnwCtINVfEPB20oO_1rhm2kLArPHMihB-z6p7HDA"}} -->
