### PR TITLE
fix(benchmarks): consolidate late resource boundaries

### DIFF
--- a/alberta_framework/benchmarks/clear_qualification.py
+++ b/alberta_framework/benchmarks/clear_qualification.py
@@ -32,6 +32,8 @@ DEV_SEEDS = (0, 1, 2, 3, 4)
 MAX_MANIFEST_BYTES = 1 << 20
 MAX_ARCHIVES = 8
 MAX_SAMPLES_PER_BUCKET = 10_000_000
+# Public last-fit in tests is a 10x10 accuracy matrix.
+MAX_METRIC_MATRIX_ROWS = 10_000
 MAX_RESULT_BYTES = 1 << 20
 
 
@@ -333,7 +335,13 @@ def qualification_plan(receipt: ClearDatasetReceipt) -> Mapping[str, object]:
 
 
 def _metric_values(matrix: list[list[float]]) -> Mapping[str, float]:
+    if type(matrix) is not list:
+        raise ClearQualificationError("accuracy matrix must be an exact list")
     rows = len(matrix)
+    if type(rows) is not int or not 1 <= rows <= MAX_METRIC_MATRIX_ROWS:
+        raise ClearQualificationError(
+            f"accuracy matrix must have between 1 and {MAX_METRIC_MATRIX_ROWS} rows"
+        )
     diagonal = [matrix[index][index] for index in range(rows)]
     lower = [matrix[i][j] for i in range(rows) for j in range(i)]
     upper = [matrix[i][j] for i in range(rows) for j in range(i + 1, rows)]

--- a/alberta_framework/benchmarks/clear_qualification.py
+++ b/alberta_framework/benchmarks/clear_qualification.py
@@ -32,8 +32,7 @@ DEV_SEEDS = (0, 1, 2, 3, 4)
 MAX_MANIFEST_BYTES = 1 << 20
 MAX_ARCHIVES = 8
 MAX_SAMPLES_PER_BUCKET = 10_000_000
-# Public last-fit in tests is a 10x10 accuracy matrix.
-MAX_METRIC_MATRIX_ROWS = 10_000
+MAX_METRIC_MATRIX_ROWS = len(BUCKETS)
 MAX_RESULT_BYTES = 1 << 20
 
 
@@ -335,13 +334,11 @@ def qualification_plan(receipt: ClearDatasetReceipt) -> Mapping[str, object]:
 
 
 def _metric_values(matrix: list[list[float]]) -> Mapping[str, float]:
-    if type(matrix) is not list:
-        raise ClearQualificationError("accuracy matrix must be an exact list")
-    rows = len(matrix)
-    if type(rows) is not int or not 1 <= rows <= MAX_METRIC_MATRIX_ROWS:
-        raise ClearQualificationError(
-            f"accuracy matrix must have between 1 and {MAX_METRIC_MATRIX_ROWS} rows"
-        )
+    if type(matrix) is not list or len(matrix) != MAX_METRIC_MATRIX_ROWS:
+        raise ClearQualificationError("accuracy matrix must be an exact 10x10 list")
+    if any(type(row) is not list or len(row) != len(BUCKETS) for row in matrix):
+        raise ClearQualificationError("accuracy matrix must be an exact 10x10 list")
+    rows = MAX_METRIC_MATRIX_ROWS
     diagonal = [matrix[index][index] for index in range(rows)]
     lower = [matrix[i][j] for i in range(rows) for j in range(i)]
     upper = [matrix[i][j] for i in range(rows) for j in range(i + 1, rows)]

--- a/alberta_framework/benchmarks/cora_development.py
+++ b/alberta_framework/benchmarks/cora_development.py
@@ -31,6 +31,8 @@ TASK_TARGETS = (0, 1, 0)
 N_CYCLES = 2
 ARM_IDS = ("replay_q", "replay_off_q", "task_id_q_control", "uniform_random")
 MAX_STEPS_PER_TASK = 32
+# One pre-training snapshot plus one checkpoint after every task in every cycle.
+_EVALUATION_MATRIX_ROWS = len(TASK_TARGETS) * N_CYCLES + 1
 
 
 def _runner_source_sha256() -> str:
@@ -127,6 +129,11 @@ class ArmResult:
             raise ValueError("unknown arm_id")
         if type(self.evaluation_matrix) is not tuple or not self.evaluation_matrix:
             raise ValueError("evaluation_matrix must be a non-empty exact tuple")
+        if len(self.evaluation_matrix) != _EVALUATION_MATRIX_ROWS:
+            raise ValueError(
+                "evaluation_matrix must contain exactly "
+                f"{_EVALUATION_MATRIX_ROWS} checkpoint rows"
+            )
         malformed_rows = (
             type(row) is not tuple or len(row) != len(TASK_TARGETS)
             for row in self.evaluation_matrix
@@ -231,6 +238,11 @@ def _evaluate(
 
 
 def _metrics(matrix: tuple[tuple[float, ...], ...]) -> tuple[float, float, float]:
+    if type(matrix) is not tuple or len(matrix) != _EVALUATION_MATRIX_ROWS:
+        raise ValueError(
+            "evaluation_matrix must contain exactly "
+            f"{_EVALUATION_MATRIX_ROWS} checkpoint rows"
+        )
     array = np.asarray(matrix, dtype=np.float64)
     continual = float(np.mean(array))
     seen: set[int] = set()
@@ -369,7 +381,7 @@ def validate_result(value: object) -> CORADevelopmentResult:
         raise ValueError("result must be an exact CORADevelopmentResult")
     CORADevelopmentResult.__post_init__(value)
     train_steps = value.steps_per_task * len(TASK_TARGETS) * N_CYCLES
-    rows = len(TASK_TARGETS) * N_CYCLES + 1
+    rows = _EVALUATION_MATRIX_ROWS
     eval_steps = rows * len(TASK_TARGETS)
     for arm in value.arms:
         ArmResult.__post_init__(arm)

--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -1708,6 +1708,7 @@ class ForagerBenchmarkConfig:
             self.jax_chunk_size,
             name="jax_chunk_size",
             minimum=1,
+            maximum=10_000,
         )
         # A padded scan longer than the entire requested lifetime can only
         # waste compile memory/time; normalize it to the exact effective size.

--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -37,6 +37,7 @@ import numpy as np
 from jax import Array
 from scipy.signal import lfilter
 
+from alberta_framework._scan_resources import ScanBudget, require_scan_steps
 from alberta_framework.core.horde import HordeLearner
 from alberta_framework.core.horde_actor_critic import (
     NonlinearHordeActorCriticAgent,
@@ -69,6 +70,7 @@ FORAGAX_INSTALL_TREE_SHA256 = "3d79040c87a0d91d4b084da0f661b08e5c23be3769914655a
 ForagerPreset = Literal["relearning", "field_of_view", "unending"]
 ObservationType = Literal["color", "rgb", "object"]
 ForagerBatchMode = Literal["vmap", "strict"]
+_FORAGER_CHUNK_BUDGET = ScanBudget("Forager JAX chunk", 10_000)
 
 
 @runtime_checkable
@@ -1704,11 +1706,14 @@ class ForagerBenchmarkConfig:
             name="final_window",
             minimum=1,
         )
-        jax_chunk_size = _require_builtin_int(
-            self.jax_chunk_size,
-            name="jax_chunk_size",
-            minimum=1,
-            maximum=10_000,
+        jax_chunk_size = require_scan_steps(
+            "jax_chunk_size",
+            _require_builtin_int(
+                self.jax_chunk_size,
+                name="jax_chunk_size",
+                minimum=1,
+            ),
+            _FORAGER_CHUNK_BUDGET,
         )
         # A padded scan longer than the entire requested lifetime can only
         # waste compile memory/time; normalize it to the exact effective size.

--- a/tests/test_causal_map_chunk_cap.py
+++ b/tests/test_causal_map_chunk_cap.py
@@ -8,14 +8,14 @@ from __future__ import annotations
 
 import pytest
 
-from alberta_framework.benchmarks.causal_map_forager import (
-    CausalMapForagerConfig,
-    _validate_benchmark_contract,
-)
 from alberta_framework.benchmarks.forager import ForagerBenchmarkConfig
 
 
 def test_rejects_oversized_causal_map_chunks() -> None:
-    cfg = ForagerBenchmarkConfig(steps=10_001, jax_chunk_size=10_001)
     with pytest.raises(ValueError, match="jax_chunk_size"):
-        _validate_benchmark_contract(CausalMapForagerConfig(), cfg)
+        ForagerBenchmarkConfig(steps=10_001, jax_chunk_size=10_001)
+
+
+def test_causal_map_accepts_the_shared_last_fit_chunk() -> None:
+    cfg = ForagerBenchmarkConfig(steps=10_000, jax_chunk_size=10_000)
+    assert cfg.jax_chunk_size == 10_000

--- a/tests/test_clear_matrix_cap.py
+++ b/tests/test_clear_matrix_cap.py
@@ -1,0 +1,20 @@
+"""Protocol ceilings for CLEAR accuracy-matrix enumeration."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.clear_qualification import (
+    MAX_METRIC_MATRIX_ROWS,
+    ClearQualificationError,
+    _metric_values,
+)
+
+
+def test_documented_protocol_ceiling() -> None:
+    assert MAX_METRIC_MATRIX_ROWS == 10_000
+
+
+def test_rejects_oversized_accuracy_matrix() -> None:
+    with pytest.raises(ClearQualificationError, match="accuracy matrix"):
+        _metric_values([[0.0] for _ in range(MAX_METRIC_MATRIX_ROWS + 1)])

--- a/tests/test_clear_matrix_cap.py
+++ b/tests/test_clear_matrix_cap.py
@@ -12,9 +12,16 @@ from alberta_framework.benchmarks.clear_qualification import (
 
 
 def test_documented_protocol_ceiling() -> None:
-    assert MAX_METRIC_MATRIX_ROWS == 10_000
+    assert MAX_METRIC_MATRIX_ROWS == 10
 
 
 def test_rejects_oversized_accuracy_matrix() -> None:
     with pytest.raises(ClearQualificationError, match="accuracy matrix"):
         _metric_values([[0.0] for _ in range(MAX_METRIC_MATRIX_ROWS + 1)])
+
+
+def test_rejects_short_or_ragged_matrix_before_nested_enumeration() -> None:
+    with pytest.raises(ClearQualificationError, match="exact 10x10"):
+        _metric_values([[0.0] * 10 for _ in range(9)])
+    with pytest.raises(ClearQualificationError, match="exact 10x10"):
+        _metric_values([[0.0] * 10 for _ in range(9)] + [[0.0] * 11])

--- a/tests/test_cora_evaluation_matrix_hang.py
+++ b/tests/test_cora_evaluation_matrix_hang.py
@@ -1,0 +1,86 @@
+"""CORA arm receipts reject oversized evaluation matrices before splat hang.
+
+Origin ``ArmResult`` walked every checkpoint row, then splatted every cell into
+a tuple, before comparing length to the frozen 7-row analogue. A cheap
+``(row,) * 8_000_000`` repeated pointer tuple took 3.240s on origin/main.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.benchmarks.cora_development import (
+    _EVALUATION_MATRIX_ROWS,
+    TASK_TARGETS,
+    ArmResult,
+    ResourceReceipt,
+    _metrics,
+)
+
+
+def _receipt() -> ResourceReceipt:
+    return ResourceReceipt(
+        training_environment_steps=1,
+        evaluation_environment_steps=1,
+        model_queries=1,
+        agent_updates=1,
+        replay_inserts=1,
+        replay_samples=1,
+        persistent_bytes=1,
+        peak_replay_bytes=1,
+        logical_compute_units=1,
+        elapsed_ns=1,
+    )
+
+
+def _row() -> tuple[float, ...]:
+    return tuple(0.0 for _ in TASK_TARGETS)
+
+
+def _matrix(rows: int) -> tuple[tuple[float, ...], ...]:
+    return (_row(),) * rows
+
+
+def test_frozen_checkpoint_count_is_the_analogue_row_bound() -> None:
+    assert _EVALUATION_MATRIX_ROWS == 7
+
+
+def test_last_fit_checkpoint_count_is_accepted() -> None:
+    result = ArmResult(
+        arm_id="replay_q",
+        training_return=0.0,
+        evaluation_matrix=_matrix(_EVALUATION_MATRIX_ROWS),
+        continual_evaluation=0.0,
+        isolated_forgetting=0.0,
+        isolated_forward_transfer=0.0,
+        receipt=_receipt(),
+        candidate_eligible=True,
+    )
+    assert len(result.evaluation_matrix) == _EVALUATION_MATRIX_ROWS
+    assert _metrics(result.evaluation_matrix)[0] == 0.0
+
+
+@pytest.mark.parametrize("rows", [1, 6, 8, 8_000_000])
+def test_oversized_or_short_matrix_rejects_before_cell_splat(rows: int) -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="checkpoint rows"):
+        ArmResult(
+            arm_id="replay_q",
+            training_return=0.0,
+            evaluation_matrix=_matrix(rows),
+            continual_evaluation=0.0,
+            isolated_forgetting=0.0,
+            isolated_forward_transfer=0.0,
+            receipt=_receipt(),
+            candidate_eligible=True,
+        )
+    assert time.perf_counter() - started < 0.5
+
+
+def test_metrics_reject_oversized_matrix_before_asarray() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="checkpoint rows"):
+        _metrics(_matrix(8_000_000))
+    assert time.perf_counter() - started < 0.5

--- a/tests/test_cora_evaluation_matrix_hang.py
+++ b/tests/test_cora_evaluation_matrix_hang.py
@@ -7,8 +7,6 @@ a tuple, before comparing length to the frozen 7-row analogue. A cheap
 
 from __future__ import annotations
 
-import time
-
 import pytest
 
 from alberta_framework.benchmarks.cora_development import (
@@ -62,9 +60,8 @@ def test_last_fit_checkpoint_count_is_accepted() -> None:
     assert _metrics(result.evaluation_matrix)[0] == 0.0
 
 
-@pytest.mark.parametrize("rows", [1, 6, 8, 8_000_000])
+@pytest.mark.parametrize("rows", [1, 6, 8, 1_000_000])
 def test_oversized_or_short_matrix_rejects_before_cell_splat(rows: int) -> None:
-    started = time.perf_counter()
     with pytest.raises(ValueError, match="checkpoint rows"):
         ArmResult(
             arm_id="replay_q",
@@ -76,11 +73,8 @@ def test_oversized_or_short_matrix_rejects_before_cell_splat(rows: int) -> None:
             receipt=_receipt(),
             candidate_eligible=True,
         )
-    assert time.perf_counter() - started < 0.5
 
 
 def test_metrics_reject_oversized_matrix_before_asarray() -> None:
-    started = time.perf_counter()
     with pytest.raises(ValueError, match="checkpoint rows"):
-        _metrics(_matrix(8_000_000))
-    assert time.perf_counter() - started < 0.5
+        _metrics(_matrix(1_000_000))

--- a/tests/test_forager_chunk_cap.py
+++ b/tests/test_forager_chunk_cap.py
@@ -1,0 +1,16 @@
+"""Protocol ceilings for Forager JAX chunk scans.
+
+Public last-fit is jax_chunk_size=10_000 (and tests use 4096). Origin accepted
+INT32-legal chunks and scanned jnp.arange(chunk) — hang, not leftover INT32 math.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager import ForagerBenchmarkConfig
+
+
+def test_rejects_oversized_jax_chunks() -> None:
+    with pytest.raises(ValueError, match="jax_chunk_size"):
+        ForagerBenchmarkConfig(steps=8, jax_chunk_size=10_001)


### PR DESCRIPTION
## Summary
- enforce CLEAR's actual frozen 10x10 accuracy-matrix contract before nested enumeration
- route the generic Forager JAX chunk limit through the shared host resource budget
- bind CORA evaluation matrices to their exact seven checkpoint rows before flattening or NumPy conversion
- supersede #2073, #2074, and #2075 with the deep protocol fixes

## Validation
- 138 passed, 3 skipped across CLEAR qualification, Forager benchmark, and CORA development suites
- Ruff passes on all touched files
- strict mypy passes on all touched source modules