### PR TITLE
fix(checkpoint): reject oversized payload_hex before charset hang

### DIFF
--- a/alberta_framework/reference_life_checkpoint.py
+++ b/alberta_framework/reference_life_checkpoint.py
@@ -431,6 +431,7 @@ def _decode_array_value(value: Any, *, path: str) -> ArrayValue:
         {"semantic_id", "dtype", "shape", "payload_hex"},
         path=path,
     )
+    semantic_id = _require_str(data["semantic_id"], path=f"{path}.semantic_id")
     shape_raw = data["shape"]
     if type(shape_raw) is not list:
         _fail(f"{path}.shape must be a JSON array")
@@ -454,7 +455,7 @@ def _decode_array_value(value: Any, *, path: str) -> ArrayValue:
         payload_hex, path=path, expected_bytes=expected_bytes
     )
     return ArrayValue(
-        semantic_id=_require_str(data["semantic_id"], path=f"{path}.semantic_id"),
+        semantic_id=semantic_id,
         dtype=dtype_name,
         shape=shape,
         payload=payload,

--- a/alberta_framework/reference_life_checkpoint.py
+++ b/alberta_framework/reference_life_checkpoint.py
@@ -14,6 +14,7 @@ import importlib.metadata
 import json
 import os
 import platform
+import re
 import shutil
 import stat as stat_module
 import struct
@@ -106,8 +107,7 @@ _MAX_CHILD_FILE_BYTES = 128 * 1024 * 1024
 _MAX_CHILD_TOTAL_BYTES = 512 * 1024 * 1024
 _PROTOTYPE_EMPTY_ARRAY_CODEC = "alberta.prototype_agent.empty_array_projection.v1"
 _PROTOTYPE_SUPPORTED_PRNG_IMPLS = frozenset({"threefry2x32", "rbg"})
-# Delete lowercase hex so a nonempty remainder means a non-hex or uppercase glyph.
-_LOWER_HEX_DELETE = str.maketrans("", "", "0123456789abcdef")
+_LOWER_HEX_PATTERN = re.compile(r"[0-9a-f]*\Z", flags=re.ASCII)
 
 
 def _fail(message: str) -> NoReturn:
@@ -401,7 +401,9 @@ def _decode_hex_payload(payload_hex: str, *, path: str, expected_bytes: int) -> 
     expected_hex = expected_bytes * 2
     if len(payload_hex) != expected_hex:
         _fail(f"{path}.payload_hex length does not match shape and dtype")
-    if payload_hex.translate(_LOWER_HEX_DELETE):
+    # Keep this validation in the regex engine. ``str.translate`` would allocate
+    # another string as large as the already-bounded checkpoint payload.
+    if _LOWER_HEX_PATTERN.fullmatch(payload_hex) is None:
         _fail(f"{path}.payload_hex must be lowercase hexadecimal")
     try:
         raw = bytes.fromhex(payload_hex)

--- a/alberta_framework/reference_life_checkpoint.py
+++ b/alberta_framework/reference_life_checkpoint.py
@@ -106,6 +106,8 @@ _MAX_CHILD_FILE_BYTES = 128 * 1024 * 1024
 _MAX_CHILD_TOTAL_BYTES = 512 * 1024 * 1024
 _PROTOTYPE_EMPTY_ARRAY_CODEC = "alberta.prototype_agent.empty_array_projection.v1"
 _PROTOTYPE_SUPPORTED_PRNG_IMPLS = frozenset({"threefry2x32", "rbg"})
+# Delete lowercase hex so a nonempty remainder means a non-hex or uppercase glyph.
+_LOWER_HEX_DELETE = str.maketrans("", "", "0123456789abcdef")
 
 
 def _fail(message: str) -> NoReturn:
@@ -378,6 +380,38 @@ def _decode_float(value: Any, *, path: str) -> float:
     return result
 
 
+def _bounded_element_count(shape: tuple[int, ...], *, path: str) -> int:
+    """Return ``prod(shape)`` or fail before a host hex walk can start."""
+
+    elements = 1
+    for dimension in shape:
+        if dimension > 0 and elements > _MAX_ARRAY_ELEMENTS // dimension:
+            _fail(f"{path}.shape exceeds the element limit")
+        elements *= dimension
+        if elements > _MAX_ARRAY_ELEMENTS:
+            _fail(f"{path}.shape exceeds the element limit")
+    return elements
+
+
+def _decode_hex_payload(payload_hex: str, *, path: str, expected_bytes: int) -> bytes:
+    """Decode lowercase hex only after ``expected_bytes`` is known from shape/dtype."""
+
+    if expected_bytes < 0 or expected_bytes > _MAX_ARRAY_BYTES:
+        _fail(f"{path} exceeds the byte limit")
+    expected_hex = expected_bytes * 2
+    if len(payload_hex) != expected_hex:
+        _fail(f"{path}.payload_hex length does not match shape and dtype")
+    if payload_hex.translate(_LOWER_HEX_DELETE):
+        _fail(f"{path}.payload_hex must be lowercase hexadecimal")
+    try:
+        raw = bytes.fromhex(payload_hex)
+    except ValueError as error:
+        raise ValueError(f"{path}.payload_hex must be lowercase hexadecimal") from error
+    if len(raw) != expected_bytes:
+        _fail(f"{path}.payload_hex length does not match shape and dtype")
+    return raw
+
+
 def _encode_array_value(value: ArrayValue) -> dict[str, Any]:
     if not isinstance(value, ArrayValue):
         raise ValueError("checkpoint protocol value must be an ArrayValue")
@@ -404,16 +438,24 @@ def _decode_array_value(value: Any, *, path: str) -> ArrayValue:
         _require_int(dimension, path=f"{path}.shape[{index}]", minimum=1)
         for index, dimension in enumerate(shape_raw)
     )
+    dtype_name = _require_str(data["dtype"], path=f"{path}.dtype")
+    try:
+        dtype = np.dtype(dtype_name)
+    except TypeError as exc:
+        raise ValueError(f"{path}.dtype is unsupported") from exc
+    if dtype.name != dtype_name:
+        _fail(f"{path}.dtype is not a canonical numeric dtype")
+    elements = _bounded_element_count(shape, path=path)
+    expected_bytes = elements * dtype.itemsize
     payload_hex = _require_str(data["payload_hex"], path=f"{path}.payload_hex")
-    if len(payload_hex) > 2 * _MAX_ARRAY_BYTES:
-        _fail(f"{path}.payload_hex exceeds the byte limit")
-    if len(payload_hex) % 2 or any(c not in "0123456789abcdef" for c in payload_hex):
-        _fail(f"{path}.payload_hex must be lowercase hexadecimal")
+    payload = _decode_hex_payload(
+        payload_hex, path=path, expected_bytes=expected_bytes
+    )
     return ArrayValue(
         semantic_id=_require_str(data["semantic_id"], path=f"{path}.semantic_id"),
-        dtype=_require_str(data["dtype"], path=f"{path}.dtype"),
+        dtype=dtype_name,
         shape=shape,
-        payload=bytes.fromhex(payload_hex),
+        payload=payload,
     )
 
 
@@ -504,20 +546,11 @@ def _decode_jax_array(value: Any, *, path: str) -> jax.Array:
         for index, dimension in enumerate(shape_raw)
     )
     payload_hex = _require_str(data["payload_hex"], path=f"{path}.payload_hex")
-    if len(payload_hex) > 2 * _MAX_ARRAY_BYTES:
-        _fail(f"{path}.payload_hex exceeds the byte limit")
-    if len(payload_hex) % 2 or any(c not in "0123456789abcdef" for c in payload_hex):
-        _fail(f"{path}.payload_hex must be lowercase hexadecimal")
-    raw = bytes.fromhex(payload_hex)
-    elements = 1
-    for dimension in shape:
-        elements *= dimension
-        if elements > _MAX_ARRAY_ELEMENTS:
-            _fail(f"{path}.shape exceeds the element limit")
-    if elements * dtype.itemsize > _MAX_ARRAY_BYTES:
-        _fail(f"{path} exceeds the byte limit")
-    if len(raw) != elements * dtype.itemsize:
-        _fail(f"{path}.payload_hex length does not match shape and dtype")
+    elements = _bounded_element_count(shape, path=path)
+    expected_bytes = elements * dtype.itemsize
+    raw = _decode_hex_payload(
+        payload_hex, path=path, expected_bytes=expected_bytes
+    )
     storage_dtype = dtype.newbyteorder("<")
     array = np.frombuffer(raw, dtype=storage_dtype).astype(dtype, copy=True).reshape(shape)
     result = jnp.asarray(array)

--- a/alberta_framework/reference_life_checkpoint.py
+++ b/alberta_framework/reference_life_checkpoint.py
@@ -48,6 +48,12 @@ from alberta_framework.prototype_reference_adapter import (
     PrototypeReferenceState,
 )
 from alberta_framework.reference_agent import (
+    _MAX_ARRAY_ELEMENTS as _MAX_ARRAY_VALUE_ELEMENTS,
+)
+from alberta_framework.reference_agent import (
+    _SUPPORTED_DTYPES as _ARRAY_VALUE_SUPPORTED_DTYPES,
+)
+from alberta_framework.reference_agent import (
     ArrayValue,
     Decision,
     ReferenceTransactionState,
@@ -380,15 +386,20 @@ def _decode_float(value: Any, *, path: str) -> float:
     return result
 
 
-def _bounded_element_count(shape: tuple[int, ...], *, path: str) -> int:
+def _bounded_element_count(
+    shape: tuple[int, ...],
+    *,
+    path: str,
+    maximum_elements: int = _MAX_ARRAY_ELEMENTS,
+) -> int:
     """Return ``prod(shape)`` or fail before a host hex walk can start."""
 
     elements = 1
     for dimension in shape:
-        if dimension > 0 and elements > _MAX_ARRAY_ELEMENTS // dimension:
+        if dimension > 0 and elements > maximum_elements // dimension:
             _fail(f"{path}.shape exceeds the element limit")
         elements *= dimension
-        if elements > _MAX_ARRAY_ELEMENTS:
+        if elements > maximum_elements:
             _fail(f"{path}.shape exceeds the element limit")
     return elements
 
@@ -446,9 +457,13 @@ def _decode_array_value(value: Any, *, path: str) -> ArrayValue:
         dtype = np.dtype(dtype_name)
     except TypeError as exc:
         raise ValueError(f"{path}.dtype is unsupported") from exc
-    if dtype.name != dtype_name:
-        _fail(f"{path}.dtype is not a canonical numeric dtype")
-    elements = _bounded_element_count(shape, path=path)
+    if dtype.name != dtype_name or dtype_name not in _ARRAY_VALUE_SUPPORTED_DTYPES:
+        _fail(f"{path}.dtype is not a portable canonical numeric dtype")
+    elements = _bounded_element_count(
+        shape,
+        path=path,
+        maximum_elements=_MAX_ARRAY_VALUE_ELEMENTS,
+    )
     expected_bytes = elements * dtype.itemsize
     payload_hex = _require_str(data["payload_hex"], path=f"{path}.payload_hex")
     payload = _decode_hex_payload(

--- a/tests/test_reference_life_checkpoint_payload_hex_hang.py
+++ b/tests/test_reference_life_checkpoint_payload_hex_hang.py
@@ -32,6 +32,10 @@ class _ForbiddenPattern:
         raise AssertionError("payload characters were inspected before its length")
 
 
+def _forbidden_decode(*_args: object, **_kwargs: object) -> bytes:
+    raise AssertionError("payload was inspected before ArrayValue metadata")
+
+
 def test_array_value_rejects_mismatched_hex_before_charset_walk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -49,7 +53,7 @@ def test_array_value_rejects_mismatched_hex_before_charset_walk(
 def test_array_value_rejects_semantic_id_before_charset_walk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    payload = dict(_SCALAR_FLOAT32)
+    payload: dict[str, object] = dict(_SCALAR_FLOAT32)
     payload["semantic_id"] = 1
     monkeypatch.setattr(checkpoint_module, "_LOWER_HEX_PATTERN", _ForbiddenPattern())
     with pytest.raises(ValueError, match="semantic_id must be a string"):
@@ -67,6 +71,26 @@ def test_array_value_rejects_uppercase_hex_of_matching_length() -> None:
     payload = dict(_SCALAR_FLOAT32)
     payload["payload_hex"] = "0000803F"
     with pytest.raises(ValueError, match="lowercase hexadecimal"):
+        _decode_array_value(payload, path="observation")
+
+
+def test_array_value_rejects_unsupported_dtype_before_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = dict(_SCALAR_FLOAT32)
+    payload["dtype"] = "complex64"
+    monkeypatch.setattr(checkpoint_module, "_decode_hex_payload", _forbidden_decode)
+    with pytest.raises(ValueError, match="portable canonical numeric dtype"):
+        _decode_array_value(payload, path="observation")
+
+
+def test_array_value_rejects_first_oversized_shape_before_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = dict(_SCALAR_FLOAT32)
+    payload["shape"] = [(1 << 20) + 1]
+    monkeypatch.setattr(checkpoint_module, "_decode_hex_payload", _forbidden_decode)
+    with pytest.raises(ValueError, match="shape exceeds the element limit"):
         _decode_array_value(payload, path="observation")
 
 

--- a/tests/test_reference_life_checkpoint_payload_hex_hang.py
+++ b/tests/test_reference_life_checkpoint_payload_hex_hang.py
@@ -46,6 +46,16 @@ def test_array_value_rejects_mismatched_hex_before_charset_walk(
         _decode_array_value(payload, path="observation")
 
 
+def test_array_value_rejects_semantic_id_before_charset_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = dict(_SCALAR_FLOAT32)
+    payload["semantic_id"] = 1
+    monkeypatch.setattr(checkpoint_module, "_LOWER_HEX_PATTERN", _ForbiddenPattern())
+    with pytest.raises(ValueError, match="semantic_id must be a string"):
+        _decode_array_value(payload, path="observation")
+
+
 def test_array_value_accepts_matching_lowercase_hex() -> None:
     value = _decode_array_value(_SCALAR_FLOAT32, path="observation")
     assert value.shape == (1,)

--- a/tests/test_reference_life_checkpoint_payload_hex_hang.py
+++ b/tests/test_reference_life_checkpoint_payload_hex_hang.py
@@ -1,10 +1,4 @@
-"""Checkpoint array hex is sized from shape/dtype before the host charset walk.
-
-Origin ``_decode_array_value`` / ``_decode_jax_array`` scanned every character of
-``payload_hex`` with a Python ``any(c not in ...)`` test before comparing the
-decoded length to the declared shape. A cheap ``'a' * (2 * 64 MiB)`` scalar
-float32 payload took 3.057s on origin/main.
-"""
+"""Checkpoint payloads are bounded by their declared shape and dtype."""
 
 from __future__ import annotations
 

--- a/tests/test_reference_life_checkpoint_payload_hex_hang.py
+++ b/tests/test_reference_life_checkpoint_payload_hex_hang.py
@@ -1,0 +1,84 @@
+"""Checkpoint array hex is sized from shape/dtype before the host charset walk.
+
+Origin ``_decode_array_value`` / ``_decode_jax_array`` scanned every character of
+``payload_hex`` with a Python ``any(c not in ...)`` test before comparing the
+decoded length to the declared shape. A cheap ``'a' * (2 * 64 MiB)`` scalar
+float32 payload took 3.057s on origin/main.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.reference_life_checkpoint import (
+    _MAX_ARRAY_BYTES,
+    _decode_array_value,
+    _decode_jax_array,
+)
+
+pytestmark = pytest.mark.unit
+
+_SCALAR_FLOAT32 = {
+    "semantic_id": "obs",
+    "dtype": "float32",
+    "shape": [1],
+    "payload_hex": "0000803f",
+}
+
+
+def _at_cap_hex() -> str:
+    return "a" * (2 * _MAX_ARRAY_BYTES)
+
+
+def test_array_value_rejects_at_cap_hex_before_charset_walk() -> None:
+    payload = {
+        "semantic_id": "obs",
+        "dtype": "float32",
+        "shape": [1],
+        "payload_hex": _at_cap_hex(),
+    }
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="payload_hex length does not match"):
+        _decode_array_value(payload, path="observation")
+    assert time.perf_counter() - started < 0.5
+
+
+def test_array_value_accepts_matching_lowercase_hex() -> None:
+    value = _decode_array_value(_SCALAR_FLOAT32, path="observation")
+    assert value.shape == (1,)
+    assert value.dtype == "float32"
+    assert value.payload == bytes.fromhex("0000803f")
+
+
+def test_array_value_rejects_uppercase_hex_of_matching_length() -> None:
+    payload = dict(_SCALAR_FLOAT32)
+    payload["payload_hex"] = "0000803F"
+    with pytest.raises(ValueError, match="lowercase hexadecimal"):
+        _decode_array_value(payload, path="observation")
+
+
+def test_jax_array_accepts_matching_lowercase_hex() -> None:
+    payload = {
+        "dtype": "float32",
+        "shape": [1],
+        "payload_hex": "0000803f",
+    }
+    array = _decode_jax_array(payload, path="state_index")
+    assert array.shape == (1,)
+    assert array.dtype == jnp.float32
+    assert float(array[0]) == pytest.approx(1.0)
+
+
+def test_jax_array_rejects_at_cap_hex_before_charset_walk() -> None:
+    payload = {
+        "dtype": "float32",
+        "shape": [1],
+        "payload_hex": _at_cap_hex(),
+    }
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="payload_hex length does not match"):
+        _decode_jax_array(payload, path="state_index")
+    assert time.perf_counter() - started < 0.5

--- a/tests/test_reference_life_checkpoint_payload_hex_hang.py
+++ b/tests/test_reference_life_checkpoint_payload_hex_hang.py
@@ -8,13 +8,11 @@ float32 payload took 3.057s on origin/main.
 
 from __future__ import annotations
 
-import time
-
 import jax.numpy as jnp
 import pytest
 
+import alberta_framework.reference_life_checkpoint as checkpoint_module
 from alberta_framework.reference_life_checkpoint import (
-    _MAX_ARRAY_BYTES,
     _decode_array_value,
     _decode_jax_array,
 )
@@ -29,21 +27,23 @@ _SCALAR_FLOAT32 = {
 }
 
 
-def _at_cap_hex() -> str:
-    return "a" * (2 * _MAX_ARRAY_BYTES)
+class _ForbiddenPattern:
+    def fullmatch(self, _value: str) -> None:
+        raise AssertionError("payload characters were inspected before its length")
 
 
-def test_array_value_rejects_at_cap_hex_before_charset_walk() -> None:
+def test_array_value_rejects_mismatched_hex_before_charset_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     payload = {
         "semantic_id": "obs",
         "dtype": "float32",
         "shape": [1],
-        "payload_hex": _at_cap_hex(),
+        "payload_hex": "a" * 10_000,
     }
-    started = time.perf_counter()
+    monkeypatch.setattr(checkpoint_module, "_LOWER_HEX_PATTERN", _ForbiddenPattern())
     with pytest.raises(ValueError, match="payload_hex length does not match"):
         _decode_array_value(payload, path="observation")
-    assert time.perf_counter() - started < 0.5
 
 
 def test_array_value_accepts_matching_lowercase_hex() -> None:
@@ -72,13 +72,14 @@ def test_jax_array_accepts_matching_lowercase_hex() -> None:
     assert float(array[0]) == pytest.approx(1.0)
 
 
-def test_jax_array_rejects_at_cap_hex_before_charset_walk() -> None:
+def test_jax_array_rejects_mismatched_hex_before_charset_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     payload = {
         "dtype": "float32",
         "shape": [1],
-        "payload_hex": _at_cap_hex(),
+        "payload_hex": "a" * 10_000,
     }
-    started = time.perf_counter()
+    monkeypatch.setattr(checkpoint_module, "_LOWER_HEX_PATTERN", _ForbiddenPattern())
     with pytest.raises(ValueError, match="payload_hex length does not match"):
         _decode_jax_array(payload, path="state_index")
-    assert time.perf_counter() - started < 0.5


### PR DESCRIPTION
## Hang

`alberta_framework/reference_life_checkpoint.py` `_decode_array_value` / `_decode_jax_array` walked every character of `payload_hex` with a Python `any(c not in "0123456789abcdef")` test **before** comparing the decoded length to the declared shape and dtype.

The 64 MiB array-byte cap still admits 128 MiB of hex text. Origin/main `a7f96320`:

```text
construct 'a'*(2*_MAX_ARRAY_BYTES)     0.011s
_decode_array_value (shape [1] f32)    3.057s  ValueError: ArrayValue payload has 67108864 bytes; expected 4
```

Cheap `'a' * N` pointer-repeat. This is a host charset walk, not leftover INT32/persist math, not json-nest RecursionError, not jax.tree.

## Fix

Size the payload from shape × dtype first. Decode lowercase hex only after `len(payload_hex) == 2 * expected_bytes`. Reject the 128 MiB mismatch in O(1).

After the audited follow-up at `6124520b455e5896ff60c510d66b96e854d0adbc`, length mismatches fail before character inspection and matching payloads use a no-copy C-level lowercase-hex check:

```text
_decode_array_value (same payload)     0.0001s  ValueError: payload_hex length does not match shape and dtype
```

## Tests

`tests/test_reference_life_checkpoint_payload_hex_hang.py` (unit):

- mismatched hex on `_decode_array_value` and `_decode_jax_array` rejects before any character inspection, without giant fixtures
- matching lowercase hex still decodes
- uppercase hex of matching length still rejects

```bash
.venv/bin/python -m pytest tests/test_reference_life_checkpoint_payload_hex_hang.py -q -o addopts=""
.venv/bin/python -m ruff check alberta_framework/reference_life_checkpoint.py tests/test_reference_life_checkpoint_payload_hex_hang.py
.venv/bin/python -m mypy alberta_framework/reference_life_checkpoint.py tests/test_reference_life_checkpoint_payload_hex_hang.py
```

8 focused tests and 23 adjacent checkpoint tests passed. Ruff, strict targeted mypy, and diff-check are clean.

<!-- evidence-head:6124520b455e5896ff60c510d66b96e854d0adbc -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok CLI via manaflow cmux
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok CLI via manaflow cmux
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-cli-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok CLI via manaflow cmux","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->