### PR TITLE
fix(serialization): bound export and provenance identities

### DIFF
--- a/alberta_framework/benchmarks/development_provenance.py
+++ b/alberta_framework/benchmarks/development_provenance.py
@@ -16,9 +16,45 @@ from typing import cast
 import jax
 import numpy as np
 
+_MAX_REGISTRY_ITEMS = 4096
+_MAX_REGISTRY_STRING_BYTES = 4096
+_MAX_REGISTRY_BYTES = 1 << 20
+
 
 def _sha256_bytes(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
+
+
+def _require_bounded_registry(value: object) -> None:
+    """Reject oversized host containers before canonical JSON encoding."""
+    if type(value) in (list, tuple):
+        items = cast(Sequence[object], value)
+        if len(items) > _MAX_REGISTRY_ITEMS:
+            raise ValueError("registry exceeds the collection limit")
+        for item in items:
+            _require_bounded_registry(item)
+        return
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[object, object], value)
+        if len(mapping) > _MAX_REGISTRY_ITEMS:
+            raise ValueError("registry exceeds the collection limit")
+        for key, item in mapping.items():
+            if type(key) is not str:
+                raise TypeError("registry mapping keys must be exact strings")
+            _require_bounded_registry(key)
+            _require_bounded_registry(item)
+        return
+    if type(value) is str:
+        try:
+            encoded = value.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise ValueError("registry string must be valid UTF-8") from exc
+        if len(encoded) > _MAX_REGISTRY_STRING_BYTES:
+            raise ValueError("registry string exceeds the byte limit")
+        return
+    if type(value) in (int, float, bool) or value is None:
+        return
+    raise TypeError(f"unsupported registry value: {type(value).__name__}")
 
 
 def _canonical(value: object) -> object:
@@ -32,9 +68,12 @@ def _canonical(value: object) -> object:
 
 
 def registry_sha256(value: object) -> str:
+    _require_bounded_registry(value)
     encoded = json.dumps(
         _canonical(value), sort_keys=True, separators=(",", ":"), ensure_ascii=True
     ).encode("ascii")
+    if len(encoded) > _MAX_REGISTRY_BYTES:
+        raise ValueError("registry exceeds the canonical JSON byte limit")
     return _sha256_bytes(encoded)
 
 

--- a/alberta_framework/benchmarks/development_provenance.py
+++ b/alberta_framework/benchmarks/development_provenance.py
@@ -40,6 +40,16 @@ class _RegistryBudget:
         self.entries += count
 
 
+def _require_registry_string(value: str) -> str:
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError("registry string must be valid UTF-8") from exc
+    if len(encoded) > _MAX_REGISTRY_STRING_BYTES:
+        raise ValueError("registry string exceeds the byte limit")
+    return value
+
+
 def _canonical(
     value: object,
     *,
@@ -56,6 +66,8 @@ def _canonical(
         budget.consume(len(mapping))
         if any(type(key) is not str for key in mapping):
             raise TypeError("registry mapping keys must be exact strings")
+        for key in mapping:
+            _require_registry_string(cast(str, key))
         return {
             key: _canonical(item, budget=budget, depth=depth + 1)
             for key, item in sorted(cast(dict[str, object], mapping).items())
@@ -65,13 +77,7 @@ def _canonical(
         budget.consume(len(items))
         return [_canonical(item, budget=budget, depth=depth + 1) for item in items]
     if type(value) is str:
-        try:
-            encoded = value.encode("utf-8")
-        except UnicodeEncodeError as exc:
-            raise ValueError("registry string must be valid UTF-8") from exc
-        if len(encoded) > _MAX_REGISTRY_STRING_BYTES:
-            raise ValueError("registry string exceeds the byte limit")
-        return value
+        return _require_registry_string(value)
     if type(value) is int:
         if value.bit_length() > _MAX_REGISTRY_INTEGER_BITS:
             raise ValueError("registry integer exceeds the scalar limit")

--- a/alberta_framework/benchmarks/development_provenance.py
+++ b/alberta_framework/benchmarks/development_provenance.py
@@ -6,44 +6,64 @@ import dataclasses
 import hashlib
 import inspect
 import json
+import math
 import platform
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
-from types import ModuleType
+from types import MappingProxyType, ModuleType
 from typing import cast
 
 import jax
 import numpy as np
 
 _MAX_REGISTRY_ITEMS = 4096
+_MAX_REGISTRY_DEPTH = 32
 _MAX_REGISTRY_STRING_BYTES = 4096
+_MAX_REGISTRY_INTEGER_BITS = 13_600
 _MAX_REGISTRY_BYTES = 1 << 20
+_MAPPING_PROXY_TYPE: type[object] = type(MappingProxyType({}))
 
 
 def _sha256_bytes(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
-def _require_bounded_registry(value: object) -> None:
-    """Reject oversized host containers before canonical JSON encoding."""
-    if type(value) in (list, tuple):
+@dataclass(slots=True)
+class _RegistryBudget:
+    entries: int = 0
+
+    def consume(self, count: int) -> None:
+        if count > _MAX_REGISTRY_ITEMS - self.entries:
+            raise ValueError("registry exceeds the collection limit")
+        self.entries += count
+
+
+def _canonical(
+    value: object,
+    *,
+    budget: _RegistryBudget | None = None,
+    depth: int = 0,
+) -> object:
+    """Canonicalize one trusted JSON-shaped value within aggregate host limits."""
+    if budget is None:
+        budget = _RegistryBudget()
+    if depth > _MAX_REGISTRY_DEPTH:
+        raise ValueError("registry exceeds the nesting-depth limit")
+    if type(value) in (dict, _MAPPING_PROXY_TYPE):
+        mapping = cast(dict[object, object], value)
+        budget.consume(len(mapping))
+        if any(type(key) is not str for key in mapping):
+            raise TypeError("registry mapping keys must be exact strings")
+        return {
+            key: _canonical(item, budget=budget, depth=depth + 1)
+            for key, item in sorted(cast(dict[str, object], mapping).items())
+        }
+    if type(value) in (tuple, list):
         items = cast(Sequence[object], value)
-        if len(items) > _MAX_REGISTRY_ITEMS:
-            raise ValueError("registry exceeds the collection limit")
-        for item in items:
-            _require_bounded_registry(item)
-        return
-    if isinstance(value, Mapping):
-        mapping = cast(Mapping[object, object], value)
-        if len(mapping) > _MAX_REGISTRY_ITEMS:
-            raise ValueError("registry exceeds the collection limit")
-        for key, item in mapping.items():
-            if type(key) is not str:
-                raise TypeError("registry mapping keys must be exact strings")
-            _require_bounded_registry(key)
-            _require_bounded_registry(item)
-        return
+        budget.consume(len(items))
+        return [_canonical(item, budget=budget, depth=depth + 1) for item in items]
     if type(value) is str:
         try:
             encoded = value.encode("utf-8")
@@ -51,26 +71,27 @@ def _require_bounded_registry(value: object) -> None:
             raise ValueError("registry string must be valid UTF-8") from exc
         if len(encoded) > _MAX_REGISTRY_STRING_BYTES:
             raise ValueError("registry string exceeds the byte limit")
-        return
-    if type(value) in (int, float, bool) or value is None:
-        return
-    raise TypeError(f"unsupported registry value: {type(value).__name__}")
-
-
-def _canonical(value: object) -> object:
-    if isinstance(value, Mapping):
-        return {key: _canonical(item) for key, item in sorted(value.items())}
-    if type(value) in (tuple, list):
-        return [_canonical(item) for item in cast(Sequence[object], value)]
-    if type(value) in (str, int, float, bool) or value is None:
+        return value
+    if type(value) is int:
+        if value.bit_length() > _MAX_REGISTRY_INTEGER_BITS:
+            raise ValueError("registry integer exceeds the scalar limit")
+        return value
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ValueError("registry floats must be finite")
+        return value
+    if type(value) is bool or value is None:
         return value
     raise TypeError(f"unsupported registry value: {type(value).__name__}")
 
 
 def registry_sha256(value: object) -> str:
-    _require_bounded_registry(value)
     encoded = json.dumps(
-        _canonical(value), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        _canonical(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
     ).encode("ascii")
     if len(encoded) > _MAX_REGISTRY_BYTES:
         raise ValueError("registry exceeds the canonical JSON byte limit")

--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_EXPORT_STRING_BYTES = 256
+_MAX_EXPORT_FILENAME_BYTES = 200
 _PATH_TYPES = frozenset({Path, type(Path())})
 _ACTUAL_INT_TYPES = frozenset(
     {
@@ -56,9 +58,22 @@ def _require_path(value: object, *, name: str = "path") -> Path:
     raise ValueError(f"{name} must be an exact str or Path")
 
 
-def _require_exact_str(name: str, value: object) -> str:
+def _require_exact_str(
+    name: str,
+    value: object,
+    *,
+    maximum: int = _MAX_EXPORT_STRING_BYTES,
+) -> str:
     if type(value) is not str:
         raise ValueError(f"{name} must be an exact string")
+    if type(maximum) is not int or maximum < 1:
+        raise ValueError("export string limit must be a positive exact integer")
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{name} must be valid UTF-8") from exc
+    if len(encoded) > maximum:
+        raise ValueError(f"{name} exceeds the {maximum}-byte export limit")
     return value
 
 
@@ -140,7 +155,7 @@ def _preflight_significance_results(
 
 
 def _require_filename_component(name: str) -> str:
-    _require_exact_str("experiment_name", name)
+    _require_exact_str("experiment_name", name, maximum=_MAX_EXPORT_FILENAME_BYTES)
     if not name or name in {".", ".."} or Path(name).name != name or "\x00" in name:
         raise ValueError("experiment_name must be one safe filename component")
     return name

--- a/tests/test_development_provenance_registry.py
+++ b/tests/test_development_provenance_registry.py
@@ -1,0 +1,40 @@
+"""Development provenance registries reject oversized host values before dump hang."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.benchmarks import development_provenance as provenance
+
+pytestmark = pytest.mark.unit
+
+
+def test_registry_sha256_rejects_oversized_list_before_dump_hang() -> None:
+    payload = [0] * (provenance._MAX_REGISTRY_ITEMS + 1)
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="collection limit"):
+        provenance.registry_sha256(payload)
+    assert time.perf_counter() - started < 0.25
+
+
+def test_registry_sha256_accepts_bounded_list_and_mapping() -> None:
+    listed = provenance.registry_sha256([1, 2, 3])
+    mapped = provenance.registry_sha256({"max_items": 16, "seeds": (1, 2)})
+    assert listed == provenance.registry_sha256([1, 2, 3])
+    assert mapped == provenance.registry_sha256({"max_items": 16, "seeds": (1, 2)})
+    assert listed != mapped
+
+
+def test_collect_development_identity_hashes_bounded_registries() -> None:
+    workload = (("arm_ids", ("a", "b")), ("max_steps", 16))
+    papers = {"paper": "arXiv:0000.00000"}
+    identity = provenance.collect_development_identity(
+        lane_module=provenance,
+        dependency_modules=(),
+        workload_registry=workload,
+        paper_registry=papers,
+    )
+    assert identity.workload_registry_sha256 == provenance.registry_sha256(workload)
+    assert identity.paper_registry_sha256 == provenance.registry_sha256(papers)

--- a/tests/test_development_provenance_registry.py
+++ b/tests/test_development_provenance_registry.py
@@ -45,6 +45,12 @@ def test_registry_budget_is_aggregate_not_per_container() -> None:
         provenance.registry_sha256(payload)
 
 
+def test_registry_rejects_large_canonical_payload_after_a_bounded_walk() -> None:
+    payload = ["x" * provenance._MAX_REGISTRY_STRING_BYTES] * 300
+    with pytest.raises(ValueError, match="canonical JSON byte limit"):
+        provenance.registry_sha256(payload)
+
+
 def test_registry_rejects_deep_or_hostile_values_before_hooks_or_dump() -> None:
     nested: object = None
     for _ in range(provenance._MAX_REGISTRY_DEPTH + 1):

--- a/tests/test_development_provenance_registry.py
+++ b/tests/test_development_provenance_registry.py
@@ -51,6 +51,12 @@ def test_registry_rejects_large_canonical_payload_after_a_bounded_walk() -> None
         provenance.registry_sha256(payload)
 
 
+def test_registry_applies_string_budget_to_mapping_keys() -> None:
+    key = "k" * (provenance._MAX_REGISTRY_STRING_BYTES + 1)
+    with pytest.raises(ValueError, match="string exceeds the byte limit"):
+        provenance.registry_sha256({key: 1})
+
+
 def test_registry_rejects_deep_or_hostile_values_before_hooks_or_dump() -> None:
     nested: object = None
     for _ in range(provenance._MAX_REGISTRY_DEPTH + 1):

--- a/tests/test_development_provenance_registry.py
+++ b/tests/test_development_provenance_registry.py
@@ -3,12 +3,24 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Iterator, Mapping
 
 import pytest
 
 from alberta_framework.benchmarks import development_provenance as provenance
 
 pytestmark = pytest.mark.unit
+
+
+class _HostileMapping(Mapping[str, object]):
+    def __getitem__(self, key: str) -> object:
+        raise AssertionError("hostile mapping indexed")
+
+    def __iter__(self) -> Iterator[str]:
+        raise AssertionError("hostile mapping iterated")
+
+    def __len__(self) -> int:
+        raise AssertionError("hostile mapping measured")
 
 
 def test_registry_sha256_rejects_oversized_list_before_dump_hang() -> None:
@@ -25,6 +37,28 @@ def test_registry_sha256_accepts_bounded_list_and_mapping() -> None:
     assert listed == provenance.registry_sha256([1, 2, 3])
     assert mapped == provenance.registry_sha256({"max_items": 16, "seeds": (1, 2)})
     assert listed != mapped
+
+
+def test_registry_budget_is_aggregate_not_per_container() -> None:
+    payload = [[0] * 2048, [0] * 2048, [0]]
+    with pytest.raises(ValueError, match="collection limit"):
+        provenance.registry_sha256(payload)
+
+
+def test_registry_rejects_deep_or_hostile_values_before_hooks_or_dump() -> None:
+    nested: object = None
+    for _ in range(provenance._MAX_REGISTRY_DEPTH + 1):
+        nested = [nested]
+    with pytest.raises(ValueError, match="nesting-depth limit"):
+        provenance.registry_sha256(nested)
+    with pytest.raises(TypeError, match="unsupported registry value"):
+        provenance.registry_sha256(_HostileMapping())
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), 1 << 13_601])
+def test_registry_rejects_noncanonical_or_oversized_scalars(value: object) -> None:
+    with pytest.raises(ValueError):
+        provenance.registry_sha256(value)
 
 
 def test_collect_development_identity_hashes_bounded_registries() -> None:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -208,6 +208,49 @@ def test_timeseries_csv_round_trips_values_under_the_matching_seed_headers(
     ]
 
 
+@pytest.mark.parametrize("mode", ["summary_csv", "timeseries_csv", "json"])
+def test_export_rejects_oversized_config_name_before_header_hang(
+    mode: str,
+    tmp_path: Path,
+) -> None:
+    name = "a" * 50_000
+    result = _constant_result("placeholder")._replace(config_name=name)
+    results = {name: result}
+    suffix = "json" if mode == "json" else "csv"
+    existing = tmp_path / f"existing.{suffix}"
+    sentinel = "existing artifact\n"
+    existing.write_text(sentinel, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="config name exceeds"):
+        _export_mode(mode, results, existing)
+
+    assert existing.read_text(encoding="utf-8") == sentinel
+
+
+def test_timeseries_csv_accepts_max_config_name(tmp_path: Path) -> None:
+    name = "a" * export_module._MAX_EXPORT_STRING_BYTES
+    result = _constant_result("placeholder")._replace(config_name=name)
+    path = tmp_path / "bounded.csv"
+    export_to_csv({name: result}, path, include_timeseries=True)
+    assert path.is_file()
+    with path.open(encoding="utf-8", newline="") as handle:
+        assert next(csv.DictReader(handle))[f"{name}_seed17"] == "1.0"
+
+
+def test_report_rejects_oversized_experiment_name_before_path_join(
+    tmp_path: Path,
+) -> None:
+    results = {"candidate": _constant_result("candidate")}
+    with pytest.raises(ValueError, match="experiment_name exceeds"):
+        save_experiment_report(
+            results,
+            tmp_path,
+            "a" * (export_module._MAX_EXPORT_FILENAME_BYTES + 1),
+            metric=_METRIC,
+        )
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_json_round_trips_summary_values_and_timeseries(tmp_path: Path) -> None:
     results = {
         f"value_{index}": _constant_result(f"value_{index}", value)


### PR DESCRIPTION
## Summary

This reviewed consolidation accepts the valid core of #2061 and deepens #2062 into a complete host-serialization boundary.

- Bounds UTF-8 export identity names before timeseries header multiplication, JSON keys, report tables, or filename joins; validates the complete aggregate before touching destination files.
- Canonicalizes development provenance registries in one bounded pass instead of walking once and checking JSON size only after a second unbounded traversal.
- Applies an aggregate entry budget across the whole registry, a nesting-depth limit, per-string and final canonical-byte limits, and bounded integer magnitude.
- Rejects non-finite floats, hostile/custom mappings, unsupported values, invalid UTF-8, and excessive structures before hooks or JSON serialization can consume unbounded work.
- Retains exact hashes for ordinary bounded registries and the existing nonpromoting development identity contract.

Supersedes #2061 and #2062.

## Review findings

#2061's per-name fix is appropriately scoped because seed lists already have a 4,096-entry canonical bound, limiting header amplification to roughly one MiB. #2062's per-container walk was not sufficient: nested containers could exceed the limit in aggregate, deep/cyclic values could exhaust recursion, huge integers and non-finite floats were unbounded/noncanonical, and encoded size was checked only after serialization. Those gaps are closed here.

## Validation

- 213 focused export and development-lane consumer tests passed.
- 9 adversarial registry budget tests passed after the final byte-limit coverage was added.
- Ruff passes repository-wide.
- Strict mypy passes across 219 source files.
- `git diff --check` passes.
