### PR TITLE
fix(core): validate scan sequence bounds and array dimensions across MultiHeadLearner, StackedHorde, and LabelEMNIST

### DIFF
--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -125,6 +125,8 @@ from alberta_framework.benchmarks.upgd_ipmnist import (
 )
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 
+_INT32_MAX = 2**31 - 1
+
 _ACTUAL_INT_TYPES: frozenset[type] = frozenset(
     {
         int,
@@ -429,6 +431,12 @@ def build_schedule(key: Array, config: LabelEMNISTConfig, n_train: int) -> Label
         The schedule; task ``t`` is exactly steps
         ``[t * task_length, (t + 1) * task_length)``.
     """
+    if type(config) is not LabelEMNISTConfig:
+        raise TypeError("config must be an exact LabelEMNISTConfig")
+    if type(n_train) is not int:
+        raise TypeError("n_train must be an exact built-in int")
+    if not 1 <= n_train <= _INT32_MAX:
+        raise ValueError("n_train must be positive and at most signed-int32")
     if n_train < config.task_length:
         raise ValueError(
             f"n_train={n_train} is smaller than task_length={config.task_length}; "
@@ -646,6 +654,10 @@ def run_label_emnist(
     Returns:
         Host-side result arrays; see :class:`LabelEMNISTRunResult`.
     """
+    if config is not None and type(config) is not LabelEMNISTConfig:
+        raise TypeError("config must be an exact LabelEMNISTConfig or None")
+    if type(return_per_step) is not bool:
+        raise TypeError("return_per_step must be a boolean")
     if progress_every is not None and (
         type(progress_every) is not int or progress_every <= 0
     ):

--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -1593,6 +1593,56 @@ def run_multi_head_learning_loop(
         ``MultiHeadLearningResult`` with final state and per-head metrics
         of shape ``(num_steps, n_heads, 3)``
     """
+    if type(learner) is not MultiHeadMLPLearner:
+        raise TypeError("learner must be an actual MultiHeadMLPLearner")
+    if type(state) is not MultiHeadMLPState:
+        raise TypeError("state must be an actual MultiHeadMLPState")
+    actual_obs_type = type(cast(object, observations))
+    if not (
+        actual_obs_type is np.ndarray
+        or isinstance(observations, (jax.Array, jax.core.Tracer))
+        or actual_obs_type is jax.ShapeDtypeStruct
+        or issubclass(actual_obs_type, jax.core.ShapedArray)
+    ):
+        raise TypeError("observations must be a trusted array")
+    actual_tgt_type = type(cast(object, targets))
+    if not (
+        actual_tgt_type is np.ndarray
+        or isinstance(targets, (jax.Array, jax.core.Tracer))
+        or actual_tgt_type is jax.ShapeDtypeStruct
+        or issubclass(actual_tgt_type, jax.core.ShapedArray)
+    ):
+        raise TypeError("targets must be a trusted array")
+
+    if observations.ndim != 2:
+        raise ValueError("observations must be 2-dimensional (num_steps, feature_dim)")
+    if targets.ndim != 2:
+        raise ValueError("targets must be 2-dimensional (num_steps, n_heads)")
+
+    try:
+        num_steps = int(observations.shape[0])
+        feature_dim = int(observations.shape[1])
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("observations must expose trusted shape metadata") from error
+
+    try:
+        targets_steps = int(targets.shape[0])
+        n_heads = int(targets.shape[1])
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("targets must expose trusted shape metadata") from error
+
+    if not 1 <= num_steps <= _INT32_MAX:
+        raise ValueError("observations must contain between 1 and signed-int32 steps")
+    if not 1 <= feature_dim <= _INT32_MAX:
+        raise ValueError("observations feature_dim must be positive and at most signed-int32")
+    if targets_steps != num_steps:
+        raise ValueError(
+            f"targets step count ({targets_steps}) must match observations ({num_steps})"
+        )
+    if n_heads != learner.n_heads:
+        raise ValueError(
+            f"targets head count ({n_heads}) must match learner.n_heads ({learner.n_heads})"
+        )
 
     def step_fn(
         carry: MultiHeadMLPState, inputs: tuple[Array, Array]
@@ -1639,7 +1689,71 @@ def run_multi_head_learning_loop_batched(
         ``BatchedMultiHeadResult`` with batched states and per-head metrics
         of shape ``(n_seeds, num_steps, n_heads, 3)``
     """
-    feature_dim = observations.shape[1]
+    if type(learner) is not MultiHeadMLPLearner:
+        raise TypeError("learner must be an actual MultiHeadMLPLearner")
+    actual_obs_type = type(cast(object, observations))
+    if not (
+        actual_obs_type is np.ndarray
+        or isinstance(observations, (jax.Array, jax.core.Tracer))
+        or actual_obs_type is jax.ShapeDtypeStruct
+        or issubclass(actual_obs_type, jax.core.ShapedArray)
+    ):
+        raise TypeError("observations must be a trusted array")
+    actual_tgt_type = type(cast(object, targets))
+    if not (
+        actual_tgt_type is np.ndarray
+        or isinstance(targets, (jax.Array, jax.core.Tracer))
+        or actual_tgt_type is jax.ShapeDtypeStruct
+        or issubclass(actual_tgt_type, jax.core.ShapedArray)
+    ):
+        raise TypeError("targets must be a trusted array")
+    actual_keys_type = type(cast(object, keys))
+    if not (
+        actual_keys_type is np.ndarray
+        or isinstance(keys, (jax.Array, jax.core.Tracer))
+        or actual_keys_type is jax.ShapeDtypeStruct
+        or issubclass(actual_keys_type, jax.core.ShapedArray)
+    ):
+        raise TypeError("keys must be a trusted array")
+
+    if observations.ndim != 2:
+        raise ValueError("observations must be 2-dimensional (num_steps, feature_dim)")
+    if targets.ndim != 2:
+        raise ValueError("targets must be 2-dimensional (num_steps, n_heads)")
+
+    try:
+        num_steps = int(observations.shape[0])
+        feature_dim = int(observations.shape[1])
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("observations must expose trusted shape metadata") from error
+
+    try:
+        targets_steps = int(targets.shape[0])
+        n_heads = int(targets.shape[1])
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("targets must expose trusted shape metadata") from error
+
+    if not 1 <= num_steps <= _INT32_MAX:
+        raise ValueError("observations must contain between 1 and signed-int32 steps")
+    if not 1 <= feature_dim <= _INT32_MAX:
+        raise ValueError("observations feature_dim must be positive and at most signed-int32")
+    if targets_steps != num_steps:
+        raise ValueError(
+            f"targets step count ({targets_steps}) must match observations ({num_steps})"
+        )
+    if n_heads != learner.n_heads:
+        raise ValueError(
+            f"targets head count ({n_heads}) must match learner.n_heads ({learner.n_heads})"
+        )
+
+    if keys.ndim not in (1, 2):
+        raise ValueError("keys must be rank-1 or rank-2 array of keys")
+    try:
+        n_seeds = int(keys.shape[0])
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("keys must expose trusted shape metadata") from error
+    if not 1 <= n_seeds <= _INT32_MAX:
+        raise ValueError("keys must contain between 1 and signed-int32 seeds")
 
     def single_run(key: Array) -> tuple[MultiHeadMLPState, Array, Array]:
         init_state = learner.init(feature_dim, key)

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -648,6 +648,27 @@ def run_stacked_horde_scan(
         ``(final_state, td_errors)`` with td_errors of shape
         ``(num_steps - 1, n_demons)``.
     """
+    if type(horde) is not StackedLinearHorde:
+        raise TypeError("horde must be an actual StackedLinearHorde")
+    if type(state) is not StackedHordeState:
+        raise TypeError("state must be an actual StackedHordeState")
+    actual_features_type = type(cast(object, features))
+    if not (
+        actual_features_type is np.ndarray
+        or isinstance(features, (jax.Array, jax.core.Tracer))
+        or actual_features_type is jax.ShapeDtypeStruct
+        or issubclass(actual_features_type, jax.core.ShapedArray)
+    ):
+        raise TypeError("features must be a trusted array")
+    actual_sources_type = type(cast(object, cumulant_sources))
+    if not (
+        actual_sources_type is np.ndarray
+        or isinstance(cumulant_sources, (jax.Array, jax.core.Tracer))
+        or actual_sources_type is jax.ShapeDtypeStruct
+        or issubclass(actual_sources_type, jax.core.ShapedArray)
+    ):
+        raise TypeError("cumulant_sources must be a trusted array")
+
     if features.ndim != 2:
         raise ValueError("features must be rank-two")
     if features.dtype != jnp.dtype(jnp.float32):
@@ -663,16 +684,31 @@ def run_stacked_horde_scan(
             f"cumulant_sources has {sources_shape[-1]} channels but "
             f"config.cumulant_indices requires index {max_index}"
         )
-    num_steps = features.shape[0]
+    try:
+        num_steps = int(features.shape[0])
+    except (AttributeError, IndexError, TypeError, ValueError) as error:
+        raise TypeError("features must expose trusted shape metadata") from error
+    _require_scan_result_resources(num_steps - 1, horde.config.n_demons)
+    if not 2 <= num_steps <= _INT32_MAX:
+        raise ValueError("features must contain between 2 and signed-int32 steps")
     if sources_shape[0] != num_steps:
         raise ValueError("features and cumulant_sources must have the same number of rows")
     if cumulant_sources.dtype != jnp.dtype(jnp.float32):
         raise TypeError("cumulant_sources must have dtype float32")
-    _require_scan_result_resources(max(num_steps - 1, 0), horde.config.n_demons)
-    if rhos is None:
-        rhos = jnp.ones((num_steps,), dtype=jnp.float32)
-    elif rhos.shape != (num_steps,):
-        raise ValueError("rhos must have shape (num_steps,)")
+    if rhos is not None:
+        actual_rhos_type = type(cast(object, rhos))
+        if not (
+            actual_rhos_type is np.ndarray
+            or isinstance(rhos, (jax.Array, jax.core.Tracer))
+            or actual_rhos_type is jax.ShapeDtypeStruct
+            or issubclass(actual_rhos_type, jax.core.ShapedArray)
+        ):
+            raise TypeError("rhos must be a trusted array")
+        if rhos.shape != (num_steps,):
+            raise ValueError("rhos must have shape (num_steps,)")
+        rhos_arr = rhos
+    else:
+        rhos_arr = jnp.ones((num_steps,), dtype=jnp.float32)
 
     def step_fn(
         carry: StackedHordeState,
@@ -685,6 +721,6 @@ def run_stacked_horde_scan(
     final_state, td_errors = jax.lax.scan(
         step_fn,
         state,
-        (features[:-1], features[1:], cumulant_sources[:-1], rhos[:-1]),
+        (features[:-1], features[1:], cumulant_sources[:-1], rhos_arr[:-1]),
     )
     return final_state, td_errors

--- a/tests/test_multi_head_stacked_horde_label_emnist_scan_bounds.py
+++ b/tests/test_multi_head_stacked_horde_label_emnist_scan_bounds.py
@@ -1,0 +1,403 @@
+"""Tests for scan sequence bounds and array dimension validation.
+
+Covers MultiHeadLearner, StackedHorde, and Label-permuted EMNIST.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.upgd_label_emnist import (
+    LabelEMNISTConfig,
+    LabelEMNISTRunResult,
+    build_schedule,
+    run_label_emnist,
+)
+from alberta_framework.core.multi_head_learner import (
+    BatchedMultiHeadResult,
+    MultiHeadLearningResult,
+    MultiHeadMLPLearner,
+    run_multi_head_learning_loop,
+    run_multi_head_learning_loop_batched,
+)
+from alberta_framework.core.stacked_horde import (
+    StackedHordeConfig,
+    StackedHordeState,
+    StackedLinearHorde,
+    run_stacked_horde_scan,
+)
+
+
+class _HostileArray:
+    """Object mimicking array interface with hostile behavior."""
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return (10, 4)
+
+    @property
+    def ndim(self) -> int:
+        return 2
+
+    @property
+    def dtype(self) -> object:
+        return jnp.float32
+
+
+class TestMultiHeadLearnerScanBounds:
+    def test_run_multi_head_learning_loop_rejects_non_learner(self) -> None:
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), sparsity=0.0)
+        state = learner.init(feature_dim=3, key=jr.key(0))
+        obs = jnp.ones((10, 3), dtype=jnp.float32)
+        tgt = jnp.ones((10, 2), dtype=jnp.float32)
+
+        with pytest.raises(TypeError, match="learner must be an actual MultiHeadMLPLearner"):
+            run_multi_head_learning_loop(
+                "not_a_learner",  # type: ignore[arg-type]
+                state,
+                obs,
+                tgt,
+            )
+
+    def test_run_multi_head_learning_loop_rejects_non_state(self) -> None:
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), sparsity=0.0)
+        obs = jnp.ones((10, 3), dtype=jnp.float32)
+        tgt = jnp.ones((10, 2), dtype=jnp.float32)
+
+        with pytest.raises(TypeError, match="state must be an actual MultiHeadMLPState"):
+            run_multi_head_learning_loop(
+                learner,
+                "not_a_state",  # type: ignore[arg-type]
+                obs,
+                tgt,
+            )
+
+    def test_run_multi_head_learning_loop_rejects_untrusted_arrays(self) -> None:
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), sparsity=0.0)
+        state = learner.init(feature_dim=4, key=jr.key(0))
+        tgt = jnp.ones((10, 2), dtype=jnp.float32)
+        obs = jnp.ones((10, 4), dtype=jnp.float32)
+
+        with pytest.raises(TypeError, match="observations must be a trusted array"):
+            run_multi_head_learning_loop(learner, state, _HostileArray(), tgt)  # type: ignore[arg-type]
+
+        with pytest.raises(TypeError, match="targets must be a trusted array"):
+            run_multi_head_learning_loop(learner, state, obs, _HostileArray())  # type: ignore[arg-type]
+
+    def test_run_multi_head_learning_loop_rejects_invalid_ranks(self) -> None:
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), sparsity=0.0)
+        state = learner.init(feature_dim=3, key=jr.key(0))
+
+        with pytest.raises(ValueError, match="observations must be 2-dimensional"):
+            run_multi_head_learning_loop(
+                learner,
+                state,
+                jnp.ones((10,), dtype=jnp.float32),
+                jnp.ones((10, 2), dtype=jnp.float32),
+            )
+
+        with pytest.raises(ValueError, match="targets must be 2-dimensional"):
+            run_multi_head_learning_loop(
+                learner,
+                state,
+                jnp.ones((10, 3), dtype=jnp.float32),
+                jnp.ones((10,), dtype=jnp.float32),
+            )
+
+    def test_run_multi_head_learning_loop_rejects_dimension_mismatches(self) -> None:
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), sparsity=0.0)
+        state = learner.init(feature_dim=3, key=jr.key(0))
+
+        with pytest.raises(ValueError, match="targets step count .* must match observations"):
+            run_multi_head_learning_loop(
+                learner,
+                state,
+                jnp.ones((10, 3), dtype=jnp.float32),
+                jnp.ones((5, 2), dtype=jnp.float32),
+            )
+
+        with pytest.raises(ValueError, match="targets head count .* must match learner.n_heads"):
+            run_multi_head_learning_loop(
+                learner,
+                state,
+                jnp.ones((10, 3), dtype=jnp.float32),
+                jnp.ones((10, 4), dtype=jnp.float32),
+            )
+
+    def test_run_multi_head_learning_loop_rejects_empty_steps(self) -> None:
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), sparsity=0.0)
+        state = learner.init(feature_dim=3, key=jr.key(0))
+
+        with pytest.raises(
+            ValueError, match="observations must contain between 1 and signed-int32 steps"
+        ):
+            run_multi_head_learning_loop(
+                learner,
+                state,
+                jnp.ones((0, 3), dtype=jnp.float32),
+                jnp.ones((0, 2), dtype=jnp.float32),
+            )
+
+    def test_run_multi_head_learning_loop_batched_validations(self) -> None:
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), sparsity=0.0)
+        obs = jnp.ones((10, 3), dtype=jnp.float32)
+        tgt = jnp.ones((10, 2), dtype=jnp.float32)
+        keys = jr.split(jr.key(0), 4)
+
+        with pytest.raises(TypeError, match="learner must be an actual MultiHeadMLPLearner"):
+            run_multi_head_learning_loop_batched(
+                "not_a_learner",  # type: ignore[arg-type]
+                obs,
+                tgt,
+                keys,
+            )
+
+        with pytest.raises(TypeError, match="keys must be a trusted array"):
+            run_multi_head_learning_loop_batched(
+                learner, obs, tgt, _HostileArray()  # type: ignore[arg-type]
+            )
+
+        with pytest.raises(ValueError, match="keys must be rank-1 or rank-2 array"):
+            run_multi_head_learning_loop_batched(
+                learner,
+                obs,
+                tgt,
+                jnp.ones((2, 2, 2), dtype=jnp.uint32),
+            )
+
+        with pytest.raises(ValueError, match="keys must contain between 1 and signed-int32 seeds"):
+            run_multi_head_learning_loop_batched(
+                learner,
+                obs,
+                tgt,
+                jnp.ones((0, 2), dtype=jnp.uint32),
+            )
+
+    def test_run_multi_head_learning_loop_success(self) -> None:
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), sparsity=0.0)
+        state = learner.init(feature_dim=3, key=jr.key(0))
+        obs = jnp.ones((5, 3), dtype=jnp.float32)
+        tgt = jnp.ones((5, 2), dtype=jnp.float32)
+
+        res = run_multi_head_learning_loop(learner, state, obs, tgt)
+        assert isinstance(res, MultiHeadLearningResult)
+        assert res.per_head_metrics.shape == (5, 2, 3)
+
+        keys = jr.split(jr.key(0), 3)
+        batched_res = run_multi_head_learning_loop_batched(learner, obs, tgt, keys)
+        assert isinstance(batched_res, BatchedMultiHeadResult)
+        assert batched_res.per_head_metrics.shape == (3, 5, 2, 3)
+
+
+class TestStackedHordeScanBounds:
+    def test_run_stacked_horde_scan_rejects_non_components(self) -> None:
+        cfg = StackedHordeConfig(
+            n_demons=2,
+            feature_dim=3,
+            gammas=(0.9, 0.9),
+            lamdas=(0.5, 0.5),
+            cumulant_indices=(0, 1),
+            step_size=0.1,
+        )
+        horde = StackedLinearHorde(cfg)
+        state = horde.init()
+        features = jnp.ones((5, 3), dtype=jnp.float32)
+        sources = jnp.ones((5, 2), dtype=jnp.float32)
+
+        with pytest.raises(TypeError, match="horde must be an actual StackedLinearHorde"):
+            run_stacked_horde_scan("not_a_horde", state, features, sources)  # type: ignore[arg-type]
+
+        with pytest.raises(TypeError, match="state must be an actual StackedHordeState"):
+            run_stacked_horde_scan(horde, "not_a_state", features, sources)  # type: ignore[arg-type]
+
+    def test_run_stacked_horde_scan_rejects_untrusted_arrays(self) -> None:
+        cfg = StackedHordeConfig(
+            n_demons=2,
+            feature_dim=4,
+            gammas=(0.9, 0.9),
+            lamdas=(0.5, 0.5),
+            cumulant_indices=(0, 1),
+            step_size=0.1,
+        )
+        horde = StackedLinearHorde(cfg)
+        state = horde.init()
+        features = jnp.ones((5, 4), dtype=jnp.float32)
+        sources = jnp.ones((5, 2), dtype=jnp.float32)
+
+        with pytest.raises(TypeError, match="features must be a trusted array"):
+            run_stacked_horde_scan(horde, state, _HostileArray(), sources)  # type: ignore[arg-type]
+
+        with pytest.raises(TypeError, match="cumulant_sources must be a trusted array"):
+            run_stacked_horde_scan(horde, state, features, _HostileArray())  # type: ignore[arg-type]
+
+        with pytest.raises(TypeError, match="rhos must be a trusted array"):
+            run_stacked_horde_scan(
+                horde,
+                state,
+                features,
+                sources,
+                rhos=_HostileArray(),  # type: ignore[arg-type]
+            )
+
+    def test_run_stacked_horde_scan_rejects_insufficient_steps(self) -> None:
+        cfg = StackedHordeConfig(
+            n_demons=2,
+            feature_dim=3,
+            gammas=(0.9, 0.9),
+            lamdas=(0.5, 0.5),
+            cumulant_indices=(0, 1),
+            step_size=0.1,
+        )
+        horde = StackedLinearHorde(cfg)
+        state = horde.init()
+
+        with pytest.raises(
+            ValueError, match="features must contain between 2 and signed-int32 steps"
+        ):
+            run_stacked_horde_scan(
+                horde,
+                state,
+                jnp.ones((1, 3), dtype=jnp.float32),
+                jnp.ones((1, 2), dtype=jnp.float32),
+            )
+
+        with pytest.raises(
+            ValueError, match="features must contain between 2 and signed-int32 steps"
+        ):
+            run_stacked_horde_scan(
+                horde,
+                state,
+                jnp.ones((0, 3), dtype=jnp.float32),
+                jnp.ones((0, 2), dtype=jnp.float32),
+            )
+
+    def test_run_stacked_horde_scan_rejects_mismatched_rows(self) -> None:
+        cfg = StackedHordeConfig(
+            n_demons=2,
+            feature_dim=3,
+            gammas=(0.9, 0.9),
+            lamdas=(0.5, 0.5),
+            cumulant_indices=(0, 1),
+            step_size=0.1,
+        )
+        horde = StackedLinearHorde(cfg)
+        state = horde.init()
+
+        with pytest.raises(
+            ValueError, match="features and cumulant_sources must have the same number of rows"
+        ):
+            run_stacked_horde_scan(
+                horde,
+                state,
+                jnp.ones((5, 3), dtype=jnp.float32),
+                jnp.ones((3, 2), dtype=jnp.float32),
+            )
+
+    def test_run_stacked_horde_scan_rejects_invalid_rhos_shape(self) -> None:
+        cfg = StackedHordeConfig(
+            n_demons=2,
+            feature_dim=3,
+            gammas=(0.9, 0.9),
+            lamdas=(0.5, 0.5),
+            cumulant_indices=(0, 1),
+            step_size=0.1,
+        )
+        horde = StackedLinearHorde(cfg)
+        state = horde.init()
+
+        with pytest.raises(ValueError, match=r"rhos must have shape \(num_steps,\)"):
+            run_stacked_horde_scan(
+                horde,
+                state,
+                jnp.ones((5, 3), dtype=jnp.float32),
+                jnp.ones((5, 2), dtype=jnp.float32),
+                rhos=jnp.ones((3,), dtype=jnp.float32),
+            )
+
+    def test_run_stacked_horde_scan_success(self) -> None:
+        cfg = StackedHordeConfig(
+            n_demons=2,
+            feature_dim=3,
+            gammas=(0.9, 0.9),
+            lamdas=(0.5, 0.5),
+            cumulant_indices=(0, 1),
+            step_size=0.1,
+        )
+        horde = StackedLinearHorde(cfg)
+        state = horde.init()
+        features = jnp.ones((5, 3), dtype=jnp.float32)
+        sources = jnp.ones((5, 2), dtype=jnp.float32)
+
+        final_state, td_errors = run_stacked_horde_scan(horde, state, features, sources)
+        assert isinstance(final_state, StackedHordeState)
+        assert td_errors.shape == (4, 2)
+
+
+class TestLabelEMNISTScanBounds:
+    def test_build_schedule_rejects_non_config(self) -> None:
+        with pytest.raises(TypeError, match="config must be an exact LabelEMNISTConfig"):
+            build_schedule(jr.key(0), "not_a_config", 100)  # type: ignore[arg-type]
+
+    def test_build_schedule_rejects_non_int_n_train(self) -> None:
+        config = LabelEMNISTConfig(n_tasks=2, task_length=4, n_classes=3)
+        with pytest.raises(TypeError, match="n_train must be an exact built-in int"):
+            build_schedule(jr.key(0), config, "100")  # type: ignore[arg-type]
+
+    def test_build_schedule_rejects_invalid_n_train(self) -> None:
+        config = LabelEMNISTConfig(n_tasks=2, task_length=4, n_classes=3)
+        with pytest.raises(ValueError, match="n_train must be positive and at most signed-int32"):
+            build_schedule(jr.key(0), config, 0)
+
+        with pytest.raises(ValueError, match="n_train=2 is smaller than task_length=4"):
+            build_schedule(jr.key(0), config, 2)
+
+    def test_run_label_emnist_rejects_invalid_config_type(self) -> None:
+        data_x = np.ones((50, 6), dtype=np.float32)
+        data_y = np.zeros((50,), dtype=np.int32)
+        with pytest.raises(TypeError, match="config must be an exact LabelEMNISTConfig or None"):
+            run_label_emnist(
+                data_x,
+                data_y,
+                "upgd_w",
+                [0],
+                config="not_a_config",  # type: ignore[arg-type]
+            )
+
+    def test_run_label_emnist_rejects_invalid_return_per_step(self) -> None:
+        data_x = np.ones((50, 6), dtype=np.float32)
+        data_y = np.zeros((50,), dtype=np.int32)
+        with pytest.raises(TypeError, match="return_per_step must be a boolean"):
+            run_label_emnist(
+                data_x,
+                data_y,
+                "upgd_w",
+                [0],
+                return_per_step="yes",  # type: ignore[arg-type]
+            )
+
+    def test_run_label_emnist_valid_execution(self) -> None:
+        config = LabelEMNISTConfig(
+            n_tasks=2,
+            task_length=4,
+            input_dim=6,
+            hidden1=4,
+            hidden2=4,
+            n_classes=3,
+        )
+        rng = np.random.default_rng(0)
+        data_x = rng.standard_normal((20, 6)).astype(np.float32)
+        data_y = rng.integers(0, 3, size=20).astype(np.int32)
+
+        res = run_label_emnist(
+            data_x,
+            data_y,
+            "upgd_w",
+            [0],
+            config=config,
+            return_per_step=True,
+        )
+        assert isinstance(res, LabelEMNISTRunResult)
+        assert res.per_task_accuracy.shape == (1, 2)


### PR DESCRIPTION
## Summary

Validates component types, trusted array metadata, shape dimensions, and scan sequence bounds across `MultiHeadLearner`, `StackedHorde`, and `LabelEMNIST`:

1. **`alberta_framework.core.multi_head_learner`**:
   - `run_multi_head_learning_loop`: Validates `MultiHeadMLPLearner` and `MultiHeadMLPState` component identities, trusted array types (`np.ndarray`, `jax.Array`, `jax.core.Tracer`, `jax.ShapeDtypeStruct`, `jax.core.ShapedArray`), 2D ranks, sequence bounds `1 <= num_steps <= 2**31 - 1`, positive `feature_dim`, and matching `targets` row and head counts.
   - `run_multi_head_learning_loop_batched`: Validates `MultiHeadMLPLearner`, trusted keys array, keys rank `1 <= ndim <= 2`, and `1 <= n_seeds <= 2**31 - 1` before dispatching `jax.vmap`.

2. **`alberta_framework.core.stacked_horde`**:
   - `run_stacked_horde_scan`: Validates `StackedLinearHorde` and `StackedHordeState` component identities, trusted array types for `features`, `cumulant_sources`, and optional `rhos`, transition sequence length bounds `2 <= num_steps <= 2**31 - 1`, matching row counts, and `rhos` shape.

3. **`alberta_framework.benchmarks.upgd_label_emnist`**:
   - `build_schedule`: Validates `LabelEMNISTConfig` identity, exact built-in int `1 <= n_train <= 2**31 - 1`, and `n_train >= config.task_length` before schedule generation.
   - `run_label_emnist`: Validates exact `LabelEMNISTConfig` and built-in `bool` for `return_per_step`.

4. **Testing**:
   - Added unit test suite in `tests/test_multi_head_stacked_horde_label_emnist_scan_bounds.py` covering hostile/invalid inputs, shape mismatches, boundary conditions, and successful execution paths.

## Verification

```bash
.venv/bin/python -m pytest tests/test_multi_head_stacked_horde_label_emnist_scan_bounds.py tests/test_multi_head_learner.py tests/test_stacked_horde.py tests/test_upgd_label_emnist.py -q
.venv/bin/python -m ruff check alberta_framework/core/multi_head_learner.py alberta_framework/core/stacked_horde.py alberta_framework/benchmarks/upgd_label_emnist.py tests/test_multi_head_stacked_horde_label_emnist_scan_bounds.py
.venv/bin/python -m mypy alberta_framework/core/multi_head_learner.py alberta_framework/core/stacked_horde.py alberta_framework/benchmarks/upgd_label_emnist.py tests/test_multi_head_stacked_horde_label_emnist_scan_bounds.py
git diff --check
```

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: Google Gemini
<!-- attribution-row:client -->
- Agent tooling: Antigravity CLI (agy)
<!-- attribution-row:status -->
- Provenance status: self-reported

## Measured project receipt
Post-hoc receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F842YGGKCQ5Y1KG0QZ48F8","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T09:30:34.320Z","completed_at":"2026-08-20T09:39:48.708Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T09:30:36.435Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2f75f52ac9b17356efcb01b269f77248f5918daa184f0796adff7fd23873843c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3732beaf-1d74-49c0-b679-38611ee0c12a","object_id":"sha256:2f75f52ac9b17356efcb01b269f77248f5918daa184f0796adff7fd23873843c","sha256":"2f75f52ac9b17356efcb01b269f77248f5918daa184f0796adff7fd23873843c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"ZGd5-1dmaY4a9nHdBp1uZ2sn9X2nGr_jhLpeOaZAtx4CDyUNCqp14aQ0CzUJELYRwS_Q3fp2FLMiBjC1nEDWAA"}} -->
