### PR TITLE
research: freeze activation/feature campaign without execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replaced the unissued activation/feature campaign's exposed seed rosters with
+  globally searched v2 rosters, quarantined both `0`–`4` and `156610`–`156614`,
+  and moved all future artifacts to NEW v2 namespaces. Public shard execution
+  now fails before dataset access or runner dispatch pending a separate reviewed
+  authorization transition. Output transactions reserve through pinned
+  no-follow directory descriptors before work, publish without replacement,
+  fsync, and strictly reread through the pinned descriptor with the artifact's
+  plan-bound validator. No campaign execution or output is included.
 - Made new IPMNIST screening shards and summaries strict v2 artifacts bound to a clean Git
   commit/tree, the actual tracked package and `uv.lock` bytes, runtime/JAX details, and the
   canonical materialized MNIST feature/label bytes. The run CLI now captures these bindings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replaced the unissued activation/feature campaign's exposed seed rosters with
-  globally searched v2 rosters, quarantined both `0`–`4` and `156610`–`156614`,
-  and moved all future artifacts to NEW v2 namespaces. Public shard execution
+  untouched v2 rosters; `0`–`4`, `156610`–`156614`, `2156600`–`2156604`, and
+  `2156610`–`2156614` are quarantined because they were exposed or exercised.
+  All future artifacts use NEW v2 namespaces. Public shard execution
   now fails before dataset access or runner dispatch pending a separate reviewed
   authorization transition. Output transactions reserve through pinned
   no-follow directory descriptors before work, publish without replacement,

--- a/alberta_framework/benchmarks/activation_feature_ipmnist.py
+++ b/alberta_framework/benchmarks/activation_feature_ipmnist.py
@@ -49,6 +49,7 @@ from alberta_framework.benchmarks.upgd_ipmnist import (
 )
 
 RESULT_SCHEMA: Final[str] = "asi.activation_feature_ipmnist.result.v1"
+CAMPAIGN_RESULT_SCHEMA: Final[str] = "asi.activation_feature_ipmnist.result.v2"
 COMPARISON_ID: Final[str] = "issue-1566-low-cost-activation-feature-controls"
 DEVELOPMENT_SEEDS: Final[tuple[int, ...]] = (0, 1, 2, 3, 4)
 DEVELOPMENT_OUTCOMES: Final[frozenset[str]] = frozenset(
@@ -447,7 +448,7 @@ def run_activation_feature_arm(
     peak_schedule_bytes = _preflight_activation_feature_resources(
         config, n_train=int(host_x.shape[0])
     )
-    root = jr.key(np.uint32(seed))
+    root = jr.key(np.uint32(seed), impl="threefry2x32")
     _, key_schedule, _ = jr.split(root, 3)
     schedule = build_schedule(key_schedule, config, int(host_x.shape[0]))
     screening = run_screening_config(
@@ -530,10 +531,26 @@ def _parameter_counts(config: IPMNISTConfig, arm: str) -> tuple[int, int]:
     return allocated, active
 
 
-def activation_feature_result_payload(
-    result: ActivationFeatureRunResult, *, outcome: str
+def _validated_seed_protocol(value: object) -> tuple[int, ...]:
+    if (
+        type(value) is not tuple
+        or not 1 <= len(value) <= 64
+        or any(type(seed) is not int or not 0 <= seed <= 2**32 - 1 for seed in value)
+        or len(set(value)) != len(value)
+    ):
+        raise ValueError("development seed protocol must be a unique exact uint32 tuple")
+    return cast(tuple[int, ...], value)
+
+
+def _activation_feature_result_payload(
+    result: ActivationFeatureRunResult,
+    *,
+    outcome: str,
+    schema: str,
+    seed_protocol: tuple[int, ...],
 ) -> dict[str, object]:
-    """Build and validate the strict nonpromotion/resource receipt."""
+    """Build one versioned strict nonpromotion/resource receipt."""
+    checked_seeds = _validated_seed_protocol(seed_protocol)
     if type(result) is not ActivationFeatureRunResult:
         raise ValueError("result must be an exact ActivationFeatureRunResult")
     if type(result.screening) is not ScreeningRunResult:
@@ -564,7 +581,7 @@ def activation_feature_result_payload(
         config = IPMNISTConfig(**config_values)
     except (TypeError, ValueError) as error:
         raise ValueError("result config is invalid") from error
-    if type(result.seed) is not int or result.seed not in DEVELOPMENT_SEEDS:
+    if type(result.seed) is not int or result.seed not in checked_seeds:
         raise ValueError("result seed must belong to the frozen development seed set")
     if (
         type(result.wall_clock_seconds) is not float
@@ -619,7 +636,7 @@ def activation_feature_result_payload(
     if family == "deep_fourier" and result.config_name != "deep_fourier_off":
         gaps.append("parameterization")
     payload: dict[str, object] = {
-        "schema": RESULT_SCHEMA,
+        "schema": schema,
         "comparison_id": COMPARISON_ID,
         "arm": result.config_name,
         "source": dict(ACTIVATION_FEATURE_SOURCES[family]),
@@ -631,7 +648,7 @@ def activation_feature_result_payload(
             "n_train": result.n_train,
         },
         "seed": result.seed,
-        "development_seed_protocol": list(DEVELOPMENT_SEEDS),
+        "development_seed_protocol": list(checked_seeds),
         "config": {
             "n_tasks": config.n_tasks,
             "task_length": config.task_length,
@@ -674,7 +691,36 @@ def activation_feature_result_payload(
         "development_only": True,
         "scientific_promotion_allowed": False,
     }
-    return validate_activation_feature_result(payload)
+    return _validate_activation_feature_result(
+        payload, schema=schema, seed_protocol=checked_seeds
+    )
+
+
+def activation_feature_result_payload(
+    result: ActivationFeatureRunResult, *, outcome: str
+) -> dict[str, object]:
+    """Build the frozen result-v1 receipt without changing its seed protocol."""
+    return _activation_feature_result_payload(
+        result,
+        outcome=outcome,
+        schema=RESULT_SCHEMA,
+        seed_protocol=DEVELOPMENT_SEEDS,
+    )
+
+
+def activation_feature_campaign_result_payload(
+    result: ActivationFeatureRunResult,
+    *,
+    outcome: str,
+    development_seeds: tuple[int, ...],
+) -> dict[str, object]:
+    """Build a result-v2 receipt for an explicitly frozen campaign seed set."""
+    return _activation_feature_result_payload(
+        result,
+        outcome=outcome,
+        schema=CAMPAIGN_RESULT_SCHEMA,
+        seed_protocol=development_seeds,
+    )
 
 
 def _exact_dict(value: object, fields: frozenset[str], context: str) -> dict[str, object]:
@@ -683,10 +729,13 @@ def _exact_dict(value: object, fields: frozenset[str], context: str) -> dict[str
     return cast(dict[str, object], value)
 
 
-def validate_activation_feature_result(payload: object) -> dict[str, object]:
-    """Fail-closed bounded validator; accepts only JSON-builtin containers."""
+def _validate_activation_feature_result(
+    payload: object, *, schema: str, seed_protocol: tuple[int, ...]
+) -> dict[str, object]:
+    """Fail-closed bounded validator for one exact receipt version."""
+    checked_seeds = _validated_seed_protocol(seed_protocol)
     root = _exact_dict(payload, _TOP_FIELDS, "result")
-    if root["schema"] != RESULT_SCHEMA or root["comparison_id"] != COMPARISON_ID:
+    if root["schema"] != schema or root["comparison_id"] != COMPARISON_ID:
         raise ValueError("unsupported result identity")
     arm = root["arm"]
     spec = activation_feature_spec(arm)
@@ -696,9 +745,9 @@ def validate_activation_feature_result(payload: object) -> dict[str, object]:
         raise ValueError("all outcomes, including negative outcomes, must be retained")
     if root["paper_metric_reported"] is not False:
         raise ValueError("paper_metric_reported must remain false")
-    if type(root["seed"]) is not int or root["seed"] not in DEVELOPMENT_SEEDS:
+    if type(root["seed"]) is not int or root["seed"] not in checked_seeds:
         raise ValueError("seed must belong to the frozen development seed set")
-    if root["development_seed_protocol"] != list(DEVELOPMENT_SEEDS):
+    if root["development_seed_protocol"] != list(checked_seeds):
         raise ValueError("development_seed_protocol must match the frozen seed set")
     if type(root["outcome"]) is not str or root["outcome"] not in DEVELOPMENT_OUTCOMES:
         raise ValueError("outcome must be supported, rejected, or inconclusive")
@@ -874,11 +923,37 @@ def validate_activation_feature_result(payload: object) -> dict[str, object]:
     return root
 
 
-def validate_matched_activation_feature_results(payloads: object) -> list[dict[str, object]]:
-    """Validate one complete, same-seed matched development comparison."""
+def validate_activation_feature_result(payload: object) -> dict[str, object]:
+    """Validate the original result-v1 contract and seed set unchanged."""
+    return _validate_activation_feature_result(
+        payload, schema=RESULT_SCHEMA, seed_protocol=DEVELOPMENT_SEEDS
+    )
+
+
+def validate_activation_feature_campaign_result(
+    payload: object, *, development_seeds: tuple[int, ...]
+) -> dict[str, object]:
+    """Validate a result-v2 receipt against its externally frozen seed set."""
+    return _validate_activation_feature_result(
+        payload,
+        schema=CAMPAIGN_RESULT_SCHEMA,
+        seed_protocol=development_seeds,
+    )
+
+
+def _validate_matched_activation_feature_results(
+    payloads: object, *, schema: str, seed_protocol: tuple[int, ...]
+) -> list[dict[str, object]]:
+    """Validate one versioned complete, same-seed matched comparison."""
+    checked_seeds = _validated_seed_protocol(seed_protocol)
     if type(payloads) is not list or len(payloads) != len(ACTIVATION_FEATURE_SPECS):
         raise ValueError("matched comparison must contain every registered arm exactly once")
-    validated = [validate_activation_feature_result(payload) for payload in payloads]
+    validated = [
+        _validate_activation_feature_result(
+            payload, schema=schema, seed_protocol=checked_seeds
+        )
+        for payload in payloads
+    ]
     by_arm = {cast(str, payload["arm"]): payload for payload in validated}
     if len(by_arm) != len(validated) or set(by_arm) != set(ACTIVATION_FEATURE_SPECS):
         raise ValueError("matched comparison must contain every registered arm exactly once")
@@ -908,6 +983,24 @@ def validate_matched_activation_feature_results(payloads: object) -> list[dict[s
             if resources[field] != first_resources[field]:
                 raise ValueError(f"matched comparison differs on resource axis {field}")
     return validated
+
+
+def validate_matched_activation_feature_results(payloads: object) -> list[dict[str, object]]:
+    """Validate the original complete result-v1 comparison unchanged."""
+    return _validate_matched_activation_feature_results(
+        payloads, schema=RESULT_SCHEMA, seed_protocol=DEVELOPMENT_SEEDS
+    )
+
+
+def validate_matched_activation_feature_campaign_results(
+    payloads: object, *, development_seeds: tuple[int, ...]
+) -> list[dict[str, object]]:
+    """Validate one complete same-seed 11-arm result-v2 comparison."""
+    return _validate_matched_activation_feature_results(
+        payloads,
+        schema=CAMPAIGN_RESULT_SCHEMA,
+        seed_protocol=development_seeds,
+    )
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/alberta_framework/benchmarks/activation_feature_ipmnist.py
+++ b/alberta_framework/benchmarks/activation_feature_ipmnist.py
@@ -325,7 +325,7 @@ def activation_feature_spec(name: object) -> ScreeningSpec:
 def _preflight_activation_feature_resources(
     config: IPMNISTConfig, *, n_train: int | None = None
 ) -> int:
-    """Reject schedules that exceed the lane's bounded persistent envelope."""
+    """Reject retained schedule payloads outside the lane's bounded envelope."""
     sampled_width = config.task_length if n_train is None else n_train
     if type(sampled_width) is not int or sampled_width < 1:
         raise ValueError("activation/feature training-row count must be positive")
@@ -385,7 +385,7 @@ class ActivationFeatureRunResult:
     source_identity: tuple[str, str, str]
     runtime_identity: tuple[str, str, str, str]
     n_train: int
-    peak_schedule_working_bytes: int
+    retained_schedule_numeric_bytes: int
 
     @property
     def config_name(self) -> str:
@@ -445,7 +445,7 @@ def run_activation_feature_arm(
     host_y = _host_array(data_y, name="data_y", dtype=np.dtype(np.int32))
     if host_x.ndim != 2 or host_y.ndim != 1 or host_x.shape[0] != host_y.shape[0]:
         raise ValueError("activation/feature data must be matched rank-2/rank-1 arrays")
-    peak_schedule_bytes = _preflight_activation_feature_resources(
+    retained_schedule_bytes = _preflight_activation_feature_resources(
         config, n_train=int(host_x.shape[0])
     )
     root = jr.key(np.uint32(seed), impl="threefry2x32")
@@ -463,7 +463,7 @@ def run_activation_feature_arm(
         source_identity=_current_source_identity(),
         runtime_identity=_runtime_identity(),
         n_train=int(host_x.shape[0]),
-        peak_schedule_working_bytes=peak_schedule_bytes,
+        retained_schedule_numeric_bytes=retained_schedule_bytes,
     )
 
 
@@ -506,7 +506,7 @@ _RESOURCE_FIELDS = frozenset(
         "sigmoid_evaluations",
         "trigonometric_evaluations",
         "persistent_numeric_bytes",
-        "peak_schedule_working_bytes",
+        "retained_schedule_numeric_bytes",
         "timing_seconds",
         "timing_is_telemetry_only",
     }
@@ -680,7 +680,7 @@ def _activation_feature_result_payload(
             "sigmoid_evaluations": sigmoid_evaluations,
             "trigonometric_evaluations": trig_evaluations,
             "persistent_numeric_bytes": 4 * (allocated + 2 * config.input_dim + 1),
-            "peak_schedule_working_bytes": result.peak_schedule_working_bytes,
+            "retained_schedule_numeric_bytes": result.retained_schedule_numeric_bytes,
             "timing_seconds": float(result.wall_clock_seconds),
             "timing_is_telemetry_only": True,
         },
@@ -802,7 +802,7 @@ def _validate_activation_feature_result(
         or not validated_config.task_length <= n_train_value <= _MAX_STEPS
     ):
         raise ValueError("n_train must be an exact bounded dataset row count")
-    peak_schedule_bytes = _preflight_activation_feature_resources(
+    retained_schedule_bytes = _preflight_activation_feature_resources(
         validated_config, n_train=n_train_value
     )
     hp = _exact_dict(root["hyperparameters"], frozenset(spec.hyperparameters), "hyperparameters")
@@ -893,7 +893,7 @@ def _validate_activation_feature_result(
         "sigmoid_evaluations": sigmoid_evaluations,
         "trigonometric_evaluations": trig_evaluations,
         "persistent_numeric_bytes": 4 * (allocated + 2 * input_dim + 1),
-        "peak_schedule_working_bytes": peak_schedule_bytes,
+        "retained_schedule_numeric_bytes": retained_schedule_bytes,
     }
     for name, expected in expected_resources.items():
         if resources[name] != expected:

--- a/alberta_framework/benchmarks/activation_feature_ipmnist.py
+++ b/alberta_framework/benchmarks/activation_feature_ipmnist.py
@@ -699,7 +699,7 @@ def _activation_feature_result_payload(
 def activation_feature_result_payload(
     result: ActivationFeatureRunResult, *, outcome: str
 ) -> dict[str, object]:
-    """Build the frozen result-v1 receipt without changing its seed protocol."""
+    """Build a result-v1 receipt under its fixed seed protocol."""
     return _activation_feature_result_payload(
         result,
         outcome=outcome,
@@ -924,7 +924,7 @@ def _validate_activation_feature_result(
 
 
 def validate_activation_feature_result(payload: object) -> dict[str, object]:
-    """Validate the original result-v1 contract and seed set unchanged."""
+    """Validate the result-v1 contract and fixed seed set."""
     return _validate_activation_feature_result(
         payload, schema=RESULT_SCHEMA, seed_protocol=DEVELOPMENT_SEEDS
     )
@@ -986,7 +986,7 @@ def _validate_matched_activation_feature_results(
 
 
 def validate_matched_activation_feature_results(payloads: object) -> list[dict[str, object]]:
-    """Validate the original complete result-v1 comparison unchanged."""
+    """Validate one complete result-v1 comparison."""
     return _validate_matched_activation_feature_results(
         payloads, schema=RESULT_SCHEMA, seed_protocol=DEVELOPMENT_SEEDS
     )

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -10449,7 +10449,7 @@ def run_screening_config(
     else:
         init_fn, step_fn = spec.factory(spec.hyperparameters)
 
-    root = jr.key(jnp.uint32(resolved_seed))
+    root = jr.key(jnp.uint32(resolved_seed), impl="threefry2x32")
     key_init, key_schedule, key_noise = jr.split(root, 3)
     params = init_mlp_params(key_init, config)
     schedule = build_schedule(key_schedule, config, n_train)

--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -1,0 +1,1505 @@
+"""Frozen, sharded, permanently nonpromoting issue #1566 campaigns.
+
+The campaign layer deliberately wraps the result-v1 shard contract instead of
+changing it.  A plan binds one exact dataset and runtime, every arm executes in
+its own CLI process, and aggregation admits only the complete 11-arm by 5-seed
+matrix.  The resulting decisions are development diagnostics, not paper
+reproductions or scientific evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import ctypes
+import errno
+import functools
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+import platform
+import stat
+import sys
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Final, cast
+
+import jax
+import jax.random as jr
+import numpy as np
+
+import alberta_framework.benchmarks.activation_feature_ipmnist as activation_lane
+import alberta_framework.benchmarks.ipmnist_screening as screening_lane
+import alberta_framework.benchmarks.plasticity_comparators as comparator_lane
+import alberta_framework.benchmarks.upgd_ipmnist as ipmnist_lane
+from alberta_framework.benchmarks.activation_feature_ipmnist import (
+    ACTIVATION_FEATURE_SPECS,
+    DEVELOPMENT_SEEDS,
+    _array_bundle_sha256,
+    activation_feature_campaign_result_payload,
+    activation_feature_result_payload,
+    run_activation_feature_arm,
+    validate_activation_feature_campaign_result,
+    validate_activation_feature_result,
+    validate_matched_activation_feature_campaign_results,
+    validate_matched_activation_feature_results,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import (
+    IPMNISTConfig,
+    build_schedule,
+    default_openml_data_home,
+    init_mlp_params,
+    load_mnist_train,
+)
+
+PLAN_SCHEMA: Final[str] = "asi.activation-feature-ipmnist.campaign-plan.v1"
+SHARD_SCHEMA: Final[str] = "asi.activation-feature-ipmnist.campaign-shard.v1"
+AGGREGATE_SCHEMA: Final[str] = "asi.activation-feature-ipmnist.campaign-aggregate.v1"
+
+ARM_ROSTER: Final[tuple[str, ...]] = tuple(ACTIVATION_FEATURE_SPECS)
+STAGE_ROSTER: Final[tuple[str, ...]] = ("cheap_screen", "full_confirmation")
+CHEAP_SCREEN_SEEDS: Final[tuple[int, ...]] = DEVELOPMENT_SEEDS
+FULL_CONFIRMATION_SEEDS: Final[tuple[int, ...]] = (
+    156_610,
+    156_611,
+    156_612,
+    156_613,
+    156_614,
+)
+_SEEDS: Final[Mapping[str, tuple[int, ...]]] = {
+    "cheap_screen": CHEAP_SCREEN_SEEDS,
+    "full_confirmation": FULL_CONFIRMATION_SEEDS,
+}
+ALL_SEEDS: Final[tuple[int, ...]] = CHEAP_SCREEN_SEEDS + FULL_CONFIRMATION_SEEDS
+CAMPAIGN_PAPER_SOURCES: Final[Mapping[str, Mapping[str, str]]] = {
+    "smooth_leaky": {
+        "publication": "ICLR-2026:XZf6wObHX4",
+        "preprint": "arXiv:2509.22562v4",
+        "official_repository": "https://github.com/lute47lillo/activations_plasticity",
+        "official_commit": "bdce354782cd183d63550819550b33312506d3e3",
+        "license_status": "no license file; read-only disambiguation reference",
+        "implementation_source": "paper Equation 1",
+    },
+    "aid": {
+        "publication": "ICML-2025:park25b; PMLR-v267:47991-48026",
+        "preprint": "arXiv:2502.01342v2",
+        "official_repository": "none located",
+        "official_commit": "none",
+        "license_status": "not applicable",
+        "implementation_source": "paper Algorithm 1 and Property 1",
+    },
+    "deep_fourier": {
+        "publication": "ICLR-2025:NIkfix2eDQ",
+        "preprint": "arXiv:2410.20634v1",
+        "official_repository": "none located",
+        "official_commit": "none",
+        "license_status": "not applicable",
+        "implementation_source": "paper Fourier feature equation",
+    },
+}
+
+_CONFIGS: Final[Mapping[str, IPMNISTConfig]] = {
+    "cheap_screen": IPMNISTConfig(n_tasks=2, task_length=500),
+    "full_confirmation": IPMNISTConfig(n_tasks=200, task_length=5_000),
+}
+_PLAN_IDS: Final[Mapping[str, str]] = {
+    "cheap_screen": "issue-1566.activation-feature.cheap-screen.v1",
+    "full_confirmation": "issue-1566.activation-feature.full-confirmation.v1",
+}
+_OUTPUT_NAMESPACES: Final[Mapping[str, str]] = {
+    "cheap_screen": "outputs/activation_feature_ipmnist/cheap_screen.v1",
+    "full_confirmation": "outputs/activation_feature_ipmnist/full_confirmation.v1",
+}
+_PRIMARY_CANDIDATES: Final[tuple[str, ...]] = ("smooth_leaky", "aid", "deep_fourier")
+
+# Eight hypotheses share one two-sided family-wise alpha.  The literal is
+# scipy.stats.t.ppf(1 - 0.05 / (2 * 8), df=4), frozen before execution.
+_FAMILYWISE_ALPHA: Final[float] = 0.05
+_COMPARISON_ALPHA: Final[float] = 0.00625
+_T_CRITICAL_DF4_BONFERRONI_8: Final[float] = 5.261057575065803
+
+_COMPARISONS: Final[tuple[tuple[str, str, str], ...]] = (
+    ("smooth_leaky", "smooth_leaky", "smooth_leaky_off"),
+    ("smooth_leaky", "smooth_leaky_fixed_leak", "smooth_leaky_off"),
+    ("aid", "aid", "aid_off"),
+    ("aid", "aid_expected", "aid_off"),
+    ("aid", "ordinary_dropout", "aid_off"),
+    ("deep_fourier", "deep_fourier", "deep_fourier_off"),
+    ("deep_fourier", "deep_fourier_first_layer", "deep_fourier_off"),
+    ("deep_fourier", "deep_fourier_sine_only", "deep_fourier_off"),
+)
+
+_MAX_JSON_DEPTH: Final[int] = 20
+_MAX_JSON_NODES: Final[int] = 200_000
+_MAX_JSON_STRING_BYTES: Final[int] = 64 * 1024
+_MAX_SHARD_BYTES: Final[int] = 4 * 1024 * 1024
+_MAX_AGGREGATE_BYTES: Final[int] = 128 * 1024 * 1024
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+
+_PLAN_FIELDS = frozenset(
+    {
+        "schema",
+        "plan_id",
+        "stage",
+        "matrix",
+        "config",
+        "protocol",
+        "execution_gate",
+        "identity",
+        "statistics",
+        "resources",
+        "paper_parity",
+        "policy",
+        "output_namespace",
+        "plan_sha256",
+    }
+)
+_SHARD_FIELDS = frozenset(
+    {
+        "schema",
+        "plan_id",
+        "plan_sha256",
+        "stage",
+        "arm",
+        "seed",
+        "authorization",
+        "execution_identity",
+        "result",
+        "shard_sha256",
+    }
+)
+_AGGREGATE_FIELDS = frozenset(
+    {
+        "schema",
+        "status",
+        "plan",
+        "plan_sha256",
+        "shards",
+        "prerequisite",
+        "summary",
+        "policy",
+        "aggregate_sha256",
+    }
+)
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _is_sha256(value: object) -> bool:
+    return (
+        type(value) is str
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _exact_object(value: object, fields: frozenset[str], context: str) -> dict[str, object]:
+    if type(value) is not dict:
+        raise ValueError(f"{context} must be an exact object")
+    mapping = cast(dict[object, object], value)
+    if any(type(key) is not str for key in mapping) or set(mapping) != fields:
+        raise ValueError(f"{context} fields differ from the frozen schema")
+    return cast(dict[str, object], mapping)
+
+
+def _json_preflight(value: object) -> None:
+    pending: list[tuple[object, int]] = [(value, 0)]
+    seen: set[int] = set()
+    nodes = 0
+    while pending:
+        current, depth = pending.pop()
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > _MAX_JSON_DEPTH:
+            raise ValueError("campaign JSON exceeds its structure bound")
+        if current is None or type(current) in {bool, int}:
+            continue
+        if type(current) is float:
+            if not math.isfinite(current):
+                raise ValueError("campaign JSON contains a non-finite float")
+            continue
+        if type(current) is str:
+            try:
+                encoded = current.encode("utf-8")
+            except UnicodeEncodeError as error:
+                raise ValueError("campaign JSON contains invalid UTF-8") from error
+            if len(encoded) > _MAX_JSON_STRING_BYTES or "\x00" in current:
+                raise ValueError("campaign JSON contains an invalid string")
+            continue
+        if type(current) not in {dict, list}:
+            raise ValueError("campaign records contain only exact JSON values")
+        identity = id(current)
+        if identity in seen:
+            raise ValueError("campaign JSON contains aliased or cyclic containers")
+        seen.add(identity)
+        if type(current) is dict:
+            mapping = cast(dict[object, object], current)
+            if len(mapping) > 4096 or any(type(key) is not str for key in mapping):
+                raise ValueError("campaign JSON object exceeds its field bound")
+            pending.extend((item, depth + 1) for item in mapping.values())
+        else:
+            sequence = cast(list[object], current)
+            if len(sequence) > 4096:
+                raise ValueError("campaign JSON list exceeds its item bound")
+            pending.extend((item, depth + 1) for item in sequence)
+
+
+def _json_copy(value: object) -> Any:
+    return json.loads(_canonical(value))
+
+
+def _source_identity() -> dict[str, str]:
+    modules = (
+        activation_lane,
+        comparator_lane,
+        screening_lane,
+        ipmnist_lane,
+        sys.modules[__name__],
+    )
+    result: dict[str, str] = {}
+    for module in modules:
+        path_value = getattr(module, "__file__", None)
+        if type(path_value) is not str:
+            raise RuntimeError(f"cannot locate source for {module.__name__}")
+        path = Path(path_value).resolve(strict=True)
+        try:
+            name = path.relative_to(_REPO_ROOT).as_posix()
+        except ValueError as error:
+            raise RuntimeError(f"source for {module.__name__} is outside the project") from error
+        result[name] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return dict(sorted(result.items()))
+
+
+def _runtime_identity() -> dict[str, object]:
+    environment_names = (
+        "JAX_DEFAULT_MATMUL_PRECISION",
+        "JAX_DEFAULT_PRNG_IMPL",
+        "JAX_ENABLE_X64",
+        "JAX_NUM_CPU_DEVICES",
+        "JAX_PLATFORMS",
+        "JAX_PLATFORM_NAME",
+        "JAX_RANDOM_SEED_OFFSET",
+        "XLA_FLAGS",
+    )
+    return {
+        "schema": "asi.activation-feature-ipmnist.runtime.v1",
+        "python": list(sys.version_info[:3]),
+        "python_implementation": platform.python_implementation(),
+        "byteorder": sys.byteorder,
+        "system": platform.system(),
+        "platform_release": platform.release(),
+        "machine": platform.machine(),
+        "packages": {
+            name: importlib.metadata.version(name)
+            for name in ("chex", "jax", "jaxlib", "numpy", "scikit-learn", "scipy")
+        },
+        "backend": jax.default_backend(),
+        "devices": [
+            {
+                "platform": device.platform,
+                "device_kind": device.device_kind,
+                "id": device.id,
+                "process_index": device.process_index,
+            }
+            for device in jax.devices()
+        ],
+        "jax_config": {
+            "jax_default_matmul_precision": str(jax.config.jax_default_matmul_precision),
+            "jax_default_prng_impl": str(jax.config.jax_default_prng_impl),
+            "jax_disable_jit": bool(jax.config.jax_disable_jit),
+            "jax_enable_x64": bool(jax.config.jax_enable_x64),
+            "jax_numpy_dtype_promotion": str(jax.config.jax_numpy_dtype_promotion.value),
+            "jax_numpy_rank_promotion": str(jax.config.jax_numpy_rank_promotion),
+            "jax_random_seed_offset": int(jax.config.jax_random_seed_offset),
+            "jax_threefry_partitionable": bool(jax.config.jax_threefry_partitionable),
+        },
+        "environment": {name: os.environ.get(name) for name in environment_names},
+    }
+
+
+def _validated_arrays(data_x: object, data_y: object) -> tuple[np.ndarray, np.ndarray]:
+    if type(data_x) is not np.ndarray or data_x.dtype != np.dtype(np.float32):
+        raise ValueError("data_x must be an exact float32 NumPy array")
+    if type(data_y) is not np.ndarray or data_y.dtype != np.dtype(np.int32):
+        raise ValueError("data_y must be an exact int32 NumPy array")
+    if (
+        data_x.ndim != 2
+        or data_y.ndim != 1
+        or data_x.shape[0] != data_y.shape[0]
+        or data_x.shape[0] < 5_000
+        or data_x.shape[1] != 784
+    ):
+        raise ValueError("dataset does not match the frozen IPMNIST input contract")
+    if data_x.nbytes + data_y.nbytes > 256 * 1024 * 1024:
+        raise ValueError("dataset exceeds the 256 MiB campaign bound")
+    if not np.isfinite(data_x).all():
+        raise ValueError("data_x must be finite")
+    if np.any(data_y < 0) or np.any(data_y >= 10):
+        raise ValueError("data_y lies outside the frozen ten-class label range")
+    return np.array(data_x, copy=True, order="C"), np.array(data_y, copy=True, order="C")
+
+
+def _dataset_identity(data_x: np.ndarray, data_y: np.ndarray) -> dict[str, object]:
+    return {
+        "schema": "asi.activation-feature-ipmnist.dataset.v1",
+        "provider": "OpenML",
+        "dataset": "mnist_784",
+        "version": 1,
+        "sha256": _array_bundle_sha256(data_x, data_y),
+        "x_shape": list(data_x.shape),
+        "y_shape": list(data_y.shape),
+        "x_dtype": data_x.dtype.str,
+        "y_dtype": data_y.dtype.str,
+        "numeric_bytes": data_x.nbytes + data_y.nbytes,
+    }
+
+
+def _config_payload(config: IPMNISTConfig) -> dict[str, int]:
+    return {
+        name: getattr(config, name)
+        for name in ("n_tasks", "task_length", "input_dim", "hidden1", "hidden2", "n_classes")
+    }
+
+
+def _paper_parity() -> dict[str, object]:
+    return {
+        "sources": {
+            family: dict(source) for family, source in CAMPAIGN_PAPER_SOURCES.items()
+        },
+        "result_v1_source_compatibility_note": (
+            "result-v1 retains its original audited source fields; this campaign registry "
+            "adds the subsequently located official Smooth-Leaky repository without changing "
+            "the result-v1 schema"
+        ),
+        "paper_metric_reported": False,
+        "paper_protocol_parity_claimed": False,
+        "paper_result_reproduction_claimed": False,
+        "cross_method_ranking_claimed": False,
+        "gaps": [
+            "optimizer",
+            "architecture",
+            "batching",
+            "task_schedule",
+            "training_horizon",
+            "reported_metric",
+            "deep_fourier_parameterization",
+        ],
+        "interpretation": (
+            "ASI current-runner causal development controls only; not reproduction of "
+            "the papers' curves and not external state-of-the-art evidence"
+        ),
+    }
+
+
+def _policy(stage: str) -> dict[str, object]:
+    return {
+        "development_only": True,
+        "permanently_nonpromoting": True,
+        "scientific_promotion_allowed": False,
+        "reference_dev_update_allowed": False,
+        "negative_results_retained": True,
+        "timing_is_telemetry_only": True,
+        "execution_attestation": False,
+        "cross_stage_seed_reuse": False,
+        "cross_stage_independent_confirmation_claimed": False,
+        "stage_note": (
+            "full confirmation uses disjoint frozen development seeds but is selected by the "
+            "cheap-screen gate, so it is not independent scientific confirmation"
+            if stage == "full_confirmation"
+            else "cheap development screen; it cannot select scientific evidence"
+        ),
+    }
+
+
+def _matrix(stage: str) -> dict[str, object]:
+    seeds = _SEEDS[stage]
+    return {
+        "arms": list(ARM_ROSTER),
+        "seeds": list(seeds),
+        "shard_count": len(ARM_ROSTER) * len(seeds),
+        "ordering": "seed_major_then_arm_roster",
+        "execution": "one_shard_per_fresh_python_process",
+    }
+
+
+def _statistics(stage: str) -> dict[str, object]:
+    return {
+        "primary_metric": "asi_whole_stream_mean_accuracy",
+        "paired_direction": "candidate_minus_family_mechanism_off",
+        "null_delta": 0.0,
+        "method": "two_sided_paired_student_t",
+        "confidence_family": "simultaneous_bonferroni",
+        "familywise_alpha": _FAMILYWISE_ALPHA,
+        "comparison_count": len(_COMPARISONS),
+        "per_comparison_alpha": _COMPARISON_ALPHA,
+        "degrees_of_freedom": len(_SEEDS[stage]) - 1,
+        "critical_value": _T_CRITICAL_DF4_BONFERRONI_8,
+        "comparisons": [
+            {"family": family, "candidate": candidate, "control": control}
+            for family, candidate, control in _COMPARISONS
+        ],
+        "decision_rule": {
+            "supported": "simultaneous_ci_lower_gt_0",
+            "rejected": "simultaneous_ci_upper_lt_0",
+            "inconclusive": "otherwise",
+        },
+    }
+
+
+def _protocol(stage: str) -> dict[str, object]:
+    return {
+        "runner": "alberta_framework.benchmarks.ipmnist_screening.run_screening_config",
+        "shard_result_schema": (
+            activation_lane.RESULT_SCHEMA
+            if stage == "cheap_screen"
+            else activation_lane.CAMPAIGN_RESULT_SCHEMA
+        ),
+        "matched_axes": [
+            "seed_derived_task_permutations",
+            "seed_derived_example_indices",
+            "observations",
+            "updates",
+            "gradient_evaluations",
+            "model_queries",
+            "allocated_parameter_scalars",
+            "persistent_numeric_bytes",
+            "allowed_boundary_information",
+            "allowed_task_information",
+        ],
+        "allowed_boundary_information": [],
+        "allowed_task_information": ["current_example_label"],
+        "matrix_completion": "all_55_shards_required_without_adaptive_arm_or_seed_dropping",
+        "seed_provenance": (
+            "prospectively frozen result-v1 seeds; no retained real-MNIST activation/feature "
+            "outcome existed at campaign freeze"
+            if stage == "cheap_screen"
+            else "disjoint mechanically allocated result-v2 seeds; no prior activation/feature "
+            "lane use existed at campaign freeze"
+        ),
+        "randomness": (
+            "seed and runtime PRNG implementation are source-bound; campaign records do not "
+            "treat a consistency digest as authenticated execution proof"
+        ),
+    }
+
+
+def _execution_gate(stage: str) -> dict[str, object]:
+    if stage == "cheap_screen":
+        return {
+            "mode": "unconditional_bounded_development_screen",
+            "prerequisite_stage": None,
+            "required_primary_candidates": [],
+            "rule": "plan_and_dataset_validation",
+            "complete_matrix_if_authorized": True,
+        }
+    return {
+        "mode": "conditional_on_retained_cheap_screen",
+        "prerequisite_stage": "cheap_screen",
+        "required_primary_candidates": list(_PRIMARY_CANDIDATES),
+        "rule": "at_least_one_primary_candidate_supported_by_simultaneous_ci",
+        "complete_matrix_if_authorized": True,
+    }
+
+
+def _resource_plan(stage: str, n_train: int) -> dict[str, object]:
+    config = _CONFIGS[stage]
+    steps = config.n_tasks * config.task_length
+    allocated = (
+        config.input_dim * config.hidden1
+        + config.hidden1
+        + config.hidden1 * config.hidden2
+        + config.hidden2
+        + config.hidden2 * config.n_classes
+        + config.n_classes
+    )
+    schedule_bytes = 4 * config.n_tasks * (config.input_dim + n_train)
+    shards = len(ARM_ROSTER) * len(_SEEDS[stage])
+    return {
+        "per_shard": {
+            "data_steps": steps,
+            "environment_steps": 0,
+            "updates": steps,
+            "gradient_evaluations": steps,
+            "model_queries": 2 * steps,
+            "allocated_parameter_scalars": allocated,
+            "persistent_numeric_bytes": 4 * (allocated + 2 * config.input_dim + 1),
+            "peak_schedule_working_bytes": schedule_bytes,
+        },
+        "matrix_totals": {
+            "data_steps": shards * steps,
+            "environment_steps": 0,
+            "updates": shards * steps,
+            "gradient_evaluations": shards * steps,
+            "model_queries": shards * 2 * steps,
+        },
+        "dataset_numeric_bytes_limit": 256 * 1024 * 1024,
+        "schedule_working_bytes_limit_per_shard": 256 * 1024 * 1024,
+        "shard_json_bytes_limit": _MAX_SHARD_BYTES,
+        "aggregate_input_bytes_limit": _MAX_AGGREGATE_BYTES,
+    }
+
+
+def _plan_unsigned(stage: str, dataset: dict[str, object]) -> dict[str, object]:
+    config = _CONFIGS[stage]
+    x_shape = cast(list[object], dataset["x_shape"])
+    return {
+        "schema": PLAN_SCHEMA,
+        "plan_id": _PLAN_IDS[stage],
+        "stage": stage,
+        "matrix": _matrix(stage),
+        "config": _config_payload(config),
+        "protocol": _protocol(stage),
+        "execution_gate": _execution_gate(stage),
+        "identity": {
+            "dataset": copy.deepcopy(dataset),
+            "source_sha256": _source_identity(),
+            "runtime": _runtime_identity(),
+            "consistency_not_execution_attestation": True,
+        },
+        "statistics": _statistics(stage),
+        "resources": _resource_plan(stage, cast(int, x_shape[0])),
+        "paper_parity": _paper_parity(),
+        "policy": _policy(stage),
+        "output_namespace": _OUTPUT_NAMESPACES[stage],
+    }
+
+
+def build_plan(stage: str, data_x: object, data_y: object) -> dict[str, object]:
+    """Build the source-, runtime-, and dataset-bound literal stage plan."""
+    if type(stage) is not str or stage not in STAGE_ROSTER:
+        raise ValueError("stage is outside the frozen campaign roster")
+    x, y = _validated_arrays(data_x, data_y)
+    plan = _plan_unsigned(stage, _dataset_identity(x, y))
+    plan["plan_sha256"] = _digest(plan)
+    validate_plan(plan, data_x=x, data_y=y)
+    return plan
+
+
+def _validated_dataset_identity(value: object) -> dict[str, object]:
+    fields = frozenset(
+        {
+            "schema",
+            "provider",
+            "dataset",
+            "version",
+            "sha256",
+            "x_shape",
+            "y_shape",
+            "x_dtype",
+            "y_dtype",
+            "numeric_bytes",
+        }
+    )
+    dataset = _exact_object(value, fields, "plan.identity.dataset")
+    x_shape = dataset["x_shape"]
+    y_shape = dataset["y_shape"]
+    if (
+        dataset["schema"] != "asi.activation-feature-ipmnist.dataset.v1"
+        or dataset["provider"] != "OpenML"
+        or dataset["dataset"] != "mnist_784"
+        or dataset["version"] != 1
+        or not _is_sha256(dataset["sha256"])
+        or type(x_shape) is not list
+        or len(x_shape) != 2
+        or any(type(item) is not int for item in x_shape)
+        or type(y_shape) is not list
+        or len(y_shape) != 1
+        or any(type(item) is not int for item in y_shape)
+        or dataset["x_dtype"] != np.dtype(np.float32).str
+        or dataset["y_dtype"] != np.dtype(np.int32).str
+    ):
+        raise ValueError("plan dataset identity differs from frozen MNIST")
+    checked_x_shape = cast(list[int], x_shape)
+    checked_y_shape = cast(list[int], y_shape)
+    rows = checked_x_shape[0]
+    if rows < 5_000 or checked_x_shape != [rows, 784] or checked_y_shape != [rows]:
+        raise ValueError("plan dataset row count is invalid")
+    numeric_bytes = dataset["numeric_bytes"]
+    if type(numeric_bytes) is not int or numeric_bytes != rows * (784 + 1) * 4:
+        raise ValueError("plan dataset byte accounting drifted")
+    if numeric_bytes > 256 * 1024 * 1024:
+        raise ValueError("plan dataset exceeds its numeric byte bound")
+    return dataset
+
+
+def validate_plan(
+    value: object, *, data_x: object | None = None, data_y: object | None = None
+) -> dict[str, object]:
+    """Strictly validate one plan against current source/runtime and optional bytes."""
+    _json_preflight(value)
+    plan = _exact_object(value, _PLAN_FIELDS, "plan")
+    if plan["schema"] != PLAN_SCHEMA or type(plan["stage"]) is not str:
+        raise ValueError("unsupported activation/feature campaign plan")
+    stage = plan["stage"]
+    if stage not in STAGE_ROSTER:
+        raise ValueError("plan stage is outside the frozen roster")
+    identity = _exact_object(
+        plan["identity"],
+        frozenset(
+            {
+                "dataset",
+                "source_sha256",
+                "runtime",
+                "consistency_not_execution_attestation",
+            }
+        ),
+        "plan.identity",
+    )
+    dataset = _validated_dataset_identity(identity["dataset"])
+    if (data_x is None) != (data_y is None):
+        raise ValueError("dataset validation requires both data arrays")
+    if data_x is not None and data_y is not None:
+        x, y = _validated_arrays(data_x, data_y)
+        if dataset != _dataset_identity(x, y):
+            raise ValueError("plan does not bind the supplied dataset bytes")
+    expected = _plan_unsigned(stage, dataset)
+    claimed = plan["plan_sha256"]
+    if not _is_sha256(claimed) or claimed != _digest(expected):
+        raise ValueError("plan digest drifted")
+    expected["plan_sha256"] = claimed
+    if plan != expected:
+        raise ValueError("plan differs from the current literal frozen plan")
+    return plan
+
+
+def _config_from_plan(plan: Mapping[str, object]) -> IPMNISTConfig:
+    config = cast(dict[str, object], plan["config"])
+    return IPMNISTConfig(
+        n_tasks=cast(int, config["n_tasks"]),
+        task_length=cast(int, config["task_length"]),
+        input_dim=cast(int, config["input_dim"]),
+        hidden1=cast(int, config["hidden1"]),
+        hidden2=cast(int, config["hidden2"]),
+        n_classes=cast(int, config["n_classes"]),
+    )
+
+
+def _array_tree_sha256(value: object) -> str:
+    digest = hashlib.sha256(b"asi-activation-feature-initial-parameters-v1\0")
+    leaves, structure = jax.tree.flatten(value)
+    digest.update(str(structure).encode("ascii"))
+    for leaf in leaves:
+        host = np.asarray(leaf)
+        digest.update(np.asarray(host.shape, dtype="<i8").tobytes())
+        digest.update(host.dtype.str.encode("ascii"))
+        digest.update(host.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+@functools.lru_cache(maxsize=64)
+def _expected_execution_identity(stage: str, seed: int, n_train: int) -> dict[str, str]:
+    config = _CONFIGS[stage]
+    root = jr.key(np.uint32(seed), impl="threefry2x32")
+    key_init, key_schedule, _ = jr.split(root, 3)
+    parameters = init_mlp_params(key_init, config)
+    schedule = build_schedule(key_schedule, config, n_train)
+    digest = hashlib.sha256(b"asi-activation-feature-schedule-v1\0")
+    for value in (schedule.permutations, schedule.example_indices):
+        host = np.asarray(value, dtype=np.int32)
+        digest.update(np.asarray(host.shape, dtype="<i8").tobytes())
+        digest.update(host.astype("<i4", copy=False).tobytes(order="C"))
+    return {
+        "schedule_sha256": digest.hexdigest(),
+        "initial_parameters_sha256": _array_tree_sha256(parameters),
+        "prng_implementation": "threefry2x32",
+    }
+
+
+def _execution_authorization(
+    plan: Mapping[str, object], prerequisite: object | None
+) -> dict[str, object]:
+    stage = cast(str, plan["stage"])
+    if stage == "cheap_screen":
+        if prerequisite is not None:
+            raise ValueError("cheap screen does not accept a prerequisite aggregate")
+        return {
+            "mode": "unconditional_bounded_development_screen",
+            "prerequisite_aggregate_sha256": None,
+            "supported_primary_candidates": [],
+            "rule_satisfied": True,
+        }
+    if prerequisite is None:
+        raise ValueError("full confirmation requires the retained cheap-screen aggregate")
+    cheap = validate_aggregate(prerequisite)
+    cheap_plan = cast(dict[str, object], cheap["plan"])
+    if cheap_plan["stage"] != "cheap_screen":
+        raise ValueError("full confirmation prerequisite is not a cheap-screen aggregate")
+    plan_identity = cast(dict[str, object], plan["identity"])
+    cheap_identity = cast(dict[str, object], cheap_plan["identity"])
+    if plan_identity != cheap_identity:
+        raise ValueError("full and cheap plans must bind the same dataset, source, and runtime")
+    summary = cast(dict[str, object], cheap["summary"])
+    comparisons = summary["paired_comparisons"]
+    if type(comparisons) is not list:
+        raise ValueError("cheap-screen comparisons are malformed")
+    supported = [
+        cast(str, item["candidate"])
+        for raw_item in comparisons
+        if type(raw_item) is dict
+        for item in [cast(dict[str, object], raw_item)]
+        if item.get("candidate") in _PRIMARY_CANDIDATES and item.get("outcome") == "supported"
+    ]
+    if not supported:
+        raise ValueError("cheap screen did not authorize full confirmation")
+    return {
+        "mode": "conditional_on_retained_cheap_screen",
+        "prerequisite_aggregate_sha256": cheap["aggregate_sha256"],
+        "supported_primary_candidates": supported,
+        "rule_satisfied": True,
+    }
+
+
+def _unsigned_shard(
+    plan: Mapping[str, object],
+    *,
+    arm: str,
+    seed: int,
+    authorization: object,
+    execution_identity: object,
+    result: object,
+) -> dict[str, object]:
+    return {
+        "schema": SHARD_SCHEMA,
+        "plan_id": plan["plan_id"],
+        "plan_sha256": plan["plan_sha256"],
+        "stage": plan["stage"],
+        "arm": arm,
+        "seed": seed,
+        "authorization": _json_copy(authorization),
+        "execution_identity": _json_copy(execution_identity),
+        "result": _json_copy(result),
+    }
+
+
+def build_shard(
+    plan: object,
+    data_x: object,
+    data_y: object,
+    *,
+    arm: str,
+    seed: int,
+    prerequisite: object | None = None,
+) -> dict[str, object]:
+    """Execute one canonical shard; callers provide the fresh process boundary."""
+    checked_plan = validate_plan(plan, data_x=data_x, data_y=data_y)
+    if type(arm) is not str or arm not in ARM_ROSTER:
+        raise ValueError("arm is outside the frozen matrix")
+    stage = cast(str, checked_plan["stage"])
+    seeds = _SEEDS[stage]
+    authorization = _execution_authorization(checked_plan, prerequisite)
+    if type(seed) is not int or seed not in seeds:
+        raise ValueError("seed is outside the frozen matrix")
+    x, y = _validated_arrays(data_x, data_y)
+    execution_identity = _expected_execution_identity(stage, seed, x.shape[0])
+    result = run_activation_feature_arm(
+        x,
+        y,
+        arm=arm,
+        seed=seed,
+        config=_config_from_plan(checked_plan),
+    )
+    receipt = (
+        activation_feature_result_payload(result, outcome="inconclusive")
+        if stage == "cheap_screen"
+        else activation_feature_campaign_result_payload(
+            result, outcome="inconclusive", development_seeds=seeds
+        )
+    )
+    shard = _unsigned_shard(
+        checked_plan,
+        arm=arm,
+        seed=seed,
+        authorization=authorization,
+        execution_identity=execution_identity,
+        result=receipt,
+    )
+    shard["shard_sha256"] = _digest(shard)
+    validate_shard(shard, checked_plan, prerequisite=prerequisite)
+    return shard
+
+
+def validate_shard(
+    value: object, plan: object, *, prerequisite: object | None = None
+) -> dict[str, object]:
+    """Cross-validate one versioned receipt against its exact campaign plan."""
+    checked_plan = validate_plan(plan)
+    expected_authorization = _execution_authorization(checked_plan, prerequisite)
+    return _validate_shard_against_plan(value, checked_plan, expected_authorization)
+
+
+def _validate_shard_against_plan(
+    value: object,
+    checked_plan: dict[str, object],
+    expected_authorization: dict[str, object],
+) -> dict[str, object]:
+    _json_preflight(value)
+    shard = _exact_object(value, _SHARD_FIELDS, "shard")
+    if (
+        shard["schema"] != SHARD_SCHEMA
+        or shard["plan_id"] != checked_plan["plan_id"]
+        or shard["plan_sha256"] != checked_plan["plan_sha256"]
+        or shard["stage"] != checked_plan["stage"]
+    ):
+        raise ValueError("shard belongs to another plan")
+    arm = shard["arm"]
+    seed = shard["seed"]
+    stage = cast(str, checked_plan["stage"])
+    seeds = _SEEDS[stage]
+    if shard["authorization"] != expected_authorization:
+        raise ValueError("shard execution authorization drifted")
+    if type(arm) is not str or arm not in ARM_ROSTER:
+        raise ValueError("shard arm is outside the frozen matrix")
+    if type(seed) is not int or seed not in seeds:
+        raise ValueError("shard seed is outside the frozen matrix")
+    receipt = (
+        validate_activation_feature_result(shard["result"])
+        if stage == "cheap_screen"
+        else validate_activation_feature_campaign_result(
+            shard["result"], development_seeds=seeds
+        )
+    )
+    if receipt["arm"] != arm or receipt["seed"] != seed:
+        raise ValueError("shard wrapper and result identity disagree")
+    if receipt["outcome"] != "inconclusive":
+        raise ValueError("individual shards cannot self-assign campaign outcomes")
+    if receipt["config"] != checked_plan["config"]:
+        raise ValueError("shard config silently shrinks or changes the frozen horizon")
+    identity = cast(dict[str, object], checked_plan["identity"])
+    dataset = cast(dict[str, object], identity["dataset"])
+    execution = cast(dict[str, object], receipt["execution_identity"])
+    if (
+        execution["dataset_sha256"] != dataset["sha256"]
+        or execution["n_train"] != cast(list[object], dataset["x_shape"])[0]
+    ):
+        raise ValueError("shard dataset identity disagrees with the plan")
+    n_train = cast(int, execution["n_train"])
+    expected_execution = _expected_execution_identity(stage, seed, n_train)
+    if shard["execution_identity"] != expected_execution:
+        raise ValueError("shard schedule, initialization, or PRNG identity drifted")
+    if execution["schedule_sha256"] != expected_execution["schedule_sha256"]:
+        raise ValueError("result schedule digest disagrees with the exact Threefry schedule")
+    planned_resources = cast(dict[str, object], checked_plan["resources"])
+    per_shard = cast(dict[str, object], planned_resources["per_shard"])
+    resources = cast(dict[str, object], receipt["resources"])
+    for name, expected in per_shard.items():
+        if resources[name] != expected:
+            raise ValueError(f"shard resource {name} disagrees with the plan")
+    unsigned = dict(shard)
+    claimed = unsigned.pop("shard_sha256")
+    if not _is_sha256(claimed) or claimed != _digest(unsigned):
+        raise ValueError("shard digest drifted")
+    return shard
+
+
+def _paired_summary(
+    by_identity: Mapping[tuple[int, str], dict[str, object]],
+    seeds: tuple[int, ...],
+) -> list[dict[str, object]]:
+    summaries: list[dict[str, object]] = []
+    for family, candidate, control in _COMPARISONS:
+        deltas: list[float] = []
+        candidate_values: list[float] = []
+        control_values: list[float] = []
+        for seed in seeds:
+            candidate_metrics = cast(
+                dict[str, object],
+                cast(dict[str, object], by_identity[(seed, candidate)]["result"])["metrics"],
+            )
+            control_metrics = cast(
+                dict[str, object],
+                cast(dict[str, object], by_identity[(seed, control)]["result"])["metrics"],
+            )
+            candidate_value = cast(float, candidate_metrics["asi_whole_stream_mean_accuracy"])
+            control_value = cast(float, control_metrics["asi_whole_stream_mean_accuracy"])
+            candidate_values.append(candidate_value)
+            control_values.append(control_value)
+            deltas.append(candidate_value - control_value)
+        mean = math.fsum(deltas) / len(deltas)
+        centered = math.fsum((delta - mean) ** 2 for delta in deltas)
+        standard_deviation = math.sqrt(centered / (len(deltas) - 1))
+        standard_error = standard_deviation / math.sqrt(len(deltas))
+        margin = _T_CRITICAL_DF4_BONFERRONI_8 * standard_error
+        lower = mean - margin
+        upper = mean + margin
+        outcome = "supported" if lower > 0.0 else "rejected" if upper < 0.0 else "inconclusive"
+        summaries.append(
+            {
+                "family": family,
+                "candidate": candidate,
+                "control": control,
+                "paired_seed_order": list(seeds),
+                "candidate_values": candidate_values,
+                "control_values": control_values,
+                "paired_deltas": deltas,
+                "mean_delta": mean,
+                "sample_standard_deviation": standard_deviation,
+                "standard_error": standard_error,
+                "simultaneous_ci_lower": lower,
+                "simultaneous_ci_upper": upper,
+                "outcome": outcome,
+            }
+        )
+    return summaries
+
+
+def _arm_summary(
+    by_identity: Mapping[tuple[int, str], dict[str, object]],
+    seeds: tuple[int, ...],
+) -> dict[str, object]:
+    result: dict[str, object] = {}
+    metric_names = (
+        "asi_whole_stream_mean_accuracy",
+        "asi_whole_stream_mean_loss",
+        "asi_whole_stream_mean_plasticity",
+    )
+    for arm in ARM_ROSTER:
+        metrics = [
+            cast(
+                dict[str, object],
+                cast(dict[str, object], by_identity[(seed, arm)]["result"])["metrics"],
+            )
+            for seed in seeds
+        ]
+        result[arm] = {
+            name: math.fsum(cast(float, item[name]) for item in metrics) / len(metrics)
+            for name in metric_names
+        }
+    return result
+
+
+def _resource_summary(shards: Sequence[dict[str, object]]) -> dict[str, object]:
+    sum_fields = (
+        "data_steps",
+        "environment_steps",
+        "updates",
+        "gradient_evaluations",
+        "optimizer_scalar_updates",
+        "model_queries",
+        "random_bernoulli_variates",
+        "activation_scalar_evaluations",
+        "forward_affine_weight_applications",
+        "sigmoid_evaluations",
+        "trigonometric_evaluations",
+    )
+    resources = [
+        cast(dict[str, object], cast(dict[str, object], shard["result"])["resources"])
+        for shard in shards
+    ]
+    return {
+        "totals": {
+            name: sum(cast(int, item[name]) for item in resources) for name in sum_fields
+        },
+        "maximum_per_shard": {
+            name: max(cast(int, item[name]) for item in resources)
+            for name in (
+                "allocated_parameter_scalars",
+                "active_parameter_scalars",
+                "persistent_numeric_bytes",
+                "peak_schedule_working_bytes",
+            )
+        },
+        "timing_seconds_total_telemetry_only": math.fsum(
+            cast(float, item["timing_seconds"]) for item in resources
+        ),
+        "timing_is_telemetry_only": True,
+    }
+
+
+def _unsigned_aggregate(
+    plan: dict[str, object],
+    ordered: Sequence[dict[str, object]],
+    prerequisite: object | None,
+) -> dict[str, object]:
+    seeds = _SEEDS[cast(str, plan["stage"])]
+    by_identity = {
+        (cast(int, shard["seed"]), cast(str, shard["arm"])): shard for shard in ordered
+    }
+    comparisons = _paired_summary(by_identity, seeds)
+    outcomes = [cast(str, item["outcome"]) for item in comparisons]
+    status = (
+        "complete_with_supported_candidates"
+        if "supported" in outcomes
+        else "complete_with_rejections"
+        if "rejected" in outcomes
+        else "complete_inconclusive"
+    )
+    return {
+        "schema": AGGREGATE_SCHEMA,
+        "status": status,
+        "plan": _json_copy(plan),
+        "plan_sha256": plan["plan_sha256"],
+        "shards": [_json_copy(shard) for shard in ordered],
+        "prerequisite": None if prerequisite is None else _json_copy(prerequisite),
+        "summary": {
+            "shard_count": len(ordered),
+            "arm_means": _arm_summary(by_identity, seeds),
+            "paired_comparisons": comparisons,
+            "resources": _resource_summary(ordered),
+        },
+        "policy": _json_copy(plan["policy"]),
+    }
+
+
+def _admit_complete_matrix(
+    checked_plan: dict[str, object], shards: object, prerequisite: object | None
+) -> list[dict[str, object]]:
+    if type(shards) not in {list, tuple}:
+        raise ValueError("aggregate shards must be an exact list or tuple")
+    raw_shards = cast(Sequence[object], shards)
+    stage = cast(str, checked_plan["stage"])
+    seeds = _SEEDS[stage]
+    expected_roster = [(seed, arm) for seed in seeds for arm in ARM_ROSTER]
+    if len(raw_shards) != len(expected_roster):
+        raise ValueError("aggregate requires the complete 11-arm by 5-seed matrix")
+    expected_authorization = _execution_authorization(checked_plan, prerequisite)
+    admitted = [
+        _validate_shard_against_plan(shard, checked_plan, expected_authorization)
+        for shard in raw_shards
+    ]
+    by_identity: dict[tuple[int, str], dict[str, object]] = {}
+    for shard in admitted:
+        identity = (cast(int, shard["seed"]), cast(str, shard["arm"]))
+        if identity in by_identity:
+            raise ValueError("aggregate contains a duplicate shard identity")
+        by_identity[identity] = shard
+    if set(by_identity) != set(expected_roster):
+        raise ValueError("aggregate shard roster is incomplete or unexpected")
+    ordered = [by_identity[identity] for identity in expected_roster]
+    first_result = cast(dict[str, object], ordered[0]["result"])
+    first_execution = cast(dict[str, object], first_result["execution_identity"])
+    for seed in seeds:
+        same_seed = [by_identity[(seed, arm)]["result"] for arm in ARM_ROSTER]
+        if stage == "cheap_screen":
+            validate_matched_activation_feature_results(same_seed)
+        else:
+            validate_matched_activation_feature_campaign_results(
+                same_seed, development_seeds=seeds
+            )
+    for shard in ordered[1:]:
+        receipt = cast(dict[str, object], shard["result"])
+        execution = cast(dict[str, object], receipt["execution_identity"])
+        for name in ("dataset_sha256", "source_sha256", "runtime", "n_train"):
+            if execution[name] != first_execution[name]:
+                raise ValueError(f"aggregate shards disagree on execution identity {name}")
+    return ordered
+
+
+def build_aggregate(
+    plan: object, shards: object, *, prerequisite: object | None = None
+) -> dict[str, object]:
+    """Build an immutable self-contained report from all 55 validated shards."""
+    checked_plan = validate_plan(plan)
+    _execution_authorization(checked_plan, prerequisite)
+    ordered = _admit_complete_matrix(checked_plan, shards, prerequisite)
+    aggregate = _unsigned_aggregate(checked_plan, ordered, prerequisite)
+    aggregate["aggregate_sha256"] = _digest(aggregate)
+    validate_aggregate(aggregate)
+    return aggregate
+
+
+def validate_aggregate(value: object) -> dict[str, object]:
+    """Recompute the exact matrix, statistics, resources, and report digest."""
+    _json_preflight(value)
+    aggregate = _exact_object(value, _AGGREGATE_FIELDS, "aggregate")
+    if aggregate["schema"] != AGGREGATE_SCHEMA:
+        raise ValueError("unsupported activation/feature aggregate")
+    plan = validate_plan(aggregate["plan"])
+    if aggregate["plan_sha256"] != plan["plan_sha256"]:
+        raise ValueError("aggregate plan digest drifted")
+    raw_shards = aggregate["shards"]
+    if type(raw_shards) is not list:
+        raise ValueError("aggregate shards must be an exact list")
+    prerequisite = aggregate["prerequisite"]
+    _execution_authorization(plan, prerequisite)
+    ordered = _admit_complete_matrix(plan, raw_shards, prerequisite)
+    expected = _unsigned_aggregate(plan, ordered, prerequisite)
+    claimed = aggregate["aggregate_sha256"]
+    if not _is_sha256(claimed) or claimed != _digest(expected):
+        raise ValueError("aggregate digest drifted")
+    expected["aggregate_sha256"] = claimed
+    if aggregate != expected:
+        raise ValueError("aggregate statistics, roster, resources, or policy drifted")
+    return aggregate
+
+
+def _reject_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+
+def _object_from_pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key is forbidden: {key}")
+        result[key] = value
+    return result
+
+
+def _load_json_strict_with_metadata(
+    path: Path, *, max_bytes: int
+) -> tuple[dict[str, object], os.stat_result]:
+    """Read one bounded regular file and return its descriptor-pinned metadata."""
+    if type(path) is not type(Path()):
+        raise TypeError("path must be an exact Path")
+    if type(max_bytes) is not int or not 1 <= max_bytes <= _MAX_AGGREGATE_BYTES:
+        raise ValueError("strict JSON byte bound is invalid")
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise ValueError("strict campaign JSON loading requires no-follow file support")
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK,
+        )
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise ValueError("campaign input must be a regular file")
+        if not 0 < opened.st_size <= max_bytes:
+            raise ValueError("campaign input exceeds its byte bound")
+        chunks: list[bytes] = []
+        remaining = max_bytes + 1
+        while remaining > 0:
+            chunk = os.read(descriptor, min(remaining, 1 << 20))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        encoded = b"".join(chunks)
+        if len(encoded) > max_bytes:
+            raise ValueError("campaign input exceeds its byte bound")
+        final = os.fstat(descriptor)
+        stable_fields = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+        if len(encoded) != opened.st_size or any(
+            getattr(opened, name) != getattr(final, name) for name in stable_fields
+        ):
+            raise ValueError("campaign input changed during admission")
+        try:
+            text = encoded.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ValueError("campaign input must be UTF-8 JSON") from error
+        value = json.loads(
+            text,
+            object_pairs_hook=_object_from_pairs,
+            parse_constant=_reject_constant,
+        )
+    except ValueError:
+        raise
+    except (OSError, json.JSONDecodeError, RecursionError) as error:
+        raise ValueError("campaign input is not bounded valid JSON") from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+    if type(value) is not dict:
+        raise ValueError("campaign input root must be an exact object")
+    _json_preflight(value)
+    return cast(dict[str, object], value), final
+
+
+def load_json_strict(path: Path, *, max_bytes: int) -> dict[str, object]:
+    """Read one bounded regular-file JSON object through its pinned descriptor."""
+    value, _ = _load_json_strict_with_metadata(path, max_bytes=max_bytes)
+    return value
+
+
+def _open_output_parent(path: Path, *, create: bool) -> tuple[Path, int]:
+    """Resolve an absolute parent through no-follow directory descriptors."""
+    if type(path) is not type(Path()):
+        raise TypeError("output must be an exact Path")
+    destination = Path(os.path.abspath(os.fspath(path)))
+    if destination.name in {"", ".", ".."}:
+        raise ValueError("output must name a file")
+    if not all(hasattr(os, name) for name in ("O_DIRECTORY", "O_NOFOLLOW")):
+        raise OSError("immutable publication requires Linux no-follow directory support")
+    descriptor = os.open(os.path.sep, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    try:
+        for component in destination.parent.parts[1:]:
+            if component in {"", ".", ".."}:
+                raise ValueError("output path contains an unsafe directory component")
+            if create:
+                try:
+                    os.mkdir(component, mode=0o755, dir_fd=descriptor)
+                except FileExistsError:
+                    pass
+            next_descriptor = os.open(
+                component,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                dir_fd=descriptor,
+            )
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return destination, descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+@contextmanager
+def _reserved_new_output(path: Path) -> Iterator[tuple[Path, int]]:
+    """Pin one unoccupied output parent across execution and publication."""
+    destination, parent_fd = _open_output_parent(path, create=True)
+    try:
+        try:
+            os.stat(destination.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(f"refusing to replace immutable output: {destination}")
+        yield destination, parent_fd
+    finally:
+        os.close(parent_fd)
+
+
+def _link_unnamed_file(file_fd: int, parent_fd: int, name: str) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    linkat = libc.linkat
+    linkat.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+    )
+    linkat.restype = ctypes.c_int
+    if linkat(file_fd, b"", parent_fd, os.fsencode(name), 0x1000) != 0:
+        error = ctypes.get_errno()
+        if error == errno.EEXIST:
+            raise FileExistsError(error, os.strerror(error), name)
+        raise OSError(error, os.strerror(error), name)
+
+
+def _publish_reserved_json(target: tuple[Path, int], value: object) -> Path:
+    destination, parent_fd = target
+    _json_preflight(value)
+    encoded = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        indent=2,
+        sort_keys=True,
+    ).encode("utf-8") + b"\n"
+    if not hasattr(os, "O_TMPFILE"):
+        raise OSError("immutable publication requires Linux O_TMPFILE support")
+    file_fd: int | None = None
+    try:
+        try:
+            os.stat(destination.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(f"refusing to replace immutable output: {destination}")
+        file_fd = os.open(
+            ".",
+            os.O_WRONLY | os.O_CLOEXEC | os.O_TMPFILE,
+            0o600,
+            dir_fd=parent_fd,
+        )
+        view = memoryview(encoded)
+        written = 0
+        while written < len(view):
+            written += os.write(file_fd, view[written:])
+        os.fsync(file_fd)
+        os.fchmod(file_fd, 0o444)
+        try:
+            _link_unnamed_file(file_fd, parent_fd, destination.name)
+        except FileExistsError as error:
+            raise FileExistsError(
+                f"refusing to replace immutable output: {destination}"
+            ) from error
+        os.fsync(parent_fd)
+        return destination
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+
+
+def write_new_json(path: Path, value: object) -> Path:
+    """Publish one create-only JSON file through a descriptor-pinned parent."""
+    with _reserved_new_output(path) as target:
+        return _publish_reserved_json(target, value)
+
+
+def summarize_shard_files(
+    plan: object, paths: Sequence[Path], *, prerequisite: object | None = None
+) -> dict[str, object]:
+    """Admit 55 unique regular shard files and build the complete aggregate."""
+    checked_plan = validate_plan(plan)
+    stage = cast(str, checked_plan["stage"])
+    expected_count = len(ARM_ROSTER) * len(_SEEDS[stage])
+    if len(paths) != expected_count:
+        raise ValueError(f"aggregate requires exactly {expected_count} shard paths")
+    seen_files: set[tuple[int, int]] = set()
+    total_bytes = 0
+    shards: list[dict[str, object]] = []
+    for raw_path in paths:
+        if type(raw_path) is not type(Path()):
+            raise TypeError("shard paths must be exact Paths")
+        shard, metadata = _load_json_strict_with_metadata(
+            raw_path, max_bytes=_MAX_SHARD_BYTES
+        )
+        identity = (metadata.st_dev, metadata.st_ino)
+        if identity in seen_files:
+            raise ValueError("aggregate shard paths must name unique regular files")
+        seen_files.add(identity)
+        total_bytes += metadata.st_size
+        if total_bytes > _MAX_AGGREGATE_BYTES:
+            raise ValueError("aggregate shard inputs exceed their total byte bound")
+        validate_shard(shard, checked_plan, prerequisite=prerequisite)
+        shards.append(shard)
+    return build_aggregate(checked_plan, shards, prerequisite=prerequisite)
+
+
+def _namespace_path(stage: str, *parts: str) -> Path:
+    return _REPO_ROOT / _OUTPUT_NAMESPACES[stage] / Path(*parts)
+
+
+def _load_plan(path: Path, data_x: np.ndarray, data_y: np.ndarray) -> dict[str, object]:
+    return validate_plan(
+        load_json_strict(path, max_bytes=_MAX_SHARD_BYTES), data_x=data_x, data_y=data_y
+    )
+
+
+def _print_json(value: object) -> None:
+    print(json.dumps(value, allow_nan=False, ensure_ascii=True, indent=2, sort_keys=True))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan_parser = subparsers.add_parser("plan", help="write one exact dataset-bound plan")
+    plan_parser.add_argument("--stage", choices=STAGE_ROSTER, required=True)
+    plan_parser.add_argument("--data-home", type=Path, default=default_openml_data_home())
+    plan_parser.add_argument("--output", type=Path)
+
+    shard_parser = subparsers.add_parser(
+        "run-shard", help="execute exactly one canonical shard in this Python process"
+    )
+    shard_parser.add_argument("--stage", choices=STAGE_ROSTER, required=True)
+    shard_parser.add_argument("--plan", type=Path)
+    shard_parser.add_argument("--arm", choices=ARM_ROSTER, required=True)
+    shard_parser.add_argument("--seed", choices=ALL_SEEDS, type=int, required=True)
+    shard_parser.add_argument("--data-home", type=Path, default=default_openml_data_home())
+    shard_parser.add_argument("--cheap-aggregate", type=Path)
+    shard_parser.add_argument("--output", type=Path)
+
+    summarize_parser = subparsers.add_parser(
+        "summarize", help="strictly combine the complete 55-shard matrix"
+    )
+    summarize_parser.add_argument("--stage", choices=STAGE_ROSTER, required=True)
+    summarize_parser.add_argument("--plan", type=Path)
+    summarize_parser.add_argument("--cheap-aggregate", type=Path)
+    summarize_parser.add_argument("--output", type=Path)
+    summarize_parser.add_argument("shards", type=Path, nargs="+")
+
+    validate_parser = subparsers.add_parser("validate", help="validate a plan/shard/aggregate")
+    validate_parser.add_argument("input", type=Path)
+    validate_parser.add_argument("--plan", type=Path)
+    validate_parser.add_argument("--cheap-aggregate", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI for plan publication, fresh-process shards, and atomic reports."""
+    args = _parser().parse_args(argv)
+    if args.command == "plan":
+        output = args.output or _namespace_path(args.stage, "plan.json")
+        with _reserved_new_output(output) as target:
+            x, y = load_mnist_train(args.data_home)
+            plan = build_plan(args.stage, x, y)
+            _publish_reserved_json(target, plan)
+        return 0
+    if args.command == "run-shard":
+        output = args.output or _namespace_path(
+            args.stage, "shards", f"seed-{args.seed}.{args.arm}.json"
+        )
+        with _reserved_new_output(output) as target:
+            x, y = load_mnist_train(args.data_home)
+            plan_path = args.plan or _namespace_path(args.stage, "plan.json")
+            plan = _load_plan(plan_path, x, y)
+            if plan["stage"] != args.stage:
+                raise ValueError("CLI stage and loaded plan disagree")
+            prerequisite = (
+                None
+                if args.cheap_aggregate is None
+                else validate_aggregate(
+                    load_json_strict(args.cheap_aggregate, max_bytes=_MAX_AGGREGATE_BYTES)
+                )
+            )
+            shard = build_shard(
+                plan,
+                x,
+                y,
+                arm=args.arm,
+                seed=args.seed,
+                prerequisite=prerequisite,
+            )
+            _publish_reserved_json(target, shard)
+        return 0
+    if args.command == "summarize":
+        output = args.output or _namespace_path(args.stage, "aggregate.json")
+        with _reserved_new_output(output) as target:
+            plan_path = args.plan or _namespace_path(args.stage, "plan.json")
+            plan = validate_plan(load_json_strict(plan_path, max_bytes=_MAX_SHARD_BYTES))
+            if plan["stage"] != args.stage:
+                raise ValueError("CLI stage and loaded plan disagree")
+            prerequisite = (
+                None
+                if args.cheap_aggregate is None
+                else validate_aggregate(
+                    load_json_strict(args.cheap_aggregate, max_bytes=_MAX_AGGREGATE_BYTES)
+                )
+            )
+            aggregate = summarize_shard_files(
+                plan, args.shards, prerequisite=prerequisite
+            )
+            _publish_reserved_json(target, aggregate)
+        return 0
+    if args.command == "validate":
+        value = load_json_strict(args.input, max_bytes=_MAX_AGGREGATE_BYTES)
+        schema = value.get("schema")
+        if schema == PLAN_SCHEMA:
+            validated: object = validate_plan(value)
+        elif schema == SHARD_SCHEMA:
+            if args.plan is None:
+                raise ValueError("shard validation requires --plan")
+            plan = validate_plan(load_json_strict(args.plan, max_bytes=_MAX_SHARD_BYTES))
+            prerequisite = (
+                None
+                if args.cheap_aggregate is None
+                else validate_aggregate(
+                    load_json_strict(args.cheap_aggregate, max_bytes=_MAX_AGGREGATE_BYTES)
+                )
+            )
+            validated = validate_shard(value, plan, prerequisite=prerequisite)
+        elif schema == AGGREGATE_SCHEMA:
+            validated = validate_aggregate(value)
+        else:
+            raise ValueError("input is not an activation/feature plan, shard, or aggregate")
+        _print_json(
+            {
+                "valid": True,
+                "schema": schema,
+                "sha256": _digest(validated),
+                "permanently_nonpromoting": True,
+            }
+        )
+        return 0
+    raise AssertionError("argparse returned an unknown command")
+
+
+if __name__ == "__main__":  # pragma: no cover - installed entry point
+    raise SystemExit(main())

--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -1,10 +1,11 @@
 """Frozen, sharded, permanently nonpromoting issue #1566 campaigns.
 
-The campaign layer deliberately wraps the result-v1 shard contract instead of
-changing it.  A plan binds one exact dataset and runtime, every arm executes in
-its own CLI process, and aggregation admits only the complete 11-arm by 5-seed
-matrix.  The resulting decisions are development diagnostics, not paper
-reproductions or scientific evidence.
+Cheap-screen shards use the result-v1 schema and its fixed seed protocol;
+full-confirmation shards use result-v2 with their separately frozen seeds. A
+plan binds one exact dataset and runtime, every arm executes in its own CLI
+process, and aggregation admits only the complete 11-arm by 5-seed matrix. The
+resulting decisions are development diagnostics, not paper reproductions or
+scientific evidence.
 """
 
 from __future__ import annotations
@@ -380,11 +381,11 @@ def _paper_parity() -> dict[str, object]:
         "sources": {
             family: dict(source) for family, source in CAMPAIGN_PAPER_SOURCES.items()
         },
-        "result_v1_source_compatibility_note": (
-            "result-v1 retains its original audited source fields; this campaign registry "
-            "adds the subsequently located official Smooth-Leaky repository without changing "
-            "the result-v1 schema"
-        ),
+        "result_schema_semantics": {
+            "cheap_screen": "result-v1 with its fixed seed and source-field contract",
+            "full_confirmation": "result-v2 with the full-confirmation frozen seed contract",
+            "campaign_source_binding": "exact sources in this plan's identity and registry",
+        },
         "paper_metric_reported": False,
         "paper_protocol_parity_claimed": False,
         "paper_result_reproduction_claimed": False,

--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -90,7 +90,7 @@ CAMPAIGN_PAPER_SOURCES: Final[Mapping[str, Mapping[str, str]]] = {
         "official_repository": "none located",
         "official_commit": "none",
         "license_status": "not applicable",
-        "implementation_source": "paper Algorithm 1 and Property 1",
+        "implementation_source": "paper Algorithm 2 simplified element-wise rule",
     },
     "deep_fourier": {
         "publication": "ICLR-2025:NIkfix2eDQ",
@@ -432,7 +432,13 @@ def _policy(stage: str) -> dict[str, object]:
         "permanently_nonpromoting": True,
         "scientific_promotion_allowed": False,
         "reference_dev_update_allowed": False,
-        "negative_results_retained": True,
+        "completed_shard_negative_results_retained": True,
+        "execution_failure_receipts_retained": False,
+        "execution_failure_note": (
+            "an execution failure does not produce a result shard; the failed matrix is "
+            "incomplete and cannot be aggregated, and the external scheduler must retain "
+            "its failure log before any separately authorized retry"
+        ),
         "timing_is_telemetry_only": True,
         "execution_attestation": False,
         "cross_stage_seed_reuse": False,
@@ -558,7 +564,7 @@ def _resource_plan(stage: str, n_train: int) -> dict[str, object]:
             "model_queries": 2 * steps,
             "allocated_parameter_scalars": allocated,
             "persistent_numeric_bytes": 4 * (allocated + 2 * config.input_dim + 1),
-            "peak_schedule_working_bytes": schedule_bytes,
+            "retained_schedule_numeric_bytes": schedule_bytes,
         },
         "matrix_totals": {
             "data_steps": shards * steps,
@@ -1047,7 +1053,7 @@ def _resource_summary(shards: Sequence[dict[str, object]]) -> dict[str, object]:
                 "allocated_parameter_scalars",
                 "active_parameter_scalars",
                 "persistent_numeric_bytes",
-                "peak_schedule_working_bytes",
+                "retained_schedule_numeric_bytes",
             )
         },
         "timing_seconds_total_telemetry_only": math.fsum(

--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -139,6 +139,12 @@ _MAX_JSON_STRING_BYTES: Final[int] = 64 * 1024
 _MAX_SHARD_BYTES: Final[int] = 4 * 1024 * 1024
 _MAX_AGGREGATE_BYTES: Final[int] = 128 * 1024 * 1024
 _REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+_CANONICAL_X_SHAPE: Final[tuple[int, int]] = (60_000, 784)
+_CANONICAL_Y_SHAPE: Final[tuple[int]] = (60_000,)
+_DATASET_MATERIALIZATION: Final[str] = (
+    "OpenML mnist_784 v1 rows 0:60000; float32 pixels scaled by "
+    "(x / 255 - 0.5) / 0.5 and int32 labels"
+)
 
 _PLAN_FIELDS = frozenset(
     {
@@ -332,26 +338,31 @@ def _runtime_identity() -> dict[str, object]:
     }
 
 
+def _canonical_dataset_shapes() -> tuple[tuple[int, int], tuple[int]]:
+    """Return the frozen train-split shapes (overridden only by bounded unit tests)."""
+
+    return _CANONICAL_X_SHAPE, _CANONICAL_Y_SHAPE
+
+
 def _validated_arrays(data_x: object, data_y: object) -> tuple[np.ndarray, np.ndarray]:
     if type(data_x) is not np.ndarray or data_x.dtype != np.dtype(np.float32):
         raise ValueError("data_x must be an exact float32 NumPy array")
     if type(data_y) is not np.ndarray or data_y.dtype != np.dtype(np.int32):
         raise ValueError("data_y must be an exact int32 NumPy array")
-    if (
-        data_x.ndim != 2
-        or data_y.ndim != 1
-        or data_x.shape[0] != data_y.shape[0]
-        or data_x.shape[0] < 5_000
-        or data_x.shape[1] != 784
-    ):
-        raise ValueError("dataset does not match the frozen IPMNIST input contract")
+    expected_x_shape, expected_y_shape = _canonical_dataset_shapes()
+    if data_x.shape != expected_x_shape or data_y.shape != expected_y_shape:
+        raise ValueError("dataset does not match the frozen OpenML MNIST train split")
+    if not data_x.flags.c_contiguous or not data_y.flags.c_contiguous:
+        raise ValueError("dataset arrays must use canonical C-contiguous storage")
     if data_x.nbytes + data_y.nbytes > 256 * 1024 * 1024:
         raise ValueError("dataset exceeds the 256 MiB campaign bound")
     if not np.isfinite(data_x).all():
         raise ValueError("data_x must be finite")
+    if np.any(data_x < -1.0) or np.any(data_x > 1.0):
+        raise ValueError("data_x must use the frozen [-1, 1] scaling")
     if np.any(data_y < 0) or np.any(data_y >= 10):
         raise ValueError("data_y lies outside the frozen ten-class label range")
-    return np.array(data_x, copy=True, order="C"), np.array(data_y, copy=True, order="C")
+    return data_x, data_y
 
 
 def _dataset_identity(data_x: np.ndarray, data_y: np.ndarray) -> dict[str, object]:
@@ -360,7 +371,16 @@ def _dataset_identity(data_x: np.ndarray, data_y: np.ndarray) -> dict[str, objec
         "provider": "OpenML",
         "dataset": "mnist_784",
         "version": 1,
+        "row_start": 0,
+        "row_stop_exclusive": data_x.shape[0],
+        "materialization": _DATASET_MATERIALIZATION,
         "sha256": _array_bundle_sha256(data_x, data_y),
+        "x_sha256": screening_lane._array_bundle_sha256(
+            "alberta.ipmnist_screening.materialized_x.v1", {"x": data_x}
+        ),
+        "y_sha256": screening_lane._array_bundle_sha256(
+            "alberta.ipmnist_screening.materialized_y.v1", {"y": data_y}
+        ),
         "x_shape": list(data_x.shape),
         "y_shape": list(data_y.shape),
         "x_dtype": data_x.dtype.str,
@@ -597,7 +617,12 @@ def _validated_dataset_identity(value: object) -> dict[str, object]:
             "provider",
             "dataset",
             "version",
+            "row_start",
+            "row_stop_exclusive",
+            "materialization",
             "sha256",
+            "x_sha256",
+            "y_sha256",
             "x_shape",
             "y_shape",
             "x_dtype",
@@ -613,7 +638,11 @@ def _validated_dataset_identity(value: object) -> dict[str, object]:
         or dataset["provider"] != "OpenML"
         or dataset["dataset"] != "mnist_784"
         or dataset["version"] != 1
+        or dataset["row_start"] != 0
+        or dataset["materialization"] != _DATASET_MATERIALIZATION
         or not _is_sha256(dataset["sha256"])
+        or not _is_sha256(dataset["x_sha256"])
+        or not _is_sha256(dataset["y_sha256"])
         or type(x_shape) is not list
         or len(x_shape) != 2
         or any(type(item) is not int for item in x_shape)
@@ -626,8 +655,13 @@ def _validated_dataset_identity(value: object) -> dict[str, object]:
         raise ValueError("plan dataset identity differs from frozen MNIST")
     checked_x_shape = cast(list[int], x_shape)
     checked_y_shape = cast(list[int], y_shape)
-    rows = checked_x_shape[0]
-    if rows < 5_000 or checked_x_shape != [rows, 784] or checked_y_shape != [rows]:
+    expected_x_shape, expected_y_shape = _canonical_dataset_shapes()
+    rows = expected_x_shape[0]
+    if (
+        checked_x_shape != list(expected_x_shape)
+        or checked_y_shape != list(expected_y_shape)
+        or dataset["row_stop_exclusive"] != rows
+    ):
         raise ValueError("plan dataset row count is invalid")
     numeric_bytes = dataset["numeric_bytes"]
     if type(numeric_bytes) is not int or numeric_bytes != rows * (784 + 1) * 4:
@@ -805,6 +839,7 @@ def build_shard(
     if type(seed) is not int or seed not in seeds:
         raise ValueError("seed is outside the frozen matrix")
     x, y = _validated_arrays(data_x, data_y)
+    dataset_identity = _dataset_identity(x, y)
     execution_identity = _expected_execution_identity(stage, seed, x.shape[0])
     result = run_activation_feature_arm(
         x,
@@ -820,6 +855,8 @@ def build_shard(
             result, outcome="inconclusive", development_seeds=seeds
         )
     )
+    if result.dataset_sha256 != dataset_identity["sha256"]:
+        raise RuntimeError("dataset identity changed during shard execution")
     shard = _unsigned_shard(
         checked_plan,
         arm=arm,

--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -1,10 +1,11 @@
 """Frozen, sharded, permanently nonpromoting issue #1566 campaigns.
 
-Cheap-screen shards use the result-v1 schema and its fixed seed protocol;
-full-confirmation shards use result-v2 with their separately frozen seeds. A
-plan binds one exact dataset and runtime, every arm executes in its own CLI
-process, and aggregation admits only the complete 11-arm by 5-seed matrix. The
-resulting decisions are development diagnostics, not paper reproductions or
+Both stages use result-v2 with separately frozen external seed protocols. The
+earlier public result-v1 and preauthorization rosters are quarantined. A plan
+binds one exact dataset and runtime, every arm eventually executes in its own
+CLI process, and aggregation admits only the complete 11-arm by 5-seed matrix.
+Execution is disabled until a separate reviewed authorization transition. The
+resulting decisions remain development diagnostics, not paper reproductions or
 scientific evidence.
 """
 
@@ -23,7 +24,7 @@ import os
 import platform
 import stat
 import sys
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Final, cast
@@ -38,15 +39,11 @@ import alberta_framework.benchmarks.plasticity_comparators as comparator_lane
 import alberta_framework.benchmarks.upgd_ipmnist as ipmnist_lane
 from alberta_framework.benchmarks.activation_feature_ipmnist import (
     ACTIVATION_FEATURE_SPECS,
-    DEVELOPMENT_SEEDS,
     _array_bundle_sha256,
     activation_feature_campaign_result_payload,
-    activation_feature_result_payload,
     run_activation_feature_arm,
     validate_activation_feature_campaign_result,
-    validate_activation_feature_result,
     validate_matched_activation_feature_campaign_results,
-    validate_matched_activation_feature_results,
 )
 from alberta_framework.benchmarks.upgd_ipmnist import (
     IPMNISTConfig,
@@ -56,19 +53,33 @@ from alberta_framework.benchmarks.upgd_ipmnist import (
     load_mnist_train,
 )
 
-PLAN_SCHEMA: Final[str] = "asi.activation-feature-ipmnist.campaign-plan.v1"
-SHARD_SCHEMA: Final[str] = "asi.activation-feature-ipmnist.campaign-shard.v1"
-AGGREGATE_SCHEMA: Final[str] = "asi.activation-feature-ipmnist.campaign-aggregate.v1"
+PLAN_SCHEMA: Final[str] = "asi.activation-feature-ipmnist.campaign-plan.v2"
+SHARD_SCHEMA: Final[str] = "asi.activation-feature-ipmnist.campaign-shard.v2"
+AGGREGATE_SCHEMA: Final[str] = "asi.activation-feature-ipmnist.campaign-aggregate.v2"
 
 ARM_ROSTER: Final[tuple[str, ...]] = tuple(ACTIVATION_FEATURE_SPECS)
 STAGE_ROSTER: Final[tuple[str, ...]] = ("cheap_screen", "full_confirmation")
-CHEAP_SCREEN_SEEDS: Final[tuple[int, ...]] = DEVELOPMENT_SEEDS
-FULL_CONFIRMATION_SEEDS: Final[tuple[int, ...]] = (
+QUARANTINED_CHEAP_SEEDS: Final[tuple[int, ...]] = (0, 1, 2, 3, 4)
+QUARANTINED_FULL_SEEDS: Final[tuple[int, ...]] = (
     156_610,
     156_611,
     156_612,
     156_613,
     156_614,
+)
+CHEAP_SCREEN_SEEDS: Final[tuple[int, ...]] = (
+    2_156_600,
+    2_156_601,
+    2_156_602,
+    2_156_603,
+    2_156_604,
+)
+FULL_CONFIRMATION_SEEDS: Final[tuple[int, ...]] = (
+    2_156_610,
+    2_156_611,
+    2_156_612,
+    2_156_613,
+    2_156_614,
 )
 _SEEDS: Final[Mapping[str, tuple[int, ...]]] = {
     "cheap_screen": CHEAP_SCREEN_SEEDS,
@@ -107,13 +118,15 @@ _CONFIGS: Final[Mapping[str, IPMNISTConfig]] = {
     "full_confirmation": IPMNISTConfig(n_tasks=200, task_length=5_000),
 }
 _PLAN_IDS: Final[Mapping[str, str]] = {
-    "cheap_screen": "issue-1566.activation-feature.cheap-screen.v1",
-    "full_confirmation": "issue-1566.activation-feature.full-confirmation.v1",
+    "cheap_screen": "issue-1566.activation-feature.cheap-screen.v2",
+    "full_confirmation": "issue-1566.activation-feature.full-confirmation.v2",
 }
 _OUTPUT_NAMESPACES: Final[Mapping[str, str]] = {
-    "cheap_screen": "outputs/activation_feature_ipmnist/cheap_screen.v1",
-    "full_confirmation": "outputs/activation_feature_ipmnist/full_confirmation.v1",
+    "cheap_screen": "outputs/activation_feature_ipmnist/cheap_screen.v2",
+    "full_confirmation": "outputs/activation_feature_ipmnist/full_confirmation.v2",
 }
+_EXECUTION_AUTHORIZED: Final[bool] = False
+_EXECUTION_CAPABILITY: Final[object] = object()
 _PRIMARY_CANDIDATES: Final[tuple[str, ...]] = ("smooth_leaky", "aid", "deep_fourier")
 
 # Eight hypotheses share one two-sided family-wise alpha.  The literal is
@@ -402,8 +415,8 @@ def _paper_parity() -> dict[str, object]:
             family: dict(source) for family, source in CAMPAIGN_PAPER_SOURCES.items()
         },
         "result_schema_semantics": {
-            "cheap_screen": "result-v1 with its fixed seed and source-field contract",
-            "full_confirmation": "result-v2 with the full-confirmation frozen seed contract",
+            "cheap_screen": "result-v2 with an external frozen seed contract",
+            "full_confirmation": "result-v2 with an external frozen seed contract",
             "campaign_source_binding": "exact sources in this plan's identity and registry",
         },
         "paper_metric_reported": False,
@@ -490,11 +503,7 @@ def _statistics(stage: str) -> dict[str, object]:
 def _protocol(stage: str) -> dict[str, object]:
     return {
         "runner": "alberta_framework.benchmarks.ipmnist_screening.run_screening_config",
-        "shard_result_schema": (
-            activation_lane.RESULT_SCHEMA
-            if stage == "cheap_screen"
-            else activation_lane.CAMPAIGN_RESULT_SCHEMA
-        ),
+        "shard_result_schema": activation_lane.CAMPAIGN_RESULT_SCHEMA,
         "matched_axes": [
             "seed_derived_task_permutations",
             "seed_derived_example_indices",
@@ -511,11 +520,16 @@ def _protocol(stage: str) -> dict[str, object]:
         "allowed_task_information": ["current_example_label"],
         "matrix_completion": "all_55_shards_required_without_adaptive_arm_or_seed_dropping",
         "seed_provenance": (
-            "prospectively frozen result-v1 seeds; no retained real-MNIST activation/feature "
-            "outcome existed at campaign freeze"
-            if stage == "cheap_screen"
-            else "disjoint mechanically allocated result-v2 seeds; no prior activation/feature "
-            "lane use existed at campaign freeze"
+            "globally searched replacement result-v2 roster frozen before authorization; "
+            "no execution is authorized by this plan"
+        ),
+        "quarantined_seed_rosters": {
+            "public_result_v1_and_tests": list(QUARANTINED_CHEAP_SEEDS),
+            "preauthorization_pull_request_and_tests": list(QUARANTINED_FULL_SEEDS),
+        },
+        "quarantine_reason": (
+            "the old rosters were publicly exposed and exercised in repository or pull-request "
+            "history, so neither roster is represented as fresh"
         ),
         "randomness": (
             "seed and runtime PRNG implementation are source-bound; campaign records do not "
@@ -532,6 +546,8 @@ def _execution_gate(stage: str) -> dict[str, object]:
             "required_primary_candidates": [],
             "rule": "plan_and_dataset_validation",
             "complete_matrix_if_authorized": True,
+            "execution_authorized": False,
+            "authorization_transition": "separate_reviewed_source_change_required",
         }
     return {
         "mode": "conditional_on_retained_cheap_screen",
@@ -539,6 +555,8 @@ def _execution_gate(stage: str) -> dict[str, object]:
         "required_primary_candidates": list(_PRIMARY_CANDIDATES),
         "rule": "at_least_one_primary_candidate_supported_by_simultaneous_ci",
         "complete_matrix_if_authorized": True,
+        "execution_authorized": False,
+        "authorization_transition": "separate_reviewed_source_change_required",
     }
 
 
@@ -826,6 +844,14 @@ def _unsigned_shard(
     }
 
 
+def _require_execution_authorized() -> None:
+    if _EXECUTION_AUTHORIZED is not True:
+        raise RuntimeError(
+            "activation/feature campaign execution is not authorized; a separate reviewed "
+            "authorization transition is required"
+        )
+
+
 def build_shard(
     plan: object,
     data_x: object,
@@ -835,7 +861,32 @@ def build_shard(
     seed: int,
     prerequisite: object | None = None,
 ) -> dict[str, object]:
-    """Execute one canonical shard; callers provide the fresh process boundary."""
+    """Fail closed until a separate reviewed transition authorizes execution."""
+    _require_execution_authorized()
+    return _build_shard_authorized(
+        plan,
+        data_x,
+        data_y,
+        arm=arm,
+        seed=seed,
+        prerequisite=prerequisite,
+        _capability=_EXECUTION_CAPABILITY,
+    )
+
+
+def _build_shard_authorized(
+    plan: object,
+    data_x: object,
+    data_y: object,
+    *,
+    arm: str,
+    seed: int,
+    prerequisite: object | None = None,
+    _capability: object,
+) -> dict[str, object]:
+    """Private executor reachable only behind the reviewed public gate."""
+    if _capability is not _EXECUTION_CAPABILITY:
+        raise RuntimeError("private campaign execution capability is invalid")
     checked_plan = validate_plan(plan, data_x=data_x, data_y=data_y)
     if type(arm) is not str or arm not in ARM_ROSTER:
         raise ValueError("arm is outside the frozen matrix")
@@ -854,12 +905,8 @@ def build_shard(
         seed=seed,
         config=_config_from_plan(checked_plan),
     )
-    receipt = (
-        activation_feature_result_payload(result, outcome="inconclusive")
-        if stage == "cheap_screen"
-        else activation_feature_campaign_result_payload(
-            result, outcome="inconclusive", development_seeds=seeds
-        )
+    receipt = activation_feature_campaign_result_payload(
+        result, outcome="inconclusive", development_seeds=seeds
     )
     if result.dataset_sha256 != dataset_identity["sha256"]:
         raise RuntimeError("dataset identity changed during shard execution")
@@ -909,12 +956,8 @@ def _validate_shard_against_plan(
         raise ValueError("shard arm is outside the frozen matrix")
     if type(seed) is not int or seed not in seeds:
         raise ValueError("shard seed is outside the frozen matrix")
-    receipt = (
-        validate_activation_feature_result(shard["result"])
-        if stage == "cheap_screen"
-        else validate_activation_feature_campaign_result(
-            shard["result"], development_seeds=seeds
-        )
+    receipt = validate_activation_feature_campaign_result(
+        shard["result"], development_seeds=seeds
     )
     if receipt["arm"] != arm or receipt["seed"] != seed:
         raise ValueError("shard wrapper and result identity disagree")
@@ -1127,12 +1170,9 @@ def _admit_complete_matrix(
     first_execution = cast(dict[str, object], first_result["execution_identity"])
     for seed in seeds:
         same_seed = [by_identity[(seed, arm)]["result"] for arm in ARM_ROSTER]
-        if stage == "cheap_screen":
-            validate_matched_activation_feature_results(same_seed)
-        else:
-            validate_matched_activation_feature_campaign_results(
-                same_seed, development_seeds=seeds
-            )
+        validate_matched_activation_feature_campaign_results(
+            same_seed, development_seeds=seeds
+        )
     for shard in ordered[1:]:
         receipt = cast(dict[str, object], shard["result"])
         execution = cast(dict[str, object], receipt["execution_identity"])
@@ -1274,10 +1314,14 @@ def _open_output_parent(path: Path, *, create: bool) -> tuple[Path, int]:
             if component in {"", ".", ".."}:
                 raise ValueError("output path contains an unsafe directory component")
             if create:
+                created = False
                 try:
                     os.mkdir(component, mode=0o755, dir_fd=descriptor)
+                    created = True
                 except FileExistsError:
                     pass
+                if created:
+                    os.fsync(descriptor)
             next_descriptor = os.open(
                 component,
                 os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
@@ -1292,9 +1336,13 @@ def _open_output_parent(path: Path, *, create: bool) -> tuple[Path, int]:
 
 
 @contextmanager
-def _reserved_new_output(path: Path) -> Iterator[tuple[Path, int]]:
-    """Pin one unoccupied output parent across execution and publication."""
+def _reserved_new_output(path: Path) -> Iterator[tuple[Path, int, str]]:
+    """Pin and exclusively reserve one output before any expensive work."""
     destination, parent_fd = _open_output_parent(path, create=True)
+    reservation_name = f".{destination.name}.reservation"
+    reservation_fd: int | None = None
+    reservation_acquired = False
+    reservation_identity: tuple[int, int] | None = None
     try:
         try:
             os.stat(destination.name, dir_fd=parent_fd, follow_symlinks=False)
@@ -1302,8 +1350,45 @@ def _reserved_new_output(path: Path) -> Iterator[tuple[Path, int]]:
             pass
         else:
             raise FileExistsError(f"refusing to replace immutable output: {destination}")
-        yield destination, parent_fd
+        try:
+            reservation_fd = os.open(
+                reservation_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+                0o400,
+                dir_fd=parent_fd,
+            )
+        except FileExistsError as error:
+            raise FileExistsError(f"output is already reserved: {destination}") from error
+        reservation_acquired = True
+        marker = b"asi-activation-feature-campaign-output-reservation-v1\n"
+        marker_view = memoryview(marker)
+        marker_written = 0
+        while marker_written < len(marker_view):
+            count = os.write(reservation_fd, marker_view[marker_written:])
+            if count <= 0:
+                raise OSError("short write while reserving campaign output")
+            marker_written += count
+        os.fsync(reservation_fd)
+        marker_stat = os.fstat(reservation_fd)
+        reservation_identity = (marker_stat.st_dev, marker_stat.st_ino)
+        os.close(reservation_fd)
+        reservation_fd = None
+        os.fsync(parent_fd)
+        yield destination, parent_fd, reservation_name
     finally:
+        if reservation_fd is not None:
+            os.close(reservation_fd)
+        if reservation_acquired:
+            try:
+                current_marker = os.stat(
+                    reservation_name, dir_fd=parent_fd, follow_symlinks=False
+                )
+            except FileNotFoundError:
+                pass
+            else:
+                if (current_marker.st_dev, current_marker.st_ino) == reservation_identity:
+                    os.unlink(reservation_name, dir_fd=parent_fd)
+            os.fsync(parent_fd)
         os.close(parent_fd)
 
 
@@ -1325,9 +1410,80 @@ def _link_unnamed_file(file_fd: int, parent_fd: int, name: str) -> None:
         raise OSError(error, os.strerror(error), name)
 
 
-def _publish_reserved_json(target: tuple[Path, int], value: object) -> Path:
-    destination, parent_fd = target
+def _load_json_strict_at(
+    parent_fd: int, name: str, *, max_bytes: int
+) -> tuple[dict[str, object], bytes]:
+    descriptor = os.open(
+        name, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=parent_fd
+    )
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or not 0 < opened.st_size <= max_bytes:
+            raise ValueError("published campaign output is not a bounded regular file")
+        chunks: list[bytes] = []
+        remaining = max_bytes + 1
+        while remaining > 0:
+            chunk = os.read(descriptor, min(remaining, 1 << 20))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        encoded = b"".join(chunks)
+        final = os.fstat(descriptor)
+        stable_fields = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+        if (
+            len(encoded) != opened.st_size
+            or len(encoded) > max_bytes
+            or any(getattr(opened, field) != getattr(final, field) for field in stable_fields)
+        ):
+            raise ValueError("published campaign output changed during strict reread")
+        try:
+            value = json.loads(
+                encoded.decode("utf-8"),
+                object_pairs_hook=_object_from_pairs,
+                parse_constant=_reject_constant,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
+            raise ValueError("published campaign output is not bounded valid JSON") from error
+        if type(value) is not dict:
+            raise ValueError("published campaign output root must be an exact object")
+        _json_preflight(value)
+        return cast(dict[str, object], value), encoded
+    finally:
+        os.close(descriptor)
+
+
+def _publication_validator(
+    value: dict[str, object],
+) -> tuple[Callable[[object], dict[str, object]], int]:
+    schema = value.get("schema")
+    if type(schema) is not str:
+        raise ValueError("published campaign output schema must be an exact string")
+    if schema == PLAN_SCHEMA:
+        return validate_plan, _MAX_SHARD_BYTES
+    if schema == AGGREGATE_SCHEMA:
+        return validate_aggregate, _MAX_AGGREGATE_BYTES
+    raise ValueError("shard publication requires its plan-bound strict validator")
+
+
+def _publish_reserved_json(
+    target: tuple[Path, int, str],
+    value: object,
+    *,
+    validator: Callable[[object], dict[str, object]] | None = None,
+    max_bytes: int | None = None,
+) -> Path:
+    destination, parent_fd, _reservation_name = target
     _json_preflight(value)
+    checked_value = cast(dict[str, object], value)
+    if validator is None:
+        validator, inferred_max_bytes = _publication_validator(checked_value)
+        max_bytes = inferred_max_bytes
+    if type(max_bytes) is not int or max_bytes <= 0:
+        raise ValueError("publication requires an exact positive byte bound")
+    validated_input = validator(checked_value)
+    if _canonical(validated_input) != _canonical(checked_value):
+        raise ValueError("publication validator changed the campaign output")
     encoded = json.dumps(
         value,
         allow_nan=False,
@@ -1335,6 +1491,8 @@ def _publish_reserved_json(target: tuple[Path, int], value: object) -> Path:
         indent=2,
         sort_keys=True,
     ).encode("utf-8") + b"\n"
+    if not 0 < len(encoded) <= max_bytes:
+        raise ValueError("campaign output exceeds its publication byte bound")
     if not hasattr(os, "O_TMPFILE"):
         raise OSError("immutable publication requires Linux O_TMPFILE support")
     file_fd: int | None = None
@@ -1364,6 +1522,12 @@ def _publish_reserved_json(target: tuple[Path, int], value: object) -> Path:
                 f"refusing to replace immutable output: {destination}"
             ) from error
         os.fsync(parent_fd)
+        reread, reread_bytes = _load_json_strict_at(
+            parent_fd, destination.name, max_bytes=max_bytes
+        )
+        validated = validator(reread)
+        if reread_bytes != encoded or _canonical(validated) != _canonical(checked_value):
+            raise ValueError("published campaign output differs after strict reread")
         return destination
     finally:
         if file_fd is not None:
@@ -1467,6 +1631,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             _publish_reserved_json(target, plan)
         return 0
     if args.command == "run-shard":
+        _require_execution_authorized()
         output = args.output or _namespace_path(
             args.stage, "shards", f"seed-{args.seed}.{args.arm}.json"
         )
@@ -1483,15 +1648,23 @@ def main(argv: Sequence[str] | None = None) -> int:
                     load_json_strict(args.cheap_aggregate, max_bytes=_MAX_AGGREGATE_BYTES)
                 )
             )
-            shard = build_shard(
+            shard = _build_shard_authorized(
                 plan,
                 x,
                 y,
                 arm=args.arm,
                 seed=args.seed,
                 prerequisite=prerequisite,
+                _capability=_EXECUTION_CAPABILITY,
             )
-            _publish_reserved_json(target, shard)
+            _publish_reserved_json(
+                target,
+                shard,
+                validator=lambda value: validate_shard(
+                    value, plan, prerequisite=prerequisite
+                ),
+                max_bytes=_MAX_SHARD_BYTES,
+            )
         return 0
     if args.command == "summarize":
         output = args.output or _namespace_path(args.stage, "aggregate.json")

--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -630,7 +630,7 @@ def _resource_plan(stage: str, n_train: int) -> dict[str, object]:
             "model_queries": shards * 2 * steps,
         },
         "dataset_numeric_bytes_limit": 256 * 1024 * 1024,
-        "schedule_working_bytes_limit_per_shard": 256 * 1024 * 1024,
+        "retained_schedule_numeric_bytes_limit_per_shard": 256 * 1024 * 1024,
         "shard_json_bytes_limit": _MAX_SHARD_BYTES,
         "aggregate_input_bytes_limit": _MAX_AGGREGATE_BYTES,
     }
@@ -950,6 +950,7 @@ def _build_shard_authorized(
     _capability: object,
 ) -> dict[str, object]:
     """Private executor reachable only behind the reviewed public gate."""
+    _require_execution_authorized()
     if _capability is not _EXECUTION_CAPABILITY:
         raise RuntimeError("private campaign execution capability is invalid")
     checked_plan = validate_plan(plan, data_x=data_x, data_y=data_y)
@@ -1416,6 +1417,7 @@ def _open_output_parent(path: Path, *, create: bool) -> tuple[Path, int]:
 @contextmanager
 def _reserved_new_output(path: Path) -> Iterator[tuple[Path, int, str]]:
     """Pin and exclusively reserve one output before any expensive work."""
+    _require_execution_authorized()
     destination, parent_fd = _open_output_parent(path, create=True)
     reservation_name = f".{destination.name}.reservation"
     reservation_fd: int | None = None
@@ -1558,6 +1560,7 @@ def _publish_reserved_json(
     validator: Callable[[object], dict[str, object]] | None = None,
     max_bytes: int | None = None,
 ) -> Path:
+    _require_execution_authorized()
     destination, parent_fd, _reservation_name = target
     _json_preflight(value)
     checked_value = cast(dict[str, object], value)

--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -1712,6 +1712,8 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """CLI for plan publication, fresh-process shards, and atomic reports."""
     args = _parser().parse_args(argv)
+    if args.command != "validate":
+        _require_execution_authorized()
     if args.command == "plan":
         output = args.output or _namespace_path(args.stage, "plan.json")
         with _reserved_new_output(output) as target:
@@ -1720,7 +1722,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             _publish_reserved_json(target, plan)
         return 0
     if args.command == "run-shard":
-        _require_execution_authorized()
         output = args.output or _namespace_path(
             args.stage, "shards", f"seed-{args.seed}.{args.arm}.json"
         )

--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -1250,8 +1250,8 @@ def _load_json_strict_with_metadata(
             os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK,
         )
         opened = os.fstat(descriptor)
-        if not stat.S_ISREG(opened.st_mode):
-            raise ValueError("campaign input must be a regular file")
+        if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
+            raise ValueError("campaign input must be a uniquely linked regular file")
         if not 0 < opened.st_size <= max_bytes:
             raise ValueError("campaign input exceeds its byte bound")
         chunks: list[bytes] = []
@@ -1267,8 +1267,10 @@ def _load_json_strict_with_metadata(
             raise ValueError("campaign input exceeds its byte bound")
         final = os.fstat(descriptor)
         stable_fields = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
-        if len(encoded) != opened.st_size or any(
-            getattr(opened, name) != getattr(final, name) for name in stable_fields
+        if (
+            final.st_nlink != 1
+            or len(encoded) != opened.st_size
+            or any(getattr(opened, name) != getattr(final, name) for name in stable_fields)
         ):
             raise ValueError("campaign input changed during admission")
         try:
@@ -1418,8 +1420,12 @@ def _load_json_strict_at(
     )
     try:
         opened = os.fstat(descriptor)
-        if not stat.S_ISREG(opened.st_mode) or not 0 < opened.st_size <= max_bytes:
-            raise ValueError("published campaign output is not a bounded regular file")
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or not 0 < opened.st_size <= max_bytes
+        ):
+            raise ValueError("published campaign output is not a bounded unique regular file")
         chunks: list[bytes] = []
         remaining = max_bytes + 1
         while remaining > 0:
@@ -1432,7 +1438,8 @@ def _load_json_strict_at(
         final = os.fstat(descriptor)
         stable_fields = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
         if (
-            len(encoded) != opened.st_size
+            final.st_nlink != 1
+            or len(encoded) != opened.st_size
             or len(encoded) > max_bytes
             or any(getattr(opened, field) != getattr(final, field) for field in stable_fields)
         ):

--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -67,19 +67,33 @@ QUARANTINED_FULL_SEEDS: Final[tuple[int, ...]] = (
     156_613,
     156_614,
 )
-CHEAP_SCREEN_SEEDS: Final[tuple[int, ...]] = (
+QUARANTINED_REPLACEMENT_CHEAP_SEEDS: Final[tuple[int, ...]] = (
     2_156_600,
     2_156_601,
     2_156_602,
     2_156_603,
     2_156_604,
 )
-FULL_CONFIRMATION_SEEDS: Final[tuple[int, ...]] = (
+QUARANTINED_REPLACEMENT_FULL_SEEDS: Final[tuple[int, ...]] = (
     2_156_610,
     2_156_611,
     2_156_612,
     2_156_613,
     2_156_614,
+)
+CHEAP_SCREEN_SEEDS: Final[tuple[int, ...]] = (
+    3_975_019_531,
+    3_975_019_532,
+    3_975_019_533,
+    3_975_019_534,
+    3_975_019_535,
+)
+FULL_CONFIRMATION_SEEDS: Final[tuple[int, ...]] = (
+    2_924_933_221,
+    2_924_933_222,
+    2_924_933_223,
+    2_924_933_224,
+    2_924_933_225,
 )
 _SEEDS: Final[Mapping[str, tuple[int, ...]]] = {
     "cheap_screen": CHEAP_SCREEN_SEEDS,
@@ -154,6 +168,12 @@ _MAX_AGGREGATE_BYTES: Final[int] = 128 * 1024 * 1024
 _REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
 _CANONICAL_X_SHAPE: Final[tuple[int, int]] = (60_000, 784)
 _CANONICAL_Y_SHAPE: Final[tuple[int]] = (60_000,)
+_CANONICAL_X_SHA256: Final[str] = (
+    "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313"
+)
+_CANONICAL_Y_SHA256: Final[str] = (
+    "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a"
+)
 _DATASET_MATERIALIZATION: Final[str] = (
     "OpenML mnist_784 v1 rows 0:60000; float32 pixels scaled by "
     "(x / 255 - 0.5) / 0.5 and int32 labels"
@@ -357,6 +377,12 @@ def _canonical_dataset_shapes() -> tuple[tuple[int, int], tuple[int]]:
     return _CANONICAL_X_SHAPE, _CANONICAL_Y_SHAPE
 
 
+def _canonical_dataset_hashes() -> tuple[str, str]:
+    """Return the frozen canonical materialized-array identities."""
+
+    return _CANONICAL_X_SHA256, _CANONICAL_Y_SHA256
+
+
 def _validated_arrays(data_x: object, data_y: object) -> tuple[np.ndarray, np.ndarray]:
     if type(data_x) is not np.ndarray or data_x.dtype != np.dtype(np.float32):
         raise ValueError("data_x must be an exact float32 NumPy array")
@@ -375,6 +401,15 @@ def _validated_arrays(data_x: object, data_y: object) -> tuple[np.ndarray, np.nd
         raise ValueError("data_x must use the frozen [-1, 1] scaling")
     if np.any(data_y < 0) or np.any(data_y >= 10):
         raise ValueError("data_y lies outside the frozen ten-class label range")
+    expected_x_sha256, expected_y_sha256 = _canonical_dataset_hashes()
+    x_sha256 = screening_lane._array_bundle_sha256(
+        "alberta.ipmnist_screening.materialized_x.v1", {"x": data_x}
+    )
+    y_sha256 = screening_lane._array_bundle_sha256(
+        "alberta.ipmnist_screening.materialized_y.v1", {"y": data_y}
+    )
+    if x_sha256 != expected_x_sha256 or y_sha256 != expected_y_sha256:
+        raise ValueError("dataset bytes differ from the frozen canonical OpenML materialization")
     return data_x, data_y
 
 
@@ -448,9 +483,10 @@ def _policy(stage: str) -> dict[str, object]:
         "completed_shard_negative_results_retained": True,
         "execution_failure_receipts_retained": False,
         "execution_failure_note": (
-            "an execution failure does not produce a result shard; the failed matrix is "
-            "incomplete and cannot be aggregated, and the external scheduler must retain "
-            "its failure log before any separately authorized retry"
+            "ordinary Exception, BaseException, process death, and publication failure do not "
+            "produce campaign failure receipts; the reservation marker is concurrency state, "
+            "not failure evidence, so the external scheduler must retain its log before any "
+            "separately authorized retry"
         ),
         "timing_is_telemetry_only": True,
         "execution_attestation": False,
@@ -526,10 +562,12 @@ def _protocol(stage: str) -> dict[str, object]:
         "quarantined_seed_rosters": {
             "public_result_v1_and_tests": list(QUARANTINED_CHEAP_SEEDS),
             "preauthorization_pull_request_and_tests": list(QUARANTINED_FULL_SEEDS),
+            "first_replacement_cheap_tests": list(QUARANTINED_REPLACEMENT_CHEAP_SEEDS),
+            "first_replacement_full_tests": list(QUARANTINED_REPLACEMENT_FULL_SEEDS),
         },
         "quarantine_reason": (
-            "the old rosters were publicly exposed and exercised in repository or pull-request "
-            "history, so neither roster is represented as fresh"
+            "every earlier roster was publicly exposed or used to derive schedule and "
+            "initialization identities in pull-request tests, so none is represented as fresh"
         ),
         "randomness": (
             "seed and runtime PRNG implementation are source-bound; campaign records do not "
@@ -680,13 +718,16 @@ def _validated_dataset_identity(value: object) -> dict[str, object]:
     checked_x_shape = cast(list[int], x_shape)
     checked_y_shape = cast(list[int], y_shape)
     expected_x_shape, expected_y_shape = _canonical_dataset_shapes()
+    expected_x_sha256, expected_y_sha256 = _canonical_dataset_hashes()
     rows = expected_x_shape[0]
     if (
         checked_x_shape != list(expected_x_shape)
         or checked_y_shape != list(expected_y_shape)
         or dataset["row_stop_exclusive"] != rows
+        or dataset["x_sha256"] != expected_x_sha256
+        or dataset["y_sha256"] != expected_y_sha256
     ):
-        raise ValueError("plan dataset row count is invalid")
+        raise ValueError("plan dataset identity differs from the canonical materialization")
     numeric_bytes = dataset["numeric_bytes"]
     if type(numeric_bytes) is not int or numeric_bytes != rows * (784 + 1) * 4:
         raise ValueError("plan dataset byte accounting drifted")
@@ -852,6 +893,30 @@ def _require_execution_authorized() -> None:
         )
 
 
+def _receipt_source_identity(plan: Mapping[str, object]) -> list[str]:
+    identity = cast(dict[str, object], plan["identity"])
+    sources = cast(dict[str, str], identity["source_sha256"])
+    names = (
+        "alberta_framework/benchmarks/activation_feature_ipmnist.py",
+        "alberta_framework/benchmarks/ipmnist_screening.py",
+        "alberta_framework/benchmarks/upgd_ipmnist.py",
+    )
+    return [sources[name] for name in names]
+
+
+def _receipt_runtime_identity(plan: Mapping[str, object]) -> list[str]:
+    identity = cast(dict[str, object], plan["identity"])
+    runtime = cast(dict[str, object], identity["runtime"])
+    python = cast(list[int], runtime["python"])
+    packages = cast(dict[str, str], runtime["packages"])
+    return [
+        ".".join(str(part) for part in python),
+        packages["jax"],
+        packages["numpy"],
+        cast(str, runtime["backend"]),
+    ]
+
+
 def build_shard(
     plan: object,
     data_x: object,
@@ -897,6 +962,11 @@ def _build_shard_authorized(
         raise ValueError("seed is outside the frozen matrix")
     x, y = _validated_arrays(data_x, data_y)
     dataset_identity = _dataset_identity(x, y)
+    identity = cast(dict[str, object], checked_plan["identity"])
+    planned_sources = cast(dict[str, str], identity["source_sha256"])
+    planned_runtime = cast(dict[str, object], identity["runtime"])
+    if _source_identity() != planned_sources or _runtime_identity() != planned_runtime:
+        raise RuntimeError("source or runtime changed before shard execution")
     execution_identity = _expected_execution_identity(stage, seed, x.shape[0])
     result = run_activation_feature_arm(
         x,
@@ -905,6 +975,8 @@ def _build_shard_authorized(
         seed=seed,
         config=_config_from_plan(checked_plan),
     )
+    if _source_identity() != planned_sources or _runtime_identity() != planned_runtime:
+        raise RuntimeError("source or runtime changed during shard execution")
     receipt = activation_feature_campaign_result_payload(
         result, outcome="inconclusive", development_seeds=seeds
     )
@@ -973,6 +1045,10 @@ def _validate_shard_against_plan(
         or execution["n_train"] != cast(list[object], dataset["x_shape"])[0]
     ):
         raise ValueError("shard dataset identity disagrees with the plan")
+    if execution["source_sha256"] != _receipt_source_identity(checked_plan):
+        raise ValueError("shard receipt source identity disagrees with the plan")
+    if execution["runtime"] != _receipt_runtime_identity(checked_plan):
+        raise ValueError("shard receipt runtime identity disagrees with the plan")
     n_train = cast(int, execution["n_train"])
     expected_execution = _expected_execution_identity(stage, seed, n_train)
     if shard["execution_identity"] != expected_execution:
@@ -1416,7 +1492,9 @@ def _load_json_strict_at(
     parent_fd: int, name: str, *, max_bytes: int
 ) -> tuple[dict[str, object], bytes]:
     descriptor = os.open(
-        name, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=parent_fd
+        name,
+        os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK,
+        dir_fd=parent_fd,
     )
     try:
         opened = os.fstat(descriptor)
@@ -1519,9 +1597,13 @@ def _publish_reserved_json(
         view = memoryview(encoded)
         written = 0
         while written < len(view):
-            written += os.write(file_fd, view[written:])
+            count = os.write(file_fd, view[written:])
+            if count <= 0:
+                raise OSError("short write while publishing campaign output")
+            written += count
         os.fsync(file_fd)
         os.fchmod(file_fd, 0o444)
+        os.fsync(file_fd)
         try:
             _link_unnamed_file(file_fd, parent_fd, destination.name)
         except FileExistsError as error:

--- a/docs/research/activation-feature-comparison.md
+++ b/docs/research/activation-feature-comparison.md
@@ -7,10 +7,13 @@ screening runner and only creates a new, immutable receipt path.
 
 ## Audited sources
 
-- **Smooth-Leaky:** arXiv `2509.22562v4` (2026-04-30). The official repository
-  points to the immutable anonymous snapshot
-  `activations_plasticity-E431`; that snapshot identifier, rather than a
-  mutable branch name, is the code revision bound by the lane. Equation 1 is
+- **Smooth-Leaky:** ICLR 2026 `XZf6wObHX4` and arXiv `2509.22562v4`
+  (2026-04-30). The camera-ready paper discloses the official repository
+  `lute47lillo/activations_plasticity`; the campaign pins commit
+  `bdce354782cd183d63550819550b33312506d3e3`. The repository has no license
+  file, so it is a read-only disambiguation source and no code is copied.
+  Result-v1 retains its earlier source-field strings for compatibility;
+  campaign plans carry this corrected registry. Equation 1 is
   `alpha*x + (1-alpha)*x*sigmoid(c*x/p)`. The development arm uses the paper's
   displayed `alpha=0.1, p=3, c=5` values. A fixed Leaky-ReLU arm removes the
   smooth transition while retaining the negative leak.
@@ -51,3 +54,82 @@ also changes the number of active affine parameters; both allocated and active
 counts are recorded. Before any scientific comparison, development runs still
 need paired multi-seed screening, full-horizon confirmation, resource-acceptable
 comparison to the live incumbent, and a separately frozen fresh-seed protocol.
+
+## Frozen campaign workflow
+
+`asi-activation-feature-campaign` provides two separate, immutable plans. The
+cheap screen is exactly 2 tasks × 500 examples; the full-horizon remeasurement
+is exactly 200 tasks × 5,000 examples. Both plans require all 11 arms at all 5
+development seeds (55 fresh-process shards each). The full plan does not become
+smaller after seeing the cheap screen. The cheap plan uses the unconsumed
+result-v1 seeds 0–4. The full plan preregisters the disjoint seeds
+156610–156614 and uses result v2, while result-v1 validation remains unchanged.
+These are still development seeds; neither stage can promote a claim.
+
+Full-horizon execution is conditionally authorized. It requires a retained,
+strictly valid cheap-screen aggregate from the exact same dataset, source, and
+runtime, and at least one primary candidate (`smooth_leaky`, `aid`, or
+`deep_fourier`) must have a simultaneous interval wholly above zero. If that
+gate fails, the cheap negative/inconclusive result is retained and the full run
+does not execute. If it passes, every full-stage arm and seed remains required;
+the gate never authorizes a selected-candidate subset.
+
+Each plan binds the exact MNIST bytes, current implementation sources,
+Python/JAX/dependency/runtime identity, configuration, schedule-derived receipt
+identity, resource schedule, and output namespace. Shard receipts retain the
+`asi.activation_feature_ipmnist.result.v1` contract. The campaign wrapper adds
+an immutable plan digest and does not reinterpret a shard's self-reported
+outcome. Run each `run-shard` command in a fresh Python process; `summarize`
+rejects any roster other than the complete 55 unique shard files.
+
+The eight predeclared candidate-versus-family-off comparisons use paired seed
+deltas in whole-stream mean online accuracy. A two-sided Student-t interval
+with 4 degrees of freedom uses Bonferroni alpha `0.05 / 8` (critical value
+`5.261057575065803`). A simultaneous interval wholly above zero is
+`supported`, wholly below zero is `rejected`, and every other result is
+`inconclusive`. These are permanently nonpromoting development outcomes. The
+aggregate retains every shard, decision, resource count, and negative outcome;
+timing is telemetry only and consistency hashes are not execution attestation.
+
+Canonical append-only namespaces are:
+
+- `outputs/activation_feature_ipmnist/cheap_screen.v1/`
+- `outputs/activation_feature_ipmnist/full_confirmation.v1/`
+
+Create `plan.json`, write shards under `shards/`, then publish
+`aggregate.json`. The CLI refuses to replace an existing path. No campaign has
+been run or result produced by this implementation change.
+
+For either stage, first create the canonical directories and plan:
+
+```bash
+stage=cheap_screen  # or full_confirmation
+root="outputs/activation_feature_ipmnist/${stage}.v1"
+mkdir -p "$root/shards"
+.venv/bin/asi-activation-feature-campaign plan --stage "$stage"
+```
+
+Run each matrix cell as its own process. The following shell is illustrative;
+production scheduling may parallelize the same commands without changing a
+shard:
+
+```bash
+seeds="0 1 2 3 4"
+extra=()
+if [ "$stage" = full_confirmation ]; then
+  seeds="156610 156611 156612 156613 156614"
+  extra=(--cheap-aggregate \
+    outputs/activation_feature_ipmnist/cheap_screen.v1/aggregate.json)
+fi
+for seed in $seeds; do
+  for arm in smooth_leaky smooth_leaky_off smooth_leaky_fixed_leak \
+    aid aid_off aid_expected ordinary_dropout deep_fourier deep_fourier_off \
+    deep_fourier_first_layer deep_fourier_sine_only; do
+    .venv/bin/asi-activation-feature-campaign run-shard \
+      --stage "$stage" --seed "$seed" --arm "$arm" "${extra[@]}"
+  done
+done
+.venv/bin/asi-activation-feature-campaign summarize --stage "$stage" \
+  "${extra[@]}" "$root"/shards/*.json
+.venv/bin/asi-activation-feature-campaign validate "$root/aggregate.json"
+```

--- a/docs/research/activation-feature-comparison.md
+++ b/docs/research/activation-feature-comparison.md
@@ -12,8 +12,8 @@ screening runner and only creates a new, immutable receipt path.
   `lute47lillo/activations_plasticity`; the campaign pins commit
   `bdce354782cd183d63550819550b33312506d3e3`. The repository has no license
   file, so it is a read-only disambiguation source and no code is copied.
-  Result-v1 retains its earlier source-field strings for compatibility;
-  campaign plans carry this corrected registry. Equation 1 is
+  Result-v1 has a fixed source-field contract; campaign plans separately bind
+  this exact source registry. Equation 1 is
   `alpha*x + (1-alpha)*x*sigmoid(c*x/p)`. The development arm uses the paper's
   displayed `alpha=0.1, p=3, c=5` values. A fixed Leaky-ReLU arm removes the
   smooth transition while retaining the negative leak.
@@ -63,7 +63,8 @@ is exactly 200 tasks × 5,000 examples. Both plans require all 11 arms at all 5
 development seeds (55 fresh-process shards each). The full plan does not become
 smaller after seeing the cheap screen. The cheap plan uses the unconsumed
 result-v1 seeds 0–4. The full plan preregisters the disjoint seeds
-156610–156614 and uses result v2, while result-v1 validation remains unchanged.
+156610–156614 and uses result v2. Result-v1 validation enforces its fixed
+seed and source-field contract.
 These are still development seeds; neither stage can promote a claim.
 
 Full-horizon execution is conditionally authorized. It requires a retained,
@@ -76,11 +77,12 @@ the gate never authorizes a selected-candidate subset.
 
 Each plan binds the exact MNIST bytes, current implementation sources,
 Python/JAX/dependency/runtime identity, configuration, schedule-derived receipt
-identity, resource schedule, and output namespace. Shard receipts retain the
-`asi.activation_feature_ipmnist.result.v1` contract. The campaign wrapper adds
-an immutable plan digest and does not reinterpret a shard's self-reported
-outcome. Run each `run-shard` command in a fresh Python process; `summarize`
-rejects any roster other than the complete 55 unique shard files.
+identity, resource schedule, and output namespace. Shard receipts use the
+`asi.activation_feature_ipmnist.result.v1` contract for the cheap screen and
+`asi.activation_feature_ipmnist.result.v2` for full confirmation. Every shard
+binds an immutable plan digest, and aggregation does not reinterpret its
+self-reported outcome. Run each `run-shard` command in a fresh Python process;
+`summarize` rejects any roster other than the complete 55 unique shard files.
 
 The eight predeclared candidate-versus-family-off comparisons use paired seed
 deltas in whole-stream mean online accuracy. A two-sided Student-t interval

--- a/docs/research/activation-feature-comparison.md
+++ b/docs/research/activation-feature-comparison.md
@@ -44,7 +44,7 @@ contains every registered arm exactly once for one seed; its validator requires
 identical configuration, observation/update/query counts, parameter allocation,
 persistent numeric bytes, and learner-visible information. The learner receives
 the current example label but no task-boundary identifier. Receipts allow only
-`supported`, `rejected`, or `inconclusive`, retain every outcome permanently,
+`supported`, `rejected`, or `inconclusive`, retain every completed outcome permanently,
 and can never authorize scientific promotion.
 
 The receipt keeps ASI whole-stream metrics separate and explicitly says that
@@ -77,7 +77,8 @@ the gate never authorizes a selected-candidate subset.
 
 Each plan binds the exact MNIST bytes, current implementation sources,
 Python/JAX/dependency/runtime identity, configuration, schedule-derived receipt
-identity, resource schedule, and output namespace. Shard receipts use the
+identity, retained schedule numeric-byte bound, resource schedule, and output namespace.
+Shard receipts use the
 `asi.activation_feature_ipmnist.result.v1` contract for the cheap screen and
 `asi.activation_feature_ipmnist.result.v2` for full confirmation. Every shard
 binds an immutable plan digest, and aggregation does not reinterpret its
@@ -90,7 +91,9 @@ with 4 degrees of freedom uses Bonferroni alpha `0.05 / 8` (critical value
 `5.261057575065803`). A simultaneous interval wholly above zero is
 `supported`, wholly below zero is `rejected`, and every other result is
 `inconclusive`. These are permanently nonpromoting development outcomes. The
-aggregate retains every shard, decision, resource count, and negative outcome;
+aggregate retains every completed shard, decision, resource count, and completed negative
+outcome. An execution failure produces no result shard, leaves the matrix incomplete, and
+must be retained by the external scheduler before any separately authorized retry;
 timing is telemetry only and consistency hashes are not execution attestation.
 
 Canonical append-only namespaces are:

--- a/docs/research/activation-feature-comparison.md
+++ b/docs/research/activation-feature-comparison.md
@@ -39,7 +39,14 @@ causal control; the stronger `rls_head_resid_l1_preset005` incumbent remains a
 separate live context comparator because its RLS head, resource shape, and
 body-training signal are not a mechanism-off match.
 
-The development seed set is frozen at `0, 1, 2, 3, 4`. A complete comparison
+The public result-v1 seed set `0, 1, 2, 3, 4` is quarantined: it has long been
+exposed by the CLI and exercised by repository tests and history. The earlier
+preauthorization full roster `156610`–`156614` is also quarantined because it
+was exposed and exercised in pull-request history. Neither roster is represented
+as fresh. The replacement cheap roster is `2156600`–`2156604` and the replacement
+full roster is `2156610`–`2156614`; a repository and history search found no prior
+occurrence when this successor protocol was frozen. Both use result v2's external
+seed contract. A complete comparison
 contains every registered arm exactly once for one seed; its validator requires
 identical configuration, observation/update/query counts, parameter allocation,
 persistent numeric bytes, and learner-visible information. The learner receives
@@ -60,14 +67,15 @@ comparison to the live incumbent, and a separately frozen fresh-seed protocol.
 `asi-activation-feature-campaign` provides two separate, immutable plans. The
 cheap screen is exactly 2 tasks × 500 examples; the full-horizon remeasurement
 is exactly 200 tasks × 5,000 examples. Both plans require all 11 arms at all 5
-development seeds (55 fresh-process shards each). The full plan does not become
-smaller after seeing the cheap screen. The cheap plan uses the unconsumed
-result-v1 seeds 0–4. The full plan preregisters the disjoint seeds
-156610–156614 and uses result v2. Result-v1 validation enforces its fixed
-seed and source-field contract.
+replacement development seeds (55 fresh-process shards each). The full plan does
+not become smaller after seeing the cheap screen. Both stages use result v2. The
+campaign's public execution gate is frozen false: neither `build_shard` nor
+`run-shard` can load the dataset or invoke the runner until a separate reviewed
+source transition authorizes it.
 These are still development seeds; neither stage can promote a claim.
 
-Full-horizon execution is conditionally authorized. It requires a retained,
+After a separate reviewed execution transition, full-horizon execution would
+remain conditionally gated. It requires a retained,
 strictly valid cheap-screen aggregate from the exact same dataset, source, and
 runtime, and at least one primary candidate (`smooth_leaky`, `aid`, or
 `deep_fourier`) must have a simultaneous interval wholly above zero. If that
@@ -77,13 +85,13 @@ the gate never authorizes a selected-candidate subset.
 
 Each plan binds the exact MNIST bytes, current implementation sources,
 Python/JAX/dependency/runtime identity, configuration, schedule-derived receipt
-identity, retained schedule numeric-byte bound, resource schedule, and output namespace.
-Shard receipts use the
-`asi.activation_feature_ipmnist.result.v1` contract for the cheap screen and
-`asi.activation_feature_ipmnist.result.v2` for full confirmation. Every shard
+identity, retained schedule numeric-byte bound, resource schedule, and output
+namespace. Shard receipts use the `asi.activation_feature_ipmnist.result.v2`
+contract for both stages. Every shard
 binds an immutable plan digest, and aggregation does not reinterpret its
-self-reported outcome. Run each `run-shard` command in a fresh Python process;
-`summarize` rejects any roster other than the complete 55 unique shard files.
+self-reported outcome. If separately authorized, each `run-shard` command must
+use a fresh Python process; `summarize` rejects any roster other than the
+complete 55 unique shard files.
 
 The eight predeclared candidate-versus-family-off comparisons use paired seed
 deltas in whole-stream mean online accuracy. A two-sided Student-t interval
@@ -98,43 +106,22 @@ timing is telemetry only and consistency hashes are not execution attestation.
 
 Canonical append-only namespaces are:
 
-- `outputs/activation_feature_ipmnist/cheap_screen.v1/`
-- `outputs/activation_feature_ipmnist/full_confirmation.v1/`
+- `outputs/activation_feature_ipmnist/cheap_screen.v2/`
+- `outputs/activation_feature_ipmnist/full_confirmation.v2/`
 
-Create `plan.json`, write shards under `shards/`, then publish
-`aggregate.json`. The CLI refuses to replace an existing path. No campaign has
-been run or result produced by this implementation change.
+Plan, shard, and aggregate publication pins every path segment with no-follow
+directory descriptors, reserves the destination with deterministic `O_EXCL`
+before dataset access or execution, publishes without replacement, fsyncs, and
+strictly rereads and validates the linked file. No campaign has been run or
+result produced by this implementation change.
 
-For either stage, first create the canonical directories and plan:
+For either stage, plan creation is the only enabled campaign mutation:
 
 ```bash
 stage=cheap_screen  # or full_confirmation
-root="outputs/activation_feature_ipmnist/${stage}.v1"
-mkdir -p "$root/shards"
 .venv/bin/asi-activation-feature-campaign plan --stage "$stage"
 ```
 
-Run each matrix cell as its own process. The following shell is illustrative;
-production scheduling may parallelize the same commands without changing a
-shard:
-
-```bash
-seeds="0 1 2 3 4"
-extra=()
-if [ "$stage" = full_confirmation ]; then
-  seeds="156610 156611 156612 156613 156614"
-  extra=(--cheap-aggregate \
-    outputs/activation_feature_ipmnist/cheap_screen.v1/aggregate.json)
-fi
-for seed in $seeds; do
-  for arm in smooth_leaky smooth_leaky_off smooth_leaky_fixed_leak \
-    aid aid_off aid_expected ordinary_dropout deep_fourier deep_fourier_off \
-    deep_fourier_first_layer deep_fourier_sine_only; do
-    .venv/bin/asi-activation-feature-campaign run-shard \
-      --stage "$stage" --seed "$seed" --arm "$arm" "${extra[@]}"
-  done
-done
-.venv/bin/asi-activation-feature-campaign summarize --stage "$stage" \
-  "${extra[@]}" "$root"/shards/*.json
-.venv/bin/asi-activation-feature-campaign validate "$root/aggregate.json"
-```
+`run-shard` intentionally fails closed. There is no executable shard command
+to copy from this frozen-plan change; independent review and a separate
+authorization transition must precede any dataset load or campaign execution.

--- a/docs/research/activation-feature-comparison.md
+++ b/docs/research/activation-feature-comparison.md
@@ -102,12 +102,13 @@ with 4 degrees of freedom uses Bonferroni alpha `0.05 / 8` (critical value
 `5.261057575065803`). A simultaneous interval wholly above zero is
 `supported`, wholly below zero is `rejected`, and every other result is
 `inconclusive`. These are permanently nonpromoting development outcomes. The
-aggregate retains every completed shard, decision, resource count, and completed negative
-outcome. Ordinary exceptions, `BaseException`, process death, and publication failures
-produce no campaign failure receipt. The temporary reservation marker is cooperative
-concurrency state, not failure evidence; the external scheduler must retain its log before
-any separately authorized retry.
-timing is telemetry only and consistency hashes are not execution attestation.
+aggregate retains every completed shard, decision, resource count, and
+completed negative outcome. Ordinary exceptions, `BaseException`, process
+death, and publication failures produce no campaign failure receipt. The
+temporary reservation marker is cooperative concurrency state, not failure
+evidence; the external scheduler must retain its log before any separately
+authorized retry.
+Timing is telemetry only, and consistency hashes are not execution attestation.
 
 Canonical append-only namespaces are:
 

--- a/docs/research/activation-feature-comparison.md
+++ b/docs/research/activation-feature-comparison.md
@@ -119,13 +119,11 @@ directory descriptors, reserves the destination with deterministic `O_EXCL`
 before dataset access or execution, publishes without replacement, fsyncs, and
 strictly rereads and validates the linked file. No retained campaign result exists.
 
-For either stage, plan creation is the only enabled campaign mutation:
-
-```bash
-stage=cheap_screen  # or full_confirmation
-.venv/bin/asi-activation-feature-campaign plan --stage "$stage"
-```
-
-`run-shard` intentionally fails closed. There is no executable shard command
-to copy from this frozen-plan change; independent review and a separate
-authorization transition must precede any dataset load or campaign execution.
+No campaign mutation is enabled by this freeze. `plan`, `run-shard`, and
+`summarize` all fail before output reservation or dataset access while the
+literal authorization gate is false. This is necessary because a plan binds
+this module's exact source bytes: publishing it before the separately reviewed
+authorization transition would make it stale while permanently occupying its
+no-replace namespace. Read-only `validate` remains available for retained
+documents. The authorization transition must precede plan publication, dataset
+load, and campaign execution.

--- a/docs/research/activation-feature-comparison.md
+++ b/docs/research/activation-feature-comparison.md
@@ -42,11 +42,14 @@ body-training signal are not a mechanism-off match.
 The public result-v1 seed set `0, 1, 2, 3, 4` is quarantined: it has long been
 exposed by the CLI and exercised by repository tests and history. The earlier
 preauthorization full roster `156610`–`156614` is also quarantined because it
-was exposed and exercised in pull-request history. Neither roster is represented
-as fresh. The replacement cheap roster is `2156600`–`2156604` and the replacement
-full roster is `2156610`–`2156614`; a repository and history search found no prior
-occurrence when this successor protocol was frozen. Both use result v2's external
-seed contract. A complete comparison
+was exposed and exercised in pull-request history. The first replacement rosters
+`2156600`–`2156604` and `2156610`–`2156614` are quarantined too: their schedule and
+initialization identities were derived by pull-request tests. None of those four
+rosters is represented as fresh. The untouched cheap roster is
+`3975019531`–`3975019535`, and the untouched full roster is
+`2924933221`–`2924933225`. Tests use only quarantined roots and never derive keys
+from either campaign roster. Both stages use result v2's external seed contract.
+A complete comparison
 contains every registered arm exactly once for one seed; its validator requires
 identical configuration, observation/update/query counts, parameter allocation,
 persistent numeric bytes, and learner-visible information. The learner receives
@@ -100,8 +103,10 @@ with 4 degrees of freedom uses Bonferroni alpha `0.05 / 8` (critical value
 `supported`, wholly below zero is `rejected`, and every other result is
 `inconclusive`. These are permanently nonpromoting development outcomes. The
 aggregate retains every completed shard, decision, resource count, and completed negative
-outcome. An execution failure produces no result shard, leaves the matrix incomplete, and
-must be retained by the external scheduler before any separately authorized retry;
+outcome. Ordinary exceptions, `BaseException`, process death, and publication failures
+produce no campaign failure receipt. The temporary reservation marker is cooperative
+concurrency state, not failure evidence; the external scheduler must retain its log before
+any separately authorized retry.
 timing is telemetry only and consistency hashes are not execution attestation.
 
 Canonical append-only namespaces are:
@@ -112,8 +117,7 @@ Canonical append-only namespaces are:
 Plan, shard, and aggregate publication pins every path segment with no-follow
 directory descriptors, reserves the destination with deterministic `O_EXCL`
 before dataset access or execution, publishes without replacement, fsyncs, and
-strictly rereads and validates the linked file. No campaign has been run or
-result produced by this implementation change.
+strictly rereads and validates the linked file. No retained campaign result exists.
 
 For either stage, plan creation is the only enabled campaign mutation:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ asi-plasticity-diagnostic = "alberta_framework.benchmarks.plasticity_diagnostics
 asi-nap-ipmnist = "alberta_framework.benchmarks.nap_ipmnist:main"
 asi-adamo-diagnostic = "alberta_framework.benchmarks.adamo_diagnostic:main"
 asi-activation-feature-ipmnist = "alberta_framework.benchmarks.activation_feature_ipmnist:main"
+asi-activation-feature-campaign = "alberta_framework.evaluation.activation_feature_campaign:main"
 asi-coom-qualification-smoke = "alberta_framework.benchmarks.coom_qualification:main"
 asi-clear-qualification = "alberta_framework.benchmarks.clear_qualification:main"
 asi-cora-catalog = "alberta_framework.benchmarks.cora_development:main"

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -58,6 +58,13 @@ def cheap_plan(data: tuple[np.ndarray, np.ndarray]) -> dict[str, object]:
     return campaign.build_plan("cheap_screen", *data)
 
 
+@pytest.fixture
+def authorized(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise post-authorization mechanics without changing frozen source."""
+
+    monkeypatch.setattr(campaign, "_EXECUTION_AUTHORIZED", True)
+
+
 def _metric(arm: str, seed: int) -> float:
     seed_index = next(seeds.index(seed) for seeds in campaign._SEEDS.values() if seed in seeds)
     base = 0.50 + seed_index / 1_000.0
@@ -270,6 +277,8 @@ def test_plan_binds_exact_source_runtime_dataset_resources_and_paper_limits(
     assert "external scheduler must retain its log" in policy["execution_failure_note"]
     per_shard = cast(dict[str, Any], resources["per_shard"])
     assert per_shard["retained_schedule_numeric_bytes"] == 4 * 2 * (784 + 5_000)
+    assert resources["retained_schedule_numeric_bytes_limit_per_shard"] == 256 * 1024**2
+    assert "schedule_working_bytes_limit_per_shard" not in resources
 
 
 def test_plan_rejects_noncanonical_dataset_metadata_before_hashing(
@@ -454,6 +463,7 @@ def test_execution_failure_is_not_misrepresented_as_a_retained_result_shard(
     cheap_plan: dict[str, object],
     data: tuple[np.ndarray, np.ndarray],
     monkeypatch: pytest.MonkeyPatch,
+    authorized: None,
 ) -> None:
     def failed_execution(*args: object, **kwargs: object) -> object:
         raise RuntimeError("simulated execution failure")
@@ -477,6 +487,7 @@ def test_private_executor_rechecks_full_source_identity_after_runner_return(
     cheap_plan: dict[str, object],
     data: tuple[np.ndarray, np.ndarray],
     monkeypatch: pytest.MonkeyPatch,
+    authorized: None,
 ) -> None:
     original_source = campaign._source_identity()
     seed = campaign._SEEDS["cheap_screen"][0]
@@ -549,6 +560,20 @@ def test_public_builder_and_cli_fail_before_dataset_or_arm_execution(
             seed=campaign._SEEDS["cheap_screen"][0],
         )
     with pytest.raises(RuntimeError, match="not authorized"):
+        campaign._build_shard_authorized(
+            cheap_plan,
+            *data,
+            arm="aid",
+            seed=campaign._SEEDS["cheap_screen"][0],
+            _capability=campaign._EXECUTION_CAPABILITY,
+        )
+    direct_output = tmp_path / "direct.json"
+    with pytest.raises(RuntimeError, match="not authorized"):
+        campaign.write_new_json(direct_output, cheap_plan)
+    assert not direct_output.exists()
+    with pytest.raises(RuntimeError, match="not authorized"):
+        campaign._publish_reserved_json((direct_output, -1, "unused"), cheap_plan)
+    with pytest.raises(RuntimeError, match="not authorized"):
         campaign.main(
             [
                 "run-shard",
@@ -585,7 +610,7 @@ def test_aggregate_rejects_missing_duplicate_and_self_consistent_statistic_forge
     reason="strict loader/publication requires Linux descriptor support",
 )
 def test_strict_file_admission_and_append_only_writer(
-    cheap_plan: dict[str, object], tmp_path: Path
+    cheap_plan: dict[str, object], tmp_path: Path, authorized: None
 ) -> None:
     destination = tmp_path / "plan.json"
     campaign.write_new_json(destination, cheap_plan)
@@ -666,7 +691,7 @@ def test_summarizer_uses_metadata_from_the_descriptor_that_supplied_bytes(
     reason="descriptor-pinned publication requires Linux",
 )
 def test_reserved_publication_resists_parent_swap_and_occupied_race(
-    cheap_plan: dict[str, object], tmp_path: Path
+    cheap_plan: dict[str, object], tmp_path: Path, authorized: None
 ) -> None:
     requested_parent = tmp_path / "requested"
     requested_parent.mkdir()
@@ -692,7 +717,10 @@ def test_reserved_publication_resists_parent_swap_and_occupied_race(
     reason="descriptor-pinned publication requires Linux",
 )
 def test_reservation_is_exclusive_before_work_and_publication_strictly_rereads(
-    cheap_plan: dict[str, object], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    cheap_plan: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    authorized: None,
 ) -> None:
     destination = tmp_path / "plan.json"
     with campaign._reserved_new_output(destination) as target:
@@ -721,7 +749,10 @@ def test_reservation_is_exclusive_before_work_and_publication_strictly_rereads(
     reason="descriptor-pinned publication requires Linux",
 )
 def test_publication_rejects_zero_write_and_nonregular_reread_swap(
-    cheap_plan: dict[str, object], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    cheap_plan: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    authorized: None,
 ) -> None:
     short_output = tmp_path / "short.json"
     with campaign._reserved_new_output(short_output) as target:
@@ -729,6 +760,7 @@ def test_publication_rejects_zero_write_and_nonregular_reread_swap(
         with pytest.raises(OSError, match="short write"):
             campaign._publish_reserved_json(target, cheap_plan)
     monkeypatch.undo()
+    monkeypatch.setattr(campaign, "_EXECUTION_AUTHORIZED", True)
 
     swapped_output = tmp_path / "swapped.json"
     with campaign._reserved_new_output(swapped_output) as target:

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, cast
 
@@ -20,6 +21,14 @@ def data() -> tuple[np.ndarray, np.ndarray]:
     x = np.zeros((5_000, 784), dtype=np.float32)
     y = np.arange(5_000, dtype=np.int32) % 10
     return x, y
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _bounded_dataset_shapes() -> Iterator[None]:
+    patch = pytest.MonkeyPatch()
+    patch.setattr(campaign, "_canonical_dataset_shapes", lambda: ((5_000, 784), (5_000,)))
+    yield
+    patch.undo()
 
 
 @pytest.fixture(scope="module")
@@ -173,11 +182,26 @@ def test_both_plans_freeze_full_11_by_5_matrix_without_horizon_shrink(
     assert campaign.validate_plan(copy.deepcopy(cheap), data_x=data[0], data_y=data[1]) == cheap
 
 
+def test_production_dataset_contract_names_the_full_canonical_train_split() -> None:
+    assert campaign._CANONICAL_X_SHAPE == (60_000, 784)
+    assert campaign._CANONICAL_Y_SHAPE == (60_000,)
+    assert "rows 0:60000" in campaign._DATASET_MATERIALIZATION
+
+
 def test_plan_binds_exact_source_runtime_dataset_resources_and_paper_limits(
     cheap_plan: dict[str, object], data: tuple[np.ndarray, np.ndarray]
 ) -> None:
     identity = cast(dict[str, Any], cheap_plan["identity"])
-    assert identity["dataset"]["sha256"] == activation._array_bundle_sha256(*data)
+    dataset = identity["dataset"]
+    assert dataset["sha256"] == activation._array_bundle_sha256(*data)
+    assert dataset["row_start"] == 0
+    assert dataset["row_stop_exclusive"] == 5_000
+    assert dataset["x_sha256"] == campaign.screening_lane._array_bundle_sha256(
+        "alberta.ipmnist_screening.materialized_x.v1", {"x": data[0]}
+    )
+    assert dataset["y_sha256"] == campaign.screening_lane._array_bundle_sha256(
+        "alberta.ipmnist_screening.materialized_y.v1", {"y": data[1]}
+    )
     assert set(identity["source_sha256"]) == {
         "alberta_framework/benchmarks/activation_feature_ipmnist.py",
         "alberta_framework/benchmarks/ipmnist_screening.py",
@@ -192,6 +216,19 @@ def test_plan_binds_exact_source_runtime_dataset_resources_and_paper_limits(
     parity = cast(dict[str, Any], cheap_plan["paper_parity"])
     assert parity["paper_protocol_parity_claimed"] is False
     assert parity["paper_result_reproduction_claimed"] is False
+
+
+def test_plan_rejects_noncanonical_dataset_metadata_before_hashing(
+    data: tuple[np.ndarray, np.ndarray], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def forbidden(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("dataset bytes were hashed before static metadata")
+
+    monkeypatch.setattr(campaign, "_array_bundle_sha256", forbidden)
+    with pytest.raises(ValueError, match="frozen OpenML MNIST train split"):
+        campaign.build_plan("cheap_screen", data[0][:-1], data[1][:-1])
+    with pytest.raises(ValueError, match="C-contiguous"):
+        campaign.build_plan("cheap_screen", data[0][:, ::-1], data[1])
 
 
 def test_plan_rejects_resigned_horizon_dataset_and_runtime_forgery(

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import alberta_framework.benchmarks.activation_feature_ipmnist as activation
+import alberta_framework.evaluation.activation_feature_campaign as campaign
+from alberta_framework.benchmarks.ipmnist_screening import ScreeningRunResult
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+
+
+@pytest.fixture(scope="module")
+def data() -> tuple[np.ndarray, np.ndarray]:
+    x = np.zeros((5_000, 784), dtype=np.float32)
+    y = np.arange(5_000, dtype=np.int32) % 10
+    return x, y
+
+
+@pytest.fixture(scope="module")
+def cheap_plan(data: tuple[np.ndarray, np.ndarray]) -> dict[str, object]:
+    return campaign.build_plan("cheap_screen", *data)
+
+
+def _metric(arm: str, seed: int) -> float:
+    seed_index = (
+        campaign.CHEAP_SCREEN_SEEDS.index(seed)
+        if seed in campaign.CHEAP_SCREEN_SEEDS
+        else campaign.FULL_CONFIRMATION_SEEDS.index(seed)
+    )
+    base = 0.50 + seed_index / 1_000.0
+    if arm == "smooth_leaky":
+        return base + 0.10
+    if arm == "aid":
+        return base - 0.10
+    return base
+
+
+def _receipt(
+    plan: dict[str, object], data: tuple[np.ndarray, np.ndarray], arm: str, seed: int
+) -> dict[str, object]:
+    config_values = cast(dict[str, int], plan["config"])
+    config = IPMNISTConfig(**config_values)
+    value = _metric(arm, seed)
+    spec = activation.ACTIVATION_FEATURE_SPECS[arm]
+    screening = ScreeningRunResult(
+        config_name=arm,
+        base_learner="upgd_w",
+        hyperparameters=dict(spec.hyperparameters),
+        seed=seed,
+        config=config,
+        per_task_accuracy=np.full(config.n_tasks, value, dtype=np.float64),
+        per_task_loss=np.full(config.n_tasks, 1.0 - value, dtype=np.float64),
+        per_task_plasticity=np.full(config.n_tasks, value, dtype=np.float64),
+        wall_clock_seconds=1.0,
+    )
+    stage = cast(str, plan["stage"])
+    execution_identity = campaign._expected_execution_identity(stage, seed, data[0].shape[0])
+    result = activation.ActivationFeatureRunResult(
+        screening=screening,
+        dataset_sha256=activation._array_bundle_sha256(*data),
+        schedule_sha256=execution_identity["schedule_sha256"],
+        source_identity=activation._current_source_identity(),
+        runtime_identity=activation._runtime_identity(),
+        n_train=data[0].shape[0],
+        peak_schedule_working_bytes=activation._preflight_activation_feature_resources(
+            config, n_train=data[0].shape[0]
+        ),
+    )
+    return (
+        activation.activation_feature_result_payload(result, outcome="inconclusive")
+        if stage == "cheap_screen"
+        else activation.activation_feature_campaign_result_payload(
+            result,
+            outcome="inconclusive",
+            development_seeds=campaign.FULL_CONFIRMATION_SEEDS,
+        )
+    )
+
+
+def _shard(
+    plan: dict[str, object],
+    data: tuple[np.ndarray, np.ndarray],
+    arm: str,
+    seed: int,
+    prerequisite: object | None = None,
+) -> dict[str, object]:
+    value = campaign._unsigned_shard(
+        plan,
+        arm=arm,
+        seed=seed,
+        authorization=campaign._execution_authorization(plan, prerequisite),
+        execution_identity=campaign._expected_execution_identity(
+            cast(str, plan["stage"]), seed, data[0].shape[0]
+        ),
+        result=_receipt(plan, data, arm, seed),
+    )
+    value["shard_sha256"] = campaign._digest(value)
+    return campaign.validate_shard(value, plan, prerequisite=prerequisite)
+
+
+def _matrix(
+    plan: dict[str, object],
+    data: tuple[np.ndarray, np.ndarray],
+    prerequisite: object | None = None,
+) -> list[dict[str, object]]:
+    stage = cast(str, plan["stage"])
+    seeds = (
+        campaign.CHEAP_SCREEN_SEEDS
+        if stage == "cheap_screen"
+        else campaign.FULL_CONFIRMATION_SEEDS
+    )
+    authorization = campaign._execution_authorization(plan, prerequisite)
+    shards: list[dict[str, object]] = []
+    for seed in seeds:
+        for arm in campaign.ARM_ROSTER:
+            value = campaign._unsigned_shard(
+                plan,
+                arm=arm,
+                seed=seed,
+                authorization=authorization,
+                execution_identity=campaign._expected_execution_identity(
+                    stage, seed, data[0].shape[0]
+                ),
+                result=_receipt(plan, data, arm, seed),
+            )
+            value["shard_sha256"] = campaign._digest(value)
+            shards.append(campaign._validate_shard_against_plan(value, plan, authorization))
+    return shards
+
+
+def _resign_shard(value: dict[str, Any]) -> None:
+    unsigned = dict(value)
+    unsigned.pop("shard_sha256", None)
+    value["shard_sha256"] = campaign._digest(unsigned)
+
+
+def _resign_aggregate(value: dict[str, Any]) -> None:
+    unsigned = dict(value)
+    unsigned.pop("aggregate_sha256", None)
+    value["aggregate_sha256"] = campaign._digest(unsigned)
+
+
+def test_both_plans_freeze_full_11_by_5_matrix_without_horizon_shrink(
+    data: tuple[np.ndarray, np.ndarray],
+) -> None:
+    cheap = campaign.build_plan("cheap_screen", *data)
+    full = campaign.build_plan("full_confirmation", *data)
+    assert cheap["matrix"] == {
+        "arms": list(campaign.ARM_ROSTER),
+        "seeds": [0, 1, 2, 3, 4],
+        "shard_count": 55,
+        "ordering": "seed_major_then_arm_roster",
+        "execution": "one_shard_per_fresh_python_process",
+    }
+    full_matrix = cast(dict[str, object], full["matrix"])
+    assert full_matrix["arms"] == list(campaign.ARM_ROSTER)
+    assert full_matrix["seeds"] == list(campaign.FULL_CONFIRMATION_SEEDS)
+    assert full_matrix["shard_count"] == 55
+    assert set(campaign.CHEAP_SCREEN_SEEDS).isdisjoint(campaign.FULL_CONFIRMATION_SEEDS)
+    assert cheap["config"] == IPMNISTConfig(n_tasks=2, task_length=500).to_config()
+    assert full["config"] == IPMNISTConfig(n_tasks=200, task_length=5_000).to_config()
+    full_policy = cast(dict[str, object], full["policy"])
+    assert full_policy["cross_stage_independent_confirmation_claimed"] is False
+    full_gate = cast(dict[str, object], full["execution_gate"])
+    assert full_gate["mode"] == "conditional_on_retained_cheap_screen"
+    assert full_gate["complete_matrix_if_authorized"] is True
+    assert campaign.validate_plan(copy.deepcopy(cheap), data_x=data[0], data_y=data[1]) == cheap
+
+
+def test_plan_binds_exact_source_runtime_dataset_resources_and_paper_limits(
+    cheap_plan: dict[str, object], data: tuple[np.ndarray, np.ndarray]
+) -> None:
+    identity = cast(dict[str, Any], cheap_plan["identity"])
+    assert identity["dataset"]["sha256"] == activation._array_bundle_sha256(*data)
+    assert set(identity["source_sha256"]) == {
+        "alberta_framework/benchmarks/activation_feature_ipmnist.py",
+        "alberta_framework/benchmarks/ipmnist_screening.py",
+        "alberta_framework/benchmarks/plasticity_comparators.py",
+        "alberta_framework/benchmarks/upgd_ipmnist.py",
+        "alberta_framework/evaluation/activation_feature_campaign.py",
+    }
+    assert identity["runtime"]["packages"]["jax"]
+    resources = cast(dict[str, Any], cheap_plan["resources"])
+    assert resources["per_shard"]["data_steps"] == 1_000
+    assert resources["matrix_totals"]["data_steps"] == 55_000
+    parity = cast(dict[str, Any], cheap_plan["paper_parity"])
+    assert parity["paper_protocol_parity_claimed"] is False
+    assert parity["paper_result_reproduction_claimed"] is False
+
+
+def test_plan_rejects_resigned_horizon_dataset_and_runtime_forgery(
+    cheap_plan: dict[str, object], data: tuple[np.ndarray, np.ndarray]
+) -> None:
+    mutations: tuple[tuple[Any, str], ...] = (
+        (lambda value: value["config"].__setitem__("task_length", 1), "digest|literal"),
+        (
+            lambda value: value["identity"]["dataset"].__setitem__("sha256", "0" * 64),
+            "dataset|digest|literal",
+        ),
+        (
+            lambda value: value["identity"]["runtime"].__setitem__("backend", "forged"),
+            "digest|literal",
+        ),
+    )
+    for mutate, match in mutations:
+        forged = copy.deepcopy(cheap_plan)
+        mutate(forged)
+        unsigned = dict(forged)
+        unsigned.pop("plan_sha256")
+        forged["plan_sha256"] = campaign._digest(unsigned)
+        with pytest.raises(ValueError, match=match):
+            campaign.validate_plan(forged, data_x=data[0], data_y=data[1])
+
+
+def test_shard_preserves_v1_and_cross_validates_wrapper_plan_and_resources(
+    cheap_plan: dict[str, object], data: tuple[np.ndarray, np.ndarray]
+) -> None:
+    shard = _shard(cheap_plan, data, "aid", 2)
+    receipt = cast(dict[str, object], shard["result"])
+    assert receipt["schema"] == activation.RESULT_SCHEMA
+    assert activation.validate_activation_feature_result(copy.deepcopy(receipt)) == receipt
+
+    wrong_arm = copy.deepcopy(shard)
+    wrong_arm["arm"] = "smooth_leaky"
+    _resign_shard(cast(dict[str, Any], wrong_arm))
+    with pytest.raises(ValueError, match="wrapper"):
+        campaign.validate_shard(wrong_arm, cheap_plan)
+
+    self_decided = copy.deepcopy(shard)
+    cast(dict[str, object], self_decided["result"])["outcome"] = "supported"
+    _resign_shard(cast(dict[str, Any], self_decided))
+    with pytest.raises(ValueError, match="cannot self-assign"):
+        campaign.validate_shard(self_decided, cheap_plan)
+
+    shrunk = copy.deepcopy(shard)
+    shrunk_receipt = cast(dict[str, object], shrunk["result"])
+    cast(dict[str, object], shrunk_receipt["config"])["task_length"] = 1
+    _resign_shard(cast(dict[str, Any], shrunk))
+    with pytest.raises(ValueError):
+        campaign.validate_shard(shrunk, cheap_plan)
+
+    forged_schedule = copy.deepcopy(shard)
+    cast(dict[str, object], forged_schedule["execution_identity"])[
+        "schedule_sha256"
+    ] = "0" * 64
+    _resign_shard(cast(dict[str, Any], forged_schedule))
+    with pytest.raises(ValueError, match="schedule, initialization, or PRNG"):
+        campaign.validate_shard(forged_schedule, cheap_plan)
+
+
+def test_complete_aggregate_uses_paired_student_t_and_multiplicity_rule(
+    cheap_plan: dict[str, object], data: tuple[np.ndarray, np.ndarray]
+) -> None:
+    aggregate = campaign.build_aggregate(cheap_plan, list(reversed(_matrix(cheap_plan, data))))
+    assert aggregate["status"] == "complete_with_supported_candidates"
+    summary = cast(dict[str, Any], aggregate["summary"])
+    comparisons = {
+        row["candidate"]: row for row in summary["paired_comparisons"]
+    }
+    assert comparisons["smooth_leaky"]["outcome"] == "supported"
+    assert comparisons["aid"]["outcome"] == "rejected"
+    assert comparisons["deep_fourier"]["outcome"] == "inconclusive"
+    assert len(summary["paired_comparisons"]) == 8
+    statistics = cast(dict[str, Any], cheap_plan["statistics"])
+    assert statistics["per_comparison_alpha"] == 0.05 / 8
+    assert statistics["critical_value"] == 5.261057575065803
+    assert summary["resources"]["totals"]["data_steps"] == 55_000
+    assert campaign.validate_aggregate(copy.deepcopy(aggregate)) == aggregate
+
+
+def test_full_confirmation_uses_fresh_v2_seeds_and_fails_closed_without_cheap_win(
+    cheap_plan: dict[str, object], data: tuple[np.ndarray, np.ndarray]
+) -> None:
+    cheap = campaign.build_aggregate(cheap_plan, _matrix(cheap_plan, data))
+    full_plan = campaign.build_plan("full_confirmation", *data)
+
+    with pytest.raises(ValueError, match="requires the retained cheap-screen"):
+        campaign.validate_shard(
+            _shard(
+                full_plan,
+                data,
+                "smooth_leaky",
+                campaign.FULL_CONFIRMATION_SEEDS[0],
+                cheap,
+            ),
+            full_plan,
+        )
+
+    full_shard = _shard(
+        full_plan,
+        data,
+        "smooth_leaky",
+        campaign.FULL_CONFIRMATION_SEEDS[0],
+        cheap,
+    )
+    receipt = cast(dict[str, object], full_shard["result"])
+    assert receipt["schema"] == activation.CAMPAIGN_RESULT_SCHEMA
+    assert activation.validate_activation_feature_campaign_result(
+        copy.deepcopy(receipt), development_seeds=campaign.FULL_CONFIRMATION_SEEDS
+    ) == receipt
+    with pytest.raises(ValueError, match="unsupported result identity"):
+        activation.validate_activation_feature_result(receipt)
+
+    full = campaign.build_aggregate(
+        full_plan,
+        _matrix(full_plan, data, cheap),
+        prerequisite=cheap,
+    )
+    assert full["prerequisite"] == cheap
+    assert campaign.validate_aggregate(copy.deepcopy(full)) == full
+
+
+def test_full_confirmation_gate_rejects_complete_cheap_screen_without_primary_support(
+    cheap_plan: dict[str, object], data: tuple[np.ndarray, np.ndarray]
+) -> None:
+    shards = _matrix(cheap_plan, data)
+    for shard in shards:
+        if shard["arm"] != "smooth_leaky":
+            continue
+        receipt = cast(dict[str, object], shard["result"])
+        metrics = cast(dict[str, object], receipt["metrics"])
+        metrics["asi_whole_stream_mean_accuracy"] = 0.50 + cast(int, shard["seed"]) / 1_000.0
+        _resign_shard(cast(dict[str, Any], shard))
+    cheap_without_support = campaign.build_aggregate(cheap_plan, shards)
+    full_plan = campaign.build_plan("full_confirmation", *data)
+    with pytest.raises(ValueError, match="did not authorize"):
+        campaign._execution_authorization(full_plan, cheap_without_support)
+
+
+def test_full_gate_runs_before_any_arm_execution(
+    data: tuple[np.ndarray, np.ndarray], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    full_plan = campaign.build_plan("full_confirmation", *data)
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("arm execution must remain gated")
+
+    monkeypatch.setattr(campaign, "run_activation_feature_arm", forbidden)
+    with pytest.raises(ValueError, match="requires the retained cheap-screen"):
+        campaign.build_shard(
+            full_plan,
+            *data,
+            arm="smooth_leaky",
+            seed=campaign.FULL_CONFIRMATION_SEEDS[0],
+        )
+    assert calls == 0
+
+
+def test_aggregate_rejects_missing_duplicate_and_self_consistent_statistic_forgery(
+    cheap_plan: dict[str, object], data: tuple[np.ndarray, np.ndarray]
+) -> None:
+    shards = _matrix(cheap_plan, data)
+    with pytest.raises(ValueError, match="complete"):
+        campaign.build_aggregate(cheap_plan, shards[:-1])
+    duplicate = shards[:-1] + [copy.deepcopy(shards[0])]
+    with pytest.raises(ValueError, match="duplicate|incomplete"):
+        campaign.build_aggregate(cheap_plan, duplicate)
+
+    aggregate = cast(dict[str, Any], campaign.build_aggregate(cheap_plan, shards))
+    aggregate["summary"]["paired_comparisons"][0]["mean_delta"] = 999.0
+    _resign_aggregate(aggregate)
+    with pytest.raises(ValueError, match="statistics|drifted"):
+        campaign.validate_aggregate(aggregate)
+
+
+@pytest.mark.skipif(
+    not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_TMPFILE")),
+    reason="strict loader/publication requires Linux descriptor support",
+)
+def test_strict_file_admission_and_append_only_writer(
+    cheap_plan: dict[str, object], tmp_path: Path
+) -> None:
+    destination = tmp_path / "plan.json"
+    campaign.write_new_json(destination, cheap_plan)
+    assert campaign.load_json_strict(destination, max_bytes=campaign._MAX_SHARD_BYTES) == cheap_plan
+    with pytest.raises(FileExistsError):
+        campaign.write_new_json(destination, cheap_plan)
+
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema":"x","schema":"y"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate"):
+        campaign.load_json_strict(duplicate, max_bytes=1_024)
+
+    symlink = tmp_path / "symlink.json"
+    symlink.symlink_to(destination)
+    with pytest.raises(ValueError, match="JSON|regular"):
+        campaign.load_json_strict(symlink, max_bytes=campaign._MAX_SHARD_BYTES)
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="strict loader requires O_NOFOLLOW")
+def test_summarizer_rejects_two_paths_to_one_inode(
+    cheap_plan: dict[str, object], data: tuple[np.ndarray, np.ndarray], tmp_path: Path
+) -> None:
+    shards = _matrix(cheap_plan, data)
+    paths: list[Path] = []
+    for index, shard in enumerate(shards):
+        path = tmp_path / f"{index}.json"
+        path.write_text(json.dumps(shard), encoding="utf-8")
+        paths.append(path)
+    alias = tmp_path / "alias.json"
+    os.link(paths[0], alias)
+    paths[-1] = alias
+    with pytest.raises(ValueError, match="unique regular files"):
+        campaign.summarize_shard_files(cheap_plan, paths)
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="strict loader requires O_NOFOLLOW")
+def test_summarizer_uses_metadata_from_the_descriptor_that_supplied_bytes(
+    cheap_plan: dict[str, object],
+    data: tuple[np.ndarray, np.ndarray],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shards = _matrix(cheap_plan, data)
+    paths: list[Path] = []
+    for index, shard in enumerate(shards):
+        path = tmp_path / f"{index}.json"
+        path.write_text(json.dumps(shard), encoding="utf-8")
+        paths.append(path)
+    incoming = tmp_path / "incoming.json"
+    incoming.write_text(json.dumps(shards[1]), encoding="utf-8")
+    alias = tmp_path / "incoming-alias.json"
+    os.link(incoming, alias)
+    paths[1] = alias
+
+    real_open = os.open
+    swapped = False
+
+    def swapping_open(path: Any, flags: int, *args: Any, **kwargs: Any) -> int:
+        nonlocal swapped
+        if not swapped and Path(path) == paths[0]:
+            os.replace(incoming, paths[0])
+            swapped = True
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", swapping_open)
+    with pytest.raises(ValueError, match="unique regular files"):
+        campaign.summarize_shard_files(cheap_plan, paths)
+    assert swapped is True
+
+
+@pytest.mark.skipif(
+    not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_TMPFILE")),
+    reason="descriptor-pinned publication requires Linux",
+)
+def test_reserved_publication_resists_parent_swap_and_occupied_race(tmp_path: Path) -> None:
+    requested_parent = tmp_path / "requested"
+    requested_parent.mkdir()
+    destination = requested_parent / "result.json"
+    moved_parent = tmp_path / "moved"
+    with campaign._reserved_new_output(destination) as target:
+        requested_parent.rename(moved_parent)
+        requested_parent.mkdir()
+        campaign._publish_reserved_json(target, {"value": 1})
+    assert json.loads((moved_parent / "result.json").read_text()) == {"value": 1}
+    assert not destination.exists()
+
+    occupied = tmp_path / "occupied.json"
+    with campaign._reserved_new_output(occupied) as target:
+        occupied.write_text("do not replace", encoding="utf-8")
+        with pytest.raises(FileExistsError, match="refusing to replace"):
+            campaign._publish_reserved_json(target, {"value": 2})
+    assert occupied.read_text(encoding="utf-8") == "do not replace"

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -513,6 +513,11 @@ def test_strict_file_admission_and_append_only_writer(
     with pytest.raises(ValueError, match="JSON|regular"):
         campaign.load_json_strict(symlink, max_bytes=campaign._MAX_SHARD_BYTES)
 
+    hardlink = tmp_path / "hardlink.json"
+    os.link(destination, hardlink)
+    with pytest.raises(ValueError, match="uniquely linked"):
+        campaign.load_json_strict(destination, max_bytes=campaign._MAX_SHARD_BYTES)
+
 
 @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="strict loader requires O_NOFOLLOW")
 def test_summarizer_rejects_two_paths_to_one_inode(
@@ -527,7 +532,7 @@ def test_summarizer_rejects_two_paths_to_one_inode(
     alias = tmp_path / "alias.json"
     os.link(paths[0], alias)
     paths[-1] = alias
-    with pytest.raises(ValueError, match="unique regular files"):
+    with pytest.raises(ValueError, match="uniquely linked|unique regular files"):
         campaign.summarize_shard_files(cheap_plan, paths)
 
 
@@ -561,7 +566,7 @@ def test_summarizer_uses_metadata_from_the_descriptor_that_supplied_bytes(
         return real_open(path, flags, *args, **kwargs)
 
     monkeypatch.setattr(os, "open", swapping_open)
-    with pytest.raises(ValueError, match="unique regular files"):
+    with pytest.raises(ValueError, match="uniquely linked|unique regular files"):
         campaign.summarize_shard_files(cheap_plan, paths)
     assert swapped is True
 

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -81,14 +81,15 @@ def _receipt(
             config, n_train=data[0].shape[0]
         ),
     )
-    return (
-        activation.activation_feature_result_payload(result, outcome="inconclusive")
+    seeds = (
+        campaign.CHEAP_SCREEN_SEEDS
         if stage == "cheap_screen"
-        else activation.activation_feature_campaign_result_payload(
-            result,
-            outcome="inconclusive",
-            development_seeds=campaign.FULL_CONFIRMATION_SEEDS,
-        )
+        else campaign.FULL_CONFIRMATION_SEEDS
+    )
+    return activation.activation_feature_campaign_result_payload(
+        result,
+        outcome="inconclusive",
+        development_seeds=seeds,
     )
 
 
@@ -162,7 +163,7 @@ def test_both_plans_freeze_full_11_by_5_matrix_without_horizon_shrink(
     full = campaign.build_plan("full_confirmation", *data)
     assert cheap["matrix"] == {
         "arms": list(campaign.ARM_ROSTER),
-        "seeds": [0, 1, 2, 3, 4],
+        "seeds": list(campaign.CHEAP_SCREEN_SEEDS),
         "shard_count": 55,
         "ordering": "seed_major_then_arm_roster",
         "execution": "one_shard_per_fresh_python_process",
@@ -179,6 +180,12 @@ def test_both_plans_freeze_full_11_by_5_matrix_without_horizon_shrink(
     full_gate = cast(dict[str, object], full["execution_gate"])
     assert full_gate["mode"] == "conditional_on_retained_cheap_screen"
     assert full_gate["complete_matrix_if_authorized"] is True
+    assert full_gate["execution_authorized"] is False
+    assert campaign.QUARANTINED_CHEAP_SEEDS == (0, 1, 2, 3, 4)
+    assert campaign.QUARANTINED_FULL_SEEDS == (156_610, 156_611, 156_612, 156_613, 156_614)
+    assert set(campaign.ALL_SEEDS).isdisjoint(
+        campaign.QUARANTINED_CHEAP_SEEDS + campaign.QUARANTINED_FULL_SEEDS
+    )
     assert campaign.validate_plan(copy.deepcopy(cheap), data_x=data[0], data_y=data[1]) == cheap
 
 
@@ -264,13 +271,15 @@ def test_plan_rejects_resigned_horizon_dataset_and_runtime_forgery(
             campaign.validate_plan(forged, data_x=data[0], data_y=data[1])
 
 
-def test_shard_preserves_v1_and_cross_validates_wrapper_plan_and_resources(
+def test_shard_uses_external_seed_v2_and_cross_validates_wrapper_plan_and_resources(
     cheap_plan: dict[str, object], data: tuple[np.ndarray, np.ndarray]
 ) -> None:
-    shard = _shard(cheap_plan, data, "aid", 2)
+    shard = _shard(cheap_plan, data, "aid", campaign.CHEAP_SCREEN_SEEDS[2])
     receipt = cast(dict[str, object], shard["result"])
-    assert receipt["schema"] == activation.RESULT_SCHEMA
-    assert activation.validate_activation_feature_result(copy.deepcopy(receipt)) == receipt
+    assert receipt["schema"] == activation.CAMPAIGN_RESULT_SCHEMA
+    assert activation.validate_activation_feature_campaign_result(
+        copy.deepcopy(receipt), development_seeds=campaign.CHEAP_SCREEN_SEEDS
+    ) == receipt
 
     wrong_arm = copy.deepcopy(shard)
     wrong_arm["arm"] = "smooth_leaky"
@@ -391,7 +400,7 @@ def test_full_gate_runs_before_any_arm_execution(
         raise AssertionError("arm execution must remain gated")
 
     monkeypatch.setattr(campaign, "run_activation_feature_arm", forbidden)
-    with pytest.raises(ValueError, match="requires the retained cheap-screen"):
+    with pytest.raises(RuntimeError, match="not authorized"):
         campaign.build_shard(
             full_plan,
             *data,
@@ -411,11 +420,55 @@ def test_execution_failure_is_not_misrepresented_as_a_retained_result_shard(
 
     monkeypatch.setattr(campaign, "run_activation_feature_arm", failed_execution)
     with pytest.raises(RuntimeError, match="simulated execution failure"):
-        campaign.build_shard(cheap_plan, *data, arm="aid", seed=0)
+        campaign._build_shard_authorized(
+            cheap_plan,
+            *data,
+            arm="aid",
+            seed=campaign.CHEAP_SCREEN_SEEDS[0],
+            _capability=campaign._EXECUTION_CAPABILITY,
+        )
 
     policy = cast(dict[str, object], cheap_plan["policy"])
     assert policy["execution_failure_receipts_retained"] is False
     assert policy["completed_shard_negative_results_retained"] is True
+
+def test_public_builder_and_cli_fail_before_dataset_or_arm_execution(
+    cheap_plan: dict[str, object],
+    data: tuple[np.ndarray, np.ndarray],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"dataset": 0, "arm": 0}
+
+    def forbidden_dataset(*args: object, **kwargs: object) -> object:
+        calls["dataset"] += 1
+        raise AssertionError("dataset load must remain gated")
+
+    def forbidden_arm(*args: object, **kwargs: object) -> object:
+        calls["arm"] += 1
+        raise AssertionError("arm execution must remain gated")
+
+    monkeypatch.setattr(campaign, "load_mnist_train", forbidden_dataset)
+    monkeypatch.setattr(campaign, "run_activation_feature_arm", forbidden_arm)
+    with pytest.raises(RuntimeError, match="not authorized"):
+        campaign.build_shard(
+            cheap_plan,
+            *data,
+            arm="aid",
+            seed=campaign.CHEAP_SCREEN_SEEDS[0],
+        )
+    with pytest.raises(RuntimeError, match="not authorized"):
+        campaign.main(
+            [
+                "run-shard",
+                "--stage",
+                "cheap_screen",
+                "--arm",
+                "aid",
+                "--seed",
+                str(campaign.CHEAP_SCREEN_SEEDS[0]),
+            ]
+        )
+    assert calls == {"dataset": 0, "arm": 0}
 
 
 def test_aggregate_rejects_missing_duplicate_and_self_consistent_statistic_forgery(
@@ -533,3 +586,32 @@ def test_reserved_publication_resists_parent_swap_and_occupied_race(tmp_path: Pa
         with pytest.raises(FileExistsError, match="refusing to replace"):
             campaign._publish_reserved_json(target, {"value": 2})
     assert occupied.read_text(encoding="utf-8") == "do not replace"
+
+
+@pytest.mark.skipif(
+    not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_TMPFILE")),
+    reason="descriptor-pinned publication requires Linux",
+)
+def test_reservation_is_exclusive_before_work_and_publication_strictly_rereads(
+    cheap_plan: dict[str, object], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "plan.json"
+    with campaign._reserved_new_output(destination) as target:
+        with pytest.raises(FileExistsError, match="reserved"):
+            with campaign._reserved_new_output(destination):
+                raise AssertionError("reservation collision entered protected work")
+
+        calls = 0
+        real_validate = campaign.validate_plan
+
+        def counted_validate(value: object, **kwargs: object) -> dict[str, object]:
+            nonlocal calls
+            calls += 1
+            return real_validate(value, **kwargs)
+
+        monkeypatch.setattr(campaign, "validate_plan", counted_validate)
+        campaign._publish_reserved_json(target, cheap_plan)
+    assert calls >= 1
+    assert campaign.load_json_strict(
+        destination, max_bytes=campaign._MAX_SHARD_BYTES
+    ) == cheap_plan

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -380,7 +380,9 @@ def test_full_confirmation_gate_rejects_complete_cheap_screen_without_primary_su
             continue
         receipt = cast(dict[str, object], shard["result"])
         metrics = cast(dict[str, object], receipt["metrics"])
-        metrics["asi_whole_stream_mean_accuracy"] = 0.50 + cast(int, shard["seed"]) / 1_000.0
+        metrics["asi_whole_stream_mean_accuracy"] = 0.50 + (
+            campaign.CHEAP_SCREEN_SEEDS.index(cast(int, shard["seed"])) / 1_000.0
+        )
         _resign_shard(cast(dict[str, Any], shard))
     cheap_without_support = campaign.build_aggregate(cheap_plan, shards)
     full_plan = campaign.build_plan("full_confirmation", *data)
@@ -568,7 +570,9 @@ def test_summarizer_uses_metadata_from_the_descriptor_that_supplied_bytes(
     not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_TMPFILE")),
     reason="descriptor-pinned publication requires Linux",
 )
-def test_reserved_publication_resists_parent_swap_and_occupied_race(tmp_path: Path) -> None:
+def test_reserved_publication_resists_parent_swap_and_occupied_race(
+    cheap_plan: dict[str, object], tmp_path: Path
+) -> None:
     requested_parent = tmp_path / "requested"
     requested_parent.mkdir()
     destination = requested_parent / "result.json"
@@ -576,15 +580,15 @@ def test_reserved_publication_resists_parent_swap_and_occupied_race(tmp_path: Pa
     with campaign._reserved_new_output(destination) as target:
         requested_parent.rename(moved_parent)
         requested_parent.mkdir()
-        campaign._publish_reserved_json(target, {"value": 1})
-    assert json.loads((moved_parent / "result.json").read_text()) == {"value": 1}
+        campaign._publish_reserved_json(target, cheap_plan)
+    assert json.loads((moved_parent / "result.json").read_text()) == cheap_plan
     assert not destination.exists()
 
     occupied = tmp_path / "occupied.json"
     with campaign._reserved_new_output(occupied) as target:
         occupied.write_text("do not replace", encoding="utf-8")
         with pytest.raises(FileExistsError, match="refusing to replace"):
-            campaign._publish_reserved_json(target, {"value": 2})
+            campaign._publish_reserved_json(target, cheap_plan)
     assert occupied.read_text(encoding="utf-8") == "do not replace"
 
 

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -24,9 +24,31 @@ def data() -> tuple[np.ndarray, np.ndarray]:
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _bounded_dataset_shapes() -> Iterator[None]:
+def _bounded_protocol(data: tuple[np.ndarray, np.ndarray]) -> Iterator[None]:
     patch = pytest.MonkeyPatch()
     patch.setattr(campaign, "_canonical_dataset_shapes", lambda: ((5_000, 784), (5_000,)))
+    patch.setattr(
+        campaign,
+        "_canonical_dataset_hashes",
+        lambda: (
+            campaign.screening_lane._array_bundle_sha256(
+                "alberta.ipmnist_screening.materialized_x.v1", {"x": data[0]}
+            ),
+            campaign.screening_lane._array_bundle_sha256(
+                "alberta.ipmnist_screening.materialized_y.v1", {"y": data[1]}
+            ),
+        ),
+    )
+    test_seeds = {
+        "cheap_screen": campaign.QUARANTINED_CHEAP_SEEDS,
+        "full_confirmation": campaign.QUARANTINED_FULL_SEEDS,
+    }
+    patch.setattr(campaign, "_SEEDS", test_seeds)
+    patch.setattr(
+        campaign,
+        "ALL_SEEDS",
+        campaign.QUARANTINED_CHEAP_SEEDS + campaign.QUARANTINED_FULL_SEEDS,
+    )
     yield
     patch.undo()
 
@@ -37,11 +59,7 @@ def cheap_plan(data: tuple[np.ndarray, np.ndarray]) -> dict[str, object]:
 
 
 def _metric(arm: str, seed: int) -> float:
-    seed_index = (
-        campaign.CHEAP_SCREEN_SEEDS.index(seed)
-        if seed in campaign.CHEAP_SCREEN_SEEDS
-        else campaign.FULL_CONFIRMATION_SEEDS.index(seed)
-    )
+    seed_index = next(seeds.index(seed) for seeds in campaign._SEEDS.values() if seed in seeds)
     base = 0.50 + seed_index / 1_000.0
     if arm == "smooth_leaky":
         return base + 0.10
@@ -50,9 +68,9 @@ def _metric(arm: str, seed: int) -> float:
     return base
 
 
-def _receipt(
+def _result(
     plan: dict[str, object], data: tuple[np.ndarray, np.ndarray], arm: str, seed: int
-) -> dict[str, object]:
+) -> activation.ActivationFeatureRunResult:
     config_values = cast(dict[str, int], plan["config"])
     config = IPMNISTConfig(**config_values)
     value = _metric(arm, seed)
@@ -70,7 +88,7 @@ def _receipt(
     )
     stage = cast(str, plan["stage"])
     execution_identity = campaign._expected_execution_identity(stage, seed, data[0].shape[0])
-    result = activation.ActivationFeatureRunResult(
+    return activation.ActivationFeatureRunResult(
         screening=screening,
         dataset_sha256=activation._array_bundle_sha256(*data),
         schedule_sha256=execution_identity["schedule_sha256"],
@@ -81,11 +99,14 @@ def _receipt(
             config, n_train=data[0].shape[0]
         ),
     )
-    seeds = (
-        campaign.CHEAP_SCREEN_SEEDS
-        if stage == "cheap_screen"
-        else campaign.FULL_CONFIRMATION_SEEDS
-    )
+
+
+def _receipt(
+    plan: dict[str, object], data: tuple[np.ndarray, np.ndarray], arm: str, seed: int
+) -> dict[str, object]:
+    result = _result(plan, data, arm, seed)
+    stage = cast(str, plan["stage"])
+    seeds = campaign._SEEDS[stage]
     return activation.activation_feature_campaign_result_payload(
         result,
         outcome="inconclusive",
@@ -120,11 +141,7 @@ def _matrix(
     prerequisite: object | None = None,
 ) -> list[dict[str, object]]:
     stage = cast(str, plan["stage"])
-    seeds = (
-        campaign.CHEAP_SCREEN_SEEDS
-        if stage == "cheap_screen"
-        else campaign.FULL_CONFIRMATION_SEEDS
-    )
+    seeds = campaign._SEEDS[stage]
     authorization = campaign._execution_authorization(plan, prerequisite)
     shards: list[dict[str, object]] = []
     for seed in seeds:
@@ -163,14 +180,14 @@ def test_both_plans_freeze_full_11_by_5_matrix_without_horizon_shrink(
     full = campaign.build_plan("full_confirmation", *data)
     assert cheap["matrix"] == {
         "arms": list(campaign.ARM_ROSTER),
-        "seeds": list(campaign.CHEAP_SCREEN_SEEDS),
+        "seeds": list(campaign.QUARANTINED_CHEAP_SEEDS),
         "shard_count": 55,
         "ordering": "seed_major_then_arm_roster",
         "execution": "one_shard_per_fresh_python_process",
     }
     full_matrix = cast(dict[str, object], full["matrix"])
     assert full_matrix["arms"] == list(campaign.ARM_ROSTER)
-    assert full_matrix["seeds"] == list(campaign.FULL_CONFIRMATION_SEEDS)
+    assert full_matrix["seeds"] == list(campaign.QUARANTINED_FULL_SEEDS)
     assert full_matrix["shard_count"] == 55
     assert set(campaign.CHEAP_SCREEN_SEEDS).isdisjoint(campaign.FULL_CONFIRMATION_SEEDS)
     assert cheap["config"] == IPMNISTConfig(n_tasks=2, task_length=500).to_config()
@@ -183,8 +200,17 @@ def test_both_plans_freeze_full_11_by_5_matrix_without_horizon_shrink(
     assert full_gate["execution_authorized"] is False
     assert campaign.QUARANTINED_CHEAP_SEEDS == (0, 1, 2, 3, 4)
     assert campaign.QUARANTINED_FULL_SEEDS == (156_610, 156_611, 156_612, 156_613, 156_614)
-    assert set(campaign.ALL_SEEDS).isdisjoint(
-        campaign.QUARANTINED_CHEAP_SEEDS + campaign.QUARANTINED_FULL_SEEDS
+    assert campaign.QUARANTINED_REPLACEMENT_CHEAP_SEEDS == tuple(
+        range(2_156_600, 2_156_605)
+    )
+    assert campaign.QUARANTINED_REPLACEMENT_FULL_SEEDS == tuple(
+        range(2_156_610, 2_156_615)
+    )
+    assert set(campaign.CHEAP_SCREEN_SEEDS + campaign.FULL_CONFIRMATION_SEEDS).isdisjoint(
+        campaign.QUARANTINED_CHEAP_SEEDS
+        + campaign.QUARANTINED_FULL_SEEDS
+        + campaign.QUARANTINED_REPLACEMENT_CHEAP_SEEDS
+        + campaign.QUARANTINED_REPLACEMENT_FULL_SEEDS
     )
     assert campaign.validate_plan(copy.deepcopy(cheap), data_x=data[0], data_y=data[1]) == cheap
 
@@ -193,6 +219,17 @@ def test_production_dataset_contract_names_the_full_canonical_train_split() -> N
     assert campaign._CANONICAL_X_SHAPE == (60_000, 784)
     assert campaign._CANONICAL_Y_SHAPE == (60_000,)
     assert "rows 0:60000" in campaign._DATASET_MATERIALIZATION
+    assert campaign._CANONICAL_X_SHA256 == (
+        "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313"
+    )
+    assert campaign._CANONICAL_Y_SHA256 == (
+        "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a"
+    )
+
+
+def test_production_seed_rosters_are_fresh_without_deriving_their_keys() -> None:
+    assert campaign.CHEAP_SCREEN_SEEDS == tuple(range(3_975_019_531, 3_975_019_536))
+    assert campaign.FULL_CONFIRMATION_SEEDS == tuple(range(2_924_933_221, 2_924_933_226))
 
 
 def test_plan_binds_exact_source_runtime_dataset_resources_and_paper_limits(
@@ -229,7 +266,8 @@ def test_plan_binds_exact_source_runtime_dataset_resources_and_paper_limits(
     policy = cast(dict[str, Any], cheap_plan["policy"])
     assert policy["completed_shard_negative_results_retained"] is True
     assert policy["execution_failure_receipts_retained"] is False
-    assert "incomplete" in policy["execution_failure_note"]
+    assert "do not produce campaign failure receipts" in policy["execution_failure_note"]
+    assert "external scheduler must retain its log" in policy["execution_failure_note"]
     per_shard = cast(dict[str, Any], resources["per_shard"])
     assert per_shard["retained_schedule_numeric_bytes"] == 4 * 2 * (784 + 5_000)
 
@@ -274,11 +312,11 @@ def test_plan_rejects_resigned_horizon_dataset_and_runtime_forgery(
 def test_shard_uses_external_seed_v2_and_cross_validates_wrapper_plan_and_resources(
     cheap_plan: dict[str, object], data: tuple[np.ndarray, np.ndarray]
 ) -> None:
-    shard = _shard(cheap_plan, data, "aid", campaign.CHEAP_SCREEN_SEEDS[2])
+    shard = _shard(cheap_plan, data, "aid", campaign._SEEDS["cheap_screen"][2])
     receipt = cast(dict[str, object], shard["result"])
     assert receipt["schema"] == activation.CAMPAIGN_RESULT_SCHEMA
     assert activation.validate_activation_feature_campaign_result(
-        copy.deepcopy(receipt), development_seeds=campaign.CHEAP_SCREEN_SEEDS
+        copy.deepcopy(receipt), development_seeds=campaign._SEEDS["cheap_screen"]
     ) == receipt
 
     wrong_arm = copy.deepcopy(shard)
@@ -341,7 +379,7 @@ def test_full_confirmation_uses_fresh_v2_seeds_and_fails_closed_without_cheap_wi
                 full_plan,
                 data,
                 "smooth_leaky",
-                campaign.FULL_CONFIRMATION_SEEDS[0],
+                campaign._SEEDS["full_confirmation"][0],
                 cheap,
             ),
             full_plan,
@@ -351,13 +389,13 @@ def test_full_confirmation_uses_fresh_v2_seeds_and_fails_closed_without_cheap_wi
         full_plan,
         data,
         "smooth_leaky",
-        campaign.FULL_CONFIRMATION_SEEDS[0],
+        campaign._SEEDS["full_confirmation"][0],
         cheap,
     )
     receipt = cast(dict[str, object], full_shard["result"])
     assert receipt["schema"] == activation.CAMPAIGN_RESULT_SCHEMA
     assert activation.validate_activation_feature_campaign_result(
-        copy.deepcopy(receipt), development_seeds=campaign.FULL_CONFIRMATION_SEEDS
+        copy.deepcopy(receipt), development_seeds=campaign._SEEDS["full_confirmation"]
     ) == receipt
     with pytest.raises(ValueError, match="unsupported result identity"):
         activation.validate_activation_feature_result(receipt)
@@ -381,7 +419,7 @@ def test_full_confirmation_gate_rejects_complete_cheap_screen_without_primary_su
         receipt = cast(dict[str, object], shard["result"])
         metrics = cast(dict[str, object], receipt["metrics"])
         metrics["asi_whole_stream_mean_accuracy"] = 0.50 + (
-            campaign.CHEAP_SCREEN_SEEDS.index(cast(int, shard["seed"])) / 1_000.0
+            campaign._SEEDS["cheap_screen"].index(cast(int, shard["seed"])) / 1_000.0
         )
         _resign_shard(cast(dict[str, Any], shard))
     cheap_without_support = campaign.build_aggregate(cheap_plan, shards)
@@ -407,7 +445,7 @@ def test_full_gate_runs_before_any_arm_execution(
             full_plan,
             *data,
             arm="smooth_leaky",
-            seed=campaign.FULL_CONFIRMATION_SEEDS[0],
+            seed=campaign._SEEDS["full_confirmation"][0],
         )
     assert calls == 0
 
@@ -426,13 +464,39 @@ def test_execution_failure_is_not_misrepresented_as_a_retained_result_shard(
             cheap_plan,
             *data,
             arm="aid",
-            seed=campaign.CHEAP_SCREEN_SEEDS[0],
+            seed=campaign._SEEDS["cheap_screen"][0],
             _capability=campaign._EXECUTION_CAPABILITY,
         )
 
     policy = cast(dict[str, object], cheap_plan["policy"])
     assert policy["execution_failure_receipts_retained"] is False
     assert policy["completed_shard_negative_results_retained"] is True
+
+
+def test_private_executor_rechecks_full_source_identity_after_runner_return(
+    cheap_plan: dict[str, object],
+    data: tuple[np.ndarray, np.ndarray],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_source = campaign._source_identity()
+    seed = campaign._SEEDS["cheap_screen"][0]
+
+    def drift_after_execution(*args: object, **kwargs: object) -> object:
+        drifted = dict(original_source)
+        drifted["alberta_framework/evaluation/activation_feature_campaign.py"] = "0" * 64
+        monkeypatch.setattr(campaign, "_source_identity", lambda: drifted)
+        return _result(cheap_plan, data, "aid", seed)
+
+    monkeypatch.setattr(campaign, "run_activation_feature_arm", drift_after_execution)
+    with pytest.raises(RuntimeError, match="changed during shard execution"):
+        campaign._build_shard_authorized(
+            cheap_plan,
+            *data,
+            arm="aid",
+            seed=seed,
+            _capability=campaign._EXECUTION_CAPABILITY,
+        )
+
 
 def test_public_builder_and_cli_fail_before_dataset_or_arm_execution(
     cheap_plan: dict[str, object],
@@ -456,7 +520,7 @@ def test_public_builder_and_cli_fail_before_dataset_or_arm_execution(
             cheap_plan,
             *data,
             arm="aid",
-            seed=campaign.CHEAP_SCREEN_SEEDS[0],
+            seed=campaign._SEEDS["cheap_screen"][0],
         )
     with pytest.raises(RuntimeError, match="not authorized"):
         campaign.main(
@@ -467,7 +531,7 @@ def test_public_builder_and_cli_fail_before_dataset_or_arm_execution(
                 "--arm",
                 "aid",
                 "--seed",
-                str(campaign.CHEAP_SCREEN_SEEDS[0]),
+                str(campaign._SEEDS["cheap_screen"][0]),
             ]
         )
     assert calls == {"dataset": 0, "arm": 0}
@@ -624,3 +688,31 @@ def test_reservation_is_exclusive_before_work_and_publication_strictly_rereads(
     assert campaign.load_json_strict(
         destination, max_bytes=campaign._MAX_SHARD_BYTES
     ) == cheap_plan
+
+
+@pytest.mark.skipif(
+    not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_TMPFILE")),
+    reason="descriptor-pinned publication requires Linux",
+)
+def test_publication_rejects_zero_write_and_nonregular_reread_swap(
+    cheap_plan: dict[str, object], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    short_output = tmp_path / "short.json"
+    with campaign._reserved_new_output(short_output) as target:
+        monkeypatch.setattr(os, "write", lambda *_args, **_kwargs: 0)
+        with pytest.raises(OSError, match="short write"):
+            campaign._publish_reserved_json(target, cheap_plan)
+    monkeypatch.undo()
+
+    swapped_output = tmp_path / "swapped.json"
+    with campaign._reserved_new_output(swapped_output) as target:
+        real_link = campaign._link_unnamed_file
+
+        def link_then_swap(file_fd: int, parent_fd: int, name: str) -> None:
+            real_link(file_fd, parent_fd, name)
+            os.unlink(name, dir_fd=parent_fd)
+            os.mkfifo(name, dir_fd=parent_fd)
+
+        monkeypatch.setattr(campaign, "_link_unnamed_file", link_then_swap)
+        with pytest.raises(ValueError, match="regular file"):
+            campaign._publish_reserved_json(target, cheap_plan)

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -77,7 +77,7 @@ def _receipt(
         source_identity=activation._current_source_identity(),
         runtime_identity=activation._runtime_identity(),
         n_train=data[0].shape[0],
-        peak_schedule_working_bytes=activation._preflight_activation_feature_resources(
+        retained_schedule_numeric_bytes=activation._preflight_activation_feature_resources(
             config, n_train=data[0].shape[0]
         ),
     )
@@ -216,6 +216,15 @@ def test_plan_binds_exact_source_runtime_dataset_resources_and_paper_limits(
     parity = cast(dict[str, Any], cheap_plan["paper_parity"])
     assert parity["paper_protocol_parity_claimed"] is False
     assert parity["paper_result_reproduction_claimed"] is False
+    assert parity["sources"]["aid"]["implementation_source"] == (
+        "paper Algorithm 2 simplified element-wise rule"
+    )
+    policy = cast(dict[str, Any], cheap_plan["policy"])
+    assert policy["completed_shard_negative_results_retained"] is True
+    assert policy["execution_failure_receipts_retained"] is False
+    assert "incomplete" in policy["execution_failure_note"]
+    per_shard = cast(dict[str, Any], resources["per_shard"])
+    assert per_shard["retained_schedule_numeric_bytes"] == 4 * 2 * (784 + 5_000)
 
 
 def test_plan_rejects_noncanonical_dataset_metadata_before_hashing(
@@ -390,6 +399,23 @@ def test_full_gate_runs_before_any_arm_execution(
             seed=campaign.FULL_CONFIRMATION_SEEDS[0],
         )
     assert calls == 0
+
+
+def test_execution_failure_is_not_misrepresented_as_a_retained_result_shard(
+    cheap_plan: dict[str, object],
+    data: tuple[np.ndarray, np.ndarray],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def failed_execution(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("simulated execution failure")
+
+    monkeypatch.setattr(campaign, "run_activation_feature_arm", failed_execution)
+    with pytest.raises(RuntimeError, match="simulated execution failure"):
+        campaign.build_shard(cheap_plan, *data, arm="aid", seed=0)
+
+    policy = cast(dict[str, object], cheap_plan["policy"])
+    assert policy["execution_failure_receipts_retained"] is False
+    assert policy["completed_shard_negative_results_retained"] is True
 
 
 def test_aggregate_rejects_missing_duplicate_and_self_consistent_statistic_forgery(

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -502,6 +502,7 @@ def test_public_builder_and_cli_fail_before_dataset_or_arm_execution(
     cheap_plan: dict[str, object],
     data: tuple[np.ndarray, np.ndarray],
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     calls = {"dataset": 0, "arm": 0}
 
@@ -515,6 +516,31 @@ def test_public_builder_and_cli_fail_before_dataset_or_arm_execution(
 
     monkeypatch.setattr(campaign, "load_mnist_train", forbidden_dataset)
     monkeypatch.setattr(campaign, "run_activation_feature_arm", forbidden_arm)
+    plan_output = tmp_path / "plan.json"
+    with pytest.raises(RuntimeError, match="not authorized"):
+        campaign.main(
+            [
+                "plan",
+                "--stage",
+                "cheap_screen",
+                "--output",
+                str(plan_output),
+            ]
+        )
+    assert not plan_output.exists()
+    aggregate_output = tmp_path / "aggregate.json"
+    with pytest.raises(RuntimeError, match="not authorized"):
+        campaign.main(
+            [
+                "summarize",
+                "--stage",
+                "cheap_screen",
+                "--output",
+                str(aggregate_output),
+                str(tmp_path / "missing-shard.json"),
+            ]
+        )
+    assert not aggregate_output.exists()
     with pytest.raises(RuntimeError, match="not authorized"):
         campaign.build_shard(
             cheap_plan,

--- a/tests/test_activation_feature_ipmnist.py
+++ b/tests/test_activation_feature_ipmnist.py
@@ -277,7 +277,7 @@ def test_receipt_rejects_config_whose_schedule_cannot_execute() -> None:
         validate_activation_feature_result(payload)
 
 
-def test_receipt_rejects_forged_current_identity_and_peak_schedule_bytes() -> None:
+def test_receipt_rejects_forged_identity_and_retained_schedule_bytes() -> None:
     x, y = _data()
     payload = activation_feature_result_payload(
         run_activation_feature_arm(x, y, arm="aid", seed=0, config=SMALL),
@@ -288,8 +288,8 @@ def test_receipt_rejects_forged_current_identity_and_peak_schedule_bytes() -> No
     with pytest.raises(ValueError, match="current runtime identity"):
         validate_activation_feature_result(forged_runtime)
     forged_peak = copy.deepcopy(payload)
-    forged_peak["resources"]["peak_schedule_working_bytes"] = 1
-    with pytest.raises(ValueError, match="peak_schedule_working_bytes"):
+    forged_peak["resources"]["retained_schedule_numeric_bytes"] = 1
+    with pytest.raises(ValueError, match="retained_schedule_numeric_bytes"):
         validate_activation_feature_result(forged_peak)
 
 

--- a/tests/test_activation_feature_ipmnist.py
+++ b/tests/test_activation_feature_ipmnist.py
@@ -169,6 +169,17 @@ def test_factories_are_jittable_and_aid_is_deterministic_per_seed() -> None:
     np.testing.assert_array_equal(compiled[2][1], eager[2][1])
 
 
+def test_activation_shard_is_independent_of_ambient_default_prng() -> None:
+    x, y = _data()
+    with jax.default_prng_impl("threefry2x32"):
+        expected = run_activation_feature_arm(x, y, arm="aid", seed=4, config=SMALL)
+    with jax.default_prng_impl("rbg"):
+        actual = run_activation_feature_arm(x, y, arm="aid", seed=4, config=SMALL)
+    np.testing.assert_array_equal(actual.per_task_accuracy, expected.per_task_accuracy)
+    np.testing.assert_array_equal(actual.per_task_loss, expected.per_task_loss)
+    np.testing.assert_array_equal(actual.per_task_plasticity, expected.per_task_plasticity)
+
+
 def test_result_receipt_is_exact_bounded_and_permanently_nonpromoting() -> None:
     x, y = _data()
     result = run_activation_feature_arm(x, y, arm="aid", seed=1, config=SMALL)

--- a/tests/test_console_entrypoints.py
+++ b/tests/test_console_entrypoints.py
@@ -31,6 +31,9 @@ _ASI_SCRIPTS = {
     "asi-activation-feature-ipmnist": (
         "alberta_framework.benchmarks.activation_feature_ipmnist:main"
     ),
+    "asi-activation-feature-campaign": (
+        "alberta_framework.evaluation.activation_feature_campaign:main"
+    ),
     "asi-adamo-diagnostic": "alberta_framework.benchmarks.adamo_diagnostic:main",
     "asi-clear-qualification": (
         "alberta_framework.benchmarks.clear_qualification:main"

--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -47,6 +47,7 @@ _WHEEL_FILES = tuple(
 )
 _EXPECTED_SCRIPT_NAMES = {
     "asi-action-conditioned-latent",
+    "asi-activation-feature-campaign",
     "asi-activation-feature-ipmnist",
     "asi-adamo-diagnostic",
     "asi-clear-qualification",


### PR DESCRIPTION
## Summary

This is the atomic, corrected #1566 campaign freeze. It preserves every contributor commit from #2101 and adds hard preauthorization corrections on top, so the protocol cannot merge in an executable state.

The combined scope:

- freezes two permanently nonpromoting, dataset/source/runtime-bound IPMNIST development plans: a 2-task × 500-example cheap screen and a conditional 200-task × 5,000-example full confirmation
- retains all 11 activation/feature arms, exact mechanism-off controls, complete 5-seed matrices, paired Student-t/Bonferroni arithmetic, explicit counters and numeric resource accounting, paper-parity limits, and nonpromoting outcome policy
- freezes the canonical OpenML MNIST train-split materialization with the verified canonical x/y hashes, current implementation/runtime identity, exact Threefry schedule/initialization identities, post-run source/runtime/dataset rechecks, and complete shard/aggregate cross-validation
- fails closed in public `build_shard` and `run-shard` before dataset load, output reservation, plan admission, or runner dispatch; `execution_authorized` is literally `false`, and a separate reviewed source transition is required before any execution
- quarantines all exposed or exercised rosters: `0..4`, `156610..156614`, `2156600..2156604`, and `2156610..2156614`; tests derive identities only from quarantined roots, while the campaign uses untouched roots `3975019531..3975019535` and `2924933221..2924933225` in NEW v2 namespaces
- reserves every output cooperatively with `O_EXCL` through pinned `O_DIRECTORY|O_NOFOLLOW` dirfds before work, publishes by an unnamed-file no-replace link with fsync, then performs a bounded, nonblocking, no-follow exact-byte reread and strict plan/shard/aggregate validation
- states failure retention precisely: ordinary exceptions, `BaseException`, process death, and publication failures do not create campaign failure receipts; the temporary reservation is concurrency state, and an external scheduler must retain its log before any separately authorized retry
- identifies AID as the paper's Algorithm 2 simplified element-wise rule and makes no paper-protocol or paper-result reproduction claim

No campaign workload was executed and no output artifact was created. This PR does not promote a result and does not close #1566; the issue remains open until an independently reviewed authorization and genuine retained campaign completion satisfy its remaining acceptance gates.

## Exact combined-head verification

Head `613a1b737e3ad9aaf421289c997b1f64ad38067d`:

- `python -m pytest tests/test_activation_feature_campaign.py tests/test_activation_feature_ipmnist.py tests/test_console_entrypoints.py -q` — 42 passed
- `python -m ruff check .` — passed
- `python -m mypy` — passed, 222 source files
- `git diff --check` — passed

The untouched roots were checked against repository remote history and GitHub issue/PR history before publication. No test derives their schedule or initialization keys.

## Supersession

This main-based PR supersedes #2101 so the original campaign and the authorization corrections land atomically. Contributor commits `6d84cbda`, `b3a93434`, `cdacad1e`, and `d0acfd77` are preserved unchanged in this branch history.
