### PR TITLE
research(bimu): freeze fresh-process matched campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the execution-gated `asi-bimu-matched-development` campaign for the
+  bounded five-task BiMU mechanism-on versus memory-off comparison. Its fixed
+  six-shard namespace, fresh-process roster, paired outcome rule, validators,
+  and resource/provenance bindings are permanently nonpromoting and not
+  paper-comparable; execution remains explicitly unauthorized.
 - Added the unfrozen `preview1` reference-agent transaction ledger, primitive
   Prototype adapter, aggregate SwitchingTwoState/RiverSwim life runner, and
   development-only quiescent checkpoint codec. These L0 mechanisms enforce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bounded five-task BiMU mechanism-on versus memory-off comparison. Its fixed
   six-shard namespace, fresh-process roster, paired outcome rule, validators,
   and resource/provenance bindings are permanently nonpromoting and not
-  paper-comparable; execution remains explicitly unauthorized.
+  paper-comparable; execution remains explicitly unauthorized. Its publicly
+  exposed three-seed development roster is consumed for promotion and has no
+  retained matched result.
 - Added the unfrozen `preview1` reference-agent transaction ledger, primitive
   Prototype adapter, aggregate SwitchingTwoState/RiverSwim life runner, and
   development-only quiescent checkpoint codec. These L0 mechanisms enforce

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -62,6 +62,7 @@ MAX_TEXT_BYTES: Final = 4096
 MAX_PLAN_BYTES: Final = 2 * 1024 * 1024
 MAX_SHARD_BYTES: Final = 4 * 1024 * 1024
 MAX_AGGREGATE_BYTES: Final = 32 * 1024 * 1024
+REGISTERED_OUTPUT_ROOT: Final = Path(__file__).resolve().parents[2]
 
 _ARMS: Final = ("memory_off", "bimu")
 _MATCHED_COUNTERS: Final = (
@@ -982,6 +983,11 @@ def _allowed_path(path: Path, root: Path) -> bool:
     return path in candidates
 
 
+def _require_registered_root(root: Path) -> None:
+    if Path(os.path.abspath(os.fspath(root))) != REGISTERED_OUTPUT_ROOT:
+        _fail("campaign output root is not the registered repository root")
+
+
 def _open_output_parent(path: Path, *, create: bool) -> tuple[Path, int]:
     """Open an absolute parent through no-follow directory descriptors."""
 
@@ -1027,19 +1033,50 @@ def _link_unnamed_file(file_descriptor: int, parent_descriptor: int, name: str) 
         raise OSError(error, os.strerror(error), name)
 
 
-def publish_json(path: Path, value: object, *, root: Path) -> None:
+def _reserve_shard_destination(path: Path, *, root: Path) -> tuple[Path, int, int]:
+    """Reserve one exact shard path before dataset load or execution."""
+
+    _require_registered_root(root)
+    if not _allowed_path(path, root) or path.parent.name != "shards":
+        _fail("only one canonical shard destination may be reserved")
+    destination, parent_descriptor = _open_output_parent(path, create=True)
+    try:
+        file_descriptor = os.open(
+            destination.name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+            0o000,
+            dir_fd=parent_descriptor,
+        )
+    except BaseException:
+        os.close(parent_descriptor)
+        raise
+    return destination, parent_descriptor, file_descriptor
+
+
+def publish_json(
+    path: Path,
+    value: object,
+    *,
+    root: Path,
+    _reservation: tuple[Path, int, int] | None = None,
+) -> None:
     """Atomically publish one canonical campaign file without replacement."""
 
     if type(path) is not type(Path()) or type(root) is not type(Path()):
         raise TypeError("path and root must be exact Paths")
+    _require_registered_root(root)
     if not _allowed_path(path, root):
         _fail("destination is outside the fixed campaign namespace")
-    if path == campaign_path(root, "plan"):
-        validate_plan_document(value)
-    elif path == campaign_path(root, "aggregate"):
-        validate_bimu_aggregate(value)
-    else:
-        validate_bimu_shard(value)
+
+    def validate(candidate: object) -> None:
+        if path == campaign_path(root, "plan"):
+            validate_plan_document(candidate)
+        elif path == campaign_path(root, "aggregate"):
+            validate_bimu_aggregate(candidate)
+        else:
+            validate_bimu_shard(candidate)
+
+    validate(value)
     raw = _canonical(value) + b"\n"
     shard_path = campaign_path(
         root,
@@ -1049,37 +1086,93 @@ def publish_json(path: Path, value: object, *, root: Path) -> None:
     )
     _, shard_parent_descriptor = _open_output_parent(shard_path, create=True)
     os.close(shard_parent_descriptor)
-    destination, parent_descriptor = _open_output_parent(path, create=True)
-    file_descriptor: int | None = None
+    if _reservation is None:
+        destination, parent_descriptor = _open_output_parent(path, create=True)
+        file_descriptor: int | None = None
+    else:
+        destination, parent_descriptor, file_descriptor = _reservation
+        if destination != Path(os.path.abspath(os.fspath(path))):
+            _fail("campaign reservation does not match its exact destination")
     try:
-        try:
-            os.stat(destination.name, dir_fd=parent_descriptor, follow_symlinks=False)
-        except FileNotFoundError:
-            pass
-        else:
-            raise FileExistsError(
-                f"refusing to replace existing campaign artifact: {destination}"
+        if _reservation is None:
+            try:
+                os.stat(destination.name, dir_fd=parent_descriptor, follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                raise FileExistsError(
+                    f"refusing to replace existing campaign artifact: {destination}"
+                )
+            if not hasattr(os, "O_TMPFILE"):
+                raise OSError("immutable publication requires Linux O_TMPFILE support")
+            file_descriptor = os.open(
+                ".",
+                os.O_WRONLY | os.O_CLOEXEC | os.O_TMPFILE,
+                0o600,
+                dir_fd=parent_descriptor,
             )
-        if not hasattr(os, "O_TMPFILE"):
-            raise OSError("immutable publication requires Linux O_TMPFILE support")
-        file_descriptor = os.open(
-            ".",
-            os.O_WRONLY | os.O_CLOEXEC | os.O_TMPFILE,
-            0o600,
-            dir_fd=parent_descriptor,
-        )
+        assert file_descriptor is not None
         view = memoryview(raw)
         written = 0
         while written < len(view):
-            written += os.write(file_descriptor, view[written:])
+            count = os.write(file_descriptor, view[written:])
+            if count <= 0:
+                raise OSError("campaign publication write made no progress")
+            written += count
         os.fsync(file_descriptor)
         os.fchmod(file_descriptor, 0o444)
+        if _reservation is None:
+            try:
+                _link_unnamed_file(file_descriptor, parent_descriptor, destination.name)
+            except FileExistsError as exc:
+                raise FileExistsError(
+                    f"refusing to replace existing campaign artifact: {destination}"
+                ) from exc
+        read_descriptor = os.open(
+            destination.name,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+            dir_fd=parent_descriptor,
+        )
         try:
-            _link_unnamed_file(file_descriptor, parent_descriptor, destination.name)
-        except FileExistsError as exc:
-            raise FileExistsError(
-                f"refusing to replace existing campaign artifact: {destination}"
-            ) from exc
+            source_stat = os.fstat(file_descriptor)
+            before = os.fstat(read_descriptor)
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or before.st_nlink != 1
+                or (before.st_dev, before.st_ino) != (source_stat.st_dev, source_stat.st_ino)
+                or before.st_size != len(raw)
+            ):
+                raise RuntimeError("published campaign artifact is not the prepared inode")
+            loaded = bytearray()
+            while len(loaded) <= len(raw):
+                chunk = os.read(read_descriptor, min(64 * 1024, len(raw) + 1 - len(loaded)))
+                if not chunk:
+                    break
+                loaded.extend(chunk)
+            after = os.fstat(read_descriptor)
+        finally:
+            os.close(read_descriptor)
+
+        def identity(item: os.stat_result) -> tuple[int, int, int, int, int]:
+            return (
+                item.st_dev,
+                item.st_ino,
+                item.st_size,
+                item.st_mtime_ns,
+                item.st_ctime_ns,
+            )
+
+        if bytes(loaded) != raw or identity(before) != identity(after):
+            raise RuntimeError("published campaign artifact changed during bounded readback")
+        try:
+            decoded = json.loads(
+                loaded,
+                object_pairs_hook=_json_object_pairs,
+                parse_constant=lambda token: _fail(f"invalid JSON constant: {token}"),
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+            raise RuntimeError("published campaign artifact is not strict JSON") from exc
+        validate(decoded)
         os.fsync(parent_descriptor)
         _, live_parent_descriptor = _open_output_parent(destination, create=False)
         try:
@@ -1202,16 +1295,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 2
         destination = campaign_path(root, "shard", arm=args.arm, seed=args.seed)
-        if os.path.lexists(destination):
-            raise FileExistsError(f"refusing to replace existing campaign shard: {destination}")
         plan = _load_plan(root)
-        shard = run_bimu_shard(
-            args.arm,
-            args.seed,
-            data_home=args.data_home,
-            plan_document=plan,
+        reservation: tuple[Path, int, int] | None = _reserve_shard_destination(
+            destination, root=root
         )
-        publish_json(destination, shard, root=root)
+        try:
+            shard = run_bimu_shard(
+                args.arm,
+                args.seed,
+                data_home=args.data_home,
+                plan_document=plan,
+            )
+            publish_json(destination, shard, root=root, _reservation=reservation)
+            reservation = None
+        finally:
+            if reservation is not None:
+                _, parent_descriptor, file_descriptor = reservation
+                os.close(file_descriptor)
+                os.close(parent_descriptor)
         _print_json({"status": "complete", "shard": str(destination)})
         return 0
     if args.command == "summarize":
@@ -1247,6 +1348,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "shards": [],
             "aggregate": None,
         }
+        shards: list[dict[str, object]] = []
         if any_shards:
             arrays = load_frozen_bimu_dataset(args.data_home)
             shards = _load_shards(root, arrays)
@@ -1255,6 +1357,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             aggregate = validate_bimu_aggregate(
                 load_json_strict(aggregate_path, byte_ceiling=MAX_AGGREGATE_BYTES)
             )
+            if any_shards and aggregate["shards"] != shards:
+                _fail("aggregate does not contain the exact retained shard roster")
             result["aggregate"] = aggregate["aggregate_sha256"]
         _print_json(result)
         return 0

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -473,6 +473,8 @@ def run_bimu_shard(
     result = run_bimu_development(*arrays, config=config, seed=seed)
     wall_seconds = time.perf_counter() - started_wall
     cpu_seconds = time.process_time() - started_cpu
+    if _dataset_sha256(*arrays) != FROZEN_BIMU_MATCHED_PLAN.dataset_sha256:
+        _fail("campaign dataset changed during shard execution")
     validate_bimu_result(result)
     payload: dict[str, object] = {
         "schema": SHARD_SCHEMA,
@@ -663,6 +665,43 @@ def validate_bimu_shard(value: object) -> dict[str, object]:
         _fail("shard digest drifted")
     if len(_canonical(root)) > MAX_SHARD_BYTES:
         _fail("shard exceeds byte ceiling")
+    return root
+
+
+def validate_bimu_shard_by_reexecution(
+    value: object,
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+) -> dict[str, object]:
+    """Reexecute one shard and compare every deterministic result field."""
+
+    root = validate_bimu_shard(value)
+    arrays = _validated_arrays(
+        train_x,
+        train_y,
+        test_x,
+        test_y,
+        plan=FROZEN_BIMU_MATCHED_PLAN,
+    )
+    spec = cast(dict[str, object], root["spec"])
+    config = _arm_config(FROZEN_BIMU_MATCHED_PLAN, cast(str, spec["arm"]))
+    replay = run_bimu_development(
+        *arrays,
+        config=config,
+        seed=cast(int, spec["seed"]),
+    )
+    validate_bimu_result(replay)
+    reported = cast(dict[str, object], root["result"])
+    deterministic_fields = set(replay) - {"timing"}
+    if set(reported) - {"timing"} != deterministic_fields or any(
+        not _json_exact_equal(reported[field], replay[field])
+        for field in deterministic_fields
+    ):
+        _fail("shard result does not match strict seed/arm reexecution")
+    if _dataset_sha256(*arrays) != FROZEN_BIMU_MATCHED_PLAN.dataset_sha256:
+        _fail("campaign dataset changed during strict shard reexecution")
     return root
 
 
@@ -1096,16 +1135,24 @@ def _validate_namespace(
         _fail("campaign shard namespace contains an unexpected entry")
 
 
-def _load_shards(root: Path) -> list[dict[str, object]]:
+def _load_shards(
+    root: Path,
+    arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None = None,
+) -> list[dict[str, object]]:
     return [
-        validate_bimu_shard(
-            load_json_strict(
-                campaign_path(root, "shard", arm=arm, seed=seed),
-                byte_ceiling=MAX_SHARD_BYTES,
-            )
+        (
+            validate_bimu_shard(loaded)
+            if arrays is None
+            else validate_bimu_shard_by_reexecution(loaded, *arrays)
         )
         for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
         for arm in _ARMS
+        for loaded in (
+            load_json_strict(
+                campaign_path(root, "shard", arm=arm, seed=seed),
+                byte_ceiling=MAX_SHARD_BYTES,
+            ),
+        )
     ]
 
 
@@ -1121,6 +1168,8 @@ def _parser() -> argparse.ArgumentParser:
     for name in ("plan", "summarize", "validate"):
         command = subparsers.add_parser(name)
         command.add_argument("--root", type=Path, required=True)
+        if name in {"summarize", "validate"}:
+            command.add_argument("--data-home", type=Path)
     shard = subparsers.add_parser("run-shard")
     shard.add_argument("--root", type=Path, required=True)
     shard.add_argument("--arm", choices=_ARMS, required=True)
@@ -1172,7 +1221,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             require_aggregate=False,
         )
         _load_plan(root)
-        aggregate = summarize_bimu_shards(_load_shards(root))
+        arrays = load_frozen_bimu_dataset(args.data_home)
+        aggregate = summarize_bimu_shards(_load_shards(root, arrays))
         destination = campaign_path(root, "aggregate")
         publish_json(destination, aggregate, root=root)
         _print_json(cast(dict[str, object], aggregate["outcome"]))
@@ -1198,7 +1248,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             "aggregate": None,
         }
         if any_shards:
-            shards = _load_shards(root)
+            arrays = load_frozen_bimu_dataset(args.data_home)
+            shards = _load_shards(root, arrays)
             result["shards"] = [shard["shard_sha256"] for shard in shards]
         if aggregate_path.exists():
             aggregate = validate_bimu_aggregate(

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -53,6 +53,7 @@ from alberta_framework.evaluation.bimu_matched_nonpromoting import (
 
 PLAN_DOCUMENT_SCHEMA: Final = "asi.bimu.matched-campaign-plan.v1"
 SHARD_SCHEMA: Final = "asi.bimu.matched-campaign-shard.v1"
+FAILED_SHARD_SCHEMA: Final = "asi.bimu.matched-campaign-failed-shard.v1"
 AGGREGATE_SCHEMA: Final = "asi.bimu.matched-campaign-aggregate.v1"
 PROCESS_SCHEMA: Final = "asi.bimu.fresh-process.v1"
 
@@ -88,8 +89,9 @@ _POLICY: Final = {
     "sota_claim_allowed": False,
     "paper_comparable": False,
     "completed_outcomes_retained": True,
-    "execution_failure_receipts_retained": False,
-    "failed_attempt_reservation_retained": True,
+    "ordinary_exception_failure_receipts_retained": True,
+    "failed_attempt_reservation_retained": False,
+    "base_exception_failure_retention_guaranteed": False,
 }
 _TIMING_POLICY: Final = {
     "qualified": False,
@@ -676,6 +678,108 @@ def validate_bimu_shard(value: object) -> dict[str, object]:
     return root
 
 
+def build_failed_bimu_shard(arm: str, seed: int) -> dict[str, object]:
+    """Build one generic receipt for an ordinary failed shard attempt."""
+
+    if type(arm) is not str or arm not in _ARMS:
+        _fail("failed shard arm is outside the frozen roster")
+    if type(seed) is not int or seed not in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        _fail("failed shard seed is outside the frozen roster")
+    payload: dict[str, object] = {
+        "schema": FAILED_SHARD_SCHEMA,
+        "status": "failed",
+        "plan_sha256": _sha256(frozen_plan_payload()),
+        "spec": {"arm": arm, "seed": seed},
+        "identity": {**_current_identity(), "process": _process_identity()},
+        "policy": {
+            **_POLICY,
+            "execution_authorized": True,
+            "used_for_outcome": False,
+            "retry_authorized": False,
+        },
+        "failure": {
+            "classification": "ordinary_execution_or_validation_failure",
+            "exception_type_retained": False,
+            "exception_message_retained": False,
+            "exception_repr_retained": False,
+            "base_exception_retention_guaranteed": False,
+        },
+    }
+    payload["failure_sha256"] = _sha256(payload)
+    validate_failed_bimu_shard(payload)
+    return payload
+
+
+def validate_failed_bimu_shard(value: object) -> dict[str, object]:
+    """Strictly validate one generic, non-outcome failed-attempt receipt."""
+
+    _validate_json_tree(value)
+    root = _exact_object(
+        value,
+        {
+            "schema",
+            "status",
+            "plan_sha256",
+            "spec",
+            "identity",
+            "policy",
+            "failure",
+            "failure_sha256",
+        },
+        "failed BiMU shard",
+    )
+    if root["schema"] != FAILED_SHARD_SCHEMA or root["status"] != "failed":
+        _fail("failed BiMU shard identity or status drifted")
+    if root["plan_sha256"] != _sha256(frozen_plan_payload()):
+        _fail("failed BiMU shard plan digest drifted")
+    spec = _exact_object(root["spec"], {"arm", "seed"}, "failed shard spec")
+    if type(spec["arm"]) is not str or spec["arm"] not in _ARMS:
+        _fail("failed shard arm is outside the frozen roster")
+    if type(spec["seed"]) is not int or spec["seed"] not in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        _fail("failed shard seed is outside the frozen roster")
+    identity = _exact_object(
+        root["identity"],
+        {
+            "source_sha256",
+            "runtime",
+            "dependencies",
+            "consistency_not_attestation",
+            "process",
+        },
+        "failed shard identity",
+    )
+    if not _json_exact_equal(
+        {key: item for key, item in identity.items() if key != "process"},
+        _current_identity(),
+    ):
+        _fail("failed shard source or runtime identity drifted")
+    _validate_process(identity["process"])
+    expected_policy = {
+        **_POLICY,
+        "execution_authorized": True,
+        "used_for_outcome": False,
+        "retry_authorized": False,
+    }
+    if not _json_exact_equal(root["policy"], expected_policy):
+        _fail("failed shard policy drifted")
+    if not _json_exact_equal(
+        root["failure"],
+        {
+            "classification": "ordinary_execution_or_validation_failure",
+            "exception_type_retained": False,
+            "exception_message_retained": False,
+            "exception_repr_retained": False,
+            "base_exception_retention_guaranteed": False,
+        },
+    ):
+        _fail("failed shard disclosure boundary drifted")
+    if root["failure_sha256"] != digest_without(root, "failure_sha256"):
+        _fail("failed shard digest drifted")
+    if len(_canonical(root)) > MAX_SHARD_BYTES:
+        _fail("failed shard exceeds byte ceiling")
+    return root
+
+
 def validate_bimu_shard_by_reexecution(
     value: object,
     train_x: object,
@@ -1054,24 +1158,69 @@ def _require_live_parent(destination: Path, parent_descriptor: int) -> None:
         os.close(live_descriptor)
 
 
-def _reserve_shard_destination(path: Path, *, root: Path) -> tuple[Path, int, int]:
+ShardReservation = tuple[Path, int, int, str]
+
+
+def _reserve_shard_destination(path: Path, *, root: Path) -> ShardReservation:
     """Reserve one exact shard path before dataset load or execution."""
 
     _require_registered_root(root)
     if not _allowed_path(path, root) or path.parent.name != "shards":
         _fail("only one canonical shard destination may be reserved")
     destination, parent_descriptor = _open_output_parent(path, create=True)
+    reservation_name = f".{destination.name}.reservation"
     try:
-        file_descriptor = os.open(
-            destination.name,
+        try:
+            os.stat(destination.name, dir_fd=parent_descriptor, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(
+                f"refusing to replace existing campaign artifact: {destination}"
+            )
+        reservation_descriptor = os.open(
+            reservation_name,
             os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
-            0o000,
+            0o400,
             dir_fd=parent_descriptor,
         )
+        marker = b"asi-bimu-matched-shard-reservation-v1\n"
+        written = os.write(reservation_descriptor, marker)
+        if written != len(marker):
+            raise OSError("campaign reservation write made no progress")
+        os.fsync(reservation_descriptor)
+        os.fsync(parent_descriptor)
     except BaseException:
-        os.close(parent_descriptor)
+        if "reservation_descriptor" in locals():
+            _release_shard_reservation(
+                (destination, parent_descriptor, reservation_descriptor, reservation_name)
+            )
+        else:
+            os.close(parent_descriptor)
         raise
-    return destination, parent_descriptor, file_descriptor
+    return destination, parent_descriptor, reservation_descriptor, reservation_name
+
+
+def _release_shard_reservation(reservation: ShardReservation) -> None:
+    destination, parent_descriptor, reservation_descriptor, reservation_name = reservation
+    del destination
+    try:
+        owned = os.fstat(reservation_descriptor)
+        try:
+            current = os.stat(
+                reservation_name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            pass
+        else:
+            if (current.st_dev, current.st_ino) == (owned.st_dev, owned.st_ino):
+                os.unlink(reservation_name, dir_fd=parent_descriptor)
+                os.fsync(parent_descriptor)
+    finally:
+        os.close(reservation_descriptor)
+        os.close(parent_descriptor)
 
 
 def publish_json(
@@ -1079,13 +1228,13 @@ def publish_json(
     value: object,
     *,
     root: Path,
-    _reservation: tuple[Path, int, int] | None = None,
+    _reservation: ShardReservation | None = None,
 ) -> None:
-    """Publish one validated canonical file and verify its held inode.
+    """Publish one canonical file without replacement and verify its held inode.
 
-    Plans and aggregates link a complete anonymous inode atomically. A shard's
-    final name is reserved before execution; failure intentionally leaves that
-    zero-byte non-result reservation occupied.
+    Every final path receives a complete anonymous inode atomically. Shard work
+    additionally holds a separate, owned reservation marker until either a
+    complete result or a generic failed-attempt receipt is durably published.
     """
 
     if type(path) is not type(Path()) or type(root) is not type(Path()):
@@ -1100,7 +1249,10 @@ def publish_json(
         elif path == campaign_path(root, "aggregate"):
             validate_bimu_aggregate(candidate)
         else:
-            validate_bimu_shard(candidate)
+            if type(candidate) is dict and candidate.get("schema") == FAILED_SHARD_SCHEMA:
+                validate_failed_bimu_shard(candidate)
+            else:
+                validate_bimu_shard(candidate)
 
     validate(value)
     raw = _canonical(value) + b"\n"
@@ -1112,48 +1264,36 @@ def publish_json(
     )
     _, shard_parent_descriptor = _open_output_parent(shard_path, create=True)
     os.close(shard_parent_descriptor)
-    owns_descriptors = _reservation is None
-    if owns_descriptors:
+    if _reservation is None:
         destination, parent_descriptor = _open_output_parent(path, create=True)
-        file_descriptor: int | None = None
+        close_parent = True
     else:
-        assert _reservation is not None
-        destination, parent_descriptor, file_descriptor = _reservation
+        destination, parent_descriptor, reservation_descriptor, _ = _reservation
+        close_parent = False
         if destination != Path(os.path.abspath(os.fspath(path))):
             _fail("campaign reservation does not match its exact destination")
         _require_live_parent(destination, parent_descriptor)
-        reserved = os.fstat(file_descriptor)
-        visible = os.stat(
-            destination.name,
-            dir_fd=parent_descriptor,
-            follow_symlinks=False,
-        )
-        if (
-            not stat.S_ISREG(reserved.st_mode)
-            or reserved.st_nlink != 1
-            or reserved.st_size != 0
-            or (reserved.st_dev, reserved.st_ino) != (visible.st_dev, visible.st_ino)
-        ):
-            raise RuntimeError("campaign shard reservation changed before publication")
+        reservation_stat = os.fstat(reservation_descriptor)
+        if not stat.S_ISREG(reservation_stat.st_mode) or reservation_stat.st_nlink != 1:
+            _fail("campaign shard reservation is not the owned regular marker")
+    file_descriptor: int | None = None
     try:
-        if owns_descriptors:
-            try:
-                os.stat(destination.name, dir_fd=parent_descriptor, follow_symlinks=False)
-            except FileNotFoundError:
-                pass
-            else:
-                raise FileExistsError(
-                    f"refusing to replace existing campaign artifact: {destination}"
-                )
-            if not hasattr(os, "O_TMPFILE"):
-                raise OSError("immutable publication requires Linux O_TMPFILE support")
-            file_descriptor = os.open(
-                ".",
-                os.O_WRONLY | os.O_CLOEXEC | os.O_TMPFILE,
-                0o600,
-                dir_fd=parent_descriptor,
+        try:
+            os.stat(destination.name, dir_fd=parent_descriptor, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(
+                f"refusing to replace existing campaign artifact: {destination}"
             )
-        assert file_descriptor is not None
+        if not hasattr(os, "O_TMPFILE"):
+            raise OSError("immutable publication requires Linux O_TMPFILE support")
+        file_descriptor = os.open(
+            ".",
+            os.O_WRONLY | os.O_CLOEXEC | os.O_TMPFILE,
+            0o600,
+            dir_fd=parent_descriptor,
+        )
         view = memoryview(raw)
         written = 0
         while written < len(view):
@@ -1163,13 +1303,12 @@ def publish_json(
             written += count
         os.fsync(file_descriptor)
         os.fchmod(file_descriptor, 0o444)
-        if owns_descriptors:
-            try:
-                _link_unnamed_file(file_descriptor, parent_descriptor, destination.name)
-            except FileExistsError as exc:
-                raise FileExistsError(
-                    f"refusing to replace existing campaign artifact: {destination}"
-                ) from exc
+        try:
+            _link_unnamed_file(file_descriptor, parent_descriptor, destination.name)
+        except FileExistsError as exc:
+            raise FileExistsError(
+                f"refusing to replace existing campaign artifact: {destination}"
+            ) from exc
         read_descriptor = os.open(
             destination.name,
             os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
@@ -1218,9 +1357,9 @@ def publish_json(
         os.fsync(parent_descriptor)
         _require_live_parent(destination, parent_descriptor)
     finally:
-        if owns_descriptors:
-            if file_descriptor is not None:
-                os.close(file_descriptor)
+        if file_descriptor is not None:
+            os.close(file_descriptor)
+        if close_parent:
             os.close(parent_descriptor)
 
 
@@ -1332,28 +1471,31 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 2
         destination = campaign_path(root, "shard", arm=args.arm, seed=args.seed)
-        reservation: tuple[Path, int, int] | None = _reserve_shard_destination(
-            destination, root=root
-        )
+        reservation = _reserve_shard_destination(destination, root=root)
         try:
-            plan = _load_plan(root)
-            shard = run_bimu_shard(
-                args.arm,
-                args.seed,
-                data_home=args.data_home,
-                plan_document=plan,
-            )
-            publish_json(
-                destination,
-                shard,
-                root=root,
-                _reservation=reservation,
-            )
+            try:
+                plan = _load_plan(root)
+                shard = run_bimu_shard(
+                    args.arm,
+                    args.seed,
+                    data_home=args.data_home,
+                    plan_document=plan,
+                )
+                publish_json(destination, shard, root=root, _reservation=reservation)
+            except Exception:
+                failed = build_failed_bimu_shard(args.arm, args.seed)
+                publish_json(destination, failed, root=root, _reservation=reservation)
+                _print_json(
+                    {
+                        "status": "failed",
+                        "failure_retained": True,
+                        "retry_authorized": False,
+                        "shard": str(destination),
+                    }
+                )
+                return 1
         finally:
-            if reservation is not None:
-                _, parent_descriptor, file_descriptor = reservation
-                os.close(file_descriptor)
-                os.close(parent_descriptor)
+            _release_shard_reservation(reservation)
         _print_json({"status": "complete", "shard": str(destination)})
         return 0
     if args.command == "summarize":

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -18,7 +18,7 @@ import os
 import secrets
 import stat
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path, PosixPath
 from typing import Any, Final, NoReturn, cast
 
@@ -92,9 +92,11 @@ _POLICY: Final = {
     "paper_comparable": False,
     "completed_outcomes_retained": True,
     "ordinary_exception_failure_receipts_enabled": True,
-    "failed_attempt_reservation_retained": False,
+    "post_dispatch_consumed_without_result_tombstone": True,
+    "pre_dispatch_reservation_released_on_failure": True,
     "failure_receipt_publication_guaranteed": False,
-    "base_exception_failure_retention_guaranteed": False,
+    "post_dispatch_base_exception_tombstone_retained": True,
+    "process_death_tombstone_retention_guaranteed": False,
     "seed_status": "frozen_exposed_consumed_for_promotion",
 }
 _TIMING_POLICY: Final = {
@@ -465,6 +467,7 @@ def run_bimu_shard(
     data_home: Path | None = None,
     plan_document: object | None = None,
     _loaded_arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None = None,
+    _on_first_dispatch: Callable[[], None] | None = None,
 ) -> dict[str, object]:
     """Execute exactly one authorized arm/seed shard in this process."""
 
@@ -492,6 +495,8 @@ def run_bimu_shard(
         arrays = _validated_arrays(*_loaded_arrays, plan=FROZEN_BIMU_MATCHED_PLAN)
     started_wall = time.perf_counter()
     started_cpu = time.process_time()
+    if _on_first_dispatch is not None:
+        _on_first_dispatch()
     result = run_bimu_development(*arrays, config=config, seed=seed)
     wall_seconds = time.perf_counter() - started_wall
     cpu_seconds = time.process_time() - started_cpu
@@ -1261,6 +1266,41 @@ def _release_shard_reservation(reservation: ShardReservation) -> None:
         os.close(parent_descriptor)
 
 
+def _retain_consumed_without_result(reservation: ShardReservation) -> None:
+    """Turn the owned visible reservation into a durable no-retry tombstone."""
+
+    destination, parent_descriptor, reservation_descriptor, reservation_name = reservation
+    del destination
+    marker = b"asi-bimu-matched-campaign-consumed-without-result-v1\n"
+    try:
+        _require_live_parent(reservation[0], parent_descriptor)
+        owned = os.fstat(reservation_descriptor)
+        visible = os.stat(
+            reservation_name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(owned.st_mode)
+            or owned.st_nlink != 1
+            or (owned.st_dev, owned.st_ino) != (visible.st_dev, visible.st_ino)
+        ):
+            raise RuntimeError("campaign reservation is not the owned visible inode")
+        os.ftruncate(reservation_descriptor, 0)
+        os.lseek(reservation_descriptor, 0, os.SEEK_SET)
+        written = 0
+        while written < len(marker):
+            count = os.write(reservation_descriptor, marker[written:])
+            if count <= 0:
+                raise OSError("campaign tombstone write made no progress")
+            written += count
+        os.fsync(reservation_descriptor)
+        os.fsync(parent_descriptor)
+    finally:
+        os.close(reservation_descriptor)
+        os.close(parent_descriptor)
+
+
 def publish_json(
     path: Path,
     value: object,
@@ -1549,6 +1589,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 2
         destination = campaign_path(root, "shard", arm=args.arm, seed=args.seed)
         reservation = _reserve_shard_destination(destination, root=root)
+        reservation_to_cleanup: ShardReservation | None = reservation
+        first_dispatch = False
+        durable_result_published = False
+
+        def mark_first_dispatch() -> None:
+            nonlocal first_dispatch
+            first_dispatch = True
+
         try:
             failed_attempt = False
             try:
@@ -1559,6 +1607,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     args.seed,
                     plan_document=plan,
                     _loaded_arrays=arrays,
+                    _on_first_dispatch=mark_first_dispatch,
                 )
             except Exception:
                 failed_attempt = True
@@ -1571,11 +1620,13 @@ def main(argv: Sequence[str] | None = None) -> int:
                         _reservation=reservation,
                         _completed_replay_arrays=arrays,
                     )
+                    durable_result_published = True
                 except _CompletedShardAdmissionError:
                     failed_attempt = True
             if failed_attempt:
                 failed = build_failed_bimu_shard(args.arm, args.seed)
                 publish_json(destination, failed, root=root, _reservation=reservation)
+                durable_result_published = True
                 _print_json(
                     {
                         "status": "failed",
@@ -1585,8 +1636,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                     }
                 )
                 return 1
+        except BaseException:
+            if first_dispatch and not durable_result_published:
+                reservation_to_cleanup = None
+                _retain_consumed_without_result(reservation)
+            raise
         finally:
-            _release_shard_reservation(reservation)
+            if reservation_to_cleanup is not None:
+                _release_shard_reservation(reservation_to_cleanup)
         _print_json({"status": "complete", "shard": str(destination)})
         return 0
     if args.command == "summarize":

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -19,6 +19,7 @@ import secrets
 import stat
 import time
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path, PosixPath
 from typing import Any, Final, NoReturn, cast
 
@@ -464,6 +465,7 @@ def run_bimu_shard(
     *,
     data_home: Path | None = None,
     plan_document: object | None = None,
+    _loaded_arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None = None,
 ) -> dict[str, object]:
     """Execute exactly one authorized arm/seed shard in this process."""
 
@@ -483,7 +485,12 @@ def run_bimu_shard(
     execution_identity = _current_identity()
     if not _json_exact_equal(plan_doc["identity"], execution_identity):
         _fail("campaign identity changed after the plan was validated")
-    arrays = load_frozen_bimu_dataset(data_home)
+    if _loaded_arrays is None:
+        arrays = load_frozen_bimu_dataset(data_home)
+    else:
+        if type(_loaded_arrays) is not tuple or tuple.__len__(_loaded_arrays) != 4:
+            raise TypeError("preloaded campaign arrays must be one exact four-item tuple")
+        arrays = _validated_arrays(*_loaded_arrays, plan=FROZEN_BIMU_MATCHED_PLAN)
     started_wall = time.perf_counter()
     started_cpu = time.process_time()
     result = run_bimu_development(*arrays, config=config, seed=seed)
@@ -1184,6 +1191,30 @@ def _require_live_parent(destination: Path, parent_descriptor: int) -> None:
 ShardReservation = tuple[Path, int, int, str]
 
 
+@dataclass(frozen=True, slots=True)
+class _CompletedShardReplayProof:
+    """Private proof that one exact completed payload passed dataset-bound replay."""
+
+    payload_sha256: str
+    shard_sha256: str
+    dataset_sha256: str
+
+
+def _prove_completed_shard_by_reexecution(
+    value: object,
+    arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+) -> _CompletedShardReplayProof:
+    if type(arrays) is not tuple or tuple.__len__(arrays) != 4:
+        raise TypeError("replay arrays must be one exact four-item tuple")
+    validated_arrays = _validated_arrays(*arrays, plan=FROZEN_BIMU_MATCHED_PLAN)
+    shard = validate_bimu_shard_by_reexecution(value, *validated_arrays)
+    return _CompletedShardReplayProof(
+        payload_sha256=hashlib.sha256(_canonical(shard)).hexdigest(),
+        shard_sha256=cast(str, shard["shard_sha256"]),
+        dataset_sha256=FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
+    )
+
+
 def _reserve_destination(path: Path, *, root: Path) -> ShardReservation:
     """Reserve one exact artifact before plan/data/replay/execution work."""
 
@@ -1257,6 +1288,7 @@ def publish_json(
     *,
     root: Path,
     _reservation: ShardReservation | None = None,
+    _completed_replay_proof: _CompletedShardReplayProof | None = None,
 ) -> None:
     """Publish one canonical file without replacement and verify its held inode.
 
@@ -1283,7 +1315,16 @@ def publish_json(
             if type(candidate) is dict and candidate.get("schema") == FAILED_SHARD_SCHEMA:
                 validate_failed_bimu_shard(candidate)
             else:
-                validate_bimu_shard(candidate)
+                completed = validate_bimu_shard(candidate)
+                if type(_completed_replay_proof) is not _CompletedShardReplayProof:
+                    _fail("completed shard publication requires a strict reexecution proof")
+                expected_proof = _CompletedShardReplayProof(
+                    payload_sha256=hashlib.sha256(_canonical(completed)).hexdigest(),
+                    shard_sha256=cast(str, completed["shard_sha256"]),
+                    dataset_sha256=FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
+                )
+                if _completed_replay_proof != expected_proof:
+                    _fail("completed shard reexecution proof does not match the payload")
 
     owns_reservation = _reservation is None
     reservation = _reserve_destination(path, root=root) if _reservation is None else _reservation
@@ -1528,13 +1569,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             try:
                 plan = _load_plan(root)
+                arrays = load_frozen_bimu_dataset(args.data_home)
                 shard = run_bimu_shard(
                     args.arm,
                     args.seed,
-                    data_home=args.data_home,
                     plan_document=plan,
+                    _loaded_arrays=arrays,
                 )
-                validate_bimu_shard(shard)
+                replay_proof = _prove_completed_shard_by_reexecution(shard, arrays)
             except Exception:
                 failed = build_failed_bimu_shard(args.arm, args.seed)
                 publish_json(destination, failed, root=root, _reservation=reservation)
@@ -1547,7 +1589,13 @@ def main(argv: Sequence[str] | None = None) -> int:
                     }
                 )
                 return 1
-            publish_json(destination, shard, root=root, _reservation=reservation)
+            publish_json(
+                destination,
+                shard,
+                root=root,
+                _reservation=reservation,
+                _completed_replay_proof=replay_proof,
+            )
         finally:
             _release_shard_reservation(reservation)
         _print_json({"status": "complete", "shard": str(destination)})

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -9,13 +9,14 @@ never contributes to the paired outcome.
 from __future__ import annotations
 
 import argparse
+import ctypes
+import errno
 import hashlib
 import json
 import math
 import os
 import secrets
 import stat
-import tempfile
 import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -942,6 +943,51 @@ def _allowed_path(path: Path, root: Path) -> bool:
     return path in candidates
 
 
+def _open_output_parent(path: Path, *, create: bool) -> tuple[Path, int]:
+    """Open an absolute parent through no-follow directory descriptors."""
+
+    destination = Path(os.path.abspath(os.fspath(path)))
+    descriptor = os.open(os.path.sep, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    try:
+        for component in destination.parent.parts[1:]:
+            if component in ("", ".", ".."):
+                _fail("campaign path contains an unsafe directory component")
+            if create:
+                try:
+                    os.mkdir(component, mode=0o755, dir_fd=descriptor)
+                except FileExistsError:
+                    pass
+            next_descriptor = os.open(
+                component,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                dir_fd=descriptor,
+            )
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return destination, descriptor
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _link_unnamed_file(file_descriptor: int, parent_descriptor: int, name: str) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    linkat = libc.linkat
+    linkat.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+    )
+    linkat.restype = ctypes.c_int
+    if linkat(file_descriptor, b"", parent_descriptor, os.fsencode(name), 0x1000) != 0:
+        error = ctypes.get_errno()
+        if error == errno.EEXIST:
+            raise FileExistsError(error, os.strerror(error), name)
+        raise OSError(error, os.strerror(error), name)
+
+
 def publish_json(path: Path, value: object, *, root: Path) -> None:
     """Atomically publish one canonical campaign file without replacement."""
 
@@ -956,40 +1002,58 @@ def publish_json(path: Path, value: object, *, root: Path) -> None:
     else:
         validate_bimu_shard(value)
     raw = _canonical(value) + b"\n"
-    root.mkdir(parents=True, exist_ok=True)
-    namespace = root / OUTPUT_NAMESPACE
-    namespace.mkdir(parents=True, exist_ok=True)
-    (namespace / "shards").mkdir(exist_ok=True)
-    for component in (root, *namespace.parents, namespace, path.parent):
-        if component.exists() and component.is_symlink():
-            _fail("campaign publication path contains a symlink")
-    if os.path.lexists(path):
-        raise FileExistsError(f"refusing to replace existing campaign artifact: {path}")
-    descriptor, temporary_name = tempfile.mkstemp(
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
+    shard_path = campaign_path(
+        root,
+        "shard",
+        arm=_ARMS[0],
+        seed=FROZEN_BIMU_MATCHED_PLAN.seeds[0],
     )
-    temporary = Path(temporary_name)
-    published = False
+    _, shard_parent_descriptor = _open_output_parent(shard_path, create=True)
+    os.close(shard_parent_descriptor)
+    destination, parent_descriptor = _open_output_parent(path, create=True)
+    file_descriptor: int | None = None
     try:
-        with os.fdopen(descriptor, "wb") as stream:
-            stream.write(raw)
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.link(temporary, path, follow_symlinks=False)
-        published = True
-        directory_descriptor = os.open(path.parent, os.O_RDONLY)
         try:
-            os.fsync(directory_descriptor)
+            os.stat(destination.name, dir_fd=parent_descriptor, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(
+                f"refusing to replace existing campaign artifact: {destination}"
+            )
+        if not hasattr(os, "O_TMPFILE"):
+            raise OSError("immutable publication requires Linux O_TMPFILE support")
+        file_descriptor = os.open(
+            ".",
+            os.O_WRONLY | os.O_CLOEXEC | os.O_TMPFILE,
+            0o600,
+            dir_fd=parent_descriptor,
+        )
+        view = memoryview(raw)
+        written = 0
+        while written < len(view):
+            written += os.write(file_descriptor, view[written:])
+        os.fsync(file_descriptor)
+        os.fchmod(file_descriptor, 0o444)
+        try:
+            _link_unnamed_file(file_descriptor, parent_descriptor, destination.name)
+        except FileExistsError as exc:
+            raise FileExistsError(
+                f"refusing to replace existing campaign artifact: {destination}"
+            ) from exc
+        os.fsync(parent_descriptor)
+        _, live_parent_descriptor = _open_output_parent(destination, create=False)
+        try:
+            pinned = os.fstat(parent_descriptor)
+            live = os.fstat(live_parent_descriptor)
+            if (pinned.st_dev, pinned.st_ino) != (live.st_dev, live.st_ino):
+                raise RuntimeError("campaign publication parent changed during publication")
         finally:
-            os.close(directory_descriptor)
-    except BaseException:
-        if published:
-            path.unlink(missing_ok=True)
-        raise
+            os.close(live_parent_descriptor)
     finally:
-        temporary.unlink(missing_ok=True)
+        if file_descriptor is not None:
+            os.close(file_descriptor)
+        os.close(parent_descriptor)
 
 
 def _load_plan(root: Path) -> dict[str, object]:

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -92,10 +92,10 @@ _POLICY: Final = {
     "paper_comparable": False,
     "completed_outcomes_retained": True,
     "ordinary_exception_failure_receipts_enabled": True,
-    "post_dispatch_consumed_without_result_tombstone": True,
-    "pre_dispatch_reservation_released_on_failure": True,
+    "post_dispatch_consumed_without_result_tombstone_enabled": True,
+    "pre_dispatch_escaped_failure_reservation_released": True,
     "failure_receipt_publication_guaranteed": False,
-    "post_dispatch_base_exception_tombstone_retained": True,
+    "post_dispatch_tombstone_retention_guaranteed": False,
     "process_death_tombstone_retention_guaranteed": False,
     "seed_status": "frozen_exposed_consumed_for_promotion",
 }

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -1364,14 +1364,14 @@ def publish_json(
             written += count
         os.fsync(file_descriptor)
         os.fchmod(file_descriptor, 0o444)
+        source_stat = os.fstat(file_descriptor)
+        published_identity = (source_stat.st_dev, source_stat.st_ino)
         try:
             _link_unnamed_file(file_descriptor, parent_descriptor, destination.name)
         except FileExistsError as exc:
             raise FileExistsError(
                 f"refusing to replace existing campaign artifact: {destination}"
             ) from exc
-        source_stat = os.fstat(file_descriptor)
-        published_identity = (source_stat.st_dev, source_stat.st_ino)
         read_descriptor = os.open(
             destination.name,
             os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -1,0 +1,1147 @@
+"""Fresh-process execution and validation for the bounded BiMU comparison.
+
+The campaign is permanently nonpromoting and not paper-comparable.  Its
+execution gate is deliberately closed in the reviewed source until a separate
+authorization change is accepted.  Timing is retained only as telemetry and
+never contributes to the paired outcome.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import secrets
+import stat
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, NoReturn, cast
+
+import jax.random as jr
+import numpy as np
+
+from alberta_framework.benchmarks.bimu import (
+    _EXAMPLE_ORDER_DOMAIN,
+    _INIT_DOMAIN,
+    _PRNG_IMPLEMENTATION,
+    _dataset_sha256,
+    _initialize_state,
+    _state_sha256,
+    _stream_key,
+    build_task_schedule,
+    run_bimu_development,
+    validate_bimu_result,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import load_mnist_train
+from alberta_framework.evaluation.bimu_matched_nonpromoting import (
+    EXECUTION_AUTHORIZED,
+    FROZEN_BIMU_MATCHED_PLAN,
+    OUTPUT_NAMESPACE,
+    BiMUMatchedDevelopmentPlan,
+    _canonical,
+    _dependency_identity,
+    _plan_payload,
+    _runtime_identity,
+    _source_identity,
+    frozen_plan_payload,
+)
+
+PLAN_DOCUMENT_SCHEMA: Final = "asi.bimu.matched-campaign-plan.v1"
+SHARD_SCHEMA: Final = "asi.bimu.matched-campaign-shard.v1"
+AGGREGATE_SCHEMA: Final = "asi.bimu.matched-campaign-aggregate.v1"
+PROCESS_SCHEMA: Final = "asi.bimu.fresh-process.v1"
+
+MAX_JSON_DEPTH: Final = 64
+MAX_JSON_NODES: Final = 50_000
+MAX_TEXT_BYTES: Final = 4096
+MAX_PLAN_BYTES: Final = 2 * 1024 * 1024
+MAX_SHARD_BYTES: Final = 4 * 1024 * 1024
+MAX_AGGREGATE_BYTES: Final = 32 * 1024 * 1024
+
+_ARMS: Final = ("memory_off", "bimu")
+_MATCHED_COUNTERS: Final = (
+    "environment_steps",
+    "observations",
+    "label_queries",
+    "optimizer_updates",
+    "optimizer_seen",
+    "model_forward_queries",
+)
+_MATCHED_RESOURCES: Final = (
+    "trainable_scalar_count",
+    "parameter_numeric_bytes",
+    "optimizer_state_numeric_bytes",
+    "initial_persistent_numeric_bytes",
+    "final_persistent_numeric_bytes",
+)
+_POLICY: Final = {
+    "evidence_class": "bounded_matched_development_comparator",
+    "development_only": True,
+    "permanently_nonpromoting": True,
+    "scientific_promotion_allowed": False,
+    "sota_claim_allowed": False,
+    "paper_comparable": False,
+    "negative_results_retained": True,
+}
+_TIMING_POLICY: Final = {
+    "qualified": False,
+    "role": "telemetry_only",
+    "used_for_outcome": False,
+    "cross_machine_comparison_supported": False,
+}
+
+
+def _fail(message: str) -> NoReturn:
+    raise ValueError(message)
+
+
+def _validate_json_tree(value: object) -> None:
+    pending: list[tuple[object, int]] = [(value, 0)]
+    nodes = 0
+    while pending:
+        current, depth = pending.pop()
+        nodes += 1
+        if nodes > MAX_JSON_NODES:
+            _fail("JSON input exceeds node ceiling")
+        if depth > MAX_JSON_DEPTH:
+            _fail("JSON nesting exceeds depth ceiling")
+        current_type = type(current)
+        if current is None or current_type is bool:
+            continue
+        if current_type is str:
+            if len(cast(str, current).encode("utf-8")) > MAX_TEXT_BYTES:
+                _fail("JSON text exceeds byte ceiling")
+            continue
+        if current_type is int:
+            if not -(2**63) <= cast(int, current) <= 2**63 - 1:
+                _fail("JSON integer exceeds signed-int64")
+            continue
+        if current_type is float:
+            if not math.isfinite(cast(float, current)):
+                _fail("JSON number must be finite")
+            continue
+        if current_type is list:
+            items = cast(list[object], current)
+            if len(items) > MAX_JSON_NODES:
+                _fail("JSON array exceeds node ceiling")
+            pending.extend((item, depth + 1) for item in items)
+            continue
+        if current_type is dict:
+            mapping = cast(dict[object, object], current)
+            if len(mapping) > MAX_JSON_NODES:
+                _fail("JSON object exceeds node ceiling")
+            for key, item in mapping.items():
+                if type(key) is not str or len(key.encode("utf-8")) > MAX_TEXT_BYTES:
+                    _fail("JSON object keys must be bounded exact strings")
+                pending.append((item, depth + 1))
+            continue
+        _fail("value is not an exact JSON tree")
+
+
+def _exact_object(value: object, fields: set[str], label: str) -> dict[str, object]:
+    if type(value) is not dict:
+        _fail(f"{label} must be an exact object")
+    resolved = cast(dict[str, object], value)
+    if len(resolved) != len(fields) or set(resolved) != fields:
+        _fail(f"{label} fields drifted")
+    return resolved
+
+
+def _sha256(value: object) -> str:
+    _validate_json_tree(value)
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _json_exact_equal(left: object, right: object) -> bool:
+    _validate_json_tree(left)
+    _validate_json_tree(right)
+    return _canonical(left) == _canonical(right)
+
+
+def digest_without(payload: Mapping[str, object], field: str) -> str:
+    """Hash a JSON object after removing its self-digest field."""
+
+    if type(payload) is not dict or type(field) is not str:
+        raise TypeError("payload and field must be exact JSON object/string values")
+    return _sha256({key: value for key, value in payload.items() if key != field})
+
+
+def _is_digest(value: object) -> bool:
+    return (
+        type(value) is str
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _json_object_pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            _fail(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json_strict(path: Path, *, byte_ceiling: int) -> dict[str, object]:
+    """Read one bounded regular JSON file with duplicate-key rejection."""
+
+    if type(path) is not type(Path()) or type(byte_ceiling) is not int or byte_ceiling < 1:
+        raise TypeError("path and byte_ceiling must be exact bounded values")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise ValueError(f"cannot open regular non-symlink JSON input: {path}") from exc
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            _fail("JSON input must be a regular non-symlink file")
+        if before.st_nlink != 1:
+            _fail("JSON input must not have a hard-link alias")
+        if before.st_size > byte_ceiling:
+            _fail("JSON input exceeds byte ceiling")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            raw = stream.read(byte_ceiling + 1)
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    if len(raw) > byte_ceiling:
+        _fail("JSON input exceeds byte ceiling")
+    before_identity = (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+        before.st_ctime_ns,
+    )
+    after_identity = (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+        after.st_ctime_ns,
+    )
+    if before_identity != after_identity or len(raw) != after.st_size:
+        _fail("JSON input changed while being read")
+    try:
+        value = json.loads(
+            raw,
+            object_pairs_hook=_json_object_pairs,
+            parse_constant=lambda token: _fail(f"invalid JSON constant: {token}"),
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("JSON input is not one strict document") from exc
+    _validate_json_tree(value)
+    if type(value) is not dict:
+        _fail("JSON document root must be an exact object")
+    return cast(dict[str, object], value)
+
+
+def _current_identity() -> dict[str, object]:
+    return {
+        "source_sha256": _source_identity(),
+        "runtime": _runtime_identity(),
+        "dependencies": _dependency_identity(),
+        "consistency_not_attestation": True,
+    }
+
+
+def build_plan_document() -> dict[str, object]:
+    """Build the source-bound literal plan without loading or executing data."""
+
+    payload = frozen_plan_payload()
+    document: dict[str, object] = {
+        "schema": PLAN_DOCUMENT_SCHEMA,
+        "plan": payload,
+        "plan_sha256": _sha256(payload),
+        "identity": _current_identity(),
+        "policy": {
+            **_POLICY,
+            "execution_authorized": EXECUTION_AUTHORIZED,
+        },
+    }
+    document["document_sha256"] = _sha256(document)
+    validate_plan_document(document)
+    return document
+
+
+def validate_plan_document(value: object) -> dict[str, object]:
+    _validate_json_tree(value)
+    root = _exact_object(
+        value,
+        {"schema", "plan", "plan_sha256", "identity", "policy", "document_sha256"},
+        "campaign plan",
+    )
+    expected_plan = frozen_plan_payload()
+    if root["schema"] != PLAN_DOCUMENT_SCHEMA or not _json_exact_equal(
+        root["plan"], expected_plan
+    ):
+        _fail("campaign plan does not match the current literal plan")
+    if root["plan_sha256"] != _sha256(expected_plan):
+        _fail("campaign plan digest drifted")
+    if not _json_exact_equal(root["identity"], _current_identity()):
+        _fail("campaign plan identity drifted")
+    expected_policy = {**_POLICY, "execution_authorized": EXECUTION_AUTHORIZED}
+    if not _json_exact_equal(root["policy"], expected_policy):
+        _fail("campaign plan policy drifted")
+    if root["document_sha256"] != digest_without(root, "document_sha256"):
+        _fail("campaign plan document digest drifted")
+    if len(_canonical(root)) > MAX_PLAN_BYTES:
+        _fail("campaign plan exceeds byte ceiling")
+    return root
+
+
+def _validated_arrays(
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+    *,
+    plan: BiMUMatchedDevelopmentPlan,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    config = plan.candidate_config
+    expected = (
+        (
+            "train_x",
+            train_x,
+            np.dtype(np.float32),
+            (config.train_examples_per_task, config.input_dim),
+        ),
+        ("train_y", train_y, np.dtype(np.int32), (config.train_examples_per_task,)),
+        ("test_x", test_x, np.dtype(np.float32), (config.test_examples_per_task, config.input_dim)),
+        ("test_y", test_y, np.dtype(np.int32), (config.test_examples_per_task,)),
+    )
+    arrays: list[np.ndarray] = []
+    byte_count = 0
+    for name, value, dtype, shape in expected:
+        if type(value) is not np.ndarray or value.dtype != dtype or value.shape != shape:
+            _fail(f"{name} does not match the exact campaign shape and dtype")
+        byte_count += int(value.nbytes)
+        if byte_count > 16 * 1024 * 1024:
+            _fail("campaign dataset exceeds its byte ceiling")
+        copied = np.array(value, dtype=dtype, order="C", copy=True)
+        if dtype == np.dtype(np.float32) and not np.all(np.isfinite(copied)):
+            _fail(f"{name} must contain finite values")
+        if dtype == np.dtype(np.int32) and (
+            np.any(copied < 0) or np.any(copied >= config.n_classes)
+        ):
+            _fail(f"{name} contains labels outside the campaign class range")
+        arrays.append(copied)
+    if _dataset_sha256(*arrays) != plan.dataset_sha256:
+        _fail("dataset slice does not match the frozen digest")
+    return arrays[0], arrays[1], arrays[2], arrays[3]
+
+
+def load_frozen_bimu_dataset(
+    data_home: Path | None = None,
+    *,
+    plan: BiMUMatchedDevelopmentPlan = FROZEN_BIMU_MATCHED_PLAN,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Load the canonical 60k OpenML materialization and copy its frozen slice."""
+
+    if data_home is not None and type(data_home) is not type(Path()):
+        raise TypeError("data_home must be an exact Path or None")
+    if type(plan) is not BiMUMatchedDevelopmentPlan:
+        raise TypeError("plan must be an exact BiMUMatchedDevelopmentPlan")
+    checked = BiMUMatchedDevelopmentPlan(**plan.__dict__)
+    full_x, full_y = load_mnist_train(data_home)
+    if (
+        type(full_x) is not np.ndarray
+        or type(full_y) is not np.ndarray
+        or full_x.dtype != np.dtype(np.float32)
+        or full_y.dtype != np.dtype(np.int32)
+        or full_x.shape != (60_000, checked.candidate_config.input_dim)
+        or full_y.shape != (60_000,)
+    ):
+        _fail("canonical OpenML loader did not return the exact 60k materialization")
+    count = checked.candidate_config.train_examples_per_task
+    test_count = checked.candidate_config.test_examples_per_task
+    if count + test_count > 60_000:
+        _fail("campaign train/test slices are not disjoint")
+    return _validated_arrays(
+        np.array(full_x[:count], dtype=np.float32, order="C", copy=True),
+        np.array(full_y[:count], dtype=np.int32, order="C", copy=True),
+        np.array(full_x[-test_count:], dtype=np.float32, order="C", copy=True),
+        np.array(full_y[-test_count:], dtype=np.int32, order="C", copy=True),
+        plan=checked,
+    )
+
+
+def _expected_fixed_identities(plan: BiMUMatchedDevelopmentPlan, seed: int) -> tuple[str, str]:
+    config = plan.control_config
+    root = jr.key(seed, impl=_PRNG_IMPLEMENTATION)
+    state = _initialize_state(config, _stream_key(root, _INIT_DOMAIN))
+    initial = _state_sha256(state, optimizer_step=0, optimizer_seen=0)
+    schedule = hashlib.sha256()
+    for task, permutation in enumerate(build_task_schedule(config, seed=seed)):
+        order = np.asarray(
+            jr.permutation(
+                _stream_key(root, _EXAMPLE_ORDER_DOMAIN, task),
+                config.train_examples_per_task,
+            ),
+            dtype=np.int32,
+        )
+        schedule.update(
+            json.dumps(
+                {
+                    "task": task,
+                    "permutation": list(permutation),
+                    "example_order": [int(value) for value in order],
+                    "query_decisions": [True] * config.train_examples_per_task,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+    return initial, schedule.hexdigest()
+
+
+def _process_identity() -> dict[str, object]:
+    boot_path = Path("/proc/sys/kernel/random/boot_id")
+    stat_path = Path("/proc/self/stat")
+    if not boot_path.is_file() or not stat_path.is_file():
+        raise RuntimeError("the fresh-process campaign requires Linux /proc identity")
+    boot_id = boot_path.read_text(encoding="ascii").strip()
+    stat_text = stat_path.read_text(encoding="ascii")
+    comm_end = stat_text.rfind(")")
+    stat_fields = stat_text[comm_end + 1 :].split() if comm_end >= 0 else []
+    if len(stat_fields) < 20 or not stat_fields[19].isdigit():
+        raise RuntimeError("cannot resolve Linux process start identity")
+    nonce = secrets.token_hex(16)
+    process = {
+        "schema": PROCESS_SCHEMA,
+        "pid": os.getpid(),
+        "proc_start_ticks": int(stat_fields[19]),
+        "boot_id_sha256": hashlib.sha256(boot_id.encode("ascii")).hexdigest(),
+        "invocation_nonce": nonce,
+        "fresh_process_required": True,
+        "identity_is_not_attestation": True,
+    }
+    process["execution_instance_id"] = _sha256(process)
+    return process
+
+
+def _arm_config(plan: BiMUMatchedDevelopmentPlan, arm: str) -> Any:
+    if type(arm) is not str or arm not in _ARMS:
+        _fail("arm is outside the frozen roster")
+    return plan.control_config if arm == "memory_off" else plan.candidate_config
+
+
+def _expected_counters(plan: BiMUMatchedDevelopmentPlan) -> dict[str, int]:
+    values = cast(dict[str, object], _plan_payload(plan)["expected_counters_per_arm"])
+    return {field: cast(int, values[field]) for field in _MATCHED_COUNTERS}
+
+
+def _expected_resources(plan: BiMUMatchedDevelopmentPlan) -> dict[str, int]:
+    values = cast(dict[str, object], _plan_payload(plan)["expected_resources_per_arm"])
+    return {
+        field: cast(int, values[field])
+        for field in (*_MATCHED_RESOURCES, "dataset_numeric_bytes")
+    }
+
+
+def run_bimu_shard(
+    arm: str,
+    seed: int,
+    *,
+    data_home: Path | None = None,
+    plan_document: object | None = None,
+) -> dict[str, object]:
+    """Execute exactly one authorized arm/seed shard in this process."""
+
+    if EXECUTION_AUTHORIZED is not True:
+        raise PermissionError("BiMU campaign execution is not authorized in this source revision")
+    if type(seed) is not int or seed not in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        _fail("seed is outside the frozen roster")
+    config = _arm_config(FROZEN_BIMU_MATCHED_PLAN, arm)
+    plan_doc = (
+        build_plan_document()
+        if plan_document is None
+        else validate_plan_document(plan_document)
+    )
+    if cast(dict[str, object], plan_doc["policy"])["execution_authorized"] is not True:
+        raise PermissionError("the bound campaign plan is not authorized for execution")
+    arrays = load_frozen_bimu_dataset(data_home)
+    started_wall = time.perf_counter()
+    started_cpu = time.process_time()
+    result = run_bimu_development(*arrays, config=config, seed=seed)
+    wall_seconds = time.perf_counter() - started_wall
+    cpu_seconds = time.process_time() - started_cpu
+    validate_bimu_result(result)
+    payload: dict[str, object] = {
+        "schema": SHARD_SCHEMA,
+        "status": "complete",
+        "plan_sha256": plan_doc["plan_sha256"],
+        "spec": {"arm": arm, "seed": seed},
+        "identity": {
+            **_current_identity(),
+            "dataset_sha256": FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
+            "process": _process_identity(),
+        },
+        "policy": {**_POLICY, "execution_authorized": True},
+        "result": result,
+        "resources": {
+            **_expected_resources(FROZEN_BIMU_MATCHED_PLAN),
+            "numeric_resource_ceiling_bytes": 256 * 1024 * 1024,
+            "aggregate_working_set_bytes_claimed": False,
+        },
+        "timing": {
+            "wall_clock_seconds": wall_seconds,
+            "process_cpu_seconds": cpu_seconds,
+            **_TIMING_POLICY,
+        },
+    }
+    payload["shard_sha256"] = _sha256(payload)
+    validate_bimu_shard(payload)
+    return payload
+
+
+def _finite_nonnegative_float(value: object, label: str) -> float:
+    if type(value) is not float or not math.isfinite(value) or value < 0.0:
+        _fail(f"{label} must be one finite nonnegative float")
+    return value
+
+
+def _validate_process(value: object) -> dict[str, object]:
+    process = _exact_object(
+        value,
+        {
+            "schema",
+            "pid",
+            "proc_start_ticks",
+            "boot_id_sha256",
+            "invocation_nonce",
+            "fresh_process_required",
+            "identity_is_not_attestation",
+            "execution_instance_id",
+        },
+        "process identity",
+    )
+    if process["schema"] != PROCESS_SCHEMA:
+        _fail("process identity schema drifted")
+    for field in ("pid", "proc_start_ticks"):
+        if type(process[field]) is not int or cast(int, process[field]) < 1:
+            _fail(f"process identity {field} drifted")
+    if not _is_digest(process["boot_id_sha256"]):
+        _fail("process boot identity drifted")
+    nonce = process["invocation_nonce"]
+    if (
+        type(nonce) is not str
+        or len(nonce) != 32
+        or any(character not in "0123456789abcdef" for character in nonce)
+    ):
+        _fail("process invocation nonce drifted")
+    if (
+        process["fresh_process_required"] is not True
+        or process["identity_is_not_attestation"] is not True
+    ):
+        _fail("process assurance drifted")
+    if process["execution_instance_id"] != digest_without(process, "execution_instance_id"):
+        _fail("process execution identity digest drifted")
+    return process
+
+
+def validate_bimu_shard(value: object) -> dict[str, object]:
+    """Strictly revalidate one complete source-bound shard."""
+
+    _validate_json_tree(value)
+    root = _exact_object(
+        value,
+        {
+            "schema",
+            "status",
+            "plan_sha256",
+            "spec",
+            "identity",
+            "policy",
+            "result",
+            "resources",
+            "timing",
+            "shard_sha256",
+        },
+        "BiMU shard",
+    )
+    if root["schema"] != SHARD_SCHEMA or root["status"] != "complete":
+        _fail("BiMU shard identity or status drifted")
+    expected_plan = frozen_plan_payload()
+    if root["plan_sha256"] != _sha256(expected_plan):
+        _fail("BiMU shard plan digest drifted")
+    spec = _exact_object(root["spec"], {"arm", "seed"}, "shard spec")
+    arm = cast(str, spec["arm"])
+    config = _arm_config(FROZEN_BIMU_MATCHED_PLAN, arm)
+    seed = spec["seed"]
+    if type(seed) is not int or seed not in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        _fail("shard seed is outside the frozen roster")
+    identity = _exact_object(
+        root["identity"],
+        {
+            "source_sha256",
+            "runtime",
+            "dependencies",
+            "consistency_not_attestation",
+            "dataset_sha256",
+            "process",
+        },
+        "shard identity",
+    )
+    expected_identity = {
+        **_current_identity(),
+        "dataset_sha256": FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
+    }
+    if not _json_exact_equal(
+        {key: value for key, value in identity.items() if key != "process"},
+        expected_identity,
+    ):
+        _fail("shard execution identity drifted")
+    _validate_process(identity["process"])
+    if not _json_exact_equal(root["policy"], {**_POLICY, "execution_authorized": True}):
+        _fail("shard policy drifted")
+    result = root["result"]
+    validate_bimu_result(result)
+    resolved = cast(dict[str, object], result)
+    if resolved["seed"] != seed or not _json_exact_equal(
+        resolved["protocol"], config.to_protocol_payload()
+    ):
+        _fail("shard result does not match its arm/seed spec")
+    if resolved["dataset_sha256"] != FROZEN_BIMU_MATCHED_PLAN.dataset_sha256:
+        _fail("shard result dataset identity drifted")
+    expected_initial, expected_schedule = _expected_fixed_identities(
+        FROZEN_BIMU_MATCHED_PLAN, seed
+    )
+    if resolved["initial_state_sha256"] != expected_initial:
+        _fail("shard initial-state identity drifted")
+    if resolved["schedule_sha256"] != expected_schedule:
+        _fail("shard schedule identity drifted")
+    counters = cast(dict[str, object], resolved["counters"])
+    expected_counters = _expected_counters(FROZEN_BIMU_MATCHED_PLAN)
+    if any(counters[field] != expected_counters[field] for field in _MATCHED_COUNTERS):
+        _fail("shard counters do not match the literal plan")
+    result_resources = cast(dict[str, object], resolved["resources"])
+    expected_resources = _expected_resources(FROZEN_BIMU_MATCHED_PLAN)
+    if any(result_resources[field] != expected_resources[field] for field in _MATCHED_RESOURCES):
+        _fail("shard result resources do not match the literal plan")
+    resources = _exact_object(
+        root["resources"],
+        {
+            *_MATCHED_RESOURCES,
+            "dataset_numeric_bytes",
+            "numeric_resource_ceiling_bytes",
+            "aggregate_working_set_bytes_claimed",
+        },
+        "shard resources",
+    )
+    if any(resources[field] != expected_resources[field] for field in expected_resources):
+        _fail("shard resource binding drifted")
+    if (
+        resources["numeric_resource_ceiling_bytes"] != 256 * 1024 * 1024
+        or resources["aggregate_working_set_bytes_claimed"] is not False
+    ):
+        _fail("shard resource ceiling policy drifted")
+    timing = _exact_object(
+        root["timing"],
+        {
+            "wall_clock_seconds",
+            "process_cpu_seconds",
+            "qualified",
+            "role",
+            "used_for_outcome",
+            "cross_machine_comparison_supported",
+        },
+        "shard timing",
+    )
+    _finite_nonnegative_float(timing["wall_clock_seconds"], "wall timing")
+    _finite_nonnegative_float(timing["process_cpu_seconds"], "CPU timing")
+    if {key: timing[key] for key in _TIMING_POLICY} != _TIMING_POLICY:
+        _fail("shard timing policy drifted")
+    if root["shard_sha256"] != digest_without(root, "shard_sha256"):
+        _fail("shard digest drifted")
+    if len(_canonical(root)) > MAX_SHARD_BYTES:
+        _fail("shard exceeds byte ceiling")
+    return root
+
+
+def _paired_metrics(shards: list[dict[str, object]]) -> dict[str, object]:
+    primary: list[float] = []
+    secondary: list[float] = []
+    for seed in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        by_arm = {
+            cast(str, cast(dict[str, object], shard["spec"])["arm"]): cast(
+                dict[str, object], shard["result"]
+            )
+            for shard in shards
+            if cast(dict[str, object], shard["spec"])["seed"] == seed
+        }
+        control_metrics = cast(dict[str, object], by_arm["memory_off"]["metrics"])
+        candidate_metrics = cast(dict[str, object], by_arm["bimu"]["metrics"])
+        primary.append(
+            cast(float, candidate_metrics["paper_late_five_test_accuracy"])
+            - cast(float, control_metrics["paper_late_five_test_accuracy"])
+        )
+        secondary.append(
+            cast(float, candidate_metrics["asi_whole_stream_online_accuracy"])
+            - cast(float, control_metrics["asi_whole_stream_online_accuracy"])
+        )
+    return {
+        "seeds": list(FROZEN_BIMU_MATCHED_PLAN.seeds),
+        "primary_metric": "paper_late_five_test_accuracy",
+        "primary_deltas": primary,
+        "primary_delta_mean": math.fsum(primary) / 3,
+        "secondary_metric": "asi_whole_stream_online_accuracy",
+        "secondary_deltas": secondary,
+        "secondary_delta_mean": math.fsum(secondary) / 3,
+    }
+
+
+def _outcome(paired: dict[str, object]) -> dict[str, object]:
+    deltas = cast(list[float], paired["primary_deltas"])
+    classification = (
+        "supported"
+        if all(delta > 0.0 for delta in deltas)
+        else "rejected"
+        if all(delta <= 0.0 for delta in deltas)
+        else "inconclusive"
+    )
+    rule = cast(dict[str, object], frozen_plan_payload()["paired_outcome_rule"])
+    return {
+        "classification": classification,
+        "rule": rule,
+        "scientific_evidence": False,
+        "paper_comparable": False,
+        "development_selection_only": True,
+    }
+
+
+def _validate_pair_matching(shards: list[dict[str, object]]) -> None:
+    for seed in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        pair = [
+            shard
+            for shard in shards
+            if cast(dict[str, object], shard["spec"])["seed"] == seed
+        ]
+        if len(pair) != 2:
+            _fail("aggregate roster lacks one complete pair per seed")
+        by_arm = {
+            cast(str, cast(dict[str, object], shard["spec"])["arm"]): cast(
+                dict[str, object], shard["result"]
+            )
+            for shard in pair
+        }
+        control = by_arm["memory_off"]
+        candidate = by_arm["bimu"]
+        for field in ("dataset_sha256", "schedule_sha256", "initial_state_sha256"):
+            if control[field] != candidate[field]:
+                _fail(f"matched pair {field} drifted")
+        control_counters = cast(dict[str, object], control["counters"])
+        candidate_counters = cast(dict[str, object], candidate["counters"])
+        if any(control_counters[field] != candidate_counters[field] for field in _MATCHED_COUNTERS):
+            _fail("matched pair counter drifted")
+        control_resources = cast(dict[str, object], control["resources"])
+        candidate_resources = cast(dict[str, object], candidate["resources"])
+        if any(
+            control_resources[field] != candidate_resources[field]
+            for field in _MATCHED_RESOURCES
+        ):
+            _fail("matched pair resource drifted")
+
+
+def _aggregate_resources(shards: list[dict[str, object]]) -> dict[str, object]:
+    totals = {
+        field: sum(
+            cast(int, cast(dict[str, object], shard["resources"])[field])
+            for shard in shards
+        )
+        for field in (*_MATCHED_RESOURCES, "dataset_numeric_bytes")
+    }
+    return {
+        "totals_across_six_independent_shards": totals,
+        "aggregate_working_set_bytes_claimed": False,
+    }
+
+
+def _aggregate_timing(shards: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "shard_wall_clock_seconds": [
+            cast(dict[str, object], shard["timing"])["wall_clock_seconds"] for shard in shards
+        ],
+        "shard_process_cpu_seconds": [
+            cast(dict[str, object], shard["timing"])["process_cpu_seconds"] for shard in shards
+        ],
+        **_TIMING_POLICY,
+    }
+
+
+def _summarize_bimu_shards_unchecked(values: object) -> dict[str, object]:
+    _validate_json_tree(values)
+    if type(values) is not list or len(cast(list[object], values)) != 6:
+        _fail("aggregate roster must contain exactly six shards")
+    shards = [validate_bimu_shard(item) for item in cast(list[object], values)]
+    expected_roster = [
+        (seed, arm) for seed in FROZEN_BIMU_MATCHED_PLAN.seeds for arm in _ARMS
+    ]
+    observed_roster = [
+        (
+            cast(dict[str, object], shard["spec"])["seed"],
+            cast(dict[str, object], shard["spec"])["arm"],
+        )
+        for shard in shards
+    ]
+    if observed_roster != expected_roster:
+        _fail("aggregate roster order, membership, or uniqueness drifted")
+    execution_ids = [
+        cast(
+            dict[str, object],
+            cast(dict[str, object], shard["identity"])["process"],
+        )["execution_instance_id"]
+        for shard in shards
+    ]
+    if len(set(cast(list[str], execution_ids))) != 6:
+        _fail("aggregate shards do not have six unique process invocations")
+    process_identities = [
+        cast(
+            dict[str, object],
+            cast(dict[str, object], shard["identity"])["process"],
+        )
+        for shard in shards
+    ]
+    process_keys = [
+        (
+            process["boot_id_sha256"],
+            process["pid"],
+            process["proc_start_ticks"],
+        )
+        for process in process_identities
+    ]
+    if len(set(process_keys)) != 6:
+        _fail("aggregate requires six independently started fresh processes")
+    shared_identity = [
+        {
+            key: value
+            for key, value in cast(dict[str, object], shard["identity"]).items()
+            if key != "process"
+        }
+        for shard in shards
+    ]
+    if any(
+        not _json_exact_equal(identity, shared_identity[0])
+        for identity in shared_identity[1:]
+    ):
+        _fail("aggregate mixes source, runtime, dependency, or dataset identities")
+    _validate_pair_matching(shards)
+    paired = _paired_metrics(shards)
+    aggregate: dict[str, object] = {
+        "schema": AGGREGATE_SCHEMA,
+        "status": "complete",
+        "plan": frozen_plan_payload(),
+        "plan_sha256": _sha256(frozen_plan_payload()),
+        "identity": {
+            **shared_identity[0],
+            "execution_instance_ids": execution_ids,
+            "fresh_process_identity_is_not_attestation": True,
+        },
+        "policy": dict(_POLICY),
+        "shards": shards,
+        "paired_metrics": paired,
+        "outcome": _outcome(paired),
+        "resources": _aggregate_resources(shards),
+        "timing": _aggregate_timing(shards),
+    }
+    aggregate["aggregate_sha256"] = _sha256(aggregate)
+    return aggregate
+
+
+def summarize_bimu_shards(values: object) -> dict[str, object]:
+    """Combine the exact six-shard roster and apply the frozen paired rule."""
+
+    aggregate = _summarize_bimu_shards_unchecked(values)
+    validate_bimu_aggregate(aggregate)
+    return aggregate
+
+
+def validate_bimu_aggregate(value: object) -> dict[str, object]:
+    """Strictly reconstruct a complete aggregate from its retained shards."""
+
+    _validate_json_tree(value)
+    root = _exact_object(
+        value,
+        {
+            "schema",
+            "status",
+            "plan",
+            "plan_sha256",
+            "identity",
+            "policy",
+            "shards",
+            "paired_metrics",
+            "outcome",
+            "resources",
+            "timing",
+            "aggregate_sha256",
+        },
+        "BiMU aggregate",
+    )
+    if root["schema"] != AGGREGATE_SCHEMA or root["status"] != "complete":
+        _fail("BiMU aggregate identity or status drifted")
+    if not _json_exact_equal(root["plan"], frozen_plan_payload()):
+        _fail("BiMU aggregate plan drifted")
+    shards_value = root["shards"]
+    if type(shards_value) is not list:
+        _fail("BiMU aggregate shards must be an exact list")
+    reconstructed = _summarize_bimu_shards_unchecked(cast(list[object], shards_value))
+    for field in (
+        "plan_sha256",
+        "identity",
+        "policy",
+        "paired_metrics",
+        "outcome",
+        "resources",
+        "timing",
+    ):
+        if not _json_exact_equal(root[field], reconstructed[field]):
+            _fail(f"BiMU aggregate {field} drifted")
+    if root["aggregate_sha256"] != digest_without(root, "aggregate_sha256"):
+        _fail("BiMU aggregate digest drifted")
+    if len(_canonical(root)) > MAX_AGGREGATE_BYTES:
+        _fail("BiMU aggregate exceeds byte ceiling")
+    return root
+
+
+def campaign_path(
+    root: Path,
+    artifact: str,
+    *,
+    arm: str | None = None,
+    seed: int | None = None,
+) -> Path:
+    if type(root) is not type(Path()):
+        raise TypeError("root must be an exact Path")
+    namespace = root / OUTPUT_NAMESPACE
+    if artifact == "plan" and arm is None and seed is None:
+        return namespace / "plan.json"
+    if artifact == "aggregate" and arm is None and seed is None:
+        return namespace / "aggregate.json"
+    if artifact == "shard" and arm in _ARMS and seed in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        return namespace / "shards" / f"seed-{seed}.{arm}.json"
+    _fail("artifact does not identify one canonical campaign path")
+
+
+def _allowed_path(path: Path, root: Path) -> bool:
+    candidates = {
+        campaign_path(root, "plan"),
+        campaign_path(root, "aggregate"),
+        *(
+            campaign_path(root, "shard", arm=arm, seed=seed)
+            for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
+            for arm in _ARMS
+        ),
+    }
+    return path in candidates
+
+
+def publish_json(path: Path, value: object, *, root: Path) -> None:
+    """Atomically publish one canonical campaign file without replacement."""
+
+    if type(path) is not type(Path()) or type(root) is not type(Path()):
+        raise TypeError("path and root must be exact Paths")
+    if not _allowed_path(path, root):
+        _fail("destination is outside the fixed campaign namespace")
+    if path == campaign_path(root, "plan"):
+        validate_plan_document(value)
+    elif path == campaign_path(root, "aggregate"):
+        validate_bimu_aggregate(value)
+    else:
+        validate_bimu_shard(value)
+    raw = _canonical(value) + b"\n"
+    root.mkdir(parents=True, exist_ok=True)
+    namespace = root / OUTPUT_NAMESPACE
+    namespace.mkdir(parents=True, exist_ok=True)
+    (namespace / "shards").mkdir(exist_ok=True)
+    for component in (root, *namespace.parents, namespace, path.parent):
+        if component.exists() and component.is_symlink():
+            _fail("campaign publication path contains a symlink")
+    if os.path.lexists(path):
+        raise FileExistsError(f"refusing to replace existing campaign artifact: {path}")
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    published = False
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(raw)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, path, follow_symlinks=False)
+        published = True
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    except BaseException:
+        if published:
+            path.unlink(missing_ok=True)
+        raise
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _load_plan(root: Path) -> dict[str, object]:
+    return validate_plan_document(
+        load_json_strict(campaign_path(root, "plan"), byte_ceiling=MAX_PLAN_BYTES)
+    )
+
+
+def _validate_namespace(
+    root: Path,
+    *,
+    require_complete_shards: bool,
+    require_aggregate: bool,
+) -> None:
+    namespace = root / OUTPUT_NAMESPACE
+    shards_directory = namespace / "shards"
+    if not namespace.is_dir() or namespace.is_symlink():
+        _fail("campaign namespace must be one real directory")
+    expected_top = {"plan.json", "shards"}
+    if require_aggregate:
+        expected_top.add("aggregate.json")
+    observed_top = {entry.name for entry in namespace.iterdir()}
+    if observed_top != expected_top:
+        _fail("campaign namespace contains missing or unexpected entries")
+    if not shards_directory.is_dir() or shards_directory.is_symlink():
+        _fail("campaign shard namespace must be one real directory")
+    expected_shards = {
+        campaign_path(root, "shard", arm=arm, seed=seed).name
+        for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
+        for arm in _ARMS
+    }
+    observed_shards = {entry.name for entry in shards_directory.iterdir()}
+    if require_complete_shards:
+        if observed_shards != expected_shards:
+            _fail("campaign shard namespace is not the exact complete roster")
+    elif not observed_shards <= expected_shards:
+        _fail("campaign shard namespace contains an unexpected entry")
+
+
+def _load_shards(root: Path) -> list[dict[str, object]]:
+    return [
+        validate_bimu_shard(
+            load_json_strict(
+                campaign_path(root, "shard", arm=arm, seed=seed),
+                byte_ceiling=MAX_SHARD_BYTES,
+            )
+        )
+        for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
+        for arm in _ARMS
+    ]
+
+
+def _print_json(value: object) -> None:
+    print(json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="permanently nonpromoting bounded BiMU matched campaign"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for name in ("plan", "summarize", "validate"):
+        command = subparsers.add_parser(name)
+        command.add_argument("--root", type=Path, required=True)
+    shard = subparsers.add_parser("run-shard")
+    shard.add_argument("--root", type=Path, required=True)
+    shard.add_argument("--arm", choices=_ARMS, required=True)
+    shard.add_argument("--seed", choices=FROZEN_BIMU_MATCHED_PLAN.seeds, required=True, type=int)
+    shard.add_argument("--data-home", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    root = cast(Path, args.root)
+    if args.command == "plan":
+        document = build_plan_document()
+        publish_json(campaign_path(root, "plan"), document, root=root)
+        _print_json({"status": "planned", "execution_authorized": EXECUTION_AUTHORIZED})
+        return 0
+    if args.command == "run-shard":
+        _validate_namespace(
+            root,
+            require_complete_shards=False,
+            require_aggregate=False,
+        )
+        if EXECUTION_AUTHORIZED is not True:
+            _print_json(
+                {
+                    "status": "execution_unauthorized",
+                    "execution_authorized": False,
+                    "shard_written": False,
+                }
+            )
+            return 2
+        destination = campaign_path(root, "shard", arm=args.arm, seed=args.seed)
+        if os.path.lexists(destination):
+            raise FileExistsError(f"refusing to replace existing campaign shard: {destination}")
+        plan = _load_plan(root)
+        shard = run_bimu_shard(
+            args.arm,
+            args.seed,
+            data_home=args.data_home,
+            plan_document=plan,
+        )
+        publish_json(destination, shard, root=root)
+        _print_json({"status": "complete", "shard": str(destination)})
+        return 0
+    if args.command == "summarize":
+        _validate_namespace(
+            root,
+            require_complete_shards=True,
+            require_aggregate=False,
+        )
+        _load_plan(root)
+        aggregate = summarize_bimu_shards(_load_shards(root))
+        destination = campaign_path(root, "aggregate")
+        publish_json(destination, aggregate, root=root)
+        _print_json(cast(dict[str, object], aggregate["outcome"]))
+        return 0
+    if args.command == "validate":
+        aggregate_path = campaign_path(root, "aggregate")
+        shard_paths = [
+            campaign_path(root, "shard", arm=arm, seed=seed)
+            for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
+            for arm in _ARMS
+        ]
+        any_shards = any(path.exists() for path in shard_paths)
+        _validate_namespace(
+            root,
+            require_complete_shards=any_shards,
+            require_aggregate=aggregate_path.exists(),
+        )
+        plan = _load_plan(root)
+        result: dict[str, object] = {
+            "plan_sha256": plan["plan_sha256"],
+            "execution_authorized": EXECUTION_AUTHORIZED,
+            "shards": [],
+            "aggregate": None,
+        }
+        if any_shards:
+            shards = _load_shards(root)
+            result["shards"] = [shard["shard_sha256"] for shard in shards]
+        if aggregate_path.exists():
+            aggregate = validate_bimu_aggregate(
+                load_json_strict(aggregate_path, byte_ceiling=MAX_AGGREGATE_BYTES)
+            )
+            result["aggregate"] = aggregate["aggregate_sha256"]
+        _print_json(result)
+        return 0
+    raise AssertionError("argparse returned an unknown command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -19,7 +19,7 @@ import secrets
 import stat
 import time
 from collections.abc import Mapping, Sequence
-from pathlib import Path
+from pathlib import Path, PosixPath
 from typing import Any, Final, NoReturn, cast
 
 import jax.random as jr
@@ -39,10 +39,12 @@ from alberta_framework.benchmarks.bimu import (
 )
 from alberta_framework.benchmarks.upgd_ipmnist import load_mnist_train
 from alberta_framework.evaluation.bimu_matched_nonpromoting import (
+    AUTHORIZATION_TRANSITION_APPROVED,
     EXECUTION_AUTHORIZED,
     FROZEN_BIMU_MATCHED_PLAN,
     OUTPUT_NAMESPACE,
     BiMUMatchedDevelopmentPlan,
+    _authorization_identity,
     _canonical,
     _dependency_identity,
     _plan_payload,
@@ -92,6 +94,7 @@ _POLICY: Final = {
     "ordinary_exception_failure_receipts_retained": True,
     "failed_attempt_reservation_retained": False,
     "base_exception_failure_retention_guaranteed": False,
+    "seed_status": "frozen_exposed_consumed_for_promotion",
 }
 _TIMING_POLICY: Final = {
     "qualified": False,
@@ -103,6 +106,11 @@ _TIMING_POLICY: Final = {
 
 def _fail(message: str) -> NoReturn:
     raise ValueError(message)
+
+
+def _require_execution_authorized() -> None:
+    if EXECUTION_AUTHORIZED is not True or AUTHORIZATION_TRANSITION_APPROVED is not True:
+        raise PermissionError("BiMU campaign execution is not authorized in this source revision")
 
 
 def _validate_json_tree(value: object) -> None:
@@ -253,6 +261,7 @@ def _current_identity() -> dict[str, object]:
         "source_sha256": _source_identity(),
         "runtime": _runtime_identity(),
         "dependencies": _dependency_identity(),
+        "authorization": _authorization_identity(),
         "consistency_not_attestation": True,
     }
 
@@ -268,7 +277,7 @@ def build_plan_document() -> dict[str, object]:
         "identity": _current_identity(),
         "policy": {
             **_POLICY,
-            "execution_authorized": EXECUTION_AUTHORIZED,
+            **_authorization_identity(),
         },
     }
     document["document_sha256"] = _sha256(document)
@@ -284,15 +293,13 @@ def validate_plan_document(value: object) -> dict[str, object]:
         "campaign plan",
     )
     expected_plan = frozen_plan_payload()
-    if root["schema"] != PLAN_DOCUMENT_SCHEMA or not _json_exact_equal(
-        root["plan"], expected_plan
-    ):
+    if root["schema"] != PLAN_DOCUMENT_SCHEMA or not _json_exact_equal(root["plan"], expected_plan):
         _fail("campaign plan does not match the current literal plan")
     if root["plan_sha256"] != _sha256(expected_plan):
         _fail("campaign plan digest drifted")
     if not _json_exact_equal(root["identity"], _current_identity()):
         _fail("campaign plan identity drifted")
-    expected_policy = {**_POLICY, "execution_authorized": EXECUTION_AUTHORIZED}
+    expected_policy = {**_POLICY, **_authorization_identity()}
     if not _json_exact_equal(root["policy"], expected_policy):
         _fail("campaign plan policy drifted")
     if root["document_sha256"] != digest_without(root, "document_sha256"):
@@ -446,8 +453,7 @@ def _expected_counters(plan: BiMUMatchedDevelopmentPlan) -> dict[str, int]:
 def _expected_resources(plan: BiMUMatchedDevelopmentPlan) -> dict[str, int]:
     values = cast(dict[str, object], _plan_payload(plan)["expected_resources_per_arm"])
     return {
-        field: cast(int, values[field])
-        for field in (*_MATCHED_RESOURCES, "dataset_numeric_bytes")
+        field: cast(int, values[field]) for field in (*_MATCHED_RESOURCES, "dataset_numeric_bytes")
     }
 
 
@@ -460,17 +466,18 @@ def run_bimu_shard(
 ) -> dict[str, object]:
     """Execute exactly one authorized arm/seed shard in this process."""
 
-    if EXECUTION_AUTHORIZED is not True:
-        raise PermissionError("BiMU campaign execution is not authorized in this source revision")
+    _require_execution_authorized()
     if type(seed) is not int or seed not in FROZEN_BIMU_MATCHED_PLAN.seeds:
         _fail("seed is outside the frozen roster")
     config = _arm_config(FROZEN_BIMU_MATCHED_PLAN, arm)
     plan_doc = (
-        build_plan_document()
-        if plan_document is None
-        else validate_plan_document(plan_document)
+        build_plan_document() if plan_document is None else validate_plan_document(plan_document)
     )
-    if cast(dict[str, object], plan_doc["policy"])["execution_authorized"] is not True:
+    bound_policy = cast(dict[str, object], plan_doc["policy"])
+    if (
+        bound_policy["execution_authorized"] is not True
+        or bound_policy["authorization_transition_approved"] is not True
+    ):
         raise PermissionError("the bound campaign plan is not authorized for execution")
     execution_identity = _current_identity()
     if not _json_exact_equal(plan_doc["identity"], execution_identity):
@@ -496,7 +503,7 @@ def run_bimu_shard(
             "dataset_sha256": FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
             "process": _process_identity(),
         },
-        "policy": {**_POLICY, "execution_authorized": True},
+        "policy": {**_POLICY, **_authorization_identity()},
         "result": result,
         "resources": {
             **_expected_resources(FROZEN_BIMU_MATCHED_PLAN),
@@ -596,6 +603,7 @@ def validate_bimu_shard(value: object) -> dict[str, object]:
             "source_sha256",
             "runtime",
             "dependencies",
+            "authorization",
             "consistency_not_attestation",
             "dataset_sha256",
             "process",
@@ -612,7 +620,7 @@ def validate_bimu_shard(value: object) -> dict[str, object]:
     ):
         _fail("shard execution identity drifted")
     _validate_process(identity["process"])
-    if not _json_exact_equal(root["policy"], {**_POLICY, "execution_authorized": True}):
+    if not _json_exact_equal(root["policy"], {**_POLICY, **_authorization_identity()}):
         _fail("shard policy drifted")
     result = root["result"]
     validate_bimu_result(result)
@@ -623,9 +631,7 @@ def validate_bimu_shard(value: object) -> dict[str, object]:
         _fail("shard result does not match its arm/seed spec")
     if resolved["dataset_sha256"] != FROZEN_BIMU_MATCHED_PLAN.dataset_sha256:
         _fail("shard result dataset identity drifted")
-    expected_initial, expected_schedule = _expected_fixed_identities(
-        FROZEN_BIMU_MATCHED_PLAN, seed
-    )
+    expected_initial, expected_schedule = _expected_fixed_identities(FROZEN_BIMU_MATCHED_PLAN, seed)
     if resolved["initial_state_sha256"] != expected_initial:
         _fail("shard initial-state identity drifted")
     if resolved["schedule_sha256"] != expected_schedule:
@@ -693,7 +699,7 @@ def build_failed_bimu_shard(arm: str, seed: int) -> dict[str, object]:
         "identity": {**_current_identity(), "process": _process_identity()},
         "policy": {
             **_POLICY,
-            "execution_authorized": True,
+            **_authorization_identity(),
             "used_for_outcome": False,
             "retry_authorized": False,
         },
@@ -743,6 +749,7 @@ def validate_failed_bimu_shard(value: object) -> dict[str, object]:
             "source_sha256",
             "runtime",
             "dependencies",
+            "authorization",
             "consistency_not_attestation",
             "process",
         },
@@ -756,7 +763,7 @@ def validate_failed_bimu_shard(value: object) -> dict[str, object]:
     _validate_process(identity["process"])
     expected_policy = {
         **_POLICY,
-        "execution_authorized": True,
+        **_authorization_identity(),
         "used_for_outcome": False,
         "retry_authorized": False,
     }
@@ -789,6 +796,7 @@ def validate_bimu_shard_by_reexecution(
 ) -> dict[str, object]:
     """Reexecute one shard and compare every deterministic result field."""
 
+    _require_execution_authorized()
     replay_identity = _current_identity()
     root = validate_bimu_shard(value)
     arrays = _validated_arrays(
@@ -809,8 +817,7 @@ def validate_bimu_shard_by_reexecution(
     reported = cast(dict[str, object], root["result"])
     deterministic_fields = set(replay) - {"timing"}
     if set(reported) - {"timing"} != deterministic_fields or any(
-        not _json_exact_equal(reported[field], replay[field])
-        for field in deterministic_fields
+        not _json_exact_equal(reported[field], replay[field]) for field in deterministic_fields
     ):
         _fail("shard result does not match strict seed/arm reexecution")
     if _dataset_sha256(*arrays) != FROZEN_BIMU_MATCHED_PLAN.dataset_sha256:
@@ -873,11 +880,7 @@ def _outcome(paired: dict[str, object]) -> dict[str, object]:
 
 def _validate_pair_matching(shards: list[dict[str, object]]) -> None:
     for seed in FROZEN_BIMU_MATCHED_PLAN.seeds:
-        pair = [
-            shard
-            for shard in shards
-            if cast(dict[str, object], shard["spec"])["seed"] == seed
-        ]
+        pair = [shard for shard in shards if cast(dict[str, object], shard["spec"])["seed"] == seed]
         if len(pair) != 2:
             _fail("aggregate roster lacks one complete pair per seed")
         by_arm = {
@@ -898,8 +901,7 @@ def _validate_pair_matching(shards: list[dict[str, object]]) -> None:
         control_resources = cast(dict[str, object], control["resources"])
         candidate_resources = cast(dict[str, object], candidate["resources"])
         if any(
-            control_resources[field] != candidate_resources[field]
-            for field in _MATCHED_RESOURCES
+            control_resources[field] != candidate_resources[field] for field in _MATCHED_RESOURCES
         ):
             _fail("matched pair resource drifted")
 
@@ -907,8 +909,7 @@ def _validate_pair_matching(shards: list[dict[str, object]]) -> None:
 def _aggregate_resources(shards: list[dict[str, object]]) -> dict[str, object]:
     totals = {
         field: sum(
-            cast(int, cast(dict[str, object], shard["resources"])[field])
-            for shard in shards
+            cast(int, cast(dict[str, object], shard["resources"])[field]) for shard in shards
         )
         for field in (*_MATCHED_RESOURCES, "dataset_numeric_bytes")
     }
@@ -935,9 +936,7 @@ def _summarize_bimu_shards_unchecked(values: object) -> dict[str, object]:
     if type(values) is not list or len(cast(list[object], values)) != 6:
         _fail("aggregate roster must contain exactly six shards")
     shards = [validate_bimu_shard(item) for item in cast(list[object], values)]
-    expected_roster = [
-        (seed, arm) for seed in FROZEN_BIMU_MATCHED_PLAN.seeds for arm in _ARMS
-    ]
+    expected_roster = [(seed, arm) for seed in FROZEN_BIMU_MATCHED_PLAN.seeds for arm in _ARMS]
     observed_roster = [
         (
             cast(dict[str, object], shard["spec"])["seed"],
@@ -981,10 +980,7 @@ def _summarize_bimu_shards_unchecked(values: object) -> dict[str, object]:
         }
         for shard in shards
     ]
-    if any(
-        not _json_exact_equal(identity, shared_identity[0])
-        for identity in shared_identity[1:]
-    ):
+    if any(not _json_exact_equal(identity, shared_identity[0]) for identity in shared_identity[1:]):
         _fail("aggregate mixes source, runtime, dependency, or dataset identities")
     _validate_pair_matching(shards)
     paired = _paired_metrics(shards)
@@ -1098,35 +1094,61 @@ def _allowed_path(path: Path, root: Path) -> bool:
 
 
 def _require_registered_root(root: Path) -> None:
-    if Path(os.path.abspath(os.fspath(root))) != REGISTERED_OUTPUT_ROOT:
+    if type(root) is not PosixPath or type(REGISTERED_OUTPUT_ROOT) is not PosixPath:
+        raise TypeError("campaign root must be an exact POSIX Path")
+    if PosixPath(os.path.abspath(os.fspath(root))) != REGISTERED_OUTPUT_ROOT:
         _fail("campaign output root is not the registered repository root")
 
 
-def _open_output_parent(path: Path, *, create: bool) -> tuple[Path, int]:
-    """Open an absolute parent through no-follow directory descriptors."""
-
-    destination = Path(os.path.abspath(os.fspath(path)))
-    descriptor = os.open(os.path.sep, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+def _open_directory_chain(root: Path, segments: Sequence[str], *, create: bool) -> int:
+    if type(root) is not PosixPath or not root.is_absolute():
+        raise ValueError("directory root must be an exact absolute POSIX Path")
+    if (type(segments) is not tuple and type(segments) is not list) or any(
+        type(segment) is not str
+        or not segment
+        or segment in {".", ".."}
+        or "/" in segment
+        or "\x00" in segment
+        for segment in segments
+    ):
+        raise ValueError("directory segments must be an exact safe sequence")
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
+    descriptor = os.open(root, flags)
     try:
-        for component in destination.parent.parts[1:]:
-            if component in ("", ".", ".."):
-                _fail("campaign path contains an unsafe directory component")
+        for segment in segments:
             if create:
                 try:
-                    os.mkdir(component, mode=0o755, dir_fd=descriptor)
+                    os.mkdir(segment, mode=0o755, dir_fd=descriptor)
                 except FileExistsError:
                     pass
-            next_descriptor = os.open(
-                component,
-                os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
-                dir_fd=descriptor,
-            )
+            child = os.open(segment, flags, dir_fd=descriptor)
             os.close(descriptor)
-            descriptor = next_descriptor
-        return destination, descriptor
+            descriptor = child
+        return descriptor
     except BaseException:
         os.close(descriptor)
         raise
+
+
+def _open_output_parent(path: Path, *, create: bool) -> tuple[Path, int]:
+    """Open one registered parent from the exact pinned repository root."""
+
+    if type(path) is not PosixPath:
+        raise TypeError("campaign path must be an exact POSIX Path")
+    destination = PosixPath(os.path.abspath(os.fspath(path)))
+    candidates = {
+        campaign_path(REGISTERED_OUTPUT_ROOT, "plan"),
+        campaign_path(REGISTERED_OUTPUT_ROOT, "aggregate"),
+        *(
+            campaign_path(REGISTERED_OUTPUT_ROOT, "shard", arm=arm, seed=seed)
+            for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
+            for arm in _ARMS
+        ),
+    }
+    if destination not in candidates:
+        _fail("destination is outside the registered campaign namespace")
+    segments = tuple(destination.parent.relative_to(REGISTERED_OUTPUT_ROOT).parts)
+    return destination, _open_directory_chain(REGISTERED_OUTPUT_ROOT, segments, create=create)
 
 
 def _link_unnamed_file(file_descriptor: int, parent_descriptor: int, name: str) -> None:
@@ -1161,12 +1183,13 @@ def _require_live_parent(destination: Path, parent_descriptor: int) -> None:
 ShardReservation = tuple[Path, int, int, str]
 
 
-def _reserve_shard_destination(path: Path, *, root: Path) -> ShardReservation:
-    """Reserve one exact shard path before dataset load or execution."""
+def _reserve_destination(path: Path, *, root: Path) -> ShardReservation:
+    """Reserve one exact artifact before plan/data/replay/execution work."""
 
+    _require_execution_authorized()
     _require_registered_root(root)
-    if not _allowed_path(path, root) or path.parent.name != "shards":
-        _fail("only one canonical shard destination may be reserved")
+    if not _allowed_path(path, root):
+        _fail("only one canonical campaign destination may be reserved")
     destination, parent_descriptor = _open_output_parent(path, create=True)
     reservation_name = f".{destination.name}.reservation"
     try:
@@ -1175,16 +1198,14 @@ def _reserve_shard_destination(path: Path, *, root: Path) -> ShardReservation:
         except FileNotFoundError:
             pass
         else:
-            raise FileExistsError(
-                f"refusing to replace existing campaign artifact: {destination}"
-            )
+            raise FileExistsError(f"refusing to replace existing campaign artifact: {destination}")
         reservation_descriptor = os.open(
             reservation_name,
             os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
             0o400,
             dir_fd=parent_descriptor,
         )
-        marker = b"asi-bimu-matched-shard-reservation-v1\n"
+        marker = b"asi-bimu-matched-campaign-reservation-v1\n"
         written = os.write(reservation_descriptor, marker)
         if written != len(marker):
             raise OSError("campaign reservation write made no progress")
@@ -1199,6 +1220,12 @@ def _reserve_shard_destination(path: Path, *, root: Path) -> ShardReservation:
             os.close(parent_descriptor)
         raise
     return destination, parent_descriptor, reservation_descriptor, reservation_name
+
+
+def _reserve_shard_destination(path: Path, *, root: Path) -> ShardReservation:
+    if path.parent.name != "shards":
+        _fail("only one canonical shard destination may be reserved")
+    return _reserve_destination(path, root=root)
 
 
 def _release_shard_reservation(reservation: ShardReservation) -> None:
@@ -1237,8 +1264,10 @@ def publish_json(
     complete result or a generic failed-attempt receipt is durably published.
     """
 
-    if type(path) is not type(Path()) or type(root) is not type(Path()):
-        raise TypeError("path and root must be exact Paths")
+    if type(path) is not PosixPath or type(root) is not PosixPath:
+        raise TypeError("path and root must be exact POSIX Paths")
+    _require_execution_authorized()
+    _require_registered_root(root)
     if not _allowed_path(path, root):
         _fail("destination is outside the fixed campaign namespace")
     if path != campaign_path(root, "plan"):
@@ -1253,55 +1282,45 @@ def publish_json(
             if type(candidate) is dict and candidate.get("schema") == FAILED_SHARD_SCHEMA:
                 validate_failed_bimu_shard(candidate)
             else:
-                validate_bimu_shard(candidate)
+                validate_bimu_shard_by_reexecution(candidate, *load_frozen_bimu_dataset())
 
-    validate(value)
-    raw = _canonical(value) + b"\n"
-    shard_path = campaign_path(
-        root,
-        "shard",
-        arm=_ARMS[0],
-        seed=FROZEN_BIMU_MATCHED_PLAN.seeds[0],
+    owns_reservation = _reservation is None
+    reservation = _reserve_destination(path, root=root) if _reservation is None else _reservation
+    destination, parent_descriptor, reservation_descriptor, reservation_name = reservation
+    if destination != PosixPath(os.path.abspath(os.fspath(path))):
+        _fail("campaign reservation does not match its exact destination")
+    _require_live_parent(destination, parent_descriptor)
+    reservation_stat = os.fstat(reservation_descriptor)
+    visible_reservation = os.stat(
+        reservation_name,
+        dir_fd=parent_descriptor,
+        follow_symlinks=False,
     )
-    _, shard_parent_descriptor = _open_output_parent(shard_path, create=True)
-    os.close(shard_parent_descriptor)
-    if _reservation is None:
-        destination, parent_descriptor = _open_output_parent(path, create=True)
-        close_parent = True
-    else:
-        (
-            destination,
-            parent_descriptor,
-            reservation_descriptor,
-            reservation_name,
-        ) = _reservation
-        close_parent = False
-        if destination != Path(os.path.abspath(os.fspath(path))):
-            _fail("campaign reservation does not match its exact destination")
-        _require_live_parent(destination, parent_descriptor)
-        reservation_stat = os.fstat(reservation_descriptor)
-        visible_reservation = os.stat(
-            reservation_name,
-            dir_fd=parent_descriptor,
-            follow_symlinks=False,
-        )
-        if (
-            not stat.S_ISREG(reservation_stat.st_mode)
-            or reservation_stat.st_nlink != 1
-            or (reservation_stat.st_dev, reservation_stat.st_ino)
-            != (visible_reservation.st_dev, visible_reservation.st_ino)
-        ):
-            _fail("campaign shard reservation is not the owned regular marker")
+    if (
+        not stat.S_ISREG(reservation_stat.st_mode)
+        or reservation_stat.st_nlink != 1
+        or (reservation_stat.st_dev, reservation_stat.st_ino)
+        != (visible_reservation.st_dev, visible_reservation.st_ino)
+    ):
+        _fail("campaign reservation is not the owned regular marker")
     file_descriptor: int | None = None
     try:
+        validate(value)
+        raw = _canonical(value) + b"\n"
+        shard_path = campaign_path(
+            root,
+            "shard",
+            arm=_ARMS[0],
+            seed=FROZEN_BIMU_MATCHED_PLAN.seeds[0],
+        )
+        _, shard_parent_descriptor = _open_output_parent(shard_path, create=True)
+        os.close(shard_parent_descriptor)
         try:
             os.stat(destination.name, dir_fd=parent_descriptor, follow_symlinks=False)
         except FileNotFoundError:
             pass
         else:
-            raise FileExistsError(
-                f"refusing to replace existing campaign artifact: {destination}"
-            )
+            raise FileExistsError(f"refusing to replace existing campaign artifact: {destination}")
         if not hasattr(os, "O_TMPFILE"):
             raise OSError("immutable publication requires Linux O_TMPFILE support")
         file_descriptor = os.open(
@@ -1375,8 +1394,8 @@ def publish_json(
     finally:
         if file_descriptor is not None:
             os.close(file_descriptor)
-        if close_parent:
-            os.close(parent_descriptor)
+        if owns_reservation:
+            _release_shard_reservation(reservation)
 
 
 def _load_plan(root: Path) -> dict[str, object]:
@@ -1466,9 +1485,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     root = cast(Path, args.root)
     if args.command == "plan":
+        _require_execution_authorized()
         document = build_plan_document()
         publish_json(campaign_path(root, "plan"), document, root=root)
-        _print_json({"status": "planned", "execution_authorized": EXECUTION_AUTHORIZED})
+        _print_json({"status": "planned", **_authorization_identity()})
         return 0
     if args.command == "run-shard":
         _require_registered_root(root)
@@ -1477,11 +1497,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             require_complete_shards=False,
             require_aggregate=False,
         )
-        if EXECUTION_AUTHORIZED is not True:
+        if EXECUTION_AUTHORIZED is not True or AUTHORIZATION_TRANSITION_APPROVED is not True:
             _print_json(
                 {
                     "status": "execution_unauthorized",
-                    "execution_authorized": False,
+                    **_authorization_identity(),
                     "shard_written": False,
                 }
             )
@@ -1521,11 +1541,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             require_complete_shards=True,
             require_aggregate=False,
         )
-        _load_plan(root)
-        arrays = load_frozen_bimu_dataset(args.data_home)
-        aggregate = summarize_bimu_shards(_load_shards(root, arrays))
         destination = campaign_path(root, "aggregate")
-        publish_json(destination, aggregate, root=root)
+        reservation = _reserve_destination(destination, root=root)
+        try:
+            _load_plan(root)
+            arrays = load_frozen_bimu_dataset(args.data_home)
+            aggregate = summarize_bimu_shards(_load_shards(root, arrays))
+            publish_json(destination, aggregate, root=root, _reservation=reservation)
+        finally:
+            _release_shard_reservation(reservation)
         _print_json(cast(dict[str, object], aggregate["outcome"]))
         return 0
     if args.command == "validate":
@@ -1544,12 +1568,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         plan = _load_plan(root)
         result: dict[str, object] = {
             "plan_sha256": plan["plan_sha256"],
-            "execution_authorized": EXECUTION_AUTHORIZED,
+            **_authorization_identity(),
             "shards": [],
             "aggregate": None,
         }
         replayed_shards: list[dict[str, object]] | None = None
         if any_shards:
+            _require_execution_authorized()
             arrays = load_frozen_bimu_dataset(args.data_home)
             replayed_shards = _load_shards(root, arrays)
             result["shards"] = [shard["shard_sha256"] for shard in replayed_shards]

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -1241,6 +1241,8 @@ def publish_json(
         raise TypeError("path and root must be exact Paths")
     if not _allowed_path(path, root):
         _fail("destination is outside the fixed campaign namespace")
+    if path != campaign_path(root, "plan"):
+        _require_registered_root(root)
 
     def validate(candidate: object) -> None:
         if path == campaign_path(root, "plan"):
@@ -1267,13 +1269,28 @@ def publish_json(
         destination, parent_descriptor = _open_output_parent(path, create=True)
         close_parent = True
     else:
-        destination, parent_descriptor, reservation_descriptor, _ = _reservation
+        (
+            destination,
+            parent_descriptor,
+            reservation_descriptor,
+            reservation_name,
+        ) = _reservation
         close_parent = False
         if destination != Path(os.path.abspath(os.fspath(path))):
             _fail("campaign reservation does not match its exact destination")
         _require_live_parent(destination, parent_descriptor)
         reservation_stat = os.fstat(reservation_descriptor)
-        if not stat.S_ISREG(reservation_stat.st_mode) or reservation_stat.st_nlink != 1:
+        visible_reservation = os.stat(
+            reservation_name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(reservation_stat.st_mode)
+            or reservation_stat.st_nlink != 1
+            or (reservation_stat.st_dev, reservation_stat.st_ino)
+            != (visible_reservation.st_dev, visible_reservation.st_ino)
+        ):
             _fail("campaign shard reservation is not the owned regular marker")
     file_descriptor: int | None = None
     try:

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -1239,7 +1239,6 @@ def publish_json(
 
     if type(path) is not type(Path()) or type(root) is not type(Path()):
         raise TypeError("path and root must be exact Paths")
-    _require_registered_root(root)
     if not _allowed_path(path, root):
         _fail("destination is outside the fixed campaign namespace")
 
@@ -1449,13 +1448,13 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     root = cast(Path, args.root)
-    _require_registered_root(root)
     if args.command == "plan":
         document = build_plan_document()
         publish_json(campaign_path(root, "plan"), document, root=root)
         _print_json({"status": "planned", "execution_authorized": EXECUTION_AUTHORIZED})
         return 0
     if args.command == "run-shard":
+        _require_registered_root(root)
         _validate_namespace(
             root,
             require_complete_shards=False,
@@ -1499,6 +1498,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         _print_json({"status": "complete", "shard": str(destination)})
         return 0
     if args.command == "summarize":
+        _require_registered_root(root)
         _validate_namespace(
             root,
             require_complete_shards=True,

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -1060,7 +1060,12 @@ def publish_json(
     root: Path,
     _reservation: tuple[Path, int, int] | None = None,
 ) -> None:
-    """Atomically publish one canonical campaign file without replacement."""
+    """Publish one canonical file without replacement and verify its held inode.
+
+    Plans and aggregates link a complete anonymous inode atomically. A shard's
+    exact final name is instead reserved before execution; an interrupted or
+    failed run intentionally leaves that non-result reservation occupied.
+    """
 
     if type(path) is not type(Path()) or type(root) is not type(Path()):
         raise TypeError("path and root must be exact Paths")
@@ -1274,6 +1279,7 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     root = cast(Path, args.root)
+    _require_registered_root(root)
     if args.command == "plan":
         document = build_plan_document()
         publish_json(campaign_path(root, "plan"), document, root=root)
@@ -1295,11 +1301,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 2
         destination = campaign_path(root, "shard", arm=args.arm, seed=args.seed)
-        plan = _load_plan(root)
         reservation: tuple[Path, int, int] | None = _reserve_shard_destination(
             destination, root=root
         )
         try:
+            plan = _load_plan(root)
             shard = run_bimu_shard(
                 args.arm,
                 args.seed,

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -87,7 +87,9 @@ _POLICY: Final = {
     "scientific_promotion_allowed": False,
     "sota_claim_allowed": False,
     "paper_comparable": False,
-    "negative_results_retained": True,
+    "completed_outcomes_retained": True,
+    "execution_failure_receipts_retained": False,
+    "failed_attempt_reservation_retained": True,
 }
 _TIMING_POLICY: Final = {
     "qualified": False,
@@ -1079,10 +1081,16 @@ def publish_json(
     root: Path,
     _reservation: tuple[Path, int, int] | None = None,
 ) -> None:
-    """Publish one validated canonical campaign file without replacement."""
+    """Publish one validated canonical file and verify its held inode.
+
+    Plans and aggregates link a complete anonymous inode atomically. A shard's
+    final name is reserved before execution; failure intentionally leaves that
+    zero-byte non-result reservation occupied.
+    """
 
     if type(path) is not type(Path()) or type(root) is not type(Path()):
         raise TypeError("path and root must be exact Paths")
+    _require_registered_root(root)
     if not _allowed_path(path, root):
         _fail("destination is outside the fixed campaign namespace")
 
@@ -1302,6 +1310,7 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     root = cast(Path, args.root)
+    _require_registered_root(root)
     if args.command == "plan":
         document = build_plan_document()
         publish_json(campaign_path(root, "plan"), document, root=root)

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -91,8 +91,9 @@ _POLICY: Final = {
     "sota_claim_allowed": False,
     "paper_comparable": False,
     "completed_outcomes_retained": True,
-    "ordinary_exception_failure_receipts_retained": True,
+    "ordinary_exception_failure_receipts_enabled": True,
     "failed_attempt_reservation_retained": False,
+    "failure_receipt_publication_guaranteed": False,
     "base_exception_failure_retention_guaranteed": False,
     "seed_status": "frozen_exposed_consumed_for_promotion",
 }
@@ -1517,7 +1518,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     data_home=args.data_home,
                     plan_document=plan,
                 )
-                publish_json(destination, shard, root=root, _reservation=reservation)
+                validate_bimu_shard(shard)
             except Exception:
                 failed = build_failed_bimu_shard(args.arm, args.seed)
                 publish_json(destination, failed, root=root, _reservation=reservation)
@@ -1530,6 +1531,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     }
                 )
                 return 1
+            publish_json(destination, shard, root=root, _reservation=reservation)
         finally:
             _release_shard_reservation(reservation)
         _print_json({"status": "complete", "shard": str(destination)})
@@ -1560,6 +1562,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             for arm in _ARMS
         ]
         any_shards = any(path.exists() for path in shard_paths)
+        if any_shards or aggregate_path.exists():
+            _require_registered_root(root)
         _validate_namespace(
             root,
             require_complete_shards=any_shards,

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -92,10 +92,10 @@ _POLICY: Final = {
     "paper_comparable": False,
     "completed_outcomes_retained": True,
     "ordinary_exception_failure_receipts_enabled": True,
-    "post_dispatch_consumed_without_result_tombstone_enabled": True,
-    "pre_dispatch_escaped_failure_reservation_released": True,
+    "post_dispatch_consumed_without_result_tombstone": True,
+    "pre_dispatch_reservation_released_on_failure": True,
     "failure_receipt_publication_guaranteed": False,
-    "post_dispatch_tombstone_retention_guaranteed": False,
+    "post_dispatch_base_exception_tombstone_retained": True,
     "process_death_tombstone_retention_guaranteed": False,
     "seed_status": "frozen_exposed_consumed_for_promotion",
 }

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -466,7 +466,6 @@ def run_bimu_shard(
     *,
     data_home: Path | None = None,
     plan_document: object | None = None,
-    _loaded_arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None = None,
     _on_first_dispatch: Callable[[], None] | None = None,
 ) -> dict[str, object]:
     """Execute exactly one authorized arm/seed shard in this process."""
@@ -487,12 +486,7 @@ def run_bimu_shard(
     execution_identity = _current_identity()
     if not _json_exact_equal(plan_doc["identity"], execution_identity):
         _fail("campaign identity changed after the plan was validated")
-    if _loaded_arrays is None:
-        arrays = load_frozen_bimu_dataset(data_home)
-    else:
-        if type(_loaded_arrays) is not tuple or tuple.__len__(_loaded_arrays) != 4:
-            raise TypeError("preloaded campaign arrays must be one exact four-item tuple")
-        arrays = _validated_arrays(*_loaded_arrays, plan=FROZEN_BIMU_MATCHED_PLAN)
+    arrays = load_frozen_bimu_dataset(data_home)
     started_wall = time.perf_counter()
     started_cpu = time.process_time()
     if _on_first_dispatch is not None:
@@ -1195,10 +1189,6 @@ def _require_live_parent(destination: Path, parent_descriptor: int) -> None:
 ShardReservation = tuple[Path, int, int, str]
 
 
-class _CompletedShardAdmissionError(ValueError):
-    """A completed payload failed structural or dataset-bound replay admission."""
-
-
 def _reserve_destination(path: Path, *, root: Path) -> ShardReservation:
     """Reserve one exact artifact before plan/data/replay/execution work."""
 
@@ -1307,8 +1297,6 @@ def publish_json(
     *,
     root: Path,
     _reservation: ShardReservation | None = None,
-    _completed_replay_arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-    | None = None,
 ) -> None:
     """Publish one canonical file without replacement and verify its held inode.
 
@@ -1326,7 +1314,7 @@ def publish_json(
     if path != campaign_path(root, "plan"):
         _require_registered_root(root)
 
-    def validate(candidate: object, *, require_completed_replay: bool) -> None:
+    def validate(candidate: object) -> None:
         if path == campaign_path(root, "plan"):
             validate_plan_document(candidate)
         elif path == campaign_path(root, "aggregate"):
@@ -1334,20 +1322,8 @@ def publish_json(
         else:
             if type(candidate) is dict and candidate.get("schema") == FAILED_SHARD_SCHEMA:
                 validate_failed_bimu_shard(candidate)
-            elif not require_completed_replay:
-                validate_bimu_shard(candidate)
             else:
-                try:
-                    if (
-                        type(_completed_replay_arrays) is not tuple
-                        or tuple.__len__(_completed_replay_arrays) != 4
-                    ):
-                        _fail("completed shard publication requires strict replay arrays")
-                    validate_bimu_shard_by_reexecution(candidate, *_completed_replay_arrays)
-                except Exception as exc:
-                    raise _CompletedShardAdmissionError(
-                        "completed shard failed strict dataset-bound admission"
-                    ) from exc
+                validate_bimu_shard(candidate)
 
     owns_reservation = _reservation is None
     reservation = _reserve_destination(path, root=root) if _reservation is None else _reservation
@@ -1371,7 +1347,7 @@ def publish_json(
     file_descriptor: int | None = None
     published_identity: tuple[int, int] | None = None
     try:
-        validate(value, require_completed_replay=True)
+        validate(value)
         raw = _canonical(value) + b"\n"
         shard_path = campaign_path(
             root,
@@ -1455,7 +1431,7 @@ def publish_json(
             )
         except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
             raise RuntimeError("published campaign artifact is not strict JSON") from exc
-        validate(decoded, require_completed_replay=False)
+        validate(decoded)
         os.fsync(parent_descriptor)
         _require_live_parent(destination, parent_descriptor)
     except BaseException:
@@ -1598,32 +1574,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             first_dispatch = True
 
         try:
-            failed_attempt = False
             try:
                 plan = _load_plan(root)
-                arrays = load_frozen_bimu_dataset(args.data_home)
                 shard = run_bimu_shard(
                     args.arm,
                     args.seed,
+                    data_home=args.data_home,
                     plan_document=plan,
-                    _loaded_arrays=arrays,
                     _on_first_dispatch=mark_first_dispatch,
                 )
+                validate_bimu_shard(shard)
             except Exception:
-                failed_attempt = True
-            else:
-                try:
-                    publish_json(
-                        destination,
-                        shard,
-                        root=root,
-                        _reservation=reservation,
-                        _completed_replay_arrays=arrays,
-                    )
-                    durable_result_published = True
-                except _CompletedShardAdmissionError:
-                    failed_attempt = True
-            if failed_attempt:
                 failed = build_failed_bimu_shard(args.arm, args.seed)
                 publish_json(destination, failed, root=root, _reservation=reservation)
                 durable_result_published = True
@@ -1636,6 +1597,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                     }
                 )
                 return 1
+            publish_json(destination, shard, root=root, _reservation=reservation)
+            durable_result_published = True
         except BaseException:
             if first_dispatch and not durable_result_published:
                 reservation_to_cleanup = None

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -464,6 +464,7 @@ def run_bimu_shard(
     *,
     data_home: Path | None = None,
     plan_document: object | None = None,
+    _loaded_arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None = None,
 ) -> dict[str, object]:
     """Execute exactly one authorized arm/seed shard in this process."""
 
@@ -483,7 +484,12 @@ def run_bimu_shard(
     execution_identity = _current_identity()
     if not _json_exact_equal(plan_doc["identity"], execution_identity):
         _fail("campaign identity changed after the plan was validated")
-    arrays = load_frozen_bimu_dataset(data_home)
+    if _loaded_arrays is None:
+        arrays = load_frozen_bimu_dataset(data_home)
+    else:
+        if type(_loaded_arrays) is not tuple or tuple.__len__(_loaded_arrays) != 4:
+            raise TypeError("preloaded campaign arrays must be one exact four-item tuple")
+        arrays = _validated_arrays(*_loaded_arrays, plan=FROZEN_BIMU_MATCHED_PLAN)
     started_wall = time.perf_counter()
     started_cpu = time.process_time()
     result = run_bimu_development(*arrays, config=config, seed=seed)
@@ -1184,6 +1190,10 @@ def _require_live_parent(destination: Path, parent_descriptor: int) -> None:
 ShardReservation = tuple[Path, int, int, str]
 
 
+class _CompletedShardAdmissionError(ValueError):
+    """A completed payload failed structural or dataset-bound replay admission."""
+
+
 def _reserve_destination(path: Path, *, root: Path) -> ShardReservation:
     """Reserve one exact artifact before plan/data/replay/execution work."""
 
@@ -1257,6 +1267,8 @@ def publish_json(
     *,
     root: Path,
     _reservation: ShardReservation | None = None,
+    _completed_replay_arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+    | None = None,
 ) -> None:
     """Publish one canonical file without replacement and verify its held inode.
 
@@ -1274,7 +1286,7 @@ def publish_json(
     if path != campaign_path(root, "plan"):
         _require_registered_root(root)
 
-    def validate(candidate: object) -> None:
+    def validate(candidate: object, *, require_completed_replay: bool) -> None:
         if path == campaign_path(root, "plan"):
             validate_plan_document(candidate)
         elif path == campaign_path(root, "aggregate"):
@@ -1282,8 +1294,20 @@ def publish_json(
         else:
             if type(candidate) is dict and candidate.get("schema") == FAILED_SHARD_SCHEMA:
                 validate_failed_bimu_shard(candidate)
-            else:
+            elif not require_completed_replay:
                 validate_bimu_shard(candidate)
+            else:
+                try:
+                    if (
+                        type(_completed_replay_arrays) is not tuple
+                        or tuple.__len__(_completed_replay_arrays) != 4
+                    ):
+                        _fail("completed shard publication requires strict replay arrays")
+                    validate_bimu_shard_by_reexecution(candidate, *_completed_replay_arrays)
+                except (TypeError, ValueError) as exc:
+                    raise _CompletedShardAdmissionError(
+                        "completed shard failed strict dataset-bound admission"
+                    ) from exc
 
     owns_reservation = _reservation is None
     reservation = _reserve_destination(path, root=root) if _reservation is None else _reservation
@@ -1307,7 +1331,7 @@ def publish_json(
     file_descriptor: int | None = None
     published_identity: tuple[int, int] | None = None
     try:
-        validate(value)
+        validate(value, require_completed_replay=True)
         raw = _canonical(value) + b"\n"
         shard_path = campaign_path(
             root,
@@ -1391,7 +1415,7 @@ def publish_json(
             )
         except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
             raise RuntimeError("published campaign artifact is not strict JSON") from exc
-        validate(decoded)
+        validate(decoded, require_completed_replay=False)
         os.fsync(parent_descriptor)
         _require_live_parent(destination, parent_descriptor)
     except BaseException:
@@ -1526,16 +1550,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         destination = campaign_path(root, "shard", arm=args.arm, seed=args.seed)
         reservation = _reserve_shard_destination(destination, root=root)
         try:
+            failed_attempt = False
             try:
                 plan = _load_plan(root)
+                arrays = load_frozen_bimu_dataset(args.data_home)
                 shard = run_bimu_shard(
                     args.arm,
                     args.seed,
-                    data_home=args.data_home,
                     plan_document=plan,
+                    _loaded_arrays=arrays,
                 )
-                validate_bimu_shard(shard)
             except Exception:
+                failed_attempt = True
+            else:
+                try:
+                    publish_json(
+                        destination,
+                        shard,
+                        root=root,
+                        _reservation=reservation,
+                        _completed_replay_arrays=arrays,
+                    )
+                except _CompletedShardAdmissionError:
+                    failed_attempt = True
+            if failed_attempt:
                 failed = build_failed_bimu_shard(args.arm, args.seed)
                 publish_json(destination, failed, root=root, _reservation=reservation)
                 _print_json(
@@ -1547,7 +1585,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                     }
                 )
                 return 1
-            publish_json(destination, shard, root=root, _reservation=reservation)
         finally:
             _release_shard_reservation(reservation)
         _print_json({"status": "complete", "shard": str(destination)})

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -1189,12 +1189,14 @@ def _require_live_parent(destination: Path, parent_descriptor: int) -> None:
 
 
 ShardReservation = tuple[Path, int, int, str]
+_COMPLETED_REPLAY_PROOF_CAPABILITY: Final = object()
 
 
 @dataclass(frozen=True, slots=True)
 class _CompletedShardReplayProof:
     """Private proof that one exact completed payload passed dataset-bound replay."""
 
+    capability: object
     payload_sha256: str
     shard_sha256: str
     dataset_sha256: str
@@ -1209,6 +1211,7 @@ def _prove_completed_shard_by_reexecution(
     validated_arrays = _validated_arrays(*arrays, plan=FROZEN_BIMU_MATCHED_PLAN)
     shard = validate_bimu_shard_by_reexecution(value, *validated_arrays)
     return _CompletedShardReplayProof(
+        capability=_COMPLETED_REPLAY_PROOF_CAPABILITY,
         payload_sha256=hashlib.sha256(_canonical(shard)).hexdigest(),
         shard_sha256=cast(str, shard["shard_sha256"]),
         dataset_sha256=FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
@@ -1316,9 +1319,14 @@ def publish_json(
                 validate_failed_bimu_shard(candidate)
             else:
                 completed = validate_bimu_shard(candidate)
-                if type(_completed_replay_proof) is not _CompletedShardReplayProof:
+                if (
+                    type(_completed_replay_proof) is not _CompletedShardReplayProof
+                    or _completed_replay_proof.capability
+                    is not _COMPLETED_REPLAY_PROOF_CAPABILITY
+                ):
                     _fail("completed shard publication requires a strict reexecution proof")
                 expected_proof = _CompletedShardReplayProof(
+                    capability=_COMPLETED_REPLAY_PROOF_CAPABILITY,
                     payload_sha256=hashlib.sha256(_canonical(completed)).hexdigest(),
                     shard_sha256=cast(str, completed["shard_sha256"]),
                     dataset_sha256=FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -466,6 +466,7 @@ def run_bimu_shard(
     *,
     data_home: Path | None = None,
     plan_document: object | None = None,
+    _loaded_arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None = None,
     _on_first_dispatch: Callable[[], None] | None = None,
 ) -> dict[str, object]:
     """Execute exactly one authorized arm/seed shard in this process."""
@@ -486,7 +487,12 @@ def run_bimu_shard(
     execution_identity = _current_identity()
     if not _json_exact_equal(plan_doc["identity"], execution_identity):
         _fail("campaign identity changed after the plan was validated")
-    arrays = load_frozen_bimu_dataset(data_home)
+    if _loaded_arrays is None:
+        arrays = load_frozen_bimu_dataset(data_home)
+    else:
+        if type(_loaded_arrays) is not tuple or tuple.__len__(_loaded_arrays) != 4:
+            raise TypeError("preloaded campaign arrays must be one exact four-item tuple")
+        arrays = _validated_arrays(*_loaded_arrays, plan=FROZEN_BIMU_MATCHED_PLAN)
     started_wall = time.perf_counter()
     started_cpu = time.process_time()
     if _on_first_dispatch is not None:
@@ -1189,6 +1195,10 @@ def _require_live_parent(destination: Path, parent_descriptor: int) -> None:
 ShardReservation = tuple[Path, int, int, str]
 
 
+class _CompletedShardAdmissionError(ValueError):
+    """A completed payload failed structural or dataset-bound replay admission."""
+
+
 def _reserve_destination(path: Path, *, root: Path) -> ShardReservation:
     """Reserve one exact artifact before plan/data/replay/execution work."""
 
@@ -1297,6 +1307,8 @@ def publish_json(
     *,
     root: Path,
     _reservation: ShardReservation | None = None,
+    _completed_replay_arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+    | None = None,
 ) -> None:
     """Publish one canonical file without replacement and verify its held inode.
 
@@ -1314,7 +1326,7 @@ def publish_json(
     if path != campaign_path(root, "plan"):
         _require_registered_root(root)
 
-    def validate(candidate: object) -> None:
+    def validate(candidate: object, *, require_completed_replay: bool) -> None:
         if path == campaign_path(root, "plan"):
             validate_plan_document(candidate)
         elif path == campaign_path(root, "aggregate"):
@@ -1322,8 +1334,20 @@ def publish_json(
         else:
             if type(candidate) is dict and candidate.get("schema") == FAILED_SHARD_SCHEMA:
                 validate_failed_bimu_shard(candidate)
-            else:
+            elif not require_completed_replay:
                 validate_bimu_shard(candidate)
+            else:
+                try:
+                    if (
+                        type(_completed_replay_arrays) is not tuple
+                        or tuple.__len__(_completed_replay_arrays) != 4
+                    ):
+                        _fail("completed shard publication requires strict replay arrays")
+                    validate_bimu_shard_by_reexecution(candidate, *_completed_replay_arrays)
+                except Exception as exc:
+                    raise _CompletedShardAdmissionError(
+                        "completed shard failed strict dataset-bound admission"
+                    ) from exc
 
     owns_reservation = _reservation is None
     reservation = _reserve_destination(path, root=root) if _reservation is None else _reservation
@@ -1347,7 +1371,7 @@ def publish_json(
     file_descriptor: int | None = None
     published_identity: tuple[int, int] | None = None
     try:
-        validate(value)
+        validate(value, require_completed_replay=True)
         raw = _canonical(value) + b"\n"
         shard_path = campaign_path(
             root,
@@ -1431,7 +1455,7 @@ def publish_json(
             )
         except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
             raise RuntimeError("published campaign artifact is not strict JSON") from exc
-        validate(decoded)
+        validate(decoded, require_completed_replay=False)
         os.fsync(parent_descriptor)
         _require_live_parent(destination, parent_descriptor)
     except BaseException:
@@ -1574,17 +1598,32 @@ def main(argv: Sequence[str] | None = None) -> int:
             first_dispatch = True
 
         try:
+            failed_attempt = False
             try:
                 plan = _load_plan(root)
+                arrays = load_frozen_bimu_dataset(args.data_home)
                 shard = run_bimu_shard(
                     args.arm,
                     args.seed,
-                    data_home=args.data_home,
                     plan_document=plan,
+                    _loaded_arrays=arrays,
                     _on_first_dispatch=mark_first_dispatch,
                 )
-                validate_bimu_shard(shard)
             except Exception:
+                failed_attempt = True
+            else:
+                try:
+                    publish_json(
+                        destination,
+                        shard,
+                        root=root,
+                        _reservation=reservation,
+                        _completed_replay_arrays=arrays,
+                    )
+                    durable_result_published = True
+                except _CompletedShardAdmissionError:
+                    failed_attempt = True
+            if failed_attempt:
                 failed = build_failed_bimu_shard(args.arm, args.seed)
                 publish_json(destination, failed, root=root, _reservation=reservation)
                 durable_result_published = True
@@ -1597,8 +1636,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                     }
                 )
                 return 1
-            publish_json(destination, shard, root=root, _reservation=reservation)
-            durable_result_published = True
         except BaseException:
             if first_dispatch and not durable_result_published:
                 reservation_to_cleanup = None

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -1283,7 +1283,7 @@ def publish_json(
             if type(candidate) is dict and candidate.get("schema") == FAILED_SHARD_SCHEMA:
                 validate_failed_bimu_shard(candidate)
             else:
-                validate_bimu_shard_by_reexecution(candidate, *load_frozen_bimu_dataset())
+                validate_bimu_shard(candidate)
 
     owns_reservation = _reservation is None
     reservation = _reserve_destination(path, root=root) if _reservation is None else _reservation
@@ -1305,6 +1305,7 @@ def publish_json(
     ):
         _fail("campaign reservation is not the owned regular marker")
     file_descriptor: int | None = None
+    published_identity: tuple[int, int] | None = None
     try:
         validate(value)
         raw = _canonical(value) + b"\n"
@@ -1345,13 +1346,14 @@ def publish_json(
             raise FileExistsError(
                 f"refusing to replace existing campaign artifact: {destination}"
             ) from exc
+        source_stat = os.fstat(file_descriptor)
+        published_identity = (source_stat.st_dev, source_stat.st_ino)
         read_descriptor = os.open(
             destination.name,
             os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
             dir_fd=parent_descriptor,
         )
         try:
-            source_stat = os.fstat(file_descriptor)
             before = os.fstat(read_descriptor)
             if (
                 not stat.S_ISREG(before.st_mode)
@@ -1392,6 +1394,20 @@ def publish_json(
         validate(decoded)
         os.fsync(parent_descriptor)
         _require_live_parent(destination, parent_descriptor)
+    except BaseException:
+        if published_identity is not None:
+            try:
+                visible = os.stat(
+                    destination.name,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+                if (visible.st_dev, visible.st_ino) == published_identity:
+                    os.unlink(destination.name, dir_fd=parent_descriptor)
+                    os.fsync(parent_descriptor)
+            except FileNotFoundError:
+                pass
+        raise
     finally:
         if file_descriptor is not None:
             os.close(file_descriptor)

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -19,7 +19,6 @@ import secrets
 import stat
 import time
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
 from pathlib import Path, PosixPath
 from typing import Any, Final, NoReturn, cast
 
@@ -465,7 +464,6 @@ def run_bimu_shard(
     *,
     data_home: Path | None = None,
     plan_document: object | None = None,
-    _loaded_arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None = None,
 ) -> dict[str, object]:
     """Execute exactly one authorized arm/seed shard in this process."""
 
@@ -485,12 +483,7 @@ def run_bimu_shard(
     execution_identity = _current_identity()
     if not _json_exact_equal(plan_doc["identity"], execution_identity):
         _fail("campaign identity changed after the plan was validated")
-    if _loaded_arrays is None:
-        arrays = load_frozen_bimu_dataset(data_home)
-    else:
-        if type(_loaded_arrays) is not tuple or tuple.__len__(_loaded_arrays) != 4:
-            raise TypeError("preloaded campaign arrays must be one exact four-item tuple")
-        arrays = _validated_arrays(*_loaded_arrays, plan=FROZEN_BIMU_MATCHED_PLAN)
+    arrays = load_frozen_bimu_dataset(data_home)
     started_wall = time.perf_counter()
     started_cpu = time.process_time()
     result = run_bimu_development(*arrays, config=config, seed=seed)
@@ -1189,33 +1182,6 @@ def _require_live_parent(destination: Path, parent_descriptor: int) -> None:
 
 
 ShardReservation = tuple[Path, int, int, str]
-_COMPLETED_REPLAY_PROOF_CAPABILITY: Final = object()
-
-
-@dataclass(frozen=True, slots=True)
-class _CompletedShardReplayProof:
-    """Private proof that one exact completed payload passed dataset-bound replay."""
-
-    capability: object
-    payload_sha256: str
-    shard_sha256: str
-    dataset_sha256: str
-
-
-def _prove_completed_shard_by_reexecution(
-    value: object,
-    arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
-) -> _CompletedShardReplayProof:
-    if type(arrays) is not tuple or tuple.__len__(arrays) != 4:
-        raise TypeError("replay arrays must be one exact four-item tuple")
-    validated_arrays = _validated_arrays(*arrays, plan=FROZEN_BIMU_MATCHED_PLAN)
-    shard = validate_bimu_shard_by_reexecution(value, *validated_arrays)
-    return _CompletedShardReplayProof(
-        capability=_COMPLETED_REPLAY_PROOF_CAPABILITY,
-        payload_sha256=hashlib.sha256(_canonical(shard)).hexdigest(),
-        shard_sha256=cast(str, shard["shard_sha256"]),
-        dataset_sha256=FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
-    )
 
 
 def _reserve_destination(path: Path, *, root: Path) -> ShardReservation:
@@ -1291,7 +1257,6 @@ def publish_json(
     *,
     root: Path,
     _reservation: ShardReservation | None = None,
-    _completed_replay_proof: _CompletedShardReplayProof | None = None,
 ) -> None:
     """Publish one canonical file without replacement and verify its held inode.
 
@@ -1318,21 +1283,7 @@ def publish_json(
             if type(candidate) is dict and candidate.get("schema") == FAILED_SHARD_SCHEMA:
                 validate_failed_bimu_shard(candidate)
             else:
-                completed = validate_bimu_shard(candidate)
-                if (
-                    type(_completed_replay_proof) is not _CompletedShardReplayProof
-                    or _completed_replay_proof.capability
-                    is not _COMPLETED_REPLAY_PROOF_CAPABILITY
-                ):
-                    _fail("completed shard publication requires a strict reexecution proof")
-                expected_proof = _CompletedShardReplayProof(
-                    capability=_COMPLETED_REPLAY_PROOF_CAPABILITY,
-                    payload_sha256=hashlib.sha256(_canonical(completed)).hexdigest(),
-                    shard_sha256=cast(str, completed["shard_sha256"]),
-                    dataset_sha256=FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
-                )
-                if _completed_replay_proof != expected_proof:
-                    _fail("completed shard reexecution proof does not match the payload")
+                validate_bimu_shard(candidate)
 
     owns_reservation = _reservation is None
     reservation = _reserve_destination(path, root=root) if _reservation is None else _reservation
@@ -1577,14 +1528,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             try:
                 plan = _load_plan(root)
-                arrays = load_frozen_bimu_dataset(args.data_home)
                 shard = run_bimu_shard(
                     args.arm,
                     args.seed,
+                    data_home=args.data_home,
                     plan_document=plan,
-                    _loaded_arrays=arrays,
                 )
-                replay_proof = _prove_completed_shard_by_reexecution(shard, arrays)
+                validate_bimu_shard(shard)
             except Exception:
                 failed = build_failed_bimu_shard(args.arm, args.seed)
                 publish_json(destination, failed, root=root, _reservation=reservation)
@@ -1597,13 +1547,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     }
                 )
                 return 1
-            publish_json(
-                destination,
-                shard,
-                root=root,
-                _reservation=reservation,
-                _completed_replay_proof=replay_proof,
-            )
+            publish_json(destination, shard, root=root, _reservation=reservation)
         finally:
             _release_shard_reservation(reservation)
         _print_json({"status": "complete", "shard": str(destination)})

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -1304,7 +1304,7 @@ def publish_json(
                     ):
                         _fail("completed shard publication requires strict replay arrays")
                     validate_bimu_shard_by_reexecution(candidate, *_completed_replay_arrays)
-                except (TypeError, ValueError) as exc:
+                except Exception as exc:
                     raise _CompletedShardAdmissionError(
                         "completed shard failed strict dataset-bound admission"
                     ) from exc

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -468,6 +468,9 @@ def run_bimu_shard(
     )
     if cast(dict[str, object], plan_doc["policy"])["execution_authorized"] is not True:
         raise PermissionError("the bound campaign plan is not authorized for execution")
+    execution_identity = _current_identity()
+    if not _json_exact_equal(plan_doc["identity"], execution_identity):
+        _fail("campaign identity changed after the plan was validated")
     arrays = load_frozen_bimu_dataset(data_home)
     started_wall = time.perf_counter()
     started_cpu = time.process_time()
@@ -476,6 +479,8 @@ def run_bimu_shard(
     cpu_seconds = time.process_time() - started_cpu
     if _dataset_sha256(*arrays) != FROZEN_BIMU_MATCHED_PLAN.dataset_sha256:
         _fail("campaign dataset changed during shard execution")
+    if not _json_exact_equal(_current_identity(), execution_identity):
+        _fail("campaign source, runtime, or dependencies changed during shard execution")
     validate_bimu_result(result)
     payload: dict[str, object] = {
         "schema": SHARD_SCHEMA,
@@ -483,7 +488,7 @@ def run_bimu_shard(
         "plan_sha256": plan_doc["plan_sha256"],
         "spec": {"arm": arm, "seed": seed},
         "identity": {
-            **_current_identity(),
+            **execution_identity,
             "dataset_sha256": FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
             "process": _process_identity(),
         },
@@ -678,6 +683,7 @@ def validate_bimu_shard_by_reexecution(
 ) -> dict[str, object]:
     """Reexecute one shard and compare every deterministic result field."""
 
+    replay_identity = _current_identity()
     root = validate_bimu_shard(value)
     arrays = _validated_arrays(
         train_x,
@@ -703,6 +709,8 @@ def validate_bimu_shard_by_reexecution(
         _fail("shard result does not match strict seed/arm reexecution")
     if _dataset_sha256(*arrays) != FROZEN_BIMU_MATCHED_PLAN.dataset_sha256:
         _fail("campaign dataset changed during strict shard reexecution")
+    if not _json_exact_equal(_current_identity(), replay_identity):
+        _fail("campaign source, runtime, or dependencies changed during shard reexecution")
     return root
 
 
@@ -1010,7 +1018,7 @@ def _open_output_parent(path: Path, *, create: bool) -> tuple[Path, int]:
             os.close(descriptor)
             descriptor = next_descriptor
         return destination, descriptor
-    except Exception:
+    except BaseException:
         os.close(descriptor)
         raise
 
@@ -1031,6 +1039,17 @@ def _link_unnamed_file(file_descriptor: int, parent_descriptor: int, name: str) 
         if error == errno.EEXIST:
             raise FileExistsError(error, os.strerror(error), name)
         raise OSError(error, os.strerror(error), name)
+
+
+def _require_live_parent(destination: Path, parent_descriptor: int) -> None:
+    _, live_descriptor = _open_output_parent(destination, create=False)
+    try:
+        pinned = os.fstat(parent_descriptor)
+        live = os.fstat(live_descriptor)
+        if (pinned.st_dev, pinned.st_ino) != (live.st_dev, live.st_ino):
+            raise RuntimeError("campaign publication parent changed during publication")
+    finally:
+        os.close(live_descriptor)
 
 
 def _reserve_shard_destination(path: Path, *, root: Path) -> tuple[Path, int, int]:
@@ -1060,16 +1079,10 @@ def publish_json(
     root: Path,
     _reservation: tuple[Path, int, int] | None = None,
 ) -> None:
-    """Publish one canonical file without replacement and verify its held inode.
-
-    Plans and aggregates link a complete anonymous inode atomically. A shard's
-    exact final name is instead reserved before execution; an interrupted or
-    failed run intentionally leaves that non-result reservation occupied.
-    """
+    """Publish one validated canonical campaign file without replacement."""
 
     if type(path) is not type(Path()) or type(root) is not type(Path()):
         raise TypeError("path and root must be exact Paths")
-    _require_registered_root(root)
     if not _allowed_path(path, root):
         _fail("destination is outside the fixed campaign namespace")
 
@@ -1091,15 +1104,31 @@ def publish_json(
     )
     _, shard_parent_descriptor = _open_output_parent(shard_path, create=True)
     os.close(shard_parent_descriptor)
-    if _reservation is None:
+    owns_descriptors = _reservation is None
+    if owns_descriptors:
         destination, parent_descriptor = _open_output_parent(path, create=True)
         file_descriptor: int | None = None
     else:
+        assert _reservation is not None
         destination, parent_descriptor, file_descriptor = _reservation
         if destination != Path(os.path.abspath(os.fspath(path))):
             _fail("campaign reservation does not match its exact destination")
+        _require_live_parent(destination, parent_descriptor)
+        reserved = os.fstat(file_descriptor)
+        visible = os.stat(
+            destination.name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(reserved.st_mode)
+            or reserved.st_nlink != 1
+            or reserved.st_size != 0
+            or (reserved.st_dev, reserved.st_ino) != (visible.st_dev, visible.st_ino)
+        ):
+            raise RuntimeError("campaign shard reservation changed before publication")
     try:
-        if _reservation is None:
+        if owns_descriptors:
             try:
                 os.stat(destination.name, dir_fd=parent_descriptor, follow_symlinks=False)
             except FileNotFoundError:
@@ -1126,7 +1155,7 @@ def publish_json(
             written += count
         os.fsync(file_descriptor)
         os.fchmod(file_descriptor, 0o444)
-        if _reservation is None:
+        if owns_descriptors:
             try:
                 _link_unnamed_file(file_descriptor, parent_descriptor, destination.name)
             except FileExistsError as exc:
@@ -1179,18 +1208,12 @@ def publish_json(
             raise RuntimeError("published campaign artifact is not strict JSON") from exc
         validate(decoded)
         os.fsync(parent_descriptor)
-        _, live_parent_descriptor = _open_output_parent(destination, create=False)
-        try:
-            pinned = os.fstat(parent_descriptor)
-            live = os.fstat(live_parent_descriptor)
-            if (pinned.st_dev, pinned.st_ino) != (live.st_dev, live.st_ino):
-                raise RuntimeError("campaign publication parent changed during publication")
-        finally:
-            os.close(live_parent_descriptor)
+        _require_live_parent(destination, parent_descriptor)
     finally:
-        if file_descriptor is not None:
-            os.close(file_descriptor)
-        os.close(parent_descriptor)
+        if owns_descriptors:
+            if file_descriptor is not None:
+                os.close(file_descriptor)
+            os.close(parent_descriptor)
 
 
 def _load_plan(root: Path) -> dict[str, object]:
@@ -1279,7 +1302,6 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     root = cast(Path, args.root)
-    _require_registered_root(root)
     if args.command == "plan":
         document = build_plan_document()
         publish_json(campaign_path(root, "plan"), document, root=root)
@@ -1312,8 +1334,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 data_home=args.data_home,
                 plan_document=plan,
             )
-            publish_json(destination, shard, root=root, _reservation=reservation)
-            reservation = None
+            publish_json(
+                destination,
+                shard,
+                root=root,
+                _reservation=reservation,
+            )
         finally:
             if reservation is not None:
                 _, parent_descriptor, file_descriptor = reservation
@@ -1354,17 +1380,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             "shards": [],
             "aggregate": None,
         }
-        shards: list[dict[str, object]] = []
+        replayed_shards: list[dict[str, object]] | None = None
         if any_shards:
             arrays = load_frozen_bimu_dataset(args.data_home)
-            shards = _load_shards(root, arrays)
-            result["shards"] = [shard["shard_sha256"] for shard in shards]
+            replayed_shards = _load_shards(root, arrays)
+            result["shards"] = [shard["shard_sha256"] for shard in replayed_shards]
         if aggregate_path.exists():
             aggregate = validate_bimu_aggregate(
                 load_json_strict(aggregate_path, byte_ceiling=MAX_AGGREGATE_BYTES)
             )
-            if any_shards and aggregate["shards"] != shards:
-                _fail("aggregate does not contain the exact retained shard roster")
+            if replayed_shards is None or not _json_exact_equal(
+                aggregate["shards"], replayed_shards
+            ):
+                _fail("aggregate shards do not match the dataset-reexecuted shard files")
             result["aggregate"] = aggregate["aggregate_sha256"]
         _print_json(result)
         return 0

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -1085,7 +1085,10 @@ def _validate_namespace(
         for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
         for arm in _ARMS
     }
-    observed_shards = {entry.name for entry in shards_directory.iterdir()}
+    shard_entries = list(shards_directory.iterdir())
+    if any(entry.is_symlink() or not entry.is_file() for entry in shard_entries):
+        _fail("campaign shard namespace entries must be regular non-symlink files")
+    observed_shards = {entry.name for entry in shard_entries}
     if require_complete_shards:
         if observed_shards != expected_shards:
             _fail("campaign shard namespace is not the exact complete roster")

--- a/alberta_framework/evaluation/bimu_matched_nonpromoting.py
+++ b/alberta_framework/evaluation/bimu_matched_nonpromoting.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import importlib.metadata
 import json
-import math
 import os
 import platform
 import sys
@@ -13,7 +12,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import Final, cast
+from typing import Final
 
 import jax
 import numpy as np
@@ -21,13 +20,8 @@ import numpy as np
 from alberta_framework.benchmarks.bimu import BiMUConfig, _dataset_sha256
 
 PLAN_SCHEMA: Final = "asi.bimu.matched-development-plan.v3"
-MANIFEST_SCHEMA: Final = "asi.bimu.matched-development-execution-manifest.v1"
 OUTPUT_NAMESPACE: Final = Path("outputs/bimu_matched/development.v1")
 EXECUTION_AUTHORIZED: Final = False
-_MAX_JSON_NODES = 20_000
-_MAX_TEXT_BYTES = 4096
-_MAX_MANIFEST_BYTES = 2 * 1024 * 1024
-_MAX_DATASET_BYTES = 16 * 1024 * 1024
 _DIGEST = "85c681c2f5fc5c274870b30c9accb3d2a6e9eb90a4575a2bf1ccca64f58b6227"
 FROZEN_PLAN_SHA256: Final = "11ddfacd0aca8108a39bd8a68225149de246efb7420d2fdb864f36ea75681f71"
 
@@ -166,48 +160,6 @@ def _canonical(value: object) -> bytes:
     return json.dumps(
         value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False
     ).encode("ascii")
-
-
-def _json_preflight(value: object) -> None:
-    pending = [value]
-    nodes = 0
-    while pending:
-        current = pending.pop()
-        nodes += 1
-        if nodes > _MAX_JSON_NODES:
-            raise ValueError("manifest exceeds exact JSON node ceiling")
-        if type(current) is dict:
-            mapping = cast(dict[object, object], current)
-            if len(mapping) > _MAX_JSON_NODES:
-                raise ValueError("manifest exceeds exact JSON node ceiling")
-            for key in mapping.keys():
-                if type(key) is not str or len(key.encode("utf-8")) > _MAX_TEXT_BYTES:
-                    raise ValueError("manifest must be an exact JSON tree")
-            pending.extend(mapping.values())
-        elif type(current) is list:
-            if len(cast(list[object], current)) > _MAX_JSON_NODES:
-                raise ValueError("manifest exceeds exact JSON node ceiling")
-            pending.extend(cast(list[object], current))
-        elif type(current) is str:
-            if len(current.encode("utf-8")) > _MAX_TEXT_BYTES:
-                raise ValueError("manifest text exceeds ceiling")
-        elif type(current) is int:
-            if not -(2**63) <= current <= 2**63 - 1:
-                raise ValueError("manifest integer exceeds signed-int64")
-        elif type(current) is float:
-            if not math.isfinite(current):
-                raise ValueError("manifest float must be finite")
-        elif type(current) is not bool and type(current) is not type(None):
-            raise ValueError("manifest must be an exact JSON tree")
-
-
-def _fields(value: object, expected: tuple[str, ...], name: str) -> dict[str, object]:
-    if type(value) is not dict:
-        raise ValueError(f"{name} must be an exact object")
-    mapping = cast(dict[str, object], value)
-    if len(mapping) != len(expected) or set(mapping) != set(expected):
-        raise ValueError(f"{name} fields drifted")
-    return mapping
 
 
 def _plan_payload(plan: BiMUMatchedDevelopmentPlan) -> dict[str, object]:
@@ -360,111 +312,3 @@ def _dependency_identity() -> dict[str, object]:
         },
         "uv_lock_sha256": hashlib.sha256((root / "uv.lock").read_bytes()).hexdigest(),
     }
-
-
-def _validated_dataset_arrays(
-    train_x: object, train_y: object, test_x: object, test_y: object
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    plan = FROZEN_BIMU_MATCHED_PLAN
-    config = plan.candidate_config
-    expected = (
-        (
-            "train_x",
-            train_x,
-            np.dtype(np.float32),
-            (config.train_examples_per_task, config.input_dim),
-        ),
-        ("train_y", train_y, np.dtype(np.int32), (config.train_examples_per_task,)),
-        ("test_x", test_x, np.dtype(np.float32), (config.test_examples_per_task, config.input_dim)),
-        ("test_y", test_y, np.dtype(np.int32), (config.test_examples_per_task,)),
-    )
-    arrays: list[np.ndarray] = []
-    total_bytes = 0
-    for name, value, dtype, shape in expected:
-        if type(value) is not np.ndarray or value.dtype != dtype or value.shape != shape:
-            raise ValueError(f"{name} does not match the frozen exact shape/dtype")
-        total_bytes += value.size * value.dtype.itemsize
-        if total_bytes > _MAX_DATASET_BYTES:
-            raise ValueError("dataset exceeds the frozen byte ceiling")
-        arrays.append(value)
-    for name, features in (("train_x", arrays[0]), ("test_x", arrays[2])):
-        if not np.all(np.isfinite(features)):
-            raise ValueError(f"{name} must contain only finite values")
-    for name, labels in (("train_y", arrays[1]), ("test_y", arrays[3])):
-        if np.any(labels < 0) or np.any(labels >= config.n_classes):
-            raise ValueError(f"{name} contains an out-of-range label")
-    return arrays[0], arrays[1], arrays[2], arrays[3]
-
-
-def build_bimu_execution_manifest(
-    train_x: object, train_y: object, test_x: object, test_y: object
-) -> dict[str, object]:
-    arrays = _validated_dataset_arrays(train_x, train_y, test_x, test_y)
-    plan = FROZEN_BIMU_MATCHED_PLAN
-    digest = _dataset_sha256(
-        *arrays,
-    )
-    if digest != plan.dataset_sha256:
-        raise ValueError("dataset does not match the frozen plan")
-    plan_payload = _plan_payload(plan)
-    manifest: dict[str, object] = {
-        "schema": MANIFEST_SCHEMA,
-        "plan": plan_payload,
-        "identity": {
-            "source_sha256": _source_identity(),
-            "runtime": _runtime_identity(),
-            "plan_sha256": hashlib.sha256(_canonical(plan_payload)).hexdigest(),
-            "consistency_not_attestation": True,
-        },
-        "policy": {
-            "development_only": True,
-            "scientific_promotion_allowed": False,
-            "execution_authorized": False,
-            "output_retained": False,
-        },
-    }
-    manifest["manifest_sha256"] = hashlib.sha256(_canonical(manifest)).hexdigest()
-    validate_bimu_execution_manifest(manifest, train_x, train_y, test_x, test_y)
-    return manifest
-
-
-def validate_bimu_execution_manifest(
-    value: object, train_x: object, train_y: object, test_x: object, test_y: object
-) -> None:
-    _json_preflight(value)
-    root = _fields(value, ("schema", "plan", "identity", "policy", "manifest_sha256"), "manifest")
-    if root["schema"] != MANIFEST_SCHEMA:
-        raise ValueError("manifest schema drifted")
-    expected_plan = _plan_payload(FROZEN_BIMU_MATCHED_PLAN)
-    if root["plan"] != expected_plan:
-        raise ValueError("plan does not match the prospective frozen plan")
-    arrays = _validated_dataset_arrays(train_x, train_y, test_x, test_y)
-    digest = _dataset_sha256(*arrays)
-    if digest != FROZEN_BIMU_MATCHED_PLAN.dataset_sha256:
-        raise ValueError("dataset does not match the frozen plan")
-    identity = _fields(
-        root["identity"],
-        ("source_sha256", "runtime", "plan_sha256", "consistency_not_attestation"),
-        "identity",
-    )
-    expected_identity = {
-        "source_sha256": _source_identity(),
-        "runtime": _runtime_identity(),
-        "plan_sha256": hashlib.sha256(_canonical(expected_plan)).hexdigest(),
-        "consistency_not_attestation": True,
-    }
-    if identity != expected_identity:
-        raise ValueError("execution identity drifted")
-    if root["policy"] != {
-        "development_only": True,
-        "scientific_promotion_allowed": False,
-        "execution_authorized": False,
-        "output_retained": False,
-    }:
-        raise ValueError("policy drifted")
-    unsigned = dict(root)
-    claimed = unsigned.pop("manifest_sha256")
-    if type(claimed) is not str or claimed != hashlib.sha256(_canonical(unsigned)).hexdigest():
-        raise ValueError("manifest digest drifted")
-    if len(_canonical(root)) > _MAX_MANIFEST_BYTES:
-        raise ValueError("manifest exceeds byte ceiling")

--- a/alberta_framework/evaluation/bimu_matched_nonpromoting.py
+++ b/alberta_framework/evaluation/bimu_matched_nonpromoting.py
@@ -20,13 +20,16 @@ import numpy as np
 
 from alberta_framework.benchmarks.bimu import BiMUConfig, _dataset_sha256
 
-PLAN_SCHEMA: Final = "asi.bimu.matched-development-plan.v2"
+PLAN_SCHEMA: Final = "asi.bimu.matched-development-plan.v3"
 MANIFEST_SCHEMA: Final = "asi.bimu.matched-development-execution-manifest.v1"
+OUTPUT_NAMESPACE: Final = Path("outputs/bimu_matched/development.v1")
+EXECUTION_AUTHORIZED: Final = False
 _MAX_JSON_NODES = 20_000
 _MAX_TEXT_BYTES = 4096
 _MAX_MANIFEST_BYTES = 2 * 1024 * 1024
 _MAX_DATASET_BYTES = 16 * 1024 * 1024
 _DIGEST = "85c681c2f5fc5c274870b30c9accb3d2a6e9eb90a4575a2bf1ccca64f58b6227"
+FROZEN_PLAN_SHA256: Final = "11ddfacd0aca8108a39bd8a68225149de246efb7420d2fdb864f36ea75681f71"
 
 INVALID_PRIOR_ATTEMPT: Final[Mapping[str, object]] = MappingProxyType({
     "pull_request": 1686,
@@ -243,7 +246,7 @@ def _plan_payload(plan: BiMUMatchedDevelopmentPlan) -> dict[str, object]:
             "label_queries": label_queries,
             "optimizer_seen": observations,
             "model_forward_queries": model_forward_queries,
-            "optimizer_updates_rule": "reported_nonzero_gradient_subcount_at_most_label_queries",
+            "optimizer_updates": observations,
         },
         "expected_resources_per_arm": {
             "trainable_scalar_count": config.trainable_scalar_count,
@@ -264,7 +267,28 @@ def _plan_payload(plan: BiMUMatchedDevelopmentPlan) -> dict[str, object]:
         },
         "primary_metric": "paper_late_five_test_accuracy",
         "secondary_metric": "asi_whole_stream_online_accuracy",
+        "paired_outcome_rule": {
+            "schema": "asi.bimu.paired-outcome-rule.v1",
+            "metric": "paper_late_five_test_accuracy",
+            "supported": "all_three_paired_deltas_strictly_positive",
+            "rejected": "all_three_paired_deltas_nonpositive",
+            "otherwise": "inconclusive",
+            "ties_are_positive": False,
+            "secondary_metric_affects_outcome": False,
+        },
+        "output_namespace": str(OUTPUT_NAMESPACE),
+        "execution_authorized": EXECUTION_AUTHORIZED,
     }
+
+
+def frozen_plan_payload() -> dict[str, object]:
+    """Return the literal plan only when its preregistered digest still matches."""
+
+    payload = _plan_payload(FROZEN_BIMU_MATCHED_PLAN)
+    observed = hashlib.sha256(_canonical(payload)).hexdigest()
+    if observed != FROZEN_PLAN_SHA256:
+        raise RuntimeError("frozen BiMU plan payload drifted from its literal digest")
+    return payload
 
 
 def _repository_root() -> Path:
@@ -277,7 +301,8 @@ def _source_identity() -> dict[str, str]:
         Path("alberta_framework/benchmarks/bimu.py"),
         Path("alberta_framework/benchmarks/upgd_ipmnist.py"),
         Path("alberta_framework/evaluation/bimu_matched_nonpromoting.py"),
-        Path("uv.lock"),
+        Path("alberta_framework/evaluation/bimu_matched_campaign.py"),
+        Path("pyproject.toml"),
     )
     return {str(path): hashlib.sha256((root / path).read_bytes()).hexdigest() for path in paths}
 
@@ -322,6 +347,18 @@ def _runtime_identity() -> dict[str, object]:
             "jax_threefry_partitionable": jax.config.jax_threefry_partitionable,
         },
         "environment": {name: os.environ.get(name) for name in environment_names},
+    }
+
+
+def _dependency_identity() -> dict[str, object]:
+    root = _repository_root()
+    return {
+        "schema": "asi.bimu.matched-dependencies.v1",
+        "packages": {
+            name: importlib.metadata.version(name)
+            for name in ("chex", "jax", "jaxlib", "numpy", "scikit-learn")
+        },
+        "uv_lock_sha256": hashlib.sha256((root / "uv.lock").read_bytes()).hexdigest(),
     }
 
 

--- a/alberta_framework/evaluation/bimu_matched_nonpromoting.py
+++ b/alberta_framework/evaluation/bimu_matched_nonpromoting.py
@@ -22,31 +22,34 @@ from alberta_framework.benchmarks.bimu import BiMUConfig, _dataset_sha256
 PLAN_SCHEMA: Final = "asi.bimu.matched-development-plan.v3"
 OUTPUT_NAMESPACE: Final = Path("outputs/bimu_matched/development.v1")
 EXECUTION_AUTHORIZED: Final = False
+AUTHORIZATION_TRANSITION_APPROVED: Final = False
 _DIGEST = "85c681c2f5fc5c274870b30c9accb3d2a6e9eb90a4575a2bf1ccca64f58b6227"
-FROZEN_PLAN_SHA256: Final = "633b8e6b6bc212798e3af6b8550e39b99d800c3aae332384cda352dde31c4c75"
+FROZEN_PLAN_SHA256: Final = "182632b37c3a8598a30fb943742605374a846d965c5602f4db039f27f78754c1"
 
-INVALID_PRIOR_ATTEMPT: Final[Mapping[str, object]] = MappingProxyType({
-    "pull_request": 1686,
-    "head_commit": "86a67df39781bba77e1a2c47451f646205daee65",
-    "seed": 23,
-    "status": "invalid_never_merged",
-    "reason": (
-        "colliding RNG domains, unpinned PRNG, majority-vote inference, and an immediate-task "
-        "metric mislabeled as the paper final-model late-five metric"
-    ),
-    "result_retained": False,
-    "seed_reuse_allowed": False,
-    "unmerged_result_sha256": (
-        "9b11c3944379323e33ee067cf80a9f4d772a3af4080f9718cec3b6e1d1e91a23",
-        "00faf161ead42d11c8daed668ba96a905ef25baf18b0c77b04bc08e4435c4fa7",
-        "0f665cbddf209422456d68835f835c8302a632372e59a0e2518297a41c30a5cb",
-    ),
-    "unmerged_artifact_file_sha256": (
-        "0e313a49c5b2e5fb3b7a4c61c6d2618815432dfc24aac30c64b16777ed1328cb",
-        "7da4d6e0411546a39d431bf1d3b6c47372c7c634c372f7133f15481851132daa",
-        "2d3a05db3ba2b8af50d522ba13564d82999829f340f426f0f4b1b1389607ade0",
-    ),
-})
+INVALID_PRIOR_ATTEMPT: Final[Mapping[str, object]] = MappingProxyType(
+    {
+        "pull_request": 1686,
+        "head_commit": "86a67df39781bba77e1a2c47451f646205daee65",
+        "seed": 23,
+        "status": "invalid_never_merged",
+        "reason": (
+            "colliding RNG domains, unpinned PRNG, majority-vote inference, and an immediate-task "
+            "metric mislabeled as the paper final-model late-five metric"
+        ),
+        "result_retained": False,
+        "seed_reuse_allowed": False,
+        "unmerged_result_sha256": (
+            "9b11c3944379323e33ee067cf80a9f4d772a3af4080f9718cec3b6e1d1e91a23",
+            "00faf161ead42d11c8daed668ba96a905ef25baf18b0c77b04bc08e4435c4fa7",
+            "0f665cbddf209422456d68835f835c8302a632372e59a0e2518297a41c30a5cb",
+        ),
+        "unmerged_artifact_file_sha256": (
+            "0e313a49c5b2e5fb3b7a4c61c6d2618815432dfc24aac30c64b16777ed1328cb",
+            "7da4d6e0411546a39d431bf1d3b6c47372c7c634c372f7133f15481851132daa",
+            "2d3a05db3ba2b8af50d522ba13564d82999829f340f426f0f4b1b1389607ade0",
+        ),
+    }
+)
 
 
 def _invalid_prior_attempt_payload() -> dict[str, object]:
@@ -57,8 +60,9 @@ def _invalid_prior_attempt_payload() -> dict[str, object]:
     }
 
 
-def _config(*, memory_window: int | None, input_dim: int = 784, n_classes: int = 10,
-            examples: int = 256) -> BiMUConfig:
+def _config(
+    *, memory_window: int | None, input_dim: int = 784, n_classes: int = 10, examples: int = 256
+) -> BiMUConfig:
     return BiMUConfig(
         input_dim=input_dim,
         hidden_units=32,
@@ -162,6 +166,13 @@ def _canonical(value: object) -> bytes:
     ).encode("ascii")
 
 
+def _authorization_identity() -> dict[str, bool]:
+    return {
+        "execution_authorized": EXECUTION_AUTHORIZED,
+        "authorization_transition_approved": AUTHORIZATION_TRANSITION_APPROVED,
+    }
+
+
 def _plan_payload(plan: BiMUMatchedDevelopmentPlan) -> dict[str, object]:
     checked = BiMUMatchedDevelopmentPlan(**plan.__dict__)
     config = checked.candidate_config
@@ -189,8 +200,14 @@ def _plan_payload(plan: BiMUMatchedDevelopmentPlan) -> dict[str, object]:
         "dataset_selection": checked.dataset_selection,
         "prior_invalid_attempts": [_invalid_prior_attempt_payload()],
         "matched_axes": [
-            "seed", "dataset", "schedule", "observations", "label_queries",
-            "optimizer_seen", "model_forward_queries", "initial_state",
+            "seed",
+            "dataset",
+            "schedule",
+            "observations",
+            "label_queries",
+            "optimizer_seen",
+            "model_forward_queries",
+            "initial_state",
         ],
         "expected_counters_per_arm": {
             "environment_steps": observations,
@@ -234,7 +251,7 @@ def _plan_payload(plan: BiMUMatchedDevelopmentPlan) -> dict[str, object]:
             "retained_matched_result_exists": False,
             "reason": "the literal development roster is publicly exposed",
         },
-        "execution_authorized": EXECUTION_AUTHORIZED,
+        "authorization": _authorization_identity(),
     }
 
 
@@ -275,9 +292,14 @@ def _runtime_identity() -> dict[str, object]:
         for device in jax.devices()
     ]
     environment_names = (
-        "JAX_DEFAULT_MATMUL_PRECISION", "JAX_DEFAULT_PRNG_IMPL", "JAX_ENABLE_X64",
-        "JAX_NUM_CPU_DEVICES", "JAX_PLATFORMS", "JAX_PLATFORM_NAME",
-        "JAX_RANDOM_SEED_OFFSET", "XLA_FLAGS",
+        "JAX_DEFAULT_MATMUL_PRECISION",
+        "JAX_DEFAULT_PRNG_IMPL",
+        "JAX_ENABLE_X64",
+        "JAX_NUM_CPU_DEVICES",
+        "JAX_PLATFORMS",
+        "JAX_PLATFORM_NAME",
+        "JAX_RANDOM_SEED_OFFSET",
+        "XLA_FLAGS",
     )
     return {
         "schema": "asi.bimu.matched-runtime.v1",

--- a/alberta_framework/evaluation/bimu_matched_nonpromoting.py
+++ b/alberta_framework/evaluation/bimu_matched_nonpromoting.py
@@ -23,7 +23,7 @@ PLAN_SCHEMA: Final = "asi.bimu.matched-development-plan.v3"
 OUTPUT_NAMESPACE: Final = Path("outputs/bimu_matched/development.v1")
 EXECUTION_AUTHORIZED: Final = False
 _DIGEST = "85c681c2f5fc5c274870b30c9accb3d2a6e9eb90a4575a2bf1ccca64f58b6227"
-FROZEN_PLAN_SHA256: Final = "11ddfacd0aca8108a39bd8a68225149de246efb7420d2fdb864f36ea75681f71"
+FROZEN_PLAN_SHA256: Final = "633b8e6b6bc212798e3af6b8550e39b99d800c3aae332384cda352dde31c4c75"
 
 INVALID_PRIOR_ATTEMPT: Final[Mapping[str, object]] = MappingProxyType({
     "pull_request": 1686,
@@ -229,6 +229,11 @@ def _plan_payload(plan: BiMUMatchedDevelopmentPlan) -> dict[str, object]:
             "secondary_metric_affects_outcome": False,
         },
         "output_namespace": str(OUTPUT_NAMESPACE),
+        "seed_status": {
+            "consumed_for_promotion": True,
+            "retained_matched_result_exists": False,
+            "reason": "the literal development roster is publicly exposed",
+        },
         "execution_authorized": EXECUTION_AUTHORIZED,
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ The package overview and development entry points are in
 ## Runbooks
 
 - [`runbooks/foragax-open-screen.md`](runbooks/foragax-open-screen.md)
+- [`runbooks/bimu-matched-development.md`](runbooks/bimu-matched-development.md)
 
 Runbooks retain their stated issuance and promotion boundaries. An unissued or
 development-only runbook does not authorize a scientific result.

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -72,12 +72,8 @@ reserved before validation, data loading, or strict replay; reservation cleanup
 compares held and live inode identities. Keep supported, rejected, and
 inconclusive aggregates. The runner attempts to publish one generic
 failed-attempt receipt when plan admission, shard execution, or prepublication
-strict dataset-bound reexecution raises an ordinary `Exception`. The dataset is
-loaded once, and the same validated arrays feed the initial execution and
-strict reexecution immediately before completed-shard publication. The
-publisher does not accept caller-asserted replay evidence. A successfully
-published receipt returns nonzero and retains no exception type, message, or
-representation,
+strict validation raises an ordinary `Exception`. A successfully published
+receipt returns nonzero, retains no exception type, message, or representation,
 cannot enter aggregation, and forbids retry in this namespace. `BaseException`,
 completed-result publication failures, and failure to build or publish the
 failure receipt after the first learner dispatch retain the inode-owned

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -72,8 +72,12 @@ reserved before validation, data loading, or strict replay; reservation cleanup
 compares held and live inode identities. Keep supported, rejected, and
 inconclusive aggregates. The runner attempts to publish one generic
 failed-attempt receipt when plan admission, shard execution, or prepublication
-strict validation raises an ordinary `Exception`. A successfully published
-receipt returns nonzero, retains no exception type, message, or representation,
+strict dataset-bound reexecution raises an ordinary `Exception`. The dataset is
+loaded once, and the same validated arrays feed the initial execution and
+strict reexecution immediately before completed-shard publication. The
+publisher does not accept caller-asserted replay evidence. A successfully
+published receipt returns nonzero and retains no exception type, message, or
+representation,
 cannot enter aggregation, and forbids retry in this namespace. `BaseException`,
 process death, completed-result publication failures, and failure to build or
 publish the failure receipt remain outside this retention boundary. Source,

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -1,0 +1,58 @@
+# BiMU bounded matched development campaign
+
+This campaign compares the current binary Bayesian learner against its exact
+mechanism-off reduction. It is a five-task, 256-train/256-test, width-32
+development slice. It is permanently nonpromoting, is not paper-comparable,
+and cannot support a scientific, SOTA, or paper-reproduction claim.
+
+The literal plan fixes OpenML `mnist_784` version 1 through the canonical
+60,000-row loader, the first 256 scaled rows as training data, the last 256 as
+a disjoint development test, seeds 157001–157003, and arms `memory_off` and
+`bimu`. The two arm configurations differ only in `memory_window` (`None`
+versus `128`). Every other configuration, schedule, initial state, counter,
+and numeric resource field must match within each pair.
+
+The preregistered primary outcome uses the final-model mean accuracy over the
+five task permutations. It is `supported` only when all three candidate-minus-
+control deltas are strictly positive, `rejected` when all three are
+nonpositive, and `inconclusive` otherwise. The whole-stream online metric is
+secondary and cannot change that classification. Timing is telemetry only.
+
+## Review and execution gate
+
+`EXECUTION_AUTHORIZED` is frozen to `False` in
+`alberta_framework/evaluation/bimu_matched_nonpromoting.py`. The `run-shard`
+command fails before loading MNIST while that literal is false. A separate
+reviewed authorization change must open the gate; that source change also
+changes the plan's source identity, so the plan must then be published from
+the authorized revision before any shard starts. That review must also update
+the literal `FROZEN_PLAN_SHA256`; an authorization flip without the matching
+reviewed plan digest fails closed.
+
+Generate and validate the currently unauthorized plan:
+
+```bash
+.venv/bin/asi-bimu-matched-development plan --root .
+.venv/bin/asi-bimu-matched-development validate --root .
+```
+
+After separate authorization, launch each of the six commands in its own fresh
+Linux process. Substitute each frozen arm and seed exactly once:
+
+```bash
+.venv/bin/asi-bimu-matched-development run-shard \
+  --root . --arm memory_off --seed 157001
+```
+
+Once all six fixed shard paths exist, summarize and revalidate:
+
+```bash
+.venv/bin/asi-bimu-matched-development summarize --root .
+.venv/bin/asi-bimu-matched-development validate --root .
+```
+
+All files publish without replacement under
+`outputs/bimu_matched/development.v1/`. Keep supported, rejected, and
+inconclusive aggregates. Source, runtime, dependency, process, dataset,
+resource, and telemetry digests are consistency bindings, not authenticated
+execution attestation.

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -34,15 +34,19 @@ the authorized revision before any shard starts. That review must also update
 the literal `FROZEN_PLAN_SHA256`; an authorization flip without the matching
 reviewed plan digest fails closed.
 
-Inspect the currently unauthorized plan without publishing an artifact:
+Inspect the currently unauthorized plan in a disposable preview namespace:
 
 ```bash
-.venv/bin/python -c 'import json; from alberta_framework.evaluation.bimu_matched_campaign import build_plan_document; print(json.dumps(build_plan_document(), sort_keys=True))'
+campaign_preview=$(mktemp -d)
+.venv/bin/asi-bimu-matched-development plan --root "$campaign_preview"
+.venv/bin/asi-bimu-matched-development validate --root "$campaign_preview"
 ```
 
-The mutating CLI accepts only the registered repository root. Do not invoke its
-`plan` command until a reviewed authorization transition is ready to publish
-the source-bound plan in the new immutable namespace.
+Disposable plan publication and read-only validation cannot dispatch a shard
+or produce an aggregate. `run-shard` and `summarize` accept only the registered
+repository root. Do not invoke `plan --root .` until a reviewed authorization
+transition is ready to publish the source-bound plan in the new immutable
+namespace.
 
 If any file already exists in `development.v1`, the authorization change must
 advance the namespace rather than replace that file.

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -76,13 +76,15 @@ strict dataset-bound reexecution raises an ordinary `Exception`. The dataset is
 loaded once, and the same validated arrays feed the initial execution and
 strict reexecution immediately before completed-shard publication. The
 publisher does not accept caller-asserted replay evidence. A successfully
-published receipt returns nonzero and retains no exception type, message, or
-representation,
-cannot enter aggregation, and forbids retry in this namespace. `BaseException`,
-completed-result publication failures, and failure to build or publish the
-failure receipt after the first learner dispatch retain the inode-owned
-reservation as a durable `consumed-without-result` tombstone, so the roster
-cannot be retried in this namespace. Pre-dispatch failures release the
-reservation. Process death remains outside this retention boundary. Source,
+published receipt returns nonzero, retains no exception type, message, or
+representation, cannot enter aggregation, and forbids retry in this namespace.
+After the first learner dispatch, the runner attempts to convert its inode-owned
+reservation into a `consumed-without-result` tombstone when a `BaseException`,
+completed-result publication failure, or failure-receipt publication failure
+escapes. A retained tombstone prevents retry in this namespace. Tombstone I/O
+failure, another asynchronous interruption during that conversion, and process
+death remain outside this retention boundary. A pre-dispatch failure that
+escapes without a published failed-attempt receipt releases the reservation.
+Source,
 runtime, dependency, process, dataset, resource, and telemetry digests are
 consistency bindings, not authenticated execution attestation.

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -76,15 +76,13 @@ strict dataset-bound reexecution raises an ordinary `Exception`. The dataset is
 loaded once, and the same validated arrays feed the initial execution and
 strict reexecution immediately before completed-shard publication. The
 publisher does not accept caller-asserted replay evidence. A successfully
-published receipt returns nonzero, retains no exception type, message, or
-representation, cannot enter aggregation, and forbids retry in this namespace.
-After the first learner dispatch, the runner attempts to convert its inode-owned
-reservation into a `consumed-without-result` tombstone when a `BaseException`,
-completed-result publication failure, or failure-receipt publication failure
-escapes. A retained tombstone prevents retry in this namespace. Tombstone I/O
-failure, another asynchronous interruption during that conversion, and process
-death remain outside this retention boundary. A pre-dispatch failure that
-escapes without a published failed-attempt receipt releases the reservation.
-Source,
+published receipt returns nonzero and retains no exception type, message, or
+representation,
+cannot enter aggregation, and forbids retry in this namespace. `BaseException`,
+completed-result publication failures, and failure to build or publish the
+failure receipt after the first learner dispatch retain the inode-owned
+reservation as a durable `consumed-without-result` tombstone, so the roster
+cannot be retried in this namespace. Pre-dispatch failures release the
+reservation. Process death remains outside this retention boundary. Source,
 runtime, dependency, process, dataset, resource, and telemetry digests are
 consistency bindings, not authenticated execution attestation.

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -37,19 +37,16 @@ the authorized revision before any shard starts. That review must also update
 the literal `FROZEN_PLAN_SHA256`; an authorization flip without the matching
 reviewed plan digest fails closed.
 
-Inspect the currently unauthorized plan in a disposable preview namespace:
+Inspect the currently unauthorized plan without publishing an artifact:
 
 ```bash
-campaign_preview=$(mktemp -d)
-.venv/bin/asi-bimu-matched-development plan --root "$campaign_preview"
-.venv/bin/asi-bimu-matched-development validate --root "$campaign_preview"
+.venv/bin/python -c 'import json; from alberta_framework.evaluation.bimu_matched_campaign import build_plan_document; print(json.dumps(build_plan_document(), sort_keys=True))'
 ```
 
-Disposable plan publication and read-only validation cannot dispatch a shard
-or produce an aggregate. `run-shard` and `summarize` accept only the registered
-repository root. Do not invoke `plan --root .` until a reviewed authorization
-transition is ready to publish the source-bound plan in the new immutable
-namespace.
+Every mutating CLI command accepts only the registered repository root and
+fails while either authorization gate is closed. Do not invoke `plan --root .`
+until a reviewed authorization transition is ready to publish the source-bound
+plan in the new immutable namespace.
 
 If any file already exists in `development.v1`, the authorization change must
 advance the namespace rather than replace that file.
@@ -73,11 +70,12 @@ All files publish without replacement under the registered repository's exact
 `outputs/bimu_matched/development.v1/` namespace. Plan and aggregate work is
 reserved before validation, data loading, or strict replay; reservation cleanup
 compares held and live inode identities. Keep supported, rejected, and
-inconclusive aggregates. An ordinary `Exception` during shard execution or
-strict validation publishes one generic failed-attempt receipt atomically at
-that shard's canonical path and returns nonzero. The receipt retains no
-exception type, message, or representation, cannot enter aggregation, and
-forbids retry in this namespace. `BaseException`, process death, and failure to
-publish the failure receipt remain outside this retention guarantee. Source,
+inconclusive aggregates. The runner attempts to publish one generic
+failed-attempt receipt when plan admission, shard execution, or prepublication
+strict validation raises an ordinary `Exception`. A successfully published
+receipt returns nonzero, retains no exception type, message, or representation,
+cannot enter aggregation, and forbids retry in this namespace. `BaseException`,
+process death, completed-result publication failures, and failure to build or
+publish the failure receipt remain outside this retention boundary. Source,
 runtime, dependency, process, dataset, resource, and telemetry digests are
 consistency bindings, not authenticated execution attestation.

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -72,8 +72,11 @@ reserved before validation, data loading, or strict replay; reservation cleanup
 compares held and live inode identities. Keep supported, rejected, and
 inconclusive aggregates. The runner attempts to publish one generic
 failed-attempt receipt when plan admission, shard execution, or prepublication
-strict validation raises an ordinary `Exception`. A successfully published
-receipt returns nonzero, retains no exception type, message, or representation,
+strict dataset-bound reexecution raises an ordinary `Exception`. The dataset is
+loaded once and the same validated arrays feed the initial execution and the
+independent strict replay. The completed publisher accepts only a private,
+payload-bound proof from that replay. A successfully published receipt returns
+nonzero, retains no exception type, message, or representation,
 cannot enter aggregation, and forbids retry in this namespace. `BaseException`,
 process death, completed-result publication failures, and failure to build or
 publish the failure receipt remain outside this retention boundary. Source,

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -34,14 +34,15 @@ the authorized revision before any shard starts. That review must also update
 the literal `FROZEN_PLAN_SHA256`; an authorization flip without the matching
 reviewed plan digest fails closed.
 
-Inspect the currently unauthorized plan in a disposable root. Do not publish it
-under the repository's immutable output namespace:
+Inspect the currently unauthorized plan without publishing an artifact:
 
 ```bash
-campaign_root=$(mktemp -d)
-.venv/bin/asi-bimu-matched-development plan --root "$campaign_root"
-.venv/bin/asi-bimu-matched-development validate --root "$campaign_root"
+.venv/bin/python -c 'import json; from alberta_framework.evaluation.bimu_matched_campaign import build_plan_document; print(json.dumps(build_plan_document(), sort_keys=True))'
 ```
+
+The mutating CLI accepts only the registered repository root. Do not invoke its
+`plan` command until a reviewed authorization transition is ready to publish
+the source-bound plan in the new immutable namespace.
 
 If any file already exists in `development.v1`, the authorization change must
 advance the namespace rather than replace that file.
@@ -63,13 +64,11 @@ Once all six fixed shard paths exist, summarize and revalidate:
 
 All files publish without replacement under
 `outputs/bimu_matched/development.v1/`. Keep supported, rejected, and
-inconclusive aggregates. Source, runtime, dependency, process, dataset,
-resource, and telemetry digests are consistency bindings, not authenticated
-execution attestation.
-
-Each shard's final path is reserved before plan admission, dataset load, or
-execution. A crash or execution failure intentionally leaves a zero-byte,
-mode-000 non-result reservation at that path: it consumes that attempt and is
-not a valid shard or permission to retry. Successful publication fills the
-same held inode, makes it read-only, rereads bounded bytes without following
-links, and strictly validates them before reporting completion.
+inconclusive aggregates. An ordinary `Exception` during shard execution or
+strict validation publishes one generic failed-attempt receipt atomically at
+that shard's canonical path and returns nonzero. The receipt retains no
+exception type, message, or representation, cannot enter aggregation, and
+forbids retry in this namespace. `BaseException`, process death, and failure to
+publish the failure receipt remain outside this retention guarantee. Source,
+runtime, dependency, process, dataset, resource, and telemetry digests are
+consistency bindings, not authenticated execution attestation.

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -79,7 +79,10 @@ publisher does not accept caller-asserted replay evidence. A successfully
 published receipt returns nonzero and retains no exception type, message, or
 representation,
 cannot enter aggregation, and forbids retry in this namespace. `BaseException`,
-process death, completed-result publication failures, and failure to build or
-publish the failure receipt remain outside this retention boundary. Source,
+completed-result publication failures, and failure to build or publish the
+failure receipt after the first learner dispatch retain the inode-owned
+reservation as a durable `consumed-without-result` tombstone, so the roster
+cannot be retried in this namespace. Pre-dispatch failures release the
+reservation. Process death remains outside this retention boundary. Source,
 runtime, dependency, process, dataset, resource, and telemetry digests are
 consistency bindings, not authenticated execution attestation.

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -72,11 +72,8 @@ reserved before validation, data loading, or strict replay; reservation cleanup
 compares held and live inode identities. Keep supported, rejected, and
 inconclusive aggregates. The runner attempts to publish one generic
 failed-attempt receipt when plan admission, shard execution, or prepublication
-strict dataset-bound reexecution raises an ordinary `Exception`. The dataset is
-loaded once and the same validated arrays feed the initial execution and the
-independent strict replay. The completed publisher accepts only a private,
-payload-bound proof from that replay. A successfully published receipt returns
-nonzero, retains no exception type, message, or representation,
+strict validation raises an ordinary `Exception`. A successfully published
+receipt returns nonzero, retains no exception type, message, or representation,
 cannot enter aggregation, and forbids retry in this namespace. `BaseException`,
 process death, completed-result publication failures, and failure to build or
 publish the failure receipt remain outside this retention boundary. Source,

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -72,8 +72,12 @@ reserved before validation, data loading, or strict replay; reservation cleanup
 compares held and live inode identities. Keep supported, rejected, and
 inconclusive aggregates. The runner attempts to publish one generic
 failed-attempt receipt when plan admission, shard execution, or prepublication
-strict validation raises an ordinary `Exception`. A successfully published
-receipt returns nonzero, retains no exception type, message, or representation,
+strict dataset-bound reexecution raises an ordinary `Exception`. The dataset is
+loaded once, and the same validated arrays feed the initial execution and
+strict reexecution immediately before completed-shard publication. The
+publisher does not accept caller-asserted replay evidence. A successfully
+published receipt returns nonzero and retains no exception type, message, or
+representation,
 cannot enter aggregation, and forbids retry in this namespace. `BaseException`,
 completed-result publication failures, and failure to build or publish the
 failure receipt after the first learner dispatch retain the inode-owned

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -25,10 +25,13 @@ secondary and cannot change that classification. Timing is telemetry only.
 
 ## Review and execution gate
 
-`EXECUTION_AUTHORIZED` is frozen to `False` in
+`EXECUTION_AUTHORIZED` and `AUTHORIZATION_TRANSITION_APPROVED` are frozen to
+`False` in
 `alberta_framework/evaluation/bimu_matched_nonpromoting.py`. The `run-shard`
-command fails before loading MNIST while that literal is false. A separate
-reviewed authorization change must open the gate; that source change also
+command and every publisher fail before plan, data, replay, or execution work
+unless both literals are exact `True`. A separate reviewed authorization change
+must open both gates; both values are bound into the plan, identity, policy,
+completed and failed shards, and status. That source change also
 changes the plan's source identity, so the plan must then be published from
 the authorized revision before any shard starts. That review must also update
 the literal `FROZEN_PLAN_SHA256`; an authorization flip without the matching
@@ -66,8 +69,10 @@ Once all six fixed shard paths exist, summarize and revalidate:
 .venv/bin/asi-bimu-matched-development validate --root .
 ```
 
-All files publish without replacement under
-`outputs/bimu_matched/development.v1/`. Keep supported, rejected, and
+All files publish without replacement under the registered repository's exact
+`outputs/bimu_matched/development.v1/` namespace. Plan and aggregate work is
+reserved before validation, data loading, or strict replay; reservation cleanup
+compares held and live inode identities. Keep supported, rejected, and
 inconclusive aggregates. An ordinary `Exception` during shard execution or
 strict validation publishes one generic failed-attempt receipt atomically at
 that shard's canonical path and returns nonzero. The receipt retains no

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -12,6 +12,11 @@ a disjoint development test, seeds 157001–157003, and arms `memory_off` and
 versus `128`). Every other configuration, schedule, initial state, counter,
 and numeric resource field must match within each pair.
 
+Seeds 157001–157003 are publicly exposed by this literal development plan and
+are therefore consumed for every promotion purpose. They have not produced a
+retained matched result. Any future scientific protocol needs a new path and
+untouched seeds; changing the execution gate cannot make this roster eligible.
+
 The preregistered primary outcome uses the final-model mean accuracy over the
 five task permutations. It is `supported` only when all three candidate-minus-
 control deltas are strictly positive, `rejected` when all three are
@@ -61,3 +66,10 @@ All files publish without replacement under
 inconclusive aggregates. Source, runtime, dependency, process, dataset,
 resource, and telemetry digests are consistency bindings, not authenticated
 execution attestation.
+
+Each shard's final path is reserved before plan admission, dataset load, or
+execution. A crash or execution failure intentionally leaves a zero-byte,
+mode-000 non-result reservation at that path: it consumes that attempt and is
+not a valid shard or permission to retry. Successful publication fills the
+same held inode, makes it read-only, rereads bounded bytes without following
+links, and strictly validates them before reporting completion.

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -29,12 +29,17 @@ the authorized revision before any shard starts. That review must also update
 the literal `FROZEN_PLAN_SHA256`; an authorization flip without the matching
 reviewed plan digest fails closed.
 
-Generate and validate the currently unauthorized plan:
+Inspect the currently unauthorized plan in a disposable root. Do not publish it
+under the repository's immutable output namespace:
 
 ```bash
-.venv/bin/asi-bimu-matched-development plan --root .
-.venv/bin/asi-bimu-matched-development validate --root .
+campaign_root=$(mktemp -d)
+.venv/bin/asi-bimu-matched-development plan --root "$campaign_root"
+.venv/bin/asi-bimu-matched-development validate --root "$campaign_root"
 ```
+
+If any file already exists in `development.v1`, the authorization change must
+advance the namespace rather than replace that file.
 
 After separate authorization, launch each of the six commands in its own fresh
 Linux process. Substitute each frozen arm and seed exactly once:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ asi-rule-discovery-summary = "alberta_framework.benchmarks.rule_discovery_summar
 asi-jepa-transfer-feasibility = "alberta_framework.benchmarks.jepa_transfer_feasibility:main"
 asi-reference-life-scorecard = "alberta_framework.benchmarks.reference_life_scorecard:main"
 asi-l2er-matched-development = "alberta_framework.benchmarks.l2er_matched_development:main"
+asi-bimu-matched-development = "alberta_framework.evaluation.bimu_matched_campaign:main"
 asi-native-supervised-catalog = "alberta_framework.benchmarks.native_supervised_suite:main"
 asi-plasticity-diagnostic = "alberta_framework.benchmarks.plasticity_diagnostics:main"
 asi-nap-ipmnist = "alberta_framework.benchmarks.nap_ipmnist:main"

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -458,26 +458,57 @@ def test_cli_reserves_exact_shard_before_execution(
         return original_load_plan(root)
 
     def fail_after_reservation(*args: object, **kwargs: object) -> dict[str, object]:
-        assert destination.is_file()
-        assert destination.stat().st_size == 0
+        assert not destination.exists()
+        marker = destination.with_name(f".{destination.name}.reservation")
+        assert marker.is_file()
         raise RuntimeError("simulated execution failure")
 
     monkeypatch.setattr(campaign, "_load_plan", load_plan_after_reservation)
     monkeypatch.setattr(campaign, "run_bimu_shard", fail_after_reservation)
-    with pytest.raises(RuntimeError, match="execution failure"):
-        campaign.main(
-            [
-                "run-shard",
-                "--root",
-                str(tmp_path),
-                "--arm",
-                "memory_off",
-                "--seed",
-                "157001",
-            ]
-        )
+    assert campaign.main(
+        [
+            "run-shard",
+            "--root",
+            str(tmp_path),
+            "--arm",
+            "memory_off",
+            "--seed",
+            "157001",
+        ]
+    ) == 1
     assert destination.is_file()
-    assert destination.stat().st_size == 0
+    assert destination.stat().st_mode & 0o777 == 0o444
+    assert not destination.with_name(f".{destination.name}.reservation").exists()
+    failed = campaign.validate_failed_bimu_shard(
+        campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)
+    )
+    assert failed["status"] == "failed"
+    encoded = destination.read_text(encoding="utf-8")
+    assert "simulated execution failure" not in encoded
+    assert "RuntimeError" not in encoded
+    with pytest.raises(ValueError, match="fields|identity|status"):
+        campaign.summarize_bimu_shards([failed] * 6)
+
+    invalid_destination = campaign.campaign_path(
+        tmp_path, "shard", arm="bimu", seed=157001
+    )
+    monkeypatch.setattr(campaign, "run_bimu_shard", lambda *args, **kwargs: {"invalid": True})
+    assert campaign.main(
+        [
+            "run-shard",
+            "--root",
+            str(tmp_path),
+            "--arm",
+            "bimu",
+            "--seed",
+            "157001",
+        ]
+    ) == 1
+    campaign.validate_failed_bimu_shard(
+        campaign.load_json_strict(
+            invalid_destination, byte_ceiling=campaign.MAX_SHARD_BYTES
+        )
+    )
 
 
 def test_cli_rejects_relocated_root_before_namespace_access(

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -271,6 +271,24 @@ def test_fixed_namespace_publication_is_append_only(
         campaign.main(["validate", "--root", str(tmp_path)])
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign validation is Linux-only")
+def test_incomplete_namespace_rejects_broken_expected_shard_symlink(
+    tmp_path: Path, tiny_campaign: Any
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+    shard_path = campaign.campaign_path(
+        tmp_path, "shard", arm="memory_off", seed=157001
+    )
+    shard_path.symlink_to(tmp_path / "absent.json")
+
+    with pytest.raises(ValueError, match="regular non-symlink"):
+        campaign.main(["validate", "--root", str(tmp_path)])
+
+
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
 def test_publication_parent_swap_never_writes_through_replacement(
     tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -117,14 +117,6 @@ def test_run_shard_refuses_before_loading_data_when_unauthorized(
     assert called is False
 
 
-def test_plan_distinguishes_tombstone_attempt_from_durability_guarantee() -> None:
-    policy = campaign.build_plan_document()["policy"]
-    assert policy["post_dispatch_consumed_without_result_tombstone_enabled"] is True
-    assert policy["post_dispatch_tombstone_retention_guaranteed"] is False
-    assert policy["process_death_tombstone_retention_guaranteed"] is False
-    assert policy["pre_dispatch_escaped_failure_reservation_released"] is True
-
-
 def test_public_publisher_refuses_flag_mismatches_before_namespace_creation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -361,6 +361,9 @@ def test_cli_validate_cross_binds_aggregate_to_reexecuted_shard_files(
     retained_shards = _six_shards()
     for shard in retained_shards:
         spec = cast(dict[str, Any], shard["spec"])
+        replay_proof = campaign._prove_completed_shard_by_reexecution(
+            shard, _slice_data()
+        )
         campaign.publish_json(
             campaign.campaign_path(
                 tmp_path,
@@ -370,6 +373,7 @@ def test_cli_validate_cross_binds_aggregate_to_reexecuted_shard_files(
             ),
             shard,
             root=tmp_path,
+            _completed_replay_proof=replay_proof,
         )
     different_valid_aggregate = campaign.summarize_bimu_shards(_six_shards())
     campaign.publish_json(
@@ -471,20 +475,93 @@ def test_publication_race_retains_concurrent_destination(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_shard_publisher_does_not_run_unreceipted_reexecution(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
+def test_completed_shard_publisher_requires_matching_reexecution_proof(
+    tmp_path: Path, tiny_campaign: Any
 ) -> None:
     destination = campaign.campaign_path(
         tmp_path, "shard", arm="memory_off", seed=157001
     )
     shard = campaign.run_bimu_shard("memory_off", 157001)
-
-    def forbidden(*args: object, **kwargs: object) -> None:
-        raise AssertionError("publisher performed an unreceipted learner replay")
-
-    monkeypatch.setattr(campaign, "validate_bimu_shard_by_reexecution", forbidden)
-    campaign.publish_json(destination, shard, root=tmp_path)
+    with pytest.raises(ValueError, match="strict reexecution proof"):
+        campaign.publish_json(destination, shard, root=tmp_path)
+    proof = campaign._prove_completed_shard_by_reexecution(shard, _slice_data())
+    campaign.publish_json(
+        destination,
+        shard,
+        root=tmp_path,
+        _completed_replay_proof=proof,
+    )
     assert destination.is_file()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_forged_self_consistent_completed_shard_cannot_be_retained(
+    tmp_path: Path, tiny_campaign: Any
+) -> None:
+    destination = campaign.campaign_path(
+        tmp_path, "shard", arm="bimu", seed=157002
+    )
+    shard = campaign.run_bimu_shard("bimu", 157002)
+    proof = campaign._prove_completed_shard_by_reexecution(shard, _slice_data())
+    forged = copy.deepcopy(shard)
+    forged["result"]["final_state_sha256"] = "0" * 64
+    forged["result"]["resources"]["state_changed"] = True
+    _resign(forged)
+    assert campaign.validate_bimu_shard(forged) == forged
+
+    with pytest.raises(ValueError, match="proof does not match"):
+        campaign.publish_json(
+            destination,
+            forged,
+            root=tmp_path,
+            _completed_replay_proof=proof,
+        )
+    assert not destination.exists()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_cli_replays_before_retaining_completed_shard_and_receipts_forgery(
+    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+    forged = copy.deepcopy(campaign.run_bimu_shard("bimu", 157002))
+    forged["result"]["final_state_sha256"] = "0" * 64
+    forged["result"]["resources"]["state_changed"] = True
+    _resign(forged)
+    assert campaign.validate_bimu_shard(forged) == forged
+    loads = 0
+
+    def load_once(_home: Path | None = None) -> tuple[np.ndarray, ...]:
+        nonlocal loads
+        loads += 1
+        return _slice_data()
+
+    monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", load_once)
+    monkeypatch.setattr(campaign, "run_bimu_shard", lambda *args, **kwargs: forged)
+    assert (
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "bimu",
+                "--seed",
+                "157002",
+            ]
+        )
+        == 1
+    )
+    destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157002)
+    retained = campaign.validate_failed_bimu_shard(
+        campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)
+    )
+    assert retained["status"] == "failed"
+    assert loads == 1
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -192,6 +192,20 @@ def test_shard_validator_rejects_forged_nested_receipts_and_hostile_trees(
         campaign.validate_plan_document(plan)
 
 
+def test_strict_shard_validator_reexecutes_final_state(tiny_campaign: Any) -> None:
+    arrays = _slice_data()
+    shard = campaign.run_bimu_shard("bimu", 157002)
+    assert campaign.validate_bimu_shard_by_reexecution(shard, *arrays) == shard
+
+    forged = copy.deepcopy(shard)
+    forged["result"]["final_state_sha256"] = "0" * 64
+    forged["result"]["resources"]["state_changed"] = True
+    _resign(forged)
+    assert campaign.validate_bimu_shard(forged) == forged
+    with pytest.raises(ValueError, match="reexecution"):
+        campaign.validate_bimu_shard_by_reexecution(forged, *arrays)
+
+
 def _six_shards() -> list[dict[str, Any]]:
     return [
         campaign.run_bimu_shard(arm, seed)

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -208,6 +208,30 @@ def test_strict_shard_validator_reexecutes_final_state(tiny_campaign: Any) -> No
         campaign.validate_bimu_shard_by_reexecution(forged, *arrays)
 
 
+def test_shard_execution_rejects_identity_drift(
+    tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stable = campaign._current_identity()
+    drifted = copy.deepcopy(stable)
+    drifted["source_sha256"] = {
+        **cast(dict[str, str], drifted["source_sha256"]),
+        "changed.py": "0" * 64,
+    }
+    original_run = campaign.run_bimu_development
+    changed = False
+
+    def run_then_drift(*args: object, **kwargs: object) -> dict[str, object]:
+        nonlocal changed
+        result = original_run(*args, **kwargs)
+        changed = True
+        return result
+
+    monkeypatch.setattr(campaign, "run_bimu_development", run_then_drift)
+    monkeypatch.setattr(campaign, "_current_identity", lambda: drifted if changed else stable)
+    with pytest.raises(ValueError, match="changed during shard execution"):
+        campaign.run_bimu_shard("memory_off", 157001)
+
+
 def _six_shards() -> list[dict[str, Any]]:
     return [
         campaign.run_bimu_shard(arm, seed)
@@ -261,6 +285,39 @@ def test_aggregate_rejects_cross_pair_schedule_or_resource_drift(tiny_campaign: 
     _resign(forged[1])
     with pytest.raises(ValueError, match="resource|accounting"):
         campaign.summarize_bimu_shards(forged)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_cli_validate_cross_binds_aggregate_to_reexecuted_shard_files(
+    tmp_path: Path, tiny_campaign: Any
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+    retained_shards = _six_shards()
+    for shard in retained_shards:
+        spec = cast(dict[str, Any], shard["spec"])
+        campaign.publish_json(
+            campaign.campaign_path(
+                tmp_path,
+                "shard",
+                arm=cast(str, spec["arm"]),
+                seed=cast(int, spec["seed"]),
+            ),
+            shard,
+            root=tmp_path,
+        )
+    different_valid_aggregate = campaign.summarize_bimu_shards(_six_shards())
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "aggregate"),
+        different_valid_aggregate,
+        root=tmp_path,
+    )
+
+    with pytest.raises(ValueError, match="dataset-reexecuted shard files"):
+        campaign.main(["validate", "--root", str(tmp_path)])
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
@@ -423,15 +480,33 @@ def test_cli_reserves_exact_shard_before_execution(
     assert destination.stat().st_size == 0
 
 
-def test_cli_rejects_relocated_root_before_namespace_access(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_cli_completes_and_revalidates_reserved_shard(
+    tmp_path: Path, tiny_campaign: Any
 ) -> None:
-    registered = tmp_path / "registered"
-    relocated = tmp_path / "relocated"
-    monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", registered)
-    with pytest.raises(ValueError, match="registered repository root"):
-        campaign.main(["validate", "--root", str(relocated)])
-    assert not relocated.exists()
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+    destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157003)
+
+    assert campaign.main(
+        [
+            "run-shard",
+            "--root",
+            str(tmp_path),
+            "--arm",
+            "bimu",
+            "--seed",
+            "157003",
+        ]
+    ) == 0
+
+    assert destination.stat().st_mode & 0o777 == 0o444
+    campaign.validate_bimu_shard(
+        campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)
+    )
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -117,6 +117,14 @@ def test_run_shard_refuses_before_loading_data_when_unauthorized(
     assert called is False
 
 
+def test_plan_distinguishes_tombstone_attempt_from_durability_guarantee() -> None:
+    policy = campaign.build_plan_document()["policy"]
+    assert policy["post_dispatch_consumed_without_result_tombstone_enabled"] is True
+    assert policy["post_dispatch_tombstone_retention_guaranteed"] is False
+    assert policy["process_death_tombstone_retention_guaranteed"] is False
+    assert policy["pre_dispatch_escaped_failure_reservation_released"] is True
+
+
 def test_public_publisher_refuses_flag_mismatches_before_namespace_creation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -625,6 +625,7 @@ def test_cli_does_not_misreport_publication_failure_as_execution_receipt(
     destination = campaign.campaign_path(
         tmp_path, "shard", arm="memory_off", seed=157001
     )
+
     def fail_publication(*args: object) -> None:
         raise OSError("simulated publication failure")
 
@@ -642,7 +643,71 @@ def test_cli_does_not_misreport_publication_failure_as_execution_receipt(
             ]
         )
     assert not destination.exists()
-    assert not destination.with_name(f".{destination.name}.reservation").exists()
+    reservation = destination.with_name(f".{destination.name}.reservation")
+    assert reservation.read_bytes() == (
+        b"asi-bimu-matched-campaign-consumed-without-result-v1\n"
+    )
+    with pytest.raises(ValueError, match="unexpected entry"):
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "memory_off",
+                "--seed",
+                "157001",
+            ]
+        )
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+@pytest.mark.parametrize("raised", [RuntimeError("late failure"), KeyboardInterrupt()])
+def test_cli_retains_tombstone_when_post_dispatch_failure_cannot_publish_receipt(
+    tmp_path: Path,
+    tiny_campaign: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    raised: BaseException,
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+    destination = campaign.campaign_path(
+        tmp_path, "shard", arm="memory_off", seed=157001
+    )
+
+    def fail_after_dispatch(*args: object, **kwargs: object) -> None:
+        raise raised
+
+    monkeypatch.setattr(campaign, "run_bimu_development", fail_after_dispatch)
+    if isinstance(raised, Exception):
+        monkeypatch.setattr(
+            campaign,
+            "_link_unnamed_file",
+            lambda *args: (_ for _ in ()).throw(OSError("receipt publication failure")),
+        )
+        expected: type[BaseException] = OSError
+    else:
+        expected = KeyboardInterrupt
+    with pytest.raises(expected):
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "memory_off",
+                "--seed",
+                "157001",
+            ]
+        )
+    assert not destination.exists()
+    reservation = destination.with_name(f".{destination.name}.reservation")
+    assert reservation.read_bytes() == (
+        b"asi-bimu-matched-campaign-consumed-without-result-v1\n"
+    )
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -520,12 +520,16 @@ def test_cli_allows_disposable_plan_preview_but_rejects_relocated_shard(
 
     def capture_plan(path: Path, value: object, *, root: Path, **kwargs: object) -> None:
         assert campaign.validate_plan_document(value) == value
+        path.parent.mkdir(parents=True)
+        (path.parent / "shards").mkdir()
+        path.write_bytes(campaign._canonical(value) + b"\n")
         published.append((path, root))
 
     monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", registered)
     monkeypatch.setattr(campaign, "publish_json", capture_plan)
 
     assert campaign.main(["plan", "--root", str(preview)]) == 0
+    assert campaign.main(["validate", "--root", str(preview)]) == 0
     assert published == [(campaign.campaign_path(preview, "plan"), preview)]
 
     monkeypatch.setattr(campaign, "EXECUTION_AUTHORIZED", True)
@@ -541,6 +545,8 @@ def test_cli_allows_disposable_plan_preview_but_rejects_relocated_shard(
                 "157001",
             ]
         )
+    with pytest.raises(ValueError, match="registered repository root"):
+        campaign.main(["summarize", "--root", str(preview)])
     assert len(published) == 1
 
 

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -370,6 +370,7 @@ def test_cli_validate_cross_binds_aggregate_to_reexecuted_shard_files(
             ),
             shard,
             root=tmp_path,
+            _completed_replay_arrays=_slice_data(),
         )
     different_valid_aggregate = campaign.summarize_bimu_shards(_six_shards())
     campaign.publish_json(
@@ -471,19 +472,145 @@ def test_publication_race_retains_concurrent_destination(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_shard_publisher_does_not_run_unreceipted_reexecution(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
+def test_completed_shard_publisher_requires_replay_arrays(
+    tmp_path: Path, tiny_campaign: Any
 ) -> None:
     destination = campaign.campaign_path(
         tmp_path, "shard", arm="memory_off", seed=157001
     )
     shard = campaign.run_bimu_shard("memory_off", 157001)
-    def forbidden(*args: object, **kwargs: object) -> None:
-        raise AssertionError("publisher performed an unreceipted learner replay")
-
-    monkeypatch.setattr(campaign, "validate_bimu_shard_by_reexecution", forbidden)
-    campaign.publish_json(destination, shard, root=tmp_path)
+    with pytest.raises(ValueError, match="strict dataset-bound admission"):
+        campaign.publish_json(destination, shard, root=tmp_path)
+    campaign.publish_json(
+        destination,
+        shard,
+        root=tmp_path,
+        _completed_replay_arrays=_slice_data(),
+    )
     assert destination.is_file()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_completed_shard_publisher_rejects_noncanonical_replay_arrays(
+    tmp_path: Path, tiny_campaign: Any
+) -> None:
+    destination = campaign.campaign_path(
+        tmp_path, "shard", arm="memory_off", seed=157001
+    )
+    shard = campaign.run_bimu_shard("memory_off", 157001)
+    invalid_arrays = list(_slice_data())
+    with pytest.raises(ValueError, match="strict dataset-bound admission"):
+        campaign.publish_json(
+            destination,
+            shard,
+            root=tmp_path,
+            _completed_replay_arrays=cast(Any, invalid_arrays),
+        )
+    assert not destination.exists()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_forged_self_consistent_completed_shard_cannot_be_retained(
+    tmp_path: Path, tiny_campaign: Any
+) -> None:
+    destination = campaign.campaign_path(
+        tmp_path, "shard", arm="bimu", seed=157002
+    )
+    shard = campaign.run_bimu_shard("bimu", 157002)
+    forged = copy.deepcopy(shard)
+    forged["result"]["final_state_sha256"] = "0" * 64
+    forged["result"]["resources"]["state_changed"] = True
+    _resign(forged)
+    assert campaign.validate_bimu_shard(forged) == forged
+
+    with pytest.raises(ValueError, match="strict dataset-bound admission"):
+        campaign.publish_json(
+            destination,
+            forged,
+            root=tmp_path,
+            _completed_replay_arrays=_slice_data(),
+        )
+    assert not destination.exists()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_cli_replays_before_retaining_completed_shard_and_receipts_forgery(
+    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+    forged = copy.deepcopy(campaign.run_bimu_shard("bimu", 157002))
+    forged["result"]["final_state_sha256"] = "0" * 64
+    forged["result"]["resources"]["state_changed"] = True
+    _resign(forged)
+    assert campaign.validate_bimu_shard(forged) == forged
+    loads = 0
+
+    def load_once(_home: Path | None = None) -> tuple[np.ndarray, ...]:
+        nonlocal loads
+        loads += 1
+        return _slice_data()
+
+    monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", load_once)
+    monkeypatch.setattr(campaign, "run_bimu_shard", lambda *args, **kwargs: forged)
+    assert (
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "bimu",
+                "--seed",
+                "157002",
+            ]
+        )
+        == 1
+    )
+    destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157002)
+    retained = campaign.validate_failed_bimu_shard(
+        campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)
+    )
+    assert retained["status"] == "failed"
+    assert loads == 1
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_cli_retains_failure_receipt_when_strict_replay_raises_runtime_error(
+    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+
+    def fail_replay(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("hostile replay failure must not escape")
+
+    monkeypatch.setattr(campaign, "validate_bimu_shard_by_reexecution", fail_replay)
+    assert (
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "bimu",
+                "--seed",
+                "157002",
+            ]
+        )
+        == 1
+    )
+    destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157002)
+    retained = campaign.validate_failed_bimu_shard(
+        campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)
+    )
+    assert retained["status"] == "failed"
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
@@ -808,7 +935,7 @@ def test_validate_rejects_relocated_shards_before_loading_them(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_cli_completes_with_exactly_one_learner_execution(
+def test_cli_completes_after_one_execution_and_one_strict_replay(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
 ) -> None:
     campaign.publish_json(
@@ -842,7 +969,7 @@ def test_cli_completes_with_exactly_one_learner_execution(
         == 0
     )
 
-    assert learner_runs == 1
+    assert learner_runs == 2
     assert destination.stat().st_mode & 0o777 == 0o444
     campaign.validate_bimu_shard(
         campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -506,6 +506,7 @@ def test_cli_reserves_exact_shard_before_execution(
     )
     destination = campaign.campaign_path(tmp_path, "shard", arm="memory_off", seed=157001)
     original_load_plan = campaign._load_plan
+    run_called = False
 
     def load_plan_after_reservation(root: Path) -> dict[str, object]:
         assert not destination.exists()
@@ -514,6 +515,8 @@ def test_cli_reserves_exact_shard_before_execution(
         return original_load_plan(root)
 
     def fail_after_reservation(*args: object, **kwargs: object) -> dict[str, object]:
+        nonlocal run_called
+        run_called = True
         assert not destination.exists()
         marker = destination.with_name(f".{destination.name}.reservation")
         assert marker.is_file()
@@ -535,6 +538,7 @@ def test_cli_reserves_exact_shard_before_execution(
         )
         == 1
     )
+    assert run_called
     assert destination.is_file()
     assert destination.stat().st_mode & 0o777 == 0o444
     assert not destination.with_name(f".{destination.name}.reservation").exists()
@@ -632,6 +636,19 @@ def test_public_publisher_rejects_relocated_shard_before_namespace_access(
             root=relocated,
         )
     assert not relocated.exists()
+
+
+def test_validate_rejects_relocated_shards_before_loading_them(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registered = tmp_path / "registered"
+    relocated = tmp_path / "relocated"
+    monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", registered)
+    shard = campaign.campaign_path(relocated, "shard", arm="memory_off", seed=157001)
+    shard.parent.mkdir(parents=True)
+    shard.write_bytes(b"")
+    with pytest.raises(ValueError, match="registered repository root"):
+        campaign.main(["validate", "--root", str(relocated)])
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -393,12 +393,19 @@ def test_cli_reserves_exact_shard_before_execution(
     destination = campaign.campaign_path(
         tmp_path, "shard", arm="memory_off", seed=157001
     )
+    original_load_plan = campaign._load_plan
+
+    def load_plan_after_reservation(root: Path) -> dict[str, object]:
+        assert destination.is_file()
+        assert destination.stat().st_size == 0
+        return original_load_plan(root)
 
     def fail_after_reservation(*args: object, **kwargs: object) -> dict[str, object]:
         assert destination.is_file()
         assert destination.stat().st_size == 0
         raise RuntimeError("simulated execution failure")
 
+    monkeypatch.setattr(campaign, "_load_plan", load_plan_after_reservation)
     monkeypatch.setattr(campaign, "run_bimu_shard", fail_after_reservation)
     with pytest.raises(RuntimeError, match="execution failure"):
         campaign.main(
@@ -414,6 +421,17 @@ def test_cli_reserves_exact_shard_before_execution(
         )
     assert destination.is_file()
     assert destination.stat().st_size == 0
+
+
+def test_cli_rejects_relocated_root_before_namespace_access(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registered = tmp_path / "registered"
+    relocated = tmp_path / "relocated"
+    monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", registered)
+    with pytest.raises(ValueError, match="registered repository root"):
+        campaign.main(["validate", "--root", str(relocated)])
+    assert not relocated.exists()
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -511,15 +511,37 @@ def test_cli_reserves_exact_shard_before_execution(
     )
 
 
-def test_cli_rejects_relocated_root_before_namespace_access(
+def test_cli_allows_disposable_plan_preview_but_rejects_relocated_shard(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     registered = tmp_path / "registered"
-    relocated = tmp_path / "relocated"
+    preview = tmp_path / "preview"
+    published: list[tuple[Path, Path]] = []
+
+    def capture_plan(path: Path, value: object, *, root: Path, **kwargs: object) -> None:
+        assert campaign.validate_plan_document(value) == value
+        published.append((path, root))
+
     monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", registered)
+    monkeypatch.setattr(campaign, "publish_json", capture_plan)
+
+    assert campaign.main(["plan", "--root", str(preview)]) == 0
+    assert published == [(campaign.campaign_path(preview, "plan"), preview)]
+
+    monkeypatch.setattr(campaign, "EXECUTION_AUTHORIZED", True)
     with pytest.raises(ValueError, match="registered repository root"):
-        campaign.main(["validate", "--root", str(relocated)])
-    assert not relocated.exists()
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(preview),
+                "--arm",
+                "memory_off",
+                "--seed",
+                "157001",
+            ]
+        )
+    assert len(published) == 1
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -579,6 +579,41 @@ def test_cli_replays_before_retaining_completed_shard_and_receipts_forgery(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_cli_retains_failure_receipt_when_strict_replay_raises_runtime_error(
+    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+
+    def fail_replay(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("hostile replay failure must not escape")
+
+    monkeypatch.setattr(campaign, "validate_bimu_shard_by_reexecution", fail_replay)
+    assert (
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "bimu",
+                "--seed",
+                "157002",
+            ]
+        )
+        == 1
+    )
+    destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157002)
+    retained = campaign.validate_failed_bimu_shard(
+        campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)
+    )
+    assert retained["status"] == "failed"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
 def test_cli_does_not_misreport_publication_failure_as_execution_receipt(
     tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import hashlib
+import os
 import sys
 from pathlib import Path
 from typing import Any, cast
@@ -270,6 +271,58 @@ def test_fixed_namespace_publication_is_append_only(
         campaign.main(["validate", "--root", str(tmp_path)])
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_publication_parent_swap_never_writes_through_replacement(
+    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = campaign.campaign_path(tmp_path, "plan")
+    retired = tmp_path / "retired"
+    replacement_bytes = b"replacement-directory"
+    original_link = campaign._link_unnamed_file
+
+    def swap_parent(file_descriptor: int, parent_descriptor: int, name: str) -> None:
+        path.parent.rename(retired)
+        path.parent.mkdir()
+        path.write_bytes(replacement_bytes)
+        original_link(file_descriptor, parent_descriptor, name)
+
+    monkeypatch.setattr(campaign, "_link_unnamed_file", swap_parent)
+    with pytest.raises(RuntimeError, match="parent changed"):
+        campaign.publish_json(path, campaign.build_plan_document(), root=tmp_path)
+
+    assert path.read_bytes() == replacement_bytes
+    assert (retired / path.name).is_file()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_publication_race_retains_concurrent_destination(
+    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = campaign.campaign_path(tmp_path, "plan")
+    competitor = b"concurrent-winner"
+    original_link = campaign._link_unnamed_file
+
+    def occupy_destination(file_descriptor: int, parent_descriptor: int, name: str) -> None:
+        competitor_descriptor = os.open(
+            name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o444,
+            dir_fd=parent_descriptor,
+        )
+        try:
+            os.write(competitor_descriptor, competitor)
+            os.fsync(competitor_descriptor)
+        finally:
+            os.close(competitor_descriptor)
+        original_link(file_descriptor, parent_descriptor, name)
+
+    monkeypatch.setattr(campaign, "_link_unnamed_file", occupy_destination)
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        campaign.publish_json(path, campaign.build_plan_document(), root=tmp_path)
+
+    assert path.read_bytes() == competitor
+
+
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign file validation is Linux-only")
 def test_strict_loader_rejects_duplicate_keys_and_oversized_input(tmp_path: Path) -> None:
     duplicate = tmp_path / "duplicate.json"
@@ -288,6 +341,30 @@ def test_strict_loader_rejects_duplicate_keys_and_oversized_input(tmp_path: Path
     linked_alias.hardlink_to(linked)
     with pytest.raises(ValueError, match="hard-link"):
         campaign.load_json_strict(linked, byte_ceiling=1024)
+
+    long_key = tmp_path / "long-key.json"
+    long_key.write_text('{"' + "x" * (campaign.MAX_TEXT_BYTES + 1) + '":0}', encoding="utf-8")
+    with pytest.raises(ValueError, match="keys|text"):
+        campaign.load_json_strict(long_key, byte_ceiling=campaign.MAX_TEXT_BYTES + 32)
+
+    recursive = tmp_path / "recursive.json"
+    recursive.write_text("[" * 2000 + "0" + "]" * 2000, encoding="ascii")
+    with pytest.raises(ValueError, match="strict document|nesting"):
+        campaign.load_json_strict(recursive, byte_ceiling=5000)
+
+
+def test_json_tree_rejects_hostile_exact_type_subclasses_without_hooks() -> None:
+    class Hostile(str):
+        calls = 0
+
+        def encode(self, *args: object, **kwargs: object) -> bytes:
+            self.calls += 1
+            raise AssertionError("subclass hooks must not run")
+
+    key = Hostile("schema")
+    with pytest.raises(ValueError, match="keys"):
+        campaign._validate_json_tree({key: "value"})
+    assert key.calls == 0
 
 
 def test_cli_has_only_plan_run_shard_summarize_and_validate() -> None:

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -453,8 +453,9 @@ def test_cli_reserves_exact_shard_before_execution(
     original_load_plan = campaign._load_plan
 
     def load_plan_after_reservation(root: Path) -> dict[str, object]:
-        assert destination.is_file()
-        assert destination.stat().st_size == 0
+        assert not destination.exists()
+        marker = destination.with_name(f".{destination.name}.reservation")
+        assert marker.is_file()
         return original_load_plan(root)
 
     def fail_after_reservation(*args: object, **kwargs: object) -> dict[str, object]:
@@ -511,6 +512,46 @@ def test_cli_reserves_exact_shard_before_execution(
     )
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_replaced_visible_reservation_cannot_publish_shard(
+    tmp_path: Path, tiny_campaign: Any
+) -> None:
+    destination = campaign.campaign_path(
+        tmp_path, "shard", arm="memory_off", seed=157001
+    )
+    reservation = campaign._reserve_shard_destination(destination, root=tmp_path)
+    _, parent_descriptor, _, reservation_name = reservation
+    hidden_name = f"{reservation_name}.held"
+    os.link(
+        reservation_name,
+        hidden_name,
+        src_dir_fd=parent_descriptor,
+        dst_dir_fd=parent_descriptor,
+        follow_symlinks=False,
+    )
+    os.unlink(reservation_name, dir_fd=parent_descriptor)
+    replacement = os.open(
+        reservation_name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+        0o400,
+        dir_fd=parent_descriptor,
+    )
+    os.close(replacement)
+    try:
+        with pytest.raises(ValueError, match="owned regular marker"):
+            campaign.publish_json(
+                destination,
+                campaign.run_bimu_shard("memory_off", 157001),
+                root=tmp_path,
+                _reservation=reservation,
+            )
+        assert not destination.exists()
+    finally:
+        os.unlink(hidden_name, dir_fd=parent_descriptor)
+        os.unlink(reservation_name, dir_fd=parent_descriptor)
+        campaign._release_shard_reservation(reservation)
+
+
 def test_cli_allows_disposable_plan_preview_but_rejects_relocated_shard(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -548,6 +589,24 @@ def test_cli_allows_disposable_plan_preview_but_rejects_relocated_shard(
     with pytest.raises(ValueError, match="registered repository root"):
         campaign.main(["summarize", "--root", str(preview)])
     assert len(published) == 1
+
+
+def test_public_publisher_rejects_relocated_shard_before_namespace_access(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
+) -> None:
+    registered = tmp_path / "registered"
+    relocated = tmp_path / "relocated"
+    monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", registered)
+    destination = campaign.campaign_path(
+        relocated, "shard", arm="memory_off", seed=157001
+    )
+    with pytest.raises(ValueError, match="registered repository root"):
+        campaign.publish_json(
+            destination,
+            campaign.build_failed_bimu_shard("memory_off", 157001),
+            root=relocated,
+        )
+    assert not relocated.exists()
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -370,7 +370,6 @@ def test_cli_validate_cross_binds_aggregate_to_reexecuted_shard_files(
             ),
             shard,
             root=tmp_path,
-            _completed_replay_arrays=_slice_data(),
         )
     different_valid_aggregate = campaign.summarize_bimu_shards(_six_shards())
     campaign.publish_json(
@@ -472,145 +471,19 @@ def test_publication_race_retains_concurrent_destination(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_completed_shard_publisher_requires_replay_arrays(
-    tmp_path: Path, tiny_campaign: Any
+def test_shard_publisher_does_not_run_unreceipted_reexecution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
 ) -> None:
     destination = campaign.campaign_path(
         tmp_path, "shard", arm="memory_off", seed=157001
     )
     shard = campaign.run_bimu_shard("memory_off", 157001)
-    with pytest.raises(ValueError, match="strict dataset-bound admission"):
-        campaign.publish_json(destination, shard, root=tmp_path)
-    campaign.publish_json(
-        destination,
-        shard,
-        root=tmp_path,
-        _completed_replay_arrays=_slice_data(),
-    )
+    def forbidden(*args: object, **kwargs: object) -> None:
+        raise AssertionError("publisher performed an unreceipted learner replay")
+
+    monkeypatch.setattr(campaign, "validate_bimu_shard_by_reexecution", forbidden)
+    campaign.publish_json(destination, shard, root=tmp_path)
     assert destination.is_file()
-
-
-@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_completed_shard_publisher_rejects_noncanonical_replay_arrays(
-    tmp_path: Path, tiny_campaign: Any
-) -> None:
-    destination = campaign.campaign_path(
-        tmp_path, "shard", arm="memory_off", seed=157001
-    )
-    shard = campaign.run_bimu_shard("memory_off", 157001)
-    invalid_arrays = list(_slice_data())
-    with pytest.raises(ValueError, match="strict dataset-bound admission"):
-        campaign.publish_json(
-            destination,
-            shard,
-            root=tmp_path,
-            _completed_replay_arrays=cast(Any, invalid_arrays),
-        )
-    assert not destination.exists()
-
-
-@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_forged_self_consistent_completed_shard_cannot_be_retained(
-    tmp_path: Path, tiny_campaign: Any
-) -> None:
-    destination = campaign.campaign_path(
-        tmp_path, "shard", arm="bimu", seed=157002
-    )
-    shard = campaign.run_bimu_shard("bimu", 157002)
-    forged = copy.deepcopy(shard)
-    forged["result"]["final_state_sha256"] = "0" * 64
-    forged["result"]["resources"]["state_changed"] = True
-    _resign(forged)
-    assert campaign.validate_bimu_shard(forged) == forged
-
-    with pytest.raises(ValueError, match="strict dataset-bound admission"):
-        campaign.publish_json(
-            destination,
-            forged,
-            root=tmp_path,
-            _completed_replay_arrays=_slice_data(),
-        )
-    assert not destination.exists()
-
-
-@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_cli_replays_before_retaining_completed_shard_and_receipts_forgery(
-    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    campaign.publish_json(
-        campaign.campaign_path(tmp_path, "plan"),
-        campaign.build_plan_document(),
-        root=tmp_path,
-    )
-    forged = copy.deepcopy(campaign.run_bimu_shard("bimu", 157002))
-    forged["result"]["final_state_sha256"] = "0" * 64
-    forged["result"]["resources"]["state_changed"] = True
-    _resign(forged)
-    assert campaign.validate_bimu_shard(forged) == forged
-    loads = 0
-
-    def load_once(_home: Path | None = None) -> tuple[np.ndarray, ...]:
-        nonlocal loads
-        loads += 1
-        return _slice_data()
-
-    monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", load_once)
-    monkeypatch.setattr(campaign, "run_bimu_shard", lambda *args, **kwargs: forged)
-    assert (
-        campaign.main(
-            [
-                "run-shard",
-                "--root",
-                str(tmp_path),
-                "--arm",
-                "bimu",
-                "--seed",
-                "157002",
-            ]
-        )
-        == 1
-    )
-    destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157002)
-    retained = campaign.validate_failed_bimu_shard(
-        campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)
-    )
-    assert retained["status"] == "failed"
-    assert loads == 1
-
-
-@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_cli_retains_failure_receipt_when_strict_replay_raises_runtime_error(
-    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    campaign.publish_json(
-        campaign.campaign_path(tmp_path, "plan"),
-        campaign.build_plan_document(),
-        root=tmp_path,
-    )
-
-    def fail_replay(*args: object, **kwargs: object) -> None:
-        raise RuntimeError("hostile replay failure must not escape")
-
-    monkeypatch.setattr(campaign, "validate_bimu_shard_by_reexecution", fail_replay)
-    assert (
-        campaign.main(
-            [
-                "run-shard",
-                "--root",
-                str(tmp_path),
-                "--arm",
-                "bimu",
-                "--seed",
-                "157002",
-            ]
-        )
-        == 1
-    )
-    destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157002)
-    retained = campaign.validate_failed_bimu_shard(
-        campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)
-    )
-    assert retained["status"] == "failed"
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
@@ -935,7 +808,7 @@ def test_validate_rejects_relocated_shards_before_loading_them(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_cli_completes_after_one_execution_and_one_strict_replay(
+def test_cli_completes_with_exactly_one_learner_execution(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
 ) -> None:
     campaign.publish_json(
@@ -969,7 +842,7 @@ def test_cli_completes_after_one_execution_and_one_strict_replay(
         == 0
     )
 
-    assert learner_runs == 2
+    assert learner_runs == 1
     assert destination.stat().st_mode & 0o777 == 0o444
     campaign.validate_bimu_shard(
         campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import copy
+import dataclasses
+import hashlib
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import alberta_framework.evaluation.bimu_matched_campaign as campaign
+import alberta_framework.evaluation.bimu_matched_nonpromoting as plan_module
+from alberta_framework.benchmarks.bimu import _dataset_sha256
+from alberta_framework.evaluation.bimu_matched_nonpromoting import _test_plan
+
+
+def _full_data(input_dim: int = 4) -> tuple[np.ndarray, np.ndarray]:
+    x = np.arange(60_000 * input_dim, dtype=np.float32).reshape(60_000, input_dim)
+    x /= np.float32(60_000 * input_dim)
+    y = np.arange(60_000, dtype=np.int32) % 2
+    return x, y
+
+
+def _slice_data() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    x = np.arange(8 * 4, dtype=np.float32).reshape(8, 4) / np.float32(32.0)
+    y = np.arange(8, dtype=np.int32) % 2
+    return x[:4], y[:4], x[4:], y[4:]
+
+
+def _resign(payload: dict[str, Any], field: str = "shard_sha256") -> None:
+    payload[field] = campaign.digest_without(payload, field)
+
+
+@pytest.fixture
+def tiny_campaign(monkeypatch: pytest.MonkeyPatch) -> Any:
+    plan = _test_plan(input_dim=4, n_classes=2, examples=4)
+    monkeypatch.setattr(plan_module, "FROZEN_BIMU_MATCHED_PLAN", plan)
+    monkeypatch.setattr(plan_module, "EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(
+        plan_module,
+        "FROZEN_PLAN_SHA256",
+        campaign._sha256(plan_module._plan_payload(plan)),
+    )
+    monkeypatch.setattr(campaign, "FROZEN_BIMU_MATCHED_PLAN", plan)
+    monkeypatch.setattr(campaign, "EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", lambda _home=None: _slice_data())
+    process_index = 0
+
+    def distinct_process_identity() -> dict[str, object]:
+        nonlocal process_index
+        process_index += 1
+        identity: dict[str, object] = {
+            "schema": campaign.PROCESS_SCHEMA,
+            "pid": 10_000 + process_index,
+            "proc_start_ticks": 20_000 + process_index,
+            "boot_id_sha256": "a" * 64,
+            "invocation_nonce": f"{process_index:032x}",
+            "fresh_process_required": True,
+            "identity_is_not_attestation": True,
+        }
+        identity["execution_instance_id"] = campaign.digest_without(
+            identity, "execution_instance_id"
+        )
+        return identity
+
+    monkeypatch.setattr(campaign, "_process_identity", distinct_process_identity)
+    return plan
+
+
+def test_frozen_dataset_loader_uses_exact_canonical_60k_slice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    x, y = _full_data()
+    monkeypatch.setattr(campaign, "load_mnist_train", lambda _home=None: (x, y))
+    plan = _test_plan(input_dim=4, n_classes=2, examples=4)
+    plan = dataclasses.replace(
+        plan,
+        dataset_sha256=_dataset_sha256(x[:4], y[:4], x[-4:], y[-4:]),
+    )
+
+    train_x, train_y, test_x, test_y = campaign.load_frozen_bimu_dataset(
+        Path("/cache"), plan=plan
+    )
+
+    np.testing.assert_array_equal(train_x, x[:4])
+    np.testing.assert_array_equal(train_y, y[:4])
+    np.testing.assert_array_equal(test_x, x[-4:])
+    np.testing.assert_array_equal(test_y, y[-4:])
+    assert not np.shares_memory(train_x, x)
+    assert not np.shares_memory(test_x, x)
+
+
+def test_run_shard_refuses_before_loading_data_when_unauthorized(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    called = False
+
+    def fail(_home: Path | None = None) -> Any:
+        nonlocal called
+        called = True
+        raise AssertionError("dataset must not be loaded")
+
+    monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", fail)
+    with pytest.raises(PermissionError, match="not authorized"):
+        campaign.run_bimu_shard("memory_off", 157001, data_home=tmp_path)
+    assert called is False
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign execution requires Linux /proc")
+def test_linux_process_identity_is_current_and_self_consistent() -> None:
+    identity = campaign._process_identity()
+    assert campaign._validate_process(identity) == identity
+    assert identity["pid"] > 0
+    assert identity["boot_id_sha256"] != hashlib.sha256(b"").hexdigest()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_cli_run_shard_refuses_before_loading_data_when_unauthorized(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+    called = False
+
+    def fail(_home: Path | None = None) -> Any:
+        nonlocal called
+        called = True
+        raise AssertionError("dataset must not be loaded")
+
+    monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", fail)
+    assert campaign.main(
+        [
+            "run-shard",
+            "--root",
+            str(tmp_path),
+            "--arm",
+            "memory_off",
+            "--seed",
+            "157001",
+        ]
+    ) == 2
+    assert called is False
+
+
+def test_one_shard_roundtrip_binds_all_execution_axes(tiny_campaign: Any) -> None:
+    shard = campaign.run_bimu_shard("memory_off", 157001)
+    validated = campaign.validate_bimu_shard(shard)
+
+    assert validated == shard
+    assert shard["spec"] == {"arm": "memory_off", "seed": 157001}
+    assert shard["identity"]["source_sha256"] == plan_module._source_identity()
+    assert shard["identity"]["runtime"] == plan_module._runtime_identity()
+    assert shard["identity"]["dependencies"] == plan_module._dependency_identity()
+    assert shard["resources"]["dataset_numeric_bytes"] == 160
+    assert shard["timing"]["qualified"] is False
+    assert shard["timing"]["used_for_outcome"] is False
+
+
+def test_shard_validator_rejects_forged_nested_receipts_and_hostile_trees(
+    tiny_campaign: Any,
+) -> None:
+    shard = campaign.run_bimu_shard("bimu", 157002)
+
+    forged = copy.deepcopy(shard)
+    forged["result"]["counters"]["optimizer_updates"] -= 1
+    _resign(forged)
+    with pytest.raises(ValueError, match="counter|optimizer"):
+        campaign.validate_bimu_shard(forged)
+
+    forged = copy.deepcopy(shard)
+    forged["identity"]["dependencies"]["uv_lock_sha256"] = "0" * 64
+    _resign(forged)
+    with pytest.raises(ValueError, match="identity"):
+        campaign.validate_bimu_shard(forged)
+
+    hostile: object = "leaf"
+    for _ in range(campaign.MAX_JSON_DEPTH + 1):
+        hostile = [hostile]
+    with pytest.raises(ValueError, match="nesting"):
+        campaign.validate_bimu_shard(hostile)
+
+    plan = campaign.build_plan_document()
+    plan["policy"]["execution_authorized"] = 1
+    plan["document_sha256"] = campaign.digest_without(plan, "document_sha256")
+    with pytest.raises(ValueError, match="policy"):
+        campaign.validate_plan_document(plan)
+
+
+def _six_shards() -> list[dict[str, Any]]:
+    return [
+        campaign.run_bimu_shard(arm, seed)
+        for seed in (157001, 157002, 157003)
+        for arm in ("memory_off", "bimu")
+    ]
+
+
+def test_aggregate_requires_six_unique_shards_and_recomputes_paired_rule(
+    tiny_campaign: Any,
+) -> None:
+    shards = _six_shards()
+    aggregate = campaign.summarize_bimu_shards(shards)
+    campaign.validate_bimu_aggregate(aggregate)
+
+    deltas = aggregate["paired_metrics"]["primary_deltas"]
+    expected = (
+        "supported"
+        if all(delta > 0.0 for delta in deltas)
+        else "rejected"
+        if all(delta <= 0.0 for delta in deltas)
+        else "inconclusive"
+    )
+    assert aggregate["outcome"]["classification"] == expected
+    assert aggregate["outcome"]["scientific_evidence"] is False
+
+    with pytest.raises(ValueError, match="roster"):
+        campaign.summarize_bimu_shards(shards[:-1])
+    with pytest.raises(ValueError, match="roster|duplicate"):
+        campaign.summarize_bimu_shards([*shards[:-1], shards[0]])
+
+    same_process = copy.deepcopy(shards)
+    same_process[1]["identity"]["process"] = copy.deepcopy(
+        same_process[0]["identity"]["process"]
+    )
+    _resign(same_process[1])
+    with pytest.raises(ValueError, match="process"):
+        campaign.summarize_bimu_shards(same_process)
+
+
+def test_aggregate_rejects_cross_pair_schedule_or_resource_drift(tiny_campaign: Any) -> None:
+    shards = _six_shards()
+    forged = copy.deepcopy(shards)
+    forged[1]["result"]["schedule_sha256"] = "0" * 64
+    _resign(forged[1])
+    with pytest.raises(ValueError, match="schedule"):
+        campaign.summarize_bimu_shards(forged)
+
+    forged = copy.deepcopy(shards)
+    forged[1]["result"]["resources"]["parameter_numeric_bytes"] += 4
+    _resign(forged[1])
+    with pytest.raises(ValueError, match="resource|accounting"):
+        campaign.summarize_bimu_shards(forged)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_fixed_namespace_publication_is_append_only(
+    tmp_path: Path, tiny_campaign: Any
+) -> None:
+    plan_path = campaign.campaign_path(tmp_path, "plan")
+    campaign.publish_json(plan_path, campaign.build_plan_document(), root=tmp_path)
+    with pytest.raises(FileExistsError):
+        campaign.publish_json(plan_path, campaign.build_plan_document(), root=tmp_path)
+
+    outside = tmp_path / "outside.json"
+    with pytest.raises(ValueError, match="namespace"):
+        campaign.publish_json(outside, {}, root=tmp_path)
+
+    invalid_shard_path = campaign.campaign_path(
+        tmp_path, "shard", arm="memory_off", seed=157001
+    )
+    with pytest.raises(ValueError, match="shard"):
+        campaign.publish_json(invalid_shard_path, {}, root=tmp_path)
+
+    (plan_path.parent / "unexpected.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError, match="unexpected"):
+        campaign.main(["validate", "--root", str(tmp_path)])
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign file validation is Linux-only")
+def test_strict_loader_rejects_duplicate_keys_and_oversized_input(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema":"a","schema":"b"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate"):
+        campaign.load_json_strict(duplicate, byte_ceiling=1024)
+
+    oversized = tmp_path / "oversized.json"
+    oversized.write_bytes(b" " * 1025)
+    with pytest.raises(ValueError, match="byte ceiling"):
+        campaign.load_json_strict(oversized, byte_ceiling=1024)
+
+    linked = tmp_path / "linked.json"
+    linked.write_text("{}", encoding="utf-8")
+    linked_alias = tmp_path / "linked-alias.json"
+    linked_alias.hardlink_to(linked)
+    with pytest.raises(ValueError, match="hard-link"):
+        campaign.load_json_strict(linked, byte_ceiling=1024)
+
+
+def test_cli_has_only_plan_run_shard_summarize_and_validate() -> None:
+    parser = campaign._parser()
+    for command in ("plan", "run-shard", "summarize", "validate"):
+        assert parser.parse_args([command, "--root", "/tmp/root", *(
+            ["--arm", "bimu", "--seed", "157001"] if command == "run-shard" else []
+        )]).command == command
+
+
+def test_aggregate_validator_rejects_resigned_outcome_reclassification(
+    tiny_campaign: Any,
+) -> None:
+    aggregate = cast(dict[str, Any], campaign.summarize_bimu_shards(_six_shards()))
+    aggregate["outcome"]["classification"] = "supported"
+    aggregate["aggregate_sha256"] = campaign.digest_without(aggregate, "aggregate_sha256")
+    with pytest.raises(ValueError, match="outcome"):
+        campaign.validate_bimu_aggregate(aggregate)

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -370,6 +370,7 @@ def test_cli_validate_cross_binds_aggregate_to_reexecuted_shard_files(
             ),
             shard,
             root=tmp_path,
+            _completed_replay_arrays=_slice_data(),
         )
     different_valid_aggregate = campaign.summarize_bimu_shards(_six_shards())
     campaign.publish_json(
@@ -471,20 +472,142 @@ def test_publication_race_retains_concurrent_destination(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_shard_publisher_does_not_run_unreceipted_reexecution(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
+def test_completed_shard_publisher_requires_replay_arrays(
+    tmp_path: Path, tiny_campaign: Any
 ) -> None:
     destination = campaign.campaign_path(
         tmp_path, "shard", arm="memory_off", seed=157001
     )
     shard = campaign.run_bimu_shard("memory_off", 157001)
-
-    def forbidden(*args: object, **kwargs: object) -> None:
-        raise AssertionError("publisher performed an unreceipted learner replay")
-
-    monkeypatch.setattr(campaign, "validate_bimu_shard_by_reexecution", forbidden)
-    campaign.publish_json(destination, shard, root=tmp_path)
+    with pytest.raises(ValueError, match="strict dataset-bound admission"):
+        campaign.publish_json(destination, shard, root=tmp_path)
+    campaign.publish_json(
+        destination,
+        shard,
+        root=tmp_path,
+        _completed_replay_arrays=_slice_data(),
+    )
     assert destination.is_file()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_completed_shard_publisher_rejects_noncanonical_replay_arrays(
+    tmp_path: Path, tiny_campaign: Any
+) -> None:
+    destination = campaign.campaign_path(
+        tmp_path, "shard", arm="memory_off", seed=157001
+    )
+    shard = campaign.run_bimu_shard("memory_off", 157001)
+    invalid_arrays = list(_slice_data())
+    with pytest.raises(ValueError, match="strict dataset-bound admission"):
+        campaign.publish_json(
+            destination,
+            shard,
+            root=tmp_path,
+            _completed_replay_arrays=cast(Any, invalid_arrays),
+        )
+    assert not destination.exists()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_forged_self_consistent_completed_shard_cannot_be_retained(
+    tmp_path: Path, tiny_campaign: Any
+) -> None:
+    destination = campaign.campaign_path(
+        tmp_path, "shard", arm="bimu", seed=157002
+    )
+    shard = campaign.run_bimu_shard("bimu", 157002)
+    forged = copy.deepcopy(shard)
+    forged["result"]["final_state_sha256"] = "0" * 64
+    forged["result"]["resources"]["state_changed"] = True
+    _resign(forged)
+    assert campaign.validate_bimu_shard(forged) == forged
+
+    with pytest.raises(ValueError, match="strict dataset-bound admission"):
+        campaign.publish_json(
+            destination,
+            forged,
+            root=tmp_path,
+            _completed_replay_arrays=_slice_data(),
+        )
+    assert not destination.exists()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_cli_replays_before_retaining_completed_shard_and_receipts_forgery(
+    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+    forged = copy.deepcopy(campaign.run_bimu_shard("bimu", 157002))
+    forged["result"]["final_state_sha256"] = "0" * 64
+    forged["result"]["resources"]["state_changed"] = True
+    _resign(forged)
+    assert campaign.validate_bimu_shard(forged) == forged
+    loads = 0
+
+    def load_once(_home: Path | None = None) -> tuple[np.ndarray, ...]:
+        nonlocal loads
+        loads += 1
+        return _slice_data()
+
+    monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", load_once)
+    monkeypatch.setattr(campaign, "run_bimu_shard", lambda *args, **kwargs: forged)
+    assert (
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "bimu",
+                "--seed",
+                "157002",
+            ]
+        )
+        == 1
+    )
+    destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157002)
+    retained = campaign.validate_failed_bimu_shard(
+        campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)
+    )
+    assert retained["status"] == "failed"
+    assert loads == 1
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_cli_does_not_misreport_publication_failure_as_execution_receipt(
+    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+    destination = campaign.campaign_path(
+        tmp_path, "shard", arm="memory_off", seed=157001
+    )
+    def fail_publication(*args: object) -> None:
+        raise OSError("simulated publication failure")
+
+    monkeypatch.setattr(campaign, "_link_unnamed_file", fail_publication)
+    with pytest.raises(OSError, match="publication failure"):
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "memory_off",
+                "--seed",
+                "157001",
+            ]
+        )
+    assert not destination.exists()
+    assert not destination.with_name(f".{destination.name}.reservation").exists()
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
@@ -693,7 +816,7 @@ def test_validate_rejects_relocated_shards_before_loading_them(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_cli_completes_with_exactly_one_learner_execution(
+def test_cli_completes_after_one_execution_and_one_strict_replay(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
 ) -> None:
     campaign.publish_json(
@@ -727,7 +850,7 @@ def test_cli_completes_with_exactly_one_learner_execution(
         == 0
     )
 
-    assert learner_runs == 1
+    assert learner_runs == 2
     assert destination.stat().st_mode & 0o777 == 0o444
     campaign.validate_bimu_shard(
         campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -39,6 +39,7 @@ def tiny_campaign(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
     plan = _test_plan(input_dim=4, n_classes=2, examples=4)
     monkeypatch.setattr(plan_module, "FROZEN_BIMU_MATCHED_PLAN", plan)
     monkeypatch.setattr(plan_module, "EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(plan_module, "AUTHORIZATION_TRANSITION_APPROVED", True)
     monkeypatch.setattr(
         plan_module,
         "FROZEN_PLAN_SHA256",
@@ -46,6 +47,7 @@ def tiny_campaign(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
     )
     monkeypatch.setattr(campaign, "FROZEN_BIMU_MATCHED_PLAN", plan)
     monkeypatch.setattr(campaign, "EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(campaign, "AUTHORIZATION_TRANSITION_APPROVED", True)
     monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", tmp_path)
     monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", lambda _home=None: _slice_data())
     process_index = 0
@@ -82,9 +84,7 @@ def test_frozen_dataset_loader_uses_exact_canonical_60k_slice(
         dataset_sha256=_dataset_sha256(x[:4], y[:4], x[-4:], y[-4:]),
     )
 
-    train_x, train_y, test_x, test_y = campaign.load_frozen_bimu_dataset(
-        Path("/cache"), plan=plan
-    )
+    train_x, train_y, test_x, test_y = campaign.load_frozen_bimu_dataset(Path("/cache"), plan=plan)
 
     np.testing.assert_array_equal(train_x, x[:4])
     np.testing.assert_array_equal(train_y, y[:4])
@@ -107,7 +107,40 @@ def test_run_shard_refuses_before_loading_data_when_unauthorized(
     monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", fail)
     with pytest.raises(PermissionError, match="not authorized"):
         campaign.run_bimu_shard("memory_off", 157001, data_home=tmp_path)
+    monkeypatch.setattr(campaign, "AUTHORIZATION_TRANSITION_APPROVED", True)
+    with pytest.raises(PermissionError, match="not authorized"):
+        campaign.run_bimu_shard("memory_off", 157001, data_home=tmp_path)
+    monkeypatch.setattr(campaign, "AUTHORIZATION_TRANSITION_APPROVED", False)
+    monkeypatch.setattr(campaign, "EXECUTION_AUTHORIZED", True)
+    with pytest.raises(PermissionError, match="not authorized"):
+        campaign.run_bimu_shard("memory_off", 157001, data_home=tmp_path)
     assert called is False
+
+
+def test_public_publisher_refuses_flag_mismatches_before_namespace_creation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", tmp_path)
+    path = campaign.campaign_path(tmp_path, "plan")
+    with pytest.raises(PermissionError, match="not authorized"):
+        campaign.publish_json(path, object(), root=tmp_path)
+    monkeypatch.setattr(campaign, "AUTHORIZATION_TRANSITION_APPROVED", True)
+    with pytest.raises(PermissionError, match="not authorized"):
+        campaign.publish_json(path, object(), root=tmp_path)
+    monkeypatch.setattr(campaign, "AUTHORIZATION_TRANSITION_APPROVED", False)
+    monkeypatch.setattr(campaign, "EXECUTION_AUTHORIZED", True)
+    with pytest.raises(PermissionError, match="not authorized"):
+        campaign.publish_json(path, object(), root=tmp_path)
+    assert not (tmp_path / "outputs").exists()
+
+
+def test_directory_chain_rejects_sequence_subclass_without_hooks(tmp_path: Path) -> None:
+    class Hostile(tuple[str, ...]):
+        def __iter__(self) -> Any:
+            raise AssertionError("subclass hooks must not run")
+
+    with pytest.raises(ValueError, match="exact safe sequence"):
+        campaign._open_directory_chain(tmp_path, Hostile(("outputs",)), create=True)
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign execution requires Linux /proc")
@@ -123,11 +156,22 @@ def test_cli_run_shard_refuses_before_loading_data_when_unauthorized(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", tmp_path)
+    monkeypatch.setattr(plan_module, "EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(plan_module, "AUTHORIZATION_TRANSITION_APPROVED", True)
+    monkeypatch.setattr(
+        plan_module,
+        "FROZEN_PLAN_SHA256",
+        campaign._sha256(plan_module._plan_payload(plan_module.FROZEN_BIMU_MATCHED_PLAN)),
+    )
+    monkeypatch.setattr(campaign, "EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(campaign, "AUTHORIZATION_TRANSITION_APPROVED", True)
     campaign.publish_json(
         campaign.campaign_path(tmp_path, "plan"),
         campaign.build_plan_document(),
         root=tmp_path,
     )
+    monkeypatch.setattr(campaign, "EXECUTION_AUTHORIZED", False)
+    monkeypatch.setattr(campaign, "AUTHORIZATION_TRANSITION_APPROVED", False)
     called = False
 
     def fail(_home: Path | None = None) -> Any:
@@ -136,17 +180,20 @@ def test_cli_run_shard_refuses_before_loading_data_when_unauthorized(
         raise AssertionError("dataset must not be loaded")
 
     monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", fail)
-    assert campaign.main(
-        [
-            "run-shard",
-            "--root",
-            str(tmp_path),
-            "--arm",
-            "memory_off",
-            "--seed",
-            "157001",
-        ]
-    ) == 2
+    assert (
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "memory_off",
+                "--seed",
+                "157001",
+            ]
+        )
+        == 2
+    )
     assert called is False
 
 
@@ -264,9 +311,7 @@ def test_aggregate_requires_six_unique_shards_and_recomputes_paired_rule(
         campaign.summarize_bimu_shards([*shards[:-1], shards[0]])
 
     same_process = copy.deepcopy(shards)
-    same_process[1]["identity"]["process"] = copy.deepcopy(
-        same_process[0]["identity"]["process"]
-    )
+    same_process[1]["identity"]["process"] = copy.deepcopy(same_process[0]["identity"]["process"])
     _resign(same_process[1])
     with pytest.raises(ValueError, match="process"):
         campaign.summarize_bimu_shards(same_process)
@@ -285,6 +330,23 @@ def test_aggregate_rejects_cross_pair_schedule_or_resource_drift(tiny_campaign: 
     _resign(forged[1])
     with pytest.raises(ValueError, match="resource|accounting"):
         campaign.summarize_bimu_shards(forged)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_summarize_reserves_aggregate_before_plan_or_replay(
+    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    marker = tmp_path / "outputs/bimu_matched/development.v1/.aggregate.json.reservation"
+    monkeypatch.setattr(campaign, "_validate_namespace", lambda *args, **kwargs: None)
+
+    def stop_after_reservation(root: Path) -> dict[str, object]:
+        assert marker.is_file()
+        raise RuntimeError("stop before plan or replay")
+
+    monkeypatch.setattr(campaign, "_load_plan", stop_after_reservation)
+    with pytest.raises(RuntimeError, match="stop before plan or replay"):
+        campaign.main(["summarize", "--root", str(tmp_path)])
+    assert not marker.exists()
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
@@ -321,9 +383,7 @@ def test_cli_validate_cross_binds_aggregate_to_reexecuted_shard_files(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_fixed_namespace_publication_is_append_only(
-    tmp_path: Path, tiny_campaign: Any
-) -> None:
+def test_fixed_namespace_publication_is_append_only(tmp_path: Path, tiny_campaign: Any) -> None:
     plan_path = campaign.campaign_path(tmp_path, "plan")
     campaign.publish_json(plan_path, campaign.build_plan_document(), root=tmp_path)
     with pytest.raises(FileExistsError):
@@ -333,9 +393,7 @@ def test_fixed_namespace_publication_is_append_only(
     with pytest.raises(ValueError, match="namespace"):
         campaign.publish_json(outside, {}, root=tmp_path)
 
-    invalid_shard_path = campaign.campaign_path(
-        tmp_path, "shard", arm="memory_off", seed=157001
-    )
+    invalid_shard_path = campaign.campaign_path(tmp_path, "shard", arm="memory_off", seed=157001)
     with pytest.raises(ValueError, match="shard"):
         campaign.publish_json(invalid_shard_path, {}, root=tmp_path)
 
@@ -353,9 +411,7 @@ def test_incomplete_namespace_rejects_broken_expected_shard_symlink(
         campaign.build_plan_document(),
         root=tmp_path,
     )
-    shard_path = campaign.campaign_path(
-        tmp_path, "shard", arm="memory_off", seed=157001
-    )
+    shard_path = campaign.campaign_path(tmp_path, "shard", arm="memory_off", seed=157001)
     shard_path.symlink_to(tmp_path / "absent.json")
 
     with pytest.raises(ValueError, match="regular non-symlink"):
@@ -416,7 +472,7 @@ def test_publication_race_retains_concurrent_destination(
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
 def test_publication_revalidates_readback_without_unlinking_visible_inode(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
 ) -> None:
     monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", tmp_path)
     plan_path = campaign.campaign_path(tmp_path, "plan")
@@ -427,6 +483,7 @@ def test_publication_revalidates_readback_without_unlinking_visible_inode(
     def fail_readback(value: object) -> dict[str, object]:
         nonlocal calls
         calls += 1
+        assert (plan_path.parent / ".plan.json.reservation").is_file()
         if calls == 2:
             raise ValueError("simulated readback rejection")
         return original(value)
@@ -447,9 +504,7 @@ def test_cli_reserves_exact_shard_before_execution(
         campaign.build_plan_document(),
         root=tmp_path,
     )
-    destination = campaign.campaign_path(
-        tmp_path, "shard", arm="memory_off", seed=157001
-    )
+    destination = campaign.campaign_path(tmp_path, "shard", arm="memory_off", seed=157001)
     original_load_plan = campaign._load_plan
 
     def load_plan_after_reservation(root: Path) -> dict[str, object]:
@@ -466,17 +521,20 @@ def test_cli_reserves_exact_shard_before_execution(
 
     monkeypatch.setattr(campaign, "_load_plan", load_plan_after_reservation)
     monkeypatch.setattr(campaign, "run_bimu_shard", fail_after_reservation)
-    assert campaign.main(
-        [
-            "run-shard",
-            "--root",
-            str(tmp_path),
-            "--arm",
-            "memory_off",
-            "--seed",
-            "157001",
-        ]
-    ) == 1
+    assert (
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "memory_off",
+                "--seed",
+                "157001",
+            ]
+        )
+        == 1
+    )
     assert destination.is_file()
     assert destination.stat().st_mode & 0o777 == 0o444
     assert not destination.with_name(f".{destination.name}.reservation").exists()
@@ -490,25 +548,24 @@ def test_cli_reserves_exact_shard_before_execution(
     with pytest.raises(ValueError, match="fields|identity|status"):
         campaign.summarize_bimu_shards([failed] * 6)
 
-    invalid_destination = campaign.campaign_path(
-        tmp_path, "shard", arm="bimu", seed=157001
-    )
+    invalid_destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157001)
     monkeypatch.setattr(campaign, "run_bimu_shard", lambda *args, **kwargs: {"invalid": True})
-    assert campaign.main(
-        [
-            "run-shard",
-            "--root",
-            str(tmp_path),
-            "--arm",
-            "bimu",
-            "--seed",
-            "157001",
-        ]
-    ) == 1
-    campaign.validate_failed_bimu_shard(
-        campaign.load_json_strict(
-            invalid_destination, byte_ceiling=campaign.MAX_SHARD_BYTES
+    assert (
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "bimu",
+                "--seed",
+                "157001",
+            ]
         )
+        == 1
+    )
+    campaign.validate_failed_bimu_shard(
+        campaign.load_json_strict(invalid_destination, byte_ceiling=campaign.MAX_SHARD_BYTES)
     )
 
 
@@ -516,9 +573,7 @@ def test_cli_reserves_exact_shard_before_execution(
 def test_replaced_visible_reservation_cannot_publish_shard(
     tmp_path: Path, tiny_campaign: Any
 ) -> None:
-    destination = campaign.campaign_path(
-        tmp_path, "shard", arm="memory_off", seed=157001
-    )
+    destination = campaign.campaign_path(tmp_path, "shard", arm="memory_off", seed=157001)
     reservation = campaign._reserve_shard_destination(destination, root=tmp_path)
     _, parent_descriptor, _, reservation_name = reservation
     hidden_name = f"{reservation_name}.held"
@@ -552,43 +607,15 @@ def test_replaced_visible_reservation_cannot_publish_shard(
         campaign._release_shard_reservation(reservation)
 
 
-def test_cli_allows_disposable_plan_preview_but_rejects_relocated_shard(
+def test_cli_rejects_unauthorized_disposable_plan_preview(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     registered = tmp_path / "registered"
     preview = tmp_path / "preview"
-    published: list[tuple[Path, Path]] = []
-
-    def capture_plan(path: Path, value: object, *, root: Path, **kwargs: object) -> None:
-        assert campaign.validate_plan_document(value) == value
-        path.parent.mkdir(parents=True)
-        (path.parent / "shards").mkdir()
-        path.write_bytes(campaign._canonical(value) + b"\n")
-        published.append((path, root))
-
     monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", registered)
-    monkeypatch.setattr(campaign, "publish_json", capture_plan)
-
-    assert campaign.main(["plan", "--root", str(preview)]) == 0
-    assert campaign.main(["validate", "--root", str(preview)]) == 0
-    assert published == [(campaign.campaign_path(preview, "plan"), preview)]
-
-    monkeypatch.setattr(campaign, "EXECUTION_AUTHORIZED", True)
-    with pytest.raises(ValueError, match="registered repository root"):
-        campaign.main(
-            [
-                "run-shard",
-                "--root",
-                str(preview),
-                "--arm",
-                "memory_off",
-                "--seed",
-                "157001",
-            ]
-        )
-    with pytest.raises(ValueError, match="registered repository root"):
-        campaign.main(["summarize", "--root", str(preview)])
-    assert len(published) == 1
+    with pytest.raises(PermissionError, match="not authorized"):
+        campaign.main(["plan", "--root", str(preview)])
+    assert not preview.exists()
 
 
 def test_public_publisher_rejects_relocated_shard_before_namespace_access(
@@ -597,9 +624,7 @@ def test_public_publisher_rejects_relocated_shard_before_namespace_access(
     registered = tmp_path / "registered"
     relocated = tmp_path / "relocated"
     monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", registered)
-    destination = campaign.campaign_path(
-        relocated, "shard", arm="memory_off", seed=157001
-    )
+    destination = campaign.campaign_path(relocated, "shard", arm="memory_off", seed=157001)
     with pytest.raises(ValueError, match="registered repository root"):
         campaign.publish_json(
             destination,
@@ -610,9 +635,7 @@ def test_public_publisher_rejects_relocated_shard_before_namespace_access(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_cli_completes_and_revalidates_reserved_shard(
-    tmp_path: Path, tiny_campaign: Any
-) -> None:
+def test_cli_completes_and_revalidates_reserved_shard(tmp_path: Path, tiny_campaign: Any) -> None:
     campaign.publish_json(
         campaign.campaign_path(tmp_path, "plan"),
         campaign.build_plan_document(),
@@ -620,17 +643,20 @@ def test_cli_completes_and_revalidates_reserved_shard(
     )
     destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157003)
 
-    assert campaign.main(
-        [
-            "run-shard",
-            "--root",
-            str(tmp_path),
-            "--arm",
-            "bimu",
-            "--seed",
-            "157003",
-        ]
-    ) == 0
+    assert (
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "bimu",
+                "--seed",
+                "157003",
+            ]
+        )
+        == 0
+    )
 
     assert destination.stat().st_mode & 0o777 == 0o444
     campaign.validate_bimu_shard(
@@ -645,9 +671,7 @@ def test_publication_rejects_zero_progress_write(
     document = campaign.build_plan_document()
     monkeypatch.setattr(campaign.os, "write", lambda *args: 0)
     with pytest.raises(OSError, match="no progress"):
-        campaign.publish_json(
-            campaign.campaign_path(tmp_path, "plan"), document, root=tmp_path
-        )
+        campaign.publish_json(campaign.campaign_path(tmp_path, "plan"), document, root=tmp_path)
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign file validation is Linux-only")
@@ -697,9 +721,17 @@ def test_json_tree_rejects_hostile_exact_type_subclasses_without_hooks() -> None
 def test_cli_has_only_plan_run_shard_summarize_and_validate() -> None:
     parser = campaign._parser()
     for command in ("plan", "run-shard", "summarize", "validate"):
-        assert parser.parse_args([command, "--root", "/tmp/root", *(
-            ["--arm", "bimu", "--seed", "157001"] if command == "run-shard" else []
-        )]).command == command
+        assert (
+            parser.parse_args(
+                [
+                    command,
+                    "--root",
+                    "/tmp/root",
+                    *(["--arm", "bimu", "--seed", "157001"] if command == "run-shard" else []),
+                ]
+            ).command
+            == command
+        )
 
 
 def test_aggregate_validator_rejects_resigned_outcome_reclassification(

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -495,6 +495,30 @@ def test_completed_shard_publisher_requires_matching_reexecution_proof(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_completed_shard_publisher_rejects_constructed_proof_without_capability(
+    tmp_path: Path, tiny_campaign: Any
+) -> None:
+    destination = campaign.campaign_path(
+        tmp_path, "shard", arm="memory_off", seed=157001
+    )
+    shard = campaign.run_bimu_shard("memory_off", 157001)
+    forged = campaign._CompletedShardReplayProof(
+        capability=object(),
+        payload_sha256=hashlib.sha256(campaign._canonical(shard)).hexdigest(),
+        shard_sha256=cast(str, shard["shard_sha256"]),
+        dataset_sha256=campaign.FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
+    )
+    with pytest.raises(ValueError, match="strict reexecution proof"):
+        campaign.publish_json(
+            destination,
+            shard,
+            root=tmp_path,
+            _completed_replay_proof=forged,
+        )
+    assert not destination.exists()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
 def test_forged_self_consistent_completed_shard_cannot_be_retained(
     tmp_path: Path, tiny_campaign: Any
 ) -> None:

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -480,6 +480,17 @@ def test_cli_reserves_exact_shard_before_execution(
     assert destination.stat().st_size == 0
 
 
+def test_cli_rejects_relocated_root_before_namespace_access(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registered = tmp_path / "registered"
+    relocated = tmp_path / "relocated"
+    monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", registered)
+    with pytest.raises(ValueError, match="registered repository root"):
+        campaign.main(["validate", "--root", str(relocated)])
+    assert not relocated.exists()
+
+
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
 def test_cli_completes_and_revalidates_reserved_shard(
     tmp_path: Path, tiny_campaign: Any

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -670,6 +670,25 @@ def test_publication_revalidation_failure_removes_published_inode(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_post_link_failure_removes_prearmed_published_inode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
+) -> None:
+    plan_path = campaign.campaign_path(tmp_path, "plan")
+    document = campaign.build_plan_document()
+    original_link = campaign._link_unnamed_file
+
+    def link_then_fail(file_descriptor: int, parent_descriptor: int, name: str) -> None:
+        original_link(file_descriptor, parent_descriptor, name)
+        raise OSError("simulated post-link publication failure")
+
+    monkeypatch.setattr(campaign, "_link_unnamed_file", link_then_fail)
+    with pytest.raises(OSError, match="post-link publication failure"):
+        campaign.publish_json(plan_path, document, root=tmp_path)
+    assert not plan_path.exists()
+    assert not plan_path.with_name(".plan.json.reservation").exists()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
 def test_post_link_replacement_is_not_removed_on_validation_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
 ) -> None:

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -35,7 +35,7 @@ def _resign(payload: dict[str, Any], field: str = "shard_sha256") -> None:
 
 
 @pytest.fixture
-def tiny_campaign(monkeypatch: pytest.MonkeyPatch) -> Any:
+def tiny_campaign(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
     plan = _test_plan(input_dim=4, n_classes=2, examples=4)
     monkeypatch.setattr(plan_module, "FROZEN_BIMU_MATCHED_PLAN", plan)
     monkeypatch.setattr(plan_module, "EXECUTION_AUTHORIZED", True)
@@ -46,6 +46,7 @@ def tiny_campaign(monkeypatch: pytest.MonkeyPatch) -> Any:
     )
     monkeypatch.setattr(campaign, "FROZEN_BIMU_MATCHED_PLAN", plan)
     monkeypatch.setattr(campaign, "EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", tmp_path)
     monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", lambda _home=None: _slice_data())
     process_index = 0
 
@@ -121,6 +122,7 @@ def test_linux_process_identity_is_current_and_self_consistent() -> None:
 def test_cli_run_shard_refuses_before_loading_data_when_unauthorized(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", tmp_path)
     campaign.publish_json(
         campaign.campaign_path(tmp_path, "plan"),
         campaign.build_plan_document(),
@@ -353,6 +355,77 @@ def test_publication_race_retains_concurrent_destination(
         campaign.publish_json(path, campaign.build_plan_document(), root=tmp_path)
 
     assert path.read_bytes() == competitor
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_publication_revalidates_readback_without_unlinking_visible_inode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", tmp_path)
+    plan_path = campaign.campaign_path(tmp_path, "plan")
+    document = campaign.build_plan_document()
+    original = campaign.validate_plan_document
+    calls = 0
+
+    def fail_readback(value: object) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise ValueError("simulated readback rejection")
+        return original(value)
+
+    monkeypatch.setattr(campaign, "validate_plan_document", fail_readback)
+    with pytest.raises(ValueError, match="readback rejection"):
+        campaign.publish_json(plan_path, document, root=tmp_path)
+    assert plan_path.is_file()
+    assert plan_path.stat().st_mode & 0o777 == 0o444
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_cli_reserves_exact_shard_before_execution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+    destination = campaign.campaign_path(
+        tmp_path, "shard", arm="memory_off", seed=157001
+    )
+
+    def fail_after_reservation(*args: object, **kwargs: object) -> dict[str, object]:
+        assert destination.is_file()
+        assert destination.stat().st_size == 0
+        raise RuntimeError("simulated execution failure")
+
+    monkeypatch.setattr(campaign, "run_bimu_shard", fail_after_reservation)
+    with pytest.raises(RuntimeError, match="execution failure"):
+        campaign.main(
+            [
+                "run-shard",
+                "--root",
+                str(tmp_path),
+                "--arm",
+                "memory_off",
+                "--seed",
+                "157001",
+            ]
+        )
+    assert destination.is_file()
+    assert destination.stat().st_size == 0
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_publication_rejects_zero_progress_write(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
+) -> None:
+    document = campaign.build_plan_document()
+    monkeypatch.setattr(campaign.os, "write", lambda *args: 0)
+    with pytest.raises(OSError, match="no progress"):
+        campaign.publish_json(
+            campaign.campaign_path(tmp_path, "plan"), document, root=tmp_path
+        )
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign file validation is Linux-only")

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -361,9 +361,6 @@ def test_cli_validate_cross_binds_aggregate_to_reexecuted_shard_files(
     retained_shards = _six_shards()
     for shard in retained_shards:
         spec = cast(dict[str, Any], shard["spec"])
-        replay_proof = campaign._prove_completed_shard_by_reexecution(
-            shard, _slice_data()
-        )
         campaign.publish_json(
             campaign.campaign_path(
                 tmp_path,
@@ -373,7 +370,6 @@ def test_cli_validate_cross_binds_aggregate_to_reexecuted_shard_files(
             ),
             shard,
             root=tmp_path,
-            _completed_replay_proof=replay_proof,
         )
     different_valid_aggregate = campaign.summarize_bimu_shards(_six_shards())
     campaign.publish_json(
@@ -475,117 +471,20 @@ def test_publication_race_retains_concurrent_destination(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_completed_shard_publisher_requires_matching_reexecution_proof(
-    tmp_path: Path, tiny_campaign: Any
+def test_shard_publisher_does_not_run_unreceipted_reexecution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
 ) -> None:
     destination = campaign.campaign_path(
         tmp_path, "shard", arm="memory_off", seed=157001
     )
     shard = campaign.run_bimu_shard("memory_off", 157001)
-    with pytest.raises(ValueError, match="strict reexecution proof"):
-        campaign.publish_json(destination, shard, root=tmp_path)
-    proof = campaign._prove_completed_shard_by_reexecution(shard, _slice_data())
-    campaign.publish_json(
-        destination,
-        shard,
-        root=tmp_path,
-        _completed_replay_proof=proof,
-    )
+
+    def forbidden(*args: object, **kwargs: object) -> None:
+        raise AssertionError("publisher performed an unreceipted learner replay")
+
+    monkeypatch.setattr(campaign, "validate_bimu_shard_by_reexecution", forbidden)
+    campaign.publish_json(destination, shard, root=tmp_path)
     assert destination.is_file()
-
-
-@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_completed_shard_publisher_rejects_constructed_proof_without_capability(
-    tmp_path: Path, tiny_campaign: Any
-) -> None:
-    destination = campaign.campaign_path(
-        tmp_path, "shard", arm="memory_off", seed=157001
-    )
-    shard = campaign.run_bimu_shard("memory_off", 157001)
-    forged = campaign._CompletedShardReplayProof(
-        capability=object(),
-        payload_sha256=hashlib.sha256(campaign._canonical(shard)).hexdigest(),
-        shard_sha256=cast(str, shard["shard_sha256"]),
-        dataset_sha256=campaign.FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
-    )
-    with pytest.raises(ValueError, match="strict reexecution proof"):
-        campaign.publish_json(
-            destination,
-            shard,
-            root=tmp_path,
-            _completed_replay_proof=forged,
-        )
-    assert not destination.exists()
-
-
-@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_forged_self_consistent_completed_shard_cannot_be_retained(
-    tmp_path: Path, tiny_campaign: Any
-) -> None:
-    destination = campaign.campaign_path(
-        tmp_path, "shard", arm="bimu", seed=157002
-    )
-    shard = campaign.run_bimu_shard("bimu", 157002)
-    proof = campaign._prove_completed_shard_by_reexecution(shard, _slice_data())
-    forged = copy.deepcopy(shard)
-    forged["result"]["final_state_sha256"] = "0" * 64
-    forged["result"]["resources"]["state_changed"] = True
-    _resign(forged)
-    assert campaign.validate_bimu_shard(forged) == forged
-
-    with pytest.raises(ValueError, match="proof does not match"):
-        campaign.publish_json(
-            destination,
-            forged,
-            root=tmp_path,
-            _completed_replay_proof=proof,
-        )
-    assert not destination.exists()
-
-
-@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_cli_replays_before_retaining_completed_shard_and_receipts_forgery(
-    tmp_path: Path, tiny_campaign: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    campaign.publish_json(
-        campaign.campaign_path(tmp_path, "plan"),
-        campaign.build_plan_document(),
-        root=tmp_path,
-    )
-    forged = copy.deepcopy(campaign.run_bimu_shard("bimu", 157002))
-    forged["result"]["final_state_sha256"] = "0" * 64
-    forged["result"]["resources"]["state_changed"] = True
-    _resign(forged)
-    assert campaign.validate_bimu_shard(forged) == forged
-    loads = 0
-
-    def load_once(_home: Path | None = None) -> tuple[np.ndarray, ...]:
-        nonlocal loads
-        loads += 1
-        return _slice_data()
-
-    monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", load_once)
-    monkeypatch.setattr(campaign, "run_bimu_shard", lambda *args, **kwargs: forged)
-    assert (
-        campaign.main(
-            [
-                "run-shard",
-                "--root",
-                str(tmp_path),
-                "--arm",
-                "bimu",
-                "--seed",
-                "157002",
-            ]
-        )
-        == 1
-    )
-    destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157002)
-    retained = campaign.validate_failed_bimu_shard(
-        campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)
-    )
-    assert retained["status"] == "failed"
-    assert loads == 1
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
@@ -794,13 +693,24 @@ def test_validate_rejects_relocated_shards_before_loading_them(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_cli_completes_and_revalidates_reserved_shard(tmp_path: Path, tiny_campaign: Any) -> None:
+def test_cli_completes_with_exactly_one_learner_execution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
+) -> None:
     campaign.publish_json(
         campaign.campaign_path(tmp_path, "plan"),
         campaign.build_plan_document(),
         root=tmp_path,
     )
     destination = campaign.campaign_path(tmp_path, "shard", arm="bimu", seed=157003)
+    original_run = campaign.run_bimu_development
+    learner_runs = 0
+
+    def counted_run(*args: Any, **kwargs: Any) -> Any:
+        nonlocal learner_runs
+        learner_runs += 1
+        return original_run(*args, **kwargs)
+
+    monkeypatch.setattr(campaign, "run_bimu_development", counted_run)
 
     assert (
         campaign.main(
@@ -817,6 +727,7 @@ def test_cli_completes_and_revalidates_reserved_shard(tmp_path: Path, tiny_campa
         == 0
     )
 
+    assert learner_runs == 1
     assert destination.stat().st_mode & 0o777 == 0o444
     campaign.validate_bimu_shard(
         campaign.load_json_strict(destination, byte_ceiling=campaign.MAX_SHARD_BYTES)

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -438,7 +438,7 @@ def test_publication_parent_swap_never_writes_through_replacement(
         campaign.publish_json(path, campaign.build_plan_document(), root=tmp_path)
 
     assert path.read_bytes() == replacement_bytes
-    assert (retired / path.name).is_file()
+    assert not (retired / path.name).exists()
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
@@ -471,7 +471,24 @@ def test_publication_race_retains_concurrent_destination(
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
-def test_publication_revalidates_readback_without_unlinking_visible_inode(
+def test_shard_publisher_does_not_run_unreceipted_reexecution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
+) -> None:
+    destination = campaign.campaign_path(
+        tmp_path, "shard", arm="memory_off", seed=157001
+    )
+    shard = campaign.run_bimu_shard("memory_off", 157001)
+
+    def forbidden(*args: object, **kwargs: object) -> None:
+        raise AssertionError("publisher performed an unreceipted learner replay")
+
+    monkeypatch.setattr(campaign, "validate_bimu_shard_by_reexecution", forbidden)
+    campaign.publish_json(destination, shard, root=tmp_path)
+    assert destination.is_file()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_publication_revalidation_failure_removes_published_inode(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
 ) -> None:
     monkeypatch.setattr(campaign, "REGISTERED_OUTPUT_ROOT", tmp_path)
@@ -491,8 +508,32 @@ def test_publication_revalidates_readback_without_unlinking_visible_inode(
     monkeypatch.setattr(campaign, "validate_plan_document", fail_readback)
     with pytest.raises(ValueError, match="readback rejection"):
         campaign.publish_json(plan_path, document, root=tmp_path)
-    assert plan_path.is_file()
-    assert plan_path.stat().st_mode & 0o777 == 0o444
+    assert not plan_path.exists()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_post_link_replacement_is_not_removed_on_validation_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tiny_campaign: Any
+) -> None:
+    plan_path = campaign.campaign_path(tmp_path, "plan")
+    document = campaign.build_plan_document()
+    competitor = b"concurrent replacement"
+    original = campaign.validate_plan_document
+    calls = 0
+
+    def replace_before_rejection(value: object) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            plan_path.unlink()
+            plan_path.write_bytes(competitor)
+            raise ValueError("simulated replacement rejection")
+        return original(value)
+
+    monkeypatch.setattr(campaign, "validate_plan_document", replace_before_rejection)
+    with pytest.raises(ValueError, match="replacement rejection"):
+        campaign.publish_json(plan_path, document, root=tmp_path)
+    assert plan_path.read_bytes() == competitor
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")

--- a/tests/test_bimu_matched_nonpromoting.py
+++ b/tests/test_bimu_matched_nonpromoting.py
@@ -21,7 +21,7 @@ def test_frozen_bimu_plan_is_matched_and_prospective() -> None:
     candidate = plan.candidate_config.to_protocol_payload()
     assert {key for key in control if control[key] != candidate[key]} == {"memory_window"}
     assert plan.dataset_sha256 == "85c681c2f5fc5c274870b30c9accb3d2a6e9eb90a4575a2bf1ccca64f58b6227"
-    assert FROZEN_PLAN_SHA256 == "633b8e6b6bc212798e3af6b8550e39b99d800c3aae332384cda352dde31c4c75"
+    assert FROZEN_PLAN_SHA256 == "182632b37c3a8598a30fb943742605374a846d965c5602f4db039f27f78754c1"
     assert bimu_plan.frozen_plan_payload()["seed_status"] == {
         "consumed_for_promotion": True,
         "retained_matched_result_exists": False,
@@ -45,7 +45,10 @@ def test_frozen_bimu_plan_is_matched_and_prospective() -> None:
         "numeric_resource_ceiling_bytes": 256 * 1024 * 1024,
     }
     assert payload["comparison_scope"]["paper_comparable"] is False
-    assert payload["execution_authorized"] is False
+    assert payload["authorization"] == {
+        "execution_authorized": False,
+        "authorization_transition_approved": False,
+    }
     assert payload["output_namespace"] == "outputs/bimu_matched/development.v1"
     assert payload["paired_outcome_rule"] == {
         "schema": "asi.bimu.paired-outcome-rule.v1",

--- a/tests/test_bimu_matched_nonpromoting.py
+++ b/tests/test_bimu_matched_nonpromoting.py
@@ -21,7 +21,12 @@ def test_frozen_bimu_plan_is_matched_and_prospective() -> None:
     candidate = plan.candidate_config.to_protocol_payload()
     assert {key for key in control if control[key] != candidate[key]} == {"memory_window"}
     assert plan.dataset_sha256 == "85c681c2f5fc5c274870b30c9accb3d2a6e9eb90a4575a2bf1ccca64f58b6227"
-    assert FROZEN_PLAN_SHA256 == "11ddfacd0aca8108a39bd8a68225149de246efb7420d2fdb864f36ea75681f71"
+    assert FROZEN_PLAN_SHA256 == "633b8e6b6bc212798e3af6b8550e39b99d800c3aae332384cda352dde31c4c75"
+    assert bimu_plan.frozen_plan_payload()["seed_status"] == {
+        "consumed_for_promotion": True,
+        "retained_matched_result_exists": False,
+        "reason": "the literal development roster is publicly exposed",
+    }
     assert INVALID_PRIOR_ATTEMPT["pull_request"] == 1686
     assert INVALID_PRIOR_ATTEMPT["seed"] == 23
     payload = _plan_payload(plan)

--- a/tests/test_bimu_matched_nonpromoting.py
+++ b/tests/test_bimu_matched_nonpromoting.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import copy
-
-import numpy as np
 import pytest
 
 import alberta_framework.evaluation.bimu_matched_nonpromoting as bimu_plan
@@ -11,15 +8,7 @@ from alberta_framework.evaluation.bimu_matched_nonpromoting import (
     FROZEN_PLAN_SHA256,
     INVALID_PRIOR_ATTEMPT,
     _plan_payload,
-    build_bimu_execution_manifest,
-    validate_bimu_execution_manifest,
 )
-
-
-def _data() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    x = np.arange(8 * 4, dtype=np.float32).reshape(8, 4) / 32.0
-    y = np.arange(8, dtype=np.int32) % 2
-    return x[:4], y[:4], x[4:], y[4:]
 
 
 def test_frozen_bimu_plan_is_matched_and_prospective() -> None:
@@ -64,70 +53,6 @@ def test_frozen_bimu_plan_is_matched_and_prospective() -> None:
     }
     with pytest.raises(TypeError):
         INVALID_PRIOR_ATTEMPT["seed"] = 157001  # type: ignore[index]
-
-
-def test_manifest_binds_exact_data_source_runtime_and_plan(monkeypatch: pytest.MonkeyPatch) -> None:
-    import alberta_framework.evaluation.bimu_matched_nonpromoting as module
-
-    tiny_plan = module._test_plan(input_dim=4, n_classes=2, examples=4)
-    monkeypatch.setattr(module, "FROZEN_BIMU_MATCHED_PLAN", tiny_plan)
-    manifest = build_bimu_execution_manifest(*_data())
-    validate_bimu_execution_manifest(manifest, *_data())
-    assert manifest["policy"]["scientific_promotion_allowed"] is False
-    assert manifest["identity"]["consistency_not_attestation"] is True
-
-
-def test_manifest_rejects_forged_nested_identity() -> None:
-    import alberta_framework.evaluation.bimu_matched_nonpromoting as module
-
-    plan = module._test_plan(input_dim=4, n_classes=2, examples=4)
-    original = module.FROZEN_BIMU_MATCHED_PLAN
-    module.FROZEN_BIMU_MATCHED_PLAN = plan
-    try:
-        manifest = build_bimu_execution_manifest(*_data())
-        forged = copy.deepcopy(manifest)
-        forged["plan"]["seeds"][0] = 23
-        with pytest.raises(ValueError, match="plan"):
-            validate_bimu_execution_manifest(forged, *_data())
-    finally:
-        module.FROZEN_BIMU_MATCHED_PLAN = original
-
-
-def test_manifest_rejects_hostile_key_without_hooks() -> None:
-    class Hostile(str):
-        calls = 0
-
-        def __hash__(self) -> int:
-            self.calls += 1
-            return super().__hash__()
-
-        def __eq__(self, other: object) -> bool:
-            self.calls += 1
-            raise AssertionError("must not compare")
-
-    key = Hostile("schema")
-    payload = {key: "x"}
-    key.calls = 0
-    with pytest.raises(ValueError, match="exact JSON"):
-        validate_bimu_execution_manifest(payload, *_data())
-    assert key.calls == 0
-
-
-def test_manifest_rejects_hostile_metaclass_without_hooks() -> None:
-    class HostileMeta(type):
-        calls = 0
-
-        def __eq__(cls, other: object) -> bool:
-            cls.calls += 1
-            raise AssertionError("must not compare runtime types")
-
-    class Hostile(metaclass=HostileMeta):
-        pass
-
-    HostileMeta.calls = 0
-    with pytest.raises(ValueError, match="exact JSON"):
-        bimu_plan._json_preflight({"value": Hostile()})
-    assert HostileMeta.calls == 0
 
 
 def test_literal_plan_digest_fails_closed_on_unreviewed_drift(

--- a/tests/test_bimu_matched_nonpromoting.py
+++ b/tests/test_bimu_matched_nonpromoting.py
@@ -8,6 +8,7 @@ import pytest
 import alberta_framework.evaluation.bimu_matched_nonpromoting as bimu_plan
 from alberta_framework.evaluation.bimu_matched_nonpromoting import (
     FROZEN_BIMU_MATCHED_PLAN,
+    FROZEN_PLAN_SHA256,
     INVALID_PRIOR_ATTEMPT,
     _plan_payload,
     build_bimu_execution_manifest,
@@ -31,11 +32,13 @@ def test_frozen_bimu_plan_is_matched_and_prospective() -> None:
     candidate = plan.candidate_config.to_protocol_payload()
     assert {key for key in control if control[key] != candidate[key]} == {"memory_window"}
     assert plan.dataset_sha256 == "85c681c2f5fc5c274870b30c9accb3d2a6e9eb90a4575a2bf1ccca64f58b6227"
+    assert FROZEN_PLAN_SHA256 == "11ddfacd0aca8108a39bd8a68225149de246efb7420d2fdb864f36ea75681f71"
     assert INVALID_PRIOR_ATTEMPT["pull_request"] == 1686
     assert INVALID_PRIOR_ATTEMPT["seed"] == 23
     payload = _plan_payload(plan)
     assert payload["expected_counters_per_arm"]["observations"] == 1280
     assert payload["expected_counters_per_arm"]["model_forward_queries"] == 10240
+    assert payload["expected_counters_per_arm"]["optimizer_updates"] == 1280
     assert payload["expected_resources_per_arm"] == {
         "trainable_scalar_count": 25408,
         "parameter_numeric_bytes": 101632,
@@ -48,6 +51,17 @@ def test_frozen_bimu_plan_is_matched_and_prospective() -> None:
         "numeric_resource_ceiling_bytes": 256 * 1024 * 1024,
     }
     assert payload["comparison_scope"]["paper_comparable"] is False
+    assert payload["execution_authorized"] is False
+    assert payload["output_namespace"] == "outputs/bimu_matched/development.v1"
+    assert payload["paired_outcome_rule"] == {
+        "schema": "asi.bimu.paired-outcome-rule.v1",
+        "metric": "paper_late_five_test_accuracy",
+        "supported": "all_three_paired_deltas_strictly_positive",
+        "rejected": "all_three_paired_deltas_nonpositive",
+        "otherwise": "inconclusive",
+        "ties_are_positive": False,
+        "secondary_metric_affects_outcome": False,
+    }
     with pytest.raises(TypeError):
         INVALID_PRIOR_ATTEMPT["seed"] = 157001  # type: ignore[index]
 
@@ -114,3 +128,11 @@ def test_manifest_rejects_hostile_metaclass_without_hooks() -> None:
     with pytest.raises(ValueError, match="exact JSON"):
         bimu_plan._json_preflight({"value": Hostile()})
     assert HostileMeta.calls == 0
+
+
+def test_literal_plan_digest_fails_closed_on_unreviewed_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(bimu_plan, "EXECUTION_AUTHORIZED", True)
+    with pytest.raises(RuntimeError, match="literal digest"):
+        bimu_plan.frozen_plan_payload()

--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -49,6 +49,7 @@ _EXPECTED_SCRIPT_NAMES = {
     "asi-action-conditioned-latent",
     "asi-activation-feature-ipmnist",
     "asi-adamo-diagnostic",
+    "asi-bimu-matched-development",
     "asi-clear-qualification",
     "asi-coom-qualification-smoke",
     "asi-cora-catalog",


### PR DESCRIPTION
## Summary

- freezes a permanently nonpromoting five-task BiMU memory-off/candidate comparison on development seeds 157001–157003, consumed for promotion
- keeps both literal authorization gates false; execution and mutation remain unavailable until a separately reviewed transition
- binds canonical MNIST, source/runtime/dependencies, authorization, schedule, initial state, counters, numeric resources, and telemetry
- reserves exact registered destinations before work and publishes strictly validated immutable inodes without replacement
- loads the frozen arrays once; completed-shard admission independently reexecutes the exact seed/arm on those arrays before linking, while experimental counters remain those of the retained primary result
- retains a generic validated receipt for ordinary execution/replay-admission failures when possible; after first dispatch, later unretained failures attempt to preserve the owned reservation as a durable consumed-without-result tombstone
- exposes plan, run-shard, summarize, and validate through `asi-bimu-matched-development`

This bounded prerequisite is not paper-comparable, scientific evidence, a retained result, or completion of #1570. Replay is validation overhead; consistency hashes and process identity are not authenticated execution attestation. Tombstone I/O, another asynchronous interruption during conversion, and process death are not guaranteed.

## Audit evidence

- exact reviewed head: `9e164cdac03a00a2488b15d716adc1dabedfc429`
- authorization remains false; no canonical campaign shard, workload, or output was executed
- 68 focused BiMU/campaign tests passed
- scoped Ruff, strict mypy across 222 source files, and diff check passed
- no output or registered evidence artifact changed