### PR TITLE
fix(benchmarks): cap causal-map JAX chunks before arange hang

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -3080,10 +3080,10 @@ def _validate_benchmark_contract(
     if (
         type(benchmark_config.jax_chunk_size) is not int
         or benchmark_config.jax_chunk_size < 1
-        or benchmark_config.jax_chunk_size >= _INT32_MAX
+        or benchmark_config.jax_chunk_size > 10_000
     ):
         raise ValueError(
-            "causal-map jax_chunk_size must be a positive int below int32 maximum"
+            "causal-map jax_chunk_size must be an integer in [1, 10000]"
         )
     if env.preset != "field_of_view" or env.resolved_env_id != "ForagaxTwoBiomeLarge-v1":
         raise ValueError(

--- a/tests/test_causal_map_chunk_cap.py
+++ b/tests/test_causal_map_chunk_cap.py
@@ -1,0 +1,21 @@
+"""Protocol ceilings for causal-map JAX chunk scans.
+
+Public Forager last-fit is jax_chunk_size=10_000. Origin accepted INT32-legal
+chunks and scanned jnp.arange(chunk) — hang, not leftover INT32 math.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.causal_map_forager import (
+    CausalMapForagerConfig,
+    _validate_benchmark_contract,
+)
+from alberta_framework.benchmarks.forager import ForagerBenchmarkConfig
+
+
+def test_rejects_oversized_causal_map_chunks() -> None:
+    cfg = ForagerBenchmarkConfig(steps=10_001, jax_chunk_size=10_001)
+    with pytest.raises(ValueError, match="jax_chunk_size"):
+        _validate_benchmark_contract(CausalMapForagerConfig(), cfg)


### PR DESCRIPTION
## Summary
- Cap causal-map `jax_chunk_size` at the public Forager last-fit of 10_000 before `jnp.arange`.
- Reject 10_001 so oversized chunk scans fail closed instead of hanging.

## Test plan
- [x] `pytest tests/test_causal_map_chunk_cap.py`
- [x] `ruff check` on the touched files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F57NN4GHQJJBKAW6CQ7V0G","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T08:40:06.052Z","completed_at":"2026-08-20T08:43:12.368Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T08:40:06.700Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0e520b134133f37cdabeeeae730e75ef4cfa1d1fda7a01c3522775280cf866d0","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"bb6909b9-b5a6-4536-9587-76e8cc88a090","object_id":"sha256:0e520b134133f37cdabeeeae730e75ef4cfa1d1fda7a01c3522775280cf866d0","sha256":"0e520b134133f37cdabeeeae730e75ef4cfa1d1fda7a01c3522775280cf866d0"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"KhC-ny3gOFZizs0x8kL6vCLGXV0QUpega-wkla0D8lvwBHV1iUwO8pgAzNdfeKQXlpwuAYJmis3wLlCp024SBQ"}} -->
