### PR TITLE
test(steps): preserve Step 1 normalizer boundary dispatch

### DIFF
--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -83,6 +83,64 @@ def test_step1_kernel_all_public_optimizers_smoke(optimizer: str) -> None:
     assert result.metrics_shape == (12, 4)
 
 
+@pytest.mark.parametrize(
+    "normalizer",
+    ["none", "ema", "welford", "streaming_batch"],
+)
+def test_step1_kernel_all_public_normalizers_smoke(normalizer: str) -> None:
+    """Every documented Step1NormalizerName must actually run end to end.
+
+    Before this test, ``run_step1_smoke``/``make_step1_normalizer`` were only
+    ever exercised with ``normalizer in {"none", "ema"}``; "welford" and
+    "streaming_batch" were touched by config-construction and JSON
+    round-trip tests but never actually driven through the smoke loop. Mirrors
+    ``test_step1_kernel_all_public_optimizers_smoke`` above.
+    """
+    config = Step1KernelConfig(
+        optimizer="autostep",
+        normalizer=normalizer,  # type: ignore[arg-type]
+        feature_dim=8,
+        num_relevant=3,
+        noise_std=0.1,
+    )
+    result = run_step1_smoke(config, steps=12, final_window=3)
+    assert result.finite
+    expected_columns = 3 if normalizer == "none" else 4
+    assert result.metrics_shape == (12, expected_columns)
+
+
+@pytest.mark.parametrize(
+    ("normalizer", "field", "value"),
+    [
+        ("ema", "ema_decay", 0.0),
+        ("ema", "ema_decay", 1.0),
+        ("streaming_batch", "streaming_batch_momentum", 0.0),
+        ("streaming_batch", "streaming_batch_momentum", 1.0),
+    ],
+)
+def test_step1_normalizer_boundary_hyperparameters_stay_finite_when_selected(
+    normalizer: str, field: str, value: float
+) -> None:
+    """Boundary decay/momentum values must stay finite for the normalizer they configure.
+
+    ``test_step1_fields_preserve_legal_endpoints`` already exercises these
+    same 0.0/1.0 endpoints for ``ema_decay``/``streaming_batch_momentum``, but
+    only while ``normalizer`` is left at its unrelated default ("ema" or
+    "none"), so the boundary value is never actually consumed by the
+    normalizer it configures. This runs the smoke loop with the matching
+    normalizer selected.
+    """
+    config = Step1KernelConfig(
+        optimizer="autostep",
+        normalizer=normalizer,  # type: ignore[arg-type]
+        feature_dim=6,
+        num_relevant=2,
+        **{field: value},
+    )
+    result = run_step1_smoke(config, steps=10, final_window=3)
+    assert result.finite
+
+
 def test_step1_kernel_rejects_unpublished_auto_alias() -> None:
     with pytest.raises(ValueError, match="optimizer"):
         Step1KernelConfig(optimizer="auto")  # type: ignore[arg-type]

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -13,6 +13,11 @@ import numpy as np
 import pytest
 
 from alberta_framework.cli import step1_smoke_main, step2_smoke_main
+from alberta_framework.core.normalizers import (
+    EMANormalizer,
+    StreamingBatchNormalizer,
+    WelfordNormalizer,
+)
 from alberta_framework.steps import (
     Step1KernelConfig,
     Step2HybridConfig,
@@ -21,6 +26,7 @@ from alberta_framework.steps import (
     Step2StrictDigitReadoutConfig,
     Step2TemporalContextConfig,
     make_step1_learner,
+    make_step1_normalizer,
     make_step1_optimizer,
     make_step1_stream,
     make_step2_hybrid_learner,
@@ -84,10 +90,18 @@ def test_step1_kernel_all_public_optimizers_smoke(optimizer: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "normalizer",
-    ["none", "ema", "welford", "streaming_batch"],
+    ("normalizer", "expected_type"),
+    [
+        ("none", None),
+        ("ema", EMANormalizer),
+        ("welford", WelfordNormalizer),
+        ("streaming_batch", StreamingBatchNormalizer),
+    ],
 )
-def test_step1_kernel_all_public_normalizers_smoke(normalizer: str) -> None:
+def test_step1_kernel_all_public_normalizers_smoke(
+    normalizer: str,
+    expected_type: type[Any] | None,
+) -> None:
     """Every documented Step1NormalizerName must actually run end to end.
 
     Before this test, ``run_step1_smoke``/``make_step1_normalizer`` were only
@@ -103,6 +117,11 @@ def test_step1_kernel_all_public_normalizers_smoke(normalizer: str) -> None:
         num_relevant=3,
         noise_std=0.1,
     )
+    implementation = make_step1_normalizer(config)
+    if expected_type is None:
+        assert implementation is None
+    else:
+        assert type(implementation) is expected_type
     result = run_step1_smoke(config, steps=12, final_window=3)
     assert result.finite
     expected_columns = 3 if normalizer == "none" else 4
@@ -137,6 +156,9 @@ def test_step1_normalizer_boundary_hyperparameters_stay_finite_when_selected(
         num_relevant=2,
         **{field: value},
     )
+    implementation = make_step1_normalizer(config)
+    assert implementation is not None
+    assert implementation.to_config()["decay" if field == "ema_decay" else "momentum"] == value
     result = run_step1_smoke(config, steps=10, final_window=3)
     assert result.finite
 

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -5,7 +5,7 @@ import json
 import tomllib
 from fractions import Fraction
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import jax.numpy as jnp
 import jax.random as jr
@@ -90,75 +90,45 @@ def test_step1_kernel_all_public_optimizers_smoke(optimizer: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("normalizer", "expected_type"),
+    ("normalizer", "expected_type", "expected_field", "endpoint"),
     [
-        ("none", None),
-        ("ema", EMANormalizer),
-        ("welford", WelfordNormalizer),
-        ("streaming_batch", StreamingBatchNormalizer),
+        ("none", None, None, None),
+        ("ema", EMANormalizer, "decay", 0.0),
+        ("ema", EMANormalizer, "decay", 1.0),
+        ("welford", WelfordNormalizer, None, None),
+        ("streaming_batch", StreamingBatchNormalizer, "momentum", 0.0),
+        ("streaming_batch", StreamingBatchNormalizer, "momentum", 1.0),
     ],
 )
-def test_step1_kernel_all_public_normalizers_smoke(
-    normalizer: str,
+def test_step1_kernel_all_public_normalizers_and_selected_endpoints_smoke(
+    normalizer: Literal["none", "ema", "welford", "streaming_batch"],
     expected_type: type[Any] | None,
+    expected_field: Literal["decay", "momentum"] | None,
+    endpoint: float | None,
 ) -> None:
-    """Every public Step 1 normalizer dispatches exactly and runs end to end."""
+    """Every public normalizer and selected endpoint reaches the Step 1 loop."""
     config = Step1KernelConfig(
-        optimizer="autostep",
-        normalizer=normalizer,  # type: ignore[arg-type]
+        normalizer=normalizer,
         feature_dim=8,
         num_relevant=3,
-        noise_std=0.1,
+        ema_decay=endpoint if normalizer == "ema" and endpoint is not None else 0.99,
+        streaming_batch_momentum=(
+            endpoint
+            if normalizer == "streaming_batch" and endpoint is not None
+            else 0.99
+        ),
     )
     implementation = make_step1_normalizer(config)
     if expected_type is None:
         assert implementation is None
     else:
         assert type(implementation) is expected_type
+        if expected_field is not None:
+            assert implementation.to_config()[expected_field] == endpoint
     result = run_step1_smoke(config, steps=12, final_window=3)
     assert result.finite
-    expected_columns = 3 if normalizer == "none" else 4
+    expected_columns = 3 if config.normalizer == "none" else 4
     assert result.metrics_shape == (12, expected_columns)
-
-
-@pytest.mark.parametrize(
-    ("normalizer", "field", "value"),
-    [
-        ("ema", "ema_decay", 0.0),
-        ("ema", "ema_decay", 1.0),
-        ("streaming_batch", "streaming_batch_momentum", 0.0),
-        ("streaming_batch", "streaming_batch_momentum", 1.0),
-    ],
-)
-def test_step1_normalizer_boundary_hyperparameters_stay_finite_when_selected(
-    normalizer: str, field: str, value: float
-) -> None:
-    """Step 1 must dispatch and consume each selected boundary value."""
-    if field == "ema_decay":
-        assert normalizer == "ema"
-        config = Step1KernelConfig(
-            optimizer="autostep",
-            normalizer="ema",
-            feature_dim=6,
-            num_relevant=2,
-            ema_decay=value,
-        )
-    else:
-        assert field == "streaming_batch_momentum"
-        assert normalizer == "streaming_batch"
-        config = Step1KernelConfig(
-            optimizer="autostep",
-            normalizer="streaming_batch",
-            feature_dim=6,
-            num_relevant=2,
-            streaming_batch_momentum=value,
-        )
-    implementation = make_step1_normalizer(config)
-    assert implementation is not None
-    implementation_field = "decay" if field == "ema_decay" else "momentum"
-    assert implementation.to_config()[implementation_field] == value
-    result = run_step1_smoke(config, steps=10, final_window=3)
-    assert result.finite
 
 
 def test_step1_kernel_rejects_unpublished_auto_alias() -> None:

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -124,6 +124,7 @@ def test_step1_kernel_all_public_normalizers_and_selected_endpoints_smoke(
     else:
         assert type(implementation) is expected_type
         if expected_field is not None:
+            assert implementation is not None
             assert implementation.to_config()[expected_field] == endpoint
     result = run_step1_smoke(config, steps=12, final_window=3)
     assert result.finite

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -121,6 +121,34 @@ def test_step1_kernel_all_public_normalizers_smoke(
     assert result.metrics_shape == (12, expected_columns)
 
 
+@pytest.mark.parametrize(
+    ("normalizer", "field", "value"),
+    [
+        ("ema", "ema_decay", 0.0),
+        ("ema", "ema_decay", 1.0),
+        ("streaming_batch", "streaming_batch_momentum", 0.0),
+        ("streaming_batch", "streaming_batch_momentum", 1.0),
+    ],
+)
+def test_step1_normalizer_boundary_hyperparameters_stay_finite_when_selected(
+    normalizer: str, field: str, value: float
+) -> None:
+    """Step 1 must dispatch and consume each selected boundary value."""
+    config = Step1KernelConfig(
+        optimizer="autostep",
+        normalizer=normalizer,  # type: ignore[arg-type]
+        feature_dim=6,
+        num_relevant=2,
+        **{field: value},
+    )
+    implementation = make_step1_normalizer(config)
+    assert implementation is not None
+    implementation_field = "decay" if field == "ema_decay" else "momentum"
+    assert implementation.to_config()[implementation_field] == value
+    result = run_step1_smoke(config, steps=10, final_window=3)
+    assert result.finite
+
+
 def test_step1_kernel_rejects_unpublished_auto_alias() -> None:
     with pytest.raises(ValueError, match="optimizer"):
         Step1KernelConfig(optimizer="auto")  # type: ignore[arg-type]

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -134,13 +134,25 @@ def test_step1_normalizer_boundary_hyperparameters_stay_finite_when_selected(
     normalizer: str, field: str, value: float
 ) -> None:
     """Step 1 must dispatch and consume each selected boundary value."""
-    config = Step1KernelConfig(
-        optimizer="autostep",
-        normalizer=normalizer,  # type: ignore[arg-type]
-        feature_dim=6,
-        num_relevant=2,
-        **{field: value},
-    )
+    if field == "ema_decay":
+        assert normalizer == "ema"
+        config = Step1KernelConfig(
+            optimizer="autostep",
+            normalizer="ema",
+            feature_dim=6,
+            num_relevant=2,
+            ema_decay=value,
+        )
+    else:
+        assert field == "streaming_batch_momentum"
+        assert normalizer == "streaming_batch"
+        config = Step1KernelConfig(
+            optimizer="autostep",
+            normalizer="streaming_batch",
+            feature_dim=6,
+            num_relevant=2,
+            streaming_batch_momentum=value,
+        )
     implementation = make_step1_normalizer(config)
     assert implementation is not None
     implementation_field = "decay" if field == "ema_decay" else "momentum"

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -102,14 +102,7 @@ def test_step1_kernel_all_public_normalizers_smoke(
     normalizer: str,
     expected_type: type[Any] | None,
 ) -> None:
-    """Every documented Step1NormalizerName must actually run end to end.
-
-    Before this test, ``run_step1_smoke``/``make_step1_normalizer`` were only
-    ever exercised with ``normalizer in {"none", "ema"}``; "welford" and
-    "streaming_batch" were touched by config-construction and JSON
-    round-trip tests but never actually driven through the smoke loop. Mirrors
-    ``test_step1_kernel_all_public_optimizers_smoke`` above.
-    """
+    """Every public Step 1 normalizer dispatches exactly and runs end to end."""
     config = Step1KernelConfig(
         optimizer="autostep",
         normalizer=normalizer,  # type: ignore[arg-type]
@@ -126,41 +119,6 @@ def test_step1_kernel_all_public_normalizers_smoke(
     assert result.finite
     expected_columns = 3 if normalizer == "none" else 4
     assert result.metrics_shape == (12, expected_columns)
-
-
-@pytest.mark.parametrize(
-    ("normalizer", "field", "value"),
-    [
-        ("ema", "ema_decay", 0.0),
-        ("ema", "ema_decay", 1.0),
-        ("streaming_batch", "streaming_batch_momentum", 0.0),
-        ("streaming_batch", "streaming_batch_momentum", 1.0),
-    ],
-)
-def test_step1_normalizer_boundary_hyperparameters_stay_finite_when_selected(
-    normalizer: str, field: str, value: float
-) -> None:
-    """Boundary decay/momentum values must stay finite for the normalizer they configure.
-
-    ``test_step1_fields_preserve_legal_endpoints`` already exercises these
-    same 0.0/1.0 endpoints for ``ema_decay``/``streaming_batch_momentum``, but
-    only while ``normalizer`` is left at its unrelated default ("ema" or
-    "none"), so the boundary value is never actually consumed by the
-    normalizer it configures. This runs the smoke loop with the matching
-    normalizer selected.
-    """
-    config = Step1KernelConfig(
-        optimizer="autostep",
-        normalizer=normalizer,  # type: ignore[arg-type]
-        feature_dim=6,
-        num_relevant=2,
-        **{field: value},
-    )
-    implementation = make_step1_normalizer(config)
-    assert implementation is not None
-    assert implementation.to_config()["decay" if field == "ema_decay" else "momentum"] == value
-    result = run_step1_smoke(config, steps=10, final_window=3)
-    assert result.finite
 
 
 def test_step1_kernel_rejects_unpublished_auto_alias() -> None:


### PR DESCRIPTION
Contributor-preserving successor to #2087/#2099.

Covers all four public Step 1 normalizer factories end to end. The EMA decay 0/1 and streaming-batch momentum 0/1 cases also prove that each selected endpoint reaches the matching normalizer and the real Step 1 smoke loop. The six-case matrix avoids duplicate default smoke runs and uses typed literals without dynamic kwargs or type-ignore bypasses.

Verification at exact head `59d7c73898989f4195dafd99e3ea9d8c8eff8e03`:

- `tests/test_production_steps.py`: 392 passed
- repository Ruff passed
- strict mypy passed
- diff check passed

This is test-only; it changes no production source, benchmark output, workflow, or evidence artifact.