### PR TITLE
research: freeze corrected bounded comparator plans

### DIFF
--- a/alberta_framework/benchmarks/adalin.py
+++ b/alberta_framework/benchmarks/adalin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import platform
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -57,6 +58,22 @@ ADALIN_PROTOCOL = MappingProxyType(
 _MAX_ARRAY_ELEMENTS = 1_000_000
 _MAX_DATASET_ELEMENTS = 10_000_000
 _INT32_MAX = 2**31 - 1
+
+_COMPARISON_RESIDUAL_GAPS = (
+    "the pinned official commit contains no implementation or experiment config",
+    "the runner input is caller-supplied and does not bind official MNIST bytes "
+    "or the paper's unspecified sampled indices",
+    "the paper does not specify pixel/example permutation seeds or exact "
+    "dataloader order",
+    "one result is one consumed development seed rather than the paper's three "
+    "final evaluation seeds",
+    "ASI records whole-stream pre-update accuracy separately from the paper's "
+    "per-task train/test summaries",
+)
+_BOUNDARY_DIFFERENCE = (
+    "paper and this runner do not pass task identity or boundary events to the "
+    "learner; the runner uses boundaries only to transform/evaluate data"
+)
 
 
 def _trusted_float_array(value: object, *, name: str) -> Array:
@@ -181,6 +198,8 @@ class AdaLinConfig:
             raise ValueError("tasks cannot exceed the paper's 400-task horizon")
         if self.examples_per_task > 10_000:
             raise ValueError("examples_per_task cannot exceed the paper's 10000-example pool")
+        if self.classes < 2:
+            raise ValueError("classes must contain at least two labels")
         if self.epochs_per_task != 1:
             raise ValueError("this PMNIST lane supports the paper's one epoch per task")
         if self.examples_per_task % self.batch_size != 0:
@@ -253,7 +272,7 @@ def make_pmnist_schedule(config: AdaLinConfig, *, seed: int, input_dim: int) -> 
         raise ValueError("input_dim must be a positive bounded integer")
     if config.tasks * (input_dim + config.examples_per_task) > _MAX_DATASET_ELEMENTS:
         raise ValueError("schedule exceeds the 10000000-element allocation limit")
-    root = jr.key(resolved_seed)
+    root = jr.key(resolved_seed, impl="threefry2x32")
     pixel_root = jr.fold_in(root, 0x414441)
     example_root = jr.fold_in(root, 0x504D4E)
     pixels = jnp.stack(
@@ -294,7 +313,9 @@ def initialize_adalin_state(
     )
     if parameter_count > _MAX_DATASET_ELEMENTS:
         raise ValueError("model exceeds the 10000000-element allocation limit")
-    keys = jr.split(jr.fold_in(jr.key(seed), 0x494E49), 5)
+    keys = jr.split(
+        jr.fold_in(jr.key(seed, impl="threefry2x32"), 0x494E49), 5
+    )
     weight1 = jr.normal(keys[0], (input_dim, width1), dtype=jnp.float32) * math.sqrt(
         2.0 / input_dim
     )
@@ -472,10 +493,13 @@ def _require_dataset(
 
 
 def _hash_arrays(*arrays: np.ndarray) -> str:
-    digest = hashlib.sha256()
-    for array in arrays:
-        digest.update(str(array.dtype).encode())
-        digest.update(str(array.shape).encode())
+    digest = hashlib.sha256(b"asi-adalin-array-bundle-v1\0")
+    for index, array in enumerate(arrays):
+        digest.update(index.to_bytes(4, "little"))
+        digest.update(np.asarray(array.shape, dtype="<i8").tobytes())
+        dtype = array.dtype.str.encode("ascii")
+        digest.update(len(dtype).to_bytes(4, "little"))
+        digest.update(dtype)
         digest.update(array.tobytes(order="C"))
     return digest.hexdigest()
 
@@ -487,6 +511,23 @@ def _state_hash(state: AdaLinState) -> str:
 
 def _implementation_hash() -> str:
     return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def _runtime_identity() -> list[str]:
+    return [platform.python_version(), jax.__version__, np.__version__, jax.default_backend()]
+
+
+def _comparison_payload(config: AdaLinConfig) -> dict[str, object]:
+    return {
+        "paper_comparable": False,
+        "residual_gaps": list(_COMPARISON_RESIDUAL_GAPS),
+        "schedule_difference": (
+            "paper: 400x10000, batch16, one epoch; ASI campaign: 200x5000, "
+            f"batch1; this result uses {config.tasks}x{config.examples_per_task}, "
+            f"batch{config.batch_size}, one epoch"
+        ),
+        "boundary_difference": _BOUNDARY_DIFFERENCE,
+    }
 
 
 def _parameter_bytes(parameters: AdaLinParameters) -> int:
@@ -568,6 +609,7 @@ def run_adalin_development(
                 learning_rate=config.learning_rate,
                 mechanism_enabled=mechanism_enabled,
             )
+            model_forward_calls += 1
         task_online.append(task_correct / config.examples_per_task)
         test_correct, test_total = _accuracy(
             adalin_logits(
@@ -599,6 +641,12 @@ def run_adalin_development(
             "test_examples": int(test_x.shape[0]),
             "input_dim": int(train_x.shape[1]),
             "classes": config.classes,
+            "train_inputs_shape": [int(train_x.shape[0]), int(train_x.shape[1])],
+            "train_labels_shape": [int(train_y.shape[0])],
+            "test_inputs_shape": [int(test_x.shape[0]), int(test_x.shape[1])],
+            "test_labels_shape": [int(test_y.shape[0])],
+            "inputs_dtype": "float32",
+            "labels_dtype": "int32",
         },
         "provenance": {
             "paper": ADALIN_PAPER_URL,
@@ -609,6 +657,7 @@ def run_adalin_development(
             "schedule_sha256": schedule_hash,
             "initial_state_sha256": initial_hash,
             "final_state_sha256": _state_hash(state),
+            "runtime": _runtime_identity(),
         },
         "metrics": {
             "asi_whole_stream_preupdate_online_accuracy": online_correct / observations,
@@ -632,33 +681,18 @@ def run_adalin_development(
             "observations": observations,
             "label_queries": observations,
             "optimizer_updates": optimizer_updates,
-            "model_queries": observations + test_queries,
+            "preupdate_prediction_model_queries": observations,
+            "differentiated_training_model_queries": observations,
+            "postupdate_test_model_queries": test_queries,
+            "model_queries": 2 * observations + test_queries,
+            "preupdate_prediction_forward_calls": optimizer_updates,
+            "differentiated_training_forward_calls": optimizer_updates,
+            "postupdate_test_forward_calls": config.tasks,
             "model_forward_calls": model_forward_calls,
             "wall_clock_seconds_telemetry": wall_clock,
             "timing_qualified": False,
         },
-        "comparison": {
-            "paper_comparable": False,
-            "residual_gaps": [
-                "the pinned official commit contains no implementation or experiment config",
-                "the runner input is caller-supplied and does not bind official MNIST bytes "
-                "or the paper's unspecified sampled indices",
-                "the paper does not specify pixel/example permutation seeds or exact "
-                "dataloader order",
-                "one result is one consumed development seed rather than the paper's three "
-                "final evaluation seeds",
-                "ASI records whole-stream pre-update accuracy separately from the paper's "
-                "per-task train/test summaries",
-            ],
-            "schedule_difference": (
-                "paper: 400x10000, batch16, one epoch; ASI campaign: 200x5000, "
-                "batch1; this result uses its embedded config"
-            ),
-            "boundary_difference": (
-                "paper and this runner do not pass task identity or boundary events to the "
-                "learner; the runner uses boundaries only to transform/evaluate data"
-            ),
-        },
+        "comparison": _comparison_payload(config),
         "policy": {
             "status": "development-only-nonpromoting",
             "development_only": True,
@@ -769,7 +803,21 @@ def validate_adalin_result(value: object) -> None:
         raise ValueError("unexpected arm")
     dataset = _exact_dict(result["dataset"], "dataset")
     _require_keys(
-        dataset, {"sha256", "train_examples", "test_examples", "input_dim", "classes"}, "dataset"
+        dataset,
+        {
+            "sha256",
+            "train_examples",
+            "test_examples",
+            "input_dim",
+            "classes",
+            "train_inputs_shape",
+            "train_labels_shape",
+            "test_inputs_shape",
+            "test_labels_shape",
+            "inputs_dtype",
+            "labels_dtype",
+        },
+        "dataset",
     )
     for field in ("train_examples", "test_examples", "input_dim", "classes"):
         if type(dataset[field]) is not int or cast(int, dataset[field]) < 1:
@@ -777,8 +825,33 @@ def validate_adalin_result(value: object) -> None:
     if (
         dataset["train_examples"] != config.examples_per_task
         or dataset["classes"] != config.classes
+        or dataset["train_examples"] * cast(int, dataset["input_dim"])
+        > _MAX_DATASET_ELEMENTS
+        or cast(int, dataset["test_examples"]) * cast(int, dataset["input_dim"])
+        > _MAX_DATASET_ELEMENTS
+        or config.tasks
+        * (cast(int, dataset["input_dim"]) + config.examples_per_task)
+        > _MAX_DATASET_ELEMENTS
     ):
         raise ValueError("dataset metadata disagrees with config")
+    expected_shapes: dict[str, object] = {
+        "train_inputs_shape": [dataset["train_examples"], dataset["input_dim"]],
+        "train_labels_shape": [dataset["train_examples"]],
+        "test_inputs_shape": [dataset["test_examples"], dataset["input_dim"]],
+        "test_labels_shape": [dataset["test_examples"]],
+        "inputs_dtype": "float32",
+        "labels_dtype": "int32",
+    }
+    for field, expected in expected_shapes.items():
+        if type(dataset[field]) is not type(expected) or dataset[field] != expected:
+            raise ValueError(f"dataset metadata field {field} is not canonical")
+    dataset_digest = dataset["sha256"]
+    if (
+        type(dataset_digest) is not str
+        or len(dataset_digest) != 64
+        or any(character not in "0123456789abcdef" for character in dataset_digest)
+    ):
+        raise ValueError("dataset.sha256 must be a lowercase SHA-256 digest")
     provenance = _exact_dict(result["provenance"], "provenance")
     _require_keys(
         provenance,
@@ -791,6 +864,7 @@ def validate_adalin_result(value: object) -> None:
             "schedule_sha256",
             "initial_state_sha256",
             "final_state_sha256",
+            "runtime",
         },
         "provenance",
     )
@@ -804,6 +878,8 @@ def validate_adalin_result(value: object) -> None:
     for field, expected in expected_literals.items():
         if type(provenance[field]) is not str or provenance[field] != expected:
             raise ValueError(f"provenance.{field} does not match current source")
+    if provenance["runtime"] != _runtime_identity():
+        raise ValueError("provenance.runtime does not match the current runtime")
     for field in (
         "schedule_sha256",
         "initial_state_sha256",
@@ -825,7 +901,13 @@ def validate_adalin_result(value: object) -> None:
             "observations",
             "label_queries",
             "optimizer_updates",
+            "preupdate_prediction_model_queries",
+            "differentiated_training_model_queries",
+            "postupdate_test_model_queries",
             "model_queries",
+            "preupdate_prediction_forward_calls",
+            "differentiated_training_forward_calls",
+            "postupdate_test_forward_calls",
             "model_forward_calls",
             "wall_clock_seconds_telemetry",
             "timing_qualified",
@@ -839,8 +921,14 @@ def validate_adalin_result(value: object) -> None:
         "observations": observations,
         "label_queries": observations,
         "optimizer_updates": updates,
-        "model_queries": observations + config.tasks * cast(int, dataset["test_examples"]),
-        "model_forward_calls": updates + config.tasks,
+        "preupdate_prediction_model_queries": observations,
+        "differentiated_training_model_queries": observations,
+        "postupdate_test_model_queries": config.tasks * cast(int, dataset["test_examples"]),
+        "model_queries": 2 * observations + config.tasks * cast(int, dataset["test_examples"]),
+        "preupdate_prediction_forward_calls": updates,
+        "differentiated_training_forward_calls": updates,
+        "postupdate_test_forward_calls": config.tasks,
+        "model_forward_calls": 2 * updates + config.tasks,
         "timing_qualified": False,
     }
     for resource_field, resource_expected in expected_resources.items():
@@ -889,6 +977,8 @@ def validate_adalin_result(value: object) -> None:
         + width2 * config.classes
         + config.classes
     )
+    if parameter_scalars > _MAX_DATASET_ELEMENTS:
+        raise ValueError("dataset metadata and config exceed the executable model bound")
     if state["parameter_bytes"] != parameter_scalars * 4:
         raise ValueError("parameter bytes disagree with the configured float32 model")
     if state["alpha_bytes"] != (width1 + width2) * 4:
@@ -948,12 +1038,8 @@ def validate_adalin_result(value: object) -> None:
         {"paper_comparable", "residual_gaps", "schedule_difference", "boundary_difference"},
         "comparison",
     )
-    if (
-        comparison["paper_comparable"] is not False
-        or type(comparison["residual_gaps"]) is not list
-        or len(cast(list[object], comparison["residual_gaps"])) < 1
-    ):
-        raise ValueError("paper comparison must fail closed with explicit gaps")
+    if comparison != _comparison_payload(config):
+        raise ValueError("paper comparison must match the exact current comparison declaration")
     policy = _exact_dict(result["policy"], "policy")
     if policy != {
         "status": "development-only-nonpromoting",

--- a/alberta_framework/benchmarks/ipmnist_gradual_family.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual_family.py
@@ -1,0 +1,783 @@
+"""Bounded matched micro-phases for gradual-transition development research.
+
+This is an additive companion to :mod:`ipmnist_gradual`.  It exercises the
+paper's output-interpolation and task-sampling definitions end to end without
+recasting the retained input-interpolation result.  The adapter is deliberately
+small, caller-fed, permanently nonpromoting, and incapable of writing results.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import operator
+import platform
+import time
+from dataclasses import dataclass
+from importlib import metadata
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, SupportsIndex, cast
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+from jax import Array
+
+from alberta_framework._seed_validation import require_jax_seed
+from alberta_framework.benchmarks.ipmnist_gradual import output_interpolation
+from alberta_framework.benchmarks.upgd_ipmnist import (
+    ADAMW_PROTOCOL_HYPERPARAMETERS,
+    IPMNISTConfig,
+    LearnerUpdateResult,
+    _make_adamw_learner,
+    init_mlp_params,
+    mlp_logits,
+    validated_ipmnist_data,
+)
+
+_SCHEMA = "asi.ipmnist.gradual-family.micro-phase-result.v1"
+_PRNG_IMPLEMENTATION = "threefry2x32"
+_ARMS = ("abrupt", "output_interpolation", "task_sampling")
+_ADAMW_IDENTITY = tuple(sorted(ADAMW_PROTOCOL_HYPERPARAMETERS.items()))
+_MAX_RESOURCE_BYTES = 256 * 1024 * 1024
+_MAX_RUN_STEPS = 1_000_000
+_INT32_MAX = 2**31 - 1
+
+GRADUAL_FAMILY_PROTOCOL = MappingProxyType(
+    {
+        "schema": "asi.ipmnist.gradual-family.micro-phase-protocol.v1",
+        "paper_revision": "arXiv:2602.09234v2",
+        "paper_revision_date": "2026-06-16",
+        "paper_full_dataset_training": False,
+        "output_interpolation_loss": "soft_target_cross_entropy",
+        "output_interpolation_input": "new-task paired example",
+        "task_sampling_count": "floor(alpha * phase_examples)",
+        "task_sampling_old_count": "ceil((1-alpha) * phase_examples)",
+        "abrupt_switch": "old task for alpha < 1/2; new task for alpha >= 1/2",
+        "matched_axes": (
+            "initial_parameters",
+            "learner_hyperparameters",
+            "phase_count",
+            "phase_examples",
+            "updates",
+            "new_task_evaluation_queries",
+        ),
+        "adaptation_gaps": (
+            "bounded paired micro-phases, not the paper's complete datasets or training horizon",
+            "the output arm presents paired new-task inputs while targets move old-uniform-new",
+            "caller-provided arrays are not an official IPMNIST dataset acquisition protocol",
+        ),
+        "retained_input_result_recast": False,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "negative_results_must_be_retained": True,
+        "timing_is_telemetry_only": True,
+    }
+)
+
+
+def _exact_int(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
+    if type(value) is not int:
+        raise ValueError(f"{name} must be an exact integer")
+    resolved = operator.index(cast(SupportsIndex, value))
+    if resolved < minimum or resolved > maximum:
+        raise ValueError(f"{name} must lie in [{minimum}, {maximum}]")
+    return resolved
+
+
+def _digest_is_canonical(value: object) -> bool:
+    return (
+        type(value) is str
+        and len(value) == 71
+        and value.startswith("sha256:")
+        and all(character in "0123456789abcdef" for character in value[7:])
+    )
+
+
+def _source_identity() -> tuple[tuple[str, str], ...]:
+    root = Path(__file__).resolve().parents[2]
+    relative_paths = (
+        "alberta_framework/_seed_validation.py",
+        "alberta_framework/benchmarks/ipmnist_gradual.py",
+        "alberta_framework/benchmarks/ipmnist_gradual_family.py",
+        "alberta_framework/benchmarks/upgd_ipmnist.py",
+        "alberta_framework/core/_float32_scalars.py",
+        "alberta_framework/core/baseline_optimizers.py",
+        "alberta_framework/core/update_safety.py",
+    )
+    return tuple(
+        (relative, hashlib.sha256((root / relative).read_bytes()).hexdigest())
+        for relative in relative_paths
+    )
+
+
+def _runtime_identity() -> tuple[tuple[str, str], ...]:
+    devices = sorted(
+        (
+            int(device.process_index),
+            int(device.id),
+            str(device.platform),
+            str(device.device_kind),
+        )
+        for device in jax.devices()
+    )
+    if not 1 <= len(devices) <= 128:
+        raise ValueError("runtime device inventory must contain 1 through 128 devices")
+    return (
+        ("python_implementation", platform.python_implementation()),
+        ("python_version", platform.python_version()),
+        ("platform_system", platform.system()),
+        ("platform_machine", platform.machine()),
+        ("jax_version", jax.__version__),
+        ("jaxlib_version", metadata.version("jaxlib")),
+        ("numpy_version", np.__version__),
+        ("jax_backend", jax.default_backend()),
+        ("jax_devices", repr(devices)),
+        ("jax_enable_x64", repr(jax.config.jax_enable_x64)),
+        ("jax_default_matmul_precision", repr(jax.config.jax_default_matmul_precision)),
+        ("jax_random_seed_offset", repr(jax.config.jax_random_seed_offset)),
+        ("jax_prng_implementation", _PRNG_IMPLEMENTATION),
+    )
+
+
+def _array_digest(domain: bytes, *arrays: np.ndarray | Array) -> str:
+    digest = hashlib.sha256(domain)
+    for value in arrays:
+        array = np.asarray(jax.device_get(value))
+        digest.update(array.dtype.str.encode("ascii"))
+        digest.update(str(array.shape).encode("ascii"))
+        digest.update(array.tobytes(order="C"))
+    return f"sha256:{digest.hexdigest()}"
+
+
+@dataclass(frozen=True, slots=True)
+class GradualMicroPhaseConfig:
+    """A bounded family of ``K + 1`` complete, equal-size transition phases."""
+
+    transition_intervals: int
+    phase_examples: int
+    input_dim: int
+    hidden1: int
+    hidden2: int
+    n_classes: int
+
+    def __post_init__(self) -> None:
+        for name, minimum in (
+            ("transition_intervals", 1),
+            ("phase_examples", 1),
+            ("input_dim", 1),
+            ("hidden1", 1),
+            ("hidden2", 1),
+            ("n_classes", 2),
+        ):
+            object.__setattr__(self, name, _exact_int(name, getattr(self, name), minimum=minimum))
+        if self.phase_count * self.phase_examples > _MAX_RUN_STEPS:
+            raise ValueError("micro-phase run exceeds the 1000000-update ceiling")
+        if self.parameter_count > _INT32_MAX:
+            raise ValueError("parameter count must fit signed int32")
+
+    @property
+    def phase_count(self) -> int:
+        return self.transition_intervals + 1
+
+    @property
+    def updates(self) -> int:
+        return self.phase_count * self.phase_examples
+
+    @property
+    def parameter_count(self) -> int:
+        return (
+            self.input_dim * self.hidden1
+            + self.hidden1 * self.hidden2
+            + self.hidden2 * self.n_classes
+            + self.hidden1
+            + self.hidden2
+            + self.n_classes
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _ResourceEstimate:
+    dataset_bytes: int
+    schedule_bytes: int
+    learner_bytes: int
+    transient_schedule_bytes: int
+    persistent_numeric_bytes: int
+    working_set_bytes: int
+
+
+def _resource_estimate(
+    config: GradualMicroPhaseConfig, old_rows: int, new_rows: int
+) -> _ResourceEstimate:
+    """Return the one protocol resource calculation used by run and validation."""
+    dataset_bytes = (old_rows + new_rows) * (config.input_dim + 1) * 4
+    schedule_bytes = config.phase_count * config.phase_examples * (4 + 4 + 1)
+    learner_bytes = config.parameter_count * 16 + 6 * 5 * 4
+    transient_schedule_bytes = max(old_rows, new_rows) * 4 * 3
+    persistent_numeric_bytes = dataset_bytes + schedule_bytes + learner_bytes
+    return _ResourceEstimate(
+        dataset_bytes=dataset_bytes,
+        schedule_bytes=schedule_bytes,
+        learner_bytes=learner_bytes,
+        transient_schedule_bytes=transient_schedule_bytes,
+        persistent_numeric_bytes=persistent_numeric_bytes,
+        working_set_bytes=persistent_numeric_bytes + transient_schedule_bytes,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class GradualMicroPhaseResult:
+    schema: str
+    arm_names: tuple[str, str, str]
+    learner_name: str
+    learner_hyperparameters: tuple[tuple[str, float], ...]
+    prng_implementation: str
+    seed: int
+    config: GradualMicroPhaseConfig
+    phase_alpha_numerators: tuple[int, ...]
+    phase_alpha_denominator: int
+    task_sampling_new_counts: np.ndarray
+    dataset_rows: tuple[int, int]
+    dataset_sha256: tuple[str, str]
+    task_sampling_sha256: str
+    source_sha256: tuple[tuple[str, str], ...]
+    runtime_identity: tuple[tuple[str, str], ...]
+    training_loss_sums: np.ndarray
+    new_task_eval_correct_counts: np.ndarray
+    new_task_eval_loss_sums: np.ndarray
+    persistent_numeric_bytes: np.ndarray
+    timing_ns: np.ndarray
+    soft_target_updates_per_arm: tuple[int, int, int]
+    observations_per_arm: int
+    updates_per_arm: int
+    data_steps_per_arm: int
+    environment_steps_per_arm: int
+    model_queries_per_arm: int
+    parent_input_result_used: bool
+    development_only: bool
+    scientific_promotion_allowed: bool
+    negative_results_must_be_retained: bool
+    execution_attestation: bool
+
+    def __post_init__(self) -> None:
+        if type(self.schema) is not str or self.schema != _SCHEMA:
+            raise ValueError(f"schema must be {_SCHEMA!r}")
+        if type(self.arm_names) is not tuple or self.arm_names != _ARMS:
+            raise ValueError("arm_names must identify the exact matched family")
+        if type(self.learner_name) is not str or self.learner_name != "adamw_control":
+            raise ValueError("learner identity must be the exact AdamW control")
+        if (
+            type(self.learner_hyperparameters) is not tuple
+            or len(self.learner_hyperparameters) != len(_ADAMW_IDENTITY)
+            or any(
+                type(item) is not tuple
+                or len(item) != 2
+                or type(item[0]) is not str
+                or type(item[1]) is not float
+                or item != expected
+                for item, expected in zip(
+                    self.learner_hyperparameters, _ADAMW_IDENTITY, strict=True
+                )
+            )
+        ):
+            raise ValueError("learner identity must be the exact AdamW control")
+        if (
+            type(self.prng_implementation) is not str
+            or self.prng_implementation != _PRNG_IMPLEMENTATION
+        ):
+            raise ValueError("prng_implementation must be threefry2x32")
+        require_jax_seed(self.seed, name="seed")
+        if type(self.config) is not GradualMicroPhaseConfig:
+            raise ValueError("config must be an exact GradualMicroPhaseConfig")
+        config = GradualMicroPhaseConfig(**{
+            name: getattr(self.config, name)
+            for name in (
+                "transition_intervals", "phase_examples", "input_dim",
+                "hidden1", "hidden2", "n_classes",
+            )
+        })
+        if (
+            type(self.phase_alpha_numerators) is not tuple
+            or any(type(value) is not int for value in self.phase_alpha_numerators)
+            or self.phase_alpha_numerators != tuple(range(config.phase_count))
+        ):
+            raise ValueError("phase alpha numerators must be the complete exact schedule")
+        if (
+            type(self.phase_alpha_denominator) is not int
+            or self.phase_alpha_denominator != config.transition_intervals
+        ):
+            raise ValueError("phase alpha denominator must equal transition_intervals")
+        if (
+            type(self.dataset_rows) is not tuple
+            or len(self.dataset_rows) != 2
+            or any(
+                type(value) is not int or value < config.phase_examples
+                for value in self.dataset_rows
+            )
+        ):
+            raise ValueError("dataset_rows must identify both bounded input datasets")
+        if (
+            type(self.dataset_sha256) is not tuple
+            or len(self.dataset_sha256) != 2
+            or not all(_digest_is_canonical(value) for value in self.dataset_sha256)
+            or not _digest_is_canonical(self.task_sampling_sha256)
+        ):
+            raise ValueError("dataset and schedule identities must be canonical SHA-256 values")
+        if self.source_sha256 != _source_identity():
+            raise ValueError("current source identity drift")
+        if self.runtime_identity != _runtime_identity():
+            raise ValueError("current runtime identity drift")
+
+        shapes = {
+            "task_sampling_new_counts": (np.int32, (config.phase_count,)),
+            "training_loss_sums": (np.float64, (len(_ARMS), config.phase_count)),
+            "new_task_eval_correct_counts": (np.int32, (len(_ARMS), config.phase_count)),
+            "new_task_eval_loss_sums": (np.float64, (len(_ARMS), config.phase_count)),
+            "persistent_numeric_bytes": (np.int64, (len(_ARMS),)),
+            "timing_ns": (np.int64, (len(_ARMS),)),
+        }
+        snapshots: dict[str, np.ndarray] = {}
+        for name, (dtype, shape) in shapes.items():
+            value = getattr(self, name)
+            if type(value) is not np.ndarray or value.dtype != dtype or value.shape != shape:
+                raise ValueError(f"{name} must be an exact {dtype.__name__} array of shape {shape}")
+            snapshot = value.copy()
+            snapshot.flags.writeable = False
+            snapshots[name] = snapshot
+        expected_counts = np.asarray(
+            [index * config.phase_examples // config.transition_intervals
+             for index in range(config.phase_count)],
+            dtype=np.int32,
+        )
+        if not np.array_equal(snapshots["task_sampling_new_counts"], expected_counts):
+            raise ValueError("task sampling counts must equal floor(alpha * phase_examples)")
+        if not np.all(np.isfinite(snapshots["training_loss_sums"])) or np.any(
+            snapshots["training_loss_sums"] < 0.0
+        ):
+            raise ValueError("training losses must be finite and nonnegative")
+        eval_loss = snapshots["new_task_eval_loss_sums"]
+        if not np.all(np.isfinite(eval_loss)) or np.any(eval_loss < 0.0):
+            raise ValueError("evaluation losses must be finite and nonnegative")
+        eval_correct = snapshots["new_task_eval_correct_counts"]
+        if np.any(eval_correct < 0) or np.any(eval_correct > config.phase_examples):
+            raise ValueError("evaluation correct counts must be valid integer numerators")
+        if np.any(snapshots["persistent_numeric_bytes"] <= 0) or np.any(
+            snapshots["persistent_numeric_bytes"] > _MAX_RESOURCE_BYTES
+        ):
+            raise ValueError("persistent numeric bytes must be positive and bounded")
+        expected_persistent = _resource_estimate(
+            config, self.dataset_rows[0], self.dataset_rows[1]
+        ).persistent_numeric_bytes
+        if not np.all(snapshots["persistent_numeric_bytes"] == expected_persistent):
+            raise ValueError("persistent numeric bytes must equal the complete exact receipt")
+        if np.any(snapshots["timing_ns"] < 0):
+            raise ValueError("timing telemetry must be nonnegative")
+
+        expected_counters = {
+            "soft_target_updates_per_arm": (0, config.updates, 0),
+            "observations_per_arm": 2 * config.updates,
+            "updates_per_arm": config.updates,
+            "data_steps_per_arm": 2 * config.updates,
+            "environment_steps_per_arm": 0,
+            "model_queries_per_arm": 3 * config.updates,
+        }
+        for name, expected in expected_counters.items():
+            value = getattr(self, name)
+            if name == "soft_target_updates_per_arm":
+                valid = (
+                    type(value) is tuple
+                    and all(type(item) is int for item in value)
+                    and value == expected
+                )
+            else:
+                valid = type(value) is int and value == expected
+            if not valid:
+                raise ValueError(f"{name} must equal the protocol-derived value")
+        flag_requirements = (
+            self.parent_input_result_used is False,
+            self.development_only is True,
+            self.scientific_promotion_allowed is False,
+            self.negative_results_must_be_retained is True,
+            self.execution_attestation is False,
+        )
+        if not all(flag_requirements):
+            raise ValueError("result must remain additive, nonpromoting, retained, and unattested")
+        object.__setattr__(self, "config", config)
+        for name, snapshot in snapshots.items():
+            object.__setattr__(self, name, snapshot)
+
+
+def _numeric_tree_bytes(value: object) -> int:
+    total = 0
+    for leaf in jax.tree_util.tree_leaves(value):
+        if type(leaf) is np.ndarray or isinstance(leaf, jax.Array):
+            array = np.asarray(jax.device_get(leaf))
+            if not np.all(np.isfinite(array)):
+                raise ValueError("learner state must remain finite")
+            total += array.size * array.dtype.itemsize
+    return total
+
+
+def _checked_dataset_metadata(
+    name: str, data_x: object, data_y: object, config: GradualMicroPhaseConfig
+) -> tuple[np.ndarray | Array, np.ndarray | Array, int]:
+    for field_name, value in ((f"{name}_x", data_x), (f"{name}_y", data_y)):
+        actual_type = type(value)
+        if not (actual_type is np.ndarray or isinstance(value, jax.Array)):
+            raise ValueError(f"{field_name} must be an exact NumPy or JAX array")
+    x = cast(np.ndarray | Array, data_x)
+    y = cast(np.ndarray | Array, data_y)
+    if len(x.shape) != 2 or x.shape[1] != config.input_dim:
+        raise ValueError(f"{name}_x must be a matrix with input_dim columns")
+    if y.shape != (x.shape[0],):
+        raise ValueError(f"{name}_y must align with {name}_x")
+    if x.shape[0] < config.phase_examples:
+        raise ValueError(f"{name} dataset is smaller than one complete phase")
+    elements = math.prod(x.shape) + math.prod(y.shape)
+    if elements > _MAX_RESOURCE_BYTES // 4:
+        raise ValueError(f"{name} materialized dataset exceeds 256 MiB")
+    return x, y, elements
+
+
+def _soft_cross_entropy(
+    params: dict[str, Array], x: Array, target: Array
+) -> tuple[Array, Array]:
+    logits = mlp_logits(params, x)
+    return -jnp.sum(target * jax.nn.log_softmax(logits)), logits
+
+
+def _realized_schedule(
+    seed: int,
+    config: GradualMicroPhaseConfig,
+    old_rows: int,
+    new_rows: int,
+) -> tuple[list[np.ndarray], list[np.ndarray], list[np.ndarray], list[int], str]:
+    root = jr.key(seed, impl=_PRNG_IMPLEMENTATION)
+    _, schedule_key, _ = jr.split(root, 3)
+    old_orders: list[np.ndarray] = []
+    new_orders: list[np.ndarray] = []
+    masks: list[np.ndarray] = []
+    new_counts: list[int] = []
+    for phase in range(config.phase_count):
+        phase_key = jr.fold_in(schedule_key, phase)
+        old_key, new_key, mask_key = jr.split(phase_key, 3)
+        old_order = np.asarray(
+            jax.device_get(jr.permutation(old_key, old_rows)[:config.phase_examples]),
+            dtype=np.int32,
+        )
+        new_order = np.asarray(
+            jax.device_get(jr.permutation(new_key, new_rows)[:config.phase_examples]),
+            dtype=np.int32,
+        )
+        count = phase * config.phase_examples // config.transition_intervals
+        order = np.asarray(
+            jax.device_get(jr.permutation(mask_key, config.phase_examples)), dtype=np.int32
+        )
+        mask = np.zeros((config.phase_examples,), dtype=np.bool_)
+        mask[order[:count]] = True
+        old_orders.append(old_order)
+        new_orders.append(new_order)
+        masks.append(mask)
+        new_counts.append(count)
+    digest = _array_digest(
+        b"asi.ipmnist.gradual-family.schedule.v1\0",
+        np.asarray(old_orders, dtype=np.int32),
+        np.asarray(new_orders, dtype=np.int32),
+        np.asarray(masks, dtype=np.bool_),
+    )
+    return old_orders, new_orders, masks, new_counts, digest
+
+
+def run_gradual_micro_phase_family(
+    old_x: object,
+    old_y: object,
+    new_x: object,
+    new_y: object,
+    *,
+    learner_name: str,
+    seed: int,
+    config: GradualMicroPhaseConfig,
+) -> GradualMicroPhaseResult:
+    """Run abrupt, output-interpolation, and exact task-sampling arms.
+
+    Every phase consumes ``phase_examples`` updates and then evaluates the
+    current learner on ``phase_examples`` paired new-task examples.  The
+    output arm alone trains with soft targets.  No result is retained here.
+    """
+    if type(learner_name) is not str or learner_name != "adamw_control":
+        raise ValueError("learner_name must be the exact 'adamw_control' adapter")
+    if type(config) is not GradualMicroPhaseConfig:
+        raise ValueError("config must be an exact GradualMicroPhaseConfig")
+    checked_config = GradualMicroPhaseConfig(**{
+        name: getattr(config, name)
+        for name in (
+            "transition_intervals", "phase_examples", "input_dim",
+            "hidden1", "hidden2", "n_classes",
+        )
+    })
+    resolved_seed = require_jax_seed(seed, name="seed")
+    raw_old_x, raw_old_y, _ = _checked_dataset_metadata(
+        "old", old_x, old_y, checked_config
+    )
+    raw_new_x, raw_new_y, _ = _checked_dataset_metadata(
+        "new", new_x, new_y, checked_config
+    )
+    resources = _resource_estimate(
+        checked_config, int(raw_old_x.shape[0]), int(raw_new_x.shape[0])
+    )
+    if resources.working_set_bytes > _MAX_RESOURCE_BYTES:
+        raise ValueError("aggregate working set exceeds 256 MiB")
+
+    resolved_old_x, resolved_old_y = validated_ipmnist_data(
+        raw_old_x,
+        raw_old_y,
+        input_dim=checked_config.input_dim,
+        n_classes=checked_config.n_classes,
+        min_length=checked_config.phase_examples,
+    )
+    resolved_new_x, resolved_new_y = validated_ipmnist_data(
+        raw_new_x,
+        raw_new_y,
+        input_dim=checked_config.input_dim,
+        n_classes=checked_config.n_classes,
+        min_length=checked_config.phase_examples,
+    )
+    if resolved_old_x.shape != resolved_new_x.shape or not np.array_equal(
+        resolved_old_x, resolved_new_x
+    ):
+        raise ValueError(
+            "output interpolation requires row-aligned identical inputs across tasks"
+        )
+    old_x_array = jnp.asarray(resolved_old_x, dtype=jnp.float32)
+    old_y_array = jnp.asarray(resolved_old_y, dtype=jnp.int32)
+    new_x_array = jnp.asarray(resolved_new_x, dtype=jnp.float32)
+    new_y_array = jnp.asarray(resolved_new_y, dtype=jnp.int32)
+
+    init_fn, step_fn = _make_adamw_learner(dict(_ADAMW_IDENTITY))
+    root = jr.key(resolved_seed, impl=_PRNG_IMPLEMENTATION)
+    init_key, _, learner_key = jr.split(root, 3)
+    model_config = IPMNISTConfig(
+        n_tasks=checked_config.phase_count,
+        task_length=checked_config.phase_examples,
+        input_dim=checked_config.input_dim,
+        hidden1=checked_config.hidden1,
+        hidden2=checked_config.hidden2,
+        n_classes=checked_config.n_classes,
+    )
+    initial_params = init_mlp_params(init_key, model_config)
+
+    old_orders, new_orders, masks, new_counts, schedule_digest = _realized_schedule(
+        resolved_seed,
+        checked_config,
+        int(old_x_array.shape[0]),
+        int(new_x_array.shape[0]),
+    )
+
+    @jax.jit
+    def checked_hard_step(
+        params: dict[str, Array], state: Any, x: Array, label: Array, key: Array
+    ) -> tuple[LearnerUpdateResult, Array, Array]:
+        def loss_fn(candidate: dict[str, Array]) -> tuple[Array, Array]:
+            logits = mlp_logits(candidate, x)
+            return -jax.nn.log_softmax(logits)[label], logits
+
+        (loss, _), grads = jax.value_and_grad(loss_fn, has_aux=True)(params)
+        transaction = step_fn(params, state, grads, key)
+        if type(transaction) is not LearnerUpdateResult:
+            raise TypeError("AdamW learner did not return its checked transaction")
+        post_loss, _ = loss_fn(transaction.params)
+        return transaction, loss, post_loss
+
+    @jax.jit
+    def checked_soft_step(
+        params: dict[str, Array], state: Any, x: Array, target: Array, key: Array
+    ) -> tuple[LearnerUpdateResult, Array, Array]:
+        (loss, _), grads = jax.value_and_grad(_soft_cross_entropy, has_aux=True)(params, x, target)
+        transaction = step_fn(params, state, grads, key)
+        if type(transaction) is not LearnerUpdateResult:
+            raise TypeError("AdamW learner did not return its checked transaction")
+        post_loss, _ = _soft_cross_entropy(transaction.params, x, target)
+        return transaction, loss, post_loss
+
+    @jax.jit
+    def evaluate(params: dict[str, Array], x: Array, label: Array) -> tuple[Array, Array]:
+        logits = mlp_logits(params, x)
+        loss = -jax.nn.log_softmax(logits)[label]
+        return (jnp.argmax(logits) == label).astype(jnp.int32), loss
+
+    def run_arm(arm: str) -> tuple[list[float], list[int], list[float], int, int]:
+        params = initial_params
+        state = init_fn(params)
+        key = learner_key
+        phase_training_losses: list[float] = []
+        phase_eval_correct: list[int] = []
+        phase_eval_losses: list[float] = []
+        started = time.perf_counter_ns()
+        for phase in range(checked_config.phase_count):
+            alpha = phase / checked_config.transition_intervals
+            training_loss = 0.0
+            for position in range(checked_config.phase_examples):
+                old_index = int(old_orders[phase][position])
+                new_index = int(new_orders[phase][position])
+                if arm == "abrupt":
+                    use_new = 2 * phase >= checked_config.transition_intervals
+                    x = new_x_array[new_index] if use_new else old_x_array[old_index]
+                    label = new_y_array[new_index] if use_new else old_y_array[old_index]
+                    target = None
+                elif arm == "output_interpolation":
+                    x = new_x_array[new_index]
+                    label = new_y_array[new_index]
+                    target = output_interpolation(
+                        int(old_y_array[new_index]),
+                        int(new_y_array[new_index]),
+                        alpha,
+                        n_classes=checked_config.n_classes,
+                    )
+                else:
+                    use_new = bool(masks[phase][position])
+                    x = new_x_array[new_index] if use_new else old_x_array[old_index]
+                    label = new_y_array[new_index] if use_new else old_y_array[old_index]
+                    target = None
+                key, step_key = jr.split(key)
+                if target is None:
+                    transaction, loss, post_loss = checked_hard_step(
+                        params, state, x, label, step_key
+                    )
+                else:
+                    transaction, loss, post_loss = checked_soft_step(
+                        params, state, x, target, step_key
+                    )
+                if type(transaction) is not LearnerUpdateResult or not bool(
+                    transaction.update_applied
+                ):
+                    raise ValueError("AdamW learner transaction became invalid")
+                if not bool(jnp.isfinite(loss) & jnp.isfinite(post_loss)):
+                    raise ValueError("training metric transaction became invalid")
+                params, state = transaction.params, transaction.state
+                training_loss += float(loss)
+            phase_training_losses.append(training_loss)
+            eval_correct = 0
+            eval_loss = 0.0
+            for position in range(checked_config.phase_examples):
+                index = int(new_orders[phase][position])
+                correct, loss = evaluate(params, new_x_array[index], new_y_array[index])
+                if not bool(jnp.isfinite(loss)):
+                    raise ValueError("evaluation metric transaction became invalid")
+                eval_correct += int(correct)
+                eval_loss += float(loss)
+            phase_eval_correct.append(eval_correct)
+            phase_eval_losses.append(eval_loss)
+        for leaf in jax.tree_util.tree_leaves((params, state)):
+            if hasattr(leaf, "block_until_ready"):
+                leaf.block_until_ready()
+        elapsed = time.perf_counter_ns() - started
+        persistent = resources.dataset_bytes + resources.schedule_bytes + _numeric_tree_bytes(
+            (initial_params, params, state)
+        )
+        if persistent > _MAX_RESOURCE_BYTES:
+            raise ValueError("complete persistent numeric state exceeds 256 MiB")
+        return phase_training_losses, phase_eval_correct, phase_eval_losses, persistent, elapsed
+
+    outputs = tuple(run_arm(arm) for arm in _ARMS)
+    result = GradualMicroPhaseResult(
+        schema=_SCHEMA,
+        arm_names=_ARMS,
+        learner_name=learner_name,
+        learner_hyperparameters=_ADAMW_IDENTITY,
+        prng_implementation=_PRNG_IMPLEMENTATION,
+        seed=resolved_seed,
+        config=checked_config,
+        phase_alpha_numerators=tuple(range(checked_config.phase_count)),
+        phase_alpha_denominator=checked_config.transition_intervals,
+        task_sampling_new_counts=np.asarray(new_counts, dtype=np.int32),
+        dataset_rows=(int(old_x_array.shape[0]), int(new_x_array.shape[0])),
+        dataset_sha256=(
+            _array_digest(b"asi.ipmnist.gradual-family.old-dataset.v1\0", old_x_array, old_y_array),
+            _array_digest(b"asi.ipmnist.gradual-family.new-dataset.v1\0", new_x_array, new_y_array),
+        ),
+        task_sampling_sha256=schedule_digest,
+        source_sha256=_source_identity(),
+        runtime_identity=_runtime_identity(),
+        training_loss_sums=np.asarray([value[0] for value in outputs], dtype=np.float64),
+        new_task_eval_correct_counts=np.asarray([value[1] for value in outputs], dtype=np.int32),
+        new_task_eval_loss_sums=np.asarray([value[2] for value in outputs], dtype=np.float64),
+        persistent_numeric_bytes=np.asarray([value[3] for value in outputs], dtype=np.int64),
+        timing_ns=np.asarray([value[4] for value in outputs], dtype=np.int64),
+        soft_target_updates_per_arm=(0, checked_config.updates, 0),
+        observations_per_arm=2 * checked_config.updates,
+        updates_per_arm=checked_config.updates,
+        data_steps_per_arm=2 * checked_config.updates,
+        environment_steps_per_arm=0,
+        model_queries_per_arm=3 * checked_config.updates,
+        parent_input_result_used=False,
+        development_only=True,
+        scientific_promotion_allowed=False,
+        negative_results_must_be_retained=True,
+        execution_attestation=False,
+    )
+    validate_gradual_micro_phase_result(result, old_x, old_y, new_x, new_y)
+    return result
+
+
+def validate_gradual_micro_phase_result(
+    result: GradualMicroPhaseResult,
+    old_x: object,
+    old_y: object,
+    new_x: object,
+    new_y: object,
+) -> None:
+    """Revalidate an in-memory receipt against current data, source, and runtime."""
+    if type(result) is not GradualMicroPhaseResult:
+        raise ValueError("result must be an exact GradualMicroPhaseResult")
+    # Reconstruction re-runs all field, source, runtime, counter, and array checks.
+    checked = GradualMicroPhaseResult(**{
+        field: getattr(result, field)
+        for field in result.__dataclass_fields__
+    })
+    config = checked.config
+    raw_old_x, raw_old_y, _ = _checked_dataset_metadata("old", old_x, old_y, config)
+    raw_new_x, raw_new_y, _ = _checked_dataset_metadata("new", new_x, new_y, config)
+    actual_rows = (int(raw_old_x.shape[0]), int(raw_new_x.shape[0]))
+    if checked.dataset_rows != actual_rows:
+        raise ValueError("dataset row identity mismatch")
+    resources = _resource_estimate(config, actual_rows[0], actual_rows[1])
+    if resources.working_set_bytes > _MAX_RESOURCE_BYTES:
+        raise ValueError("aggregate working set exceeds 256 MiB")
+    resolved_old_x, resolved_old_y = validated_ipmnist_data(
+        raw_old_x, raw_old_y, input_dim=config.input_dim,
+        n_classes=config.n_classes, min_length=config.phase_examples,
+    )
+    resolved_new_x, resolved_new_y = validated_ipmnist_data(
+        raw_new_x, raw_new_y, input_dim=config.input_dim,
+        n_classes=config.n_classes, min_length=config.phase_examples,
+    )
+    expected = (
+        _array_digest(
+            b"asi.ipmnist.gradual-family.old-dataset.v1\0", resolved_old_x, resolved_old_y
+        ),
+        _array_digest(
+            b"asi.ipmnist.gradual-family.new-dataset.v1\0", resolved_new_x, resolved_new_y
+        ),
+    )
+    if checked.dataset_sha256 != expected:
+        raise ValueError("dataset content identity mismatch")
+    if resolved_old_x.shape != resolved_new_x.shape or not np.array_equal(
+        resolved_old_x, resolved_new_x
+    ):
+        raise ValueError(
+            "output interpolation requires row-aligned identical inputs across tasks"
+        )
+    _, _, _, expected_counts, expected_schedule = _realized_schedule(
+        checked.seed,
+        config,
+        resolved_old_x.shape[0],
+        resolved_new_x.shape[0],
+    )
+    if not np.array_equal(
+        checked.task_sampling_new_counts, np.asarray(expected_counts, dtype=np.int32)
+    ):
+        raise ValueError("realized task-sampling counts mismatch")
+    if checked.task_sampling_sha256 != expected_schedule:
+        raise ValueError("realized task-sampling schedule identity mismatch")

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -10369,6 +10369,12 @@ def noise_curvature_development_result_payload(
     return validate_noise_curvature_development_result(payload)
 
 
+def _screening_root_key(seed: int) -> Array:
+    """Return the explicit Threefry root shared by matched screening arms."""
+
+    return jr.key(jnp.uint32(seed), impl="threefry2x32")
+
+
 def run_screening_config(
     data_x: np.ndarray | Array,
     data_y: np.ndarray | Array,
@@ -10449,7 +10455,7 @@ def run_screening_config(
     else:
         init_fn, step_fn = spec.factory(spec.hyperparameters)
 
-    root = jr.key(jnp.uint32(resolved_seed))
+    root = _screening_root_key(resolved_seed)
     key_init, key_schedule, key_noise = jr.split(root, 3)
     params = init_mlp_params(key_init, config)
     schedule = build_schedule(key_schedule, config, n_train)

--- a/alberta_framework/benchmarks/qualification_provenance.py
+++ b/alberta_framework/benchmarks/qualification_provenance.py
@@ -1,0 +1,171 @@
+"""Current-tree identity helpers for nonpromoting qualification smokes."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import inspect
+import json
+import platform
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from types import ModuleType
+from typing import cast
+
+import jax
+import numpy as np
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _canonical(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {key: _canonical(item) for key, item in sorted(value.items())}
+    if type(value) in (tuple, list):
+        return [_canonical(item) for item in cast(Sequence[object], value)]
+    if type(value) in (str, int, float, bool) or value is None:
+        return value
+    raise TypeError(f"unsupported registry value: {type(value).__name__}")
+
+
+def _registry_sha256(value: object) -> str:
+    raw = json.dumps(
+        _canonical(value), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("ascii")
+    return _sha256_bytes(raw)
+
+
+def _module_sha256(module: ModuleType) -> str:
+    source = inspect.getsourcefile(module)
+    if source is None:
+        raise RuntimeError(f"cannot locate source for {module.__name__}")
+    return _sha256_bytes(Path(source).read_bytes())
+
+
+def _require_sha256(value: object, name: str) -> str:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256")
+    return value
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class QualificationIdentity:
+    lane_source_sha256: str
+    dependency_source_sha256: tuple[tuple[str, str], ...]
+    runtime_identity: tuple[tuple[str, str], ...]
+    dependency_versions: tuple[tuple[str, str], ...]
+    workload_registry_sha256: str
+    paper_registry_sha256: str
+
+    def __post_init__(self) -> None:
+        _require_sha256(self.lane_source_sha256, "lane_source_sha256")
+        _require_sha256(self.workload_registry_sha256, "workload_registry_sha256")
+        _require_sha256(self.paper_registry_sha256, "paper_registry_sha256")
+        for name, entries, hashed in (
+            ("dependency_source_sha256", self.dependency_source_sha256, True),
+            ("runtime_identity", self.runtime_identity, False),
+            ("dependency_versions", self.dependency_versions, False),
+        ):
+            if type(entries) is not tuple or not entries:
+                raise ValueError(f"{name} must be a nonempty exact tuple")
+            keys: list[str] = []
+            for item in entries:
+                if (
+                    type(item) is not tuple
+                    or len(item) != 2
+                    or type(item[0]) is not str
+                    or not item[0]
+                    or type(item[1]) is not str
+                    or not item[1]
+                ):
+                    raise ValueError(f"{name} entries must be exact string pairs")
+                keys.append(item[0])
+                if hashed:
+                    _require_sha256(item[1], f"{name}.{item[0]}")
+            if keys != sorted(keys) or len(keys) != len(set(keys)):
+                raise ValueError(f"{name} keys must be sorted and unique")
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "lane_source_sha256": self.lane_source_sha256,
+            "dependency_source_sha256": [list(item) for item in self.dependency_source_sha256],
+            "runtime_identity": [list(item) for item in self.runtime_identity],
+            "dependency_versions": [list(item) for item in self.dependency_versions],
+            "workload_registry_sha256": self.workload_registry_sha256,
+            "paper_registry_sha256": self.paper_registry_sha256,
+        }
+
+
+def collect_qualification_identity(
+    *,
+    lane_module: ModuleType,
+    dependency_modules: Sequence[ModuleType],
+    workload_registry: object,
+    paper_registry: object,
+) -> QualificationIdentity:
+    modules = {module.__name__: module for module in dependency_modules}
+    modules[__name__] = sys.modules[__name__]
+    dependencies = tuple(
+        sorted((name, _module_sha256(module)) for name, module in modules.items())
+    )
+    runtime = tuple(
+        sorted(
+            (
+                ("jax_backend", jax.default_backend()),
+                ("machine", platform.machine()),
+                ("python_implementation", sys.implementation.name),
+                ("python_version", platform.python_version()),
+                ("system", platform.system()),
+            )
+        )
+    )
+    versions = tuple(sorted((("jax", jax.__version__), ("numpy", np.__version__))))
+    return QualificationIdentity(
+        lane_source_sha256=_module_sha256(lane_module),
+        dependency_source_sha256=dependencies,
+        runtime_identity=runtime,
+        dependency_versions=versions,
+        workload_registry_sha256=_registry_sha256(workload_registry),
+        paper_registry_sha256=_registry_sha256(paper_registry),
+    )
+
+
+def identity_from_payload(value: object) -> QualificationIdentity:
+    expected = {field.name for field in dataclasses.fields(QualificationIdentity)}
+    if type(value) is not dict or set(value) != expected:
+        raise ValueError("identity payload differs from the schema")
+    raw = dict(value)
+    for name in ("dependency_source_sha256", "runtime_identity", "dependency_versions"):
+        entries = raw[name]
+        if type(entries) is not list or any(
+            type(item) is not list
+            or len(item) != 2
+            or any(type(part) is not str for part in item)
+            for item in entries
+        ):
+            raise ValueError(f"identity {name} must be an exact list of string pairs")
+        raw[name] = tuple((item[0], item[1]) for item in entries)
+    return QualificationIdentity(**raw)
+
+
+def require_current_identity(
+    actual: object, expected: QualificationIdentity
+) -> QualificationIdentity:
+    if type(actual) is not QualificationIdentity or actual != expected:
+        raise ValueError("qualification identity differs from the current tree/runtime")
+    return actual
+
+
+__all__ = [
+    "QualificationIdentity",
+    "collect_qualification_identity",
+    "identity_from_payload",
+    "require_current_identity",
+]

--- a/alberta_framework/benchmarks/replay_frozen_ipmnist.py
+++ b/alberta_framework/benchmarks/replay_frozen_ipmnist.py
@@ -73,7 +73,7 @@ class FrozenFeatureState:
 
 def _key_from_params(params: dict[str, Array], domain: int) -> Array:
     bits = jax.lax.bitcast_convert_type(params["w1"].reshape(-1), jnp.uint32)
-    key = jr.fold_in(jr.key(jnp.uint32(domain)), bits[0])
+    key = jr.fold_in(jr.key(jnp.uint32(domain), impl="threefry2x32"), bits[0])
     return jr.fold_in(key, bits[-1])
 
 
@@ -183,7 +183,12 @@ def make_replay_context_learner(
             name: task_gradient[name] + hp["replay_weight"] * replay_gradient[name]
             for name in _PARAM_KEYS
         }
-        update = adam_step(params, state.optimizer_state, combined, jr.key(0))
+        update = adam_step(
+            params,
+            state.optimizer_state,
+            combined,
+            jr.key(0, impl="threefry2x32"),
+        )
         if type(update) is not LearnerUpdateResult:
             raise TypeError("matched Adam returned an unsupported update")
         candidate_examples = state.examples.at[safe_cursor].set(x)

--- a/alberta_framework/benchmarks/telapa_qualification.py
+++ b/alberta_framework/benchmarks/telapa_qualification.py
@@ -14,6 +14,7 @@ import json
 import math
 import sys
 from dataclasses import asdict, dataclass
+from pathlib import Path, PosixPath
 from typing import Any, Literal, cast
 
 import jax
@@ -24,16 +25,17 @@ from jax import Array
 
 import alberta_framework.core.policy_archive as policy_archive_module
 import alberta_framework.streams.closed_loop as closed_loop_module
-from alberta_framework.benchmarks.development_provenance import (
-    DevelopmentIdentity,
-    collect_development_identity,
+from alberta_framework.benchmarks.qualification_provenance import (
+    QualificationIdentity,
+    collect_qualification_identity,
     identity_from_payload,
     require_current_identity,
 )
+from alberta_framework.benchmarks.upgd_ipmnist import atomic_write_new
 from alberta_framework.core.policy_archive import BoundedPolicyArchive, PolicyEntry
 from alberta_framework.streams.closed_loop import SwitchingTwoStateConfig, SwitchingTwoStateMDP
 
-SCHEMA = "asi.telapa_qualification_smoke.development.v1"
+SCHEMA = "asi.telapa_qualification_smoke.development.v2"
 PAPER_REVISION = "arXiv:2604.15414v1"
 PAPER_DATE = "2026-04-16"
 DISCLOSED_REPOSITORY = "https://anonymous.4open.science/r/telapa-map_elites-54E8/"
@@ -43,21 +45,63 @@ _MAX_JSON_NODES = 50_000
 _MAX_JSON_CONTAINER_ITEMS = 10_000
 _MAX_JSON_STRING_BYTES = 100_000
 _MAX_STEPS = 64
+_MAX_SEEDS = 4
 FROZEN_DEVELOPMENT_SEEDS = (1_586_000, 1_586_001, 1_586_002)
 _POLICY_SHAPE = (2, 2)
 _POLICY_BYTES = 16
+_RNG_IMPL = "threefry2x32"
+_RNG_ROOT_BYTES = 8
 _ARMS = ("diverse_archive", "one_model", "fixed_snapshot", "mechanism_off")
+_PAPER_MECHANISM = (
+    "per-task policy neighborhoods, MAP-Elites illumination, few-shot retrieval, "
+    "and a learned trajectory latent maintained with anchors/replay/re-embedding"
+)
+_DEVELOPMENT_ADAPTER = (
+    "two-state tabular policy snapshots and a fixed four-statistic rollout descriptor"
+)
+_PROTOCOL_DIFFERENCES = (
+    "SwitchingTwoStateMDP instead of the paper MiniGrid and MuJoCo curricula",
+    "tabular reward update instead of PPO",
+    "bounded deterministic insertion instead of MAP-Elites illumination",
+    "fixed statistic descriptor instead of a learned aligned trajectory embedder",
+    "no anchor/replay bank, re-embedding, few-shot adaptation, or transfer metric",
+)
+_PAPER_METRICS = (
+    "standardized_time_to_threshold",
+    "success_rate",
+    "backward_transfer",
+    "transfer_ratio",
+)
 Arm = Literal["diverse_archive", "one_model", "fixed_snapshot", "mechanism_off"]
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+_LOCK_IDENTITIES = tuple(
+    (name, hashlib.sha256((_REPOSITORY_ROOT / name).read_bytes()).hexdigest())
+    for name in ("pyproject.toml", "uv.lock")
+)
+_WORKLOAD_REGISTRY = (
+    ("arms", _ARMS),
+    ("comparison_metric", "mean_reward"),
+    ("development_seeds", FROZEN_DEVELOPMENT_SEEDS),
+    ("max_steps", _MAX_STEPS),
+    ("policy_shape", _POLICY_SHAPE),
+    ("rng_implementation", _RNG_IMPL),
+    ("dependency_lock_sha256", _LOCK_IDENTITIES),
+)
+_PAPER_REGISTRY = (
+    ("disclosed_repository", DISCLOSED_REPOSITORY),
+    ("paper_date", PAPER_DATE),
+    ("paper_revision", PAPER_REVISION),
+    ("repository_revision", None),
+    ("repository_tree_digest", None),
+)
 
 
-def _current_identity(
-    config: TeLAPASmokeConfig, catalog: TeLAPACatalogEntry
-) -> DevelopmentIdentity:
-    return collect_development_identity(
+def _current_identity() -> QualificationIdentity:
+    return collect_qualification_identity(
         lane_module=sys.modules[__name__],
         dependency_modules=(policy_archive_module, closed_loop_module),
-        workload_registry={"config": _config_payload(config), "arms": _ARMS},
-        paper_registry=_catalog_payload(catalog),
+        workload_registry=_WORKLOAD_REGISTRY,
+        paper_registry=_PAPER_REGISTRY,
     )
 
 
@@ -154,26 +198,10 @@ class TeLAPACatalogEntry:
     repository_tree_digest: None = None
     immutable_external_source_established: bool = False
     paper_parity_allowed: bool = False
-    paper_mechanism: str = (
-        "per-task policy neighborhoods, MAP-Elites illumination, few-shot retrieval, "
-        "and a learned trajectory latent maintained with anchors/replay/re-embedding"
-    )
-    development_adapter: str = (
-        "two-state tabular policy snapshots and a fixed four-statistic rollout descriptor"
-    )
-    protocol_differences: tuple[str, ...] = (
-        "SwitchingTwoStateMDP instead of the paper MiniGrid and MuJoCo curricula",
-        "tabular reward update instead of PPO",
-        "bounded deterministic insertion instead of MAP-Elites illumination",
-        "fixed statistic descriptor instead of a learned aligned trajectory embedder",
-        "no anchor/replay bank, re-embedding, few-shot adaptation, or transfer metric",
-    )
-    paper_metrics: tuple[str, ...] = (
-        "standardized_time_to_threshold",
-        "success_rate",
-        "backward_transfer",
-        "transfer_ratio",
-    )
+    paper_mechanism: str = _PAPER_MECHANISM
+    development_adapter: str = _DEVELOPMENT_ADAPTER
+    protocol_differences: tuple[str, ...] = _PROTOCOL_DIFFERENCES
+    paper_metrics: tuple[str, ...] = _PAPER_METRICS
     timing_policy: str = "telemetry_only"
     promotion_policy: str = "permanently_nonpromoting_development_smoke"
 
@@ -200,12 +228,14 @@ class TeLAPACatalogEntry:
             raise ValueError("anonymous source provenance must fail closed")
         if (
             type(self.paper_mechanism) is not str
+            or self.paper_mechanism != _PAPER_MECHANISM
             or type(self.development_adapter) is not str
+            or self.development_adapter != _DEVELOPMENT_ADAPTER
             or type(self.protocol_differences) is not tuple
-            or len(self.protocol_differences) != 5
+            or self.protocol_differences != _PROTOCOL_DIFFERENCES
             or any(type(value) is not str for value in self.protocol_differences)
             or type(self.paper_metrics) is not tuple
-            or len(self.paper_metrics) != 4
+            or self.paper_metrics != _PAPER_METRICS
             or any(type(value) is not str for value in self.paper_metrics)
         ):
             raise ValueError("protocol differences must remain explicit")
@@ -383,9 +413,11 @@ def _run_arm(config: TeLAPASmokeConfig, seed: int, arm: Arm) -> dict[str, Any]:
         phase_length=config.phase_length,
         learning_rate=config.learning_rate,
     )
-    root = jr.key(seed)
+    root = jr.key(seed, impl=_RNG_IMPL)
+    if int(jr.key_data(root).nbytes) != _RNG_ROOT_BYTES:
+        raise AssertionError("Threefry root key width drifted")
     environment_state, policy = adapter.init(root)
-    initial_policy = _policy_bytes(policy)
+    initial_policy_sha256 = hashlib.sha256(_policy_bytes(policy)).hexdigest()
     archive = BoundedPolicyArchive(
         byte_budget=config.archive_byte_budget,
         min_latent_distance=config.min_latent_distance,
@@ -398,9 +430,11 @@ def _run_arm(config: TeLAPASmokeConfig, seed: int, arm: Arm) -> dict[str, Any]:
     phase_observations: list[np.ndarray] = []
     phase_actions: list[int] = []
     phase_rewards: list[float] = []
-    archive_queries = 0
+    archive_selection_queries = 0
+    anchor_selection_queries = 0
     descriptor_queries = 0
     boundary_disclosures = 0
+    reward_sum = 0.0
 
     for step in range(config.steps):
         environment_state, policy, observation, action, reward = adapter.step(
@@ -411,6 +445,7 @@ def _run_arm(config: TeLAPASmokeConfig, seed: int, arm: Arm) -> dict[str, Any]:
         observations.append(np.ascontiguousarray(observation).tobytes())
         actions.append(np.asarray(action, dtype="<i4").tobytes())
         rewards.append(np.asarray(reward, dtype="<f4").tobytes())
+        reward_sum += reward
         phase_observations.append(observation)
         phase_actions.append(action)
         phase_rewards.append(reward)
@@ -427,7 +462,7 @@ def _run_arm(config: TeLAPASmokeConfig, seed: int, arm: Arm) -> dict[str, Any]:
             boundary_disclosures += 1
             score = float(np.mean(np.asarray(phase_rewards, dtype=np.float64)))
             snapshot = _policy_bytes(policy)
-            if fixed_anchor is None:
+            if arm == "mechanism_off" and fixed_anchor is None:
                 fixed_anchor = snapshot
             if arm != "mechanism_off":
                 archive = archive.add(
@@ -438,7 +473,7 @@ def _run_arm(config: TeLAPASmokeConfig, seed: int, arm: Arm) -> dict[str, Any]:
                         score=score,
                     )
                 )
-                archive_queries += len(archive.entries)
+                archive_selection_queries += len(archive.entries)
                 if arm == "diverse_archive":
                     selected = max(archive.entries, key=lambda entry: (entry.score, entry.identity))
                     policy = _decode_policy(selected.policy_bytes)
@@ -448,7 +483,9 @@ def _run_arm(config: TeLAPASmokeConfig, seed: int, arm: Arm) -> dict[str, Any]:
                     policy = _decode_policy(archive.entries[0].policy_bytes)
             else:
                 # Exact archive-off reduction of the fixed-snapshot behavior.
-                archive_queries += 1
+                if fixed_anchor is None:
+                    raise AssertionError("mechanism-off anchor was not initialized")
+                anchor_selection_queries += 1
                 policy = _decode_policy(fixed_anchor)
             phase_observations.clear()
             phase_actions.clear()
@@ -463,16 +500,23 @@ def _run_arm(config: TeLAPASmokeConfig, seed: int, arm: Arm) -> dict[str, Any]:
         "observation_sha256": _digest(observations),
         "action_sha256": _digest(actions),
         "reward_sha256": _digest(rewards),
-        "initial_policy_sha256": hashlib.sha256(initial_policy).hexdigest(),
+        "initial_policy_sha256": initial_policy_sha256,
         "final_policy_sha256": hashlib.sha256(_policy_bytes(policy)).hexdigest(),
+        "reward_sum": reward_sum,
+        "mean_reward": reward_sum / config.steps,
         "archive_entry_count": len(archive.entries) if arm != "mechanism_off" else 0,
         "resource_receipt": {
             "environment_steps": config.steps,
             "observations_consumed": config.steps,
             "policy_updates": config.steps,
             "policy_queries": config.steps,
+            "rng_implementation": _RNG_IMPL,
+            "rng_root_keys": 1,
+            "rng_key_derivations": config.steps + 2,
+            "rng_root_persistent_bytes": _RNG_ROOT_BYTES,
             "descriptor_model_queries": descriptor_queries,
-            "archive_entry_queries": archive_queries,
+            "archive_selection_entry_queries": archive_selection_queries,
+            "anchor_selection_queries": anchor_selection_queries,
             "task_boundary_disclosures": boundary_disclosures,
             "observation_bytes": 8 * config.steps,
             "action_bytes": 4 * config.steps,
@@ -486,6 +530,42 @@ def _run_arm(config: TeLAPASmokeConfig, seed: int, arm: Arm) -> dict[str, Any]:
             "timing_policy": "telemetry_only",
         },
     }
+
+
+def _comparison_payloads(
+    records: list[dict[str, Any]], config: TeLAPASmokeConfig
+) -> list[dict[str, Any]]:
+    """Build exact descriptive archive-versus-control comparisons."""
+
+    by_pair = {(record["seed"], record["arm"]): record for record in records}
+    comparisons: list[dict[str, Any]] = []
+    for control in ("one_model", "fixed_snapshot"):
+        per_seed: list[dict[str, Any]] = []
+        for seed in config.seeds:
+            candidate_value = float(by_pair[(seed, "diverse_archive")]["mean_reward"])
+            control_value = float(by_pair[(seed, control)]["mean_reward"])
+            per_seed.append(
+                {
+                    "seed": seed,
+                    "candidate_value": candidate_value,
+                    "control_value": control_value,
+                    "delta": candidate_value - control_value,
+                }
+            )
+        mean_delta = math.fsum(item["delta"] for item in per_seed) / len(per_seed)
+        direction = "improved" if mean_delta > 0.0 else "regressed" if mean_delta < 0.0 else "tied"
+        comparisons.append(
+            {
+                "candidate": "diverse_archive",
+                "control": control,
+                "metric": "mean_reward",
+                "per_seed": per_seed,
+                "mean_delta": mean_delta,
+                "direction": direction,
+                "classification": "descriptive_nonpromoting",
+            }
+        )
+    return comparisons
 
 
 def run_smoke(config: TeLAPASmokeConfig | None = None) -> dict[str, Any]:
@@ -519,15 +599,18 @@ def run_smoke(config: TeLAPASmokeConfig | None = None) -> dict[str, Any]:
             raise AssertionError("mechanism-off reduction diverged from fixed snapshot")
     result = {
         "schema": SCHEMA,
+        "identity": _current_identity().to_payload(),
         "catalog": _catalog_payload(catalog),
         "config": _config_payload(config),
-        "identity": _current_identity(config, catalog).to_payload(),
         "matched_axes": [
             "seed",
             "environment_steps",
             "observations_consumed",
             "policy_updates",
             "policy_queries",
+            "rng_root_keys",
+            "rng_key_derivations",
+            "rng_root_persistent_bytes",
             "descriptor_model_queries",
             "task_boundary_disclosures",
         ],
@@ -539,6 +622,7 @@ def run_smoke(config: TeLAPASmokeConfig | None = None) -> dict[str, Any]:
         },
         "mechanism_off_parity": "exact_behavior_and_active_policy_state_vs_fixed_snapshot",
         "records": records,
+        "comparisons": _comparison_payloads(records, config),
         "negative_retention": {
             "required": True,
             "policy": "retain every valid development outcome, including ties and regressions",
@@ -568,8 +652,9 @@ def validate_result(value: object) -> None:
     root = _require_exact_keys(
         value,
         {
-            "schema", "catalog", "config", "identity", "matched_axes", "allowed_information",
-            "mechanism_off_parity", "records", "negative_retention", "classification",
+            "schema", "identity", "catalog", "config", "matched_axes", "allowed_information",
+            "mechanism_off_parity", "records", "comparisons", "negative_retention",
+            "classification",
             "scientific_promotion_allowed", "paper_parity_claimed", "performance_claimed",
         },
         "result",
@@ -581,6 +666,8 @@ def validate_result(value: object) -> None:
         or root["classification"] != "bounded_synthetic_development_smoke"
     ):
         raise ValueError("result identity mismatch")
+    identity = identity_from_payload(root["identity"])
+    require_current_identity(identity, _current_identity())
     for field in ("scientific_promotion_allowed", "paper_parity_claimed", "performance_claimed"):
         if root[field] is not False:
             raise ValueError(f"{field} must remain false")
@@ -589,19 +676,17 @@ def validate_result(value: object) -> None:
     )
     catalog_payload["protocol_differences"] = tuple(catalog_payload["protocol_differences"])
     catalog_payload["paper_metrics"] = tuple(catalog_payload["paper_metrics"])
-    catalog = TeLAPACatalogEntry(**catalog_payload)
-    catalog.validate()
+    TeLAPACatalogEntry(**catalog_payload).validate()
     config_payload = dict(
         _require_exact_keys(root["config"], set(asdict(TeLAPASmokeConfig())), "config")
     )
     config_payload["seeds"] = tuple(config_payload["seeds"])
     config = TeLAPASmokeConfig(**config_payload)
-    require_current_identity(
-        identity_from_payload(root["identity"]), _current_identity(config, catalog)
-    )
     expected_axes = [
         "seed", "environment_steps", "observations_consumed", "policy_updates",
-        "policy_queries", "descriptor_model_queries", "task_boundary_disclosures",
+        "policy_queries", "rng_root_keys", "rng_key_derivations",
+        "rng_root_persistent_bytes", "descriptor_model_queries",
+        "task_boundary_disclosures",
     ]
     if (
         type(root["matched_axes"]) is not list
@@ -650,12 +735,15 @@ def validate_result(value: object) -> None:
         raise ValueError("record matrix is incomplete")
     record_keys = {
         "arm", "seed", "observation_sha256", "action_sha256", "reward_sha256",
-        "initial_policy_sha256", "final_policy_sha256", "archive_entry_count",
-        "resource_receipt",
+        "initial_policy_sha256", "final_policy_sha256", "reward_sum", "mean_reward",
+        "archive_entry_count", "resource_receipt",
     }
     receipt_keys = {
         "environment_steps", "observations_consumed", "policy_updates", "policy_queries",
-        "descriptor_model_queries", "archive_entry_queries", "task_boundary_disclosures",
+        "rng_implementation", "rng_root_keys", "rng_key_derivations",
+        "rng_root_persistent_bytes",
+        "descriptor_model_queries", "archive_selection_entry_queries",
+        "anchor_selection_queries", "task_boundary_disclosures",
         "observation_bytes", "action_bytes", "reward_bytes",
         "active_policy_persistent_bytes", "archive_persistent_bytes",
         "mechanism_off_anchor_bytes", "descriptor_model_persistent_bytes",
@@ -684,6 +772,13 @@ def validate_result(value: object) -> None:
                 or any(c not in "0123456789abcdef" for c in digest)
             ):
                 raise ValueError(f"{field} must be a lowercase SHA-256 digest")
+        for field in ("reward_sum", "mean_reward"):
+            if type(record[field]) is not float or not math.isfinite(record[field]):
+                raise ValueError(f"{field} must be a finite exact float")
+        if not 0.0 <= record["reward_sum"] <= float(config.steps):
+            raise ValueError("reward_sum is outside the fixed reward lattice bounds")
+        if not 0.0 <= record["mean_reward"] <= 1.0:
+            raise ValueError("mean_reward is outside the fixed reward lattice bounds")
         if (
             type(record["archive_entry_count"]) is not int
             or not 0
@@ -697,6 +792,9 @@ def validate_result(value: object) -> None:
             "observations_consumed": config.steps,
             "policy_updates": config.steps,
             "policy_queries": config.steps,
+            "rng_root_keys": 1,
+            "rng_key_derivations": config.steps + 2,
+            "rng_root_persistent_bytes": _RNG_ROOT_BYTES,
             "descriptor_model_queries": config.steps // config.phase_length,
             "task_boundary_disclosures": config.steps // config.phase_length,
             "observation_bytes": 8 * config.steps,
@@ -711,8 +809,14 @@ def validate_result(value: object) -> None:
             for name, expected in exact.items()
         ):
             raise ValueError("exact resource receipt mismatch")
+        if (
+            type(receipt["rng_implementation"]) is not str
+            or receipt["rng_implementation"] != _RNG_IMPL
+        ):
+            raise ValueError("RNG implementation must remain explicit Threefry")
         for field in (
-            "archive_entry_queries",
+            "archive_selection_entry_queries",
+            "anchor_selection_queries",
             "archive_persistent_bytes",
             "mechanism_off_anchor_bytes",
         ):
@@ -731,15 +835,25 @@ def validate_result(value: object) -> None:
                 record["archive_entry_count"] != 0
                 or receipt["archive_persistent_bytes"] != 0
                 or receipt["mechanism_off_anchor_bytes"] != _POLICY_BYTES
+                or receipt["archive_selection_entry_queries"] != 0
+                or receipt["anchor_selection_queries"]
+                != config.steps // config.phase_length
             ):
                 raise ValueError("mechanism-off resource reduction is invalid")
-        elif receipt["mechanism_off_anchor_bytes"] != 0:
-            raise ValueError("archive arms cannot retain mechanism-off anchor bytes")
-        expected_record = _run_arm(config, pair[0], cast(Arm, pair[1]))
+        elif (
+            receipt["mechanism_off_anchor_bytes"] != 0
+            or receipt["anchor_selection_queries"] != 0
+            or receipt["archive_selection_entry_queries"]
+            < config.steps // config.phase_length
+        ):
+            raise ValueError("archive-arm selection resources are invalid")
+        expected_record = _run_arm(config, record["seed"], cast(Arm, record["arm"]))
         if record != expected_record:
-            raise ValueError("record does not replay from the bound configuration")
+            raise ValueError("deterministic arm replay or exact archive receipt mismatch")
     if observed_pairs != expected_pairs:
         raise ValueError("record matrix is incomplete")
+    if root["comparisons"] != _comparison_payloads(records, config):
+        raise ValueError("descriptive control comparison mismatch")
     for seed in config.seeds:
         fixed = by_pair[(seed, "fixed_snapshot")]
         off = by_pair[(seed, "mechanism_off")]
@@ -749,6 +863,38 @@ def validate_result(value: object) -> None:
         ):
             if fixed[field] != off[field]:
                 raise ValueError("mechanism-off exact parity failed")
+
+
+def retain_local_comparator_result(value: object, *, repository_root: Path) -> Path:
+    """Retain one validated local comparator at a new content-addressed path."""
+
+    if type(repository_root) is not PosixPath or not repository_root.is_absolute():
+        raise ValueError("repository_root must be an exact absolute POSIX Path")
+    validate_result(value)
+    encoded = _bounded_json_bytes(value) + b"\n"
+    digest = hashlib.sha256(encoded).hexdigest()
+    directory = repository_root / "outputs" / "telapa" / "local-comparator.v2"
+    directory.mkdir(parents=True, exist_ok=True)
+    if not directory.resolve().is_relative_to(repository_root.resolve()):
+        raise ValueError("local comparator output directory escapes repository_root")
+    return atomic_write_new(directory / f"result.{digest}.json", encoded)
+
+
+def load_local_comparator_result(path: Path) -> dict[str, Any]:
+    """Load and strictly validate one bounded retained local comparator."""
+
+    if type(path) is not PosixPath:
+        raise ValueError("path must be an exact POSIX Path")
+    with path.open("rb") as stream:
+        encoded = stream.read(_MAX_JSON_BYTES + 2)
+    if len(encoded) > _MAX_JSON_BYTES + 1:
+        raise ValueError("retained local comparator exceeds its byte bound")
+    try:
+        value = json.loads(encoded)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("retained local comparator must contain exact JSON") from exc
+    validate_result(value)
+    return cast(dict[str, Any], value)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/alberta_framework/evaluation/adalin_matched_runner.py
+++ b/alberta_framework/evaluation/adalin_matched_runner.py
@@ -1,0 +1,662 @@
+"""Run the complete, permanently nonpromoting issue #1571 AdaLin campaign."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+import platform
+import sys
+import tempfile
+import zipfile
+from dataclasses import asdict
+from pathlib import Path
+from types import MappingProxyType
+from typing import Final, cast
+
+import jax
+import numpy as np
+
+from alberta_framework.benchmarks.adalin import (
+    AdaLinConfig,
+    initialize_adalin_state,
+    make_pmnist_schedule,
+    run_adalin_development,
+    validate_adalin_result,
+)
+
+RESULT_SCHEMA: Final = "asi.adalin.matched-development.v1"
+DEVELOPMENT_SEEDS: Final = (15710, 15711, 15712, 15713, 15714)
+ARMS: Final = ("relu_alpha_zero_mechanism_off", "adalin")
+_ARM_ENABLED: Final = MappingProxyType(
+    {"relu_alpha_zero_mechanism_off": False, "adalin": True}
+)
+CAMPAIGN_PROFILES: Final = MappingProxyType(
+    {
+        "contract-smoke": AdaLinConfig(
+            tasks=2,
+            examples_per_task=4,
+            batch_size=2,
+            hidden_widths=(3, 2),
+            classes=2,
+        ),
+        "bounded-development": AdaLinConfig(
+            tasks=8,
+            examples_per_task=64,
+            batch_size=1,
+            hidden_widths=(300, 150),
+            classes=10,
+        ),
+    }
+)
+_POLICY: Final = {
+    "development_only": True,
+    "scientific_promotion_allowed": False,
+    "sota_claim_allowed": False,
+    "negative_results_retained": True,
+}
+_MAX_BYTES: Final = 256 * 1024 * 1024
+_MAX_JSON_NODES: Final = 100_000
+_MAX_JSON_STRING_BYTES: Final = 16_384
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False
+    ).encode("ascii")
+
+
+def _same_json_type_and_value(actual: object, expected: object) -> bool:
+    """Compare canonical JSON so booleans, integers, and floats cannot alias."""
+    try:
+        return _canonical(actual) == _canonical(expected)
+    except (TypeError, ValueError):
+        return False
+
+
+def _json_preflight(value: object) -> None:
+    pending: list[tuple[object, int]] = [(value, 0)]
+    seen: set[int] = set()
+    nodes = 0
+    while pending:
+        current, depth = pending.pop()
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > 18:
+            raise ValueError("matched result exceeds its JSON structure bound")
+        if current is None or type(current) in {bool, int}:
+            continue
+        if type(current) is float:
+            if not math.isfinite(current):
+                raise ValueError("matched result contains a non-finite float")
+            continue
+        if type(current) is str:
+            if len(current.encode("utf-8")) > _MAX_JSON_STRING_BYTES:
+                raise ValueError("matched result contains an oversized string")
+            continue
+        if type(current) not in {dict, list}:
+            raise ValueError("matched result must contain only exact JSON values")
+        identity = id(current)
+        if identity in seen:
+            raise ValueError("matched result contains an aliased or cyclic container")
+        seen.add(identity)
+        if type(current) is dict:
+            mapping = cast(dict[object, object], current)
+            if len(mapping) > 4096 or any(type(key) is not str for key in mapping):
+                raise ValueError("matched result object exceeds its field bound")
+            pending.extend((item, depth + 1) for item in mapping.values())
+        else:
+            sequence = cast(list[object], current)
+            if len(sequence) > 4096:
+                raise ValueError("matched result list exceeds its item bound")
+            pending.extend((item, depth + 1) for item in sequence)
+
+
+def _exact_object(value: object, fields: set[str], label: str) -> dict[str, object]:
+    if type(value) is not dict or set(cast(dict[object, object], value)) != fields:
+        raise ValueError(f"{label} fields drifted")
+    return cast(dict[str, object], value)
+
+
+def _source_identity() -> dict[str, str]:
+    root = Path(__file__).resolve().parents[2]
+    relative_paths = (
+        "pyproject.toml",
+        "uv.lock",
+        "alberta_framework/benchmarks/adalin.py",
+        "alberta_framework/evaluation/adalin_matched_runner.py",
+    )
+    return {
+        relative: hashlib.sha256((root / relative).read_bytes()).hexdigest()
+        for relative in relative_paths
+    }
+
+
+def _runtime_identity() -> dict[str, object]:
+    environment_names = (
+        "JAX_DEFAULT_MATMUL_PRECISION",
+        "JAX_DEFAULT_PRNG_IMPL",
+        "JAX_ENABLE_X64",
+        "JAX_NUM_CPU_DEVICES",
+        "JAX_PLATFORMS",
+        "JAX_PLATFORM_NAME",
+        "JAX_RANDOM_SEED_OFFSET",
+        "XLA_FLAGS",
+    )
+    return {
+        "schema": "asi.adalin.runtime.v1",
+        "python": list(sys.version_info[:3]),
+        "python_implementation": platform.python_implementation(),
+        "byteorder": sys.byteorder,
+        "platform": sys.platform,
+        "platform_release": platform.release(),
+        "machine": platform.machine(),
+        "packages": {
+            name: importlib.metadata.version(name)
+            for name in ("chex", "jax", "jaxlib", "numpy")
+        },
+        "backend": jax.default_backend(),
+        "devices": [
+            {
+                "platform": device.platform,
+                "device_kind": device.device_kind,
+                "id": device.id,
+                "process_index": device.process_index,
+            }
+            for device in jax.devices()
+        ],
+        "jax_config": {
+            "jax_default_matmul_precision": str(jax.config.jax_default_matmul_precision),
+            "jax_default_prng_impl": str(jax.config.jax_default_prng_impl),
+            "jax_disable_jit": bool(jax.config.jax_disable_jit),
+            "jax_enable_x64": bool(jax.config.jax_enable_x64),
+            "jax_numpy_dtype_promotion": str(jax.config.jax_numpy_dtype_promotion.value),
+            "jax_numpy_rank_promotion": str(jax.config.jax_numpy_rank_promotion),
+            "jax_random_seed_offset": int(jax.config.jax_random_seed_offset),
+            "jax_threefry_partitionable": bool(jax.config.jax_threefry_partitionable),
+        },
+        "environment": {name: os.environ.get(name) for name in environment_names},
+    }
+
+
+def _checked_profile(value: object) -> str:
+    if type(value) is not str or value not in CAMPAIGN_PROFILES:
+        raise ValueError("profile must name one registered AdaLin campaign profile")
+    return value
+
+
+def _validated_arrays(
+    train_inputs: object,
+    train_labels: object,
+    test_inputs: object,
+    test_labels: object,
+    profile: str,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    config = CAMPAIGN_PROFILES[profile]
+    for value, name in ((train_inputs, "train_inputs"), (test_inputs, "test_inputs")):
+        if type(value) is not np.ndarray or value.dtype != np.dtype(np.float32):
+            raise ValueError(f"{name} must be an exact float32 NumPy array")
+        if value.ndim != 2 or not np.isfinite(value).all():
+            raise ValueError(f"{name} must be a finite matrix")
+    for value, name in ((train_labels, "train_labels"), (test_labels, "test_labels")):
+        if type(value) is not np.ndarray or value.dtype != np.dtype(np.int32):
+            raise ValueError(f"{name} must be an exact int32 NumPy array")
+        if value.ndim != 1:
+            raise ValueError(f"{name} must be a vector")
+    train_x = cast(np.ndarray, train_inputs)
+    train_y = cast(np.ndarray, train_labels)
+    test_x = cast(np.ndarray, test_inputs)
+    test_y = cast(np.ndarray, test_labels)
+    if (
+        train_x.shape[0] != config.examples_per_task
+        or train_y.shape[0] != train_x.shape[0]
+        or test_x.shape[0] < 1
+        or test_y.shape[0] != test_x.shape[0]
+        or train_x.shape[1] != test_x.shape[1]
+        or train_x.shape[1] < 1
+    ):
+        raise ValueError("dataset shape does not match the AdaLin campaign profile")
+    if sum(value.nbytes for value in (train_x, train_y, test_x, test_y)) > _MAX_BYTES:
+        raise ValueError("dataset exceeds the campaign's 256 MiB byte bound")
+    if (
+        np.any(train_y < 0)
+        or np.any(train_y >= config.classes)
+        or np.any(test_y < 0)
+        or np.any(test_y >= config.classes)
+    ):
+        raise ValueError("labels are outside the configured class range")
+    return tuple(
+        np.array(value, copy=True, order="C")
+        for value in (train_x, train_y, test_x, test_y)
+    )  # type: ignore[return-value]
+
+
+def _hash_arrays(*arrays: np.ndarray) -> str:
+    digest = hashlib.sha256(b"asi-adalin-array-bundle-v1\0")
+    for index, array in enumerate(arrays):
+        digest.update(index.to_bytes(4, "little"))
+        digest.update(np.asarray(array.shape, dtype="<i8").tobytes())
+        dtype = array.dtype.str.encode("ascii")
+        digest.update(len(dtype).to_bytes(4, "little"))
+        digest.update(dtype)
+        digest.update(array.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+def _state_hash(state: object) -> str:
+    return _hash_arrays(*(np.asarray(leaf) for leaf in jax.tree_util.tree_leaves(state)))
+
+
+def _execution_identity(
+    seed: int, profile: str, input_dim: int, *, mechanism_enabled: bool
+) -> dict[str, str]:
+    config = CAMPAIGN_PROFILES[profile]
+    schedule = make_pmnist_schedule(config, seed=seed, input_dim=input_dim)
+    state = initialize_adalin_state(
+        config,
+        input_dim=input_dim,
+        classes=config.classes,
+        seed=seed,
+        mechanism_enabled=mechanism_enabled,
+    )
+    return {
+        "schedule_sha256": _hash_arrays(
+            np.asarray(schedule.pixel_permutations), np.asarray(schedule.example_orders)
+        ),
+        "initial_state_sha256": _state_hash(state),
+        "prng_implementation": "threefry2x32",
+    }
+
+
+def _config_payload(profile: str) -> dict[str, object]:
+    return cast(dict[str, object], json.loads(json.dumps(asdict(CAMPAIGN_PROFILES[profile]))))
+
+
+def _aggregate(rows: list[dict[str, object]]) -> dict[str, object]:
+    arms: dict[str, object] = {}
+    additive_names = (
+        "environment_data_steps",
+        "observations",
+        "label_queries",
+        "optimizer_updates",
+        "preupdate_prediction_model_queries",
+        "differentiated_training_model_queries",
+        "postupdate_test_model_queries",
+        "model_queries",
+        "preupdate_prediction_forward_calls",
+        "differentiated_training_forward_calls",
+        "postupdate_test_forward_calls",
+        "model_forward_calls",
+    )
+    peak_names = (
+        "initial_total_bytes",
+        "final_total_bytes",
+        "parameter_bytes",
+        "alpha_bytes",
+        "optimizer_state_bytes",
+    )
+    for arm in ARMS:
+        results = [
+            cast(dict[str, object], row["result"]) for row in rows if row["arm"] == arm
+        ]
+        metrics = [cast(dict[str, object], result["metrics"]) for result in results]
+        resources = [cast(dict[str, object], result["resources"]) for result in results]
+        states = [cast(dict[str, object], result["state"]) for result in results]
+        arms[arm] = {
+            "mean_metrics": {
+                "asi_whole_stream_preupdate_online_accuracy": math.fsum(
+                    cast(float, metric["asi_whole_stream_preupdate_online_accuracy"])
+                    for metric in metrics
+                )
+                / len(metrics),
+                "paper_current_task_test_accuracy_mean": math.fsum(
+                    cast(float, metric["paper_current_task_test_accuracy_mean"])
+                    for metric in metrics
+                )
+                / len(metrics),
+                "final_alpha_l2": math.fsum(
+                    cast(float, state["final_alpha_l2"]) for state in states
+                )
+                / len(states),
+            },
+            "total_additive_resources": {
+                name: sum(cast(int, resource[name]) for resource in resources)
+                for name in additive_names
+            },
+            "max_per_shard_state_bytes": {
+                name: max(cast(int, state[name]) for state in states)
+                for name in peak_names
+            },
+        }
+    return {"arms": arms, "row_count": len(rows)}
+
+
+def run_adalin_matched(
+    train_inputs: object,
+    train_labels: object,
+    test_inputs: object,
+    test_labels: object,
+    *,
+    profile: str = "bounded-development",
+) -> dict[str, object]:
+    """Execute all five development seeds across the exact two-arm roster."""
+    checked_profile = _checked_profile(profile)
+    train_x, train_y, test_x, test_y = _validated_arrays(
+        train_inputs, train_labels, test_inputs, test_labels, checked_profile
+    )
+    rows: list[dict[str, object]] = []
+    for seed in DEVELOPMENT_SEEDS:
+        for arm in ARMS:
+            enabled = _ARM_ENABLED[arm]
+            rows.append(
+                {
+                    "seed": seed,
+                    "arm": arm,
+                    "execution_identity": _execution_identity(
+                        seed,
+                        checked_profile,
+                        train_x.shape[1],
+                        mechanism_enabled=enabled,
+                    ),
+                    "result": run_adalin_development(
+                        train_x,
+                        train_y,
+                        test_x,
+                        test_y,
+                        config=CAMPAIGN_PROFILES[checked_profile],
+                        seed=seed,
+                        mechanism_enabled=enabled,
+                    ),
+                }
+            )
+    campaign: dict[str, object] = {
+        "schema": RESULT_SCHEMA,
+        "status": "complete",
+        "profile": checked_profile,
+        "config": _config_payload(checked_profile),
+        "development_seeds": list(DEVELOPMENT_SEEDS),
+        "arms": list(ARMS),
+        "identity": {
+            "dataset_sha256": _hash_arrays(train_x, train_y, test_x, test_y),
+            "source_sha256": _source_identity(),
+            "runtime": _runtime_identity(),
+            "consistency_not_attestation": True,
+        },
+        "policy": dict(_POLICY),
+        "decision": "inconclusive",
+        "rows": rows,
+        "aggregate": _aggregate(rows),
+    }
+    campaign["result_sha256"] = hashlib.sha256(_canonical(campaign)).hexdigest()
+    _validate_adalin_matched(
+        campaign,
+        train_x,
+        train_y,
+        test_x,
+        test_y,
+        profile=checked_profile,
+        reexecute=False,
+    )
+    return campaign
+
+
+def validate_adalin_matched(
+    value: object,
+    train_inputs: object,
+    train_labels: object,
+    test_inputs: object,
+    test_labels: object,
+    *,
+    profile: str = "bounded-development",
+) -> None:
+    """Strictly validate and replay every row, excluding timing telemetry."""
+    _validate_adalin_matched(
+        value,
+        train_inputs,
+        train_labels,
+        test_inputs,
+        test_labels,
+        profile=profile,
+        reexecute=True,
+    )
+
+
+def _validate_adalin_matched(
+    value: object,
+    train_inputs: object,
+    train_labels: object,
+    test_inputs: object,
+    test_labels: object,
+    *,
+    profile: str,
+    reexecute: bool,
+) -> None:
+    _json_preflight(value)
+    root = _exact_object(
+        value,
+        {
+            "schema",
+            "status",
+            "profile",
+            "config",
+            "development_seeds",
+            "arms",
+            "identity",
+            "policy",
+            "decision",
+            "rows",
+            "aggregate",
+            "result_sha256",
+        },
+        "matched result",
+    )
+    if root["schema"] != RESULT_SCHEMA or root["status"] != "complete":
+        raise ValueError("matched result identity drifted")
+    checked_profile = _checked_profile(profile)
+    train_x, train_y, test_x, test_y = _validated_arrays(
+        train_inputs, train_labels, test_inputs, test_labels, checked_profile
+    )
+    if root["profile"] != checked_profile or not _same_json_type_and_value(
+        root["config"], _config_payload(checked_profile)
+    ):
+        raise ValueError("matched result profile or config drifted")
+    if root["development_seeds"] != list(DEVELOPMENT_SEEDS) or root["arms"] != list(ARMS):
+        raise ValueError("matched result protocol roster drifted")
+    expected_identity = {
+        "dataset_sha256": _hash_arrays(train_x, train_y, test_x, test_y),
+        "source_sha256": _source_identity(),
+        "runtime": _runtime_identity(),
+        "consistency_not_attestation": True,
+    }
+    if not _same_json_type_and_value(root["identity"], expected_identity):
+        raise ValueError("matched result identity drifted")
+    if not _same_json_type_and_value(root["policy"], _POLICY):
+        raise ValueError("matched result must remain permanently nonpromoting")
+    if root["decision"] != "inconclusive" or type(root["decision"]) is not str:
+        raise ValueError("matched campaign decision must remain inconclusive")
+    expected_roster = [(seed, arm) for seed in DEVELOPMENT_SEEDS for arm in ARMS]
+    raw_rows = root["rows"]
+    if type(raw_rows) is not list or len(raw_rows) != len(expected_roster):
+        raise ValueError("matched result roster is incomplete")
+    rows = cast(list[dict[str, object]], raw_rows)
+    observed: list[tuple[object, object]] = []
+    for row in rows:
+        checked_row = _exact_object(
+            row, {"seed", "arm", "execution_identity", "result"}, "matched row"
+        )
+        seed = checked_row["seed"]
+        arm = checked_row["arm"]
+        if (
+            type(seed) is not int
+            or seed not in DEVELOPMENT_SEEDS
+            or type(arm) is not str
+            or arm not in ARMS
+        ):
+            raise ValueError("matched row roster identity drifted")
+        enabled = _ARM_ENABLED[arm]
+        expected_execution = _execution_identity(
+            seed,
+            checked_profile,
+            train_x.shape[1],
+            mechanism_enabled=enabled,
+        )
+        if not _same_json_type_and_value(
+            checked_row["execution_identity"], expected_execution
+        ):
+            raise ValueError("matched row execution identity drifted")
+        validate_adalin_result(checked_row["result"])
+        result = cast(dict[str, object], checked_row["result"])
+        if result["seed"] != seed or result["arm"] != arm:
+            raise ValueError("matched row result identity drifted")
+        dataset = cast(dict[str, object], result["dataset"])
+        provenance = cast(dict[str, object], result["provenance"])
+        if dataset["sha256"] != expected_identity["dataset_sha256"]:
+            raise ValueError("matched row dataset identity drifted")
+        if (
+            provenance["schedule_sha256"] != expected_execution["schedule_sha256"]
+            or provenance["initial_state_sha256"]
+            != expected_execution["initial_state_sha256"]
+        ):
+            raise ValueError("matched row provenance identity drifted")
+        observed.append((seed, arm))
+    if observed != expected_roster:
+        raise ValueError("matched result roster order drifted")
+    if not _same_json_type_and_value(root["aggregate"], _aggregate(rows)):
+        raise ValueError("matched result aggregate drifted")
+    unsigned = dict(root)
+    claimed = unsigned.pop("result_sha256")
+    if type(claimed) is not str or claimed != hashlib.sha256(_canonical(unsigned)).hexdigest():
+        raise ValueError("matched result digest drifted")
+    if reexecute:
+        for row in rows:
+            claimed_result = cast(dict[str, object], row["result"])
+            expected_result = run_adalin_development(
+                train_x,
+                train_y,
+                test_x,
+                test_y,
+                config=CAMPAIGN_PROFILES[checked_profile],
+                seed=cast(int, row["seed"]),
+                mechanism_enabled=_ARM_ENABLED[cast(str, row["arm"])],
+            )
+            expected_resources = cast(dict[str, object], expected_result["resources"])
+            claimed_resources = cast(dict[str, object], claimed_result["resources"])
+            expected_resources["wall_clock_seconds_telemetry"] = claimed_resources[
+                "wall_clock_seconds_telemetry"
+            ]
+            if expected_result != claimed_result:
+                raise ValueError("matched row disagrees with strict current-source reexecution")
+
+
+def _preflight_destination(destination: Path) -> Path:
+    if type(destination) is not type(Path()):
+        raise TypeError("destination must be an exact Path")
+    parent = destination.parent.resolve(strict=True)
+    resolved = parent / destination.name
+    if not parent.is_dir() or destination.name in {"", ".", ".."}:
+        raise ValueError("destination parent must be an existing directory")
+    if os.path.lexists(resolved):
+        raise FileExistsError(f"refusing to replace existing result: {resolved}")
+    return resolved
+
+
+def write_adalin_matched(
+    destination: Path,
+    value: object,
+    train_inputs: object,
+    train_labels: object,
+    test_inputs: object,
+    test_labels: object,
+    *,
+    profile: str = "bounded-development",
+) -> None:
+    """Strictly replay and publish one result without replacing retained data."""
+    resolved = _preflight_destination(destination)
+    validate_adalin_matched(
+        value,
+        train_inputs,
+        train_labels,
+        test_inputs,
+        test_labels,
+        profile=profile,
+    )
+    parent = resolved.parent
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=parent, prefix=f".{resolved.name}.", suffix=".tmp"
+    )
+    temporary = Path(temporary_name)
+    published = False
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(_canonical(value) + b"\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, resolved, follow_symlinks=False)
+        published = True
+        directory = os.open(parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except BaseException:
+        if published:
+            resolved.unlink(missing_ok=True)
+        raise
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _load_dataset(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    if path.is_symlink() or not path.is_file() or path.stat().st_size > _MAX_BYTES:
+        raise ValueError("dataset must be a bounded non-symlink NPZ file")
+    expected = {
+        "train_inputs.npy",
+        "train_labels.npy",
+        "test_inputs.npy",
+        "test_labels.npy",
+    }
+    try:
+        with zipfile.ZipFile(path) as archive:
+            members = archive.infolist()
+            if (
+                len(members) != 4
+                or {member.filename for member in members} != expected
+                or sum(member.file_size for member in members) > _MAX_BYTES
+                or any(member.is_dir() for member in members)
+            ):
+                raise ValueError("dataset NPZ members exceed the exact bounded contract")
+    except zipfile.BadZipFile as error:
+        raise ValueError("dataset must be a valid NPZ archive") from error
+    with np.load(path, allow_pickle=False) as archive:
+        if set(archive.files) != {
+            "train_inputs",
+            "train_labels",
+            "test_inputs",
+            "test_labels",
+        }:
+            raise ValueError("dataset NPZ fields drifted")
+        return tuple(
+            np.array(archive[name], copy=True)
+            for name in ("train_inputs", "train_labels", "test_inputs", "test_labels")
+        )  # type: ignore[return-value]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--dataset", required=True, type=Path)
+    parser.add_argument(
+        "--profile", choices=tuple(CAMPAIGN_PROFILES), default="bounded-development"
+    )
+    args = parser.parse_args(argv)
+    _preflight_destination(args.output)
+    arrays = _load_dataset(args.dataset)
+    result = run_adalin_matched(*arrays, profile=args.profile)
+    write_adalin_matched(args.output, result, *arrays, profile=args.profile)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/alberta_framework/evaluation/bimu_matched_runner.py
+++ b/alberta_framework/evaluation/bimu_matched_runner.py
@@ -1,0 +1,411 @@
+"""Execute and validate the frozen, permanently nonpromoting BiMU comparison."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import tempfile
+from pathlib import Path
+from typing import Final, cast
+
+import jax.random as jr
+import numpy as np
+
+from alberta_framework.benchmarks.bimu import (
+    _EXAMPLE_ORDER_DOMAIN,
+    _INIT_DOMAIN,
+    _PRNG_IMPLEMENTATION,
+    _dataset_sha256,
+    _initialize_state,
+    _state_sha256,
+    _stream_key,
+    build_task_schedule,
+    run_bimu_development,
+    validate_bimu_result,
+)
+from alberta_framework.evaluation.bimu_matched_nonpromoting import (
+    FROZEN_BIMU_MATCHED_PLAN,
+    BiMUMatchedDevelopmentPlan,
+    _json_preflight,
+    _plan_payload,
+    _runtime_identity,
+)
+
+RESULT_SCHEMA: Final = "asi.bimu.matched-development-result.v1"
+_POLICY: Final = {
+    "development_only": True,
+    "scientific_promotion_allowed": False,
+    "sota_claim_allowed": False,
+    "negative_results_retained": True,
+}
+_MATCHED_COUNTERS: Final = (
+    "environment_steps",
+    "observations",
+    "label_queries",
+    "optimizer_seen",
+    "model_forward_queries",
+)
+_RESOURCE_FIELDS: Final = (
+    "trainable_scalar_count",
+    "parameter_numeric_bytes",
+    "optimizer_state_numeric_bytes",
+    "initial_persistent_numeric_bytes",
+    "final_persistent_numeric_bytes",
+)
+_MAX_DATASET_BYTES: Final = 16 * 1024 * 1024
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False
+    ).encode("ascii")
+
+
+def _exact_object(value: object, fields: set[str], label: str) -> dict[str, object]:
+    if type(value) is not dict:
+        raise ValueError(f"{label} must be an exact object")
+    resolved = cast(dict[str, object], value)
+    if set(resolved) != fields:
+        raise ValueError(f"{label} fields drifted")
+    return resolved
+
+
+def _source_identity() -> dict[str, str]:
+    root = Path(__file__).resolve().parents[2]
+    relative_paths = (
+        "alberta_framework/benchmarks/bimu.py",
+        "alberta_framework/evaluation/bimu_matched_nonpromoting.py",
+        "alberta_framework/evaluation/bimu_matched_runner.py",
+    )
+    return {
+        relative: hashlib.sha256((root / relative).read_bytes()).hexdigest()
+        for relative in relative_paths
+    }
+
+
+def _validated_arrays(
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+    *,
+    plan: BiMUMatchedDevelopmentPlan,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    config = plan.candidate_config
+    expected = (
+        (train_x, np.dtype(np.float32), (config.train_examples_per_task, config.input_dim)),
+        (train_y, np.dtype(np.int32), (config.train_examples_per_task,)),
+        (test_x, np.dtype(np.float32), (config.test_examples_per_task, config.input_dim)),
+        (test_y, np.dtype(np.int32), (config.test_examples_per_task,)),
+    )
+    arrays: list[np.ndarray] = []
+    total_bytes = 0
+    for index, (value, dtype, shape) in enumerate(expected):
+        if type(value) is not np.ndarray or value.dtype != dtype or value.shape != shape:
+            raise ValueError(f"dataset array {index} does not match the plan")
+        total_bytes += value.size * value.dtype.itemsize
+        if total_bytes > _MAX_DATASET_BYTES:
+            raise ValueError("dataset arrays exceed the matched runner byte ceiling")
+        arrays.append(np.array(value, dtype=dtype, order="C", copy=True))
+    if not np.all(np.isfinite(arrays[0])) or not np.all(np.isfinite(arrays[2])):
+        raise ValueError("dataset features must be finite")
+    if any(
+        np.any(labels < 0) or np.any(labels >= config.n_classes)
+        for labels in (arrays[1], arrays[3])
+    ):
+        raise ValueError("dataset labels are outside the plan class range")
+    if _dataset_sha256(*arrays) != plan.dataset_sha256:
+        raise ValueError("dataset does not match the plan digest")
+    return arrays[0], arrays[1], arrays[2], arrays[3]
+
+
+def _expected_fixed_identities(
+    plan: BiMUMatchedDevelopmentPlan, seed: int
+) -> tuple[str, str]:
+    config = plan.control_config
+    if config.query_threshold != 0.0:
+        raise ValueError("matched runner requires the frozen zero query threshold")
+    root = jr.key(seed, impl=_PRNG_IMPLEMENTATION)
+    state = _initialize_state(config, _stream_key(root, _INIT_DOMAIN))
+    initial_state_sha256 = _state_sha256(state, optimizer_step=0, optimizer_seen=0)
+    schedule_digest = hashlib.sha256()
+    for task, permutation in enumerate(build_task_schedule(config, seed=seed)):
+        order = np.asarray(
+            jr.permutation(
+                _stream_key(root, _EXAMPLE_ORDER_DOMAIN, task),
+                config.train_examples_per_task,
+            ),
+            dtype=np.int32,
+        )
+        schedule_digest.update(
+            json.dumps(
+                {
+                    "task": task,
+                    "permutation": list(permutation),
+                    "example_order": [int(value) for value in order],
+                    "query_decisions": [True] * config.train_examples_per_task,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+    return initial_state_sha256, schedule_digest.hexdigest()
+
+
+def _sum_result_field(rows: list[dict[str, object]], section: str, field: str) -> int:
+    total = 0
+    for row in rows:
+        result = cast(dict[str, object], row["result"])
+        values = cast(dict[str, object], result[section])
+        total += cast(int, values[field])
+    return total
+
+
+def _aggregate(
+    rows: list[dict[str, object]], plan: BiMUMatchedDevelopmentPlan
+) -> dict[str, object]:
+    late_deltas: list[float] = []
+    online_deltas: list[float] = []
+    for seed in plan.seeds:
+        pair = [row for row in rows if row["seed"] == seed]
+        if len(pair) != 2:
+            raise ValueError("aggregate does not have one complete pair per seed")
+        by_arm = {cast(str, row["arm"]): cast(dict[str, object], row["result"]) for row in pair}
+        control_metrics = cast(dict[str, object], by_arm["memory_off"]["metrics"])
+        candidate_metrics = cast(dict[str, object], by_arm["bimu"]["metrics"])
+        late_deltas.append(
+            cast(float, candidate_metrics["paper_late_five_test_accuracy"])
+            - cast(float, control_metrics["paper_late_five_test_accuracy"])
+        )
+        online_deltas.append(
+            cast(float, candidate_metrics["asi_whole_stream_online_accuracy"])
+            - cast(float, control_metrics["asi_whole_stream_online_accuracy"])
+        )
+    totals = {field: _sum_result_field(rows, "resources", field) for field in _RESOURCE_FIELDS}
+    counter_totals = {
+        field: _sum_result_field(rows, "counters", field)
+        for field in (*_MATCHED_COUNTERS, "optimizer_updates")
+    }
+    return {
+        "paired_late_five_deltas": late_deltas,
+        "paired_late_five_delta_mean": math.fsum(late_deltas) / len(late_deltas),
+        "paired_online_deltas": online_deltas,
+        "paired_online_delta_mean": math.fsum(online_deltas) / len(online_deltas),
+        "resource_totals": totals,
+        "counter_totals": counter_totals,
+    }
+
+
+def run_bimu_matched_development(
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+    *,
+    plan: BiMUMatchedDevelopmentPlan = FROZEN_BIMU_MATCHED_PLAN,
+) -> dict[str, object]:
+    """Run every matched arm and seed; this never promotes the observed result."""
+    if type(plan) is not BiMUMatchedDevelopmentPlan:
+        raise ValueError("plan must be an exact BiMUMatchedDevelopmentPlan")
+    checked_plan = BiMUMatchedDevelopmentPlan(**plan.__dict__)
+    arrays = _validated_arrays(train_x, train_y, test_x, test_y, plan=checked_plan)
+    rows: list[dict[str, object]] = []
+    configs = (checked_plan.control_config, checked_plan.candidate_config)
+    for seed in checked_plan.seeds:
+        for arm, config in zip(checked_plan.arm_names, configs, strict=True):
+            arm_result = run_bimu_development(*arrays, config=config, seed=seed)
+            validate_bimu_result(arm_result)
+            rows.append({"seed": seed, "arm": arm, "result": arm_result})
+    plan_payload = _plan_payload(checked_plan)
+    result: dict[str, object] = {
+        "schema": RESULT_SCHEMA,
+        "status": "complete",
+        "plan": plan_payload,
+        "identity": {
+            "dataset_sha256": checked_plan.dataset_sha256,
+            "plan_sha256": hashlib.sha256(_canonical(plan_payload)).hexdigest(),
+            "source_sha256": _source_identity(),
+            "runtime": _runtime_identity(),
+            "consistency_not_attestation": True,
+        },
+        "policy": dict(_POLICY),
+        "rows": rows,
+        "aggregate": _aggregate(rows, checked_plan),
+    }
+    result["result_sha256"] = hashlib.sha256(_canonical(result)).hexdigest()
+    validate_bimu_matched_result(result, *arrays, plan=checked_plan)
+    return result
+
+
+def validate_bimu_matched_result(
+    value: object,
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+    *,
+    plan: BiMUMatchedDevelopmentPlan = FROZEN_BIMU_MATCHED_PLAN,
+) -> None:
+    """Validate roster, matched axes, derived aggregates, identities, and policy."""
+    _json_preflight(value)
+    root = _exact_object(
+        value,
+        {"schema", "status", "plan", "identity", "policy", "rows", "aggregate", "result_sha256"},
+        "matched result",
+    )
+    if root["schema"] != RESULT_SCHEMA or root["status"] != "complete":
+        raise ValueError("matched result identity drifted")
+    if type(plan) is not BiMUMatchedDevelopmentPlan:
+        raise ValueError("plan must be an exact BiMUMatchedDevelopmentPlan")
+    checked_plan = BiMUMatchedDevelopmentPlan(**plan.__dict__)
+    arrays = _validated_arrays(train_x, train_y, test_x, test_y, plan=checked_plan)
+    expected_plan = _plan_payload(checked_plan)
+    if root["plan"] != expected_plan:
+        raise ValueError("matched result plan drifted")
+    expected_identity = {
+        "dataset_sha256": checked_plan.dataset_sha256,
+        "plan_sha256": hashlib.sha256(_canonical(expected_plan)).hexdigest(),
+        "source_sha256": _source_identity(),
+        "runtime": _runtime_identity(),
+        "consistency_not_attestation": True,
+    }
+    if root["identity"] != expected_identity:
+        raise ValueError("matched result identity drifted")
+    if root["policy"] != _POLICY:
+        raise ValueError("matched result must remain permanently nonpromoting")
+    raw_rows = root["rows"]
+    if type(raw_rows) is not list or len(raw_rows) != len(checked_plan.seeds) * 2:
+        raise ValueError("matched result roster is incomplete")
+    rows = cast(list[dict[str, object]], raw_rows)
+    expected_roster = [
+        (seed, arm) for seed in checked_plan.seeds for arm in checked_plan.arm_names
+    ]
+    observed_roster: list[tuple[object, object]] = []
+    for row in rows:
+        checked_row = _exact_object(row, {"seed", "arm", "result"}, "matched row")
+        observed_roster.append((checked_row["seed"], checked_row["arm"]))
+        arm_result = checked_row["result"]
+        validate_bimu_result(arm_result)
+        resolved_result = cast(dict[str, object], arm_result)
+        if resolved_result["seed"] != checked_row["seed"]:
+            raise ValueError("matched row seed drifted")
+        config = (
+            checked_plan.control_config
+            if checked_row["arm"] == "memory_off"
+            else checked_plan.candidate_config
+        )
+        if resolved_result["protocol"] != config.to_protocol_payload():
+            raise ValueError("matched row protocol drifted")
+        if resolved_result["dataset_sha256"] != checked_plan.dataset_sha256:
+            raise ValueError("matched row dataset digest drifted")
+        # The benchmark validator deliberately treats producer-reported metrics and
+        # consistency digests as unauthenticated. A retained matched result has a
+        # stronger contract: reproduce the exact seed/arm transaction from the
+        # supplied, digest-bound arrays and compare every non-timing field.
+        reproduced = run_bimu_development(
+            *arrays,
+            config=config,
+            seed=cast(int, checked_row["seed"]),
+        )
+        reproduced["timing"] = resolved_result["timing"]
+        if resolved_result != reproduced:
+            raise ValueError("matched row does not reproduce from the frozen inputs")
+    if observed_roster != expected_roster:
+        raise ValueError("matched result roster order drifted")
+    for offset in range(0, len(rows), 2):
+        seed = checked_plan.seeds[offset // 2]
+        control = cast(dict[str, object], rows[offset]["result"])
+        candidate = cast(dict[str, object], rows[offset + 1]["result"])
+        expected_initial, expected_schedule = _expected_fixed_identities(checked_plan, seed)
+        if (
+            control["initial_state_sha256"] != expected_initial
+            or candidate["initial_state_sha256"] != expected_initial
+        ):
+            raise ValueError("matched pair initial-state identity drifted")
+        if (
+            control["schedule_sha256"] != expected_schedule
+            or candidate["schedule_sha256"] != expected_schedule
+        ):
+            raise ValueError("matched pair schedule identity drifted")
+        for field in ("dataset_sha256", "schedule_sha256", "initial_state_sha256"):
+            if control[field] != candidate[field]:
+                raise ValueError(f"matched pair {field} drifted")
+        control_counters = cast(dict[str, object], control["counters"])
+        candidate_counters = cast(dict[str, object], candidate["counters"])
+        if any(control_counters[field] != candidate_counters[field] for field in _MATCHED_COUNTERS):
+            raise ValueError("matched pair counters drifted")
+        config = checked_plan.control_config
+        observations = config.n_tasks * config.train_examples_per_task
+        expected_counters = {
+            "environment_steps": observations,
+            "observations": observations,
+            "label_queries": observations,
+            "optimizer_seen": observations,
+            "model_forward_queries": (
+                observations * (config.query_samples + config.train_samples)
+                + 5 * config.test_examples_per_task * config.test_samples
+            ),
+        }
+        if any(control_counters[field] != value for field, value in expected_counters.items()):
+            raise ValueError("matched pair counters do not match the frozen plan")
+        control_resources = cast(dict[str, object], control["resources"])
+        candidate_resources = cast(dict[str, object], candidate["resources"])
+        if any(
+            control_resources[field] != candidate_resources[field]
+            for field in _RESOURCE_FIELDS
+        ):
+            raise ValueError("matched pair resources drifted")
+    if root["aggregate"] != _aggregate(rows, checked_plan):
+        raise ValueError("matched aggregate drifted")
+    unsigned = dict(root)
+    claimed = unsigned.pop("result_sha256")
+    if type(claimed) is not str or claimed != hashlib.sha256(_canonical(unsigned)).hexdigest():
+        raise ValueError("matched result digest drifted")
+
+
+def write_bimu_matched_result(
+    destination: Path,
+    value: object,
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+    *,
+    plan: BiMUMatchedDevelopmentPlan = FROZEN_BIMU_MATCHED_PLAN,
+) -> None:
+    """Durably publish one validated result without replacing existing evidence."""
+    if type(destination) is not type(Path()):
+        raise TypeError("destination must be an exact Path")
+    validate_bimu_matched_result(value, train_x, train_y, test_x, test_y, plan=plan)
+    parent = destination.parent.resolve(strict=True)
+    if not parent.is_dir() or destination.name in {"", ".", ".."}:
+        raise ValueError("destination parent must be an existing directory")
+    resolved = parent / destination.name
+    if os.path.lexists(resolved):
+        raise FileExistsError(f"refusing to replace existing result: {resolved}")
+    raw = _canonical(value) + b"\n"
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=parent, prefix=f".{destination.name}.", suffix=".tmp"
+    )
+    temporary = Path(temporary_name)
+    published = False
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(raw)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, resolved, follow_symlinks=False)
+        published = True
+        directory_descriptor = os.open(parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    except BaseException:
+        if published:
+            resolved.unlink(missing_ok=True)
+        raise
+    finally:
+        temporary.unlink(missing_ok=True)

--- a/alberta_framework/evaluation/gradual_micro_phase_campaign.py
+++ b/alberta_framework/evaluation/gradual_micro_phase_campaign.py
@@ -1,0 +1,590 @@
+"""Strict five-seed development campaign for gradual micro-phase arms.
+
+The campaign is permanently nonpromoting and has no registered selection rule.
+Validation reexecutes all five three-arm runs; consistency hashes are not
+authenticated execution proof.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+import os
+import platform
+import stat
+from importlib import metadata
+from pathlib import Path
+from typing import Final, cast
+
+import jax
+import jax.random as jr
+import numpy as np
+
+from alberta_framework.benchmarks.ipmnist_gradual_family import (
+    _ADAMW_IDENTITY,
+    GradualMicroPhaseConfig,
+    GradualMicroPhaseResult,
+    _realized_schedule,
+    run_gradual_micro_phase_family,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import (
+    IPMNISTConfig,
+    _make_adamw_learner,
+    atomic_write_new,
+    init_mlp_params,
+    validated_ipmnist_data,
+)
+
+SCHEMA: Final[str] = "asi.gradual-micro-phase.matched-campaign.v1"
+SEEDS: Final[tuple[int, ...]] = (156901, 156902, 156903, 156904, 156905)
+ARM_IDS: Final[tuple[str, ...]] = ("abrupt", "output_interpolation", "task_sampling")
+DEFAULT_FROZEN_CONFIG: Final[GradualMicroPhaseConfig] = GradualMicroPhaseConfig(
+    transition_intervals=10,
+    phase_examples=5000,
+    input_dim=784,
+    hidden1=300,
+    hidden2=150,
+    n_classes=10,
+)
+FROZEN_CONFIG = DEFAULT_FROZEN_CONFIG
+POLICY: Final[dict[str, object]] = {
+    "development_only": True,
+    "scientific_promotion_allowed": False,
+    "publication_equivalent": False,
+    "sota_claim_allowed": False,
+    "negative_outcomes_retained": True,
+}
+_DECISION: Final[dict[str, object]] = {
+    "status": "inconclusive",
+    "reason": "no_registered_selection_rule",
+    "candidate_selected": None,
+}
+_MAX_JSON_BYTES = 32 * 1024 * 1024
+_MAX_JSON_NODES = 200_000
+_MAX_DATASET_BYTES = 256 * 1024 * 1024
+_ROOT = Path(__file__).resolve().parents[2]
+_SOURCE_FILES = (
+    "alberta_framework/evaluation/gradual_micro_phase_campaign.py",
+    "alberta_framework/_seed_validation.py",
+    "alberta_framework/benchmarks/ipmnist_gradual_family.py",
+    "alberta_framework/benchmarks/ipmnist_gradual.py",
+    "alberta_framework/benchmarks/upgd_ipmnist.py",
+    "alberta_framework/core/baseline_optimizers.py",
+    "alberta_framework/core/_float32_scalars.py",
+    "alberta_framework/core/update_safety.py",
+    "pyproject.toml",
+    "uv.lock",
+)
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+
+
+def _sha(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _array_hash(domain: str, *values: np.ndarray) -> str:
+    digest = hashlib.sha256(domain.encode("ascii") + b"\0")
+    for value in values:
+        array = np.ascontiguousarray(value.astype(value.dtype.newbyteorder("<"), copy=False))
+        header = _canonical({"dtype": array.dtype.str, "shape": list(array.shape)})
+        digest.update(len(header).to_bytes(8, "little"))
+        digest.update(header)
+        digest.update(array.nbytes.to_bytes(8, "little"))
+        digest.update(memoryview(array).cast("B"))
+    return "sha256:" + digest.hexdigest()
+
+
+def _tree_hash(domain: str, value: object) -> str:
+    leaves, treedef = jax.tree_util.tree_flatten(value)
+    digest = hashlib.sha256(domain.encode("ascii") + b"\0" + str(treedef).encode())
+    for leaf in leaves:
+        array = np.asarray(jax.device_get(leaf))
+        array = np.ascontiguousarray(array.astype(array.dtype.newbyteorder("<"), copy=False))
+        digest.update(_canonical({"dtype": array.dtype.str, "shape": list(array.shape)}))
+        digest.update(memoryview(array).cast("B"))
+    return "sha256:" + digest.hexdigest()
+
+
+def _sources() -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
+    for relative in _SOURCE_FILES:
+        path = _ROOT / relative
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
+            before = os.fstat(descriptor)
+            if not stat.S_ISREG(before.st_mode) or not 0 < before.st_size <= 2 * 1024 * 1024:
+                raise ValueError("campaign source must be a bounded regular file")
+            payload = bytearray()
+            while len(payload) <= before.st_size:
+                chunk = os.read(
+                    descriptor,
+                    min(64 * 1024, before.st_size + 1 - len(payload)),
+                )
+                if not chunk:
+                    break
+                payload.extend(chunk)
+            after = os.fstat(descriptor)
+            if len(payload) != before.st_size or (
+                before.st_dev,
+                before.st_ino,
+                before.st_size,
+                before.st_mtime_ns,
+            ) != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns):
+                raise ValueError("campaign source changed during bounded capture")
+        finally:
+            os.close(descriptor)
+        result.append(
+            {
+                "path": relative,
+                "bytes": len(payload),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+            }
+        )
+    return result
+
+
+def _runtime() -> dict[str, object]:
+    return {
+        "python_implementation": platform.python_implementation(),
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "jax": jax.__version__,
+        "jaxlib": metadata.version("jaxlib"),
+        "numpy": np.__version__,
+        "backend": jax.default_backend(),
+        "devices": [
+            {
+                "id": int(device.id),
+                "process_index": int(device.process_index),
+                "platform": str(device.platform),
+                "kind": str(device.device_kind),
+            }
+            for device in jax.devices()
+        ],
+        "jax_config": {
+            "enable_x64": bool(jax.config.jax_enable_x64),
+            "default_prng_impl": str(jax.config.jax_default_prng_impl),
+            "default_matmul_precision": str(jax.config.jax_default_matmul_precision),
+            "random_seed_offset": int(jax.config.jax_random_seed_offset),
+            "threefry_partitionable": bool(jax.config.jax_threefry_partitionable),
+            "numpy_dtype_promotion": str(jax.config.jax_numpy_dtype_promotion),
+            "numpy_rank_promotion": str(jax.config.jax_numpy_rank_promotion),
+            "disable_jit": bool(jax.config.jax_disable_jit),
+        },
+        "environment": {
+            name: os.environ.get(name)
+            for name in (
+                "JAX_PLATFORMS",
+                "JAX_PLATFORM_NAME",
+                "JAX_ENABLE_X64",
+                "JAX_DEFAULT_PRNG_IMPL",
+                "JAX_DEFAULT_MATMUL_PRECISION",
+                "JAX_RANDOM_SEED_OFFSET",
+                "XLA_FLAGS",
+            )
+        },
+        "agent_rng": "jax.random.key(seed, impl='threefry2x32')",
+    }
+
+
+def _config_payload(config: GradualMicroPhaseConfig) -> dict[str, int]:
+    return {
+        name: cast(int, getattr(config, name))
+        for name in (
+            "transition_intervals",
+            "phase_examples",
+            "input_dim",
+            "hidden1",
+            "hidden2",
+            "n_classes",
+        )
+    }
+
+
+def _datasets(
+    old_x: object, old_y: object, new_x: object, new_y: object
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, object]]:
+    config = FROZEN_CONFIG
+    for name, value, dtype in (
+        ("old_x", old_x, np.dtype(np.float32)),
+        ("old_y", old_y, np.dtype(np.int32)),
+        ("new_x", new_x, np.dtype(np.float32)),
+        ("new_y", new_y, np.dtype(np.int32)),
+    ):
+        if type(value) is not np.ndarray or value.dtype != dtype:
+            raise ValueError(f"{name} must be an exact {dtype} numpy array")
+    old_x_array = cast(np.ndarray, old_x)
+    old_y_array = cast(np.ndarray, old_y)
+    new_x_array = cast(np.ndarray, new_x)
+    new_y_array = cast(np.ndarray, new_y)
+    if (
+        old_x_array.shape != (config.phase_examples, config.input_dim)
+        or new_x_array.shape != old_x_array.shape
+        or old_y_array.shape != (config.phase_examples,)
+        or new_y_array.shape != old_y_array.shape
+    ):
+        raise ValueError("campaign datasets must contain exactly one row-aligned phase")
+    if (
+        sum(value.nbytes for value in (old_x_array, old_y_array, new_x_array, new_y_array))
+        > _MAX_DATASET_BYTES
+    ):
+        raise ValueError("campaign dataset byte bound exceeded before materialization")
+    ox, oy = validated_ipmnist_data(
+        old_x_array,
+        old_y_array,
+        input_dim=config.input_dim,
+        n_classes=config.n_classes,
+        min_length=config.phase_examples,
+    )
+    nx, ny = validated_ipmnist_data(
+        new_x_array,
+        new_y_array,
+        input_dim=config.input_dim,
+        n_classes=config.n_classes,
+        min_length=config.phase_examples,
+    )
+    ox = np.array(ox, np.float32, order="C", copy=True)
+    oy = np.array(oy, np.int32, order="C", copy=True)
+    nx = np.array(nx, np.float32, order="C", copy=True)
+    ny = np.array(ny, np.int32, order="C", copy=True)
+    if np.any(ox < -1.0) or np.any(ox > 1.0) or np.any(nx < -1.0) or np.any(nx > 1.0):
+        raise ValueError("campaign features must use the frozen [-1, 1] domain")
+    if ox.shape != nx.shape or not np.array_equal(ox, nx):
+        raise ValueError("campaign requires exact row-aligned old/new inputs")
+    identity = {
+        "protocol": "caller-fed-paired-micro-phase-data-not-official-dataset-acquisition",
+        "old": _array_hash("asi.gradual-campaign.old.v1", ox, oy),
+        "new": _array_hash("asi.gradual-campaign.new.v1", nx, ny),
+        "rows": int(ox.shape[0]),
+        "input_dim": config.input_dim,
+        "numeric_bytes": int(ox.nbytes + oy.nbytes + nx.nbytes + ny.nbytes),
+        "row_aligned_inputs": True,
+    }
+    return ox, oy, nx, ny, identity
+
+
+def _seed_identity(seed: int, config: GradualMicroPhaseConfig, rows: int) -> dict[str, object]:
+    root = jr.key(seed, impl="threefry2x32")
+    init_key, _, learner_key = jr.split(root, 3)
+    model_config = IPMNISTConfig(
+        n_tasks=config.phase_count,
+        task_length=config.phase_examples,
+        input_dim=config.input_dim,
+        hidden1=config.hidden1,
+        hidden2=config.hidden2,
+        n_classes=config.n_classes,
+    )
+    params = init_mlp_params(init_key, model_config)
+    init_fn, _ = _make_adamw_learner(dict(_ADAMW_IDENTITY))
+    state = init_fn(params)
+    _, _, _, counts, schedule = _realized_schedule(seed, config, rows, rows)
+    payload: dict[str, object] = {
+        "seed": seed,
+        "rng_impl": "threefry2x32",
+        "root_sha256": _tree_hash("asi.gradual-campaign.root.v1", jr.key_data(root)),
+        "learner_root_sha256": _tree_hash(
+            "asi.gradual-campaign.learner-root.v1", jr.key_data(learner_key)
+        ),
+        "initial_parameters_sha256": _tree_hash("asi.gradual-campaign.initial-params.v1", params),
+        "initial_learner_state_sha256": _tree_hash("asi.gradual-campaign.initial-state.v1", state),
+        "schedule_sha256": schedule,
+        "task_sampling_new_counts": counts,
+    }
+    payload["identity_sha256"] = _sha(payload)
+    return payload
+
+
+def _records(result: GradualMicroPhaseResult, seed_identity: str) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for index, arm in enumerate(ARM_IDS):
+        records.append(
+            {
+                "seed": result.seed,
+                "arm": arm,
+                "seed_identity_sha256": seed_identity,
+                "training_loss_sums": result.training_loss_sums[index].tolist(),
+                "new_task_eval_correct_counts": result.new_task_eval_correct_counts[index].tolist(),
+                "new_task_eval_loss_sums": result.new_task_eval_loss_sums[index].tolist(),
+                "persistent_numeric_bytes": int(result.persistent_numeric_bytes[index]),
+                "observations": result.observations_per_arm,
+                "updates": result.updates_per_arm,
+                "data_steps": result.data_steps_per_arm,
+                "environment_steps": result.environment_steps_per_arm,
+                "model_queries": result.model_queries_per_arm,
+                "soft_target_updates": result.soft_target_updates_per_arm[index],
+                "timing_retained": False,
+                "execution_attestation": False,
+            }
+        )
+    return records
+
+
+def _comparisons(
+    records: list[dict[str, object]], config: GradualMicroPhaseConfig
+) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for arm in ARM_IDS[1:]:
+        deltas: list[float] = []
+        for seed in SEEDS:
+            by_arm = {r["arm"]: r for r in records if r["seed"] == seed}
+            candidate = cast(list[int], by_arm[arm]["new_task_eval_correct_counts"])[-1]
+            control = cast(list[int], by_arm[ARM_IDS[0]]["new_task_eval_correct_counts"])[-1]
+            deltas.append(float((candidate - control) / config.phase_examples))
+        mean = math.fsum(deltas) / len(deltas)
+        variance = math.fsum((value - mean) ** 2 for value in deltas) / 4
+        half = 2.7764451051977987 * math.sqrt(variance / 5)
+        result[arm] = {
+            "control": "abrupt",
+            "metric": "final_phase_new_task_accuracy",
+            "paired_deltas": deltas,
+            "mean_delta": mean,
+            "confidence_interval_95": [mean - half, mean + half],
+            "interval_method": "two_sided_student_t_df4_descriptive_only",
+        }
+    return result
+
+
+def _resources(records: list[dict[str, object]], dataset: dict[str, object]) -> dict[str, object]:
+    return {
+        "runs": len(SEEDS),
+        "arm_cells": len(records),
+        "dataset_numeric_bytes": dataset["numeric_bytes"],
+        "total_observations": sum(cast(int, row["observations"]) for row in records),
+        "total_updates": sum(cast(int, row["updates"]) for row in records),
+        "total_data_steps": sum(cast(int, row["data_steps"]) for row in records),
+        "total_environment_steps": sum(cast(int, row["environment_steps"]) for row in records),
+        "total_model_queries": sum(cast(int, row["model_queries"]) for row in records),
+        "summed_persistent_numeric_bytes": sum(
+            cast(int, row["persistent_numeric_bytes"]) for row in records
+        ),
+        "max_cell_persistent_numeric_bytes": max(
+            cast(int, row["persistent_numeric_bytes"]) for row in records
+        ),
+        "physical_peak_rss_claimed": False,
+        "timing_measured_but_discarded": True,
+        "timing_is_selection_metric": False,
+    }
+
+
+def _execute(
+    old_x: np.ndarray, old_y: np.ndarray, new_x: np.ndarray, new_y: np.ndarray
+) -> dict[str, object]:
+    config = FROZEN_CONFIG
+    sources = _sources()
+    runtime = _runtime()
+    ox, oy, nx, ny, dataset = _datasets(old_x, old_y, new_x, new_y)
+    identities = [_seed_identity(seed, config, int(ox.shape[0])) for seed in SEEDS]
+    records: list[dict[str, object]] = []
+    for identity in identities:
+        seed = cast(int, identity["seed"])
+        result = run_gradual_micro_phase_family(
+            ox,
+            oy,
+            nx,
+            ny,
+            learner_name="adamw_control",
+            seed=seed,
+            config=config,
+        )
+        records.extend(_records(result, cast(str, identity["identity_sha256"])))
+    if sources != _sources() or runtime != _runtime():
+        raise RuntimeError("campaign source or runtime changed during execution")
+    plan = {
+        "seeds": list(SEEDS),
+        "arms": list(ARM_IDS),
+        "run_order": "seed_major_with_arm_major_records_per_seed",
+        "config": _config_payload(config),
+        "learner": "adamw_control",
+        "rng_impl": "threefry2x32",
+        "row_alignment": "old_x_equals_new_x_exactly",
+        "feature_domain": "finite_float32_closed_interval_-1_1",
+        "paper_scale": False,
+        "execution_authorized": False,
+        "seed_history_audit": (
+            "156901--156905 had no exact current-main use when prospectively reserved on "
+            "2026-08-20; seeds are immutable after merge"
+        ),
+    }
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": "complete",
+        "plan": plan,
+        "identity": {"dataset": dataset, "sources": sources, "runtime": runtime},
+        "policy": copy.deepcopy(POLICY),
+        "decision": copy.deepcopy(_DECISION),
+        "seed_identities": identities,
+        "records": records,
+        "comparisons": _comparisons(records, config),
+        "resources": _resources(records, dataset),
+        "validation_scope": "strict_five_run_learner_reexecution_and_exact_report_replay",
+    }
+    payload["result_sha256"] = _sha(payload)
+    return payload
+
+
+def run_gradual_micro_phase_campaign(
+    old_x: np.ndarray, old_y: np.ndarray, new_x: np.ndarray, new_y: np.ndarray
+) -> dict[str, object]:
+    result = _execute(old_x, old_y, new_x, new_y)
+    _json_preflight(result)
+    return result
+
+
+def _json_preflight(value: object) -> None:
+    seen: set[int] = set()
+    nodes = 0
+    text_bytes = 0
+    stack: list[tuple[object, int]] = [(value, 0)]
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > 24:
+            raise ValueError("exact JSON work bound exceeded")
+        if type(item) is dict:
+            if id(item) in seen:
+                raise ValueError("exact JSON alias or cycle detected")
+            seen.add(id(item))
+            mapping = cast(dict[object, object], item)
+            if any(type(key) is not str for key in mapping):
+                raise ValueError("exact JSON object keys required")
+            stack.extend((child, depth + 1) for child in mapping.values())
+        elif type(item) is list:
+            if id(item) in seen:
+                raise ValueError("exact JSON alias or cycle detected")
+            seen.add(id(item))
+            stack.extend((child, depth + 1) for child in cast(list[object], item))
+        elif type(item) is str:
+            text_bytes += len(item.encode("utf-8"))
+            if text_bytes > _MAX_JSON_BYTES:
+                raise ValueError("exact JSON text bound exceeded")
+        elif type(item) is float:
+            if not math.isfinite(item):
+                raise ValueError("exact JSON floats must be finite")
+        elif type(item) not in (int, bool, type(None)):
+            raise ValueError("exact JSON primitives required")
+
+
+def _static_preflight(value: object) -> dict[str, object]:
+    _json_preflight(value)
+    if type(value) is not dict:
+        raise ValueError("campaign must be an exact object")
+    root = cast(dict[str, object], value)
+    expected = {
+        "schema",
+        "status",
+        "plan",
+        "identity",
+        "policy",
+        "decision",
+        "seed_identities",
+        "records",
+        "comparisons",
+        "resources",
+        "validation_scope",
+        "result_sha256",
+    }
+    if set(root) != expected or root["schema"] != SCHEMA or root["status"] != "complete":
+        raise ValueError("campaign exact JSON fields/schema drifted")
+    if root["policy"] != POLICY:
+        raise ValueError("campaign policy must remain permanently nonpromoting")
+    if root["decision"] != _DECISION:
+        raise ValueError("campaign decision must remain inconclusive")
+    unsigned = dict(root)
+    claimed = unsigned.pop("result_sha256")
+    if claimed != _sha(unsigned):
+        raise ValueError("campaign result digest drifted")
+    records = root["records"]
+    if type(records) is not list or len(records) != 15:
+        raise ValueError("campaign record roster drifted")
+    roster = [(row.get("seed"), row.get("arm")) for row in records if type(row) is dict]
+    if roster != [(seed, arm) for seed in SEEDS for arm in ARM_IDS]:
+        raise ValueError("campaign record roster drifted")
+    return root
+
+
+def validate_gradual_micro_phase_campaign(
+    value: object,
+    old_x: np.ndarray,
+    old_y: np.ndarray,
+    new_x: np.ndarray,
+    new_y: np.ndarray,
+) -> dict[str, object]:
+    root = _static_preflight(value)
+    identity = root["identity"]
+    if type(identity) is not dict:
+        raise ValueError("campaign identity must be an exact object")
+    checked = _datasets(old_x, old_y, new_x, new_y)
+    current_data = checked[-1]
+    if identity.get("dataset") != current_data:
+        raise ValueError("campaign dataset identity drifted")
+    if identity.get("sources") != _sources():
+        raise ValueError("campaign source identity drifted")
+    if identity.get("runtime") != _runtime():
+        raise ValueError("campaign runtime identity drifted")
+    expected_seed_identities = [
+        _seed_identity(seed, FROZEN_CONFIG, int(checked[0].shape[0])) for seed in SEEDS
+    ]
+    if root["seed_identities"] != expected_seed_identities:
+        raise ValueError("campaign schedule/initial-state identity drifted")
+    expected = _execute(old_x, old_y, new_x, new_y)
+    if root != expected:
+        raise ValueError("campaign record/resource replay mismatch")
+    return expected
+
+
+def _resign_for_test(value: dict[str, object]) -> None:
+    unsigned = dict(value)
+    unsigned.pop("result_sha256", None)
+    value["result_sha256"] = _sha(unsigned)
+
+
+def write_gradual_micro_phase_campaign_new(
+    path: Path,
+    value: object,
+    old_x: np.ndarray,
+    old_y: np.ndarray,
+    new_x: np.ndarray,
+    new_y: np.ndarray,
+) -> Path:
+    validated = validate_gradual_micro_phase_campaign(value, old_x, old_y, new_x, new_y)
+    encoded = (
+        json.dumps(validated, allow_nan=False, ensure_ascii=True, indent=2, sort_keys=True).encode(
+            "ascii"
+        )
+        + b"\n"
+    )
+    if len(encoded) > _MAX_JSON_BYTES:
+        raise ValueError("campaign JSON byte bound exceeded")
+    return atomic_write_new(Path(path), encoded)
+
+
+def load_gradual_micro_phase_campaign(
+    path: Path,
+    old_x: np.ndarray,
+    old_y: np.ndarray,
+    new_x: np.ndarray,
+    new_y: np.ndarray,
+) -> dict[str, object]:
+    with Path(path).open("rb") as handle:
+        encoded = handle.read(_MAX_JSON_BYTES + 1)
+    if len(encoded) > _MAX_JSON_BYTES:
+        raise ValueError("campaign JSON byte bound exceeded")
+    try:
+        value = json.loads(encoded)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("campaign must contain exact JSON") from exc
+    return validate_gradual_micro_phase_campaign(value, old_x, old_y, new_x, new_y)

--- a/alberta_framework/evaluation/optimization_readiness.py
+++ b/alberta_framework/evaluation/optimization_readiness.py
@@ -27,6 +27,8 @@ _MAX_RESULT_COUNT: Final[int] = 256
 _MAX_PERSISTENT_BYTES: Final[int] = 256 * 1024 * 1024
 _MAX_WORKING_SET_BYTES: Final[int] = 512 * 1024 * 1024
 _MAX_ARRAY_BYTES: Final[int] = 512 * 1024 * 1024
+_MAX_ENERGY_RANK_LOGICAL_WORK: Final[int] = 100_000_000
+_MAX_ENERGY_RANK_WORKING_SET_BYTES: Final[int] = 256 * 1024 * 1024
 _FLOAT64_BYTES: Final[int] = np.dtype(np.float64).itemsize
 _APPENDIX_C1_VALIDATION_OBSERVATIONS: Final[int] = 10_000
 _APPENDIX_C1_BATCH_SIZE: Final[int] = 4
@@ -112,6 +114,9 @@ OPTIMIZATION_READINESS_PROTOCOL = MappingProxyType(
         "resource_receipts_are_authenticated": False,
         "metrics_are_recomputed_by_this_module": False,
         "outcomes_are_derived_by_this_module": False,
+        "energy_rank_max_logical_work": _MAX_ENERGY_RANK_LOGICAL_WORK,
+        "energy_rank_max_working_set_bytes": _MAX_ENERGY_RANK_WORKING_SET_BYTES,
+        "energy_rank_working_set_scope": "total_live_bytes_including_logical_input",
         "completed_result_exists": False,
     }
 )
@@ -181,6 +186,17 @@ class DevelopmentResultReceipt:
     parameter_norm: float
     future_relative_loss_reduction: float
     reported_outcome: str
+
+
+@dataclass(frozen=True)
+class EnergyRankResourceEstimate:
+    """Metadata-derived total-live-memory bounds charged before an energy-rank SVD."""
+
+    rows: int
+    columns: int
+    input_bytes: int
+    logical_work: int
+    peak_working_set_bytes: int
 
 
 def _finite_array(
@@ -322,12 +338,59 @@ def estimate_appendix_c1_optimization_readiness(
     )
 
 
+def _preflight_energy_rank_resources(matrix: object) -> EnergyRankResourceEstimate:
+    """Reject an unsafe SVD from trusted ndarray metadata alone.
+
+    The logical-work charge is ``m * n * min(m, n)``.  The workspace bound
+    conservatively includes the caller-owned logical input payload, a float64
+    conversion, a LAPACK-owned matrix copy, a finite-value mask, singular-value
+    temporaries, and a quadratic LAPACK workspace allowance.  Charging logical
+    ``nbytes`` is deliberately conservative for strided and broadcast views.
+    This runs before any element scan, conversion, or call into ``numpy.linalg``.
+    """
+    if type(matrix) is not np.ndarray:
+        raise ValueError("matrix must be an exact numpy.ndarray")
+    if matrix.ndim != 2 or any(size < 1 for size in matrix.shape):
+        raise ValueError("matrix must be a non-empty 2-dimensional array")
+    if matrix.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError("matrix must have a real numeric dtype")
+    rows = int(matrix.shape[0])
+    columns = int(matrix.shape[1])
+    rank = min(rows, columns)
+    elements = rows * columns
+    input_bytes = int(matrix.nbytes)
+    logical_work = elements * rank
+    if logical_work > _MAX_ENERGY_RANK_LOGICAL_WORK:
+        raise ValueError("matrix SVD logical work exceeds the bounded energy-rank budget")
+
+    # 17 bytes/element accounts for two float64 matrices plus a one-byte
+    # finite-value mask.  The remainder deliberately over-approximates the
+    # no-singular-vector LAPACK workspace and the rank-length energy arrays.
+    peak_working_set_bytes = (
+        input_bytes
+        + 17 * elements
+        + 24 * rank * rank
+        + 8 * max(rows, columns)
+        + 96 * rank
+    )
+    if peak_working_set_bytes > _MAX_ENERGY_RANK_WORKING_SET_BYTES:
+        raise ValueError("matrix SVD working set exceeds the bounded energy-rank budget")
+    return EnergyRankResourceEstimate(
+        rows=rows,
+        columns=columns,
+        input_bytes=input_bytes,
+        logical_work=logical_work,
+        peak_working_set_bytes=peak_working_set_bytes,
+    )
+
+
 def energy_rank(matrix: object, *, threshold: float = 0.99) -> int:
     """Return the smallest singular-value count reaching squared-energy mass."""
     if type(threshold) is not float:
         raise ValueError("threshold must be a float in (0, 1]")
     if not math.isfinite(threshold) or not 0.0 < threshold <= 1.0:
         raise ValueError("threshold must be a float in (0, 1]")
+    _preflight_energy_rank_resources(matrix)
     resolved = _finite_array(matrix, name="matrix", dimensions=2)
     try:
         singular_values = np.linalg.svd(resolved, compute_uv=False)

--- a/alberta_framework/evaluation/optimization_readiness_entk.py
+++ b/alberta_framework/evaluation/optimization_readiness_entk.py
@@ -1,0 +1,500 @@
+"""Bounded nonlinear representation/eNTK Optimization Readiness diagnostic.
+
+This development-only adapter evaluates an exact two-layer ReLU regression
+checkpoint.  It constructs the checkpoint's hidden representation and analytic
+empirical neural tangent feature matrix, reports their 99% energy ranks, and
+measures one full-gradient step.  It is a real model-bound diagnostic, not a
+paper reproduction or a promotion path.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import math
+import platform
+from pathlib import Path
+from typing import Final, cast
+
+import numpy as np
+
+SCHEMA: Final[str] = "asi.optimization-readiness.entk.v1"
+LEARNING_RATE: Final[float] = 1e-3
+ENERGY_THRESHOLD: Final[float] = 0.99
+MAX_OBSERVATIONS: Final[int] = 256
+MAX_INPUT_DIMENSION: Final[int] = 32
+MAX_HIDDEN_UNITS: Final[int] = 64
+MAX_PARAMETERS: Final[int] = 4096
+MAX_PEAK_BYTES: Final[int] = 256 << 20
+MAX_SVD_WORK_UNITS: Final[int] = 100_000_000
+MAX_ROLLOUT_WORK_UNITS: Final[int] = 200_000_000
+FUTURE_HORIZONS: Final[tuple[int, ...]] = (1, 10, 100)
+MAX_JSON_NODES: Final[int] = 4096
+MAX_JSON_STRING_BYTES: Final[int] = 64 << 10
+MAX_JSON_INTEGER: Final[int] = (1 << 63) - 1
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MLPCheckpoint:
+    """Caller-owned parameters for one scalar-output two-layer ReLU MLP."""
+
+    input_weights: np.ndarray
+    hidden_bias: np.ndarray
+    output_weights: np.ndarray
+    output_bias: np.ndarray
+
+
+def _utf8_length(value: str, *, name: str) -> int:
+    try:
+        return len(value.encode("utf-8"))
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{name} must be valid UTF-8") from exc
+
+
+def _text(value: object, *, name: str) -> str:
+    if type(value) is not str or not value or _utf8_length(value, name=name) > 256:
+        raise ValueError(f"{name} must be bounded non-empty exact text")
+    return value
+
+
+def _array(value: object, *, name: str, ndim: int) -> np.ndarray:
+    if type(value) is not np.ndarray or value.dtype != np.dtype(np.float64):
+        raise ValueError(f"{name} must be an exact float64 ndarray")
+    if value.ndim != ndim:
+        raise ValueError(f"{name} must have rank {ndim}")
+    return value
+
+
+def _checkpoint_arrays(checkpoint: object) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    if type(checkpoint) is not MLPCheckpoint:
+        raise ValueError("checkpoint must be an exact MLPCheckpoint")
+    w1 = _array(checkpoint.input_weights, name="input_weights", ndim=2)
+    b1 = _array(checkpoint.hidden_bias, name="hidden_bias", ndim=1)
+    w2 = _array(checkpoint.output_weights, name="output_weights", ndim=1)
+    bias = _array(checkpoint.output_bias, name="output_bias", ndim=0)
+    if w1.shape[1:] != b1.shape or b1.shape != w2.shape:
+        raise ValueError("checkpoint hidden axes differ")
+    return w1, b1, w2, bias
+
+
+def _preflight(
+    inputs: object, labels: object, checkpoint: object
+) -> tuple[
+    np.ndarray,
+    np.ndarray,
+    tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    dict[str, int],
+]:
+    x = _array(inputs, name="validation_inputs", ndim=2)
+    y = _array(labels, name="validation_labels", ndim=1)
+    w1, b1, w2, bias = _checkpoint_arrays(checkpoint)
+    observations, dimension = (int(size) for size in x.shape)
+    hidden = int(b1.size)
+    if not 2 <= observations <= MAX_OBSERVATIONS:
+        raise ValueError("observations lie outside the bounded eNTK protocol")
+    if not 1 <= dimension <= MAX_INPUT_DIMENSION:
+        raise ValueError("input dimension lies outside the bounded eNTK protocol")
+    if not 1 <= hidden <= MAX_HIDDEN_UNITS:
+        raise ValueError("hidden units lie outside the bounded eNTK protocol")
+    if y.shape != (observations,) or w1.shape != (dimension, hidden):
+        raise ValueError("dataset and checkpoint axes differ")
+    parameters = dimension * hidden + hidden + hidden + 1
+    if parameters > MAX_PARAMETERS:
+        raise ValueError("parameter count exceeds the bounded eNTK protocol")
+    representation_bytes = observations * hidden * np.dtype(np.float64).itemsize
+    jacobian_bytes = observations * parameters * np.dtype(np.float64).itemsize
+    caller_bytes = x.nbytes + y.nbytes + w1.nbytes + b1.nbytes + w2.nbytes + bias.nbytes
+    itemsize = np.dtype(np.float64).itemsize
+    vector_bytes = observations * itemsize
+    parameter_bytes = parameters * itemsize
+    # Caller arrays and immutable snapshots plus the initial diagnostic remain live while
+    # each independent rollout executes.  The rollout allowance covers preactivation,
+    # representation, masks/weighted masks, both Jacobian constructions, residuals, and
+    # parameter/gradient vectors.  Each SVD allowance additionally follows the established
+    # bounded energy-rank convention: two float64 copies, a finite mask, rank temporaries,
+    # and conservative quadratic LAPACK workspace.
+    persistent_bytes = (
+        2 * caller_bytes
+        + representation_bytes
+        + jacobian_bytes
+        + 2 * vector_bytes
+        + parameter_bytes
+    )
+    rollout_peak_bytes = persistent_bytes + (
+        3 * jacobian_bytes
+        + 4 * representation_bytes
+        + 4 * vector_bytes
+        + 3 * parameter_bytes
+    )
+
+    def svd_extra_bytes(columns: int) -> int:
+        rank = min(observations, columns)
+        elements = observations * columns
+        return 17 * elements + 24 * rank * rank + 8 * max(observations, columns) + 96 * rank
+
+    peak_bytes = max(
+        rollout_peak_bytes,
+        persistent_bytes + svd_extra_bytes(hidden),
+        persistent_bytes + svd_extra_bytes(parameters),
+    )
+    representation_svd_work = observations * hidden * min(observations, hidden)
+    jacobian_svd_work = observations * parameters * min(observations, parameters)
+    svd_work_units = representation_svd_work + jacobian_svd_work
+    optimizer_updates = sum(FUTURE_HORIZONS)
+    terminal_evaluations = len(FUTURE_HORIZONS)
+    rollout_work_units = (
+        optimizer_updates + terminal_evaluations
+    ) * observations * parameters
+    diagnostic_work_units = observations * parameters
+    if peak_bytes > MAX_PEAK_BYTES:
+        raise ValueError("eNTK peak bytes exceed the bounded protocol")
+    if svd_work_units > MAX_SVD_WORK_UNITS:
+        raise ValueError("eNTK SVD work exceeds the bounded protocol")
+    if rollout_work_units > MAX_ROLLOUT_WORK_UNITS:
+        raise ValueError("eNTK rollout work exceeds the bounded protocol")
+    return x, y, (w1, b1, w2, bias), {
+        "observations": observations,
+        "input_dimension": dimension,
+        "hidden_units": hidden,
+        "parameter_count": parameters,
+        "caller_numeric_bytes": caller_bytes,
+        "representation_bytes": representation_bytes,
+        "jacobian_bytes": jacobian_bytes,
+        "peak_numeric_bytes": peak_bytes,
+        "svd_work_units": svd_work_units,
+        "diagnostic_work_units": diagnostic_work_units,
+        "rollout_work_units": rollout_work_units,
+        "total_logical_work_units": (
+            svd_work_units + diagnostic_work_units + rollout_work_units
+        ),
+        "gradient_evaluations": 1 + optimizer_updates,
+        "optimizer_updates": optimizer_updates,
+        "model_queries": (1 + optimizer_updates + terminal_evaluations) * observations,
+    }
+
+
+def _snapshot(value: np.ndarray) -> np.ndarray:
+    result = value.copy(order="C")
+    if not np.isfinite(result).all():
+        raise ValueError("model inputs and parameters must be finite")
+    return result
+
+
+def _array_identity(domain: str, value: np.ndarray) -> dict[str, object]:
+    digest = hashlib.sha256(domain.encode("ascii"))
+    digest.update(value.dtype.str.encode("ascii"))
+    digest.update(str(value.shape).encode("ascii"))
+    digest.update(value.tobytes(order="C"))
+    return {"dtype": value.dtype.str, "shape": list(value.shape), "sha256": digest.hexdigest()}
+
+
+def _checkpoint_identity(arrays: tuple[np.ndarray, ...]) -> dict[str, object]:
+    names = ("input_weights", "hidden_bias", "output_weights", "output_bias")
+    return {
+        name: _array_identity(name, value)
+        for name, value in zip(names, arrays, strict=True)
+    }
+
+
+def _flatten(arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]) -> np.ndarray:
+    return np.concatenate(tuple(value.reshape(-1) for value in arrays))
+
+
+def _unpack(
+    flat: np.ndarray, dimension: int, hidden: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    w1_end = dimension * hidden
+    b1_end = w1_end + hidden
+    w2_end = b1_end + hidden
+    return (
+        flat[:w1_end].reshape(dimension, hidden),
+        flat[w1_end:b1_end],
+        flat[b1_end:w2_end],
+        flat[w2_end:].reshape(()),
+    )
+
+
+def _model(
+    inputs: np.ndarray, arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    w1, b1, w2, bias = arrays
+    preactivation = inputs @ w1 + b1
+    hidden = np.maximum(preactivation, 0.0)
+    predictions = hidden @ w2 + bias
+    mask = preactivation > 0.0
+    w1_jacobian = (inputs[:, :, None] * (mask * w2)[:, None, :]).reshape(inputs.shape[0], -1)
+    jacobian = np.concatenate(
+        (w1_jacobian, mask * w2, hidden, np.ones((inputs.shape[0], 1), dtype=np.float64)),
+        axis=1,
+    )
+    return predictions, hidden, jacobian
+
+
+def _predict(
+    inputs: np.ndarray, arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+) -> np.ndarray:
+    w1, b1, w2, bias = arrays
+    return cast(np.ndarray, np.maximum(inputs @ w1 + b1, 0.0) @ w2 + bias)
+
+
+def _energy_rank(value: np.ndarray) -> int:
+    scale = float(np.max(np.abs(value)))
+    if scale == 0.0:
+        return 0
+    singular_values = np.linalg.svd(value / scale, compute_uv=False)
+    leading = float(singular_values[0])
+    energy = np.square(singular_values / leading)
+    total = float(np.sum(energy))
+    if not math.isfinite(total):
+        raise ValueError("eNTK singular-value energy must be finite")
+    target = np.nextafter(ENERGY_THRESHOLD * total, -math.inf)
+    found = int(np.searchsorted(np.cumsum(energy), target, side="left") + 1)
+    return min(found, int(singular_values.shape[0]))
+
+
+def _gradient(
+    inputs: np.ndarray,
+    labels: np.ndarray,
+    arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+) -> np.ndarray:
+    predictions, _, jacobian = _model(inputs, arrays)
+    return cast(np.ndarray, 2.0 * (jacobian.T @ (predictions - labels)) / inputs.shape[0])
+
+
+def _future_gain(
+    inputs: np.ndarray,
+    labels: np.ndarray,
+    arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    initial_loss: float,
+    dimension: int,
+    hidden: int,
+) -> dict[str, float]:
+    initial = _flatten(arrays)
+    gains: dict[str, float] = {}
+    for horizon in FUTURE_HORIZONS:
+        parameters = initial.copy()
+        for _ in range(horizon):
+            current = _unpack(parameters, dimension, hidden)
+            parameters -= LEARNING_RATE * _gradient(inputs, labels, current)
+        terminal = _predict(inputs, _unpack(parameters, dimension, hidden))
+        terminal_loss = float(np.mean(np.square(terminal - labels)))
+        gains[str(horizon)] = initial_loss - terminal_loss
+    return gains
+
+
+def _source_sha256() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def _runtime() -> dict[str, str]:
+    numpy_build = json.dumps(
+        np.__config__.CONFIG,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return {
+        "python_implementation": platform.python_implementation(),
+        "python_version": platform.python_version(),
+        "numpy_version": np.__version__,
+        "numpy_build_sha256": hashlib.sha256(numpy_build).hexdigest(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+    }
+
+
+def _json_preflight(value: object) -> None:
+    stack = [(value, 0)]
+    seen: set[int] = set()
+    nodes = 0
+    strings = 0
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > MAX_JSON_NODES or depth > 16:
+            raise ValueError("eNTK payload exceeds its JSON work bound")
+        if item is None or type(item) is bool:
+            continue
+        if type(item) is int:
+            if not -MAX_JSON_INTEGER - 1 <= item <= MAX_JSON_INTEGER:
+                raise ValueError("eNTK payload contains an unbounded integer")
+            continue
+        if type(item) is float:
+            if not math.isfinite(item):
+                raise ValueError("eNTK payload contains nonfinite JSON")
+            continue
+        if type(item) is str:
+            strings += _utf8_length(item, name="eNTK JSON string")
+            if strings > MAX_JSON_STRING_BYTES:
+                raise ValueError("eNTK payload exceeds its string-byte bound")
+            continue
+        if type(item) not in (dict, list):
+            raise ValueError("eNTK payload must contain exact JSON primitives")
+        identity = id(item)
+        if identity in seen:
+            raise ValueError("eNTK payload cannot contain aliases or cycles")
+        seen.add(identity)
+        if type(item) is dict:
+            mapping = cast(dict[object, object], item)
+            if len(mapping) > 128:
+                raise ValueError("eNTK JSON container exceeds its item bound")
+            for key, child in mapping.items():
+                if type(key) is not str:
+                    raise ValueError("eNTK JSON keys must be exact strings")
+                strings += _utf8_length(key, name="eNTK JSON key")
+                if strings > MAX_JSON_STRING_BYTES:
+                    raise ValueError("eNTK payload exceeds its string-byte bound")
+                stack.append((child, depth + 1))
+        else:
+            sequence = cast(list[object], item)
+            if len(sequence) > 128:
+                raise ValueError("eNTK JSON container exceeds its item bound")
+            stack.extend((child, depth + 1) for child in sequence)
+
+
+def _canonical(value: object) -> bytes:
+    _json_preflight(value)
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
+
+
+def execute_entk_readiness(
+    validation_inputs: object,
+    validation_labels: object,
+    checkpoint: object,
+    *,
+    task_id: str,
+    checkpoint_id: str,
+) -> dict[str, object]:
+    """Execute the bounded nonlinear representation/eNTK diagnostic."""
+    resolved_task = _text(task_id, name="task_id")
+    resolved_checkpoint = _text(checkpoint_id, name="checkpoint_id")
+    source_before = _source_sha256()
+    raw_x, raw_y, raw_arrays, resources = _preflight(
+        validation_inputs, validation_labels, checkpoint
+    )
+    x, y = _snapshot(raw_x), _snapshot(raw_y)
+    arrays = cast(
+        tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+        tuple(_snapshot(value) for value in raw_arrays),
+    )
+    predictions, representation, jacobian = _model(x, arrays)
+    residual = predictions - y
+    initial_loss = float(np.mean(np.square(residual)))
+    gradient = 2.0 * (jacobian.T @ residual) / x.shape[0]
+    future_gain = _future_gain(
+        x,
+        y,
+        arrays,
+        initial_loss,
+        resources["input_dimension"],
+        resources["hidden_units"],
+    )
+    metrics: dict[str, object] = {
+        "initial_loss": initial_loss,
+        "future_loss_gain": future_gain,
+        "gradient_norm": float(np.linalg.norm(gradient)),
+        "representation_frobenius_norm": float(np.linalg.norm(representation)),
+        "entk_feature_frobenius_norm": float(np.linalg.norm(jacobian)),
+        "representation_energy_rank_99": _energy_rank(representation),
+        "entk_energy_rank_99": _energy_rank(jacobian),
+    }
+    scalar_metrics = tuple(value for key, value in metrics.items() if key != "future_loss_gain")
+    if not all(
+        type(value) is int or (type(value) is float and math.isfinite(value))
+        for value in (*scalar_metrics, *future_gain.values())
+    ):
+        raise RuntimeError("eNTK diagnostic produced invalid metrics")
+    if _source_sha256() != source_before:
+        raise RuntimeError("eNTK source changed during execution")
+    result: dict[str, object] = {
+        "schema": SCHEMA,
+        "protocol": {
+            "model": "two_layer_relu_scalar_regression",
+            "learning_rate": LEARNING_RATE,
+            "energy_threshold": ENERGY_THRESHOLD,
+            "future_horizons": list(FUTURE_HORIZONS),
+            "rng": "none_full_batch_deterministic",
+            "relu_zero_derivative": 0.0,
+            "task_id": resolved_task,
+            "checkpoint_id": resolved_checkpoint,
+        },
+        "identity": {
+            "source_sha256": source_before,
+            "runtime": _runtime(),
+            "dataset": {
+                "inputs": _array_identity("validation_inputs", x),
+                "labels": _array_identity("validation_labels", y),
+            },
+            "checkpoint": _checkpoint_identity(arrays),
+        },
+        "metrics": metrics,
+        "resources": resources,
+        "policy": {
+            "development_only": True,
+            "scientific_promotion_allowed": False,
+            "timing_is_measured": False,
+        },
+    }
+    return cast(dict[str, object], json.loads(_canonical(result)))
+
+
+def validate_entk_readiness(
+    value: object,
+    validation_inputs: object,
+    validation_labels: object,
+    checkpoint: object,
+) -> dict[str, object]:
+    """Strictly validate identities and replay the complete nonlinear diagnostic."""
+    _json_preflight(value)
+    if type(value) is not dict or set(value) != {
+        "schema", "protocol", "identity", "metrics", "resources", "policy"
+    }:
+        raise ValueError("eNTK result fields differ from the schema")
+    raw = cast(dict[str, object], value)
+    protocol = raw["protocol"]
+    identity = raw["identity"]
+    if type(protocol) is not dict or set(protocol) != {
+        "model",
+        "learning_rate",
+        "energy_threshold",
+        "future_horizons",
+        "rng",
+        "relu_zero_derivative",
+        "task_id",
+        "checkpoint_id",
+    }:
+        raise ValueError("eNTK protocol fields differ")
+    if type(identity) is not dict or set(identity) != {
+        "source_sha256", "runtime", "dataset", "checkpoint"
+    }:
+        raise ValueError("eNTK identity fields differ")
+    raw_x, raw_y, raw_arrays, _ = _preflight(validation_inputs, validation_labels, checkpoint)
+    x, y = _snapshot(raw_x), _snapshot(raw_y)
+    arrays = cast(
+        tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+        tuple(_snapshot(value) for value in raw_arrays),
+    )
+    dataset = identity["dataset"]
+    if type(dataset) is not dict or dataset != {
+        "inputs": _array_identity("validation_inputs", x),
+        "labels": _array_identity("validation_labels", y),
+    }:
+        raise ValueError("supplied arrays do not match the dataset identity")
+    if identity["checkpoint"] != _checkpoint_identity(arrays):
+        raise ValueError("supplied checkpoint does not match the checkpoint identity")
+    expected = execute_entk_readiness(
+        x,
+        y,
+        MLPCheckpoint(*arrays),
+        task_id=cast(str, protocol["task_id"]),
+        checkpoint_id=cast(str, protocol["checkpoint_id"]),
+    )
+    if _canonical(raw) != _canonical(expected):
+        raise ValueError("eNTK result differs from strict replay")
+    return expected
+
+
+__all__ = ["MLPCheckpoint", "execute_entk_readiness", "validate_entk_readiness"]

--- a/alberta_framework/evaluation/optimization_readiness_executor.py
+++ b/alberta_framework/evaluation/optimization_readiness_executor.py
@@ -1,0 +1,598 @@
+"""Bounded, model-bound prospective Optimization Readiness execution.
+
+This is a permanently nonpromoting development diagnostic.  It executes a
+fully specified linear squared-loss model from an explicit checkpoint against
+one supplied 10,000-example task.  The validator repeats the execution from
+the bound inputs instead of accepting reported metrics or counters.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import platform
+import stat
+import sys
+from importlib.metadata import version
+from pathlib import Path
+from types import MappingProxyType
+from typing import Final
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+
+from alberta_framework.evaluation.optimization_readiness import (
+    energy_rank,
+    estimate_appendix_c1_optimization_readiness,
+)
+
+EXECUTION_SCHEMA: Final[str] = "asi.optimization-readiness.execution.v1"
+_OBSERVATIONS: Final[int] = 10_000
+_MAX_PARAMETERS: Final[int] = 64
+_BATCH_SIZE: Final[int] = 4
+_ROLLOUTS: Final[int] = 128
+_DIAGNOSTIC_BATCHES: Final[int] = 128
+_GAIN_STEPS: Final[tuple[int, ...]] = (1, 10, 100)
+_STEP_SIZE: Final[float] = 1e-3
+_MAX_LIVE_BYTES: Final[int] = 256 * 1024 * 1024
+_MAX_PREFLIGHT_WORK_UNITS: Final[int] = 500_000_000
+_MAX_JSON_NODES: Final[int] = 4_096
+_MAX_JSON_STRING_BYTES: Final[int] = 64 * 1024
+_SAMPLING_PROVENANCE: Final[str] = (
+    "executor_derived_independent_with_replacement_jax_threefry2x32"
+)
+_SOURCE_FILES: Final[tuple[str, ...]] = (
+    "alberta_framework/evaluation/optimization_readiness.py",
+    "alberta_framework/evaluation/optimization_readiness_executor.py",
+)
+
+FROZEN_EXECUTION_PLAN = MappingProxyType(
+    {
+        "model": "linear_squared_loss_no_bias",
+        "full_validation_observations": _OBSERVATIONS,
+        "diagnostic_batch_count": _DIAGNOSTIC_BATCHES,
+        "diagnostic_batch_size": _BATCH_SIZE,
+        "diagnostic_sampling": "independent_with_replacement",
+        "future_gain_steps": _GAIN_STEPS,
+        "future_gain_rollout_count": _ROLLOUTS,
+        "future_gain_batch_size": _BATCH_SIZE,
+        "future_gain_step_size": _STEP_SIZE,
+        "optimizer": "plain_sgd",
+        "rng_impl": "threefry2x32",
+        "sampling_provenance": _SAMPLING_PROVENANCE,
+        "representation": "linear_model_input_matrix",
+        "curvature": "exact_full_validation_squared_loss_hessian",
+        "preflight_work_unit_scope": (
+            "safety_only_parameter_data_incidence_not_scalar_flops_or_comparison_receipt"
+        ),
+    }
+)
+
+
+def _exact_string(value: object, *, name: str) -> str:
+    if type(value) is not str:
+        raise ValueError(f"{name} must be an exact string")
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{name} must be valid UTF-8") from exc
+    if not encoded or len(encoded) > 4_096 or "\x00" in value:
+        raise ValueError(f"{name} must be a bounded non-empty UTF-8 string")
+    return value
+
+
+def _assert_plain_json(value: object) -> None:
+    """Reject subclasses, aliases, cycles, and aggregate-unbounded JSON trees."""
+    seen_containers: set[int] = set()
+    node_count = 0
+    string_bytes = 0
+
+    def visit(item: object, *, depth: int) -> None:
+        nonlocal node_count, string_bytes
+        node_count += 1
+        if node_count > _MAX_JSON_NODES:
+            raise ValueError("execution artifact exceeds the aggregate node limit")
+        if depth > 8:
+            raise ValueError("execution artifact must be bounded plain JSON")
+        if item is None or type(item) is bool:
+            return
+        if type(item) is int:
+            if not -(1 << 63) <= item <= (1 << 63) - 1:
+                raise ValueError("execution artifact must be bounded plain JSON")
+            return
+        if type(item) is float:
+            if not math.isfinite(item):
+                raise ValueError("execution artifact must be bounded plain JSON")
+            return
+        if type(item) is str:
+            resolved = _exact_string(item, name="execution artifact string")
+            string_bytes += len(resolved.encode("utf-8"))
+            if string_bytes > _MAX_JSON_STRING_BYTES:
+                raise ValueError("execution artifact exceeds the aggregate string-byte limit")
+            return
+        if type(item) is list:
+            identity = id(item)
+            if identity in seen_containers:
+                raise ValueError("execution artifact contains an aliased or cyclic container")
+            seen_containers.add(identity)
+            if list.__len__(item) > 512:
+                raise ValueError("execution artifact must be bounded plain JSON")
+            for child in list.__iter__(item):
+                visit(child, depth=depth + 1)
+            return
+        if type(item) is dict:
+            identity = id(item)
+            if identity in seen_containers:
+                raise ValueError("execution artifact contains an aliased or cyclic container")
+            seen_containers.add(identity)
+            if dict.__len__(item) > 128:
+                raise ValueError("execution artifact must be bounded plain JSON")
+            for key, child in dict.items(item):
+                if type(key) is not str:
+                    raise ValueError("execution artifact must be bounded plain JSON")
+                visit(key, depth=depth + 1)
+                visit(child, depth=depth + 1)
+            return
+        raise ValueError("execution artifact must be bounded plain JSON")
+
+    visit(value, depth=0)
+
+
+def _preflight_arrays(
+    validation_inputs: object,
+    validation_labels: object,
+    checkpoint_parameters: object,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict[str, int]]:
+    """Check trusted ndarray metadata and total work before scanning values."""
+    named = (
+        ("validation_inputs", validation_inputs, 2),
+        ("validation_labels", validation_labels, 1),
+        ("checkpoint_parameters", checkpoint_parameters, 1),
+    )
+    for name, value, dimensions in named:
+        if type(value) is not np.ndarray:
+            raise ValueError(f"{name} must be an exact numpy.ndarray")
+        if value.ndim != dimensions or any(axis < 1 for axis in value.shape):
+            raise ValueError(f"{name} must be a non-empty {dimensions}-dimensional array")
+        if value.dtype != np.dtype(np.float64):
+            raise ValueError(f"{name} must have exact float64 dtype")
+    inputs = validation_inputs
+    labels = validation_labels
+    checkpoint = checkpoint_parameters
+    assert isinstance(inputs, np.ndarray)
+    assert isinstance(labels, np.ndarray)
+    assert isinstance(checkpoint, np.ndarray)
+    if inputs.shape[0] != _OBSERVATIONS or labels.shape != (_OBSERVATIONS,):
+        raise ValueError("the frozen task requires exactly 10,000 aligned observations")
+    parameters = int(inputs.shape[1])
+    if not 1 <= parameters <= _MAX_PARAMETERS:
+        raise ValueError("parameter count exceeds the bounded model protocol")
+    if checkpoint.shape != (parameters,):
+        raise ValueError("checkpoint parameter axis must match validation inputs")
+
+    total_updates = _ROLLOUTS * sum(_GAIN_STEPS)
+    preflight_work_units = (
+        _OBSERVATIONS * parameters
+        + _DIAGNOSTIC_BATCHES * _BATCH_SIZE * parameters
+        + total_updates * _BATCH_SIZE * parameters
+        + len(_GAIN_STEPS) * _ROLLOUTS * _OBSERVATIONS * parameters
+        + _OBSERVATIONS * parameters * parameters
+    )
+    if preflight_work_units > _MAX_PREFLIGHT_WORK_UNITS:
+        raise ValueError("execution preflight work exceeds the bounded protocol")
+    schedule_items = _BATCH_SIZE * (_DIAGNOSTIC_BATCHES + total_updates)
+    caller_bytes = int(inputs.nbytes + labels.nbytes + checkpoint.nbytes)
+    owned_bytes = caller_bytes
+    schedule_bytes = schedule_items * np.dtype(np.int64).itemsize
+    schedule_device_bytes = schedule_items * np.dtype(np.int32).itemsize
+    diagnostic_bytes = _DIAGNOSTIC_BATCHES * parameters * np.dtype(np.float64).itemsize
+    # Terminal loss evaluation retains two full observation-by-rollout arrays:
+    # matmul output beside residual, then residual beside its squared temporary.
+    terminal_loss_bytes = (
+        2 * _OBSERVATIONS * _ROLLOUTS * np.dtype(np.float64).itemsize
+    )
+    rollout_state_bytes = (
+        _ROLLOUTS
+        * (parameters + 2 * _BATCH_SIZE * parameters + 2 * _BATCH_SIZE)
+        * np.dtype(np.float64).itemsize
+    )
+    diagnostic_state_bytes = (
+        parameters * parameters + 2 * parameters
+    ) * np.dtype(np.float64).itemsize
+    # The input-matrix SVD is conservatively charged with its float64 copy,
+    # LAPACK copy, finite mask, and a quadratic workspace allowance.  Caller
+    # inputs and our immutable snapshots remain live throughout.
+    representation_svd_bytes = (
+        int(inputs.nbytes)
+        + 17 * int(inputs.size)
+        + 24 * parameters * parameters
+        + 8 * max(inputs.shape)
+        + 96 * parameters
+    )
+    peak_bytes = (
+        caller_bytes
+        + owned_bytes
+        + schedule_bytes
+        + schedule_device_bytes
+        + diagnostic_bytes
+        + terminal_loss_bytes
+        + rollout_state_bytes
+        + diagnostic_state_bytes
+        + representation_svd_bytes
+    )
+    if peak_bytes > _MAX_LIVE_BYTES:
+        raise ValueError("execution total live memory exceeds the bounded protocol")
+    return inputs, labels, checkpoint, {
+        "parameter_count": parameters,
+        "preflight_work_units": preflight_work_units,
+        "persistent_bytes": owned_bytes + schedule_bytes,
+        "peak_working_set_bytes": peak_bytes,
+        "model_queries": (
+            _OBSERVATIONS
+            + _DIAGNOSTIC_BATCHES * _BATCH_SIZE
+            + _ROLLOUTS
+            * sum(step * _BATCH_SIZE + _OBSERVATIONS for step in _GAIN_STEPS)
+        ),
+        "parameter_updates": total_updates,
+    }
+
+
+def _snapshot(value: np.ndarray, *, name: str) -> np.ndarray:
+    result = np.array(value, dtype=np.float64, order="C", copy=True)
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must contain only finite values")
+    result.flags.writeable = False
+    return result
+
+
+def _array_identity(value: np.ndarray) -> dict[str, object]:
+    digest = hashlib.sha256()
+    digest.update(json.dumps(list(value.shape), separators=(",", ":")).encode())
+    digest.update(value.dtype.str.encode())
+    digest.update(value.tobytes(order="C"))
+    return {
+        "shape": list(value.shape),
+        "dtype": value.dtype.str,
+        "sha256": digest.hexdigest(),
+    }
+
+
+def _dataset_identity(inputs: np.ndarray, labels: np.ndarray) -> dict[str, object]:
+    return {"inputs": _array_identity(inputs), "labels": _array_identity(labels)}
+
+
+def _source_identity() -> dict[str, str]:
+    root = Path(__file__).resolve().parents[2]
+    identities: dict[str, str] = {}
+    for relative in _SOURCE_FILES:
+        path = root / relative
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(path, flags)
+        except OSError as exc:
+            raise ValueError("source identity file cannot be opened safely") from exc
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode) or not 0 < metadata.st_size <= 2 * 1024 * 1024:
+                raise ValueError("source identity file must be a bounded regular file")
+            chunks: list[bytes] = []
+            remaining = metadata.st_size + 1
+            while remaining:
+                chunk = os.read(descriptor, min(remaining, 64 * 1024))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            payload = b"".join(chunks)
+            if len(payload) != metadata.st_size:
+                raise ValueError("source identity file changed during its bounded read")
+            after = os.fstat(descriptor)
+            if (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns) != (
+                metadata.st_dev,
+                metadata.st_ino,
+                metadata.st_size,
+                metadata.st_mtime_ns,
+            ):
+                raise ValueError("source identity file changed during its bounded read")
+        finally:
+            os.close(descriptor)
+        identities[relative] = hashlib.sha256(payload).hexdigest()
+    return identities
+
+
+def _runtime_identity() -> dict[str, object]:
+    numpy_build = json.dumps(
+        np.__config__.CONFIG, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return {
+        "python": platform.python_version(),
+        "implementation": platform.python_implementation(),
+        "platform": platform.platform(),
+        "byteorder": sys.byteorder,
+        "numpy": np.__version__,
+        "numpy_build_sha256": hashlib.sha256(numpy_build).hexdigest(),
+        "jax": jax.__version__,
+        "jaxlib": version("jaxlib"),
+        "jax_backend": jax.default_backend(),
+        "jax_devices": [
+            {"platform": device.platform, "device_kind": device.device_kind}
+            for device in jax.devices()
+        ],
+        "jax_enable_x64": bool(jax.config.jax_enable_x64),
+        "agent_rng_impl": "jax.random.key(seed, impl='threefry2x32')",
+    }
+
+
+def _plan_payload() -> dict[str, object]:
+    payload = dict(FROZEN_EXECUTION_PLAN)
+    payload["future_gain_steps"] = list(_GAIN_STEPS)
+    return payload
+
+
+def _schedule(seed: int) -> tuple[np.ndarray, dict[int, np.ndarray]]:
+    root = jr.key(seed, impl="threefry2x32")
+    diagnostic_key, rollout_root = jr.split(root)
+    diagnostic = np.asarray(
+        jr.randint(
+            diagnostic_key,
+            (_DIAGNOSTIC_BATCHES, _BATCH_SIZE),
+            0,
+            _OBSERVATIONS,
+            dtype=jnp.int32,
+        ),
+        dtype=np.int64,
+    )
+    horizon_keys = jr.split(rollout_root, len(_GAIN_STEPS))
+    rollouts: dict[int, np.ndarray] = {}
+    for step, key in zip(_GAIN_STEPS, horizon_keys, strict=True):
+        rollouts[step] = np.asarray(
+            jr.randint(
+                key,
+                (_ROLLOUTS, step, _BATCH_SIZE),
+                0,
+                _OBSERVATIONS,
+                dtype=jnp.int32,
+            ),
+            dtype=np.int64,
+        )
+    return diagnostic, rollouts
+
+
+def _schedule_sha256(diagnostic: np.ndarray, rollouts: dict[int, np.ndarray]) -> str:
+    digest = hashlib.sha256(diagnostic.tobytes(order="C"))
+    for step in _GAIN_STEPS:
+        digest.update(step.to_bytes(2, "big"))
+        digest.update(rollouts[step].tobytes(order="C"))
+    return digest.hexdigest()
+
+
+def _loss_and_gradient(
+    inputs: np.ndarray, labels: np.ndarray, parameters: np.ndarray
+) -> tuple[float, np.ndarray]:
+    residual = inputs @ parameters - labels
+    loss = float(np.mean(np.square(residual)))
+    gradient = np.asarray(2.0 * (inputs.T @ residual) / inputs.shape[0], dtype=np.float64)
+    if not math.isfinite(loss) or not np.all(np.isfinite(gradient)):
+        raise ValueError("model loss and gradient must remain finite")
+    return loss, gradient
+
+
+def _future_gain(
+    inputs: np.ndarray,
+    labels: np.ndarray,
+    checkpoint: np.ndarray,
+    schedule: np.ndarray,
+    initial_loss: float,
+) -> float:
+    parameters = np.broadcast_to(checkpoint, (_ROLLOUTS, checkpoint.size)).copy()
+    for update in range(schedule.shape[1]):
+        indices = schedule[:, update, :]
+        batch_inputs = inputs[indices]
+        batch_labels = labels[indices]
+        prediction = np.einsum("rbp,rp->rb", batch_inputs, parameters, optimize=False)
+        residual = prediction - batch_labels
+        gradient = 2.0 * np.einsum(
+            "rbp,rb->rp", batch_inputs, residual, optimize=False
+        ) / _BATCH_SIZE
+        parameters -= _STEP_SIZE * gradient
+    terminal_residual = inputs @ parameters.T - labels[:, None]
+    terminal_losses = np.mean(np.square(terminal_residual), axis=0)
+    if not np.all(np.isfinite(terminal_losses)):
+        raise ValueError("future-gain rollout produced non-finite losses")
+    if initial_loss == 0.0:
+        return 0.0
+    return float(np.mean((initial_loss - terminal_losses) / initial_loss))
+
+
+def execute_optimization_readiness(
+    *,
+    validation_inputs: object,
+    validation_labels: object,
+    checkpoint_parameters: object,
+    seed: int,
+    task_id: str,
+    checkpoint_id: str,
+) -> dict[str, object]:
+    """Execute the frozen bounded diagnostic from a real model checkpoint."""
+    if type(seed) is not int or not 0 <= seed <= (1 << 32) - 1:
+        raise ValueError("seed must be a bounded nonnegative built-in int")
+    resolved_task = _exact_string(task_id, name="task_id")
+    resolved_checkpoint_id = _exact_string(checkpoint_id, name="checkpoint_id")
+    raw_inputs, raw_labels, raw_checkpoint, resources = _preflight_arrays(
+        validation_inputs, validation_labels, checkpoint_parameters
+    )
+    inputs = _snapshot(raw_inputs, name="validation_inputs")
+    labels = _snapshot(raw_labels, name="validation_labels")
+    checkpoint = _snapshot(raw_checkpoint, name="checkpoint_parameters")
+
+    dataset = _dataset_identity(inputs, labels)
+    checkpoint_identity = _array_identity(checkpoint)
+    diagnostic_indices, rollout_indices = _schedule(seed)
+    initial_loss, full_gradient = _loss_and_gradient(inputs, labels, checkpoint)
+    batch_gradients = np.empty(
+        (_DIAGNOSTIC_BATCHES, checkpoint.size), dtype=np.float64
+    )
+    for row, indices in enumerate(diagnostic_indices):
+        _, batch_gradients[row] = _loss_and_gradient(
+            inputs[indices], labels[indices], checkpoint
+        )
+    readiness = estimate_appendix_c1_optimization_readiness(
+        loss=initial_loss,
+        full_validation_gradient=full_gradient,
+        batch_gradients=batch_gradients,
+        full_validation_observations=_OBSERVATIONS,
+        mini_batch_size=_BATCH_SIZE,
+        sampling_provenance=(
+            "caller_reported_independent_with_replacement_not_verified_from_gradients"
+        ),
+    )
+    curvature = np.asarray(2.0 * (inputs.T @ inputs) / _OBSERVATIONS, dtype=np.float64)
+    gains = {
+        str(step): _future_gain(
+            inputs, labels, checkpoint, rollout_indices[step], initial_loss
+        )
+        for step in _GAIN_STEPS
+    }
+    metrics: dict[str, object] = {
+        "initial_validation_loss": initial_loss,
+        "optimization_readiness": readiness.optimization_readiness,
+        "gradient_strength": readiness.gradient_strength,
+        "gradient_reliability": readiness.gradient_reliability,
+        "gradient_norm": readiness.gradient_norm,
+        "parameter_norm": float(np.linalg.norm(checkpoint)),
+        "representation_energy_rank_0_99": energy_rank(inputs, threshold=0.99),
+        "curvature_energy_rank_0_99": energy_rank(curvature, threshold=0.99),
+        "future_relative_loss_reduction": gains,
+    }
+    scalar_metrics = (
+        initial_loss,
+        readiness.optimization_readiness,
+        readiness.gradient_strength,
+        readiness.gradient_reliability,
+        readiness.gradient_norm,
+        float(np.linalg.norm(checkpoint)),
+    )
+    if not all(math.isfinite(value) for value in scalar_metrics) or not all(
+        math.isfinite(value) for value in gains.values()
+    ):
+        raise ValueError("execution metrics must be finite")
+    return {
+        "schema": EXECUTION_SCHEMA,
+        "policy": {
+            "development_only": True,
+            "scientific_promotion_allowed": False,
+            "timing_is_telemetry_only": True,
+        },
+        "plan": _plan_payload(),
+        "execution": {
+            "seed": seed,
+            "task_id": resolved_task,
+            "checkpoint_id": resolved_checkpoint_id,
+        },
+        "identity": {
+            "source_sha256": _source_identity(),
+            "runtime": _runtime_identity(),
+            "dataset": dataset,
+            "checkpoint": checkpoint_identity,
+        },
+        "sampling": {
+            "rng_impl": "threefry2x32",
+            "diagnostic_gradient_count": _DIAGNOSTIC_BATCHES,
+            "schedule_sha256": _schedule_sha256(diagnostic_indices, rollout_indices),
+        },
+        "resources": {
+            **resources,
+            "environment_steps": 0,
+            "data_steps": resources["model_queries"],
+            "timing_seconds": 0.0,
+            "timing_measured": False,
+            "timing_is_telemetry_only": True,
+        },
+        "metrics": metrics,
+    }
+
+
+def validate_optimization_readiness_execution(
+    payload: object,
+    *,
+    validation_inputs: object,
+    validation_labels: object,
+    checkpoint_parameters: object,
+) -> dict[str, object]:
+    """Fail closed unless a supplied execution repeats exactly from its inputs."""
+    if type(payload) is not dict:
+        raise ValueError("execution artifact must be an exact dict")
+    expected_keys = {
+        "schema",
+        "policy",
+        "plan",
+        "execution",
+        "identity",
+        "sampling",
+        "resources",
+        "metrics",
+    }
+    if dict.__len__(payload) != len(expected_keys):
+        raise ValueError("execution artifact has unexpected keys")
+    if any(
+        type(key) is not str or key not in expected_keys
+        for key in dict.keys(payload)
+    ):
+        raise ValueError("execution artifact has unexpected keys")
+    _assert_plain_json(payload)
+    if payload.get("schema") != EXECUTION_SCHEMA:
+        raise ValueError("execution artifact schema is not supported")
+    execution = payload.get("execution")
+    identity = payload.get("identity")
+    if type(execution) is not dict or set(execution) != {
+        "seed",
+        "task_id",
+        "checkpoint_id",
+    }:
+        raise ValueError("execution descriptor is malformed")
+    if type(identity) is not dict or set(identity) != {
+        "source_sha256",
+        "runtime",
+        "dataset",
+        "checkpoint",
+    }:
+        raise ValueError("execution identity is malformed")
+    seed = execution["seed"]
+    if type(seed) is not int:
+        raise ValueError("execution seed must be an exact int")
+    task_id = _exact_string(execution["task_id"], name="task_id")
+    checkpoint_id = _exact_string(execution["checkpoint_id"], name="checkpoint_id")
+
+    raw_inputs, raw_labels, raw_checkpoint, _ = _preflight_arrays(
+        validation_inputs, validation_labels, checkpoint_parameters
+    )
+    inputs = _snapshot(raw_inputs, name="validation_inputs")
+    labels = _snapshot(raw_labels, name="validation_labels")
+    checkpoint = _snapshot(raw_checkpoint, name="checkpoint_parameters")
+    if identity["dataset"] != _dataset_identity(inputs, labels):
+        raise ValueError("supplied arrays do not match the bound dataset identity")
+    if identity["checkpoint"] != _array_identity(checkpoint):
+        raise ValueError("supplied parameters do not match the bound checkpoint identity")
+    recomputed = execute_optimization_readiness(
+        validation_inputs=inputs,
+        validation_labels=labels,
+        checkpoint_parameters=checkpoint,
+        seed=seed,
+        task_id=task_id,
+        checkpoint_id=checkpoint_id,
+    )
+    if payload != recomputed:
+        raise ValueError("execution artifact does not recompute exactly")
+    return recomputed
+
+
+__all__ = [
+    "EXECUTION_SCHEMA",
+    "FROZEN_EXECUTION_PLAN",
+    "execute_optimization_readiness",
+    "validate_optimization_readiness_execution",
+]

--- a/alberta_framework/evaluation/optimization_readiness_panel.py
+++ b/alberta_framework/evaluation/optimization_readiness_panel.py
@@ -1,0 +1,516 @@
+"""Matched, permanently nonpromoting Optimization Readiness checkpoint panel.
+
+The panel composes the model-bound executor over a bounded roster of real
+caller-supplied task/checkpoint arrays.  It derives the association between the
+prospective readiness score and subsequent measured gains; it does not promote
+the association or turn a development panel into scientific evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path, PosixPath
+from typing import Final, cast
+
+import numpy as np
+
+from alberta_framework.evaluation.optimization_readiness_executor import (
+    execute_optimization_readiness,
+)
+
+PANEL_SCHEMA: Final[str] = "asi.optimization-readiness.checkpoint-panel.v1"
+_MIN_CASES: Final[int] = 6
+_MAX_CASES: Final[int] = 6
+_MAX_CALLER_BYTES: Final[int] = 512 * 1024 * 1024
+_MAX_JSON_NODES: Final[int] = 50_000
+_MAX_JSON_STRING_BYTES: Final[int] = 1024 * 1024
+_MAX_RESULT_BYTES: Final[int] = 4 * 1024 * 1024
+_HORIZONS: Final[tuple[str, ...]] = ("1", "10", "100")
+_PREDICTORS: Final[tuple[tuple[str, str], ...]] = (
+    ("optimization_readiness", "optimization_readiness"),
+    ("gradient_norm", "gradient_norm"),
+    ("representation_rank", "representation_energy_rank_0_99"),
+    ("curvature_rank", "curvature_energy_rank_0_99"),
+    ("parameter_norm", "parameter_norm"),
+)
+FROZEN_PANEL_ROSTER: Final[tuple[tuple[str, str, int], ...]] = tuple(
+    ("ipmnist-linear-readiness", f"checkpoint-{index}", 1_568_001 + index) for index in range(6)
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OptimizationReadinessPanelCase:
+    """One supplied model checkpoint and its aligned validation task."""
+
+    task_id: str
+    checkpoint_id: str
+    seed: int
+    validation_inputs: np.ndarray
+    validation_labels: np.ndarray
+    checkpoint_parameters: np.ndarray
+
+
+def _bounded_text(value: object, *, name: str) -> str:
+    if type(value) is not str:
+        raise ValueError(f"{name} must be an exact string")
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{name} must be valid UTF-8") from exc
+    if not encoded or len(encoded) > 4_096 or b"\x00" in encoded:
+        raise ValueError(f"{name} must be bounded non-empty UTF-8")
+    return value
+
+
+def _preflight_cases(
+    cases: object,
+) -> tuple[OptimizationReadinessPanelCase, ...]:
+    if type(cases) is not tuple or not _MIN_CASES <= tuple.__len__(cases) <= _MAX_CASES:
+        raise ValueError("panel must contain the exact six-case prospective roster")
+    resolved = cast(tuple[object, ...], cases)
+    identities: set[tuple[str, str]] = set()
+    seeds: set[int] = set()
+    caller_bytes = 0
+    for index, value in enumerate(resolved):
+        if type(value) is not OptimizationReadinessPanelCase:
+            raise ValueError(f"cases[{index}] must be an exact panel case")
+        case = value
+        task_id = _bounded_text(case.task_id, name=f"cases[{index}].task_id")
+        checkpoint_id = _bounded_text(case.checkpoint_id, name=f"cases[{index}].checkpoint_id")
+        if type(case.seed) is not int or not 0 <= case.seed <= (1 << 32) - 1:
+            raise ValueError(f"cases[{index}].seed must be a bounded exact int")
+        identity = (task_id, checkpoint_id)
+        if identity in identities:
+            raise ValueError("panel task/checkpoint identities must be unique")
+        identities.add(identity)
+        if case.seed in seeds:
+            raise ValueError("panel sampling seeds must be unique")
+        seeds.add(case.seed)
+        arrays = (
+            case.validation_inputs,
+            case.validation_labels,
+            case.checkpoint_parameters,
+        )
+        if any(type(array) is not np.ndarray for array in arrays):
+            raise ValueError(f"cases[{index}] arrays must be exact numpy.ndarray values")
+        caller_bytes += sum(int(array.nbytes) for array in arrays)
+        if caller_bytes > _MAX_CALLER_BYTES:
+            raise ValueError("panel caller arrays exceed the aggregate byte ceiling")
+    observed_roster = tuple(
+        (case.task_id, case.checkpoint_id, case.seed)
+        for case in cast(tuple[OptimizationReadinessPanelCase, ...], resolved)
+    )
+    if observed_roster != FROZEN_PANEL_ROSTER:
+        raise ValueError("panel cases do not match the frozen prospective roster")
+    return cast(tuple[OptimizationReadinessPanelCase, ...], resolved)
+
+
+def _rank(values: list[float]) -> list[float]:
+    order = sorted(range(len(values)), key=values.__getitem__)
+    result = [0.0] * len(values)
+    start = 0
+    while start < len(order):
+        end = start + 1
+        while end < len(order) and values[order[end]] == values[order[start]]:
+            end += 1
+        average = (start + 1 + end) / 2.0
+        for position in range(start, end):
+            result[order[position]] = average
+        start = end
+    return result
+
+
+def _spearman(left: list[float], right: list[float]) -> float | None:
+    left_rank = _rank(left)
+    right_rank = _rank(right)
+    left_mean = sum(left_rank) / len(left_rank)
+    right_mean = sum(right_rank) / len(right_rank)
+    left_delta = [value - left_mean for value in left_rank]
+    right_delta = [value - right_mean for value in right_rank]
+    left_norm = math.sqrt(sum(value * value for value in left_delta))
+    right_norm = math.sqrt(sum(value * value for value in right_delta))
+    if left_norm == 0.0 or right_norm == 0.0:
+        return None
+    value = sum(a * b for a, b in zip(left_delta, right_delta, strict=True)) / (
+        left_norm * right_norm
+    )
+    if not math.isfinite(value):
+        raise ValueError("panel association must be finite")
+    return float(max(-1.0, min(1.0, value)))
+
+
+def _canonical_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _internal_float(value: object) -> float:
+    if type(value) is not float or not math.isfinite(value):
+        raise RuntimeError("model-bound executor returned a malformed float")
+    return value
+
+
+def _predictor_float(value: object) -> float:
+    if type(value) is int and value >= 0:
+        return float(value)
+    return _internal_float(value)
+
+
+def _internal_int(value: object) -> int:
+    if type(value) is not int or value < 0:
+        raise RuntimeError("model-bound executor returned a malformed counter")
+    return value
+
+
+def _panel_source_sha256() -> str:
+    path = Path(__file__).resolve()
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or not 0 < before.st_size <= 2 * 1024 * 1024:
+            raise ValueError("panel source must be a bounded regular file")
+        payload = bytearray()
+        while len(payload) <= before.st_size:
+            chunk = os.read(descriptor, min(64 * 1024, before.st_size + 1 - len(payload)))
+            if not chunk:
+                break
+            payload.extend(chunk)
+        after = os.fstat(descriptor)
+        if len(payload) != before.st_size or (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+        ) != (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns):
+            raise ValueError("panel source changed during its bounded read")
+    finally:
+        os.close(descriptor)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _assert_plain_json(value: object) -> None:
+    seen: set[int] = set()
+    nodes = 0
+    string_bytes = 0
+    stack: list[tuple[object, int]] = [(value, 0)]
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > 12:
+            raise ValueError("panel artifact exceeds its JSON work bound")
+        if item is None or type(item) is bool:
+            continue
+        if type(item) is int:
+            if not -(1 << 63) <= item <= (1 << 63) - 1:
+                raise ValueError("panel artifact contains an unbounded integer")
+            continue
+        if type(item) is float:
+            if not math.isfinite(item):
+                raise ValueError("panel artifact contains a non-finite float")
+            continue
+        if type(item) is str:
+            string_bytes += len(_bounded_text(item, name="panel string").encode("utf-8"))
+            if string_bytes > _MAX_JSON_STRING_BYTES:
+                raise ValueError("panel artifact exceeds its string-byte bound")
+            continue
+        if type(item) is list:
+            identity = id(item)
+            if identity in seen or list.__len__(item) > 512:
+                raise ValueError("panel artifact contains an alias, cycle, or oversized list")
+            seen.add(identity)
+            stack.extend((child, depth + 1) for child in list.__iter__(item))
+            continue
+        if type(item) is dict:
+            identity = id(item)
+            if identity in seen or dict.__len__(item) > 128:
+                raise ValueError("panel artifact contains an alias, cycle, or oversized mapping")
+            seen.add(identity)
+            for key, child in dict.items(item):
+                if type(key) is not str:
+                    raise ValueError("panel artifact keys must be exact strings")
+                stack.append((key, depth + 1))
+                stack.append((child, depth + 1))
+            continue
+        raise ValueError("panel artifact must be exact plain JSON")
+
+
+def run_optimization_readiness_panel(
+    cases: object,
+) -> dict[str, object]:
+    """Execute and aggregate a bounded matched checkpoint panel."""
+    roster = _preflight_cases(cases)
+    executions = [
+        execute_optimization_readiness(
+            validation_inputs=case.validation_inputs,
+            validation_labels=case.validation_labels,
+            checkpoint_parameters=case.checkpoint_parameters,
+            seed=case.seed,
+            task_id=case.task_id,
+            checkpoint_id=case.checkpoint_id,
+        )
+        for case in roster
+    ]
+    content_identities: set[str] = set()
+    for execution in executions:
+        raw_identity = execution.get("identity")
+        if type(raw_identity) is not dict:
+            raise RuntimeError("model-bound executor returned a malformed identity")
+        identity = cast(dict[str, object], raw_identity)
+        if set(identity) != {"source_sha256", "runtime", "dataset", "checkpoint"}:
+            raise RuntimeError("model-bound executor returned a malformed identity")
+        content_identity = hashlib.sha256(
+            _canonical_bytes(
+                {
+                    "dataset": identity["dataset"],
+                    "checkpoint": identity["checkpoint"],
+                }
+            )
+        ).hexdigest()
+        if content_identity in content_identities:
+            raise ValueError("panel dataset/checkpoint content identities must be unique")
+        content_identities.add(content_identity)
+    metrics: list[dict[str, object]] = []
+    child_resources: list[dict[str, object]] = []
+    for execution in executions:
+        raw_metrics = execution["metrics"]
+        raw_resources = execution["resources"]
+        if type(raw_metrics) is not dict or type(raw_resources) is not dict:
+            raise RuntimeError("model-bound executor returned malformed internal records")
+        metrics.append(cast(dict[str, object], raw_metrics))
+        child_resources.append(cast(dict[str, object], raw_resources))
+    correlations: dict[str, dict[str, float | None]] = {name: {} for name, _field in _PREDICTORS}
+    for horizon in _HORIZONS:
+        gains: list[float] = []
+        for metric in metrics:
+            raw_gains = metric["future_relative_loss_reduction"]
+            if type(raw_gains) is not dict:
+                raise RuntimeError("model-bound executor returned malformed future gains")
+            gains.append(_internal_float(cast(dict[str, object], raw_gains)[horizon]))
+        for name, field in _PREDICTORS:
+            predictor = [_predictor_float(metric[field]) for metric in metrics]
+            correlations[name][horizon] = _spearman(predictor, gains)
+    readiness = correlations["optimization_readiness"]
+    baselines = {
+        name: values for name, values in correlations.items() if name != "optimization_readiness"
+    }
+    paired_deltas: dict[str, dict[str, float | None]] = {}
+    for name, values in baselines.items():
+        paired_deltas[name] = {}
+        for horizon in _HORIZONS:
+            left, right = readiness[horizon], values[horizon]
+            paired_deltas[name][horizon] = None if left is None or right is None else left - right
+    all_deltas = [delta for values in paired_deltas.values() for delta in values.values()]
+    if any(value is None for value in readiness.values()) or any(
+        delta is None or delta == 0.0 for delta in all_deltas
+    ):
+        outcome = "inconclusive"
+    elif all(cast(float, value) > 0.0 for value in readiness.values()) and all(
+        cast(float, delta) > 0.0 for delta in all_deltas
+    ):
+        outcome = "supported"
+    else:
+        outcome = "rejected"
+    resources = {
+        "case_executions": len(executions),
+        "aggregate_caller_bytes": sum(
+            int(array.nbytes)
+            for case in roster
+            for array in (
+                case.validation_inputs,
+                case.validation_labels,
+                case.checkpoint_parameters,
+            )
+        ),
+        "model_queries": sum(
+            _internal_int(resource["model_queries"]) for resource in child_resources
+        ),
+        "data_steps": sum(_internal_int(resource["data_steps"]) for resource in child_resources),
+        "environment_steps": sum(
+            _internal_int(resource["environment_steps"]) for resource in child_resources
+        ),
+        "parameter_updates": sum(
+            _internal_int(resource["parameter_updates"]) for resource in child_resources
+        ),
+        "summed_child_preflight_work_units": sum(
+            _internal_int(resource["preflight_work_units"]) for resource in child_resources
+        ),
+        "summed_child_persistent_bytes": sum(
+            _internal_int(resource["persistent_bytes"]) for resource in child_resources
+        ),
+        "max_child_peak_working_set_bytes": max(
+            _internal_int(resource["peak_working_set_bytes"]) for resource in child_resources
+        ),
+        "timing_measured": False,
+    }
+    payload: dict[str, object] = {
+        "schema": PANEL_SCHEMA,
+        "policy": {
+            "development_only": True,
+            "negative_outcomes_retained": True,
+            "scientific_promotion_allowed": False,
+        },
+        "panel_source_sha256": _panel_source_sha256(),
+        "case_count": len(executions),
+        "cases": executions,
+        "association": {
+            "metric": "spearman_rank_correlation",
+            "predictors": [name for name, _field in _PREDICTORS],
+            "target": "future_relative_loss_reduction",
+            "spearman_by_predictor_and_gain_horizon": correlations,
+            "optimization_readiness_minus_baseline": paired_deltas,
+            "decision_rule": (
+                "supported iff optimization readiness has positive finite correlation and "
+                "strictly exceeds every registered baseline at all three horizons; ties or "
+                "undefined correlations are inconclusive; otherwise rejected"
+            ),
+            "execution_authorized": False,
+            "seed_history_audit": (
+                "1568001--1568006 had zero exact matches on current main when prospectively "
+                "frozen on 2026-08-20"
+            ),
+            "status": outcome,
+            "scope": "development_association_not_scientific_evidence",
+        },
+        "resources": resources,
+    }
+    payload["result_sha256"] = hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+    return payload
+
+
+def validate_optimization_readiness_panel(
+    payload: object,
+    *,
+    cases: object,
+) -> dict[str, object]:
+    """Reexecute every supplied case and reject any panel drift or forgery."""
+    if type(payload) is not dict:
+        raise ValueError("panel artifact must be an exact dict")
+    expected_keys = {
+        "schema",
+        "policy",
+        "panel_source_sha256",
+        "case_count",
+        "cases",
+        "association",
+        "resources",
+        "result_sha256",
+    }
+    if dict.__len__(payload) != len(expected_keys):
+        raise ValueError("panel artifact has unexpected keys")
+    if any(type(key) is not str or key not in expected_keys for key in dict.keys(payload)):
+        raise ValueError("panel artifact has unexpected keys")
+    _assert_plain_json(payload)
+    recomputed = run_optimization_readiness_panel(cases)
+    if payload != recomputed:
+        raise ValueError("panel artifact does not recompute exactly")
+    return recomputed
+
+
+def retain_optimization_readiness_panel(
+    payload: object,
+    *,
+    cases: object,
+    repository_root: Path,
+) -> Path:
+    """Publish one validated panel atomically without replacing prior bytes."""
+    if type(repository_root) is not PosixPath or not repository_root.is_absolute():
+        raise ValueError("repository_root must be an exact absolute POSIX Path")
+    validated = validate_optimization_readiness_panel(payload, cases=cases)
+    encoded = _canonical_bytes(validated)
+    if len(encoded) > _MAX_RESULT_BYTES:
+        raise ValueError("panel artifact exceeds its encoded byte ceiling")
+    digest = cast(str, validated["result_sha256"])
+    segments = ("outputs", "optimization_readiness", "development.v1")
+    directory_descriptor = os.open(
+        repository_root,
+        os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        for segment in segments:
+            try:
+                os.mkdir(segment, mode=0o755, dir_fd=directory_descriptor)
+            except FileExistsError:
+                pass
+            next_descriptor = os.open(
+                segment,
+                os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=directory_descriptor,
+            )
+            os.close(directory_descriptor)
+            directory_descriptor = next_descriptor
+        name = f"result.{digest}.json"
+        temporary_name = f".result.{digest}.tmp"
+        descriptor = os.open(
+            temporary_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o444,
+            dir_fd=directory_descriptor,
+        )
+        try:
+            offset = 0
+            while offset < len(encoded):
+                written = os.write(descriptor, encoded[offset:])
+                if written <= 0:
+                    raise OSError("panel publication write made no progress")
+                offset += written
+            os.fsync(descriptor)
+        except BaseException:
+            os.close(descriptor)
+            os.unlink(temporary_name, dir_fd=directory_descriptor)
+            raise
+        else:
+            os.close(descriptor)
+        try:
+            os.link(
+                temporary_name,
+                name,
+                src_dir_fd=directory_descriptor,
+                dst_dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+        finally:
+            os.unlink(temporary_name, dir_fd=directory_descriptor)
+        read_descriptor = os.open(
+            name,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=directory_descriptor,
+        )
+        try:
+            loaded = bytearray()
+            while len(loaded) <= _MAX_RESULT_BYTES:
+                chunk = os.read(
+                    read_descriptor,
+                    min(64 * 1024, _MAX_RESULT_BYTES + 1 - len(loaded)),
+                )
+                if not chunk:
+                    break
+                loaded.extend(chunk)
+        finally:
+            os.close(read_descriptor)
+        if bytes(loaded) != encoded:
+            raise RuntimeError("retained panel bytes changed during publication")
+        os.fsync(directory_descriptor)
+    finally:
+        os.close(directory_descriptor)
+    return repository_root.joinpath(*segments, f"result.{digest}.json")
+
+
+__all__ = [
+    "PANEL_SCHEMA",
+    "FROZEN_PANEL_ROSTER",
+    "OptimizationReadinessPanelCase",
+    "retain_optimization_readiness_panel",
+    "run_optimization_readiness_panel",
+    "validate_optimization_readiness_panel",
+]

--- a/alberta_framework/evaluation/replay_frozen_campaign.py
+++ b/alberta_framework/evaluation/replay_frozen_campaign.py
@@ -1,0 +1,773 @@
+"""Matched, permanently nonpromoting replay/frozen IPMNIST campaign."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import platform
+import stat
+import sys
+from importlib.metadata import version
+from pathlib import Path, PosixPath
+from typing import Any, Final, cast
+
+import jax
+import jax.random as jr
+import numpy as np
+
+from alberta_framework.benchmarks.ipmnist_screening import (
+    _screening_dataset_provenance,
+    _screening_root_key,
+    replay_frozen_development_result_payload,
+    run_screening_config,
+    screening_spec,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import (
+    IPMNISTConfig,
+    build_schedule,
+    init_mlp_params,
+)
+from alberta_framework.evaluation.replay_frozen_ipmnist_nonpromoting import (
+    DEVELOPMENT_SEEDS,
+    PROTOCOL,
+    PROTOCOL_GAPS,
+    expected_resources_for_result,
+    registered_arms,
+    validate_matched_replay_frozen_results,
+    validate_replay_frozen_result,
+)
+
+CAMPAIGN_SCHEMA: Final = "asi.replay-frozen-ipmnist.matched-campaign.v1"
+PLAN_SCHEMA: Final = "asi.replay-frozen-ipmnist.matched-plan.v1"
+_RNG_IMPL: Final = "threefry2x32"
+_MAX_DATASET_BYTES: Final = 256 * 1024 * 1024
+_MAX_RESULT_BYTES: Final = 8 * 1024 * 1024
+_MAX_JSON_NODES: Final = 100_000
+_MAX_JSON_STRING_BYTES: Final = 2 * 1024 * 1024
+_MAX_SOURCE_FILES: Final = 1_024
+_MAX_CAMPAIGN_OBSERVATIONS: Final = 40_000_000
+_MAX_CAMPAIGN_MODEL_QUERIES: Final = 800_000_000
+_MAX_SCHEDULE_BYTES: Final = 128 * 1024 * 1024
+_CANONICAL_X_SHA256: Final = (
+    "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313"
+)
+_CANONICAL_Y_SHA256: Final = (
+    "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a"
+)
+_DATASET_SOURCE: Final = {
+    "provider": "openml",
+    "name": "mnist_784",
+    "version": 1,
+    "row_start": 0,
+    "row_stop_exclusive": 60_000,
+}
+_DATASET_MATERIALIZATION: Final = "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1"
+_SOURCE_ROOT_FILES: Final = ("pyproject.toml", "uv.lock")
+_POLICY: Final = {
+    "development_only": True,
+    "scientific_promotion_allowed": False,
+    "sota_claim_allowed": False,
+    "negative_outcomes_retained": True,
+    "pretrained_ceiling_claim_allowed": False,
+    "hillclimb_gate_evaluated": False,
+}
+FROZEN_CAMPAIGN_CONFIG: Final = IPMNISTConfig(n_tasks=20, task_length=5_000)
+
+
+def _canonical(value: object) -> bytes:
+    encoded = json.dumps(
+        value, allow_nan=False, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("ascii")
+    if len(encoded) > _MAX_RESULT_BYTES:
+        raise ValueError("campaign artifact exceeds its encoded byte ceiling")
+    return encoded
+
+
+def _sha256(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _assert_plain_json(value: object) -> None:
+    seen: set[int] = set()
+    nodes = 0
+    strings = 0
+    stack: list[tuple[object, int]] = [(value, 0)]
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > 14:
+            raise ValueError("campaign artifact exceeds its JSON work bound")
+        if item is None or type(item) is bool:
+            continue
+        if type(item) is int:
+            if not -(1 << 63) <= item <= (1 << 63) - 1:
+                raise ValueError("campaign JSON integer exceeds signed int64")
+            continue
+        if type(item) is float:
+            if not math.isfinite(item):
+                raise ValueError("campaign JSON float must be finite")
+            continue
+        if type(item) is str:
+            try:
+                encoded = item.encode("utf-8")
+            except UnicodeEncodeError as exc:
+                raise ValueError("campaign JSON string must be valid UTF-8") from exc
+            if len(encoded) > 4_096 or b"\x00" in encoded:
+                raise ValueError("campaign JSON string must be bounded UTF-8")
+            strings += len(encoded)
+            if strings > _MAX_JSON_STRING_BYTES:
+                raise ValueError("campaign JSON string budget exceeded")
+            continue
+        if type(item) is list:
+            identity = id(item)
+            if identity in seen or len(item) > 1_024:
+                raise ValueError("campaign JSON contains an alias, cycle, or oversized list")
+            seen.add(identity)
+            stack.extend((child, depth + 1) for child in item)
+            continue
+        if type(item) is dict:
+            identity = id(item)
+            if identity in seen or len(item) > 256:
+                raise ValueError("campaign JSON contains an alias, cycle, or oversized object")
+            seen.add(identity)
+            for key, child in item.items():
+                if type(key) is not str:
+                    raise ValueError("campaign JSON keys must be exact strings")
+                stack.append((key, depth + 1))
+                stack.append((child, depth + 1))
+            continue
+        raise ValueError("campaign artifact must be exact plain JSON")
+
+
+def _preflight_config(config: object) -> IPMNISTConfig:
+    if type(config) is not IPMNISTConfig:
+        raise ValueError("config must be an exact IPMNISTConfig")
+    checked = IPMNISTConfig(**config.to_config())
+    run_count = len(DEVELOPMENT_SEEDS) * len(registered_arms())
+    observations = checked.n_steps * run_count
+    if observations > _MAX_CAMPAIGN_OBSERVATIONS:
+        raise ValueError("campaign observation plan exceeds its bound")
+    total_queries = 0
+    for arm in registered_arms():
+        total_queries += expected_resources_for_result(
+            _receipt_family(arm),
+            checked.n_steps,
+            checked.input_dim,
+            checked.hidden1,
+            checked.hidden2,
+            checked.n_classes,
+        )["model_queries"] * len(DEVELOPMENT_SEEDS)
+    if total_queries > _MAX_CAMPAIGN_MODEL_QUERIES:
+        raise ValueError("campaign model-query plan exceeds its bound")
+    schedule_bytes = (
+        len(DEVELOPMENT_SEEDS)
+        * checked.n_tasks
+        * (checked.input_dim + checked.task_length)
+        * np.dtype(np.int32).itemsize
+    )
+    if schedule_bytes > _MAX_SCHEDULE_BYTES:
+        raise ValueError("campaign schedule plan exceeds its byte bound")
+    return checked
+
+
+def _receipt_family(arm: str) -> str:
+    if arm not in registered_arms():
+        raise ValueError("arm is outside the replay/frozen campaign roster")
+    return "replay" if screening_spec(arm).mechanism == "replay_in_context" else {
+        "randumb_random_features": "randumb",
+        "ranpac_random_projection": "ranpac",
+        "prol_prompt_mechanism_off": "prol",
+        "prol_prompt_proxy": "prol",
+    }[arm]
+
+
+def _validated_arrays(
+    data_x: object, data_y: object, *, config: IPMNISTConfig
+) -> tuple[np.ndarray, np.ndarray]:
+    if type(data_x) is not np.ndarray or data_x.dtype != np.dtype(np.float32):
+        raise ValueError("data_x must be an exact float32 numpy.ndarray")
+    if type(data_y) is not np.ndarray or data_y.dtype != np.dtype(np.int32):
+        raise ValueError("data_y must be an exact int32 numpy.ndarray")
+    if (
+        data_x.ndim != 2
+        or data_x.shape[1] != config.input_dim
+        or data_y.shape != (data_x.shape[0],)
+        or data_x.shape[0] < config.task_length
+    ):
+        raise ValueError("dataset shapes do not match the campaign config")
+    if data_x.nbytes + data_y.nbytes > _MAX_DATASET_BYTES:
+        raise ValueError("dataset exceeds the campaign byte ceiling")
+    x = np.array(data_x, dtype=np.float32, order="C", copy=True)
+    y = np.array(data_y, dtype=np.int32, order="C", copy=True)
+    if not np.all(np.isfinite(x)):
+        raise ValueError("data_x must contain only finite values")
+    if np.any(y < 0) or np.any(y >= config.n_classes):
+        raise ValueError("data_y contains a label outside the configured classes")
+    x.flags.writeable = False
+    y.flags.writeable = False
+    return x, y
+
+
+def _require_frozen_dataset_identity(value: object) -> dict[str, object]:
+    if type(value) is not dict or set(value) != {
+        "schema", "source", "materialization", "x", "y"
+    }:
+        raise ValueError("frozen dataset identity fields drifted")
+    identity = cast(dict[str, object], value)
+    if (
+        identity["schema"] != "alberta.ipmnist_screening.dataset_provenance.v1"
+        or identity["source"] != _DATASET_SOURCE
+        or identity["materialization"] != _DATASET_MATERIALIZATION
+        or identity["x"]
+        != {"dtype": "<f4", "shape": [60_000, 784], "sha256": _CANONICAL_X_SHA256}
+        or identity["y"]
+        != {"dtype": "<i4", "shape": [60_000], "sha256": _CANONICAL_Y_SHA256}
+    ):
+        raise ValueError("dataset does not match the retained canonical identity")
+    return identity
+
+
+def _read_source(path: Path) -> bytes:
+    descriptor = os.open(
+        path, os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or not 0 < before.st_size <= 2 * 1024 * 1024:
+            raise ValueError("campaign source must be a bounded regular file")
+        payload = bytearray()
+        while len(payload) <= before.st_size:
+            chunk = os.read(descriptor, min(64 * 1024, before.st_size + 1 - len(payload)))
+            if not chunk:
+                break
+            payload.extend(chunk)
+        after = os.fstat(descriptor)
+        if len(payload) != before.st_size or (
+            before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns
+        ) != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns):
+            raise ValueError("campaign source changed during its bounded read")
+        return bytes(payload)
+    finally:
+        os.close(descriptor)
+
+
+def _source_inventory(root: Path) -> tuple[str, ...]:
+    package = tuple(
+        path.relative_to(root).as_posix()
+        for path in sorted((root / "alberta_framework").rglob("*.py"))
+    )
+    inventory = (*_SOURCE_ROOT_FILES, *package)
+    if not package or len(inventory) > _MAX_SOURCE_FILES or len(set(inventory)) != len(inventory):
+        raise ValueError("campaign source inventory is invalid")
+    return inventory
+
+
+def _source_identity() -> dict[str, str]:
+    root = Path(__file__).resolve().parents[2]
+    inventory = _source_inventory(root)
+    result = {
+        relative: hashlib.sha256(_read_source(root / relative)).hexdigest()
+        for relative in inventory
+    }
+    if _source_inventory(root) != inventory:
+        raise ValueError("campaign source inventory changed during capture")
+    return result
+
+
+def _runtime_identity() -> dict[str, object]:
+    build = json.dumps(
+        np.__config__.CONFIG, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("ascii")
+    names = (
+        "JAX_PLATFORMS", "JAX_PLATFORM_NAME", "JAX_ENABLE_X64",
+        "JAX_DEFAULT_PRNG_IMPL", "JAX_DEFAULT_MATMUL_PRECISION",
+        "JAX_RANDOM_SEED_OFFSET", "JAX_NUM_CPU_DEVICES", "XLA_FLAGS",
+    )
+    environment: dict[str, str | None] = {}
+    for name in names:
+        value = os.environ.get(name)
+        if value is not None and (len(value.encode("utf-8")) > 4_096 or "\x00" in value):
+            raise ValueError("runtime environment exceeds its text bound")
+        environment[name] = value
+    return {
+        "python": platform.python_version(),
+        "implementation": platform.python_implementation(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "byteorder": sys.byteorder,
+        "numpy": np.__version__,
+        "numpy_build_sha256": hashlib.sha256(build).hexdigest(),
+        "jax": jax.__version__,
+        "jaxlib": version("jaxlib"),
+        "chex": version("chex"),
+        "jaxtyping": version("jaxtyping"),
+        "jax_backend": jax.default_backend(),
+        "jax_devices": [
+            {
+                "platform": device.platform,
+                "device_kind": device.device_kind,
+                "process_index": int(device.process_index),
+                "id": int(device.id),
+            }
+            for device in jax.devices()
+        ],
+        "jax_enable_x64": bool(jax.config.jax_enable_x64),
+        "jax_default_prng_impl": str(jax.config.jax_default_prng_impl),
+        "jax_default_matmul_precision": str(jax.config.jax_default_matmul_precision),
+        "jax_random_seed_offset": int(jax.config.jax_random_seed_offset),
+        "jax_threefry_partitionable": bool(jax.config.jax_threefry_partitionable),
+        "jax_numpy_dtype_promotion": str(jax.config.jax_numpy_dtype_promotion),
+        "jax_numpy_rank_promotion": str(jax.config.jax_numpy_rank_promotion),
+        "environment": environment,
+        "agent_rng_impl": "jax.random.key(seed, impl='threefry2x32')",
+    }
+
+
+def _tree_identity(value: object) -> tuple[str, int]:
+    paths_and_leaves, treedef = jax.tree_util.tree_flatten_with_path(value)
+    digest = hashlib.sha256(str(treedef).encode("utf-8"))
+    total = 0
+    for path, leaf in paths_and_leaves:
+        array = np.asarray(jax.device_get(leaf))
+        if array.dtype.hasobject:
+            raise ValueError("initial state must contain numeric arrays")
+        encoded_path = jax.tree_util.keystr(path).encode("utf-8")
+        digest.update(len(encoded_path).to_bytes(4, "little"))
+        digest.update(encoded_path)
+        digest.update(json.dumps(list(array.shape), separators=(",", ":")).encode("ascii"))
+        digest.update(array.dtype.str.encode("ascii"))
+        digest.update(array.tobytes(order="C"))
+        total += int(array.nbytes)
+    return digest.hexdigest(), total
+
+
+def _key_sha256(key: jax.Array) -> str:
+    return hashlib.sha256(
+        np.asarray(jr.key_data(key), dtype=np.uint32).tobytes(order="C")
+    ).hexdigest()
+
+
+def _seed_identity(seed: int, *, config: IPMNISTConfig, n_train: int) -> dict[str, object]:
+    if type(seed) is not int or seed not in DEVELOPMENT_SEEDS:
+        raise ValueError("seed must belong to the frozen development roster")
+    root = _screening_root_key(seed)
+    key_init, key_schedule, key_noise = jr.split(root, 3)
+    params = init_mlp_params(key_init, config)
+    parameter_sha, parameter_bytes = _tree_identity(params)
+    schedule = build_schedule(key_schedule, config, n_train)
+    schedule_sha, schedule_bytes = _tree_identity(schedule)
+    initial_states: list[dict[str, object]] = []
+    for arm in registered_arms():
+        spec = screening_spec(arm)
+        init_fn, _step_fn = spec.factory(spec.hyperparameters)
+        state_sha, state_bytes = _tree_identity(init_fn(params))
+        persistent_bytes = parameter_bytes + state_bytes
+        expected_persistent_bytes = expected_resources_for_result(
+            _receipt_family(arm),
+            config.n_steps,
+            config.input_dim,
+            config.hidden1,
+            config.hidden2,
+            config.n_classes,
+        )["persistent_bytes"]
+        if persistent_bytes != expected_persistent_bytes:
+            raise RuntimeError("initial state bytes disagree with the resource receipt")
+        initial_states.append(
+            {
+                "arm": arm,
+                "sha256": state_sha,
+                "numeric_bytes": state_bytes,
+                "persistent_numeric_bytes": persistent_bytes,
+            }
+        )
+    result: dict[str, object] = {
+        "seed": seed,
+        "rng_impl": _RNG_IMPL,
+        "root_key_data_sha256": _key_sha256(root),
+        "noise_root_key_data_sha256": _key_sha256(key_noise),
+        "initial_parameters_sha256": parameter_sha,
+        "initial_parameter_numeric_bytes": parameter_bytes,
+        "schedule_sha256": schedule_sha,
+        "schedule_numeric_bytes": schedule_bytes,
+        "initial_states": initial_states,
+    }
+    result["identity_sha256"] = _sha256(result)
+    return result
+
+
+def _plan(config: IPMNISTConfig) -> dict[str, object]:
+    raw_official = cast(dict[str, object], PROTOCOL["official_code"])
+    official = {
+        name: list(value) if type(value) is tuple else value
+        for name, value in raw_official.items()
+    }
+    return {
+        "schema": PLAN_SCHEMA,
+        "comparison_id": "asi.replay-frozen-ipmnist.current-runner.v1",
+        "seeds": list(DEVELOPMENT_SEEDS),
+        "arms": list(registered_arms()),
+        "config": config.to_config(),
+        "run_order": "seed_major_arm_minor",
+        "rng_impl": _RNG_IMPL,
+        "noise_mode": "step",
+        "decision_rule": "inconclusive_only_no_selection",
+        "execution_authorized": False,
+        "seed_history_audit": (
+            "1573001--1573005 had zero exact matches on current main or full git history "
+            "when prospectively frozen on 2026-08-20; retained seeds 0--4 are excluded"
+        ),
+        "selected_ipmnist_configuration": config.matches_selected_publication_configuration,
+        "timing_measured": False,
+        "runner_timing_telemetry_discarded": True,
+        "papers": list(cast(tuple[str, ...], PROTOCOL["papers"])),
+        "official_code": official,
+        "protocol_gaps": list(PROTOCOL_GAPS),
+        "pretrained_feature_extractor_present": False,
+        "external_pretraining_examples": 0,
+        "external_pretraining_updates": 0,
+    }
+
+
+def _normalized_receipt(result: object) -> dict[str, object]:
+    receipt = replay_frozen_development_result_payload(cast(Any, result), outcome="inconclusive")
+    resources = cast(dict[str, object], receipt["resources"])
+    resources["timing_seconds"] = 0.0
+    return validate_replay_frozen_result(receipt)
+
+
+def _resources(
+    runs: list[dict[str, object]],
+    seeds: list[dict[str, object]],
+    data_x: np.ndarray,
+    data_y: np.ndarray,
+) -> dict[str, object]:
+    child = [
+        cast(dict[str, object], cast(dict[str, object], row["receipt"])["resources"])
+        for row in runs
+    ]
+    integer_fields = sorted(
+        name for name, value in child[0].items() if type(value) is int
+    )
+    totals = {
+        name: sum(cast(int, resource[name]) for resource in child)
+        for name in integer_fields
+    }
+    state_bytes = sum(
+        cast(int, state["numeric_bytes"])
+        for seed in seeds
+        for state in cast(list[dict[str, object]], seed["initial_states"])
+    )
+    identity_persistent_bytes = sum(
+        cast(int, state["persistent_numeric_bytes"])
+        for seed in seeds
+        for state in cast(list[dict[str, object]], seed["initial_states"])
+    )
+    if identity_persistent_bytes != totals["persistent_bytes"]:
+        raise RuntimeError("campaign state identities disagree with receipt resource totals")
+    return {
+        "run_count": len(runs),
+        "dataset_snapshot_numeric_bytes": int(data_x.nbytes + data_y.nbytes),
+        "identity_schedule_derivations": len(seeds),
+        "execution_schedule_derivations": len(runs),
+        "schedule_numeric_bytes_across_seed_identities": sum(
+            cast(int, seed["schedule_numeric_bytes"]) for seed in seeds
+        ),
+        "initial_parameter_numeric_bytes_across_seed_identities": sum(
+            cast(int, seed["initial_parameter_numeric_bytes"]) for seed in seeds
+        ),
+        "initial_state_numeric_bytes_across_seed_arm_identities": state_bytes,
+        "persistent_numeric_bytes_across_seed_arm_identities": identity_persistent_bytes,
+        "receipt_integer_totals": totals,
+        "max_arm_persistent_bytes": max(
+            cast(int, resource["persistent_bytes"]) for resource in child
+        ),
+        "timing_seconds": 0.0,
+        "timing_measured": False,
+        "timing_is_telemetry_only": True,
+        "peak_working_set_claimed": False,
+        "preflight_scope": (
+            "bounded observations model queries dataset schedules and persistent numeric state; "
+            "not scalar FLOPs compiler temporaries or a timing comparison"
+        ),
+    }
+
+
+def _build_campaign(
+    data_x: np.ndarray,
+    data_y: np.ndarray,
+    *,
+    config: IPMNISTConfig,
+    dataset_identity: dict[str, object],
+) -> dict[str, object]:
+    source = _source_identity()
+    runtime = _runtime_identity()
+    seeds = [
+        _seed_identity(seed, config=config, n_train=int(data_x.shape[0]))
+        for seed in DEVELOPMENT_SEEDS
+    ]
+    identity_by_seed = {
+        cast(int, item["seed"]): cast(str, item["identity_sha256"]) for item in seeds
+    }
+    runs: list[dict[str, object]] = []
+    for seed in DEVELOPMENT_SEEDS:
+        for arm in registered_arms():
+            result = run_screening_config(
+                data_x,
+                data_y,
+                screening_spec(arm),
+                seed=seed,
+                config=config,
+                noise_mode="step",
+            )
+            runs.append(
+                {
+                    "seed": seed,
+                    "arm": arm,
+                    "seed_identity_sha256": identity_by_seed[seed],
+                    "receipt": _normalized_receipt(result),
+                }
+            )
+    if _source_identity() != source:
+        raise RuntimeError("campaign source changed during execution")
+    if _runtime_identity() != runtime:
+        raise RuntimeError("campaign runtime changed during execution")
+    plan = _plan(config)
+    payload: dict[str, object] = {
+        "schema": CAMPAIGN_SCHEMA,
+        "status": "complete",
+        "plan": plan,
+        "identity": {
+            "dataset": dataset_identity,
+            "plan_sha256": _sha256(plan),
+            "source_sha256": source,
+            "runtime": runtime,
+            "consistency_not_attestation": True,
+        },
+        "policy": dict(_POLICY),
+        "seed_identities": seeds,
+        "runs": runs,
+        "development_outcome": "inconclusive",
+        "resources": _resources(runs, seeds, data_x, data_y),
+    }
+    payload["result_sha256"] = _sha256(payload)
+    return payload
+
+
+def run_replay_frozen_campaign(
+    data_x: object,
+    data_y: object,
+    *,
+    config: IPMNISTConfig = FROZEN_CAMPAIGN_CONFIG,
+) -> dict[str, object]:
+    """Execute the exact forty-shard development roster without selecting a winner."""
+    checked_config = _preflight_config(config)
+    _assert_plain_json(_plan(checked_config))
+    x, y = _validated_arrays(data_x, data_y, config=checked_config)
+    dataset = _require_frozen_dataset_identity(_screening_dataset_provenance(x, y))
+    result = _build_campaign(x, y, config=checked_config, dataset_identity=dataset)
+    _assert_plain_json(result)
+    return result
+
+
+def _static_preflight(value: object) -> dict[str, object]:
+    _assert_plain_json(value)
+    if type(value) is not dict:
+        raise ValueError("campaign must be an exact object")
+    root = cast(dict[str, object], value)
+    expected = {
+        "schema", "status", "plan", "identity", "policy", "seed_identities",
+        "runs", "development_outcome", "resources", "result_sha256",
+    }
+    if set(root) != expected or root["schema"] != CAMPAIGN_SCHEMA or root["status"] != "complete":
+        raise ValueError("campaign schema or fields drifted")
+    if root["policy"] != _POLICY or root["development_outcome"] != "inconclusive":
+        raise ValueError("campaign must remain permanently nonpromoting and inconclusive")
+    if type(root["plan"]) is not dict or type(root["identity"]) is not dict:
+        raise ValueError("campaign plan and identity must be exact objects")
+    if type(root["resources"]) is not dict:
+        raise ValueError("campaign resources must be an exact object")
+    seeds = root["seed_identities"]
+    if type(seeds) is not list or len(seeds) != len(DEVELOPMENT_SEEDS):
+        raise ValueError("campaign seed identities are incomplete")
+    runs = root["runs"]
+    if type(runs) is not list or len(runs) != len(DEVELOPMENT_SEEDS) * len(registered_arms()):
+        raise ValueError("campaign roster is incomplete")
+    roster: list[tuple[object, object]] = []
+    by_seed: dict[int, list[dict[str, object]]] = {seed: [] for seed in DEVELOPMENT_SEEDS}
+    for row in runs:
+        if type(row) is not dict or set(row) != {
+            "seed", "arm", "seed_identity_sha256", "receipt"
+        }:
+            raise ValueError("campaign run row fields drifted")
+        seed, arm = row["seed"], row["arm"]
+        if type(seed) is not int or seed not in DEVELOPMENT_SEEDS:
+            raise ValueError("campaign run seed drifted")
+        if type(arm) is not str or arm not in registered_arms():
+            raise ValueError("campaign run arm drifted")
+        receipt = validate_replay_frozen_result(row["receipt"])
+        resources = cast(dict[str, object], receipt["resources"])
+        if (
+            receipt != row["receipt"]
+            or receipt["seed"] != seed
+            or receipt["arm"] != arm
+            or receipt["outcome"] != "inconclusive"
+            or resources["timing_seconds"] != 0.0
+        ):
+            raise ValueError("campaign run receipt drifted")
+        if type(row["seed_identity_sha256"]) is not str or len(row["seed_identity_sha256"]) != 64:
+            raise ValueError("campaign run seed identity drifted")
+        roster.append((seed, arm))
+        by_seed[seed].append(receipt)
+    expected_roster = [
+        (seed, arm) for seed in DEVELOPMENT_SEEDS for arm in registered_arms()
+    ]
+    if roster != expected_roster:
+        raise ValueError("campaign run roster order drifted")
+    for seed in DEVELOPMENT_SEEDS:
+        validate_matched_replay_frozen_results(by_seed[seed])
+    claimed = root["result_sha256"]
+    unsigned = dict(root)
+    del unsigned["result_sha256"]
+    if type(claimed) is not str or claimed != _sha256(unsigned):
+        raise ValueError("campaign result digest drifted")
+    return root
+
+
+def validate_replay_frozen_campaign(
+    value: object,
+    data_x: object,
+    data_y: object,
+    *,
+    config: IPMNISTConfig = FROZEN_CAMPAIGN_CONFIG,
+) -> dict[str, object]:
+    """Fail closed unless every identity and all forty runs recompute exactly."""
+    root = _static_preflight(value)
+    checked_config = _preflight_config(config)
+    x, y = _validated_arrays(data_x, data_y, config=checked_config)
+    dataset = _require_frozen_dataset_identity(_screening_dataset_provenance(x, y))
+    plan = _plan(checked_config)
+    if root["plan"] != plan:
+        raise ValueError("campaign plan does not match the supplied config")
+    seeds = [
+        _seed_identity(seed, config=checked_config, n_train=int(x.shape[0]))
+        for seed in DEVELOPMENT_SEEDS
+    ]
+    if root["seed_identities"] != seeds:
+        raise ValueError("campaign seed identities do not match the supplied inputs")
+    digests = {cast(int, seed["seed"]): cast(str, seed["identity_sha256"]) for seed in seeds}
+    for row in cast(list[dict[str, object]], root["runs"]):
+        if row["seed_identity_sha256"] != digests[cast(int, row["seed"])]:
+            raise ValueError("campaign run does not bind its exact seed identity")
+    identity = {
+        "dataset": dataset,
+        "plan_sha256": _sha256(plan),
+        "source_sha256": _source_identity(),
+        "runtime": _runtime_identity(),
+        "consistency_not_attestation": True,
+    }
+    if root["identity"] != identity:
+        raise ValueError("campaign identity does not match current inputs/source/runtime")
+    expected = _build_campaign(x, y, config=checked_config, dataset_identity=dataset)
+    if root != expected:
+        raise ValueError("campaign does not recompute exactly from the bound inputs")
+    return expected
+
+
+def _recompute_derived_fields_for_test(value: dict[str, object]) -> None:
+    """Re-sign a hostile test fixture so it reaches strict replay."""
+    unsigned = dict(value)
+    unsigned.pop("result_sha256", None)
+    value["result_sha256"] = _sha256(unsigned)
+
+
+def retain_replay_frozen_campaign(
+    value: object,
+    data_x: object,
+    data_y: object,
+    *,
+    config: IPMNISTConfig = FROZEN_CAMPAIGN_CONFIG,
+    repository_root: Path,
+) -> Path:
+    """Validate and publish one content-named result without replacement."""
+    if type(repository_root) is not PosixPath or not repository_root.is_absolute():
+        raise ValueError("repository_root must be an exact absolute POSIX Path")
+    validated = validate_replay_frozen_campaign(value, data_x, data_y, config=config)
+    encoded = _canonical(validated)
+    digest = cast(str, validated["result_sha256"])
+    segments = ("outputs", "replay_frozen", "development.v1")
+    flags = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0)
+    directory = os.open(repository_root, flags)
+    destination = f"result.{digest}.json"
+    temporary = f".result.{digest}.tmp"
+    published = False
+    try:
+        for segment in segments:
+            try:
+                os.mkdir(segment, mode=0o755, dir_fd=directory)
+            except FileExistsError:
+                pass
+            next_directory = os.open(segment, flags, dir_fd=directory)
+            os.close(directory)
+            directory = next_directory
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o444,
+            dir_fd=directory,
+        )
+        try:
+            offset = 0
+            while offset < len(encoded):
+                written = os.write(descriptor, encoded[offset:])
+                if written <= 0:
+                    raise OSError("campaign retention write made no progress")
+                offset += written
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        try:
+            os.link(
+                temporary,
+                destination,
+                src_dir_fd=directory,
+                dst_dir_fd=directory,
+                follow_symlinks=False,
+            )
+            published = True
+        finally:
+            os.unlink(temporary, dir_fd=directory)
+        descriptor = os.open(
+            destination,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=directory,
+        )
+        try:
+            loaded = bytearray()
+            while len(loaded) <= _MAX_RESULT_BYTES:
+                chunk = os.read(descriptor, min(64 * 1024, _MAX_RESULT_BYTES + 1 - len(loaded)))
+                if not chunk:
+                    break
+                loaded.extend(chunk)
+        finally:
+            os.close(descriptor)
+        if bytes(loaded) != encoded:
+            raise RuntimeError("retained campaign bytes changed during publication")
+        os.fsync(directory)
+    except BaseException:
+        if published:
+            os.unlink(destination, dir_fd=directory)
+        raise
+    finally:
+        os.close(directory)
+    return repository_root.joinpath(*segments, destination)
+
+
+__all__ = [
+    "CAMPAIGN_SCHEMA",
+    "FROZEN_CAMPAIGN_CONFIG",
+    "retain_replay_frozen_campaign",
+    "run_replay_frozen_campaign",
+    "validate_replay_frozen_campaign",
+]

--- a/alberta_framework/evaluation/replay_frozen_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/replay_frozen_ipmnist_nonpromoting.py
@@ -24,6 +24,9 @@ from alberta_framework.benchmarks.replay_frozen_ipmnist import (
 
 RESULT_SCHEMA: Final = "asi.replay-frozen-ipmnist.development-result.v1"
 COMPARISON_ID: Final = "asi.replay-frozen-ipmnist.current-runner.v1"
+# Reserved prospectively on 2026-08-20 after an exact repository and full-history
+# search. In particular, the retained IPMNIST seeds 0--4 are permanently excluded.
+DEVELOPMENT_SEEDS: Final[tuple[int, ...]] = (1573001, 1573002, 1573003, 1573004, 1573005)
 
 PROTOCOL_GAPS: Final = (
     "all arms use ASI's online IPMNIST stream and pre-update metric",
@@ -81,6 +84,12 @@ _ARMS: Final = MappingProxyType(
 _INT32_MAX = (1 << 31) - 1
 _MAX_BYTES = 256 * 1024 * 1024
 _PARAMETER_LEAVES = 6
+
+
+def registered_arms() -> tuple[str, ...]:
+    """Return the exact replay/frozen campaign roster in execution order."""
+
+    return tuple(_ARMS)
 
 
 def _object(value: object, keys: frozenset[str], context: str) -> Mapping[str, Any]:

--- a/docs/research/adalin-matched-development.md
+++ b/docs/research/adalin-matched-development.md
@@ -1,0 +1,35 @@
+# AdaLin matched development campaign
+
+This lane compares the AdaLin ReLU mechanism with its exact alpha-zero,
+mechanism-disabled control over five consumed development seeds. It is permanently
+nonpromoting: its only valid campaign decision is `inconclusive`, including when every
+paired metric favors one arm. No result has been produced by adding this machinery.
+
+Run `asi-adalin-matched-development --help` for the create-only CLI contract. The caller
+must supply one NPZ file with exact `train_inputs`, `train_labels`, `test_inputs`, and
+`test_labels` arrays. The runner binds the complete dataset bytes, current execution
+sources, Python/JAX/dependency/runtime configuration, the explicit Threefry schedule,
+each arm's initial state, and the exact seed-by-arm roster. Its strict validator reruns
+all ten shards and compares every result except wall-clock telemetry. Additive work is
+summed across shards; persistent state is reported as the maximum per-shard allocation.
+
+The bounded profile uses eight tasks, 64 training examples per task, batch size one,
+and a 300-by-150 MLP. These settings intentionally keep a development campaign finite;
+they do not reproduce the paper's 400 tasks, 10,000 examples per task, batch size 16,
+or 100-by-100 MLP. The learner receives neither task identity nor boundary events, while
+the evaluator necessarily uses task boundaries for permutation and test evaluation.
+
+The following gates remain open before any paper-level or scientific conclusion:
+
+- The pinned official repository commit contains only a README and supplies no runnable
+  implementation or experiment configuration to compare against.
+- Official MNIST bytes, sampled indices, permutation seeds, example orders, and exact
+  dataloader behavior are not specified or bound. Caller-supplied data is not a substitute.
+- The paper-scale architecture, batching, 400-task horizon, per-task reporting, and its
+  three final evaluation seeds have not been reproduced.
+- A separate preregistered protocol would require untouched seeds, frozen thresholds and
+  artifacts, independent validation, and explicit promotion authorization. These five
+  development seeds can never be reused for that purpose.
+
+Consistency hashes detect drift but are not authenticated execution attestation. Timing
+remains telemetry-only, and the lane makes no performance, scientific, or SOTA claim.

--- a/docs/research/gradual-transition-family.md
+++ b/docs/research/gradual-transition-family.md
@@ -1,0 +1,72 @@
+# Gradual-transition development family
+
+ASI has two deliberately separate adapters for the transition definitions in
+[Liu and Mou, arXiv:2602.09234v2](https://arxiv.org/abs/2602.09234v2):
+
+- `ipmnist_gradual.py` owns the retained abrupt-versus-input-interpolation
+  single-pass result and its correction chain. Nothing in the new family
+  reinterprets or promotes that record.
+- `ipmnist_gradual_family.py` adds bounded, caller-fed, end-to-end
+  output-interpolation and task-sampling arms beside an abrupt control.
+
+The additive runner uses `K + 1` complete micro-phases at coefficients
+`0/K, ..., K/K`. Every arm receives the same number of training observations,
+updates, and post-phase new-task evaluation observations. Output interpolation
+uses soft-target cross entropy for the paper's old-one-hot to uniform to
+new-one-hot path. That arm requires the old and new task arrays to contain
+identical, row-aligned inputs, and uses each shared row's corresponding old
+and new labels. Task sampling selects exactly
+`floor(alpha * M)` new-task examples and therefore
+`ceil((1 - alpha) * M)` old-task examples from each `M`-example phase. Its
+realized positions and old/new sample orders come from explicit Threefry keys.
+The abrupt control switches from the old paired data to the new paired data at
+the midpoint.
+
+This is not a paper reproduction. In particular, it uses bounded paired
+micro-phases rather than the paper's full datasets and horizon. The output arm
+presents paired new-task inputs while its target moves from the paired old
+label through the uniform distribution to the paired new label. Callers supply
+the arrays; the adapter does not establish an official dataset acquisition
+protocol.
+
+Each result binds both materialized datasets, the realized schedule, the
+current adapter, learner, optimizer-safety, and seed-validation source files,
+Python/JAX/NumPy/backend identity,
+exact counters, and persistent numeric bytes. Validation recomputes the data
+and schedule identities. Timing is telemetry only. The runner does not write
+artifacts, authenticate execution, or authorize promotion. All results are
+development-only, and negative results must be retained if a future reviewed
+campaign chooses to persist them.
+
+## Five-seed matched campaign
+
+`gradual_micro_phase_campaign.py` composes the additive runner into a frozen,
+permanently nonpromoting five-seed development campaign. Its bounded plan uses
+10 transition intervals, 5,000 paired rows, the 784-300-150-10 AdamW network,
+and exactly one row-aligned old/new phase dataset. The resulting 15 arm cells
+consume 825,000 updates and 2,475,000 model queries. This is intentionally not
+the paper's complete dataset or training horizon. Features must be exact
+float32 arrays in `[-1, 1]`; labels must be exact int32 arrays in the configured
+class range.
+
+The campaign binds exact caller-fed dataset bytes (without claiming an official
+acquisition protocol), current relevant sources and lockfile, runtime/JAX
+configuration, explicit Threefry roots, realized schedules, initial parameters
+and learner states, exact counters, and numeric resource receipts. Validation
+reexecutes all five three-arm runs and exact-compares the normalized report;
+unqualified timing is discarded. The writer validates before create-only,
+read-only publication. No output is created automatically.
+
+The paired intervals are descriptive only. Every report records an
+`inconclusive` decision because no selection rule is registered. Before any
+campaign execution, contributors must preregister a selection rule, minimum
+effect, multiplicity and resource gates, obtain compute approval, and choose a
+new append-only destination. Paper-scale replication, official dataset
+acquisition, untouched scientific seeds, downstream recurrence/control tests,
+measured peak RSS, and qualified timing remain separate open gates.
+
+Run the bounded contract checks with:
+
+```bash
+.venv/bin/python -m pytest tests/test_ipmnist_gradual_family.py -q
+```

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -1,0 +1,37 @@
+# BiMU matched development run
+
+This lane is a permanently nonpromoting, bounded comparison between the
+current binary Bayesian learner with its memory disabled and the same learner
+with the frozen 128-example memory window. It is not a reproduction of the
+paper's 1,000-task result and cannot support an external SOTA claim.
+
+The prospective plan is
+`alberta_framework.evaluation.bimu_matched_nonpromoting.FROZEN_BIMU_MATCHED_PLAN`.
+It fixes three consumed development seeds, the two-arm roster, five tasks,
+256 training and 256 test examples, width 32, the exact OpenML-derived dataset
+digest, counters, resource bounds, and comparison scope. The executable and
+strict aggregate validator are in
+`alberta_framework.evaluation.bimu_matched_runner`.
+
+An operator must first reconstruct the exact float32/int32 arrays described by
+the plan and independently verify their digest. Then call
+`run_bimu_matched_development(train_x, train_y, test_x, test_y)` and retain the
+returned result with `write_bimu_matched_result` at a new path. Publication is
+durable and no-replace; supported, rejected, and inconclusive outcomes are all
+retained. Never write into an existing output path.
+
+Before treating a retained record as a development result, require:
+
+- all six seed-arm rows and both arms for every seed;
+- exact dataset, task schedule, initial state, observations, label queries,
+  optimizer-seen count, model queries, and numeric resource matching;
+- `validate_bimu_matched_result` against the same exact input arrays;
+- current source and runtime identity equality; and
+- permanent `development_only`, no-promotion, no-SOTA, and negative-retention
+  policy fields.
+
+The aggregate reports paired late-five and whole-stream online deltas. Timing
+is telemetry only. Consistency hashes are not authenticated execution proof.
+Paper comparison remains closed until the official data order, five-run
+aggregate, paper-scale 1,000-task stream, and other recorded protocol gaps are
+reproduced under a separately reviewed protocol.

--- a/docs/runbooks/optimization-readiness-development.md
+++ b/docs/runbooks/optimization-readiness-development.md
@@ -1,0 +1,81 @@
+# Optimization Readiness development execution
+
+ASI's prospective Optimization Readiness slice is implemented in
+`alberta_framework/evaluation/optimization_readiness_executor.py`. It is a
+permanently nonpromoting execution protocol, not a completed experiment or an
+external-comparator claim.
+
+The current slice deliberately uses one bounded model whose entire computation
+can be independently repeated: float64 linear regression without a bias term,
+mean squared loss, and a supplied 10,000-example task/checkpoint. Before reading
+array elements, it rejects more than 64 parameters, more than 500 million
+preflight work units, or more than 256 MiB of conservatively estimated total
+live memory. A preflight work unit is a safety-only parameter/data-incidence
+proxy used to bound this fixed implementation. It is not a floating-point
+operation count or a resource-comparison metric.
+
+For each execution it derives rather than accepts:
+
+- the full-validation loss and gradient;
+- 128 size-four gradients sampled independently with replacement from an
+  explicit JAX Threefry root;
+- Optimization Readiness strength, reliability, and combined score;
+- parameter and gradient norms;
+- 99% energy ranks for the input representation and exact squared-loss
+  curvature; and
+- mean relative validation-loss reduction across 128 independent SGD rollouts
+  at each frozen horizon: 1, 10, and 100 steps.
+
+The artifact binds package-source hashes, Python/NumPy/JAX/runtime facts, the
+RNG implementation and schedule digest, exact dataset and checkpoint content,
+seed, task/checkpoint labels, and deterministic resource counters. Call
+`validate_optimization_readiness_execution(...)` with the original arrays and
+checkpoint. The validator checks their identities and repeats every schedule,
+gradient, update, diagnostic, metric, and counter; it does not trust artifact
+claims.
+
+Wall time is deliberately recorded as unmeasured (`0.0`, with
+`timing_measured=false`) because this protocol has not qualified a timing
+environment. It is never an acceptance input.
+
+The additive `optimization_readiness_entk.py` adapter closes one important
+model gap without rewriting the linear Appendix C.1 slice. It accepts an exact
+caller-owned float64 two-layer ReLU regression checkpoint, analytically builds
+its empirical neural-tangent feature matrix, measures hidden-representation and
+eNTK 99% energy ranks, and derives the loss gain from one exact full-gradient
+trajectory at each independent 1/10/100-step horizon. Its strict validator binds
+and replays the dataset, checkpoint, current source, NumPy build/runtime,
+metrics, and conservative memory/work receipt. One model query is one example
+evaluation, including a differentiated evaluation only once; the receipt
+charges the initial diagnostic, all 111 optimizer updates, three terminal
+evaluations, and both representation and Jacobian SVDs.
+It bounds observations at 256, input dimension at 32, hidden width at 64,
+parameters at 4,096, SVD work at 100 million units, rollout work at 200 million
+units, and total numeric memory at 256 MiB before copying arrays or invoking
+linear algebra. This is a real
+nonlinear checkpoint diagnostic, but not the paper's deep-network eNTK panel.
+
+No campaign output is checked in. A comparison campaign still needs a
+predeclared, matched panel of real continual-learning model checkpoints and
+tasks, the paper's exact architectures/representations and eNTK baselines,
+retained failures, and fresh execution after its protocol is reviewed and
+frozen. Any such run must write to a new append-only output path and remains
+development-only.
+
+The additive checkpoint-panel adapter in
+`alberta_framework/evaluation/optimization_readiness_panel.py` supplies the
+bounded orchestration and retention boundary for that next step. It requires
+the exact prospective six-case roster with seeds `1568001`--`1568006` and
+distinct dataset/checkpoint content identities (not merely distinct labels),
+runs the exact model-bound executor for every case, derives Spearman association
+for Optimization Readiness, gradient norm, representation rank, curvature rank,
+and parameter norm against the 1/10/100-step future-gain measurements, sums
+logical work receipts, and validates by re-executing the complete roster. Its
+status is only a development association (`supported`, `rejected`, or
+`inconclusive`); it cannot promote a claim. Retention is create-only under
+`outputs/optimization_readiness/development.v1/` and requires the original
+arrays for strict validation. The outcome is supported only when Optimization
+Readiness is positive and strictly exceeds every baseline at all horizons;
+ties and undefined correlations are inconclusive. No result is supplied by the
+repository: binding the six labels to real continual checkpoint bytes,
+independently reviewing the protocol, and retaining all outcomes remain open.

--- a/docs/runbooks/replay-frozen-development.md
+++ b/docs/runbooks/replay-frozen-development.md
@@ -1,0 +1,87 @@
+# Replay/frozen matched development campaign
+
+The maintained adapter is
+`alberta_framework/evaluation/replay_frozen_campaign.py`. Its prospective plan
+reserves fresh seeds `1573001`--`1573005` across the exact eight-arm
+replay/frozen roster; retained IPMNIST seeds `0`--`4` are explicitly excluded.
+Every retained outcome is permanently `inconclusive`: this campaign verifies
+execution and accounting but neither ranks arms nor advances a candidate.
+
+The 40-shard transaction binds the frozen OpenML `mnist_784` v1 bytes, full
+bounded 20-task by 5,000-example IPMNIST configuration, explicit Threefry roots,
+seed schedules and initial
+parameters, every seed/arm initial learner state, current package/config
+sources, runtime/dependencies, exact per-run receipts, and aggregate logical
+resource counters. Validation recomputes every shard. Unqualified runner timing
+is discarded and canonicalized to zero; peak working set and scalar FLOPs are
+not claimed.
+
+## Operator sequence
+
+Do not execute this campaign from pytest. Use a new absolute run root and
+retain every outcome without replacement:
+
+```python
+from pathlib import Path
+
+from alberta_framework.benchmarks.upgd_ipmnist import load_mnist_train
+from alberta_framework.evaluation.replay_frozen_campaign import (
+    FROZEN_CAMPAIGN_CONFIG,
+    retain_replay_frozen_campaign,
+    run_replay_frozen_campaign,
+)
+
+x, y = load_mnist_train()
+config = FROZEN_CAMPAIGN_CONFIG
+result = run_replay_frozen_campaign(x, y, config=config)
+destination = retain_replay_frozen_campaign(
+    result,
+    x,
+    y,
+    config=config,
+    repository_root=Path("/absolute/new/asi-run-root"),
+)
+print(destination)
+```
+
+The writer creates
+`outputs/replay_frozen/development.v1/result.<sha256>.json` below the new root.
+It refuses an existing content name or symlinked namespace. Do not copy a
+result into a pinned output root without a separately reviewed retention
+decision.
+
+## Interpretation boundary
+
+These arms are protocol-extended local controls, not paper reproductions or
+pretrained ceilings. RanDumb uses raw IPMNIST pixels. The RanPAC arm uses a
+random raw-pixel projection and recursive ridge readout, not a pretrained ViT
+and task-end Gram recomputation. The PROL arms are architecture-only
+prompt/affine proxies without the pretrained model and adapt class-incremental
+semantics to task-free streaming. The replay Transformer is represented only
+by bounded label attention and raw-example replay.
+
+All local arms charge zero pretraining examples, updates, queries, and bytes;
+therefore none can support a pretrained-feature ceiling claim. A useful result
+would still need faithful upstream implementations and checkpoints, exact
+pretraining/extractor data and compute provenance, matched current controls,
+development selection criteria, transfer/retention tests, qualified memory and
+timing, and a separately frozen fresh-seed scientific protocol.
+
+## External feature qualification boundary
+
+`asi-pretrained-feature-qualification` prints a static, fail-closed blocker
+manifest for the genuine RanDumb, RanPAC, and PROL qualification lane. It pins
+the official repositories and commits but performs no clone, download, model
+execution, or output write. The accompanying Python provider protocol requires
+a future isolated adapter to receive a caller-bound checkpoint/random
+initialization, preprocessing, evaluation and pretraining dataset identities,
+runtime image and lock identities, and exact pretraining and extraction costs.
+Its bounded smoke receipt is permanently nonpromoting and cannot turn the
+existing proxy arms into ceilings.
+
+The issue remains open. Official artifacts and licenses must be acquired and
+verified; RanPAC/PROL pretraining datasets and costs must be attested; the
+RanDumb random initialization artifact must be reconstructed exactly; isolated
+official adapters need parity traces; and replay plus all three ceiling arms
+must run as one matched IPMNIST campaign with charged storage, queries,
+compute, memory, and qualified timing before any ceiling comparison exists.

--- a/docs/runbooks/telapa-qualification.md
+++ b/docs/runbooks/telapa-qualification.md
@@ -39,6 +39,9 @@ The live adapter uses the repository's action-dependent two-state switching
 environment. A policy is a 2x2 float32 action-value table. At each declared
 phase boundary, a JIT-compatible descriptor summarizes state occupancy, action
 occupancy, reward, and action switching. The descriptor has no learned state.
+Every arm creates an explicit `threefry2x32` root, and the workload identity
+and receipt bind the implementation, root count, derivation count, and root
+bytes; the ambient JAX PRNG default cannot select this protocol's generator.
 Task boundaries are visible only to archive maintenance; task identity is not
 an input to the policy, future tasks are hidden, and prior environments cannot
 be queried.
@@ -46,11 +49,18 @@ be queried.
 The fixed-snapshot and archive-off paths must have identical observation,
 action, reward, initial-policy, and final-policy hashes. Resource receipts
 separately count environment steps, observations, updates, policy/descriptor/
-archive queries, disclosed boundaries, payload bytes, active policy bytes,
-archive or anchor bytes, and environment-state bytes. Timing is absent and
-telemetry-only. Every valid development outcome, including a tie or regression,
-must be retained outside this smoke under a new nonpromoting path; this CLI does
-not write `outputs/`.
+archive-selection and anchor-selection queries, disclosed boundaries, payload
+bytes, active policy bytes, archive or anchor bytes, RNG roots/derivations/root
+bytes, and environment-state bytes. The result reports exact per-arm reward
+sums and means plus descriptive
+per-seed and mean deltas for `diverse_archive` against both requested controls.
+Those comparisons are nonpromoting diagnostics, not a selection or benefit
+claim. Timing is absent and telemetry-only. Every valid development outcome,
+including a tie or regression, can be retained through the create-only Python
+publisher at
+`outputs/telapa/local-comparator.v2/result.<content-sha256>.json`. The CLI itself
+does not write `outputs/`. Publication remains unauthorized until this
+prospective protocol is independently reviewed and merged.
 
 Run the CI-cheap smoke or print only its catalog:
 
@@ -58,6 +68,9 @@ Run the CI-cheap smoke or print only its catalog:
 .venv/bin/asi-telapa-qualification-smoke --steps 32 --phase-length 4
 .venv/bin/asi-telapa-qualification-smoke --catalog
 ```
+
+The CLI emits schema `asi.telapa_qualification_smoke.development.v2`; its
+strict validator rejects the earlier smoke schema rather than upgrading it.
 
 ## Gates still closed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ asi-native-supervised-catalog = "alberta_framework.benchmarks.native_supervised_
 asi-plasticity-diagnostic = "alberta_framework.benchmarks.plasticity_diagnostics:main"
 asi-nap-ipmnist = "alberta_framework.benchmarks.nap_ipmnist:main"
 asi-adamo-diagnostic = "alberta_framework.benchmarks.adamo_diagnostic:main"
+asi-adalin-matched-development = "alberta_framework.evaluation.adalin_matched_runner:main"
 asi-activation-feature-ipmnist = "alberta_framework.benchmarks.activation_feature_ipmnist:main"
 asi-coom-qualification-smoke = "alberta_framework.benchmarks.coom_qualification:main"
 asi-clear-qualification = "alberta_framework.benchmarks.clear_qualification:main"

--- a/tests/test_adalin.py
+++ b/tests/test_adalin.py
@@ -113,6 +113,14 @@ def test_tiny_adalin_runner_is_strict_and_nonpromoting() -> None:
     validate_adalin_result(result)
     assert result["policy"]["scientific_promotion_allowed"] is False
     assert result["resources"]["optimizer_updates"] == 4
+    assert result["resources"]["preupdate_prediction_forward_calls"] == 4
+    assert result["resources"]["differentiated_training_forward_calls"] == 4
+    assert result["resources"]["postupdate_test_forward_calls"] == 2
+    assert result["resources"]["model_forward_calls"] == 10
+    assert result["resources"]["preupdate_prediction_model_queries"] == 8
+    assert result["resources"]["differentiated_training_model_queries"] == 8
+    assert result["resources"]["postupdate_test_model_queries"] == 8
+    assert result["resources"]["model_queries"] == 24
     assert (
         result["provenance"]["initial_state_sha256"] != result["provenance"]["final_state_sha256"]
     )
@@ -203,6 +211,35 @@ def test_validator_rejects_tampering(section: str, field: str, replacement: obje
     tampered[section][field] = replacement
     with pytest.raises(ValueError):
         validate_adalin_result(tampered)
+
+
+def test_validator_binds_current_runtime_dataset_digest_and_exact_gap_roster() -> None:
+    inputs = np.eye(4, dtype=np.float32)
+    labels = np.array([0, 1, 0, 1], dtype=np.int32)
+    config = AdaLinConfig(
+        tasks=1, examples_per_task=4, batch_size=2, hidden_widths=(3, 2), classes=2
+    )
+    result = run_adalin_development(inputs, labels, inputs, labels, config=config, seed=6)
+
+    forged_runtime = copy.deepcopy(result)
+    forged_runtime["provenance"]["runtime"] = ["forged"] * 4
+    with pytest.raises(ValueError, match="current runtime"):
+        validate_adalin_result(forged_runtime)
+
+    forged_digest = copy.deepcopy(result)
+    forged_digest["dataset"]["sha256"] = "0" * 63
+    with pytest.raises(ValueError, match="dataset.sha256"):
+        validate_adalin_result(forged_digest)
+
+    unbounded_metadata = copy.deepcopy(result)
+    unbounded_metadata["dataset"]["test_examples"] = 10_000_001
+    with pytest.raises(ValueError, match="dataset metadata"):
+        validate_adalin_result(unbounded_metadata)
+
+    missing_gap = copy.deepcopy(result)
+    missing_gap["comparison"]["residual_gaps"].pop()
+    with pytest.raises(ValueError, match="comparison"):
+        validate_adalin_result(missing_gap)
 
 
 def test_validator_and_runner_reject_hostile_containers_without_hooks() -> None:

--- a/tests/test_adalin_matched_runner.py
+++ b/tests/test_adalin_matched_runner.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import alberta_framework.evaluation.adalin_matched_runner as runner
+from alberta_framework.benchmarks.adalin import run_adalin_development
+
+
+@pytest.fixture(scope="module")
+def data() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    train_x = np.eye(4, dtype=np.float32)
+    train_y = np.asarray([0, 1, 0, 1], dtype=np.int32)
+    return train_x, train_y, train_x.copy(), train_y.copy()
+
+
+@pytest.fixture(scope="module")
+def base_receipts(
+    data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+) -> dict[bool, dict[str, object]]:
+    config = runner.CAMPAIGN_PROFILES["contract-smoke"]
+    return {
+        enabled: run_adalin_development(
+            *data,
+            config=config,
+            seed=runner.DEVELOPMENT_SEEDS[0],
+            mechanism_enabled=enabled,
+        )
+        for enabled in (False, True)
+    }
+
+
+def _fake_runner(base: dict[bool, dict[str, object]]) -> Any:
+    def fake(
+        train_inputs: np.ndarray,
+        train_labels: np.ndarray,
+        test_inputs: np.ndarray,
+        test_labels: np.ndarray,
+        *,
+        config: object,
+        seed: int,
+        mechanism_enabled: bool,
+    ) -> dict[str, object]:
+        del train_inputs, train_labels, test_inputs, test_labels, config
+        value = copy.deepcopy(base[mechanism_enabled])
+        identity = runner._execution_identity(
+            seed, "contract-smoke", 4, mechanism_enabled=mechanism_enabled
+        )
+        value["seed"] = seed
+        value["provenance"]["schedule_sha256"] = identity["schedule_sha256"]
+        value["provenance"]["initial_state_sha256"] = identity["initial_state_sha256"]
+        return value
+
+    return fake
+
+
+def _resign(value: dict[str, Any]) -> None:
+    unsigned = dict(value)
+    unsigned.pop("result_sha256", None)
+    value["result_sha256"] = hashlib.sha256(runner._canonical(unsigned)).hexdigest()
+
+
+def test_campaign_runs_exact_five_seed_two_arm_roster(
+    monkeypatch: pytest.MonkeyPatch,
+    data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    base_receipts: dict[bool, dict[str, object]],
+) -> None:
+    monkeypatch.setattr(runner, "run_adalin_development", _fake_runner(base_receipts))
+    result = cast(
+        dict[str, Any], runner.run_adalin_matched(*data, profile="contract-smoke")
+    )
+    runner.validate_adalin_matched(result, *data, profile="contract-smoke")
+    assert len(runner.DEVELOPMENT_SEEDS) == 5
+    assert [(row["seed"], row["arm"]) for row in result["rows"]] == [
+        (seed, arm) for seed in runner.DEVELOPMENT_SEEDS for arm in runner.ARMS
+    ]
+    assert result["decision"] == "inconclusive"
+    first = result["rows"][0]["execution_identity"]
+    assert first["prng_implementation"] == "threefry2x32"
+    assert len(first["initial_state_sha256"]) == 64
+    assert len(first["schedule_sha256"]) == 64
+
+
+def test_validator_rejects_self_consistent_metric_forgery_and_decision(
+    monkeypatch: pytest.MonkeyPatch,
+    data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    base_receipts: dict[bool, dict[str, object]],
+) -> None:
+    monkeypatch.setattr(runner, "run_adalin_development", _fake_runner(base_receipts))
+    result = cast(
+        dict[str, Any], runner.run_adalin_matched(*data, profile="contract-smoke")
+    )
+    forged = copy.deepcopy(result)
+    metrics = forged["rows"][1]["result"]["metrics"]
+    metrics["task_preupdate_online_accuracy"][0] = 0.99
+    metrics["asi_whole_stream_preupdate_online_accuracy"] = float(
+        np.mean(metrics["task_preupdate_online_accuracy"])
+    )
+    forged["aggregate"] = runner._aggregate(forged["rows"])
+    _resign(forged)
+    with pytest.raises(ValueError, match="reexecution"):
+        runner.validate_adalin_matched(forged, *data, profile="contract-smoke")
+
+    decided = copy.deepcopy(result)
+    decided["decision"] = "supported"
+    _resign(decided)
+    with pytest.raises(ValueError, match="inconclusive"):
+        runner.validate_adalin_matched(decided, *data, profile="contract-smoke")
+
+    mistyped_policy = copy.deepcopy(result)
+    mistyped_policy["policy"]["development_only"] = 1
+    _resign(mistyped_policy)
+    with pytest.raises(ValueError, match="nonpromoting"):
+        runner.validate_adalin_matched(
+            mistyped_policy, *data, profile="contract-smoke"
+        )
+
+
+def test_validator_rejects_roster_identity_and_resource_forgery(
+    monkeypatch: pytest.MonkeyPatch,
+    data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    base_receipts: dict[bool, dict[str, object]],
+) -> None:
+    monkeypatch.setattr(runner, "run_adalin_development", _fake_runner(base_receipts))
+    result = cast(
+        dict[str, Any], runner.run_adalin_matched(*data, profile="contract-smoke")
+    )
+    missing = copy.deepcopy(result)
+    missing["rows"].pop()
+    _resign(missing)
+    with pytest.raises(ValueError, match="roster"):
+        runner.validate_adalin_matched(missing, *data, profile="contract-smoke")
+
+    forged = copy.deepcopy(result)
+    forged["rows"][0]["execution_identity"]["initial_state_sha256"] = "0" * 64
+    _resign(forged)
+    with pytest.raises(ValueError, match="execution identity"):
+        runner.validate_adalin_matched(forged, *data, profile="contract-smoke")
+
+    forged = copy.deepcopy(result)
+    forged["rows"][0]["result"]["resources"]["model_queries"] += 1
+    _resign(forged)
+    with pytest.raises(ValueError, match="canonical count"):
+        runner.validate_adalin_matched(forged, *data, profile="contract-smoke")
+
+
+def test_writer_is_create_only_and_replays(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    base_receipts: dict[bool, dict[str, object]],
+) -> None:
+    monkeypatch.setattr(runner, "run_adalin_development", _fake_runner(base_receipts))
+    result = runner.run_adalin_matched(*data, profile="contract-smoke")
+    destination = tmp_path / "adalin-matched.json"
+    runner.write_adalin_matched(
+        destination, result, *data, profile="contract-smoke"
+    )
+    retained = json.loads(destination.read_bytes())
+    runner.validate_adalin_matched(retained, *data, profile="contract-smoke")
+    with pytest.raises(FileExistsError):
+        runner.write_adalin_matched(
+            destination, result, *data, profile="contract-smoke"
+        )
+
+
+def test_preflight_rejects_dataset_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    data: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+) -> None:
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("AdaLin row must not execute")
+
+    monkeypatch.setattr(runner, "run_adalin_development", forbidden)
+    with pytest.raises(ValueError, match="float32"):
+        runner.run_adalin_matched(
+            data[0].astype(np.float64), *data[1:], profile="contract-smoke"
+        )
+    assert calls == 0
+
+
+def test_source_identity_covers_current_execution_closure() -> None:
+    assert set(runner._source_identity()) == {
+        "pyproject.toml",
+        "uv.lock",
+        "alberta_framework/benchmarks/adalin.py",
+        "alberta_framework/evaluation/adalin_matched_runner.py",
+    }

--- a/tests/test_bimu_matched_runner.py
+++ b/tests/test_bimu_matched_runner.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import alberta_framework.evaluation.bimu_matched_nonpromoting as bimu_plan
+import alberta_framework.evaluation.bimu_matched_runner as runner
+from alberta_framework.evaluation.bimu_matched_nonpromoting import (
+    BiMUMatchedDevelopmentPlan,
+    _test_plan,
+)
+from alberta_framework.evaluation.bimu_matched_runner import (
+    run_bimu_matched_development,
+    validate_bimu_matched_result,
+    write_bimu_matched_result,
+)
+
+
+def _data() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    features = np.arange(8 * 3, dtype=np.float32).reshape(8, 3) / 32.0
+    labels = np.arange(8, dtype=np.int32) % 2
+    return features[:4], labels[:4], features[4:], labels[4:]
+
+
+def test_matched_runner_executes_complete_two_arm_three_seed_roster() -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    result = cast(dict[str, Any], run_bimu_matched_development(*_data(), plan=plan))
+    validate_bimu_matched_result(result, *_data(), plan=plan)
+
+    assert result["policy"] == {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "sota_claim_allowed": False,
+        "negative_results_retained": True,
+    }
+    rows = result["rows"]
+    assert [(row["seed"], row["arm"]) for row in rows] == [
+        (seed, arm) for seed in plan.seeds for arm in plan.arm_names
+    ]
+    for seed in plan.seeds:
+        control, candidate = [row for row in rows if row["seed"] == seed]
+        assert control["result"]["dataset_sha256"] == candidate["result"]["dataset_sha256"]
+        assert control["result"]["schedule_sha256"] == candidate["result"]["schedule_sha256"]
+        assert (
+            control["result"]["initial_state_sha256"]
+            == candidate["result"]["initial_state_sha256"]
+        )
+        assert control["result"]["counters"] == candidate["result"]["counters"]
+
+
+def test_matched_validator_recomputes_aggregate_and_rejects_axis_forgery() -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    result = cast(dict[str, Any], run_bimu_matched_development(*_data(), plan=plan))
+
+    forged = copy.deepcopy(result)
+    forged["aggregate"]["paired_late_five_delta_mean"] += 0.01
+    with pytest.raises(ValueError, match="aggregate"):
+        validate_bimu_matched_result(forged, *_data(), plan=plan)
+
+    forged = copy.deepcopy(result)
+    forged["rows"][1]["result"]["schedule_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="matched|digest"):
+        validate_bimu_matched_result(forged, *_data(), plan=plan)
+
+
+def test_matched_runner_rejects_dataset_before_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    bad = list(_data())
+    bad[0] = np.asarray(bad[0]).copy()
+    bad[0][0, 0] += 1.0
+
+    called = False
+
+    def fail(*_args: object, **_kwargs: object) -> object:
+        nonlocal called
+        called = True
+        raise AssertionError("execution must not start")
+
+    monkeypatch.setattr(
+        "alberta_framework.evaluation.bimu_matched_runner.run_bimu_development", fail
+    )
+    with pytest.raises(ValueError, match="dataset"):
+        run_bimu_matched_development(*bad, plan=plan)
+    assert called is False
+
+
+def test_matched_result_writer_is_append_only(tmp_path: Path) -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    result = run_bimu_matched_development(*_data(), plan=plan)
+    destination = tmp_path / "matched-result.json"
+
+    write_bimu_matched_result(destination, result, *_data(), plan=plan)
+    retained = json.loads(destination.read_bytes())
+    validate_bimu_matched_result(retained, *_data(), plan=plan)
+    with pytest.raises(FileExistsError):
+        write_bimu_matched_result(destination, result, *_data(), plan=plan)
+
+
+def _resign(result: dict[str, Any], plan: BiMUMatchedDevelopmentPlan) -> None:
+    result["aggregate"] = runner._aggregate(result["rows"], plan)
+    unsigned = dict(result)
+    unsigned.pop("result_sha256")
+    result["result_sha256"] = hashlib.sha256(runner._canonical(unsigned)).hexdigest()
+
+
+def test_validator_derives_frozen_counters_schedule_and_initial_state() -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    original = cast(dict[str, Any], run_bimu_matched_development(*_data(), plan=plan))
+
+    forged = copy.deepcopy(original)
+    for row in forged["rows"]:
+        counters = row["result"]["counters"]
+        counters["label_queries"] = 0
+        counters["optimizer_updates"] = 0
+        counters["model_forward_queries"] = 120
+    _resign(forged, plan)
+    with pytest.raises(ValueError, match="counter|does not reproduce"):
+        validate_bimu_matched_result(forged, *_data(), plan=plan)
+
+    for field in ("schedule_sha256", "initial_state_sha256"):
+        forged = copy.deepcopy(original)
+        for row in forged["rows"]:
+            row["result"][field] = "0" * 64
+        _resign(forged, plan)
+        with pytest.raises(ValueError, match="schedule|initial|does not reproduce"):
+            validate_bimu_matched_result(forged, *_data(), plan=plan)
+
+
+def test_validator_reexecutes_and_rejects_rehashed_forged_metrics() -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    forged = copy.deepcopy(run_bimu_matched_development(*_data(), plan=plan))
+    metrics = forged["rows"][0]["result"]["metrics"]
+    metrics["asi_whole_stream_online_accuracy"] = 0.0
+    metrics["paper_late_five_test_accuracy"] = 0.0
+    metrics["online_correct"] = 0
+    metrics["final_five_test_accuracy"] = [0.0] * 5
+    metrics["final_five_test_correct"] = [0] * 5
+    _resign(forged, plan)
+
+    with pytest.raises(ValueError, match="does not reproduce"):
+        validate_bimu_matched_result(forged, *_data(), plan=plan)
+
+
+def test_source_identity_preserves_audited_dependency_lock() -> None:
+    identity = runner._source_identity()
+    assert "uv.lock" not in identity
+    assert set(identity) == {
+        "alberta_framework/benchmarks/bimu.py",
+        "alberta_framework/evaluation/bimu_matched_nonpromoting.py",
+        "alberta_framework/evaluation/bimu_matched_runner.py",
+    }
+    assert "uv.lock" in bimu_plan._source_identity()

--- a/tests/test_gradual_micro_phase_campaign.py
+++ b/tests/test_gradual_micro_phase_campaign.py
@@ -1,0 +1,168 @@
+"""Five-seed nonpromoting campaign for the additive gradual-transition family."""
+
+from __future__ import annotations
+
+import copy
+import os
+from pathlib import Path
+
+import jax
+import numpy as np
+import pytest
+
+from alberta_framework.evaluation import gradual_micro_phase_campaign as campaign
+
+pytestmark = pytest.mark.integration
+
+
+def _data() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    x = np.asarray([[-1.0, 1.0], [1.0, -1.0]], dtype=np.float32)
+    return x, np.asarray([0, 1], np.int32), x.copy(), np.asarray([1, 0], np.int32)
+
+
+@pytest.fixture(autouse=True)
+def _tiny_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        campaign,
+        "FROZEN_CONFIG",
+        campaign.GradualMicroPhaseConfig(
+            transition_intervals=2,
+            phase_examples=2,
+            input_dim=2,
+            hidden1=2,
+            hidden2=2,
+            n_classes=2,
+        ),
+    )
+
+
+def test_frozen_plan_is_five_seed_three_arm_and_permanently_nonpromoting() -> None:
+    assert campaign.SEEDS == (156901, 156902, 156903, 156904, 156905)
+    assert campaign.ARM_IDS == ("abrupt", "output_interpolation", "task_sampling")
+    assert campaign.DEFAULT_FROZEN_CONFIG == campaign.GradualMicroPhaseConfig(
+        transition_intervals=10,
+        phase_examples=5000,
+        input_dim=784,
+        hidden1=300,
+        hidden2=150,
+        n_classes=10,
+    )
+    assert campaign.POLICY["scientific_promotion_allowed"] is False
+
+
+def test_campaign_executes_exact_roster_and_strictly_replays_all_five_runs() -> None:
+    report = campaign.run_gradual_micro_phase_campaign(*_data())
+    assert campaign.validate_gradual_micro_phase_campaign(report, *_data()) == report
+    assert [(r["seed"], r["arm"]) for r in report["records"]] == [
+        (seed, arm) for seed in campaign.SEEDS for arm in campaign.ARM_IDS
+    ]
+    assert len(report["seed_identities"]) == 5
+    assert report["decision"] == {
+        "status": "inconclusive",
+        "reason": "no_registered_selection_rule",
+        "candidate_selected": None,
+    }
+    assert report["resources"]["runs"] == 5
+    assert report["resources"]["arm_cells"] == 15
+    assert report["resources"]["total_updates"] == 90
+    assert report["resources"]["total_model_queries"] == 270
+    assert report["resources"]["physical_peak_rss_claimed"] is False
+
+
+def test_seed_identity_and_execution_are_ambient_prng_invariant() -> None:
+    with jax.default_prng_impl("threefry2x32"):
+        first = campaign.run_gradual_micro_phase_campaign(*_data())
+    with jax.default_prng_impl("rbg"):
+        second = campaign.run_gradual_micro_phase_campaign(*_data())
+    assert first["seed_identities"] == second["seed_identities"]
+    assert first["records"] == second["records"]
+
+
+def test_validator_rejects_hostile_self_consistent_forgery_before_acceptance() -> None:
+    report = campaign.run_gradual_micro_phase_campaign(*_data())
+    mutations: list[tuple[dict[str, object], str]] = []
+    metric = copy.deepcopy(report)
+    metric["records"][0]["training_loss_sums"][0] += 0.25
+    campaign._resign_for_test(metric)
+    mutations.append((metric, "replay|record"))
+    schedule = copy.deepcopy(report)
+    schedule["seed_identities"][0]["schedule_sha256"] = "sha256:" + "0" * 64
+    campaign._resign_for_test(schedule)
+    mutations.append((schedule, "identity|schedule"))
+    resource = copy.deepcopy(report)
+    resource["resources"]["total_updates"] -= 1
+    campaign._resign_for_test(resource)
+    mutations.append((resource, "resource|replay"))
+    policy = copy.deepcopy(report)
+    policy["policy"]["scientific_promotion_allowed"] = True
+    campaign._resign_for_test(policy)
+    mutations.append((policy, "policy|nonpromoting"))
+    decision = copy.deepcopy(report)
+    decision["decision"]["status"] = "selected"
+    campaign._resign_for_test(decision)
+    mutations.append((decision, "decision|inconclusive"))
+    for forged, message in mutations:
+        with pytest.raises(ValueError, match=message):
+            campaign.validate_gradual_micro_phase_campaign(forged, *_data())
+
+    changed = list(_data())
+    changed[2] = changed[2].copy()
+    changed[2][0, 0] += np.float32(0.25)
+    with pytest.raises(ValueError, match="row-aligned|dataset"):
+        campaign.validate_gradual_micro_phase_campaign(report, *changed)
+
+
+def test_validator_rejects_source_runtime_and_nonexact_json() -> None:
+    report = campaign.run_gradual_micro_phase_campaign(*_data())
+    source = copy.deepcopy(report)
+    source["identity"]["sources"][0]["sha256"] = "0" * 64
+    campaign._resign_for_test(source)
+    with pytest.raises(ValueError, match="source"):
+        campaign.validate_gradual_micro_phase_campaign(source, *_data())
+    runtime = copy.deepcopy(report)
+    runtime["identity"]["runtime"]["python_version"] = "forged"
+    campaign._resign_for_test(runtime)
+    with pytest.raises(ValueError, match="runtime"):
+        campaign.validate_gradual_micro_phase_campaign(runtime, *_data())
+
+    class DictSubclass(dict[str, object]):
+        pass
+
+    with pytest.raises(ValueError, match="exact JSON|exact object"):
+        campaign.validate_gradual_micro_phase_campaign(DictSubclass(report), *_data())
+    cyclic: dict[str, object] = {}
+    cyclic["cycle"] = cyclic
+    with pytest.raises(ValueError, match="alias|cycle|exact JSON"):
+        campaign.validate_gradual_micro_phase_campaign(cyclic, *_data())
+
+    old_x, old_y, new_x, new_y = _data()
+    with pytest.raises(ValueError, match="exactly one row-aligned phase"):
+        campaign.run_gradual_micro_phase_campaign(
+            np.concatenate((old_x, old_x)),
+            np.concatenate((old_y, old_y)),
+            np.concatenate((new_x, new_x)),
+            np.concatenate((new_y, new_y)),
+        )
+    out_of_domain = old_x.copy()
+    out_of_domain[0, 0] = np.float32(-1.25)
+    with pytest.raises(ValueError, match=r"\[-1, 1\]"):
+        campaign.run_gradual_micro_phase_campaign(
+            out_of_domain, old_y, out_of_domain.copy(), new_y
+        )
+
+
+def test_create_only_writer_validates_and_never_overwrites(tmp_path: Path) -> None:
+    report = campaign.run_gradual_micro_phase_campaign(*_data())
+    path = tmp_path / "campaign.json"
+    assert campaign.write_gradual_micro_phase_campaign_new(path, report, *_data()) == path
+    assert os.stat(path).st_mode & 0o222 == 0
+    assert campaign.load_gradual_micro_phase_campaign(path, *_data()) == report
+    with pytest.raises(FileExistsError, match="overwrite|exists"):
+        campaign.write_gradual_micro_phase_campaign_new(path, report, *_data())
+    target = tmp_path / "target"
+    target.write_text("preserve", encoding="utf-8")
+    symlink = tmp_path / "link.json"
+    symlink.symlink_to(target)
+    with pytest.raises(FileExistsError, match="overwrite|exists"):
+        campaign.write_gradual_micro_phase_campaign_new(symlink, report, *_data())
+    assert target.read_text(encoding="utf-8") == "preserve"

--- a/tests/test_ipmnist_gradual_family.py
+++ b/tests/test_ipmnist_gradual_family.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import jax
+import numpy as np
+import pytest
+
+import alberta_framework.benchmarks.ipmnist_gradual_family as gradual_family
+from alberta_framework.benchmarks.ipmnist_gradual_family import (
+    GRADUAL_FAMILY_PROTOCOL,
+    GradualMicroPhaseConfig,
+    run_gradual_micro_phase_family,
+    validate_gradual_micro_phase_result,
+)
+
+
+def _tiny() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, GradualMicroPhaseConfig]:
+    old_x = np.asarray([[-1.0, 1.0], [1.0, -1.0]], dtype=np.float32)
+    old_y = np.asarray([0, 1], dtype=np.int32)
+    new_x = old_x.copy()
+    new_y = np.asarray([1, 0], dtype=np.int32)
+    config = GradualMicroPhaseConfig(
+        transition_intervals=2,
+        phase_examples=2,
+        input_dim=2,
+        hidden1=2,
+        hidden2=2,
+        n_classes=2,
+    )
+    return old_x, old_y, new_x, new_y, config
+
+
+def test_micro_phase_family_runs_all_additive_matched_arms() -> None:
+    old_x, old_y, new_x, new_y, config = _tiny()
+    result = run_gradual_micro_phase_family(
+        old_x,
+        old_y,
+        new_x,
+        new_y,
+        learner_name="adamw_control",
+        seed=1_569_101,
+        config=config,
+    )
+
+    assert result.schema == "asi.ipmnist.gradual-family.micro-phase-result.v1"
+    assert result.arm_names == ("abrupt", "output_interpolation", "task_sampling")
+    assert result.parent_input_result_used is False
+    assert result.development_only is True
+    assert result.scientific_promotion_allowed is False
+    assert result.execution_attestation is False
+    assert result.phase_alpha_numerators == (0, 1, 2)
+    assert result.phase_alpha_denominator == 2
+    np.testing.assert_array_equal(result.task_sampling_new_counts, [0, 1, 2])
+    assert result.training_loss_sums.shape == (3, 3)
+    assert result.new_task_eval_correct_counts.shape == (3, 3)
+    assert result.new_task_eval_loss_sums.shape == (3, 3)
+    assert np.all(np.isfinite(result.training_loss_sums))
+    assert np.all(np.isfinite(result.new_task_eval_loss_sums))
+    assert result.soft_target_updates_per_arm == (0, 6, 0)
+    assert result.observations_per_arm == 12
+    assert result.updates_per_arm == 6
+    assert result.data_steps_per_arm == 12
+    assert result.environment_steps_per_arm == 0
+    assert result.model_queries_per_arm == 18
+    assert len(result.dataset_sha256) == 2
+    assert result.task_sampling_sha256.startswith("sha256:")
+    assert result.source_sha256 == gradual_family._source_identity()
+    assert result.runtime_identity == gradual_family._runtime_identity()
+    assert {
+        "jaxlib_version",
+        "jax_devices",
+        "jax_enable_x64",
+        "jax_default_matmul_precision",
+        "jax_random_seed_offset",
+    }.issubset(dict(result.runtime_identity))
+
+
+def test_micro_phase_family_uses_soft_targets_for_real_gradient_updates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_x, old_y, new_x, new_y, config = _tiny()
+    calls: list[tuple[int, int, float]] = []
+    original = gradual_family.output_interpolation
+
+    def observed(old_label: int, new_label: int, alpha: float, *, n_classes: int):  # type: ignore[no-untyped-def]
+        calls.append((old_label, new_label, alpha))
+        return original(old_label, new_label, alpha, n_classes=n_classes)
+
+    monkeypatch.setattr(gradual_family, "output_interpolation", observed)
+    result = run_gradual_micro_phase_family(
+        old_x,
+        old_y,
+        new_x,
+        new_y,
+        learner_name="adamw_control",
+        seed=7,
+        config=config,
+    )
+    assert len(calls) == config.phase_count * config.phase_examples
+    assert {call[2] for call in calls} == {0.0, 0.5, 1.0}
+    assert result.soft_target_updates_per_arm[1] == 6
+
+
+def test_output_interpolation_uses_row_aligned_inputs_and_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared_x = np.eye(4, dtype=np.float32)
+    old_y = np.asarray([0, 1, 2, 3], dtype=np.int32)
+    new_y = np.asarray([1, 2, 3, 0], dtype=np.int32)
+    config = GradualMicroPhaseConfig(
+        transition_intervals=1,
+        phase_examples=4,
+        input_dim=4,
+        hidden1=2,
+        hidden2=2,
+        n_classes=4,
+    )
+    calls: list[tuple[int, int]] = []
+    original = gradual_family.output_interpolation
+
+    def observed(old_label: int, new_label: int, alpha: float, *, n_classes: int):  # type: ignore[no-untyped-def]
+        calls.append((old_label, new_label))
+        return original(old_label, new_label, alpha, n_classes=n_classes)
+
+    monkeypatch.setattr(gradual_family, "output_interpolation", observed)
+    run_gradual_micro_phase_family(
+        shared_x,
+        old_y,
+        shared_x.copy(),
+        new_y,
+        learner_name="adamw_control",
+        seed=37,
+        config=config,
+    )
+    assert set(calls) == set(zip(old_y.tolist(), new_y.tolist(), strict=True))
+
+
+def test_output_interpolation_rejects_noncorresponding_inputs_before_learner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_x, old_y, new_x, new_y, config = _tiny()
+    new_x[0, 0] += 0.25
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise AssertionError("learner construction must follow correspondence validation")
+
+    monkeypatch.setattr(gradual_family, "_make_adamw_learner", forbidden)
+    with pytest.raises(ValueError, match="row-aligned identical inputs"):
+        run_gradual_micro_phase_family(
+            old_x,
+            old_y,
+            new_x,
+            new_y,
+            learner_name="adamw_control",
+            seed=41,
+            config=config,
+        )
+
+
+def test_micro_phase_family_exact_sampling_counts_include_nondivisible_phases() -> None:
+    old_x = np.arange(15, dtype=np.float32).reshape(5, 3)
+    new_x = old_x.copy()
+    old_y = np.asarray([0, 1, 2, 0, 1], dtype=np.int32)
+    new_y = np.asarray([2, 1, 0, 2, 1], dtype=np.int32)
+    config = GradualMicroPhaseConfig(
+        transition_intervals=3,
+        phase_examples=5,
+        input_dim=3,
+        hidden1=2,
+        hidden2=2,
+        n_classes=3,
+    )
+    result = run_gradual_micro_phase_family(
+        old_x,
+        old_y,
+        new_x,
+        new_y,
+        learner_name="adamw_control",
+        seed=11,
+        config=config,
+    )
+    np.testing.assert_array_equal(result.task_sampling_new_counts, [0, 1, 3, 5])
+
+
+def test_micro_phase_family_is_independent_of_ambient_jax_prng_default() -> None:
+    old_x, old_y, new_x, new_y, config = _tiny()
+    with jax.default_prng_impl("threefry2x32"):
+        first = run_gradual_micro_phase_family(
+            old_x, old_y, new_x, new_y, learner_name="adamw_control", seed=19, config=config
+        )
+    with jax.default_prng_impl("rbg"):
+        second = run_gradual_micro_phase_family(
+            old_x, old_y, new_x, new_y, learner_name="adamw_control", seed=19, config=config
+        )
+    np.testing.assert_array_equal(first.training_loss_sums, second.training_loss_sums)
+    np.testing.assert_array_equal(
+        first.new_task_eval_correct_counts, second.new_task_eval_correct_counts
+    )
+    assert first.task_sampling_sha256 == second.task_sampling_sha256
+
+
+def test_micro_phase_result_snapshots_arrays_and_revalidates_current_identity() -> None:
+    old_x, old_y, new_x, new_y, config = _tiny()
+    result = run_gradual_micro_phase_family(
+        old_x, old_y, new_x, new_y, learner_name="adamw_control", seed=23, config=config
+    )
+    assert not result.training_loss_sums.flags.writeable
+    with pytest.raises(ValueError, match="read-only"):
+        result.training_loss_sums[0, 0] = 1.0
+    with pytest.raises(ValueError, match="current source identity"):
+        replace(result, source_sha256=(("forged.py", "0" * 64),))
+    with pytest.raises(ValueError, match="current runtime identity"):
+        replace(result, runtime_identity=(("python_version", "forged"),))
+
+
+def test_micro_phase_validator_recomputes_dataset_and_realized_schedule() -> None:
+    old_x, old_y, new_x, new_y, config = _tiny()
+    result = run_gradual_micro_phase_family(
+        old_x, old_y, new_x, new_y, learner_name="adamw_control", seed=29, config=config
+    )
+    validate_gradual_micro_phase_result(result, old_x, old_y, new_x, new_y)
+
+    changed = old_x.copy()
+    changed[0, 0] += 0.25
+    with pytest.raises(ValueError, match="dataset content identity"):
+        validate_gradual_micro_phase_result(result, changed, old_y, new_x, new_y)
+
+    forged_schedule = replace(result, task_sampling_sha256="sha256:" + "0" * 64)
+    with pytest.raises(ValueError, match="schedule identity"):
+        validate_gradual_micro_phase_result(forged_schedule, old_x, old_y, new_x, new_y)
+
+
+def test_micro_phase_result_rejects_forged_resource_and_promotion_receipts() -> None:
+    old_x, old_y, new_x, new_y, config = _tiny()
+    result = run_gradual_micro_phase_family(
+        old_x, old_y, new_x, new_y, learner_name="adamw_control", seed=31, config=config
+    )
+    forged_bytes = result.persistent_numeric_bytes.copy()
+    forged_bytes[0] += 4
+    with pytest.raises(ValueError, match="complete exact receipt"):
+        replace(result, persistent_numeric_bytes=forged_bytes)
+    with pytest.raises(ValueError, match="nonpromoting"):
+        replace(result, scientific_promotion_allowed=True)
+
+
+def test_micro_phase_family_preflights_resources_before_learner_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = GradualMicroPhaseConfig(
+        transition_intervals=1,
+        phase_examples=2,
+        input_dim=100_000,
+        hidden1=1_000,
+        hidden2=2,
+        n_classes=2,
+    )
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise AssertionError("learner construction must happen after the resource preflight")
+
+    monkeypatch.setattr(gradual_family, "_make_adamw_learner", forbidden)
+    with pytest.raises(ValueError, match="working set"):
+        run_gradual_micro_phase_family(
+            np.zeros((2, 100_000), dtype=np.float32),
+            np.zeros(2, dtype=np.int32),
+            np.zeros((2, 100_000), dtype=np.float32),
+            np.zeros(2, dtype=np.int32),
+            learner_name="adamw_control",
+            seed=1,
+            config=config,
+        )
+
+
+def test_micro_phase_validator_preflights_working_set_before_materialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_x, old_y, new_x, new_y, _ = _tiny()
+    config = GradualMicroPhaseConfig(
+        transition_intervals=1,
+        phase_examples=1,
+        input_dim=1,
+        hidden1=1,
+        hidden2=1,
+        n_classes=2,
+    )
+    base = run_gradual_micro_phase_family(
+        old_x[:, :1],
+        old_y,
+        old_x[:, :1].copy(),
+        new_y,
+        learner_name="adamw_control",
+        seed=43,
+        config=config,
+    )
+    rows = 12_000_000
+    persistent = rows * 2 * (config.input_dim + 1) * 4
+    persistent += config.phase_count * config.phase_examples * (4 + 4 + 1)
+    persistent += config.parameter_count * 16 + 6 * 5 * 4
+    forged = replace(
+        base,
+        dataset_rows=(rows, rows),
+        dataset_sha256=("sha256:" + "0" * 64, "sha256:" + "1" * 64),
+        task_sampling_sha256="sha256:" + "2" * 64,
+        persistent_numeric_bytes=np.full(3, persistent, dtype=np.int64),
+    )
+    huge_x = np.broadcast_to(np.asarray([0.0], dtype=np.float32), (rows, 1))
+    huge_y = np.broadcast_to(np.asarray([0], dtype=np.int32), (rows,))
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise AssertionError("materialization and scheduling must follow the resource preflight")
+
+    monkeypatch.setattr(gradual_family, "validated_ipmnist_data", forbidden)
+    monkeypatch.setattr(gradual_family, "_realized_schedule", forbidden)
+    with pytest.raises(ValueError, match="working set"):
+        validate_gradual_micro_phase_result(forged, huge_x, huge_y, huge_x, huge_y)
+
+
+def test_gradual_family_protocol_states_paper_and_asi_boundaries() -> None:
+    assert GRADUAL_FAMILY_PROTOCOL["paper_revision"] == "arXiv:2602.09234v2"
+    assert GRADUAL_FAMILY_PROTOCOL["paper_full_dataset_training"] is False
+    assert GRADUAL_FAMILY_PROTOCOL["output_interpolation_loss"] == "soft_target_cross_entropy"
+    assert GRADUAL_FAMILY_PROTOCOL["task_sampling_count"] == "floor(alpha * phase_examples)"
+    assert GRADUAL_FAMILY_PROTOCOL["retained_input_result_recast"] is False
+    assert GRADUAL_FAMILY_PROTOCOL["adaptation_gaps"]
+    assert GRADUAL_FAMILY_PROTOCOL["development_only"] is True
+    assert GRADUAL_FAMILY_PROTOCOL["scientific_promotion_allowed"] is False

--- a/tests/test_optimization_readiness.py
+++ b/tests/test_optimization_readiness.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import numpy as np
 import pytest
 
+import alberta_framework.evaluation.optimization_readiness as optimization_readiness_module
 from alberta_framework.evaluation.optimization_readiness import (
     OPTIMIZATION_READINESS_PROTOCOL,
     energy_rank,
@@ -155,8 +156,84 @@ def test_energy_rank_is_scale_stable() -> None:
     assert energy_rank(np.diag([9e307, 1e307]), threshold=0.99) == 2
 
 
+def test_energy_rank_preflights_logical_work_before_numeric_scan_or_svd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    matrix = np.broadcast_to(np.zeros(1, dtype=np.float64), (10, 1_000_001))
+
+    def forbidden_finite_array(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise AssertionError("numeric scanning must happen after the SVD preflight")
+
+    monkeypatch.setattr(optimization_readiness_module, "_finite_array", forbidden_finite_array)
+    with pytest.raises(ValueError, match="logical work"):
+        energy_rank(matrix)
+
+
+def test_energy_rank_preflights_workspace_before_numeric_scan_or_svd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    matrix = np.broadcast_to(np.zeros(1, dtype=np.float64), (1, 16_000_000))
+
+    def forbidden_finite_array(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise AssertionError("numeric scanning must happen after the SVD preflight")
+
+    monkeypatch.setattr(optimization_readiness_module, "_finite_array", forbidden_finite_array)
+    with pytest.raises(ValueError, match="working set"):
+        energy_rank(matrix)
+
+
+def test_energy_rank_peak_includes_caller_owned_logical_input_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The previous incremental-workspace estimate accepted this shape even
+    # though its 102 MiB int64 input remained live beside conversion/LAPACK
+    # storage.  A broadcast view also proves the charge follows safe logical
+    # metadata rather than assuming the tiny backing allocation is contiguous.
+    matrix = np.broadcast_to(np.zeros(1, dtype=np.int64), (2, 6_391_300))
+
+    def forbidden_finite_array(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise AssertionError("numeric scanning must happen after the total-peak preflight")
+
+    monkeypatch.setattr(optimization_readiness_module, "_finite_array", forbidden_finite_array)
+    with pytest.raises(ValueError, match="working set"):
+        energy_rank(matrix)
+
+
+def test_energy_rank_preflight_accepts_documented_validation_scale() -> None:
+    estimate = optimization_readiness_module._preflight_energy_rank_resources(
+        np.broadcast_to(np.zeros(1, dtype=np.float64), (10_000, 16))
+    )
+    assert estimate.logical_work == 2_560_000
+    assert estimate.peak_working_set_bytes <= 256 * 1024 * 1024
+
+    exact_logical_limit = optimization_readiness_module._preflight_energy_rank_resources(
+        np.broadcast_to(np.zeros(1, dtype=np.float64), (10, 1_000_000))
+    )
+    assert exact_logical_limit.logical_work == 100_000_000
+
+
+def test_energy_rank_workspace_preflight_has_an_exact_adjacent_boundary() -> None:
+    scalar = np.zeros(1, dtype=np.float64)
+    accepted = optimization_readiness_module._preflight_energy_rank_resources(
+        np.broadcast_to(scalar, (1, 8_134_404))
+    )
+    assert accepted.input_bytes == 8 * 8_134_404
+    assert accepted.peak_working_set_bytes == 268_435_452
+    with pytest.raises(ValueError, match="working set"):
+        optimization_readiness_module._preflight_energy_rank_resources(
+            np.broadcast_to(scalar, (1, 8_134_405))
+        )
+
+
 def test_protocol_is_prospective_and_nonpromoting() -> None:
     assert OPTIMIZATION_READINESS_PROTOCOL["paper_revision"] == "arXiv:2605.09044v1"
+    assert (
+        OPTIMIZATION_READINESS_PROTOCOL["energy_rank_working_set_scope"]
+        == "total_live_bytes_including_logical_input"
+    )
     assert OPTIMIZATION_READINESS_PROTOCOL["population_gradient_estimator"] == (
         "full_validation_set_gradient"
     )

--- a/tests/test_optimization_readiness_entk.py
+++ b/tests/test_optimization_readiness_entk.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pytest
+
+import alberta_framework.evaluation.optimization_readiness_entk as entk_module
+from alberta_framework.evaluation.optimization_readiness_entk import (
+    MLPCheckpoint,
+    execute_entk_readiness,
+    validate_entk_readiness,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _case() -> tuple[np.ndarray, np.ndarray, MLPCheckpoint]:
+    x = np.asarray(
+        [[-1.0, 0.5], [-0.5, 1.0], [0.25, -0.75], [0.75, 0.25], [1.0, -0.5]],
+        dtype=np.float64,
+    )
+    y = np.asarray([-0.75, -0.25, 0.5, 0.75, 1.0], dtype=np.float64)
+    checkpoint = MLPCheckpoint(
+        input_weights=np.asarray([[0.4, -0.3, 0.2], [-0.1, 0.5, 0.25]], dtype=np.float64),
+        hidden_bias=np.asarray([0.1, -0.2, 0.05], dtype=np.float64),
+        output_weights=np.asarray([0.6, -0.4, 0.3], dtype=np.float64),
+        output_bias=np.asarray(0.02, dtype=np.float64),
+    )
+    return x, y, checkpoint
+
+
+def test_entk_executor_is_model_bound_and_strictly_replayable() -> None:
+    x, y, checkpoint = _case()
+    result = execute_entk_readiness(
+        x,
+        y,
+        checkpoint,
+        task_id="tiny-regression",
+        checkpoint_id="mlp-0001",
+    )
+    checked = validate_entk_readiness(result, x, y, checkpoint)
+    assert checked == result
+    assert result["protocol"]["rng"] == "none_full_batch_deterministic"
+    assert result["protocol"]["relu_zero_derivative"] == 0.0
+    assert result["policy"] == {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "timing_is_measured": False,
+    }
+    metrics = result["metrics"]
+    assert metrics["representation_energy_rank_99"] >= 1
+    assert metrics["entk_energy_rank_99"] >= 1
+    assert metrics["future_loss_gain"]["1"] > 0.0
+    assert set(metrics["future_loss_gain"]) == {"1", "10", "100"}
+    resources = result["resources"]
+    assert resources["optimizer_updates"] == 111
+    assert resources["model_queries"] == 115 * x.shape[0]
+    parameters = resources["parameter_count"]
+    representation_work = x.shape[0] * 3 * min(x.shape[0], 3)
+    jacobian_work = x.shape[0] * parameters * min(x.shape[0], parameters)
+    assert resources["svd_work_units"] == representation_work + jacobian_work
+    assert resources["rollout_work_units"] == 114 * x.shape[0] * parameters
+    assert resources["jacobian_bytes"] > resources["representation_bytes"]
+
+
+def test_entk_validator_rejects_forgery_and_different_inputs() -> None:
+    x, y, checkpoint = _case()
+    result = execute_entk_readiness(x, y, checkpoint, task_id="task", checkpoint_id="ckpt")
+    forged = copy.deepcopy(result)
+    forged["metrics"]["future_loss_gain"]["100"] = 1.0
+    with pytest.raises(ValueError, match="replay"):
+        validate_entk_readiness(forged, x, y, checkpoint)
+    changed = x.copy()
+    changed[0, 0] += 0.01
+    with pytest.raises(ValueError, match="dataset identity"):
+        validate_entk_readiness(result, changed, y, checkpoint)
+
+    integer_as_float = copy.deepcopy(result)
+    integer_as_float["resources"]["hidden_units"] = 3.0
+    with pytest.raises(ValueError, match="replay"):
+        validate_entk_readiness(integer_as_float, x, y, checkpoint)
+
+    boolean_as_integer = copy.deepcopy(result)
+    boolean_as_integer["policy"]["development_only"] = 1
+    with pytest.raises(ValueError, match="replay"):
+        validate_entk_readiness(boolean_as_integer, x, y, checkpoint)
+
+
+def test_entk_preflight_rejects_before_expensive_linear_algebra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    x, y, checkpoint = _case()
+    oversized_x = np.zeros((257, 2), dtype=np.float64)
+    oversized_y = np.zeros(257, dtype=np.float64)
+    monkeypatch.setattr(np.linalg, "svd", lambda *args, **kwargs: pytest.fail("SVD reached"))
+    with pytest.raises(ValueError, match="observations"):
+        execute_entk_readiness(
+            oversized_x,
+            oversized_y,
+            checkpoint,
+            task_id="task",
+            checkpoint_id="ckpt",
+        )
+
+    # At this shape each SVD is individually below the limit, but their complete
+    # logical work exceeds it. Rejection must still precede snapshots and LAPACK.
+    combined_x = np.zeros((214, 32), dtype=np.float64)
+    combined_y = np.zeros(214, dtype=np.float64)
+    combined_checkpoint = MLPCheckpoint(
+        input_weights=np.zeros((32, 64), dtype=np.float64),
+        hidden_bias=np.zeros(64, dtype=np.float64),
+        output_weights=np.zeros(64, dtype=np.float64),
+        output_bias=np.asarray(0.0, dtype=np.float64),
+    )
+    monkeypatch.setattr(entk_module, "_snapshot", lambda value: pytest.fail("snapshot reached"))
+    with pytest.raises(ValueError, match="SVD work"):
+        execute_entk_readiness(
+            combined_x,
+            combined_y,
+            combined_checkpoint,
+            task_id="task",
+            checkpoint_id="ckpt",
+        )
+
+
+def test_entk_rejects_checkpoint_and_json_type_confusion() -> None:
+    x, y, checkpoint = _case()
+    bad = MLPCheckpoint(
+        input_weights=checkpoint.input_weights,
+        hidden_bias=checkpoint.hidden_bias,
+        output_weights=checkpoint.output_weights,
+        output_bias=np.asarray([0.0], dtype=np.float64),
+    )
+    with pytest.raises(ValueError, match="output_bias"):
+        execute_entk_readiness(x, y, bad, task_id="task", checkpoint_id="ckpt")
+
+    result = execute_entk_readiness(x, y, checkpoint, task_id="task", checkpoint_id="ckpt")
+    forged = copy.deepcopy(result)
+    forged["resources"]["observations"] = True
+    with pytest.raises(ValueError):
+        validate_entk_readiness(forged, x, y, checkpoint)
+
+
+def test_entk_energy_rank_is_scale_stable_and_uses_zero_relu_derivative() -> None:
+    assert entk_module._energy_rank(np.diag([9e307, 1e307])) == 2
+    assert entk_module._energy_rank(np.full((2, 2), 9e307, dtype=np.float64)) == 1
+
+    x = np.asarray([[1.0], [-1.0]], dtype=np.float64)
+    y = np.zeros(2, dtype=np.float64)
+    checkpoint = MLPCheckpoint(
+        input_weights=np.asarray([[1.0]], dtype=np.float64),
+        hidden_bias=np.asarray([-1.0], dtype=np.float64),
+        output_weights=np.asarray([4.0], dtype=np.float64),
+        output_bias=np.asarray(0.0, dtype=np.float64),
+    )
+    result = execute_entk_readiness(x, y, checkpoint, task_id="zeros", checkpoint_id="zero")
+    # Both preactivations are non-positive. Only the scalar output bias has a derivative.
+    assert result["metrics"]["entk_feature_frobenius_norm"] == pytest.approx(np.sqrt(2.0))
+
+
+def test_entk_json_preflight_bounds_keys_and_integers() -> None:
+    with pytest.raises(ValueError, match="string-byte bound"):
+        entk_module._json_preflight({"x" * (entk_module.MAX_JSON_STRING_BYTES + 1): None})
+    with pytest.raises(ValueError, match="bounded integer"):
+        entk_module._json_preflight(1 << 64)

--- a/tests/test_optimization_readiness_executor.py
+++ b/tests/test_optimization_readiness_executor.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import tracemalloc
+from copy import deepcopy
+
+import numpy as np
+import pytest
+
+import alberta_framework.evaluation.optimization_readiness_executor as executor_module
+from alberta_framework.evaluation.optimization_readiness_executor import (
+    FROZEN_EXECUTION_PLAN,
+    execute_optimization_readiness,
+    validate_optimization_readiness_execution,
+)
+
+
+def _task() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    axis = np.linspace(-1.0, 1.0, 10_000, dtype=np.float64)
+    inputs = np.column_stack((axis, np.square(axis)))
+    labels = 0.75 * axis - 0.25 * np.square(axis)
+    checkpoint = np.asarray([0.1, -0.1], dtype=np.float64)
+    return inputs, labels, checkpoint
+
+
+def test_executor_derives_and_validator_recomputes_real_measurements() -> None:
+    inputs, labels, checkpoint = _task()
+    artifact = execute_optimization_readiness(
+        validation_inputs=inputs,
+        validation_labels=labels,
+        checkpoint_parameters=checkpoint,
+        seed=7,
+        task_id="bounded-linear-regression-v1",
+        checkpoint_id="checkpoint-0007",
+    )
+
+    assert artifact["schema"] == "asi.optimization-readiness.execution.v1"
+    assert artifact["policy"] == {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "timing_is_telemetry_only": True,
+    }
+    plan = artifact["plan"]
+    assert isinstance(plan, dict)
+    assert plan == {**FROZEN_EXECUTION_PLAN, "future_gain_steps": [1, 10, 100]}
+    metrics = artifact["metrics"]
+    assert isinstance(metrics, dict)
+    assert set(metrics["future_relative_loss_reduction"]) == {"1", "10", "100"}
+    assert metrics["optimization_readiness"] > 0.0
+    assert metrics["gradient_norm"] > 0.0
+    assert metrics["parameter_norm"] > 0.0
+    assert 0 <= metrics["representation_energy_rank_0_99"] <= 2
+    assert 0 <= metrics["curvature_energy_rank_0_99"] <= 2
+    sampling = artifact["sampling"]
+    assert isinstance(sampling, dict)
+    assert sampling["diagnostic_gradient_count"] == 128
+    assert validate_optimization_readiness_execution(
+        artifact,
+        validation_inputs=inputs,
+        validation_labels=labels,
+        checkpoint_parameters=checkpoint,
+    ) == artifact
+
+
+def test_validator_rejects_forged_metric_by_reexecution() -> None:
+    inputs, labels, checkpoint = _task()
+    artifact = execute_optimization_readiness(
+        validation_inputs=inputs,
+        validation_labels=labels,
+        checkpoint_parameters=checkpoint,
+        seed=11,
+        task_id="task",
+        checkpoint_id="checkpoint",
+    )
+    forged = deepcopy(artifact)
+    metrics = forged["metrics"]
+    assert isinstance(metrics, dict)
+    metrics["gradient_norm"] = float(metrics["gradient_norm"]) + 1.0
+    with pytest.raises(ValueError, match="recompute exactly"):
+        validate_optimization_readiness_execution(
+            forged,
+            validation_inputs=inputs,
+            validation_labels=labels,
+            checkpoint_parameters=checkpoint,
+        )
+
+
+@pytest.mark.parametrize("section", ["sampling", "resources", "identity"])
+def test_validator_rejects_forged_execution_provenance(section: str) -> None:
+    inputs, labels, checkpoint = _task()
+    artifact = execute_optimization_readiness(
+        validation_inputs=inputs,
+        validation_labels=labels,
+        checkpoint_parameters=checkpoint,
+        seed=17,
+        task_id="task",
+        checkpoint_id="checkpoint",
+    )
+    forged = deepcopy(artifact)
+    nested = forged[section]
+    assert isinstance(nested, dict)
+    if section == "sampling":
+        nested["schedule_sha256"] = "0" * 64
+    elif section == "resources":
+        nested["model_queries"] = int(nested["model_queries"]) - 1
+    else:
+        runtime = nested["runtime"]
+        assert isinstance(runtime, dict)
+        runtime["numpy"] = "forged"
+    with pytest.raises(ValueError, match="recompute exactly"):
+        validate_optimization_readiness_execution(
+            forged,
+            validation_inputs=inputs,
+            validation_labels=labels,
+            checkpoint_parameters=checkpoint,
+        )
+
+
+def test_validator_rejects_hostile_nested_runtime_types_without_hooks() -> None:
+    class HostileDict(dict[str, object]):
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("hostile iteration hook must not run")
+
+    inputs, labels, checkpoint = _task()
+    artifact = execute_optimization_readiness(
+        validation_inputs=inputs,
+        validation_labels=labels,
+        checkpoint_parameters=checkpoint,
+        seed=3,
+        task_id="task",
+        checkpoint_id="checkpoint",
+    )
+    artifact["metrics"] = HostileDict()
+    with pytest.raises(ValueError, match="plain JSON"):
+        validate_optimization_readiness_execution(
+            artifact,
+            validation_inputs=inputs,
+            validation_labels=labels,
+            checkpoint_parameters=checkpoint,
+        )
+
+
+def test_validator_rejects_shallow_schema_before_recursive_payload_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden(value: object) -> None:
+        del value
+        raise AssertionError("recursive validation must follow the exact shallow schema")
+
+    monkeypatch.setattr(executor_module, "_assert_plain_json", forbidden)
+    with pytest.raises(ValueError, match="unexpected keys"):
+        validate_optimization_readiness_execution(
+            {"unexpected": []},
+            validation_inputs=None,
+            validation_labels=None,
+            checkpoint_parameters=None,
+        )
+
+
+def test_validator_rejects_huge_exact_root_before_materializing_keys() -> None:
+    payload = {f"unexpected-{index}": None for index in range(10_000)}
+    tracemalloc.start()
+    try:
+        with pytest.raises(ValueError, match="unexpected keys"):
+            validate_optimization_readiness_execution(
+                payload,
+                validation_inputs=None,
+                validation_labels=None,
+                checkpoint_parameters=None,
+            )
+        _, peak_bytes = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    assert peak_bytes < 64 * 1024
+
+
+def test_plain_json_gate_rejects_aliased_or_cyclic_containers() -> None:
+    child: list[object] = [0]
+    with pytest.raises(ValueError, match="aliased or cyclic"):
+        executor_module._assert_plain_json([child, child])
+
+    cycle: list[object] = []
+    cycle.append(cycle)
+    with pytest.raises(ValueError, match="aliased or cyclic"):
+        executor_module._assert_plain_json(cycle)
+
+
+def test_plain_json_gate_has_aggregate_node_and_string_byte_limits() -> None:
+    too_many_nodes = [list(range(512)) for _ in range(9)]
+    with pytest.raises(ValueError, match="aggregate node limit"):
+        executor_module._assert_plain_json(too_many_nodes)
+
+    too_many_string_bytes = [str(index) + ("x" * 4_090) for index in range(17)]
+    with pytest.raises(ValueError, match="aggregate string-byte limit"):
+        executor_module._assert_plain_json(too_many_string_bytes)
+
+
+def test_validator_rejects_different_dataset_and_checkpoint() -> None:
+    inputs, labels, checkpoint = _task()
+    artifact = execute_optimization_readiness(
+        validation_inputs=inputs,
+        validation_labels=labels,
+        checkpoint_parameters=checkpoint,
+        seed=1,
+        task_id="task",
+        checkpoint_id="checkpoint",
+    )
+    changed_labels = labels.copy()
+    changed_labels[0] += 1.0
+    with pytest.raises(ValueError, match="dataset identity"):
+        validate_optimization_readiness_execution(
+            artifact,
+            validation_inputs=inputs,
+            validation_labels=changed_labels,
+            checkpoint_parameters=checkpoint,
+        )
+    changed_checkpoint = checkpoint.copy()
+    changed_checkpoint[0] += 1.0
+    with pytest.raises(ValueError, match="checkpoint identity"):
+        validate_optimization_readiness_execution(
+            artifact,
+            validation_inputs=inputs,
+            validation_labels=labels,
+            checkpoint_parameters=changed_checkpoint,
+        )
+
+
+def test_executor_preflights_metadata_before_numeric_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    inputs = np.broadcast_to(np.zeros(1, dtype=np.float64), (10_000, 65))
+    labels = np.zeros(10_000, dtype=np.float64)
+    checkpoint = np.zeros(65, dtype=np.float64)
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise AssertionError("hashing/scanning must follow metadata preflight")
+
+    monkeypatch.setattr("hashlib.sha256", forbidden)
+    with pytest.raises(ValueError, match="parameter count"):
+        execute_optimization_readiness(
+            validation_inputs=inputs,
+            validation_labels=labels,
+            checkpoint_parameters=checkpoint,
+            seed=0,
+            task_id="task",
+            checkpoint_id="checkpoint",
+        )
+
+
+def test_executor_peak_charges_both_terminal_loss_arrays_and_scopes_work_units() -> None:
+    inputs, labels, checkpoint = _task()
+    _, _, _, resources = executor_module._preflight_arrays(inputs, labels, checkpoint)
+    parameters = checkpoint.size
+    total_updates = 128 * (1 + 10 + 100)
+    schedule_items = 4 * (128 + total_updates)
+    caller_bytes = inputs.nbytes + labels.nbytes + checkpoint.nbytes
+    nonterminal_bytes = (
+        caller_bytes
+        + caller_bytes
+        + schedule_items * np.dtype(np.int64).itemsize
+        + schedule_items * np.dtype(np.int32).itemsize
+        + 128 * parameters * np.dtype(np.float64).itemsize
+        + 128
+        * (parameters + 2 * 4 * parameters + 2 * 4)
+        * np.dtype(np.float64).itemsize
+        + (parameters * parameters + 2 * parameters) * np.dtype(np.float64).itemsize
+        + inputs.nbytes
+        + 17 * inputs.size
+        + 24 * parameters * parameters
+        + 8 * max(inputs.shape)
+        + 96 * parameters
+    )
+    terminal_loss_bytes = 2 * 10_000 * 128 * np.dtype(np.float64).itemsize
+    assert resources["peak_working_set_bytes"] == nonterminal_bytes + terminal_loss_bytes
+    assert "scalar_work" not in resources
+    assert resources["preflight_work_units"] > 0
+
+
+@pytest.mark.parametrize("field", ["validation_inputs", "validation_labels", "checkpoint"])
+def test_executor_rejects_nonfinite_model_inputs(field: str) -> None:
+    inputs, labels, checkpoint = _task()
+    if field == "validation_inputs":
+        inputs[0, 0] = np.nan
+    elif field == "validation_labels":
+        labels[0] = np.inf
+    else:
+        checkpoint[0] = np.nan
+    with pytest.raises(ValueError, match="finite"):
+        execute_optimization_readiness(
+            validation_inputs=inputs,
+            validation_labels=labels,
+            checkpoint_parameters=checkpoint,
+            seed=0,
+            task_id="task",
+            checkpoint_id="checkpoint",
+        )

--- a/tests/test_optimization_readiness_panel.py
+++ b/tests/test_optimization_readiness_panel.py
@@ -1,0 +1,191 @@
+import copy
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import alberta_framework.evaluation.optimization_readiness_panel as panel_module
+from alberta_framework.evaluation.optimization_readiness_panel import (
+    PANEL_SCHEMA,
+    OptimizationReadinessPanelCase,
+    retain_optimization_readiness_panel,
+    run_optimization_readiness_panel,
+    validate_optimization_readiness_panel,
+)
+
+
+def _cases() -> tuple[OptimizationReadinessPanelCase, ...]:
+    x = np.linspace(-1.0, 1.0, 20_000, dtype=np.float64).reshape(10_000, 2)
+    y = 0.75 * x[:, 0] - 0.25 * x[:, 1]
+    return tuple(
+        OptimizationReadinessPanelCase(
+            task_id="ipmnist-linear-readiness",
+            checkpoint_id=f"checkpoint-{index}",
+            seed=1_568_001 + index,
+            validation_inputs=x,
+            validation_labels=y,
+            checkpoint_parameters=np.asarray(parameters, dtype=np.float64),
+        )
+        for index, parameters in enumerate(
+            ([0.0, 0.0], [0.1, -0.05], [0.25, -0.1], [0.4, -0.15], [0.6, -0.2], [0.7, -0.23])
+        )
+    )
+
+
+def test_panel_executes_unique_real_cases_and_derives_association() -> None:
+    cases = _cases()
+    result = run_optimization_readiness_panel(cases)
+
+    assert result["schema"] == PANEL_SCHEMA
+    assert result["policy"] == {
+        "development_only": True,
+        "negative_outcomes_retained": True,
+        "scientific_promotion_allowed": False,
+    }
+    assert result["case_count"] == 6
+    assert [case["execution"]["checkpoint_id"] for case in result["cases"]] == [
+        "checkpoint-0",
+        "checkpoint-1",
+        "checkpoint-2",
+        "checkpoint-3",
+        "checkpoint-4",
+        "checkpoint-5",
+    ]
+    correlations = result["association"]["spearman_by_predictor_and_gain_horizon"]
+    assert set(correlations) == {
+        "optimization_readiness",
+        "gradient_norm",
+        "representation_rank",
+        "curvature_rank",
+        "parameter_norm",
+    }
+    assert all(set(values) == {"1", "10", "100"} for values in correlations.values())
+    assert result["association"]["status"] in {"supported", "rejected", "inconclusive"}
+    assert result["resources"]["case_executions"] == 6
+    assert result["resources"]["aggregate_caller_bytes"] == sum(
+        case.validation_inputs.nbytes
+        + case.validation_labels.nbytes
+        + case.checkpoint_parameters.nbytes
+        for case in cases
+    )
+    assert result["resources"]["model_queries"] == sum(
+        case["resources"]["model_queries"] for case in result["cases"]
+    )
+    assert result["resources"]["data_steps"] == sum(
+        case["resources"]["data_steps"] for case in result["cases"]
+    )
+    assert result["resources"]["environment_steps"] == 0
+    validate_optimization_readiness_panel(result, cases=cases)
+
+
+def test_panel_validator_reexecutes_and_rejects_forged_outcome() -> None:
+    cases = _cases()
+    result = run_optimization_readiness_panel(cases)
+    forged = copy.deepcopy(result)
+    forged["association"]["status"] = "supported"
+    if result["association"]["status"] == "supported":
+        forged["association"]["status"] = "rejected"
+    with pytest.raises(ValueError, match="recompute"):
+        validate_optimization_readiness_panel(forged, cases=cases)
+
+
+def test_panel_requires_exact_unique_case_roster_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cases = list(_cases())
+    cases[1] = OptimizationReadinessPanelCase(
+        task_id=cases[0].task_id,
+        checkpoint_id=cases[0].checkpoint_id,
+        seed=999,
+        validation_inputs=cases[1].validation_inputs,
+        validation_labels=cases[1].validation_labels,
+        checkpoint_parameters=cases[1].checkpoint_parameters,
+    )
+
+    def forbidden(**_kwargs: object) -> dict[str, object]:
+        raise AssertionError("duplicate roster must reject before execution")
+
+    monkeypatch.setattr(
+        "alberta_framework.evaluation.optimization_readiness_panel.execute_optimization_readiness",
+        forbidden,
+    )
+    with pytest.raises(ValueError, match="unique"):
+        run_optimization_readiness_panel(tuple(cases))
+
+
+def test_panel_rejects_renamed_duplicate_dataset_checkpoint_content() -> None:
+    cases = list(_cases())
+    original = cases[0]
+    registered = cases[1]
+    cases[1] = OptimizationReadinessPanelCase(
+        task_id=registered.task_id,
+        checkpoint_id=registered.checkpoint_id,
+        seed=registered.seed,
+        validation_inputs=original.validation_inputs.copy(),
+        validation_labels=original.validation_labels.copy(),
+        checkpoint_parameters=original.checkpoint_parameters.copy(),
+    )
+
+    with pytest.raises(ValueError, match="content identities must be unique"):
+        run_optimization_readiness_panel(tuple(cases))
+
+
+def test_panel_retention_is_create_only_and_round_trips(tmp_path: Path) -> None:
+    cases = _cases()
+    result = run_optimization_readiness_panel(cases)
+    destination = retain_optimization_readiness_panel(
+        result,
+        cases=cases,
+        repository_root=tmp_path,
+    )
+    loaded = json.loads(destination.read_bytes())
+    validate_optimization_readiness_panel(loaded, cases=cases)
+    assert destination.parent == tmp_path / "outputs/optimization_readiness/development.v1"
+    with pytest.raises(FileExistsError):
+        retain_optimization_readiness_panel(
+            result,
+            cases=cases,
+            repository_root=tmp_path,
+        )
+
+
+def test_panel_retention_rejects_namespace_symlink(tmp_path: Path) -> None:
+    cases = _cases()
+    result = run_optimization_readiness_panel(cases)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (tmp_path / "outputs").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(OSError):
+        retain_optimization_readiness_panel(result, cases=cases, repository_root=tmp_path)
+    assert not (outside / "optimization_readiness").exists()
+
+
+def test_panel_retention_removes_partial_bytes_after_write_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cases = _cases()
+    result = run_optimization_readiness_panel(cases)
+
+    def failed_write(_descriptor: int, _payload: bytes) -> int:
+        raise OSError("injected write failure")
+
+    monkeypatch.setattr(panel_module.os, "write", failed_write)
+    with pytest.raises(OSError, match="injected"):
+        retain_optimization_readiness_panel(result, cases=cases, repository_root=tmp_path)
+    destination = tmp_path / "outputs/optimization_readiness/development.v1"
+    assert list(destination.iterdir()) == []
+
+
+def test_panel_rejects_oversized_case_roster_before_array_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = _cases()[0]
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("oversized roster must reject before array access")
+
+    monkeypatch.setattr(np, "asarray", forbidden)
+    with pytest.raises(ValueError, match="six-case"):
+        run_optimization_readiness_panel((case,) * 17)

--- a/tests/test_replay_frozen_campaign.py
+++ b/tests/test_replay_frozen_campaign.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import jax
+import numpy as np
+import pytest
+
+import alberta_framework.evaluation.replay_frozen_campaign as campaign_module
+from alberta_framework.benchmarks.ipmnist_screening import ScreeningRunResult
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+from alberta_framework.evaluation.replay_frozen_campaign import (
+    CAMPAIGN_SCHEMA,
+    retain_replay_frozen_campaign,
+    run_replay_frozen_campaign,
+    validate_replay_frozen_campaign,
+)
+from alberta_framework.evaluation.replay_frozen_ipmnist_nonpromoting import (
+    DEVELOPMENT_SEEDS,
+    PROTOCOL_GAPS,
+    registered_arms,
+)
+
+
+def _config() -> IPMNISTConfig:
+    return IPMNISTConfig(
+        n_tasks=1,
+        task_length=4,
+        input_dim=4,
+        hidden1=3,
+        hidden2=2,
+        n_classes=2,
+    )
+
+
+def _data() -> tuple[np.ndarray, np.ndarray]:
+    return (
+        np.asarray(
+            [
+                [-1.0, -0.5, 0.5, 1.0],
+                [1.0, 0.5, -0.5, -1.0],
+                [-0.5, 1.0, -1.0, 0.5],
+                [0.5, -1.0, 1.0, -0.5],
+            ],
+            dtype=np.float32,
+        ),
+        np.asarray([0, 1, 0, 1], dtype=np.int32),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _bounded_campaign_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    def dataset_provenance(_x: object, _y: object) -> dict[str, object]:
+        return {
+            "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
+            "source": {
+                "provider": "openml",
+                "name": "mnist_784",
+                "version": 1,
+                "row_start": 0,
+                "row_stop_exclusive": 60_000,
+            },
+            "materialization": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
+            "x": {
+                "dtype": "<f4",
+                "shape": [60_000, 784],
+                "sha256": campaign_module._CANONICAL_X_SHA256,
+            },
+            "y": {
+                "dtype": "<i4",
+                "shape": [60_000],
+                "sha256": campaign_module._CANONICAL_Y_SHA256,
+            },
+        }
+
+    def execute(
+        _data_x: object,
+        _data_y: object,
+        spec: Any,
+        seed: int,
+        config: IPMNISTConfig,
+        **_kwargs: object,
+    ) -> ScreeningRunResult:
+        arm_index = registered_arms().index(spec.name)
+        seed_index = DEVELOPMENT_SEEDS.index(seed)
+        accuracy = 0.3 + 0.01 * arm_index + 0.001 * seed_index
+        return ScreeningRunResult(
+            config_name=spec.name,
+            base_learner=spec.base_learner,
+            hyperparameters=dict(spec.hyperparameters),
+            seed=seed,
+            config=config,
+            per_task_accuracy=np.full(config.n_tasks, accuracy, dtype=np.float64),
+            per_task_loss=np.full(config.n_tasks, 1.0 - accuracy, dtype=np.float64),
+            per_task_plasticity=np.full(config.n_tasks, 0.1, dtype=np.float64),
+            wall_clock_seconds=99.0,
+            noise_mode="step",
+            noise_pool_steps=None,
+        )
+
+    monkeypatch.setattr(campaign_module, "_screening_dataset_provenance", dataset_provenance)
+    monkeypatch.setattr(campaign_module, "run_screening_config", execute)
+
+
+@pytest.fixture
+def completed_campaign() -> dict[str, Any]:
+    x, y = _data()
+    return cast(dict[str, Any], run_replay_frozen_campaign(x, y, config=_config()))
+
+
+def test_campaign_has_exact_roster_inconclusive_policy_and_limitations(
+    completed_campaign: dict[str, Any],
+) -> None:
+    assert completed_campaign["schema"] == CAMPAIGN_SCHEMA
+    assert completed_campaign["status"] == "complete"
+    assert completed_campaign["development_outcome"] == "inconclusive"
+    assert completed_campaign["policy"] == {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "sota_claim_allowed": False,
+        "negative_outcomes_retained": True,
+        "pretrained_ceiling_claim_allowed": False,
+        "hillclimb_gate_evaluated": False,
+    }
+    assert completed_campaign["plan"]["decision_rule"] == "inconclusive_only_no_selection"
+    assert [(row["seed"], row["arm"]) for row in completed_campaign["runs"]] == [
+        (seed, arm) for seed in DEVELOPMENT_SEEDS for arm in registered_arms()
+    ]
+    assert completed_campaign["plan"]["protocol_gaps"] == list(PROTOCOL_GAPS)
+    assert completed_campaign["resources"]["run_count"] == 40
+    assert completed_campaign["resources"]["timing_measured"] is False
+    assert completed_campaign["resources"]["peak_working_set_claimed"] is False
+    assert completed_campaign["resources"][
+        "persistent_numeric_bytes_across_seed_arm_identities"
+    ] == completed_campaign["resources"]["receipt_integer_totals"]["persistent_bytes"]
+    assert all(row["receipt"]["outcome"] == "inconclusive" for row in completed_campaign["runs"])
+
+
+def test_source_identity_covers_every_package_source_and_lock(
+    completed_campaign: dict[str, Any],
+) -> None:
+    source = completed_campaign["identity"]["source_sha256"]
+    root = Path(campaign_module.__file__).resolve().parents[2]
+    assert set(source) == {
+        "pyproject.toml",
+        "uv.lock",
+        *(path.relative_to(root).as_posix() for path in (root / "alberta_framework").rglob("*.py")),
+    }
+
+
+def test_seed_identity_binds_explicit_threefry_schedule_parameters_and_all_states(
+    completed_campaign: dict[str, Any],
+) -> None:
+    identities = completed_campaign["seed_identities"]
+    assert [item["seed"] for item in identities] == list(DEVELOPMENT_SEEDS)
+    assert all(item["rng_impl"] == "threefry2x32" for item in identities)
+    assert all(
+        [state["arm"] for state in item["initial_states"]] == list(registered_arms())
+        for item in identities
+    )
+    by_seed = {item["seed"]: item["identity_sha256"] for item in identities}
+    assert all(
+        row["seed_identity_sha256"] == by_seed[row["seed"]]
+        for row in completed_campaign["runs"]
+    )
+
+
+def test_seed_identity_is_ambient_prng_invariant() -> None:
+    prior = str(jax.config.jax_default_prng_impl)
+    try:
+        jax.config.update("jax_default_prng_impl", "threefry2x32")
+        seed = DEVELOPMENT_SEEDS[0]
+        threefry = campaign_module._seed_identity(seed, config=_config(), n_train=4)
+        jax.config.update("jax_default_prng_impl", "rbg")
+        rbg = campaign_module._seed_identity(seed, config=_config(), n_train=4)
+    finally:
+        jax.config.update("jax_default_prng_impl", prior)
+    assert threefry == rbg
+
+
+def test_strict_validator_replays_every_shard(
+    completed_campaign: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    execute = campaign_module.run_screening_config
+    calls: list[tuple[int, str]] = []
+
+    def counting_execute(
+        data_x: object,
+        data_y: object,
+        spec: Any,
+        seed: int,
+        config: IPMNISTConfig,
+        **kwargs: object,
+    ) -> ScreeningRunResult:
+        calls.append((seed, spec.name))
+        return execute(data_x, data_y, spec, seed, config, **kwargs)
+
+    monkeypatch.setattr(campaign_module, "run_screening_config", counting_execute)
+    x, y = _data()
+    validate_replay_frozen_campaign(completed_campaign, x, y, config=_config())
+    assert calls == [(seed, arm) for seed in DEVELOPMENT_SEEDS for arm in registered_arms()]
+
+
+def test_hostile_self_consistent_metric_forgery_requires_replay(
+    completed_campaign: dict[str, Any],
+) -> None:
+    forged = copy.deepcopy(completed_campaign)
+    forged["runs"][0]["receipt"]["metrics"]["mean_online_accuracy"] += 0.01
+    campaign_module._recompute_derived_fields_for_test(forged)
+    x, y = _data()
+    with pytest.raises(ValueError, match="recompute exactly"):
+        validate_replay_frozen_campaign(forged, x, y, config=_config())
+
+
+def test_identity_forgery_rejects_before_shard_execution(
+    completed_campaign: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    forged = copy.deepcopy(completed_campaign)
+    forged["seed_identities"][0]["initial_states"][0]["sha256"] = "0" * 64
+    campaign_module._recompute_derived_fields_for_test(forged)
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("identity forgery must reject before execution")
+
+    monkeypatch.setattr(campaign_module, "run_screening_config", forbidden)
+    x, y = _data()
+    with pytest.raises(ValueError, match="seed identities"):
+        validate_replay_frozen_campaign(forged, x, y, config=_config())
+
+
+def test_default_plan_is_bounded_without_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = campaign_module._preflight_config(campaign_module.FROZEN_CAMPAIGN_CONFIG)
+    assert config.n_steps * len(DEVELOPMENT_SEEDS) * len(registered_arms()) == 4_000_000
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("preflight must not execute")
+
+    monkeypatch.setattr(campaign_module, "run_screening_config", forbidden)
+    assert campaign_module._plan(config)["selected_ipmnist_configuration"] is False
+    assert campaign_module._plan(config)["execution_authorized"] is False
+
+
+def test_input_preflight_rejects_before_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    x, y = _data()
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("execution must not start")
+
+    monkeypatch.setattr(campaign_module, "run_screening_config", forbidden)
+    with pytest.raises(ValueError, match="float32"):
+        run_replay_frozen_campaign(x.astype(np.float64), y, config=_config())
+
+
+@pytest.mark.parametrize("field", ("source", "materialization", "x", "y"))
+def test_frozen_dataset_gate_rejects_self_consistent_identity_drift(field: str) -> None:
+    identity = {
+        "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
+        "source": dict(campaign_module._DATASET_SOURCE),
+        "materialization": campaign_module._DATASET_MATERIALIZATION,
+        "x": {
+            "dtype": "<f4",
+            "shape": [60_000, 784],
+            "sha256": campaign_module._CANONICAL_X_SHA256,
+        },
+        "y": {
+            "dtype": "<i4",
+            "shape": [60_000],
+            "sha256": campaign_module._CANONICAL_Y_SHA256,
+        },
+    }
+    if field == "source":
+        identity[field]["version"] = 2
+    elif field == "materialization":
+        identity[field] = "forged"
+    else:
+        identity[field]["sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="canonical identity"):
+        campaign_module._require_frozen_dataset_identity(identity)
+
+
+def test_source_drift_across_execution_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    x, y = _data()
+    calls = 0
+
+    def drifting_source() -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        return {"source": ("a" if calls == 1 else "b") * 64}
+
+    monkeypatch.setattr(campaign_module, "_source_identity", drifting_source)
+    with pytest.raises(RuntimeError, match="source changed"):
+        run_replay_frozen_campaign(x, y, config=_config())
+
+
+def test_oversized_json_rejects_before_execution(
+    completed_campaign: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hostile = copy.deepcopy(completed_campaign)
+    hostile["runs"] = [None] * 100_001
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("hostile payload must reject before execution")
+
+    monkeypatch.setattr(campaign_module, "run_screening_config", forbidden)
+    x, y = _data()
+    with pytest.raises(ValueError, match="JSON|roster"):
+        validate_replay_frozen_campaign(hostile, x, y, config=_config())
+
+
+def test_create_only_retention_roundtrip(
+    completed_campaign: dict[str, Any], tmp_path: Path
+) -> None:
+    x, y = _data()
+    destination = retain_replay_frozen_campaign(
+        completed_campaign,
+        x,
+        y,
+        config=_config(),
+        repository_root=tmp_path,
+    )
+    assert destination.name == f"result.{completed_campaign['result_sha256']}.json"
+    validate_replay_frozen_campaign(json.loads(destination.read_bytes()), x, y, config=_config())
+    with pytest.raises(FileExistsError):
+        retain_replay_frozen_campaign(
+            completed_campaign,
+            x,
+            y,
+            config=_config(),
+            repository_root=tmp_path,
+        )
+
+
+def test_retention_rejects_namespace_symlink(
+    completed_campaign: dict[str, Any], tmp_path: Path
+) -> None:
+    x, y = _data()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (tmp_path / "outputs").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(OSError):
+        retain_replay_frozen_campaign(
+            completed_campaign,
+            x,
+            y,
+            config=_config(),
+            repository_root=tmp_path,
+        )
+    assert list(outside.iterdir()) == []

--- a/tests/test_replay_frozen_ipmnist.py
+++ b/tests/test_replay_frozen_ipmnist.py
@@ -109,6 +109,25 @@ def test_charged_mechanism_off_is_end_to_end_exact_adam_control() -> None:
     assert np.array_equal(off.per_task_plasticity, control.per_task_plasticity)
 
 
+def test_replay_frozen_runner_is_ambient_prng_invariant() -> None:
+    x, y = _data()
+    prior = str(jax.config.jax_default_prng_impl)
+    try:
+        jax.config.update("jax_default_prng_impl", "threefry2x32")
+        threefry = run_screening_config(
+            x, y, screening_spec("ranpac_random_projection"), 3, _config()
+        )
+        jax.config.update("jax_default_prng_impl", "rbg")
+        rbg = run_screening_config(
+            x, y, screening_spec("ranpac_random_projection"), 3, _config()
+        )
+    finally:
+        jax.config.update("jax_default_prng_impl", prior)
+    assert np.array_equal(threefry.per_task_accuracy, rbg.per_task_accuracy)
+    assert np.array_equal(threefry.per_task_loss, rbg.per_task_loss)
+    assert np.array_equal(threefry.per_task_plasticity, rbg.per_task_plasticity)
+
+
 def test_active_replay_step_has_eager_jit_parity() -> None:
     params = init_mlp_params(jr.key(4), _config())
     spec = screening_spec("replay_context_full")

--- a/tests/test_telapa_qualification.py
+++ b/tests/test_telapa_qualification.py
@@ -4,6 +4,7 @@ import copy
 import json
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 
 import jax
@@ -19,6 +20,8 @@ from alberta_framework.benchmarks.telapa_qualification import (
     TeLAPASmokeConfig,
     _bounded_json_bytes,
     _preflight_json_tree,
+    load_local_comparator_result,
+    retain_local_comparator_result,
     rollout_latent_descriptor,
     run_smoke,
     validate_result,
@@ -42,6 +45,28 @@ def test_catalog_fails_closed_without_immutable_anonymous_revision() -> None:
         TeLAPACatalogEntry(immutable_external_source_established=True).validate()
 
 
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    (
+        ("paper_mechanism", "forged mechanism"),
+        ("development_adapter", "forged adapter"),
+        ("protocol_differences", ("a", "b", "c", "d", "e")),
+        ("paper_metrics", ("a", "b", "c", "d")),
+        ("timing_policy", "decision_axis"),
+        ("promotion_policy", "promoting"),
+    ),
+)
+def test_catalog_rejects_same_shape_semantic_forgery(field: str, replacement: object) -> None:
+    values = {field: replacement}
+    with pytest.raises(ValueError, match="catalog|protocol|timing|nonpromoting"):
+        TeLAPACatalogEntry(**values).validate()  # type: ignore[arg-type]
+
+    payload = _result()
+    payload["catalog"][field] = list(replacement) if type(replacement) is tuple else replacement
+    with pytest.raises(ValueError, match="catalog|protocol|timing|nonpromoting"):
+        validate_result(payload)
+
+
 def test_latent_descriptor_is_jittable_and_deterministic() -> None:
     observations = jnp.asarray([[1.0, 0.0], [0.0, 1.0]], dtype=jnp.float32)
     actions = jnp.asarray([1, 0], dtype=jnp.int32)
@@ -55,17 +80,47 @@ def test_latent_descriptor_is_jittable_and_deterministic() -> None:
 def test_current_life_adapter_is_deterministic_for_the_same_key() -> None:
     first = SwitchingPolicyLifeAdapter(phase_length=2, learning_rate=0.125)
     second = SwitchingPolicyLifeAdapter(phase_length=2, learning_rate=0.125)
-    first_state, first_policy = first.init(jax.random.key(7))
-    second_state, second_policy = second.init(jax.random.key(7))
-    first_step = first.step(first_state, first_policy, key=jax.random.key(8))
-    second_step = second.step(second_state, second_policy, key=jax.random.key(8))
+    first_state, first_policy = first.init(jax.random.key(7, impl="threefry2x32"))
+    second_state, second_policy = second.init(jax.random.key(7, impl="threefry2x32"))
+    first_step = first.step(
+        first_state, first_policy, key=jax.random.key(8, impl="threefry2x32")
+    )
+    second_step = second.step(
+        second_state, second_policy, key=jax.random.key(8, impl="threefry2x32")
+    )
     np.testing.assert_array_equal(first_step[1], second_step[1])
     np.testing.assert_array_equal(first_step[2], second_step[2])
     assert first_step[3:] == second_step[3:]
     with pytest.raises(ValueError, match="learning_rate"):
         SwitchingPolicyLifeAdapter(phase_length=2, learning_rate=True)
     with pytest.raises(ValueError, match="live policy"):
-        first.step(first_state, np.ones((2, 2), dtype=np.float64), key=jax.random.key(8))
+        first.step(
+            first_state,
+            np.ones((2, 2), dtype=np.float64),
+            key=jax.random.key(8, impl="threefry2x32"),
+        )
+
+
+def test_smoke_explicitly_requests_threefry_rng_roots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_key = telapa.jr.key
+    requested_impls: list[object] = []
+
+    def recording_key(seed: int, *, impl: object = None) -> jax.Array:
+        requested_impls.append(impl)
+        return original_key(seed, impl=impl)
+
+    monkeypatch.setattr(telapa.jr, "key", recording_key)
+    result = _result()
+    assert requested_impls
+    assert set(requested_impls) == {"threefry2x32"}
+    for record in result["records"]:
+        receipt = record["resource_receipt"]
+        assert receipt["rng_implementation"] == "threefry2x32"
+        assert receipt["rng_root_keys"] == 1
+        assert receipt["rng_key_derivations"] == 10
+        assert receipt["rng_root_persistent_bytes"] == 8
 
 
 def test_end_to_end_matrix_has_exact_mechanism_off_parity() -> None:
@@ -94,6 +149,30 @@ def test_end_to_end_matrix_has_exact_mechanism_off_parity() -> None:
     assert off["resource_receipt"]["archive_persistent_bytes"] == 0
 
 
+def test_result_contains_replayed_descriptive_archive_vs_control_comparisons() -> None:
+    result = _result()
+    comparisons = result["comparisons"]
+    assert [comparison["control"] for comparison in comparisons] == [
+        "one_model",
+        "fixed_snapshot",
+    ]
+    for comparison in comparisons:
+        assert comparison["candidate"] == "diverse_archive"
+        assert comparison["metric"] == "mean_reward"
+        assert comparison["classification"] == "descriptive_nonpromoting"
+        assert comparison["direction"] in {"improved", "tied", "regressed"}
+        assert [item["seed"] for item in comparison["per_seed"]] == list(
+            TeLAPASmokeConfig().seeds
+        )
+        expected_delta = sum(item["delta"] for item in comparison["per_seed"]) / 3
+        assert comparison["mean_delta"] == expected_delta
+
+    records = result["records"]
+    for record in records:
+        assert 0.0 <= record["mean_reward"] <= 1.0
+        assert record["reward_sum"] == record["mean_reward"] * 8
+
+
 def test_matched_axes_and_exact_resource_receipts() -> None:
     result = _result()
     for record in result["records"]:
@@ -112,6 +191,13 @@ def test_matched_axes_and_exact_resource_receipts() -> None:
         assert receipt["timing"] is None
         assert receipt["timing_policy"] == "telemetry_only"
 
+        if record["arm"] == "mechanism_off":
+            assert receipt["archive_selection_entry_queries"] == 0
+            assert receipt["anchor_selection_queries"] == 4
+        else:
+            assert receipt["archive_selection_entry_queries"] >= 4
+            assert receipt["anchor_selection_queries"] == 0
+
 
 @pytest.mark.parametrize(
     ("path", "replacement", "match"),
@@ -125,6 +211,9 @@ def test_matched_axes_and_exact_resource_receipts() -> None:
         (("records", 0, "resource_receipt", "environment_steps"), True, "resource receipt"),
         (("records", 0, "resource_receipt", "timing"), 0.1, "timing"),
         (("records", 0, "action_sha256"), "x" * 64, "SHA-256"),
+        (("records", 0, "mean_reward"), 0.12345, "replay|comparison"),
+        (("comparisons", 0, "mean_delta"), 0.5, "comparison"),
+        (("comparisons", 0, "direction"), "forged", "comparison"),
     ),
 )
 def test_validator_rejects_hostile_or_promoting_payloads(
@@ -145,7 +234,9 @@ def test_validator_rejects_nan_extra_fields_and_unbounded_config() -> None:
     with pytest.raises(ValueError, match="fields"):
         validate_result(payload)
     payload = _result()
-    payload["records"][0]["resource_receipt"]["archive_entry_queries"] = float("nan")
+    payload["records"][0]["resource_receipt"][
+        "archive_selection_entry_queries"
+    ] = float("nan")
     with pytest.raises(ValueError, match="finite JSON"):
         validate_result(payload)
     with pytest.raises(ValueError, match=r"\[1, 64\]"):
@@ -156,19 +247,34 @@ def test_validator_rejects_nan_extra_fields_and_unbounded_config() -> None:
         TeLAPASmokeConfig(steps=64, phase_length=1, archive_byte_budget=128)
 
 
-def test_validator_replays_archive_accounting_and_binds_current_identity() -> None:
-    payload = copy.deepcopy(_result())
-    payload["records"][0]["resource_receipt"]["archive_entry_queries"] += 1
+def test_validator_rejects_forged_archive_totals_and_current_identity() -> None:
+    forged = copy.deepcopy(_result())
+    receipt = forged["records"][0]["resource_receipt"]
+    receipt["archive_selection_entry_queries"] = 2**62
+    receipt["archive_persistent_bytes"] = 2**62
+    forged["records"][0]["archive_entry_count"] = 0
+    with pytest.raises(ValueError, match="budget|replay"):
+        validate_result(forged)
+
+    forged = copy.deepcopy(_result())
+    forged["records"][0]["resource_receipt"]["archive_persistent_bytes"] += 1
     with pytest.raises(ValueError, match="replay"):
-        validate_result(payload)
-    payload = copy.deepcopy(_result())
-    payload["records"][0]["archive_entry_count"] = 0
+        validate_result(forged)
+
+    forged = copy.deepcopy(_result())
+    forged["records"][3]["resource_receipt"]["archive_selection_entry_queries"] = 1
+    with pytest.raises(ValueError, match="mechanism-off"):
+        validate_result(forged)
+
+    forged = copy.deepcopy(_result())
+    forged["records"][0]["reward_sha256"] = "0" * 64
     with pytest.raises(ValueError, match="replay"):
-        validate_result(payload)
-    payload = copy.deepcopy(_result())
-    payload["identity"]["lane_source_sha256"] = "0" * 64
-    with pytest.raises(ValueError, match="identity"):
-        validate_result(payload)
+        validate_result(forged)
+
+    forged = copy.deepcopy(_result())
+    forged["identity"]["lane_source_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="current tree/runtime"):
+        validate_result(forged)
 
 
 def test_json_preflight_rejects_deep_cyclic_and_oversized_trees_before_serialization(
@@ -238,3 +344,13 @@ def test_cli_executes_and_round_trips() -> None:
     payload = json.loads(process.stdout)
     validate_result(payload)
     assert len(payload["records"]) == 12
+
+
+def test_local_comparator_retention_is_content_named_and_create_only(tmp_path: Path) -> None:
+    result = _result()
+    destination = retain_local_comparator_result(result, repository_root=tmp_path)
+    assert destination.name.startswith("result.")
+    assert destination.parent == tmp_path / "outputs/telapa/local-comparator.v2"
+    assert load_local_comparator_result(destination) == result
+    with pytest.raises(FileExistsError):
+        retain_local_comparator_result(result, repository_root=tmp_path)


### PR DESCRIPTION
## Summary

Rebuilds the useful owned slices from closed PR #2086 on current main without its unrelated integration wave or hardening regressions.

- #1569: exact abrupt/output-interpolation/task-sampling micro-phase adapter and strict matched campaign
- #1570: BiMU matched runner with exact seed/arm non-timing reexecution; preserves the audited `uv.lock` binding
- #1571: AdaLin mechanism-off/candidate runner, strict replay, append-only report, and lock-bound provenance
- #1573: replay/frozen eight-arm campaign with fresh seeds `1573001`–`1573005`, explicit Threefry roots, strict replay, and bounded 20×5,000 plan
- #1568: bounded linear and eNTK executors plus a frozen six-case panel comparing Optimization Readiness against gradient norm, representation rank, curvature rank, and parameter norm at horizons 1/10/100
- #1586: hardened bounded TeLAPA-inspired local comparator plus content-addressed create-only retention; immutable upstream/paper parity remains explicitly blocked

## Integrity corrections relative to #2086

- rejects rehashed BiMU metric forgeries by reexecuting every exact seed/arm transaction
- does not delete current-main exact-string hostile guards in `ipmnist_screening.py`
- does not reuse retained IPMNIST seeds 0–4
- records prospective seed-history statements and `execution_authorized: false`
- binds `pyproject.toml` and `uv.lock` where the earlier runners omitted them
- gives Optimization Readiness a real named-baseline comparison and predeclared outcome rule
- adds a NEW immutable TeLAPA local result path without claiming TeLAPA reproduction

## Verification

- `184 passed` across the 12 owned unit/contract modules
- `ruff check` on all touched Python/test files
- `mypy`: `Success: no issues found in 230 source files`
- `git diff --check`

No prospective campaign was executed and no output artifact was created. This PR freezes implementation/plans only. Every referenced issue remains open until an independently audited merged plan is executed where authorized and all named acceptance/report/paper-parity gaps are actually satisfied.

Refs #1568
Refs #1569
Refs #1570
Refs #1571
Refs #1573
Refs #1586
