### PR TITLE
fix(core): cap compositional-feature scan lengths before arange hang

### DIFF
--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -55,6 +55,9 @@ from alberta_framework.core.update_safety import (
 )
 
 _INT32_MAX = 2**31 - 1
+# Public last-fit in tests is 600 array steps. Origin handed ``10**12`` to
+# ``jnp.arange`` with no reject — hang/OOM, not an INT32 leftover.
+_COMPOSITIONAL_LOOP_MAX_STEPS = 10_000
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -82,6 +85,31 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     if not minimum <= canonical <= maximum:
         raise ValueError(f"{name} must be an integer in [{minimum}, {maximum}]")
     return canonical
+
+
+def _require_compositional_loop_steps(name: str, value: object) -> int:
+    """Reject scan lengths above the public last-fit before ``jnp.arange``."""
+    if type(value) is not int or value < 1 or value > _COMPOSITIONAL_LOOP_MAX_STEPS:
+        raise ValueError(
+            f"{name} must be an integer in [1, {_COMPOSITIONAL_LOOP_MAX_STEPS}]"
+        )
+    return value
+
+
+def _require_compositional_array_steps(observations: object, targets: object) -> int:
+    """Reject pre-collected scan lengths above the public last-fit before scan."""
+    if not isinstance(observations, jax.Array) or not isinstance(targets, jax.Array):
+        raise TypeError("observations and targets must be JAX arrays")
+    if observations.ndim != 2 or targets.ndim != 2:
+        raise ValueError("observations and targets must be rank-2")
+    num_steps = observations.shape[0]
+    if type(num_steps) is not int or num_steps < 1 or num_steps > _COMPOSITIONAL_LOOP_MAX_STEPS:
+        raise ValueError(
+            f"observations num_steps must be an integer in [1, {_COMPOSITIONAL_LOOP_MAX_STEPS}]"
+        )
+    if targets.shape[0] != num_steps:
+        raise ValueError("observations and targets must share num_steps")
+    return num_steps
 
 
 def _require_choice(name: str, value: object, choices: frozenset[str]) -> str:
@@ -4733,7 +4761,14 @@ def run_compositional_arrays(
     observations: Array,
     targets: Array,
 ) -> CompositionalFeatureLearningResult:
-    """Run a compositional learner over pre-collected stream arrays."""
+    """Run a compositional learner over pre-collected stream arrays.
+
+    Raises:
+        TypeError: If ``observations`` or ``targets`` is not a JAX array.
+        ValueError: If ``num_steps`` is not an exact integer in
+            ``[1, 10_000]``.
+    """
+    _require_compositional_array_steps(observations, targets)
 
     def step_fn(
         carry: CompositionalFeatureState,
@@ -4763,7 +4798,13 @@ def run_compositional_loop(
     key: Array,
     learner_state: CompositionalFeatureState | None = None,
 ) -> CompositionalFeatureLearningResult:
-    """Run compositional feature discovery directly from a scan-compatible stream."""
+    """Run compositional feature discovery directly from a scan-compatible stream.
+
+    Raises:
+        ValueError: If ``num_steps`` exceeds the documented protocol ceiling
+            (``10_000``).
+    """
+    num_steps = _require_compositional_loop_steps("num_steps", num_steps)
     stream_key, learner_key = jr.split(key)
     stream_state = stream.init(stream_key)
     if learner_state is None:

--- a/tests/test_compositional_loop_steps.py
+++ b/tests/test_compositional_loop_steps.py
@@ -1,0 +1,152 @@
+"""Protocol step ceilings for public compositional-feature scans.
+
+Documented last-fit in tests is ``num_steps=600`` for arrays. Origin handed
+``10**12`` to ``jnp.arange`` with no reject — hang/OOM, not an INT32 leftover.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.compositional_features import (
+    _COMPOSITIONAL_LOOP_MAX_STEPS,
+    _require_compositional_array_steps,
+    _require_compositional_loop_steps,
+    run_compositional_arrays,
+    run_compositional_loop,
+)
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:  # pragma: no cover
+        raise AssertionError("index hook executed")
+
+    def __int__(self) -> int:  # pragma: no cover
+        raise AssertionError("int hook executed")
+
+
+class _HostileArrays:
+    calls = 0
+
+    @property
+    def ndim(self) -> Any:
+        type(self).calls += 1
+        raise AssertionError("ndim hook executed")
+
+    @property
+    def shape(self) -> Any:
+        type(self).calls += 1
+        raise AssertionError("shape hook executed")
+
+
+def _spy_arange(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    seen: list[object] = []
+
+    def spy(*args: object, **kwargs: object) -> Any:
+        seen.append((args, kwargs))
+        raise AssertionError(f"jnp.arange must not run: {args} {kwargs}")
+
+    monkeypatch.setattr("alberta_framework.core.compositional_features.jnp.arange", spy)
+    return seen
+
+
+def _spy_scan(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    seen: list[object] = []
+
+    def spy(*args: object, **kwargs: object) -> Any:
+        seen.append((args, kwargs))
+        raise AssertionError(f"jax.lax.scan must not run: {args} {kwargs}")
+
+    monkeypatch.setattr("alberta_framework.core.compositional_features.jax.lax.scan", spy)
+    return seen
+
+
+def test_documented_protocol_ceiling() -> None:
+    assert _COMPOSITIONAL_LOOP_MAX_STEPS == 10_000
+
+
+def test_last_fit_protocol_step_count_is_accepted() -> None:
+    assert _require_compositional_loop_steps("num_steps", _COMPOSITIONAL_LOOP_MAX_STEPS) == 10_000
+
+
+def test_trillion_steps_rejected_before_arange(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        run_compositional_loop(
+            cast(Any, object()),
+            cast(Any, object()),
+            10**12,
+            jr.key(0),
+        )
+    assert seen == []
+
+
+def test_int32_max_steps_rejected_before_arange(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        run_compositional_loop(
+            cast(Any, object()),
+            cast(Any, object()),
+            2**31 - 1,
+            jr.key(0),
+        )
+    assert seen == []
+
+
+def test_first_overflow_rejected_before_arange(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _spy_arange(monkeypatch)
+    with pytest.raises(ValueError, match=r"num_steps must be an integer in \[1, 10000\]"):
+        run_compositional_loop(
+            cast(Any, object()),
+            cast(Any, object()),
+            _COMPOSITIONAL_LOOP_MAX_STEPS + 1,
+            jr.key(0),
+        )
+    assert seen == []
+
+
+@pytest.mark.parametrize("value", [True, False, 0, -1, 1.0, 10_000.0])
+def test_rejects_non_exact_or_non_positive_step_counts(value: object) -> None:
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_compositional_loop_steps("num_steps", value)
+
+
+def test_rejects_numpy_and_subclass_step_counts_without_index_hooks() -> None:
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_compositional_loop_steps("num_steps", np.int64(10))
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        _require_compositional_loop_steps("num_steps", _HostileInt(10))
+
+
+def test_array_last_fit_length_is_accepted() -> None:
+    observations = jnp.zeros((_COMPOSITIONAL_LOOP_MAX_STEPS, 2), dtype=jnp.float32)
+    targets = jnp.zeros((_COMPOSITIONAL_LOOP_MAX_STEPS, 1), dtype=jnp.float32)
+    assert _require_compositional_array_steps(observations, targets) == 10_000
+
+
+def test_array_first_overflow_rejected_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _spy_scan(monkeypatch)
+    observations = jnp.zeros((_COMPOSITIONAL_LOOP_MAX_STEPS + 1, 2), dtype=jnp.float32)
+    targets = jnp.zeros((_COMPOSITIONAL_LOOP_MAX_STEPS + 1, 1), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="observations num_steps must be an integer in"):
+        run_compositional_arrays(
+            cast(Any, object()),
+            cast(Any, object()),
+            observations,
+            targets,
+        )
+    assert seen == []
+
+
+def test_array_gate_does_not_read_hostile_shape() -> None:
+    _HostileArrays.calls = 0
+    with pytest.raises(TypeError, match="observations and targets must be JAX arrays"):
+        _require_compositional_array_steps(_HostileArrays(), _HostileArrays())
+    assert _HostileArrays.calls == 0


### PR DESCRIPTION
## Summary
- `run_compositional_loop` passed `num_steps` straight to `jnp.arange`, so `10**12` or `2**31-1` could hang or OOM before any learning happened.
- `run_compositional_arrays` scanned pre-collected tensors with the same missing ceiling.
- Both now reject non-exact ints and lengths above the public last-fit (`10_000`) before `arange`/`scan`.

This is a validator Fix, not a hill-climb: no shard, seed, or threshold was changed.

## Test plan
- [x] `python -m pytest tests/test_compositional_loop_steps.py tests/test_compositional_features.py::TestCompositionalFeatureLearner::test_scan_loop_runs tests/test_compositional_features.py::TestCompositionalFeatureLearner::test_online_readout_learns_prewired_depth2_polynomial tests/test_resource_manager.py::test_learned_resource_manager_integer_validation -q -o addopts=""` → **18 passed**
- [x] `ruff check` on the two touched files → clean
- [ ] maintainer CI on `ubuntu-latest`

`JAX_PLATFORMS=cpu` Python 3.12, jax 0.11.1. No IPMNIST shard was launched.

AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi

Source HEAD: `b3f0560b2065d011175fa7384d6760f4bd0bf56b`

<!-- evidence-head:b3f0560b2065d011175fa7384d6760f4bd0bf56b -->
<!-- evidence-row:logs -->
- [x] logs: N/A - pytest/ruff stdout recorded in this body; no separate log artifact
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - validator-only Fix; no campaign shard or summary was written

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0EHCS5SVKV8GPXB6D9NC5FC","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T02:53:21.977Z","completed_at":"2026-08-20T03:17:54.983Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T02:53:22.663Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5d41333380c38c9fa7043afd74602338bb8881602af2aade76b21ab98762a84b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"68a368c6-615d-4a10-98e1-d820288e79f7","object_id":"sha256:5d41333380c38c9fa7043afd74602338bb8881602af2aade76b21ab98762a84b","sha256":"5d41333380c38c9fa7043afd74602338bb8881602af2aade76b21ab98762a84b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"tJNl4s1kr_YwBlw2veY3_7N3qyvVVMemINQ1a_XLN5pFOnqfLTGgpb5zKPaBY1nZflqN7QZAGp84WooZzG1gCA"}} -->
