### PR TITLE
fix(benchmarks): reject oversized FTL MPC horizons before 4**H hang

### DIFF
--- a/alberta_framework/benchmarks/ftl_online_agent_development.py
+++ b/alberta_framework/benchmarks/ftl_online_agent_development.py
@@ -42,6 +42,7 @@ ARM_IDS = ("sparse_ftl_online", "sparse_ftl_frozen", "privileged_dynamics_mpc")
 ACTION_DELTAS = np.asarray(((1, 0), (-1, 0), (0, 1), (0, -1)), dtype=np.float32)
 ACTION_DELTAS.flags.writeable = False
 MAX_STEPS_PER_TASK = 16
+MAX_PLANNING_HORIZON = 4
 WORKLOAD_REGISTRY = (
     ("arm_ids", ARM_IDS),
     ("action_deltas", ((1, 0), (-1, 0), (0, 1), (0, -1))),
@@ -146,7 +147,7 @@ class DevelopmentResult:
         if self.seed not in FROZEN_SEEDS:
             raise ValueError("seed is outside the frozen development schedule")
         _int(self.steps_per_task, "steps_per_task", 1, MAX_STEPS_PER_TASK)
-        _int(self.planning_horizon, "planning_horizon", 1, 4)
+        _int(self.planning_horizon, "planning_horizon", 1, MAX_PLANNING_HORIZON)
         if (
             type(self.arms) is not tuple
             or any(type(arm) is not ArmResult for arm in self.arms)
@@ -187,7 +188,8 @@ def _mpc_action(
     horizon: int,
     predict: Callable[[np.ndarray, int], np.ndarray],
 ) -> tuple[int, int, int]:
-    sequences = tuple(itertools.product(range(4), repeat=horizon))
+    host_horizon = _int(horizon, "planning_horizon", 1, MAX_PLANNING_HORIZON)
+    sequences = tuple(itertools.product(range(4), repeat=host_horizon))
     best_score = -math.inf
     best_action = 0
     queries = 0
@@ -279,7 +281,7 @@ def run_development_lane(
     if host_seed not in FROZEN_SEEDS:
         raise ValueError("seed is outside the frozen development schedule")
     steps = _int(steps_per_task, "steps_per_task", 1, MAX_STEPS_PER_TASK)
-    horizon = _int(planning_horizon, "planning_horizon", 1, 4)
+    horizon = _int(planning_horizon, "planning_horizon", 1, MAX_PLANNING_HORIZON)
     result = DevelopmentResult(
         schema=SCHEMA,
         seed=host_seed,

--- a/tests/test_ftl_mpc_enumeration_hang.py
+++ b/tests/test_ftl_mpc_enumeration_hang.py
@@ -1,0 +1,39 @@
+"""FTL MPC enumeration rejects oversized horizons before 4**H hang."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.ftl_online_agent_development import (
+    MAX_PLANNING_HORIZON,
+    _mpc_action,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _identity_predict(observation: np.ndarray, action: int) -> np.ndarray:
+    return observation
+
+
+def test_mpc_rejects_unbounded_horizon_before_product_hang() -> None:
+    observation = np.zeros(2, dtype=np.float32)
+    goal = np.ones(2, dtype=np.float32)
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="planning_horizon"):
+        _mpc_action(observation, goal, MAX_PLANNING_HORIZON + 6, _identity_predict)
+    assert time.perf_counter() - started < 0.25
+
+
+def test_mpc_enumerates_the_public_horizon_bound() -> None:
+    observation = np.zeros(2, dtype=np.float32)
+    goal = np.ones(2, dtype=np.float32)
+    action, queries, candidates = _mpc_action(
+        observation, goal, MAX_PLANNING_HORIZON, _identity_predict
+    )
+    assert action == 0
+    assert candidates == 4**MAX_PLANNING_HORIZON
+    assert queries == MAX_PLANNING_HORIZON * candidates


### PR DESCRIPTION
## Summary

`_mpc_action` builds `tuple(itertools.product(range(4), repeat=horizon))` before any horizon bound. Origin/main (`5b889323`) enumerates `4**10 = 1,048,576` action sequences in 9.2s (10,485,760 predict queries). The public `run_development_lane` cap of 4 does not protect the enumerator.

This PR validates `planning_horizon` in `[1, 4]` inside `_mpc_action` before the product is constructed. Horizon 4 still enumerates 256 sequences. Ordinary development-lane receipts are unchanged.

Occupancy-FREE (`alberta_framework/benchmarks/ftl_online_agent_development.py`). Not leftover-tax persist/INT32, json-nest, jax.tree, SIGReg, scan-T, prototype_feature_lifecycle, rule_discovery, forager, clocks, or IA.

## Proof

Origin red: `_mpc_action(..., horizon=10)` returned after 9.156s.

This head: the same call raises `ValueError: planning_horizon must lie in [1, 4]` in 4µs. 2 new unit tests plus 9 existing lane tests passed (11).

```
.venv/bin/python -m pytest tests/test_ftl_mpc_enumeration_hang.py tests/test_ftl_online_agent_development.py -q
```

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:76b060361edfca1e43f05d651b4e995b7d6681eb -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
