### PR TITLE
fix(evaluation): bound pair-sequence validation before traversal

### DIFF
--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -264,6 +264,22 @@ def _integer_pairs(
     return tuple(pairs)
 
 
+def _pair_counter_dimensions(*, relevant_dim: object, input_dim: object) -> tuple[int, int]:
+    """Admit exact nonnegative dimensions before pair comparisons."""
+
+    if type(relevant_dim) is not int:
+        raise TypeError("relevant_dim must be an exact int")
+    if type(input_dim) is not int:
+        raise TypeError("input_dim must be an exact int")
+    normalized_relevant_dim = relevant_dim
+    normalized_input_dim = input_dim
+    if normalized_relevant_dim < 0:
+        raise ValueError("relevant_dim must be nonnegative")
+    if normalized_input_dim < normalized_relevant_dim:
+        raise ValueError("input_dim must be at least relevant_dim")
+    return normalized_relevant_dim, normalized_input_dim
+
+
 def _resource_accounting_map(value: object) -> dict[str, dict[str, int | bool]]:
     if type(value) is not dict:
         raise TypeError("memory_by_condition must be an exact dictionary")
@@ -525,6 +541,9 @@ def count_relevant_context_pairs(
 ) -> int:
     """Count unique canonical context products over relevant input channels."""
 
+    relevant_dim, input_dim = _pair_counter_dimensions(
+        relevant_dim=relevant_dim, input_dim=input_dim
+    )
     normalized_pairs = _integer_pairs(pairs, name="pairs", allow_list=True)
     relevant_pairs = {
         (min(left, right), max(left, right))
@@ -542,6 +561,9 @@ def count_relevant_context_pairs_by_task(
 ) -> tuple[int, int]:
     """Count unique relevant products for the supplied C and D cues separately."""
 
+    relevant_dim, input_dim = _pair_counter_dimensions(
+        relevant_dim=relevant_dim, input_dim=input_dim
+    )
     normalized_pairs = _integer_pairs(pairs, name="pairs", allow_list=True)
     canonical_pairs = {(min(left, right), max(left, right)) for left, right in normalized_pairs}
     counts = tuple(

--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -95,8 +95,9 @@ CONDITION_NAMES = (
 EARLY_WINDOW_STEPS = 200
 TAIL_WINDOW_STEPS = 500
 ASYMPTOTIC_WINDOW_STEPS = 1_500
-# Origin ConditionSeedRecord rebuilt every pair before any count bound.
-# A cheap ``((0, 1),) * 25_000_000`` pointer-repeat took 4.107s on origin/main.
+# Host-provided pair collections share the repository's 4,096-item traversal
+# ceiling. This leaves more than 45x headroom over the frozen 91-pair candidate
+# archive and more than 170x over each 24-pair active bank.
 _MAX_INTEGER_PAIRS = 4096
 
 FROZEN_STREAM_CONFIGURATION: dict[str, int | float] = {
@@ -517,7 +518,7 @@ def make_condition_learner(condition: str) -> FixedBudgetInteractionLearner:
 
 
 def count_relevant_context_pairs(
-    pairs: Sequence[tuple[int, int]],
+    pairs: tuple[tuple[int, int], ...] | list[tuple[int, int]],
     *,
     relevant_dim: int = 8,
     input_dim: int = 12,
@@ -534,7 +535,7 @@ def count_relevant_context_pairs(
 
 
 def count_relevant_context_pairs_by_task(
-    pairs: Sequence[tuple[int, int]],
+    pairs: tuple[tuple[int, int], ...] | list[tuple[int, int]],
     *,
     relevant_dim: int = 8,
     input_dim: int = 12,

--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -237,8 +237,8 @@ def _bounded_pair_sequence_length(
 ) -> int:
     """Return a pair-sequence length after rejecting oversized host collections."""
 
-    allowed: tuple[type, ...] = (tuple, list) if allow_list else (tuple,)
-    if type(value) not in allowed:
+    value_type = type(value)
+    if value_type is not tuple and (not allow_list or value_type is not list):
         kind = "tuple or list" if allow_list else "tuple"
         raise TypeError(f"{name} must be an exact {kind}")
     count = len(cast(tuple[object, ...] | list[object], value))
@@ -248,12 +248,13 @@ def _bounded_pair_sequence_length(
 
 
 def _integer_pairs(
-    value: object, *, name: str
+    value: object, *, name: str, allow_list: bool = False
 ) -> tuple[tuple[int, int], ...]:
-    _bounded_pair_sequence_length(value, name=name)
+    _bounded_pair_sequence_length(value, name=name, allow_list=allow_list)
     pairs: list[tuple[int, int]] = []
-    for index, pair in enumerate(cast(tuple[object, ...], value)):
-        if type(pair) is not tuple or len(pair) != 2:
+    sequence = cast(tuple[object, ...] | list[object], value)
+    for index, pair in enumerate(sequence):
+        if type(pair) is not tuple or tuple.__len__(pair) != 2:
             raise ValueError(f"{name}[{index}] must be an exact integer pair")
         left, right = pair
         if type(left) is not int or type(right) is not int:
@@ -523,10 +524,10 @@ def count_relevant_context_pairs(
 ) -> int:
     """Count unique canonical context products over relevant input channels."""
 
-    _bounded_pair_sequence_length(pairs, name="pairs", allow_list=True)
+    normalized_pairs = _integer_pairs(pairs, name="pairs", allow_list=True)
     relevant_pairs = {
         (min(left, right), max(left, right))
-        for left, right in pairs
+        for left, right in normalized_pairs
         if ((left >= input_dim) ^ (right >= input_dim)) and min(left, right) < relevant_dim
     }
     return len(relevant_pairs)
@@ -540,8 +541,8 @@ def count_relevant_context_pairs_by_task(
 ) -> tuple[int, int]:
     """Count unique relevant products for the supplied C and D cues separately."""
 
-    _bounded_pair_sequence_length(pairs, name="pairs", allow_list=True)
-    canonical_pairs = {(min(left, right), max(left, right)) for left, right in pairs}
+    normalized_pairs = _integer_pairs(pairs, name="pairs", allow_list=True)
+    canonical_pairs = {(min(left, right), max(left, right)) for left, right in normalized_pairs}
     counts = tuple(
         sum(
             1

--- a/alberta_framework/evaluation/scale_robust_feature.py
+++ b/alberta_framework/evaluation/scale_robust_feature.py
@@ -24,7 +24,7 @@ import math
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import jax
 import jax.numpy as jnp
@@ -95,6 +95,9 @@ CONDITION_NAMES = (
 EARLY_WINDOW_STEPS = 200
 TAIL_WINDOW_STEPS = 500
 ASYMPTOTIC_WINDOW_STEPS = 1_500
+# Origin ConditionSeedRecord rebuilt every pair before any count bound.
+# A cheap ``((0, 1),) * 25_000_000`` pointer-repeat took 4.107s on origin/main.
+_MAX_INTEGER_PAIRS = 4096
 
 FROZEN_STREAM_CONFIGURATION: dict[str, int | float] = {
     "relevant_dim": 8,
@@ -226,13 +229,30 @@ def _finite_float(value: object, *, name: str) -> float:
     return nonnegative_finite_real(name, value)
 
 
+def _bounded_pair_sequence_length(
+    value: object,
+    *,
+    name: str,
+    allow_list: bool = False,
+) -> int:
+    """Return a pair-sequence length after rejecting oversized host collections."""
+
+    allowed: tuple[type, ...] = (tuple, list) if allow_list else (tuple,)
+    if type(value) not in allowed:
+        kind = "tuple or list" if allow_list else "tuple"
+        raise TypeError(f"{name} must be an exact {kind}")
+    count = len(cast(tuple[object, ...] | list[object], value))
+    if count > _MAX_INTEGER_PAIRS:
+        raise ValueError(f"{name} exceeds the {_MAX_INTEGER_PAIRS}-pair limit")
+    return count
+
+
 def _integer_pairs(
     value: object, *, name: str
 ) -> tuple[tuple[int, int], ...]:
-    if type(value) is not tuple:
-        raise TypeError(f"{name} must be an exact tuple")
+    _bounded_pair_sequence_length(value, name=name)
     pairs: list[tuple[int, int]] = []
-    for index, pair in enumerate(value):
+    for index, pair in enumerate(cast(tuple[object, ...], value)):
         if type(pair) is not tuple or len(pair) != 2:
             raise ValueError(f"{name}[{index}] must be an exact integer pair")
         left, right = pair
@@ -503,6 +523,7 @@ def count_relevant_context_pairs(
 ) -> int:
     """Count unique canonical context products over relevant input channels."""
 
+    _bounded_pair_sequence_length(pairs, name="pairs", allow_list=True)
     relevant_pairs = {
         (min(left, right), max(left, right))
         for left, right in pairs
@@ -519,6 +540,7 @@ def count_relevant_context_pairs_by_task(
 ) -> tuple[int, int]:
     """Count unique relevant products for the supplied C and D cues separately."""
 
+    _bounded_pair_sequence_length(pairs, name="pairs", allow_list=True)
     canonical_pairs = {(min(left, right), max(left, right)) for left, right in pairs}
     counts = tuple(
         sum(

--- a/tests/test_scale_robust_pair_sequence_hang.py
+++ b/tests/test_scale_robust_pair_sequence_hang.py
@@ -1,0 +1,68 @@
+"""Scale-robust pair sequences reject oversized host collections before hang.
+
+Origin ``ConditionSeedRecord`` rebuilt every integer pair with no count bound.
+A cheap ``((0, 1),) * 25_000_000`` pointer-repeat took 4.107s on origin/main.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.evaluation.scale_robust_feature import (
+    _MAX_INTEGER_PAIRS,
+    CONDITION_PRIMARY,
+    ConditionSeedRecord,
+    count_relevant_context_pairs,
+    count_relevant_context_pairs_by_task,
+)
+
+pytestmark = pytest.mark.unit
+
+_PAIR = (0, 12)
+
+
+def test_frozen_pair_count_bound() -> None:
+    assert _MAX_INTEGER_PAIRS == 4096
+
+
+def test_last_fit_pair_count_is_accepted() -> None:
+    pairs = (_PAIR,) * _MAX_INTEGER_PAIRS
+    record = ConditionSeedRecord(
+        seed=0,
+        condition=CONDITION_PRIMARY,
+        phases=(),
+        end_segment_5_active_pairs=pairs,
+        end_segment_7_active_pairs=(),
+        final_active_pairs=(),
+    )
+    assert len(record.end_segment_5_active_pairs) == _MAX_INTEGER_PAIRS
+    assert count_relevant_context_pairs(pairs) == 1
+    assert count_relevant_context_pairs_by_task(pairs) == (1, 0)
+
+
+@pytest.mark.parametrize("count", [4097, 25_000_000])
+def test_condition_record_rejects_oversized_pair_pointer_repeat(count: int) -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="4096-pair limit"):
+        ConditionSeedRecord(
+            seed=0,
+            condition=CONDITION_PRIMARY,
+            phases=(),
+            end_segment_5_active_pairs=(_PAIR,) * count,
+            end_segment_7_active_pairs=(),
+            final_active_pairs=(),
+        )
+    assert time.perf_counter() - started < 0.5
+
+
+@pytest.mark.parametrize("count", [4097, 25_000_000])
+def test_pair_counters_reject_oversized_pointer_repeat(count: int) -> None:
+    pairs = (_PAIR,) * count
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="4096-pair limit"):
+        count_relevant_context_pairs(pairs)
+    with pytest.raises(ValueError, match="4096-pair limit"):
+        count_relevant_context_pairs_by_task(pairs)
+    assert time.perf_counter() - started < 0.5

--- a/tests/test_scale_robust_pair_sequence_hang.py
+++ b/tests/test_scale_robust_pair_sequence_hang.py
@@ -1,14 +1,6 @@
-"""Scale-robust pair sequences reject oversized host collections before hang.
-
-Origin ``ConditionSeedRecord`` rebuilt every integer pair with no count bound.
-A cheap ``((0, 1),) * 25_000_000`` pointer-repeat took 4.107s on origin/main.
-"""
+"""Scale-robust pair sequences reject oversized host collections before traversal."""
 
 from __future__ import annotations
-
-import time
-from collections.abc import Sequence
-from typing import cast
 
 import pytest
 
@@ -59,42 +51,38 @@ def test_last_fit_pair_count_is_accepted() -> None:
     assert len(record.end_segment_5_active_pairs) == _MAX_INTEGER_PAIRS
     assert count_relevant_context_pairs(pairs) == 1
     assert count_relevant_context_pairs_by_task(pairs) == (1, 0)
+    assert count_relevant_context_pairs(list(pairs)) == 1
+    assert count_relevant_context_pairs_by_task(list(pairs)) == (1, 0)
 
 
-@pytest.mark.parametrize("count", [4097, 25_000_000])
-def test_condition_record_rejects_oversized_pair_pointer_repeat(count: int) -> None:
-    started = time.perf_counter()
+def test_condition_record_rejects_oversized_pairs_before_inspecting_elements() -> None:
+    pairs = (object(),) * (_MAX_INTEGER_PAIRS + 1)
     with pytest.raises(ValueError, match="4096-pair limit"):
         ConditionSeedRecord(
             seed=0,
             condition=CONDITION_PRIMARY,
             phases=(),
-            end_segment_5_active_pairs=(_PAIR,) * count,
+            end_segment_5_active_pairs=pairs,  # type: ignore[arg-type]
             end_segment_7_active_pairs=(),
             final_active_pairs=(),
         )
-    assert time.perf_counter() - started < 0.5
 
 
-@pytest.mark.parametrize("count", [4097, 25_000_000])
-def test_pair_counters_reject_oversized_pointer_repeat(count: int) -> None:
-    pairs = (_PAIR,) * count
-    started = time.perf_counter()
+def test_pair_counters_reject_oversized_pairs_before_inspecting_elements() -> None:
+    pairs = [object()] * (_MAX_INTEGER_PAIRS + 1)
     with pytest.raises(ValueError, match="4096-pair limit"):
-        count_relevant_context_pairs(pairs)
+        count_relevant_context_pairs(pairs)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="4096-pair limit"):
-        count_relevant_context_pairs_by_task(pairs)
-    assert time.perf_counter() - started < 0.5
+        count_relevant_context_pairs_by_task(pairs)  # type: ignore[arg-type]
 
 
 def test_pair_admission_rejects_hostile_sequence_without_type_hooks() -> None:
     _HostileMeta.calls = 0
     hostile = _HostileSequence((_PAIR,))
-    hostile_pairs = cast(Sequence[tuple[int, int]], hostile)
     with pytest.raises(TypeError, match="exact tuple or list"):
-        count_relevant_context_pairs(hostile_pairs)
+        count_relevant_context_pairs(hostile)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="exact tuple or list"):
-        count_relevant_context_pairs_by_task(hostile_pairs)
+        count_relevant_context_pairs_by_task(hostile)  # type: ignore[arg-type]
     assert _HostileMeta.calls == 0
 
 

--- a/tests/test_scale_robust_pair_sequence_hang.py
+++ b/tests/test_scale_robust_pair_sequence_hang.py
@@ -7,6 +7,8 @@ A cheap ``((0, 1),) * 25_000_000`` pointer-repeat took 4.107s on origin/main.
 from __future__ import annotations
 
 import time
+from collections.abc import Sequence
+from typing import cast
 
 import pytest
 
@@ -21,6 +23,23 @@ from alberta_framework.evaluation.scale_robust_feature import (
 pytestmark = pytest.mark.unit
 
 _PAIR = (0, 12)
+
+
+class _HostileMeta(type):
+    calls = 0
+
+    def __eq__(cls, other: object) -> bool:
+        del other
+        cls.calls += 1
+        raise AssertionError("hostile metaclass equality must not run")
+
+    def __hash__(cls) -> int:
+        cls.calls += 1
+        raise AssertionError("hostile metaclass hashing must not run")
+
+
+class _HostileSequence(tuple[object, ...], metaclass=_HostileMeta):
+    pass
 
 
 def test_frozen_pair_count_bound() -> None:
@@ -66,3 +85,30 @@ def test_pair_counters_reject_oversized_pointer_repeat(count: int) -> None:
     with pytest.raises(ValueError, match="4096-pair limit"):
         count_relevant_context_pairs_by_task(pairs)
     assert time.perf_counter() - started < 0.5
+
+
+def test_pair_admission_rejects_hostile_sequence_without_type_hooks() -> None:
+    _HostileMeta.calls = 0
+    hostile = _HostileSequence((_PAIR,))
+    hostile_pairs = cast(Sequence[tuple[int, int]], hostile)
+    with pytest.raises(TypeError, match="exact tuple or list"):
+        count_relevant_context_pairs(hostile_pairs)
+    with pytest.raises(TypeError, match="exact tuple or list"):
+        count_relevant_context_pairs_by_task(hostile_pairs)
+    assert _HostileMeta.calls == 0
+
+
+def test_pair_counters_reject_hostile_nested_values_before_comparison() -> None:
+    class HostileInt(int):
+        def __lt__(self, other: object) -> bool:
+            del other
+            raise AssertionError("hostile comparison must not run")
+
+        def __hash__(self) -> int:
+            raise AssertionError("hostile hashing must not run")
+
+    pairs = ((HostileInt(0), 12),)
+    with pytest.raises(ValueError, match="must contain integers"):
+        count_relevant_context_pairs(pairs)
+    with pytest.raises(ValueError, match="must contain integers"):
+        count_relevant_context_pairs_by_task(pairs)

--- a/tests/test_scale_robust_pair_sequence_hang.py
+++ b/tests/test_scale_robust_pair_sequence_hang.py
@@ -100,3 +100,24 @@ def test_pair_counters_reject_hostile_nested_values_before_comparison() -> None:
         count_relevant_context_pairs(pairs)
     with pytest.raises(ValueError, match="must contain integers"):
         count_relevant_context_pairs_by_task(pairs)
+
+
+@pytest.mark.parametrize(
+    "counter", [count_relevant_context_pairs, count_relevant_context_pairs_by_task]
+)
+@pytest.mark.parametrize("name", ["relevant_dim", "input_dim"])
+def test_pair_counters_reject_hostile_dimensions_without_comparison_hooks(
+    counter: object, name: str
+) -> None:
+    class HostileInt(int):
+        calls = 0
+
+        def __lt__(self, other: object) -> bool:
+            del other
+            type(self).calls += 1
+            raise AssertionError("hostile comparison must not run")
+
+    arguments = {name: HostileInt(8 if name == "relevant_dim" else 12)}
+    with pytest.raises(TypeError, match=rf"{name} must be an exact int"):
+        counter((_PAIR,), **arguments)  # type: ignore[operator]
+    assert HostileInt.calls == 0


### PR DESCRIPTION
Supersedes #2103 after maintainer audit while preserving contributor commits 6e290bbb and 7f59aa25.

The production repair caps exact tuple/list pair collections at the repository-wide 4,096-item host traversal ceiling before element access; validates exact nested tuple/int identities before comparison or hashing; and keeps more than 45x headroom over the frozen 91-pair candidate archive and 170x over each 24-pair active bank. Exported helper annotations now match the exact accepted containers.

The successor replaces the 25,000,000-pointer wall-clock regression (421 MiB observed focused-test RSS) with deterministic poison-element last-fit/first-reject tests. Main reproduction independently measured 4.82s in the counter and 5.33s in `ConditionSeedRecord` for the reported pointer repeat.

Validation: 27 focused tests passed; Ruff, strict mypy, and diff checks clean. The changed protocol source is registered evidence: no pinned output is modified, and current evidence remains fail-closed/invalid pending a separately authorized frozen rerun. This is validation hardening, not new performance or scientific evidence.

Co-authored-by: ss251 <ss251@uw.edu>