### PR TITLE
fix(scorecard): retain failed development shards

### DIFF
--- a/.github/workflows/reference-life-scorecard-dev.yml
+++ b/.github/workflows/reference-life-scorecard-dev.yml
@@ -43,6 +43,7 @@ jobs:
           test "$GITHUB_REF" = "refs/heads/main"
           test "$GITHUB_SHA" = "$LAUNCH_SHA"
           test "$WORKFLOW_SHA" = "$LAUNCH_SHA"
+          test "$GITHUB_RUN_ATTEMPT" = "1"
           test "$(git rev-parse HEAD)" = "$LAUNCH_SHA"
           test -z "$(git status --short)"
 
@@ -66,6 +67,15 @@ jobs:
           test "$uv_version" = "0.9.24"
           printf 'PYTHON_PATH=%s\nUV_PATH=%s\n' "$python_path" "$uv_path" >> "$GITHUB_ENV"
 
+      - name: Reverify exact authorized source after setup
+        shell: bash
+        env:
+          LAUNCH_SHA: ${{ inputs.launch_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$LAUNCH_SHA"
+          test -z "$(git status --short)"
+
       - name: Run and validate one fresh-process shard
         shell: bash
         env:
@@ -76,9 +86,16 @@ jobs:
           set -euo pipefail
           mkdir -p scorecard/shards
           output="scorecard/shards/${ENVIRONMENT}__${ARM}__${SEED}.json"
+          set +e
           "$PYTHON_PATH" -m alberta_framework.benchmarks.reference_life_scorecard \
             run-shard --environment "$ENVIRONMENT" --arm "$ARM" --seed "$SEED" \
             --output "$output"
+          shard_status=$?
+          set -e
+          if (( shard_status != 0 && shard_status != 1 )); then
+            echo "run-shard returned unexpected status $shard_status" >&2
+            exit "$shard_status"
+          fi
           "$PYTHON_PATH" -m alberta_framework.benchmarks.reference_life_scorecard \
             validate "$output"
           test "$(find scorecard/shards -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')" = 1
@@ -114,6 +131,7 @@ jobs:
           test "$GITHUB_REF" = "refs/heads/main"
           test "$GITHUB_SHA" = "$LAUNCH_SHA"
           test "$WORKFLOW_SHA" = "$LAUNCH_SHA"
+          test "$GITHUB_RUN_ATTEMPT" = "1"
           test "$(git rev-parse HEAD)" = "$LAUNCH_SHA"
           test -z "$(git status --short)"
 
@@ -136,6 +154,15 @@ jobs:
           uv_version="$("$uv_path" --version | sed -E 's/^uv ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
           test "$uv_version" = "0.9.24"
           printf 'PYTHON_PATH=%s\nUV_PATH=%s\n' "$python_path" "$uv_path" >> "$GITHUB_ENV"
+
+      - name: Reverify exact authorized source after setup
+        shell: bash
+        env:
+          LAUNCH_SHA: ${{ inputs.launch_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$LAUNCH_SHA"
+          test -z "$(git status --short)"
 
       - name: Download all source-bound shard records
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/tests/test_reference_life_scorecard_workflow.py
+++ b/tests/test_reference_life_scorecard_workflow.py
@@ -40,7 +40,9 @@ def test_reference_life_scorecard_fails_closed_on_source_and_runtime() -> None:
     assert text.count('test "$GITHUB_REF" = "refs/heads/main"') == 2
     assert text.count('test "$GITHUB_SHA" = "$LAUNCH_SHA"') == 2
     assert text.count('test "$WORKFLOW_SHA" = "$LAUNCH_SHA"') == 2
-    assert text.count('test "$(git rev-parse HEAD)" = "$LAUNCH_SHA"') == 2
+    assert text.count('test "$GITHUB_RUN_ATTEMPT" = "1"') == 2
+    assert text.count('test "$(git rev-parse HEAD)" = "$LAUNCH_SHA"') == 4
+    assert text.count("Reverify exact authorized source after setup") == 2
     assert text.count('python-version: "3.12.12"') == 2
     assert text.count('test "$uv_version" = "0.9.24"') == 2
     assert text.count('python_path="$GITHUB_WORKSPACE/.venv/bin/python"') == 2
@@ -49,6 +51,15 @@ def test_reference_life_scorecard_fails_closed_on_source_and_runtime() -> None:
     assert "import alberta_framework, jax" in text
     assert "retention-days: 90" in text
     assert "retention-days: 30" not in text
+
+
+def test_reference_life_scorecard_retains_valid_failed_shards() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "shard_status=$?" in text
+    assert "shard_status != 0 && shard_status != 1" in text
+    assert "run-shard returned unexpected status" in text
+    assert "validate \"$output\"" in text
 
 
 def test_reference_life_scorecard_artifacts_and_receipt_bind_the_run() -> None:


### PR DESCRIPTION
The manual 144-shard workflow used `set -e` around `run-shard`, but the CLI intentionally returns 1 after publishing a strictly valid non-completed shard. That made the workflow discard exactly the negative/fault outcomes the frozen nonpromoting protocol requires it to retain.

This repair accepts only run-shard statuses 0 and 1, validates and uploads either record, rejects every other status, blocks workflow reruns, and reverifies the exact clean authorized checkout after dependency setup in both shard and aggregate jobs.

Validation: 5 workflow contract tests passed; Ruff passed; actionlint passed when available; diff check passed. No benchmark was launched and no output changed.

Refs #1585.