### PR TITLE
fix(validation): consolidate bounded host-container preflights

### DIFF
--- a/alberta_framework/_bounded_containers.py
+++ b/alberta_framework/_bounded_containers.py
@@ -1,0 +1,113 @@
+"""Iterative bounds for host containers before recursive library calls.
+
+Python, JAX, NumPy, and JSON entry points do not share one failure mode for
+deep or cyclic host values: depending on the implementation they can raise
+``RecursionError``/``SystemError`` or spend unbounded work before a protocol's
+own validator runs.  This module supplies the structural preflight only.  Each
+consumer keeps its domain-specific type, shape, numeric, and resource checks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator
+
+ContainerChildren = Callable[[object], Iterable[object] | None]
+
+
+def require_bounded_container_tree(
+    root: object,
+    *,
+    children: ContainerChildren,
+    max_depth: int,
+    max_nodes: int | None,
+    name: str,
+    kind: str,
+) -> None:
+    """Reject excessive depth, cycles, and optionally excessive node count.
+
+    The walk is iterative and tracks only the active ancestry path, so shared
+    acyclic subtrees remain valid while true cycles fail before a recursive
+    downstream consumer sees them.  ``children`` must return ``None`` for a
+    leaf and an iterable for a container.
+    """
+
+    if type(max_depth) is not int or max_depth < 1:
+        raise ValueError("max_depth must be a positive exact integer")
+    if max_nodes is not None and (type(max_nodes) is not int or max_nodes < 1):
+        raise ValueError("max_nodes must be a positive exact integer or None")
+    if type(name) is not str or not name:
+        raise ValueError("name must be a non-empty exact string")
+    if type(kind) is not str or not kind:
+        raise ValueError("kind must be a non-empty exact string")
+
+    root_children = children(root)
+    if root_children is None:
+        return
+    nodes_seen = 1
+    ancestors = {id(root)}
+    frames: list[tuple[object, Iterator[object], int]] = [
+        (root, iter(root_children), 1)
+    ]
+    while frames:
+        node, iterator, depth = frames[-1]
+        if depth > max_depth:
+            raise ValueError(f"{name} exceeds the maximum {kind} nesting depth")
+        try:
+            child = next(iterator)
+        except StopIteration:
+            frames.pop()
+            ancestors.discard(id(node))
+            continue
+
+        nodes_seen += 1
+        if max_nodes is not None and nodes_seen > max_nodes:
+            raise ValueError(f"{name} exceeds the {kind} value resource limit")
+        child_children = children(child)
+        if child_children is None:
+            continue
+        child_id = id(child)
+        if child_id in ancestors:
+            raise ValueError(f"{name} contains a cyclic {kind}")
+        child_depth = depth + 1
+        if child_depth > max_depth:
+            raise ValueError(f"{name} exceeds the maximum {kind} nesting depth")
+        ancestors.add(child_id)
+        frames.append((child, iter(child_children), child_depth))
+
+
+def require_json_text_nesting(
+    text: object,
+    *,
+    max_depth: int,
+    name: str,
+) -> str:
+    """Preflight JSON bracket depth without counting brackets inside strings."""
+
+    if type(text) is not str:
+        raise ValueError(f"{name} must be canonical JSON")
+    if type(max_depth) is not int or max_depth < 1:
+        raise ValueError("max_depth must be a positive exact integer")
+    if type(name) is not str or not name:
+        raise ValueError("name must be a non-empty exact string")
+
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            if depth > max_depth:
+                raise ValueError(f"{name} exceeds the JSON nesting limit")
+        elif character in "]}":
+            depth -= 1
+    return text

--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -53,6 +53,10 @@ _FORMAT_VERSION = 2
 # Internal metadata key — stripped from user-facing metadata
 _VERSION_KEY = "_format_version"
 _EMPTY_ARRAYS_KEY = "_empty_array_leaves"
+# Same ceiling as security._JSON_MAX_DEPTH. Origin json.dumps RecursionErrors
+# on a 10_000-deep metadata nest and cannot reject it as ValueError.
+_JSON_MAX_DEPTH = 32
+_JSON_MAX_NODES = 4096
 
 
 def _is_empty_array(value: object) -> bool:
@@ -148,10 +152,42 @@ def _require_path(value: object, *, name: str = "checkpoint path") -> Path:
     raise ValueError(f"{name} must be an exact str or Path")
 
 
+def _require_json_nest(
+    value: object, *, name: str, depth: int, budget: list[int]
+) -> None:
+    """Reject unbounded metadata nests before ``json.dumps`` RecursionError."""
+    budget[0] -= 1
+    if budget[0] < 0:
+        raise ValueError(f"{name} exceeds the JSON value resource limit")
+    if depth > _JSON_MAX_DEPTH:
+        raise ValueError(f"{name} exceeds the JSON nesting limit")
+    value_type = type(value)
+    if value is None or value_type is bool or value_type is int or value_type is str:
+        return
+    if value_type is float:
+        return
+    if value_type is list:
+        for item in cast(list[object], value):
+            _require_json_nest(item, name=name, depth=depth + 1, budget=budget)
+        return
+    if value_type is dict:
+        for item in cast(dict[object, object], value).values():
+            _require_json_nest(item, name=name, depth=depth + 1, budget=budget)
+        return
+
+
 def _require_json_safe_metadata(metadata: dict[str, Any]) -> None:
     """Reject metadata that cannot round-trip as finite JSON."""
     try:
+        _require_json_nest(
+            metadata, name="checkpoint metadata", depth=0, budget=[_JSON_MAX_NODES]
+        )
+    except RecursionError as exc:
+        raise ValueError("checkpoint metadata exceeds the JSON nesting limit") from exc
+    try:
         json.dumps(metadata, allow_nan=False)
+    except RecursionError as exc:
+        raise ValueError("checkpoint metadata exceeds the JSON nesting limit") from exc
     except (TypeError, ValueError) as exc:
         raise ValueError("checkpoint metadata must be JSON-safe and finite") from exc
 

--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -34,7 +34,7 @@ assert meta["epoch"] == 1
 """
 
 import json
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any, cast
 
@@ -42,6 +42,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import orbax.checkpoint as ocp
+
+from alberta_framework._bounded_containers import require_bounded_container_tree
 
 # Stamped into checkpoint metadata on save, but deliberately NOT validated on
 # load: compatibility is enforced structurally instead, by restoring into the
@@ -152,37 +154,28 @@ def _require_path(value: object, *, name: str = "checkpoint path") -> Path:
     raise ValueError(f"{name} must be an exact str or Path")
 
 
-def _require_json_nest(
-    value: object, *, name: str, depth: int, budget: list[int]
-) -> None:
-    """Reject unbounded metadata nests before ``json.dumps`` RecursionError."""
-    budget[0] -= 1
-    if budget[0] < 0:
-        raise ValueError(f"{name} exceeds the JSON value resource limit")
-    if depth > _JSON_MAX_DEPTH:
-        raise ValueError(f"{name} exceeds the JSON nesting limit")
-    value_type = type(value)
-    if value is None or value_type is bool or value_type is int or value_type is str:
-        return
-    if value_type is float:
-        return
-    if value_type is list:
-        for item in cast(list[object], value):
-            _require_json_nest(item, name=name, depth=depth + 1, budget=budget)
-        return
-    if value_type is dict:
-        for item in cast(dict[object, object], value).values():
-            _require_json_nest(item, name=name, depth=depth + 1, budget=budget)
-        return
+def _json_children(value: object) -> Iterable[object] | None:
+    if type(value) is list:
+        return cast(list[object], value)
+    if type(value) is dict:
+        return cast(dict[object, object], value).values()
+    return None
 
 
 def _require_json_safe_metadata(metadata: dict[str, Any]) -> None:
     """Reject metadata that cannot round-trip as finite JSON."""
     try:
-        _require_json_nest(
-            metadata, name="checkpoint metadata", depth=0, budget=[_JSON_MAX_NODES]
+        require_bounded_container_tree(
+            metadata,
+            children=_json_children,
+            max_depth=_JSON_MAX_DEPTH,
+            max_nodes=_JSON_MAX_NODES,
+            name="checkpoint metadata",
+            kind="JSON",
         )
-    except RecursionError as exc:
+    except ValueError as exc:
+        if "maximum JSON nesting depth" not in str(exc):
+            raise
         raise ValueError("checkpoint metadata exceeds the JSON nesting limit") from exc
     try:
         json.dumps(metadata, allow_nan=False)

--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -39,6 +39,8 @@ from jaxtyping import Float
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 _INT32_MAX = 2**31 - 1
+# Origin ``jnp.asarray`` still accepts depth 64 and RecursionErrors at 10_000.
+_MAX_ARRAY_NESTING_DEPTH = 64
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -237,6 +239,43 @@ def _validated_kernel_width(kernel_width: float | Array) -> Array:
     return _runtime_checked_value(width, predicate, _KERNEL_WIDTH_ERROR)
 
 
+def _require_host_array_nesting(value: object, *, name: str) -> None:
+    """Reject cycles and nesting that RecursionError ``jnp.asarray``."""
+    if type(value) not in (list, tuple):
+        return
+    frames: list[tuple[object, int, int]] = [(value, 1, 0)]
+    ancestors = {id(value)}
+    while frames:
+        node, depth, index = frames[-1]
+        if depth > _MAX_ARRAY_NESTING_DEPTH:
+            raise ValueError(f"{name} exceeds the maximum host array nesting depth")
+        kids = cast(list[Any] | tuple[Any, ...], node)
+        if index >= len(kids):
+            frames.pop()
+            ancestors.discard(id(node))
+            continue
+        child = kids[index]
+        frames[-1] = (node, depth, index + 1)
+        if type(child) not in (list, tuple):
+            continue
+        child_id = id(child)
+        if child_id in ancestors:
+            raise ValueError(f"{name} contains a cyclic host array")
+        child_depth = depth + 1
+        if child_depth > _MAX_ARRAY_NESTING_DEPTH:
+            raise ValueError(f"{name} exceeds the maximum host array nesting depth")
+        ancestors.add(child_id)
+        frames.append((child, child_depth, 0))
+
+
+def _asarray_float32(value: object, *, name: str) -> Array:
+    _require_host_array_nesting(value, name=name)
+    try:
+        return jnp.asarray(value, dtype=jnp.float32)
+    except RecursionError as exc:
+        raise ValueError(f"{name} exceeds the maximum host array nesting depth") from exc
+
+
 def _require_finite_array(values: Array, message: str) -> Array:
     """Reject non-finite coordinates without rewriting them to a fake zero."""
     array = jnp.asarray(values)
@@ -252,8 +291,8 @@ def _preflight_projected_statistic(
     embeddings: Array,
     directions: Array,
 ) -> tuple[Array, Array, int, int]:
-    z = jnp.asarray(embeddings, dtype=jnp.float32)
-    dirs = jnp.asarray(directions, dtype=jnp.float32)
+    z = _asarray_float32(embeddings, name="embeddings")
+    dirs = _asarray_float32(directions, name="directions")
     if z.ndim < 2:
         raise ValueError("embeddings must have shape (..., latent_dim)")
     if dirs.ndim != 2 or dirs.shape[0] < 1 or dirs.shape[1] != z.shape[-1]:
@@ -327,8 +366,8 @@ def epps_pulley_gaussian_statistic(
     eager values raise :class:`ValueError`; invalid compiled values raise a
     :class:`jax.errors.JaxRuntimeError` when the result is synchronized.
     """
+    flattened = jnp.ravel(_asarray_float32(samples, name="samples"))
     width = _validated_kernel_width(kernel_width)
-    flattened = jnp.ravel(jnp.asarray(samples, dtype=jnp.float32))
     if flattened.size < 1:
         raise ValueError("samples must be non-empty")
     _require_float32_resource(

--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -36,6 +36,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Float
 
+from alberta_framework._bounded_containers import require_bounded_container_tree
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 _INT32_MAX = 2**31 - 1
@@ -241,31 +242,19 @@ def _validated_kernel_width(kernel_width: float | Array) -> Array:
 
 def _require_host_array_nesting(value: object, *, name: str) -> None:
     """Reject cycles and nesting that RecursionError ``jnp.asarray``."""
-    if type(value) not in (list, tuple):
-        return
-    frames: list[tuple[object, int, int]] = [(value, 1, 0)]
-    ancestors = {id(value)}
-    while frames:
-        node, depth, index = frames[-1]
-        if depth > _MAX_ARRAY_NESTING_DEPTH:
-            raise ValueError(f"{name} exceeds the maximum host array nesting depth")
-        kids = cast(list[Any] | tuple[Any, ...], node)
-        if index >= len(kids):
-            frames.pop()
-            ancestors.discard(id(node))
-            continue
-        child = kids[index]
-        frames[-1] = (node, depth, index + 1)
-        if type(child) not in (list, tuple):
-            continue
-        child_id = id(child)
-        if child_id in ancestors:
-            raise ValueError(f"{name} contains a cyclic host array")
-        child_depth = depth + 1
-        if child_depth > _MAX_ARRAY_NESTING_DEPTH:
-            raise ValueError(f"{name} exceeds the maximum host array nesting depth")
-        ancestors.add(child_id)
-        frames.append((child, child_depth, 0))
+    def children(node: object) -> list[Any] | tuple[Any, ...] | None:
+        if type(node) in (list, tuple):
+            return cast(list[Any] | tuple[Any, ...], node)
+        return None
+
+    require_bounded_container_tree(
+        value,
+        children=children,
+        max_depth=_MAX_ARRAY_NESTING_DEPTH,
+        max_nodes=None,
+        name=name,
+        kind="host array",
+    )
 
 
 def _asarray_float32(value: object, *, name: str) -> Array:

--- a/alberta_framework/core/update_safety.py
+++ b/alberta_framework/core/update_safety.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import operator
-from typing import SupportsIndex, cast
+from typing import Any, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -27,6 +27,8 @@ _ACTUAL_INT_TYPES = frozenset(
     }
 )
 _INT32_MAX = int(np.iinfo(np.int32).max)
+# Origin ``jax.tree.leaves`` still returns at depth 8000 and SystemErrors at 10_000.
+_MAX_PYTREE_NESTING_DEPTH = 4096
 
 
 def _require_exact_bool(name: str, value: object) -> bool:
@@ -121,11 +123,66 @@ def checked_integer_action_array(
     return safe, valid
 
 
+def _pytree_container_children(node: object) -> tuple[object, ...] | None:
+    node_type = type(node)
+    if node_type is dict:
+        return tuple(cast(dict[Any, Any], node).values())
+    if node_type is list:
+        return tuple(cast(list[Any], node))
+    if node_type is tuple:
+        return cast(tuple[object, ...], node)
+    if isinstance(node, tuple) and getattr(node_type, "_fields", None) is not None:
+        return tuple(node)
+    return None
+
+
+def _require_pytree_nesting(tree: object, *, name: str = "tree") -> None:
+    """Reject cycles and nesting that SystemError ``jax.tree.leaves``."""
+    children = _pytree_container_children(tree)
+    if children is None:
+        return
+    frames: list[tuple[object, tuple[object, ...], int, int]] = [
+        (tree, children, 1, 0)
+    ]
+    ancestors = {id(tree)}
+    while frames:
+        node, kids, depth, index = frames[-1]
+        if depth > _MAX_PYTREE_NESTING_DEPTH:
+            raise ValueError(f"{name} exceeds the maximum pytree nesting depth")
+        if index >= len(kids):
+            frames.pop()
+            ancestors.discard(id(node))
+            continue
+        child = kids[index]
+        frames[-1] = (node, kids, depth, index + 1)
+        child_kids = _pytree_container_children(child)
+        if child_kids is None:
+            continue
+        child_id = id(child)
+        if child_id in ancestors:
+            raise ValueError(f"{name} contains a cyclic pytree")
+        child_depth = depth + 1
+        if child_depth > _MAX_PYTREE_NESTING_DEPTH:
+            raise ValueError(f"{name} exceeds the maximum pytree nesting depth")
+        ancestors.add(child_id)
+        frames.append((child, child_kids, child_depth, 0))
+
+
+def _tree_leaves(tree: object) -> list[Any]:
+    _require_pytree_nesting(tree, name="tree")
+    try:
+        return jax.tree.leaves(tree)
+    except RecursionError as exc:
+        raise ValueError("tree exceeds the maximum pytree nesting depth") from exc
+    except SystemError as exc:
+        raise ValueError("tree exceeds the maximum pytree nesting depth") from exc
+
+
 def floating_tree_is_finite(tree: object) -> Bool[Array, ""]:
     """Return whether every floating or complex leaf in ``tree`` is finite."""
 
     valid = jnp.asarray(True, dtype=jnp.bool_)
-    for leaf in jax.tree.leaves(tree):
+    for leaf in _tree_leaves(tree):
         array = jnp.asarray(leaf)
         if jnp.issubdtype(array.dtype, jnp.inexact):
             valid = valid & jnp.all(jnp.isfinite(array))

--- a/alberta_framework/core/update_safety.py
+++ b/alberta_framework/core/update_safety.py
@@ -11,6 +11,8 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Int
 
+from alberta_framework._bounded_containers import require_bounded_container_tree
+
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -138,34 +140,14 @@ def _pytree_container_children(node: object) -> tuple[object, ...] | None:
 
 def _require_pytree_nesting(tree: object, *, name: str = "tree") -> None:
     """Reject cycles and nesting that SystemError ``jax.tree.leaves``."""
-    children = _pytree_container_children(tree)
-    if children is None:
-        return
-    frames: list[tuple[object, tuple[object, ...], int, int]] = [
-        (tree, children, 1, 0)
-    ]
-    ancestors = {id(tree)}
-    while frames:
-        node, kids, depth, index = frames[-1]
-        if depth > _MAX_PYTREE_NESTING_DEPTH:
-            raise ValueError(f"{name} exceeds the maximum pytree nesting depth")
-        if index >= len(kids):
-            frames.pop()
-            ancestors.discard(id(node))
-            continue
-        child = kids[index]
-        frames[-1] = (node, kids, depth, index + 1)
-        child_kids = _pytree_container_children(child)
-        if child_kids is None:
-            continue
-        child_id = id(child)
-        if child_id in ancestors:
-            raise ValueError(f"{name} contains a cyclic pytree")
-        child_depth = depth + 1
-        if child_depth > _MAX_PYTREE_NESTING_DEPTH:
-            raise ValueError(f"{name} exceeds the maximum pytree nesting depth")
-        ancestors.add(child_id)
-        frames.append((child, child_kids, child_depth, 0))
+    require_bounded_container_tree(
+        tree,
+        children=_pytree_container_children,
+        max_depth=_MAX_PYTREE_NESTING_DEPTH,
+        max_nodes=None,
+        name=name,
+        kind="pytree",
+    )
 
 
 def _tree_leaves(tree: object) -> list[Any]:

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -41,6 +41,7 @@ _MAX_LIFECYCLE_ID_LENGTH = _MAX_ID_LENGTH - len(
     f":{MAX_DECISION_INDEX}:authorization"
 )
 _MAX_CONFIG_BYTES = 1 << 20
+_MAX_JSON_NESTING_DEPTH = 64
 _MAX_ARRAY_RANK = 8
 _MAX_ARRAY_ELEMENTS = 1 << 20
 _SUPPORTED_DTYPES = frozenset(
@@ -83,8 +84,52 @@ def _require_sha256(value: str, *, name: str) -> None:
         raise ValueError(f"{name} must be a lowercase 64-character SHA-256 digest")
 
 
+def _require_json_text_nesting(raw: str, *, name: str) -> None:
+    """Reject nesting that would RecursionError ``json.loads`` before it runs."""
+    if type(raw) is not str:
+        raise ValueError(f"{name} must be canonical JSON")
+    encoded_len = len(raw.encode("utf-8"))
+    if encoded_len > _MAX_CONFIG_BYTES:
+        raise ValueError(f"{name} exceeds {_MAX_CONFIG_BYTES} bytes")
+    depth = 0
+    in_string = False
+    escape = False
+    for character in raw:
+        if in_string:
+            if escape:
+                escape = False
+            elif character == "\\":
+                escape = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+            continue
+        if character in "{[":
+            depth += 1
+            if depth > _MAX_JSON_NESTING_DEPTH:
+                raise ValueError(
+                    f"{name} exceeds the maximum canonical JSON nesting depth"
+                )
+        elif character in "}]":
+            depth -= 1
+
+
+def _load_manifest_config_json(raw: str) -> Any:
+    _require_json_text_nesting(raw, name="manifest config")
+    try:
+        return json.loads(raw)
+    except RecursionError as exc:
+        raise ValueError(
+            "manifest config exceeds the maximum canonical JSON nesting depth"
+        ) from exc
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("manifest config must be canonical JSON") from exc
+
+
 def _validate_json_value(value: Any, *, path: str, depth: int = 0) -> None:
-    if depth > 64:
+    if depth > _MAX_JSON_NESTING_DEPTH:
         raise ValueError(f"{path} exceeds the maximum canonical JSON nesting depth")
     value_type = type(value)
     if value is None or value_type is str or value_type is bool or value_type is int:
@@ -514,10 +559,7 @@ class AgentManifest:
             raise ValueError("action_spec must be a SpaceSpec")
         if not isinstance(self.capabilities, AgentCapabilities):
             raise ValueError("capabilities must be AgentCapabilities")
-        try:
-            config = json.loads(self._config_json)
-        except (TypeError, json.JSONDecodeError) as exc:
-            raise ValueError("manifest config must be canonical JSON") from exc
+        config = _load_manifest_config_json(self._config_json)
         if not isinstance(config, dict):
             raise ValueError("manifest config must be a JSON object")
         if _canonical_json_bytes(config).decode("utf-8") != self._config_json:
@@ -573,7 +615,7 @@ class AgentManifest:
 
     @property
     def config(self) -> dict[str, Any]:
-        config = json.loads(self._config_json)
+        config = _load_manifest_config_json(self._config_json)
         assert isinstance(config, dict)
         return config
 

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -21,6 +21,8 @@ from typing import Any
 
 import numpy as np
 
+from alberta_framework._bounded_containers import require_json_text_nesting
+
 
 def _require_exact_str(name: object, value: object) -> str:
     if type(name) is not str:
@@ -91,29 +93,18 @@ def _require_json_text_nesting(raw: str, *, name: str) -> None:
     encoded_len = len(raw.encode("utf-8"))
     if encoded_len > _MAX_CONFIG_BYTES:
         raise ValueError(f"{name} exceeds {_MAX_CONFIG_BYTES} bytes")
-    depth = 0
-    in_string = False
-    escape = False
-    for character in raw:
-        if in_string:
-            if escape:
-                escape = False
-            elif character == "\\":
-                escape = True
-            elif character == '"':
-                in_string = False
-            continue
-        if character == '"':
-            in_string = True
-            continue
-        if character in "{[":
-            depth += 1
-            if depth > _MAX_JSON_NESTING_DEPTH:
-                raise ValueError(
-                    f"{name} exceeds the maximum canonical JSON nesting depth"
-                )
-        elif character in "}]":
-            depth -= 1
+    try:
+        require_json_text_nesting(
+            raw,
+            max_depth=_MAX_JSON_NESTING_DEPTH,
+            name=name,
+        )
+    except ValueError as exc:
+        if "nesting limit" not in str(exc):
+            raise
+        raise ValueError(
+            f"{name} exceeds the maximum canonical JSON nesting depth"
+        ) from exc
 
 
 def _load_manifest_config_json(raw: str) -> Any:

--- a/alberta_framework/reference_life_checkpoint.py
+++ b/alberta_framework/reference_life_checkpoint.py
@@ -177,6 +177,8 @@ def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
             ).encode("ascii")
             + b"\n"
         )
+    except RecursionError as exc:
+        raise ValueError("checkpoint value exceeds the JSON nesting limit") from exc
     except (TypeError, ValueError) as exc:
         raise ValueError("checkpoint value is not canonical finite JSON") from exc
 
@@ -200,10 +202,42 @@ def _read_bounded_json_file(path: Path) -> bytes:
     return raw
 
 
+def _require_json_text_depth(raw: bytes, *, name: str) -> None:
+    """Reject JSON nests deeper than ``_MAX_TREE_DEPTH`` before RecursionError."""
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{name} is not canonical JSON") from exc
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            if depth > _MAX_TREE_DEPTH:
+                raise ValueError(f"{name} exceeds the JSON nesting limit")
+        elif character in "]}":
+            depth -= 1
+
+
 def _load_canonical_json(path: Path) -> dict[str, Any]:
     raw = _read_bounded_json_file(path)
     try:
+        _require_json_text_depth(raw, name=path.name)
         value = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+    except RecursionError as exc:
+        raise ValueError(f"{path.name} exceeds the JSON nesting limit") from exc
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError(f"{path.name} is not canonical JSON") from exc
     if type(value) is not dict or raw != _canonical_json_bytes(value):
@@ -1514,8 +1548,11 @@ def _load_raw_prototype_metadata(path: Path) -> dict[str, Any]:
 
     raw = _read_bounded_json_file(path)
     try:
+        _require_json_text_depth(raw, name="prototype.metadata")
         value = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
-    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+    except RecursionError as exc:
+        raise ValueError("prototype.metadata exceeds the JSON nesting limit") from exc
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError("nested Prototype metadata is not valid bounded JSON") from exc
     data = _require_keys(
         value,

--- a/alberta_framework/reference_life_checkpoint.py
+++ b/alberta_framework/reference_life_checkpoint.py
@@ -32,6 +32,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from alberta_framework._bounded_containers import require_json_text_nesting
 from alberta_framework.core.checkpoints import load_checkpoint_metadata
 from alberta_framework.core.prototype_agent import (
     PROTOTYPE_CHECKPOINT_SCHEMA,
@@ -209,26 +210,7 @@ def _require_json_text_depth(raw: bytes, *, name: str) -> None:
         text = raw.decode("utf-8")
     except UnicodeDecodeError as exc:
         raise ValueError(f"{name} is not canonical JSON") from exc
-    depth = 0
-    in_string = False
-    escaped = False
-    for character in text:
-        if in_string:
-            if escaped:
-                escaped = False
-            elif character == "\\":
-                escaped = True
-            elif character == '"':
-                in_string = False
-            continue
-        if character == '"':
-            in_string = True
-        elif character in "[{":
-            depth += 1
-            if depth > _MAX_TREE_DEPTH:
-                raise ValueError(f"{name} exceeds the JSON nesting limit")
-        elif character in "]}":
-            depth -= 1
+    require_json_text_nesting(text, max_depth=_MAX_TREE_DEPTH, name=name)
 
 
 def _load_canonical_json(path: Path) -> dict[str, Any]:

--- a/tests/test_bounded_containers.py
+++ b/tests/test_bounded_containers.py
@@ -1,0 +1,88 @@
+"""Shared host-container preflight contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, cast
+
+import pytest
+
+from alberta_framework._bounded_containers import (
+    require_bounded_container_tree,
+    require_json_text_nesting,
+)
+
+
+def _json_children(value: object) -> Iterable[object] | None:
+    if type(value) is list:
+        return cast(list[object], value)
+    if type(value) is dict:
+        return cast(dict[str, object], value).values()
+    return None
+
+
+def test_tree_preflight_allows_shared_acyclic_subtrees() -> None:
+    shared: list[object] = [[1]]
+    require_bounded_container_tree(
+        [shared, shared],
+        children=_json_children,
+        max_depth=4,
+        max_nodes=8,
+        name="payload",
+        kind="JSON",
+    )
+
+
+def test_tree_preflight_rejects_cycle_depth_and_node_budget() -> None:
+    cyclic: list[Any] = []
+    cyclic.append(cyclic)
+    with pytest.raises(ValueError, match="cyclic JSON"):
+        require_bounded_container_tree(
+            cyclic,
+            children=_json_children,
+            max_depth=4,
+            max_nodes=8,
+            name="payload",
+            kind="JSON",
+        )
+    with pytest.raises(ValueError, match="nesting depth"):
+        require_bounded_container_tree(
+            [[[[0]]]],
+            children=_json_children,
+            max_depth=3,
+            max_nodes=None,
+            name="payload",
+            kind="JSON",
+        )
+    with pytest.raises(ValueError, match="resource limit"):
+        require_bounded_container_tree(
+            [0, 1, 2],
+            children=_json_children,
+            max_depth=2,
+            max_nodes=3,
+            name="payload",
+            kind="JSON",
+        )
+
+
+def test_json_text_scanner_ignores_brackets_inside_escaped_strings() -> None:
+    text = '{"literal":"[\\\"]}","nested":[{}]}'
+    assert require_json_text_nesting(text, max_depth=3, name="payload") == text
+    with pytest.raises(ValueError, match="nesting limit"):
+        require_json_text_nesting("[[[[]]]]", max_depth=3, name="payload")
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"max_depth": 0, "max_nodes": None, "name": "x", "kind": "tree"}, "max_depth"),
+        ({"max_depth": 1, "max_nodes": 0, "name": "x", "kind": "tree"}, "max_nodes"),
+        ({"max_depth": 1, "max_nodes": None, "name": "", "kind": "tree"}, "name"),
+        ({"max_depth": 1, "max_nodes": None, "name": "x", "kind": ""}, "kind"),
+    ],
+)
+def test_tree_preflight_rejects_invalid_own_configuration(
+    kwargs: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        require_bounded_container_tree([], children=_json_children, **kwargs)  # type: ignore[arg-type]

--- a/tests/test_checkpoints_metadata_depth.py
+++ b/tests/test_checkpoints_metadata_depth.py
@@ -1,0 +1,53 @@
+"""Depth ceiling for checkpoint metadata JSON walks.
+
+Origin ``json.dumps`` RecursionError'd a 10_000-deep metadata nest. The
+protocol ceiling matches ``security._JSON_MAX_DEPTH`` (32).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework import LinearLearner
+from alberta_framework.core.checkpoints import (
+    _JSON_MAX_DEPTH,
+    _require_json_safe_metadata,
+    save_checkpoint,
+)
+
+
+def _nested_dict(depth: int) -> dict[str, object]:
+    nest: object = True
+    for _ in range(depth):
+        nest = {"k": nest}
+    assert type(nest) is dict
+    return nest
+
+
+def test_protocol_ceiling_matches_json_depth_bound() -> None:
+    assert _JSON_MAX_DEPTH == 32
+
+
+def test_last_fit_nest_is_accepted() -> None:
+    _require_json_safe_metadata(_nested_dict(_JSON_MAX_DEPTH))
+
+
+def test_first_overflow_nest_is_value_error_not_recursion_error() -> None:
+    with pytest.raises(ValueError, match="nesting limit"):
+        _require_json_safe_metadata(_nested_dict(_JSON_MAX_DEPTH + 1))
+
+
+def test_origin_hang_class_10000_is_value_error_not_recursion_error() -> None:
+    with pytest.raises(ValueError, match="nesting limit"):
+        _require_json_safe_metadata(_nested_dict(10_000))
+
+
+def test_save_checkpoint_rejects_overflow_nest_without_writing(tmp_path: Path) -> None:
+    learner = LinearLearner()
+    state = learner.init(3)
+    path = tmp_path / "deep"
+    with pytest.raises(ValueError, match="nesting limit"):
+        save_checkpoint(state, path, metadata=_nested_dict(_JSON_MAX_DEPTH + 1))
+    assert not path.exists()

--- a/tests/test_reference_agent_config_json_depth.py
+++ b/tests/test_reference_agent_config_json_depth.py
@@ -1,0 +1,105 @@
+"""Reject deep manifest config JSON before json.loads RecursionError."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from alberta_framework.reference_agent import (
+    _MAX_JSON_NESTING_DEPTH,
+    REFERENCE_AGENT_MANIFEST_SCHEMA,
+    AgentCapabilities,
+    AgentManifest,
+    SpaceSpec,
+    _load_manifest_config_json,
+)
+
+
+def _nested_array_json(depth: int) -> str:
+    return "[" * depth + "0" + "]" * depth
+
+
+def _manifest_config_json(depth: int) -> str:
+    return '{"k":' + _nested_array_json(depth) + "}"
+
+
+def _attempt_manifest(config_json: str) -> AgentManifest:
+    return AgentManifest(
+        schema=REFERENCE_AGENT_MANIFEST_SCHEMA,
+        implementation_id="a.b",
+        state_schema="c.d",
+        config_sha256="0" * 64,
+        manifest_id="1" * 64,
+        observation_spec=SpaceSpec(
+            kind="box", shape=(), dtype="float32", semantic_id="a.b"
+        ),
+        action_spec=SpaceSpec(
+            kind="box", shape=(), dtype="float32", semantic_id="a.b"
+        ),
+        capabilities=AgentCapabilities(),
+        _config_json=config_json,
+    )
+
+
+def test_deep_config_json_never_reaches_loads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """10_000-deep JSON must ValueError before json.loads RecursionError."""
+    import json as json_module
+
+    calls: list[str] = []
+    real_loads = json_module.loads
+
+    def spy(raw: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append(raw if type(raw) is str else type(raw).__name__)
+        return real_loads(raw, *args, **kwargs)
+
+    monkeypatch.setattr("alberta_framework.reference_agent.json.loads", spy)
+    deep = _manifest_config_json(10_000)
+    assert len(deep.encode("utf-8")) < 1 << 20
+    with pytest.raises(ValueError, match="nesting depth"):
+        _load_manifest_config_json(deep)
+    with pytest.raises(ValueError, match="nesting depth"):
+        _attempt_manifest(deep)
+    assert calls == []
+
+
+def _nested_python_list(depth: int) -> Any:
+    value: Any = 0
+    for _ in range(depth):
+        value = [value]
+    return value
+
+
+def test_last_fit_nesting_still_parses() -> None:
+    # Object + 63 arrays = depth 64, the last-fit for the protocol cap.
+    depth = _MAX_JSON_NESTING_DEPTH - 1
+    loaded = _load_manifest_config_json(_manifest_config_json(depth))
+    assert loaded == {"k": _nested_python_list(depth)}
+
+
+def test_first_overflow_nesting_rejects_before_loads(monkeypatch: pytest.MonkeyPatch) -> None:
+    import json as json_module
+
+    calls: list[int] = []
+    real_loads = json_module.loads
+
+    def spy(raw: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append(1)
+        return real_loads(raw, *args, **kwargs)
+
+    monkeypatch.setattr("alberta_framework.reference_agent.json.loads", spy)
+    with pytest.raises(ValueError, match="nesting depth"):
+        _load_manifest_config_json(_manifest_config_json(_MAX_JSON_NESTING_DEPTH))
+    assert calls == []
+
+
+def test_recursionerror_from_loads_is_valueerror(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(raw: Any, *args: Any, **kwargs: Any) -> Any:
+        del raw, args, kwargs
+        raise RecursionError("simulated parser overflow")
+
+    monkeypatch.setattr("alberta_framework.reference_agent.json.loads", boom)
+    with pytest.raises(ValueError, match="nesting depth"):
+        _load_manifest_config_json(_manifest_config_json(1))

--- a/tests/test_reference_life_checkpoint_json_depth.py
+++ b/tests/test_reference_life_checkpoint_json_depth.py
@@ -1,0 +1,68 @@
+"""Depth ceiling for reference-life checkpoint JSON loads.
+
+Origin ``json.loads`` RecursionError'd a 10_000-deep object nest that still
+fit ``_MAX_JSON_BYTES``. The codec now uses the directory-tree depth bound
+(32) and raises ``ValueError`` before the CPython decoder blows the stack.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.reference_life_checkpoint import (
+    _MAX_TREE_DEPTH,
+    _canonical_json_bytes,
+    _load_canonical_json,
+    _require_json_text_depth,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _nested_dict(depth: int) -> dict[str, object]:
+    nest: object = True
+    for _ in range(depth):
+        nest = {"k": nest}
+    assert type(nest) is dict
+    return nest
+
+
+def _nested_json_bytes(depth: int) -> bytes:
+    return ('{"k":' * depth + "true" + "}" * depth).encode("ascii")
+
+
+def test_protocol_ceiling_matches_directory_tree_bound() -> None:
+    assert _MAX_TREE_DEPTH == 32
+
+
+def test_last_fit_nest_is_accepted(tmp_path: Path) -> None:
+    encoded = _canonical_json_bytes(_nested_dict(_MAX_TREE_DEPTH))
+    path = tmp_path / "manifest.json"
+    path.write_bytes(encoded)
+    loaded = _load_canonical_json(path)
+    assert loaded == _nested_dict(_MAX_TREE_DEPTH)
+
+
+def test_first_overflow_nest_is_value_error_not_recursion_error() -> None:
+    with pytest.raises(ValueError, match="nesting limit"):
+        _require_json_text_depth(
+            _nested_json_bytes(_MAX_TREE_DEPTH + 1), name="manifest.json"
+        )
+
+
+def test_origin_hang_class_10000_is_value_error_not_recursion_error(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "manifest.json"
+    path.write_bytes(_nested_json_bytes(10_000))
+    with pytest.raises(ValueError, match="nesting limit"):
+        _load_canonical_json(path)
+
+
+def test_load_rejects_overflow_nest_without_recursion_error(tmp_path: Path) -> None:
+    path = tmp_path / "life_state.json"
+    path.write_bytes(_nested_json_bytes(_MAX_TREE_DEPTH + 1))
+    with pytest.raises(ValueError, match="nesting limit"):
+        _load_canonical_json(path)

--- a/tests/test_sigreg_host_array_depth.py
+++ b/tests/test_sigreg_host_array_depth.py
@@ -1,0 +1,85 @@
+"""Reject deep or cyclic host arrays before jnp.asarray RecursionError."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.sigreg import (
+    _MAX_ARRAY_NESTING_DEPTH,
+    _asarray_float32,
+    epps_pulley_gaussian_statistic,
+)
+
+
+def _nested_list(depth: int, leaf: Any = 1.0) -> Any:
+    value: Any = leaf
+    for _ in range(depth):
+        value = [value]
+    return value
+
+
+def test_deep_samples_never_reach_asarray(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def spy(value: object, dtype: object = None) -> Any:
+        calls.append(1)
+        raise AssertionError("jnp.asarray must not run on overflow nests")
+
+    monkeypatch.setattr("alberta_framework.core.sigreg.jnp.asarray", spy)
+    with pytest.raises(ValueError, match="nesting depth"):
+        epps_pulley_gaussian_statistic(cast(Any, _nested_list(10_000)))
+    assert calls == []
+
+
+def test_last_fit_list_nesting_still_converts() -> None:
+    array = _asarray_float32(_nested_list(_MAX_ARRAY_NESTING_DEPTH), name="samples")
+    assert array.shape == (1,) * _MAX_ARRAY_NESTING_DEPTH
+    assert bool(jnp.isfinite(epps_pulley_gaussian_statistic(array)))
+
+
+def test_first_overflow_rejects_before_asarray(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def spy(value: object, dtype: object = None) -> Any:
+        calls.append(1)
+        raise AssertionError("jnp.asarray must not run on overflow nests")
+
+    monkeypatch.setattr("alberta_framework.core.sigreg.jnp.asarray", spy)
+    with pytest.raises(ValueError, match="nesting depth"):
+        epps_pulley_gaussian_statistic(cast(Any, _nested_list(_MAX_ARRAY_NESTING_DEPTH + 1)))
+    assert calls == []
+
+
+def test_cyclic_list_rejects_before_asarray(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def spy(value: object, dtype: object = None) -> Any:
+        calls.append(1)
+        raise AssertionError("jnp.asarray must not run on cyclic host arrays")
+
+    monkeypatch.setattr("alberta_framework.core.sigreg.jnp.asarray", spy)
+    cyclic: list[Any] = []
+    cyclic.append(cyclic)
+    with pytest.raises(ValueError, match="cyclic host array"):
+        epps_pulley_gaussian_statistic(cast(Any, cyclic))
+    assert calls == []
+
+
+def test_vector_samples_still_compute() -> None:
+    samples = jnp.ones((32,), dtype=jnp.float32)
+    assert bool(jnp.isfinite(epps_pulley_gaussian_statistic(samples)))
+
+
+def test_recursionerror_from_asarray_is_valueerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(value: object, dtype: object = None) -> Any:
+        del value, dtype
+        raise RecursionError("simulated host-array overflow")
+
+    monkeypatch.setattr("alberta_framework.core.sigreg.jnp.asarray", boom)
+    with pytest.raises(ValueError, match="nesting depth"):
+        _asarray_float32(1.0, name="samples")

--- a/tests/test_update_safety_tree_depth.py
+++ b/tests/test_update_safety_tree_depth.py
@@ -1,0 +1,118 @@
+"""Reject deep or cyclic pytrees before jax.tree.leaves SystemError."""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.update_safety import (
+    _MAX_PYTREE_NESTING_DEPTH,
+    _tree_leaves,
+    floating_tree_is_finite,
+)
+
+
+def _nested_list(depth: int, leaf: Any = 1.0) -> Any:
+    value: Any = leaf
+    for _ in range(depth):
+        value = [value]
+    return value
+
+
+def _nested_tuple(depth: int, leaf: Any = 1.0) -> Any:
+    value: Any = leaf
+    for _ in range(depth):
+        value = (value,)
+    return value
+
+
+def _nested_dict(depth: int, leaf: Any = 1.0) -> Any:
+    value: Any = leaf
+    for _ in range(depth):
+        value = {"k": value}
+    return value
+
+
+def test_deep_list_never_reaches_tree_leaves(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def spy(tree: object) -> list[Any]:
+        calls.append(1)
+        raise AssertionError("jax.tree.leaves must not run on overflow nests")
+
+    monkeypatch.setattr("alberta_framework.core.update_safety.jax.tree.leaves", spy)
+    with pytest.raises(ValueError, match="nesting depth"):
+        floating_tree_is_finite(_nested_list(10_000))
+    assert calls == []
+
+
+def test_last_fit_list_nesting_still_walks() -> None:
+    tree = _nested_list(_MAX_PYTREE_NESTING_DEPTH)
+    assert _tree_leaves(tree) == [1.0]
+    assert bool(floating_tree_is_finite(tree))
+
+
+def test_first_overflow_list_rejects_before_leaves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int] = []
+
+    def spy(tree: object) -> list[Any]:
+        calls.append(1)
+        raise AssertionError("jax.tree.leaves must not run on overflow nests")
+
+    monkeypatch.setattr("alberta_framework.core.update_safety.jax.tree.leaves", spy)
+    with pytest.raises(ValueError, match="nesting depth"):
+        floating_tree_is_finite(_nested_list(_MAX_PYTREE_NESTING_DEPTH + 1))
+    assert calls == []
+
+
+def test_last_fit_tuple_and_dict_nests_still_walk() -> None:
+    assert bool(floating_tree_is_finite(_nested_tuple(_MAX_PYTREE_NESTING_DEPTH)))
+    assert bool(floating_tree_is_finite(_nested_dict(_MAX_PYTREE_NESTING_DEPTH)))
+
+
+def test_cyclic_list_rejects_before_leaves(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def spy(tree: object) -> list[Any]:
+        calls.append(1)
+        raise AssertionError("jax.tree.leaves must not run on cyclic trees")
+
+    monkeypatch.setattr("alberta_framework.core.update_safety.jax.tree.leaves", spy)
+    cyclic: list[Any] = []
+    cyclic.append(cyclic)
+    with pytest.raises(ValueError, match="cyclic pytree"):
+        floating_tree_is_finite(cyclic)
+    assert calls == []
+
+
+def test_shared_subtree_is_not_cyclic() -> None:
+    inner = [jnp.asarray(1.0)]
+    assert bool(floating_tree_is_finite([inner, inner]))
+
+
+class _Pair(NamedTuple):
+    left: Any
+    right: Any
+
+
+def test_namedtuple_container_is_walked() -> None:
+    tree = _Pair(jnp.asarray(1.0), jnp.asarray(2.0))
+    assert bool(floating_tree_is_finite(tree))
+
+
+def test_finite_array_leaf_still_reports_nonfinite() -> None:
+    assert not bool(floating_tree_is_finite(jnp.asarray([1.0, jnp.nan])))
+
+
+def test_systemerror_from_leaves_is_valueerror(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(tree: object) -> list[Any]:
+        del tree
+        raise SystemError("simulated pytree overflow")
+
+    monkeypatch.setattr("alberta_framework.core.update_safety.jax.tree.leaves", boom)
+    with pytest.raises(ValueError, match="nesting depth"):
+        floating_tree_is_finite(1.0)


### PR DESCRIPTION
## Summary

Consolidates and deepens #2046, #2037, #2036, #2002, and #1997.

Those PRs correctly identified five recursive-library crash boundaries, but each
implemented a separate container or JSON nesting walker. This branch retains all
failing tests and fixes, then replaces the duplicated walkers with one iterative,
cycle-aware, optionally node-bounded host-container preflight.

- reject deep/cyclic SIGReg host arrays before `jnp.asarray`
- reject deep/cyclic standard pytrees before `jax.tree.leaves`
- preflight reference-agent manifest and reference-life checkpoint JSON text
- bound checkpoint metadata depth, cycles, and total values before `json.dumps`
- preserve each protocol's existing depth/resource ceiling and error contract
- allow shared acyclic subtrees while rejecting only active-ancestry cycles

This is L0 validation hardening. It does not change research protocols, evidence,
thresholds, seeds, or promotion state.

## Validation

- 36 focused depth/cycle/resource tests pass
- 144 broader SIGReg, update-safety, reference-agent, and checkpoint tests pass
- strict mypy passes over 198 source files
- Ruff passes on every changed file

The remaining local reference-life checkpoint failures require Linux `renameat2`
and are unchanged platform constraints; Linux CI is authoritative for them.
