### PR TITLE
fix(core): reject deep SIGReg host arrays before RecursionError

### DIFF
--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -39,6 +39,8 @@ from jaxtyping import Float
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 _INT32_MAX = 2**31 - 1
+# Origin ``jnp.asarray`` still accepts depth 64 and RecursionErrors at 10_000.
+_MAX_ARRAY_NESTING_DEPTH = 64
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -237,6 +239,43 @@ def _validated_kernel_width(kernel_width: float | Array) -> Array:
     return _runtime_checked_value(width, predicate, _KERNEL_WIDTH_ERROR)
 
 
+def _require_host_array_nesting(value: object, *, name: str) -> None:
+    """Reject cycles and nesting that RecursionError ``jnp.asarray``."""
+    if type(value) not in (list, tuple):
+        return
+    frames: list[tuple[object, int, int]] = [(value, 1, 0)]
+    ancestors = {id(value)}
+    while frames:
+        node, depth, index = frames[-1]
+        if depth > _MAX_ARRAY_NESTING_DEPTH:
+            raise ValueError(f"{name} exceeds the maximum host array nesting depth")
+        kids = cast(list[Any] | tuple[Any, ...], node)
+        if index >= len(kids):
+            frames.pop()
+            ancestors.discard(id(node))
+            continue
+        child = kids[index]
+        frames[-1] = (node, depth, index + 1)
+        if type(child) not in (list, tuple):
+            continue
+        child_id = id(child)
+        if child_id in ancestors:
+            raise ValueError(f"{name} contains a cyclic host array")
+        child_depth = depth + 1
+        if child_depth > _MAX_ARRAY_NESTING_DEPTH:
+            raise ValueError(f"{name} exceeds the maximum host array nesting depth")
+        ancestors.add(child_id)
+        frames.append((child, child_depth, 0))
+
+
+def _asarray_float32(value: object, *, name: str) -> Array:
+    _require_host_array_nesting(value, name=name)
+    try:
+        return jnp.asarray(value, dtype=jnp.float32)
+    except RecursionError as exc:
+        raise ValueError(f"{name} exceeds the maximum host array nesting depth") from exc
+
+
 def _require_finite_array(values: Array, message: str) -> Array:
     """Reject non-finite coordinates without rewriting them to a fake zero."""
     array = jnp.asarray(values)
@@ -252,8 +291,8 @@ def _preflight_projected_statistic(
     embeddings: Array,
     directions: Array,
 ) -> tuple[Array, Array, int, int]:
-    z = jnp.asarray(embeddings, dtype=jnp.float32)
-    dirs = jnp.asarray(directions, dtype=jnp.float32)
+    z = _asarray_float32(embeddings, name="embeddings")
+    dirs = _asarray_float32(directions, name="directions")
     if z.ndim < 2:
         raise ValueError("embeddings must have shape (..., latent_dim)")
     if dirs.ndim != 2 or dirs.shape[0] < 1 or dirs.shape[1] != z.shape[-1]:
@@ -327,8 +366,8 @@ def epps_pulley_gaussian_statistic(
     eager values raise :class:`ValueError`; invalid compiled values raise a
     :class:`jax.errors.JaxRuntimeError` when the result is synchronized.
     """
+    flattened = jnp.ravel(_asarray_float32(samples, name="samples"))
     width = _validated_kernel_width(kernel_width)
-    flattened = jnp.ravel(jnp.asarray(samples, dtype=jnp.float32))
     if flattened.size < 1:
         raise ValueError("samples must be non-empty")
     _require_float32_resource(

--- a/tests/test_sigreg_host_array_depth.py
+++ b/tests/test_sigreg_host_array_depth.py
@@ -1,0 +1,85 @@
+"""Reject deep or cyclic host arrays before jnp.asarray RecursionError."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.sigreg import (
+    _MAX_ARRAY_NESTING_DEPTH,
+    _asarray_float32,
+    epps_pulley_gaussian_statistic,
+)
+
+
+def _nested_list(depth: int, leaf: Any = 1.0) -> Any:
+    value: Any = leaf
+    for _ in range(depth):
+        value = [value]
+    return value
+
+
+def test_deep_samples_never_reach_asarray(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def spy(value: object, dtype: object = None) -> Any:
+        calls.append(1)
+        raise AssertionError("jnp.asarray must not run on overflow nests")
+
+    monkeypatch.setattr("alberta_framework.core.sigreg.jnp.asarray", spy)
+    with pytest.raises(ValueError, match="nesting depth"):
+        epps_pulley_gaussian_statistic(cast(Any, _nested_list(10_000)))
+    assert calls == []
+
+
+def test_last_fit_list_nesting_still_converts() -> None:
+    array = _asarray_float32(_nested_list(_MAX_ARRAY_NESTING_DEPTH), name="samples")
+    assert array.shape == (1,) * _MAX_ARRAY_NESTING_DEPTH
+    assert bool(jnp.isfinite(epps_pulley_gaussian_statistic(array)))
+
+
+def test_first_overflow_rejects_before_asarray(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def spy(value: object, dtype: object = None) -> Any:
+        calls.append(1)
+        raise AssertionError("jnp.asarray must not run on overflow nests")
+
+    monkeypatch.setattr("alberta_framework.core.sigreg.jnp.asarray", spy)
+    with pytest.raises(ValueError, match="nesting depth"):
+        epps_pulley_gaussian_statistic(cast(Any, _nested_list(_MAX_ARRAY_NESTING_DEPTH + 1)))
+    assert calls == []
+
+
+def test_cyclic_list_rejects_before_asarray(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def spy(value: object, dtype: object = None) -> Any:
+        calls.append(1)
+        raise AssertionError("jnp.asarray must not run on cyclic host arrays")
+
+    monkeypatch.setattr("alberta_framework.core.sigreg.jnp.asarray", spy)
+    cyclic: list[Any] = []
+    cyclic.append(cyclic)
+    with pytest.raises(ValueError, match="cyclic host array"):
+        epps_pulley_gaussian_statistic(cast(Any, cyclic))
+    assert calls == []
+
+
+def test_vector_samples_still_compute() -> None:
+    samples = jnp.ones((32,), dtype=jnp.float32)
+    assert bool(jnp.isfinite(epps_pulley_gaussian_statistic(samples)))
+
+
+def test_recursionerror_from_asarray_is_valueerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(value: object, dtype: object = None) -> Any:
+        del value, dtype
+        raise RecursionError("simulated host-array overflow")
+
+    monkeypatch.setattr("alberta_framework.core.sigreg.jnp.asarray", boom)
+    with pytest.raises(ValueError, match="nesting depth"):
+        _asarray_float32(1.0, name="samples")


### PR DESCRIPTION
## Summary

Occupancy-FREE complete RecursionError hang on `origin/main` `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`.

`epps_pulley_gaussian_statistic` called `jnp.asarray(samples)` before any rank or resource gate. A 10_000-deep list nest and a cyclic list RecursionError:

```text
epps_pulley_gaussian_statistic([[[[... 1.0 ...]]]] * 10000) -> RecursionError
epps_pulley_gaussian_statistic(cyclic list) -> RecursionError
```

Non-scan (not `jax.lax.scan` / `jnp.arange` T). Non-leftover persist/INT32/256 MiB — the crash is before the existing pairwise INT32 preflight. Not `#2005` / `#1989` scan-T (snipe `#2039` owns those hosts). Not `#2037` `jax.tree.leaves`. Not `#2036` JSON `json.loads` nest. Not `#1874` / forager / clocks / IA / FTL.

## Expected behavior

Host list/tuple nests of depth `<= 64` still convert. Depth `65`, the origin hang-class `10_000`, and cyclic lists raise `ValueError` (`nesting depth` / `cyclic host array`) and never call `jnp.asarray`. Ordinary 1-d float32 sample vectors still compute.

## Scope

- `alberta_framework/core/sigreg.py`
- `tests/test_sigreg_host_array_depth.py`

## Verification

```text
# red on origin/main ec035f73
epps_pulley_gaussian_statistic(10000-deep list) -> RecursionError
epps_pulley_gaussian_statistic(cyclic list) -> RecursionError

# green at this head
.venv/bin/python -m pytest tests/test_sigreg_host_array_depth.py tests/test_sigreg.py -q
# 52 passed
.venv/bin/python -m ruff check alberta_framework/core/sigreg.py tests/test_sigreg_host_array_depth.py
.venv/bin/python -m mypy alberta_framework/core/sigreg.py tests/test_sigreg_host_array_depth.py
```

<!-- evidence-head:1da3a0e0201456bf7ce267145a67ff1aa37952db -->
<!-- evidence-row:logs -->
- [x] logs: origin `ec035f73` RecursionError'd 10_000-deep and cyclic SIGReg host arrays; this head raises ValueError before jnp.asarray; 52 focused tests passed
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - protocol host-array RecursionError preflight, no IPMNIST shard
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - local fail-before-RecursionError proof, no model-trajectory artifact

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
