### PR TITLE
research(adamo): freeze matched-development plan (#1560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `asi-adamo-matched-development`, a prospectively frozen and initially
-  execution-disabled four-seed AdamO development plan. It binds a pre-materialized
-  MNIST input, fresh seeds, current package/lock/runtime identity, exact paired
-  Student-t arithmetic, Jacobian/isometry diagnostics, resource deltas, immutable
-  publication, and permanently nonpromoting outcome policy. It contains no run or
-  result; execution requires a separate reviewed authorization change.
+  execution-disabled four-seed AdamO development plan. It binds the canonical
+  OpenML-v1 MNIST materialization, fresh seeds, current package/lock/runtime identity,
+  exact paired Student-t arithmetic, Jacobian/isometry diagnostics, resource deltas,
+  immutable publication, and permanently nonpromoting outcome policy. It contains no
+  run or result; execution requires a separate reviewed authorization change.
 - Added the unfrozen `preview1` reference-agent transaction ledger, primitive
   Prototype adapter, aggregate SwitchingTwoState/RiverSwim life runner, and
   development-only quiescent checkpoint codec. These L0 mechanisms enforce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `asi-adamo-matched-development`, a prospectively frozen and initially
-  execution-disabled four-seed AdamO development plan. It binds the canonical
-  OpenML-v1 MNIST materialization, fresh seeds, current package/lock/runtime identity,
-  exact paired Student-t arithmetic, Jacobian/isometry diagnostics, resource deltas,
-  immutable publication, and permanently nonpromoting outcome policy. It contains no
-  run or result; execution requires a separate reviewed authorization change.
+  execution-disabled four-seed AdamO development plan. It binds the canonical OpenML MNIST
+  materialization, fresh seeds, current package/lock/runtime identity,
+  offline pinned-runtime validation, exact paired
+  Student-t arithmetic, Jacobian/isometry diagnostics, resource deltas, immutable
+  publication, and permanently nonpromoting outcome policy. It contains no run or
+  result; execution requires a separate reviewed authorization change.
 - Added the unfrozen `preview1` reference-agent transaction ledger, primitive
   Prototype adapter, aggregate SwitchingTwoState/RiverSwim life runner, and
   development-only quiescent checkpoint codec. These L0 mechanisms enforce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `asi-adamo-matched-development`, a prospectively frozen and initially
+  execution-disabled four-seed AdamO development plan. It binds a pre-materialized
+  MNIST input, fresh seeds, current package/lock/runtime identity, exact paired
+  Student-t arithmetic, Jacobian/isometry diagnostics, resource deltas, immutable
+  publication, and permanently nonpromoting outcome policy. It contains no run or
+  result; execution requires a separate reviewed authorization change.
 - Added the unfrozen `preview1` reference-agent transaction ledger, primitive
   Prototype adapter, aggregate SwitchingTwoState/RiverSwim life runner, and
   development-only quiescent checkpoint codec. These L0 mechanisms enforce

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ The console scripts are grouped by responsibility; every command supports `--hel
 |---|---|
 | `alberta-step1-smoke`, `alberta-step2-smoke` | Nonpromoting mechanism smoke checks |
 | `asi-native-supervised-catalog`, `asi-plasticity-diagnostic` | Inspect or run bounded, permanently nonpromoting supervised diagnostics |
-| `asi-adamo-diagnostic` | Catalog or run the bounded, permanently nonpromoting AdamO dynamical-isometry comparator |
+| `asi-adamo-diagnostic`, `asi-adamo-matched-development` | Inspect the AdamO comparator or its prospectively frozen, execution-disabled matched-development plan |
 | `asi-clear-qualification` | Verify local CLEAR archive identities and emit a permanently nonpromoting matched setup plan |
 | `asi-coom-qualification-smoke` | Inspect or run the bounded, synthetic, permanently nonpromoting COOM qualification smoke |
 | `asi-cora-catalog` | Inspect the blocked CORA qualification catalog without importing external runtimes |

--- a/alberta_framework/benchmarks/adamo_diagnostic.py
+++ b/alberta_framework/benchmarks/adamo_diagnostic.py
@@ -192,9 +192,7 @@ def _arm_payload(
 def run_adamo_diagnostic(
     inputs: np.ndarray, labels: np.ndarray, *, profile: str, seed: int,
 ) -> dict[str, object]:
-    """Run only the consumed contract-smoke qualification surface."""
-    if type(profile) is not str or profile != "contract-smoke":
-        raise ValueError("public AdamO diagnostics are restricted to contract-smoke")
+    """Run a public diagnostic with the already-consumed qualification schedule."""
     return _run_adamo_diagnostic_schedule(
         inputs,
         labels,
@@ -680,7 +678,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--catalog", action="store_true")
     parser.add_argument("--dataset", type=Path)
-    parser.add_argument("--profile", choices=("contract-smoke",), default="contract-smoke")
+    parser.add_argument("--profile", choices=tuple(PROFILES), default="contract-smoke")
     parser.add_argument("--seed", type=int)
     args = parser.parse_args(argv)
     if args.catalog:
@@ -689,7 +687,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(json.dumps({
             "schema": SCHEMA, "paper_revision": ADAMO_PAPER_REVISION,
             "official_code": None,
-            "profiles": {"contract-smoke": asdict(PROFILES["contract-smoke"].config)},
+            "profiles": {name: asdict(value.config) for name, value in PROFILES.items()},
             "arms": list(ARMS), "frozen_development_seeds": list(FROZEN_DEVELOPMENT_SEEDS),
             "development_only": True, "negative_outcomes_retained": True,
             "scientific_promotion_allowed": False,
@@ -698,6 +696,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.dataset is None:
         parser.error("--dataset is required unless --catalog is used")
     seed = FROZEN_DEVELOPMENT_SEEDS[0] if args.seed is None else args.seed
+    if seed not in FROZEN_DEVELOPMENT_SEEDS:
+        parser.error("--seed must name one consumed public diagnostic seed")
     inputs, labels = _load_dataset(args.dataset)
     print(json.dumps(run_adamo_diagnostic(inputs, labels, profile=args.profile, seed=seed),
                      sort_keys=True, separators=(",", ":")))

--- a/alberta_framework/benchmarks/adamo_diagnostic.py
+++ b/alberta_framework/benchmarks/adamo_diagnostic.py
@@ -28,26 +28,21 @@ from jax import Array
 from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.benchmarks.ipmnist_screening import (
     ScreeningRunResult,
+    _array_bundle_sha256,
     run_screening_config,
     screening_spec,
 )
 from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig, mlp_logits
 from alberta_framework.core.adamo import ADAMO_PAPER_REVISION, gram_working_bytes
 
-SCHEMA = "asi.adamo_dynamical_isometry_diagnostic.v1"
+SCHEMA = "asi.adamo_dynamical_isometry_diagnostic.v2"
 COMPARISON_ID = "adamo-arxiv-2606.09762v1-ipmnist-adapter-v1"
 PAPER_URL = "https://arxiv.org/abs/2606.09762v1"
 OFFICIAL_CODE = None
 OFFICIAL_CODE_SEARCH_DATE = "2026-08-17"
 ARMS = ("adamw_control", "adamo_inert", "adamo_l1e3", "adam_iso_joint_l1e3")
-# Preserve the original executable-qualification schedule as a compatibility and
-# provenance interface. The matched campaign owns a distinct prospective schedule.
 FROZEN_DEVELOPMENT_SEEDS = (15600, 15601, 15602, 15603)
-ADAMO_MATCHED_DEVELOPMENT_SEEDS = (25600, 25601, 25602, 25603)
-_ALLOWED_SEED_SCHEDULES = (
-    FROZEN_DEVELOPMENT_SEEDS,
-    ADAMO_MATCHED_DEVELOPMENT_SEEDS,
-)
+FROZEN_MATCHED_DEVELOPMENT_SEEDS = (9156001, 9156002, 9156003, 9156004)
 _MAX_DATASET_BYTES = 256 * 1024 * 1024
 _HEX = frozenset("0123456789abcdef")
 _MAX_RECEIPT_NODES = 100_000
@@ -191,43 +186,19 @@ def _arm_payload(
 
 
 def run_adamo_diagnostic(
-    inputs: np.ndarray,
-    labels: np.ndarray,
-    *,
-    profile: str,
-    seed: int,
+    inputs: np.ndarray, labels: np.ndarray, *, profile: str, seed: int,
 ) -> dict[str, object]:
-    """Run the public, qualification-consumed AdamO diagnostic schedule."""
-    return _run_adamo_diagnostic_schedule(
-        inputs,
-        labels,
-        profile=profile,
-        seed=seed,
-        seed_schedule=FROZEN_DEVELOPMENT_SEEDS,
-    )
-
-
-def _run_adamo_diagnostic_schedule(
-    inputs: np.ndarray,
-    labels: np.ndarray,
-    *,
-    profile: str,
-    seed: int,
-    seed_schedule: tuple[int, ...],
-) -> dict[str, object]:
-    """Run all four arms under one exact registered seed schedule."""
+    """Run all four matched arms through the current IPMNIST screening runner."""
     if type(profile) is not str or profile not in PROFILES:
         raise ValueError("profile must name one registered AdamO diagnostic profile")
-    if (
-        type(seed_schedule) is not tuple
-        or len(seed_schedule) != len(FROZEN_DEVELOPMENT_SEEDS)
-        or any(type(value) is not int for value in seed_schedule)
-        or seed_schedule not in _ALLOWED_SEED_SCHEDULES
-    ):
-        raise ValueError("seed_schedule is not an exact registered AdamO schedule")
     resolved_seed = require_jax_seed(seed, name="seed")
-    if resolved_seed not in seed_schedule:
-        raise ValueError("seed is not in the frozen, consumed development schedule")
+    frozen_seeds = (
+        FROZEN_DEVELOPMENT_SEEDS
+        if profile == "contract-smoke"
+        else FROZEN_MATCHED_DEVELOPMENT_SEEDS
+    )
+    if resolved_seed not in frozen_seeds:
+        raise ValueError("seed is not in the frozen development schedule for this profile")
     if type(inputs) is not np.ndarray or type(labels) is not np.ndarray:
         raise TypeError("inputs and labels must be exact numpy arrays")
     config = PROFILES[profile].config
@@ -279,10 +250,16 @@ def _run_adamo_diagnostic_schedule(
         "official_parity_status": "blocked_no_author_maintained_code_located",
         "profile": profile,
         "seed": resolved_seed,
-        "frozen_development_seeds": list(seed_schedule),
+        "frozen_development_seeds": list(frozen_seeds),
         "config": asdict(config),
         "dataset": {
             "sha256": _sha256_arrays(inputs, labels),
+            "x_sha256": _array_bundle_sha256(
+                "alberta.ipmnist_screening.materialized_x.v1", {"x": inputs}
+            ),
+            "y_sha256": _array_bundle_sha256(
+                "alberta.ipmnist_screening.materialized_y.v1", {"y": labels}
+            ),
             "loaded_numeric_bytes": inputs.nbytes + labels.nbytes,
             "rows": inputs.shape[0],
             "materialization": "caller-supplied-float32-inputs-int32-labels-v1",
@@ -315,7 +292,7 @@ def _run_adamo_diagnostic_schedule(
         "development_only": True,
         "scientific_promotion_allowed": False,
     }
-    return validate_adamo_diagnostic(payload, seed_schedule=seed_schedule)
+    return validate_adamo_diagnostic(payload)
 
 
 def _exact_int(value: object, name: str, *, minimum: int = 0) -> int:
@@ -400,18 +377,11 @@ def _exact_object(
 
 
 def validate_adamo_diagnostic(
-    payload: object,
-    *,
-    seed_schedule: tuple[int, ...] = FROZEN_DEVELOPMENT_SEEDS,
+    payload: object, *, require_current_identity: bool = True
 ) -> dict[str, object]:
     """Fail closed on malformed, drifted, promoting, or unmatched receipts."""
-    if (
-        type(seed_schedule) is not tuple
-        or len(seed_schedule) != len(FROZEN_DEVELOPMENT_SEEDS)
-        or any(type(value) is not int for value in seed_schedule)
-        or seed_schedule not in _ALLOWED_SEED_SCHEDULES
-    ):
-        raise ValueError("seed_schedule is not an exact registered AdamO schedule")
+    if type(require_current_identity) is not bool:
+        raise ValueError("require_current_identity must be an exact bool")
     if type(payload) is not dict:
         raise TypeError("payload must be an exact dict")
     result = cast(dict[str, object], _bounded_exact_json(payload))
@@ -423,7 +393,7 @@ def validate_adamo_diagnostic(
         "negative_outcomes_retained", "scientific_promotion_allowed",
     }
     if frozenset(result) != required:
-        raise ValueError("payload fields do not match the AdamO v1 schema")
+        raise ValueError("payload fields do not match the AdamO v2 schema")
     constants = {
         "schema": SCHEMA, "comparison_id": COMPARISON_ID,
         "paper_revision": ADAMO_PAPER_REVISION, "paper_url": PAPER_URL,
@@ -440,14 +410,19 @@ def validate_adamo_diagnostic(
     if type(profile) is not str or profile not in PROFILES:
         raise ValueError("unknown profile")
     seed = _exact_int(result["seed"], "seed")
-    if seed not in seed_schedule:
+    expected_seeds = (
+        FROZEN_DEVELOPMENT_SEEDS
+        if profile == "contract-smoke"
+        else FROZEN_MATCHED_DEVELOPMENT_SEEDS
+    )
+    if seed not in expected_seeds:
         raise ValueError("seed is outside the frozen development schedule")
     frozen_seeds = result["frozen_development_seeds"]
     if (
         type(frozen_seeds) is not list
-        or len(frozen_seeds) != len(seed_schedule)
+        or len(frozen_seeds) != len(expected_seeds)
         or any(type(value) is not int for value in frozen_seeds)
-        or tuple(frozen_seeds) != seed_schedule
+        or tuple(frozen_seeds) != expected_seeds
     ):
         raise ValueError("frozen seed schedule drift")
     config = PROFILES[profile].config
@@ -462,10 +437,14 @@ def validate_adamo_diagnostic(
         raise ValueError("profile configuration drift")
     dataset = _exact_object(
         result["dataset"],
-        frozenset({"sha256", "loaded_numeric_bytes", "rows", "materialization"}),
+        frozenset(
+            {"sha256", "x_sha256", "y_sha256", "loaded_numeric_bytes", "rows", "materialization"}
+        ),
         context="dataset receipt",
     )
     _digest(dataset["sha256"], "dataset.sha256")
+    _digest(dataset["x_sha256"], "dataset.x_sha256")
+    _digest(dataset["y_sha256"], "dataset.y_sha256")
     loaded_bytes = _exact_int(dataset["loaded_numeric_bytes"], "loaded_numeric_bytes", minimum=1)
     rows = _exact_int(dataset["rows"], "rows", minimum=config.task_length)
     if loaded_bytes != rows * (config.input_dim * 4 + 4) or loaded_bytes > _MAX_DATASET_BYTES:
@@ -493,25 +472,27 @@ def validate_adamo_diagnostic(
     runtime = result["runtime"]
     if type(runtime) is not dict or frozenset(runtime) != {"python", "jax", "numpy", "backend"}:
         raise ValueError("invalid runtime identity")
-    expected_runtime = {
-        "python": platform.python_version(),
-        "jax": jax.__version__,
-        "numpy": np.__version__,
-        "backend": jax.default_backend(),
-    }
-    if (
-        any(type(runtime[key]) is not str for key in expected_runtime)
-        or runtime != expected_runtime
-    ):
-        raise ValueError("runtime identity does not match the current runtime")
+    if any(type(value) is not str or not value for value in runtime.values()):
+        raise ValueError("runtime identity values must be nonempty exact strings")
+    if require_current_identity:
+        expected_runtime = {
+            "python": platform.python_version(),
+            "jax": jax.__version__,
+            "numpy": np.__version__,
+            "backend": jax.default_backend(),
+        }
+        if runtime != expected_runtime:
+            raise ValueError("runtime identity does not match the current runtime")
     sources = result["source"]
     if type(sources) is not dict or frozenset(sources) != {"adapter_sha256", "runner_sha256"}:
         raise ValueError("invalid source receipt")
     _digest(sources["adapter_sha256"], "adapter_sha256")
     _digest(sources["runner_sha256"], "runner_sha256")
-    if sources["adapter_sha256"] != _source_sha256(Path(__file__)) or sources[
-        "runner_sha256"
-    ] != _source_sha256(Path(__file__).with_name("ipmnist_screening.py")):
+    if require_current_identity and (
+        sources["adapter_sha256"] != _source_sha256(Path(__file__))
+        or sources["runner_sha256"]
+        != _source_sha256(Path(__file__).with_name("ipmnist_screening.py"))
+    ):
         raise ValueError("source identity does not match the current runner")
     arms = result["arms"]
     if type(arms) is not list or len(arms) != len(ARMS):
@@ -647,7 +628,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--catalog", action="store_true")
     parser.add_argument("--dataset", type=Path)
     parser.add_argument("--profile", choices=tuple(PROFILES), default="contract-smoke")
-    parser.add_argument("--seed", type=int, default=FROZEN_DEVELOPMENT_SEEDS[0])
+    parser.add_argument("--seed", type=int)
     args = parser.parse_args(argv)
     if args.catalog:
         if args.dataset is not None:
@@ -657,14 +638,22 @@ def main(argv: Sequence[str] | None = None) -> int:
             "official_code": None, "profiles": {name: asdict(value.config)
                                                    for name, value in PROFILES.items()},
             "arms": list(ARMS), "frozen_development_seeds": list(FROZEN_DEVELOPMENT_SEEDS),
+            "frozen_matched_development_seeds": list(FROZEN_MATCHED_DEVELOPMENT_SEEDS),
             "development_only": True, "negative_outcomes_retained": True,
             "scientific_promotion_allowed": False,
         }, sort_keys=True))
         return 0
     if args.dataset is None:
         parser.error("--dataset is required unless --catalog is used")
+    seed = args.seed
+    if seed is None:
+        seed = (
+            FROZEN_DEVELOPMENT_SEEDS[0]
+            if args.profile == "contract-smoke"
+            else FROZEN_MATCHED_DEVELOPMENT_SEEDS[0]
+        )
     inputs, labels = _load_dataset(args.dataset)
-    print(json.dumps(run_adamo_diagnostic(inputs, labels, profile=args.profile, seed=args.seed),
+    print(json.dumps(run_adamo_diagnostic(inputs, labels, profile=args.profile, seed=seed),
                      sort_keys=True, separators=(",", ":")))
     return 0
 

--- a/alberta_framework/benchmarks/adamo_diagnostic.py
+++ b/alberta_framework/benchmarks/adamo_diagnostic.py
@@ -46,6 +46,7 @@ FROZEN_MATCHED_DEVELOPMENT_SEEDS = (9156001, 9156002, 9156003, 9156004)
 _ALLOWED_SEED_SCHEDULES = frozenset(
     {FROZEN_DEVELOPMENT_SEEDS, FROZEN_MATCHED_DEVELOPMENT_SEEDS}
 )
+_MATCHED_EXECUTION_CAPABILITY = object()
 _MAX_DATASET_BYTES = 256 * 1024 * 1024
 _HEX = frozenset("0123456789abcdef")
 _MAX_RECEIPT_NODES = 100_000
@@ -191,13 +192,37 @@ def _arm_payload(
 def run_adamo_diagnostic(
     inputs: np.ndarray, labels: np.ndarray, *, profile: str, seed: int,
 ) -> dict[str, object]:
-    """Run the public diagnostic with the already-consumed qualification schedule."""
+    """Run only the consumed contract-smoke qualification surface."""
+    if type(profile) is not str or profile != "contract-smoke":
+        raise ValueError("public AdamO diagnostics are restricted to contract-smoke")
     return _run_adamo_diagnostic_schedule(
         inputs,
         labels,
         profile=profile,
         seed=seed,
         seed_schedule=FROZEN_DEVELOPMENT_SEEDS,
+    )
+
+
+def _run_matched_adamo_diagnostic(
+    inputs: np.ndarray,
+    labels: np.ndarray,
+    *,
+    profile: str,
+    seed: int,
+    capability: object,
+) -> dict[str, object]:
+    """Private matched executor reachable only after the aggregate authorization gate."""
+    if capability is not _MATCHED_EXECUTION_CAPABILITY:
+        raise RuntimeError("matched AdamO execution capability is unavailable")
+    if type(profile) is not str or profile != "bounded-development":
+        raise ValueError("matched AdamO execution requires bounded-development")
+    return _run_adamo_diagnostic_schedule(
+        inputs,
+        labels,
+        profile=profile,
+        seed=seed,
+        seed_schedule=FROZEN_MATCHED_DEVELOPMENT_SEEDS,
     )
 
 
@@ -209,7 +234,7 @@ def _run_adamo_diagnostic_schedule(
     seed: int,
     seed_schedule: tuple[int, ...],
 ) -> dict[str, object]:
-    """Run all four matched arms under one exact registered seed schedule."""
+    """Run all four matched arms through the current IPMNIST screening runner."""
     if type(profile) is not str or profile not in PROFILES:
         raise ValueError("profile must name one registered AdamO diagnostic profile")
     if (
@@ -655,7 +680,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--catalog", action="store_true")
     parser.add_argument("--dataset", type=Path)
-    parser.add_argument("--profile", choices=tuple(PROFILES), default="contract-smoke")
+    parser.add_argument("--profile", choices=("contract-smoke",), default="contract-smoke")
     parser.add_argument("--seed", type=int)
     args = parser.parse_args(argv)
     if args.catalog:
@@ -663,10 +688,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             parser.error("--catalog and --dataset are mutually exclusive")
         print(json.dumps({
             "schema": SCHEMA, "paper_revision": ADAMO_PAPER_REVISION,
-            "official_code": None, "profiles": {name: asdict(value.config)
-                                                   for name, value in PROFILES.items()},
+            "official_code": None,
+            "profiles": {"contract-smoke": asdict(PROFILES["contract-smoke"].config)},
             "arms": list(ARMS), "frozen_development_seeds": list(FROZEN_DEVELOPMENT_SEEDS),
-            "frozen_matched_development_seeds": list(FROZEN_MATCHED_DEVELOPMENT_SEEDS),
             "development_only": True, "negative_outcomes_retained": True,
             "scientific_promotion_allowed": False,
         }, sort_keys=True))

--- a/alberta_framework/benchmarks/adamo_diagnostic.py
+++ b/alberta_framework/benchmarks/adamo_diagnostic.py
@@ -45,6 +45,8 @@ ARMS = ("adamw_control", "adamo_inert", "adamo_l1e3", "adam_iso_joint_l1e3")
 FROZEN_DEVELOPMENT_SEEDS = (25600, 25601, 25602, 25603)
 _MAX_DATASET_BYTES = 256 * 1024 * 1024
 _HEX = frozenset("0123456789abcdef")
+_MAX_RECEIPT_NODES = 100_000
+_MAX_RECEIPT_STRING_BYTES = 2 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -303,11 +305,71 @@ def _digest(value: object, name: str) -> str:
     return value
 
 
+def _bounded_exact_json(value: object) -> object:
+    """Copy bounded built-in JSON values before any semantic operation."""
+    nodes = 0
+    string_bytes = 0
+
+    def visit(item: object, *, depth: int, context: str) -> object:
+        nonlocal nodes, string_bytes
+        nodes += 1
+        if nodes > _MAX_RECEIPT_NODES or depth > 18:
+            raise ValueError("receipt must contain bounded exact JSON")
+        if item is None or type(item) is bool:
+            return item
+        if type(item) is int:
+            if not -(1 << 63) <= item <= (1 << 63) - 1:
+                raise ValueError("receipt integer exceeds signed-int64")
+            return item
+        if type(item) is float:
+            if not math.isfinite(item):
+                raise ValueError("receipt must contain finite exact JSON")
+            return item
+        if type(item) is str:
+            try:
+                encoded = item.encode("utf-8")
+            except UnicodeEncodeError as error:
+                raise ValueError("receipt strings must be valid UTF-8") from error
+            if len(encoded) > 16_384 or b"\0" in encoded:
+                raise ValueError("receipt must contain bounded exact JSON strings")
+            string_bytes += len(encoded)
+            if string_bytes > _MAX_RECEIPT_STRING_BYTES:
+                raise ValueError("receipt exceeds its exact JSON string-byte budget")
+            return item
+        if type(item) is list:
+            if list.__len__(item) > 4096:
+                raise ValueError("receipt exact JSON list exceeds its bound")
+            return [
+                visit(child, depth=depth + 1, context=f"{context}[{index}]")
+                for index, child in enumerate(list.__iter__(item))
+            ]
+        if type(item) is dict:
+            if dict.__len__(item) > 4096:
+                raise ValueError("receipt exact JSON object exceeds its bound")
+            copied: dict[str, object] = {}
+            for key, child in dict.items(item):
+                if type(key) is not str:
+                    raise ValueError("receipt exact JSON keys must be built-in strings")
+                copied[key] = visit(child, depth=depth + 1, context=f"{context}.{key}")
+            return copied
+        raise ValueError(f"{context} must contain only bounded exact JSON values")
+
+    return visit(value, depth=0, context="receipt")
+
+
+def _exact_object(
+    value: object, keys: frozenset[str], *, context: str
+) -> dict[str, object]:
+    if type(value) is not dict or frozenset(value) != keys:
+        raise ValueError(f"{context} fields do not match the exact schema")
+    return cast(dict[str, object], value)
+
+
 def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
     """Fail closed on malformed, drifted, promoting, or unmatched receipts."""
     if type(payload) is not dict:
         raise TypeError("payload must be an exact dict")
-    result = cast(dict[str, object], payload)
+    result = cast(dict[str, object], _bounded_exact_json(payload))
     required = {
         "schema", "comparison_id", "paper_revision", "paper_url", "official_code",
         "official_code_search_date", "official_parity_status", "profile", "seed",
@@ -315,7 +377,7 @@ def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
         "arms", "outcome", "outcome_retained", "development_only",
         "negative_outcomes_retained", "scientific_promotion_allowed",
     }
-    if set(result) != required:
+    if frozenset(result) != required:
         raise ValueError("payload fields do not match the AdamO v1 schema")
     constants = {
         "schema": SCHEMA, "comparison_id": COMPARISON_ID,
@@ -327,7 +389,7 @@ def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
         "development_only": True, "scientific_promotion_allowed": False,
     }
     for key, expected in constants.items():
-        if result[key] != expected or type(result[key]) is not type(expected):
+        if type(result[key]) is not type(expected) or result[key] != expected:
             raise ValueError(f"{key} violates the permanent protocol")
     profile = result["profile"]
     if type(profile) is not str or profile not in PROFILES:
@@ -335,22 +397,39 @@ def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
     seed = _exact_int(result["seed"], "seed")
     if seed not in FROZEN_DEVELOPMENT_SEEDS:
         raise ValueError("seed is outside the frozen development schedule")
-    if result["frozen_development_seeds"] != list(FROZEN_DEVELOPMENT_SEEDS):
+    frozen_seeds = result["frozen_development_seeds"]
+    if (
+        type(frozen_seeds) is not list
+        or len(frozen_seeds) != len(FROZEN_DEVELOPMENT_SEEDS)
+        or any(type(value) is not int for value in frozen_seeds)
+        or tuple(frozen_seeds) != FROZEN_DEVELOPMENT_SEEDS
+    ):
         raise ValueError("frozen seed schedule drift")
     config = PROFILES[profile].config
-    if result["config"] != asdict(config):
+    expected_config = asdict(config)
+    config_receipt = _exact_object(
+        result["config"], frozenset(expected_config), context="profile configuration"
+    )
+    if any(
+        type(config_receipt[key]) is not int or config_receipt[key] != expected
+        for key, expected in expected_config.items()
+    ):
         raise ValueError("profile configuration drift")
-    dataset = result["dataset"]
-    if type(dataset) is not dict or set(dataset) != {
-        "sha256", "loaded_numeric_bytes", "rows", "materialization"
-    }:
-        raise ValueError("invalid dataset receipt")
+    dataset = _exact_object(
+        result["dataset"],
+        frozenset({"sha256", "loaded_numeric_bytes", "rows", "materialization"}),
+        context="dataset receipt",
+    )
     _digest(dataset["sha256"], "dataset.sha256")
     loaded_bytes = _exact_int(dataset["loaded_numeric_bytes"], "loaded_numeric_bytes", minimum=1)
     rows = _exact_int(dataset["rows"], "rows", minimum=config.task_length)
     if loaded_bytes != rows * (config.input_dim * 4 + 4) or loaded_bytes > _MAX_DATASET_BYTES:
         raise ValueError("dataset byte accounting mismatch")
-    if dataset["materialization"] != "caller-supplied-float32-inputs-int32-labels-v1":
+    if (
+        type(dataset["materialization"]) is not str
+        or dataset["materialization"]
+        != "caller-supplied-float32-inputs-int32-labels-v1"
+    ):
         raise ValueError("dataset materialization drift")
     protocol = result["protocol"]
     expected_protocol = {
@@ -367,7 +446,7 @@ def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
     if type(protocol) is not dict or protocol != expected_protocol:
         raise ValueError("protocol identity or information boundary drift")
     runtime = result["runtime"]
-    if type(runtime) is not dict or set(runtime) != {"python", "jax", "numpy", "backend"}:
+    if type(runtime) is not dict or frozenset(runtime) != {"python", "jax", "numpy", "backend"}:
         raise ValueError("invalid runtime identity")
     expected_runtime = {
         "python": platform.python_version(),
@@ -375,10 +454,13 @@ def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
         "numpy": np.__version__,
         "backend": jax.default_backend(),
     }
-    if runtime != expected_runtime:
+    if (
+        any(type(runtime[key]) is not str for key in expected_runtime)
+        or runtime != expected_runtime
+    ):
         raise ValueError("runtime identity does not match the current runtime")
     sources = result["source"]
-    if type(sources) is not dict or set(sources) != {"adapter_sha256", "runner_sha256"}:
+    if type(sources) is not dict or frozenset(sources) != {"adapter_sha256", "runner_sha256"}:
         raise ValueError("invalid source receipt")
     _digest(sources["adapter_sha256"], "adapter_sha256")
     _digest(sources["runner_sha256"], "runner_sha256")
@@ -392,21 +474,32 @@ def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
     observations = config.n_tasks * config.task_length
     parameter_count = _parameter_count(config)
     for expected_name, arm in zip(ARMS, arms, strict=True):
-        if type(arm) is not dict or set(arm) != {
+        if type(arm) is not dict or frozenset(arm) != {
             "arm", "mechanism", "hyperparameters", "per_task_accuracy", "per_task_loss",
             "per_task_plasticity", "post_task_diagnostics", "resources",
-        } or arm.get("arm") != expected_name:
+        } or type(arm.get("arm")) is not str or arm.get("arm") != expected_name:
             raise ValueError("arm ordering or identity drift")
         expected_spec = screening_spec(expected_name)
-        if arm.get("mechanism") != expected_spec.mechanism or arm.get(
-            "hyperparameters"
-        ) != expected_spec.hyperparameters:
+        hyperparameters = arm.get("hyperparameters")
+        if (
+            type(arm.get("mechanism")) is not str
+            or arm.get("mechanism") != expected_spec.mechanism
+            or type(hyperparameters) is not dict
+            or frozenset(hyperparameters) != frozenset(expected_spec.hyperparameters)
+            or any(
+                type(hyperparameters[key]) is not type(expected)
+                or hyperparameters[key] != expected
+                for key, expected in expected_spec.hyperparameters.items()
+            )
+        ):
             raise ValueError("arm mechanism or hyperparameter drift")
         for curve_name in ("per_task_accuracy", "per_task_loss", "per_task_plasticity"):
             curve = arm.get(curve_name)
             if type(curve) is not list or len(curve) != config.n_tasks:
                 raise ValueError(f"{expected_name}.{curve_name} has invalid shape")
             for value in curve:
+                if type(value) is not float:
+                    raise ValueError(f"{expected_name}.{curve_name} must contain exact floats")
                 numeric = _finite(value, f"{expected_name}.{curve_name}")
                 if curve_name != "per_task_loss" and numeric > 1.0:
                     raise ValueError(f"{expected_name}.{curve_name} must lie in [0, 1]")
@@ -414,12 +507,12 @@ def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
         if type(snapshots) is not list or len(snapshots) != config.n_tasks:
             raise ValueError("diagnostic task coverage mismatch")
         for index, snapshot in enumerate(snapshots):
-            if type(snapshot) is not dict or set(snapshot) != {
+            if type(snapshot) is not dict or frozenset(snapshot) != {
                 "task_index", "parameter_sha256", "learner_state_sha256",
                 "jacobian_min_singular_value", "jacobian_max_singular_value",
                 "jacobian_mean_singular_value", "jacobian_condition_number_clipped_1e12",
                 "jacobian_rms_distance_from_one", "weight_gram_penalty",
-            } or snapshot.get("task_index") != index:
+            } or type(snapshot.get("task_index")) is not int or snapshot.get("task_index") != index:
                 raise ValueError("diagnostic task index mismatch")
             _digest(snapshot.get("parameter_sha256"), "parameter_sha256")
             _digest(snapshot.get("learner_state_sha256"), "learner_state_sha256")
@@ -428,9 +521,12 @@ def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
                 "jacobian_mean_singular_value", "jacobian_condition_number_clipped_1e12",
                 "jacobian_rms_distance_from_one", "weight_gram_penalty",
             ):
-                _finite(snapshot.get(metric), metric)
+                metric_value = snapshot.get(metric)
+                if type(metric_value) is not float:
+                    raise ValueError(f"{metric} must be an exact float")
+                _finite(metric_value, metric)
         resources = arm.get("resources")
-        if type(resources) is not dict or set(resources) != {
+        if type(resources) is not dict or frozenset(resources) != {
             "observations", "updates", "data_steps", "environment_steps", "model_queries",
             "jacobian_reverse_rows", "parameter_count", "persistent_numeric_bytes",
             "peak_gram_working_bytes", "logical_compute_units", "logical_compute_definition",
@@ -466,6 +562,8 @@ def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
             "jacobian_reverse_rows*parameters + active Gram matrix multiply-adds"
         ):
             raise ValueError("logical compute definition drift")
+        if type(resources.get("timing_seconds")) is not float:
+            raise ValueError("timing_seconds must be an exact float")
         _finite(resources.get("timing_seconds"), "timing_seconds")
         if resources.get("timing_is_telemetry_only") is not True:
             raise ValueError("timing may only be telemetry")

--- a/alberta_framework/benchmarks/adamo_diagnostic.py
+++ b/alberta_framework/benchmarks/adamo_diagnostic.py
@@ -212,7 +212,7 @@ def _run_matched_adamo_diagnostic(
     seed: int,
     capability: object,
 ) -> dict[str, object]:
-    """Private matched executor reachable only after the aggregate authorization gate."""
+    """Internal matched executor requiring the aggregate's exact capability token."""
     if capability is not _MATCHED_EXECUTION_CAPABILITY:
         raise RuntimeError("matched AdamO execution capability is unavailable")
     if type(profile) is not str or profile != "bounded-development":

--- a/alberta_framework/benchmarks/adamo_diagnostic.py
+++ b/alberta_framework/benchmarks/adamo_diagnostic.py
@@ -40,9 +40,10 @@ PAPER_URL = "https://arxiv.org/abs/2606.09762v1"
 OFFICIAL_CODE = None
 OFFICIAL_CODE_SEARCH_DATE = "2026-08-17"
 ARMS = ("adamw_control", "adamo_inert", "adamo_l1e3", "adam_iso_joint_l1e3")
-# The original 15600-15603 schedule was consumed by executable qualification.
-# The matched campaign prospectively reserves a disjoint schedule.
-FROZEN_DEVELOPMENT_SEEDS = (25600, 25601, 25602, 25603)
+# Preserve the original executable-qualification schedule as a compatibility and
+# provenance interface. The matched campaign owns a distinct prospective schedule.
+FROZEN_DEVELOPMENT_SEEDS = (15600, 15601, 15602, 15603)
+ADAMO_MATCHED_DEVELOPMENT_SEEDS = (25600, 25601, 25602, 25603)
 _MAX_DATASET_BYTES = 256 * 1024 * 1024
 _HEX = frozenset("0123456789abcdef")
 _MAX_RECEIPT_NODES = 100_000
@@ -192,8 +193,14 @@ def run_adamo_diagnostic(
     if type(profile) is not str or profile not in PROFILES:
         raise ValueError("profile must name one registered AdamO diagnostic profile")
     resolved_seed = require_jax_seed(seed, name="seed")
-    if resolved_seed not in FROZEN_DEVELOPMENT_SEEDS:
-        raise ValueError("seed is not in the frozen, consumed development schedule")
+    allowed_seeds = FROZEN_DEVELOPMENT_SEEDS + ADAMO_MATCHED_DEVELOPMENT_SEEDS
+    if resolved_seed not in allowed_seeds:
+        raise ValueError("seed is not in a frozen AdamO development schedule")
+    receipt_seeds = (
+        ADAMO_MATCHED_DEVELOPMENT_SEEDS
+        if resolved_seed in ADAMO_MATCHED_DEVELOPMENT_SEEDS
+        else FROZEN_DEVELOPMENT_SEEDS
+    )
     if type(inputs) is not np.ndarray or type(labels) is not np.ndarray:
         raise TypeError("inputs and labels must be exact numpy arrays")
     config = PROFILES[profile].config
@@ -245,7 +252,7 @@ def run_adamo_diagnostic(
         "official_parity_status": "blocked_no_author_maintained_code_located",
         "profile": profile,
         "seed": resolved_seed,
-        "frozen_development_seeds": list(FROZEN_DEVELOPMENT_SEEDS),
+        "frozen_development_seeds": list(receipt_seeds),
         "config": asdict(config),
         "dataset": {
             "sha256": _sha256_arrays(inputs, labels),
@@ -395,14 +402,20 @@ def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
     if type(profile) is not str or profile not in PROFILES:
         raise ValueError("unknown profile")
     seed = _exact_int(result["seed"], "seed")
-    if seed not in FROZEN_DEVELOPMENT_SEEDS:
+    allowed_seeds = FROZEN_DEVELOPMENT_SEEDS + ADAMO_MATCHED_DEVELOPMENT_SEEDS
+    if seed not in allowed_seeds:
         raise ValueError("seed is outside the frozen development schedule")
     frozen_seeds = result["frozen_development_seeds"]
+    expected_seeds = (
+        ADAMO_MATCHED_DEVELOPMENT_SEEDS
+        if seed in ADAMO_MATCHED_DEVELOPMENT_SEEDS
+        else FROZEN_DEVELOPMENT_SEEDS
+    )
     if (
         type(frozen_seeds) is not list
-        or len(frozen_seeds) != len(FROZEN_DEVELOPMENT_SEEDS)
+        or len(frozen_seeds) != len(expected_seeds)
         or any(type(value) is not int for value in frozen_seeds)
-        or tuple(frozen_seeds) != FROZEN_DEVELOPMENT_SEEDS
+        or tuple(frozen_seeds) != expected_seeds
     ):
         raise ValueError("frozen seed schedule drift")
     config = PROFILES[profile].config

--- a/alberta_framework/benchmarks/adamo_diagnostic.py
+++ b/alberta_framework/benchmarks/adamo_diagnostic.py
@@ -43,6 +43,9 @@ OFFICIAL_CODE_SEARCH_DATE = "2026-08-17"
 ARMS = ("adamw_control", "adamo_inert", "adamo_l1e3", "adam_iso_joint_l1e3")
 FROZEN_DEVELOPMENT_SEEDS = (15600, 15601, 15602, 15603)
 FROZEN_MATCHED_DEVELOPMENT_SEEDS = (9156001, 9156002, 9156003, 9156004)
+_ALLOWED_SEED_SCHEDULES = frozenset(
+    {FROZEN_DEVELOPMENT_SEEDS, FROZEN_MATCHED_DEVELOPMENT_SEEDS}
+)
 _MAX_DATASET_BYTES = 256 * 1024 * 1024
 _HEX = frozenset("0123456789abcdef")
 _MAX_RECEIPT_NODES = 100_000
@@ -188,17 +191,37 @@ def _arm_payload(
 def run_adamo_diagnostic(
     inputs: np.ndarray, labels: np.ndarray, *, profile: str, seed: int,
 ) -> dict[str, object]:
-    """Run all four matched arms through the current IPMNIST screening runner."""
+    """Run the public diagnostic with the already-consumed qualification schedule."""
+    return _run_adamo_diagnostic_schedule(
+        inputs,
+        labels,
+        profile=profile,
+        seed=seed,
+        seed_schedule=FROZEN_DEVELOPMENT_SEEDS,
+    )
+
+
+def _run_adamo_diagnostic_schedule(
+    inputs: np.ndarray,
+    labels: np.ndarray,
+    *,
+    profile: str,
+    seed: int,
+    seed_schedule: tuple[int, ...],
+) -> dict[str, object]:
+    """Run all four matched arms under one exact registered seed schedule."""
     if type(profile) is not str or profile not in PROFILES:
         raise ValueError("profile must name one registered AdamO diagnostic profile")
+    if (
+        type(seed_schedule) is not tuple
+        or len(seed_schedule) != len(FROZEN_DEVELOPMENT_SEEDS)
+        or any(type(value) is not int for value in seed_schedule)
+        or seed_schedule not in _ALLOWED_SEED_SCHEDULES
+    ):
+        raise ValueError("seed_schedule is not an exact registered AdamO schedule")
     resolved_seed = require_jax_seed(seed, name="seed")
-    frozen_seeds = (
-        FROZEN_DEVELOPMENT_SEEDS
-        if profile == "contract-smoke"
-        else FROZEN_MATCHED_DEVELOPMENT_SEEDS
-    )
-    if resolved_seed not in frozen_seeds:
-        raise ValueError("seed is not in the frozen development schedule for this profile")
+    if resolved_seed not in seed_schedule:
+        raise ValueError("seed is not in the selected frozen development schedule")
     if type(inputs) is not np.ndarray or type(labels) is not np.ndarray:
         raise TypeError("inputs and labels must be exact numpy arrays")
     config = PROFILES[profile].config
@@ -250,7 +273,7 @@ def run_adamo_diagnostic(
         "official_parity_status": "blocked_no_author_maintained_code_located",
         "profile": profile,
         "seed": resolved_seed,
-        "frozen_development_seeds": list(frozen_seeds),
+        "frozen_development_seeds": list(seed_schedule),
         "config": asdict(config),
         "dataset": {
             "sha256": _sha256_arrays(inputs, labels),
@@ -377,9 +400,19 @@ def _exact_object(
 
 
 def validate_adamo_diagnostic(
-    payload: object, *, require_current_identity: bool = True
+    payload: object,
+    *,
+    seed_schedule: tuple[int, ...] = FROZEN_DEVELOPMENT_SEEDS,
+    require_current_identity: bool = True,
 ) -> dict[str, object]:
     """Fail closed on malformed, drifted, promoting, or unmatched receipts."""
+    if (
+        type(seed_schedule) is not tuple
+        or len(seed_schedule) != len(FROZEN_DEVELOPMENT_SEEDS)
+        or any(type(value) is not int for value in seed_schedule)
+        or seed_schedule not in _ALLOWED_SEED_SCHEDULES
+    ):
+        raise ValueError("seed_schedule is not an exact registered AdamO schedule")
     if type(require_current_identity) is not bool:
         raise ValueError("require_current_identity must be an exact bool")
     if type(payload) is not dict:
@@ -410,19 +443,14 @@ def validate_adamo_diagnostic(
     if type(profile) is not str or profile not in PROFILES:
         raise ValueError("unknown profile")
     seed = _exact_int(result["seed"], "seed")
-    expected_seeds = (
-        FROZEN_DEVELOPMENT_SEEDS
-        if profile == "contract-smoke"
-        else FROZEN_MATCHED_DEVELOPMENT_SEEDS
-    )
-    if seed not in expected_seeds:
+    if seed not in seed_schedule:
         raise ValueError("seed is outside the frozen development schedule")
     frozen_seeds = result["frozen_development_seeds"]
     if (
         type(frozen_seeds) is not list
-        or len(frozen_seeds) != len(expected_seeds)
+        or len(frozen_seeds) != len(seed_schedule)
         or any(type(value) is not int for value in frozen_seeds)
-        or tuple(frozen_seeds) != expected_seeds
+        or tuple(frozen_seeds) != seed_schedule
     ):
         raise ValueError("frozen seed schedule drift")
     config = PROFILES[profile].config
@@ -645,13 +673,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     if args.dataset is None:
         parser.error("--dataset is required unless --catalog is used")
-    seed = args.seed
-    if seed is None:
-        seed = (
-            FROZEN_DEVELOPMENT_SEEDS[0]
-            if args.profile == "contract-smoke"
-            else FROZEN_MATCHED_DEVELOPMENT_SEEDS[0]
-        )
+    seed = FROZEN_DEVELOPMENT_SEEDS[0] if args.seed is None else args.seed
     inputs, labels = _load_dataset(args.dataset)
     print(json.dumps(run_adamo_diagnostic(inputs, labels, profile=args.profile, seed=seed),
                      sort_keys=True, separators=(",", ":")))

--- a/alberta_framework/benchmarks/adamo_diagnostic.py
+++ b/alberta_framework/benchmarks/adamo_diagnostic.py
@@ -40,7 +40,9 @@ PAPER_URL = "https://arxiv.org/abs/2606.09762v1"
 OFFICIAL_CODE = None
 OFFICIAL_CODE_SEARCH_DATE = "2026-08-17"
 ARMS = ("adamw_control", "adamo_inert", "adamo_l1e3", "adam_iso_joint_l1e3")
-FROZEN_DEVELOPMENT_SEEDS = (15600, 15601, 15602, 15603)
+# The original 15600-15603 schedule was consumed by executable qualification.
+# The matched campaign prospectively reserves a disjoint schedule.
+FROZEN_DEVELOPMENT_SEEDS = (25600, 25601, 25602, 25603)
 _MAX_DATASET_BYTES = 256 * 1024 * 1024
 _HEX = frozenset("0123456789abcdef")
 

--- a/alberta_framework/benchmarks/adamo_diagnostic.py
+++ b/alberta_framework/benchmarks/adamo_diagnostic.py
@@ -44,6 +44,10 @@ ARMS = ("adamw_control", "adamo_inert", "adamo_l1e3", "adam_iso_joint_l1e3")
 # provenance interface. The matched campaign owns a distinct prospective schedule.
 FROZEN_DEVELOPMENT_SEEDS = (15600, 15601, 15602, 15603)
 ADAMO_MATCHED_DEVELOPMENT_SEEDS = (25600, 25601, 25602, 25603)
+_ALLOWED_SEED_SCHEDULES = (
+    FROZEN_DEVELOPMENT_SEEDS,
+    ADAMO_MATCHED_DEVELOPMENT_SEEDS,
+)
 _MAX_DATASET_BYTES = 256 * 1024 * 1024
 _HEX = frozenset("0123456789abcdef")
 _MAX_RECEIPT_NODES = 100_000
@@ -187,20 +191,43 @@ def _arm_payload(
 
 
 def run_adamo_diagnostic(
-    inputs: np.ndarray, labels: np.ndarray, *, profile: str, seed: int,
+    inputs: np.ndarray,
+    labels: np.ndarray,
+    *,
+    profile: str,
+    seed: int,
 ) -> dict[str, object]:
-    """Run all four matched arms through the current IPMNIST screening runner."""
+    """Run the public, qualification-consumed AdamO diagnostic schedule."""
+    return _run_adamo_diagnostic_schedule(
+        inputs,
+        labels,
+        profile=profile,
+        seed=seed,
+        seed_schedule=FROZEN_DEVELOPMENT_SEEDS,
+    )
+
+
+def _run_adamo_diagnostic_schedule(
+    inputs: np.ndarray,
+    labels: np.ndarray,
+    *,
+    profile: str,
+    seed: int,
+    seed_schedule: tuple[int, ...],
+) -> dict[str, object]:
+    """Run all four arms under one exact registered seed schedule."""
     if type(profile) is not str or profile not in PROFILES:
         raise ValueError("profile must name one registered AdamO diagnostic profile")
+    if (
+        type(seed_schedule) is not tuple
+        or len(seed_schedule) != len(FROZEN_DEVELOPMENT_SEEDS)
+        or any(type(value) is not int for value in seed_schedule)
+        or seed_schedule not in _ALLOWED_SEED_SCHEDULES
+    ):
+        raise ValueError("seed_schedule is not an exact registered AdamO schedule")
     resolved_seed = require_jax_seed(seed, name="seed")
-    allowed_seeds = FROZEN_DEVELOPMENT_SEEDS + ADAMO_MATCHED_DEVELOPMENT_SEEDS
-    if resolved_seed not in allowed_seeds:
-        raise ValueError("seed is not in a frozen AdamO development schedule")
-    receipt_seeds = (
-        ADAMO_MATCHED_DEVELOPMENT_SEEDS
-        if resolved_seed in ADAMO_MATCHED_DEVELOPMENT_SEEDS
-        else FROZEN_DEVELOPMENT_SEEDS
-    )
+    if resolved_seed not in seed_schedule:
+        raise ValueError("seed is not in the frozen, consumed development schedule")
     if type(inputs) is not np.ndarray or type(labels) is not np.ndarray:
         raise TypeError("inputs and labels must be exact numpy arrays")
     config = PROFILES[profile].config
@@ -252,7 +279,7 @@ def run_adamo_diagnostic(
         "official_parity_status": "blocked_no_author_maintained_code_located",
         "profile": profile,
         "seed": resolved_seed,
-        "frozen_development_seeds": list(receipt_seeds),
+        "frozen_development_seeds": list(seed_schedule),
         "config": asdict(config),
         "dataset": {
             "sha256": _sha256_arrays(inputs, labels),
@@ -288,7 +315,7 @@ def run_adamo_diagnostic(
         "development_only": True,
         "scientific_promotion_allowed": False,
     }
-    return validate_adamo_diagnostic(payload)
+    return validate_adamo_diagnostic(payload, seed_schedule=seed_schedule)
 
 
 def _exact_int(value: object, name: str, *, minimum: int = 0) -> int:
@@ -372,8 +399,19 @@ def _exact_object(
     return cast(dict[str, object], value)
 
 
-def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
+def validate_adamo_diagnostic(
+    payload: object,
+    *,
+    seed_schedule: tuple[int, ...] = FROZEN_DEVELOPMENT_SEEDS,
+) -> dict[str, object]:
     """Fail closed on malformed, drifted, promoting, or unmatched receipts."""
+    if (
+        type(seed_schedule) is not tuple
+        or len(seed_schedule) != len(FROZEN_DEVELOPMENT_SEEDS)
+        or any(type(value) is not int for value in seed_schedule)
+        or seed_schedule not in _ALLOWED_SEED_SCHEDULES
+    ):
+        raise ValueError("seed_schedule is not an exact registered AdamO schedule")
     if type(payload) is not dict:
         raise TypeError("payload must be an exact dict")
     result = cast(dict[str, object], _bounded_exact_json(payload))
@@ -402,20 +440,14 @@ def validate_adamo_diagnostic(payload: object) -> dict[str, object]:
     if type(profile) is not str or profile not in PROFILES:
         raise ValueError("unknown profile")
     seed = _exact_int(result["seed"], "seed")
-    allowed_seeds = FROZEN_DEVELOPMENT_SEEDS + ADAMO_MATCHED_DEVELOPMENT_SEEDS
-    if seed not in allowed_seeds:
+    if seed not in seed_schedule:
         raise ValueError("seed is outside the frozen development schedule")
     frozen_seeds = result["frozen_development_seeds"]
-    expected_seeds = (
-        ADAMO_MATCHED_DEVELOPMENT_SEEDS
-        if seed in ADAMO_MATCHED_DEVELOPMENT_SEEDS
-        else FROZEN_DEVELOPMENT_SEEDS
-    )
     if (
         type(frozen_seeds) is not list
-        or len(frozen_seeds) != len(expected_seeds)
+        or len(frozen_seeds) != len(seed_schedule)
         or any(type(value) is not int for value in frozen_seeds)
-        or tuple(frozen_seeds) != expected_seeds
+        or tuple(frozen_seeds) != seed_schedule
     ):
         raise ValueError("frozen seed schedule drift")
     config = PROFILES[profile].config

--- a/alberta_framework/benchmarks/adamo_matched_development.py
+++ b/alberta_framework/benchmarks/adamo_matched_development.py
@@ -1,7 +1,7 @@
 """Prospectively frozen, permanently nonpromoting AdamO matched screen.
 
-The initial merge keeps execution closed. A separate reviewed authorization
-change must flip ``_EXECUTION_AUTHORIZED`` before the reserved matrix can run.
+Execution is closed until a separate reviewed authorization change flips
+``_EXECUTION_AUTHORIZED`` for the reserved matrix.
 """
 
 from __future__ import annotations
@@ -52,6 +52,12 @@ CONTROL_ARM: Final[str] = "adamw_control"
 CANDIDATE_ARMS: Final[tuple[str, ...]] = ("adamo_l1e3", "adam_iso_joint_l1e3")
 T95_DF3: Final[float] = 3.1824463052837078
 DATASET_NUMERIC_BYTES: Final[int] = 188_400_000
+CANONICAL_X_SHA256: Final[str] = (
+    "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313"
+)
+CANONICAL_Y_SHA256: Final[str] = (
+    "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a"
+)
 _EXECUTION_AUTHORIZED: Final[bool] = False
 _HEX: Final[frozenset[str]] = frozenset("0123456789abcdef")
 _REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
@@ -131,8 +137,18 @@ def frozen_plan() -> dict[str, object]:
                 "row_stop_exclusive": 60000,
             },
             "numeric_bytes": DATASET_NUMERIC_BYTES,
-            "dtypes": ["<f4", "<i4"],
-            "shapes": [[60000, 784], [60000]],
+            "arrays": {
+                "x": {
+                    "dtype": "<f4",
+                    "shape": [60000, 784],
+                    "sha256": CANONICAL_X_SHA256,
+                },
+                "y": {
+                    "dtype": "<i4",
+                    "shape": [60000],
+                    "sha256": CANONICAL_Y_SHA256,
+                },
+            },
             "materialization": (
                 "OpenML mnist_784 v1 rows 0:60000; float32 pixels scaled by "
                 "(x / 255 - 0.5) / 0.5 and int32 labels"
@@ -252,6 +268,24 @@ def _current_source_provenance() -> dict[str, object]:
 
 def _current_runtime_environment() -> dict[str, object]:
     return _screening_runtime_environment()
+
+
+def _validated_canonical_dataset_provenance(
+    value: object, *, context: str
+) -> dict[str, Any]:
+    provenance = _validated_dataset_provenance(value, context=context)
+    x_binding = cast(dict[str, object], provenance["x"])
+    y_binding = cast(dict[str, object], provenance["y"])
+    if (
+        x_binding["sha256"] != CANONICAL_X_SHA256
+        or y_binding["sha256"] != CANONICAL_Y_SHA256
+    ):
+        raise ValueError(
+            f"{context} dataset does not match the frozen canonical OpenML materialization"
+        )
+    return provenance
+
+
 def _validate_plan(value: object) -> dict[str, object]:
     expected = frozen_plan()
     plan = _exact_object(value, frozenset(expected), context="plan")
@@ -380,7 +414,7 @@ def build_report(
             raise ValueError("receipt profile does not match the frozen plan")
         by_seed[seed] = receipt
         ordered.append(receipt)
-    normalized_dataset = _validated_dataset_provenance(
+    normalized_dataset = _validated_canonical_dataset_provenance(
         dataset_provenance, context="AdamO report"
     )
     normalized_source = _validated_source_provenance(
@@ -452,7 +486,7 @@ def validate_report(
     if type(report["schema"]) is not str or report["schema"] != SCHEMA:
         raise ValueError("report schema does not match the frozen protocol")
     _validate_plan(report["plan"])
-    dataset_provenance = _validated_dataset_provenance(
+    dataset_provenance = _validated_canonical_dataset_provenance(
         report["dataset_provenance"], context="AdamO report"
     )
     source = _validated_source_provenance(
@@ -728,6 +762,9 @@ def run_campaign(
         runtime_before = _current_runtime_environment()
         inputs, labels = load_mnist_train(data_home)
         dataset_before = _screening_dataset_provenance(inputs, labels)
+        _validated_canonical_dataset_provenance(
+            dataset_before, context="AdamO execution"
+        )
         receipts = [
             _run_matched_adamo_diagnostic(
                 inputs,

--- a/alberta_framework/benchmarks/adamo_matched_development.py
+++ b/alberta_framework/benchmarks/adamo_matched_development.py
@@ -18,13 +18,14 @@ from pathlib import Path
 from typing import Any, Final, cast
 
 from alberta_framework.benchmarks.adamo_diagnostic import (
+    _MATCHED_EXECUTION_CAPABILITY,
     ARMS,
     COMPARISON_ID,
     FROZEN_MATCHED_DEVELOPMENT_SEEDS,
     OFFICIAL_CODE,
     OFFICIAL_CODE_SEARCH_DATE,
     PAPER_URL,
-    _run_adamo_diagnostic_schedule,
+    _run_matched_adamo_diagnostic,
     validate_adamo_diagnostic,
 )
 from alberta_framework.benchmarks.ipmnist_screening import (
@@ -728,8 +729,12 @@ def run_campaign(
         inputs, labels = load_mnist_train(data_home)
         dataset_before = _screening_dataset_provenance(inputs, labels)
         receipts = [
-            _run_adamo_diagnostic_schedule(
-                inputs, labels, profile=PROFILE, seed=seed, seed_schedule=SEEDS
+            _run_matched_adamo_diagnostic(
+                inputs,
+                labels,
+                profile=PROFILE,
+                seed=seed,
+                capability=_MATCHED_EXECUTION_CAPABILITY,
             )
             for seed in SEEDS
         ]

--- a/alberta_framework/benchmarks/adamo_matched_development.py
+++ b/alberta_framework/benchmarks/adamo_matched_development.py
@@ -7,9 +7,13 @@ change must flip ``_EXECUTION_AUTHORIZED`` before the reserved matrix can run.
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import hashlib
 import json
 import math
+import os
+import secrets
+import stat
 import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -26,7 +30,6 @@ from alberta_framework.benchmarks.ipmnist_screening import (
     _screening_runtime_environment,
     _screening_source_provenance,
 )
-from alberta_framework.benchmarks.upgd_ipmnist import atomic_write_new_json
 
 SCHEMA: Final[str] = "asi.adamo-matched-development.report.v1"
 PLAN_ID: Final[str] = "issue-1560-adamo-bounded-development-v1"
@@ -49,6 +52,14 @@ _REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
 OUTPUT_PATH: Final[Path] = _REPO_ROOT / "outputs/adamo_matched_development/report.v1.json"
 _MAX_JSON_NODES: Final[int] = 100_000
 _MAX_JSON_STRING_BYTES: Final[int] = 2 * 1024 * 1024
+_MAX_REPORT_BYTES: Final[int] = 32 * 1024 * 1024
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _OutputReservation:
+    directory_fd: int
+    destination_name: str
+    reservation_name: str
 
 
 def frozen_plan() -> dict[str, object]:
@@ -336,7 +347,9 @@ def build_report(
     execution_source_commit: str,
 ) -> dict[str, object]:
     """Build and strictly validate the complete seed-by-arm campaign report."""
-    if type(receipts) not in {list, tuple} or len(receipts) != len(SEEDS):
+    if (type(receipts) is not list and type(receipts) is not tuple) or len(receipts) != len(
+        SEEDS
+    ):
         raise ValueError("receipts must contain the complete frozen seed schedule")
     by_seed: dict[int, dict[str, object]] = {}
     ordered: list[dict[str, object]] = []
@@ -417,7 +430,7 @@ def validate_report(
         ),
         context="report",
     )
-    if report["schema"] != SCHEMA or type(report["schema"]) is not str:
+    if type(report["schema"]) is not str or report["schema"] != SCHEMA:
         raise ValueError("report schema does not match the frozen protocol")
     _validate_plan(report["plan"])
     file_digest = _digest(report["dataset_file_sha256"], context="dataset file sha256")
@@ -487,14 +500,165 @@ def validate_report(
     return cast(dict[str, object], report)
 
 
-def publish_report(path: Path, report: object) -> Path:
-    """Validate then atomically publish one immutable report generation."""
+def _open_pinned_parent(path: Path) -> int:
+    """Open or create the final directory without following its leaf name."""
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        return os.open(path.parent, flags)
+    except FileNotFoundError:
+        grandparent_fd = os.open(path.parent.parent, flags)
+        try:
+            try:
+                os.mkdir(path.parent.name, mode=0o755, dir_fd=grandparent_fd)
+                os.fsync(grandparent_fd)
+            except FileExistsError:
+                pass
+            return os.open(path.parent.name, flags, dir_fd=grandparent_fd)
+        finally:
+            os.close(grandparent_fd)
+
+
+def _reserve_output(path: Path) -> _OutputReservation:
+    """Acquire an O_EXCL sibling before execution and pin the destination directory."""
     if type(path) is not type(Path()):
         raise ValueError("output path must be an exact pathlib.Path")
     if path.absolute() != OUTPUT_PATH.absolute():
         raise ValueError(f"output path must be the reserved NEW path {OUTPUT_PATH}")
-    validated = validate_report(report, require_current_source=True)
-    return atomic_write_new_json(path, validated)
+    if not path.name or path.name in {".", ".."}:
+        raise ValueError("output path must have one exact destination name")
+    directory_fd = _open_pinned_parent(path)
+    reservation_name = f".{path.name}.reservation"
+    reservation_fd = -1
+    try:
+        reservation_fd = os.open(
+            reservation_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o400,
+            dir_fd=directory_fd,
+        )
+        reservation_bytes = f"reserved:{path.name}\n".encode("ascii")
+        written = os.write(reservation_fd, reservation_bytes)
+        if written != len(reservation_bytes):
+            raise OSError("short write while reserving immutable output")
+        os.fsync(reservation_fd)
+        os.close(reservation_fd)
+        reservation_fd = -1
+        os.fsync(directory_fd)
+        try:
+            os.stat(path.name, dir_fd=directory_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(f"refusing to overwrite immutable output: {path}")
+        return _OutputReservation(directory_fd, path.name, reservation_name)
+    except BaseException:
+        if reservation_fd >= 0:
+            os.close(reservation_fd)
+        try:
+            os.unlink(reservation_name, dir_fd=directory_fd)
+            os.fsync(directory_fd)
+        except FileNotFoundError:
+            pass
+        os.close(directory_fd)
+        raise
+
+
+def _release_reservation(reservation: _OutputReservation) -> None:
+    try:
+        os.unlink(reservation.reservation_name, dir_fd=reservation.directory_fd)
+        os.fsync(reservation.directory_fd)
+    except FileNotFoundError:
+        pass
+    finally:
+        os.close(reservation.directory_fd)
+
+
+def _strict_reread(reservation: _OutputReservation, expected: bytes) -> object:
+    descriptor = os.open(
+        reservation.destination_name,
+        os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        dir_fd=reservation.directory_fd,
+    )
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or not 0 < metadata.st_size <= _MAX_REPORT_BYTES:
+            raise ValueError("published report is not one bounded regular file")
+        chunks: list[bytes] = []
+        remaining = metadata.st_size
+        while remaining:
+            chunk = os.read(descriptor, min(remaining, 1024 * 1024))
+            if not chunk:
+                raise ValueError("published report ended before its signed size")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        if os.read(descriptor, 1):
+            raise ValueError("published report grew during strict reread")
+        actual = b"".join(chunks)
+    finally:
+        os.close(descriptor)
+    if actual != expected:
+        raise ValueError("published report bytes differ from the validated generation")
+    try:
+        parsed = json.loads(actual)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("published report is not strict JSON") from error
+    return _bounded_json(parsed, context="published report")
+
+
+def _publish_reserved(reservation: _OutputReservation, report: dict[str, object]) -> None:
+    encoded = (
+        json.dumps(report, allow_nan=False, ensure_ascii=True, indent=2, sort_keys=True) + "\n"
+    ).encode("ascii")
+    if len(encoded) > _MAX_REPORT_BYTES:
+        raise ValueError("validated report exceeds the immutable publication bound")
+    temporary_name = f".{reservation.destination_name}.{secrets.token_hex(16)}.tmp"
+    temporary_fd = -1
+    try:
+        temporary_fd = os.open(
+            temporary_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o400,
+            dir_fd=reservation.directory_fd,
+        )
+        view = memoryview(encoded)
+        while view:
+            count = os.write(temporary_fd, view)
+            if count <= 0:
+                raise OSError("immutable report write made no progress")
+            view = view[count:]
+        os.fsync(temporary_fd)
+        os.close(temporary_fd)
+        temporary_fd = -1
+        os.link(
+            temporary_name,
+            reservation.destination_name,
+            src_dir_fd=reservation.directory_fd,
+            dst_dir_fd=reservation.directory_fd,
+            follow_symlinks=False,
+        )
+        os.fsync(reservation.directory_fd)
+        reread = _strict_reread(reservation, encoded)
+        if reread != report:
+            raise ValueError("published report semantic reread differs from validation")
+    finally:
+        if temporary_fd >= 0:
+            os.close(temporary_fd)
+        try:
+            os.unlink(temporary_name, dir_fd=reservation.directory_fd)
+            os.fsync(reservation.directory_fd)
+        except FileNotFoundError:
+            pass
+
+
+def publish_report(path: Path, report: object) -> Path:
+    """Reserve, validate, and no-replace publish one immutable generation."""
+    reservation = _reserve_output(path)
+    try:
+        validated = validate_report(report, require_current_source=True)
+        _publish_reserved(reservation, validated)
+    finally:
+        _release_reservation(reservation)
+    return path
 
 
 def _execution_commit() -> str:
@@ -516,25 +680,29 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
         raise ValueError("dataset and output paths must be exact pathlib.Path values")
     if output_path.absolute() != OUTPUT_PATH.absolute():
         raise ValueError(f"output path must be the reserved NEW path {OUTPUT_PATH}")
-    if _sha256_file(dataset_path) != DATASET_FILE_SHA256:
-        raise ValueError("dataset file does not match the prospectively frozen input")
-    source_before = _current_source_provenance()
-    runtime_before = _current_runtime_environment()
-    inputs, labels = _load_dataset(dataset_path)
-    receipts = [
-        run_adamo_diagnostic(inputs, labels, profile=PROFILE, seed=seed) for seed in SEEDS
-    ]
-    if source_before != _current_source_provenance():
-        raise RuntimeError("source identity changed during matched execution")
-    if runtime_before != _current_runtime_environment():
-        raise RuntimeError("runtime identity changed during matched execution")
-    report = build_report(
-        receipts,
-        dataset_file_sha256=_sha256_file(dataset_path),
-        execution_source_commit=_execution_commit(),
-    )
-    publish_report(output_path, report)
-    return report
+    reservation = _reserve_output(output_path)
+    try:
+        if _sha256_file(dataset_path) != DATASET_FILE_SHA256:
+            raise ValueError("dataset file does not match the prospectively frozen input")
+        source_before = _current_source_provenance()
+        runtime_before = _current_runtime_environment()
+        inputs, labels = _load_dataset(dataset_path)
+        receipts = [
+            run_adamo_diagnostic(inputs, labels, profile=PROFILE, seed=seed) for seed in SEEDS
+        ]
+        if source_before != _current_source_provenance():
+            raise RuntimeError("source identity changed during matched execution")
+        if runtime_before != _current_runtime_environment():
+            raise RuntimeError("runtime identity changed during matched execution")
+        report = build_report(
+            receipts,
+            dataset_file_sha256=_sha256_file(dataset_path),
+            execution_source_commit=_execution_commit(),
+        )
+        _publish_reserved(reservation, report)
+        return report
+    finally:
+        _release_reservation(reservation)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/alberta_framework/benchmarks/adamo_matched_development.py
+++ b/alberta_framework/benchmarks/adamo_matched_development.py
@@ -23,7 +23,7 @@ from alberta_framework.benchmarks.adamo_diagnostic import (
     ADAMO_MATCHED_DEVELOPMENT_SEEDS,
     ARMS,
     _load_dataset,
-    run_adamo_diagnostic,
+    _run_adamo_diagnostic_schedule,
     validate_adamo_diagnostic,
 )
 from alberta_framework.benchmarks.ipmnist_screening import (
@@ -42,6 +42,12 @@ CANDIDATE_ARMS: Final[tuple[str, ...]] = ("adamo_l1e3", "adam_iso_joint_l1e3")
 T95_DF3: Final[float] = 3.1824463052837078
 DATASET_SEMANTIC_SHA256: Final[str] = (
     "220e4a97a6d345a9f09bbee8e6ba65e8cc117604428392ae08fed2bd8ea0ab27"
+)
+DATASET_INPUTS_SHA256: Final[str] = (
+    "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313"
+)
+DATASET_LABELS_SHA256: Final[str] = (
+    "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a"
 )
 DATASET_NUMERIC_BYTES: Final[int] = 188_400_000
 _EXECUTION_AUTHORIZED: Final[bool] = False
@@ -121,8 +127,8 @@ def frozen_plan() -> dict[str, object]:
             },
             "materialization_id": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
             "array_sha256": {
-                "inputs": "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313",
-                "labels": "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a",
+                "inputs": DATASET_INPUTS_SHA256,
+                "labels": DATASET_LABELS_SHA256,
             },
             "materialization": (
                 "fetch_openml('mnist_784', version=1, as_frame=False), rows 0:60000; "
@@ -365,7 +371,7 @@ def build_report(
     by_seed: dict[int, dict[str, object]] = {}
     ordered: list[dict[str, object]] = []
     for index, raw_receipt in enumerate(receipts):
-        receipt = validate_adamo_diagnostic(raw_receipt)
+        receipt = validate_adamo_diagnostic(raw_receipt, seed_schedule=SEEDS)
         seed = receipt["seed"]
         if type(seed) is not int or seed != SEEDS[index] or seed in by_seed:
             raise ValueError("receipts must use deterministic frozen seed ordering")
@@ -481,7 +487,7 @@ def validate_report(
         raise ValueError("runs must contain the complete frozen seed schedule")
     by_seed: dict[int, dict[str, object]] = {}
     for index, raw_run in enumerate(runs):
-        run = validate_adamo_diagnostic(raw_run)
+        run = validate_adamo_diagnostic(raw_run, seed_schedule=SEEDS)
         seed = run["seed"]
         if type(seed) is not int or seed != SEEDS[index] or seed in by_seed:
             raise ValueError("runs must use deterministic frozen seed ordering")
@@ -695,11 +701,25 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
         source_before = _current_source_provenance()
         runtime_before = _current_runtime_environment()
         inputs, labels = _load_dataset(dataset_path)
-        _screening_dataset_provenance(inputs, labels)
+        dataset_provenance = _screening_dataset_provenance(inputs, labels)
+        dataset_x = cast(dict[str, object], dataset_provenance["x"])
+        dataset_y = cast(dict[str, object], dataset_provenance["y"])
+        if (
+            dataset_x.get("sha256") != DATASET_INPUTS_SHA256
+            or dataset_y.get("sha256") != DATASET_LABELS_SHA256
+        ):
+            raise ValueError("dataset arrays do not match the prospectively frozen input")
         if _sha256_file(dataset_path) != dataset_file_sha256:
             raise RuntimeError("dataset container changed while it was loaded")
         receipts = [
-            run_adamo_diagnostic(inputs, labels, profile=PROFILE, seed=seed) for seed in SEEDS
+            _run_adamo_diagnostic_schedule(
+                inputs,
+                labels,
+                profile=PROFILE,
+                seed=seed,
+                seed_schedule=SEEDS,
+            )
+            for seed in SEEDS
         ]
         if source_before != _current_source_provenance():
             raise RuntimeError("source identity changed during matched execution")

--- a/alberta_framework/benchmarks/adamo_matched_development.py
+++ b/alberta_framework/benchmarks/adamo_matched_development.py
@@ -20,13 +20,14 @@ from pathlib import Path
 from typing import Any, Final, cast
 
 from alberta_framework.benchmarks.adamo_diagnostic import (
+    ADAMO_MATCHED_DEVELOPMENT_SEEDS,
     ARMS,
-    FROZEN_DEVELOPMENT_SEEDS,
     _load_dataset,
     run_adamo_diagnostic,
     validate_adamo_diagnostic,
 )
 from alberta_framework.benchmarks.ipmnist_screening import (
+    _screening_dataset_provenance,
     _screening_runtime_environment,
     _screening_source_provenance,
 )
@@ -34,18 +35,15 @@ from alberta_framework.benchmarks.ipmnist_screening import (
 SCHEMA: Final[str] = "asi.adamo-matched-development.report.v1"
 PLAN_ID: Final[str] = "issue-1560-adamo-bounded-development-v1"
 PROFILE: Final[str] = "bounded-development"
-SEEDS: Final[tuple[int, ...]] = FROZEN_DEVELOPMENT_SEEDS
+SEEDS: Final[tuple[int, ...]] = ADAMO_MATCHED_DEVELOPMENT_SEEDS
 CONSUMED_QUALIFICATION_SEEDS: Final[tuple[int, ...]] = (15600, 15601, 15602, 15603)
 CONTROL_ARM: Final[str] = "adamw_control"
 CANDIDATE_ARMS: Final[tuple[str, ...]] = ("adamo_l1e3", "adam_iso_joint_l1e3")
 T95_DF3: Final[float] = 3.1824463052837078
-DATASET_FILE_SHA256: Final[str] = (
-    "58320c334531afce90c4899ea0c05976c9b9d1c10b7b37e8eb4289cabd0a00ba"
-)
 DATASET_SEMANTIC_SHA256: Final[str] = (
-    "d25060db8f3f3f6ae7b0bb972e848733e15a1158f02021645e86a2923a5ee8a3"
+    "220e4a97a6d345a9f09bbee8e6ba65e8cc117604428392ae08fed2bd8ea0ab27"
 )
-DATASET_NUMERIC_BYTES: Final[int] = 219_800_000
+DATASET_NUMERIC_BYTES: Final[int] = 188_400_000
 _EXECUTION_AUTHORIZED: Final[bool] = False
 _HEX: Final[frozenset[str]] = frozenset("0123456789abcdef")
 _REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
@@ -109,15 +107,28 @@ def frozen_plan() -> dict[str, object]:
         "allowed_task_information": ["current_example_label"],
         "diagnostic_information": ["post_task_boundary_index", "fixed_input_row_0"],
         "dataset": {
-            "file_sha256": DATASET_FILE_SHA256,
             "semantic_sha256": DATASET_SEMANTIC_SHA256,
             "numeric_bytes": DATASET_NUMERIC_BYTES,
             "keys": ["inputs", "labels"],
             "dtypes": ["float32", "int32"],
-            "shapes": [[70000, 784], [70000]],
+            "shapes": [[60000, 784], [60000]],
+            "source": {
+                "provider": "openml",
+                "name": "mnist_784",
+                "version": 1,
+                "row_start": 0,
+                "row_stop_exclusive": 60000,
+            },
+            "materialization_id": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
+            "array_sha256": {
+                "inputs": "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313",
+                "labels": "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a",
+            },
             "materialization": (
-                "caller-frozen MNIST cache x/y copied without numeric conversion into "
-                "compressed NPZ inputs/labels before plan review"
+                "fetch_openml('mnist_784', version=1, as_frame=False), rows 0:60000; "
+                "inputs=np.asarray(data,float32); inputs=(inputs/255-0.5)/0.5; "
+                "labels=np.asarray(target,int32); NPZ transport bytes are recorded but are "
+                "not the semantic dataset identity"
             ),
         },
         "mechanism_off_reduction": "adamo_inert == adamw_control bit-exact",
@@ -397,8 +408,6 @@ def build_report(
             "timing_is_telemetry_only": True,
         },
     }
-    if report["dataset_file_sha256"] != DATASET_FILE_SHA256:
-        raise ValueError("dataset file does not match the prospectively frozen input")
     comparisons = cast(dict[str, object], report["paired_comparisons"])
     primary_comparison = cast(dict[str, object], comparisons["adamo_l1e3"])
     report["development_disposition"] = primary_comparison["outcome"]
@@ -433,9 +442,9 @@ def validate_report(
     if type(report["schema"]) is not str or report["schema"] != SCHEMA:
         raise ValueError("report schema does not match the frozen protocol")
     _validate_plan(report["plan"])
-    file_digest = _digest(report["dataset_file_sha256"], context="dataset file sha256")
+    _digest(report["dataset_file_sha256"], context="dataset file sha256")
     semantic = _digest(report["dataset_semantic_sha256"], context="dataset semantic sha256")
-    if file_digest != DATASET_FILE_SHA256 or semantic != DATASET_SEMANTIC_SHA256:
+    if semantic != DATASET_SEMANTIC_SHA256:
         raise ValueError("report dataset does not match the prospectively frozen input")
     _digest(report["execution_source_commit"], context="execution source commit", length=40)
     source = _bounded_json(report["source_provenance"], context="source provenance")
@@ -682,11 +691,13 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
         raise ValueError(f"output path must be the reserved NEW path {OUTPUT_PATH}")
     reservation = _reserve_output(output_path)
     try:
-        if _sha256_file(dataset_path) != DATASET_FILE_SHA256:
-            raise ValueError("dataset file does not match the prospectively frozen input")
+        dataset_file_sha256 = _sha256_file(dataset_path)
         source_before = _current_source_provenance()
         runtime_before = _current_runtime_environment()
         inputs, labels = _load_dataset(dataset_path)
+        _screening_dataset_provenance(inputs, labels)
+        if _sha256_file(dataset_path) != dataset_file_sha256:
+            raise RuntimeError("dataset container changed while it was loaded")
         receipts = [
             run_adamo_diagnostic(inputs, labels, profile=PROFILE, seed=seed) for seed in SEEDS
         ]
@@ -696,7 +707,7 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
             raise RuntimeError("runtime identity changed during matched execution")
         report = build_report(
             receipts,
-            dataset_file_sha256=_sha256_file(dataset_path),
+            dataset_file_sha256=dataset_file_sha256,
             execution_source_commit=_execution_commit(),
         )
         _publish_reserved(reservation, report)

--- a/alberta_framework/benchmarks/adamo_matched_development.py
+++ b/alberta_framework/benchmarks/adamo_matched_development.py
@@ -8,47 +8,48 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
-import hashlib
 import json
 import math
 import os
 import secrets
 import stat
-import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Final, cast
 
 from alberta_framework.benchmarks.adamo_diagnostic import (
-    ADAMO_MATCHED_DEVELOPMENT_SEEDS,
     ARMS,
-    _load_dataset,
-    _run_adamo_diagnostic_schedule,
+    COMPARISON_ID,
+    FROZEN_MATCHED_DEVELOPMENT_SEEDS,
+    OFFICIAL_CODE,
+    OFFICIAL_CODE_SEARCH_DATE,
+    PAPER_URL,
+    run_adamo_diagnostic,
     validate_adamo_diagnostic,
 )
 from alberta_framework.benchmarks.ipmnist_screening import (
     _screening_dataset_provenance,
     _screening_runtime_environment,
     _screening_source_provenance,
+    _validated_dataset_provenance,
+    _validated_runtime_environment,
+    _validated_source_provenance,
 )
+from alberta_framework.benchmarks.upgd_ipmnist import (
+    default_openml_data_home,
+    load_mnist_train,
+)
+from alberta_framework.core.adamo import ADAMO_PAPER_REVISION
 
 SCHEMA: Final[str] = "asi.adamo-matched-development.report.v1"
 PLAN_ID: Final[str] = "issue-1560-adamo-bounded-development-v1"
 PROFILE: Final[str] = "bounded-development"
-SEEDS: Final[tuple[int, ...]] = ADAMO_MATCHED_DEVELOPMENT_SEEDS
+SEEDS: Final[tuple[int, ...]] = FROZEN_MATCHED_DEVELOPMENT_SEEDS
 CONSUMED_QUALIFICATION_SEEDS: Final[tuple[int, ...]] = (15600, 15601, 15602, 15603)
+QUARANTINED_PREPLAN_SEEDS: Final[tuple[int, ...]] = (25600, 25601, 25602, 25603)
 CONTROL_ARM: Final[str] = "adamw_control"
 CANDIDATE_ARMS: Final[tuple[str, ...]] = ("adamo_l1e3", "adam_iso_joint_l1e3")
 T95_DF3: Final[float] = 3.1824463052837078
-DATASET_SEMANTIC_SHA256: Final[str] = (
-    "220e4a97a6d345a9f09bbee8e6ba65e8cc117604428392ae08fed2bd8ea0ab27"
-)
-DATASET_INPUTS_SHA256: Final[str] = (
-    "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313"
-)
-DATASET_LABELS_SHA256: Final[str] = (
-    "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a"
-)
 DATASET_NUMERIC_BYTES: Final[int] = 188_400_000
 _EXECUTION_AUTHORIZED: Final[bool] = False
 _HEX: Final[frozenset[str]] = frozenset("0123456789abcdef")
@@ -70,15 +71,23 @@ def frozen_plan() -> dict[str, object]:
     """Return the literal plan that must be merged before any execution."""
     return {
         "plan_id": PLAN_ID,
+        "paper_revision": ADAMO_PAPER_REVISION,
+        "paper_url": PAPER_URL,
+        "official_code": OFFICIAL_CODE,
+        "official_code_search_date": OFFICIAL_CODE_SEARCH_DATE,
+        "official_parity_status": "blocked_no_author_maintained_code_located",
+        "comparison_id": COMPARISON_ID,
         "profile": PROFILE,
         "arms": list(ARMS),
         "control_arm": CONTROL_ARM,
         "candidate_arms": list(CANDIDATE_ARMS),
         "seeds": list(SEEDS),
         "consumed_qualification_seeds": list(CONSUMED_QUALIFICATION_SEEDS),
+        "quarantined_preplan_seeds": list(QUARANTINED_PREPLAN_SEEDS),
         "qualification_seed_note": (
             "15600-15603 were exercised by contract qualification and are excluded from "
-            "the retained matched matrix"
+            "the retained matched matrix; the exposed 25600-25603 preplan roster is also "
+            "quarantined because 25600 was exercised by an earlier test fixture"
         ),
         "primary_metric": "mean_online_accuracy",
         "selection_arm": "adamo_l1e3",
@@ -113,11 +122,6 @@ def frozen_plan() -> dict[str, object]:
         "allowed_task_information": ["current_example_label"],
         "diagnostic_information": ["post_task_boundary_index", "fixed_input_row_0"],
         "dataset": {
-            "semantic_sha256": DATASET_SEMANTIC_SHA256,
-            "numeric_bytes": DATASET_NUMERIC_BYTES,
-            "keys": ["inputs", "labels"],
-            "dtypes": ["float32", "int32"],
-            "shapes": [[60000, 784], [60000]],
             "source": {
                 "provider": "openml",
                 "name": "mnist_784",
@@ -125,18 +129,21 @@ def frozen_plan() -> dict[str, object]:
                 "row_start": 0,
                 "row_stop_exclusive": 60000,
             },
-            "materialization_id": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
-            "array_sha256": {
-                "inputs": DATASET_INPUTS_SHA256,
-                "labels": DATASET_LABELS_SHA256,
-            },
+            "numeric_bytes": DATASET_NUMERIC_BYTES,
+            "dtypes": ["<f4", "<i4"],
+            "shapes": [[60000, 784], [60000]],
             "materialization": (
-                "fetch_openml('mnist_784', version=1, as_frame=False), rows 0:60000; "
-                "inputs=np.asarray(data,float32); inputs=(inputs/255-0.5)/0.5; "
-                "labels=np.asarray(target,int32); NPZ transport bytes are recorded but are "
-                "not the semantic dataset identity"
+                "OpenML mnist_784 v1 rows 0:60000; float32 pixels scaled by "
+                "(x / 255 - 0.5) / 0.5 and int32 labels"
             ),
         },
+        "paper_protocol_differences": [
+            "IPMNIST adaptation, not reproduction of a paper task",
+            "784-300-150-10 ReLU MLP instead of the paper depth-4 width-512 MLP",
+            "existing protocol initialization instead of paper orthogonal initialization",
+            "eight tasks of 64 updates instead of a paper training horizon",
+            "no convolutional, RL, transformer, GroupSort, Newton-Schulz, NTK, or rank protocol",
+        ],
         "mechanism_off_reduction": "adamo_inert == adamw_control bit-exact",
         "resource_policy": (
             "observations, updates, data/environment steps, model queries, Jacobian rows, "
@@ -238,22 +245,12 @@ def _bounded_json(value: object, *, context: str) -> object:
     return visit(value, depth=0, label=context)
 
 
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        while chunk := handle.read(1024 * 1024):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
 def _current_source_provenance() -> dict[str, object]:
     return _screening_source_provenance(_REPO_ROOT)
 
 
 def _current_runtime_environment() -> dict[str, object]:
     return _screening_runtime_environment()
-
-
 def _validate_plan(value: object) -> dict[str, object]:
     expected = frozen_plan()
     plan = _exact_object(value, frozenset(expected), context="plan")
@@ -360,8 +357,9 @@ def _paired_comparison(
 def build_report(
     receipts: Sequence[dict[str, object]],
     *,
-    dataset_file_sha256: str,
-    execution_source_commit: str,
+    dataset_provenance: Mapping[str, object],
+    source_provenance: Mapping[str, object],
+    runtime_environment: Mapping[str, object],
 ) -> dict[str, object]:
     """Build and strictly validate the complete seed-by-arm campaign report."""
     if (type(receipts) is not list and type(receipts) is not tuple) or len(receipts) != len(
@@ -371,7 +369,7 @@ def build_report(
     by_seed: dict[int, dict[str, object]] = {}
     ordered: list[dict[str, object]] = []
     for index, raw_receipt in enumerate(receipts):
-        receipt = validate_adamo_diagnostic(raw_receipt, seed_schedule=SEEDS)
+        receipt = validate_adamo_diagnostic(raw_receipt, require_current_identity=True)
         seed = receipt["seed"]
         if type(seed) is not int or seed != SEEDS[index] or seed in by_seed:
             raise ValueError("receipts must use deterministic frozen seed ordering")
@@ -379,11 +377,19 @@ def build_report(
             raise ValueError("receipt profile does not match the frozen plan")
         by_seed[seed] = receipt
         ordered.append(receipt)
-    semantic_digests = {cast(dict[str, object], item["dataset"])["sha256"] for item in ordered}
-    if len(semantic_digests) != 1:
-        raise ValueError("all receipts must bind one identical semantic dataset")
-    if semantic_digests != {DATASET_SEMANTIC_SHA256}:
-        raise ValueError("receipt semantic dataset does not match the prospectively frozen input")
+    normalized_dataset = _validated_dataset_provenance(
+        dataset_provenance, context="AdamO report"
+    )
+    normalized_source = _validated_source_provenance(
+        source_provenance, context="AdamO report"
+    )
+    normalized_runtime = _validated_runtime_environment(
+        runtime_environment, context="AdamO report"
+    )
+    if normalized_source != _current_source_provenance():
+        raise ValueError("source provenance does not match the current source")
+    if normalized_runtime != _current_runtime_environment():
+        raise ValueError("runtime environment does not match the current runtime")
     source_receipts = [item["source"] for item in ordered]
     runtime_receipts = [item["runtime"] for item in ordered]
     if any(value != source_receipts[0] for value in source_receipts[1:]):
@@ -393,15 +399,9 @@ def build_report(
     report: dict[str, object] = {
         "schema": SCHEMA,
         "plan": frozen_plan(),
-        "dataset_file_sha256": _digest(dataset_file_sha256, context="dataset file sha256"),
-        "dataset_semantic_sha256": _digest(
-            next(iter(semantic_digests)), context="dataset semantic sha256"
-        ),
-        "execution_source_commit": _digest(
-            execution_source_commit, context="execution source commit", length=40
-        ),
-        "source_provenance": _current_source_provenance(),
-        "runtime_environment": _current_runtime_environment(),
+        "dataset_provenance": normalized_dataset,
+        "source_provenance": normalized_source,
+        "runtime_environment": normalized_runtime,
         "runs": ordered,
         "paired_comparisons": {
             candidate: _paired_comparison(by_seed, candidate) for candidate in CANDIDATE_ARMS
@@ -417,24 +417,25 @@ def build_report(
     comparisons = cast(dict[str, object], report["paired_comparisons"])
     primary_comparison = cast(dict[str, object], comparisons["adamo_l1e3"])
     report["development_disposition"] = primary_comparison["outcome"]
-    return validate_report(report, require_current_source=True)
+    return validate_report(report, require_current_execution_identity=True)
 
 
 def validate_report(
-    payload: object, *, require_current_source: bool = True
+    payload: object, *, require_current_execution_identity: bool = False
 ) -> dict[str, object]:
-    """Fail closed over completeness, identities, resources, and paired arithmetic."""
-    if type(require_current_source) is not bool:
-        raise ValueError("require_current_source must be an exact bool")
+    """Validate a retained report offline, optionally requiring this execution identity."""
+    if type(require_current_execution_identity) is not bool:
+        raise ValueError("require_current_execution_identity must be an exact bool")
+    if type(payload) is not dict:
+        raise TypeError("report must be an exact dict")
+    normalized_payload = _bounded_json(payload, context="report")
     report = _exact_object(
-        payload,
+        normalized_payload,
         frozenset(
             {
                 "schema",
                 "plan",
-                "dataset_file_sha256",
-                "dataset_semantic_sha256",
-                "execution_source_commit",
+                "dataset_provenance",
                 "source_provenance",
                 "runtime_environment",
                 "runs",
@@ -448,20 +449,18 @@ def validate_report(
     if type(report["schema"]) is not str or report["schema"] != SCHEMA:
         raise ValueError("report schema does not match the frozen protocol")
     _validate_plan(report["plan"])
-    _digest(report["dataset_file_sha256"], context="dataset file sha256")
-    semantic = _digest(report["dataset_semantic_sha256"], context="dataset semantic sha256")
-    if semantic != DATASET_SEMANTIC_SHA256:
-        raise ValueError("report dataset does not match the prospectively frozen input")
-    _digest(report["execution_source_commit"], context="execution source commit", length=40)
-    source = _bounded_json(report["source_provenance"], context="source provenance")
-    runtime = _bounded_json(report["runtime_environment"], context="runtime environment")
-    if type(source) is not dict or type(runtime) is not dict:
-        raise ValueError("source and runtime identities must be exact objects")
-    if source.get("git_commit") != report["execution_source_commit"]:
-        raise ValueError("execution commit does not match source provenance")
-    if require_current_source and source != _current_source_provenance():
+    dataset_provenance = _validated_dataset_provenance(
+        report["dataset_provenance"], context="AdamO report"
+    )
+    source = _validated_source_provenance(
+        report["source_provenance"], context="AdamO report"
+    )
+    runtime = _validated_runtime_environment(
+        report["runtime_environment"], context="AdamO report"
+    )
+    if require_current_execution_identity and source != _current_source_provenance():
         raise ValueError("report source provenance does not match current source")
-    if require_current_source and runtime != _current_runtime_environment():
+    if require_current_execution_identity and runtime != _current_runtime_environment():
         raise ValueError("report runtime environment does not match the current runtime")
     policy = _exact_object(
         report["policy"],
@@ -486,16 +485,46 @@ def validate_report(
     if type(runs) is not list or len(runs) != len(SEEDS):
         raise ValueError("runs must contain the complete frozen seed schedule")
     by_seed: dict[int, dict[str, object]] = {}
+    run_source_identity: object | None = None
+    combined_dataset_identity: object | None = None
     for index, raw_run in enumerate(runs):
-        run = validate_adamo_diagnostic(raw_run, seed_schedule=SEEDS)
+        run = validate_adamo_diagnostic(
+            raw_run, require_current_identity=require_current_execution_identity
+        )
         seed = run["seed"]
         if type(seed) is not int or seed != SEEDS[index] or seed in by_seed:
             raise ValueError("runs must use deterministic frozen seed ordering")
         if run["profile"] != PROFILE:
             raise ValueError("run profile does not match the frozen plan")
-        dataset = cast(dict[str, object], run["dataset"])
-        if dataset["sha256"] != semantic:
-            raise ValueError("run semantic dataset identity does not match the aggregate")
+        run_dataset = cast(dict[str, object], run["dataset"])
+        x_binding = cast(dict[str, object], dataset_provenance["x"])
+        y_binding = cast(dict[str, object], dataset_provenance["y"])
+        if (
+            run_dataset["x_sha256"] != x_binding["sha256"]
+            or run_dataset["y_sha256"] != y_binding["sha256"]
+            or run_dataset["rows"] != cast(list[int], x_binding["shape"])[0]
+        ):
+            raise ValueError("run dataset identity does not match the aggregate")
+        if combined_dataset_identity is None:
+            combined_dataset_identity = run_dataset["sha256"]
+        elif run_dataset["sha256"] != combined_dataset_identity:
+            raise ValueError("runs do not bind one combined dataset identity")
+        if run_source_identity is None:
+            run_source_identity = run["source"]
+        elif run["source"] != run_source_identity:
+            raise ValueError("runs do not bind one diagnostic source identity")
+        run_runtime = cast(dict[str, object], run["runtime"])
+        python_binding = cast(dict[str, object], runtime["python"])
+        packages = cast(dict[str, object], runtime["packages"])
+        jax_binding = cast(dict[str, object], runtime["jax"])
+        expected_run_runtime = {
+            "python": python_binding["version"],
+            "jax": packages["jax"],
+            "numpy": packages["numpy"],
+            "backend": jax_binding["backend"],
+        }
+        if run_runtime != expected_run_runtime:
+            raise ValueError("run runtime identity does not match the aggregate")
         by_seed[seed] = run
     paired = _exact_object(
         report["paired_comparisons"], frozenset(CANDIDATE_ARMS), context="paired comparisons"
@@ -667,68 +696,47 @@ def _publish_reserved(reservation: _OutputReservation, report: dict[str, object]
 
 def publish_report(path: Path, report: object) -> Path:
     """Reserve, validate, and no-replace publish one immutable generation."""
+    if not _EXECUTION_AUTHORIZED:
+        raise RuntimeError("AdamO matched-development publication is not authorized")
     reservation = _reserve_output(path)
     try:
-        validated = validate_report(report, require_current_source=True)
+        validated = validate_report(report, require_current_execution_identity=True)
         _publish_reserved(reservation, validated)
     finally:
         _release_reservation(reservation)
     return path
 
 
-def _execution_commit() -> str:
-    completed = subprocess.run(
-        ("git", "rev-parse", "HEAD"),
-        cwd=_REPO_ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return _digest(completed.stdout.strip(), context="execution source commit", length=40)
-
-
-def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[str, object]:
+def run_campaign(
+    data_home: Path, output_path: Path = OUTPUT_PATH
+) -> dict[str, object]:
     """Execute exactly once after the separately reviewed authorization change."""
     if not _EXECUTION_AUTHORIZED:
         raise RuntimeError("AdamO matched-development execution is not authorized")
-    if type(dataset_path) is not type(Path()) or type(output_path) is not type(Path()):
-        raise ValueError("dataset and output paths must be exact pathlib.Path values")
+    if type(data_home) is not type(Path()) or type(output_path) is not type(Path()):
+        raise ValueError("data home and output paths must be exact pathlib.Path values")
     if output_path.absolute() != OUTPUT_PATH.absolute():
         raise ValueError(f"output path must be the reserved NEW path {OUTPUT_PATH}")
     reservation = _reserve_output(output_path)
     try:
-        dataset_file_sha256 = _sha256_file(dataset_path)
         source_before = _current_source_provenance()
         runtime_before = _current_runtime_environment()
-        inputs, labels = _load_dataset(dataset_path)
-        dataset_provenance = _screening_dataset_provenance(inputs, labels)
-        dataset_x = cast(dict[str, object], dataset_provenance["x"])
-        dataset_y = cast(dict[str, object], dataset_provenance["y"])
-        if (
-            dataset_x.get("sha256") != DATASET_INPUTS_SHA256
-            or dataset_y.get("sha256") != DATASET_LABELS_SHA256
-        ):
-            raise ValueError("dataset arrays do not match the prospectively frozen input")
-        if _sha256_file(dataset_path) != dataset_file_sha256:
-            raise RuntimeError("dataset container changed while it was loaded")
+        inputs, labels = load_mnist_train(data_home)
+        dataset_before = _screening_dataset_provenance(inputs, labels)
         receipts = [
-            _run_adamo_diagnostic_schedule(
-                inputs,
-                labels,
-                profile=PROFILE,
-                seed=seed,
-                seed_schedule=SEEDS,
-            )
-            for seed in SEEDS
+            run_adamo_diagnostic(inputs, labels, profile=PROFILE, seed=seed) for seed in SEEDS
         ]
         if source_before != _current_source_provenance():
             raise RuntimeError("source identity changed during matched execution")
         if runtime_before != _current_runtime_environment():
             raise RuntimeError("runtime identity changed during matched execution")
+        if dataset_before != _screening_dataset_provenance(inputs, labels):
+            raise RuntimeError("dataset identity changed during matched execution")
         report = build_report(
             receipts,
-            dataset_file_sha256=dataset_file_sha256,
-            execution_source_commit=_execution_commit(),
+            dataset_provenance=dataset_before,
+            source_provenance=source_before,
+            runtime_environment=runtime_before,
         )
         _publish_reserved(reservation, report)
         return report
@@ -739,17 +747,12 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--catalog", action="store_true")
-    parser.add_argument("--dataset", type=Path)
-    parser.add_argument("--output", type=Path, default=OUTPUT_PATH)
+    parser.add_argument("--data-home", type=Path, default=default_openml_data_home())
     args = parser.parse_args(argv)
     if args.catalog:
-        if args.dataset is not None:
-            parser.error("--catalog and --dataset are mutually exclusive")
         print(json.dumps(frozen_plan(), sort_keys=True))
         return 0
-    if args.dataset is None:
-        parser.error("--dataset is required unless --catalog is used")
-    run_campaign(args.dataset, args.output)
+    run_campaign(args.data_home)
     return 0
 
 

--- a/alberta_framework/benchmarks/adamo_matched_development.py
+++ b/alberta_framework/benchmarks/adamo_matched_development.py
@@ -1,0 +1,558 @@
+"""Prospectively frozen, permanently nonpromoting AdamO matched screen.
+
+The initial merge keeps execution closed. A separate reviewed authorization
+change must flip ``_EXECUTION_AUTHORIZED`` before the reserved matrix can run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, cast
+
+from alberta_framework.benchmarks.adamo_diagnostic import (
+    ARMS,
+    FROZEN_DEVELOPMENT_SEEDS,
+    _load_dataset,
+    run_adamo_diagnostic,
+    validate_adamo_diagnostic,
+)
+from alberta_framework.benchmarks.ipmnist_screening import (
+    _screening_runtime_environment,
+    _screening_source_provenance,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import atomic_write_new_json
+
+SCHEMA: Final[str] = "asi.adamo-matched-development.report.v1"
+PLAN_ID: Final[str] = "issue-1560-adamo-bounded-development-v1"
+PROFILE: Final[str] = "bounded-development"
+SEEDS: Final[tuple[int, ...]] = FROZEN_DEVELOPMENT_SEEDS
+CONSUMED_QUALIFICATION_SEEDS: Final[tuple[int, ...]] = (15600, 15601, 15602, 15603)
+CONTROL_ARM: Final[str] = "adamw_control"
+CANDIDATE_ARMS: Final[tuple[str, ...]] = ("adamo_l1e3", "adam_iso_joint_l1e3")
+T95_DF3: Final[float] = 3.1824463052837078
+DATASET_FILE_SHA256: Final[str] = (
+    "58320c334531afce90c4899ea0c05976c9b9d1c10b7b37e8eb4289cabd0a00ba"
+)
+DATASET_SEMANTIC_SHA256: Final[str] = (
+    "d25060db8f3f3f6ae7b0bb972e848733e15a1158f02021645e86a2923a5ee8a3"
+)
+DATASET_NUMERIC_BYTES: Final[int] = 219_800_000
+_EXECUTION_AUTHORIZED: Final[bool] = False
+_HEX: Final[frozenset[str]] = frozenset("0123456789abcdef")
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+OUTPUT_PATH: Final[Path] = _REPO_ROOT / "outputs/adamo_matched_development/report.v1.json"
+_MAX_JSON_NODES: Final[int] = 100_000
+_MAX_JSON_STRING_BYTES: Final[int] = 2 * 1024 * 1024
+
+
+def frozen_plan() -> dict[str, object]:
+    """Return the literal plan that must be merged before any execution."""
+    return {
+        "plan_id": PLAN_ID,
+        "profile": PROFILE,
+        "arms": list(ARMS),
+        "control_arm": CONTROL_ARM,
+        "candidate_arms": list(CANDIDATE_ARMS),
+        "seeds": list(SEEDS),
+        "consumed_qualification_seeds": list(CONSUMED_QUALIFICATION_SEEDS),
+        "qualification_seed_note": (
+            "15600-15603 were exercised by contract qualification and are excluded from "
+            "the retained matched matrix"
+        ),
+        "primary_metric": "mean_online_accuracy",
+        "selection_arm": "adamo_l1e3",
+        "causal_ablation_arm": "adam_iso_joint_l1e3",
+        "hypothesis": (
+            "the decoupled AdamO isometry step reduces Jacobian/Gram degradation and yields "
+            "a positive paired mean-online-accuracy delta against AdamW"
+        ),
+        "failure_condition": (
+            "the AdamO accuracy interval is not wholly positive, the inert reduction fails, "
+            "or any frozen identity/resource invariant fails"
+        ),
+        "paired_direction": "higher_is_better",
+        "confidence_method": "two_sided_student_t",
+        "confidence_level": 0.95,
+        "confidence_degrees_of_freedom": 3,
+        "confidence_critical": T95_DF3,
+        "multiple_comparison_policy": (
+            "only adamo_l1e3 informs the development disposition; the joint-gradient arm is "
+            "a descriptive causal ablation"
+        ),
+        "matched_axes": [
+            "dataset",
+            "initialization_root",
+            "task_permutations",
+            "example_schedule",
+            "observations",
+            "updates",
+            "allowed_learner_information",
+        ],
+        "allowed_boundary_information": [],
+        "allowed_task_information": ["current_example_label"],
+        "diagnostic_information": ["post_task_boundary_index", "fixed_input_row_0"],
+        "dataset": {
+            "file_sha256": DATASET_FILE_SHA256,
+            "semantic_sha256": DATASET_SEMANTIC_SHA256,
+            "numeric_bytes": DATASET_NUMERIC_BYTES,
+            "keys": ["inputs", "labels"],
+            "dtypes": ["float32", "int32"],
+            "shapes": [[70000, 784], [70000]],
+            "materialization": (
+                "caller-frozen MNIST cache x/y copied without numeric conversion into "
+                "compressed NPZ inputs/labels before plan review"
+            ),
+        },
+        "mechanism_off_reduction": "adamo_inert == adamw_control bit-exact",
+        "resource_policy": (
+            "observations, updates, data/environment steps, model queries, Jacobian rows, "
+            "persistent numeric bytes, peak Gram workspace, logical compute, and telemetry "
+            "timing are retained per arm and seed"
+        ),
+        "output_path": "outputs/adamo_matched_development/report.v1.json",
+        "execution_authorized": _EXECUTION_AUTHORIZED,
+        "execution_status": (
+            "authorized_after_separate_review"
+            if _EXECUTION_AUTHORIZED
+            else "blocked_pending_independent_plan_audit"
+        ),
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "outcome_retention_required": True,
+    }
+
+
+def _digest(value: object, *, context: str, length: int = 64) -> str:
+    if (
+        type(value) is not str
+        or len(value) != length
+        or any(character not in _HEX for character in value)
+    ):
+        raise ValueError(f"{context} must be a lowercase hexadecimal digest")
+    return value
+
+
+def _exact_object(
+    value: object, expected_keys: frozenset[str], *, context: str
+) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise ValueError(f"{context} must be an exact object")
+    mapping = cast(dict[object, object], value)
+    raw_keys = tuple(mapping)
+    if (
+        len(raw_keys) != len(expected_keys)
+        or any(type(key) is not str for key in raw_keys)
+        or frozenset(cast(tuple[str, ...], raw_keys)) != expected_keys
+    ):
+        raise ValueError(f"{context} keys do not match the frozen schema")
+    return cast(dict[str, Any], mapping)
+
+
+def _finite_float(value: object, *, context: str) -> float:
+    if type(value) is not float or not math.isfinite(value):
+        raise ValueError(f"{context} must be an exact finite float")
+    return value
+
+
+def _bounded_json(value: object, *, context: str) -> object:
+    """Copy exact JSON without invoking subclass hooks or unbounded traversal."""
+    budget = [0, 0]
+
+    def visit(item: object, *, depth: int, label: str) -> object:
+        budget[0] += 1
+        if budget[0] > _MAX_JSON_NODES or depth > 18:
+            raise ValueError(f"{context} exceeds the JSON structure bound")
+        if item is None or type(item) is bool:
+            return item
+        if type(item) is int:
+            if not -(1 << 63) <= item <= (1 << 63) - 1:
+                raise ValueError(f"{label} exceeds signed-int64")
+            return item
+        if type(item) is float:
+            if not math.isfinite(item):
+                raise ValueError(f"{label} must be finite")
+            return item
+        if type(item) is str:
+            try:
+                encoded = item.encode("utf-8")
+            except UnicodeEncodeError as error:
+                raise ValueError(f"{label} must be valid UTF-8") from error
+            if len(encoded) > 16_384 or b"\0" in encoded:
+                raise ValueError(f"{label} must be a bounded string")
+            budget[1] += len(encoded)
+            if budget[1] > _MAX_JSON_STRING_BYTES:
+                raise ValueError(f"{context} exceeds the JSON string-byte bound")
+            return item
+        if type(item) is list:
+            if list.__len__(item) > 4096:
+                raise ValueError(f"{label} exceeds the list bound")
+            return [
+                visit(child, depth=depth + 1, label=f"{label}[{index}]")
+                for index, child in enumerate(list.__iter__(item))
+            ]
+        if type(item) is dict:
+            if dict.__len__(item) > 4096:
+                raise ValueError(f"{label} exceeds the object bound")
+            result: dict[str, object] = {}
+            for key, child in dict.items(item):
+                if type(key) is not str:
+                    raise ValueError(f"{label} keys must be exact strings")
+                result[key] = visit(child, depth=depth + 1, label=f"{label}.{key}")
+            return result
+        raise ValueError(f"{label} must contain only exact JSON values")
+
+    return visit(value, depth=0, label=context)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _current_source_provenance() -> dict[str, object]:
+    return _screening_source_provenance(_REPO_ROOT)
+
+
+def _current_runtime_environment() -> dict[str, object]:
+    return _screening_runtime_environment()
+
+
+def _validate_plan(value: object) -> dict[str, object]:
+    expected = frozen_plan()
+    plan = _exact_object(value, frozenset(expected), context="plan")
+    normalized = _bounded_json(plan, context="plan")
+    if normalized != expected:
+        raise ValueError("report plan does not equal the literal frozen plan")
+    return cast(dict[str, object], normalized)
+
+
+def _arm_by_name(receipt: Mapping[str, object], name: str) -> dict[str, object]:
+    arms = receipt["arms"]
+    if type(arms) is not list:
+        raise ValueError("receipt arms must be an exact list")
+    for raw_arm in arms:
+        if type(raw_arm) is dict and raw_arm.get("arm") == name:
+            return cast(dict[str, object], raw_arm)
+    raise ValueError(f"receipt is missing arm {name}")
+
+
+def _mean_accuracy(receipt: Mapping[str, object], arm: str) -> float:
+    values = _arm_by_name(receipt, arm)["per_task_accuracy"]
+    if type(values) is not list or not values:
+        raise ValueError("per_task_accuracy must be a nonempty exact list")
+    converted = tuple(_finite_float(value, context="per_task_accuracy") for value in values)
+    return math.fsum(converted) / len(converted)
+
+
+def _final_diagnostic(receipt: Mapping[str, object], arm: str, key: str) -> float:
+    diagnostics = _arm_by_name(receipt, arm)["post_task_diagnostics"]
+    if type(diagnostics) is not list or not diagnostics or type(diagnostics[-1]) is not dict:
+        raise ValueError("post_task_diagnostics must be a nonempty exact object list")
+    return _finite_float(
+        cast(dict[str, object], diagnostics[-1])[key], context=f"final {key}"
+    )
+
+
+def _resource_deltas(receipt: Mapping[str, object], candidate: str) -> dict[str, int]:
+    control_resources = _arm_by_name(receipt, CONTROL_ARM)["resources"]
+    candidate_resources = _arm_by_name(receipt, candidate)["resources"]
+    if type(control_resources) is not dict or type(candidate_resources) is not dict:
+        raise ValueError("arm resources must be exact objects")
+    keys = (
+        "observations",
+        "updates",
+        "data_steps",
+        "environment_steps",
+        "model_queries",
+        "jacobian_reverse_rows",
+        "persistent_numeric_bytes",
+        "peak_gram_working_bytes",
+        "logical_compute_units",
+    )
+    deltas: dict[str, int] = {}
+    for key in keys:
+        control = control_resources.get(key)
+        value = candidate_resources.get(key)
+        if type(control) is not int or type(value) is not int:
+            raise ValueError(f"resource {key} must be an exact integer")
+        deltas[key] = value - control
+    return deltas
+
+
+def _paired_comparison(
+    receipts: Mapping[int, Mapping[str, object]], candidate: str
+) -> dict[str, object]:
+    accuracy_deltas = tuple(
+        _mean_accuracy(receipts[seed], candidate)
+        - _mean_accuracy(receipts[seed], CONTROL_ARM)
+        for seed in SEEDS
+    )
+    mean = math.fsum(accuracy_deltas) / len(accuracy_deltas)
+    centered = math.fsum((value - mean) ** 2 for value in accuracy_deltas)
+    standard_error = math.sqrt(centered / (len(accuracy_deltas) - 1)) / math.sqrt(
+        len(accuracy_deltas)
+    )
+    lower = mean - T95_DF3 * standard_error
+    upper = mean + T95_DF3 * standard_error
+    outcome = "supported" if lower > 0.0 else "rejected" if upper <= 0.0 else "inconclusive"
+    rms_deltas = [
+        _final_diagnostic(receipts[seed], candidate, "jacobian_rms_distance_from_one")
+        - _final_diagnostic(receipts[seed], CONTROL_ARM, "jacobian_rms_distance_from_one")
+        for seed in SEEDS
+    ]
+    gram_deltas = [
+        _final_diagnostic(receipts[seed], candidate, "weight_gram_penalty")
+        - _final_diagnostic(receipts[seed], CONTROL_ARM, "weight_gram_penalty")
+        for seed in SEEDS
+    ]
+    resource_deltas = _resource_deltas(receipts[SEEDS[0]], candidate)
+    if any(_resource_deltas(receipts[seed], candidate) != resource_deltas for seed in SEEDS[1:]):
+        raise ValueError("candidate resource deltas must be seed-invariant")
+    return {
+        "accuracy_deltas": list(accuracy_deltas),
+        "mean_accuracy_delta": mean,
+        "ci95_lower": lower,
+        "ci95_upper": upper,
+        "outcome": outcome,
+        "final_jacobian_rms_distance_deltas": rms_deltas,
+        "final_weight_gram_penalty_deltas": gram_deltas,
+        "resource_deltas_vs_control": resource_deltas,
+    }
+
+
+def build_report(
+    receipts: Sequence[dict[str, object]],
+    *,
+    dataset_file_sha256: str,
+    execution_source_commit: str,
+) -> dict[str, object]:
+    """Build and strictly validate the complete seed-by-arm campaign report."""
+    if type(receipts) not in {list, tuple} or len(receipts) != len(SEEDS):
+        raise ValueError("receipts must contain the complete frozen seed schedule")
+    by_seed: dict[int, dict[str, object]] = {}
+    ordered: list[dict[str, object]] = []
+    for index, raw_receipt in enumerate(receipts):
+        receipt = validate_adamo_diagnostic(raw_receipt)
+        seed = receipt["seed"]
+        if type(seed) is not int or seed != SEEDS[index] or seed in by_seed:
+            raise ValueError("receipts must use deterministic frozen seed ordering")
+        if receipt["profile"] != PROFILE:
+            raise ValueError("receipt profile does not match the frozen plan")
+        by_seed[seed] = receipt
+        ordered.append(receipt)
+    semantic_digests = {cast(dict[str, object], item["dataset"])["sha256"] for item in ordered}
+    if len(semantic_digests) != 1:
+        raise ValueError("all receipts must bind one identical semantic dataset")
+    if semantic_digests != {DATASET_SEMANTIC_SHA256}:
+        raise ValueError("receipt semantic dataset does not match the prospectively frozen input")
+    source_receipts = [item["source"] for item in ordered]
+    runtime_receipts = [item["runtime"] for item in ordered]
+    if any(value != source_receipts[0] for value in source_receipts[1:]):
+        raise ValueError("all receipts must bind one source identity")
+    if any(value != runtime_receipts[0] for value in runtime_receipts[1:]):
+        raise ValueError("all receipts must bind one runtime identity")
+    report: dict[str, object] = {
+        "schema": SCHEMA,
+        "plan": frozen_plan(),
+        "dataset_file_sha256": _digest(dataset_file_sha256, context="dataset file sha256"),
+        "dataset_semantic_sha256": _digest(
+            next(iter(semantic_digests)), context="dataset semantic sha256"
+        ),
+        "execution_source_commit": _digest(
+            execution_source_commit, context="execution source commit", length=40
+        ),
+        "source_provenance": _current_source_provenance(),
+        "runtime_environment": _current_runtime_environment(),
+        "runs": ordered,
+        "paired_comparisons": {
+            candidate: _paired_comparison(by_seed, candidate) for candidate in CANDIDATE_ARMS
+        },
+        "development_disposition": "inconclusive",
+        "policy": {
+            "development_only": True,
+            "scientific_promotion_allowed": False,
+            "outcome_retained": True,
+            "timing_is_telemetry_only": True,
+        },
+    }
+    if report["dataset_file_sha256"] != DATASET_FILE_SHA256:
+        raise ValueError("dataset file does not match the prospectively frozen input")
+    comparisons = cast(dict[str, object], report["paired_comparisons"])
+    primary_comparison = cast(dict[str, object], comparisons["adamo_l1e3"])
+    report["development_disposition"] = primary_comparison["outcome"]
+    return validate_report(report, require_current_source=True)
+
+
+def validate_report(
+    payload: object, *, require_current_source: bool = True
+) -> dict[str, object]:
+    """Fail closed over completeness, identities, resources, and paired arithmetic."""
+    if type(require_current_source) is not bool:
+        raise ValueError("require_current_source must be an exact bool")
+    report = _exact_object(
+        payload,
+        frozenset(
+            {
+                "schema",
+                "plan",
+                "dataset_file_sha256",
+                "dataset_semantic_sha256",
+                "execution_source_commit",
+                "source_provenance",
+                "runtime_environment",
+                "runs",
+                "paired_comparisons",
+                "development_disposition",
+                "policy",
+            }
+        ),
+        context="report",
+    )
+    if report["schema"] != SCHEMA or type(report["schema"]) is not str:
+        raise ValueError("report schema does not match the frozen protocol")
+    _validate_plan(report["plan"])
+    file_digest = _digest(report["dataset_file_sha256"], context="dataset file sha256")
+    semantic = _digest(report["dataset_semantic_sha256"], context="dataset semantic sha256")
+    if file_digest != DATASET_FILE_SHA256 or semantic != DATASET_SEMANTIC_SHA256:
+        raise ValueError("report dataset does not match the prospectively frozen input")
+    _digest(report["execution_source_commit"], context="execution source commit", length=40)
+    source = _bounded_json(report["source_provenance"], context="source provenance")
+    runtime = _bounded_json(report["runtime_environment"], context="runtime environment")
+    if type(source) is not dict or type(runtime) is not dict:
+        raise ValueError("source and runtime identities must be exact objects")
+    if source.get("git_commit") != report["execution_source_commit"]:
+        raise ValueError("execution commit does not match source provenance")
+    if require_current_source and source != _current_source_provenance():
+        raise ValueError("report source provenance does not match current source")
+    if require_current_source and runtime != _current_runtime_environment():
+        raise ValueError("report runtime environment does not match the current runtime")
+    policy = _exact_object(
+        report["policy"],
+        frozenset(
+            {
+                "development_only",
+                "scientific_promotion_allowed",
+                "outcome_retained",
+                "timing_is_telemetry_only",
+            }
+        ),
+        context="policy",
+    )
+    if any(type(value) is not bool for value in policy.values()) or policy != {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "outcome_retained": True,
+        "timing_is_telemetry_only": True,
+    }:
+        raise ValueError("report policy must remain permanently nonpromoting")
+    runs = report["runs"]
+    if type(runs) is not list or len(runs) != len(SEEDS):
+        raise ValueError("runs must contain the complete frozen seed schedule")
+    by_seed: dict[int, dict[str, object]] = {}
+    for index, raw_run in enumerate(runs):
+        run = validate_adamo_diagnostic(raw_run)
+        seed = run["seed"]
+        if type(seed) is not int or seed != SEEDS[index] or seed in by_seed:
+            raise ValueError("runs must use deterministic frozen seed ordering")
+        if run["profile"] != PROFILE:
+            raise ValueError("run profile does not match the frozen plan")
+        dataset = cast(dict[str, object], run["dataset"])
+        if dataset["sha256"] != semantic:
+            raise ValueError("run semantic dataset identity does not match the aggregate")
+        by_seed[seed] = run
+    paired = _exact_object(
+        report["paired_comparisons"], frozenset(CANDIDATE_ARMS), context="paired comparisons"
+    )
+    normalized_paired = _bounded_json(paired, context="paired comparisons")
+    expected_paired = {
+        candidate: _paired_comparison(by_seed, candidate) for candidate in CANDIDATE_ARMS
+    }
+    if normalized_paired != expected_paired:
+        raise ValueError("paired arithmetic does not match the retained runs")
+    disposition = report["development_disposition"]
+    if (
+        type(disposition) is not str
+        or disposition != expected_paired["adamo_l1e3"]["outcome"]
+    ):
+        raise ValueError("development disposition must equal the primary paired outcome")
+    return cast(dict[str, object], report)
+
+
+def publish_report(path: Path, report: object) -> Path:
+    """Validate then atomically publish one immutable report generation."""
+    if type(path) is not type(Path()):
+        raise ValueError("output path must be an exact pathlib.Path")
+    if path.absolute() != OUTPUT_PATH.absolute():
+        raise ValueError(f"output path must be the reserved NEW path {OUTPUT_PATH}")
+    validated = validate_report(report, require_current_source=True)
+    return atomic_write_new_json(path, validated)
+
+
+def _execution_commit() -> str:
+    completed = subprocess.run(
+        ("git", "rev-parse", "HEAD"),
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return _digest(completed.stdout.strip(), context="execution source commit", length=40)
+
+
+def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[str, object]:
+    """Execute exactly once after the separately reviewed authorization change."""
+    if not _EXECUTION_AUTHORIZED:
+        raise RuntimeError("AdamO matched-development execution is not authorized")
+    if type(dataset_path) is not type(Path()) or type(output_path) is not type(Path()):
+        raise ValueError("dataset and output paths must be exact pathlib.Path values")
+    if output_path.absolute() != OUTPUT_PATH.absolute():
+        raise ValueError(f"output path must be the reserved NEW path {OUTPUT_PATH}")
+    if _sha256_file(dataset_path) != DATASET_FILE_SHA256:
+        raise ValueError("dataset file does not match the prospectively frozen input")
+    source_before = _current_source_provenance()
+    runtime_before = _current_runtime_environment()
+    inputs, labels = _load_dataset(dataset_path)
+    receipts = [
+        run_adamo_diagnostic(inputs, labels, profile=PROFILE, seed=seed) for seed in SEEDS
+    ]
+    if source_before != _current_source_provenance():
+        raise RuntimeError("source identity changed during matched execution")
+    if runtime_before != _current_runtime_environment():
+        raise RuntimeError("runtime identity changed during matched execution")
+    report = build_report(
+        receipts,
+        dataset_file_sha256=_sha256_file(dataset_path),
+        execution_source_commit=_execution_commit(),
+    )
+    publish_report(output_path, report)
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", action="store_true")
+    parser.add_argument("--dataset", type=Path)
+    parser.add_argument("--output", type=Path, default=OUTPUT_PATH)
+    args = parser.parse_args(argv)
+    if args.catalog:
+        if args.dataset is not None:
+            parser.error("--catalog and --dataset are mutually exclusive")
+        print(json.dumps(frozen_plan(), sort_keys=True))
+        return 0
+    if args.dataset is None:
+        parser.error("--dataset is required unless --catalog is used")
+    run_campaign(args.dataset, args.output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/alberta_framework/benchmarks/adamo_matched_development.py
+++ b/alberta_framework/benchmarks/adamo_matched_development.py
@@ -24,7 +24,7 @@ from alberta_framework.benchmarks.adamo_diagnostic import (
     OFFICIAL_CODE,
     OFFICIAL_CODE_SEARCH_DATE,
     PAPER_URL,
-    run_adamo_diagnostic,
+    _run_adamo_diagnostic_schedule,
     validate_adamo_diagnostic,
 )
 from alberta_framework.benchmarks.ipmnist_screening import (
@@ -369,7 +369,9 @@ def build_report(
     by_seed: dict[int, dict[str, object]] = {}
     ordered: list[dict[str, object]] = []
     for index, raw_receipt in enumerate(receipts):
-        receipt = validate_adamo_diagnostic(raw_receipt, require_current_identity=True)
+        receipt = validate_adamo_diagnostic(
+            raw_receipt, seed_schedule=SEEDS, require_current_identity=True
+        )
         seed = receipt["seed"]
         if type(seed) is not int or seed != SEEDS[index] or seed in by_seed:
             raise ValueError("receipts must use deterministic frozen seed ordering")
@@ -489,7 +491,9 @@ def validate_report(
     combined_dataset_identity: object | None = None
     for index, raw_run in enumerate(runs):
         run = validate_adamo_diagnostic(
-            raw_run, require_current_identity=require_current_execution_identity
+            raw_run,
+            seed_schedule=SEEDS,
+            require_current_identity=require_current_execution_identity,
         )
         seed = run["seed"]
         if type(seed) is not int or seed != SEEDS[index] or seed in by_seed:
@@ -724,7 +728,10 @@ def run_campaign(
         inputs, labels = load_mnist_train(data_home)
         dataset_before = _screening_dataset_provenance(inputs, labels)
         receipts = [
-            run_adamo_diagnostic(inputs, labels, profile=PROFILE, seed=seed) for seed in SEEDS
+            _run_adamo_diagnostic_schedule(
+                inputs, labels, profile=PROFILE, seed=seed, seed_schedule=SEEDS
+            )
+            for seed in SEEDS
         ]
         if source_before != _current_source_provenance():
             raise RuntimeError("source identity changed during matched execution")

--- a/docs/research/adamo-diagnostic.md
+++ b/docs/research/adamo-diagnostic.md
@@ -43,10 +43,10 @@ Run only on a caller-materialized NPZ containing exactly float32 `inputs` and in
   --profile contract-smoke --seed 15600
 ```
 
-That public function/CLI surface is restricted to the consumed `contract-smoke` roster. It cannot
-select `bounded-development` or any prospectively reserved matched seed. The bounded executor is a
-private capability-gated dependency of the still-disabled matched campaign; publication remains
-separately gated as well.
+That public function/CLI surface is restricted to the consumed `15600`--`15603` roster for both
+registered profiles. It cannot select any prospectively reserved matched seed. The fresh-schedule
+executor is a private capability-gated dependency of the still-disabled matched campaign;
+publication remains separately gated as well.
 
 Receipts bind exact dataset and current-source hashes, runtime identity, data steps, observations,
 updates, logical model queries, reverse-mode Jacobian rows, persistent numeric bytes, peak Gram

--- a/docs/research/adamo-diagnostic.md
+++ b/docs/research/adamo-diagnostic.md
@@ -40,7 +40,7 @@ Run only on a caller-materialized NPZ containing exactly float32 `inputs` and in
 ```bash
 .venv/bin/asi-adamo-diagnostic --catalog
 .venv/bin/asi-adamo-diagnostic --dataset /new/path/data.npz \
-  --profile contract-smoke --seed 25600
+  --profile contract-smoke --seed 15600
 ```
 
 Receipts bind exact dataset and current-source hashes, runtime identity, data steps, observations,
@@ -65,7 +65,9 @@ protocol and untouched seeds; and establish calibrated compute, memory, and timi
 original `15600`-`15603` schedule was consumed by executable qualification and is excluded from
 the retained matched screen. The prospectively frozen `25600`-`25603` schedule can execute only
 through `asi-adamo-matched-development` after a separate authorization review. Any exposed
-outcome consumes those seeds and can never promote a claim. The plan also freezes the exact
-caller-materialized MNIST NPZ (`58320c334531afce90c4899ea0c05976c9b9d1c10b7b37e8eb4289cabd0a00ba`)
-and its canonical numeric-array digest
-(`d25060db8f3f3f6ae7b0bb972e848733e15a1158f02021645e86a2923a5ee8a3`).
+outcome consumes those seeds and can never promote a claim. The plan freezes the independently
+reconstructable canonical IPMNIST materialization: OpenML `mnist_784` version 1 rows `0:60000`,
+float32 inputs scaled to `[-1,1]`, and int32 labels. Its input and label array hashes are
+`b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313` and
+`4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a`; the combined semantic
+digest is `220e4a97a6d345a9f09bbee8e6ba65e8cc117604428392ae08fed2bd8ea0ab27`.

--- a/docs/research/adamo-diagnostic.md
+++ b/docs/research/adamo-diagnostic.md
@@ -74,7 +74,8 @@ matrix. The prospectively frozen, repository-audited `9156001`-`9156004` schedul
 through `asi-adamo-matched-development` after a separate authorization review. Any exposed
 outcome consumes those seeds and can never promote a claim. The plan also freezes the exact
 OpenML `mnist_784` version 1 rows 0--59999 materialization and records canonical per-array
-dtype, shape, and SHA-256 identities at execution. There is no opaque or unavailable NPZ input.
+dtype, shape, and SHA-256 identities before execution; dispatch fails closed unless the loaded
+arrays match those frozen hashes. There is no opaque or unavailable NPZ input.
 Use `--data-home` to select an OpenML cache; it does not change the frozen source selection or
 materialized-array validation. Reports validate structurally against their pinned runtime by
 default, so a GPU-produced report remains auditable on CPU; execution and publication separately

--- a/docs/research/adamo-diagnostic.md
+++ b/docs/research/adamo-diagnostic.md
@@ -62,13 +62,15 @@ Before a scientific comparison: locate and pin official code or independently ve
 implement the exact paper dataset/task construction, architecture, initialization and full
 diagnostic definitions; qualify the missing model families; freeze a separate preregistered
 protocol and untouched seeds; and establish calibrated compute, memory, and timing gates. The
-public `15600`-`15603` schedule was consumed by executable qualification and is excluded from
-the retained matched screen. The prospectively frozen `25600`-`25603` schedule is unavailable
-through the public diagnostic and can execute through `asi-adamo-matched-development` only after
-a separate authorization review. Any exposed outcome consumes those seeds and can never promote
-a claim. The plan freezes the independently
-reconstructable canonical IPMNIST materialization: OpenML `mnist_784` version 1 rows `0:60000`,
-float32 inputs scaled to `[-1,1]`, and int32 labels. Its input and label array hashes are
-`b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313` and
-`4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a`; the combined semantic
-digest is `220e4a97a6d345a9f09bbee8e6ba65e8cc117604428392ae08fed2bd8ea0ab27`.
+original `15600`-`15603` schedule was consumed by executable qualification and is excluded from
+the retained matched screen. The exposed `25600`-`25603` preplan roster is also quarantined
+because an earlier test fixture exercised seed `25600`; none of those roots may enter the retained
+matrix. The prospectively frozen, repository-audited `9156001`-`9156004` schedule can execute only
+through `asi-adamo-matched-development` after a separate authorization review. Any exposed
+outcome consumes those seeds and can never promote a claim. The plan also freezes the exact
+OpenML `mnist_784` version 1 rows 0--59999 materialization and records canonical per-array
+dtype, shape, and SHA-256 identities at execution. There is no opaque or unavailable NPZ input.
+Use `--data-home` to select an OpenML cache; it does not change the frozen source selection or
+materialized-array validation. Reports validate structurally against their pinned runtime by
+default, so a GPU-produced report remains auditable on CPU; execution and publication separately
+require an exact current source/runtime match.

--- a/docs/research/adamo-diagnostic.md
+++ b/docs/research/adamo-diagnostic.md
@@ -62,10 +62,11 @@ Before a scientific comparison: locate and pin official code or independently ve
 implement the exact paper dataset/task construction, architecture, initialization and full
 diagnostic definitions; qualify the missing model families; freeze a separate preregistered
 protocol and untouched seeds; and establish calibrated compute, memory, and timing gates. The
-original `15600`-`15603` schedule was consumed by executable qualification and is excluded from
-the retained matched screen. The prospectively frozen `25600`-`25603` schedule can execute only
-through `asi-adamo-matched-development` after a separate authorization review. Any exposed
-outcome consumes those seeds and can never promote a claim. The plan freezes the independently
+public `15600`-`15603` schedule was consumed by executable qualification and is excluded from
+the retained matched screen. The prospectively frozen `25600`-`25603` schedule is unavailable
+through the public diagnostic and can execute through `asi-adamo-matched-development` only after
+a separate authorization review. Any exposed outcome consumes those seeds and can never promote
+a claim. The plan freezes the independently
 reconstructable canonical IPMNIST materialization: OpenML `mnist_784` version 1 rows `0:60000`,
 float32 inputs scaled to `[-1,1]`, and int32 labels. Its input and label array hashes are
 `b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313` and

--- a/docs/research/adamo-diagnostic.md
+++ b/docs/research/adamo-diagnostic.md
@@ -43,6 +43,11 @@ Run only on a caller-materialized NPZ containing exactly float32 `inputs` and in
   --profile contract-smoke --seed 15600
 ```
 
+That public function/CLI surface is restricted to the consumed `contract-smoke` roster. It cannot
+select `bounded-development` or any prospectively reserved matched seed. The bounded executor is a
+private capability-gated dependency of the still-disabled matched campaign; publication remains
+separately gated as well.
+
 Receipts bind exact dataset and current-source hashes, runtime identity, data steps, observations,
 updates, logical model queries, reverse-mode Jacobian rows, persistent numeric bytes, peak Gram
 workspace, and a named logical-compute convention. Timing is telemetry only. Successful execution

--- a/docs/research/adamo-diagnostic.md
+++ b/docs/research/adamo-diagnostic.md
@@ -40,7 +40,7 @@ Run only on a caller-materialized NPZ containing exactly float32 `inputs` and in
 ```bash
 .venv/bin/asi-adamo-diagnostic --catalog
 .venv/bin/asi-adamo-diagnostic --dataset /new/path/data.npz \
-  --profile contract-smoke --seed 15600
+  --profile contract-smoke --seed 25600
 ```
 
 Receipts bind exact dataset and current-source hashes, runtime identity, data steps, observations,
@@ -61,5 +61,11 @@ Newton-Schulz, ReLU-revival, empirical NTK, effective-rank, CNN, RL, or transfor
 Before a scientific comparison: locate and pin official code or independently verify equations;
 implement the exact paper dataset/task construction, architecture, initialization and full
 diagnostic definitions; qualify the missing model families; freeze a separate preregistered
-protocol and untouched seeds; and establish calibrated compute, memory, and timing gates. The four
-listed seeds are consumed development seeds and can never promote a claim.
+protocol and untouched seeds; and establish calibrated compute, memory, and timing gates. The
+original `15600`-`15603` schedule was consumed by executable qualification and is excluded from
+the retained matched screen. The prospectively frozen `25600`-`25603` schedule can execute only
+through `asi-adamo-matched-development` after a separate authorization review. Any exposed
+outcome consumes those seeds and can never promote a claim. The plan also freezes the exact
+caller-materialized MNIST NPZ (`58320c334531afce90c4899ea0c05976c9b9d1c10b7b37e8eb4289cabd0a00ba`)
+and its canonical numeric-array digest
+(`d25060db8f3f3f6ae7b0bb972e848733e15a1158f02021645e86a2923a5ee8a3`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ asi-native-supervised-catalog = "alberta_framework.benchmarks.native_supervised_
 asi-plasticity-diagnostic = "alberta_framework.benchmarks.plasticity_diagnostics:main"
 asi-nap-ipmnist = "alberta_framework.benchmarks.nap_ipmnist:main"
 asi-adamo-diagnostic = "alberta_framework.benchmarks.adamo_diagnostic:main"
+asi-adamo-matched-development = "alberta_framework.benchmarks.adamo_matched_development:main"
 asi-activation-feature-ipmnist = "alberta_framework.benchmarks.activation_feature_ipmnist:main"
 asi-coom-qualification-smoke = "alberta_framework.benchmarks.coom_qualification:main"
 asi-clear-qualification = "alberta_framework.benchmarks.clear_qualification:main"

--- a/tests/test_adamo_diagnostic.py
+++ b/tests/test_adamo_diagnostic.py
@@ -116,7 +116,7 @@ def test_contract_and_matched_seed_schedules_are_disjoint(
             profile="contract-smoke",
             seed=FROZEN_MATCHED_DEVELOPMENT_SEEDS[0],
         )
-    with pytest.raises(ValueError, match="selected frozen"):
+    with pytest.raises(ValueError, match="contract-smoke"):
         run_adamo_diagnostic(
             *tiny_data,
             profile="bounded-development",
@@ -162,6 +162,27 @@ def test_public_cli_cannot_consume_reserved_matched_seed_before_loading(
                 "--profile", "bounded-development",
                 "--seed", str(FROZEN_MATCHED_DEVELOPMENT_SEEDS[0]),
             ]
+        )
+    assert calls == 0
+
+
+def test_private_matched_executor_requires_exact_capability_before_run(
+    tiny_data: tuple[np.ndarray, np.ndarray], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def forbidden_run(*args: object, **kwargs: object) -> Never:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("unauthorized private execution must not start")
+
+    monkeypatch.setattr(diagnostic, "run_screening_config", forbidden_run)
+    with pytest.raises(RuntimeError, match="capability"):
+        diagnostic._run_matched_adamo_diagnostic(
+            *tiny_data,
+            profile="bounded-development",
+            seed=FROZEN_MATCHED_DEVELOPMENT_SEEDS[0],
+            capability=object(),
         )
     assert calls == 0
 

--- a/tests/test_adamo_diagnostic.py
+++ b/tests/test_adamo_diagnostic.py
@@ -13,6 +13,8 @@ import pytest
 from alberta_framework.benchmarks.adamo_diagnostic import (
     ARMS,
     FROZEN_DEVELOPMENT_SEEDS,
+    FROZEN_MATCHED_DEVELOPMENT_SEEDS,
+    SCHEMA,
     main,
     run_adamo_diagnostic,
     validate_adamo_diagnostic,
@@ -42,6 +44,7 @@ def test_end_to_end_runner_binds_diagnostics_and_exact_resources(
     receipt: dict[str, object],
 ) -> None:
     assert validate_adamo_diagnostic(receipt) == receipt
+    assert receipt["schema"] == SCHEMA
     arms = receipt["arms"]
     assert isinstance(arms, list)
     assert [arm["arm"] for arm in arms] == list(ARMS)
@@ -100,6 +103,29 @@ def test_hostile_scalar_alias_and_unfrozen_seed_are_rejected(
         validate_adamo_diagnostic(hostile)
     with pytest.raises(ValueError, match="frozen"):
         run_adamo_diagnostic(*tiny_data, profile="contract-smoke", seed=9)
+
+
+def test_contract_and_matched_seed_schedules_are_disjoint(
+    tiny_data: tuple[np.ndarray, np.ndarray],
+) -> None:
+    assert set(FROZEN_DEVELOPMENT_SEEDS).isdisjoint(FROZEN_MATCHED_DEVELOPMENT_SEEDS)
+    with pytest.raises(ValueError, match="frozen"):
+        run_adamo_diagnostic(
+            *tiny_data,
+            profile="contract-smoke",
+            seed=FROZEN_MATCHED_DEVELOPMENT_SEEDS[0],
+        )
+
+
+def test_retained_receipt_can_be_validated_offline(
+    receipt: dict[str, object],
+) -> None:
+    retained = copy.deepcopy(receipt)
+    retained["runtime"]["backend"] = "gpu"
+    retained["source"]["adapter_sha256"] = "0" * 64
+    assert validate_adamo_diagnostic(retained, require_current_identity=False) == retained
+    with pytest.raises(ValueError, match="current runtime"):
+        validate_adamo_diagnostic(retained)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_adamo_diagnostic.py
+++ b/tests/test_adamo_diagnostic.py
@@ -115,6 +115,12 @@ def test_contract_and_matched_seed_schedules_are_disjoint(
             profile="contract-smoke",
             seed=FROZEN_MATCHED_DEVELOPMENT_SEEDS[0],
         )
+    with pytest.raises(ValueError, match="selected frozen"):
+        run_adamo_diagnostic(
+            *tiny_data,
+            profile="bounded-development",
+            seed=FROZEN_MATCHED_DEVELOPMENT_SEEDS[0],
+        )
 
 
 def test_retained_receipt_can_be_validated_offline(

--- a/tests/test_adamo_diagnostic.py
+++ b/tests/test_adamo_diagnostic.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import json
 from pathlib import Path
+from typing import Never
 
 import numpy as np
 import pytest
@@ -99,6 +100,70 @@ def test_hostile_scalar_alias_and_unfrozen_seed_are_rejected(
         validate_adamo_diagnostic(hostile)
     with pytest.raises(ValueError, match="frozen"):
         run_adamo_diagnostic(*tiny_data, profile="contract-smoke", seed=9)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ("frozen_development_seeds",),
+        ("config",),
+        ("dataset",),
+        ("protocol",),
+        ("runtime",),
+        ("source",),
+        ("arms",),
+        ("arms", 0),
+        ("arms", 0, "hyperparameters"),
+        ("arms", 0, "post_task_diagnostics"),
+        ("arms", 0, "post_task_diagnostics", 0),
+        ("arms", 0, "resources"),
+    ],
+)
+def test_nested_container_subclasses_are_rejected_without_invoking_hooks(
+    receipt: dict[str, object], path: tuple[object, ...],
+) -> None:
+    class HostileDict(dict[object, object]):
+        calls = 0
+
+        def __iter__(self) -> Never:
+            type(self).calls += 1
+            raise AssertionError("must not iterate hostile dict")
+
+        def __eq__(self, other: object) -> Never:
+            type(self).calls += 1
+            raise AssertionError("must not compare hostile dict")
+
+    class HostileList(list[object]):
+        calls = 0
+
+        def __iter__(self) -> Never:
+            type(self).calls += 1
+            raise AssertionError("must not iterate hostile list")
+
+        def __eq__(self, other: object) -> Never:
+            type(self).calls += 1
+            raise AssertionError("must not compare hostile list")
+
+    hostile = copy.deepcopy(receipt)
+    parent: object = hostile
+    for component in path[:-1]:
+        parent = parent[component]  # type: ignore[index]
+    leaf = parent[path[-1]]  # type: ignore[index]
+    replacement = HostileDict(leaf) if type(leaf) is dict else HostileList(leaf)
+    parent[path[-1]] = replacement  # type: ignore[index]
+    with pytest.raises(ValueError, match="exact JSON"):
+        validate_adamo_diagnostic(hostile)
+    assert HostileDict.calls == 0
+    assert HostileList.calls == 0
+
+
+def test_frozen_seed_schedule_rejects_boolean_member_alias(
+    receipt: dict[str, object],
+) -> None:
+    hostile = copy.deepcopy(receipt)
+    hostile["frozen_development_seeds"][0] = True
+    with pytest.raises(ValueError, match="frozen seed schedule"):
+        validate_adamo_diagnostic(hostile)
 
 
 def test_runner_observer_is_a_downstream_exact_function_only(

--- a/tests/test_adamo_diagnostic.py
+++ b/tests/test_adamo_diagnostic.py
@@ -116,7 +116,7 @@ def test_contract_and_matched_seed_schedules_are_disjoint(
             profile="contract-smoke",
             seed=FROZEN_MATCHED_DEVELOPMENT_SEEDS[0],
         )
-    with pytest.raises(ValueError, match="contract-smoke"):
+    with pytest.raises(ValueError, match="selected frozen"):
         run_adamo_diagnostic(
             *tiny_data,
             profile="bounded-development",
@@ -135,13 +135,32 @@ def test_public_function_cannot_consume_reserved_matched_seed(
         raise AssertionError("reserved matched execution must not start")
 
     monkeypatch.setattr(diagnostic, "run_screening_config", forbidden_run)
-    with pytest.raises(ValueError, match="contract-smoke"):
+    with pytest.raises(ValueError, match="selected frozen"):
         run_adamo_diagnostic(
             *tiny_data,
             profile="bounded-development",
             seed=FROZEN_MATCHED_DEVELOPMENT_SEEDS[0],
         )
     assert calls == 0
+
+
+def test_public_bounded_profile_retains_consumed_schedule_compatibility(
+    tiny_data: tuple[np.ndarray, np.ndarray], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def capture_schedule(*args: object, **kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"profile": kwargs["profile"], "seed": kwargs["seed"]}
+
+    monkeypatch.setattr(diagnostic, "_run_adamo_diagnostic_schedule", capture_schedule)
+    result = run_adamo_diagnostic(
+        *tiny_data,
+        profile="bounded-development",
+        seed=FROZEN_DEVELOPMENT_SEEDS[0],
+    )
+    assert result == {"profile": "bounded-development", "seed": FROZEN_DEVELOPMENT_SEEDS[0]}
+    assert captured["seed_schedule"] == FROZEN_DEVELOPMENT_SEEDS
 
 
 def test_public_cli_cannot_consume_reserved_matched_seed_before_loading(
@@ -286,6 +305,7 @@ def test_catalog_cli_is_read_only_json(capsys: pytest.CaptureFixture[str]) -> No
     assert main(["--catalog"]) == 0
     catalog = json.loads(capsys.readouterr().out)
     assert catalog["arms"] == list(ARMS)
+    assert set(catalog["profiles"]) == {"contract-smoke", "bounded-development"}
     assert catalog["negative_outcomes_retained"] is True
     assert catalog["scientific_promotion_allowed"] is False
 

--- a/tests/test_adamo_diagnostic.py
+++ b/tests/test_adamo_diagnostic.py
@@ -10,6 +10,7 @@ from typing import Never
 import numpy as np
 import pytest
 
+import alberta_framework.benchmarks.adamo_diagnostic as diagnostic
 from alberta_framework.benchmarks.adamo_diagnostic import (
     ARMS,
     FROZEN_DEVELOPMENT_SEEDS,
@@ -121,6 +122,48 @@ def test_contract_and_matched_seed_schedules_are_disjoint(
             profile="bounded-development",
             seed=FROZEN_MATCHED_DEVELOPMENT_SEEDS[0],
         )
+
+
+def test_public_function_cannot_consume_reserved_matched_seed(
+    tiny_data: tuple[np.ndarray, np.ndarray], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def forbidden_run(*args: object, **kwargs: object) -> Never:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("reserved matched execution must not start")
+
+    monkeypatch.setattr(diagnostic, "run_screening_config", forbidden_run)
+    with pytest.raises(ValueError, match="contract-smoke"):
+        run_adamo_diagnostic(
+            *tiny_data,
+            profile="bounded-development",
+            seed=FROZEN_MATCHED_DEVELOPMENT_SEEDS[0],
+        )
+    assert calls == 0
+
+
+def test_public_cli_cannot_consume_reserved_matched_seed_before_loading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def forbidden_load(path: Path) -> Never:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("reserved matched CLI must not load data")
+
+    monkeypatch.setattr(diagnostic, "_load_dataset", forbidden_load)
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "--dataset", str(tmp_path / "unused.npz"),
+                "--profile", "bounded-development",
+                "--seed", str(FROZEN_MATCHED_DEVELOPMENT_SEEDS[0]),
+            ]
+        )
+    assert calls == 0
 
 
 def test_retained_receipt_can_be_validated_offline(

--- a/tests/test_adamo_matched_development.py
+++ b/tests/test_adamo_matched_development.py
@@ -185,3 +185,65 @@ def test_validator_binds_execution_commit_to_source_provenance(
     hostile["execution_source_commit"] = "d" * 40
     with pytest.raises(ValueError, match="does not match source provenance"):
         matched.validate_report(hostile, require_current_source=False)
+
+
+def test_build_report_rejects_hostile_sequence_without_hashing_its_metaclass() -> None:
+    class ExplosiveMeta(type):
+        def __hash__(cls) -> Never:
+            raise AssertionError("must not hash a hostile sequence type")
+
+    class HostileSequence(list[object], metaclass=ExplosiveMeta):
+        pass
+
+    with pytest.raises(ValueError, match="complete frozen seed schedule"):
+        matched.build_report(
+            HostileSequence(),
+            dataset_file_sha256="a" * 64,
+            execution_source_commit="b" * 40,
+        )
+
+
+def test_report_schema_subclass_is_rejected_without_equality_hook(
+    receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_identities(monkeypatch, receipts)
+    report = matched.build_report(
+        receipts,
+        dataset_file_sha256="b" * 64,
+        execution_source_commit="c" * 40,
+    )
+
+    class HostileString(str):
+        calls = 0
+
+        def __eq__(self, other: object) -> Never:
+            type(self).calls += 1
+            raise AssertionError("must not compare hostile string")
+
+    hostile = copy.deepcopy(report)
+    hostile["schema"] = HostileString(matched.SCHEMA)
+    with pytest.raises(ValueError, match="schema"):
+        matched.validate_report(hostile, require_current_source=False)
+    assert HostileString.calls == 0
+
+
+def test_publication_rejects_symlink_parent_without_touching_target(
+    tmp_path: Path,
+    receipts: list[dict[str, object]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_identities(monkeypatch, receipts)
+    report = matched.build_report(
+        receipts,
+        dataset_file_sha256="b" * 64,
+        execution_source_commit="c" * 40,
+    )
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    linked_parent = tmp_path / "linked"
+    linked_parent.symlink_to(real_parent, target_is_directory=True)
+    destination = linked_parent / "report.json"
+    monkeypatch.setattr(matched, "OUTPUT_PATH", destination)
+    with pytest.raises(OSError):
+        matched.publish_report(destination, report)
+    assert not (real_parent / "report.json").exists()

--- a/tests/test_adamo_matched_development.py
+++ b/tests/test_adamo_matched_development.py
@@ -20,8 +20,8 @@ def _patch_identities(
 ) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
     run_runtime = receipts[0]["runtime"]
     dataset = {
-        "x": {"shape": [60_000, 784], "sha256": receipts[0]["dataset"]["x_sha256"]},
-        "y": {"shape": [60_000], "sha256": receipts[0]["dataset"]["y_sha256"]},
+        "x": {"shape": [60_000, 784], "sha256": matched.CANONICAL_X_SHA256},
+        "y": {"shape": [60_000], "sha256": matched.CANONICAL_Y_SHA256},
     }
     source = {"git_commit": "c" * 40, "relevant_source_sha256": "a" * 64}
     runtime = {
@@ -68,6 +68,8 @@ def receipts() -> list[dict[str, object]]:
         receipt["seed"] = seed
         receipt["profile"] = matched.PROFILE
         receipt["frozen_development_seeds"] = list(matched.SEEDS)
+        receipt["dataset"]["x_sha256"] = matched.CANONICAL_X_SHA256
+        receipt["dataset"]["y_sha256"] = matched.CANONICAL_Y_SHA256
         receipt["dataset"]["rows"] = 60_000
         receipt["dataset"]["loaded_numeric_bytes"] = 60_000 * (4 * 4 + 4)
         result.append(receipt)
@@ -92,6 +94,52 @@ def test_plan_is_prospective_exact_and_permanently_nonpromoting() -> None:
         "row_start": 0,
         "row_stop_exclusive": 60_000,
     }
+    assert plan["dataset"]["arrays"] == {
+        "x": {
+            "dtype": "<f4",
+            "shape": [60_000, 784],
+            "sha256": matched.CANONICAL_X_SHA256,
+        },
+        "y": {
+            "dtype": "<i4",
+            "shape": [60_000],
+            "sha256": matched.CANONICAL_Y_SHA256,
+        },
+    }
+
+
+def test_canonical_dataset_hashes_are_required_before_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = {
+        "x": {"shape": [60_000, 784], "sha256": "0" * 64},
+        "y": {"shape": [60_000], "sha256": "1" * 64},
+    }
+    monkeypatch.setattr(matched, "_validated_dataset_provenance", lambda value, **_: value)
+    destination = tmp_path / "report.json"
+    monkeypatch.setattr(matched, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(matched, "_EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(matched, "_current_source_provenance", lambda: {})
+    monkeypatch.setattr(matched, "_current_runtime_environment", lambda: {})
+    monkeypatch.setattr(
+        matched,
+        "load_mnist_train",
+        lambda _: (np.zeros((1, 1), dtype=np.float32), np.zeros(1, dtype=np.int32)),
+    )
+    monkeypatch.setattr(matched, "_screening_dataset_provenance", lambda *_: fake)
+    dispatched = 0
+
+    def unexpected_dispatch(*_: object, **__: object) -> Never:
+        nonlocal dispatched
+        dispatched += 1
+        raise AssertionError("reserved seeds must not dispatch")
+
+    monkeypatch.setattr(matched, "_run_matched_adamo_diagnostic", unexpected_dispatch)
+    with pytest.raises(ValueError, match="canonical OpenML materialization"):
+        matched.run_campaign(Path("unused"), destination)
+    assert dispatched == 0
+    assert not destination.exists()
 
 
 def test_report_recomputes_paired_statistics_and_retains_every_outcome(

--- a/tests/test_adamo_matched_development.py
+++ b/tests/test_adamo_matched_development.py
@@ -152,6 +152,7 @@ def test_atomic_publication_refuses_overwrite(
 
 
 def test_execution_gate_is_closed_until_plan_review() -> None:
+    assert not hasattr(matched, "run_adamo_diagnostic")
     with pytest.raises(RuntimeError, match="not authorized"):
         matched.run_campaign(Path("unused.npz"), Path("unused.json"))
 

--- a/tests/test_adamo_matched_development.py
+++ b/tests/test_adamo_matched_development.py
@@ -9,36 +9,47 @@ from typing import Never
 import numpy as np
 import pytest
 
-from alberta_framework.benchmarks import adamo_diagnostic
 from alberta_framework.benchmarks import adamo_matched_development as matched
-from alberta_framework.benchmarks.adamo_diagnostic import (
-    FROZEN_DEVELOPMENT_SEEDS,
-    run_adamo_diagnostic,
-)
+from alberta_framework.benchmarks.adamo_diagnostic import run_adamo_diagnostic
 
 pytestmark = pytest.mark.integration
 
 
 def _patch_identities(
     monkeypatch: pytest.MonkeyPatch, receipts: list[dict[str, object]]
-) -> None:
+) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+    run_runtime = receipts[0]["runtime"]
+    dataset = {
+        "x": {"shape": [60_000, 784], "sha256": receipts[0]["dataset"]["x_sha256"]},
+        "y": {"shape": [60_000], "sha256": receipts[0]["dataset"]["y_sha256"]},
+    }
+    source = {"git_commit": "c" * 40, "relevant_source_sha256": "a" * 64}
+    runtime = {
+        "python": {"version": run_runtime["python"]},
+        "packages": {"jax": run_runtime["jax"], "numpy": run_runtime["numpy"]},
+        "jax": {"backend": run_runtime["backend"]},
+    }
     monkeypatch.setattr(
-        matched,
-        "_current_source_provenance",
-        lambda: {"git_commit": "c" * 40, "relevant_source_sha256": "a" * 64},
+        matched, "_current_source_provenance", lambda: source
     )
-    monkeypatch.setattr(
-        matched,
-        "_current_runtime_environment",
-        lambda: {"schema": "test-runtime", "backend": "cpu"},
+    monkeypatch.setattr(matched, "_current_runtime_environment", lambda: runtime)
+    monkeypatch.setattr(matched, "validate_adamo_diagnostic", lambda value, **_: value)
+    monkeypatch.setattr(matched, "_validated_dataset_provenance", lambda value, **_: value)
+    monkeypatch.setattr(matched, "_validated_source_provenance", lambda value, **_: value)
+    monkeypatch.setattr(matched, "_validated_runtime_environment", lambda value, **_: value)
+    return dataset, source, runtime
+
+
+def _build_report(
+    receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
+) -> dict[str, object]:
+    dataset, source, runtime = _patch_identities(monkeypatch, receipts)
+    return matched.build_report(
+        receipts,
+        dataset_provenance=dataset,
+        source_provenance=source,
+        runtime_environment=runtime,
     )
-    monkeypatch.setattr(
-        matched,
-        "validate_adamo_diagnostic",
-        lambda value, *, seed_schedule: value,
-    )
-    semantic = receipts[0]["dataset"]["sha256"]
-    monkeypatch.setattr(matched, "DATASET_SEMANTIC_SHA256", semantic)
 
 
 @pytest.fixture(scope="module")
@@ -49,47 +60,44 @@ def receipts() -> list[dict[str, object]]:
         inputs,
         labels,
         profile="contract-smoke",
-        seed=FROZEN_DEVELOPMENT_SEEDS[0],
+        seed=matched.CONSUMED_QUALIFICATION_SEEDS[0],
     )
     result = []
     for seed in matched.SEEDS:
         receipt = copy.deepcopy(first)
         receipt["seed"] = seed
-        receipt["frozen_development_seeds"] = list(matched.SEEDS)
         receipt["profile"] = matched.PROFILE
+        receipt["frozen_development_seeds"] = list(matched.SEEDS)
+        receipt["dataset"]["rows"] = 60_000
+        receipt["dataset"]["loaded_numeric_bytes"] = 60_000 * (4 * 4 + 4)
         result.append(receipt)
     return result
 
 
 def test_plan_is_prospective_exact_and_permanently_nonpromoting() -> None:
     plan = matched.frozen_plan()
-    assert adamo_diagnostic.FROZEN_DEVELOPMENT_SEEDS == (15600, 15601, 15602, 15603)
-    assert adamo_diagnostic.ADAMO_MATCHED_DEVELOPMENT_SEEDS == matched.SEEDS
     assert plan["seeds"] == list(matched.SEEDS)
     assert plan["profile"] == "bounded-development"
     assert plan["execution_authorized"] is False
     assert plan["scientific_promotion_allowed"] is False
     assert plan["outcome_retention_required"] is True
     assert plan["consumed_qualification_seeds"] == [15600, 15601, 15602, 15603]
+    assert plan["quarantined_preplan_seeds"] == [25600, 25601, 25602, 25603]
+    assert set(plan["seeds"]).isdisjoint(plan["consumed_qualification_seeds"])
+    assert set(plan["seeds"]).isdisjoint(plan["quarantined_preplan_seeds"])
     assert plan["dataset"]["source"] == {
         "provider": "openml",
         "name": "mnist_784",
         "version": 1,
         "row_start": 0,
-        "row_stop_exclusive": 60000,
+        "row_stop_exclusive": 60_000,
     }
-    assert plan["dataset"]["numeric_bytes"] == 188_400_000
 
 
 def test_report_recomputes_paired_statistics_and_retains_every_outcome(
     receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _patch_identities(monkeypatch, receipts)
-    report = matched.build_report(
-        receipts,
-        dataset_file_sha256="b" * 64,
-        execution_source_commit="c" * 40,
-    )
+    report = _build_report(receipts, monkeypatch)
     assert len(report["runs"]) == len(matched.SEEDS)
     assert set(report["paired_comparisons"]) == {
         "adamo_l1e3",
@@ -105,33 +113,28 @@ def test_report_recomputes_paired_statistics_and_retains_every_outcome(
         "outcome_retained": True,
         "timing_is_telemetry_only": True,
     }
-    assert matched.validate_report(report, require_current_source=True) == report
+    assert matched.validate_report(report, require_current_execution_identity=True) == report
 
 
 def test_validator_rejects_missing_seed_tampering_and_promotion(
     receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _patch_identities(monkeypatch, receipts)
-    report = matched.build_report(
-        receipts,
-        dataset_file_sha256="b" * 64,
-        execution_source_commit="c" * 40,
-    )
+    report = _build_report(receipts, monkeypatch)
 
     missing = copy.deepcopy(report)
     missing["runs"].pop()
     with pytest.raises(ValueError, match="complete frozen seed schedule"):
-        matched.validate_report(missing, require_current_source=True)
+        matched.validate_report(missing, require_current_execution_identity=True)
 
     arithmetic = copy.deepcopy(report)
     arithmetic["paired_comparisons"]["adamo_l1e3"]["mean_accuracy_delta"] = 1.0
     with pytest.raises(ValueError, match="paired arithmetic"):
-        matched.validate_report(arithmetic, require_current_source=True)
+        matched.validate_report(arithmetic, require_current_execution_identity=True)
 
     promoting = copy.deepcopy(report)
     promoting["policy"]["scientific_promotion_allowed"] = True
     with pytest.raises(ValueError, match="permanently nonpromoting"):
-        matched.validate_report(promoting, require_current_source=True)
+        matched.validate_report(promoting, require_current_execution_identity=True)
 
 
 def test_atomic_publication_refuses_overwrite(
@@ -139,14 +142,10 @@ def test_atomic_publication_refuses_overwrite(
     receipts: list[dict[str, object]],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_identities(monkeypatch, receipts)
-    report = matched.build_report(
-        receipts,
-        dataset_file_sha256="b" * 64,
-        execution_source_commit="c" * 40,
-    )
     destination = tmp_path / "report.json"
     monkeypatch.setattr(matched, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(matched, "_EXECUTION_AUTHORIZED", True)
+    report = _build_report(receipts, monkeypatch)
     matched.publish_report(destination, report)
     with pytest.raises(FileExistsError):
         matched.publish_report(destination, report)
@@ -157,18 +156,6 @@ def test_execution_gate_is_closed_until_plan_review() -> None:
         matched.run_campaign(Path("unused.npz"), Path("unused.json"))
 
 
-def test_public_diagnostic_schedule_cannot_consume_reserved_matched_seed() -> None:
-    inputs = np.linspace(-1.0, 1.0, 32, dtype=np.float32).reshape(8, 4)
-    labels = np.arange(8, dtype=np.int32) % 2
-    with pytest.raises(ValueError, match="frozen, consumed development schedule"):
-        run_adamo_diagnostic(
-            inputs,
-            labels,
-            profile="contract-smoke",
-            seed=matched.SEEDS[0],
-        )
-
-
 def test_student_t_df3_constant_is_exact() -> None:
     assert matched.T95_DF3 == 3.1824463052837078
     assert matched.T95_DF3.hex() == "0x1.975a66893c1a7p+1"
@@ -177,12 +164,7 @@ def test_student_t_df3_constant_is_exact() -> None:
 def test_validator_preflights_hostile_nested_plan_without_dispatch(
     receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _patch_identities(monkeypatch, receipts)
-    report = matched.build_report(
-        receipts,
-        dataset_file_sha256="b" * 64,
-        execution_source_commit="c" * 40,
-    )
+    report = _build_report(receipts, monkeypatch)
 
     class HostileList(list[object]):
         calls = 0
@@ -198,23 +180,19 @@ def test_validator_preflights_hostile_nested_plan_without_dispatch(
     hostile = copy.deepcopy(report)
     hostile["plan"]["arms"] = HostileList(hostile["plan"]["arms"])
     with pytest.raises(ValueError, match="exact JSON"):
-        matched.validate_report(hostile, require_current_source=True)
+        matched.validate_report(hostile, require_current_execution_identity=True)
     assert HostileList.calls == 0
 
 
-def test_validator_binds_execution_commit_to_source_provenance(
+def test_offline_validation_does_not_require_the_execution_runtime(
     receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _patch_identities(monkeypatch, receipts)
-    report = matched.build_report(
-        receipts,
-        dataset_file_sha256="b" * 64,
-        execution_source_commit="c" * 40,
-    )
-    hostile = copy.deepcopy(report)
-    hostile["execution_source_commit"] = "d" * 40
-    with pytest.raises(ValueError, match="does not match source provenance"):
-        matched.validate_report(hostile, require_current_source=False)
+    report = _build_report(receipts, monkeypatch)
+    monkeypatch.setattr(matched, "_current_source_provenance", lambda: {"different": True})
+    monkeypatch.setattr(matched, "_current_runtime_environment", lambda: {"different": True})
+    assert matched.validate_report(report) == report
+    with pytest.raises(ValueError, match="current source"):
+        matched.validate_report(report, require_current_execution_identity=True)
 
 
 def test_build_report_rejects_hostile_sequence_without_hashing_its_metaclass() -> None:
@@ -228,20 +206,16 @@ def test_build_report_rejects_hostile_sequence_without_hashing_its_metaclass() -
     with pytest.raises(ValueError, match="complete frozen seed schedule"):
         matched.build_report(
             HostileSequence(),
-            dataset_file_sha256="a" * 64,
-            execution_source_commit="b" * 40,
+            dataset_provenance={},
+            source_provenance={},
+            runtime_environment={},
         )
 
 
 def test_report_schema_subclass_is_rejected_without_equality_hook(
     receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_identities(monkeypatch, receipts)
-    report = matched.build_report(
-        receipts,
-        dataset_file_sha256="b" * 64,
-        execution_source_commit="c" * 40,
-    )
+    report = _build_report(receipts, monkeypatch)
 
     class HostileString(str):
         calls = 0
@@ -253,8 +227,27 @@ def test_report_schema_subclass_is_rejected_without_equality_hook(
     hostile = copy.deepcopy(report)
     hostile["schema"] = HostileString(matched.SCHEMA)
     with pytest.raises(ValueError, match="schema"):
-        matched.validate_report(hostile, require_current_source=False)
+        matched.validate_report(hostile)
     assert HostileString.calls == 0
+
+
+def test_dataset_provenance_subclass_is_rejected_before_validator_hooks(
+    receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    report = _build_report(receipts, monkeypatch)
+
+    class HostileDict(dict[object, object]):
+        calls = 0
+
+        def __iter__(self) -> Never:
+            type(self).calls += 1
+            raise AssertionError("must not iterate hostile provenance")
+
+    hostile = copy.deepcopy(report)
+    hostile["dataset_provenance"] = HostileDict(hostile["dataset_provenance"])
+    with pytest.raises(ValueError, match="exact JSON"):
+        matched.validate_report(hostile)
+    assert HostileDict.calls == 0
 
 
 def test_publication_rejects_symlink_parent_without_touching_target(
@@ -262,18 +255,14 @@ def test_publication_rejects_symlink_parent_without_touching_target(
     receipts: list[dict[str, object]],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _patch_identities(monkeypatch, receipts)
-    report = matched.build_report(
-        receipts,
-        dataset_file_sha256="b" * 64,
-        execution_source_commit="c" * 40,
-    )
     real_parent = tmp_path / "real"
     real_parent.mkdir()
     linked_parent = tmp_path / "linked"
     linked_parent.symlink_to(real_parent, target_is_directory=True)
     destination = linked_parent / "report.json"
     monkeypatch.setattr(matched, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(matched, "_EXECUTION_AUTHORIZED", True)
+    report = _build_report(receipts, monkeypatch)
     with pytest.raises(OSError):
         matched.publish_report(destination, report)
     assert not (real_parent / "report.json").exists()

--- a/tests/test_adamo_matched_development.py
+++ b/tests/test_adamo_matched_development.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 from pathlib import Path
+from typing import Never
 
 import numpy as np
 import pytest
@@ -12,6 +13,25 @@ from alberta_framework.benchmarks import adamo_matched_development as matched
 from alberta_framework.benchmarks.adamo_diagnostic import run_adamo_diagnostic
 
 pytestmark = pytest.mark.integration
+
+
+def _patch_identities(
+    monkeypatch: pytest.MonkeyPatch, receipts: list[dict[str, object]]
+) -> None:
+    monkeypatch.setattr(
+        matched,
+        "_current_source_provenance",
+        lambda: {"git_commit": "c" * 40, "relevant_source_sha256": "a" * 64},
+    )
+    monkeypatch.setattr(
+        matched,
+        "_current_runtime_environment",
+        lambda: {"schema": "test-runtime", "backend": "cpu"},
+    )
+    monkeypatch.setattr(matched, "validate_adamo_diagnostic", lambda value: value)
+    semantic = receipts[0]["dataset"]["sha256"]
+    monkeypatch.setattr(matched, "DATASET_FILE_SHA256", "b" * 64)
+    monkeypatch.setattr(matched, "DATASET_SEMANTIC_SHA256", semantic)
 
 
 @pytest.fixture(scope="module")
@@ -28,6 +48,7 @@ def receipts() -> list[dict[str, object]]:
     for seed in matched.SEEDS:
         receipt = copy.deepcopy(first)
         receipt["seed"] = seed
+        receipt["profile"] = matched.PROFILE
         result.append(receipt)
     return result
 
@@ -45,7 +66,7 @@ def test_plan_is_prospective_exact_and_permanently_nonpromoting() -> None:
 def test_report_recomputes_paired_statistics_and_retains_every_outcome(
     receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(matched, "_current_source_manifest", lambda: {"x.py": "a" * 64})
+    _patch_identities(monkeypatch, receipts)
     report = matched.build_report(
         receipts,
         dataset_file_sha256="b" * 64,
@@ -72,7 +93,7 @@ def test_report_recomputes_paired_statistics_and_retains_every_outcome(
 def test_validator_rejects_missing_seed_tampering_and_promotion(
     receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(matched, "_current_source_manifest", lambda: {"x.py": "a" * 64})
+    _patch_identities(monkeypatch, receipts)
     report = matched.build_report(
         receipts,
         dataset_file_sha256="b" * 64,
@@ -100,13 +121,14 @@ def test_atomic_publication_refuses_overwrite(
     receipts: list[dict[str, object]],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(matched, "_current_source_manifest", lambda: {"x.py": "a" * 64})
+    _patch_identities(monkeypatch, receipts)
     report = matched.build_report(
         receipts,
         dataset_file_sha256="b" * 64,
         execution_source_commit="c" * 40,
     )
     destination = tmp_path / "report.json"
+    monkeypatch.setattr(matched, "OUTPUT_PATH", destination)
     matched.publish_report(destination, report)
     with pytest.raises(FileExistsError):
         matched.publish_report(destination, report)
@@ -120,3 +142,46 @@ def test_execution_gate_is_closed_until_plan_review() -> None:
 def test_student_t_df3_constant_is_exact() -> None:
     assert matched.T95_DF3 == 3.1824463052837078
     assert matched.T95_DF3.hex() == "0x1.975a66893c1a7p+1"
+
+
+def test_validator_preflights_hostile_nested_plan_without_dispatch(
+    receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_identities(monkeypatch, receipts)
+    report = matched.build_report(
+        receipts,
+        dataset_file_sha256="b" * 64,
+        execution_source_commit="c" * 40,
+    )
+
+    class HostileList(list[object]):
+        calls = 0
+
+        def __iter__(self) -> Never:
+            type(self).calls += 1
+            raise AssertionError("hostile iteration")
+
+        def __eq__(self, other: object) -> Never:
+            type(self).calls += 1
+            raise AssertionError("hostile equality")
+
+    hostile = copy.deepcopy(report)
+    hostile["plan"]["arms"] = HostileList(hostile["plan"]["arms"])
+    with pytest.raises(ValueError, match="exact JSON"):
+        matched.validate_report(hostile, require_current_source=True)
+    assert HostileList.calls == 0
+
+
+def test_validator_binds_execution_commit_to_source_provenance(
+    receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_identities(monkeypatch, receipts)
+    report = matched.build_report(
+        receipts,
+        dataset_file_sha256="b" * 64,
+        execution_source_commit="c" * 40,
+    )
+    hostile = copy.deepcopy(report)
+    hostile["execution_source_commit"] = "d" * 40
+    with pytest.raises(ValueError, match="does not match source provenance"):
+        matched.validate_report(hostile, require_current_source=False)

--- a/tests/test_adamo_matched_development.py
+++ b/tests/test_adamo_matched_development.py
@@ -1,0 +1,122 @@
+"""Prospectively frozen matched-development campaign for issue #1560."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks import adamo_matched_development as matched
+from alberta_framework.benchmarks.adamo_diagnostic import run_adamo_diagnostic
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def receipts() -> list[dict[str, object]]:
+    inputs = np.linspace(-1.0, 1.0, 32, dtype=np.float32).reshape(8, 4)
+    labels = np.arange(8, dtype=np.int32) % 2
+    first = run_adamo_diagnostic(
+        inputs,
+        labels,
+        profile="contract-smoke",
+        seed=matched.SEEDS[0],
+    )
+    result = []
+    for seed in matched.SEEDS:
+        receipt = copy.deepcopy(first)
+        receipt["seed"] = seed
+        result.append(receipt)
+    return result
+
+
+def test_plan_is_prospective_exact_and_permanently_nonpromoting() -> None:
+    plan = matched.frozen_plan()
+    assert plan["seeds"] == list(matched.SEEDS)
+    assert plan["profile"] == "bounded-development"
+    assert plan["execution_authorized"] is False
+    assert plan["scientific_promotion_allowed"] is False
+    assert plan["outcome_retention_required"] is True
+    assert plan["consumed_qualification_seeds"] == [15600, 15601, 15602, 15603]
+
+
+def test_report_recomputes_paired_statistics_and_retains_every_outcome(
+    receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(matched, "_current_source_manifest", lambda: {"x.py": "a" * 64})
+    report = matched.build_report(
+        receipts,
+        dataset_file_sha256="b" * 64,
+        execution_source_commit="c" * 40,
+    )
+    assert len(report["runs"]) == len(matched.SEEDS)
+    assert set(report["paired_comparisons"]) == {
+        "adamo_l1e3",
+        "adam_iso_joint_l1e3",
+    }
+    assert all(
+        comparison["outcome"] in {"supported", "rejected", "inconclusive"}
+        for comparison in report["paired_comparisons"].values()
+    )
+    assert report["policy"] == {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "outcome_retained": True,
+        "timing_is_telemetry_only": True,
+    }
+    assert matched.validate_report(report, require_current_source=True) == report
+
+
+def test_validator_rejects_missing_seed_tampering_and_promotion(
+    receipts: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(matched, "_current_source_manifest", lambda: {"x.py": "a" * 64})
+    report = matched.build_report(
+        receipts,
+        dataset_file_sha256="b" * 64,
+        execution_source_commit="c" * 40,
+    )
+
+    missing = copy.deepcopy(report)
+    missing["runs"].pop()
+    with pytest.raises(ValueError, match="complete frozen seed schedule"):
+        matched.validate_report(missing, require_current_source=True)
+
+    arithmetic = copy.deepcopy(report)
+    arithmetic["paired_comparisons"]["adamo_l1e3"]["mean_accuracy_delta"] = 1.0
+    with pytest.raises(ValueError, match="paired arithmetic"):
+        matched.validate_report(arithmetic, require_current_source=True)
+
+    promoting = copy.deepcopy(report)
+    promoting["policy"]["scientific_promotion_allowed"] = True
+    with pytest.raises(ValueError, match="permanently nonpromoting"):
+        matched.validate_report(promoting, require_current_source=True)
+
+
+def test_atomic_publication_refuses_overwrite(
+    tmp_path: Path,
+    receipts: list[dict[str, object]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(matched, "_current_source_manifest", lambda: {"x.py": "a" * 64})
+    report = matched.build_report(
+        receipts,
+        dataset_file_sha256="b" * 64,
+        execution_source_commit="c" * 40,
+    )
+    destination = tmp_path / "report.json"
+    matched.publish_report(destination, report)
+    with pytest.raises(FileExistsError):
+        matched.publish_report(destination, report)
+
+
+def test_execution_gate_is_closed_until_plan_review() -> None:
+    with pytest.raises(RuntimeError, match="not authorized"):
+        matched.run_campaign(Path("unused.npz"), Path("unused.json"))
+
+
+def test_student_t_df3_constant_is_exact() -> None:
+    assert matched.T95_DF3 == 3.1824463052837078
+    assert matched.T95_DF3.hex() == "0x1.975a66893c1a7p+1"

--- a/tests/test_adamo_matched_development.py
+++ b/tests/test_adamo_matched_development.py
@@ -11,7 +11,10 @@ import pytest
 
 from alberta_framework.benchmarks import adamo_diagnostic
 from alberta_framework.benchmarks import adamo_matched_development as matched
-from alberta_framework.benchmarks.adamo_diagnostic import run_adamo_diagnostic
+from alberta_framework.benchmarks.adamo_diagnostic import (
+    FROZEN_DEVELOPMENT_SEEDS,
+    run_adamo_diagnostic,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -29,7 +32,11 @@ def _patch_identities(
         "_current_runtime_environment",
         lambda: {"schema": "test-runtime", "backend": "cpu"},
     )
-    monkeypatch.setattr(matched, "validate_adamo_diagnostic", lambda value: value)
+    monkeypatch.setattr(
+        matched,
+        "validate_adamo_diagnostic",
+        lambda value, *, seed_schedule: value,
+    )
     semantic = receipts[0]["dataset"]["sha256"]
     monkeypatch.setattr(matched, "DATASET_SEMANTIC_SHA256", semantic)
 
@@ -42,12 +49,13 @@ def receipts() -> list[dict[str, object]]:
         inputs,
         labels,
         profile="contract-smoke",
-        seed=matched.SEEDS[0],
+        seed=FROZEN_DEVELOPMENT_SEEDS[0],
     )
     result = []
     for seed in matched.SEEDS:
         receipt = copy.deepcopy(first)
         receipt["seed"] = seed
+        receipt["frozen_development_seeds"] = list(matched.SEEDS)
         receipt["profile"] = matched.PROFILE
         result.append(receipt)
     return result
@@ -147,6 +155,18 @@ def test_atomic_publication_refuses_overwrite(
 def test_execution_gate_is_closed_until_plan_review() -> None:
     with pytest.raises(RuntimeError, match="not authorized"):
         matched.run_campaign(Path("unused.npz"), Path("unused.json"))
+
+
+def test_public_diagnostic_schedule_cannot_consume_reserved_matched_seed() -> None:
+    inputs = np.linspace(-1.0, 1.0, 32, dtype=np.float32).reshape(8, 4)
+    labels = np.arange(8, dtype=np.int32) % 2
+    with pytest.raises(ValueError, match="frozen, consumed development schedule"):
+        run_adamo_diagnostic(
+            inputs,
+            labels,
+            profile="contract-smoke",
+            seed=matched.SEEDS[0],
+        )
 
 
 def test_student_t_df3_constant_is_exact() -> None:

--- a/tests/test_adamo_matched_development.py
+++ b/tests/test_adamo_matched_development.py
@@ -9,6 +9,7 @@ from typing import Never
 import numpy as np
 import pytest
 
+from alberta_framework.benchmarks import adamo_diagnostic
 from alberta_framework.benchmarks import adamo_matched_development as matched
 from alberta_framework.benchmarks.adamo_diagnostic import run_adamo_diagnostic
 
@@ -30,7 +31,6 @@ def _patch_identities(
     )
     monkeypatch.setattr(matched, "validate_adamo_diagnostic", lambda value: value)
     semantic = receipts[0]["dataset"]["sha256"]
-    monkeypatch.setattr(matched, "DATASET_FILE_SHA256", "b" * 64)
     monkeypatch.setattr(matched, "DATASET_SEMANTIC_SHA256", semantic)
 
 
@@ -55,12 +55,22 @@ def receipts() -> list[dict[str, object]]:
 
 def test_plan_is_prospective_exact_and_permanently_nonpromoting() -> None:
     plan = matched.frozen_plan()
+    assert adamo_diagnostic.FROZEN_DEVELOPMENT_SEEDS == (15600, 15601, 15602, 15603)
+    assert adamo_diagnostic.ADAMO_MATCHED_DEVELOPMENT_SEEDS == matched.SEEDS
     assert plan["seeds"] == list(matched.SEEDS)
     assert plan["profile"] == "bounded-development"
     assert plan["execution_authorized"] is False
     assert plan["scientific_promotion_allowed"] is False
     assert plan["outcome_retention_required"] is True
     assert plan["consumed_qualification_seeds"] == [15600, 15601, 15602, 15603]
+    assert plan["dataset"]["source"] == {
+        "provider": "openml",
+        "name": "mnist_784",
+        "version": 1,
+        "row_start": 0,
+        "row_stop_exclusive": 60000,
+    }
+    assert plan["dataset"]["numeric_bytes"] == 188_400_000
 
 
 def test_report_recomputes_paired_statistics_and_retains_every_outcome(

--- a/tests/test_console_entrypoints.py
+++ b/tests/test_console_entrypoints.py
@@ -32,6 +32,9 @@ _ASI_SCRIPTS = {
         "alberta_framework.benchmarks.activation_feature_ipmnist:main"
     ),
     "asi-adamo-diagnostic": "alberta_framework.benchmarks.adamo_diagnostic:main",
+    "asi-adamo-matched-development": (
+        "alberta_framework.benchmarks.adamo_matched_development:main"
+    ),
     "asi-clear-qualification": (
         "alberta_framework.benchmarks.clear_qualification:main"
     ),

--- a/tests/test_dreamer_continual_development.py
+++ b/tests/test_dreamer_continual_development.py
@@ -13,7 +13,7 @@ from alberta_framework.benchmarks.dreamer_continual_development import (
     validate_result,
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
 
 def test_end_to_end_lane_exercises_world_model_replay_imagination_and_control() -> None:

--- a/tests/test_dreamer_continual_development.py
+++ b/tests/test_dreamer_continual_development.py
@@ -13,7 +13,7 @@ from alberta_framework.benchmarks.dreamer_continual_development import (
     validate_result,
 )
 
-pytestmark = [pytest.mark.integration, pytest.mark.slow]
+pytestmark = pytest.mark.integration
 
 
 def test_end_to_end_lane_exercises_world_model_replay_imagination_and_control() -> None:

--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -49,6 +49,7 @@ _EXPECTED_SCRIPT_NAMES = {
     "asi-action-conditioned-latent",
     "asi-activation-feature-ipmnist",
     "asi-adamo-diagnostic",
+    "asi-adamo-matched-development",
     "asi-clear-qualification",
     "asi-coom-qualification-smoke",
     "asi-cora-catalog",


### PR DESCRIPTION
## Summary

- prospectively freeze issue #1560's bounded AdamO IPMNIST matched-development transaction before execution
- preserve qualification-consumed seeds 15600-15603, quarantine the exposed 25600-25603 preplan roster because an earlier fixture exercised 25600, and reserve the repository/history-audited fresh roster 9156001-9156004
- materialize OpenML `mnist_784` v1 rows 0:60000 through the existing loader and require the frozen canonical effective-array identities before any reserved seed dispatch: float32 `[-1,1]` x SHA-256 `b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313` and int32 y SHA-256 `4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a`
- bind every run and the aggregate to one exact clean source/package/lock identity and one exact runtime/JAX environment
- validate retained reports structurally and semantically offline on a different host/runtime, while requiring the exact current execution identity for report construction, campaign execution, and publication
- retain hostile-safe bounded receipt/report validation, pinned pre-execution output reservation, no-replace publication, exact paired Student-t/resource recomputation, the bit-exact AdamO-off reduction, paper-parity disclaimers, and permanently nonpromoting policy
- preserve the existing public diagnostic profiles on the consumed 15600-15603 qualification roster while preventing that CLI/function from selecting any reserved matched seed; the fresh-schedule executor remains internal to the authorization-gated aggregate path

## Execution boundary

`_EXECUTION_AUTHORIZED` is deliberately `False`. This PR creates no fixed output and runs no matched-development campaign. Publication is also closed while authorization is false. A separate reviewed authorization change is required after the frozen plan merges; issue #1560 remains open until a complete retained result is independently audited.

## Validation

- exact head `532c265861e3991bf5c970d130cdf74a5b80cf1e`
- 55 focused AdamO/CLI/package tests passed after final reconciliation
- focused Ruff clean
- strict mypy clean for both production modules
- `git diff --check` clean
- history audit finds reserved seeds 9156001-9156004 only in this unexecuted plan lineage
- verified canonical OpenML cache hashes match the frozen x/y bindings; an all-zero MNIST-shaped counterexample is rejected before dispatch
- `outputs/adamo_matched_development/report.v1.json` absent
