### PR TITLE
test(streams): consolidate NEXT_STATE trajectory coverage

### DIFF
--- a/tests/test_gymnasium_streams.py
+++ b/tests/test_gymnasium_streams.py
@@ -922,67 +922,28 @@ class _TwoStepEpisodeEnv:
         return observation, 0.0, self._step == 2, False, {}
 
 
-class TestCollectTrajectoryNextStateMode:
-    """collect_trajectory NEXT_STATE targets.
+def test_collect_trajectory_next_state_preserves_terminal_target_across_reset() -> None:
+    """NEXT_STATE targets use post-step observations, including at reset boundaries."""
+    observations, targets = collect_trajectory(
+        _TwoStepEpisodeEnv(),  # type: ignore[arg-type]
+        lambda _observation: 0,
+        num_steps=4,
+        mode=PredictionMode.NEXT_STATE,
+        include_action_in_features=True,
+        seed=42,
+    )
 
-    The only PredictionMode this function's own dispatch (as opposed to
-    ``GymnasiumStream``'s separate dispatch) was never exercised end to
-    end anywhere in this suite.
-    """
-
-    def test_target_dim_matches_observation_dim(self) -> None:
-        """target_dim is observation_dim for NEXT_STATE.
-
-        Independent of include_action_in_features (which only changes
-        the feature width).
-        """
-        observations, targets = collect_trajectory(
-            _TwoStepEpisodeEnv(),  # type: ignore[arg-type]
-            lambda _observation: 0,
-            num_steps=3,
-            mode=PredictionMode.NEXT_STATE,
-            include_action_in_features=True,
-            seed=1,
-        )
-        assert observations.shape == (3, 3)  # obs(2) + action(1)
-        assert targets.shape == (3, 2)  # observation_dim, not feature_dim
-
-    def test_target_equals_next_observation_within_episode(self) -> None:
-        """Within an episode (no reset), target[i] equals features[i + 1].
-
-        Compared over the shared two-dimensional observation part of each
-        feature row.
-        """
-        observations, targets = collect_trajectory(
-            _TwoStepEpisodeEnv(),  # type: ignore[arg-type]
-            lambda _observation: 0,
-            num_steps=4,
-            mode=PredictionMode.NEXT_STATE,
-            include_action_in_features=True,
-            seed=42,
-        )
-        matches = jnp.all(jnp.isclose(observations[1:, :2], targets[:-1]), axis=1)
-        # Step 1 continues, step 2 terminates and resets, step 3 continues.
-        np.testing.assert_array_equal(
-            np.asarray(matches), np.asarray((True, False, True))
-        )
-
-    def test_target_is_true_terminal_observation_not_the_reset(self) -> None:
-        """At a terminal step, target[i] is the real post-step observation.
-
-        It is the observation the episode ended on, not clobbered by the reset
-        that seeds the following row's features.
-        """
-        observations, targets = collect_trajectory(
-            _TwoStepEpisodeEnv(),  # type: ignore[arg-type]
-            lambda _observation: 0,
-            num_steps=3,
-            mode=PredictionMode.NEXT_STATE,
-            include_action_in_features=False,
-            seed=42,
-        )
-        # Row 1 terminates at [2, -2]. Row 2 begins after reset at [100, -100].
-        np.testing.assert_array_equal(np.asarray(targets[1]), np.asarray((2.0, -2.0)))
-        np.testing.assert_array_equal(
-            np.asarray(observations[2]), np.asarray((100.0, -100.0))
-        )
+    assert observations.shape == (4, 3)  # observation(2) + action(1)
+    assert targets.shape == (4, 2)
+    matches_next_feature = jnp.all(
+        jnp.isclose(observations[1:, :2], targets[:-1]), axis=1
+    )
+    # The middle target is the terminal [2, -2], while the next feature starts
+    # the reset episode at [100, -100]. The surrounding transitions continue.
+    np.testing.assert_array_equal(
+        np.asarray(matches_next_feature), np.asarray((True, False, True))
+    )
+    np.testing.assert_array_equal(np.asarray(targets[1]), np.asarray((2.0, -2.0)))
+    np.testing.assert_array_equal(
+        np.asarray(observations[2, :2]), np.asarray((100.0, -100.0))
+    )

--- a/tests/test_gymnasium_streams.py
+++ b/tests/test_gymnasium_streams.py
@@ -888,3 +888,83 @@ class TestCollectTrajectoryValueMode:
         )
 
         assert jnp.allclose(plain, with_estimator)
+
+
+class TestCollectTrajectoryNextStateMode:
+    """collect_trajectory NEXT_STATE targets.
+
+    The only PredictionMode this function's own dispatch (as opposed to
+    ``GymnasiumStream``'s separate dispatch) was never exercised end to
+    end anywhere in this suite.
+    """
+
+    def test_target_dim_matches_observation_dim(self) -> None:
+        """target_dim is observation_dim for NEXT_STATE.
+
+        Independent of include_action_in_features (which only changes
+        the feature width).
+        """
+        env = gymnasium.make("CartPole-v1")
+        observations, targets = collect_trajectory(
+            env,
+            None,
+            num_steps=15,
+            mode=PredictionMode.NEXT_STATE,
+            include_action_in_features=True,
+            seed=1,
+        )
+        assert observations.shape == (15, 5)  # obs(4) + action(1)
+        assert targets.shape == (15, 4)  # observation_dim, not feature_dim
+
+    def test_target_equals_next_observation_within_episode(self) -> None:
+        """Within an episode (no reset), target[i] equals features[i + 1].
+
+        Compared over the shared 4-dim observation half of the feature row.
+        """
+        env = gymnasium.make("CartPole-v1")
+        observations, targets = collect_trajectory(
+            env,
+            None,
+            num_steps=100,
+            mode=PredictionMode.NEXT_STATE,
+            include_action_in_features=True,
+            seed=42,
+        )
+        matches = jnp.all(jnp.isclose(observations[1:, :4], targets[:-1]), axis=1)
+        # CartPole-v1 caps episodes at 500 steps but seed=42 terminates
+        # early; some rows must match (no reset) and some must not
+        # (reset overwrote current_obs after a terminal target was recorded).
+        assert bool(jnp.any(matches))
+        assert bool(jnp.any(~matches))
+
+    def test_target_is_true_terminal_observation_not_the_reset(self) -> None:
+        """At a terminal step, target[i] is the real post-step observation.
+
+        It is the observation the episode ended on (satisfying CartPole's
+        own termination bounds), not clobbered by the reset that seeds the
+        following row's features.
+        """
+        env = gymnasium.make("CartPole-v1")
+        observations, targets = collect_trajectory(
+            env,
+            None,
+            num_steps=200,
+            mode=PredictionMode.NEXT_STATE,
+            include_action_in_features=False,
+            seed=42,
+        )
+        mismatches = [
+            i
+            for i in range(len(observations) - 1)
+            if not jnp.allclose(observations[i + 1], targets[i])
+        ]
+        assert mismatches  # seed=42 must terminate at least once inside 200 steps
+
+        x_threshold = 2.4
+        theta_threshold = 12 * 2 * jnp.pi / 360
+        for i in mismatches:
+            x, _x_dot, theta, _theta_dot = (float(v) for v in targets[i])
+            assert abs(x) > x_threshold or abs(theta) > theta_threshold, (
+                f"row {i}: target is neither continuous with the next row "
+                "nor a genuine CartPole termination state"
+            )

--- a/tests/test_gymnasium_streams.py
+++ b/tests/test_gymnasium_streams.py
@@ -905,14 +905,17 @@ class TestCollectTrajectoryNextStateMode:
         the feature width).
         """
         env = gymnasium.make("CartPole-v1")
-        observations, targets = collect_trajectory(
-            env,
-            None,
-            num_steps=15,
-            mode=PredictionMode.NEXT_STATE,
-            include_action_in_features=True,
-            seed=1,
-        )
+        try:
+            observations, targets = collect_trajectory(
+                env,
+                None,
+                num_steps=15,
+                mode=PredictionMode.NEXT_STATE,
+                include_action_in_features=True,
+                seed=1,
+            )
+        finally:
+            env.close()
         assert observations.shape == (15, 5)  # obs(4) + action(1)
         assert targets.shape == (15, 4)  # observation_dim, not feature_dim
 
@@ -922,14 +925,17 @@ class TestCollectTrajectoryNextStateMode:
         Compared over the shared 4-dim observation half of the feature row.
         """
         env = gymnasium.make("CartPole-v1")
-        observations, targets = collect_trajectory(
-            env,
-            None,
-            num_steps=100,
-            mode=PredictionMode.NEXT_STATE,
-            include_action_in_features=True,
-            seed=42,
-        )
+        try:
+            observations, targets = collect_trajectory(
+                env,
+                None,
+                num_steps=40,
+                mode=PredictionMode.NEXT_STATE,
+                include_action_in_features=True,
+                seed=42,
+            )
+        finally:
+            env.close()
         matches = jnp.all(jnp.isclose(observations[1:, :4], targets[:-1]), axis=1)
         # CartPole-v1 caps episodes at 500 steps but seed=42 terminates
         # early; some rows must match (no reset) and some must not
@@ -945,20 +951,23 @@ class TestCollectTrajectoryNextStateMode:
         following row's features.
         """
         env = gymnasium.make("CartPole-v1")
-        observations, targets = collect_trajectory(
-            env,
-            None,
-            num_steps=200,
-            mode=PredictionMode.NEXT_STATE,
-            include_action_in_features=False,
-            seed=42,
-        )
+        try:
+            observations, targets = collect_trajectory(
+                env,
+                None,
+                num_steps=40,
+                mode=PredictionMode.NEXT_STATE,
+                include_action_in_features=False,
+                seed=42,
+            )
+        finally:
+            env.close()
         mismatches = [
             i
             for i in range(len(observations) - 1)
             if not jnp.allclose(observations[i + 1], targets[i])
         ]
-        assert mismatches  # seed=42 must terminate at least once inside 200 steps
+        assert mismatches  # seed=42 must terminate at least once inside 40 steps
 
         x_threshold = 2.4
         theta_threshold = 12 * 2 * jnp.pi / 360

--- a/tests/test_gymnasium_streams.py
+++ b/tests/test_gymnasium_streams.py
@@ -890,6 +890,38 @@ class TestCollectTrajectoryValueMode:
         assert jnp.allclose(plain, with_estimator)
 
 
+class _TwoStepEpisodeEnv:
+    """Deterministic reset boundary for trajectory-target tests."""
+
+    observation_space = gymnasium.spaces.Box(
+        low=-1_000.0,
+        high=1_000.0,
+        shape=(2,),
+        dtype=np.float32,
+    )
+    action_space = gymnasium.spaces.Discrete(2)
+
+    def __init__(self) -> None:
+        self._episode = -1
+        self._step = 0
+
+    def reset(self, *, seed: int | None = None) -> tuple[np.ndarray, dict[str, object]]:
+        del seed
+        self._episode += 1
+        self._step = 0
+        value = float(100 * self._episode)
+        return np.asarray((value, -value), dtype=np.float32), {}
+
+    def step(
+        self, action: int
+    ) -> tuple[np.ndarray, float, bool, bool, dict[str, object]]:
+        del action
+        self._step += 1
+        value = float(100 * self._episode + self._step)
+        observation = np.asarray((value, -value), dtype=np.float32)
+        return observation, 0.0, self._step == 2, False, {}
+
+
 class TestCollectTrajectoryNextStateMode:
     """collect_trajectory NEXT_STATE targets.
 
@@ -904,76 +936,53 @@ class TestCollectTrajectoryNextStateMode:
         Independent of include_action_in_features (which only changes
         the feature width).
         """
-        env = gymnasium.make("CartPole-v1")
-        try:
-            observations, targets = collect_trajectory(
-                env,
-                None,
-                num_steps=15,
-                mode=PredictionMode.NEXT_STATE,
-                include_action_in_features=True,
-                seed=1,
-            )
-        finally:
-            env.close()
-        assert observations.shape == (15, 5)  # obs(4) + action(1)
-        assert targets.shape == (15, 4)  # observation_dim, not feature_dim
+        observations, targets = collect_trajectory(
+            _TwoStepEpisodeEnv(),  # type: ignore[arg-type]
+            lambda _observation: 0,
+            num_steps=3,
+            mode=PredictionMode.NEXT_STATE,
+            include_action_in_features=True,
+            seed=1,
+        )
+        assert observations.shape == (3, 3)  # obs(2) + action(1)
+        assert targets.shape == (3, 2)  # observation_dim, not feature_dim
 
     def test_target_equals_next_observation_within_episode(self) -> None:
         """Within an episode (no reset), target[i] equals features[i + 1].
 
-        Compared over the shared 4-dim observation half of the feature row.
+        Compared over the shared two-dimensional observation part of each
+        feature row.
         """
-        env = gymnasium.make("CartPole-v1")
-        try:
-            observations, targets = collect_trajectory(
-                env,
-                None,
-                num_steps=40,
-                mode=PredictionMode.NEXT_STATE,
-                include_action_in_features=True,
-                seed=42,
-            )
-        finally:
-            env.close()
-        matches = jnp.all(jnp.isclose(observations[1:, :4], targets[:-1]), axis=1)
-        # CartPole-v1 caps episodes at 500 steps but seed=42 terminates
-        # early; some rows must match (no reset) and some must not
-        # (reset overwrote current_obs after a terminal target was recorded).
-        assert bool(jnp.any(matches))
-        assert bool(jnp.any(~matches))
+        observations, targets = collect_trajectory(
+            _TwoStepEpisodeEnv(),  # type: ignore[arg-type]
+            lambda _observation: 0,
+            num_steps=4,
+            mode=PredictionMode.NEXT_STATE,
+            include_action_in_features=True,
+            seed=42,
+        )
+        matches = jnp.all(jnp.isclose(observations[1:, :2], targets[:-1]), axis=1)
+        # Step 1 continues, step 2 terminates and resets, step 3 continues.
+        np.testing.assert_array_equal(
+            np.asarray(matches), np.asarray((True, False, True))
+        )
 
     def test_target_is_true_terminal_observation_not_the_reset(self) -> None:
         """At a terminal step, target[i] is the real post-step observation.
 
-        It is the observation the episode ended on (satisfying CartPole's
-        own termination bounds), not clobbered by the reset that seeds the
-        following row's features.
+        It is the observation the episode ended on, not clobbered by the reset
+        that seeds the following row's features.
         """
-        env = gymnasium.make("CartPole-v1")
-        try:
-            observations, targets = collect_trajectory(
-                env,
-                None,
-                num_steps=40,
-                mode=PredictionMode.NEXT_STATE,
-                include_action_in_features=False,
-                seed=42,
-            )
-        finally:
-            env.close()
-        mismatches = [
-            i
-            for i in range(len(observations) - 1)
-            if not jnp.allclose(observations[i + 1], targets[i])
-        ]
-        assert mismatches  # seed=42 must terminate at least once inside 40 steps
-
-        x_threshold = 2.4
-        theta_threshold = 12 * 2 * jnp.pi / 360
-        for i in mismatches:
-            x, _x_dot, theta, _theta_dot = (float(v) for v in targets[i])
-            assert abs(x) > x_threshold or abs(theta) > theta_threshold, (
-                f"row {i}: target is neither continuous with the next row "
-                "nor a genuine CartPole termination state"
-            )
+        observations, targets = collect_trajectory(
+            _TwoStepEpisodeEnv(),  # type: ignore[arg-type]
+            lambda _observation: 0,
+            num_steps=3,
+            mode=PredictionMode.NEXT_STATE,
+            include_action_in_features=False,
+            seed=42,
+        )
+        # Row 1 terminates at [2, -2]. Row 2 begins after reset at [100, -100].
+        np.testing.assert_array_equal(np.asarray(targets[1]), np.asarray((2.0, -2.0)))
+        np.testing.assert_array_equal(
+            np.asarray(observations[2]), np.asarray((100.0, -100.0))
+        )


### PR DESCRIPTION
Supersedes #2091 after maintainer review.

This retains the nonredundant `collect_trajectory(..., NEXT_STATE)` reset-boundary contract in one deterministic end-to-end transaction: feature/target shapes, continuous transitions, the reset discontinuity, and preservation of the true terminal target are all asserted from the same rollout.

Validation: 66 focused Gymnasium tests passed; Ruff passed; `git diff --check` passed. No production or evidence files change.