### PR TITLE
fix(benchmarks): reject deeply-nested result.json before RecursionError

### DIFF
--- a/alberta_framework/benchmarks/historical_forager.py
+++ b/alberta_framework/benchmarks/historical_forager.py
@@ -106,6 +106,11 @@ _REWARD_DTYPE = np.dtype("<f8")
 _MAX_STEPS = 100_000_000
 _MAX_SEED = 2**32 - 1
 _MAX_JSON_BYTES = 4 * 1024 * 1024
+# Same ceiling as security._JSON_MAX_DEPTH and reference_life_checkpoint's
+# _MAX_TREE_DEPTH. A deeply nested result.json well under _MAX_JSON_BYTES
+# (e.g. 10_000 nested arrays, ~20KB) still RecursionErrors CPython's json
+# decoder before the byte-size gate can reject it.
+_MAX_JSON_DEPTH = 32
 _MAX_KERNEL_METADATA_BYTES = 1024 * 1024
 _HASH_CHUNK_BYTES = 1024 * 1024
 _VALIDATION_CHUNK_VALUES = 65_536
@@ -1040,6 +1045,42 @@ def run_historical_forager[KernelStateT](
     )
 
 
+def _require_json_text_depth(raw: bytes, *, name: str) -> None:
+    """Reject JSON nests deeper than ``_MAX_JSON_DEPTH`` before RecursionError.
+
+    A small, byte-bounded artifact can still nest thousands of arrays or
+    objects; CPython's ``json`` decoder recurses per level and RecursionErrors
+    well before ``_MAX_JSON_BYTES`` would reject it. Scan the raw text for
+    bracket depth (skipping string contents) so the artifact fails closed with
+    ``HistoricalForagerArtifactError`` instead of an uncaught interpreter
+    error.
+    """
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise HistoricalForagerArtifactError(f"{name} is not valid UTF-8 JSON") from exc
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            if depth > _MAX_JSON_DEPTH:
+                raise HistoricalForagerArtifactError(f"{name} exceeds the JSON nesting limit")
+        elif character in "]}":
+            depth -= 1
+
+
 def _strict_json_object(path: Path) -> tuple[dict[str, Any], bytes]:
     try:
         metadata = path.lstat()
@@ -1053,6 +1094,7 @@ def _strict_json_object(path: Path) -> tuple[dict[str, Any], bytes]:
     ):
         raise HistoricalForagerArtifactError(f"artifact file {path.name!r} is not canonical")
     payload = path.read_bytes()
+    _require_json_text_depth(payload, name=path.name)
 
     def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
         result: dict[str, Any] = {}
@@ -1084,6 +1126,8 @@ def _strict_json_object(path: Path) -> tuple[dict[str, Any], bytes]:
             parse_constant=invalid_constant,
             parse_float=parse_float,
         )
+    except RecursionError as exc:
+        raise HistoricalForagerArtifactError("result.json exceeds the JSON nesting limit") from exc
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise HistoricalForagerArtifactError("result.json is not valid UTF-8 JSON") from exc
     if not isinstance(parsed, dict):

--- a/tests/test_historical_forager_result_json_depth.py
+++ b/tests/test_historical_forager_result_json_depth.py
@@ -1,0 +1,78 @@
+"""Depth ceiling for historical Forager ``result.json`` artifact loads.
+
+``_strict_json_object`` bounds ``result.json`` by byte size
+(``_MAX_JSON_BYTES``, 4MiB) but, before this fix, not by nesting depth. A
+deeply nested JSON array is small in bytes (10_000 levels of ``[`` is ~20KB)
+but RecursionErrors CPython's ``json`` decoder well before the byte-size gate
+can reject it, so ``validate_historical_forager_artifact`` — a fail-closed
+artifact validator — crashed with an uncaught ``RecursionError`` instead of
+cleanly raising ``HistoricalForagerArtifactError`` on a hostile artifact
+directory. The protocol ceiling matches ``security._JSON_MAX_DEPTH`` and
+``reference_life_checkpoint._MAX_TREE_DEPTH`` (32).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.historical_forager import (
+    _MAX_JSON_DEPTH,
+    HistoricalForagerArtifactError,
+    _strict_json_object,
+    validate_historical_forager_artifact,
+)
+
+
+def _nested_array_bytes(depth: int) -> bytes:
+    return ("[" * depth + "]" * depth).encode("utf-8")
+
+
+def _write_canonical_artifact_file(path: Path, payload: bytes) -> None:
+    path.write_bytes(payload)
+    os.chmod(path, 0o444)
+
+
+def test_protocol_ceiling_matches_json_depth_bound() -> None:
+    assert _MAX_JSON_DEPTH == 32
+
+
+def test_first_overflow_nest_is_artifact_error_not_recursion_error(tmp_path: Path) -> None:
+    result_path = tmp_path / "result.json"
+    _write_canonical_artifact_file(result_path, _nested_array_bytes(_MAX_JSON_DEPTH + 1))
+    with pytest.raises(HistoricalForagerArtifactError, match="nesting limit"):
+        _strict_json_object(result_path)
+
+
+def test_origin_hang_class_10000_is_artifact_error_not_recursion_error(tmp_path: Path) -> None:
+    """The 10_000-deep nest is ~20KB, far under ``_MAX_JSON_BYTES`` (4MiB)."""
+    result_path = tmp_path / "result.json"
+    payload = _nested_array_bytes(10_000)
+    assert len(payload) < 1024 * 1024
+    _write_canonical_artifact_file(result_path, payload)
+    with pytest.raises(HistoricalForagerArtifactError, match="nesting limit"):
+        _strict_json_object(result_path)
+
+
+def test_validate_historical_forager_artifact_rejects_deep_result_json_without_crashing(
+    tmp_path: Path,
+) -> None:
+    """The public fail-closed validator must reject, not RecursionError, a hostile artifact."""
+    artifact_dir = tmp_path / "artifact"
+    artifact_dir.mkdir()
+    _write_canonical_artifact_file(
+        artifact_dir / "result.json", _nested_array_bytes(_MAX_JSON_DEPTH + 1)
+    )
+    _write_canonical_artifact_file(artifact_dir / "rewards.npy", b"\x00")
+    with pytest.raises(HistoricalForagerArtifactError, match="nesting limit"):
+        validate_historical_forager_artifact(artifact_dir)
+
+
+def test_boundary_depth_is_not_rejected_by_the_depth_scan(tmp_path: Path) -> None:
+    """At exactly the ceiling, the pre-check passes; JSON-object-shape errors take over."""
+    result_path = tmp_path / "result.json"
+    _write_canonical_artifact_file(result_path, _nested_array_bytes(_MAX_JSON_DEPTH))
+    with pytest.raises(HistoricalForagerArtifactError, match="must contain an object"):
+        _strict_json_object(result_path)


### PR DESCRIPTION
## Problem

`_strict_json_object` bounds `result.json` by byte size (`_MAX_JSON_BYTES`, 4MiB) but not by nesting depth. A deeply nested JSON array is small in bytes (10,000 levels of `[` is ~20KB) but RecursionErrors CPython's `json` decoder well before the byte-size gate can reject it, so `validate_historical_forager_artifact` — a fail-closed artifact validator — crashed with an uncaught `RecursionError` instead of cleanly raising `HistoricalForagerArtifactError` on a hostile artifact directory.

## Fix

Adds `_require_json_text_depth`, a bracket-depth scan (skipping string contents) run before `json.loads`, plus a `RecursionError` catch as defense in depth. Ceiling (32) matches the existing `security._JSON_MAX_DEPTH` and `reference_life_checkpoint._MAX_TREE_DEPTH` conventions elsewhere in the repo.

## Verification

- `pytest tests/test_historical_forager_result_json_depth.py` — 5 passed (new failing-test-first cases, including the realistic ~20KB/10,000-level "origin hang class" case and a boundary-acceptance case at exactly the ceiling).
- `pytest tests/test_historical_forager_cli_package.py tests/test_historical_forager_hostile_validation.py tests/test_historical_forager_reconstructed.py tests/test_historical_forager_result_json_depth.py` — 52 passed, no regressions.
- `ruff check` — all checks passed.
- `mypy` — no issues.

## Collision check

`gh pr list --repo elizaOS/asi --state open --json number,title,files` confirmed no open PR touches `alberta_framework/benchmarks/historical_forager.py`.

## Attribution

- Client: claude-code
- Provider: anthropic
- Model: claude-sonnet-5
- Lane: rama0x1-asi-claude-worker-2

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F36GJ3EP343PM3FDMB7C55","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T08:04:30.916Z","completed_at":"2026-08-20T08:05:21.885Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T08:04:33.041Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5b9a876134ee65c142e9195097802f2e25177a18bc3a5195afb00b3649b5ac8a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3a448c8b-d1d7-4e28-abe5-9874041feee8","object_id":"sha256:5b9a876134ee65c142e9195097802f2e25177a18bc3a5195afb00b3649b5ac8a","sha256":"5b9a876134ee65c142e9195097802f2e25177a18bc3a5195afb00b3649b5ac8a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"aTRY7ohCLtzYMlY7BJpZ_uubeofHfnT6f9dv6ARGpMHqoH7_E8qz-YzOw-zTYeQwfEMdvlpGMfPuqtsRo4tmAA"}} -->
