### PR TITLE
fix(reference): reject oversized SpaceSpec sequences before tuple hang

### DIFF
--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -174,6 +174,21 @@ def _shape_size(shape: tuple[int, ...]) -> int:
     return size
 
 
+def _require_bounded_sequence_length(
+    value: object,
+    *,
+    name: str,
+    maximum: int,
+) -> int:
+    try:
+        count = len(value)  # type: ignore[arg-type]
+    except TypeError as exc:
+        raise ValueError(f"{name} must be a sized sequence") from exc
+    if type(count) is not int or count < 0 or count > maximum:
+        raise ValueError(f"{name} exceed the array element limit")
+    return count
+
+
 def _numeric_array(value: Any, *, name: str) -> np.ndarray[Any, Any]:
     try:
         array = np.array(value, copy=True)
@@ -344,9 +359,17 @@ class SpaceSpec:
         if self.low is None:
             return
         assert self.high is not None
+        size = _shape_size(self.shape)
+        low_count = _require_bounded_sequence_length(
+            self.low, name="box low bounds", maximum=_MAX_ARRAY_ELEMENTS
+        )
+        high_count = _require_bounded_sequence_length(
+            self.high, name="box high bounds", maximum=_MAX_ARRAY_ELEMENTS
+        )
+        if low_count != size or high_count != size:
+            raise ValueError("box bounds must contain one value per flattened shape entry")
         lows = _numeric_array(self.low, name="box low bounds")
         highs = _numeric_array(self.high, name="box high bounds")
-        size = _shape_size(self.shape)
         if lows.shape != (size,) or highs.shape != (size,):
             raise ValueError("box bounds must contain one value per flattened shape entry")
         if np.any(lows > highs):
@@ -398,13 +421,39 @@ class SpaceSpec:
         high: Sequence[float | int] | None,
         semantic_id: str,
     ) -> SpaceSpec:
+        try:
+            rank = len(shape)
+        except TypeError as exc:
+            raise ValueError("shape must be a tuple of positive integer dimensions or ()") from exc
+        if rank > _MAX_ARRAY_RANK:
+            raise ValueError(f"space rank must be <= {_MAX_ARRAY_RANK}")
+        host_shape = tuple(shape)
+        host_low: tuple[float | int, ...] | None = None
+        host_high: tuple[float | int, ...] | None = None
+        if low is not None or high is not None:
+            if low is None or high is None:
+                raise ValueError("box low and high bounds must both be present or both be absent")
+            low_count = _require_bounded_sequence_length(
+                low, name="box low bounds", maximum=_MAX_ARRAY_ELEMENTS
+            )
+            high_count = _require_bounded_sequence_length(
+                high, name="box high bounds", maximum=_MAX_ARRAY_ELEMENTS
+            )
+            if any(type(dimension) is not int or dimension <= 0 for dimension in host_shape):
+                if host_shape:
+                    raise ValueError("shape must be a tuple of positive integer dimensions or ()")
+            size = _shape_size(host_shape)
+            if low_count != size or high_count != size:
+                raise ValueError("box bounds must contain one value per flattened shape entry")
+            host_low = tuple(low)
+            host_high = tuple(high)
         return cls(
             kind="box",
-            shape=tuple(shape),
+            shape=host_shape,
             dtype=dtype,
             semantic_id=semantic_id,
-            low=None if low is None else tuple(low),
-            high=None if high is None else tuple(high),
+            low=host_low,
+            high=host_high,
         )
 
     def encode(self, value: Any) -> ArrayValue:
@@ -429,6 +478,15 @@ class SpaceSpec:
                 if supplied_name != self.dtype:
                     raise ValueError(
                         f"space value dtype must be exactly {self.dtype}, got {supplied_name}"
+                    )
+            if self.shape != () and not hasattr(value, "dtype"):
+                expected = _shape_size(self.shape)
+                count = _require_bounded_sequence_length(
+                    value, name="space value", maximum=_MAX_ARRAY_ELEMENTS
+                )
+                if count != expected:
+                    raise ValueError(
+                        f"space value shape must be {self.shape}, got ({count},)"
                     )
             array = _numeric_array(value, name="space value")
             if array.shape != self.shape:

--- a/tests/test_reference_agent_box_bounds_hang.py
+++ b/tests/test_reference_agent_box_bounds_hang.py
@@ -1,0 +1,65 @@
+"""SpaceSpec.box rejects oversized sequences before tuple() hang."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.reference_agent import _MAX_ARRAY_ELEMENTS, _MAX_ARRAY_RANK, SpaceSpec
+
+pytestmark = pytest.mark.unit
+
+
+def test_box_rejects_oversized_range_bounds_before_tuple_hang() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="array element limit"):
+        SpaceSpec.box(
+            shape=(2,),
+            dtype="float32",
+            low=range(_MAX_ARRAY_ELEMENTS + 1),
+            high=range(_MAX_ARRAY_ELEMENTS + 1),
+            semantic_id="obs",
+        )
+    assert time.perf_counter() - started < 0.25
+
+
+def test_box_rejects_oversized_range_shape_before_tuple_hang() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="rank"):
+        SpaceSpec.box(
+            shape=range(_MAX_ARRAY_RANK + 1_000_000),  # type: ignore[arg-type]
+            dtype="float32",
+            low=None,
+            high=None,
+            semantic_id="obs",
+        )
+    assert time.perf_counter() - started < 0.25
+
+
+def test_box_encode_rejects_oversized_range_before_numpy_convert() -> None:
+    spec = SpaceSpec.box(
+        shape=(2,),
+        dtype="float32",
+        low=None,
+        high=None,
+        semantic_id="obs",
+    )
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="array element limit"):
+        spec.encode(range(_MAX_ARRAY_ELEMENTS + 1))
+    assert time.perf_counter() - started < 0.25
+
+
+def test_box_still_accepts_matched_bounds() -> None:
+    spec = SpaceSpec.box(
+        shape=(2,),
+        dtype="float32",
+        low=(-1.0, -1.0),
+        high=(1.0, 1.0),
+        semantic_id="obs",
+    )
+    assert spec.low == (-1.0, -1.0)
+    assert spec.high == (1.0, 1.0)
+    encoded = spec.encode((0.0, 0.5))
+    assert encoded.shape == (2,)


### PR DESCRIPTION
## Summary

`SpaceSpec.box` did `tuple(low)`, `tuple(high)`, and `tuple(shape)` before any length check. Origin/main (`45540be4`) spent 4.888s converting `range(50_000_000)` into tuples, then raised a shape-mismatch `ValueError`. `len(range(n))` is O(1); the factory never consulted it.

This PR rejects oversized sequences against the existing rank and `_MAX_ARRAY_ELEMENTS` limits before materializing them. Matched `(-1.0, -1.0)` / `(1.0, 1.0)` boxes still encode.

Occupancy-FREE (`alberta_framework/reference_agent.py`). Not leftover-tax persist/INT32, json-nest, jax.tree, SIGReg, scan-T, prototype_feature_lifecycle, rule_discovery, forager, clocks, or IA.

## Proof

Origin red: `SpaceSpec.box(..., low=range(50_000_000), high=range(50_000_000))` returned after 4.888s.

This head: the same call raises `ValueError: box low bounds exceed the array element limit` in 3µs. 4 new unit tests plus 34 existing reference-agent tests passed (38).

```
.venv/bin/python -m pytest tests/test_reference_agent_box_bounds_hang.py tests/test_reference_agent_protocol.py tests/test_reference_agent_hostile_strings.py tests/test_reference_agent_hostile_validation.py -q
```

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:6694930f580f47542654b5dfd125e89e825f36c0 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
