### PR TITLE
fix(steps): cover welford/streaming_batch Step 1 normalizers end to end

### DIFF
--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -83,6 +83,64 @@ def test_step1_kernel_all_public_optimizers_smoke(optimizer: str) -> None:
     assert result.metrics_shape == (12, 4)
 
 
+@pytest.mark.parametrize(
+    "normalizer",
+    ["none", "ema", "welford", "streaming_batch"],
+)
+def test_step1_kernel_all_public_normalizers_smoke(normalizer: str) -> None:
+    """Every documented Step1NormalizerName must actually run end to end.
+
+    Before this test, ``run_step1_smoke``/``make_step1_normalizer`` were only
+    ever exercised with ``normalizer in {"none", "ema"}``; "welford" and
+    "streaming_batch" were touched by config-construction and JSON
+    round-trip tests but never actually driven through the smoke loop. Mirrors
+    ``test_step1_kernel_all_public_optimizers_smoke`` above.
+    """
+    config = Step1KernelConfig(
+        optimizer="autostep",
+        normalizer=normalizer,  # type: ignore[arg-type]
+        feature_dim=8,
+        num_relevant=3,
+        noise_std=0.1,
+    )
+    result = run_step1_smoke(config, steps=12, final_window=3)
+    assert result.finite
+    expected_columns = 3 if normalizer == "none" else 4
+    assert result.metrics_shape == (12, expected_columns)
+
+
+@pytest.mark.parametrize(
+    ("normalizer", "field", "value"),
+    [
+        ("ema", "ema_decay", 0.0),
+        ("ema", "ema_decay", 1.0),
+        ("streaming_batch", "streaming_batch_momentum", 0.0),
+        ("streaming_batch", "streaming_batch_momentum", 1.0),
+    ],
+)
+def test_step1_normalizer_boundary_hyperparameters_stay_finite_when_selected(
+    normalizer: str, field: str, value: float
+) -> None:
+    """Boundary decay/momentum values must stay finite for the normalizer they configure.
+
+    ``test_step1_fields_preserve_legal_endpoints`` already exercises these
+    same 0.0/1.0 endpoints for ``ema_decay``/``streaming_batch_momentum``, but
+    only while ``normalizer`` is left at its unrelated default ("ema" or
+    "none"), so the boundary value is never actually consumed by the
+    normalizer it configures. This runs the smoke loop with the matching
+    normalizer selected.
+    """
+    config = Step1KernelConfig(
+        optimizer="autostep",
+        normalizer=normalizer,  # type: ignore[arg-type]
+        feature_dim=6,
+        num_relevant=2,
+        **{field: value},
+    )
+    result = run_step1_smoke(config, steps=10, final_window=3)
+    assert result.finite
+
+
 def test_step1_kernel_rejects_unpublished_auto_alias() -> None:
     with pytest.raises(ValueError, match="optimizer"):
         Step1KernelConfig(optimizer="auto")  # type: ignore[arg-type]

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -13,6 +13,11 @@ import numpy as np
 import pytest
 
 from alberta_framework.cli import step1_smoke_main, step2_smoke_main
+from alberta_framework.core.normalizers import (
+    EMANormalizer,
+    StreamingBatchNormalizer,
+    WelfordNormalizer,
+)
 from alberta_framework.steps import (
     Step1KernelConfig,
     Step2HybridConfig,
@@ -21,6 +26,7 @@ from alberta_framework.steps import (
     Step2StrictDigitReadoutConfig,
     Step2TemporalContextConfig,
     make_step1_learner,
+    make_step1_normalizer,
     make_step1_optimizer,
     make_step1_stream,
     make_step2_hybrid_learner,
@@ -84,10 +90,18 @@ def test_step1_kernel_all_public_optimizers_smoke(optimizer: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "normalizer",
-    ["none", "ema", "welford", "streaming_batch"],
+    ("normalizer", "expected_type"),
+    [
+        ("none", None),
+        ("ema", EMANormalizer),
+        ("welford", WelfordNormalizer),
+        ("streaming_batch", StreamingBatchNormalizer),
+    ],
 )
-def test_step1_kernel_all_public_normalizers_smoke(normalizer: str) -> None:
+def test_step1_kernel_all_public_normalizers_smoke(
+    normalizer: str,
+    expected_type: type[Any] | None,
+) -> None:
     """Every documented Step1NormalizerName must actually run end to end.
 
     Before this test, ``run_step1_smoke``/``make_step1_normalizer`` were only
@@ -103,6 +117,11 @@ def test_step1_kernel_all_public_normalizers_smoke(normalizer: str) -> None:
         num_relevant=3,
         noise_std=0.1,
     )
+    implementation = make_step1_normalizer(config)
+    if expected_type is None:
+        assert implementation is None
+    else:
+        assert type(implementation) is expected_type
     result = run_step1_smoke(config, steps=12, final_window=3)
     assert result.finite
     expected_columns = 3 if normalizer == "none" else 4
@@ -137,6 +156,9 @@ def test_step1_normalizer_boundary_hyperparameters_stay_finite_when_selected(
         num_relevant=2,
         **{field: value},
     )
+    implementation = make_step1_normalizer(config)
+    assert implementation is not None
+    assert implementation.to_config()["decay" if field == "ema_decay" else "momentum"] == value
     result = run_step1_smoke(config, steps=10, final_window=3)
     assert result.finite
 


### PR DESCRIPTION
<!-- evidence-head:842aff97b251ad2051276fad2e35dfd6720a1b4a -->

## Problem

`alberta_framework/steps/step1.py` documents four Step 1 normalizer
options (`Step1NormalizerName = Literal["none", "ema", "welford",
"streaming_batch"]`), each with its own branch in `make_step1_normalizer`
and its own state-width entry in `_step1_state_scalar_count`
(`{"none": 0, "ema": 2, "welford": 3, "streaming_batch": 2}`).

Before this change, `run_step1_smoke`/`make_step1_normalizer` were only
ever driven through the smoke loop with `normalizer in {"none", "ema"}`.
The optimizer side of the same facade already has full coverage
(`test_step1_kernel_all_public_optimizers_smoke`, parametrized over all
eight `Step1OptimizerName` values) but there was no normalizer
counterpart. `"welford"` and `"streaming_batch"` were touched only by
config-construction and JSON round-trip assertions
(`test_config_serialization.py::test_welford_round_trip`/
`test_streaming_batch_round_trip`), never by an actual
`make_step1_normalizer`/`run_step1_smoke` execution. Even the existing
boundary-value tests for `ema_decay`/`streaming_batch_momentum` (0.0 and
1.0) exercised those fields while leaving `normalizer` at its unrelated
default (`"ema"` or `"none"`), so the boundary values were schema-validated
but never actually consumed by the normalizer they configure.

This is the same "documented option with zero test *execution* coverage"
pattern as #2083 (Step 7 `prioritized`/`learned` Dyna strategies), applied
to the Step 1 normalizer dispatch in my territory
(`alberta_framework/steps/`).

## Fix

- Add `test_step1_kernel_all_public_normalizers_smoke`, parametrized over
  all four documented `Step1NormalizerName` values, running
  `run_step1_smoke` end to end and asserting finiteness and the correct
  metrics-column width (3 for `"none"`, 4 otherwise).
- Add
  `test_step1_normalizer_boundary_hyperparameters_stay_finite_when_selected`,
  parametrized over `ema_decay`/`streaming_batch_momentum` at their 0.0/1.0
  endpoints *with the matching normalizer actually selected*, running the
  smoke loop and asserting finiteness.

No production code changed. I manually ran `make_step1_normalizer`/
`run_step1_smoke` for all four normalizers and both boundary endpoints
before writing the tests (see Verification below); current `main` is
finite and stable for all of them — no bug found today. The value of this
PR is that a future regression in the `WelfordNormalizer`/
`StreamingBatchNormalizer` wiring, or a bad interaction with the boundary
decay/momentum values once actually selected, will now fail CI instead of
shipping silently.

## Manual verification (pre-test, ad hoc)

```
$ .venv/bin/python -c "
from alberta_framework.steps.step1 import Step1KernelConfig, run_step1_smoke, make_step1_normalizer
for norm in ['none', 'ema', 'welford', 'streaming_batch']:
    config = Step1KernelConfig(optimizer='autostep', normalizer=norm, feature_dim=8, num_relevant=3)
    n = make_step1_normalizer(config)
    result = run_step1_smoke(config, steps=12, final_window=3)
    print(norm, type(n).__name__ if n else None, result.finite, result.metrics_shape, result.final_window_mse)
"
none None True (12, 3) 11.877333641052246
ema EMANormalizer True (12, 4) 10.897257804870605
welford WelfordNormalizer True (12, 4) 10.85169792175293
streaming_batch StreamingBatchNormalizer True (12, 4) 12.5791015625
```

```
$ .venv/bin/python -c "
from alberta_framework.steps.step1 import Step1KernelConfig, run_step1_smoke
for decay in [0.0, 1.0]:
    r = run_step1_smoke(Step1KernelConfig(optimizer='autostep', normalizer='ema', feature_dim=6, num_relevant=2, ema_decay=decay), steps=10, final_window=3)
    print('ema_decay', decay, r.finite, r.final_window_mse)
for mom in [0.0, 1.0]:
    r = run_step1_smoke(Step1KernelConfig(optimizer='autostep', normalizer='streaming_batch', feature_dim=6, num_relevant=2, streaming_batch_momentum=mom), steps=10, final_window=3)
    print('streaming_batch_momentum', mom, r.finite, r.final_window_mse)
"
ema_decay 0.0 True 1.012017846107483
ema_decay 1.0 True 0.8574377298355103
streaming_batch_momentum 0.0 True 1.012017846107483
streaming_batch_momentum 1.0 True 0.8274437189102173
```

## Verification

Commit under test: `842aff97b251ad2051276fad2e35dfd6720a1b4a`

```
.venv/bin/python -m pytest tests/test_production_steps.py -q -o addopts=""
394 passed in 65.40s
```

```
.venv/bin/python -m ruff check tests/test_production_steps.py
All checks passed!
```

```
.venv/bin/python -m mypy
Success: no issues found in 221 source files
```

(`tests/` is intentionally outside `[tool.mypy].files = ["alberta_framework"]`,
so the new test code is not part of the mypy gate — same as every other
test file in this repo.)

## Collision check

Ran immediately before picking and again immediately before this commit/push:

```
gh issue list --repo elizaOS/asi --state open --search "step1 normalizer"
gh pr list --repo elizaOS/asi --state open --json number,title,files --limit 200
```

Neither pass found an open issue or PR touching `alberta_framework/steps/step1.py`
or `tests/test_production_steps.py`. The four currently open PRs (#2085,
#2084, #2081, #2080) touch `alberta_framework/utils/metrics.py` and
`alberta_framework/streams/partial_observation.py` only. #2083 (my prior
cycle's Step 7 coverage fix, same pattern) is no longer in the open list.

## Provenance

AI provider/model: anthropic / claude-sonnet-5
Client / agent tooling: Claude Code
Lane: rama0x1-asi-claude-worker

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0F547B9K7GPQRH6GD6DF0D1","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T08:38:13.098Z","completed_at":"2026-08-20T08:38:48.756Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T08:38:14.648Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"7d1ee46b30b238991c0cf08e28f851c10e2b833428923394a0a67aa5c3aff9a2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7e5f17ce-b0bc-48fd-9eb2-eaa83df96542","object_id":"sha256:7d1ee46b30b238991c0cf08e28f851c10e2b833428923394a0a67aa5c3aff9a2","sha256":"7d1ee46b30b238991c0cf08e28f851c10e2b833428923394a0a67aa5c3aff9a2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"GBM8N1gEajtfz6CAbnunBnY9G_vU5t90bdGblGvMky0S7Eebr5jn-4EqVP4QCWm3I02_Bhv9LI0iN3eksB-NCQ"}} -->
