### PR TITLE
fix(core): reject oversized lifecycle subtask lists before hang

### DIFF
--- a/alberta_framework/core/prototype_feature_lifecycle.py
+++ b/alberta_framework/core/prototype_feature_lifecycle.py
@@ -527,9 +527,15 @@ class PrototypeFeatureLifecycleConfig:
         if type(payload["carry_survivors"]) is not bool:
             raise ValueError("serialized carry_survivors must be a JSON boolean")
         raw_subtask_indices = payload.get("option_subtask_feature_indices")
-        if type(raw_subtask_indices) is not list or not all(
-            type(index) is int for index in raw_subtask_indices
-        ):
+        if type(raw_subtask_indices) is not list:
+            raise ValueError(
+                "serialized option_subtask_feature_indices must be a JSON integer list"
+            )
+        if len(raw_subtask_indices) > _MAX_PYTHON_COLLECTION_LENGTH:
+            raise ValueError(
+                "serialized option_subtask_feature_indices exceeds the collection limit"
+            )
+        if not all(type(index) is int for index in raw_subtask_indices):
             raise ValueError(
                 "serialized option_subtask_feature_indices must be a JSON integer list"
             )

--- a/tests/test_prototype_lifecycle_subtask_list_hang.py
+++ b/tests/test_prototype_lifecycle_subtask_list_hang.py
@@ -1,0 +1,61 @@
+"""Reject oversized subtask-index lists before unbounded from_config walks."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.core.prototype_feature_lifecycle import (
+    _MAX_PYTHON_COLLECTION_LENGTH,
+    PROTOTYPE_FEATURE_LIFECYCLE_CONFIG_SCHEMA,
+    PROTOTYPE_FEATURE_LIFECYCLE_MECHANISM_STATUS,
+    PrototypeFeatureLifecycleConfig,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _payload(*, indices: list[int]) -> dict[str, object]:
+    return {
+        "schema": PROTOTYPE_FEATURE_LIFECYCLE_CONFIG_SCHEMA,
+        "type": "PrototypeFeatureLifecycleConfig",
+        "mechanism_status": PROTOTYPE_FEATURE_LIFECYCLE_MECHANISM_STATUS,
+        "scientific_promotion_allowed": False,
+        "base_feature_dim": 4,
+        "active_pair_slots": 2,
+        "candidate_pair_slots": 6,
+        "n_tasks": 2,
+        "n_options": 2,
+        "n_primitive_actions": 2,
+        "option_subtask_feature_indices": indices,
+        "step_size_output": 0.05,
+        "utility_decay": 0.9,
+        "replacement_interval": 1,
+        "min_feature_age": 0,
+        "candidate_min_age": 0,
+        "promotion_margin": 1.0,
+        "scale_normalizer_decay": 0.9,
+        "scale_normalizer_epsilon": 1.0e-6,
+        "carry_survivors": True,
+        "max_observations": 100,
+    }
+
+
+def test_from_config_rejects_first_overflow_list_length() -> None:
+    with pytest.raises(ValueError, match="collection limit"):
+        PrototypeFeatureLifecycleConfig.from_config(
+            _payload(indices=[0] * (_MAX_PYTHON_COLLECTION_LENGTH + 1))
+        )
+
+
+def test_from_config_rejects_million_index_list_before_walk() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="collection limit"):
+        PrototypeFeatureLifecycleConfig.from_config(_payload(indices=[0] * 5_000_000))
+    assert time.perf_counter() - started < 0.25
+
+
+def test_from_config_last_fit_pair_still_roundtrips() -> None:
+    config = PrototypeFeatureLifecycleConfig.from_config(_payload(indices=[0, 1]))
+    assert config.option_subtask_feature_indices == (0, 1)


### PR DESCRIPTION
## Summary

Occupancy-FREE complete hang on `origin/main` `98289be3`.

`PrototypeFeatureLifecycleConfig.from_config` walked `option_subtask_feature_indices` with `all(...)` and `tuple(...)` **before** the existing 4096 collection cap. A `[0]*5_000_000` list took ~2.9s on origin, then failed the n_options length check.

```text
# red on origin/main 98289be3
from_config(indices=[0]*5_000_000)
# 2.9s then ValueError: must be an exact tuple with one entry per option
```

This PR rejects `len > 4096` before the walk. Last-fit `[0, 1]` still roundtrips. Not json-nest / jax.tree / SIGReg / leftover INT32 persist / scan T.

## Expected behavior

Lists of length `<= 4096` still validate element types. Length `4097` and `5_000_000` raise `ValueError` matching `collection limit` in well under 250ms.

## Scope

- `alberta_framework/core/prototype_feature_lifecycle.py`
- `tests/test_prototype_lifecycle_subtask_list_hang.py`

## Verification

```text
# red on origin/main 98289be3
from_config([0]*5_000_000) walked ~2.9s before n_options mismatch

# green at this head
.venv/bin/python -m pytest tests/test_prototype_lifecycle_subtask_list_hang.py tests/test_prototype_feature_lifecycle.py -q -o addopts=""
# 147 passed
.venv/bin/python -m ruff check alberta_framework/core/prototype_feature_lifecycle.py tests/test_prototype_lifecycle_subtask_list_hang.py
.venv/bin/python -m mypy alberta_framework/core/prototype_feature_lifecycle.py tests/test_prototype_lifecycle_subtask_list_hang.py
```

<!-- evidence-head:4a4b0803fa4fd7c884d1f89afa4789e400293648 -->
<!-- evidence-row:logs -->
- [x] logs: origin `98289be3` walked a 5e6-int subtask list for 2.9s; this head rejects length 4097 / 5e6 before the walk; 3 hang tests + 144 existing lifecycle tests passed (147)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - collection-length hang preflight, no IPMNIST shard
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - local fail-before-walk proof, no model-trajectory artifact

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
