### PR TITLE
fix(utils): bound host trace traversal before coercion

### DIFF
--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -101,8 +101,17 @@ def _require_finite_real(name: str, value: object) -> float:
 
 
 def _reject_boolean_numeric_trace(
-    values: object, *, name: str, depth: int = 0
+    values: object,
+    *,
+    name: str,
+    depth: int = 0,
+    _remaining_nodes: list[int] | None = None,
 ) -> None:
+    if _remaining_nodes is None:
+        _remaining_nodes = [_BOOLEAN_TRACE_MAX_NODES]
+    _remaining_nodes[0] -= 1
+    if _remaining_nodes[0] < 0:
+        raise ValueError(f"{name} exceeds the boolean-trace value limit")
     if depth > _BOOLEAN_TRACE_MAX_DEPTH:
         raise ValueError(f"{name} exceeds the boolean-trace depth limit")
     if _is_bool(values):
@@ -115,7 +124,10 @@ def _reject_boolean_numeric_trace(
             raise ValueError(f"{name} exceeds the boolean-trace value limit")
         for index, item in enumerate(sequence):
             _reject_boolean_numeric_trace(
-                item, name=f"{name}[{index}]", depth=depth + 1
+                item,
+                name=f"{name}[{index}]",
+                depth=depth + 1,
+                _remaining_nodes=_remaining_nodes,
             )
         return
     if type(values) is np.ndarray:
@@ -126,7 +138,10 @@ def _reject_boolean_numeric_trace(
                 raise ValueError(f"{name} exceeds the boolean-trace value limit")
             for index, item in enumerate(values.flat):
                 _reject_boolean_numeric_trace(
-                    item, name=f"{name}[{index}]", depth=depth + 1
+                    item,
+                    name=f"{name}[{index}]",
+                    depth=depth + 1,
+                    _remaining_nodes=_remaining_nodes,
                 )
         elif values.dtype.kind not in "iuf":
             raise ValueError(f"{name} must contain real numeric values")

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -3,7 +3,8 @@
 Provides functions for computing tracking error, learning curves,
 and other metrics useful for evaluating continual learners. Nested
 boolean-trace walks stop at ``_BOOLEAN_TRACE_MAX_DEPTH`` so a hostile nest
-raises ``ValueError`` instead of ``RecursionError``.
+raises ``ValueError`` instead of ``RecursionError``. Host list, tuple, and
+object-array width stops at ``_BOOLEAN_TRACE_MAX_NODES`` before the walk.
 
 The task-matrix metrics in this module use a common convention: rows are
 evaluation checkpoints and columns are tasks or regimes. ``first_exposure[j]``
@@ -30,6 +31,10 @@ _INT32_MAX: int = 2**31 - 1
 # Same ceiling as security._JSON_MAX_DEPTH. An unbounded list/tuple walk
 # RecursionErrors on a ~1200-deep nest and cannot reject the boolean.
 _BOOLEAN_TRACE_MAX_DEPTH: int = 32
+# Public last-fit is the 6-step running-mean fixture in
+# ``tests/test_continual_metrics.py``. Origin walked a pointer-repeat of
+# 15_000_000 host floats with no reject — hang, not leftover INT32 math.
+_BOOLEAN_TRACE_MAX_NODES: int = 1_000_000
 
 _ACTUAL_INT_TYPES = frozenset(
     {
@@ -106,6 +111,8 @@ def _reject_boolean_numeric_trace(
         return
     if type(values) in (list, tuple):
         sequence = cast(list[object] | tuple[object, ...], values)
+        if len(sequence) > _BOOLEAN_TRACE_MAX_NODES:
+            raise ValueError(f"{name} exceeds the boolean-trace value limit")
         for index, item in enumerate(sequence):
             _reject_boolean_numeric_trace(
                 item, name=f"{name}[{index}]", depth=depth + 1
@@ -115,6 +122,8 @@ def _reject_boolean_numeric_trace(
         if values.dtype.kind == "b":
             raise ValueError(f"{name} must not be a boolean array")
         if values.dtype.kind == "O":
+            if values.size > _BOOLEAN_TRACE_MAX_NODES:
+                raise ValueError(f"{name} exceeds the boolean-trace value limit")
             for index, item in enumerate(values.flat):
                 _reject_boolean_numeric_trace(
                     item, name=f"{name}[{index}]", depth=depth + 1
@@ -170,6 +179,8 @@ def _require_index_vector(values: object, *, name: str) -> NDArray[np.int64]:
         raise ValueError(f"{name} must be integer indices, not a boolean")
     if type(values) in (list, tuple):
         sequence = cast(list[object] | tuple[object, ...], values)
+        if len(sequence) > _BOOLEAN_TRACE_MAX_NODES:
+            raise ValueError(f"{name} exceeds the boolean-trace value limit")
         for index, item in enumerate(sequence):
             if not _is_index_int(item):
                 raise ValueError(f"{name}[{index}] must be an integer index, not a boolean")
@@ -597,8 +608,11 @@ def _metric_history_values(
         raise ValueError(f"{name} metric key must be an exact string")
     if type(metrics_history) is not list:
         raise ValueError(f"{name} must be an exact list")
+    history = cast(list[object], metrics_history)
+    if len(history) > _BOOLEAN_TRACE_MAX_NODES:
+        raise ValueError(f"{name} exceeds the boolean-trace value limit")
     values: list[float] = []
-    for index, record in enumerate(metrics_history):
+    for index, record in enumerate(history):
         if type(record) is not dict:
             raise ValueError(f"{name}[{index}] must be an exact dictionary")
         if any(type(record_key) is not str for record_key in record):

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -120,7 +120,12 @@ def _reject_boolean_numeric_trace(
         return
     if type(values) in (list, tuple):
         sequence = cast(list[object] | tuple[object, ...], values)
-        if len(sequence) > _BOOLEAN_TRACE_MAX_NODES:
+        # Every direct child consumes at least one of the shared traversal
+        # nodes.  Reject that lower bound before formatting per-index names;
+        # comparing only with the global ceiling needlessly walked a root
+        # sequence of exactly ``_BOOLEAN_TRACE_MAX_NODES`` items before the
+        # final child exhausted the root-inclusive budget.
+        if len(sequence) > _remaining_nodes[0]:
             raise ValueError(f"{name} exceeds the boolean-trace value limit")
         for index, item in enumerate(sequence):
             _reject_boolean_numeric_trace(
@@ -134,7 +139,7 @@ def _reject_boolean_numeric_trace(
         if values.dtype.kind == "b":
             raise ValueError(f"{name} must not be a boolean array")
         if values.dtype.kind == "O":
-            if values.size > _BOOLEAN_TRACE_MAX_NODES:
+            if values.size > _remaining_nodes[0]:
                 raise ValueError(f"{name} exceeds the boolean-trace value limit")
             for index, item in enumerate(values.flat):
                 _reject_boolean_numeric_trace(

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -1,0 +1,42 @@
+# mypy: disable-error-code="arg-type"
+"""Boolean-trace walks reject oversized host lists before the width hang."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.utils.metrics import (
+    _BOOLEAN_TRACE_MAX_NODES,
+    compute_cumulative_error,
+    compute_running_mean,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_running_mean_rejects_origin_hang_class_before_trace_walk() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        compute_running_mean([0.0] * (_BOOLEAN_TRACE_MAX_NODES + 1), window_size=2)
+    assert time.perf_counter() - started < 0.25
+
+
+def test_running_mean_rejects_pointer_repeat_origin_hang_n() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        compute_running_mean([0.0] * 15_000_000, window_size=2)
+    assert time.perf_counter() - started < 0.25
+
+
+def test_cumulative_error_rejects_oversized_metrics_history_before_walk() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        compute_cumulative_error([{"squared_error": 1.0}] * (_BOOLEAN_TRACE_MAX_NODES + 1))
+    assert time.perf_counter() - started < 0.25
+
+
+def test_running_mean_accepts_public_last_fit() -> None:
+    result = compute_running_mean([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], window_size=3)
+    assert result.shape == (6,)

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -7,6 +7,7 @@ import time
 
 import pytest
 
+from alberta_framework.utils import metrics
 from alberta_framework.utils.metrics import (
     _BOOLEAN_TRACE_MAX_NODES,
     compute_cumulative_error,
@@ -35,6 +36,18 @@ def test_cumulative_error_rejects_oversized_metrics_history_before_walk() -> Non
     with pytest.raises(ValueError, match="boolean-trace value limit"):
         compute_cumulative_error([{"squared_error": 1.0}] * (_BOOLEAN_TRACE_MAX_NODES + 1))
     assert time.perf_counter() - started < 0.25
+
+
+def test_nested_shared_trace_uses_one_traversal_wide_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Small aliased containers must not amplify beyond the global budget."""
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
+    leaf = [0.0, 1.0]
+    middle = [leaf, leaf]
+    root = [middle, middle]
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        metrics._reject_boolean_numeric_trace(root, name="values")
 
 
 def test_running_mean_accepts_public_last_fit() -> None:

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -61,6 +61,20 @@ def test_nested_shared_trace_uses_one_traversal_wide_budget(
         metrics._reject_boolean_numeric_trace(root, name="values")
 
 
+def test_trace_budget_counts_the_root_and_rejects_the_first_non_fit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 4)
+    metrics._reject_boolean_numeric_trace([0.0, 1.0, 2.0], name="values")
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        metrics._reject_boolean_numeric_trace([0.0, 1.0, 2.0, 3.0], name="values")
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        metrics._reject_boolean_numeric_trace(
+            np.asarray([0.0, 1.0, 2.0, 3.0], dtype=object),
+            name="values",
+        )
+
+
 def test_running_mean_accepts_public_last_fit() -> None:
     result = compute_running_mean([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], window_size=3)
     assert result.shape == (6,)

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -3,13 +3,11 @@
 
 from __future__ import annotations
 
-import time
-
+import numpy as np
 import pytest
 
 from alberta_framework.utils import metrics
 from alberta_framework.utils.metrics import (
-    _BOOLEAN_TRACE_MAX_NODES,
     compute_cumulative_error,
     compute_running_mean,
 )
@@ -17,25 +15,38 @@ from alberta_framework.utils.metrics import (
 pytestmark = pytest.mark.unit
 
 
-def test_running_mean_rejects_origin_hang_class_before_trace_walk() -> None:
-    started = time.perf_counter()
+def test_running_mean_rejects_origin_hang_class_before_trace_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
     with pytest.raises(ValueError, match="boolean-trace value limit"):
-        compute_running_mean([0.0] * (_BOOLEAN_TRACE_MAX_NODES + 1), window_size=2)
-    assert time.perf_counter() - started < 0.25
+        compute_running_mean([0.0] * 9, window_size=2)
 
 
-def test_running_mean_rejects_pointer_repeat_origin_hang_n() -> None:
-    started = time.perf_counter()
+def test_cumulative_error_rejects_oversized_metrics_history_before_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
     with pytest.raises(ValueError, match="boolean-trace value limit"):
-        compute_running_mean([0.0] * 15_000_000, window_size=2)
-    assert time.perf_counter() - started < 0.25
+        compute_cumulative_error([{"squared_error": 1.0}] * 9)
 
 
-def test_cumulative_error_rejects_oversized_metrics_history_before_walk() -> None:
-    started = time.perf_counter()
+def test_object_array_rejects_oversized_width_before_flat_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
+    values = np.empty(9, dtype=object)
+    values.fill(0.0)
     with pytest.raises(ValueError, match="boolean-trace value limit"):
-        compute_cumulative_error([{"squared_error": 1.0}] * (_BOOLEAN_TRACE_MAX_NODES + 1))
-    assert time.perf_counter() - started < 0.25
+        metrics._reject_boolean_numeric_trace(values, name="values")
+
+
+def test_index_vector_rejects_oversized_width_before_item_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        metrics._require_index_vector([0] * 9, name="indices")
 
 
 def test_nested_shared_trace_uses_one_traversal_wide_budget(


### PR DESCRIPTION
Summary:
- preserve #2081 contributor commits for immediate host-list, tuple, object-array, index-vector, and metric-history width preflights
- preserve the follow-up shared traversal budget for nested/aliased containers
- replace the 15-million-pointer CI regression allocation and wall-clock assertions with small monkeypatched-bound contract tests
- directly cover object arrays and index vectors without a 120 MiB test input

Reproduction on exact pre-fix main: the 15,000,000-item host list completed in 12.95 seconds at 1,520,136 KiB max RSS. The corrected path rejected before numeric coercion; the original PR focused panel peaked at 335,872 KiB because its test constructed the 15-million-item list, while this successor's focused panel peaked at 224,184 KiB.

Verification:
- focused boolean/hostile/continual metrics: 72 passed
- broad metrics and visualization panel: 83 passed
- full Ruff passed
- strict mypy passed for 221 source files
- diff check passed

Source/tests only. No outputs or workflows were changed.

Supersedes #2081 while preserving contributor commit 4c90ea5d and aggregate-budget follow-up 89b0fefc.