### PR TITLE
fix(benchmarks): parse Foragax probe metadata strictly

### DIFF
--- a/alberta_framework/benchmarks/_official_foragax_image_helper.py
+++ b/alberta_framework/benchmarks/_official_foragax_image_helper.py
@@ -80,13 +80,15 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _strict_json(path: Path) -> dict[str, Any]:
+def _strict_json_text(value: str | bytes, *, label: str) -> dict[str, Any]:
+    """Decode one strict JSON object from a trusted bounded producer."""
+
     def pairs(items: list[tuple[str, Any]]) -> dict[str, Any]:
         result: dict[str, Any] = {}
         for key, value in items:
             host_key = _require_exact_str("key", key)
             if host_key in result:
-                raise ImageHelperError(f"{path} repeats JSON key")
+                raise ImageHelperError(f"{label} repeats JSON key")
             result[host_key] = value
         return result
 
@@ -94,23 +96,31 @@ def _strict_json(path: Path) -> dict[str, Any]:
         host_value = _require_exact_str("value", value)
         parsed = float(host_value)
         if not math.isfinite(parsed):
-            raise ImageHelperError(f"{path} contains non-finite JSON number")
+            raise ImageHelperError(f"{label} contains non-finite JSON number")
         return parsed
 
     try:
-        value = json.loads(
-            path.read_bytes(),
+        parsed = json.loads(
+            value,
             object_pairs_hook=pairs,
             parse_constant=lambda value: (_ for _ in ()).throw(
-                ImageHelperError(f"{path} contains JSON constant")
+                ImageHelperError(f"{label} contains JSON constant")
             ),
             parse_float=parse_float,
         )
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ImageHelperError(f"{label} is not strict JSON") from exc
+    if type(parsed) is not dict:
+        raise ImageHelperError(f"{label} must contain a JSON object")
+    return parsed
+
+
+def _strict_json(path: Path) -> dict[str, Any]:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
         raise ImageHelperError(f"{path} is not strict JSON") from exc
-    if type(value) is not dict:
-        raise ImageHelperError(f"{path} must contain a JSON object")
-    return value
+    return _strict_json_text(raw, label=str(path))
 
 
 def _safe_relative(value: str, *, label: str) -> PurePosixPath:
@@ -576,13 +586,7 @@ print(json.dumps(payload, allow_nan=False, separators=(",", ":"), sort_keys=True
         raise ImageHelperError(
             "runtime package probe failed: " + completed.stderr.strip()
         )
-    try:
-        value = json.loads(completed.stdout)
-    except json.JSONDecodeError as exc:
-        raise ImageHelperError("runtime package probe returned invalid JSON") from exc
-    if type(value) is not dict:
-        raise ImageHelperError("runtime package probe returned a non-object")
-    return value
+    return _strict_json_text(completed.stdout, label="runtime package probe")
 
 
 def _write(path: Path, value: Any) -> None:

--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -3692,9 +3692,18 @@ def _sanitize_package_freeze_line(line: str) -> str:
     if not separator:
         return line
     try:
-        direct_url = json.loads(direct_url_text)
-    except json.JSONDecodeError:
-        return prefix + " ; direct_url=<REDACTED>"
+        direct_url = _strict_json_loads(
+            direct_url_text,
+            label="package freeze direct_url",
+        )
+    except OfficialForagaxValidationError as exc:
+        if isinstance(exc.__cause__, json.JSONDecodeError):
+            return prefix + " ; direct_url=<REDACTED>"
+        if "duplicate object key" in str(exc):
+            raise
+        raise OfficialForagaxValidationError(
+            "package freeze direct_url is not finite JSON"
+        ) from exc
     if isinstance(direct_url, dict):
         url = direct_url.get("url")
         if isinstance(url, str):
@@ -4086,6 +4095,36 @@ sys.stdout.write({_PROBE_PREFIX!r} + json.dumps(payload, sort_keys=True, allow_n
     return _extract_probe_payload(result.stdout)
 
 
+_STRICT_DIRECT_URL_HELPER_SOURCE = r'''\
+class _DuplicateDirectUrlKey(ValueError):
+    pass
+
+def _direct_url_pairs(items):
+    result = {}
+    for key, value in items:
+        if key in result:
+            raise _DuplicateDirectUrlKey("direct_url.json contains a duplicate key")
+        result[key] = value
+    return result
+
+def _direct_url_float(value):
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError("direct_url.json contains a non-finite number")
+    return parsed
+
+def _strict_direct_url_loads(value):
+    return json.loads(
+        value,
+        object_pairs_hook=_direct_url_pairs,
+        parse_constant=lambda token: (_ for _ in ()).throw(
+            ValueError("direct_url.json contains a non-finite constant")
+        ),
+        parse_float=_direct_url_float,
+    )
+'''
+
+
 def _probe_runtime(
     *,
     repository: Path,
@@ -4250,6 +4289,7 @@ import hashlib
 import importlib.metadata
 import importlib.util
 import json
+import math
 import os
 import platform
 import re
@@ -4261,13 +4301,15 @@ from pathlib import Path
 import jax
 import numpy
 
+{_STRICT_DIRECT_URL_HELPER_SOURCE}
+
 distribution_name = "continual-foragax"
 distribution = importlib.metadata.distribution(distribution_name)
 direct_url_text = distribution.read_text("direct_url.json")
 direct_url = None
 if direct_url_text:
     try:
-        direct_url = json.loads(direct_url_text)
+        direct_url = _strict_direct_url_loads(direct_url_text)
     except json.JSONDecodeError:
         direct_url = {{"unparsed": direct_url_text.strip()}}
 

--- a/tests/test_official_foragax_strict_json_probes.py
+++ b/tests/test_official_foragax_strict_json_probes.py
@@ -1,0 +1,74 @@
+"""Strict JSON admission for official Foragax runtime metadata."""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks import _official_foragax_image_helper as image_helper
+from alberta_framework.benchmarks import official_foragax
+
+
+def test_image_runtime_probe_rejects_duplicate_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    completed = subprocess.CompletedProcess(
+        args=("python",),
+        returncode=0,
+        stdout='{"packages":[],"packages":{}}',
+        stderr="",
+    )
+    monkeypatch.setattr(image_helper.subprocess, "run", lambda *args, **kwargs: completed)
+
+    with pytest.raises(image_helper.ImageHelperError, match="repeats JSON key"):
+        image_helper._runtime_probe(Path("/trusted/python"))
+
+
+def test_package_freeze_direct_url_rejects_duplicate_keys() -> None:
+    with pytest.raises(
+        official_foragax.OfficialForagaxValidationError,
+        match="duplicate object key",
+    ):
+        official_foragax._sanitize_package_freeze_line(
+            'pkg==1.0 ; direct_url={"url":"https://first","url":"https://second"}'
+        )
+
+
+def test_generated_distribution_probe_uses_strict_direct_url_decoder() -> None:
+    namespace: dict[str, object] = {"json": json, "math": math}
+    exec(official_foragax._STRICT_DIRECT_URL_HELPER_SOURCE, namespace)
+    loads = namespace["_strict_direct_url_loads"]
+    assert callable(loads)
+    assert loads('{"url":"https://example.test"}') == {"url": "https://example.test"}
+    with pytest.raises(ValueError, match="duplicate key"):
+        loads('{"url":"https://first","url":"https://second"}')
+    with pytest.raises(ValueError, match="non-finite"):
+        loads('{"weight":1e999}')
+
+
+def test_runtime_probe_embeds_and_calls_the_strict_direct_url_decoder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_execution(**kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        captured["script"] = str(kwargs["script"])
+        return subprocess.CompletedProcess(("python",), 0, b"", b"")
+
+    monkeypatch.setattr(official_foragax, "_run_execution_python", fake_execution)
+    with pytest.raises(
+        official_foragax.OfficialForagaxValidationError,
+        match="did not return probe metadata",
+    ):
+        official_foragax._probe_runtime(
+            repository=Path("/trusted/repository"),
+            interpreter=Path("/trusted/python"),
+            environment={},
+        )
+
+    assert official_foragax._STRICT_DIRECT_URL_HELPER_SOURCE in captured["script"]
+    assert "direct_url = _strict_direct_url_loads(direct_url_text)" in captured["script"]


### PR DESCRIPTION
Supersedes closed #2102 on current main.

- rejects duplicate keys/non-finite values in the image runtime probe
- uses the existing strict decoder for host package-freeze `direct_url` metadata while preserving malformed-input redaction
- embeds a standalone strict decoder in the generated distribution probe, avoiding the prior head's undefined repository-helper call
- adds behavioral and wiring regressions for all three boundaries

Validation: 11 focused image-helper/probe tests passed; the adjacent strict JSON/archive contract passed; Ruff, strict source mypy, and diff checks passed. No valid-JSON behavior changes.