### PR TITLE
fix(benchmarks): reject oversized provenance registries before JSON hang

### DIFF
--- a/alberta_framework/benchmarks/development_provenance.py
+++ b/alberta_framework/benchmarks/development_provenance.py
@@ -16,9 +16,45 @@ from typing import cast
 import jax
 import numpy as np
 
+_MAX_REGISTRY_ITEMS = 4096
+_MAX_REGISTRY_STRING_BYTES = 4096
+_MAX_REGISTRY_BYTES = 1 << 20
+
 
 def _sha256_bytes(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
+
+
+def _require_bounded_registry(value: object) -> None:
+    """Reject oversized host containers before canonical JSON encoding."""
+    if type(value) in (list, tuple):
+        items = cast(Sequence[object], value)
+        if len(items) > _MAX_REGISTRY_ITEMS:
+            raise ValueError("registry exceeds the collection limit")
+        for item in items:
+            _require_bounded_registry(item)
+        return
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[object, object], value)
+        if len(mapping) > _MAX_REGISTRY_ITEMS:
+            raise ValueError("registry exceeds the collection limit")
+        for key, item in mapping.items():
+            if type(key) is not str:
+                raise TypeError("registry mapping keys must be exact strings")
+            _require_bounded_registry(key)
+            _require_bounded_registry(item)
+        return
+    if type(value) is str:
+        try:
+            encoded = value.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise ValueError("registry string must be valid UTF-8") from exc
+        if len(encoded) > _MAX_REGISTRY_STRING_BYTES:
+            raise ValueError("registry string exceeds the byte limit")
+        return
+    if type(value) in (int, float, bool) or value is None:
+        return
+    raise TypeError(f"unsupported registry value: {type(value).__name__}")
 
 
 def _canonical(value: object) -> object:
@@ -32,9 +68,12 @@ def _canonical(value: object) -> object:
 
 
 def registry_sha256(value: object) -> str:
+    _require_bounded_registry(value)
     encoded = json.dumps(
         _canonical(value), sort_keys=True, separators=(",", ":"), ensure_ascii=True
     ).encode("ascii")
+    if len(encoded) > _MAX_REGISTRY_BYTES:
+        raise ValueError("registry exceeds the canonical JSON byte limit")
     return _sha256_bytes(encoded)
 
 

--- a/tests/test_development_provenance_registry.py
+++ b/tests/test_development_provenance_registry.py
@@ -1,0 +1,40 @@
+"""Development provenance registries reject oversized host values before dump hang."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.benchmarks import development_provenance as provenance
+
+pytestmark = pytest.mark.unit
+
+
+def test_registry_sha256_rejects_oversized_list_before_dump_hang() -> None:
+    payload = [0] * (provenance._MAX_REGISTRY_ITEMS + 1)
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="collection limit"):
+        provenance.registry_sha256(payload)
+    assert time.perf_counter() - started < 0.25
+
+
+def test_registry_sha256_accepts_bounded_list_and_mapping() -> None:
+    listed = provenance.registry_sha256([1, 2, 3])
+    mapped = provenance.registry_sha256({"max_items": 16, "seeds": (1, 2)})
+    assert listed == provenance.registry_sha256([1, 2, 3])
+    assert mapped == provenance.registry_sha256({"max_items": 16, "seeds": (1, 2)})
+    assert listed != mapped
+
+
+def test_collect_development_identity_hashes_bounded_registries() -> None:
+    workload = (("arm_ids", ("a", "b")), ("max_steps", 16))
+    papers = {"paper": "arXiv:0000.00000"}
+    identity = provenance.collect_development_identity(
+        lane_module=provenance,
+        dependency_modules=(),
+        workload_registry=workload,
+        paper_registry=papers,
+    )
+    assert identity.workload_registry_sha256 == provenance.registry_sha256(workload)
+    assert identity.paper_registry_sha256 == provenance.registry_sha256(papers)


### PR DESCRIPTION
## Summary

Public `registry_sha256` (and every development lane identity that calls it) canonicalizes then `json.dumps` host lists/mappings with no collection bound. Origin/main (`0d6f7d1d`) dumped a 12e6-int registry in 3.375s.

This PR rejects containers above 4096 items (and strings above 4096 UTF-8 bytes) before the walk and dump. Ordinary bounded workload/paper registries keep the same digest.

Occupancy-FREE (`alberta_framework/benchmarks/development_provenance.py`). Not leftover-tax persist/INT32, json-nest, jax.tree, SIGReg, scan-T, prototype_feature_lifecycle, export headers, forager, clocks, or IA.

## Proof

Origin red: `registry_sha256([0]*12_000_000)` returned after 3.375s.

This head: the same call raises `ValueError: registry exceeds the collection limit` in 0.009s. 3 new unit tests plus 55 consuming-lane tests passed.

```
.venv/bin/python -m pytest tests/test_development_provenance_registry.py -q
```

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7955f25dc47002cfe69a56cd1d9b29145f9ed48a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
