### PR TITLE
fix(core): cap Gradient-TD scan T before leftover INT32 hang

### DIFF
--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -72,6 +72,9 @@ from alberta_framework.core.update_safety import (
 )
 
 _INT32_MAX = 2**31 - 1
+# Public last-fit is the 600-step off-policy positive control. Leftover INT32
+# still admits T=10_000_000 (feature_dim=2) into jax.lax.scan.
+_MAX_LEARNING_LOOP_STEPS = 10_000
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -1156,6 +1159,8 @@ def run_gradient_td_learning_loop(
         raise ValueError("observations must have shape (num_steps, feature_dim)")
     num_steps = observations_shape[0]
     _require_scan_resources(num_steps, feature_dim)
+    if num_steps > _MAX_LEARNING_LOOP_STEPS:
+        raise ValueError("num_steps exceeds the learning-loop scan limit")
     _array_metadata("observations", observations, (num_steps, feature_dim))
     _array_metadata("next_observations", next_observations, (num_steps, feature_dim))
     for name, value in (("rewards", rewards), ("gammas", gammas), ("rhos", rhos)):

--- a/tests/test_off_policy_td_scan_steps.py
+++ b/tests/test_off_policy_td_scan_steps.py
@@ -1,0 +1,60 @@
+"""Reject Gradient-TD scan T that leftover INT32 still admits before hang."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.off_policy_td import (
+    GradientTDLinearLearner,
+    _require_scan_resources,
+    run_gradient_td_learning_loop,
+)
+
+pytestmark = pytest.mark.unit
+
+_LAST_FIT_STEPS = 10_000
+_OVERFLOW_STEPS = _LAST_FIT_STEPS + 1
+
+
+def _loop_inputs(steps: int, feature_dim: int = 2) -> tuple[Any, Any, Any, Any, Any]:
+    observations = jnp.ones((steps, feature_dim), dtype=jnp.float32)
+    rewards = jnp.ones((steps,), dtype=jnp.float32)
+    next_observations = jnp.ones((steps, feature_dim), dtype=jnp.float32)
+    gammas = jnp.zeros((steps,), dtype=jnp.float32)
+    rhos = jnp.ones((steps,), dtype=jnp.float32)
+    return observations, rewards, next_observations, gammas, rhos
+
+
+def test_leftover_int32_still_admits_ten_million_steps() -> None:
+    _require_scan_resources(10_000_000, 2)
+
+
+def test_overflow_scan_t_rejects_before_lax_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unexpected_scan(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("overflow scan T reached jax.lax.scan")
+
+    monkeypatch.setattr(jax.lax, "scan", unexpected_scan)
+    learner = GradientTDLinearLearner()
+    state = learner.init(2)
+    with pytest.raises(ValueError, match="scan limit"):
+        run_gradient_td_learning_loop(
+            learner,
+            state,
+            *_loop_inputs(_OVERFLOW_STEPS),
+        )
+
+
+def test_last_fit_scan_t_still_runs() -> None:
+    learner = GradientTDLinearLearner(step_size=0.01)
+    state = learner.init(2)
+    result = run_gradient_td_learning_loop(
+        learner,
+        state,
+        *_loop_inputs(_LAST_FIT_STEPS),
+    )
+    assert result.predictions.shape == (_LAST_FIT_STEPS,)


### PR DESCRIPTION
## Summary

Occupancy-FREE complete hang on `origin/main` `b08bfc90`.

`run_gradient_td_learning_loop` leftover INT32 still admits `T=10_000_000` (`feature_dim=2`) into `jax.lax.scan`. Origin red: `_require_scan_resources(10_000_000, 2)` passes; `T=10001` reaches `jax.lax.scan`. Test last-fit is 600 steps.

```text
# red on origin/main b08bfc90
_require_scan_resources(10_000_000, 2)  # leftover INT32 PASS
run_gradient_td_learning_loop(..., T=10001) -> jax.lax.scan
```

This PR rejects `T>10_000` before scan. `T=10_000` still runs. Leftover INT32 `T=100_000_000` still fails closed on aggregate resources first.

Not `#1874`. Not clocks / forager / IA / FTL. Not json-nest / jax.tree / SIGReg. Not `#2047` `rule_discovery.py`. Not `#2005` `option_value_duration.py`.

## Expected behavior

`T` in `[1, 10_000]` still scans. `10001` raises `ValueError` matching `scan limit` before `jax.lax.scan`. `100_000_000` still raises leftover INT32 `aggregate resources`.

## Scope

- `alberta_framework/core/off_policy_td.py`
- `tests/test_off_policy_td_scan_steps.py`

## Verification

```text
# red on origin/main b08bfc90
_require_scan_resources(10_000_000, 2) passes; T=10001 reaches jax.lax.scan

# green at this head
.venv/bin/python -m pytest tests/test_off_policy_td_scan_steps.py tests/test_off_policy_td.py -q -o addopts=""
# 103 passed
.venv/bin/python -m ruff check alberta_framework/core/off_policy_td.py tests/test_off_policy_td_scan_steps.py
.venv/bin/python -m mypy alberta_framework/core/off_policy_td.py tests/test_off_policy_td_scan_steps.py
```

<!-- evidence-head:4b7015420959141c59e940f068bd457e1aba45d7 -->
<!-- evidence-row:logs -->
- [x] logs: origin `b08bfc90` leftover INT32 admits `T=10_000_000`; `T=10001` reached `jax.lax.scan`; this head rejects `10001` before scan; 3 hang tests + 100 existing off-policy-td tests passed (103)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - scan-length hang preflight, no IPMNIST shard
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - local fail-before-scan proof, no model-trajectory artifact

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
