### PR TITLE
fix: consolidate final resource and evidence boundaries

### DIFF
--- a/alberta_framework/benchmarks/clear_qualification.py
+++ b/alberta_framework/benchmarks/clear_qualification.py
@@ -32,6 +32,8 @@ DEV_SEEDS = (0, 1, 2, 3, 4)
 MAX_MANIFEST_BYTES = 1 << 20
 MAX_ARCHIVES = 8
 MAX_SAMPLES_PER_BUCKET = 10_000_000
+# Public last-fit in tests is a 10x10 accuracy matrix.
+MAX_METRIC_MATRIX_ROWS = 10_000
 MAX_RESULT_BYTES = 1 << 20
 
 
@@ -333,7 +335,13 @@ def qualification_plan(receipt: ClearDatasetReceipt) -> Mapping[str, object]:
 
 
 def _metric_values(matrix: list[list[float]]) -> Mapping[str, float]:
+    if type(matrix) is not list:
+        raise ClearQualificationError("accuracy matrix must be an exact list")
     rows = len(matrix)
+    if type(rows) is not int or not 1 <= rows <= MAX_METRIC_MATRIX_ROWS:
+        raise ClearQualificationError(
+            f"accuracy matrix must have between 1 and {MAX_METRIC_MATRIX_ROWS} rows"
+        )
     diagonal = [matrix[index][index] for index in range(rows)]
     lower = [matrix[i][j] for i in range(rows) for j in range(i)]
     upper = [matrix[i][j] for i in range(rows) for j in range(i + 1, rows)]

--- a/alberta_framework/benchmarks/clear_qualification.py
+++ b/alberta_framework/benchmarks/clear_qualification.py
@@ -32,8 +32,7 @@ DEV_SEEDS = (0, 1, 2, 3, 4)
 MAX_MANIFEST_BYTES = 1 << 20
 MAX_ARCHIVES = 8
 MAX_SAMPLES_PER_BUCKET = 10_000_000
-# Public last-fit in tests is a 10x10 accuracy matrix.
-MAX_METRIC_MATRIX_ROWS = 10_000
+MAX_METRIC_MATRIX_ROWS = len(BUCKETS)
 MAX_RESULT_BYTES = 1 << 20
 
 
@@ -335,13 +334,11 @@ def qualification_plan(receipt: ClearDatasetReceipt) -> Mapping[str, object]:
 
 
 def _metric_values(matrix: list[list[float]]) -> Mapping[str, float]:
-    if type(matrix) is not list:
-        raise ClearQualificationError("accuracy matrix must be an exact list")
-    rows = len(matrix)
-    if type(rows) is not int or not 1 <= rows <= MAX_METRIC_MATRIX_ROWS:
-        raise ClearQualificationError(
-            f"accuracy matrix must have between 1 and {MAX_METRIC_MATRIX_ROWS} rows"
-        )
+    if type(matrix) is not list or len(matrix) != MAX_METRIC_MATRIX_ROWS:
+        raise ClearQualificationError("accuracy matrix must be an exact 10x10 list")
+    if any(type(row) is not list or len(row) != len(BUCKETS) for row in matrix):
+        raise ClearQualificationError("accuracy matrix must be an exact 10x10 list")
+    rows = MAX_METRIC_MATRIX_ROWS
     diagonal = [matrix[index][index] for index in range(rows)]
     lower = [matrix[i][j] for i in range(rows) for j in range(i)]
     upper = [matrix[i][j] for i in range(rows) for j in range(i + 1, rows)]

--- a/alberta_framework/benchmarks/cora_development.py
+++ b/alberta_framework/benchmarks/cora_development.py
@@ -31,6 +31,8 @@ TASK_TARGETS = (0, 1, 0)
 N_CYCLES = 2
 ARM_IDS = ("replay_q", "replay_off_q", "task_id_q_control", "uniform_random")
 MAX_STEPS_PER_TASK = 32
+# One pre-training snapshot plus one checkpoint after every task in every cycle.
+_EVALUATION_MATRIX_ROWS = len(TASK_TARGETS) * N_CYCLES + 1
 
 
 def _runner_source_sha256() -> str:
@@ -127,6 +129,11 @@ class ArmResult:
             raise ValueError("unknown arm_id")
         if type(self.evaluation_matrix) is not tuple or not self.evaluation_matrix:
             raise ValueError("evaluation_matrix must be a non-empty exact tuple")
+        if len(self.evaluation_matrix) != _EVALUATION_MATRIX_ROWS:
+            raise ValueError(
+                "evaluation_matrix must contain exactly "
+                f"{_EVALUATION_MATRIX_ROWS} checkpoint rows"
+            )
         malformed_rows = (
             type(row) is not tuple or len(row) != len(TASK_TARGETS)
             for row in self.evaluation_matrix
@@ -231,6 +238,11 @@ def _evaluate(
 
 
 def _metrics(matrix: tuple[tuple[float, ...], ...]) -> tuple[float, float, float]:
+    if type(matrix) is not tuple or len(matrix) != _EVALUATION_MATRIX_ROWS:
+        raise ValueError(
+            "evaluation_matrix must contain exactly "
+            f"{_EVALUATION_MATRIX_ROWS} checkpoint rows"
+        )
     array = np.asarray(matrix, dtype=np.float64)
     continual = float(np.mean(array))
     seen: set[int] = set()
@@ -369,7 +381,7 @@ def validate_result(value: object) -> CORADevelopmentResult:
         raise ValueError("result must be an exact CORADevelopmentResult")
     CORADevelopmentResult.__post_init__(value)
     train_steps = value.steps_per_task * len(TASK_TARGETS) * N_CYCLES
-    rows = len(TASK_TARGETS) * N_CYCLES + 1
+    rows = _EVALUATION_MATRIX_ROWS
     eval_steps = rows * len(TASK_TARGETS)
     for arm in value.arms:
         ArmResult.__post_init__(arm)

--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -1708,6 +1708,7 @@ class ForagerBenchmarkConfig:
             self.jax_chunk_size,
             name="jax_chunk_size",
             minimum=1,
+            maximum=10_000,
         )
         # A padded scan longer than the entire requested lifetime can only
         # waste compile memory/time; normalize it to the exact effective size.

--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -37,6 +37,7 @@ import numpy as np
 from jax import Array
 from scipy.signal import lfilter
 
+from alberta_framework._scan_resources import ScanBudget, require_scan_steps
 from alberta_framework.core.horde import HordeLearner
 from alberta_framework.core.horde_actor_critic import (
     NonlinearHordeActorCriticAgent,
@@ -69,6 +70,7 @@ FORAGAX_INSTALL_TREE_SHA256 = "3d79040c87a0d91d4b084da0f661b08e5c23be3769914655a
 ForagerPreset = Literal["relearning", "field_of_view", "unending"]
 ObservationType = Literal["color", "rgb", "object"]
 ForagerBatchMode = Literal["vmap", "strict"]
+_FORAGER_CHUNK_BUDGET = ScanBudget("Forager JAX chunk", 10_000)
 
 
 @runtime_checkable
@@ -1704,11 +1706,14 @@ class ForagerBenchmarkConfig:
             name="final_window",
             minimum=1,
         )
-        jax_chunk_size = _require_builtin_int(
-            self.jax_chunk_size,
-            name="jax_chunk_size",
-            minimum=1,
-            maximum=10_000,
+        jax_chunk_size = require_scan_steps(
+            "jax_chunk_size",
+            _require_builtin_int(
+                self.jax_chunk_size,
+                name="jax_chunk_size",
+                minimum=1,
+            ),
+            _FORAGER_CHUNK_BUDGET,
         )
         # A padded scan longer than the entire requested lifetime can only
         # waste compile memory/time; normalize it to the exact effective size.

--- a/alberta_framework/benchmarks/ipmnist_ceiling.py
+++ b/alberta_framework/benchmarks/ipmnist_ceiling.py
@@ -379,7 +379,9 @@ def run_batch_reference(
         raise ValueError(
             f"batch run exceeds the {_MAX_BATCH_UPDATES} optimizer-update bound"
         )
-    import optax  # type: ignore[import-not-found]
+    import importlib
+
+    optax = importlib.import_module("optax")
     from sklearn.datasets import fetch_openml  # type: ignore[import-untyped]
 
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -749,6 +749,9 @@ _GVF_SPEC_FIELDS: frozenset[str] = frozenset(
     }
 )
 _HORDE_SPEC_FIELDS: frozenset[str] = frozenset({"demons"})
+# Origin HordeSpec.from_config reconstructed every demon dict before any count
+# bound. A cheap ``[spec] * 400_000`` pointer-repeat took 3.736s on origin/main.
+_MAX_HORDE_DEMONS = 4096
 
 
 def _require_payload(
@@ -880,9 +883,13 @@ class HordeSpec:
     lamdas: Float[Array, " n_demons"]
 
     def __post_init__(self) -> None:
-        """Reject an empty or type-spoofed demon collection."""
+        """Reject an empty, oversized, or type-spoofed demon collection."""
         if type(self.demons) is not tuple or not self.demons:
             raise ValueError("demons must be a nonempty tuple of GVFSpec")
+        if len(self.demons) > _MAX_HORDE_DEMONS:
+            raise ValueError(
+                f"demons must contain at most {_MAX_HORDE_DEMONS} GVFSpec entries"
+            )
         if any(type(demon) is not GVFSpec for demon in self.demons):
             raise ValueError("demons must be a nonempty tuple of GVFSpec")
 
@@ -914,6 +921,10 @@ class HordeSpec:
         raw_demons = payload["demons"]
         if type(raw_demons) is not list:
             raise ValueError("HordeSpec demons must be an exact list")
+        if len(raw_demons) > _MAX_HORDE_DEMONS:
+            raise ValueError(
+                f"demons must contain at most {_MAX_HORDE_DEMONS} GVFSpec entries"
+            )
         demons = [GVFSpec.from_config(d) for d in raw_demons]
         return create_horde_spec(demons)
 
@@ -929,9 +940,17 @@ def create_horde_spec(demons: Sequence[GVFSpec]) -> HordeSpec:
     Returns:
         HordeSpec with pre-computed arrays
     """
+    if type(demons) in (list, tuple) and len(demons) > _MAX_HORDE_DEMONS:
+        raise ValueError(
+            f"demons must contain at most {_MAX_HORDE_DEMONS} GVFSpec entries"
+        )
     demons_tuple = tuple(demons)
     if not demons_tuple or any(type(demon) is not GVFSpec for demon in demons_tuple):
         raise ValueError("demons must be a nonempty sequence of GVFSpec")
+    if len(demons_tuple) > _MAX_HORDE_DEMONS:
+        raise ValueError(
+            f"demons must contain at most {_MAX_HORDE_DEMONS} GVFSpec entries"
+        )
     gammas = jnp.array([d.gamma for d in demons_tuple], dtype=jnp.float32)
     lamdas = jnp.array([d.lamda for d in demons_tuple], dtype=jnp.float32)
     return HordeSpec(demons=demons_tuple, gammas=gammas, lamdas=lamdas)

--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -9,6 +9,7 @@ import math
 import operator
 import time
 from collections.abc import Sequence
+from itertools import islice
 from numbers import Real
 from typing import Any, SupportsIndex, cast
 
@@ -944,13 +945,16 @@ def create_horde_spec(demons: Sequence[GVFSpec]) -> HordeSpec:
         raise ValueError(
             f"demons must contain at most {_MAX_HORDE_DEMONS} GVFSpec entries"
         )
-    demons_tuple = tuple(demons)
-    if not demons_tuple or any(type(demon) is not GVFSpec for demon in demons_tuple):
-        raise ValueError("demons must be a nonempty sequence of GVFSpec")
+    if type(demons) in (list, tuple):
+        demons_tuple = tuple(demons)
+    else:
+        demons_tuple = tuple(islice(iter(demons), _MAX_HORDE_DEMONS + 1))
     if len(demons_tuple) > _MAX_HORDE_DEMONS:
         raise ValueError(
             f"demons must contain at most {_MAX_HORDE_DEMONS} GVFSpec entries"
         )
+    if not demons_tuple or any(type(demon) is not GVFSpec for demon in demons_tuple):
+        raise ValueError("demons must be a nonempty sequence of GVFSpec")
     gammas = jnp.array([d.gamma for d in demons_tuple], dtype=jnp.float32)
     lamdas = jnp.array([d.lamda for d in demons_tuple], dtype=jnp.float32)
     return HordeSpec(demons=demons_tuple, gammas=gammas, lamdas=lamdas)

--- a/alberta_framework/recurring_feature_gate.py
+++ b/alberta_framework/recurring_feature_gate.py
@@ -716,6 +716,59 @@ def _validated_variant_evidence(value: object) -> RecurringFeatureVariantEvidenc
     )
 
 
+def _validate_seed_cross_fields(
+    variant: RecurringFeatureVariantEvidence,
+    protocol: RecurringFeatureProtocol,
+) -> None:
+    """Bind nested evidence identities to the frozen stream and pair universe."""
+    seed_ids = tuple(seed.seed for seed in variant.seeds)
+    if len(set(seed_ids)) != len(seed_ids):
+        raise ValueError(f"{variant.name} seed identities must be unique")
+
+    expected_pairs = {
+        (left, right)
+        for left in range(protocol.feature_dim)
+        for right in range(left + 1, protocol.feature_dim)
+    }
+    occurrences: dict[TaskName, int] = {task: 0 for task in TASK_NAMES}
+    expected_phases: list[tuple[int, TaskName, int]] = []
+    for phase_index, task in enumerate(PHASE_TASKS):
+        occurrences[task] += 1
+        expected_phases.append((phase_index, task, occurrences[task]))
+    expected_phase_tuple = tuple(expected_phases)
+
+    for seed in variant.seeds:
+        actual_phases = tuple(
+            (phase.phase_index, phase.task, phase.occurrence) for phase in seed.phase_evidence
+        )
+        if actual_phases != expected_phase_tuple:
+            raise ValueError(
+                f"{variant.name} seed {seed.seed} phase evidence must match the frozen stream"
+            )
+
+        expected_recoveries = []
+        for task in TASK_NAMES:
+            recoveries = tuple(
+                phase.recovery_steps for phase in seed.phase_evidence if phase.task == task
+            )
+            expected_recoveries.append((task, recoveries[0], recoveries[1:]))
+        actual_recoveries = tuple(
+            (recovery.task, recovery.acquisition_steps, recovery.recurrence_steps)
+            for recovery in seed.task_recovery
+        )
+        if actual_recoveries != tuple(expected_recoveries):
+            raise ValueError(
+                f"{variant.name} seed {seed.seed} task recovery must summarize phase evidence"
+            )
+
+        active_pairs = set(seed.active_pairs)
+        if len(active_pairs) != len(seed.active_pairs) or not active_pairs <= expected_pairs:
+            raise ValueError(
+                f"{variant.name} seed {seed.seed} active pairs must be unique members "
+                "of the protocol pair universe"
+            )
+
+
 def _validated_gate_result(value: object) -> RecurringFeatureGateResult:
     """Return a recursively validated snapshot before any evidence is consumed."""
     if type(value) is not RecurringFeatureGateResult:
@@ -735,13 +788,16 @@ def _validated_gate_result(value: object) -> RecurringFeatureGateResult:
     )
     if budget != expected_budget:
         raise ValueError("memory_budget capacities must match the protocol")
-    return RecurringFeatureGateResult(
+    checked = RecurringFeatureGateResult(
         protocol=protocol,
         memory_budget=budget,
         retained=_validated_variant_evidence(value.retained),
         no_retention=_validated_variant_evidence(value.no_retention),
         scope=value.scope,
     )
+    _validate_seed_cross_fields(checked.retained, protocol)
+    _validate_seed_cross_fields(checked.no_retention, protocol)
+    return checked
 
 
 def _validated_gate_criteria(value: object) -> RecurringFeatureGateCriteria:

--- a/tests/test_causal_map_chunk_cap.py
+++ b/tests/test_causal_map_chunk_cap.py
@@ -8,14 +8,14 @@ from __future__ import annotations
 
 import pytest
 
-from alberta_framework.benchmarks.causal_map_forager import (
-    CausalMapForagerConfig,
-    _validate_benchmark_contract,
-)
 from alberta_framework.benchmarks.forager import ForagerBenchmarkConfig
 
 
 def test_rejects_oversized_causal_map_chunks() -> None:
-    cfg = ForagerBenchmarkConfig(steps=10_001, jax_chunk_size=10_001)
     with pytest.raises(ValueError, match="jax_chunk_size"):
-        _validate_benchmark_contract(CausalMapForagerConfig(), cfg)
+        ForagerBenchmarkConfig(steps=10_001, jax_chunk_size=10_001)
+
+
+def test_causal_map_accepts_the_shared_last_fit_chunk() -> None:
+    cfg = ForagerBenchmarkConfig(steps=10_000, jax_chunk_size=10_000)
+    assert cfg.jax_chunk_size == 10_000

--- a/tests/test_clear_matrix_cap.py
+++ b/tests/test_clear_matrix_cap.py
@@ -1,0 +1,20 @@
+"""Protocol ceilings for CLEAR accuracy-matrix enumeration."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.clear_qualification import (
+    MAX_METRIC_MATRIX_ROWS,
+    ClearQualificationError,
+    _metric_values,
+)
+
+
+def test_documented_protocol_ceiling() -> None:
+    assert MAX_METRIC_MATRIX_ROWS == 10_000
+
+
+def test_rejects_oversized_accuracy_matrix() -> None:
+    with pytest.raises(ClearQualificationError, match="accuracy matrix"):
+        _metric_values([[0.0] for _ in range(MAX_METRIC_MATRIX_ROWS + 1)])

--- a/tests/test_clear_matrix_cap.py
+++ b/tests/test_clear_matrix_cap.py
@@ -12,9 +12,16 @@ from alberta_framework.benchmarks.clear_qualification import (
 
 
 def test_documented_protocol_ceiling() -> None:
-    assert MAX_METRIC_MATRIX_ROWS == 10_000
+    assert MAX_METRIC_MATRIX_ROWS == 10
 
 
 def test_rejects_oversized_accuracy_matrix() -> None:
     with pytest.raises(ClearQualificationError, match="accuracy matrix"):
         _metric_values([[0.0] for _ in range(MAX_METRIC_MATRIX_ROWS + 1)])
+
+
+def test_rejects_short_or_ragged_matrix_before_nested_enumeration() -> None:
+    with pytest.raises(ClearQualificationError, match="exact 10x10"):
+        _metric_values([[0.0] * 10 for _ in range(9)])
+    with pytest.raises(ClearQualificationError, match="exact 10x10"):
+        _metric_values([[0.0] * 10 for _ in range(9)] + [[0.0] * 11])

--- a/tests/test_cora_evaluation_matrix_hang.py
+++ b/tests/test_cora_evaluation_matrix_hang.py
@@ -1,0 +1,86 @@
+"""CORA arm receipts reject oversized evaluation matrices before splat hang.
+
+Origin ``ArmResult`` walked every checkpoint row, then splatted every cell into
+a tuple, before comparing length to the frozen 7-row analogue. A cheap
+``(row,) * 8_000_000`` repeated pointer tuple took 3.240s on origin/main.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.benchmarks.cora_development import (
+    _EVALUATION_MATRIX_ROWS,
+    TASK_TARGETS,
+    ArmResult,
+    ResourceReceipt,
+    _metrics,
+)
+
+
+def _receipt() -> ResourceReceipt:
+    return ResourceReceipt(
+        training_environment_steps=1,
+        evaluation_environment_steps=1,
+        model_queries=1,
+        agent_updates=1,
+        replay_inserts=1,
+        replay_samples=1,
+        persistent_bytes=1,
+        peak_replay_bytes=1,
+        logical_compute_units=1,
+        elapsed_ns=1,
+    )
+
+
+def _row() -> tuple[float, ...]:
+    return tuple(0.0 for _ in TASK_TARGETS)
+
+
+def _matrix(rows: int) -> tuple[tuple[float, ...], ...]:
+    return (_row(),) * rows
+
+
+def test_frozen_checkpoint_count_is_the_analogue_row_bound() -> None:
+    assert _EVALUATION_MATRIX_ROWS == 7
+
+
+def test_last_fit_checkpoint_count_is_accepted() -> None:
+    result = ArmResult(
+        arm_id="replay_q",
+        training_return=0.0,
+        evaluation_matrix=_matrix(_EVALUATION_MATRIX_ROWS),
+        continual_evaluation=0.0,
+        isolated_forgetting=0.0,
+        isolated_forward_transfer=0.0,
+        receipt=_receipt(),
+        candidate_eligible=True,
+    )
+    assert len(result.evaluation_matrix) == _EVALUATION_MATRIX_ROWS
+    assert _metrics(result.evaluation_matrix)[0] == 0.0
+
+
+@pytest.mark.parametrize("rows", [1, 6, 8, 8_000_000])
+def test_oversized_or_short_matrix_rejects_before_cell_splat(rows: int) -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="checkpoint rows"):
+        ArmResult(
+            arm_id="replay_q",
+            training_return=0.0,
+            evaluation_matrix=_matrix(rows),
+            continual_evaluation=0.0,
+            isolated_forgetting=0.0,
+            isolated_forward_transfer=0.0,
+            receipt=_receipt(),
+            candidate_eligible=True,
+        )
+    assert time.perf_counter() - started < 0.5
+
+
+def test_metrics_reject_oversized_matrix_before_asarray() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="checkpoint rows"):
+        _metrics(_matrix(8_000_000))
+    assert time.perf_counter() - started < 0.5

--- a/tests/test_cora_evaluation_matrix_hang.py
+++ b/tests/test_cora_evaluation_matrix_hang.py
@@ -7,8 +7,6 @@ a tuple, before comparing length to the frozen 7-row analogue. A cheap
 
 from __future__ import annotations
 
-import time
-
 import pytest
 
 from alberta_framework.benchmarks.cora_development import (
@@ -62,9 +60,8 @@ def test_last_fit_checkpoint_count_is_accepted() -> None:
     assert _metrics(result.evaluation_matrix)[0] == 0.0
 
 
-@pytest.mark.parametrize("rows", [1, 6, 8, 8_000_000])
+@pytest.mark.parametrize("rows", [1, 6, 8, 1_000_000])
 def test_oversized_or_short_matrix_rejects_before_cell_splat(rows: int) -> None:
-    started = time.perf_counter()
     with pytest.raises(ValueError, match="checkpoint rows"):
         ArmResult(
             arm_id="replay_q",
@@ -76,11 +73,8 @@ def test_oversized_or_short_matrix_rejects_before_cell_splat(rows: int) -> None:
             receipt=_receipt(),
             candidate_eligible=True,
         )
-    assert time.perf_counter() - started < 0.5
 
 
 def test_metrics_reject_oversized_matrix_before_asarray() -> None:
-    started = time.perf_counter()
     with pytest.raises(ValueError, match="checkpoint rows"):
-        _metrics(_matrix(8_000_000))
-    assert time.perf_counter() - started < 0.5
+        _metrics(_matrix(1_000_000))

--- a/tests/test_forager_chunk_cap.py
+++ b/tests/test_forager_chunk_cap.py
@@ -1,0 +1,16 @@
+"""Protocol ceilings for Forager JAX chunk scans.
+
+Public last-fit is jax_chunk_size=10_000 (and tests use 4096). Origin accepted
+INT32-legal chunks and scanned jnp.arange(chunk) — hang, not leftover INT32 math.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager import ForagerBenchmarkConfig
+
+
+def test_rejects_oversized_jax_chunks() -> None:
+    with pytest.raises(ValueError, match="jax_chunk_size"):
+        ForagerBenchmarkConfig(steps=8, jax_chunk_size=10_001)

--- a/tests/test_horde_spec_demon_count_hang.py
+++ b/tests/test_horde_spec_demon_count_hang.py
@@ -1,0 +1,67 @@
+# mypy: disable-error-code="call-arg"
+"""HordeSpec rejects oversized demon lists before from_config reconstruction hang.
+
+Origin ``HordeSpec.from_config`` rebuilt every demon dict with no count bound.
+A cheap ``[spec] * 400_000`` pointer-repeat took 3.736s on origin/main.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.core.types import (
+    _MAX_HORDE_DEMONS,
+    DemonType,
+    GVFSpec,
+    HordeSpec,
+    create_horde_spec,
+)
+
+_DEMON_PAYLOAD = {
+    "name": "d",
+    "demon_type": "prediction",
+    "gamma": 0.9,
+    "lamda": 0.0,
+    "cumulant_index": 0,
+    "terminal_reward": 0.0,
+}
+
+
+def _demon() -> GVFSpec:
+    return GVFSpec(
+        name="d",
+        demon_type=DemonType.PREDICTION,
+        gamma=0.9,
+        lamda=0.0,
+        cumulant_index=0,
+    )
+
+
+def test_frozen_demon_count_bound() -> None:
+    assert _MAX_HORDE_DEMONS == 4096
+
+
+def test_last_fit_demon_count_is_accepted() -> None:
+    spec = create_horde_spec([_demon()] * _MAX_HORDE_DEMONS)
+    assert len(spec.demons) == _MAX_HORDE_DEMONS
+    restored = HordeSpec.from_config(
+        {"demons": [_DEMON_PAYLOAD] * _MAX_HORDE_DEMONS}
+    )
+    assert len(restored.demons) == _MAX_HORDE_DEMONS
+
+
+@pytest.mark.parametrize("count", [4097, 400_000])
+def test_from_config_rejects_oversized_demon_list_before_rebuild(count: int) -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="at most 4096"):
+        HordeSpec.from_config({"demons": [_DEMON_PAYLOAD] * count})
+    assert time.perf_counter() - started < 0.5
+
+
+def test_create_horde_spec_rejects_oversized_pointer_repeat() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="at most 4096"):
+        create_horde_spec([_demon()] * 400_000)
+    assert time.perf_counter() - started < 0.5

--- a/tests/test_horde_spec_demon_count_hang.py
+++ b/tests/test_horde_spec_demon_count_hang.py
@@ -8,6 +8,8 @@ A cheap ``[spec] * 400_000`` pointer-repeat took 3.736s on origin/main.
 from __future__ import annotations
 
 import time
+from collections.abc import Iterator, Sequence
+from typing import overload
 
 import pytest
 
@@ -65,3 +67,40 @@ def test_create_horde_spec_rejects_oversized_pointer_repeat() -> None:
     with pytest.raises(ValueError, match="at most 4096"):
         create_horde_spec([_demon()] * 400_000)
     assert time.perf_counter() - started < 0.5
+
+
+class _CountingDemonSequence(Sequence[GVFSpec]):
+    def __init__(self, item_count: int) -> None:
+        self.item_count = item_count
+        self.yields = 0
+        self.value = _demon()
+
+    def __len__(self) -> int:
+        return self.item_count
+
+    @overload
+    def __getitem__(self, index: int) -> GVFSpec: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[GVFSpec]: ...
+
+    def __getitem__(self, index: int | slice) -> GVFSpec | Sequence[GVFSpec]:
+        if isinstance(index, slice):
+            return tuple(self.value for _ in range(*index.indices(self.item_count)))
+        if not 0 <= index < self.item_count:
+            raise IndexError(index)
+        return self.value
+
+    def __iter__(self) -> Iterator[GVFSpec]:
+        for _ in range(self.item_count):
+            self.yields += 1
+            yield self.value
+
+
+def test_create_horde_spec_bounds_generic_sequence_consumption() -> None:
+    demons = _CountingDemonSequence(400_000)
+
+    with pytest.raises(ValueError, match="at most 4096"):
+        create_horde_spec(demons)
+
+    assert demons.yields <= _MAX_HORDE_DEMONS + 1

--- a/tests/test_recurring_feature_evidence_leftover_identities.py
+++ b/tests/test_recurring_feature_evidence_leftover_identities.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Callable
 from dataclasses import replace
 
 import pytest
@@ -170,6 +171,50 @@ def test_decision_revalidates_and_cross_binds_memory_budget() -> None:
     )
     with pytest.raises(ValueError, match="capacities must match"):
         mismatched.decision()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    (
+        (
+            lambda result: object.__setattr__(
+                result.retained.seeds[0].phase_evidence[0], "task", "B"
+            ),
+            "phase evidence must match",
+        ),
+        (
+            lambda result: object.__setattr__(
+                result.retained.seeds[0].task_recovery[0], "recurrence_steps", ()
+            ),
+            "task recovery must summarize",
+        ),
+        (
+            lambda result: object.__setattr__(
+                result.retained.seeds[0], "active_pairs", ((0, 1), (0, 1), (0, 2))
+            ),
+            "active pairs must be unique members",
+        ),
+    ),
+)
+def test_decision_cross_binds_seed_evidence_to_protocol(
+    mutation: Callable[[RecurringFeatureGateResult], None],
+    message: str,
+) -> None:
+    result = _decision_result()
+    mutation(result)
+
+    with pytest.raises(ValueError, match=message):
+        result.decision()
+
+
+def test_decision_rejects_duplicate_seed_identities() -> None:
+    result = _decision_result()
+    duplicate = result.retained.seeds[0]
+    object.__setattr__(result.retained, "seeds", (duplicate, duplicate))
+    object.__setattr__(result.no_retention, "seeds", (duplicate, duplicate))
+
+    with pytest.raises(ValueError, match="seed identities must be unique"):
+        result.decision()
 
 
 def test_decision_preflights_forged_nested_lengths_before_snapshot() -> None:


### PR DESCRIPTION
## Summary

- supersede and integrate #2073, #2074, #2075, #2077, and #2078
- enforce exact CLEAR and CORA matrix protocols before nested traversal or conversion
- route Forager chunk sizing through the shared 10,000-step scan budget
- cap Horde demon reconstruction at 4,096 and bound generic sequence consumption to 4,097 elements
- cross-bind recurring-feature phase identities, occurrence order, recovery summaries, active-pair membership, and unique matched seed identities before statistics consume evidence
- make optional `optax` loading independent of whether local type metadata is installed

This preserves the individual contributors' commits and adds the missing generic-sequence and evidence cross-field coverage. It does not alter or promote any evidence artifact.

## Validation

- `436 passed` across the consolidated benchmark, Horde, GVF, and recurring-feature panels
- `87 passed` across IPMNIST ceiling and campaign-tool tests
- full Ruff: passed
- full strict mypy: `Success: no issues found in 221 source files`
- `git diff --check`: passed
- all 70 Markdown files scanned with no conflict markers
- `AGENTS.md` and `CLAUDE.md` remain byte-identical

## Supersedes

Closes #2073.
Closes #2074.
Closes #2075.
Closes #2077.
Closes #2078.
