### PR TITLE
research(bimu): complete strict matched-development campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the execution-gated `asi-bimu-matched-development` campaign for the
+  bounded five-task BiMU mechanism-on versus memory-off comparison. Its fixed
+  six-shard namespace, fresh-process roster, paired outcome rule, validators,
+  and resource/provenance bindings are permanently nonpromoting and not
+  paper-comparable; execution remains explicitly unauthorized.
 - Added the unfrozen `preview1` reference-agent transaction ledger, primitive
   Prototype adapter, aggregate SwitchingTwoState/RiverSwim life runner, and
   development-only quiescent checkpoint codec. These L0 mechanisms enforce

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -1,0 +1,1147 @@
+"""Fresh-process execution and validation for the bounded BiMU comparison.
+
+The campaign is permanently nonpromoting and not paper-comparable.  Its
+execution gate is deliberately closed in the reviewed source until a separate
+authorization change is accepted.  Timing is retained only as telemetry and
+never contributes to the paired outcome.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import secrets
+import stat
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, NoReturn, cast
+
+import jax.random as jr
+import numpy as np
+
+from alberta_framework.benchmarks.bimu import (
+    _EXAMPLE_ORDER_DOMAIN,
+    _INIT_DOMAIN,
+    _PRNG_IMPLEMENTATION,
+    _dataset_sha256,
+    _initialize_state,
+    _state_sha256,
+    _stream_key,
+    build_task_schedule,
+    run_bimu_development,
+    validate_bimu_result,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import load_mnist_train
+from alberta_framework.evaluation.bimu_matched_nonpromoting import (
+    EXECUTION_AUTHORIZED,
+    FROZEN_BIMU_MATCHED_PLAN,
+    OUTPUT_NAMESPACE,
+    BiMUMatchedDevelopmentPlan,
+    _canonical,
+    _dependency_identity,
+    _plan_payload,
+    _runtime_identity,
+    _source_identity,
+    frozen_plan_payload,
+)
+
+PLAN_DOCUMENT_SCHEMA: Final = "asi.bimu.matched-campaign-plan.v1"
+SHARD_SCHEMA: Final = "asi.bimu.matched-campaign-shard.v1"
+AGGREGATE_SCHEMA: Final = "asi.bimu.matched-campaign-aggregate.v1"
+PROCESS_SCHEMA: Final = "asi.bimu.fresh-process.v1"
+
+MAX_JSON_DEPTH: Final = 64
+MAX_JSON_NODES: Final = 50_000
+MAX_TEXT_BYTES: Final = 4096
+MAX_PLAN_BYTES: Final = 2 * 1024 * 1024
+MAX_SHARD_BYTES: Final = 4 * 1024 * 1024
+MAX_AGGREGATE_BYTES: Final = 32 * 1024 * 1024
+
+_ARMS: Final = ("memory_off", "bimu")
+_MATCHED_COUNTERS: Final = (
+    "environment_steps",
+    "observations",
+    "label_queries",
+    "optimizer_updates",
+    "optimizer_seen",
+    "model_forward_queries",
+)
+_MATCHED_RESOURCES: Final = (
+    "trainable_scalar_count",
+    "parameter_numeric_bytes",
+    "optimizer_state_numeric_bytes",
+    "initial_persistent_numeric_bytes",
+    "final_persistent_numeric_bytes",
+)
+_POLICY: Final = {
+    "evidence_class": "bounded_matched_development_comparator",
+    "development_only": True,
+    "permanently_nonpromoting": True,
+    "scientific_promotion_allowed": False,
+    "sota_claim_allowed": False,
+    "paper_comparable": False,
+    "negative_results_retained": True,
+}
+_TIMING_POLICY: Final = {
+    "qualified": False,
+    "role": "telemetry_only",
+    "used_for_outcome": False,
+    "cross_machine_comparison_supported": False,
+}
+
+
+def _fail(message: str) -> NoReturn:
+    raise ValueError(message)
+
+
+def _validate_json_tree(value: object) -> None:
+    pending: list[tuple[object, int]] = [(value, 0)]
+    nodes = 0
+    while pending:
+        current, depth = pending.pop()
+        nodes += 1
+        if nodes > MAX_JSON_NODES:
+            _fail("JSON input exceeds node ceiling")
+        if depth > MAX_JSON_DEPTH:
+            _fail("JSON nesting exceeds depth ceiling")
+        current_type = type(current)
+        if current is None or current_type is bool:
+            continue
+        if current_type is str:
+            if len(cast(str, current).encode("utf-8")) > MAX_TEXT_BYTES:
+                _fail("JSON text exceeds byte ceiling")
+            continue
+        if current_type is int:
+            if not -(2**63) <= cast(int, current) <= 2**63 - 1:
+                _fail("JSON integer exceeds signed-int64")
+            continue
+        if current_type is float:
+            if not math.isfinite(cast(float, current)):
+                _fail("JSON number must be finite")
+            continue
+        if current_type is list:
+            items = cast(list[object], current)
+            if len(items) > MAX_JSON_NODES:
+                _fail("JSON array exceeds node ceiling")
+            pending.extend((item, depth + 1) for item in items)
+            continue
+        if current_type is dict:
+            mapping = cast(dict[object, object], current)
+            if len(mapping) > MAX_JSON_NODES:
+                _fail("JSON object exceeds node ceiling")
+            for key, item in mapping.items():
+                if type(key) is not str or len(key.encode("utf-8")) > MAX_TEXT_BYTES:
+                    _fail("JSON object keys must be bounded exact strings")
+                pending.append((item, depth + 1))
+            continue
+        _fail("value is not an exact JSON tree")
+
+
+def _exact_object(value: object, fields: set[str], label: str) -> dict[str, object]:
+    if type(value) is not dict:
+        _fail(f"{label} must be an exact object")
+    resolved = cast(dict[str, object], value)
+    if len(resolved) != len(fields) or set(resolved) != fields:
+        _fail(f"{label} fields drifted")
+    return resolved
+
+
+def _sha256(value: object) -> str:
+    _validate_json_tree(value)
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _json_exact_equal(left: object, right: object) -> bool:
+    _validate_json_tree(left)
+    _validate_json_tree(right)
+    return _canonical(left) == _canonical(right)
+
+
+def digest_without(payload: Mapping[str, object], field: str) -> str:
+    """Hash a JSON object after removing its self-digest field."""
+
+    if type(payload) is not dict or type(field) is not str:
+        raise TypeError("payload and field must be exact JSON object/string values")
+    return _sha256({key: value for key, value in payload.items() if key != field})
+
+
+def _is_digest(value: object) -> bool:
+    return (
+        type(value) is str
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _json_object_pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            _fail(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json_strict(path: Path, *, byte_ceiling: int) -> dict[str, object]:
+    """Read one bounded regular JSON file with duplicate-key rejection."""
+
+    if type(path) is not type(Path()) or type(byte_ceiling) is not int or byte_ceiling < 1:
+        raise TypeError("path and byte_ceiling must be exact bounded values")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise ValueError(f"cannot open regular non-symlink JSON input: {path}") from exc
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            _fail("JSON input must be a regular non-symlink file")
+        if before.st_nlink != 1:
+            _fail("JSON input must not have a hard-link alias")
+        if before.st_size > byte_ceiling:
+            _fail("JSON input exceeds byte ceiling")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            raw = stream.read(byte_ceiling + 1)
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    if len(raw) > byte_ceiling:
+        _fail("JSON input exceeds byte ceiling")
+    before_identity = (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+        before.st_ctime_ns,
+    )
+    after_identity = (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+        after.st_ctime_ns,
+    )
+    if before_identity != after_identity or len(raw) != after.st_size:
+        _fail("JSON input changed while being read")
+    try:
+        value = json.loads(
+            raw,
+            object_pairs_hook=_json_object_pairs,
+            parse_constant=lambda token: _fail(f"invalid JSON constant: {token}"),
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("JSON input is not one strict document") from exc
+    _validate_json_tree(value)
+    if type(value) is not dict:
+        _fail("JSON document root must be an exact object")
+    return cast(dict[str, object], value)
+
+
+def _current_identity() -> dict[str, object]:
+    return {
+        "source_sha256": _source_identity(),
+        "runtime": _runtime_identity(),
+        "dependencies": _dependency_identity(),
+        "consistency_not_attestation": True,
+    }
+
+
+def build_plan_document() -> dict[str, object]:
+    """Build the source-bound literal plan without loading or executing data."""
+
+    payload = frozen_plan_payload()
+    document: dict[str, object] = {
+        "schema": PLAN_DOCUMENT_SCHEMA,
+        "plan": payload,
+        "plan_sha256": _sha256(payload),
+        "identity": _current_identity(),
+        "policy": {
+            **_POLICY,
+            "execution_authorized": EXECUTION_AUTHORIZED,
+        },
+    }
+    document["document_sha256"] = _sha256(document)
+    validate_plan_document(document)
+    return document
+
+
+def validate_plan_document(value: object) -> dict[str, object]:
+    _validate_json_tree(value)
+    root = _exact_object(
+        value,
+        {"schema", "plan", "plan_sha256", "identity", "policy", "document_sha256"},
+        "campaign plan",
+    )
+    expected_plan = frozen_plan_payload()
+    if root["schema"] != PLAN_DOCUMENT_SCHEMA or not _json_exact_equal(
+        root["plan"], expected_plan
+    ):
+        _fail("campaign plan does not match the current literal plan")
+    if root["plan_sha256"] != _sha256(expected_plan):
+        _fail("campaign plan digest drifted")
+    if not _json_exact_equal(root["identity"], _current_identity()):
+        _fail("campaign plan identity drifted")
+    expected_policy = {**_POLICY, "execution_authorized": EXECUTION_AUTHORIZED}
+    if not _json_exact_equal(root["policy"], expected_policy):
+        _fail("campaign plan policy drifted")
+    if root["document_sha256"] != digest_without(root, "document_sha256"):
+        _fail("campaign plan document digest drifted")
+    if len(_canonical(root)) > MAX_PLAN_BYTES:
+        _fail("campaign plan exceeds byte ceiling")
+    return root
+
+
+def _validated_arrays(
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+    *,
+    plan: BiMUMatchedDevelopmentPlan,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    config = plan.candidate_config
+    expected = (
+        (
+            "train_x",
+            train_x,
+            np.dtype(np.float32),
+            (config.train_examples_per_task, config.input_dim),
+        ),
+        ("train_y", train_y, np.dtype(np.int32), (config.train_examples_per_task,)),
+        ("test_x", test_x, np.dtype(np.float32), (config.test_examples_per_task, config.input_dim)),
+        ("test_y", test_y, np.dtype(np.int32), (config.test_examples_per_task,)),
+    )
+    arrays: list[np.ndarray] = []
+    byte_count = 0
+    for name, value, dtype, shape in expected:
+        if type(value) is not np.ndarray or value.dtype != dtype or value.shape != shape:
+            _fail(f"{name} does not match the exact campaign shape and dtype")
+        byte_count += int(value.nbytes)
+        if byte_count > 16 * 1024 * 1024:
+            _fail("campaign dataset exceeds its byte ceiling")
+        copied = np.array(value, dtype=dtype, order="C", copy=True)
+        if dtype == np.dtype(np.float32) and not np.all(np.isfinite(copied)):
+            _fail(f"{name} must contain finite values")
+        if dtype == np.dtype(np.int32) and (
+            np.any(copied < 0) or np.any(copied >= config.n_classes)
+        ):
+            _fail(f"{name} contains labels outside the campaign class range")
+        arrays.append(copied)
+    if _dataset_sha256(*arrays) != plan.dataset_sha256:
+        _fail("dataset slice does not match the frozen digest")
+    return arrays[0], arrays[1], arrays[2], arrays[3]
+
+
+def load_frozen_bimu_dataset(
+    data_home: Path | None = None,
+    *,
+    plan: BiMUMatchedDevelopmentPlan = FROZEN_BIMU_MATCHED_PLAN,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Load the canonical 60k OpenML materialization and copy its frozen slice."""
+
+    if data_home is not None and type(data_home) is not type(Path()):
+        raise TypeError("data_home must be an exact Path or None")
+    if type(plan) is not BiMUMatchedDevelopmentPlan:
+        raise TypeError("plan must be an exact BiMUMatchedDevelopmentPlan")
+    checked = BiMUMatchedDevelopmentPlan(**plan.__dict__)
+    full_x, full_y = load_mnist_train(data_home)
+    if (
+        type(full_x) is not np.ndarray
+        or type(full_y) is not np.ndarray
+        or full_x.dtype != np.dtype(np.float32)
+        or full_y.dtype != np.dtype(np.int32)
+        or full_x.shape != (60_000, checked.candidate_config.input_dim)
+        or full_y.shape != (60_000,)
+    ):
+        _fail("canonical OpenML loader did not return the exact 60k materialization")
+    count = checked.candidate_config.train_examples_per_task
+    test_count = checked.candidate_config.test_examples_per_task
+    if count + test_count > 60_000:
+        _fail("campaign train/test slices are not disjoint")
+    return _validated_arrays(
+        np.array(full_x[:count], dtype=np.float32, order="C", copy=True),
+        np.array(full_y[:count], dtype=np.int32, order="C", copy=True),
+        np.array(full_x[-test_count:], dtype=np.float32, order="C", copy=True),
+        np.array(full_y[-test_count:], dtype=np.int32, order="C", copy=True),
+        plan=checked,
+    )
+
+
+def _expected_fixed_identities(plan: BiMUMatchedDevelopmentPlan, seed: int) -> tuple[str, str]:
+    config = plan.control_config
+    root = jr.key(seed, impl=_PRNG_IMPLEMENTATION)
+    state = _initialize_state(config, _stream_key(root, _INIT_DOMAIN))
+    initial = _state_sha256(state, optimizer_step=0, optimizer_seen=0)
+    schedule = hashlib.sha256()
+    for task, permutation in enumerate(build_task_schedule(config, seed=seed)):
+        order = np.asarray(
+            jr.permutation(
+                _stream_key(root, _EXAMPLE_ORDER_DOMAIN, task),
+                config.train_examples_per_task,
+            ),
+            dtype=np.int32,
+        )
+        schedule.update(
+            json.dumps(
+                {
+                    "task": task,
+                    "permutation": list(permutation),
+                    "example_order": [int(value) for value in order],
+                    "query_decisions": [True] * config.train_examples_per_task,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+    return initial, schedule.hexdigest()
+
+
+def _process_identity() -> dict[str, object]:
+    boot_path = Path("/proc/sys/kernel/random/boot_id")
+    stat_path = Path("/proc/self/stat")
+    if not boot_path.is_file() or not stat_path.is_file():
+        raise RuntimeError("the fresh-process campaign requires Linux /proc identity")
+    boot_id = boot_path.read_text(encoding="ascii").strip()
+    stat_text = stat_path.read_text(encoding="ascii")
+    comm_end = stat_text.rfind(")")
+    stat_fields = stat_text[comm_end + 1 :].split() if comm_end >= 0 else []
+    if len(stat_fields) < 20 or not stat_fields[19].isdigit():
+        raise RuntimeError("cannot resolve Linux process start identity")
+    nonce = secrets.token_hex(16)
+    process = {
+        "schema": PROCESS_SCHEMA,
+        "pid": os.getpid(),
+        "proc_start_ticks": int(stat_fields[19]),
+        "boot_id_sha256": hashlib.sha256(boot_id.encode("ascii")).hexdigest(),
+        "invocation_nonce": nonce,
+        "fresh_process_required": True,
+        "identity_is_not_attestation": True,
+    }
+    process["execution_instance_id"] = _sha256(process)
+    return process
+
+
+def _arm_config(plan: BiMUMatchedDevelopmentPlan, arm: str) -> Any:
+    if type(arm) is not str or arm not in _ARMS:
+        _fail("arm is outside the frozen roster")
+    return plan.control_config if arm == "memory_off" else plan.candidate_config
+
+
+def _expected_counters(plan: BiMUMatchedDevelopmentPlan) -> dict[str, int]:
+    values = cast(dict[str, object], _plan_payload(plan)["expected_counters_per_arm"])
+    return {field: cast(int, values[field]) for field in _MATCHED_COUNTERS}
+
+
+def _expected_resources(plan: BiMUMatchedDevelopmentPlan) -> dict[str, int]:
+    values = cast(dict[str, object], _plan_payload(plan)["expected_resources_per_arm"])
+    return {
+        field: cast(int, values[field])
+        for field in (*_MATCHED_RESOURCES, "dataset_numeric_bytes")
+    }
+
+
+def run_bimu_shard(
+    arm: str,
+    seed: int,
+    *,
+    data_home: Path | None = None,
+    plan_document: object | None = None,
+) -> dict[str, object]:
+    """Execute exactly one authorized arm/seed shard in this process."""
+
+    if EXECUTION_AUTHORIZED is not True:
+        raise PermissionError("BiMU campaign execution is not authorized in this source revision")
+    if type(seed) is not int or seed not in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        _fail("seed is outside the frozen roster")
+    config = _arm_config(FROZEN_BIMU_MATCHED_PLAN, arm)
+    plan_doc = (
+        build_plan_document()
+        if plan_document is None
+        else validate_plan_document(plan_document)
+    )
+    if cast(dict[str, object], plan_doc["policy"])["execution_authorized"] is not True:
+        raise PermissionError("the bound campaign plan is not authorized for execution")
+    arrays = load_frozen_bimu_dataset(data_home)
+    started_wall = time.perf_counter()
+    started_cpu = time.process_time()
+    result = run_bimu_development(*arrays, config=config, seed=seed)
+    wall_seconds = time.perf_counter() - started_wall
+    cpu_seconds = time.process_time() - started_cpu
+    validate_bimu_result(result)
+    payload: dict[str, object] = {
+        "schema": SHARD_SCHEMA,
+        "status": "complete",
+        "plan_sha256": plan_doc["plan_sha256"],
+        "spec": {"arm": arm, "seed": seed},
+        "identity": {
+            **_current_identity(),
+            "dataset_sha256": FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
+            "process": _process_identity(),
+        },
+        "policy": {**_POLICY, "execution_authorized": True},
+        "result": result,
+        "resources": {
+            **_expected_resources(FROZEN_BIMU_MATCHED_PLAN),
+            "numeric_resource_ceiling_bytes": 256 * 1024 * 1024,
+            "aggregate_working_set_bytes_claimed": False,
+        },
+        "timing": {
+            "wall_clock_seconds": wall_seconds,
+            "process_cpu_seconds": cpu_seconds,
+            **_TIMING_POLICY,
+        },
+    }
+    payload["shard_sha256"] = _sha256(payload)
+    validate_bimu_shard(payload)
+    return payload
+
+
+def _finite_nonnegative_float(value: object, label: str) -> float:
+    if type(value) is not float or not math.isfinite(value) or value < 0.0:
+        _fail(f"{label} must be one finite nonnegative float")
+    return value
+
+
+def _validate_process(value: object) -> dict[str, object]:
+    process = _exact_object(
+        value,
+        {
+            "schema",
+            "pid",
+            "proc_start_ticks",
+            "boot_id_sha256",
+            "invocation_nonce",
+            "fresh_process_required",
+            "identity_is_not_attestation",
+            "execution_instance_id",
+        },
+        "process identity",
+    )
+    if process["schema"] != PROCESS_SCHEMA:
+        _fail("process identity schema drifted")
+    for field in ("pid", "proc_start_ticks"):
+        if type(process[field]) is not int or cast(int, process[field]) < 1:
+            _fail(f"process identity {field} drifted")
+    if not _is_digest(process["boot_id_sha256"]):
+        _fail("process boot identity drifted")
+    nonce = process["invocation_nonce"]
+    if (
+        type(nonce) is not str
+        or len(nonce) != 32
+        or any(character not in "0123456789abcdef" for character in nonce)
+    ):
+        _fail("process invocation nonce drifted")
+    if (
+        process["fresh_process_required"] is not True
+        or process["identity_is_not_attestation"] is not True
+    ):
+        _fail("process assurance drifted")
+    if process["execution_instance_id"] != digest_without(process, "execution_instance_id"):
+        _fail("process execution identity digest drifted")
+    return process
+
+
+def validate_bimu_shard(value: object) -> dict[str, object]:
+    """Strictly revalidate one complete source-bound shard."""
+
+    _validate_json_tree(value)
+    root = _exact_object(
+        value,
+        {
+            "schema",
+            "status",
+            "plan_sha256",
+            "spec",
+            "identity",
+            "policy",
+            "result",
+            "resources",
+            "timing",
+            "shard_sha256",
+        },
+        "BiMU shard",
+    )
+    if root["schema"] != SHARD_SCHEMA or root["status"] != "complete":
+        _fail("BiMU shard identity or status drifted")
+    expected_plan = frozen_plan_payload()
+    if root["plan_sha256"] != _sha256(expected_plan):
+        _fail("BiMU shard plan digest drifted")
+    spec = _exact_object(root["spec"], {"arm", "seed"}, "shard spec")
+    arm = cast(str, spec["arm"])
+    config = _arm_config(FROZEN_BIMU_MATCHED_PLAN, arm)
+    seed = spec["seed"]
+    if type(seed) is not int or seed not in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        _fail("shard seed is outside the frozen roster")
+    identity = _exact_object(
+        root["identity"],
+        {
+            "source_sha256",
+            "runtime",
+            "dependencies",
+            "consistency_not_attestation",
+            "dataset_sha256",
+            "process",
+        },
+        "shard identity",
+    )
+    expected_identity = {
+        **_current_identity(),
+        "dataset_sha256": FROZEN_BIMU_MATCHED_PLAN.dataset_sha256,
+    }
+    if not _json_exact_equal(
+        {key: value for key, value in identity.items() if key != "process"},
+        expected_identity,
+    ):
+        _fail("shard execution identity drifted")
+    _validate_process(identity["process"])
+    if not _json_exact_equal(root["policy"], {**_POLICY, "execution_authorized": True}):
+        _fail("shard policy drifted")
+    result = root["result"]
+    validate_bimu_result(result)
+    resolved = cast(dict[str, object], result)
+    if resolved["seed"] != seed or not _json_exact_equal(
+        resolved["protocol"], config.to_protocol_payload()
+    ):
+        _fail("shard result does not match its arm/seed spec")
+    if resolved["dataset_sha256"] != FROZEN_BIMU_MATCHED_PLAN.dataset_sha256:
+        _fail("shard result dataset identity drifted")
+    expected_initial, expected_schedule = _expected_fixed_identities(
+        FROZEN_BIMU_MATCHED_PLAN, seed
+    )
+    if resolved["initial_state_sha256"] != expected_initial:
+        _fail("shard initial-state identity drifted")
+    if resolved["schedule_sha256"] != expected_schedule:
+        _fail("shard schedule identity drifted")
+    counters = cast(dict[str, object], resolved["counters"])
+    expected_counters = _expected_counters(FROZEN_BIMU_MATCHED_PLAN)
+    if any(counters[field] != expected_counters[field] for field in _MATCHED_COUNTERS):
+        _fail("shard counters do not match the literal plan")
+    result_resources = cast(dict[str, object], resolved["resources"])
+    expected_resources = _expected_resources(FROZEN_BIMU_MATCHED_PLAN)
+    if any(result_resources[field] != expected_resources[field] for field in _MATCHED_RESOURCES):
+        _fail("shard result resources do not match the literal plan")
+    resources = _exact_object(
+        root["resources"],
+        {
+            *_MATCHED_RESOURCES,
+            "dataset_numeric_bytes",
+            "numeric_resource_ceiling_bytes",
+            "aggregate_working_set_bytes_claimed",
+        },
+        "shard resources",
+    )
+    if any(resources[field] != expected_resources[field] for field in expected_resources):
+        _fail("shard resource binding drifted")
+    if (
+        resources["numeric_resource_ceiling_bytes"] != 256 * 1024 * 1024
+        or resources["aggregate_working_set_bytes_claimed"] is not False
+    ):
+        _fail("shard resource ceiling policy drifted")
+    timing = _exact_object(
+        root["timing"],
+        {
+            "wall_clock_seconds",
+            "process_cpu_seconds",
+            "qualified",
+            "role",
+            "used_for_outcome",
+            "cross_machine_comparison_supported",
+        },
+        "shard timing",
+    )
+    _finite_nonnegative_float(timing["wall_clock_seconds"], "wall timing")
+    _finite_nonnegative_float(timing["process_cpu_seconds"], "CPU timing")
+    if {key: timing[key] for key in _TIMING_POLICY} != _TIMING_POLICY:
+        _fail("shard timing policy drifted")
+    if root["shard_sha256"] != digest_without(root, "shard_sha256"):
+        _fail("shard digest drifted")
+    if len(_canonical(root)) > MAX_SHARD_BYTES:
+        _fail("shard exceeds byte ceiling")
+    return root
+
+
+def _paired_metrics(shards: list[dict[str, object]]) -> dict[str, object]:
+    primary: list[float] = []
+    secondary: list[float] = []
+    for seed in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        by_arm = {
+            cast(str, cast(dict[str, object], shard["spec"])["arm"]): cast(
+                dict[str, object], shard["result"]
+            )
+            for shard in shards
+            if cast(dict[str, object], shard["spec"])["seed"] == seed
+        }
+        control_metrics = cast(dict[str, object], by_arm["memory_off"]["metrics"])
+        candidate_metrics = cast(dict[str, object], by_arm["bimu"]["metrics"])
+        primary.append(
+            cast(float, candidate_metrics["paper_late_five_test_accuracy"])
+            - cast(float, control_metrics["paper_late_five_test_accuracy"])
+        )
+        secondary.append(
+            cast(float, candidate_metrics["asi_whole_stream_online_accuracy"])
+            - cast(float, control_metrics["asi_whole_stream_online_accuracy"])
+        )
+    return {
+        "seeds": list(FROZEN_BIMU_MATCHED_PLAN.seeds),
+        "primary_metric": "paper_late_five_test_accuracy",
+        "primary_deltas": primary,
+        "primary_delta_mean": math.fsum(primary) / 3,
+        "secondary_metric": "asi_whole_stream_online_accuracy",
+        "secondary_deltas": secondary,
+        "secondary_delta_mean": math.fsum(secondary) / 3,
+    }
+
+
+def _outcome(paired: dict[str, object]) -> dict[str, object]:
+    deltas = cast(list[float], paired["primary_deltas"])
+    classification = (
+        "supported"
+        if all(delta > 0.0 for delta in deltas)
+        else "rejected"
+        if all(delta <= 0.0 for delta in deltas)
+        else "inconclusive"
+    )
+    rule = cast(dict[str, object], frozen_plan_payload()["paired_outcome_rule"])
+    return {
+        "classification": classification,
+        "rule": rule,
+        "scientific_evidence": False,
+        "paper_comparable": False,
+        "development_selection_only": True,
+    }
+
+
+def _validate_pair_matching(shards: list[dict[str, object]]) -> None:
+    for seed in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        pair = [
+            shard
+            for shard in shards
+            if cast(dict[str, object], shard["spec"])["seed"] == seed
+        ]
+        if len(pair) != 2:
+            _fail("aggregate roster lacks one complete pair per seed")
+        by_arm = {
+            cast(str, cast(dict[str, object], shard["spec"])["arm"]): cast(
+                dict[str, object], shard["result"]
+            )
+            for shard in pair
+        }
+        control = by_arm["memory_off"]
+        candidate = by_arm["bimu"]
+        for field in ("dataset_sha256", "schedule_sha256", "initial_state_sha256"):
+            if control[field] != candidate[field]:
+                _fail(f"matched pair {field} drifted")
+        control_counters = cast(dict[str, object], control["counters"])
+        candidate_counters = cast(dict[str, object], candidate["counters"])
+        if any(control_counters[field] != candidate_counters[field] for field in _MATCHED_COUNTERS):
+            _fail("matched pair counter drifted")
+        control_resources = cast(dict[str, object], control["resources"])
+        candidate_resources = cast(dict[str, object], candidate["resources"])
+        if any(
+            control_resources[field] != candidate_resources[field]
+            for field in _MATCHED_RESOURCES
+        ):
+            _fail("matched pair resource drifted")
+
+
+def _aggregate_resources(shards: list[dict[str, object]]) -> dict[str, object]:
+    totals = {
+        field: sum(
+            cast(int, cast(dict[str, object], shard["resources"])[field])
+            for shard in shards
+        )
+        for field in (*_MATCHED_RESOURCES, "dataset_numeric_bytes")
+    }
+    return {
+        "totals_across_six_independent_shards": totals,
+        "aggregate_working_set_bytes_claimed": False,
+    }
+
+
+def _aggregate_timing(shards: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "shard_wall_clock_seconds": [
+            cast(dict[str, object], shard["timing"])["wall_clock_seconds"] for shard in shards
+        ],
+        "shard_process_cpu_seconds": [
+            cast(dict[str, object], shard["timing"])["process_cpu_seconds"] for shard in shards
+        ],
+        **_TIMING_POLICY,
+    }
+
+
+def _summarize_bimu_shards_unchecked(values: object) -> dict[str, object]:
+    _validate_json_tree(values)
+    if type(values) is not list or len(cast(list[object], values)) != 6:
+        _fail("aggregate roster must contain exactly six shards")
+    shards = [validate_bimu_shard(item) for item in cast(list[object], values)]
+    expected_roster = [
+        (seed, arm) for seed in FROZEN_BIMU_MATCHED_PLAN.seeds for arm in _ARMS
+    ]
+    observed_roster = [
+        (
+            cast(dict[str, object], shard["spec"])["seed"],
+            cast(dict[str, object], shard["spec"])["arm"],
+        )
+        for shard in shards
+    ]
+    if observed_roster != expected_roster:
+        _fail("aggregate roster order, membership, or uniqueness drifted")
+    execution_ids = [
+        cast(
+            dict[str, object],
+            cast(dict[str, object], shard["identity"])["process"],
+        )["execution_instance_id"]
+        for shard in shards
+    ]
+    if len(set(cast(list[str], execution_ids))) != 6:
+        _fail("aggregate shards do not have six unique process invocations")
+    process_identities = [
+        cast(
+            dict[str, object],
+            cast(dict[str, object], shard["identity"])["process"],
+        )
+        for shard in shards
+    ]
+    process_keys = [
+        (
+            process["boot_id_sha256"],
+            process["pid"],
+            process["proc_start_ticks"],
+        )
+        for process in process_identities
+    ]
+    if len(set(process_keys)) != 6:
+        _fail("aggregate requires six independently started fresh processes")
+    shared_identity = [
+        {
+            key: value
+            for key, value in cast(dict[str, object], shard["identity"]).items()
+            if key != "process"
+        }
+        for shard in shards
+    ]
+    if any(
+        not _json_exact_equal(identity, shared_identity[0])
+        for identity in shared_identity[1:]
+    ):
+        _fail("aggregate mixes source, runtime, dependency, or dataset identities")
+    _validate_pair_matching(shards)
+    paired = _paired_metrics(shards)
+    aggregate: dict[str, object] = {
+        "schema": AGGREGATE_SCHEMA,
+        "status": "complete",
+        "plan": frozen_plan_payload(),
+        "plan_sha256": _sha256(frozen_plan_payload()),
+        "identity": {
+            **shared_identity[0],
+            "execution_instance_ids": execution_ids,
+            "fresh_process_identity_is_not_attestation": True,
+        },
+        "policy": dict(_POLICY),
+        "shards": shards,
+        "paired_metrics": paired,
+        "outcome": _outcome(paired),
+        "resources": _aggregate_resources(shards),
+        "timing": _aggregate_timing(shards),
+    }
+    aggregate["aggregate_sha256"] = _sha256(aggregate)
+    return aggregate
+
+
+def summarize_bimu_shards(values: object) -> dict[str, object]:
+    """Combine the exact six-shard roster and apply the frozen paired rule."""
+
+    aggregate = _summarize_bimu_shards_unchecked(values)
+    validate_bimu_aggregate(aggregate)
+    return aggregate
+
+
+def validate_bimu_aggregate(value: object) -> dict[str, object]:
+    """Strictly reconstruct a complete aggregate from its retained shards."""
+
+    _validate_json_tree(value)
+    root = _exact_object(
+        value,
+        {
+            "schema",
+            "status",
+            "plan",
+            "plan_sha256",
+            "identity",
+            "policy",
+            "shards",
+            "paired_metrics",
+            "outcome",
+            "resources",
+            "timing",
+            "aggregate_sha256",
+        },
+        "BiMU aggregate",
+    )
+    if root["schema"] != AGGREGATE_SCHEMA or root["status"] != "complete":
+        _fail("BiMU aggregate identity or status drifted")
+    if not _json_exact_equal(root["plan"], frozen_plan_payload()):
+        _fail("BiMU aggregate plan drifted")
+    shards_value = root["shards"]
+    if type(shards_value) is not list:
+        _fail("BiMU aggregate shards must be an exact list")
+    reconstructed = _summarize_bimu_shards_unchecked(cast(list[object], shards_value))
+    for field in (
+        "plan_sha256",
+        "identity",
+        "policy",
+        "paired_metrics",
+        "outcome",
+        "resources",
+        "timing",
+    ):
+        if not _json_exact_equal(root[field], reconstructed[field]):
+            _fail(f"BiMU aggregate {field} drifted")
+    if root["aggregate_sha256"] != digest_without(root, "aggregate_sha256"):
+        _fail("BiMU aggregate digest drifted")
+    if len(_canonical(root)) > MAX_AGGREGATE_BYTES:
+        _fail("BiMU aggregate exceeds byte ceiling")
+    return root
+
+
+def campaign_path(
+    root: Path,
+    artifact: str,
+    *,
+    arm: str | None = None,
+    seed: int | None = None,
+) -> Path:
+    if type(root) is not type(Path()):
+        raise TypeError("root must be an exact Path")
+    namespace = root / OUTPUT_NAMESPACE
+    if artifact == "plan" and arm is None and seed is None:
+        return namespace / "plan.json"
+    if artifact == "aggregate" and arm is None and seed is None:
+        return namespace / "aggregate.json"
+    if artifact == "shard" and arm in _ARMS and seed in FROZEN_BIMU_MATCHED_PLAN.seeds:
+        return namespace / "shards" / f"seed-{seed}.{arm}.json"
+    _fail("artifact does not identify one canonical campaign path")
+
+
+def _allowed_path(path: Path, root: Path) -> bool:
+    candidates = {
+        campaign_path(root, "plan"),
+        campaign_path(root, "aggregate"),
+        *(
+            campaign_path(root, "shard", arm=arm, seed=seed)
+            for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
+            for arm in _ARMS
+        ),
+    }
+    return path in candidates
+
+
+def publish_json(path: Path, value: object, *, root: Path) -> None:
+    """Atomically publish one canonical campaign file without replacement."""
+
+    if type(path) is not type(Path()) or type(root) is not type(Path()):
+        raise TypeError("path and root must be exact Paths")
+    if not _allowed_path(path, root):
+        _fail("destination is outside the fixed campaign namespace")
+    if path == campaign_path(root, "plan"):
+        validate_plan_document(value)
+    elif path == campaign_path(root, "aggregate"):
+        validate_bimu_aggregate(value)
+    else:
+        validate_bimu_shard(value)
+    raw = _canonical(value) + b"\n"
+    root.mkdir(parents=True, exist_ok=True)
+    namespace = root / OUTPUT_NAMESPACE
+    namespace.mkdir(parents=True, exist_ok=True)
+    (namespace / "shards").mkdir(exist_ok=True)
+    for component in (root, *namespace.parents, namespace, path.parent):
+        if component.exists() and component.is_symlink():
+            _fail("campaign publication path contains a symlink")
+    if os.path.lexists(path):
+        raise FileExistsError(f"refusing to replace existing campaign artifact: {path}")
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    published = False
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(raw)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, path, follow_symlinks=False)
+        published = True
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    except BaseException:
+        if published:
+            path.unlink(missing_ok=True)
+        raise
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _load_plan(root: Path) -> dict[str, object]:
+    return validate_plan_document(
+        load_json_strict(campaign_path(root, "plan"), byte_ceiling=MAX_PLAN_BYTES)
+    )
+
+
+def _validate_namespace(
+    root: Path,
+    *,
+    require_complete_shards: bool,
+    require_aggregate: bool,
+) -> None:
+    namespace = root / OUTPUT_NAMESPACE
+    shards_directory = namespace / "shards"
+    if not namespace.is_dir() or namespace.is_symlink():
+        _fail("campaign namespace must be one real directory")
+    expected_top = {"plan.json", "shards"}
+    if require_aggregate:
+        expected_top.add("aggregate.json")
+    observed_top = {entry.name for entry in namespace.iterdir()}
+    if observed_top != expected_top:
+        _fail("campaign namespace contains missing or unexpected entries")
+    if not shards_directory.is_dir() or shards_directory.is_symlink():
+        _fail("campaign shard namespace must be one real directory")
+    expected_shards = {
+        campaign_path(root, "shard", arm=arm, seed=seed).name
+        for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
+        for arm in _ARMS
+    }
+    observed_shards = {entry.name for entry in shards_directory.iterdir()}
+    if require_complete_shards:
+        if observed_shards != expected_shards:
+            _fail("campaign shard namespace is not the exact complete roster")
+    elif not observed_shards <= expected_shards:
+        _fail("campaign shard namespace contains an unexpected entry")
+
+
+def _load_shards(root: Path) -> list[dict[str, object]]:
+    return [
+        validate_bimu_shard(
+            load_json_strict(
+                campaign_path(root, "shard", arm=arm, seed=seed),
+                byte_ceiling=MAX_SHARD_BYTES,
+            )
+        )
+        for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
+        for arm in _ARMS
+    ]
+
+
+def _print_json(value: object) -> None:
+    print(json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="permanently nonpromoting bounded BiMU matched campaign"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for name in ("plan", "summarize", "validate"):
+        command = subparsers.add_parser(name)
+        command.add_argument("--root", type=Path, required=True)
+    shard = subparsers.add_parser("run-shard")
+    shard.add_argument("--root", type=Path, required=True)
+    shard.add_argument("--arm", choices=_ARMS, required=True)
+    shard.add_argument("--seed", choices=FROZEN_BIMU_MATCHED_PLAN.seeds, required=True, type=int)
+    shard.add_argument("--data-home", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    root = cast(Path, args.root)
+    if args.command == "plan":
+        document = build_plan_document()
+        publish_json(campaign_path(root, "plan"), document, root=root)
+        _print_json({"status": "planned", "execution_authorized": EXECUTION_AUTHORIZED})
+        return 0
+    if args.command == "run-shard":
+        _validate_namespace(
+            root,
+            require_complete_shards=False,
+            require_aggregate=False,
+        )
+        if EXECUTION_AUTHORIZED is not True:
+            _print_json(
+                {
+                    "status": "execution_unauthorized",
+                    "execution_authorized": False,
+                    "shard_written": False,
+                }
+            )
+            return 2
+        destination = campaign_path(root, "shard", arm=args.arm, seed=args.seed)
+        if os.path.lexists(destination):
+            raise FileExistsError(f"refusing to replace existing campaign shard: {destination}")
+        plan = _load_plan(root)
+        shard = run_bimu_shard(
+            args.arm,
+            args.seed,
+            data_home=args.data_home,
+            plan_document=plan,
+        )
+        publish_json(destination, shard, root=root)
+        _print_json({"status": "complete", "shard": str(destination)})
+        return 0
+    if args.command == "summarize":
+        _validate_namespace(
+            root,
+            require_complete_shards=True,
+            require_aggregate=False,
+        )
+        _load_plan(root)
+        aggregate = summarize_bimu_shards(_load_shards(root))
+        destination = campaign_path(root, "aggregate")
+        publish_json(destination, aggregate, root=root)
+        _print_json(cast(dict[str, object], aggregate["outcome"]))
+        return 0
+    if args.command == "validate":
+        aggregate_path = campaign_path(root, "aggregate")
+        shard_paths = [
+            campaign_path(root, "shard", arm=arm, seed=seed)
+            for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
+            for arm in _ARMS
+        ]
+        any_shards = any(path.exists() for path in shard_paths)
+        _validate_namespace(
+            root,
+            require_complete_shards=any_shards,
+            require_aggregate=aggregate_path.exists(),
+        )
+        plan = _load_plan(root)
+        result: dict[str, object] = {
+            "plan_sha256": plan["plan_sha256"],
+            "execution_authorized": EXECUTION_AUTHORIZED,
+            "shards": [],
+            "aggregate": None,
+        }
+        if any_shards:
+            shards = _load_shards(root)
+            result["shards"] = [shard["shard_sha256"] for shard in shards]
+        if aggregate_path.exists():
+            aggregate = validate_bimu_aggregate(
+                load_json_strict(aggregate_path, byte_ceiling=MAX_AGGREGATE_BYTES)
+            )
+            result["aggregate"] = aggregate["aggregate_sha256"]
+        _print_json(result)
+        return 0
+    raise AssertionError("argparse returned an unknown command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/alberta_framework/evaluation/bimu_matched_campaign.py
+++ b/alberta_framework/evaluation/bimu_matched_campaign.py
@@ -9,13 +9,14 @@ never contributes to the paired outcome.
 from __future__ import annotations
 
 import argparse
+import ctypes
+import errno
 import hashlib
 import json
 import math
 import os
 import secrets
 import stat
-import tempfile
 import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -472,6 +473,8 @@ def run_bimu_shard(
     result = run_bimu_development(*arrays, config=config, seed=seed)
     wall_seconds = time.perf_counter() - started_wall
     cpu_seconds = time.process_time() - started_cpu
+    if _dataset_sha256(*arrays) != FROZEN_BIMU_MATCHED_PLAN.dataset_sha256:
+        _fail("campaign dataset changed during shard execution")
     validate_bimu_result(result)
     payload: dict[str, object] = {
         "schema": SHARD_SCHEMA,
@@ -662,6 +665,43 @@ def validate_bimu_shard(value: object) -> dict[str, object]:
         _fail("shard digest drifted")
     if len(_canonical(root)) > MAX_SHARD_BYTES:
         _fail("shard exceeds byte ceiling")
+    return root
+
+
+def validate_bimu_shard_by_reexecution(
+    value: object,
+    train_x: object,
+    train_y: object,
+    test_x: object,
+    test_y: object,
+) -> dict[str, object]:
+    """Reexecute one shard and compare every deterministic result field."""
+
+    root = validate_bimu_shard(value)
+    arrays = _validated_arrays(
+        train_x,
+        train_y,
+        test_x,
+        test_y,
+        plan=FROZEN_BIMU_MATCHED_PLAN,
+    )
+    spec = cast(dict[str, object], root["spec"])
+    config = _arm_config(FROZEN_BIMU_MATCHED_PLAN, cast(str, spec["arm"]))
+    replay = run_bimu_development(
+        *arrays,
+        config=config,
+        seed=cast(int, spec["seed"]),
+    )
+    validate_bimu_result(replay)
+    reported = cast(dict[str, object], root["result"])
+    deterministic_fields = set(replay) - {"timing"}
+    if set(reported) - {"timing"} != deterministic_fields or any(
+        not _json_exact_equal(reported[field], replay[field])
+        for field in deterministic_fields
+    ):
+        _fail("shard result does not match strict seed/arm reexecution")
+    if _dataset_sha256(*arrays) != FROZEN_BIMU_MATCHED_PLAN.dataset_sha256:
+        _fail("campaign dataset changed during strict shard reexecution")
     return root
 
 
@@ -942,6 +982,56 @@ def _allowed_path(path: Path, root: Path) -> bool:
     return path in candidates
 
 
+def _open_output_parent(path: Path) -> tuple[Path, int]:
+    """Create and descriptor-pin an absolute output parent without following links."""
+
+    destination = Path(os.path.abspath(os.fspath(path)))
+    if destination.name in {"", ".", ".."}:
+        _fail("campaign output must name one file")
+    if not all(hasattr(os, name) for name in ("O_DIRECTORY", "O_NOFOLLOW", "O_TMPFILE")):
+        raise OSError("immutable campaign publication requires Linux descriptor support")
+    descriptor = os.open(os.path.sep, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    try:
+        for component in destination.parent.parts[1:]:
+            if component in {"", ".", ".."}:
+                _fail("campaign output contains an unsafe directory component")
+            try:
+                os.mkdir(component, mode=0o755, dir_fd=descriptor)
+            except FileExistsError:
+                pass
+            next_descriptor = os.open(
+                component,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                dir_fd=descriptor,
+            )
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return destination, descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _link_unnamed_file(file_fd: int, parent_fd: int, name: str) -> None:
+    """Give one fully written anonymous inode its immutable destination name."""
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    linkat = libc.linkat
+    linkat.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+    )
+    linkat.restype = ctypes.c_int
+    if linkat(file_fd, b"", parent_fd, os.fsencode(name), 0x1000) != 0:
+        error = ctypes.get_errno()
+        if error == errno.EEXIST:
+            raise FileExistsError(error, os.strerror(error), name)
+        raise OSError(error, os.strerror(error), name)
+
+
 def publish_json(path: Path, value: object, *, root: Path) -> None:
     """Atomically publish one canonical campaign file without replacement."""
 
@@ -956,40 +1046,52 @@ def publish_json(path: Path, value: object, *, root: Path) -> None:
     else:
         validate_bimu_shard(value)
     raw = _canonical(value) + b"\n"
-    root.mkdir(parents=True, exist_ok=True)
-    namespace = root / OUTPUT_NAMESPACE
-    namespace.mkdir(parents=True, exist_ok=True)
-    (namespace / "shards").mkdir(exist_ok=True)
-    for component in (root, *namespace.parents, namespace, path.parent):
-        if component.exists() and component.is_symlink():
-            _fail("campaign publication path contains a symlink")
-    if os.path.lexists(path):
-        raise FileExistsError(f"refusing to replace existing campaign artifact: {path}")
-    descriptor, temporary_name = tempfile.mkstemp(
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-    )
-    temporary = Path(temporary_name)
-    published = False
+    destination, parent_fd = _open_output_parent(path)
+    file_fd: int | None = None
     try:
-        with os.fdopen(descriptor, "wb") as stream:
-            stream.write(raw)
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.link(temporary, path, follow_symlinks=False)
-        published = True
-        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        namespace = Path(os.path.abspath(os.fspath(root / OUTPUT_NAMESPACE)))
+        if destination.parent == namespace:
+            try:
+                os.mkdir("shards", mode=0o755, dir_fd=parent_fd)
+            except FileExistsError:
+                pass
+            shards_fd = os.open(
+                "shards",
+                os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                dir_fd=parent_fd,
+            )
+            os.close(shards_fd)
         try:
-            os.fsync(directory_descriptor)
-        finally:
-            os.close(directory_descriptor)
-    except BaseException:
-        if published:
-            path.unlink(missing_ok=True)
-        raise
+            os.stat(destination.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(
+                f"refusing to replace existing campaign artifact: {destination}"
+            )
+        file_fd = os.open(
+            ".",
+            os.O_WRONLY | os.O_CLOEXEC | os.O_TMPFILE,
+            0o600,
+            dir_fd=parent_fd,
+        )
+        view = memoryview(raw)
+        written = 0
+        while written < len(view):
+            written += os.write(file_fd, view[written:])
+        os.fsync(file_fd)
+        os.fchmod(file_fd, 0o444)
+        try:
+            _link_unnamed_file(file_fd, parent_fd, destination.name)
+        except FileExistsError as error:
+            raise FileExistsError(
+                f"refusing to replace existing campaign artifact: {destination}"
+            ) from error
+        os.fsync(parent_fd)
     finally:
-        temporary.unlink(missing_ok=True)
+        if file_fd is not None:
+            os.close(file_fd)
+        os.close(parent_fd)
 
 
 def _load_plan(root: Path) -> dict[str, object]:
@@ -1029,16 +1131,24 @@ def _validate_namespace(
         _fail("campaign shard namespace contains an unexpected entry")
 
 
-def _load_shards(root: Path) -> list[dict[str, object]]:
+def _load_shards(
+    root: Path,
+    arrays: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None = None,
+) -> list[dict[str, object]]:
     return [
-        validate_bimu_shard(
-            load_json_strict(
-                campaign_path(root, "shard", arm=arm, seed=seed),
-                byte_ceiling=MAX_SHARD_BYTES,
-            )
+        (
+            validate_bimu_shard(loaded)
+            if arrays is None
+            else validate_bimu_shard_by_reexecution(loaded, *arrays)
         )
         for seed in FROZEN_BIMU_MATCHED_PLAN.seeds
         for arm in _ARMS
+        for loaded in (
+            load_json_strict(
+                campaign_path(root, "shard", arm=arm, seed=seed),
+                byte_ceiling=MAX_SHARD_BYTES,
+            ),
+        )
     ]
 
 
@@ -1054,6 +1164,8 @@ def _parser() -> argparse.ArgumentParser:
     for name in ("plan", "summarize", "validate"):
         command = subparsers.add_parser(name)
         command.add_argument("--root", type=Path, required=True)
+        if name in {"summarize", "validate"}:
+            command.add_argument("--data-home", type=Path)
     shard = subparsers.add_parser("run-shard")
     shard.add_argument("--root", type=Path, required=True)
     shard.add_argument("--arm", choices=_ARMS, required=True)
@@ -1105,7 +1217,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             require_aggregate=False,
         )
         _load_plan(root)
-        aggregate = summarize_bimu_shards(_load_shards(root))
+        arrays = load_frozen_bimu_dataset(args.data_home)
+        aggregate = summarize_bimu_shards(_load_shards(root, arrays))
         destination = campaign_path(root, "aggregate")
         publish_json(destination, aggregate, root=root)
         _print_json(cast(dict[str, object], aggregate["outcome"]))
@@ -1131,7 +1244,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             "aggregate": None,
         }
         if any_shards:
-            shards = _load_shards(root)
+            arrays = load_frozen_bimu_dataset(args.data_home)
+            shards = _load_shards(root, arrays)
             result["shards"] = [shard["shard_sha256"] for shard in shards]
         if aggregate_path.exists():
             aggregate = validate_bimu_aggregate(

--- a/alberta_framework/evaluation/bimu_matched_nonpromoting.py
+++ b/alberta_framework/evaluation/bimu_matched_nonpromoting.py
@@ -20,13 +20,16 @@ import numpy as np
 
 from alberta_framework.benchmarks.bimu import BiMUConfig, _dataset_sha256
 
-PLAN_SCHEMA: Final = "asi.bimu.matched-development-plan.v2"
+PLAN_SCHEMA: Final = "asi.bimu.matched-development-plan.v3"
 MANIFEST_SCHEMA: Final = "asi.bimu.matched-development-execution-manifest.v1"
+OUTPUT_NAMESPACE: Final = Path("outputs/bimu_matched/development.v1")
+EXECUTION_AUTHORIZED: Final = False
 _MAX_JSON_NODES = 20_000
 _MAX_TEXT_BYTES = 4096
 _MAX_MANIFEST_BYTES = 2 * 1024 * 1024
 _MAX_DATASET_BYTES = 16 * 1024 * 1024
 _DIGEST = "85c681c2f5fc5c274870b30c9accb3d2a6e9eb90a4575a2bf1ccca64f58b6227"
+FROZEN_PLAN_SHA256: Final = "11ddfacd0aca8108a39bd8a68225149de246efb7420d2fdb864f36ea75681f71"
 
 INVALID_PRIOR_ATTEMPT: Final[Mapping[str, object]] = MappingProxyType({
     "pull_request": 1686,
@@ -243,7 +246,7 @@ def _plan_payload(plan: BiMUMatchedDevelopmentPlan) -> dict[str, object]:
             "label_queries": label_queries,
             "optimizer_seen": observations,
             "model_forward_queries": model_forward_queries,
-            "optimizer_updates_rule": "reported_nonzero_gradient_subcount_at_most_label_queries",
+            "optimizer_updates": observations,
         },
         "expected_resources_per_arm": {
             "trainable_scalar_count": config.trainable_scalar_count,
@@ -264,7 +267,28 @@ def _plan_payload(plan: BiMUMatchedDevelopmentPlan) -> dict[str, object]:
         },
         "primary_metric": "paper_late_five_test_accuracy",
         "secondary_metric": "asi_whole_stream_online_accuracy",
+        "paired_outcome_rule": {
+            "schema": "asi.bimu.paired-outcome-rule.v1",
+            "metric": "paper_late_five_test_accuracy",
+            "supported": "all_three_paired_deltas_strictly_positive",
+            "rejected": "all_three_paired_deltas_nonpositive",
+            "otherwise": "inconclusive",
+            "ties_are_positive": False,
+            "secondary_metric_affects_outcome": False,
+        },
+        "output_namespace": str(OUTPUT_NAMESPACE),
+        "execution_authorized": EXECUTION_AUTHORIZED,
     }
+
+
+def frozen_plan_payload() -> dict[str, object]:
+    """Return the literal plan only when its preregistered digest still matches."""
+
+    payload = _plan_payload(FROZEN_BIMU_MATCHED_PLAN)
+    observed = hashlib.sha256(_canonical(payload)).hexdigest()
+    if observed != FROZEN_PLAN_SHA256:
+        raise RuntimeError("frozen BiMU plan payload drifted from its literal digest")
+    return payload
 
 
 def _repository_root() -> Path:
@@ -277,7 +301,8 @@ def _source_identity() -> dict[str, str]:
         Path("alberta_framework/benchmarks/bimu.py"),
         Path("alberta_framework/benchmarks/upgd_ipmnist.py"),
         Path("alberta_framework/evaluation/bimu_matched_nonpromoting.py"),
-        Path("uv.lock"),
+        Path("alberta_framework/evaluation/bimu_matched_campaign.py"),
+        Path("pyproject.toml"),
     )
     return {str(path): hashlib.sha256((root / path).read_bytes()).hexdigest() for path in paths}
 
@@ -322,6 +347,18 @@ def _runtime_identity() -> dict[str, object]:
             "jax_threefry_partitionable": jax.config.jax_threefry_partitionable,
         },
         "environment": {name: os.environ.get(name) for name in environment_names},
+    }
+
+
+def _dependency_identity() -> dict[str, object]:
+    root = _repository_root()
+    return {
+        "schema": "asi.bimu.matched-dependencies.v1",
+        "packages": {
+            name: importlib.metadata.version(name)
+            for name in ("chex", "jax", "jaxlib", "numpy", "scikit-learn")
+        },
+        "uv_lock_sha256": hashlib.sha256((root / "uv.lock").read_bytes()).hexdigest(),
     }
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ The package overview and development entry points are in
 ## Runbooks
 
 - [`runbooks/foragax-open-screen.md`](runbooks/foragax-open-screen.md)
+- [`runbooks/bimu-matched-development.md`](runbooks/bimu-matched-development.md)
 
 Runbooks retain their stated issuance and promotion boundaries. An unissued or
 development-only runbook does not authorize a scientific result.

--- a/docs/runbooks/bimu-matched-development.md
+++ b/docs/runbooks/bimu-matched-development.md
@@ -1,0 +1,58 @@
+# BiMU bounded matched development campaign
+
+This campaign compares the current binary Bayesian learner against its exact
+mechanism-off reduction. It is a five-task, 256-train/256-test, width-32
+development slice. It is permanently nonpromoting, is not paper-comparable,
+and cannot support a scientific, SOTA, or paper-reproduction claim.
+
+The literal plan fixes OpenML `mnist_784` version 1 through the canonical
+60,000-row loader, the first 256 scaled rows as training data, the last 256 as
+a disjoint development test, seeds 157001–157003, and arms `memory_off` and
+`bimu`. The two arm configurations differ only in `memory_window` (`None`
+versus `128`). Every other configuration, schedule, initial state, counter,
+and numeric resource field must match within each pair.
+
+The preregistered primary outcome uses the final-model mean accuracy over the
+five task permutations. It is `supported` only when all three candidate-minus-
+control deltas are strictly positive, `rejected` when all three are
+nonpositive, and `inconclusive` otherwise. The whole-stream online metric is
+secondary and cannot change that classification. Timing is telemetry only.
+
+## Review and execution gate
+
+`EXECUTION_AUTHORIZED` is frozen to `False` in
+`alberta_framework/evaluation/bimu_matched_nonpromoting.py`. The `run-shard`
+command fails before loading MNIST while that literal is false. A separate
+reviewed authorization change must open the gate; that source change also
+changes the plan's source identity, so the plan must then be published from
+the authorized revision before any shard starts. That review must also update
+the literal `FROZEN_PLAN_SHA256`; an authorization flip without the matching
+reviewed plan digest fails closed.
+
+Generate and validate the currently unauthorized plan:
+
+```bash
+.venv/bin/asi-bimu-matched-development plan --root .
+.venv/bin/asi-bimu-matched-development validate --root .
+```
+
+After separate authorization, launch each of the six commands in its own fresh
+Linux process. Substitute each frozen arm and seed exactly once:
+
+```bash
+.venv/bin/asi-bimu-matched-development run-shard \
+  --root . --arm memory_off --seed 157001
+```
+
+Once all six fixed shard paths exist, summarize and revalidate:
+
+```bash
+.venv/bin/asi-bimu-matched-development summarize --root .
+.venv/bin/asi-bimu-matched-development validate --root .
+```
+
+All files publish without replacement under
+`outputs/bimu_matched/development.v1/`. Keep supported, rejected, and
+inconclusive aggregates. Source, runtime, dependency, process, dataset,
+resource, and telemetry digests are consistency bindings, not authenticated
+execution attestation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ asi-rule-discovery-summary = "alberta_framework.benchmarks.rule_discovery_summar
 asi-jepa-transfer-feasibility = "alberta_framework.benchmarks.jepa_transfer_feasibility:main"
 asi-reference-life-scorecard = "alberta_framework.benchmarks.reference_life_scorecard:main"
 asi-l2er-matched-development = "alberta_framework.benchmarks.l2er_matched_development:main"
+asi-bimu-matched-development = "alberta_framework.evaluation.bimu_matched_campaign:main"
 asi-native-supervised-catalog = "alberta_framework.benchmarks.native_supervised_suite:main"
 asi-plasticity-diagnostic = "alberta_framework.benchmarks.plasticity_diagnostics:main"
 asi-nap-ipmnist = "alberta_framework.benchmarks.nap_ipmnist:main"

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -191,6 +191,20 @@ def test_shard_validator_rejects_forged_nested_receipts_and_hostile_trees(
         campaign.validate_plan_document(plan)
 
 
+def test_strict_shard_validator_reexecutes_final_state(tiny_campaign: Any) -> None:
+    arrays = _slice_data()
+    shard = campaign.run_bimu_shard("bimu", 157002)
+    assert campaign.validate_bimu_shard_by_reexecution(shard, *arrays) == shard
+
+    forged = copy.deepcopy(shard)
+    forged["result"]["final_state_sha256"] = "0" * 64
+    forged["result"]["resources"]["state_changed"] = True
+    _resign(forged)
+    assert campaign.validate_bimu_shard(forged) == forged
+    with pytest.raises(ValueError, match="reexecution"):
+        campaign.validate_bimu_shard_by_reexecution(forged, *arrays)
+
+
 def _six_shards() -> list[dict[str, Any]]:
     return [
         campaign.run_bimu_shard(arm, seed)
@@ -268,6 +282,23 @@ def test_fixed_namespace_publication_is_append_only(
     (plan_path.parent / "unexpected.json").write_text("{}", encoding="utf-8")
     with pytest.raises(ValueError, match="unexpected"):
         campaign.main(["validate", "--root", str(tmp_path)])
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_publication_is_read_only_and_rejects_symlinked_parent(tmp_path: Path) -> None:
+    plan_path = campaign.campaign_path(tmp_path, "plan")
+    campaign.publish_json(plan_path, campaign.build_plan_document(), root=tmp_path)
+    assert plan_path.stat().st_mode & 0o777 == 0o444
+    assert plan_path.stat().st_nlink == 1
+
+    redirected = tmp_path / "redirected"
+    redirected.mkdir()
+    linked_root = tmp_path / "linked-root"
+    linked_root.symlink_to(redirected, target_is_directory=True)
+    linked_path = campaign.campaign_path(linked_root, "plan")
+    with pytest.raises(OSError):
+        campaign.publish_json(linked_path, campaign.build_plan_document(), root=linked_root)
+    assert not campaign.campaign_path(redirected, "plan").exists()
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="campaign file validation is Linux-only")

--- a/tests/test_bimu_matched_campaign.py
+++ b/tests/test_bimu_matched_campaign.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import copy
+import dataclasses
+import hashlib
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import alberta_framework.evaluation.bimu_matched_campaign as campaign
+import alberta_framework.evaluation.bimu_matched_nonpromoting as plan_module
+from alberta_framework.benchmarks.bimu import _dataset_sha256
+from alberta_framework.evaluation.bimu_matched_nonpromoting import _test_plan
+
+
+def _full_data(input_dim: int = 4) -> tuple[np.ndarray, np.ndarray]:
+    x = np.arange(60_000 * input_dim, dtype=np.float32).reshape(60_000, input_dim)
+    x /= np.float32(60_000 * input_dim)
+    y = np.arange(60_000, dtype=np.int32) % 2
+    return x, y
+
+
+def _slice_data() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    x = np.arange(8 * 4, dtype=np.float32).reshape(8, 4) / np.float32(32.0)
+    y = np.arange(8, dtype=np.int32) % 2
+    return x[:4], y[:4], x[4:], y[4:]
+
+
+def _resign(payload: dict[str, Any], field: str = "shard_sha256") -> None:
+    payload[field] = campaign.digest_without(payload, field)
+
+
+@pytest.fixture
+def tiny_campaign(monkeypatch: pytest.MonkeyPatch) -> Any:
+    plan = _test_plan(input_dim=4, n_classes=2, examples=4)
+    monkeypatch.setattr(plan_module, "FROZEN_BIMU_MATCHED_PLAN", plan)
+    monkeypatch.setattr(plan_module, "EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(
+        plan_module,
+        "FROZEN_PLAN_SHA256",
+        campaign._sha256(plan_module._plan_payload(plan)),
+    )
+    monkeypatch.setattr(campaign, "FROZEN_BIMU_MATCHED_PLAN", plan)
+    monkeypatch.setattr(campaign, "EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", lambda _home=None: _slice_data())
+    process_index = 0
+
+    def distinct_process_identity() -> dict[str, object]:
+        nonlocal process_index
+        process_index += 1
+        identity: dict[str, object] = {
+            "schema": campaign.PROCESS_SCHEMA,
+            "pid": 10_000 + process_index,
+            "proc_start_ticks": 20_000 + process_index,
+            "boot_id_sha256": "a" * 64,
+            "invocation_nonce": f"{process_index:032x}",
+            "fresh_process_required": True,
+            "identity_is_not_attestation": True,
+        }
+        identity["execution_instance_id"] = campaign.digest_without(
+            identity, "execution_instance_id"
+        )
+        return identity
+
+    monkeypatch.setattr(campaign, "_process_identity", distinct_process_identity)
+    return plan
+
+
+def test_frozen_dataset_loader_uses_exact_canonical_60k_slice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    x, y = _full_data()
+    monkeypatch.setattr(campaign, "load_mnist_train", lambda _home=None: (x, y))
+    plan = _test_plan(input_dim=4, n_classes=2, examples=4)
+    plan = dataclasses.replace(
+        plan,
+        dataset_sha256=_dataset_sha256(x[:4], y[:4], x[-4:], y[-4:]),
+    )
+
+    train_x, train_y, test_x, test_y = campaign.load_frozen_bimu_dataset(
+        Path("/cache"), plan=plan
+    )
+
+    np.testing.assert_array_equal(train_x, x[:4])
+    np.testing.assert_array_equal(train_y, y[:4])
+    np.testing.assert_array_equal(test_x, x[-4:])
+    np.testing.assert_array_equal(test_y, y[-4:])
+    assert not np.shares_memory(train_x, x)
+    assert not np.shares_memory(test_x, x)
+
+
+def test_run_shard_refuses_before_loading_data_when_unauthorized(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    called = False
+
+    def fail(_home: Path | None = None) -> Any:
+        nonlocal called
+        called = True
+        raise AssertionError("dataset must not be loaded")
+
+    monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", fail)
+    with pytest.raises(PermissionError, match="not authorized"):
+        campaign.run_bimu_shard("memory_off", 157001, data_home=tmp_path)
+    assert called is False
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign execution requires Linux /proc")
+def test_linux_process_identity_is_current_and_self_consistent() -> None:
+    identity = campaign._process_identity()
+    assert campaign._validate_process(identity) == identity
+    assert identity["pid"] > 0
+    assert identity["boot_id_sha256"] != hashlib.sha256(b"").hexdigest()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_cli_run_shard_refuses_before_loading_data_when_unauthorized(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    campaign.publish_json(
+        campaign.campaign_path(tmp_path, "plan"),
+        campaign.build_plan_document(),
+        root=tmp_path,
+    )
+    called = False
+
+    def fail(_home: Path | None = None) -> Any:
+        nonlocal called
+        called = True
+        raise AssertionError("dataset must not be loaded")
+
+    monkeypatch.setattr(campaign, "load_frozen_bimu_dataset", fail)
+    assert campaign.main(
+        [
+            "run-shard",
+            "--root",
+            str(tmp_path),
+            "--arm",
+            "memory_off",
+            "--seed",
+            "157001",
+        ]
+    ) == 2
+    assert called is False
+
+
+def test_one_shard_roundtrip_binds_all_execution_axes(tiny_campaign: Any) -> None:
+    shard = campaign.run_bimu_shard("memory_off", 157001)
+    validated = campaign.validate_bimu_shard(shard)
+
+    assert validated == shard
+    assert shard["spec"] == {"arm": "memory_off", "seed": 157001}
+    assert shard["identity"]["source_sha256"] == plan_module._source_identity()
+    assert shard["identity"]["runtime"] == plan_module._runtime_identity()
+    assert shard["identity"]["dependencies"] == plan_module._dependency_identity()
+    assert shard["resources"]["dataset_numeric_bytes"] == 160
+    assert shard["timing"]["qualified"] is False
+    assert shard["timing"]["used_for_outcome"] is False
+
+
+def test_shard_validator_rejects_forged_nested_receipts_and_hostile_trees(
+    tiny_campaign: Any,
+) -> None:
+    shard = campaign.run_bimu_shard("bimu", 157002)
+
+    forged = copy.deepcopy(shard)
+    forged["result"]["counters"]["optimizer_updates"] -= 1
+    _resign(forged)
+    with pytest.raises(ValueError, match="counter|optimizer"):
+        campaign.validate_bimu_shard(forged)
+
+    forged = copy.deepcopy(shard)
+    forged["identity"]["dependencies"]["uv_lock_sha256"] = "0" * 64
+    _resign(forged)
+    with pytest.raises(ValueError, match="identity"):
+        campaign.validate_bimu_shard(forged)
+
+    hostile: object = "leaf"
+    for _ in range(campaign.MAX_JSON_DEPTH + 1):
+        hostile = [hostile]
+    with pytest.raises(ValueError, match="nesting"):
+        campaign.validate_bimu_shard(hostile)
+
+    plan = campaign.build_plan_document()
+    plan["policy"]["execution_authorized"] = 1
+    plan["document_sha256"] = campaign.digest_without(plan, "document_sha256")
+    with pytest.raises(ValueError, match="policy"):
+        campaign.validate_plan_document(plan)
+
+
+def _six_shards() -> list[dict[str, Any]]:
+    return [
+        campaign.run_bimu_shard(arm, seed)
+        for seed in (157001, 157002, 157003)
+        for arm in ("memory_off", "bimu")
+    ]
+
+
+def test_aggregate_requires_six_unique_shards_and_recomputes_paired_rule(
+    tiny_campaign: Any,
+) -> None:
+    shards = _six_shards()
+    aggregate = campaign.summarize_bimu_shards(shards)
+    campaign.validate_bimu_aggregate(aggregate)
+
+    deltas = aggregate["paired_metrics"]["primary_deltas"]
+    expected = (
+        "supported"
+        if all(delta > 0.0 for delta in deltas)
+        else "rejected"
+        if all(delta <= 0.0 for delta in deltas)
+        else "inconclusive"
+    )
+    assert aggregate["outcome"]["classification"] == expected
+    assert aggregate["outcome"]["scientific_evidence"] is False
+
+    with pytest.raises(ValueError, match="roster"):
+        campaign.summarize_bimu_shards(shards[:-1])
+    with pytest.raises(ValueError, match="roster|duplicate"):
+        campaign.summarize_bimu_shards([*shards[:-1], shards[0]])
+
+    same_process = copy.deepcopy(shards)
+    same_process[1]["identity"]["process"] = copy.deepcopy(
+        same_process[0]["identity"]["process"]
+    )
+    _resign(same_process[1])
+    with pytest.raises(ValueError, match="process"):
+        campaign.summarize_bimu_shards(same_process)
+
+
+def test_aggregate_rejects_cross_pair_schedule_or_resource_drift(tiny_campaign: Any) -> None:
+    shards = _six_shards()
+    forged = copy.deepcopy(shards)
+    forged[1]["result"]["schedule_sha256"] = "0" * 64
+    _resign(forged[1])
+    with pytest.raises(ValueError, match="schedule"):
+        campaign.summarize_bimu_shards(forged)
+
+    forged = copy.deepcopy(shards)
+    forged[1]["result"]["resources"]["parameter_numeric_bytes"] += 4
+    _resign(forged[1])
+    with pytest.raises(ValueError, match="resource|accounting"):
+        campaign.summarize_bimu_shards(forged)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign publication is Linux-only")
+def test_fixed_namespace_publication_is_append_only(
+    tmp_path: Path, tiny_campaign: Any
+) -> None:
+    plan_path = campaign.campaign_path(tmp_path, "plan")
+    campaign.publish_json(plan_path, campaign.build_plan_document(), root=tmp_path)
+    with pytest.raises(FileExistsError):
+        campaign.publish_json(plan_path, campaign.build_plan_document(), root=tmp_path)
+
+    outside = tmp_path / "outside.json"
+    with pytest.raises(ValueError, match="namespace"):
+        campaign.publish_json(outside, {}, root=tmp_path)
+
+    invalid_shard_path = campaign.campaign_path(
+        tmp_path, "shard", arm="memory_off", seed=157001
+    )
+    with pytest.raises(ValueError, match="shard"):
+        campaign.publish_json(invalid_shard_path, {}, root=tmp_path)
+
+    (plan_path.parent / "unexpected.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError, match="unexpected"):
+        campaign.main(["validate", "--root", str(tmp_path)])
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="campaign file validation is Linux-only")
+def test_strict_loader_rejects_duplicate_keys_and_oversized_input(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema":"a","schema":"b"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate"):
+        campaign.load_json_strict(duplicate, byte_ceiling=1024)
+
+    oversized = tmp_path / "oversized.json"
+    oversized.write_bytes(b" " * 1025)
+    with pytest.raises(ValueError, match="byte ceiling"):
+        campaign.load_json_strict(oversized, byte_ceiling=1024)
+
+    linked = tmp_path / "linked.json"
+    linked.write_text("{}", encoding="utf-8")
+    linked_alias = tmp_path / "linked-alias.json"
+    linked_alias.hardlink_to(linked)
+    with pytest.raises(ValueError, match="hard-link"):
+        campaign.load_json_strict(linked, byte_ceiling=1024)
+
+
+def test_cli_has_only_plan_run_shard_summarize_and_validate() -> None:
+    parser = campaign._parser()
+    for command in ("plan", "run-shard", "summarize", "validate"):
+        assert parser.parse_args([command, "--root", "/tmp/root", *(
+            ["--arm", "bimu", "--seed", "157001"] if command == "run-shard" else []
+        )]).command == command
+
+
+def test_aggregate_validator_rejects_resigned_outcome_reclassification(
+    tiny_campaign: Any,
+) -> None:
+    aggregate = cast(dict[str, Any], campaign.summarize_bimu_shards(_six_shards()))
+    aggregate["outcome"]["classification"] = "supported"
+    aggregate["aggregate_sha256"] = campaign.digest_without(aggregate, "aggregate_sha256")
+    with pytest.raises(ValueError, match="outcome"):
+        campaign.validate_bimu_aggregate(aggregate)

--- a/tests/test_bimu_matched_nonpromoting.py
+++ b/tests/test_bimu_matched_nonpromoting.py
@@ -8,6 +8,7 @@ import pytest
 import alberta_framework.evaluation.bimu_matched_nonpromoting as bimu_plan
 from alberta_framework.evaluation.bimu_matched_nonpromoting import (
     FROZEN_BIMU_MATCHED_PLAN,
+    FROZEN_PLAN_SHA256,
     INVALID_PRIOR_ATTEMPT,
     _plan_payload,
     build_bimu_execution_manifest,
@@ -31,11 +32,13 @@ def test_frozen_bimu_plan_is_matched_and_prospective() -> None:
     candidate = plan.candidate_config.to_protocol_payload()
     assert {key for key in control if control[key] != candidate[key]} == {"memory_window"}
     assert plan.dataset_sha256 == "85c681c2f5fc5c274870b30c9accb3d2a6e9eb90a4575a2bf1ccca64f58b6227"
+    assert FROZEN_PLAN_SHA256 == "11ddfacd0aca8108a39bd8a68225149de246efb7420d2fdb864f36ea75681f71"
     assert INVALID_PRIOR_ATTEMPT["pull_request"] == 1686
     assert INVALID_PRIOR_ATTEMPT["seed"] == 23
     payload = _plan_payload(plan)
     assert payload["expected_counters_per_arm"]["observations"] == 1280
     assert payload["expected_counters_per_arm"]["model_forward_queries"] == 10240
+    assert payload["expected_counters_per_arm"]["optimizer_updates"] == 1280
     assert payload["expected_resources_per_arm"] == {
         "trainable_scalar_count": 25408,
         "parameter_numeric_bytes": 101632,
@@ -48,6 +51,17 @@ def test_frozen_bimu_plan_is_matched_and_prospective() -> None:
         "numeric_resource_ceiling_bytes": 256 * 1024 * 1024,
     }
     assert payload["comparison_scope"]["paper_comparable"] is False
+    assert payload["execution_authorized"] is False
+    assert payload["output_namespace"] == "outputs/bimu_matched/development.v1"
+    assert payload["paired_outcome_rule"] == {
+        "schema": "asi.bimu.paired-outcome-rule.v1",
+        "metric": "paper_late_five_test_accuracy",
+        "supported": "all_three_paired_deltas_strictly_positive",
+        "rejected": "all_three_paired_deltas_nonpositive",
+        "otherwise": "inconclusive",
+        "ties_are_positive": False,
+        "secondary_metric_affects_outcome": False,
+    }
     with pytest.raises(TypeError):
         INVALID_PRIOR_ATTEMPT["seed"] = 157001  # type: ignore[index]
 
@@ -114,3 +128,11 @@ def test_manifest_rejects_hostile_metaclass_without_hooks() -> None:
     with pytest.raises(ValueError, match="exact JSON"):
         bimu_plan._json_preflight({"value": Hostile()})
     assert HostileMeta.calls == 0
+
+
+def test_literal_plan_digest_fails_closed_on_unreviewed_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(bimu_plan, "EXECUTION_AUTHORIZED", True)
+    with pytest.raises(RuntimeError, match="literal digest"):
+        bimu_plan.frozen_plan_payload()


### PR DESCRIPTION
## Summary

Contributor-preserving successor to closed #2104 and #2107 for issue #1570. It keeps the stronger six-shard fresh-process campaign architecture and incorporates the useful strict-reexecution property from the alternate lineage.

- fixed three-seed/two-arm roster and fixed append-only development namespace
- exact source/runtime/dependency/OpenML-slice identities, counters, resources, initial state, schedule, and paired outcome rule
- strict validation reexecutes each exact seed/arm against the digest-bound arrays and compares every deterministic result field, rejecting self-consistent metric/final-state forgeries
- CLI summarize/validate use that strict replay path before aggregate admission
- output parents are opened component-by-component with pinned directory descriptors and no symlink following
- publication uses a fully written/fsynced read-only anonymous O_TMPFILE inode and no-replace linkat; visible artifacts are never unlinked on a later sync failure
- dataset identity is rechecked after both execution and validation replay

Seeds 157001-157003 were already publicly frozen by the merged prospective plan and are therefore consumed for any promotion purpose. They have not produced a retained matched result. This lane remains permanently nonpromoting, execution authorization remains literally false, no workload was executed, and no output was created. Issue #1570 stays open.

## Audit evidence

- Real `load_mnist_train()` OpenML-v1 materialization reproduced frozen slice SHA-256 `85c681c2f5fc5c274870b30c9accb3d2a6e9eb90a4575a2bf1ccca64f58b6227`
- Official repository/commit/license independently verified
- 45 tests passed across BiMU kernel, plan, campaign, hostile validators, strict replay, and publication
- scoped Ruff passed
- strict mypy passed
- diff-check passed

No registered evidence artifact or output is changed.