### PR TITLE
fix(streams): bound and vectorize periodic schedule construction

### DIFF
--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -54,6 +54,10 @@ class MaskMode(enum.Enum):
 # ``tests/test_partial_observation.py``. Origin stacked a pointer-repeat of
 # 5_000 identical masks with no reject — hang, not leftover INT32 math.
 _MAX_PERIODIC_SCHEDULE_LENGTH = 4_096
+# Each logical boolean is retained once in the per-row converted masks and
+# once again in the stacked schedule.  Cap the logical payload at 64 MiB so
+# those two runner-owned arrays stay below 128 MiB before allocator overhead.
+_MAX_PERIODIC_SCHEDULE_VALUES = 64 * 1024 * 1024
 
 
 def _require_unit_interval_probability(name: str, value: object) -> float:
@@ -170,6 +174,12 @@ class PartialObservationWrapper[InnerStateT]:
                 raise ValueError(
                     "periodic schedule length must be an integer in "
                     f"[1, {_MAX_PERIODIC_SCHEDULE_LENGTH}]"
+                )
+            schedule_values = len(schedule) * feature_dim
+            if schedule_values > _MAX_PERIODIC_SCHEDULE_VALUES:
+                raise ValueError(
+                    "periodic schedule working set exceeds the bounded "
+                    f"{_MAX_PERIODIC_SCHEDULE_VALUES}-value payload"
                 )
             masks = [jnp.asarray(m, dtype=jnp.bool_) for m in schedule]
             if any(mask.shape != (feature_dim,) for mask in masks):

--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -50,6 +50,12 @@ class MaskMode(enum.Enum):
     PERIODIC = "periodic"
 
 
+# Public last-fit is the three-mask cycling schedule in
+# ``tests/test_partial_observation.py``. Origin stacked a pointer-repeat of
+# 5_000 identical masks with no reject — hang, not leftover INT32 math.
+_MAX_PERIODIC_SCHEDULE_LENGTH = 4_096
+
+
 def _require_unit_interval_probability(name: str, value: object) -> float:
     """Return a canonical probability valid at the float32 execution sink."""
     return validated_float32_scalar(name, value, lower=0.0, upper=1.0)
@@ -159,6 +165,11 @@ class PartialObservationWrapper[InnerStateT]:
             if schedule is None or len(schedule) == 0:
                 raise ValueError(
                     "MaskMode.PERIODIC requires a non-empty schedule."
+                )
+            if len(schedule) > _MAX_PERIODIC_SCHEDULE_LENGTH:
+                raise ValueError(
+                    "periodic schedule length must be an integer in "
+                    f"[1, {_MAX_PERIODIC_SCHEDULE_LENGTH}]"
                 )
             masks = [jnp.asarray(m, dtype=jnp.bool_) for m in schedule]
             if any(mask.shape != (feature_dim,) for mask in masks):

--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -26,6 +26,7 @@ from typing import TypeVar
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, PRNGKeyArray
 
@@ -54,10 +55,17 @@ class MaskMode(enum.Enum):
 # ``tests/test_partial_observation.py``. Origin stacked a pointer-repeat of
 # 5_000 identical masks with no reject — hang, not leftover INT32 math.
 _MAX_PERIODIC_SCHEDULE_LENGTH = 4_096
-# Each logical boolean is retained once in the per-row converted masks and
-# once again in the stacked schedule.  Cap the logical payload at 64 MiB so
-# those two runner-owned arrays stay below 128 MiB before allocator overhead.
+# Cap the final boolean schedule payload at 64 MiB.  The schedule is converted
+# in one operation below: converting each row separately makes construction
+# time grow with thousands of JAX dispatches even when every row is a repeated
+# pointer to the same tiny host array.
 _MAX_PERIODIC_SCHEDULE_VALUES = 64 * 1024 * 1024
+
+
+def _is_trusted_mask_array(value: object) -> bool:
+    """Accept only concrete NumPy or JAX array runtime types."""
+    actual_type = type(value)
+    return actual_type is np.ndarray or issubclass(actual_type, Array)
 
 
 def _require_unit_interval_probability(name: str, value: object) -> float:
@@ -75,6 +83,13 @@ def _require_mode(mode: object) -> MaskMode:
     if type(mode) is not MaskMode:
         raise ValueError("mode must be an exact MaskMode")
     return mode
+
+
+def _require_feature_dim(value: object) -> int:
+    """Reject non-builtin protocol dimensions before resource arithmetic."""
+    if type(value) is not int or not 1 <= value <= 2**31 - 1:
+        raise ValueError("inner.feature_dim must be an integer in [1, 2147483647]")
+    return value
 
 
 # =============================================================================
@@ -151,7 +166,7 @@ class PartialObservationWrapper[InnerStateT]:
         self._mask_prob = mask_prob
         self._sentinel = validated_float32_scalar("sentinel", sentinel)
 
-        feature_dim = inner.feature_dim
+        feature_dim = _require_feature_dim(inner.feature_dim)
 
         if mode == MaskMode.FIXED:
             if fixed_mask is None:
@@ -166,7 +181,13 @@ class PartialObservationWrapper[InnerStateT]:
             self._fixed_mask = None
 
         if mode == MaskMode.PERIODIC:
-            if schedule is None or len(schedule) == 0:
+            if schedule is None:
+                raise ValueError(
+                    "MaskMode.PERIODIC requires a non-empty schedule."
+                )
+            if type(schedule) is not tuple:
+                raise ValueError("periodic schedule must be an exact tuple")
+            if len(schedule) == 0:
                 raise ValueError(
                     "MaskMode.PERIODIC requires a non-empty schedule."
                 )
@@ -181,12 +202,16 @@ class PartialObservationWrapper[InnerStateT]:
                     "periodic schedule working set exceeds the bounded "
                     f"{_MAX_PERIODIC_SCHEDULE_VALUES}-value payload"
                 )
-            masks = [jnp.asarray(m, dtype=jnp.bool_) for m in schedule]
-            if any(mask.shape != (feature_dim,) for mask in masks):
+            if any(
+                not _is_trusted_mask_array(mask)
+                or mask.shape != (feature_dim,)
+                for mask in schedule
+            ):
                 raise ValueError(
                     f"schedule masks must each have shape (feature_dim={feature_dim},)"
                 )
-            sched = jnp.stack(masks, axis=0)
+            sched = jnp.asarray(schedule, dtype=jnp.bool_)
+            assert sched.shape == (len(schedule), feature_dim)
             self._schedule: Array | None = sched
         else:
             self._schedule = None

--- a/tests/test_partial_observation_schedule_hang.py
+++ b/tests/test_partial_observation_schedule_hang.py
@@ -1,0 +1,57 @@
+# mypy: disable-error-code="arg-type"
+"""Periodic mask schedules reject oversized tuples before asarray/stack hang."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from alberta_framework.streams.partial_observation import (
+    _MAX_PERIODIC_SCHEDULE_LENGTH,
+    MaskMode,
+    PartialObservationWrapper,
+)
+from alberta_framework.streams.synthetic import RandomWalkStream
+
+pytestmark = pytest.mark.unit
+
+
+def _inner() -> RandomWalkStream:
+    return RandomWalkStream(feature_dim=2, drift_rate=0.0, noise_std=0.0)
+
+
+def test_periodic_schedule_rejects_origin_hang_class_before_stack() -> None:
+    row = np.array([True, False], dtype=bool)
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="periodic schedule length"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=MaskMode.PERIODIC,
+            schedule=(row,) * (_MAX_PERIODIC_SCHEDULE_LENGTH + 1),
+        )
+    assert time.perf_counter() - started < 0.25
+
+
+def test_periodic_schedule_rejects_pointer_repeat_origin_hang_n() -> None:
+    row = np.array([True, False], dtype=bool)
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="periodic schedule length"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=MaskMode.PERIODIC,
+            schedule=(row,) * 5_000,
+        )
+    assert time.perf_counter() - started < 0.25
+
+
+def test_periodic_schedule_accepts_public_last_fit() -> None:
+    row_a = np.array([True, False], dtype=bool)
+    row_b = np.array([False, True], dtype=bool)
+    wrapper = PartialObservationWrapper(
+        _inner(),
+        mode=MaskMode.PERIODIC,
+        schedule=(row_a, row_b, row_a),
+    )
+    assert wrapper.mode is MaskMode.PERIODIC

--- a/tests/test_partial_observation_schedule_hang.py
+++ b/tests/test_partial_observation_schedule_hang.py
@@ -8,8 +8,10 @@ import time
 import numpy as np
 import pytest
 
+from alberta_framework.streams import partial_observation
 from alberta_framework.streams.partial_observation import (
     _MAX_PERIODIC_SCHEDULE_LENGTH,
+    _MAX_PERIODIC_SCHEDULE_VALUES,
     MaskMode,
     PartialObservationWrapper,
 )
@@ -55,3 +57,23 @@ def test_periodic_schedule_accepts_public_last_fit() -> None:
         schedule=(row_a, row_b, row_a),
     )
     assert wrapper.mode is MaskMode.PERIODIC
+
+
+def test_periodic_schedule_rejects_large_rows_before_array_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pointer-repeated row cannot amplify into a multi-gigabyte stack."""
+    feature_dim = 1_000_000
+    row = np.zeros((feature_dim,), dtype=bool)
+    schedule_length = _MAX_PERIODIC_SCHEDULE_VALUES // feature_dim + 1
+
+    def fail_asarray(*args: object, **kwargs: object) -> object:
+        raise AssertionError("array conversion ran before the working-set gate")
+
+    monkeypatch.setattr(partial_observation.jnp, "asarray", fail_asarray)
+    with pytest.raises(ValueError, match="periodic schedule working set"):
+        PartialObservationWrapper(
+            RandomWalkStream(feature_dim=feature_dim, drift_rate=0.0, noise_std=0.0),
+            mode=MaskMode.PERIODIC,
+            schedule=(row,) * schedule_length,
+        )

--- a/tests/test_partial_observation_schedule_hang.py
+++ b/tests/test_partial_observation_schedule_hang.py
@@ -48,6 +48,45 @@ def test_periodic_schedule_rejects_pointer_repeat_origin_hang_n() -> None:
     assert time.perf_counter() - started < 0.25
 
 
+def test_periodic_schedule_rejects_non_tuple_without_len_hook() -> None:
+    class HostileTuple(tuple[object, ...]):
+        def __len__(self) -> int:
+            raise AssertionError("untrusted length hook executed")
+
+        def __repr__(self) -> str:
+            raise AssertionError("untrusted repr hook executed")
+
+    with pytest.raises(ValueError, match="exact tuple"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=MaskMode.PERIODIC,
+            schedule=HostileTuple((np.array([True, False]),)),  # type: ignore[arg-type]
+        )
+
+
+def test_periodic_schedule_rejects_hostile_feature_dim_before_arithmetic() -> None:
+    class HostileInt(int):
+        calls = 0
+
+        def __mul__(self, other: object) -> int:
+            type(self).calls += 1
+            raise AssertionError("untrusted multiplication hook executed")
+
+        def __le__(self, other: object) -> bool:
+            type(self).calls += 1
+            raise AssertionError("untrusted comparison hook executed")
+
+    inner = _inner()
+    object.__setattr__(inner, "_feature_dim", HostileInt(2))
+    with pytest.raises(ValueError, match="inner.feature_dim"):
+        PartialObservationWrapper(
+            inner,
+            mode=MaskMode.PERIODIC,
+            schedule=(np.array([True, False], dtype=bool),),
+        )
+    assert HostileInt.calls == 0
+
+
 def test_periodic_schedule_accepts_public_last_fit() -> None:
     row_a = np.array([True, False], dtype=bool)
     row_b = np.array([False, True], dtype=bool)
@@ -57,6 +96,29 @@ def test_periodic_schedule_accepts_public_last_fit() -> None:
         schedule=(row_a, row_b, row_a),
     )
     assert wrapper.mode is MaskMode.PERIODIC
+
+
+def test_periodic_schedule_maximum_uses_one_array_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The admitted maximum must not restore one JAX dispatch per row."""
+    row = np.array([True, False], dtype=bool)
+    original_asarray = partial_observation.jnp.asarray
+    calls = 0
+
+    def counted_asarray(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original_asarray(*args, **kwargs)
+
+    monkeypatch.setattr(partial_observation.jnp, "asarray", counted_asarray)
+    wrapper = PartialObservationWrapper(
+        _inner(),
+        mode=MaskMode.PERIODIC,
+        schedule=(row,) * _MAX_PERIODIC_SCHEDULE_LENGTH,
+    )
+    assert wrapper.mode is MaskMode.PERIODIC
+    assert calls == 1
 
 
 def test_periodic_schedule_rejects_large_rows_before_array_conversion(
@@ -76,4 +138,22 @@ def test_periodic_schedule_rejects_large_rows_before_array_conversion(
             RandomWalkStream(feature_dim=feature_dim, drift_rate=0.0, noise_std=0.0),
             mode=MaskMode.PERIODIC,
             schedule=(row,) * schedule_length,
+        )
+
+
+def test_periodic_schedule_rejects_wrong_large_row_before_array_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A huge caller-owned row is checked by metadata before conversion."""
+    row = np.zeros((1_000_000,), dtype=bool)
+
+    def fail_asarray(*args: object, **kwargs: object) -> object:
+        raise AssertionError("array conversion ran before the row-shape gate")
+
+    monkeypatch.setattr(partial_observation.jnp, "asarray", fail_asarray)
+    with pytest.raises(ValueError, match="schedule masks"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=MaskMode.PERIODIC,
+            schedule=(row,),
         )


### PR DESCRIPTION
Successor to #2080 preserving the contributor commits while closing its accepted-boundary, resource-accounting, and hostile-input gaps.

The original implementation called `jnp.asarray` once per row and then stacked, so its admitted 4,096-row boundary still took 8.96s after warmup (5,000 rows: 13.7s). This repair retains the repository-standard 4,096 generic-sequence ceiling and the 64 MiB logical boolean payload ceiling, but converts the whole validated tuple once. The accepted 4,096-row boundary now takes about 0.015s; 5,000 rows reject in about 0.0003s.

Before conversion, it requires the annotated/public schedule container to be an exact tuple, validates `inner.feature_dim` as an exact positive builtin int, and checks every row through trusted NumPy/JAX metadata. This prevents hostile `len` hooks and a single wrong-shape giant row from reaching array conversion. The final retained wrapper schedule is one <=64 MiB boolean array; the prior claim that per-row buffers plus a stack were exactly two retained runner-owned arrays was not a robust JAX allocation contract.

All public three-row schedules and periodic clock/JIT behavior remain unchanged. No outputs, evidence artifacts, workflows, or claims are touched.

Verification on the repaired head: 111 focused/adjacent partial-observation and Forager protocol tests passed; Ruff clean; strict mypy clean for the touched source; diff check clean.