### PR TITLE
chore: migrate ASI to SlopDotCash org

### DIFF
--- a/.github/scripts/ipmnist_local_prereg.py
+++ b/.github/scripts/ipmnist_local_prereg.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, Final, cast
 
-AUTHORIZED_REPOSITORY: Final = "elizaOS/asi"
+AUTHORIZED_REPOSITORY: Final = "SlopDotCash/asi"
 AUTHORIZED_LOGIN: Final = "lalalune"
 AUTHORIZED_USER_ID: Final = 18_633_264
 AUTHORIZED_ASSOCIATION: Final = "MEMBER"

--- a/.github/scripts/ipmnist_prereg.py
+++ b/.github/scripts/ipmnist_prereg.py
@@ -20,7 +20,7 @@ from typing import Any, Final, cast
 
 WORKFLOW_PATH: Final = ".github/workflows/ipmnist-prereg.yml"
 DRIVER_PATH: Final = ".github/scripts/ipmnist_prereg.py"
-AUTHORIZED_REPOSITORY: Final = "elizaOS/asi"
+AUTHORIZED_REPOSITORY: Final = "SlopDotCash/asi"
 AUTHORIZED_LOGIN: Final = "lalalune"
 AUTHORIZED_USER_ID: Final = 18_633_264
 AUTHORIZED_ASSOCIATION: Final = "MEMBER"

--- a/.github/slop-project.json
+++ b/.github/slop-project.json
@@ -1,17 +1,17 @@
 {
   "kind": "slop-project-authority",
-  "policyRevision": "2026-08-18.1",
+  "policyRevision": "2026-08-20.1",
   "projectId": "asi",
-  "proposal": "https://github.com/elizaOS/slopdotcash/issues/115",
+  "proposal": "https://github.com/SlopDotCash/slopdotcash/issues/115",
   "repository": {
-    "fullName": "elizaOS/asi",
+    "fullName": "SlopDotCash/asi",
     "id": "1332593244",
     "integrationBranch": "main"
   },
   "schemaVersion": "1",
   "steward": {
-    "actorId": "186240462",
-    "login": "elizaOS",
-    "nodeId": "O_kgDOCxnNzg"
+    "actorId": "318901292",
+    "login": "SlopDotCash",
+    "nodeId": "O_kgDOEwIMLA"
   }
 }

--- a/.github/workflows/ipmnist-prereg.yml
+++ b/.github/workflows/ipmnist-prereg.yml
@@ -44,7 +44,7 @@ env:
 
 jobs:
   run:
-    if: github.repository == 'elizaOS/asi'
+    if: github.repository == 'SlopDotCash/asi'
     runs-on: macos-14
     timeout-minutes: 360
     steps:

--- a/.github/workflows/reference-life-scorecard-dev.yml
+++ b/.github/workflows/reference-life-scorecard-dev.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   shards:
     name: ${{ matrix.environment }} / ${{ matrix.arm }} / ${{ matrix.seed }}
-    if: github.repository == 'elizaOS/asi'
+    if: github.repository == 'SlopDotCash/asi'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -94,7 +94,7 @@ jobs:
 
   aggregate:
     name: aggregate and validate
-    if: github.repository == 'elizaOS/asi'
+    if: github.repository == 'SlopDotCash/asi'
     needs: shards
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # ASI — agent guide
 
-ASI is elizaOS's JAX continual-learning research and hillclimbing project. Its
+ASI is SlopDotCash's JAX continual-learning research and hillclimbing project. Its
 north star is one end-to-end agent that keeps learning through an operational
 life, retains and reuses useful knowledge, adapts without whole-agent or
 task-by-task reinitialization, operates within explicit compute, memory, and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
   - family-names: Lawson
     given-names: Keith
   - name: "elizaOS research contributors"
-repository-code: "https://github.com/elizaOS/asi"
+repository-code: "https://github.com/SlopDotCash/asi"
 license: Apache-2.0
 version: "0.29.0"
 date-released: "2026-08-14"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # ASI — agent guide
 
-ASI is elizaOS's JAX continual-learning research and hillclimbing project. Its
+ASI is SlopDotCash's JAX continual-learning research and hillclimbing project. Its
 north star is one end-to-end agent that keeps learning through an operational
 life, retains and reuses useful knowledge, adapts without whole-agent or
 task-by-task reinitialization, operates within explicit compute, memory, and

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ required before any state-of-the-art claim.
 
 ## Identity and compatibility
 
-This repository is [`elizaOS/asi`](https://github.com/elizaOS/asi). It began from
+This repository is [`SlopDotCash/asi`](https://github.com/SlopDotCash/asi). It began from
 [`lalalune/alberta`](https://github.com/lalalune/alberta) at fork point `2ac3533` and is now a
 substantially divergent development line. [VENDORING.md](VENDORING.md) records that history.
 
@@ -173,7 +173,7 @@ fork's version, Python floor, or dependency extras.
 Install ASI from a checkout instead:
 
 ```bash
-git clone https://github.com/elizaOS/asi.git
+git clone https://github.com/SlopDotCash/asi.git
 cd asi
 python3.12 -m venv .venv
 .venv/bin/python -m pip install -e .

--- a/docs/runbooks/forager-matched-rerun-preflight.md
+++ b/docs/runbooks/forager-matched-rerun-preflight.md
@@ -1,7 +1,7 @@
 # Matched Forager rerun preflight
 
 `asi-forager-rerun-preflight` is a read-only, non-executing readiness check for
-[issue #1584](https://github.com/elizaOS/asi/issues/1584).
+[issue #1584](https://github.com/SlopDotCash/asi/issues/1584).
 It does not pull, build, load, or run an OCI image; prepare an output directory; read reward arrays;
 or authorize a campaign. A blocked report exits 2 and is not an execution receipt.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,9 @@ gpu = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/elizaOS/asi"
-Repository = "https://github.com/elizaOS/asi"
-Issues = "https://github.com/elizaOS/asi/issues"
+Homepage = "https://github.com/SlopDotCash/asi"
+Repository = "https://github.com/SlopDotCash/asi"
+Issues = "https://github.com/SlopDotCash/asi/issues"
 Upstream = "https://github.com/lalalune/alberta"
 
 [project.scripts]

--- a/tests/test_ipmnist_local_prereg.py
+++ b/tests/test_ipmnist_local_prereg.py
@@ -113,7 +113,7 @@ def _owner_comment(
         "created_at": timestamp,
         "updated_at": timestamp,
         "html_url": (
-            f"https://github.com/elizaOS/asi/issues/{issue}"
+            f"https://github.com/SlopDotCash/asi/issues/{issue}"
             f"#issuecomment-{comment_id}"
         ),
     }
@@ -467,7 +467,7 @@ def test_launch_atomically_claims_namespace_and_writes_bound_receipts(tmp_path: 
     namespace = _claim_local_launch(
         protocol_key="issue184",
         root=tmp_path,
-        repository="elizaOS/asi",
+        repository="SlopDotCash/asi",
         ref_name="ipmnist-prereg-example",
         cpuset="0-2",
         data_home=data_home,
@@ -491,7 +491,7 @@ def test_launch_atomically_claims_namespace_and_writes_bound_receipts(tmp_path: 
         _claim_local_launch(
             protocol_key="issue184",
             root=tmp_path,
-            repository="elizaOS/asi",
+            repository="SlopDotCash/asi",
             ref_name="ipmnist-prereg-example",
             cpuset="0-2",
             data_home=data_home,
@@ -518,7 +518,7 @@ def test_launch_rejects_existing_cache_or_noncanonical_remote_tag(tmp_path: Path
     kwargs = {
         "protocol_key": "issue184",
         "root": tmp_path,
-        "repository": "elizaOS/asi",
+        "repository": "SlopDotCash/asi",
         "ref_name": "ipmnist-prereg-example",
         "cpuset": "0-2",
         "data_home": data_home,
@@ -639,7 +639,7 @@ def _write_protocol_receipts(root: Path, protocol_key: str) -> Path:
     authorization = {
         "amendment_comment_id": 123,
         "amendment_comment_url": (
-            f"https://github.com/elizaOS/asi/issues/{protocol.issue}#issuecomment-123"
+            f"https://github.com/SlopDotCash/asi/issues/{protocol.issue}#issuecomment-123"
         ),
         "amendment_created_at": "2026-08-16T09:00:00Z",
         "amendment_updated_at": "2026-08-16T09:00:00Z",
@@ -647,7 +647,7 @@ def _write_protocol_receipts(root: Path, protocol_key: str) -> Path:
         "amendment_sha256": _canonical_sha256(amendment),
         "authorization_comment_id": 456,
         "authorization_comment_url": (
-            f"https://github.com/elizaOS/asi/issues/{protocol.issue}#issuecomment-456"
+            f"https://github.com/SlopDotCash/asi/issues/{protocol.issue}#issuecomment-456"
         ),
         "authorization_created_at": "2026-08-16T09:01:00Z",
         "authorization_updated_at": "2026-08-16T09:01:00Z",
@@ -1749,7 +1749,7 @@ def test_result_validation_rejects_external_hard_link_alias(tmp_path: Path) -> N
             "amendment",
             [
                 "--repository",
-                "elizaOS/asi",
+                "SlopDotCash/asi",
                 "--ref-name",
                 "ipmnist-prereg-example",
                 "--cpuset",
@@ -1762,7 +1762,7 @@ def test_result_validation_rejects_external_hard_link_alias(tmp_path: Path) -> N
             "authorization",
             [
                 "--repository",
-                "elizaOS/asi",
+                "SlopDotCash/asi",
                 "--ref-name",
                 "ipmnist-prereg-example",
                 "--cpuset",
@@ -1775,7 +1775,7 @@ def test_result_validation_rejects_external_hard_link_alias(tmp_path: Path) -> N
             "launch",
             [
                 "--repository",
-                "elizaOS/asi",
+                "SlopDotCash/asi",
                 "--ref-name",
                 "ipmnist-prereg-example",
                 "--cpuset",

--- a/tests/test_ipmnist_prereg_workflow.py
+++ b/tests/test_ipmnist_prereg_workflow.py
@@ -40,7 +40,7 @@ _SEAL_GLOBALS = cast(dict[str, Any], _seal_completion_bundle.__globals__)
 def test_artifact_redirect_does_not_forward_github_api_authorization() -> None:
     handler = cast(Any, _DRIVER["_AuthorizationStrippingRedirectHandler"])()
     request = urllib.request.Request(
-        "https://api.github.com/repos/elizaOS/asi/actions/artifacts/1/zip",
+        "https://api.github.com/repos/SlopDotCash/asi/actions/artifacts/1/zip",
         headers={"Authorization": "Bearer secret"},
     )
     redirected = handler.redirect_request(
@@ -370,7 +370,7 @@ def _launch_api_payloads(comment: dict[str, Any]) -> tuple[dict[str, Any], list[
         "run_attempt": 1,
         "path": ".github/workflows/ipmnist-prereg.yml",
         "created_at": "2026-08-16T10:00:00Z",
-        "html_url": "https://github.com/elizaOS/asi/actions/runs/123",
+        "html_url": "https://github.com/SlopDotCash/asi/actions/runs/123",
     }
     return current, [comment]
 
@@ -393,7 +393,7 @@ def _verify_with_comment(
     monkeypatch.setitem(_DRIVER_GLOBALS, "_github_pages", lambda *_args, **_kwargs: comments)
     arguments: dict[str, Any] = {
         "protocol_key": "issue51",
-        "repository": "elizaOS/asi",
+        "repository": "SlopDotCash/asi",
         "source": "1" * 40,
         "tree": "2" * 40,
         "uv_lock_sha256": "3" * 64,
@@ -428,7 +428,7 @@ def _authorization_comment(**overrides: Any) -> dict[str, Any]:
         "author_association": "MEMBER",
         "created_at": "2026-08-16T09:00:00Z",
         "updated_at": "2026-08-16T09:00:00Z",
-        "html_url": "https://github.com/elizaOS/asi/issues/51#issuecomment-456",
+        "html_url": "https://github.com/SlopDotCash/asi/issues/51#issuecomment-456",
     }
     comment.update(overrides)
     return comment
@@ -454,7 +454,7 @@ def test_launch_authorization_ignores_consumed_dispatches_for_prior_sources(
         "run_attempt": 1,
         "path": ".github/workflows/ipmnist-prereg.yml",
         "created_at": "2026-08-15T10:00:00Z",
-        "html_url": "https://github.com/elizaOS/asi/actions/runs/122",
+        "html_url": "https://github.com/SlopDotCash/asi/actions/runs/122",
         "status": "completed",
         "conclusion": "cancelled",
     }
@@ -535,7 +535,7 @@ def test_launch_authorization_requires_strictly_pre_dispatch_timestamp(
         {"id": -1},
         {"id": 456.0},
         {"html_url": None},
-        {"html_url": "https://github.com/elizaOS/asi/issues/51#issuecomment-999"},
+        {"html_url": "https://github.com/SlopDotCash/asi/issues/51#issuecomment-999"},
         {"html_url": "https://attacker.invalid/issues/51#issuecomment-456"},
     ],
 )
@@ -604,7 +604,7 @@ def _issue188_authorization_comment(**overrides: Any) -> dict[str, Any]:
         "author_association": "MEMBER",
         "created_at": "2026-08-16T09:30:00Z",
         "updated_at": "2026-08-16T09:30:00Z",
-        "html_url": "https://github.com/elizaOS/asi/issues/188#issuecomment-456",
+        "html_url": "https://github.com/SlopDotCash/asi/issues/188#issuecomment-456",
     }
     comment.update(overrides)
     return comment
@@ -627,7 +627,7 @@ def _issue188_amendment_comment(**overrides: Any) -> dict[str, Any]:
         "author_association": "MEMBER",
         "created_at": "2026-08-16T09:00:00Z",
         "updated_at": "2026-08-16T09:00:00Z",
-        "html_url": "https://github.com/elizaOS/asi/issues/188#issuecomment-455",
+        "html_url": "https://github.com/SlopDotCash/asi/issues/188#issuecomment-455",
     }
     comment.update(overrides)
     return comment
@@ -645,7 +645,7 @@ def _verify_issue188(
         "run_attempt": 1,
         "path": ".github/workflows/ipmnist-prereg.yml",
         "created_at": "2026-08-16T10:00:00Z",
-        "html_url": "https://github.com/elizaOS/asi/actions/runs/123",
+        "html_url": "https://github.com/SlopDotCash/asi/actions/runs/123",
     }
     monkeypatch.setitem(_DRIVER_GLOBALS, "_github_json", lambda *_args, **_kwargs: current)
     monkeypatch.setitem(_DRIVER_GLOBALS, "_workflow_runs", lambda *_args, **_kwargs: [current])
@@ -654,7 +654,7 @@ def _verify_issue188(
         dict[str, Any],
         _verify_launch_authorization(
             protocol_key="issue188",
-            repository="elizaOS/asi",
+            repository="SlopDotCash/asi",
             source="1" * 40,
             tree="2" * 40,
             uv_lock_sha256="3" * 64,
@@ -688,7 +688,7 @@ def test_issue188_requires_one_exact_amendment_before_final_authorization(
         {"id": -1},
         {"id": 455.0},
         {"html_url": None},
-        {"html_url": "https://github.com/elizaOS/asi/issues/188#issuecomment-999"},
+        {"html_url": "https://github.com/SlopDotCash/asi/issues/188#issuecomment-999"},
         {"html_url": "https://attacker.invalid/issues/188#issuecomment-455"},
     ],
 )
@@ -792,7 +792,7 @@ def test_issue184_requires_prerequisite_closure_before_amendment(
             "author_association": "MEMBER",
             "created_at": "2026-08-16T09:00:00Z",
             "updated_at": "2026-08-16T09:00:00Z",
-            "html_url": "https://github.com/elizaOS/asi/issues/184#issuecomment-455",
+            "html_url": "https://github.com/SlopDotCash/asi/issues/184#issuecomment-455",
         },
         {
             "id": 456,
@@ -801,7 +801,7 @@ def test_issue184_requires_prerequisite_closure_before_amendment(
             "author_association": "MEMBER",
             "created_at": "2026-08-16T09:30:00Z",
             "updated_at": "2026-08-16T09:30:00Z",
-            "html_url": "https://github.com/elizaOS/asi/issues/184#issuecomment-456",
+            "html_url": "https://github.com/SlopDotCash/asi/issues/184#issuecomment-456",
         },
     ]
     current = {
@@ -812,7 +812,7 @@ def test_issue184_requires_prerequisite_closure_before_amendment(
         "run_attempt": 1,
         "path": ".github/workflows/ipmnist-prereg.yml",
         "created_at": "2026-08-16T10:00:00Z",
-        "html_url": "https://github.com/elizaOS/asi/actions/runs/123",
+        "html_url": "https://github.com/SlopDotCash/asi/actions/runs/123",
     }
     monkeypatch.setitem(_DRIVER_GLOBALS, "_github_json", lambda *_args, **_kwargs: current)
     monkeypatch.setitem(_DRIVER_GLOBALS, "_workflow_runs", lambda *_args, **_kwargs: [current])
@@ -828,7 +828,7 @@ def test_issue184_requires_prerequisite_closure_before_amendment(
     )
     payload = _verify_launch_authorization(
         protocol_key="issue184",
-        repository="elizaOS/asi",
+        repository="SlopDotCash/asi",
         run_id=123,
         run_attempt=1,
         token="token",
@@ -841,7 +841,7 @@ def test_issue184_requires_prerequisite_closure_before_amendment(
     with pytest.raises(RuntimeError, match="closed before"):
         _verify_launch_authorization(
             protocol_key="issue184",
-            repository="elizaOS/asi",
+            repository="SlopDotCash/asi",
             run_id=123,
             run_attempt=1,
             token="token",
@@ -878,7 +878,7 @@ def test_workflow_run_search_binds_source_and_paginates_exact_total(
         return responses.pop(0)
 
     monkeypatch.setitem(_WORKFLOW_RUN_GLOBALS, "_github_json", fake_github_json)
-    runs = _workflow_runs("elizaOS/asi", source="1" * 40, token="token")
+    runs = _workflow_runs("SlopDotCash/asi", source="1" * 40, token="token")
 
     assert [run["id"] for run in runs] == list(range(1, 102))
     assert len(calls) == 2
@@ -895,7 +895,7 @@ def test_workflow_run_search_rejects_unsearchable_or_changing_total(
         lambda *_args, **_kwargs: {"total_count": 1001, "workflow_runs": []},
     )
     with pytest.raises(RuntimeError, match="1,000"):
-        _workflow_runs("elizaOS/asi", source="1" * 40, token="token")
+        _workflow_runs("SlopDotCash/asi", source="1" * 40, token="token")
 
     responses = [
         {
@@ -910,7 +910,7 @@ def test_workflow_run_search_rejects_unsearchable_or_changing_total(
         lambda *_args, **_kwargs: responses.pop(0),
     )
     with pytest.raises(RuntimeError, match="changed during pagination"):
-        _workflow_runs("elizaOS/asi", source="1" * 40, token="token")
+        _workflow_runs("SlopDotCash/asi", source="1" * 40, token="token")
 
 
 def test_workflow_run_search_never_skips_a_malformed_page(
@@ -933,7 +933,7 @@ def test_workflow_run_search_never_skips_a_malformed_page(
 
     monkeypatch.setitem(_WORKFLOW_RUN_GLOBALS, "_github_json", fake_github_json)
     with pytest.raises(RuntimeError, match="malformed result page"):
-        _workflow_runs("elizaOS/asi", source="1" * 40, token="token")
+        _workflow_runs("SlopDotCash/asi", source="1" * 40, token="token")
 
     assert len(calls) == 2
     assert calls[-1].endswith("page=2")
@@ -955,7 +955,7 @@ def test_workflow_run_search_rejects_duplicate_ids_across_pages(
         lambda *_args, **_kwargs: responses.pop(0),
     )
     with pytest.raises(RuntimeError, match="repeated a workflow run ID"):
-        _workflow_runs("elizaOS/asi", source="1" * 40, token="token")
+        _workflow_runs("SlopDotCash/asi", source="1" * 40, token="token")
 
 
 def test_workflow_installs_exact_uv_managed_python() -> None:
@@ -1051,7 +1051,7 @@ def test_completion_seal_copies_runner_and_binds_fresh_reconstruction(
         "tree": "2" * 40,
         "uv_lock_sha256": "3" * 64,
         "run_id": 123,
-        "run_url": "https://github.com/elizaOS/asi/actions/runs/123",
+        "run_url": "https://github.com/SlopDotCash/asi/actions/runs/123",
     }
     result = {
         "schema": "asi.ipmnist_prereg.result_validation.v1",
@@ -1128,7 +1128,7 @@ def test_issue184_prerequisite_requires_eligible_committed_result_live_success_a
             "tree": "2" * 40,
             "uv_lock_sha256": "3" * 64,
             "run_id": 123,
-            "run_url": "https://github.com/elizaOS/asi/actions/runs/123",
+            "run_url": "https://github.com/SlopDotCash/asi/actions/runs/123",
         },
         "result_validation": result,
         "runner_receipt": "outputs/ipmnist_screening/replication_r1/runner.v2.json",
@@ -1170,7 +1170,7 @@ def test_issue184_prerequisite_requires_eligible_committed_result_live_success_a
                 "run_attempt": 1,
                 "status": "completed",
                 "conclusion": "success",
-                "html_url": "https://github.com/elizaOS/asi/actions/runs/123",
+                "html_url": "https://github.com/SlopDotCash/asi/actions/runs/123",
                 "created_at": "2026-05-18T08:59:00Z",
                 "updated_at": "2026-08-16T08:59:00Z",
             }
@@ -1201,7 +1201,7 @@ def test_issue184_prerequisite_requires_eligible_committed_result_live_success_a
     )
     receipt = _verify_prerequisite_completion(
         _PROTOCOLS["issue184"],
-        repository="elizaOS/asi",
+        repository="SlopDotCash/asi",
         launch_source="5" * 40,
         root=tmp_path,
         token="token",
@@ -1218,7 +1218,7 @@ def test_issue184_prerequisite_requires_eligible_committed_result_live_success_a
     with pytest.raises(RuntimeError, match="registered 90-day"):
         _verify_prerequisite_completion(
             _PROTOCOLS["issue184"],
-            repository="elizaOS/asi",
+            repository="SlopDotCash/asi",
             launch_source="5" * 40,
             root=tmp_path,
             token="token",
@@ -1229,7 +1229,7 @@ def test_issue184_prerequisite_requires_eligible_committed_result_live_success_a
     with pytest.raises(RuntimeError, match="created before the workflow run"):
         _verify_prerequisite_completion(
             _PROTOCOLS["issue184"],
-            repository="elizaOS/asi",
+            repository="SlopDotCash/asi",
             launch_source="5" * 40,
             root=tmp_path,
             token="token",
@@ -1240,7 +1240,7 @@ def test_issue184_prerequisite_requires_eligible_committed_result_live_success_a
     with pytest.raises(RuntimeError, match="artifact digest mismatch"):
         _verify_prerequisite_completion(
             _PROTOCOLS["issue184"],
-            repository="elizaOS/asi",
+            repository="SlopDotCash/asi",
             launch_source="5" * 40,
             root=tmp_path,
             token="token",
@@ -1268,7 +1268,7 @@ def test_issue184_prerequisite_requires_eligible_committed_result_live_success_a
     with pytest.raises(RuntimeError, match="differ"):
         _verify_prerequisite_completion(
             _PROTOCOLS["issue184"],
-            repository="elizaOS/asi",
+            repository="SlopDotCash/asi",
             launch_source="5" * 40,
             root=tmp_path,
             token="token",
@@ -1301,7 +1301,7 @@ def test_issue184_prerequisite_rejects_ineligible_incumbent_outcome(
             "tree": "2" * 40,
             "uv_lock_sha256": "3" * 64,
             "run_id": 123,
-            "run_url": "https://github.com/elizaOS/asi/actions/runs/123",
+            "run_url": "https://github.com/SlopDotCash/asi/actions/runs/123",
         },
         "result_validation": result,
         "runner_receipt": "outputs/ipmnist_screening/replication_r1/runner.v2.json",
@@ -1317,7 +1317,7 @@ def test_issue184_prerequisite_rejects_ineligible_incumbent_outcome(
     with pytest.raises(RuntimeError, match="all-positive live incumbent"):
         _verify_prerequisite_completion(
             _PROTOCOLS["issue184"],
-            repository="elizaOS/asi",
+            repository="SlopDotCash/asi",
             launch_source="5" * 40,
             root=tmp_path,
             token="token",

--- a/tests/test_reference_life_scorecard_workflow.py
+++ b/tests/test_reference_life_scorecard_workflow.py
@@ -36,7 +36,7 @@ def test_reference_life_scorecard_fails_closed_on_source_and_runtime() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
     assert "launch_sha:" in text
-    assert text.count("if: github.repository == 'elizaOS/asi'") == 2
+    assert text.count("if: github.repository == 'SlopDotCash/asi'") == 2
     assert text.count('test "$GITHUB_REF" = "refs/heads/main"') == 2
     assert text.count('test "$GITHUB_SHA" = "$LAUNCH_SHA"') == 2
     assert text.count('test "$WORKFLOW_SHA" = "$LAUNCH_SHA"') == 2

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -62,9 +62,9 @@ def test_release_repository_and_runtime_floors_are_explicit() -> None:
         "editables==0.6",
     ]
     assert project["urls"] == {
-        "Homepage": "https://github.com/elizaOS/asi",
-        "Repository": "https://github.com/elizaOS/asi",
-        "Issues": "https://github.com/elizaOS/asi/issues",
+        "Homepage": "https://github.com/SlopDotCash/asi",
+        "Repository": "https://github.com/SlopDotCash/asi",
+        "Issues": "https://github.com/SlopDotCash/asi/issues",
         "Upstream": "https://github.com/lalalune/alberta",
     }
     assert _citation_scalar("repository-code") == project["urls"]["Repository"]
@@ -100,7 +100,7 @@ def test_readme_does_not_claim_the_external_pypi_distribution() -> None:
     readme = (_ROOT / "README.md").read_text(encoding="utf-8")
 
     assert "pip install alberta-framework" not in readme
-    assert "git clone https://github.com/elizaOS/asi.git" in readme
+    assert "git clone https://github.com/SlopDotCash/asi.git" in readme
     assert "existing `alberta-framework` project on PyPI is a different distribution" in readme
 
 


### PR DESCRIPTION
## Summary
- update canonical repository and package URLs after the GitHub transfer
- update workflow repository guards and preregistration authority checks
- move the Slop authority manifest to the SlopDotCash steward identity
- preserve immutable `outputs/` evidence with its historical pre-transfer URLs

## Validation
- `python3 -m py_compile .github/scripts/ipmnist_local_prereg.py .github/scripts/ipmnist_prereg.py`
- `python3 -m pytest --noconftest tests/test_reference_life_scorecard_workflow.py -q` (4 passed)
- `git diff --check`
- broader local tests require the project JAX/chex environment and are left to protected CI