### PR TITLE
fix(utils): reject oversized export names before timeseries header hang

### DIFF
--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_EXPORT_STRING_BYTES = 256
+_MAX_EXPORT_FILENAME_BYTES = 200
 _PATH_TYPES = frozenset({Path, type(Path())})
 _ACTUAL_INT_TYPES = frozenset(
     {
@@ -56,9 +58,22 @@ def _require_path(value: object, *, name: str = "path") -> Path:
     raise ValueError(f"{name} must be an exact str or Path")
 
 
-def _require_exact_str(name: str, value: object) -> str:
+def _require_exact_str(
+    name: str,
+    value: object,
+    *,
+    maximum: int = _MAX_EXPORT_STRING_BYTES,
+) -> str:
     if type(value) is not str:
         raise ValueError(f"{name} must be an exact string")
+    if type(maximum) is not int or maximum < 1:
+        raise ValueError("export string limit must be a positive exact integer")
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{name} must be valid UTF-8") from exc
+    if len(encoded) > maximum:
+        raise ValueError(f"{name} exceeds the {maximum}-byte export limit")
     return value
 
 
@@ -140,7 +155,7 @@ def _preflight_significance_results(
 
 
 def _require_filename_component(name: str) -> str:
-    _require_exact_str("experiment_name", name)
+    _require_exact_str("experiment_name", name, maximum=_MAX_EXPORT_FILENAME_BYTES)
     if not name or name in {".", ".."} or Path(name).name != name or "\x00" in name:
         raise ValueError("experiment_name must be one safe filename component")
     return name

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -208,6 +208,49 @@ def test_timeseries_csv_round_trips_values_under_the_matching_seed_headers(
     ]
 
 
+@pytest.mark.parametrize("mode", ["summary_csv", "timeseries_csv", "json"])
+def test_export_rejects_oversized_config_name_before_header_hang(
+    mode: str,
+    tmp_path: Path,
+) -> None:
+    name = "a" * 50_000
+    result = _constant_result("placeholder")._replace(config_name=name)
+    results = {name: result}
+    suffix = "json" if mode == "json" else "csv"
+    existing = tmp_path / f"existing.{suffix}"
+    sentinel = "existing artifact\n"
+    existing.write_text(sentinel, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="config name exceeds"):
+        _export_mode(mode, results, existing)
+
+    assert existing.read_text(encoding="utf-8") == sentinel
+
+
+def test_timeseries_csv_accepts_max_config_name(tmp_path: Path) -> None:
+    name = "a" * export_module._MAX_EXPORT_STRING_BYTES
+    result = _constant_result("placeholder")._replace(config_name=name)
+    path = tmp_path / "bounded.csv"
+    export_to_csv({name: result}, path, include_timeseries=True)
+    assert path.is_file()
+    with path.open(encoding="utf-8", newline="") as handle:
+        assert next(csv.DictReader(handle))[f"{name}_seed17"] == "1.0"
+
+
+def test_report_rejects_oversized_experiment_name_before_path_join(
+    tmp_path: Path,
+) -> None:
+    results = {"candidate": _constant_result("candidate")}
+    with pytest.raises(ValueError, match="experiment_name exceeds"):
+        save_experiment_report(
+            results,
+            tmp_path,
+            "a" * (export_module._MAX_EXPORT_FILENAME_BYTES + 1),
+            metric=_METRIC,
+        )
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_json_round_trips_summary_values_and_timeseries(tmp_path: Path) -> None:
     results = {
         f"value_{index}": _constant_result(f"value_{index}", value)


### PR DESCRIPTION
## Summary

`export_to_csv(..., include_timeseries=True)` builds one CSV header field per seed as `{config_name}_seed{seed}` before any string bound. Origin/main (`0d6f7d1d`) accepts the already-capped 4096 unique seeds, so a 50_000-byte config name hangs ~2.8s concatenating headers and then writes a hundreds-of-megabytes CSV. Leftover INT32 cell accounting does not cover identity strings.

This PR rejects export identity strings above 256 UTF-8 bytes (200 for experiment filenames) in the shared preflight, before timeseries headers, JSON keys, LaTeX/markdown method names, or report path joins. Ordinary bounded names keep the existing round-trip contract.

Occupancy-FREE (`alberta_framework/utils/export.py`). Not leftover-tax persist/INT32, json-nest, jax.tree, SIGReg, scan-T, collection-walk of integer lists, prototype_feature_lifecycle, forager, clocks, or IA.

## Proof

Origin red: `export_to_csv` of one aggregate with `config_name="a"*50_000` and 4096 seeds, `include_timeseries=True`, returned after 2.763s and wrote the file.

This head: the same call raises `ValueError: config name exceeds the 256-byte export limit` in 0.001s and does not create/replace the destination. 122 `tests/test_export.py` passed, including oversized-name mutation tests and a max-length name that still round-trips.

```
.venv/bin/python -m pytest tests/test_export.py -q
```

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f306768337567f42c9bde52a01f93c762f3b69d0 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
