### PR TITLE
fix(benchmarks): cap rule-discovery search ints before hang

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery.py
+++ b/alberta_framework/benchmarks/rule_discovery.py
@@ -868,11 +868,18 @@ def _require_unique_task_names(task_names: Sequence[str], *, name: str) -> tuple
     return names
 
 
+# CLI last-fit is `--n-random 3072`. `10**12` still reaches
+# `random_genomes(key, n)` as shape `(n, GENOME_SIZE)` float32.
+_MAX_SEARCH_INT = 1_000_000
+
+
 def _require_search_int(name: str, value: object, *, minimum: int) -> int:
     if type(name) is not str:
         raise ValueError("name must be an exact string")
     if type(value) is not int or value < minimum:
         raise ValueError(f"{name} must be an integer >= {minimum}")
+    if value > _MAX_SEARCH_INT:
+        raise ValueError(f"{name} exceeds the search integer limit")
     return value
 
 

--- a/tests/test_rule_discovery_search_int_hang.py
+++ b/tests/test_rule_discovery_search_int_hang.py
@@ -1,0 +1,83 @@
+"""Reject unbounded rule-discovery search ints before genome/stream allocation."""
+
+from __future__ import annotations
+
+import jax.random as jr
+import pytest
+
+import alberta_framework.benchmarks.rule_discovery as rule_discovery
+from alberta_framework.benchmarks.micro_continual import MICRO_SUITE
+from alberta_framework.benchmarks.rule_discovery import (
+    _require_search_int,
+    run_search,
+    tune_champion_baseline,
+)
+
+pytestmark = pytest.mark.unit
+
+_OVERFLOW_SEARCH_INT = 10**12
+_SEARCH_INT_LIMIT = 1_000_000
+
+
+def test_require_search_int_rejects_trillion_n_random() -> None:
+    with pytest.raises(ValueError, match="n_random"):
+        _require_search_int("n_random", _OVERFLOW_SEARCH_INT, minimum=0)
+
+
+def test_require_search_int_rejects_first_overflow_int() -> None:
+    with pytest.raises(ValueError, match="search integer limit"):
+        _require_search_int("generations", _SEARCH_INT_LIMIT + 1, minimum=0)
+
+
+def test_require_search_int_last_fit_still_accepted() -> None:
+    assert _require_search_int("n_random", _SEARCH_INT_LIMIT, minimum=0) == _SEARCH_INT_LIMIT
+    assert _require_search_int("n_random", 0, minimum=0) == 0
+    assert _require_search_int("population", 3072, minimum=1) == 3072
+
+
+def test_run_search_rejects_trillion_n_random_before_genome_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_generation(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("overflow n_random reached genome generation")
+
+    monkeypatch.setattr(rule_discovery, "seed_genomes", unexpected_generation)
+    monkeypatch.setattr(rule_discovery, "random_genomes", unexpected_generation)
+    with pytest.raises(ValueError, match="n_random"):
+        run_search(
+            n_random=_OVERFLOW_SEARCH_INT,
+            population=2,
+            generations=0,
+            elite=1,
+            eval_seeds=(0,),
+            holdout_seeds=(101,),
+            top_k=1,
+            batch_size=2,
+        )
+
+
+def test_resolved_suite_rejects_trillion_task_length() -> None:
+    with pytest.raises(ValueError, match="task_length"):
+        rule_discovery._resolved_suite(None, _OVERFLOW_SEARCH_INT)
+
+
+def test_tune_champion_baseline_rejects_trillion_generations_before_genomes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_generation(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("overflow generations reached genome generation")
+
+    monkeypatch.setattr(rule_discovery, "random_genomes", unexpected_generation)
+    with pytest.raises(ValueError, match="generations"):
+        tune_champion_baseline(
+            jr.key(0),
+            task_names=("M1",),
+            eval_seeds=(0,),
+            batch_size=2,
+            suite=MICRO_SUITE,
+            n_random=2,
+            generations=_OVERFLOW_SEARCH_INT,
+            children=1,
+        )


### PR DESCRIPTION
## Summary

Occupancy-FREE complete hang on `origin/main` `ec035f73ad8e1e0545155e94c3e689d4b8d5d82b`.

`_require_search_int` was type-exact with a minimum and **no maximum**. Public `run_search` / CLI `--n-random` fed that int into `random_genomes(key, n)` as shape `(n, GENOME_SIZE)` float32 (`GENOME_SIZE=33`). `tune_champion_baseline` does the same, then `range(generations)`.

```text
# red on origin/main ec035f73
_require_search_int("n_random", 10**12, minimum=0) == 1000000000000
# 10**12 * 33 * 4 = 132_000_000_000_000 bytes
run_search(n_random=10**12, ...) reached seed_genomes / random_genomes
```

That is the hang/OOM class. Public last-fit is CLI `--n-random 3072`. This PR rejects `1_000_001` and `10**12` rather than blessing leftover INT32 persist.

Not `#1874` (`rule_discovery_summary.py` only). Not clocks / forager / IA / FTL. Not `#2005` / `#1989` / JSON-nest / jax.tree / SIGReg nest.

## Expected behavior

Search ints in `[minimum, 1_000_000]` still pass. `10**12` and `1_000_001` raise `ValueError` matching `exceeds the search integer limit` before `random_genomes` / stream materialization.

## Scope

- `alberta_framework/benchmarks/rule_discovery.py`
- `tests/test_rule_discovery_search_int_hang.py`

## Verification

```text
# red on origin/main ec035f73
_require_search_int("n_random", 10**12, minimum=0) == 1000000000000

# green at this head
.venv/bin/python -m pytest tests/test_rule_discovery_search_int_hang.py tests/test_rule_discovery_hostile_validation.py tests/test_rule_discovery.py -q -o addopts=""
# 87 passed
.venv/bin/python -m ruff check alberta_framework/benchmarks/rule_discovery.py tests/test_rule_discovery_search_int_hang.py
.venv/bin/python -m mypy alberta_framework/benchmarks/rule_discovery.py tests/test_rule_discovery_search_int_hang.py
```

<!-- evidence-head:98b2c5a1aebaace0b5f3e91626fc11316f0817f0 -->
<!-- evidence-row:logs -->
- [x] logs: origin `ec035f73` `_require_search_int("n_random", 10**12)` returned `1000000000000` and `run_search` reached genome generation; this head rejects `10**12` / `1_000_001` before `random_genomes`; 6 hang tests + 81 existing rule-discovery tests passed (87)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - search-int hang preflight, no IPMNIST shard
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - local fail-before-allocation proof, no model-trajectory artifact

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
