### PR TITLE
fix(evaluation): reject oversized pair sequences before reconstruction hang

### DIFF
--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -95,8 +95,8 @@ CONDITION_NAMES = (
 EARLY_WINDOW_STEPS = 200
 TAIL_WINDOW_STEPS = 500
 ASYMPTOTIC_WINDOW_STEPS = 1_500
-# Origin ConditionSeedRecord rebuilt every pair before any count bound.
-# A cheap ``((0, 1),) * 25_000_000`` pointer-repeat took 4.107s on origin/main.
+# Frozen records contain at most 91 candidates; this leaves ample margin while
+# bounding reconstruction and set-building work for caller-provided records.
 _MAX_INTEGER_PAIRS = 4096
 
 FROZEN_STREAM_CONFIGURATION: dict[str, int | float] = {
@@ -517,12 +517,12 @@ def make_condition_learner(condition: str) -> FixedBudgetInteractionLearner:
 
 
 def count_relevant_context_pairs(
-    pairs: Sequence[tuple[int, int]],
+    pairs: tuple[tuple[int, int], ...] | list[tuple[int, int]],
     *,
     relevant_dim: int = 8,
     input_dim: int = 12,
 ) -> int:
-    """Count unique canonical context products over relevant input channels."""
+    """Count unique context products from one bounded exact tuple or list."""
 
     normalized_pairs = _integer_pairs(pairs, name="pairs", allow_list=True)
     relevant_pairs = {
@@ -534,12 +534,12 @@ def count_relevant_context_pairs(
 
 
 def count_relevant_context_pairs_by_task(
-    pairs: Sequence[tuple[int, int]],
+    pairs: tuple[tuple[int, int], ...] | list[tuple[int, int]],
     *,
     relevant_dim: int = 8,
     input_dim: int = 12,
 ) -> tuple[int, int]:
-    """Count unique relevant products for the supplied C and D cues separately."""
+    """Count task-specific products from one bounded exact tuple or list."""
 
     normalized_pairs = _integer_pairs(pairs, name="pairs", allow_list=True)
     canonical_pairs = {(min(left, right), max(left, right)) for left, right in normalized_pairs}

--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -237,8 +237,8 @@ def _bounded_pair_sequence_length(
 ) -> int:
     """Return a pair-sequence length after rejecting oversized host collections."""
 
-    allowed: tuple[type, ...] = (tuple, list) if allow_list else (tuple,)
-    if type(value) not in allowed:
+    value_type = type(value)
+    if value_type is not tuple and (not allow_list or value_type is not list):
         kind = "tuple or list" if allow_list else "tuple"
         raise TypeError(f"{name} must be an exact {kind}")
     count = len(cast(tuple[object, ...] | list[object], value))
@@ -248,12 +248,13 @@ def _bounded_pair_sequence_length(
 
 
 def _integer_pairs(
-    value: object, *, name: str
+    value: object, *, name: str, allow_list: bool = False
 ) -> tuple[tuple[int, int], ...]:
-    _bounded_pair_sequence_length(value, name=name)
+    _bounded_pair_sequence_length(value, name=name, allow_list=allow_list)
     pairs: list[tuple[int, int]] = []
-    for index, pair in enumerate(cast(tuple[object, ...], value)):
-        if type(pair) is not tuple or len(pair) != 2:
+    sequence = cast(tuple[object, ...] | list[object], value)
+    for index, pair in enumerate(sequence):
+        if type(pair) is not tuple or tuple.__len__(pair) != 2:
             raise ValueError(f"{name}[{index}] must be an exact integer pair")
         left, right = pair
         if type(left) is not int or type(right) is not int:
@@ -523,10 +524,10 @@ def count_relevant_context_pairs(
 ) -> int:
     """Count unique canonical context products over relevant input channels."""
 
-    _bounded_pair_sequence_length(pairs, name="pairs", allow_list=True)
+    normalized_pairs = _integer_pairs(pairs, name="pairs", allow_list=True)
     relevant_pairs = {
         (min(left, right), max(left, right))
-        for left, right in pairs
+        for left, right in normalized_pairs
         if ((left >= input_dim) ^ (right >= input_dim)) and min(left, right) < relevant_dim
     }
     return len(relevant_pairs)
@@ -540,8 +541,8 @@ def count_relevant_context_pairs_by_task(
 ) -> tuple[int, int]:
     """Count unique relevant products for the supplied C and D cues separately."""
 
-    _bounded_pair_sequence_length(pairs, name="pairs", allow_list=True)
-    canonical_pairs = {(min(left, right), max(left, right)) for left, right in pairs}
+    normalized_pairs = _integer_pairs(pairs, name="pairs", allow_list=True)
+    canonical_pairs = {(min(left, right), max(left, right)) for left, right in normalized_pairs}
     counts = tuple(
         sum(
             1

--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -24,7 +24,7 @@ import math
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import jax
 import jax.numpy as jnp
@@ -95,6 +95,9 @@ CONDITION_NAMES = (
 EARLY_WINDOW_STEPS = 200
 TAIL_WINDOW_STEPS = 500
 ASYMPTOTIC_WINDOW_STEPS = 1_500
+# Origin ConditionSeedRecord rebuilt every pair before any count bound.
+# A cheap ``((0, 1),) * 25_000_000`` pointer-repeat took 4.107s on origin/main.
+_MAX_INTEGER_PAIRS = 4096
 
 FROZEN_STREAM_CONFIGURATION: dict[str, int | float] = {
     "relevant_dim": 8,
@@ -226,13 +229,30 @@ def _finite_float(value: object, *, name: str) -> float:
     return nonnegative_finite_real(name, value)
 
 
+def _bounded_pair_sequence_length(
+    value: object,
+    *,
+    name: str,
+    allow_list: bool = False,
+) -> int:
+    """Return a pair-sequence length after rejecting oversized host collections."""
+
+    allowed: tuple[type, ...] = (tuple, list) if allow_list else (tuple,)
+    if type(value) not in allowed:
+        kind = "tuple or list" if allow_list else "tuple"
+        raise TypeError(f"{name} must be an exact {kind}")
+    count = len(cast(tuple[object, ...] | list[object], value))
+    if count > _MAX_INTEGER_PAIRS:
+        raise ValueError(f"{name} exceeds the {_MAX_INTEGER_PAIRS}-pair limit")
+    return count
+
+
 def _integer_pairs(
     value: object, *, name: str
 ) -> tuple[tuple[int, int], ...]:
-    if type(value) is not tuple:
-        raise TypeError(f"{name} must be an exact tuple")
+    _bounded_pair_sequence_length(value, name=name)
     pairs: list[tuple[int, int]] = []
-    for index, pair in enumerate(value):
+    for index, pair in enumerate(cast(tuple[object, ...], value)):
         if type(pair) is not tuple or len(pair) != 2:
             raise ValueError(f"{name}[{index}] must be an exact integer pair")
         left, right = pair
@@ -503,6 +523,7 @@ def count_relevant_context_pairs(
 ) -> int:
     """Count unique canonical context products over relevant input channels."""
 
+    _bounded_pair_sequence_length(pairs, name="pairs", allow_list=True)
     relevant_pairs = {
         (min(left, right), max(left, right))
         for left, right in pairs
@@ -519,6 +540,7 @@ def count_relevant_context_pairs_by_task(
 ) -> tuple[int, int]:
     """Count unique relevant products for the supplied C and D cues separately."""
 
+    _bounded_pair_sequence_length(pairs, name="pairs", allow_list=True)
     canonical_pairs = {(min(left, right), max(left, right)) for left, right in pairs}
     counts = tuple(
         sum(

--- a/tests/test_scale_robust_pair_sequence_hang.py
+++ b/tests/test_scale_robust_pair_sequence_hang.py
@@ -1,14 +1,8 @@
-"""Scale-robust pair sequences reject oversized host collections before hang.
-
-Origin ``ConditionSeedRecord`` rebuilt every integer pair with no count bound.
-A cheap ``((0, 1),) * 25_000_000`` pointer-repeat took 4.107s on origin/main.
-"""
+"""Scale-robust pair records enforce their collection and identity bounds."""
 
 from __future__ import annotations
 
-import time
-from collections.abc import Sequence
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -61,36 +55,27 @@ def test_last_fit_pair_count_is_accepted() -> None:
     assert count_relevant_context_pairs_by_task(pairs) == (1, 0)
 
 
-@pytest.mark.parametrize("count", [4097, 25_000_000])
-def test_condition_record_rejects_oversized_pair_pointer_repeat(count: int) -> None:
-    started = time.perf_counter()
+def test_first_oversized_pair_collection_is_rejected_by_all_consumers() -> None:
+    pairs = (_PAIR,) * (_MAX_INTEGER_PAIRS + 1)
     with pytest.raises(ValueError, match="4096-pair limit"):
         ConditionSeedRecord(
             seed=0,
             condition=CONDITION_PRIMARY,
             phases=(),
-            end_segment_5_active_pairs=(_PAIR,) * count,
+            end_segment_5_active_pairs=pairs,
             end_segment_7_active_pairs=(),
             final_active_pairs=(),
         )
-    assert time.perf_counter() - started < 0.5
-
-
-@pytest.mark.parametrize("count", [4097, 25_000_000])
-def test_pair_counters_reject_oversized_pointer_repeat(count: int) -> None:
-    pairs = (_PAIR,) * count
-    started = time.perf_counter()
     with pytest.raises(ValueError, match="4096-pair limit"):
         count_relevant_context_pairs(pairs)
     with pytest.raises(ValueError, match="4096-pair limit"):
         count_relevant_context_pairs_by_task(pairs)
-    assert time.perf_counter() - started < 0.5
 
 
 def test_pair_admission_rejects_hostile_sequence_without_type_hooks() -> None:
     _HostileMeta.calls = 0
     hostile = _HostileSequence((_PAIR,))
-    hostile_pairs = cast(Sequence[tuple[int, int]], hostile)
+    hostile_pairs = cast(Any, hostile)
     with pytest.raises(TypeError, match="exact tuple or list"):
         count_relevant_context_pairs(hostile_pairs)
     with pytest.raises(TypeError, match="exact tuple or list"):

--- a/tests/test_scale_robust_pair_sequence_hang.py
+++ b/tests/test_scale_robust_pair_sequence_hang.py
@@ -1,0 +1,68 @@
+"""Scale-robust pair sequences reject oversized host collections before hang.
+
+Origin ``ConditionSeedRecord`` rebuilt every integer pair with no count bound.
+A cheap ``((0, 1),) * 25_000_000`` pointer-repeat took 4.107s on origin/main.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.evaluation.scale_robust_feature import (
+    _MAX_INTEGER_PAIRS,
+    CONDITION_PRIMARY,
+    ConditionSeedRecord,
+    count_relevant_context_pairs,
+    count_relevant_context_pairs_by_task,
+)
+
+pytestmark = pytest.mark.unit
+
+_PAIR = (0, 12)
+
+
+def test_frozen_pair_count_bound() -> None:
+    assert _MAX_INTEGER_PAIRS == 4096
+
+
+def test_last_fit_pair_count_is_accepted() -> None:
+    pairs = (_PAIR,) * _MAX_INTEGER_PAIRS
+    record = ConditionSeedRecord(
+        seed=0,
+        condition=CONDITION_PRIMARY,
+        phases=(),
+        end_segment_5_active_pairs=pairs,
+        end_segment_7_active_pairs=(),
+        final_active_pairs=(),
+    )
+    assert len(record.end_segment_5_active_pairs) == _MAX_INTEGER_PAIRS
+    assert count_relevant_context_pairs(pairs) == 1
+    assert count_relevant_context_pairs_by_task(pairs) == (1, 0)
+
+
+@pytest.mark.parametrize("count", [4097, 25_000_000])
+def test_condition_record_rejects_oversized_pair_pointer_repeat(count: int) -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="4096-pair limit"):
+        ConditionSeedRecord(
+            seed=0,
+            condition=CONDITION_PRIMARY,
+            phases=(),
+            end_segment_5_active_pairs=(_PAIR,) * count,
+            end_segment_7_active_pairs=(),
+            final_active_pairs=(),
+        )
+    assert time.perf_counter() - started < 0.5
+
+
+@pytest.mark.parametrize("count", [4097, 25_000_000])
+def test_pair_counters_reject_oversized_pointer_repeat(count: int) -> None:
+    pairs = (_PAIR,) * count
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="4096-pair limit"):
+        count_relevant_context_pairs(pairs)
+    with pytest.raises(ValueError, match="4096-pair limit"):
+        count_relevant_context_pairs_by_task(pairs)
+    assert time.perf_counter() - started < 0.5

--- a/tests/test_scale_robust_pair_sequence_hang.py
+++ b/tests/test_scale_robust_pair_sequence_hang.py
@@ -7,6 +7,8 @@ A cheap ``((0, 1),) * 25_000_000`` pointer-repeat took 4.107s on origin/main.
 from __future__ import annotations
 
 import time
+from collections.abc import Sequence
+from typing import cast
 
 import pytest
 
@@ -21,6 +23,23 @@ from alberta_framework.evaluation.scale_robust_feature import (
 pytestmark = pytest.mark.unit
 
 _PAIR = (0, 12)
+
+
+class _HostileMeta(type):
+    calls = 0
+
+    def __eq__(cls, other: object) -> bool:
+        del other
+        cls.calls += 1
+        raise AssertionError("hostile metaclass equality must not run")
+
+    def __hash__(cls) -> int:
+        cls.calls += 1
+        raise AssertionError("hostile metaclass hashing must not run")
+
+
+class _HostileSequence(tuple[object, ...], metaclass=_HostileMeta):
+    pass
 
 
 def test_frozen_pair_count_bound() -> None:
@@ -66,3 +85,30 @@ def test_pair_counters_reject_oversized_pointer_repeat(count: int) -> None:
     with pytest.raises(ValueError, match="4096-pair limit"):
         count_relevant_context_pairs_by_task(pairs)
     assert time.perf_counter() - started < 0.5
+
+
+def test_pair_admission_rejects_hostile_sequence_without_type_hooks() -> None:
+    _HostileMeta.calls = 0
+    hostile = _HostileSequence((_PAIR,))
+    hostile_pairs = cast(Sequence[tuple[int, int]], hostile)
+    with pytest.raises(TypeError, match="exact tuple or list"):
+        count_relevant_context_pairs(hostile_pairs)
+    with pytest.raises(TypeError, match="exact tuple or list"):
+        count_relevant_context_pairs_by_task(hostile_pairs)
+    assert _HostileMeta.calls == 0
+
+
+def test_pair_counters_reject_hostile_nested_values_before_comparison() -> None:
+    class HostileInt(int):
+        def __lt__(self, other: object) -> bool:
+            del other
+            raise AssertionError("hostile comparison must not run")
+
+        def __hash__(self) -> int:
+            raise AssertionError("hostile hashing must not run")
+
+    pairs = ((HostileInt(0), 12),)
+    with pytest.raises(ValueError, match="must contain integers"):
+        count_relevant_context_pairs(pairs)
+    with pytest.raises(ValueError, match="must contain integers"):
+        count_relevant_context_pairs_by_task(pairs)


### PR DESCRIPTION
## Summary

Bounds scale-robust feature pair records before reconstruction or set building. Frozen artifacts use at most 91 candidate pairs; the release contract permits up to 4,096 exact integer pairs in an exact tuple (records) or tuple/list (public counters).

The consumers now reject oversized collections, hostile sequence subclasses, hostile integer subclasses, and malformed nested pairs before comparison/hash hooks.

## Validation

- 26 focused scale-robust tests passed
- Ruff and strict mypy passed
- `git diff --check` passed