### PR TITLE
fix(streams): reject oversized periodic mask schedules before stack hang

### DIFF
--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -54,6 +54,10 @@ class MaskMode(enum.Enum):
 # ``tests/test_partial_observation.py``. Origin stacked a pointer-repeat of
 # 5_000 identical masks with no reject — hang, not leftover INT32 math.
 _MAX_PERIODIC_SCHEDULE_LENGTH = 4_096
+# Each logical boolean is retained once in the per-row converted masks and
+# once again in the stacked schedule.  Cap the logical payload at 64 MiB so
+# those two runner-owned arrays stay below 128 MiB before allocator overhead.
+_MAX_PERIODIC_SCHEDULE_VALUES = 64 * 1024 * 1024
 
 
 def _require_unit_interval_probability(name: str, value: object) -> float:
@@ -170,6 +174,12 @@ class PartialObservationWrapper[InnerStateT]:
                 raise ValueError(
                     "periodic schedule length must be an integer in "
                     f"[1, {_MAX_PERIODIC_SCHEDULE_LENGTH}]"
+                )
+            schedule_values = len(schedule) * feature_dim
+            if schedule_values > _MAX_PERIODIC_SCHEDULE_VALUES:
+                raise ValueError(
+                    "periodic schedule working set exceeds the bounded "
+                    f"{_MAX_PERIODIC_SCHEDULE_VALUES}-value payload"
                 )
             masks = [jnp.asarray(m, dtype=jnp.bool_) for m in schedule]
             if any(mask.shape != (feature_dim,) for mask in masks):

--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -50,6 +50,12 @@ class MaskMode(enum.Enum):
     PERIODIC = "periodic"
 
 
+# Public last-fit is the three-mask cycling schedule in
+# ``tests/test_partial_observation.py``. Origin stacked a pointer-repeat of
+# 5_000 identical masks with no reject — hang, not leftover INT32 math.
+_MAX_PERIODIC_SCHEDULE_LENGTH = 4_096
+
+
 def _require_unit_interval_probability(name: str, value: object) -> float:
     """Return a canonical probability valid at the float32 execution sink."""
     return validated_float32_scalar(name, value, lower=0.0, upper=1.0)
@@ -159,6 +165,11 @@ class PartialObservationWrapper[InnerStateT]:
             if schedule is None or len(schedule) == 0:
                 raise ValueError(
                     "MaskMode.PERIODIC requires a non-empty schedule."
+                )
+            if len(schedule) > _MAX_PERIODIC_SCHEDULE_LENGTH:
+                raise ValueError(
+                    "periodic schedule length must be an integer in "
+                    f"[1, {_MAX_PERIODIC_SCHEDULE_LENGTH}]"
                 )
             masks = [jnp.asarray(m, dtype=jnp.bool_) for m in schedule]
             if any(mask.shape != (feature_dim,) for mask in masks):

--- a/tests/test_partial_observation_schedule_hang.py
+++ b/tests/test_partial_observation_schedule_hang.py
@@ -1,0 +1,57 @@
+# mypy: disable-error-code="arg-type"
+"""Periodic mask schedules reject oversized tuples before asarray/stack hang."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from alberta_framework.streams.partial_observation import (
+    _MAX_PERIODIC_SCHEDULE_LENGTH,
+    MaskMode,
+    PartialObservationWrapper,
+)
+from alberta_framework.streams.synthetic import RandomWalkStream
+
+pytestmark = pytest.mark.unit
+
+
+def _inner() -> RandomWalkStream:
+    return RandomWalkStream(feature_dim=2, drift_rate=0.0, noise_std=0.0)
+
+
+def test_periodic_schedule_rejects_origin_hang_class_before_stack() -> None:
+    row = np.array([True, False], dtype=bool)
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="periodic schedule length"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=MaskMode.PERIODIC,
+            schedule=(row,) * (_MAX_PERIODIC_SCHEDULE_LENGTH + 1),
+        )
+    assert time.perf_counter() - started < 0.25
+
+
+def test_periodic_schedule_rejects_pointer_repeat_origin_hang_n() -> None:
+    row = np.array([True, False], dtype=bool)
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="periodic schedule length"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=MaskMode.PERIODIC,
+            schedule=(row,) * 5_000,
+        )
+    assert time.perf_counter() - started < 0.25
+
+
+def test_periodic_schedule_accepts_public_last_fit() -> None:
+    row_a = np.array([True, False], dtype=bool)
+    row_b = np.array([False, True], dtype=bool)
+    wrapper = PartialObservationWrapper(
+        _inner(),
+        mode=MaskMode.PERIODIC,
+        schedule=(row_a, row_b, row_a),
+    )
+    assert wrapper.mode is MaskMode.PERIODIC

--- a/tests/test_partial_observation_schedule_hang.py
+++ b/tests/test_partial_observation_schedule_hang.py
@@ -8,8 +8,10 @@ import time
 import numpy as np
 import pytest
 
+from alberta_framework.streams import partial_observation
 from alberta_framework.streams.partial_observation import (
     _MAX_PERIODIC_SCHEDULE_LENGTH,
+    _MAX_PERIODIC_SCHEDULE_VALUES,
     MaskMode,
     PartialObservationWrapper,
 )
@@ -55,3 +57,23 @@ def test_periodic_schedule_accepts_public_last_fit() -> None:
         schedule=(row_a, row_b, row_a),
     )
     assert wrapper.mode is MaskMode.PERIODIC
+
+
+def test_periodic_schedule_rejects_large_rows_before_array_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pointer-repeated row cannot amplify into a multi-gigabyte stack."""
+    feature_dim = 1_000_000
+    row = np.zeros((feature_dim,), dtype=bool)
+    schedule_length = _MAX_PERIODIC_SCHEDULE_VALUES // feature_dim + 1
+
+    def fail_asarray(*args: object, **kwargs: object) -> object:
+        raise AssertionError("array conversion ran before the working-set gate")
+
+    monkeypatch.setattr(partial_observation.jnp, "asarray", fail_asarray)
+    with pytest.raises(ValueError, match="periodic schedule working set"):
+        PartialObservationWrapper(
+            RandomWalkStream(feature_dim=feature_dim, drift_rate=0.0, noise_std=0.0),
+            mode=MaskMode.PERIODIC,
+            schedule=(row,) * schedule_length,
+        )


### PR DESCRIPTION
## Hang

`PartialObservationWrapper` PERIODIC mode walked every caller-supplied schedule mask with `jnp.asarray`, then `jnp.stack`, before any length bound.

On origin/main `b7bafadd` (after warmup):

```
schedule = (np.array([True, False], dtype=bool),) * 5_000
PartialObservationWrapper(RandomWalkStream(feature_dim=2), mode=MaskMode.PERIODIC, schedule=schedule)
```

took **6.414s**. Construction of the pointer-repeat tuple is O(1). The cost is converting and stacking every mask.

This is occupancy-FREE (`alberta_framework/streams/partial_observation.py`). It is not leftover INT32/256MiB, not forager/clocks/IA, not JSON nesting, not `jax.tree`, not scan-T, and not a from_config collection rebuild.

## Fix

Cap `_MAX_PERIODIC_SCHEDULE_LENGTH = 4096` and reject oversized schedules **before** the asarray/stack loop. Public last-fit remains the three-mask cycling schedule in `tests/test_partial_observation.py`.

Oversized pointer-repeat now raises `ValueError` in <0.25s.

## Tests

`tests/test_partial_observation_schedule_hang.py` plus the existing partial-observation suite (35 passed).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via manaflow cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f0dbdb4018badd226eef9206a239f9dde8c05637 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via manaflow cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via manaflow cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->
