### PR TITLE
research(bimu): add gated matched development runner

### DIFF
--- a/alberta_framework/evaluation/bimu_matched_runner.py
+++ b/alberta_framework/evaluation/bimu_matched_runner.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import math
 import os
-import tempfile
 from pathlib import Path
 from typing import Final, cast
 
@@ -32,6 +31,7 @@ from alberta_framework.evaluation.bimu_matched_nonpromoting import (
     _plan_payload,
     _runtime_identity,
 )
+from alberta_framework.evaluation.prospective_publication import publish_prepared_json_at
 
 RESULT_SCHEMA: Final = "asi.bimu.matched-development-result.v1"
 _POLICY: Final = {
@@ -55,6 +55,14 @@ _RESOURCE_FIELDS: Final = (
     "final_persistent_numeric_bytes",
 )
 _MAX_DATASET_BYTES: Final = 16 * 1024 * 1024
+_MAX_RESULT_BYTES: Final = 16 * 1024 * 1024
+EXECUTION_AUTHORIZED: Final = False
+AUTHORIZATION_TRANSITION_APPROVED: Final = False
+
+
+def _require_execution_authorized() -> None:
+    if AUTHORIZATION_TRANSITION_APPROVED is not True:
+        raise RuntimeError("BiMU matched execution is not independently authorized")
 
 
 def _canonical(value: object) -> bytes:
@@ -78,6 +86,7 @@ def _source_identity() -> dict[str, str]:
         "alberta_framework/benchmarks/bimu.py",
         "alberta_framework/evaluation/bimu_matched_nonpromoting.py",
         "alberta_framework/evaluation/bimu_matched_runner.py",
+        "alberta_framework/evaluation/prospective_publication.py",
     )
     return {
         relative: hashlib.sha256((root / relative).read_bytes()).hexdigest()
@@ -121,9 +130,7 @@ def _validated_arrays(
     return arrays[0], arrays[1], arrays[2], arrays[3]
 
 
-def _expected_fixed_identities(
-    plan: BiMUMatchedDevelopmentPlan, seed: int
-) -> tuple[str, str]:
+def _expected_fixed_identities(plan: BiMUMatchedDevelopmentPlan, seed: int) -> tuple[str, str]:
     config = plan.control_config
     if config.query_threshold != 0.0:
         raise ValueError("matched runner requires the frozen zero query threshold")
@@ -198,7 +205,7 @@ def _aggregate(
     }
 
 
-def run_bimu_matched_development(
+def _execute_bimu_matched_development(
     train_x: object,
     train_y: object,
     test_x: object,
@@ -239,6 +246,19 @@ def run_bimu_matched_development(
     return result
 
 
+def run_bimu_matched_development(
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+    *,
+    plan: BiMUMatchedDevelopmentPlan = FROZEN_BIMU_MATCHED_PLAN,
+) -> dict[str, object]:
+    """Fail closed until a separately reviewed change authorizes this plan."""
+    _require_execution_authorized()
+    return _execute_bimu_matched_development(train_x, train_y, test_x, test_y, plan=plan)
+
+
 def validate_bimu_matched_result(
     value: object,
     train_x: object,
@@ -261,7 +281,6 @@ def validate_bimu_matched_result(
         raise ValueError("plan must be an exact BiMUMatchedDevelopmentPlan")
     checked_plan = BiMUMatchedDevelopmentPlan(**plan.__dict__)
     arrays = _validated_arrays(train_x, train_y, test_x, test_y, plan=checked_plan)
-    del arrays
     expected_plan = _plan_payload(checked_plan)
     if root["plan"] != expected_plan:
         raise ValueError("matched result plan drifted")
@@ -280,9 +299,7 @@ def validate_bimu_matched_result(
     if type(raw_rows) is not list or len(raw_rows) != len(checked_plan.seeds) * 2:
         raise ValueError("matched result roster is incomplete")
     rows = cast(list[dict[str, object]], raw_rows)
-    expected_roster = [
-        (seed, arm) for seed in checked_plan.seeds for arm in checked_plan.arm_names
-    ]
+    expected_roster = [(seed, arm) for seed in checked_plan.seeds for arm in checked_plan.arm_names]
     observed_roster: list[tuple[object, object]] = []
     for row in rows:
         checked_row = _exact_object(row, {"seed", "arm", "result"}, "matched row")
@@ -301,6 +318,18 @@ def validate_bimu_matched_result(
             raise ValueError("matched row protocol drifted")
         if resolved_result["dataset_sha256"] != checked_plan.dataset_sha256:
             raise ValueError("matched row dataset digest drifted")
+        # The benchmark validator deliberately treats producer-reported metrics and
+        # consistency digests as unauthenticated. A retained matched result has a
+        # stronger contract: reproduce the exact seed/arm transaction from the
+        # supplied, digest-bound arrays and compare every non-timing field.
+        reproduced = run_bimu_development(
+            *arrays,
+            config=config,
+            seed=cast(int, checked_row["seed"]),
+        )
+        reproduced["timing"] = resolved_result["timing"]
+        if resolved_result != reproduced:
+            raise ValueError("matched row does not reproduce from the frozen inputs")
     if observed_roster != expected_roster:
         raise ValueError("matched result roster order drifted")
     for offset in range(0, len(rows), 2):
@@ -342,8 +371,7 @@ def validate_bimu_matched_result(
         control_resources = cast(dict[str, object], control["resources"])
         candidate_resources = cast(dict[str, object], candidate["resources"])
         if any(
-            control_resources[field] != candidate_resources[field]
-            for field in _RESOURCE_FIELDS
+            control_resources[field] != candidate_resources[field] for field in _RESOURCE_FIELDS
         ):
             raise ValueError("matched pair resources drifted")
     if root["aggregate"] != _aggregate(rows, checked_plan):
@@ -365,36 +393,26 @@ def write_bimu_matched_result(
     plan: BiMUMatchedDevelopmentPlan = FROZEN_BIMU_MATCHED_PLAN,
 ) -> None:
     """Durably publish one validated result without replacing existing evidence."""
+    _require_execution_authorized()
     if type(destination) is not type(Path()):
         raise TypeError("destination must be an exact Path")
-    validate_bimu_matched_result(value, train_x, train_y, test_x, test_y, plan=plan)
-    parent = destination.parent.resolve(strict=True)
-    if not parent.is_dir() or destination.name in {"", ".", ".."}:
-        raise ValueError("destination parent must be an existing directory")
-    resolved = parent / destination.name
-    if os.path.lexists(resolved):
-        raise FileExistsError(f"refusing to replace existing result: {resolved}")
-    raw = _canonical(value) + b"\n"
-    descriptor, temporary_name = tempfile.mkstemp(
-        dir=parent, prefix=f".{destination.name}.", suffix=".tmp"
-    )
-    temporary = Path(temporary_name)
-    published = False
+    flags = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0)
+    directory = os.open(destination.parent, flags)
     try:
-        with os.fdopen(descriptor, "wb") as stream:
-            stream.write(raw)
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.link(temporary, resolved, follow_symlinks=False)
-        published = True
-        directory_descriptor = os.open(parent, os.O_RDONLY)
-        try:
-            os.fsync(directory_descriptor)
-        finally:
-            os.close(directory_descriptor)
-    except BaseException:
-        if published:
-            resolved.unlink(missing_ok=True)
-        raise
+
+        def prepare() -> bytes:
+            validate_bimu_matched_result(value, train_x, train_y, test_x, test_y, plan=plan)
+            return _canonical(value) + b"\n"
+
+        def validate_loaded(loaded: object) -> None:
+            validate_bimu_matched_result(loaded, train_x, train_y, test_x, test_y, plan=plan)
+
+        publish_prepared_json_at(
+            directory,
+            destination.name,
+            prepare=prepare,
+            validate_loaded=validate_loaded,
+            max_bytes=_MAX_RESULT_BYTES,
+        )
     finally:
-        temporary.unlink(missing_ok=True)
+        os.close(directory)

--- a/alberta_framework/evaluation/bimu_matched_runner.py
+++ b/alberta_framework/evaluation/bimu_matched_runner.py
@@ -1,0 +1,400 @@
+"""Execute and validate the frozen, permanently nonpromoting BiMU comparison."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import tempfile
+from pathlib import Path
+from typing import Final, cast
+
+import jax.random as jr
+import numpy as np
+
+from alberta_framework.benchmarks.bimu import (
+    _EXAMPLE_ORDER_DOMAIN,
+    _INIT_DOMAIN,
+    _PRNG_IMPLEMENTATION,
+    _dataset_sha256,
+    _initialize_state,
+    _state_sha256,
+    _stream_key,
+    build_task_schedule,
+    run_bimu_development,
+    validate_bimu_result,
+)
+from alberta_framework.evaluation.bimu_matched_nonpromoting import (
+    FROZEN_BIMU_MATCHED_PLAN,
+    BiMUMatchedDevelopmentPlan,
+    _json_preflight,
+    _plan_payload,
+    _runtime_identity,
+)
+
+RESULT_SCHEMA: Final = "asi.bimu.matched-development-result.v1"
+_POLICY: Final = {
+    "development_only": True,
+    "scientific_promotion_allowed": False,
+    "sota_claim_allowed": False,
+    "negative_results_retained": True,
+}
+_MATCHED_COUNTERS: Final = (
+    "environment_steps",
+    "observations",
+    "label_queries",
+    "optimizer_seen",
+    "model_forward_queries",
+)
+_RESOURCE_FIELDS: Final = (
+    "trainable_scalar_count",
+    "parameter_numeric_bytes",
+    "optimizer_state_numeric_bytes",
+    "initial_persistent_numeric_bytes",
+    "final_persistent_numeric_bytes",
+)
+_MAX_DATASET_BYTES: Final = 16 * 1024 * 1024
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False
+    ).encode("ascii")
+
+
+def _exact_object(value: object, fields: set[str], label: str) -> dict[str, object]:
+    if type(value) is not dict:
+        raise ValueError(f"{label} must be an exact object")
+    resolved = cast(dict[str, object], value)
+    if set(resolved) != fields:
+        raise ValueError(f"{label} fields drifted")
+    return resolved
+
+
+def _source_identity() -> dict[str, str]:
+    root = Path(__file__).resolve().parents[2]
+    relative_paths = (
+        "alberta_framework/benchmarks/bimu.py",
+        "alberta_framework/evaluation/bimu_matched_nonpromoting.py",
+        "alberta_framework/evaluation/bimu_matched_runner.py",
+    )
+    return {
+        relative: hashlib.sha256((root / relative).read_bytes()).hexdigest()
+        for relative in relative_paths
+    }
+
+
+def _validated_arrays(
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+    *,
+    plan: BiMUMatchedDevelopmentPlan,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    config = plan.candidate_config
+    expected = (
+        (train_x, np.dtype(np.float32), (config.train_examples_per_task, config.input_dim)),
+        (train_y, np.dtype(np.int32), (config.train_examples_per_task,)),
+        (test_x, np.dtype(np.float32), (config.test_examples_per_task, config.input_dim)),
+        (test_y, np.dtype(np.int32), (config.test_examples_per_task,)),
+    )
+    arrays: list[np.ndarray] = []
+    total_bytes = 0
+    for index, (value, dtype, shape) in enumerate(expected):
+        if type(value) is not np.ndarray or value.dtype != dtype or value.shape != shape:
+            raise ValueError(f"dataset array {index} does not match the plan")
+        total_bytes += value.size * value.dtype.itemsize
+        if total_bytes > _MAX_DATASET_BYTES:
+            raise ValueError("dataset arrays exceed the matched runner byte ceiling")
+        arrays.append(np.array(value, dtype=dtype, order="C", copy=True))
+    if not np.all(np.isfinite(arrays[0])) or not np.all(np.isfinite(arrays[2])):
+        raise ValueError("dataset features must be finite")
+    if any(
+        np.any(labels < 0) or np.any(labels >= config.n_classes)
+        for labels in (arrays[1], arrays[3])
+    ):
+        raise ValueError("dataset labels are outside the plan class range")
+    if _dataset_sha256(*arrays) != plan.dataset_sha256:
+        raise ValueError("dataset does not match the plan digest")
+    return arrays[0], arrays[1], arrays[2], arrays[3]
+
+
+def _expected_fixed_identities(
+    plan: BiMUMatchedDevelopmentPlan, seed: int
+) -> tuple[str, str]:
+    config = plan.control_config
+    if config.query_threshold != 0.0:
+        raise ValueError("matched runner requires the frozen zero query threshold")
+    root = jr.key(seed, impl=_PRNG_IMPLEMENTATION)
+    state = _initialize_state(config, _stream_key(root, _INIT_DOMAIN))
+    initial_state_sha256 = _state_sha256(state, optimizer_step=0, optimizer_seen=0)
+    schedule_digest = hashlib.sha256()
+    for task, permutation in enumerate(build_task_schedule(config, seed=seed)):
+        order = np.asarray(
+            jr.permutation(
+                _stream_key(root, _EXAMPLE_ORDER_DOMAIN, task),
+                config.train_examples_per_task,
+            ),
+            dtype=np.int32,
+        )
+        schedule_digest.update(
+            json.dumps(
+                {
+                    "task": task,
+                    "permutation": list(permutation),
+                    "example_order": [int(value) for value in order],
+                    "query_decisions": [True] * config.train_examples_per_task,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+    return initial_state_sha256, schedule_digest.hexdigest()
+
+
+def _sum_result_field(rows: list[dict[str, object]], section: str, field: str) -> int:
+    total = 0
+    for row in rows:
+        result = cast(dict[str, object], row["result"])
+        values = cast(dict[str, object], result[section])
+        total += cast(int, values[field])
+    return total
+
+
+def _aggregate(
+    rows: list[dict[str, object]], plan: BiMUMatchedDevelopmentPlan
+) -> dict[str, object]:
+    late_deltas: list[float] = []
+    online_deltas: list[float] = []
+    for seed in plan.seeds:
+        pair = [row for row in rows if row["seed"] == seed]
+        if len(pair) != 2:
+            raise ValueError("aggregate does not have one complete pair per seed")
+        by_arm = {cast(str, row["arm"]): cast(dict[str, object], row["result"]) for row in pair}
+        control_metrics = cast(dict[str, object], by_arm["memory_off"]["metrics"])
+        candidate_metrics = cast(dict[str, object], by_arm["bimu"]["metrics"])
+        late_deltas.append(
+            cast(float, candidate_metrics["paper_late_five_test_accuracy"])
+            - cast(float, control_metrics["paper_late_five_test_accuracy"])
+        )
+        online_deltas.append(
+            cast(float, candidate_metrics["asi_whole_stream_online_accuracy"])
+            - cast(float, control_metrics["asi_whole_stream_online_accuracy"])
+        )
+    totals = {field: _sum_result_field(rows, "resources", field) for field in _RESOURCE_FIELDS}
+    counter_totals = {
+        field: _sum_result_field(rows, "counters", field)
+        for field in (*_MATCHED_COUNTERS, "optimizer_updates")
+    }
+    return {
+        "paired_late_five_deltas": late_deltas,
+        "paired_late_five_delta_mean": math.fsum(late_deltas) / len(late_deltas),
+        "paired_online_deltas": online_deltas,
+        "paired_online_delta_mean": math.fsum(online_deltas) / len(online_deltas),
+        "resource_totals": totals,
+        "counter_totals": counter_totals,
+    }
+
+
+def run_bimu_matched_development(
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+    *,
+    plan: BiMUMatchedDevelopmentPlan = FROZEN_BIMU_MATCHED_PLAN,
+) -> dict[str, object]:
+    """Run every matched arm and seed; this never promotes the observed result."""
+    if type(plan) is not BiMUMatchedDevelopmentPlan:
+        raise ValueError("plan must be an exact BiMUMatchedDevelopmentPlan")
+    checked_plan = BiMUMatchedDevelopmentPlan(**plan.__dict__)
+    arrays = _validated_arrays(train_x, train_y, test_x, test_y, plan=checked_plan)
+    rows: list[dict[str, object]] = []
+    configs = (checked_plan.control_config, checked_plan.candidate_config)
+    for seed in checked_plan.seeds:
+        for arm, config in zip(checked_plan.arm_names, configs, strict=True):
+            arm_result = run_bimu_development(*arrays, config=config, seed=seed)
+            validate_bimu_result(arm_result)
+            rows.append({"seed": seed, "arm": arm, "result": arm_result})
+    plan_payload = _plan_payload(checked_plan)
+    result: dict[str, object] = {
+        "schema": RESULT_SCHEMA,
+        "status": "complete",
+        "plan": plan_payload,
+        "identity": {
+            "dataset_sha256": checked_plan.dataset_sha256,
+            "plan_sha256": hashlib.sha256(_canonical(plan_payload)).hexdigest(),
+            "source_sha256": _source_identity(),
+            "runtime": _runtime_identity(),
+            "consistency_not_attestation": True,
+        },
+        "policy": dict(_POLICY),
+        "rows": rows,
+        "aggregate": _aggregate(rows, checked_plan),
+    }
+    result["result_sha256"] = hashlib.sha256(_canonical(result)).hexdigest()
+    validate_bimu_matched_result(result, *arrays, plan=checked_plan)
+    return result
+
+
+def validate_bimu_matched_result(
+    value: object,
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+    *,
+    plan: BiMUMatchedDevelopmentPlan = FROZEN_BIMU_MATCHED_PLAN,
+) -> None:
+    """Validate roster, matched axes, derived aggregates, identities, and policy."""
+    _json_preflight(value)
+    root = _exact_object(
+        value,
+        {"schema", "status", "plan", "identity", "policy", "rows", "aggregate", "result_sha256"},
+        "matched result",
+    )
+    if root["schema"] != RESULT_SCHEMA or root["status"] != "complete":
+        raise ValueError("matched result identity drifted")
+    if type(plan) is not BiMUMatchedDevelopmentPlan:
+        raise ValueError("plan must be an exact BiMUMatchedDevelopmentPlan")
+    checked_plan = BiMUMatchedDevelopmentPlan(**plan.__dict__)
+    arrays = _validated_arrays(train_x, train_y, test_x, test_y, plan=checked_plan)
+    del arrays
+    expected_plan = _plan_payload(checked_plan)
+    if root["plan"] != expected_plan:
+        raise ValueError("matched result plan drifted")
+    expected_identity = {
+        "dataset_sha256": checked_plan.dataset_sha256,
+        "plan_sha256": hashlib.sha256(_canonical(expected_plan)).hexdigest(),
+        "source_sha256": _source_identity(),
+        "runtime": _runtime_identity(),
+        "consistency_not_attestation": True,
+    }
+    if root["identity"] != expected_identity:
+        raise ValueError("matched result identity drifted")
+    if root["policy"] != _POLICY:
+        raise ValueError("matched result must remain permanently nonpromoting")
+    raw_rows = root["rows"]
+    if type(raw_rows) is not list or len(raw_rows) != len(checked_plan.seeds) * 2:
+        raise ValueError("matched result roster is incomplete")
+    rows = cast(list[dict[str, object]], raw_rows)
+    expected_roster = [
+        (seed, arm) for seed in checked_plan.seeds for arm in checked_plan.arm_names
+    ]
+    observed_roster: list[tuple[object, object]] = []
+    for row in rows:
+        checked_row = _exact_object(row, {"seed", "arm", "result"}, "matched row")
+        observed_roster.append((checked_row["seed"], checked_row["arm"]))
+        arm_result = checked_row["result"]
+        validate_bimu_result(arm_result)
+        resolved_result = cast(dict[str, object], arm_result)
+        if resolved_result["seed"] != checked_row["seed"]:
+            raise ValueError("matched row seed drifted")
+        config = (
+            checked_plan.control_config
+            if checked_row["arm"] == "memory_off"
+            else checked_plan.candidate_config
+        )
+        if resolved_result["protocol"] != config.to_protocol_payload():
+            raise ValueError("matched row protocol drifted")
+        if resolved_result["dataset_sha256"] != checked_plan.dataset_sha256:
+            raise ValueError("matched row dataset digest drifted")
+    if observed_roster != expected_roster:
+        raise ValueError("matched result roster order drifted")
+    for offset in range(0, len(rows), 2):
+        seed = checked_plan.seeds[offset // 2]
+        control = cast(dict[str, object], rows[offset]["result"])
+        candidate = cast(dict[str, object], rows[offset + 1]["result"])
+        expected_initial, expected_schedule = _expected_fixed_identities(checked_plan, seed)
+        if (
+            control["initial_state_sha256"] != expected_initial
+            or candidate["initial_state_sha256"] != expected_initial
+        ):
+            raise ValueError("matched pair initial-state identity drifted")
+        if (
+            control["schedule_sha256"] != expected_schedule
+            or candidate["schedule_sha256"] != expected_schedule
+        ):
+            raise ValueError("matched pair schedule identity drifted")
+        for field in ("dataset_sha256", "schedule_sha256", "initial_state_sha256"):
+            if control[field] != candidate[field]:
+                raise ValueError(f"matched pair {field} drifted")
+        control_counters = cast(dict[str, object], control["counters"])
+        candidate_counters = cast(dict[str, object], candidate["counters"])
+        if any(control_counters[field] != candidate_counters[field] for field in _MATCHED_COUNTERS):
+            raise ValueError("matched pair counters drifted")
+        config = checked_plan.control_config
+        observations = config.n_tasks * config.train_examples_per_task
+        expected_counters = {
+            "environment_steps": observations,
+            "observations": observations,
+            "label_queries": observations,
+            "optimizer_seen": observations,
+            "model_forward_queries": (
+                observations * (config.query_samples + config.train_samples)
+                + 5 * config.test_examples_per_task * config.test_samples
+            ),
+        }
+        if any(control_counters[field] != value for field, value in expected_counters.items()):
+            raise ValueError("matched pair counters do not match the frozen plan")
+        control_resources = cast(dict[str, object], control["resources"])
+        candidate_resources = cast(dict[str, object], candidate["resources"])
+        if any(
+            control_resources[field] != candidate_resources[field]
+            for field in _RESOURCE_FIELDS
+        ):
+            raise ValueError("matched pair resources drifted")
+    if root["aggregate"] != _aggregate(rows, checked_plan):
+        raise ValueError("matched aggregate drifted")
+    unsigned = dict(root)
+    claimed = unsigned.pop("result_sha256")
+    if type(claimed) is not str or claimed != hashlib.sha256(_canonical(unsigned)).hexdigest():
+        raise ValueError("matched result digest drifted")
+
+
+def write_bimu_matched_result(
+    destination: Path,
+    value: object,
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+    *,
+    plan: BiMUMatchedDevelopmentPlan = FROZEN_BIMU_MATCHED_PLAN,
+) -> None:
+    """Durably publish one validated result without replacing existing evidence."""
+    if type(destination) is not type(Path()):
+        raise TypeError("destination must be an exact Path")
+    validate_bimu_matched_result(value, train_x, train_y, test_x, test_y, plan=plan)
+    parent = destination.parent.resolve(strict=True)
+    if not parent.is_dir() or destination.name in {"", ".", ".."}:
+        raise ValueError("destination parent must be an existing directory")
+    resolved = parent / destination.name
+    if os.path.lexists(resolved):
+        raise FileExistsError(f"refusing to replace existing result: {resolved}")
+    raw = _canonical(value) + b"\n"
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=parent, prefix=f".{destination.name}.", suffix=".tmp"
+    )
+    temporary = Path(temporary_name)
+    published = False
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(raw)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, resolved, follow_symlinks=False)
+        published = True
+        directory_descriptor = os.open(parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    except BaseException:
+        if published:
+            resolved.unlink(missing_ok=True)
+        raise
+    finally:
+        temporary.unlink(missing_ok=True)

--- a/alberta_framework/evaluation/prospective_publication.py
+++ b/alberta_framework/evaluation/prospective_publication.py
@@ -1,0 +1,133 @@
+"""Pinned-directory, create-only publication for prospective development reports."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from collections.abc import Callable, Sequence
+from pathlib import Path, PosixPath
+
+
+def open_directory_chain(root: Path, segments: Sequence[str]) -> int:
+    """Open/create a directory chain without following its named components."""
+    if type(root) is not PosixPath or not root.is_absolute():
+        raise ValueError("publication root must be an exact absolute POSIX Path")
+    if type(segments) not in (tuple, list) or any(
+        type(segment) is not str
+        or not segment
+        or segment in {".", ".."}
+        or "/" in segment
+        or "\x00" in segment
+        for segment in segments
+    ):
+        raise ValueError("publication directory segments are invalid")
+    flags = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0)
+    directory = os.open(root, flags)
+    try:
+        for segment in segments:
+            try:
+                os.mkdir(segment, mode=0o755, dir_fd=directory)
+            except FileExistsError:
+                pass
+            child = os.open(segment, flags, dir_fd=directory)
+            os.close(directory)
+            directory = child
+        return directory
+    except BaseException:
+        os.close(directory)
+        raise
+
+
+def publish_prepared_json_at(
+    directory: int,
+    name: str,
+    *,
+    prepare: Callable[[], bytes],
+    validate_loaded: Callable[[object], None],
+    max_bytes: int,
+) -> None:
+    """Reserve, prepare, link without replacement, reread, and strictly validate JSON."""
+    if type(directory) is not int or directory < 0:
+        raise ValueError("directory must be one pinned directory descriptor")
+    if (
+        type(name) is not str
+        or not name
+        or name in {".", ".."}
+        or "/" in name
+        or "\x00" in name
+        or len(name.encode("utf-8")) > 240
+    ):
+        raise ValueError("publication name is invalid")
+    if type(max_bytes) is not int or not 0 < max_bytes <= 64 * 1024 * 1024:
+        raise ValueError("publication byte bound is invalid")
+    reserve = f".{name}.reserve"
+    temporary = f".{name}.tmp"
+    create_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    reserve_descriptor = os.open(reserve, create_flags, 0o400, dir_fd=directory)
+    os.close(reserve_descriptor)
+    temporary_created = False
+    published = False
+    try:
+        encoded = prepare()
+        if type(encoded) is not bytes or not 0 < len(encoded) <= max_bytes:
+            raise ValueError("prepared report exceeds its exact byte bound")
+        descriptor = os.open(temporary, create_flags, 0o400, dir_fd=directory)
+        temporary_created = True
+        try:
+            offset = 0
+            while offset < len(encoded):
+                written = os.write(descriptor, encoded[offset:])
+                if written <= 0:
+                    raise OSError("publication write made no progress")
+                offset += written
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.link(
+            temporary,
+            name,
+            src_dir_fd=directory,
+            dst_dir_fd=directory,
+            follow_symlinks=False,
+        )
+        published = True
+        read_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(name, read_flags, dir_fd=directory)
+        try:
+            before = os.fstat(descriptor)
+            if not stat.S_ISREG(before.st_mode) or before.st_size != len(encoded):
+                raise RuntimeError("published report is not the prepared regular file")
+            loaded = bytearray()
+            while len(loaded) <= max_bytes:
+                chunk = os.read(descriptor, min(64 * 1024, max_bytes + 1 - len(loaded)))
+                if not chunk:
+                    break
+                loaded.extend(chunk)
+            after = os.fstat(descriptor)
+        finally:
+            os.close(descriptor)
+        if bytes(loaded) != encoded or (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+        ) != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns):
+            raise RuntimeError("published report changed during its bounded reread")
+        try:
+            decoded = json.loads(loaded)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("published report is not exact JSON") from exc
+        validate_loaded(decoded)
+        os.fsync(directory)
+    except BaseException:
+        if published:
+            os.unlink(name, dir_fd=directory)
+        raise
+    finally:
+        if temporary_created:
+            os.unlink(temporary, dir_fd=directory)
+        os.unlink(reserve, dir_fd=directory)
+
+
+__all__ = ["open_directory_chain", "publish_prepared_json_at"]

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -1,0 +1,37 @@
+# BiMU matched development run
+
+This lane is a permanently nonpromoting, bounded comparison between the
+current binary Bayesian learner with its memory disabled and the same learner
+with the frozen 128-example memory window. It is not a reproduction of the
+paper's 1,000-task result and cannot support an external SOTA claim.
+
+The prospective plan is
+`alberta_framework.evaluation.bimu_matched_nonpromoting.FROZEN_BIMU_MATCHED_PLAN`.
+It fixes three consumed development seeds, the two-arm roster, five tasks,
+256 training and 256 test examples, width 32, the exact OpenML-derived dataset
+digest, counters, resource bounds, and comparison scope. The executable and
+strict aggregate validator are in
+`alberta_framework.evaluation.bimu_matched_runner`.
+
+An operator must first reconstruct the exact float32/int32 arrays described by
+the plan and independently verify their digest. Then call
+`run_bimu_matched_development(train_x, train_y, test_x, test_y)` and retain the
+returned result with `write_bimu_matched_result` at a new path. Publication is
+durable and no-replace; supported, rejected, and inconclusive outcomes are all
+retained. Never write into an existing output path.
+
+Before treating a retained record as a development result, require:
+
+- all six seed-arm rows and both arms for every seed;
+- exact dataset, task schedule, initial state, observations, label queries,
+  optimizer-seen count, model queries, and numeric resource matching;
+- `validate_bimu_matched_result` against the same exact input arrays;
+- current source and runtime identity equality; and
+- permanent `development_only`, no-promotion, no-SOTA, and negative-retention
+  policy fields.
+
+The aggregate reports paired late-five and whole-stream online deltas. Timing
+is telemetry only. Consistency hashes are not authenticated execution proof.
+Paper comparison remains closed until the official data order, five-run
+aggregate, paper-scale 1,000-task stream, and other recorded protocol gaps are
+reproduced under a separately reviewed protocol.

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -35,3 +35,10 @@ is telemetry only. Consistency hashes are not authenticated execution proof.
 Paper comparison remains closed until the official data order, five-run
 aggregate, paper-scale 1,000-task stream, and other recorded protocol gaps are
 reproduced under a separately reviewed protocol.
+
+The public runner and publisher are hard-disabled. A later, independently
+reviewed authorization change must flip both the plan authorization and the
+runner transition gate. Tests exercise only the private bounded executor.
+Publication reserves a deterministic create-only name through a pinned
+no-follow directory descriptor before strict reexecution, then uses a
+no-replace link, fsync, bounded reread, and strict reload validation.

--- a/tests/test_bimu_matched_runner.py
+++ b/tests/test_bimu_matched_runner.py
@@ -16,7 +16,7 @@ from alberta_framework.evaluation.bimu_matched_nonpromoting import (
     _test_plan,
 )
 from alberta_framework.evaluation.bimu_matched_runner import (
-    run_bimu_matched_development,
+    _execute_bimu_matched_development,
     validate_bimu_matched_result,
     write_bimu_matched_result,
 )
@@ -30,7 +30,7 @@ def _data() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
 
 def test_matched_runner_executes_complete_two_arm_three_seed_roster() -> None:
     plan = _test_plan(input_dim=3, n_classes=2, examples=4)
-    result = cast(dict[str, Any], run_bimu_matched_development(*_data(), plan=plan))
+    result = cast(dict[str, Any], _execute_bimu_matched_development(*_data(), plan=plan))
     validate_bimu_matched_result(result, *_data(), plan=plan)
 
     assert result["policy"] == {
@@ -48,15 +48,14 @@ def test_matched_runner_executes_complete_two_arm_three_seed_roster() -> None:
         assert control["result"]["dataset_sha256"] == candidate["result"]["dataset_sha256"]
         assert control["result"]["schedule_sha256"] == candidate["result"]["schedule_sha256"]
         assert (
-            control["result"]["initial_state_sha256"]
-            == candidate["result"]["initial_state_sha256"]
+            control["result"]["initial_state_sha256"] == candidate["result"]["initial_state_sha256"]
         )
         assert control["result"]["counters"] == candidate["result"]["counters"]
 
 
 def test_matched_validator_recomputes_aggregate_and_rejects_axis_forgery() -> None:
     plan = _test_plan(input_dim=3, n_classes=2, examples=4)
-    result = cast(dict[str, Any], run_bimu_matched_development(*_data(), plan=plan))
+    result = cast(dict[str, Any], _execute_bimu_matched_development(*_data(), plan=plan))
 
     forged = copy.deepcopy(result)
     forged["aggregate"]["paired_late_five_delta_mean"] += 0.01
@@ -86,13 +85,25 @@ def test_matched_runner_rejects_dataset_before_execution(monkeypatch: pytest.Mon
         "alberta_framework.evaluation.bimu_matched_runner.run_bimu_development", fail
     )
     with pytest.raises(ValueError, match="dataset"):
-        run_bimu_matched_development(*bad, plan=plan)
+        _execute_bimu_matched_development(*bad, plan=plan)
     assert called is False
 
 
-def test_matched_result_writer_is_append_only(tmp_path: Path) -> None:
+def test_public_runner_and_writer_fail_closed_before_input_work(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="not independently authorized"):
+        runner.run_bimu_matched_development(object(), object(), object(), object())
+    with pytest.raises(RuntimeError, match="not independently authorized"):
+        write_bimu_matched_result(
+            tmp_path / "result.json", object(), object(), object(), object(), object()
+        )
+
+
+def test_matched_result_writer_is_append_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(runner, "AUTHORIZATION_TRANSITION_APPROVED", True)
     plan = _test_plan(input_dim=3, n_classes=2, examples=4)
-    result = run_bimu_matched_development(*_data(), plan=plan)
+    result = _execute_bimu_matched_development(*_data(), plan=plan)
     destination = tmp_path / "matched-result.json"
 
     write_bimu_matched_result(destination, result, *_data(), plan=plan)
@@ -111,7 +122,7 @@ def _resign(result: dict[str, Any], plan: BiMUMatchedDevelopmentPlan) -> None:
 
 def test_validator_derives_frozen_counters_schedule_and_initial_state() -> None:
     plan = _test_plan(input_dim=3, n_classes=2, examples=4)
-    original = cast(dict[str, Any], run_bimu_matched_development(*_data(), plan=plan))
+    original = cast(dict[str, Any], _execute_bimu_matched_development(*_data(), plan=plan))
 
     forged = copy.deepcopy(original)
     for row in forged["rows"]:
@@ -120,7 +131,7 @@ def test_validator_derives_frozen_counters_schedule_and_initial_state() -> None:
         counters["optimizer_updates"] = 0
         counters["model_forward_queries"] = 120
     _resign(forged, plan)
-    with pytest.raises(ValueError, match="counter"):
+    with pytest.raises(ValueError, match="counter|does not reproduce"):
         validate_bimu_matched_result(forged, *_data(), plan=plan)
 
     for field in ("schedule_sha256", "initial_state_sha256"):
@@ -128,16 +139,32 @@ def test_validator_derives_frozen_counters_schedule_and_initial_state() -> None:
         for row in forged["rows"]:
             row["result"][field] = "0" * 64
         _resign(forged, plan)
-        with pytest.raises(ValueError, match="schedule|initial"):
+        with pytest.raises(ValueError, match="schedule|initial|does not reproduce"):
             validate_bimu_matched_result(forged, *_data(), plan=plan)
 
 
-def test_source_identity_contains_only_installed_package_sources() -> None:
+def test_validator_reexecutes_and_rejects_rehashed_forged_metrics() -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    forged = copy.deepcopy(_execute_bimu_matched_development(*_data(), plan=plan))
+    metrics = forged["rows"][0]["result"]["metrics"]
+    metrics["asi_whole_stream_online_accuracy"] = 0.0
+    metrics["paper_late_five_test_accuracy"] = 0.0
+    metrics["online_correct"] = 0
+    metrics["final_five_test_accuracy"] = [0.0] * 5
+    metrics["final_five_test_correct"] = [0] * 5
+    _resign(forged, plan)
+
+    with pytest.raises(ValueError, match="does not reproduce"):
+        validate_bimu_matched_result(forged, *_data(), plan=plan)
+
+
+def test_source_identity_preserves_audited_dependency_lock() -> None:
     identity = runner._source_identity()
     assert "uv.lock" not in identity
     assert set(identity) == {
         "alberta_framework/benchmarks/bimu.py",
         "alberta_framework/evaluation/bimu_matched_nonpromoting.py",
         "alberta_framework/evaluation/bimu_matched_runner.py",
+        "alberta_framework/evaluation/prospective_publication.py",
     }
-    assert "uv.lock" not in bimu_plan._source_identity()
+    assert "uv.lock" in bimu_plan._source_identity()

--- a/tests/test_bimu_matched_runner.py
+++ b/tests/test_bimu_matched_runner.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import alberta_framework.evaluation.bimu_matched_nonpromoting as bimu_plan
+import alberta_framework.evaluation.bimu_matched_runner as runner
+from alberta_framework.evaluation.bimu_matched_nonpromoting import (
+    BiMUMatchedDevelopmentPlan,
+    _test_plan,
+)
+from alberta_framework.evaluation.bimu_matched_runner import (
+    run_bimu_matched_development,
+    validate_bimu_matched_result,
+    write_bimu_matched_result,
+)
+
+
+def _data() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    features = np.arange(8 * 3, dtype=np.float32).reshape(8, 3) / 32.0
+    labels = np.arange(8, dtype=np.int32) % 2
+    return features[:4], labels[:4], features[4:], labels[4:]
+
+
+def test_matched_runner_executes_complete_two_arm_three_seed_roster() -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    result = cast(dict[str, Any], run_bimu_matched_development(*_data(), plan=plan))
+    validate_bimu_matched_result(result, *_data(), plan=plan)
+
+    assert result["policy"] == {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "sota_claim_allowed": False,
+        "negative_results_retained": True,
+    }
+    rows = result["rows"]
+    assert [(row["seed"], row["arm"]) for row in rows] == [
+        (seed, arm) for seed in plan.seeds for arm in plan.arm_names
+    ]
+    for seed in plan.seeds:
+        control, candidate = [row for row in rows if row["seed"] == seed]
+        assert control["result"]["dataset_sha256"] == candidate["result"]["dataset_sha256"]
+        assert control["result"]["schedule_sha256"] == candidate["result"]["schedule_sha256"]
+        assert (
+            control["result"]["initial_state_sha256"]
+            == candidate["result"]["initial_state_sha256"]
+        )
+        assert control["result"]["counters"] == candidate["result"]["counters"]
+
+
+def test_matched_validator_recomputes_aggregate_and_rejects_axis_forgery() -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    result = cast(dict[str, Any], run_bimu_matched_development(*_data(), plan=plan))
+
+    forged = copy.deepcopy(result)
+    forged["aggregate"]["paired_late_five_delta_mean"] += 0.01
+    with pytest.raises(ValueError, match="aggregate"):
+        validate_bimu_matched_result(forged, *_data(), plan=plan)
+
+    forged = copy.deepcopy(result)
+    forged["rows"][1]["result"]["schedule_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="matched|digest"):
+        validate_bimu_matched_result(forged, *_data(), plan=plan)
+
+
+def test_matched_runner_rejects_dataset_before_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    bad = list(_data())
+    bad[0] = np.asarray(bad[0]).copy()
+    bad[0][0, 0] += 1.0
+
+    called = False
+
+    def fail(*_args: object, **_kwargs: object) -> object:
+        nonlocal called
+        called = True
+        raise AssertionError("execution must not start")
+
+    monkeypatch.setattr(
+        "alberta_framework.evaluation.bimu_matched_runner.run_bimu_development", fail
+    )
+    with pytest.raises(ValueError, match="dataset"):
+        run_bimu_matched_development(*bad, plan=plan)
+    assert called is False
+
+
+def test_matched_result_writer_is_append_only(tmp_path: Path) -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    result = run_bimu_matched_development(*_data(), plan=plan)
+    destination = tmp_path / "matched-result.json"
+
+    write_bimu_matched_result(destination, result, *_data(), plan=plan)
+    retained = json.loads(destination.read_bytes())
+    validate_bimu_matched_result(retained, *_data(), plan=plan)
+    with pytest.raises(FileExistsError):
+        write_bimu_matched_result(destination, result, *_data(), plan=plan)
+
+
+def _resign(result: dict[str, Any], plan: BiMUMatchedDevelopmentPlan) -> None:
+    result["aggregate"] = runner._aggregate(result["rows"], plan)
+    unsigned = dict(result)
+    unsigned.pop("result_sha256")
+    result["result_sha256"] = hashlib.sha256(runner._canonical(unsigned)).hexdigest()
+
+
+def test_validator_derives_frozen_counters_schedule_and_initial_state() -> None:
+    plan = _test_plan(input_dim=3, n_classes=2, examples=4)
+    original = cast(dict[str, Any], run_bimu_matched_development(*_data(), plan=plan))
+
+    forged = copy.deepcopy(original)
+    for row in forged["rows"]:
+        counters = row["result"]["counters"]
+        counters["label_queries"] = 0
+        counters["optimizer_updates"] = 0
+        counters["model_forward_queries"] = 120
+    _resign(forged, plan)
+    with pytest.raises(ValueError, match="counter"):
+        validate_bimu_matched_result(forged, *_data(), plan=plan)
+
+    for field in ("schedule_sha256", "initial_state_sha256"):
+        forged = copy.deepcopy(original)
+        for row in forged["rows"]:
+            row["result"][field] = "0" * 64
+        _resign(forged, plan)
+        with pytest.raises(ValueError, match="schedule|initial"):
+            validate_bimu_matched_result(forged, *_data(), plan=plan)
+
+
+def test_source_identity_contains_only_installed_package_sources() -> None:
+    identity = runner._source_identity()
+    assert "uv.lock" not in identity
+    assert set(identity) == {
+        "alberta_framework/benchmarks/bimu.py",
+        "alberta_framework/evaluation/bimu_matched_nonpromoting.py",
+        "alberta_framework/evaluation/bimu_matched_runner.py",
+    }
+    assert "uv.lock" not in bimu_plan._source_identity()


### PR DESCRIPTION
## Scope

One issue and one contract only: the bounded, permanently nonpromoting BiMU matched development runner for #1570.

- consumes the already-merged frozen three-seed/two-arm plan
- matches dataset, schedule, initial state, counters, and numeric resources
- strictly reexecutes every seed/arm and compares every non-timing field, rejecting rehashed metric forgeries
- preserves the plan's `pyproject.toml`/`uv.lock` identity
- keeps public execution and publication fail-closed behind a separate false authorization-transition gate
- publishes only through a consumer-backed pinned-dirfd helper with deterministic `O_EXCL` reservation before replay, no-replace link, fsync, bounded `O_NOFOLLOW` reread, byte equality, JSON reload, and strict validator replay

## Seed status

Seeds `157001`, `157002`, and `157003` are exposed/frozen development seeds and therefore consumed for any promotion purpose. They have not produced a retained matched result. Invalid-attempt seed `23` remains excluded. This PR performs no campaign execution and creates no output.

## Authorship

The two-commit history preserves the source lineage: the extracted runner commit retains Shaw Walters's authorship from the integration source, and the strict gate/publication correction retains lalalune's authorship.

## Verification

- `13 passed` (`test_bimu_matched_runner.py` plus the frozen-plan tests)
- Ruff passes on the runner, publication helper, and runner tests
- mypy: `Success: no issues found in 223 source files`
- diff check clean

No closing keyword: #1570 remains open until an independently audited authorization transition, valid retained report, and every named acceptance gap are complete.

Refs #1570
