### PR TITLE
ci: restore runtime shard headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ name: ci
 # Benchmarks never execute in CI. The runtime lane collects only tests selected
 # by `not slow and not package`, balances their files by collected-node count,
 # and caps xdist at two workers so JAX compilation remains inside hosted-runner
-# memory limits. Sixteen partitions also keep file-level runtime skew inside the
-# hosted-runner execution envelope; collected-node count alone underestimates
-# several integration-heavy files.
+# memory limits. Twenty-four partitions keep the growing suite and file-level
+# runtime skew inside the repository's five-minute hosted-runner envelope;
+# collected-node count alone underestimates several integration-heavy files.
 "on":
   push:
     branches: [main]
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  SHARD_COUNT: "16"
+  SHARD_COUNT: "24"
   XLA_PYTHON_CLIENT_PREALLOCATE: "false"
 
 jobs:


### PR DESCRIPTION
## Summary

Increase the fast runtime matrix from 16 to 24 deterministic file shards.

Three independent reviewed consolidations reached 92–98% in their overloaded shards and were then canceled at the repository's effective five-minute runner envelope on both Python versions. There were no test failures. The suite has grown past the capacity assumption documented when 16 partitions were chosen, and collected-node balancing underestimates integration-heavy files.

Twenty-four shards reduce the planned node load by one third while preserving the existing whole-file deterministic planner, two-worker JAX memory cap, markers, Python coverage, and stable `ci-ok` gate.

## Validation

- `tests/test_ci_shard_planner.py`: 4 passed
- Ruff on planner and planner tests: passed
- `git diff --check`: passed
