### PR TITLE
fix(step7): cover prioritized/learned Dyna planning strategies

### DIFF
--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -494,7 +494,10 @@ class TestStep7Scan:
         result = run_step7_scan(cfg, agent, model, state, jnp.zeros(n_steps), obs)
         assert int(result.state.step_count) == n_steps
 
-    @pytest.mark.parametrize("strategy", ["random", "reward", "surprise", "predecessor"])
+    @pytest.mark.parametrize(
+        "strategy",
+        ["random", "reward", "surprise", "predecessor", "prioritized", "learned"],
+    )
     def test_scan_strategies(self, strategy: str) -> None:
         cfg = _cfg(strategy=strategy, planning_steps=1)
         agent, model, state = _init(cfg)
@@ -544,6 +547,16 @@ class TestStep7Smoke:
         result = run_step7_smoke(cfg, steps=16, seed=0)
         assert result.finite
 
+    def test_smoke_prioritized_strategy(self) -> None:
+        cfg = _cfg(planning_steps=2, strategy="prioritized")
+        result = run_step7_smoke(cfg, steps=16, seed=0)
+        assert result.finite
+
+    def test_smoke_learned_strategy(self) -> None:
+        cfg = _cfg(planning_steps=2, strategy="learned")
+        result = run_step7_smoke(cfg, steps=16, seed=0)
+        assert result.finite
+
 
 # ---------------------------------------------------------------------------
 # 200-step fineness
@@ -572,6 +585,29 @@ class TestStep7Fineness:
         acceptance = jnp.sum(result.planning_accepted)
         # At least some steps should have accepted planning
         assert int(acceptance) > 0
+
+    @pytest.mark.parametrize("strategy", ["prioritized", "learned"])
+    def test_200_step_priority_queue_strategies_stay_finite(self, strategy: str) -> None:
+        # ``prioritized`` and ``predecessor``-scores its own popped anchor
+        # against its own successor when computing propagated priorities
+        # (see ``_propagate_predecessor_priorities``), and ``learned`` feeds
+        # ``rollout_td_signal`` straight back into the per-anchor utility EMA
+        # (see ``_update_planning_utility``). Neither self-referential update
+        # loop was exercised at 200-step length before this test: run it long
+        # enough that a degenerate feedback loop (unbounded priority growth,
+        # NaN from a runaway utility EMA) would show up.
+        cfg = _cfg(planning_steps=2, strategy=strategy, warmup=5)
+        agent, model, state = _init(cfg)
+        n_steps = 200
+        rewards = jr.normal(jr.key(70), (n_steps,))
+        next_obs = jr.normal(jr.key(71), (n_steps, OBS_DIM))
+        result = run_step7_scan(cfg, agent, model, state, rewards, next_obs)
+        chex.assert_tree_all_finite(result.real_td_errors)
+        chex.assert_tree_all_finite(result.planning_td_errors)
+        chex.assert_tree_all_finite(result.state.memory_priorities)
+        chex.assert_tree_all_finite(result.state.memory_utilities)
+        assert int(result.state.step_count) == n_steps
+        assert int(jnp.sum(result.planning_accepted)) > 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- evidence-head:6217758c674b3d0ec66d6f71634615a444107944 -->

## Problem

`alberta_framework/steps/step7.py` documents six Dyna search-control
strategies (`Step7PlanningStrategy`): `random`, `reward`, `surprise`,
`predecessor`, `prioritized`, `learned`. Each of `prioritized` and
`learned` has its own dedicated, self-referential code path:

- `prioritized` — `_pop_prioritized_planning_anchor` pops the
  highest-priority memory slot, backs it up, then
  `_propagate_predecessor_priorities` writes new priorities back into
  the same memory array based on the resulting TD signal.
- `learned` — `_update_planning_utility` folds the imagined rollout's
  `|TD|` into a per-anchor EMA (`memory_utilities`) that then biases
  future anchor selection.

Before this change, `tests/test_step7_production.py::test_scan_strategies`
(and the smoke / 200-step fineness tests) only ran `random`, `reward`,
`surprise`, and `predecessor` through `run_step7_scan`/`step7_update`.
`prioritized` and `learned` were touched only by config-construction
and JSON round-trip tests — never actually executed. A regression in
either feedback loop (e.g. unbounded priority growth, a NaN from the
utility EMA, or the anchor's own priority never draining because
`_propagate_predecessor_priorities` also scores the anchor's own
`(observation, next_observation)` pair against itself) would corrupt
any future benchmark that exercises these strategies through the Step 7
facade, with nothing in CI to catch it.

## Fix

- Add `prioritized` and `learned` to the `test_scan_strategies`
  parametrization (now covers all six documented strategies).
- Add `test_smoke_prioritized_strategy` / `test_smoke_learned_strategy`,
  mirroring the existing `test_smoke_reward_strategy` /
  `test_smoke_predecessor_strategy`.
- Add `test_200_step_priority_queue_strategies_stay_finite`, parametrized
  over `prioritized`/`learned`, asserting `real_td_errors`,
  `planning_td_errors`, `memory_priorities`, and `memory_utilities` stay
  finite over 200 steps and that planning is actually accepted at least
  once — the existing 200-step fineness test only covered `random`.

No production code changed; this closes a test-coverage gap on already
-shipped behavior. I manually ran both strategies through
`run_step7_scan` at 6 and 200 steps before writing the tests to confirm
current `main` is in fact finite/stable (no bug found today — the
value of this PR is that a future regression here will now fail CI
instead of shipping silently).

## Verification

Commit under test: `6217758c674b3d0ec66d6f71634615a444107944`

```
.venv/bin/python -m pytest tests/test_step7_production.py -q -o addopts=""
127 passed in 234.40s
```

```
.venv/bin/python -m ruff check tests/test_step7_production.py
All checks passed!
```

```
.venv/bin/python -m mypy
Success: no issues found in 221 source files
```

(`tests/` is intentionally outside `[tool.mypy].files = ["alberta_framework"]`,
so the new test code is not part of the mypy gate — same as every other
test file in this repo.)

## Collision check

Ran immediately before picking and again immediately before this commit:

```
gh issue list --repo SlopDotCash/asi --state open --search "step7"
gh pr list --repo SlopDotCash/asi --state open --json number,title,files --limit 200
```

No open issue or PR touches `alberta_framework/steps/step7.py` or
`tests/test_step7_production.py`. Also checked PR #2060 ("consolidate
bounded JAX scan contracts") did not touch `step7.py` or this test file.

## Provenance

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Lane: rama0x1-asi-claude-worker

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F4964M7V4KMWVG3R5V489K","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T08:23:27.124Z","completed_at":"2026-08-20T08:24:02.786Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T08:23:27.931Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a565e5aaf53f6daa6c6f30b594503a48c9e0e013e7eb427685408b916d381c86","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"8c1076c1-ea76-4bab-b98d-039acba6382a","object_id":"sha256:a565e5aaf53f6daa6c6f30b594503a48c9e0e013e7eb427685408b916d381c86","sha256":"a565e5aaf53f6daa6c6f30b594503a48c9e0e013e7eb427685408b916d381c86"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"TFNNsyOxqSYti2b9dSdV_7r23DcdioV-CgX-Cpj1HcPpBXa5cn7VOMN8lVZP_74FXavhuMqrksyVijPlC5CoBQ"}} -->
