### PR TITLE
fix(runtime): bound host traversals and periodic mask schedules

### DIFF
--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -54,6 +54,10 @@ class MaskMode(enum.Enum):
 # ``tests/test_partial_observation.py``. Origin stacked a pointer-repeat of
 # 5_000 identical masks with no reject — hang, not leftover INT32 math.
 _MAX_PERIODIC_SCHEDULE_LENGTH = 4_096
+# Each logical boolean is retained once in the per-row converted masks and
+# once again in the stacked schedule.  Cap the logical payload at 64 MiB so
+# those two runner-owned arrays stay below 128 MiB before allocator overhead.
+_MAX_PERIODIC_SCHEDULE_VALUES = 64 * 1024 * 1024
 
 
 def _require_unit_interval_probability(name: str, value: object) -> float:
@@ -170,6 +174,12 @@ class PartialObservationWrapper[InnerStateT]:
                 raise ValueError(
                     "periodic schedule length must be an integer in "
                     f"[1, {_MAX_PERIODIC_SCHEDULE_LENGTH}]"
+                )
+            schedule_values = len(schedule) * feature_dim
+            if schedule_values > _MAX_PERIODIC_SCHEDULE_VALUES:
+                raise ValueError(
+                    "periodic schedule working set exceeds the bounded "
+                    f"{_MAX_PERIODIC_SCHEDULE_VALUES}-value payload"
                 )
             masks = [jnp.asarray(m, dtype=jnp.bool_) for m in schedule]
             if any(mask.shape != (feature_dim,) for mask in masks):

--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -50,6 +50,12 @@ class MaskMode(enum.Enum):
     PERIODIC = "periodic"
 
 
+# Public last-fit is the three-mask cycling schedule in
+# ``tests/test_partial_observation.py``. Origin stacked a pointer-repeat of
+# 5_000 identical masks with no reject — hang, not leftover INT32 math.
+_MAX_PERIODIC_SCHEDULE_LENGTH = 4_096
+
+
 def _require_unit_interval_probability(name: str, value: object) -> float:
     """Return a canonical probability valid at the float32 execution sink."""
     return validated_float32_scalar(name, value, lower=0.0, upper=1.0)
@@ -159,6 +165,11 @@ class PartialObservationWrapper[InnerStateT]:
             if schedule is None or len(schedule) == 0:
                 raise ValueError(
                     "MaskMode.PERIODIC requires a non-empty schedule."
+                )
+            if len(schedule) > _MAX_PERIODIC_SCHEDULE_LENGTH:
+                raise ValueError(
+                    "periodic schedule length must be an integer in "
+                    f"[1, {_MAX_PERIODIC_SCHEDULE_LENGTH}]"
                 )
             masks = [jnp.asarray(m, dtype=jnp.bool_) for m in schedule]
             if any(mask.shape != (feature_dim,) for mask in masks):

--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -56,9 +56,10 @@ class MaskMode(enum.Enum):
 # ``tests/test_partial_observation.py``. Origin stacked a pointer-repeat of
 # 5_000 identical masks with no reject — hang, not leftover INT32 math.
 _MAX_PERIODIC_SCHEDULE_LENGTH = 4_096
-# Each logical boolean is retained once in the per-row converted masks and
-# once again in the stacked schedule.  Cap the logical payload at 64 MiB so
-# those two runner-owned arrays stay below 128 MiB before allocator overhead.
+# Cap the final boolean schedule payload at 64 MiB. The schedule is converted
+# in one operation below: converting each row separately makes construction
+# time grow with thousands of JAX dispatches even when every row is a repeated
+# pointer to the same tiny host array.
 _MAX_PERIODIC_SCHEDULE_VALUES = 64 * 1024 * 1024
 
 

--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -21,11 +21,13 @@ just receives less information about the underlying state.
 from __future__ import annotations
 
 import enum
-from typing import TypeVar
+from typing import TypeVar, cast
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 from jax import Array
 from jaxtyping import Bool, PRNGKeyArray
 
@@ -58,6 +60,21 @@ _MAX_PERIODIC_SCHEDULE_LENGTH = 4_096
 # once again in the stacked schedule.  Cap the logical payload at 64 MiB so
 # those two runner-owned arrays stay below 128 MiB before allocator overhead.
 _MAX_PERIODIC_SCHEDULE_VALUES = 64 * 1024 * 1024
+
+
+def _trusted_boolean_mask(name: str, value: object, feature_dim: int) -> Array:
+    """Validate mask metadata before JAX conversion can dispatch user hooks."""
+    actual_type = type(value)
+    if actual_type is not np.ndarray and not issubclass(
+        actual_type, (jax.Array, jax.core.Tracer)
+    ):
+        raise ValueError(f"{name} must be an exact NumPy or JAX array")
+    trusted = cast(Array, value)
+    if trusted.shape != (feature_dim,) or trusted.dtype != jnp.dtype(jnp.bool_):
+        raise ValueError(
+            f"{name} must have shape (feature_dim={feature_dim},) and dtype bool"
+        )
+    return jnp.asarray(trusted)
 
 
 def _require_unit_interval_probability(name: str, value: object) -> float:
@@ -156,17 +173,15 @@ class PartialObservationWrapper[InnerStateT]:
         if mode == MaskMode.FIXED:
             if fixed_mask is None:
                 raise ValueError("MaskMode.FIXED requires fixed_mask.")
-            mask = jnp.asarray(fixed_mask, dtype=jnp.bool_)
-            if mask.shape != (feature_dim,):
-                raise ValueError(
-                    f"fixed_mask shape {mask.shape} != (feature_dim={feature_dim},)"
-                )
+            mask = _trusted_boolean_mask("fixed_mask shape", fixed_mask, feature_dim)
             self._fixed_mask: Array | None = mask
         else:
             self._fixed_mask = None
 
         if mode == MaskMode.PERIODIC:
-            if schedule is None or len(schedule) == 0:
+            if type(schedule) is not tuple:
+                raise ValueError("periodic schedule must be an exact tuple")
+            if len(schedule) == 0:
                 raise ValueError(
                     "MaskMode.PERIODIC requires a non-empty schedule."
                 )
@@ -181,11 +196,10 @@ class PartialObservationWrapper[InnerStateT]:
                     "periodic schedule working set exceeds the bounded "
                     f"{_MAX_PERIODIC_SCHEDULE_VALUES}-value payload"
                 )
-            masks = [jnp.asarray(m, dtype=jnp.bool_) for m in schedule]
-            if any(mask.shape != (feature_dim,) for mask in masks):
-                raise ValueError(
-                    f"schedule masks must each have shape (feature_dim={feature_dim},)"
-                )
+            masks = [
+                _trusted_boolean_mask("schedule masks", row, feature_dim)
+                for row in schedule
+            ]
             sched = jnp.stack(masks, axis=0)
             self._schedule: Array | None = sched
         else:

--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -74,7 +74,7 @@ def _trusted_boolean_mask(name: str, value: object, feature_dim: int) -> Array:
         raise ValueError(
             f"{name} must have shape (feature_dim={feature_dim},) and dtype bool"
         )
-    return jnp.asarray(trusted)
+    return trusted
 
 
 def _require_unit_interval_probability(name: str, value: object) -> float:
@@ -92,6 +92,13 @@ def _require_mode(mode: object) -> MaskMode:
     if type(mode) is not MaskMode:
         raise ValueError("mode must be an exact MaskMode")
     return mode
+
+
+def _require_feature_dim(value: object) -> int:
+    """Reject non-builtin protocol dimensions before resource arithmetic."""
+    if type(value) is not int or not 1 <= value <= 2**31 - 1:
+        raise ValueError("inner.feature_dim must be an integer in [1, 2147483647]")
+    return value
 
 
 # =============================================================================
@@ -168,12 +175,14 @@ class PartialObservationWrapper[InnerStateT]:
         self._mask_prob = mask_prob
         self._sentinel = validated_float32_scalar("sentinel", sentinel)
 
-        feature_dim = inner.feature_dim
+        feature_dim = _require_feature_dim(inner.feature_dim)
 
         if mode == MaskMode.FIXED:
             if fixed_mask is None:
                 raise ValueError("MaskMode.FIXED requires fixed_mask.")
-            mask = _trusted_boolean_mask("fixed_mask shape", fixed_mask, feature_dim)
+            mask = jnp.asarray(
+                _trusted_boolean_mask("fixed_mask shape", fixed_mask, feature_dim)
+            )
             self._fixed_mask: Array | None = mask
         else:
             self._fixed_mask = None
@@ -196,11 +205,14 @@ class PartialObservationWrapper[InnerStateT]:
                     "periodic schedule working set exceeds the bounded "
                     f"{_MAX_PERIODIC_SCHEDULE_VALUES}-value payload"
                 )
-            masks = [
+            for row in schedule:
                 _trusted_boolean_mask("schedule masks", row, feature_dim)
-                for row in schedule
-            ]
-            sched = jnp.stack(masks, axis=0)
+            # Convert the complete trusted tuple once.  Per-row conversion plus
+            # stacking turns the admitted 4,096-row boundary into thousands of
+            # independent JAX dispatches even for pointer-repeated rows.
+            sched = jnp.asarray(schedule)
+            assert sched.shape == (len(schedule), feature_dim)
+            assert sched.dtype == jnp.dtype(jnp.bool_)
             self._schedule: Array | None = sched
         else:
             self._schedule = None

--- a/alberta_framework/streams/partial_observation.py
+++ b/alberta_framework/streams/partial_observation.py
@@ -52,9 +52,7 @@ class MaskMode(enum.Enum):
     PERIODIC = "periodic"
 
 
-# Public last-fit is the three-mask cycling schedule in
-# ``tests/test_partial_observation.py``. Origin stacked a pointer-repeat of
-# 5_000 identical masks with no reject — hang, not leftover INT32 math.
+# Bound schedule construction by both row count and total boolean payload.
 _MAX_PERIODIC_SCHEDULE_LENGTH = 4_096
 # Cap the final boolean schedule payload at 64 MiB. The schedule is converted
 # in one operation below: converting each row separately makes construction
@@ -136,13 +134,15 @@ class PartialObservationWrapper[InnerStateT]:
             partially masked.
         mode: Exact ``MaskMode`` member (FIXED / RANDOM / PERIODIC).
             Leftover string, bool, and int identities are rejected.
-        fixed_mask: Boolean mask of shape ``(feature_dim,)`` for FIXED.
-            ``True`` means VISIBLE; ``False`` means HIDDEN.
+        fixed_mask: Exact NumPy or JAX boolean array of shape
+            ``(feature_dim,)`` for FIXED. ``True`` means VISIBLE;
+            ``False`` means HIDDEN.
         mask_prob: Per-channel KEEP probability for RANDOM. So
             ``mask_prob = 0.5`` keeps half the channels each step in
             expectation.
-        schedule: Tuple of boolean masks of shape ``(feature_dim,)``;
-            cycled each step under PERIODIC mode.
+        schedule: Non-empty exact tuple of at most 4,096 NumPy or JAX
+            boolean arrays of shape ``(feature_dim,)`` and at most
+            67,108,864 total values; cycled under PERIODIC mode.
         sentinel: Finite real that replaces masked entries (default ``0.0``).
             Boolean and non-finite values are rejected so a hidden channel
             cannot silently become ``1.0``, ``NaN``, or ``Inf``.

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -101,8 +101,17 @@ def _require_finite_real(name: str, value: object) -> float:
 
 
 def _reject_boolean_numeric_trace(
-    values: object, *, name: str, depth: int = 0
+    values: object,
+    *,
+    name: str,
+    depth: int = 0,
+    _remaining_nodes: list[int] | None = None,
 ) -> None:
+    if _remaining_nodes is None:
+        _remaining_nodes = [_BOOLEAN_TRACE_MAX_NODES]
+    _remaining_nodes[0] -= 1
+    if _remaining_nodes[0] < 0:
+        raise ValueError(f"{name} exceeds the boolean-trace value limit")
     if depth > _BOOLEAN_TRACE_MAX_DEPTH:
         raise ValueError(f"{name} exceeds the boolean-trace depth limit")
     if _is_bool(values):
@@ -115,7 +124,10 @@ def _reject_boolean_numeric_trace(
             raise ValueError(f"{name} exceeds the boolean-trace value limit")
         for index, item in enumerate(sequence):
             _reject_boolean_numeric_trace(
-                item, name=f"{name}[{index}]", depth=depth + 1
+                item,
+                name=f"{name}[{index}]",
+                depth=depth + 1,
+                _remaining_nodes=_remaining_nodes,
             )
         return
     if type(values) is np.ndarray:
@@ -126,7 +138,10 @@ def _reject_boolean_numeric_trace(
                 raise ValueError(f"{name} exceeds the boolean-trace value limit")
             for index, item in enumerate(values.flat):
                 _reject_boolean_numeric_trace(
-                    item, name=f"{name}[{index}]", depth=depth + 1
+                    item,
+                    name=f"{name}[{index}]",
+                    depth=depth + 1,
+                    _remaining_nodes=_remaining_nodes,
                 )
         elif values.dtype.kind not in "iuf":
             raise ValueError(f"{name} must contain real numeric values")

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -3,7 +3,8 @@
 Provides functions for computing tracking error, learning curves,
 and other metrics useful for evaluating continual learners. Nested
 boolean-trace walks stop at ``_BOOLEAN_TRACE_MAX_DEPTH`` so a hostile nest
-raises ``ValueError`` instead of ``RecursionError``.
+raises ``ValueError`` instead of ``RecursionError``. Host list, tuple, and
+object-array width stops at ``_BOOLEAN_TRACE_MAX_NODES`` before the walk.
 
 The task-matrix metrics in this module use a common convention: rows are
 evaluation checkpoints and columns are tasks or regimes. ``first_exposure[j]``
@@ -30,6 +31,10 @@ _INT32_MAX: int = 2**31 - 1
 # Same ceiling as security._JSON_MAX_DEPTH. An unbounded list/tuple walk
 # RecursionErrors on a ~1200-deep nest and cannot reject the boolean.
 _BOOLEAN_TRACE_MAX_DEPTH: int = 32
+# Public last-fit is the 6-step running-mean fixture in
+# ``tests/test_continual_metrics.py``. Origin walked a pointer-repeat of
+# 15_000_000 host floats with no reject — hang, not leftover INT32 math.
+_BOOLEAN_TRACE_MAX_NODES: int = 1_000_000
 
 _ACTUAL_INT_TYPES = frozenset(
     {
@@ -106,6 +111,8 @@ def _reject_boolean_numeric_trace(
         return
     if type(values) in (list, tuple):
         sequence = cast(list[object] | tuple[object, ...], values)
+        if len(sequence) > _BOOLEAN_TRACE_MAX_NODES:
+            raise ValueError(f"{name} exceeds the boolean-trace value limit")
         for index, item in enumerate(sequence):
             _reject_boolean_numeric_trace(
                 item, name=f"{name}[{index}]", depth=depth + 1
@@ -115,6 +122,8 @@ def _reject_boolean_numeric_trace(
         if values.dtype.kind == "b":
             raise ValueError(f"{name} must not be a boolean array")
         if values.dtype.kind == "O":
+            if values.size > _BOOLEAN_TRACE_MAX_NODES:
+                raise ValueError(f"{name} exceeds the boolean-trace value limit")
             for index, item in enumerate(values.flat):
                 _reject_boolean_numeric_trace(
                     item, name=f"{name}[{index}]", depth=depth + 1
@@ -170,6 +179,8 @@ def _require_index_vector(values: object, *, name: str) -> NDArray[np.int64]:
         raise ValueError(f"{name} must be integer indices, not a boolean")
     if type(values) in (list, tuple):
         sequence = cast(list[object] | tuple[object, ...], values)
+        if len(sequence) > _BOOLEAN_TRACE_MAX_NODES:
+            raise ValueError(f"{name} exceeds the boolean-trace value limit")
         for index, item in enumerate(sequence):
             if not _is_index_int(item):
                 raise ValueError(f"{name}[{index}] must be an integer index, not a boolean")
@@ -597,8 +608,11 @@ def _metric_history_values(
         raise ValueError(f"{name} metric key must be an exact string")
     if type(metrics_history) is not list:
         raise ValueError(f"{name} must be an exact list")
+    history = cast(list[object], metrics_history)
+    if len(history) > _BOOLEAN_TRACE_MAX_NODES:
+        raise ValueError(f"{name} exceeds the boolean-trace value limit")
     values: list[float] = []
-    for index, record in enumerate(metrics_history):
+    for index, record in enumerate(history):
         if type(record) is not dict:
             raise ValueError(f"{name}[{index}] must be an exact dictionary")
         if any(type(record_key) is not str for record_key in record):

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -114,9 +114,12 @@ def _reject_boolean_numeric_trace(
     name: str,
     depth: int = 0,
     _remaining_nodes: list[int] | None = None,
+    _remaining_dense_values: list[int] | None = None,
 ) -> None:
     if _remaining_nodes is None:
         _remaining_nodes = [_BOOLEAN_TRACE_MAX_NODES]
+    if _remaining_dense_values is None:
+        _remaining_dense_values = [_NUMERIC_TRACE_MAX_VALUES]
     _remaining_nodes[0] -= 1
     if _remaining_nodes[0] < 0:
         raise ValueError(f"{name} exceeds the boolean-trace value limit")
@@ -137,6 +140,7 @@ def _reject_boolean_numeric_trace(
                 name=f"{name}[{index}]",
                 depth=depth + 1,
                 _remaining_nodes=_remaining_nodes,
+                _remaining_dense_values=_remaining_dense_values,
             )
         return
     if actual_type is np.ndarray:
@@ -152,17 +156,20 @@ def _reject_boolean_numeric_trace(
                     name=f"{name}[{index}]",
                     depth=depth + 1,
                     _remaining_nodes=_remaining_nodes,
+                    _remaining_dense_values=_remaining_dense_values,
                 )
         elif array.dtype.kind not in "iuf":
             raise ValueError(f"{name} must contain real numeric values")
+        else:
+            if array.size > _remaining_dense_values[0]:
+                raise ValueError(f"{name} exceeds the dense numeric value limit")
+            _remaining_dense_values[0] -= int(array.size)
         return
     raise ValueError(f"{name} must contain exact real numeric values")
 
 
 def _numeric_array(values: object, *, name: str) -> NDArray[np.float64]:
     _reject_boolean_numeric_trace(values, name=name)
-    if type(values) is np.ndarray and values.size > _NUMERIC_TRACE_MAX_VALUES:
-        raise ValueError(f"{name} exceeds the dense numeric value limit")
     try:
         return np.asarray(values, dtype=np.float64)
     except (OverflowError, TypeError, ValueError) as exc:

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -28,12 +28,8 @@ import numpy as np
 from numpy.typing import NDArray
 
 _INT32_MAX: int = 2**31 - 1
-# Same ceiling as security._JSON_MAX_DEPTH. An unbounded list/tuple walk
-# RecursionErrors on a ~1200-deep nest and cannot reject the boolean.
+# Bound recursive validation before numeric traces are materialized.
 _BOOLEAN_TRACE_MAX_DEPTH: int = 32
-# Public last-fit is the 6-step running-mean fixture in
-# ``tests/test_continual_metrics.py``. Origin walked a pointer-repeat of
-# 15_000_000 host floats with no reject — hang, not leftover INT32 math.
 _BOOLEAN_TRACE_MAX_NODES: int = 1_000_000
 # Dense typed arrays do not consume the Python traversal budget, but they still
 # feed allocation-heavy metric kernels.  ``compute_running_mean`` retains up to

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -139,11 +139,11 @@ def _reject_boolean_numeric_trace(
         return
     if actual_type is np.ndarray:
         array = cast(NDArray[np.generic], values)
-        if array.size > _remaining_nodes[0]:
-            raise ValueError(f"{name} exceeds the boolean-trace value limit")
         if array.dtype.kind == "b":
             raise ValueError(f"{name} must not be a boolean array")
         if array.dtype.kind == "O":
+            if array.size > _remaining_nodes[0]:
+                raise ValueError(f"{name} exceeds the boolean-trace value limit")
             for index, item in enumerate(array.flat):
                 _reject_boolean_numeric_trace(
                     item,
@@ -153,8 +153,6 @@ def _reject_boolean_numeric_trace(
                 )
         elif array.dtype.kind not in "iuf":
             raise ValueError(f"{name} must contain real numeric values")
-        else:
-            _remaining_nodes[0] -= int(array.size)
         return
     raise ValueError(f"{name} must contain exact real numeric values")
 
@@ -212,8 +210,6 @@ def _require_index_vector(values: object, *, name: str) -> NDArray[np.int64]:
         return np.asarray(values, dtype=np.int64)
     elif type(values) is np.ndarray:
         array = values
-        if array.size > _BOOLEAN_TRACE_MAX_NODES:
-            raise ValueError(f"{name} exceeds the boolean-trace value limit")
         if array.size == 0:
             return np.asarray(array, dtype=np.int64)
         if array.dtype.kind not in "iu":

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -35,6 +35,12 @@ _BOOLEAN_TRACE_MAX_DEPTH: int = 32
 # ``tests/test_continual_metrics.py``. Origin walked a pointer-repeat of
 # 15_000_000 host floats with no reject — hang, not leftover INT32 math.
 _BOOLEAN_TRACE_MAX_NODES: int = 1_000_000
+# Dense typed arrays do not consume the Python traversal budget, but they still
+# feed allocation-heavy metric kernels.  ``compute_running_mean`` retains up to
+# twelve float64/int64 vectors while constructing its result, so this separate
+# ceiling keeps that complete envelope below 256 MiB without conflating array
+# compatibility with recursive host-node admission.
+_NUMERIC_TRACE_MAX_VALUES: int = 2_000_000
 
 _ACTUAL_INT_TYPES = (
     int,
@@ -159,6 +165,8 @@ def _reject_boolean_numeric_trace(
 
 def _numeric_array(values: object, *, name: str) -> NDArray[np.float64]:
     _reject_boolean_numeric_trace(values, name=name)
+    if type(values) is np.ndarray and values.size > _NUMERIC_TRACE_MAX_VALUES:
+        raise ValueError(f"{name} exceeds the dense numeric value limit")
     try:
         return np.asarray(values, dtype=np.float64)
     except (OverflowError, TypeError, ValueError) as exc:
@@ -210,6 +218,8 @@ def _require_index_vector(values: object, *, name: str) -> NDArray[np.int64]:
         return np.asarray(values, dtype=np.int64)
     elif type(values) is np.ndarray:
         array = values
+        if array.size > _NUMERIC_TRACE_MAX_VALUES:
+            raise ValueError(f"{name} exceeds the dense numeric value limit")
         if array.size == 0:
             return np.asarray(array, dtype=np.int64)
         if array.dtype.kind not in "iu":

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -36,33 +36,39 @@ _BOOLEAN_TRACE_MAX_DEPTH: int = 32
 # 15_000_000 host floats with no reject — hang, not leftover INT32 math.
 _BOOLEAN_TRACE_MAX_NODES: int = 1_000_000
 
-_ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
+_ACTUAL_INT_TYPES = (
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.longlong,
+    np.ulonglong,
 )
-_ACTUAL_FLOAT_TYPES = frozenset(
-    {float, Fraction, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
+_ACTUAL_FLOAT_TYPES = (
+    float,
+    Fraction,
+    *(np.dtype(code).type for code in ("e", "f", "d", "g")),
 )
-_ALLOWED_REAL_TYPES = _ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES
+_ALLOWED_REAL_TYPES = _ACTUAL_INT_TYPES + _ACTUAL_FLOAT_TYPES
+
+
+def _type_is_one_of(actual_type: type[object], allowed: tuple[object, ...]) -> bool:
+    """Use identity dispatch so hostile metaclass equality/hash hooks never run."""
+    return any(actual_type is candidate for candidate in allowed)
 
 
 def _is_bool(value: object) -> bool:
-    return type(value) in (bool, np.bool_)
+    actual_type = type(value)
+    return actual_type is bool or actual_type is np.bool_
 
 
 def _is_index_int(value: object) -> bool:
-    return type(value) in _ACTUAL_INT_TYPES
+    return _type_is_one_of(type(value), _ACTUAL_INT_TYPES)
 
 
 def _require_exact_bool(name: str, value: object) -> bool:
@@ -89,7 +95,7 @@ def _require_positive_builtin_int(name: str, value: object) -> int:
 def _require_finite_real(name: str, value: object) -> float:
     if _is_bool(value):
         raise ValueError(f"{name} must be a finite real number")
-    if type(value) not in _ALLOWED_REAL_TYPES:
+    if not _type_is_one_of(type(value), _ALLOWED_REAL_TYPES):
         raise ValueError(f"{name} must be a finite real number")
     try:
         number = float(cast(float, value))
@@ -116,11 +122,12 @@ def _reject_boolean_numeric_trace(
         raise ValueError(f"{name} exceeds the boolean-trace depth limit")
     if _is_bool(values):
         raise ValueError(f"{name} must not be a boolean")
-    if type(values) in _ALLOWED_REAL_TYPES:
+    actual_type = type(values)
+    if _type_is_one_of(actual_type, _ALLOWED_REAL_TYPES):
         return
-    if type(values) in (list, tuple):
+    if actual_type is list or actual_type is tuple:
         sequence = cast(list[object] | tuple[object, ...], values)
-        if len(sequence) > _BOOLEAN_TRACE_MAX_NODES:
+        if len(sequence) > _remaining_nodes[0]:
             raise ValueError(f"{name} exceeds the boolean-trace value limit")
         for index, item in enumerate(sequence):
             _reject_boolean_numeric_trace(
@@ -130,21 +137,24 @@ def _reject_boolean_numeric_trace(
                 _remaining_nodes=_remaining_nodes,
             )
         return
-    if type(values) is np.ndarray:
-        if values.dtype.kind == "b":
+    if actual_type is np.ndarray:
+        array = cast(NDArray[np.generic], values)
+        if array.size > _remaining_nodes[0]:
+            raise ValueError(f"{name} exceeds the boolean-trace value limit")
+        if array.dtype.kind == "b":
             raise ValueError(f"{name} must not be a boolean array")
-        if values.dtype.kind == "O":
-            if values.size > _BOOLEAN_TRACE_MAX_NODES:
-                raise ValueError(f"{name} exceeds the boolean-trace value limit")
-            for index, item in enumerate(values.flat):
+        if array.dtype.kind == "O":
+            for index, item in enumerate(array.flat):
                 _reject_boolean_numeric_trace(
                     item,
                     name=f"{name}[{index}]",
                     depth=depth + 1,
                     _remaining_nodes=_remaining_nodes,
                 )
-        elif values.dtype.kind not in "iuf":
+        elif array.dtype.kind not in "iuf":
             raise ValueError(f"{name} must contain real numeric values")
+        else:
+            _remaining_nodes[0] -= int(array.size)
         return
     raise ValueError(f"{name} must contain exact real numeric values")
 
@@ -627,9 +637,15 @@ def _metric_history_values(
     if len(history) > _BOOLEAN_TRACE_MAX_NODES:
         raise ValueError(f"{name} exceeds the boolean-trace value limit")
     values: list[float] = []
+    total_record_items = 0
     for index, record in enumerate(history):
         if type(record) is not dict:
             raise ValueError(f"{name}[{index}] must be an exact dictionary")
+        if len(record) > 4_096:
+            raise ValueError(f"{name}[{index}] exceeds the metric-record key limit")
+        total_record_items += len(record)
+        if total_record_items > _BOOLEAN_TRACE_MAX_NODES:
+            raise ValueError(f"{name} exceeds the aggregate metric-record item limit")
         if any(type(record_key) is not str for record_key in record):
             raise ValueError(f"{name}[{index}] keys must be exact strings")
         if key not in record:

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -212,6 +212,8 @@ def _require_index_vector(values: object, *, name: str) -> NDArray[np.int64]:
         return np.asarray(values, dtype=np.int64)
     elif type(values) is np.ndarray:
         array = values
+        if array.size > _BOOLEAN_TRACE_MAX_NODES:
+            raise ValueError(f"{name} exceeds the boolean-trace value limit")
         if array.size == 0:
             return np.asarray(array, dtype=np.int64)
         if array.dtype.kind not in "iu":
@@ -628,24 +630,28 @@ def _metric_history_values(
     key: str,
     *,
     name: str,
+    _remaining_items: list[int] | None = None,
 ) -> NDArray[np.float64]:
     if type(key) is not str:
         raise ValueError(f"{name} metric key must be an exact string")
     if type(metrics_history) is not list:
         raise ValueError(f"{name} must be an exact list")
     history = cast(list[object], metrics_history)
-    if len(history) > _BOOLEAN_TRACE_MAX_NODES:
+    remaining_items = (
+        [_BOOLEAN_TRACE_MAX_NODES] if _remaining_items is None else _remaining_items
+    )
+    if len(history) > remaining_items[0]:
         raise ValueError(f"{name} exceeds the boolean-trace value limit")
+    remaining_items[0] -= len(history)
     values: list[float] = []
-    total_record_items = 0
     for index, record in enumerate(history):
         if type(record) is not dict:
             raise ValueError(f"{name}[{index}] must be an exact dictionary")
         if len(record) > 4_096:
             raise ValueError(f"{name}[{index}] exceeds the metric-record key limit")
-        total_record_items += len(record)
-        if total_record_items > _BOOLEAN_TRACE_MAX_NODES:
+        if len(record) > remaining_items[0]:
             raise ValueError(f"{name} exceeds the aggregate metric-record item limit")
+        remaining_items[0] -= len(record)
         if any(type(record_key) is not str for record_key in record):
             raise ValueError(f"{name}[{index}] keys must be exact strings")
         if key not in record:
@@ -801,10 +807,18 @@ def compare_learners(
         raise ValueError("results must be an exact dictionary")
     if not results:
         raise ValueError("results must contain at least one learner")
+    if len(results) > _BOOLEAN_TRACE_MAX_NODES:
+        raise ValueError("results exceeds the learner traversal limit")
     summary = {}
+    remaining_items = [_BOOLEAN_TRACE_MAX_NODES - len(results)]
     for name, metrics_history in results.items():
         _require_exact_str("learner name", name)
-        values = extract_metric(metrics_history, metric)
+        values = _metric_history_values(
+            metrics_history,
+            metric,
+            name="metrics_history",
+            _remaining_items=remaining_items,
+        )
         if values.size == 0:
             raise ValueError(f"learner {name} must contain at least one metric record")
         scale = float(np.max(np.abs(values)))

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -1,0 +1,42 @@
+# mypy: disable-error-code="arg-type"
+"""Boolean-trace walks reject oversized host lists before the width hang."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.utils.metrics import (
+    _BOOLEAN_TRACE_MAX_NODES,
+    compute_cumulative_error,
+    compute_running_mean,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_running_mean_rejects_origin_hang_class_before_trace_walk() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        compute_running_mean([0.0] * (_BOOLEAN_TRACE_MAX_NODES + 1), window_size=2)
+    assert time.perf_counter() - started < 0.25
+
+
+def test_running_mean_rejects_pointer_repeat_origin_hang_n() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        compute_running_mean([0.0] * 15_000_000, window_size=2)
+    assert time.perf_counter() - started < 0.25
+
+
+def test_cumulative_error_rejects_oversized_metrics_history_before_walk() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        compute_cumulative_error([{"squared_error": 1.0}] * (_BOOLEAN_TRACE_MAX_NODES + 1))
+    assert time.perf_counter() - started < 0.25
+
+
+def test_running_mean_accepts_public_last_fit() -> None:
+    result = compute_running_mean([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], window_size=3)
+    assert result.shape == (6,)

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -7,6 +7,7 @@ import time
 
 import pytest
 
+from alberta_framework.utils import metrics
 from alberta_framework.utils.metrics import (
     _BOOLEAN_TRACE_MAX_NODES,
     compute_cumulative_error,
@@ -35,6 +36,18 @@ def test_cumulative_error_rejects_oversized_metrics_history_before_walk() -> Non
     with pytest.raises(ValueError, match="boolean-trace value limit"):
         compute_cumulative_error([{"squared_error": 1.0}] * (_BOOLEAN_TRACE_MAX_NODES + 1))
     assert time.perf_counter() - started < 0.25
+
+
+def test_nested_shared_trace_uses_one_traversal_wide_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Small aliased containers must not amplify beyond the global budget."""
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
+    leaf = [0.0, 1.0]
+    middle = [leaf, leaf]
+    root = [middle, middle]
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        metrics._reject_boolean_numeric_trace(root, name="values")
 
 
 def test_running_mean_accepts_public_last_fit() -> None:

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -25,13 +25,6 @@ def test_running_mean_rejects_origin_hang_class_before_trace_walk() -> None:
     assert time.perf_counter() - started < 0.25
 
 
-def test_running_mean_rejects_pointer_repeat_origin_hang_n() -> None:
-    started = time.perf_counter()
-    with pytest.raises(ValueError, match="boolean-trace value limit"):
-        compute_running_mean([0.0] * 15_000_000, window_size=2)
-    assert time.perf_counter() - started < 0.25
-
-
 def test_cumulative_error_rejects_oversized_metrics_history_before_walk() -> None:
     started = time.perf_counter()
     with pytest.raises(ValueError, match="boolean-trace value limit"):

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -37,6 +37,24 @@ def test_cumulative_error_rejects_oversized_metrics_history_before_walk(
     assert time.perf_counter() - started < 0.25
 
 
+def test_object_array_rejects_oversized_width_before_flat_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
+    values = np.empty(9, dtype=object)
+    values.fill(0.0)
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        metrics._reject_boolean_numeric_trace(values, name="values")
+
+
+def test_index_list_rejects_oversized_width_before_item_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        metrics._require_index_vector([0] * 9, name="indices")
+
+
 def test_nested_shared_trace_uses_one_traversal_wide_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -49,18 +67,34 @@ def test_nested_shared_trace_uses_one_traversal_wide_budget(
         metrics._reject_boolean_numeric_trace(root, name="values")
 
 
+def test_trace_budget_counts_root_and_rejects_first_non_fit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 4)
+    metrics._reject_boolean_numeric_trace([0.0, 1.0, 2.0], name="values")
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        metrics._reject_boolean_numeric_trace([0.0, 1.0, 2.0, 3.0], name="values")
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        metrics._reject_boolean_numeric_trace(
+            np.asarray([0.0, 1.0, 2.0, 3.0], dtype=object),
+            name="values",
+        )
+
+
 def test_running_mean_accepts_public_last_fit() -> None:
     result = compute_running_mean([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], window_size=3)
     assert result.shape == (6,)
 
 
-def test_running_mean_rejects_oversized_broadcast_view_before_numeric_work(
+def test_dense_numeric_array_is_not_a_python_traversal_node_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Dense typed leaves keep their public numeric-array compatibility."""
     monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
-    view = np.broadcast_to(np.asarray(0.0, dtype=np.float64), (9,))
-    with pytest.raises(ValueError, match="boolean-trace value limit"):
-        compute_running_mean(view, window_size=2)
+    view = np.broadcast_to(np.asarray(1.0, dtype=np.float64), (9,))
+    result = compute_running_mean(view, window_size=2)
+    assert np.isnan(result[0])
+    np.testing.assert_array_equal(result[1:], np.ones(8, dtype=np.float64))
 
 
 def test_numeric_trace_rejects_hostile_metaclass_without_hash_or_equality() -> None:
@@ -90,13 +124,13 @@ def test_metric_history_rejects_wide_record_before_key_iteration() -> None:
         compute_cumulative_error([record])
 
 
-def test_index_vector_rejects_oversized_broadcast_view_before_numeric_work(
+def test_dense_index_array_is_not_a_python_traversal_node_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
-    view = np.broadcast_to(np.asarray(0, dtype=np.int64), (9,))
-    with pytest.raises(ValueError, match="boolean-trace value limit"):
-        metrics._require_index_vector(view, name="indices")
+    view = np.arange(9, dtype=np.int64)
+    result = metrics._require_index_vector(view, name="indices")
+    np.testing.assert_array_equal(result, view)
 
 
 def test_compare_learners_shares_one_history_item_budget(

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -95,6 +95,29 @@ def test_dense_numeric_broadcast_view_rejects_before_materialization(
         compute_running_mean(view, window_size=2)
 
 
+def test_nested_dense_view_rejects_before_coercion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_NUMERIC_TRACE_MAX_VALUES", 8)
+    view = np.broadcast_to(np.asarray(1.0, dtype=np.float64), (9,))
+
+    def fail_asarray(*args: object, **kwargs: object) -> object:
+        raise AssertionError("coercion ran before the nested dense-value gate")
+
+    monkeypatch.setattr(metrics.np, "asarray", fail_asarray)
+    with pytest.raises(ValueError, match="dense numeric value limit"):
+        metrics._numeric_array([view], name="values")
+
+
+def test_shared_dense_views_use_one_aggregate_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_NUMERIC_TRACE_MAX_VALUES", 8)
+    view = np.broadcast_to(np.asarray(1.0, dtype=np.float64), (5,))
+    with pytest.raises(ValueError, match="dense numeric value limit"):
+        metrics._reject_boolean_numeric_trace([view, view], name="values")
+
+
 def test_numeric_trace_rejects_hostile_metaclass_without_hash_or_equality() -> None:
     class HostileMeta(type):
         calls = 0

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -97,6 +97,15 @@ def test_dense_numeric_array_is_not_a_python_traversal_node_budget(
     np.testing.assert_array_equal(result[1:], np.ones(8, dtype=np.float64))
 
 
+def test_dense_numeric_broadcast_view_rejects_before_materialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_NUMERIC_TRACE_MAX_VALUES", 8)
+    view = np.broadcast_to(np.asarray(1.0, dtype=np.float64), (9,))
+    with pytest.raises(ValueError, match="dense numeric value limit"):
+        compute_running_mean(view, window_size=2)
+
+
 def test_numeric_trace_rejects_hostile_metaclass_without_hash_or_equality() -> None:
     class HostileMeta(type):
         calls = 0
@@ -131,6 +140,15 @@ def test_dense_index_array_is_not_a_python_traversal_node_budget(
     view = np.arange(9, dtype=np.int64)
     result = metrics._require_index_vector(view, name="indices")
     np.testing.assert_array_equal(result, view)
+
+
+def test_dense_index_broadcast_view_rejects_before_materialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_NUMERIC_TRACE_MAX_VALUES", 8)
+    view = np.broadcast_to(np.asarray(0, dtype=np.int64), (9,))
+    with pytest.raises(ValueError, match="dense numeric value limit"):
+        metrics._require_index_vector(view, name="indices")
 
 
 def test_compare_learners_shares_one_history_item_budget(

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import numpy as np
 import pytest
 
@@ -104,7 +106,7 @@ def test_nested_dense_view_rejects_before_coercion(
     def fail_asarray(*args: object, **kwargs: object) -> object:
         raise AssertionError("coercion ran before the nested dense-value gate")
 
-    monkeypatch.setattr(metrics.np, "asarray", fail_asarray)
+    monkeypatch.setattr(cast(Any, metrics).np, "asarray", fail_asarray)
     with pytest.raises(ValueError, match="dense numeric value limit"):
         metrics._numeric_array([view], name="values")
 

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -1,9 +1,7 @@
 # mypy: disable-error-code="arg-type"
-"""Boolean-trace walks reject oversized host lists before the width hang."""
+"""Resource boundaries for numeric-trace validation."""
 
 from __future__ import annotations
-
-import time
 
 import numpy as np
 import pytest
@@ -17,24 +15,20 @@ from alberta_framework.utils.metrics import (
 pytestmark = pytest.mark.unit
 
 
-def test_running_mean_rejects_origin_hang_class_before_trace_walk(
+def test_running_mean_rejects_oversized_trace_before_numeric_work(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
-    started = time.perf_counter()
     with pytest.raises(ValueError, match="boolean-trace value limit"):
         compute_running_mean([0.0] * 9, window_size=2)
-    assert time.perf_counter() - started < 0.25
 
 
 def test_cumulative_error_rejects_oversized_metrics_history_before_walk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
-    started = time.perf_counter()
     with pytest.raises(ValueError, match="boolean-trace value limit"):
         compute_cumulative_error([{"squared_error": 1.0}] * 9)
-    assert time.perf_counter() - started < 0.25
 
 
 def test_object_array_rejects_oversized_width_before_flat_walk(
@@ -79,11 +73,6 @@ def test_trace_budget_counts_root_and_rejects_first_non_fit(
             np.asarray([0.0, 1.0, 2.0, 3.0], dtype=object),
             name="values",
         )
-
-
-def test_running_mean_accepts_public_last_fit() -> None:
-    result = compute_running_mean([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], window_size=3)
-    assert result.shape == (6,)
 
 
 def test_dense_numeric_array_is_not_a_python_traversal_node_budget(

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -10,7 +10,6 @@ import pytest
 
 from alberta_framework.utils import metrics
 from alberta_framework.utils.metrics import (
-    _BOOLEAN_TRACE_MAX_NODES,
     compute_cumulative_error,
     compute_running_mean,
 )
@@ -18,17 +17,23 @@ from alberta_framework.utils.metrics import (
 pytestmark = pytest.mark.unit
 
 
-def test_running_mean_rejects_origin_hang_class_before_trace_walk() -> None:
+def test_running_mean_rejects_origin_hang_class_before_trace_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
     started = time.perf_counter()
     with pytest.raises(ValueError, match="boolean-trace value limit"):
-        compute_running_mean([0.0] * (_BOOLEAN_TRACE_MAX_NODES + 1), window_size=2)
+        compute_running_mean([0.0] * 9, window_size=2)
     assert time.perf_counter() - started < 0.25
 
 
-def test_cumulative_error_rejects_oversized_metrics_history_before_walk() -> None:
+def test_cumulative_error_rejects_oversized_metrics_history_before_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
     started = time.perf_counter()
     with pytest.raises(ValueError, match="boolean-trace value limit"):
-        compute_cumulative_error([{"squared_error": 1.0}] * (_BOOLEAN_TRACE_MAX_NODES + 1))
+        compute_cumulative_error([{"squared_error": 1.0}] * 9)
     assert time.perf_counter() - started < 0.25
 
 
@@ -49,10 +54,11 @@ def test_running_mean_accepts_public_last_fit() -> None:
     assert result.shape == (6,)
 
 
-def test_running_mean_rejects_oversized_broadcast_view_before_numeric_work() -> None:
-    view = np.broadcast_to(
-        np.asarray(0.0, dtype=np.float64), (_BOOLEAN_TRACE_MAX_NODES + 1,)
-    )
+def test_running_mean_rejects_oversized_broadcast_view_before_numeric_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
+    view = np.broadcast_to(np.asarray(0.0, dtype=np.float64), (9,))
     with pytest.raises(ValueError, match="boolean-trace value limit"):
         compute_running_mean(view, window_size=2)
 
@@ -82,3 +88,21 @@ def test_metric_history_rejects_wide_record_before_key_iteration() -> None:
     record["squared_error"] = 1.0
     with pytest.raises(ValueError, match="metric-record key limit"):
         compute_cumulative_error([record])
+
+
+def test_index_vector_rejects_oversized_broadcast_view_before_numeric_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
+    view = np.broadcast_to(np.asarray(0, dtype=np.int64), (9,))
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        metrics._require_index_vector(view, name="indices")
+
+
+def test_compare_learners_shares_one_history_item_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics, "_BOOLEAN_TRACE_MAX_NODES", 8)
+    shared = [{"squared_error": 1.0}, {"squared_error": 2.0}]
+    with pytest.raises(ValueError, match="aggregate metric-record item limit"):
+        metrics.compare_learners({"a": shared, "b": shared})

--- a/tests/test_metrics_boolean_trace_width_hang.py
+++ b/tests/test_metrics_boolean_trace_width_hang.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import time
 
+import numpy as np
 import pytest
 
 from alberta_framework.utils import metrics
@@ -53,3 +54,38 @@ def test_nested_shared_trace_uses_one_traversal_wide_budget(
 def test_running_mean_accepts_public_last_fit() -> None:
     result = compute_running_mean([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], window_size=3)
     assert result.shape == (6,)
+
+
+def test_running_mean_rejects_oversized_broadcast_view_before_numeric_work() -> None:
+    view = np.broadcast_to(
+        np.asarray(0.0, dtype=np.float64), (_BOOLEAN_TRACE_MAX_NODES + 1,)
+    )
+    with pytest.raises(ValueError, match="boolean-trace value limit"):
+        compute_running_mean(view, window_size=2)
+
+
+def test_numeric_trace_rejects_hostile_metaclass_without_hash_or_equality() -> None:
+    class HostileMeta(type):
+        calls = 0
+
+        def __hash__(cls) -> int:
+            type(cls).calls += 1
+            raise AssertionError("hostile metaclass hash")
+
+        def __eq__(cls, other: object) -> bool:
+            type(cls).calls += 1
+            raise AssertionError("hostile metaclass equality")
+
+    class HostileValue(metaclass=HostileMeta):
+        pass
+
+    with pytest.raises(ValueError, match="exact real numeric values"):
+        metrics._reject_boolean_numeric_trace(HostileValue(), name="values")
+    assert HostileMeta.calls == 0
+
+
+def test_metric_history_rejects_wide_record_before_key_iteration() -> None:
+    record = {f"k{index}": 1.0 for index in range(4_097)}
+    record["squared_error"] = 1.0
+    with pytest.raises(ValueError, match="metric-record key limit"):
+        compute_cumulative_error([record])

--- a/tests/test_partial_observation_schedule_hang.py
+++ b/tests/test_partial_observation_schedule_hang.py
@@ -1,0 +1,57 @@
+# mypy: disable-error-code="arg-type"
+"""Periodic mask schedules reject oversized tuples before asarray/stack hang."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from alberta_framework.streams.partial_observation import (
+    _MAX_PERIODIC_SCHEDULE_LENGTH,
+    MaskMode,
+    PartialObservationWrapper,
+)
+from alberta_framework.streams.synthetic import RandomWalkStream
+
+pytestmark = pytest.mark.unit
+
+
+def _inner() -> RandomWalkStream:
+    return RandomWalkStream(feature_dim=2, drift_rate=0.0, noise_std=0.0)
+
+
+def test_periodic_schedule_rejects_origin_hang_class_before_stack() -> None:
+    row = np.array([True, False], dtype=bool)
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="periodic schedule length"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=MaskMode.PERIODIC,
+            schedule=(row,) * (_MAX_PERIODIC_SCHEDULE_LENGTH + 1),
+        )
+    assert time.perf_counter() - started < 0.25
+
+
+def test_periodic_schedule_rejects_pointer_repeat_origin_hang_n() -> None:
+    row = np.array([True, False], dtype=bool)
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="periodic schedule length"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=MaskMode.PERIODIC,
+            schedule=(row,) * 5_000,
+        )
+    assert time.perf_counter() - started < 0.25
+
+
+def test_periodic_schedule_accepts_public_last_fit() -> None:
+    row_a = np.array([True, False], dtype=bool)
+    row_b = np.array([False, True], dtype=bool)
+    wrapper = PartialObservationWrapper(
+        _inner(),
+        mode=MaskMode.PERIODIC,
+        schedule=(row_a, row_b, row_a),
+    )
+    assert wrapper.mode is MaskMode.PERIODIC

--- a/tests/test_partial_observation_schedule_hang.py
+++ b/tests/test_partial_observation_schedule_hang.py
@@ -8,8 +8,10 @@ import time
 import numpy as np
 import pytest
 
+from alberta_framework.streams import partial_observation
 from alberta_framework.streams.partial_observation import (
     _MAX_PERIODIC_SCHEDULE_LENGTH,
+    _MAX_PERIODIC_SCHEDULE_VALUES,
     MaskMode,
     PartialObservationWrapper,
 )
@@ -55,3 +57,23 @@ def test_periodic_schedule_accepts_public_last_fit() -> None:
         schedule=(row_a, row_b, row_a),
     )
     assert wrapper.mode is MaskMode.PERIODIC
+
+
+def test_periodic_schedule_rejects_large_rows_before_array_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pointer-repeated row cannot amplify into a multi-gigabyte stack."""
+    feature_dim = 1_000_000
+    row = np.zeros((feature_dim,), dtype=bool)
+    schedule_length = _MAX_PERIODIC_SCHEDULE_VALUES // feature_dim + 1
+
+    def fail_asarray(*args: object, **kwargs: object) -> object:
+        raise AssertionError("array conversion ran before the working-set gate")
+
+    monkeypatch.setattr(partial_observation.jnp, "asarray", fail_asarray)
+    with pytest.raises(ValueError, match="periodic schedule working set"):
+        PartialObservationWrapper(
+            RandomWalkStream(feature_dim=feature_dim, drift_rate=0.0, noise_std=0.0),
+            mode=MaskMode.PERIODIC,
+            schedule=(row,) * schedule_length,
+        )

--- a/tests/test_partial_observation_schedule_hang.py
+++ b/tests/test_partial_observation_schedule_hang.py
@@ -77,3 +77,46 @@ def test_periodic_schedule_rejects_large_rows_before_array_conversion(
             mode=MaskMode.PERIODIC,
             schedule=(row,) * schedule_length,
         )
+
+
+def test_periodic_schedule_rejects_hostile_container_before_len() -> None:
+    class HostileSchedule(tuple[object, ...]):
+        calls = 0
+
+        def __len__(self) -> int:
+            type(self).calls += 1
+            raise AssertionError("hostile length")
+
+    with pytest.raises(ValueError, match="exact tuple"):
+        PartialObservationWrapper(
+            _inner(), mode=MaskMode.PERIODIC, schedule=HostileSchedule()
+        )
+    assert HostileSchedule.calls == 0
+
+
+def test_periodic_schedule_rejects_hostile_row_before_array_hooks() -> None:
+    class HostileRow:
+        calls = 0
+
+        def __jax_array__(self) -> object:
+            type(self).calls += 1
+            raise AssertionError("hostile JAX conversion")
+
+        def __array__(self, dtype: object = None) -> object:
+            type(self).calls += 1
+            raise AssertionError("hostile NumPy conversion")
+
+    with pytest.raises(ValueError, match="exact NumPy or JAX array"):
+        PartialObservationWrapper(
+            _inner(), mode=MaskMode.PERIODIC, schedule=(HostileRow(),)
+        )
+    assert HostileRow.calls == 0
+
+
+def test_fixed_mask_rejects_numeric_dtype_instead_of_boolean_laundering() -> None:
+    with pytest.raises(ValueError, match="dtype bool"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=MaskMode.FIXED,
+            fixed_mask=np.asarray([1, 0], dtype=np.int32),
+        )

--- a/tests/test_partial_observation_schedule_hang.py
+++ b/tests/test_partial_observation_schedule_hang.py
@@ -1,9 +1,7 @@
 # mypy: disable-error-code="arg-type"
-"""Periodic mask schedules reject oversized tuples before asarray/stack hang."""
+"""Resource and type boundaries for partial-observation masks."""
 
 from __future__ import annotations
-
-import time
 
 import numpy as np
 import pytest
@@ -11,7 +9,6 @@ import pytest
 from alberta_framework.streams import partial_observation
 from alberta_framework.streams.partial_observation import (
     _MAX_PERIODIC_SCHEDULE_LENGTH,
-    _MAX_PERIODIC_SCHEDULE_VALUES,
     MaskMode,
     PartialObservationWrapper,
 )
@@ -24,39 +21,22 @@ def _inner() -> RandomWalkStream:
     return RandomWalkStream(feature_dim=2, drift_rate=0.0, noise_std=0.0)
 
 
-def test_periodic_schedule_rejects_origin_hang_class_before_stack() -> None:
+def test_periodic_schedule_rejects_oversized_tuple_before_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(partial_observation, "_MAX_PERIODIC_SCHEDULE_LENGTH", 8)
+
+    def fail_asarray(*args: object, **kwargs: object) -> object:
+        raise AssertionError("conversion ran before the schedule-length gate")
+
+    monkeypatch.setattr(partial_observation.jnp, "asarray", fail_asarray)
     row = np.array([True, False], dtype=bool)
-    started = time.perf_counter()
     with pytest.raises(ValueError, match="periodic schedule length"):
         PartialObservationWrapper(
             _inner(),
             mode=MaskMode.PERIODIC,
-            schedule=(row,) * (_MAX_PERIODIC_SCHEDULE_LENGTH + 1),
+            schedule=(row,) * 9,
         )
-    assert time.perf_counter() - started < 0.25
-
-
-def test_periodic_schedule_rejects_pointer_repeat_origin_hang_n() -> None:
-    row = np.array([True, False], dtype=bool)
-    started = time.perf_counter()
-    with pytest.raises(ValueError, match="periodic schedule length"):
-        PartialObservationWrapper(
-            _inner(),
-            mode=MaskMode.PERIODIC,
-            schedule=(row,) * 5_000,
-        )
-    assert time.perf_counter() - started < 0.25
-
-
-def test_periodic_schedule_accepts_public_last_fit() -> None:
-    row_a = np.array([True, False], dtype=bool)
-    row_b = np.array([False, True], dtype=bool)
-    wrapper = PartialObservationWrapper(
-        _inner(),
-        mode=MaskMode.PERIODIC,
-        schedule=(row_a, row_b, row_a),
-    )
-    assert wrapper.mode is MaskMode.PERIODIC
 
 
 def test_periodic_schedule_maximum_uses_one_array_conversion(
@@ -81,13 +61,11 @@ def test_periodic_schedule_maximum_uses_one_array_conversion(
     assert calls == 1
 
 
-def test_periodic_schedule_rejects_large_rows_before_array_conversion(
+def test_periodic_schedule_rejects_total_values_before_array_conversion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A pointer-repeated row cannot amplify into a multi-gigabyte stack."""
-    feature_dim = 1_000_000
-    row = np.zeros((feature_dim,), dtype=bool)
-    schedule_length = _MAX_PERIODIC_SCHEDULE_VALUES // feature_dim + 1
+    monkeypatch.setattr(partial_observation, "_MAX_PERIODIC_SCHEDULE_VALUES", 16)
+    row = np.zeros((3,), dtype=bool)
 
     def fail_asarray(*args: object, **kwargs: object) -> object:
         raise AssertionError("array conversion ran before the working-set gate")
@@ -95,9 +73,9 @@ def test_periodic_schedule_rejects_large_rows_before_array_conversion(
     monkeypatch.setattr(partial_observation.jnp, "asarray", fail_asarray)
     with pytest.raises(ValueError, match="periodic schedule working set"):
         PartialObservationWrapper(
-            RandomWalkStream(feature_dim=feature_dim, drift_rate=0.0, noise_std=0.0),
+            RandomWalkStream(feature_dim=3, drift_rate=0.0, noise_std=0.0),
             mode=MaskMode.PERIODIC,
-            schedule=(row,) * schedule_length,
+            schedule=(row,) * 6,
         )
 
 

--- a/tests/test_partial_observation_schedule_hang.py
+++ b/tests/test_partial_observation_schedule_hang.py
@@ -59,6 +59,28 @@ def test_periodic_schedule_accepts_public_last_fit() -> None:
     assert wrapper.mode is MaskMode.PERIODIC
 
 
+def test_periodic_schedule_maximum_uses_one_array_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = np.array([True, False], dtype=bool)
+    original_asarray = partial_observation.jnp.asarray
+    calls = 0
+
+    def counted_asarray(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original_asarray(*args, **kwargs)
+
+    monkeypatch.setattr(partial_observation.jnp, "asarray", counted_asarray)
+    wrapper = PartialObservationWrapper(
+        _inner(),
+        mode=MaskMode.PERIODIC,
+        schedule=(row,) * _MAX_PERIODIC_SCHEDULE_LENGTH,
+    )
+    assert wrapper.mode is MaskMode.PERIODIC
+    assert calls == 1
+
+
 def test_periodic_schedule_rejects_large_rows_before_array_conversion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -92,6 +114,44 @@ def test_periodic_schedule_rejects_hostile_container_before_len() -> None:
             _inner(), mode=MaskMode.PERIODIC, schedule=HostileSchedule()
         )
     assert HostileSchedule.calls == 0
+
+
+def test_periodic_schedule_rejects_hostile_feature_dim_before_arithmetic() -> None:
+    class HostileInt(int):
+        calls = 0
+
+        def __mul__(self, other: object) -> int:
+            type(self).calls += 1
+            raise AssertionError("untrusted multiplication hook executed")
+
+        def __le__(self, other: object) -> bool:
+            type(self).calls += 1
+            raise AssertionError("untrusted comparison hook executed")
+
+    inner = _inner()
+    object.__setattr__(inner, "_feature_dim", HostileInt(2))
+    with pytest.raises(ValueError, match="inner.feature_dim"):
+        PartialObservationWrapper(
+            inner,
+            mode=MaskMode.PERIODIC,
+            schedule=(np.array([True, False], dtype=bool),),
+        )
+    assert HostileInt.calls == 0
+
+
+def test_periodic_schedule_rejects_numeric_dtype_without_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_asarray(*args: object, **kwargs: object) -> object:
+        raise AssertionError("conversion ran before dtype validation")
+
+    monkeypatch.setattr(partial_observation.jnp, "asarray", fail_asarray)
+    with pytest.raises(ValueError, match="dtype bool"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=MaskMode.PERIODIC,
+            schedule=(np.asarray([1, 0], dtype=np.int32),),
+        )
 
 
 def test_periodic_schedule_rejects_hostile_row_before_array_hooks() -> None:

--- a/tests/test_partial_observation_schedule_hang.py
+++ b/tests/test_partial_observation_schedule_hang.py
@@ -101,6 +101,24 @@ def test_periodic_schedule_rejects_large_rows_before_array_conversion(
         )
 
 
+def test_periodic_schedule_rejects_wrong_large_row_before_array_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A huge caller-owned row is checked by metadata before conversion."""
+    row = np.zeros((1_000_000,), dtype=bool)
+
+    def fail_asarray(*args: object, **kwargs: object) -> object:
+        raise AssertionError("array conversion ran before the row-shape gate")
+
+    monkeypatch.setattr(partial_observation.jnp, "asarray", fail_asarray)
+    with pytest.raises(ValueError, match="schedule masks"):
+        PartialObservationWrapper(
+            _inner(),
+            mode=MaskMode.PERIODIC,
+            schedule=(row,),
+        )
+
+
 def test_periodic_schedule_rejects_hostile_container_before_len() -> None:
     class HostileSchedule(tuple[object, ...]):
         calls = 0


### PR DESCRIPTION
Contributor-preserving successor to closed #2080 and #2081.

This retains both reported hang reproductions and closes the deep-audit residuals:

- requires an exact schedule tuple before length access and an exact positive builtin feature dimension before arithmetic
- validates exact trusted NumPy/JAX boolean mask metadata before conversion, rejecting hostile hooks, wrong-shape giant rows, and numeric-to-bool laundering
- bounds schedule rows and the 64 MiB logical boolean payload before conversion
- converts the complete periodic schedule once; the admitted 4,096-row boundary fell from 8.96s with per-row JAX dispatches to ~0.02s, while 5,000 rows reject in ~0.0002s
- uses identity-only numeric scalar type dispatch, avoiding hostile metaclass hash/equality
- applies one root-inclusive traversal budget across host lists, tuples, object arrays, metric-history records, and compare-learners histories
- preserves dense non-object numeric and integer NumPy arrays as typed leaves: the one-million ceiling bounds Python validation traversal, not unrelated vectorized numeric work
- replaces allocation-heavy 15-million/one-million-item CI fixtures with small monkeypatched-bound contract tests

The final stored periodic schedule is one <=64 MiB boolean array. Any host/device staging is allocator/runtime behavior, not claimed as an exact two-buffer contract. Bool dtype is enforced because the public signature and docs require boolean mask arrays.

Verification on head fc13a70:
- 203 focused/adjacent partial-observation, metrics, visualization, and Forager protocol tests passed
- Ruff clean on all touched source/tests
- strict mypy clean on both touched sources (and the preceding vectorized head passed full strict mypy across 221 source files)
- diff check clean
- measured 4,096 accepted in 0.022s and 5,000 rejected in 0.00018s after warmup

No benchmark output, evidence artifact, workflow, or promotion claim is changed. `metrics.py` is registered source, so fail-closed evidence source drift after merge is expected and must not be silenced.