### PR TITLE
fix(core): validate scan sequence bounds and array dimensions across Step 3, Gymnasium, and PrototypeAgent

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -7274,6 +7274,8 @@ class PrototypeAgent:
         Returns:
             :class:`PrototypeArrayResult` with final state and per-step arrays.
         """
+        if type(state) is not PrototypeAgentState:
+            raise TypeError("state must be an exact PrototypeAgentState")
         if horde_discounts is not None and discounts is None:
             raise ValueError("horde_discounts requires explicit discounts")
         if self._state_builder is not None:
@@ -7289,24 +7291,35 @@ class PrototypeAgent:
         use_explicit_discounts = discounts is not None
         use_horde_cumulants = horde_cumulants is not None
         use_horde_discounts = horde_discounts is not None
-        n = int(rewards.shape[0])
+        actual_type = type(cast(object, rewards))
+        if not (
+            actual_type is np.ndarray
+            or isinstance(rewards, (jax.Array, jax.core.Tracer))
+        ):
+            raise TypeError("rewards must be a trusted array")
+        try:
+            n = int(rewards.shape[0])
+        except (AttributeError, IndexError, TypeError, ValueError) as error:
+            raise TypeError("rewards must expose trusted shape metadata") from error
+        if not 1 <= n <= _INT32_MAX:
+            raise ValueError("rewards must contain between 1 and signed-int32 steps")
 
+        raw_observation_dim = (
+            self._config.gru_perception.observation_dim
+            if self._config.gru_perception is not None
+            else self._config.oak.observation_dim
+        )
+        rewards = _checked_finite_array(
+            rewards,
+            (n,),
+            name="rewards",
+        )
+        next_observations = _checked_finite_array(
+            next_observations,
+            (n, raw_observation_dim),
+            name="next_observations",
+        )
         if use_explicit_discounts:
-            rewards = _checked_finite_array(
-                rewards,
-                (n,),
-                name="rewards",
-            )
-            raw_observation_dim = (
-                self._config.gru_perception.observation_dim
-                if self._config.gru_perception is not None
-                else self._config.oak.observation_dim
-            )
-            next_observations = _checked_finite_array(
-                next_observations,
-                (n, raw_observation_dim),
-                name="next_observations",
-            )
             discounts = _checked_unit_discount(
                 discounts,
                 (n,),
@@ -7431,6 +7444,17 @@ class PrototypeAgent:
         ) = None,
     ) -> PrototypeArrayResult:
         """Run authoritative transitions and fixed optional sidecars through scan."""
+
+        if type(state) is not PrototypeAgentState:
+            raise TypeError("state must be an exact PrototypeAgentState")
+        if type(transitions) is not PrototypeTransition:
+            raise TypeError("transitions must be an exact PrototypeTransition")
+        try:
+            n = int(transitions.reward.shape[0])
+        except (AttributeError, IndexError, TypeError, ValueError) as error:
+            raise TypeError("transitions must expose trusted shape metadata") from error
+        if not 1 <= n <= _INT32_MAX:
+            raise ValueError("transitions must contain between 1 and signed-int32 steps")
 
         use_partner_input = partner_policy_fusion_input is not None
         use_partner_feedback = partner_policy_fusion_feedback is not None

--- a/alberta_framework/steps/step3.py
+++ b/alberta_framework/steps/step3.py
@@ -721,16 +721,44 @@ def run_step3_scan(
 ) -> HordeLearningResult:
     """Run the Step 3 Horde over transition arrays."""
     if type(horde) is not HordeLearner:
-        raise ValueError("horde must be an exact HordeLearner")
+        raise TypeError("horde must be an exact HordeLearner")
     if type(state) is not MultiHeadMLPState:
-        raise ValueError("state must be an exact MultiHeadMLPState")
+        raise TypeError("state must be an exact MultiHeadMLPState")
     features = _require_float32_matrix("features", features)
     cumulants = _require_float32_matrix("cumulants", cumulants)
     next_features = _require_float32_matrix("next_features", next_features)
+    steps = int(features.shape[0])
+    feature_dim = int(features.shape[1])
+    if not 1 <= steps <= _INT32_MAX:
+        raise ValueError("features must contain between 1 and signed-int32 steps")
+    if not 1 <= feature_dim <= _INT32_MAX:
+        raise ValueError("features must have at least one feature column")
     if next_features.shape != features.shape:
         raise ValueError("next_features must match features")
-    if cumulants.shape != (features.shape[0], horde.n_demons):
+    if cumulants.shape != (steps, horde.n_demons):
         raise ValueError("cumulants must match steps and configured demons")
+    state_feature_dim = (
+        state.trunk_params.weights[0].shape[1]
+        if state.trunk_params.weights
+        else state.head_params.weights[0].shape[1]
+    )
+    if state_feature_dim != feature_dim:
+        msg = (
+            f"state feature dimension ({state_feature_dim}) does not match features ({feature_dim})"
+        )
+        raise ValueError(msg)
+    if len(state.head_params.weights) != horde.n_demons:
+        msg = (
+            f"state demon count ({len(state.head_params.weights)}) does not match "
+            f"horde demon count ({horde.n_demons})"
+        )
+        raise ValueError(msg)
+    _require_handoff_resources(
+        steps=steps,
+        raw_dim=feature_dim,
+        constructed_dim=0,
+        n_demons=horde.n_demons,
+    )
     return run_horde_learning_loop(
         horde,
         state,

--- a/alberta_framework/streams/gymnasium.py
+++ b/alberta_framework/streams/gymnasium.py
@@ -492,8 +492,62 @@ def learn_from_trajectory(
         [squared_error, error, mean_step_size]; a learner constructed with
         a normalizer emits a fourth column, normalizer_mean_var.
     """
-    if learner_state is None:
-        learner_state = learner.init(observations.shape[1])
+    if type(learner) is not LinearLearner and not isinstance(learner, LinearLearner):
+        raise TypeError("learner must be an instance of LinearLearner")
+    actual_obs_type = type(cast(object, observations))
+    if not (
+        actual_obs_type is np.ndarray
+        or isinstance(observations, (jax.Array, jax.core.Tracer))
+    ):
+        raise TypeError("observations must be a trusted array")
+    actual_tgt_type = type(cast(object, targets))
+    if not (
+        actual_tgt_type is np.ndarray
+        or isinstance(targets, (jax.Array, jax.core.Tracer))
+    ):
+        raise TypeError("targets must be a trusted array")
+    try:
+        obs_ndim = observations.ndim
+        tgt_ndim = targets.ndim
+        num_steps = int(observations.shape[0])
+        target_steps = int(targets.shape[0])
+        feature_dim = int(observations.shape[1]) if obs_ndim >= 2 else None
+        target_dim = int(targets.shape[1]) if tgt_ndim >= 2 else 1
+    except Exception as error:
+        raise TypeError("observations and targets must expose trusted shape metadata") from error
+
+    if obs_ndim != 2:
+        raise ValueError("observations must be a 2D array of shape (num_steps, feature_dim)")
+    if tgt_ndim not in (1, 2):
+        raise ValueError("targets must be a 1D or 2D array")
+    if not 1 <= num_steps <= _INT32_MAX:
+        raise ValueError("observations sequence length must be an integer in [1, 2147483647]")
+    if target_steps != num_steps:
+        raise ValueError("targets sequence length must match observations sequence length")
+    if feature_dim is None or not 1 <= feature_dim <= _INT32_MAX:
+        raise ValueError("feature_dim must be an integer in [1, 2147483647]")
+    if target_dim is not None and not 1 <= target_dim <= _INT32_MAX:
+        raise ValueError("target_dim must be an integer in [1, 2147483647]")
+
+    if observations.dtype != jnp.float32:
+        raise TypeError("observations must have dtype float32")
+    if targets.dtype != jnp.float32:
+        raise TypeError("targets must have dtype float32")
+
+    _require_float32_allocation("observations", num_steps * feature_dim)
+    _require_float32_allocation("targets", num_steps * (target_dim if tgt_ndim == 2 else 1))
+    _require_float32_allocation("metrics output", num_steps * 4)
+
+    if learner_state is not None:
+        if type(learner_state) is not LearnerState:
+            raise TypeError("learner_state must be an exact LearnerState")
+        if learner_state.weights.ndim != 1 or learner_state.weights.shape[0] != feature_dim:
+            raise ValueError(
+                f"learner_state.weights shape {learner_state.weights.shape} does not match "
+                f"feature_dim={feature_dim}"
+            )
+    else:
+        learner_state = learner.init(feature_dim)
 
     def step_fn(state: LearnerState, inputs: tuple[Array, Array]) -> tuple[LearnerState, Array]:
         obs, target = inputs

--- a/tests/test_step3_gymnasium_prototype_scan_bounds.py
+++ b/tests/test_step3_gymnasium_prototype_scan_bounds.py
@@ -1,0 +1,346 @@
+# mypy: disable-error-code="call-arg,no-untyped-def,untyped-decorator"
+"""Tests for scan sequence bounds and array dimension validation.
+
+Covers Step 3, Gymnasium stream learning, and PrototypeAgent.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.learners import LinearLearner
+from alberta_framework.core.optimizers import LMS
+from alberta_framework.core.prototype_agent import (
+    PrototypeAgent,
+    PrototypeAgentConfig,
+    PrototypeTransition,
+)
+from alberta_framework.core.types import LearnerState
+from alberta_framework.steps.step3 import (
+    Step3HordeConfig,
+    make_step3_horde,
+    run_step3_scan,
+)
+from alberta_framework.streams.gymnasium import (
+    learn_from_trajectory,
+    learn_from_trajectory_normalized,
+)
+
+# =============================================================================
+# Step 3 Horde scan bounds and dimensions
+# =============================================================================
+
+
+class TestStep3ScanValidation:
+    @pytest.fixture
+    def horde_and_state(self):
+        cfg = Step3HordeConfig(
+            gammas=(0.0, 0.9),
+            lamdas=(0.0, 0.5),
+            hidden_sizes=(16,),
+        )
+        horde = make_step3_horde(cfg)
+        key = jr.key(42)
+        state = horde.init(feature_dim=4, key=key)
+        return horde, state
+
+    def test_rejects_non_horde_type(self, horde_and_state) -> None:
+        _, state = horde_and_state
+        features = jnp.zeros((8, 4), dtype=jnp.float32)
+        cumulants = jnp.zeros((8, 2), dtype=jnp.float32)
+        with pytest.raises(TypeError, match="horde must be an exact HordeLearner"):
+            run_step3_scan(
+                cast(Any, object()),
+                state,
+                features,
+                cumulants,
+                features,
+            )
+
+    def test_rejects_non_state_type(self, horde_and_state) -> None:
+        horde, _ = horde_and_state
+        features = jnp.zeros((8, 4), dtype=jnp.float32)
+        cumulants = jnp.zeros((8, 2), dtype=jnp.float32)
+        with pytest.raises(TypeError, match="state must be an exact MultiHeadMLPState"):
+            run_step3_scan(
+                horde,
+                cast(Any, object()),
+                features,
+                cumulants,
+                features,
+            )
+
+    def test_rejects_zero_steps(self, horde_and_state) -> None:
+        horde, state = horde_and_state
+        features = jnp.zeros((0, 4), dtype=jnp.float32)
+        cumulants = jnp.zeros((0, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="between 1 and signed-int32 steps"):
+            run_step3_scan(
+                horde,
+                state,
+                features,
+                cumulants,
+                features,
+            )
+
+    def test_rejects_zero_feature_dim(self, horde_and_state) -> None:
+        horde, state = horde_and_state
+        features = jnp.zeros((8, 0), dtype=jnp.float32)
+        cumulants = jnp.zeros((8, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="at least one feature column"):
+            run_step3_scan(
+                horde,
+                state,
+                features,
+                cumulants,
+                features,
+            )
+
+    def test_rejects_mismatched_next_features(self, horde_and_state) -> None:
+        horde, state = horde_and_state
+        features = jnp.zeros((8, 4), dtype=jnp.float32)
+        next_features = jnp.zeros((8, 5), dtype=jnp.float32)
+        cumulants = jnp.zeros((8, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="next_features must match features"):
+            run_step3_scan(
+                horde,
+                state,
+                features,
+                cumulants,
+                next_features,
+            )
+
+    def test_rejects_mismatched_cumulants_steps(self, horde_and_state) -> None:
+        horde, state = horde_and_state
+        features = jnp.zeros((8, 4), dtype=jnp.float32)
+        cumulants = jnp.zeros((6, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="cumulants must match steps and configured demons"):
+            run_step3_scan(
+                horde,
+                state,
+                features,
+                cumulants,
+                features,
+            )
+
+    def test_rejects_mismatched_cumulants_demons(self, horde_and_state) -> None:
+        horde, state = horde_and_state
+        features = jnp.zeros((8, 4), dtype=jnp.float32)
+        cumulants = jnp.zeros((8, 3), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="cumulants must match steps and configured demons"):
+            run_step3_scan(
+                horde,
+                state,
+                features,
+                cumulants,
+                features,
+            )
+
+    def test_rejects_state_feature_dim_mismatch(self, horde_and_state) -> None:
+        horde, state = horde_and_state  # state initialized for feature_dim=4
+        features = jnp.zeros((8, 6), dtype=jnp.float32)
+        cumulants = jnp.zeros((8, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="state feature dimension .* does not match features"):
+            run_step3_scan(
+                horde,
+                state,
+                features,
+                cumulants,
+                features,
+            )
+
+    def test_valid_step3_scan_runs_cleanly(self, horde_and_state) -> None:
+        horde, state = horde_and_state
+        features = jnp.ones((10, 4), dtype=jnp.float32)
+        cumulants = jnp.ones((10, 2), dtype=jnp.float32)
+        result = run_step3_scan(
+            horde,
+            state,
+            features,
+            cumulants,
+            features,
+        )
+        assert result.td_errors.shape == (10, 2)
+        assert result.per_demon_metrics.shape == (10, 2, 3)
+        assert result.updates_applied.shape == (10,)
+
+
+# =============================================================================
+# Gymnasium learn_from_trajectory bounds and dimensions
+# =============================================================================
+
+
+class TestGymnasiumTrajectoryScanValidation:
+    @pytest.fixture
+    def learner(self):
+        return LinearLearner(optimizer=LMS(step_size=0.01))
+
+    def test_rejects_non_linear_learner_type(self) -> None:
+        obs = jnp.zeros((5, 3), dtype=jnp.float32)
+        targets = jnp.zeros((5, 1), dtype=jnp.float32)
+        with pytest.raises(TypeError, match="learner must be an instance of LinearLearner"):
+            learn_from_trajectory(cast(Any, object()), obs, targets)
+
+    def test_rejects_untrusted_observations(self, learner) -> None:
+        targets = jnp.zeros((5, 1), dtype=jnp.float32)
+        with pytest.raises(TypeError, match="observations must be a trusted array"):
+            learn_from_trajectory(learner, cast(Any, [1.0, 2.0]), targets)
+
+    def test_rejects_untrusted_targets(self, learner) -> None:
+        obs = jnp.zeros((5, 3), dtype=jnp.float32)
+        with pytest.raises(TypeError, match="targets must be a trusted array"):
+            learn_from_trajectory(learner, obs, cast(Any, [1.0, 2.0]))
+
+    def test_rejects_1d_observations(self, learner) -> None:
+        obs = jnp.zeros((5,), dtype=jnp.float32)
+        targets = jnp.zeros((5, 1), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="observations must be a 2D array"):
+            learn_from_trajectory(learner, obs, targets)
+
+    def test_rejects_3d_targets(self, learner) -> None:
+        obs = jnp.zeros((5, 3), dtype=jnp.float32)
+        targets = jnp.zeros((5, 1, 1), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="targets must be a 1D or 2D array"):
+            learn_from_trajectory(learner, obs, targets)
+
+    def test_rejects_zero_sequence_length(self, learner) -> None:
+        obs = jnp.zeros((0, 3), dtype=jnp.float32)
+        targets = jnp.zeros((0, 1), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="observations sequence length must be an integer"):
+            learn_from_trajectory(learner, obs, targets)
+
+    def test_rejects_step_mismatch(self, learner) -> None:
+        obs = jnp.zeros((5, 3), dtype=jnp.float32)
+        targets = jnp.zeros((4, 1), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="targets sequence length must match"):
+            learn_from_trajectory(learner, obs, targets)
+
+    def test_rejects_non_float32_observations(self, learner) -> None:
+        obs = jnp.zeros((5, 3), dtype=jnp.int32)
+        targets = jnp.zeros((5, 1), dtype=jnp.float32)
+        with pytest.raises(TypeError, match="observations must have dtype float32"):
+            learn_from_trajectory(learner, cast(Any, obs), targets)
+
+    def test_rejects_non_float32_targets(self, learner) -> None:
+        obs = jnp.zeros((5, 3), dtype=jnp.float32)
+        targets = jnp.zeros((5, 1), dtype=jnp.int32)
+        with pytest.raises(TypeError, match="targets must have dtype float32"):
+            learn_from_trajectory(learner, obs, cast(Any, targets))
+
+    def test_rejects_mismatched_learner_state(self, learner) -> None:
+        obs = jnp.zeros((5, 3), dtype=jnp.float32)
+        targets = jnp.zeros((5, 1), dtype=jnp.float32)
+        state_wrong_dim = learner.init(4)
+        with pytest.raises(ValueError, match="learner_state.weights shape"):
+            learn_from_trajectory(learner, obs, targets, learner_state=state_wrong_dim)
+
+    def test_rejects_invalid_learner_state_type(self, learner) -> None:
+        obs = jnp.zeros((5, 3), dtype=jnp.float32)
+        targets = jnp.zeros((5, 1), dtype=jnp.float32)
+        with pytest.raises(TypeError, match="learner_state must be an exact LearnerState"):
+            learn_from_trajectory(learner, obs, targets, learner_state=cast(Any, object()))
+
+    def test_valid_trajectory_learning_runs_cleanly(self, learner) -> None:
+        obs = jnp.ones((8, 3), dtype=jnp.float32)
+        targets = jnp.ones((8, 1), dtype=jnp.float32)
+        final_state, metrics = learn_from_trajectory(learner, obs, targets)
+        assert isinstance(final_state, LearnerState)
+        assert metrics.shape == (8, 3)
+
+    def test_learn_from_trajectory_normalized_alias(self, learner) -> None:
+        obs = jnp.ones((8, 3), dtype=jnp.float32)
+        targets = jnp.ones((8, 1), dtype=jnp.float32)
+        final_state, metrics = learn_from_trajectory_normalized(learner, obs, targets)
+        assert isinstance(final_state, LearnerState)
+        assert metrics.shape == (8, 3)
+
+
+# =============================================================================
+# PrototypeAgent scan and scan_transitions bounds
+# =============================================================================
+
+
+class TestPrototypeAgentScanValidation:
+    @pytest.fixture
+    def agent_and_state(self):
+        config = PrototypeAgentConfig()
+        agent = PrototypeAgent(config)
+        key = jr.key(123)
+        state = agent.init(key)
+        state = agent.start(state, jnp.zeros(config.oak.observation_dim, dtype=jnp.float32))
+        return agent, state
+
+    def test_scan_rejects_non_prototype_state(self, agent_and_state) -> None:
+        agent, _ = agent_and_state
+        rewards = jnp.zeros((5,), dtype=jnp.float32)
+        next_obs = jnp.zeros((5, agent.config.oak.observation_dim), dtype=jnp.float32)
+        with pytest.raises(TypeError, match="state must be an exact PrototypeAgentState"):
+            agent.scan(cast(Any, object()), rewards, next_obs)
+
+    def test_scan_rejects_untrusted_rewards(self, agent_and_state) -> None:
+        agent, state = agent_and_state
+        next_obs = jnp.zeros((5, agent.config.oak.observation_dim), dtype=jnp.float32)
+        with pytest.raises(TypeError, match="rewards must be a trusted array"):
+            agent.scan(state, cast(Any, [1.0, 2.0]), next_obs)
+
+    def test_scan_rejects_zero_steps(self, agent_and_state) -> None:
+        agent, state = agent_and_state
+        rewards = jnp.zeros((0,), dtype=jnp.float32)
+        next_obs = jnp.zeros((0, agent.config.oak.observation_dim), dtype=jnp.float32)
+        with pytest.raises(
+            ValueError, match="rewards must contain between 1 and signed-int32 steps"
+        ):
+            agent.scan(state, rewards, next_obs)
+
+    def test_scan_transitions_rejects_non_prototype_state(self, agent_and_state) -> None:
+        agent, _ = agent_and_state
+        obs_dim = agent.config.oak.observation_dim
+        transition = PrototypeTransition(
+            observation=jnp.zeros((4, obs_dim), dtype=jnp.float32),
+            action=jnp.zeros((4,), dtype=jnp.int32),
+            decision_id=jnp.zeros((4,), dtype=jnp.int32),
+            reward=jnp.zeros((4,), dtype=jnp.float32),
+            discount=jnp.ones((4,), dtype=jnp.float32),
+            terminated=jnp.zeros((4,), dtype=jnp.bool_),
+            truncated=jnp.zeros((4,), dtype=jnp.bool_),
+            next_observation=jnp.zeros((4, obs_dim), dtype=jnp.float32),
+            next_decision_observation=jnp.zeros((4, obs_dim), dtype=jnp.float32),
+        )
+        with pytest.raises(TypeError, match="state must be an exact PrototypeAgentState"):
+            agent.scan_transitions(cast(Any, object()), transition)
+
+    def test_scan_transitions_rejects_non_transition_type(self, agent_and_state) -> None:
+        agent, state = agent_and_state
+        with pytest.raises(TypeError, match="transitions must be an exact PrototypeTransition"):
+            agent.scan_transitions(state, cast(Any, object()))
+
+    def test_scan_transitions_rejects_zero_steps(self, agent_and_state) -> None:
+        agent, state = agent_and_state
+        obs_dim = agent.config.oak.observation_dim
+        transition = PrototypeTransition(
+            observation=jnp.zeros((0, obs_dim), dtype=jnp.float32),
+            action=jnp.zeros((0,), dtype=jnp.int32),
+            decision_id=jnp.zeros((0,), dtype=jnp.int32),
+            reward=jnp.zeros((0,), dtype=jnp.float32),
+            discount=jnp.ones((0,), dtype=jnp.float32),
+            terminated=jnp.zeros((0,), dtype=jnp.bool_),
+            truncated=jnp.zeros((0,), dtype=jnp.bool_),
+            next_observation=jnp.zeros((0, obs_dim), dtype=jnp.float32),
+            next_decision_observation=jnp.zeros((0, obs_dim), dtype=jnp.float32),
+        )
+        with pytest.raises(
+            ValueError, match="transitions must contain between 1 and signed-int32 steps"
+        ):
+            agent.scan_transitions(state, transition)
+
+    def test_valid_scan_runs_cleanly(self, agent_and_state) -> None:
+        agent, state = agent_and_state
+        rewards = jnp.zeros((4,), dtype=jnp.float32)
+        next_obs = jnp.zeros((4, agent.config.oak.observation_dim), dtype=jnp.float32)
+        result = agent.scan(state, rewards, next_obs)
+        assert result.actions.shape == (4,)
+        assert result.oak_td_errors.shape == (4,)


### PR DESCRIPTION
### Summary

Enforces exact container and agent/state types, trusted array metadata, non-empty and bounded `1 <= steps <= INT32_MAX` sequence lengths, and exact array shape/dtype compatibility across remaining scan and learning-loop entrypoints in:

- **Step 3 Horde**: `run_step3_scan` (MultiHeadMLP state feature dimension, demon count, and sequence length bounds)
- **Gymnasium Streams**: `learn_from_trajectory` and `learn_from_trajectory_normalized` (exact LinearLearner type, 2D observation and target arrays, sequence length bounds, state shape validation, float32 resource preflight)
- **PrototypeAgent**: `scan` and `scan_transitions` (exact PrototypeAgentState type, trusted array and sequence length bounds on raw array scan, and transition sequence bounds on structured transitions)

### Validation & Testing
- Unit tests added in `tests/test_step3_gymnasium_prototype_scan_bounds.py` covering state/agent type gating, trusted array validation, sequence length bounds, shape/dtype mismatches, and valid execution paths.
- Existing tests verified: 302 passed across Step 3, Gymnasium, and PrototypeAgent test suites.
- `ruff` check, `mypy` strict type checking, and `git diff --check` pass cleanly.

Declared identity: Antigravity CLI + Gemini (Google DeepMind).

## Measured project receipt
Post-hoc receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F8NHGFGXA6HH185AK146H8","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T09:40:06.288Z","completed_at":"2026-08-20T09:40:20.993Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T09:40:06.682Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"88fbf1976c94a3839d226a07bccecfa56dbc372d876eee2a26519b8cab7cd93d","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"14190455-17ad-4b83-bcf9-502cd804597f","object_id":"sha256:88fbf1976c94a3839d226a07bccecfa56dbc372d876eee2a26519b8cab7cd93d","sha256":"88fbf1976c94a3839d226a07bccecfa56dbc372d876eee2a26519b8cab7cd93d"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"UnGsaC-NPDIPwkkCe8uwGkc7sgwtrtMKYOg-SKSj3jKcRdRAx75dWYhyJ4nm4NiHoKSdVVDNyrU7jPkn-rlUBg"}} -->
