### PR TITLE
fix(forager): validate strict dispatch before execution

### DIFF
--- a/alberta_framework/benchmarks/_foragax_open_screen_probe.py
+++ b/alberta_framework/benchmarks/_foragax_open_screen_probe.py
@@ -13,6 +13,7 @@ import hashlib
 import importlib.metadata
 import importlib.util
 import json
+from alberta_framework._strict_json import load_strict_json_object
 import os
 import sqlite3
 import subprocess
@@ -170,8 +171,7 @@ def _root_is_read_only() -> bool:
 
 
 def _load_config(path: Path) -> dict[str, Any]:
-    with path.open("r", encoding="utf-8") as stream:
-        value = json.load(stream)
+    value = load_strict_json_object(path)
     if not isinstance(value, dict):
         _fail(f"configuration must be an object: {path}")
     return cast(dict[str, Any], value)

--- a/alberta_framework/benchmarks/_foragax_open_screen_probe.py
+++ b/alberta_framework/benchmarks/_foragax_open_screen_probe.py
@@ -13,13 +13,14 @@ import hashlib
 import importlib.metadata
 import importlib.util
 import json
-from alberta_framework._strict_json import load_strict_json_object
 import os
 import sqlite3
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
 from typing import Any, NoReturn, TypeGuard, cast
+
+from alberta_framework._strict_json import load_strict_json_object
 
 _SOURCE_ROOT = Path("/opt/foragax-agents")
 _PROTOCOL_ROOT = Path("/protocol")

--- a/alberta_framework/benchmarks/_foragax_open_screen_probe.py
+++ b/alberta_framework/benchmarks/_foragax_open_screen_probe.py
@@ -175,7 +175,7 @@ def _load_config(path: Path) -> dict[str, Any]:
     value = load_strict_json_object(path)
     if not isinstance(value, dict):
         _fail(f"configuration must be an object: {path}")
-    return cast(dict[str, Any], value)
+    return value
 
 
 def _canonical_sqlite(path: Path) -> dict[str, Any]:

--- a/alberta_framework/forager_cli.py
+++ b/alberta_framework/forager_cli.py
@@ -28,6 +28,8 @@ import tempfile
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
+
+from alberta_framework._strict_json import load_strict_json_object
 from typing import Any, cast
 
 import jax
@@ -763,8 +765,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
     for manifest_path in args.reference_manifest:
         try:
-            dispatch = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            dispatch = load_strict_json_object(manifest_path)
+        except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
             parser.error(
                 f"could not decode --reference-manifest {manifest_path}: {exc}"
             )

--- a/alberta_framework/forager_cli.py
+++ b/alberta_framework/forager_cli.py
@@ -28,12 +28,11 @@ import tempfile
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
-
-from alberta_framework._strict_json import load_strict_json_object
 from typing import Any, cast
 
 import jax
 
+from alberta_framework._strict_json import load_strict_json_object
 from alberta_framework.benchmarks.causal_map_forager import (
     CAUSAL_MAP_VARIANT_KIND,
     CausalMapForagerAgent,
@@ -557,6 +556,51 @@ def historical_main(
     return 0
 
 
+def _verified_reference_manifest_specs(
+    parser: argparse.ArgumentParser,
+    manifest_paths: Sequence[Path],
+    environment: Any,
+) -> tuple[Any, ...]:
+    """Verify reference manifests before any benchmark execution begins."""
+
+    from alberta_framework.benchmarks import official_foragax as official_foragax_module
+
+    specs: list[Any] = []
+    for manifest_path in manifest_paths:
+        try:
+            dispatch = load_strict_json_object(manifest_path)
+        except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
+            parser.error(f"could not decode --reference-manifest {manifest_path}: {exc}")
+        manifest_kind = dispatch.get("manifest_kind")
+        try:
+            if manifest_kind == "official_foragax_single":
+                verified = (
+                    official_foragax_module.official_foragax_run_spec_from_manifest(
+                        manifest_path,
+                        environment=environment,
+                    ),
+                )
+            elif manifest_kind == "official_foragax_batch":
+                verified = (
+                    official_foragax_module.official_foragax_batch_run_specs_from_manifest(
+                        manifest_path,
+                        environment=environment,
+                    )
+                )
+            else:
+                parser.error(
+                    f"--reference-manifest {manifest_path} has unsupported "
+                    f"manifest_kind {manifest_kind!r}"
+                )
+        except (
+            official_foragax_module.OfficialForagaxValidationError,
+            FileNotFoundError,
+        ) as exc:
+            parser.error(f"--reference-manifest {manifest_path} did not verify: {exc}")
+        specs.extend(verified)
+    return tuple(specs)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the benchmark CLI."""
     _configure_logging()
@@ -698,6 +742,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         features=features,
     )
 
+    manifest_specs = _verified_reference_manifest_specs(
+        parser,
+        args.reference_manifest,
+        environment,
+    )
+
     agents = args.agents or ["alberta", "random"]
     if "causal-map" in agents and preset != "field_of_view":
         parser.error("--agent causal-map is defined only for --preset field_of_view")
@@ -763,56 +813,15 @@ def main(argv: Sequence[str] | None = None) -> int:
                 final_window=benchmark_config.final_window,
             )
         )
-    for manifest_path in args.reference_manifest:
-        try:
-            dispatch = load_strict_json_object(manifest_path)
-        except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
-            parser.error(
-                f"could not decode --reference-manifest {manifest_path}: {exc}"
-            )
-        if not isinstance(dispatch, Mapping):
-            parser.error(
-                f"--reference-manifest {manifest_path} must contain a JSON object"
-            )
-        manifest_kind = dispatch.get("manifest_kind")
-        from alberta_framework.benchmarks import (
-            official_foragax as official_foragax_module,
+    runs.extend(
+        import_official_foragax_npz(
+            spec,
+            ewm_decay=protocol.ewm_decay,
+            record_every=args.record_every,
+            final_window=benchmark_config.final_window,
         )
-
-        try:
-            if manifest_kind == "official_foragax_single":
-                specs = (
-                    official_foragax_module.official_foragax_run_spec_from_manifest(
-                        manifest_path,
-                        environment=environment,
-                    ),
-                )
-            elif manifest_kind == "official_foragax_batch":
-                specs = official_foragax_module.official_foragax_batch_run_specs_from_manifest(
-                    manifest_path,
-                    environment=environment,
-                )
-            else:
-                parser.error(
-                    f"--reference-manifest {manifest_path} has unsupported "
-                    f"manifest_kind {manifest_kind!r}"
-                )
-        except (
-            official_foragax_module.OfficialForagaxValidationError,
-            FileNotFoundError,
-        ) as exc:
-            parser.error(
-                f"--reference-manifest {manifest_path} did not verify: {exc}"
-            )
-        runs.extend(
-            import_official_foragax_npz(
-                spec,
-                ewm_decay=protocol.ewm_decay,
-                record_every=args.record_every,
-                final_window=benchmark_config.final_window,
-            )
-            for spec in specs
-        )
+        for spec in manifest_specs
+    )
 
     grouped: dict[str, list[Any]] = {}
     for run in runs:

--- a/tests/test_foragax_open_screen.py
+++ b/tests/test_foragax_open_screen.py
@@ -38,6 +38,14 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def test_probe_configuration_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text('{"run_id":"first","run_id":"second"}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        probe._load_config(path)
+
+
 def _result_root(config: screen.FrozenConfiguration) -> str:
     return f"results/synthetic/{config.run_id}"
 

--- a/tests/test_forager_cli.py
+++ b/tests/test_forager_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -107,6 +108,16 @@ def test_json_safe_rejects_nonfinite_protocol_identities() -> None:
     for bad in (float("nan"), float("inf"), float("-inf"), np.float64("nan")):
         with pytest.raises(ValueError, match="forager CLI payload is not finite JSON"):
             forager_cli._json_safe({"scale": bad})
+
+
+def test_reference_manifest_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    manifest = tmp_path / "duplicate.json"
+    manifest.write_text('{"schema":"first","schema":"second"}', encoding="utf-8")
+
+    with pytest.raises(SystemExit) as error:
+        forager_cli.main(("--reference-manifest", str(manifest)))
+
+    assert error.value.code == 2
 
 
 def test_protocol_and_baseline_dumps_refuse_nonfinite_json() -> None:


### PR DESCRIPTION
Consolidates and deepens #2053.

Both Foragax probe configuration and reference-dispatch manifests now use the shared duplicate-key-rejecting JSON loader. Reference manifests are also parsed and fully verified before any local benchmark run starts, so malformed dispatch cannot consume environment steps before failing.

Added public-path regressions for duplicate keys at both boundaries. Focused tests pass, Ruff is clean, and the touched source passes strict mypy.
