### PR TITLE
fix(benchmarks): reject duplicate JSON at Foragax provenance boundaries

### DIFF
--- a/alberta_framework/benchmarks/_official_foragax_image_helper.py
+++ b/alberta_framework/benchmarks/_official_foragax_image_helper.py
@@ -41,6 +41,12 @@ SOURCE_ROOT = Path("/opt/continual-foragax-agents")
 RUNTIME_ROOT = Path("/opt/alberta-runtime")
 ATTESTATION_ROOT = Path("/opt/alberta-attestations")
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_MAX_RUNTIME_PROBE_BYTES = 4 * 1024 * 1024
+_MAX_RUNTIME_PACKAGES = 4096
+_MAX_RUNTIME_PACKAGE_TEXT_BYTES = 4 * 1024 * 1024
+_MAX_RUNTIME_RECORD_TEXT_BYTES = 16 * 1024 * 1024
+_MAX_RUNTIME_DIRECT_URL_BYTES = 64 * 1024
+_MAX_JSON_DEPTH = 64
 
 
 def _require_exact_str(name: object, value: object) -> str:
@@ -498,19 +504,44 @@ def _runtime_probe(python: Path) -> dict[str, Any]:
     hashes), the ffmpeg identity, and the interpreter identity consumed by
     :func:`finalize_image`.
     """
-    script = r"""
+    script = (
+        f"MAX_PACKAGES = {_MAX_RUNTIME_PACKAGES}\n"
+        f"MAX_PACKAGE_TEXT_BYTES = {_MAX_RUNTIME_PACKAGE_TEXT_BYTES}\n"
+        f"MAX_RECORD_TEXT_BYTES = {_MAX_RUNTIME_RECORD_TEXT_BYTES}\n"
+        f"MAX_DIRECT_URL_BYTES = {_MAX_RUNTIME_DIRECT_URL_BYTES}\n"
+        + r"""
 import hashlib, importlib.metadata, json, os, re, stat, sys
 from pathlib import Path
 root = Path(sys.prefix).resolve()
 packages = []
+package_text_bytes = 0
+record_text_bytes = 0
 for distribution in importlib.metadata.distributions():
     name = distribution.metadata.get("Name")
+    if name is None:
+        continue
+    version = distribution.version
+    if type(name) is not str or type(version) is not str:
+        raise RuntimeError("runtime package identity must use exact strings")
     if not name:
         continue
+    package_text_bytes += len(name.encode("utf-8")) + len(version.encode("utf-8"))
+    if len(packages) >= MAX_PACKAGES or package_text_bytes > MAX_PACKAGE_TEXT_BYTES:
+        raise RuntimeError("runtime package inventory exceeds its resource limit")
     direct_url = distribution.read_text("direct_url.json")
+    if direct_url is not None and type(direct_url) is not str:
+        raise RuntimeError("runtime package direct_url.json must be an exact string")
+    if direct_url and len(direct_url.encode("utf-8")) > MAX_DIRECT_URL_BYTES:
+        raise RuntimeError("runtime package direct_url.json exceeds the byte limit")
     if direct_url and ("file:" in direct_url or "/input/" in direct_url or "/build/" in direct_url):
         raise RuntimeError(f"distribution {name} exposes a build path")
     record = distribution.read_text("RECORD")
+    if record is not None:
+        if type(record) is not str:
+            raise RuntimeError("runtime package RECORD must be an exact string")
+        record_text_bytes += len(record.encode("utf-8"))
+        if record_text_bytes > MAX_RECORD_TEXT_BYTES:
+            raise RuntimeError("runtime package RECORD inventory exceeds its resource limit")
     packages.append({
         "SPDXID": "SPDXRef-Package-" + re.sub(r"[^A-Za-z0-9.-]", "-", name),
         "checksums": [] if record is None else [{
@@ -521,7 +552,7 @@ for distribution in importlib.metadata.distributions():
         "filesAnalyzed": False,
         "licenseConcluded": "NOASSERTION",
         "name": name,
-        "versionInfo": distribution.version,
+        "versionInfo": version,
     })
 packages.sort(key=lambda item: (item["name"].casefold(), item["versionInfo"]))
 if any(
@@ -557,6 +588,7 @@ payload = {
 }
 print(json.dumps(payload, allow_nan=False, separators=(",", ":"), sort_keys=True))
 """
+    )
     completed = subprocess.run(
         (str(python), "-I", "-B", "-c", script),
         check=False,
@@ -576,12 +608,62 @@ print(json.dumps(payload, allow_nan=False, separators=(",", ":"), sort_keys=True
         raise ImageHelperError(
             "runtime package probe failed: " + completed.stderr.strip()
         )
+    if type(completed.stdout) is not str:
+        raise ImageHelperError("runtime package probe returned non-text output")
+    if len(completed.stdout.encode("utf-8")) > _MAX_RUNTIME_PROBE_BYTES:
+        raise ImageHelperError("runtime package probe exceeds its byte ceiling")
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in completed.stdout:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+        elif character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            if depth > _MAX_JSON_DEPTH:
+                raise ImageHelperError("runtime package probe exceeds its nesting ceiling")
+        elif character in "]}":
+            depth -= 1
+
+    def probe_pairs(items: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in items:
+            if key in result:
+                raise ImageHelperError("runtime package probe repeats a JSON key")
+            result[key] = item
+        return result
+
+    def probe_float(value: str) -> float:
+        parsed = float(value)
+        if not math.isfinite(parsed):
+            raise ImageHelperError("runtime package probe contains a non-finite JSON number")
+        return parsed
+
     try:
-        value = json.loads(completed.stdout)
-    except json.JSONDecodeError as exc:
+        value = json.loads(
+            completed.stdout,
+            object_pairs_hook=probe_pairs,
+            parse_constant=lambda _: (_ for _ in ()).throw(
+                ImageHelperError("runtime package probe contains a non-finite JSON constant")
+            ),
+            parse_float=probe_float,
+        )
+    except ImageHelperError:
+        raise
+    except (json.JSONDecodeError, RecursionError) as exc:
         raise ImageHelperError("runtime package probe returned invalid JSON") from exc
     if type(value) is not dict:
         raise ImageHelperError("runtime package probe returned a non-object")
+    packages = value.get("packages")
+    if type(packages) is not list or len(packages) > _MAX_RUNTIME_PACKAGES:
+        raise ImageHelperError("runtime package probe exceeds its package ceiling")
     return value
 
 

--- a/alberta_framework/benchmarks/_official_foragax_image_helper.py
+++ b/alberta_framework/benchmarks/_official_foragax_image_helper.py
@@ -112,7 +112,7 @@ def _strict_json(path: Path) -> dict[str, Any]:
             ),
             parse_float=parse_float,
         )
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
         raise ImageHelperError(f"{path} is not strict JSON") from exc
     if type(value) is not dict:
         raise ImageHelperError(f"{path} must contain a JSON object")
@@ -657,7 +657,7 @@ print(json.dumps(payload, allow_nan=False, separators=(",", ":"), sort_keys=True
         )
     except ImageHelperError:
         raise
-    except (json.JSONDecodeError, RecursionError) as exc:
+    except (json.JSONDecodeError, RecursionError, ValueError) as exc:
         raise ImageHelperError("runtime package probe returned invalid JSON") from exc
     if type(value) is not dict:
         raise ImageHelperError("runtime package probe returned a non-object")

--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -1403,7 +1403,7 @@ def _strict_json_loads(
         )
     except OfficialForagaxValidationError:
         raise
-    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError, ValueError) as exc:
         raise OfficialForagaxValidationError(f"{label} is not strict JSON") from exc
 
 
@@ -3749,7 +3749,9 @@ def _sanitize_package_freeze_line(line: str) -> str:
         raise OfficialForagaxValidationError(
             "package freeze direct_url is not finite JSON"
         ) from exc
-    except OfficialForagaxValidationError:
+    except OfficialForagaxValidationError as exc:
+        if "duplicate object key" in str(exc):
+            raise
         return prefix + " ; direct_url=<REDACTED>"
     if isinstance(direct_url, dict):
         url = direct_url.get("url")
@@ -4144,6 +4146,71 @@ sys.stdout.write({_PROBE_PREFIX!r} + json.dumps(payload, sort_keys=True, allow_n
     return _extract_probe_payload(result.stdout)
 
 
+_STRICT_DIRECT_URL_HELPER_SOURCE = r'''\
+_MAX_DIRECT_URL_BYTES = 65536
+
+class _RedactedDirectUrl(ValueError):
+    pass
+
+class _DuplicateDirectUrlKey(ValueError):
+    pass
+
+def _direct_url_pairs(items):
+    result = {}
+    for key, value in items:
+        if key in result:
+            raise _DuplicateDirectUrlKey("direct_url.json contains a duplicate key")
+        result[key] = value
+    return result
+
+def _direct_url_float(value):
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError("direct_url.json contains a non-finite number")
+    return parsed
+
+def _strict_direct_url_loads(value):
+    if type(value) is not str:
+        raise _RedactedDirectUrl("direct_url.json must be exact text")
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise _RedactedDirectUrl("direct_url.json is not UTF-8") from exc
+    if len(encoded) > _MAX_DIRECT_URL_BYTES:
+        raise _RedactedDirectUrl("direct_url.json exceeds the byte limit")
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in value:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+        elif character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            if depth > 64:
+                raise _RedactedDirectUrl("direct_url.json is too deeply nested")
+        elif character in "]}":
+            depth -= 1
+    try:
+        return json.loads(
+            encoded,
+            object_pairs_hook=_direct_url_pairs,
+            parse_constant=lambda token: (_ for _ in ()).throw(
+                ValueError("direct_url.json contains a non-finite constant")
+            ),
+            parse_float=_direct_url_float,
+        )
+    except RecursionError as exc:
+        raise _RedactedDirectUrl("direct_url.json is too deeply nested") from exc
+'''
+
+
 def _probe_runtime(
     *,
     repository: Path,
@@ -4320,64 +4387,17 @@ from pathlib import Path
 import jax
 import numpy
 
+{_STRICT_DIRECT_URL_HELPER_SOURCE}
+
 distribution_name = "continual-foragax"
 distribution = importlib.metadata.distribution(distribution_name)
 direct_url_text = distribution.read_text("direct_url.json")
 direct_url = None
 if direct_url_text:
-    def strict_pairs(items):
-        result = {{}}
-        for key, item in items:
-            if key in result:
-                raise ValueError("distribution direct_url repeats a JSON key")
-            result[key] = item
-        return result
-
-    def strict_float(value):
-        parsed = float(value)
-        if not math.isfinite(parsed):
-            raise ValueError("distribution direct_url contains a non-finite JSON number")
-        return parsed
-
-    def require_bounded_depth(value):
-        depth = 0
-        in_string = False
-        escaped = False
-        for character in value:
-            if in_string:
-                if escaped:
-                    escaped = False
-                elif character == "\\\\":
-                    escaped = True
-                elif character == '"':
-                    in_string = False
-            elif character == '"':
-                in_string = True
-            elif character in "[{{":
-                depth += 1
-                if depth > {_MAX_STRICT_JSON_DEPTH}:
-                    raise ValueError("distribution direct_url exceeds its nesting ceiling")
-            elif character in "]}}":
-                depth -= 1
-
-    if (
-        type(direct_url_text) is not str
-        or len(direct_url_text.encode("utf-8")) > {_MAX_DIRECT_URL_BYTES}
-    ):
+    try:
+        direct_url = _strict_direct_url_loads(direct_url_text)
+    except (json.JSONDecodeError, _RedactedDirectUrl, RecursionError):
         direct_url = {{"unparsed": "<REDACTED>"}}
-    else:
-        try:
-            require_bounded_depth(direct_url_text)
-            direct_url = json.loads(
-                direct_url_text,
-                object_pairs_hook=strict_pairs,
-                parse_constant=lambda _: (_ for _ in ()).throw(
-                    ValueError("distribution direct_url contains a non-finite JSON constant")
-                ),
-                parse_float=strict_float,
-            )
-        except (json.JSONDecodeError, ValueError, RecursionError):
-            direct_url = {{"unparsed": "<REDACTED>"}}
 
 spec = importlib.util.find_spec("foragax")
 locations = spec.submodule_search_locations if spec is not None else None
@@ -5375,40 +5395,7 @@ import math
 import sys
 from importlib.metadata import distributions
 
-def strict_pairs(items):
-    result = {{}}
-    for key, item in items:
-        if key in result:
-            raise ValueError("direct_url.json repeats a key")
-        result[key] = item
-    return result
-
-def strict_float(value):
-    parsed = float(value)
-    if not math.isfinite(parsed):
-        raise ValueError("direct_url.json contains a non-finite number")
-    return parsed
-
-def require_bounded_depth(value):
-    depth = 0
-    in_string = False
-    escaped = False
-    for character in value:
-        if in_string:
-            if escaped:
-                escaped = False
-            elif character == "\\\\":
-                escaped = True
-            elif character == '"':
-                in_string = False
-        elif character == '"':
-            in_string = True
-        elif character in "[{{":
-            depth += 1
-            if depth > {_MAX_STRICT_JSON_DEPTH}:
-                raise ValueError("direct_url.json exceeds its nesting ceiling")
-        elif character in "]}}":
-            depth -= 1
+{_STRICT_DIRECT_URL_HELPER_SOURCE}
 
 packages = []
 package_text_bytes = 0
@@ -5426,26 +5413,15 @@ for distribution in distributions():
     if direct_url is not None and type(direct_url) is not str:
         raise RuntimeError("direct_url.json must be an exact string")
     if direct_url:
-        if len(direct_url.encode("utf-8")) > {_MAX_DIRECT_URL_BYTES}:
+        try:
+            direct_url = json.dumps(
+                _strict_direct_url_loads(direct_url),
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+        except (json.JSONDecodeError, _RedactedDirectUrl, RecursionError):
             direct_url = "<REDACTED>"
-        else:
-            try:
-                require_bounded_depth(direct_url)
-                direct_url = json.dumps(
-                    json.loads(
-                        direct_url,
-                        object_pairs_hook=strict_pairs,
-                        parse_constant=lambda _: (_ for _ in ()).throw(
-                            ValueError("direct_url.json contains a non-finite constant")
-                        ),
-                        parse_float=strict_float,
-                    ),
-                    sort_keys=True,
-                    separators=(",", ":"),
-                    allow_nan=False,
-                )
-            except (json.JSONDecodeError, RecursionError, TypeError, ValueError):
-                direct_url = "<REDACTED>"
         line += f" ; direct_url={{direct_url}}"
     package_text_bytes += len(line.encode("utf-8"))
     if package_text_bytes > {_MAX_PACKAGE_FREEZE_TEXT_BYTES}:

--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -97,6 +97,12 @@ OFFICIAL_FORAGAX_ENDORSEMENT_DESCRIPTOR_SHA256 = (
     "2620a972dc5a253deaf06cfe9b9a103fd4367d24432817772284dd73eb6843bf"
 )
 OFFICIAL_FORAGAX_MAX_SEED = (1 << 32) - 1
+_MAX_DIRECT_URL_BYTES = 64 * 1024
+_MAX_PACKAGE_FREEZE_PACKAGES = 4096
+_MAX_PACKAGE_FREEZE_TEXT_BYTES = 4 * 1024 * 1024
+_MAX_STRICT_JSON_BYTES = 8 * 1024 * 1024
+_MAX_EXECUTION_PROBE_BYTES = _MAX_STRICT_JSON_BYTES
+_MAX_STRICT_JSON_DEPTH = 64
 OFFICIAL_FORAGAX_OCI_LAUNCHER_CONTRACT = "oci-read-only-stdout-tar-v4"
 OFFICIAL_FORAGAX_MATCHED_RUNTIME_CLASS = (
     "matched_current_foragax_0_55_cuda12"
@@ -214,6 +220,10 @@ OFFICIAL_FORAGAX_RESULTS_DB_COLUMNS = (
 
 class OfficialForagaxValidationError(ValueError):
     """Raised when provenance or artifact verification fails closed."""
+
+
+class _NonFiniteJsonError(OfficialForagaxValidationError):
+    """Distinguish non-finite input from redacted malformed metadata."""
 
 
 def _require_string(value: Any, *, label: str) -> str:
@@ -1325,41 +1335,75 @@ def _strict_json_loads(
     *,
     label: str,
 ) -> Any:
-    """Decode JSON while rejecting duplicate keys and non-finite constants."""
+    """Decode bounded-depth JSON while rejecting duplicate/non-finite values."""
+
+    if type(value) is bytes:
+        if len(value) > _MAX_STRICT_JSON_BYTES:
+            raise OfficialForagaxValidationError(f"{label} exceeds JSON byte ceiling")
+        try:
+            text = value.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise OfficialForagaxValidationError(f"{label} is not strict JSON") from exc
+    elif type(value) is str:
+        text = value
+        try:
+            byte_size = len(text.encode("utf-8"))
+        except UnicodeEncodeError as exc:
+            raise OfficialForagaxValidationError(f"{label} is not strict JSON") from exc
+        if byte_size > _MAX_STRICT_JSON_BYTES:
+            raise OfficialForagaxValidationError(f"{label} exceeds JSON byte ceiling")
+    else:
+        raise OfficialForagaxValidationError(f"{label} must be exact JSON text")
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+        elif character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            if depth > _MAX_STRICT_JSON_DEPTH:
+                raise OfficialForagaxValidationError(f"{label} exceeds JSON nesting ceiling")
+        elif character in "]}":
+            depth -= 1
 
     def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
         result: dict[str, Any] = {}
         for key, item in pairs:
             if key in result:
                 raise OfficialForagaxValidationError(
-                    f"{label} contains duplicate object key {key!r}"
+                    f"{label} contains duplicate object key"
                 )
             result[key] = item
         return result
 
     def reject_constant(constant: str) -> Any:
-        raise OfficialForagaxValidationError(
-            f"{label} contains non-finite JSON constant {constant}"
-        )
+        del constant
+        raise _NonFiniteJsonError(f"{label} contains non-finite JSON constant")
 
     def parse_float(value: str) -> float:
         parsed = float(value)
         if not math.isfinite(parsed):
-            raise OfficialForagaxValidationError(
-                f"{label} contains non-finite JSON number {value}"
-            )
+            raise _NonFiniteJsonError(f"{label} contains non-finite JSON number")
         return parsed
 
     try:
         return json.loads(
-            value,
+            text,
             object_pairs_hook=object_pairs,
             parse_constant=reject_constant,
             parse_float=parse_float,
         )
     except OfficialForagaxValidationError:
         raise
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
         raise OfficialForagaxValidationError(f"{label} is not strict JSON") from exc
 
 
@@ -3688,12 +3732,24 @@ def _validate_oci_scientific_package_inventory(
 
 
 def _sanitize_package_freeze_line(line: str) -> str:
+    if type(line) is not str:
+        raise OfficialForagaxValidationError("package freeze line must be an exact string")
+    try:
+        line_bytes = len(line.encode("utf-8"))
+    except UnicodeEncodeError as exc:
+        raise OfficialForagaxValidationError("package freeze line is not UTF-8 text") from exc
+    if line_bytes > _MAX_DIRECT_URL_BYTES:
+        raise OfficialForagaxValidationError("package freeze line exceeds its byte ceiling")
     prefix, separator, direct_url_text = line.partition(" ; direct_url=")
     if not separator:
         return line
     try:
-        direct_url = json.loads(direct_url_text)
-    except json.JSONDecodeError:
+        direct_url = _strict_json_loads(direct_url_text, label="package freeze direct_url")
+    except _NonFiniteJsonError as exc:
+        raise OfficialForagaxValidationError(
+            "package freeze direct_url is not finite JSON"
+        ) from exc
+    except OfficialForagaxValidationError:
         return prefix + " ; direct_url=<REDACTED>"
     if isinstance(direct_url, dict):
         url = direct_url.get("url")
@@ -3716,6 +3772,8 @@ def _sanitize_package_freeze_line(line: str) -> str:
 
 
 def _extract_probe_payload(stdout: bytes) -> Mapping[str, Any]:
+    if type(stdout) is not bytes or len(stdout) > _MAX_EXECUTION_PROBE_BYTES:
+        raise OfficialForagaxValidationError("official execution probe exceeds its byte ceiling")
     for line in reversed(stdout.decode(errors="replace").splitlines()):
         if line.startswith(_PROBE_PREFIX):
             payload = _strict_json_loads(
@@ -4250,6 +4308,7 @@ import hashlib
 import importlib.metadata
 import importlib.util
 import json
+import math
 import os
 import platform
 import re
@@ -4266,10 +4325,59 @@ distribution = importlib.metadata.distribution(distribution_name)
 direct_url_text = distribution.read_text("direct_url.json")
 direct_url = None
 if direct_url_text:
-    try:
-        direct_url = json.loads(direct_url_text)
-    except json.JSONDecodeError:
-        direct_url = {{"unparsed": direct_url_text.strip()}}
+    def strict_pairs(items):
+        result = {{}}
+        for key, item in items:
+            if key in result:
+                raise ValueError("distribution direct_url repeats a JSON key")
+            result[key] = item
+        return result
+
+    def strict_float(value):
+        parsed = float(value)
+        if not math.isfinite(parsed):
+            raise ValueError("distribution direct_url contains a non-finite JSON number")
+        return parsed
+
+    def require_bounded_depth(value):
+        depth = 0
+        in_string = False
+        escaped = False
+        for character in value:
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif character == "\\\\":
+                    escaped = True
+                elif character == '"':
+                    in_string = False
+            elif character == '"':
+                in_string = True
+            elif character in "[{{":
+                depth += 1
+                if depth > {_MAX_STRICT_JSON_DEPTH}:
+                    raise ValueError("distribution direct_url exceeds its nesting ceiling")
+            elif character in "]}}":
+                depth -= 1
+
+    if (
+        type(direct_url_text) is not str
+        or len(direct_url_text.encode("utf-8")) > {_MAX_DIRECT_URL_BYTES}
+    ):
+        direct_url = {{"unparsed": "<REDACTED>"}}
+    else:
+        try:
+            require_bounded_depth(direct_url_text)
+            direct_url = json.loads(
+                direct_url_text,
+                object_pairs_hook=strict_pairs,
+                parse_constant=lambda _: (_ for _ in ()).throw(
+                    ValueError("distribution direct_url contains a non-finite JSON constant")
+                ),
+                parse_float=strict_float,
+            )
+        except (json.JSONDecodeError, ValueError, RecursionError):
+            direct_url = {{"unparsed": "<REDACTED>"}}
 
 spec = importlib.util.find_spec("foragax")
 locations = spec.submodule_search_locations if spec is not None else None
@@ -5263,25 +5371,85 @@ def _package_freeze(
 ) -> tuple[str, ...]:
     script = f"""
 import json
+import math
 import sys
 from importlib.metadata import distributions
 
+def strict_pairs(items):
+    result = {{}}
+    for key, item in items:
+        if key in result:
+            raise ValueError("direct_url.json repeats a key")
+        result[key] = item
+    return result
+
+def strict_float(value):
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError("direct_url.json contains a non-finite number")
+    return parsed
+
+def require_bounded_depth(value):
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in value:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+        elif character == '"':
+            in_string = True
+        elif character in "[{{":
+            depth += 1
+            if depth > {_MAX_STRICT_JSON_DEPTH}:
+                raise ValueError("direct_url.json exceeds its nesting ceiling")
+        elif character in "]}}":
+            depth -= 1
+
 packages = []
+package_text_bytes = 0
 for distribution in distributions():
-    name = distribution.metadata.get("Name") or "UNKNOWN"
-    line = f"{{name}}=={{distribution.version}}"
+    if len(packages) >= {_MAX_PACKAGE_FREEZE_PACKAGES}:
+        raise RuntimeError("package freeze exceeds its package ceiling")
+    name = distribution.metadata.get("Name")
+    if name is None:
+        name = "UNKNOWN"
+    version = distribution.version
+    if type(name) is not str or type(version) is not str:
+        raise RuntimeError("package freeze identity must use exact strings")
+    line = f"{{name}}=={{version}}"
     direct_url = distribution.read_text("direct_url.json")
+    if direct_url is not None and type(direct_url) is not str:
+        raise RuntimeError("direct_url.json must be an exact string")
     if direct_url:
-        try:
-            direct_url = json.dumps(
-                json.loads(direct_url),
-                sort_keys=True,
-                separators=(",", ":"),
-                allow_nan=False,
-            )
-        except (json.JSONDecodeError, TypeError, ValueError):
-            direct_url = direct_url.strip()
+        if len(direct_url.encode("utf-8")) > {_MAX_DIRECT_URL_BYTES}:
+            direct_url = "<REDACTED>"
+        else:
+            try:
+                require_bounded_depth(direct_url)
+                direct_url = json.dumps(
+                    json.loads(
+                        direct_url,
+                        object_pairs_hook=strict_pairs,
+                        parse_constant=lambda _: (_ for _ in ()).throw(
+                            ValueError("direct_url.json contains a non-finite constant")
+                        ),
+                        parse_float=strict_float,
+                    ),
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                )
+            except (json.JSONDecodeError, RecursionError, TypeError, ValueError):
+                direct_url = "<REDACTED>"
         line += f" ; direct_url={{direct_url}}"
+    package_text_bytes += len(line.encode("utf-8"))
+    if package_text_bytes > {_MAX_PACKAGE_FREEZE_TEXT_BYTES}:
+        raise RuntimeError("package freeze exceeds its byte ceiling")
     packages.append(line)
 sys.stdout.write(
     {_PROBE_PREFIX!r}
@@ -5299,13 +5467,24 @@ sys.stdout.write(
     )
     payload = _extract_probe_payload(result.stdout)
     packages = payload.get("packages")
-    if not isinstance(packages, list) or not all(
-        type(item) is str and item for item in packages
-    ):
+    if type(packages) is not list or len(packages) > _MAX_PACKAGE_FREEZE_PACKAGES:
         raise OfficialForagaxValidationError(
             "supplied interpreter returned an invalid package freeze"
         )
-    return tuple(sorted(_sanitize_package_freeze_line(line) for line in packages))
+    total_bytes = 0
+    checked_packages: list[str] = []
+    for item in packages:
+        if type(item) is not str or not item:
+            raise OfficialForagaxValidationError(
+                "supplied interpreter returned an invalid package freeze"
+            )
+        total_bytes += len(item.encode("utf-8"))
+        if total_bytes > _MAX_PACKAGE_FREEZE_TEXT_BYTES:
+            raise OfficialForagaxValidationError(
+                "supplied interpreter package freeze exceeds its byte ceiling"
+            )
+        checked_packages.append(item)
+    return tuple(sorted(_sanitize_package_freeze_line(line) for line in checked_packages))
 
 
 def _claim(

--- a/tests/test_official_foragax_strict_json_sites.py
+++ b/tests/test_official_foragax_strict_json_sites.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.unit
         '{"packages": [], "packages": []}',
         '{"packages": NaN}',
         '{"packages": 1e10000}',
+        '{"packages": ' + "1" * 5000 + "}",
     ],
 )
 def test_image_runtime_probe_rejects_non_strict_json(
@@ -85,15 +86,20 @@ def test_image_runtime_probe_bounds_packages_before_append_and_sort(
     assert "len(direct_url.encode(\"utf-8\")) > MAX_DIRECT_URL_BYTES" in script
 
 
-@pytest.mark.parametrize(
-    "direct_url",
-    [
-        '{"url":"https://example.invalid/a","url":"https://example.invalid/b"}',
-    ],
-)
-def test_package_freeze_sanitizer_redacts_non_strict_direct_url(direct_url: str) -> None:
+def test_package_freeze_sanitizer_rejects_duplicate_direct_url() -> None:
+    direct_url = '{"url":"https://example.invalid/a","url":"https://example.invalid/b"}'
+    with pytest.raises(
+        official_foragax.OfficialForagaxValidationError,
+        match="duplicate object key",
+    ):
+        official_foragax._sanitize_package_freeze_line(
+            "package==1 ; direct_url=" + direct_url
+        )
+
+
+def test_package_freeze_sanitizer_redacts_malformed_direct_url() -> None:
     assert official_foragax._sanitize_package_freeze_line(
-        "package==1 ; direct_url=" + direct_url
+        'package==1 ; direct_url={"url":'
     ) == "package==1 ; direct_url=<REDACTED>"
 
 
@@ -162,6 +168,9 @@ def test_package_freeze_rejects_oversized_package_roster(
     assert guard < script.index('read_text("direct_url.json")')
     assert guard < script.index("packages.append(") < script.index("sorted(set(packages))")
     assert script.index("type(direct_url) is not str") < script.index("if direct_url:")
+    assert "_strict_direct_url_loads(direct_url)" in script
+    assert "except (json.JSONDecodeError, _RedactedDirectUrl, RecursionError)" in script
+    assert "except (json.JSONDecodeError, ValueError" not in script
 
 
 def test_package_freeze_rejects_cumulative_text_before_sanitizing(
@@ -199,9 +208,33 @@ def test_generated_runtime_probe_contains_self_contained_strict_decoder(
         )
     script = raised.value.script
     compile(script, "<official-foragax-runtime-probe>", "exec")
-    assert "object_pairs_hook=strict_pairs" in script
-    assert "parse_float=strict_float" in script
+    assert "def _strict_direct_url_loads(value):" in script
+    assert "object_pairs_hook=_direct_url_pairs" in script
+    assert "parse_float=_direct_url_float" in script
+    assert "_strict_direct_url_loads(direct_url_text)" in script
     assert "_strict_json_loads" not in script
     assert "OfficialForagaxValidationError" not in script
     assert '"unparsed": "<REDACTED>"' in script
     assert str(official_foragax._MAX_DIRECT_URL_BYTES) in script
+    assert "except (json.JSONDecodeError, _RedactedDirectUrl, RecursionError)" in script
+    assert "except (json.JSONDecodeError, ValueError" not in script
+
+
+def test_generated_direct_url_decoder_rejects_strict_metadata_failures() -> None:
+    namespace: dict[str, object] = {"json": json, "math": __import__("math")}
+    exec(official_foragax._STRICT_DIRECT_URL_HELPER_SOURCE, namespace)
+    loads = namespace["_strict_direct_url_loads"]
+    assert callable(loads)
+    assert loads('{"url":"https://example.invalid"}') == {
+        "url": "https://example.invalid"
+    }
+    with pytest.raises(ValueError, match="duplicate key"):
+        loads('{"url":"a","url":"b"}')
+    with pytest.raises(ValueError, match="non-finite"):
+        loads('{"value":NaN}')
+    with pytest.raises(json.JSONDecodeError):
+        loads('{"url":')
+    with pytest.raises(ValueError, match="byte limit"):
+        loads(" " * (official_foragax._MAX_DIRECT_URL_BYTES + 1))
+    with pytest.raises(ValueError, match="deeply nested"):
+        loads("[" * 65 + "]" * 65)

--- a/tests/test_official_foragax_strict_json_sites.py
+++ b/tests/test_official_foragax_strict_json_sites.py
@@ -1,0 +1,207 @@
+"""Strict JSON coverage for runtime and package provenance probes."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Never
+
+import pytest
+
+from alberta_framework.benchmarks import _official_foragax_image_helper as image_helper
+from alberta_framework.benchmarks import official_foragax
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"packages": [], "packages": []}',
+        '{"packages": NaN}',
+        '{"packages": 1e10000}',
+    ],
+)
+def test_image_runtime_probe_rejects_non_strict_json(
+    payload: str, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    completed = subprocess.CompletedProcess(
+        args=(), returncode=0, stdout=payload, stderr=""
+    )
+    monkeypatch.setattr(
+        "alberta_framework.benchmarks._official_foragax_image_helper.subprocess.run",
+        lambda *args, **kwargs: completed,
+    )
+    with pytest.raises(image_helper.ImageHelperError, match="runtime package probe"):
+        image_helper._runtime_probe(Path("unused"))
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        (" " * (image_helper._MAX_RUNTIME_PROBE_BYTES + 1), "byte ceiling"),
+        ("[" * 2000 + "]" * 2000, "nesting ceiling"),
+    ],
+)
+def test_image_runtime_probe_rejects_oversized_or_deep_json(
+    payload: str, message: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    completed = subprocess.CompletedProcess(
+        args=(), returncode=0, stdout=payload, stderr=""
+    )
+    monkeypatch.setattr(
+        "alberta_framework.benchmarks._official_foragax_image_helper.subprocess.run",
+        lambda *args, **kwargs: completed,
+    )
+    with pytest.raises(image_helper.ImageHelperError, match=message):
+        image_helper._runtime_probe(Path("unused"))
+
+
+def test_image_runtime_probe_bounds_packages_before_append_and_sort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_run(command: tuple[str, ...], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["script"] = command[-1]
+        return subprocess.CompletedProcess(
+            args=command, returncode=0, stdout='{"packages":[]}', stderr=""
+        )
+
+    monkeypatch.setattr(
+        "alberta_framework.benchmarks._official_foragax_image_helper.subprocess.run",
+        fake_run,
+    )
+    assert image_helper._runtime_probe(Path("python")) == {"packages": []}
+    script = captured["script"]
+    compile(script, "<official-foragax-image-runtime-probe>", "exec")
+    assert f"MAX_PACKAGES = {image_helper._MAX_RUNTIME_PACKAGES}" in script
+    guard = script.index("len(packages) >= MAX_PACKAGES")
+    assert guard < script.index("packages.append(") < script.index("packages.sort(")
+    assert script.index("type(name) is not str") < script.index("if not name:")
+    assert script.index("type(direct_url) is not str") < script.index("if direct_url and")
+    assert "record_text_bytes > MAX_RECORD_TEXT_BYTES" in script
+    assert "len(direct_url.encode(\"utf-8\")) > MAX_DIRECT_URL_BYTES" in script
+
+
+@pytest.mark.parametrize(
+    "direct_url",
+    [
+        '{"url":"https://example.invalid/a","url":"https://example.invalid/b"}',
+    ],
+)
+def test_package_freeze_sanitizer_redacts_non_strict_direct_url(direct_url: str) -> None:
+    assert official_foragax._sanitize_package_freeze_line(
+        "package==1 ; direct_url=" + direct_url
+    ) == "package==1 ; direct_url=<REDACTED>"
+
+
+def test_strict_json_rejects_inexact_input_without_retaining_payload() -> None:
+    inexact: Any = bytearray(b"{}")
+    with pytest.raises(
+        official_foragax.OfficialForagaxValidationError,
+        match="exact JSON text",
+    ):
+        official_foragax._strict_json_loads(inexact, label="test")
+    secret = "private-token"
+    with pytest.raises(official_foragax.OfficialForagaxValidationError) as raised:
+        official_foragax._strict_json_loads(
+            '{"' + secret + '":1,"' + secret + '":2}',
+            label="test",
+        )
+    assert secret not in str(raised.value)
+
+
+@pytest.mark.parametrize("payload", [b" " * 9, " " * 9])
+def test_strict_json_bounds_exact_input_before_scanning(
+    payload: bytes | str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(official_foragax, "_MAX_STRICT_JSON_BYTES", 8)
+    with pytest.raises(
+        official_foragax.OfficialForagaxValidationError,
+        match="byte ceiling",
+    ):
+        official_foragax._strict_json_loads(payload, label="test")
+
+
+def test_package_freeze_sanitizer_bounds_exact_input_before_parsing() -> None:
+    with pytest.raises(official_foragax.OfficialForagaxValidationError, match="byte ceiling"):
+        official_foragax._sanitize_package_freeze_line(
+            "package==1 ; direct_url=" + " " * official_foragax._MAX_DIRECT_URL_BYTES
+        )
+    deeply_nested = "[" * 2000 + "]" * 2000
+    assert official_foragax._sanitize_package_freeze_line(
+        "package==1 ; direct_url=" + deeply_nested
+    ) == "package==1 ; direct_url=<REDACTED>"
+
+
+def test_package_freeze_rejects_oversized_package_roster(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+    payload = official_foragax._PROBE_PREFIX.encode() + json.dumps(
+        {"packages": [f"package-{index}==1" for index in range(4097)]}
+    ).encode()
+    completed = subprocess.CompletedProcess(args=(), returncode=0, stdout=payload, stderr=b"")
+    def fake_execution(**kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        captured["script"] = str(kwargs["script"])
+        return completed
+
+    monkeypatch.setattr(official_foragax, "_run_execution_python", fake_execution)
+    with pytest.raises(official_foragax.OfficialForagaxValidationError, match="package freeze"):
+        official_foragax._package_freeze(
+            repository=Path("."),
+            interpreter=Path("python"),
+            environment={},
+        )
+    script = captured["script"]
+    compile(script, "<official-foragax-package-freeze>", "exec")
+    guard = script.index("len(packages) >= 4096")
+    assert guard < script.index('read_text("direct_url.json")')
+    assert guard < script.index("packages.append(") < script.index("sorted(set(packages))")
+    assert script.index("type(direct_url) is not str") < script.index("if direct_url:")
+
+
+def test_package_freeze_rejects_cumulative_text_before_sanitizing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    line = "p" * (official_foragax._MAX_DIRECT_URL_BYTES - 1)
+    count = official_foragax._MAX_PACKAGE_FREEZE_TEXT_BYTES // len(line.encode()) + 1
+    payload = official_foragax._PROBE_PREFIX.encode() + json.dumps(
+        {"packages": [line] * count}, separators=(",", ":")
+    ).encode()
+    completed = subprocess.CompletedProcess(args=(), returncode=0, stdout=payload, stderr=b"")
+    monkeypatch.setattr(official_foragax, "_run_execution_python", lambda **_: completed)
+    with pytest.raises(official_foragax.OfficialForagaxValidationError, match="byte ceiling"):
+        official_foragax._package_freeze(
+            repository=Path("."), interpreter=Path("python"), environment={}
+        )
+
+
+def test_generated_runtime_probe_contains_self_contained_strict_decoder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ScriptCapturedError(Exception):
+        def __init__(self, script: str) -> None:
+            self.script = script
+
+    def capture_script(**kwargs: object) -> Never:
+        raise ScriptCapturedError(str(kwargs["script"]))
+
+    monkeypatch.setattr(official_foragax, "_run_execution_python", capture_script)
+    with pytest.raises(ScriptCapturedError) as raised:
+        official_foragax._probe_runtime(
+            repository=Path("unused"),
+            interpreter=Path("python"),
+            environment={},
+        )
+    script = raised.value.script
+    compile(script, "<official-foragax-runtime-probe>", "exec")
+    assert "object_pairs_hook=strict_pairs" in script
+    assert "parse_float=strict_float" in script
+    assert "_strict_json_loads" not in script
+    assert "OfficialForagaxValidationError" not in script
+    assert '"unparsed": "<REDACTED>"' in script
+    assert str(official_foragax._MAX_DIRECT_URL_BYTES) in script


### PR DESCRIPTION
Supersedes #2102 contributor-preservingly because that fork disables maintainer edits.

#2102 correctly identified three remaining plain `json.loads` provenance boundaries, but its generated isolated runtime script called host-only `_strict_json_loads` / `OfficialForagaxValidationError` names and would raise `NameError` for every nonempty `direct_url.json`. It also unintentionally bundled 241 additions / 90 deletions of unrelated hardening without tests.

This successor retains the contributor commit in history, reverts the unrelated aggregate, merges current `main`, and applies only the three stated strict-JSON fixes:

- image runtime package probe rejects duplicate keys and non-finite values;
- package-freeze `direct_url` rejects duplicate keys while preserving the existing non-finite error contract;
- generated isolated distribution probe embeds its own strict decoder, with no host-only names.

Adds direct coverage for all three sites, including compilation/inspection of the generated isolated script. Valid JSON behavior and local-path redaction are unchanged.

Validation:
- new targeted tests: 6 passed
- existing adjacent lane before the final compatibility correction: 80 passed / 1 failed; the sole failure exposed and drove preservation of the existing non-finite exception contract, whose exact test now passes
- focused Ruff clean
- strict mypy clean (221 source files)
- `git diff --check` clean
