### PR TITLE
test(forager): refresh source-bound bundle goldens

### DIFF
--- a/tests/test_forager_matched_final_analysis.py
+++ b/tests/test_forager_matched_final_analysis.py
@@ -924,19 +924,19 @@ def test_publish_orders_authentication_before_analysis_and_replays_offline(
     # executor, score, and selection identities from both campaign stages.
     golden_payload_sha256 = {
         "manifest.json": (
-            "2cd3ca64f3e7f59e9a463d9a91c9ec80332c9c2815d11c9e98f9a992181bc9b1"
+            "d7e66d2f5837cd4d99f586cbbaff573dc623c1f9d3ffcd3e79c8d8fc7f188ba2"
         ),
         "analysis/analysis-runtime-source.json": (
             "ca6656e3d1e12aeab5c660921cc3a9ce00611e9c41a612e646a2ca458f70f52b"
         ),
         "analysis/evaluation-authenticated-bindings-cache.json": (
-            "16113cdaed428b31d579646d35d0d96cade9358b36c75cbd7287bece606168d7"
+            "9c9009378889de2fad11529e8309c21f6d0b6bceb947380d6bc1cad813a99165"
         ),
         "analysis/statistics-contract.json": (
-            "2444a37a4e77d6d9697d80a19f374208d0d3f2a17380eea650744fd5aff9412a"
+            "588dda289387561fb1a319e1e2b28aae667b089711a800afc200cd86eab47f61"
         ),
         "analysis/statistics-result.json": (
-            "cd3e6972c1364c976180923c8e5035b180ddf8966a9fa4110601c8fd34d12492"
+            "d9b2019ed316bdf860b882118b0cc9f5fdb361e2b1cf29951a702e820783e75a"
         ),
     }
     for relative, expected_sha256 in golden_payload_sha256.items():
@@ -946,7 +946,7 @@ def test_publish_orders_authentication_before_analysis_and_replays_offline(
             f"{expected_sha256}\n".encode("ascii")
         )
     assert content.manifest["payload_sha256"] == (
-        "7997b8e9b47db22d172b36864cb2ae740791ee2e5300fe70e0e2806bcb7f85bc"
+        "1540121cbbb83040fe9e32c8cbe84a63e4563476dcc829237c3f151bb4903ea4"
     )
     assert content.analysis_runtime_source["payload_sha256"] == (
         "a23e65272f0785d4a2b3843610800088a5f2ca8352ef858d9ab4dfeed3caafd6"

--- a/tests/test_forager_matched_sealed_evaluation_campaign.py
+++ b/tests/test_forager_matched_sealed_evaluation_campaign.py
@@ -772,16 +772,16 @@ def test_full_evaluation_finalizes_stage_specific_unresolved_content(
     # changes deterministically when the qualified helper bytes change.
     golden_final_sha256 = {
         "execution-receipt-index.json": (
-            "39642af77c69525d6f669c94648d15d57d54b51f17ef0145e0efad672ea781fd"
+            "b174f3098d9afa82946f2052b9a0440424b0f2b759af43f153feefbceafedade"
         ),
         "score-evidence.json": (
-            "41d0fbbdb00e63745d0dc1415529147f843b0dc04d81bf1e7ac956b3269613e3"
+            "189b6e407d9525b15f57f0b68eded6604a020f9cee159541847c0c8642b0e2b0"
         ),
         "verification-request.json": (
-            "b7c092fba2bb4b5cbb6b74440f8a6e31860ed649e12365437a912e18f14dae9c"
+            "182b70f579727c074e34e2068e5bd733cf627bce39cbccb428cade9c70cff984"
         ),
         "completion-summary.json": (
-            "a3e52dfcef4982579b44444ed71934257cff7f94adf1f17d7669bae69e87237f"
+            "db3bfa1971b69a6a8301ee8a304eaa313d54ec154be23bcfb81ead54a946aa48"
         ),
     }
     for name, expected_sha256 in golden_final_sha256.items():


### PR DESCRIPTION
## Summary

Reviewed boundary-hardening integrations changed the content-addressed identities carried by these matched evaluation/final-analysis bundles. The automatic fast CI selector excludes `slow`, so two slow golden assertions retained stale payload digests.

Historical reconstruction narrows the cause: the current replacement bytes are already produced by pre-#2079 commit `7a863d0e`, so #2079 is not the causal change. The final-analysis drift appears across the #2052 boundary-hardening integration, while the sealed-evaluation golden was already stale before that merge and changed again during it.

This refreshes only deterministic expected SHA-256 values emitted by the existing fixtures:

- final-analysis manifest, authenticated evaluation cache, statistics contract/result, and enclosing payload digest
- sealed-evaluation receipt index, score evidence, verification request, and completion summary

No production code or evidence artifact changes. The unchanged `analysis-runtime-source.json` expectation is intentional: this test installs fixed runtime source records and runtime metadata, while the enclosing campaign/source closures bind the current implementation.

## Validation

- current `main` `a7f96320`: both selected slow nodes fail, with actual hashes exactly matching this PR
- PR head `6a257994`: both selected nodes pass (`2 passed`)
- pre-#2079 `7a863d0e`: produces the same replacement hashes, disproving the original #2079 attribution
- pre-#2052 `45540be4`: final-analysis old golden passes; sealed-evaluation old golden is already stale
- all generated `.json.sha256` sidecars recomputed successfully
- embedded manifest and runtime-source payload hashes recomputed successfully
- Ruff on both changed files: passed
- `git diff --check`: passed