### PR TITLE
research: freeze Intentional Updates matched-development plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add a prospectively frozen, execution-disabled Intentional Updates matched-development
+  campaign spanning the existing batch-size-one supervised adapter plus new end-to-end linear
+  TD(0), TD(lambda), and Q(lambda) consumers. The two workload families retain separate paired
+  questions, exact resource receipts, telemetry-only timing, immutable negative outcomes, and a
+  permanently nonpromoting report policy. No campaign run or output is included.
+
 ### Added
 
 - Added the unfrozen `preview1` reference-agent transaction ledger, primitive

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ The console scripts are grouped by responsibility; every command supports `--hel
 | `alberta-step1-smoke`, `alberta-step2-smoke` | Nonpromoting mechanism smoke checks |
 | `asi-native-supervised-catalog`, `asi-plasticity-diagnostic` | Inspect or run bounded, permanently nonpromoting supervised diagnostics |
 | `asi-adamo-diagnostic` | Catalog or run the bounded, permanently nonpromoting AdamO dynamical-isometry comparator |
+| `asi-intentional-updates-matched-development` | Inspect the frozen, execution-disabled supervised + TD/control Intentional Updates development plan |
 | `asi-clear-qualification` | Verify local CLEAR archive identities and emit a permanently nonpromoting matched setup plan |
 | `asi-coom-qualification-smoke` | Inspect or run the bounded, synthetic, permanently nonpromoting COOM qualification smoke |
 | `asi-cora-catalog` | Inspect the blocked CORA qualification catalog without importing external runtimes |

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -202,9 +202,7 @@ def frozen_plan() -> dict[str, object]:
             "RNG operations, optimizer solves, persistent bytes, and timing per shard"
         ),
         "output_path": "outputs/intentional_updates_matched_development/report.v1.json",
-        # These are historical properties of the plan at freeze time.  A later,
-        # independently reviewed code-only authorization must not mutate the plan
-        # that was reviewed before any retained execution.
+        # Runtime authorization is separate from this immutable plan identity.
         "execution_authorized": False,
         "reviewed_execution_transition": False,
         "execution_status": "blocked_pending_independent_plan_audit",

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -120,8 +120,19 @@ def frozen_plan() -> dict[str, object]:
         "plan_id": PLAN_ID,
         "paper_revision": PAPER_REVISION,
         "official_code_revision": OFFICIAL_CODE_REVISION,
-        "source_identity": _source_identity(),
-        "runtime_identity": _runtime_identity(),
+        "source_identity_policy": {
+            "binding": "execution-time Git/source hashes retained in every report",
+            "hashed_files": [
+                "alberta_framework/benchmarks/intentional_updates_control.py",
+                "alberta_framework/benchmarks/ipmnist_screening.py",
+                "alberta_framework/benchmarks/plasticity_comparators.py",
+                "alberta_framework/benchmarks/upgd_ipmnist.py",
+            ],
+        },
+        "runtime_identity_policy": (
+            "retain the exact execution Python, platform, package, JAX backend, "
+            "device, and configuration identity in every report"
+        ),
         "seeds": list(CAMPAIGN_SEEDS),
         "quarantined_test_consumed_seeds": list(QUARANTINED_SEEDS),
         "protocol_families": ["supervised_ipmnist", "td_control"],
@@ -153,15 +164,22 @@ def frozen_plan() -> dict[str, object]:
             "trace_decay": 0.8,
             "epsilon_greedy": 0.1,
         },
-        "matched_axes": [
-            "seed",
-            "initial_parameters",
-            "observations",
-            "updates",
-            "allowed_boundary_and_task_information",
-            "environment_definition",
-            "exogenous_exploration_rng",
-        ],
+        "matched_axes": {
+            "all_families": [
+                "seed",
+                "initial_parameters",
+                "observations",
+                "updates",
+                "allowed_boundary_and_task_information",
+            ],
+            "supervised_ipmnist": ["example_schedule"],
+            "td_prediction": ["transition_schedule"],
+            "q_lambda_control": [
+                "environment_dynamics",
+                "agent_rng_root_and_index_schedule",
+                "policy-dependent realized trajectories are not matched",
+            ],
+        },
         "boundary_information": [],
         "task_information": [],
         "paired_metrics": {
@@ -184,14 +202,12 @@ def frozen_plan() -> dict[str, object]:
             "RNG operations, optimizer solves, persistent bytes, and timing per shard"
         ),
         "output_path": "outputs/intentional_updates_matched_development/report.v1.json",
-        "execution_authorized": _EXECUTION_AUTHORIZED,
-        "reviewed_execution_transition": _REVIEWED_EXECUTION_TRANSITION,
-        "execution_status": (
-            "authorized_after_separate_review"
-            if _REVIEWED_EXECUTION_TRANSITION is True
-            and _EXECUTION_AUTHORIZED is True
-            else "blocked_pending_independent_plan_audit"
-        ),
+        # These are historical properties of the plan at freeze time.  A later,
+        # independently reviewed code-only authorization must not mutate the plan
+        # that was reviewed before any retained execution.
+        "execution_authorized": False,
+        "reviewed_execution_transition": False,
+        "execution_status": "blocked_pending_independent_plan_audit",
         "development_only": True,
         "scientific_promotion_allowed": False,
         "negative_outcomes_retained": True,
@@ -426,7 +442,7 @@ def _run(
     if intentional:
         numeric_bytes += int(
             second.nbytes
-            + 3 * np.dtype(np.float32).itemsize
+            + 2 * np.dtype(np.float32).itemsize
             + np.dtype(np.int32).itemsize
         )
     if root is not None:

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -83,6 +83,7 @@ _MAX_JSON_NODES: Final[int] = 200_000
 _MAX_STRING_BYTES: Final[int] = 2 * 1024 * 1024
 _MAX_TIMING_NS: Final[int] = 7 * 24 * 60 * 60 * 1_000_000_000
 _MAX_REPORT_BYTES: Final[int] = 64 * 1024 * 1024
+_MAX_RUNTIME_DEVICES: Final[int] = 64
 _AGENT_RNG_IMPL: Final[str] = "threefry2x32"
 _REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
 OUTPUT_PATH: Final[Path] = (
@@ -303,6 +304,9 @@ def _runtime_identity() -> dict[str, object]:
         "JAX_RANDOM_SEED_OFFSET",
         "XLA_FLAGS",
     )
+    devices = tuple(jax.devices())
+    if len(devices) == 0 or len(devices) > _MAX_RUNTIME_DEVICES:
+        raise RuntimeError("Intentional Updates runtime device inventory is out of bounds")
     return {
         "schema": "asi.intentional-updates.runtime.v1",
         "python": list(sys.version_info[:3]),
@@ -335,7 +339,7 @@ def _runtime_identity() -> dict[str, object]:
                     "device_kind": str(device.device_kind),
                     "process_index": int(device.process_index),
                 }
-                for device in jax.devices()
+                for device in devices
             ],
             "config": {
                 "jax_default_matmul_precision": str(

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -156,10 +156,11 @@ def frozen_plan() -> dict[str, object]:
         "matched_axes": [
             "seed",
             "initial_parameters",
-            "example_or_transition_schedule",
             "observations",
             "updates",
             "allowed_boundary_and_task_information",
+            "environment_definition",
+            "exogenous_exploration_rng",
         ],
         "boundary_information": [],
         "task_information": [],
@@ -294,12 +295,12 @@ def _transition(state: int, action: int, step: int, phase_length: int) -> tuple[
     return successor, 1.0 if successor == goal else 0.0
 
 
-def _select_action(values: np.ndarray, key: jax.Array) -> tuple[int, bool]:
+def _select_action(values: np.ndarray, key: jax.Array) -> tuple[int, bool, bool]:
     explore_key, action_key = jr.split(key)
     greedy = int(np.argmax(values))
     explore = float(jr.uniform(explore_key, (), dtype=np.float32)) < 0.1
     action = int(jr.randint(action_key, (), 0, 2)) if explore else greedy
-    return action, action != greedy
+    return action, explore, action != greedy
 
 
 def _intentional_update(
@@ -364,11 +365,15 @@ def _run(
     rewards: list[float] = []
     errors: list[float] = []
     step_sizes: list[float] = []
+    integer_draws = 0
     start_ns = time.perf_counter_ns()
     for index in range(horizon):
         if is_control:
             assert root is not None
-            action, non_greedy = _select_action(weights[state], jr.fold_in(root, index))
+            action, explored, non_greedy = _select_action(
+                weights[state], jr.fold_in(root, index)
+            )
+            integer_draws += int(explored)
         else:
             action = (index + seed) % 2
             non_greedy = False
@@ -415,7 +420,11 @@ def _run(
     timing_ns = time.perf_counter_ns() - start_ns
     numeric_bytes = int(weights.nbytes + trace.nbytes)
     if intentional:
-        numeric_bytes += int(second.nbytes + 3 * np.dtype(np.float32).itemsize)
+        numeric_bytes += int(
+            second.nbytes
+            + 3 * np.dtype(np.float32).itemsize
+            + np.dtype(np.int32).itemsize
+        )
     if root is not None:
         numeric_bytes += int(root.nbytes)
     trajectory = {
@@ -444,6 +453,8 @@ def _run(
         "action_queries": horizon if is_control else 0,
         "rng_splits": horizon if is_control else 0,
         "rng_fold_ins": horizon if is_control else 0,
+        "rng_uniform_draws": horizon if is_control else 0,
+        "rng_integer_draws": integer_draws if is_control else 0,
         "intentional_step_size_solves": horizon if intentional else 0,
         "persistent_numeric_bytes": numeric_bytes,
         "timing_telemetry_ns": timing_ns,
@@ -593,6 +604,7 @@ def validate_control_shard(value: object) -> dict[str, object]:
             {
                 "observations", "environment_steps", "data_steps", "reward_observations",
                 "updates", "model_queries", "action_queries", "rng_splits", "rng_fold_ins",
+                "rng_uniform_draws", "rng_integer_draws",
                 "intentional_step_size_solves", "persistent_numeric_bytes",
                 "timing_telemetry_ns", "timing_is_selection_metric",
             }
@@ -1049,7 +1061,12 @@ def _release(reservation: _Reservation) -> None:
         os.close(reservation.directory_fd)
 
 
-def _strict_reread(reservation: _Reservation, expected: bytes) -> object:
+def _strict_reread(
+    reservation: _Reservation,
+    expected: bytes,
+    *,
+    expected_identity: tuple[int, int],
+) -> object:
     descriptor = os.open(
         reservation.destination_name,
         os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
@@ -1057,7 +1074,12 @@ def _strict_reread(reservation: _Reservation, expected: bytes) -> object:
     )
     try:
         metadata = os.fstat(descriptor)
-        if not stat.S_ISREG(metadata.st_mode) or not 0 < metadata.st_size <= _MAX_REPORT_BYTES:
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or (metadata.st_dev, metadata.st_ino) != expected_identity
+            or metadata.st_nlink != 1
+            or not 0 < metadata.st_size <= _MAX_REPORT_BYTES
+        ):
             raise ValueError("published report must be one bounded regular file")
         chunks: list[bytes] = []
         remaining = metadata.st_size
@@ -1071,7 +1093,10 @@ def _strict_reread(reservation: _Reservation, expected: bytes) -> object:
             raise ValueError("published report grew during strict reread")
         final = os.fstat(descriptor)
         stable = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
-        if any(getattr(metadata, field) != getattr(final, field) for field in stable):
+        if (
+            any(getattr(metadata, field) != getattr(final, field) for field in stable)
+            or final.st_nlink != 1
+        ):
             raise ValueError("published report changed during strict reread")
     finally:
         os.close(descriptor)
@@ -1103,6 +1128,7 @@ def _publish_reserved(reservation: _Reservation, report: dict[str, object]) -> N
         raise ValueError("validated report exceeds its publication bound")
     temporary_name = f".{reservation.destination_name}.{secrets.token_hex(16)}.tmp"
     descriptor = -1
+    published_identity: tuple[int, int] | None = None
     try:
         descriptor = os.open(
             temporary_name,
@@ -1117,6 +1143,10 @@ def _publish_reserved(reservation: _Reservation, report: dict[str, object]) -> N
                 raise OSError("immutable report write made no progress")
             view = view[written:]
         os.fsync(descriptor)
+        temporary = os.fstat(descriptor)
+        if not stat.S_ISREG(temporary.st_mode) or temporary.st_nlink != 1:
+            raise RuntimeError("temporary report must have one private regular-file link")
+        published_identity = (temporary.st_dev, temporary.st_ino)
         os.close(descriptor)
         descriptor = -1
         os.link(
@@ -1132,12 +1162,32 @@ def _publish_reserved(reservation: _Reservation, report: dict[str, object]) -> N
             dir_fd=reservation.directory_fd,
             follow_symlinks=False,
         )
-        if not stat.S_ISREG(linked.st_mode) or linked.st_nlink != 1:
+        if (
+            not stat.S_ISREG(linked.st_mode)
+            or (linked.st_dev, linked.st_ino) != published_identity
+            or linked.st_nlink != 1
+        ):
             raise ValueError("published report must have one unique regular-file link")
         os.fsync(reservation.directory_fd)
-        reread = _strict_reread(reservation, encoded)
+        reread = _strict_reread(
+            reservation, encoded, expected_identity=published_identity
+        )
         if validate_report(reread, require_current_source=True) != report:
             raise ValueError("published semantic payload differs from validated report")
+    except BaseException:
+        if published_identity is not None:
+            try:
+                destination = os.stat(
+                    reservation.destination_name,
+                    dir_fd=reservation.directory_fd,
+                    follow_symlinks=False,
+                )
+                if (destination.st_dev, destination.st_ino) == published_identity:
+                    os.unlink(reservation.destination_name, dir_fd=reservation.directory_fd)
+                    os.fsync(reservation.directory_fd)
+            except FileNotFoundError:
+                pass
+        raise
     finally:
         if descriptor >= 0:
             os.close(descriptor)
@@ -1230,6 +1280,8 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
             raise RuntimeError("source identity changed during matched execution")
         if runtime_before != _current_runtime():
             raise RuntimeError("runtime identity changed during matched execution")
+        if dataset_provenance != _screening_dataset_provenance(inputs, labels):
+            raise RuntimeError("dataset numeric payload changed during matched execution")
         report = build_report(
             supervised_records,
             control_records,

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -8,6 +8,7 @@ reviewed authorization change.
 
 from __future__ import annotations
 
+import argparse
 import dataclasses
 import hashlib
 import importlib.metadata
@@ -19,6 +20,7 @@ import secrets
 import stat
 import subprocess
 import time
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Final, cast
 
@@ -26,8 +28,9 @@ import jax
 import jax.random as jr
 import numpy as np
 
-from alberta_framework.benchmarks.adamo_diagnostic import _load_dataset, _sha256_arrays
+from alberta_framework.benchmarks.adamo_diagnostic import _load_dataset
 from alberta_framework.benchmarks.ipmnist_screening import (
+    _screening_dataset_provenance,
     _screening_runtime_environment,
     _screening_source_provenance,
     intentional_updates_development_record,
@@ -44,7 +47,7 @@ PAPER_REVISION: Final[str] = "arXiv:2604.19033v1"
 OFFICIAL_CODE_REVISION: Final[str] = (
     "sharifnassab/Intentional_RL@e86e26fd8613ac212e9a52c3fed8a01d0a31f685"
 )
-SEEDS: Final[tuple[int, ...]] = (25610, 25611, 25612, 25613)
+SEEDS: Final[tuple[int, ...]] = (31_561_001, 31_561_002, 31_561_003, 31_561_004)
 CONTROL_ARMS: Final[tuple[str, ...]] = (
     "fixed_td0",
     "intentional_td0",
@@ -59,6 +62,7 @@ _OFF_ALIASES: Final[dict[str, str]] = {
     "intentional_q_lambda_off": "fixed_q_lambda",
 }
 _EXECUTION_AUTHORIZED: Final[bool] = False
+_EXECUTION_CAPABILITY: Final[object] = object()
 _MAX_HORIZON: Final[int] = 10_000
 _MAX_JSON_NODES: Final[int] = 200_000
 _MAX_STRING_BYTES: Final[int] = 2 * 1024 * 1024
@@ -70,11 +74,11 @@ OUTPUT_PATH: Final[Path] = (
     _REPO_ROOT / "outputs/intentional_updates_matched_development/report.v1.json"
 )
 BONFERRONI_T_DF3: Final[float] = 5.391949071934058
-DATASET_FILE_SHA256: Final[str] = (
-    "58320c334531afce90c4899ea0c05976c9b9d1c10b7b37e8eb4289cabd0a00ba"
+DATASET_X_SHA256: Final[str] = (
+    "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313"
 )
-DATASET_SEMANTIC_SHA256: Final[str] = (
-    "d25060db8f3f3f6ae7b0bb972e848733e15a1158f02021645e86a2923a5ee8a3"
+DATASET_Y_SHA256: Final[str] = (
+    "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a"
 )
 SUPERVISED_CONFIG: Final[IPMNISTConfig] = IPMNISTConfig(
     n_tasks=8,
@@ -91,6 +95,8 @@ class _Reservation:
     directory_fd: int
     destination_name: str
     reservation_name: str
+    reservation_device: int
+    reservation_inode: int
 
 
 def frozen_plan() -> dict[str, object]:
@@ -99,16 +105,24 @@ def frozen_plan() -> dict[str, object]:
         "plan_id": PLAN_ID,
         "paper_revision": PAPER_REVISION,
         "official_code_revision": OFFICIAL_CODE_REVISION,
+        "source_identity": _source_identity(),
+        "runtime_identity": _runtime_identity(),
         "seeds": list(SEEDS),
         "protocol_families": ["supervised_ipmnist", "td_control"],
         "supervised_pair": ["intentional_updates_off", "intentional_updates_ipmnist"],
         "supervised_config": SUPERVISED_CONFIG.to_config(),
         "dataset": {
-            "file_sha256": DATASET_FILE_SHA256,
-            "semantic_sha256": DATASET_SEMANTIC_SHA256,
-            "keys": ["inputs", "labels"],
-            "dtypes": ["float32", "int32"],
-            "shapes": [[70000, 784], [70000]],
+            "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
+            "source": {
+                "provider": "openml",
+                "name": "mnist_784",
+                "version": 1,
+                "row_start": 0,
+                "row_stop_exclusive": 60_000,
+            },
+            "materialization": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
+            "x": {"dtype": "<f4", "shape": [60_000, 784], "sha256": DATASET_X_SHA256},
+            "y": {"dtype": "<i4", "shape": [60_000], "sha256": DATASET_Y_SHA256},
         },
         "control_pairs": [
             ["fixed_td0", "intentional_td0"],
@@ -227,8 +241,16 @@ def _version(name: str) -> str:
 
 
 def _source_identity() -> dict[str, str]:
-    path = Path(__file__)
-    return {"intentional_updates_control.py": hashlib.sha256(path.read_bytes()).hexdigest()}
+    relative_paths = (
+        "alberta_framework/benchmarks/intentional_updates_control.py",
+        "alberta_framework/benchmarks/ipmnist_screening.py",
+        "alberta_framework/benchmarks/plasticity_comparators.py",
+        "alberta_framework/benchmarks/upgd_ipmnist.py",
+    )
+    return {
+        relative: hashlib.sha256((_REPO_ROOT / relative).read_bytes()).hexdigest()
+        for relative in relative_paths
+    }
 
 
 def _runtime_identity() -> dict[str, str]:
@@ -415,7 +437,29 @@ def _run(
 def run_control_shard(
     arm: str, *, seed: int, horizon: int = 512, phase_length: int = 64
 ) -> dict[str, object]:
-    """Run one bounded in-memory shard; this does not retain or promote it."""
+    """Fail closed until a separate reviewed transition authorizes execution."""
+    if _EXECUTION_AUTHORIZED is not True:
+        raise RuntimeError("Intentional Updates matched-development execution is not authorized")
+    return _run_control_shard_authorized(
+        arm,
+        seed=seed,
+        horizon=horizon,
+        phase_length=phase_length,
+        _capability=_EXECUTION_CAPABILITY,
+    )
+
+
+def _run_control_shard_authorized(
+    arm: str,
+    *,
+    seed: int,
+    horizon: int = 512,
+    phase_length: int = 64,
+    _capability: object,
+) -> dict[str, object]:
+    """Private bounded executor used by contract tests and a future gated campaign."""
+    if _capability is not _EXECUTION_CAPABILITY:
+        raise RuntimeError("private Intentional execution capability is invalid")
     if type(arm) is not str or (arm not in CONTROL_ARMS and arm not in _OFF_ALIASES):
         raise ValueError("arm must name one exact registered control arm")
     if type(seed) is not int or seed not in SEEDS:
@@ -514,6 +558,10 @@ def validate_control_shard(value: object) -> dict[str, object]:
     seed = record["seed"]
     horizon = config["horizon"]
     phase_length = config["phase_length"]
+    if not 1 <= horizon <= _MAX_HORIZON:
+        raise ValueError("control config horizon is outside the exact bound")
+    if not 1 <= phase_length <= horizon:
+        raise ValueError("control config phase_length is outside the exact bound")
     resources = _exact_object(
         record["resources"],
         frozenset(
@@ -593,7 +641,9 @@ def validate_control_shard(value: object) -> dict[str, object]:
 
 
 def _current_source() -> dict[str, object]:
-    return _screening_source_provenance(_REPO_ROOT)
+    result = dict(_screening_source_provenance(_REPO_ROOT))
+    result["intentional_updates_control_source_sha256"] = _source_identity()
+    return result
 
 
 def _current_runtime() -> dict[str, object]:
@@ -753,22 +803,19 @@ def build_report(
     supervised_records: object,
     control_records: object,
     *,
-    dataset_file_sha256: object,
-    dataset_semantic_sha256: object,
+    dataset_provenance: object,
     execution_source_commit: object,
 ) -> dict[str, object]:
     """Build the complete two-family development report without cross-family ranking."""
-    file_digest = _digest(dataset_file_sha256, length=64, context="dataset file")
-    semantic_digest = _digest(dataset_semantic_sha256, length=64, context="dataset semantic")
     commit = _digest(execution_source_commit, length=40, context="execution source commit")
-    if file_digest != DATASET_FILE_SHA256 or semantic_digest != DATASET_SEMANTIC_SHA256:
+    checked_dataset = _bounded_json(dataset_provenance, context="dataset provenance")
+    if checked_dataset != frozen_plan()["dataset"]:
         raise ValueError("dataset identity does not match the frozen plan")
     runs = _validated_runs(supervised_records, control_records)
     report: dict[str, object] = {
         "schema": REPORT_SCHEMA,
         "plan": frozen_plan(),
-        "dataset_file_sha256": file_digest,
-        "dataset_semantic_sha256": semantic_digest,
+        "dataset_provenance": checked_dataset,
         "execution_source_commit": commit,
         "source_provenance": _current_source(),
         "runtime_environment": _current_runtime(),
@@ -797,7 +844,7 @@ def validate_report(value: object, *, require_current_source: bool = True) -> di
         report,
         frozenset(
             {
-                "schema", "plan", "dataset_file_sha256", "dataset_semantic_sha256",
+                "schema", "plan", "dataset_provenance",
                 "execution_source_commit", "source_provenance", "runtime_environment",
                 "runs", "paired_comparisons", "development_disposition", "policy",
             }
@@ -810,12 +857,7 @@ def validate_report(value: object, *, require_current_source: bool = True) -> di
         frozen_plan(), sort_keys=True, separators=(",", ":")
     ):
         raise ValueError("report plan differs from the literal prospective plan")
-    if (
-        _digest(report["dataset_file_sha256"], length=64, context="dataset file")
-        != DATASET_FILE_SHA256
-        or _digest(report["dataset_semantic_sha256"], length=64, context="dataset semantic")
-        != DATASET_SEMANTIC_SHA256
-    ):
+    if report["dataset_provenance"] != frozen_plan()["dataset"]:
         raise ValueError("report dataset identity drift")
     commit = _digest(report["execution_source_commit"], length=40, context="execution commit")
     source = _bounded_json(report["source_provenance"], context="source provenance")
@@ -876,19 +918,27 @@ def validate_report(value: object, *, require_current_source: bool = True) -> di
 
 def _open_parent(path: Path) -> int:
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    absolute = Path(os.path.abspath(os.fspath(path)))
+    descriptor = os.open(os.path.sep, flags)
     try:
-        return os.open(path.parent, flags)
-    except FileNotFoundError:
-        parent_fd = os.open(path.parent.parent, flags)
-        try:
+        for component in absolute.parent.parts[1:]:
+            if component in {"", ".", ".."}:
+                raise ValueError("output path contains an unsafe directory component")
+            created = False
             try:
-                os.mkdir(path.parent.name, 0o755, dir_fd=parent_fd)
-                os.fsync(parent_fd)
+                os.mkdir(component, 0o755, dir_fd=descriptor)
+                created = True
             except FileExistsError:
                 pass
-            return os.open(path.parent.name, flags, dir_fd=parent_fd)
-        finally:
-            os.close(parent_fd)
+            if created:
+                os.fsync(descriptor)
+            next_descriptor = os.open(component, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
 
 
 def _reserve(path: Path) -> _Reservation:
@@ -897,43 +947,72 @@ def _reserve(path: Path) -> _Reservation:
     directory_fd = _open_parent(path)
     reservation_name = f".{path.name}.reservation"
     descriptor = -1
+    reservation_acquired = False
+    reservation_identity: tuple[int, int] | None = None
     try:
-        descriptor = os.open(
-            reservation_name,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
-            0o400,
-            dir_fd=directory_fd,
-        )
-        marker = f"reserved:{path.name}\n".encode("ascii")
-        if os.write(descriptor, marker) != len(marker):
-            raise OSError("short immutable-output reservation write")
-        os.fsync(descriptor)
-        os.close(descriptor)
-        descriptor = -1
-        os.fsync(directory_fd)
         try:
             os.stat(path.name, dir_fd=directory_fd, follow_symlinks=False)
         except FileNotFoundError:
             pass
         else:
             raise FileExistsError(f"refusing to overwrite immutable output: {path}")
-        return _Reservation(directory_fd, path.name, reservation_name)
+        descriptor = os.open(
+            reservation_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o400,
+            dir_fd=directory_fd,
+        )
+        reservation_acquired = True
+        marker = f"reserved:{path.name}\n".encode("ascii")
+        view = memoryview(marker)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("short immutable-output reservation write")
+            view = view[written:]
+        os.fsync(descriptor)
+        marker_stat = os.fstat(descriptor)
+        reservation_identity = (marker_stat.st_dev, marker_stat.st_ino)
+        os.close(descriptor)
+        descriptor = -1
+        os.fsync(directory_fd)
+        return _Reservation(
+            directory_fd,
+            path.name,
+            reservation_name,
+            marker_stat.st_dev,
+            marker_stat.st_ino,
+        )
     except BaseException:
         if descriptor >= 0:
             os.close(descriptor)
-        try:
-            os.unlink(reservation_name, dir_fd=directory_fd)
-            os.fsync(directory_fd)
-        except FileNotFoundError:
-            pass
+        if reservation_acquired:
+            try:
+                marker_stat = os.stat(
+                    reservation_name, dir_fd=directory_fd, follow_symlinks=False
+                )
+                if (marker_stat.st_dev, marker_stat.st_ino) == reservation_identity:
+                    os.unlink(reservation_name, dir_fd=directory_fd)
+                    os.fsync(directory_fd)
+            except FileNotFoundError:
+                pass
         os.close(directory_fd)
         raise
 
 
 def _release(reservation: _Reservation) -> None:
     try:
-        os.unlink(reservation.reservation_name, dir_fd=reservation.directory_fd)
-        os.fsync(reservation.directory_fd)
+        marker = os.stat(
+            reservation.reservation_name,
+            dir_fd=reservation.directory_fd,
+            follow_symlinks=False,
+        )
+        if (marker.st_dev, marker.st_ino) == (
+            reservation.reservation_device,
+            reservation.reservation_inode,
+        ):
+            os.unlink(reservation.reservation_name, dir_fd=reservation.directory_fd)
+            os.fsync(reservation.directory_fd)
     except FileNotFoundError:
         pass
     finally:
@@ -960,13 +1039,28 @@ def _strict_reread(reservation: _Reservation, expected: bytes) -> object:
             remaining -= len(chunk)
         if os.read(descriptor, 1):
             raise ValueError("published report grew during strict reread")
+        final = os.fstat(descriptor)
+        stable = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+        if any(getattr(metadata, field) != getattr(final, field) for field in stable):
+            raise ValueError("published report changed during strict reread")
     finally:
         os.close(descriptor)
     actual = b"".join(chunks)
     if actual != expected:
         raise ValueError("published bytes differ from the validated generation")
     try:
-        return _bounded_json(json.loads(actual), context="published report")
+        def exact_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+            result: dict[str, object] = {}
+            for key, item in pairs:
+                if key in result:
+                    raise ValueError("published report contains a duplicate JSON key")
+                result[key] = item
+            return result
+
+        return _bounded_json(
+            json.loads(actual.decode("utf-8"), object_pairs_hook=exact_object),
+            context="published report",
+        )
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ValueError("published report is not strict JSON") from error
 
@@ -1003,7 +1097,8 @@ def _publish_reserved(reservation: _Reservation, report: dict[str, object]) -> N
             follow_symlinks=False,
         )
         os.fsync(reservation.directory_fd)
-        if _strict_reread(reservation, encoded) != report:
+        reread = _strict_reread(reservation, encoded)
+        if validate_report(reread, require_current_source=True) != report:
             raise ValueError("published semantic payload differs from validated report")
     finally:
         if descriptor >= 0:
@@ -1026,14 +1121,6 @@ def publish_report(path: Path, report: object) -> Path:
     return path
 
 
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        while chunk := handle.read(1024 * 1024):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
 def _execution_commit() -> str:
     completed = subprocess.run(
         ("git", "rev-parse", "HEAD"),
@@ -1053,14 +1140,11 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
         raise ValueError("dataset and output must be exact pathlib.Path values")
     reservation = _reserve(output_path)
     try:
-        file_digest = _sha256_file(dataset_path)
-        if file_digest != DATASET_FILE_SHA256:
-            raise ValueError("dataset file does not match the frozen reviewed input")
         source_before = _current_source()
         runtime_before = _current_runtime()
         inputs, labels = _load_dataset(dataset_path)
-        semantic_digest = _sha256_arrays(inputs, labels)
-        if semantic_digest != DATASET_SEMANTIC_SHA256:
+        dataset_provenance = _screening_dataset_provenance(inputs, labels)
+        if dataset_provenance != frozen_plan()["dataset"]:
             raise ValueError("dataset numeric payload does not match the frozen reviewed input")
         supervised_records = [
             intentional_updates_development_record(
@@ -1076,7 +1160,11 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
             for arm in ("intentional_updates_off", "intentional_updates_ipmnist")
         ]
         control_records = [
-            run_control_shard(arm, seed=seed) for seed in SEEDS for arm in CONTROL_ARMS
+            _run_control_shard_authorized(
+                arm, seed=seed, _capability=_EXECUTION_CAPABILITY
+            )
+            for seed in SEEDS
+            for arm in CONTROL_ARMS
         ]
         if source_before != _current_source():
             raise RuntimeError("source identity changed during matched execution")
@@ -1085,8 +1173,7 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
         report = build_report(
             supervised_records,
             control_records,
-            dataset_file_sha256=file_digest,
-            dataset_semantic_sha256=semantic_digest,
+            dataset_provenance=dataset_provenance,
             execution_source_commit=_execution_commit(),
         )
         _publish_reserved(reservation, report)
@@ -1095,15 +1182,34 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
         _release(reservation)
 
 
+def main(argv: Sequence[str] | None = None) -> int:
+    """Inspect the frozen plan or reject execution while authorization is false."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", action="store_true")
+    parser.add_argument("--dataset", type=Path)
+    parser.add_argument("--output", type=Path, default=OUTPUT_PATH)
+    args = parser.parse_args(argv)
+    if args.catalog:
+        if args.dataset is not None:
+            parser.error("--catalog and --dataset are mutually exclusive")
+        print(json.dumps(frozen_plan(), sort_keys=True))
+        return 0
+    if args.dataset is None:
+        parser.error("--dataset is required unless --catalog is used")
+    run_campaign(args.dataset, args.output)
+    return 0
+
+
 __all__ = [
     "BONFERRONI_T_DF3",
     "CONTROL_ARMS",
-    "DATASET_FILE_SHA256",
-    "DATASET_SEMANTIC_SHA256",
+    "DATASET_X_SHA256",
+    "DATASET_Y_SHA256",
     "SEEDS",
     "SUPERVISED_CONFIG",
     "build_report",
     "frozen_plan",
+    "main",
     "publish_report",
     "run_campaign",
     "run_control_shard",

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -749,7 +749,10 @@ def _current_source() -> dict[str, object]:
 
 
 def _current_runtime() -> dict[str, object]:
-    return _runtime_identity()
+    runtime = _bounded_json(_runtime_identity(), context="runtime identity")
+    if type(runtime) is not dict:  # pragma: no cover - construction is a dict
+        raise RuntimeError("runtime identity must be one exact object")
+    return cast(dict[str, object], runtime)
 
 
 def _digest(value: object, *, length: int, context: str) -> str:

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -47,7 +47,20 @@ PAPER_REVISION: Final[str] = "arXiv:2604.19033v1"
 OFFICIAL_CODE_REVISION: Final[str] = (
     "sharifnassab/Intentional_RL@e86e26fd8613ac212e9a52c3fed8a01d0a31f685"
 )
-SEEDS: Final[tuple[int, ...]] = (31_561_001, 31_561_002, 31_561_003, 31_561_004)
+QUARANTINED_SEEDS: Final[tuple[int, ...]] = (
+    31_561_001,
+    31_561_002,
+    31_561_003,
+    31_561_004,
+)
+CAMPAIGN_SEEDS: Final[tuple[int, ...]] = (
+    41_562_001,
+    41_562_002,
+    41_562_003,
+    41_562_004,
+)
+TEST_ONLY_SEEDS: Final[tuple[int, ...]] = (101, 102, 103, 104)
+SEEDS: tuple[int, ...] = CAMPAIGN_SEEDS
 CONTROL_ARMS: Final[tuple[str, ...]] = (
     "fixed_td0",
     "intentional_td0",
@@ -62,7 +75,9 @@ _OFF_ALIASES: Final[dict[str, str]] = {
     "intentional_q_lambda_off": "fixed_q_lambda",
 }
 _EXECUTION_AUTHORIZED: Final[bool] = False
+_REVIEWED_EXECUTION_TRANSITION: Final[bool] = False
 _EXECUTION_CAPABILITY: Final[object] = object()
+_TEST_EXECUTION_CAPABILITY: Final[object] = object()
 _MAX_HORIZON: Final[int] = 10_000
 _MAX_JSON_NODES: Final[int] = 200_000
 _MAX_STRING_BYTES: Final[int] = 2 * 1024 * 1024
@@ -107,7 +122,8 @@ def frozen_plan() -> dict[str, object]:
         "official_code_revision": OFFICIAL_CODE_REVISION,
         "source_identity": _source_identity(),
         "runtime_identity": _runtime_identity(),
-        "seeds": list(SEEDS),
+        "seeds": list(CAMPAIGN_SEEDS),
+        "quarantined_test_consumed_seeds": list(QUARANTINED_SEEDS),
         "protocol_families": ["supervised_ipmnist", "td_control"],
         "supervised_pair": ["intentional_updates_off", "intentional_updates_ipmnist"],
         "supervised_config": SUPERVISED_CONFIG.to_config(),
@@ -168,9 +184,11 @@ def frozen_plan() -> dict[str, object]:
         ),
         "output_path": "outputs/intentional_updates_matched_development/report.v1.json",
         "execution_authorized": _EXECUTION_AUTHORIZED,
+        "reviewed_execution_transition": _REVIEWED_EXECUTION_TRANSITION,
         "execution_status": (
             "authorized_after_separate_review"
-            if _EXECUTION_AUTHORIZED
+            if _REVIEWED_EXECUTION_TRANSITION is True
+            and _EXECUTION_AUTHORIZED is True
             else "blocked_pending_independent_plan_audit"
         ),
         "development_only": True,
@@ -438,7 +456,10 @@ def run_control_shard(
     arm: str, *, seed: int, horizon: int = 512, phase_length: int = 64
 ) -> dict[str, object]:
     """Fail closed until a separate reviewed transition authorizes execution."""
-    if _EXECUTION_AUTHORIZED is not True:
+    if (
+        _REVIEWED_EXECUTION_TRANSITION is not True
+        or _EXECUTION_AUTHORIZED is not True
+    ):
         raise RuntimeError("Intentional Updates matched-development execution is not authorized")
     return _run_control_shard_authorized(
         arm,
@@ -458,11 +479,15 @@ def _run_control_shard_authorized(
     _capability: object,
 ) -> dict[str, object]:
     """Private bounded executor used by contract tests and a future gated campaign."""
-    if _capability is not _EXECUTION_CAPABILITY:
+    if _capability is _EXECUTION_CAPABILITY:
+        allowed_seeds = CAMPAIGN_SEEDS
+    elif _capability is _TEST_EXECUTION_CAPABILITY:
+        allowed_seeds = TEST_ONLY_SEEDS
+    else:
         raise RuntimeError("private Intentional execution capability is invalid")
     if type(arm) is not str or (arm not in CONTROL_ARMS and arm not in _OFF_ALIASES):
         raise ValueError("arm must name one exact registered control arm")
-    if type(seed) is not int or seed not in SEEDS:
+    if type(seed) is not int or seed not in allowed_seeds:
         raise ValueError("seed must be one exact prospectively reserved seed")
     if type(horizon) is not int or not 1 <= horizon <= _MAX_HORIZON:
         raise ValueError("horizon must be an exact integer in [1, 10000]")
@@ -823,6 +848,8 @@ def build_report(
         "paired_comparisons": _comparisons(runs),
         "development_disposition": "four_separate_nonpromoting_outcomes",
         "policy": {
+            "reviewed_execution_transition": _REVIEWED_EXECUTION_TRANSITION,
+            "execution_authorized": _EXECUTION_AUTHORIZED,
             "development_only": True,
             "scientific_promotion_allowed": False,
             "negative_outcomes_retained": True,
@@ -895,12 +922,15 @@ def validate_report(value: object, *, require_current_source: bool = True) -> di
             {
                 "development_only", "scientific_promotion_allowed",
                 "negative_outcomes_retained", "timing_is_telemetry_only",
-                "cross_family_ranking_allowed",
+                "cross_family_ranking_allowed", "reviewed_execution_transition",
+                "execution_authorized",
             }
         ),
         context="report policy",
     )
     if policy != {
+        "reviewed_execution_transition": _REVIEWED_EXECUTION_TRANSITION,
+        "execution_authorized": _EXECUTION_AUTHORIZED,
         "development_only": True,
         "scientific_promotion_allowed": False,
         "negative_outcomes_retained": True,
@@ -1061,7 +1091,7 @@ def _strict_reread(reservation: _Reservation, expected: bytes) -> object:
             json.loads(actual.decode("utf-8"), object_pairs_hook=exact_object),
             context="published report",
         )
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
         raise ValueError("published report is not strict JSON") from error
 
 
@@ -1096,6 +1126,14 @@ def _publish_reserved(reservation: _Reservation, report: dict[str, object]) -> N
             dst_dir_fd=reservation.directory_fd,
             follow_symlinks=False,
         )
+        os.unlink(temporary_name, dir_fd=reservation.directory_fd)
+        linked = os.stat(
+            reservation.destination_name,
+            dir_fd=reservation.directory_fd,
+            follow_symlinks=False,
+        )
+        if not stat.S_ISREG(linked.st_mode) or linked.st_nlink != 1:
+            raise ValueError("published report must have one unique regular-file link")
         os.fsync(reservation.directory_fd)
         reread = _strict_reread(reservation, encoded)
         if validate_report(reread, require_current_source=True) != report:
@@ -1111,7 +1149,26 @@ def _publish_reserved(reservation: _Reservation, report: dict[str, object]) -> N
 
 
 def publish_report(path: Path, report: object) -> Path:
-    """Reserve, validate, hard-link no-replace, fsync, and strictly reread."""
+    """Fail closed until both reviewed and runtime authorization are true."""
+    if (
+        _REVIEWED_EXECUTION_TRANSITION is not True
+        or _EXECUTION_AUTHORIZED is not True
+    ):
+        raise RuntimeError("Intentional Updates matched-development execution is not authorized")
+    return _publish_report_authorized(
+        path, report, _capability=_EXECUTION_CAPABILITY
+    )
+
+
+def _publish_report_authorized(
+    path: Path, report: object, *, _capability: object
+) -> Path:
+    """Capability-private immutable publisher used only after an outer gate."""
+    if (
+        _capability is not _EXECUTION_CAPABILITY
+        and _capability is not _TEST_EXECUTION_CAPABILITY
+    ):
+        raise RuntimeError("private Intentional publication capability is invalid")
     reservation = _reserve(path)
     try:
         validated = validate_report(report, require_current_source=True)
@@ -1134,7 +1191,10 @@ def _execution_commit() -> str:
 
 def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[str, object]:
     """Run both frozen subprotocols exactly once after separate authorization."""
-    if not _EXECUTION_AUTHORIZED:
+    if (
+        _REVIEWED_EXECUTION_TRANSITION is not True
+        or _EXECUTION_AUTHORIZED is not True
+    ):
         raise RuntimeError("Intentional Updates matched-development execution is not authorized")
     if type(dataset_path) is not type(Path()) or type(output_path) is not type(Path()):
         raise ValueError("dataset and output must be exact pathlib.Path values")
@@ -1156,14 +1216,14 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
                     SUPERVISED_CONFIG,
                 )
             )
-            for seed in SEEDS
+            for seed in CAMPAIGN_SEEDS
             for arm in ("intentional_updates_off", "intentional_updates_ipmnist")
         ]
         control_records = [
             _run_control_shard_authorized(
                 arm, seed=seed, _capability=_EXECUTION_CAPABILITY
             )
-            for seed in SEEDS
+            for seed in CAMPAIGN_SEEDS
             for arm in CONTROL_ARMS
         ]
         if source_before != _current_source():

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -162,7 +162,7 @@ def frozen_plan() -> dict[str, object]:
             "phase_length": 64,
             "discount": 0.95,
             "trace_decay": 0.8,
-            "epsilon_greedy": 0.1,
+            "behavior_policy": "seeded_uniform_random_common_within_pair",
         },
         "matched_axes": {
             "all_families": [
@@ -173,11 +173,9 @@ def frozen_plan() -> dict[str, object]:
                 "allowed_boundary_and_task_information",
             ],
             "supervised_ipmnist": ["example_schedule"],
-            "td_prediction": ["transition_schedule"],
-            "q_lambda_control": [
-                "environment_dynamics",
-                "agent_rng_root_and_index_schedule",
-                "policy-dependent realized trajectories are not matched",
+            "td_control": [
+                "transition_schedule",
+                "behavior_rng_root_and_index_schedule",
             ],
         },
         "boundary_information": [],
@@ -186,7 +184,7 @@ def frozen_plan() -> dict[str, object]:
             "supervised_ipmnist": "mean_per_task_accuracy:higher",
             "td0": "mean_squared_td_error:lower",
             "trace": "mean_squared_td_error:lower",
-            "q_lambda": "mean_reward:higher",
+            "q_lambda": "mean_squared_td_error:lower",
         },
         "confidence_method": "two_sided_student_t_bonferroni_four_comparisons",
         "familywise_confidence": 0.95,
@@ -313,12 +311,9 @@ def _transition(state: int, action: int, step: int, phase_length: int) -> tuple[
     return successor, 1.0 if successor == goal else 0.0
 
 
-def _select_action(values: np.ndarray, key: jax.Array) -> tuple[int, bool, bool]:
-    explore_key, action_key = jr.split(key)
-    greedy = int(np.argmax(values))
-    explore = float(jr.uniform(explore_key, (), dtype=np.float32)) < 0.1
-    action = int(jr.randint(action_key, (), 0, 2)) if explore else greedy
-    return action, explore, action != greedy
+def _behavior_action(key: jax.Array) -> int:
+    """Return one arm-independent action from the paired behavior stream."""
+    return int(jr.randint(key, (), 0, 2))
 
 
 def _intentional_update(
@@ -376,25 +371,17 @@ def _run(
     second = np.zeros(shape, dtype=np.float32)
     sigma = np.float32(0.0)
     clip_ema = np.float32(0.0)
-    root = jr.key(seed, impl=_AGENT_RNG_IMPL) if is_control else None
-    state = seed % 2
+    root = jr.key(seed, impl=_AGENT_RNG_IMPL)
+    state = int(jr.randint(jr.fold_in(root, _MAX_HORIZON), (), 0, 2))
     states = [state]
     actions: list[int] = []
     rewards: list[float] = []
     errors: list[float] = []
     step_sizes: list[float] = []
-    integer_draws = 0
     start_ns = time.perf_counter_ns()
     for index in range(horizon):
-        if is_control:
-            assert root is not None
-            action, explored, non_greedy = _select_action(
-                weights[state], jr.fold_in(root, index)
-            )
-            integer_draws += int(explored)
-        else:
-            action = (index + seed) % 2
-            non_greedy = False
+        action = _behavior_action(jr.fold_in(root, index))
+        non_greedy = is_control and action != int(np.argmax(weights[state]))
         successor, reward = _transition(state, action, index, phase_length)
         if is_control:
             prediction = np.float32(weights[state, action])
@@ -443,8 +430,7 @@ def _run(
             + 2 * np.dtype(np.float32).itemsize
             + np.dtype(np.int32).itemsize
         )
-    if root is not None:
-        numeric_bytes += int(root.nbytes)
+    numeric_bytes += int(root.nbytes)
     trajectory = {
         "states": states,
         "actions": actions,
@@ -459,7 +445,7 @@ def _run(
         "global_normalizer": float(sigma) if intentional else 0.0,
         "clip_squared_error_ema": float(clip_ema) if intentional else 0.0,
         "optimizer_step": horizon if intentional else 0,
-        "agent_rng_root": jr.key_data(root).tolist() if root is not None else [],
+        "behavior_rng_root": jr.key_data(root).tolist(),
     }
     resources: dict[str, object] = {
         "observations": horizon,
@@ -468,11 +454,11 @@ def _run(
         "reward_observations": horizon,
         "updates": horizon,
         "model_queries": 2 * horizon,
-        "action_queries": horizon if is_control else 0,
-        "rng_splits": horizon if is_control else 0,
-        "rng_fold_ins": horizon if is_control else 0,
-        "rng_uniform_draws": horizon if is_control else 0,
-        "rng_integer_draws": integer_draws if is_control else 0,
+        "action_queries": 0,
+        "rng_splits": 0,
+        "rng_fold_ins": horizon + 1,
+        "rng_uniform_draws": 0,
+        "rng_integer_draws": horizon + 1,
         "intentional_step_size_solves": horizon if intentional else 0,
         "persistent_numeric_bytes": numeric_bytes,
         "timing_telemetry_ns": timing_ns,
@@ -540,7 +526,7 @@ def _run_control_shard_authorized(
             "trace_decay": 0.0 if execution_arm.endswith("td0") else 0.8,
             "fixed_step_size": 0.05,
             "intentional_fraction": 0.5,
-            "epsilon_greedy": 0.1,
+            "behavior_policy": "seeded_uniform_random_common_within_pair",
         },
         "references": {
             "paper": PAPER_REVISION,
@@ -552,7 +538,7 @@ def _run_control_shard_authorized(
         },
         "information": {"boundary_information": [], "task_information": []},
         "identity": {
-            "agent_rng_impl": _AGENT_RNG_IMPL,
+            "behavior_rng_impl": _AGENT_RNG_IMPL,
             "source_sha256": _source_identity(),
             "runtime": _runtime_identity(),
             "workload": "asi.recurring-two-state-continuing-mdp.v1",
@@ -601,7 +587,7 @@ def validate_control_shard(value: object) -> dict[str, object]:
         frozenset(
             {
                 "horizon", "phase_length", "discount", "trace_decay", "fixed_step_size",
-                "intentional_fraction", "epsilon_greedy",
+                "intentional_fraction", "behavior_policy",
             }
         ),
         context="control config",
@@ -660,7 +646,7 @@ def validate_control_shard(value: object) -> dict[str, object]:
         "trace_decay": 0.0 if execution_arm.endswith("td0") else 0.8,
         "fixed_step_size": 0.05,
         "intentional_fraction": 0.5,
-        "epsilon_greedy": 0.1,
+        "behavior_policy": "seeded_uniform_random_common_within_pair",
     }
     expected_record["references"] = {
         "paper": PAPER_REVISION,
@@ -672,7 +658,7 @@ def validate_control_shard(value: object) -> dict[str, object]:
     }
     expected_record["information"] = {"boundary_information": [], "task_information": []}
     expected_record["identity"] = {
-        "agent_rng_impl": _AGENT_RNG_IMPL,
+        "behavior_rng_impl": _AGENT_RNG_IMPL,
         "source_sha256": _source_identity(),
         "runtime": _runtime_identity(),
         "workload": "asi.recurring-two-state-continuing-mdp.v1",
@@ -843,8 +829,8 @@ def _comparisons(runs: list[dict[str, object]]) -> dict[str, object]:
             - metric("intentional_trace", "mean_squared_td_error")
         )
         q_deltas.append(
-            metric("intentional_q_lambda", "mean_reward")
-            - metric("fixed_q_lambda", "mean_reward")
+            metric("fixed_q_lambda", "mean_squared_td_error")
+            - metric("intentional_q_lambda", "mean_squared_td_error")
         )
     return {
         "supervised_ipmnist": _paired(supervised_deltas),

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -19,6 +19,7 @@ import platform
 import secrets
 import stat
 import subprocess
+import sys
 import time
 from collections.abc import Sequence
 from pathlib import Path
@@ -31,7 +32,6 @@ import numpy as np
 from alberta_framework.benchmarks.adamo_diagnostic import _load_dataset
 from alberta_framework.benchmarks.ipmnist_screening import (
     _screening_dataset_provenance,
-    _screening_runtime_environment,
     _screening_source_provenance,
     intentional_updates_development_record,
     run_screening_config,
@@ -127,11 +127,13 @@ def frozen_plan() -> dict[str, object]:
                 "alberta_framework/benchmarks/ipmnist_screening.py",
                 "alberta_framework/benchmarks/plasticity_comparators.py",
                 "alberta_framework/benchmarks/upgd_ipmnist.py",
+                "pyproject.toml",
+                "uv.lock",
             ],
         },
         "runtime_identity_policy": (
-            "retain the exact execution Python, platform, package, JAX backend, "
-            "device, and configuration identity in every report"
+            "retain exact execution Python, platform, all direct dependency versions, "
+            "JAX backend/device/configuration, and relevant process environment"
         ),
         "seeds": list(CAMPAIGN_SEEDS),
         "quarantined_test_consumed_seeds": list(QUARANTINED_SEEDS),
@@ -281,6 +283,8 @@ def _source_identity() -> dict[str, str]:
         "alberta_framework/benchmarks/ipmnist_screening.py",
         "alberta_framework/benchmarks/plasticity_comparators.py",
         "alberta_framework/benchmarks/upgd_ipmnist.py",
+        "pyproject.toml",
+        "uv.lock",
     )
     return {
         relative: hashlib.sha256((_REPO_ROOT / relative).read_bytes()).hexdigest()
@@ -288,14 +292,71 @@ def _source_identity() -> dict[str, str]:
     }
 
 
-def _runtime_identity() -> dict[str, str]:
+def _runtime_identity() -> dict[str, object]:
+    environment_names = (
+        "JAX_DEFAULT_MATMUL_PRECISION",
+        "JAX_DEFAULT_PRNG_IMPL",
+        "JAX_ENABLE_X64",
+        "JAX_NUM_CPU_DEVICES",
+        "JAX_PLATFORMS",
+        "JAX_PLATFORM_NAME",
+        "JAX_RANDOM_SEED_OFFSET",
+        "XLA_FLAGS",
+    )
     return {
-        "python": platform.python_version(),
-        "jax": _version("jax"),
-        "jaxlib": _version("jaxlib"),
-        "numpy": _version("numpy"),
-        "backend": jax.default_backend(),
-        "platform": platform.platform(),
+        "schema": "asi.intentional-updates.runtime.v1",
+        "python": list(sys.version_info[:3]),
+        "python_implementation": platform.python_implementation(),
+        "byteorder": sys.byteorder,
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "packages": {
+            name: _version(name)
+            for name in (
+                "chex",
+                "jax",
+                "jaxlib",
+                "jaxtyping",
+                "numpy",
+                "orbax-checkpoint",
+                "scikit-learn",
+                "scipy",
+            )
+        },
+        "jax": {
+            "backend": jax.default_backend(),
+            "devices": [
+                {
+                    "id": int(device.id),
+                    "platform": str(device.platform),
+                    "device_kind": str(device.device_kind),
+                    "process_index": int(device.process_index),
+                }
+                for device in jax.devices()
+            ],
+            "config": {
+                "jax_default_matmul_precision": str(
+                    jax.config.jax_default_matmul_precision
+                ),
+                "jax_default_prng_impl": str(jax.config.jax_default_prng_impl),
+                "jax_disable_jit": bool(jax.config.jax_disable_jit),
+                "jax_enable_x64": bool(jax.config.jax_enable_x64),
+                "jax_numpy_dtype_promotion": str(
+                    jax.config.jax_numpy_dtype_promotion.value
+                ),
+                "jax_numpy_rank_promotion": str(jax.config.jax_numpy_rank_promotion),
+                "jax_random_seed_offset": int(jax.config.jax_random_seed_offset),
+                "jax_threefry_partitionable": bool(
+                    jax.config.jax_threefry_partitionable
+                ),
+            },
+        },
+        "process_environment": {
+            name: os.environ.get(name) for name in environment_names
+        },
     }
 
 
@@ -688,7 +749,7 @@ def _current_source() -> dict[str, object]:
 
 
 def _current_runtime() -> dict[str, object]:
-    return _screening_runtime_environment()
+    return _runtime_identity()
 
 
 def _digest(value: object, *, length: int, context: str) -> str:

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -1,0 +1,1112 @@
+"""Prospective Intentional Updates TD/control matched-development lane.
+
+This is a linear end-to-end consumer of the optimizer published at the pinned
+author revision. It is development infrastructure, not a reproduction result
+or scientific evidence. Campaign execution remains closed until a separate
+reviewed authorization change.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+import platform
+import secrets
+import stat
+import subprocess
+import time
+from pathlib import Path
+from typing import Final, cast
+
+import jax
+import jax.random as jr
+import numpy as np
+
+from alberta_framework.benchmarks.adamo_diagnostic import _load_dataset, _sha256_arrays
+from alberta_framework.benchmarks.ipmnist_screening import (
+    _screening_runtime_environment,
+    _screening_source_provenance,
+    intentional_updates_development_record,
+    run_screening_config,
+    screening_spec,
+    validate_intentional_updates_development_record,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+
+SCHEMA: Final[str] = "asi.intentional-updates.control-shard.v1"
+REPORT_SCHEMA: Final[str] = "asi.intentional-updates.matched-development-report.v1"
+PLAN_ID: Final[str] = "issue-1561-intentional-updates-matched-development-v1"
+PAPER_REVISION: Final[str] = "arXiv:2604.19033v1"
+OFFICIAL_CODE_REVISION: Final[str] = (
+    "sharifnassab/Intentional_RL@e86e26fd8613ac212e9a52c3fed8a01d0a31f685"
+)
+SEEDS: Final[tuple[int, ...]] = (25610, 25611, 25612, 25613)
+CONTROL_ARMS: Final[tuple[str, ...]] = (
+    "fixed_td0",
+    "intentional_td0",
+    "fixed_trace",
+    "intentional_trace",
+    "fixed_q_lambda",
+    "intentional_q_lambda",
+)
+_OFF_ALIASES: Final[dict[str, str]] = {
+    "intentional_td0_off": "fixed_td0",
+    "intentional_trace_off": "fixed_trace",
+    "intentional_q_lambda_off": "fixed_q_lambda",
+}
+_EXECUTION_AUTHORIZED: Final[bool] = False
+_MAX_HORIZON: Final[int] = 10_000
+_MAX_JSON_NODES: Final[int] = 200_000
+_MAX_STRING_BYTES: Final[int] = 2 * 1024 * 1024
+_MAX_TIMING_NS: Final[int] = 7 * 24 * 60 * 60 * 1_000_000_000
+_MAX_REPORT_BYTES: Final[int] = 64 * 1024 * 1024
+_AGENT_RNG_IMPL: Final[str] = "threefry2x32"
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+OUTPUT_PATH: Final[Path] = (
+    _REPO_ROOT / "outputs/intentional_updates_matched_development/report.v1.json"
+)
+BONFERRONI_T_DF3: Final[float] = 5.391949071934058
+DATASET_FILE_SHA256: Final[str] = (
+    "58320c334531afce90c4899ea0c05976c9b9d1c10b7b37e8eb4289cabd0a00ba"
+)
+DATASET_SEMANTIC_SHA256: Final[str] = (
+    "d25060db8f3f3f6ae7b0bb972e848733e15a1158f02021645e86a2923a5ee8a3"
+)
+SUPERVISED_CONFIG: Final[IPMNISTConfig] = IPMNISTConfig(
+    n_tasks=8,
+    task_length=64,
+    input_dim=784,
+    hidden1=300,
+    hidden2=150,
+    n_classes=10,
+)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _Reservation:
+    directory_fd: int
+    destination_name: str
+    reservation_name: str
+
+
+def frozen_plan() -> dict[str, object]:
+    """Return the literal protocol that must precede any retained execution."""
+    return {
+        "plan_id": PLAN_ID,
+        "paper_revision": PAPER_REVISION,
+        "official_code_revision": OFFICIAL_CODE_REVISION,
+        "seeds": list(SEEDS),
+        "protocol_families": ["supervised_ipmnist", "td_control"],
+        "supervised_pair": ["intentional_updates_off", "intentional_updates_ipmnist"],
+        "supervised_config": SUPERVISED_CONFIG.to_config(),
+        "dataset": {
+            "file_sha256": DATASET_FILE_SHA256,
+            "semantic_sha256": DATASET_SEMANTIC_SHA256,
+            "keys": ["inputs", "labels"],
+            "dtypes": ["float32", "int32"],
+            "shapes": [[70000, 784], [70000]],
+        },
+        "control_pairs": [
+            ["fixed_td0", "intentional_td0"],
+            ["fixed_trace", "intentional_trace"],
+            ["fixed_q_lambda", "intentional_q_lambda"],
+        ],
+        "control_workload": {
+            "id": "asi.recurring-two-state-continuing-mdp.v1",
+            "horizon": 512,
+            "phase_length": 64,
+            "discount": 0.95,
+            "trace_decay": 0.8,
+            "epsilon_greedy": 0.1,
+        },
+        "matched_axes": [
+            "seed",
+            "initial_parameters",
+            "example_or_transition_schedule",
+            "observations",
+            "updates",
+            "allowed_boundary_and_task_information",
+        ],
+        "boundary_information": [],
+        "task_information": [],
+        "paired_metrics": {
+            "supervised_ipmnist": "mean_per_task_accuracy:higher",
+            "td0": "mean_squared_td_error:lower",
+            "trace": "mean_squared_td_error:lower",
+            "q_lambda": "mean_reward:higher",
+        },
+        "confidence_method": "two_sided_student_t_bonferroni_four_comparisons",
+        "familywise_confidence": 0.95,
+        "per_comparison_confidence": 0.9875,
+        "confidence_degrees_of_freedom": 3,
+        "confidence_critical": BONFERRONI_T_DF3,
+        "multiple_comparison_policy": (
+            "four predeclared paired questions; no cross-family ranking or aggregate winner"
+        ),
+        "timing_policy": "retained telemetry only; never a selection metric",
+        "resource_policy": (
+            "retain observations, environment/data steps, updates, model/action queries, "
+            "RNG operations, optimizer solves, persistent bytes, and timing per shard"
+        ),
+        "output_path": "outputs/intentional_updates_matched_development/report.v1.json",
+        "execution_authorized": _EXECUTION_AUTHORIZED,
+        "execution_status": (
+            "authorized_after_separate_review"
+            if _EXECUTION_AUTHORIZED
+            else "blocked_pending_independent_plan_audit"
+        ),
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "negative_outcomes_retained": True,
+    }
+
+
+def _bounded_json(value: object, *, context: str) -> object:
+    nodes = 0
+    string_bytes = 0
+
+    def visit(item: object, *, depth: int, label: str) -> object:
+        nonlocal nodes, string_bytes
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > 18:
+            raise ValueError(f"{context} exceeds the bounded exact JSON structure")
+        if item is None or type(item) is bool:
+            return item
+        if type(item) is int:
+            if not -(1 << 63) <= item <= (1 << 63) - 1:
+                raise ValueError(f"{label} exceeds signed-int64")
+            return item
+        if type(item) is float:
+            if not math.isfinite(item):
+                raise ValueError(f"{label} must be finite exact JSON")
+            return item
+        if type(item) is str:
+            encoded = item.encode("utf-8")
+            if len(encoded) > 16_384 or b"\0" in encoded:
+                raise ValueError(f"{label} must be a bounded exact JSON string")
+            string_bytes += len(encoded)
+            if string_bytes > _MAX_STRING_BYTES:
+                raise ValueError(f"{context} exceeds its exact JSON string budget")
+            return item
+        if type(item) is list:
+            if list.__len__(item) > _MAX_HORIZON + 1:
+                raise ValueError(f"{label} exceeds its exact JSON list bound")
+            return [
+                visit(child, depth=depth + 1, label=f"{label}[{index}]")
+                for index, child in enumerate(list.__iter__(item))
+            ]
+        if type(item) is dict:
+            if dict.__len__(item) > 128:
+                raise ValueError(f"{label} exceeds its exact JSON object bound")
+            result: dict[str, object] = {}
+            for key, child in dict.items(item):
+                if type(key) is not str:
+                    raise ValueError(f"{label} keys must be exact JSON strings")
+                result[key] = visit(child, depth=depth + 1, label=f"{label}.{key}")
+            return result
+        raise ValueError(f"{label} must contain only bounded exact JSON values")
+
+    return visit(value, depth=0, label=context)
+
+
+def _exact_object(value: object, keys: frozenset[str], *, context: str) -> dict[str, object]:
+    if type(value) is not dict or frozenset(value) != keys:
+        raise ValueError(f"{context} keys do not match the exact contract")
+    return cast(dict[str, object], value)
+
+
+def _version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return "not-installed"
+
+
+def _source_identity() -> dict[str, str]:
+    path = Path(__file__)
+    return {"intentional_updates_control.py": hashlib.sha256(path.read_bytes()).hexdigest()}
+
+
+def _runtime_identity() -> dict[str, str]:
+    return {
+        "python": platform.python_version(),
+        "jax": _version("jax"),
+        "jaxlib": _version("jaxlib"),
+        "numpy": _version("numpy"),
+        "backend": jax.default_backend(),
+        "platform": platform.platform(),
+    }
+
+
+def _features(state: int) -> np.ndarray:
+    value = np.zeros(2, dtype=np.float32)
+    value[state] = np.float32(1.0)
+    return value
+
+
+def _transition(state: int, action: int, step: int, phase_length: int) -> tuple[int, float]:
+    successor = state if action == 0 else 1 - state
+    goal = (step // phase_length) % 2
+    return successor, 1.0 if successor == goal else 0.0
+
+
+def _select_action(values: np.ndarray, key: jax.Array) -> tuple[int, bool]:
+    explore_key, action_key = jr.split(key)
+    greedy = int(np.argmax(values))
+    explore = float(jr.uniform(explore_key, (), dtype=np.float32)) < 0.1
+    action = int(jr.randint(action_key, (), 0, 2)) if explore else greedy
+    return action, action != greedy
+
+
+def _intentional_update(
+    *,
+    gradient: np.ndarray,
+    trace: np.ndarray,
+    second_moment: np.ndarray,
+    sigma: np.float32,
+    clip_ema: np.float32,
+    step: int,
+    delta: np.float32,
+    discount: float,
+    trace_decay: float,
+) -> tuple[
+    np.ndarray, np.ndarray, np.ndarray, np.float32, np.float32, np.float32
+]:
+    """Pinned author optimizer equations specialized to one linear parameter array."""
+    beta2 = np.float32(0.999)
+    beta_clip = np.float32(0.9998)
+    gamma_lambda = np.float32(discount * trace_decay)
+    second = (beta2 * second_moment + (np.float32(1.0) - beta2) * gradient**2).astype(
+        np.float32
+    )
+    correction = np.float32(1.0 - float(beta2) ** step)
+    v_hat = (np.sqrt(second / correction) + np.float32(1e-8)).astype(np.float32)
+    updated_trace = (gamma_lambda * trace + gradient).astype(np.float32)
+    norm_gradient = np.float32(np.sum(gradient**2 / v_hat, dtype=np.float32))
+    sigma_next = np.float32(
+        sigma + (np.float32(1.0) - gamma_lambda) * (norm_gradient - sigma)
+    )
+    sigma_correction = np.float32(1.0 - float(gamma_lambda) ** step)
+    sigma_hat = np.float32(sigma_next / sigma_correction)
+    trace_energy = np.float32(np.sum(updated_trace**2 / v_hat, dtype=np.float32))
+    normalizer = np.float32(np.sqrt(max(float(sigma_hat * trace_energy), 0.0)))
+    step_size = np.float32(0.5 / max(float(normalizer), 1e-8))
+    clip_next = np.float32(
+        beta_clip * clip_ema + (np.float32(1.0) - beta_clip) * delta**2
+    )
+    clip_correction = np.float32(1.0 - float(beta_clip) ** step)
+    cap = np.float32(20.0 * np.sqrt(max(float(clip_next / clip_correction), 0.0)))
+    safe_delta = np.float32(math.copysign(min(abs(float(delta)), float(cap)), float(delta)))
+    direction = (updated_trace / v_hat).astype(np.float32)
+    return direction, updated_trace, second, sigma_next, clip_next, step_size * safe_delta
+
+
+def _run(
+    execution_arm: str, *, seed: int, horizon: int, phase_length: int
+) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+    is_control = execution_arm.endswith("q_lambda")
+    intentional = execution_arm.startswith("intentional_")
+    trace_decay = 0.0 if execution_arm.endswith("td0") else 0.8
+    shape = (2, 2) if is_control else (2,)
+    weights = np.zeros(shape, dtype=np.float32)
+    trace = np.zeros(shape, dtype=np.float32)
+    second = np.zeros(shape, dtype=np.float32)
+    sigma = np.float32(0.0)
+    clip_ema = np.float32(0.0)
+    root = jr.key(seed, impl=_AGENT_RNG_IMPL) if is_control else None
+    state = seed % 2
+    states = [state]
+    actions: list[int] = []
+    rewards: list[float] = []
+    errors: list[float] = []
+    step_sizes: list[float] = []
+    start_ns = time.perf_counter_ns()
+    for index in range(horizon):
+        if is_control:
+            assert root is not None
+            action, non_greedy = _select_action(weights[state], jr.fold_in(root, index))
+        else:
+            action = (index + seed) % 2
+            non_greedy = False
+        successor, reward = _transition(state, action, index, phase_length)
+        if is_control:
+            prediction = np.float32(weights[state, action])
+            successor_prediction = np.float32(np.max(weights[successor]))
+            gradient = np.zeros(shape, dtype=np.float32)
+            gradient[state, action] = np.float32(1.0)
+        else:
+            feature = _features(state)
+            next_feature = _features(successor)
+            prediction = np.float32(np.dot(weights, feature))
+            successor_prediction = np.float32(np.dot(weights, next_feature))
+            gradient = feature
+        delta = np.float32(reward + 0.95 * float(successor_prediction) - float(prediction))
+        if intentional:
+            direction, trace, second, sigma, clip_ema, update_scale = _intentional_update(
+                gradient=gradient,
+                trace=trace,
+                second_moment=second,
+                sigma=sigma,
+                clip_ema=clip_ema,
+                step=index + 1,
+                delta=delta,
+                discount=0.95,
+                trace_decay=trace_decay,
+            )
+            weights = (weights + update_scale * direction).astype(np.float32)
+            step_sizes.append(float(update_scale / delta) if delta != 0.0 else 0.0)
+        else:
+            trace = (np.float32(0.95 * trace_decay) * trace + gradient).astype(np.float32)
+            weights = (weights + np.float32(0.05) * delta * trace).astype(np.float32)
+            step_sizes.append(0.05)
+        if is_control and non_greedy:
+            trace.fill(np.float32(0.0))
+        if not np.isfinite(weights).all():
+            raise ValueError("Intentional Updates consumer produced non-finite state")
+        states.append(successor)
+        actions.append(action)
+        rewards.append(float(reward))
+        errors.append(float(delta))
+        state = successor
+    timing_ns = time.perf_counter_ns() - start_ns
+    numeric_bytes = int(weights.nbytes + trace.nbytes)
+    if intentional:
+        numeric_bytes += int(second.nbytes + 3 * np.dtype(np.float32).itemsize)
+    if root is not None:
+        numeric_bytes += int(root.nbytes)
+    trajectory = {
+        "states": states,
+        "actions": actions,
+        "rewards": rewards,
+        "td_errors": errors,
+        "step_sizes": step_sizes,
+    }
+    final_state = {
+        "weights": weights.tolist(),
+        "eligibility_trace": trace.tolist(),
+        "entrywise_squared_gradient": second.tolist() if intentional else [],
+        "global_normalizer": float(sigma) if intentional else 0.0,
+        "clip_squared_error_ema": float(clip_ema) if intentional else 0.0,
+        "optimizer_step": horizon if intentional else 0,
+        "agent_rng_root": jr.key_data(root).tolist() if root is not None else [],
+    }
+    resources: dict[str, object] = {
+        "observations": horizon,
+        "environment_steps": horizon,
+        "data_steps": 0,
+        "reward_observations": horizon,
+        "updates": horizon,
+        "model_queries": 2 * horizon,
+        "action_queries": horizon if is_control else 0,
+        "rng_splits": horizon if is_control else 0,
+        "rng_fold_ins": horizon if is_control else 0,
+        "intentional_step_size_solves": horizon if intentional else 0,
+        "persistent_numeric_bytes": numeric_bytes,
+        "timing_telemetry_ns": timing_ns,
+        "timing_is_selection_metric": False,
+    }
+    return trajectory, final_state, resources
+
+
+def run_control_shard(
+    arm: str, *, seed: int, horizon: int = 512, phase_length: int = 64
+) -> dict[str, object]:
+    """Run one bounded in-memory shard; this does not retain or promote it."""
+    if type(arm) is not str or (arm not in CONTROL_ARMS and arm not in _OFF_ALIASES):
+        raise ValueError("arm must name one exact registered control arm")
+    if type(seed) is not int or seed not in SEEDS:
+        raise ValueError("seed must be one exact prospectively reserved seed")
+    if type(horizon) is not int or not 1 <= horizon <= _MAX_HORIZON:
+        raise ValueError("horizon must be an exact integer in [1, 10000]")
+    if type(phase_length) is not int or not 1 <= phase_length <= horizon:
+        raise ValueError("phase_length must be an exact integer in [1, horizon]")
+    execution_arm = _OFF_ALIASES.get(arm, arm)
+    trajectory, final_state, resources = _run(
+        execution_arm, seed=seed, horizon=horizon, phase_length=phase_length
+    )
+    errors = np.asarray(trajectory["td_errors"], dtype=np.float64)
+    rewards = np.asarray(trajectory["rewards"], dtype=np.float64)
+    record: dict[str, object] = {
+        "schema": SCHEMA,
+        "arm": arm,
+        "execution_arm": execution_arm,
+        "seed": seed,
+        "config": {
+            "horizon": horizon,
+            "phase_length": phase_length,
+            "discount": 0.95,
+            "trace_decay": 0.0 if execution_arm.endswith("td0") else 0.8,
+            "fixed_step_size": 0.05,
+            "intentional_fraction": 0.5,
+            "epsilon_greedy": 0.1,
+        },
+        "references": {
+            "paper": PAPER_REVISION,
+            "official_code": OFFICIAL_CODE_REVISION,
+            "protocol_difference": (
+                "linear two-state ASI consumer with fixed float32 arithmetic; not the "
+                "author neural-network benchmark or publication-equivalent"
+            ),
+        },
+        "information": {"boundary_information": [], "task_information": []},
+        "identity": {
+            "agent_rng_impl": _AGENT_RNG_IMPL,
+            "source_sha256": _source_identity(),
+            "runtime": _runtime_identity(),
+            "workload": "asi.recurring-two-state-continuing-mdp.v1",
+        },
+        "policy": {
+            "development_only": True,
+            "scientific_promotion_allowed": False,
+            "negative_outcome_retention_required": True,
+            "publication_equivalent": False,
+        },
+        "resources": resources,
+        "trajectory": trajectory,
+        "final_state": final_state,
+        "metrics": {
+            "mean_reward": float(np.mean(rewards)),
+            "mean_squared_td_error": float(np.mean(np.square(errors))),
+        },
+    }
+    return validate_control_shard(record)
+
+
+def validate_control_shard(value: object) -> dict[str, object]:
+    """Strictly reexecute all deterministic fields and admit timing as telemetry only."""
+    if type(value) is not dict:
+        raise ValueError("control shard must be an exact JSON object")
+    record = cast(dict[str, object], _bounded_json(value, context="control shard"))
+    expected_keys = frozenset(
+        {
+            "schema", "arm", "execution_arm", "seed", "config", "references",
+            "information", "identity", "policy", "resources", "trajectory",
+            "final_state", "metrics",
+        }
+    )
+    _exact_object(record, expected_keys, context="control shard")
+    if type(record["schema"]) is not str or record["schema"] != SCHEMA:
+        raise ValueError("control shard schema drift")
+    if (
+        type(record["arm"]) is not str
+        or (record["arm"] not in CONTROL_ARMS and record["arm"] not in _OFF_ALIASES)
+        or type(record["seed"]) is not int
+        or record["seed"] not in SEEDS
+    ):
+        raise ValueError("control shard arm and seed must be exact")
+    config = _exact_object(
+        record["config"],
+        frozenset(
+            {
+                "horizon", "phase_length", "discount", "trace_decay", "fixed_step_size",
+                "intentional_fraction", "epsilon_greedy",
+            }
+        ),
+        context="control config",
+    )
+    if type(config["horizon"]) is not int or type(config["phase_length"]) is not int:
+        raise ValueError("control config counters must be exact integers")
+    arm = record["arm"]
+    seed = record["seed"]
+    horizon = config["horizon"]
+    phase_length = config["phase_length"]
+    resources = _exact_object(
+        record["resources"],
+        frozenset(
+            {
+                "observations", "environment_steps", "data_steps", "reward_observations",
+                "updates", "model_queries", "action_queries", "rng_splits", "rng_fold_ins",
+                "intentional_step_size_solves", "persistent_numeric_bytes",
+                "timing_telemetry_ns", "timing_is_selection_metric",
+            }
+        ),
+        context="control resources",
+    )
+    timing = resources["timing_telemetry_ns"]
+    if (
+        type(timing) is not int
+        or not 0 <= timing <= _MAX_TIMING_NS
+        or resources["timing_is_selection_metric"] is not False
+    ):
+        raise ValueError("timing must remain bounded telemetry only")
+    # Avoid validator recursion: execute the primitive once, then construct through a
+    # private clone of the public record with the observed timing substituted below.
+    trajectory, final_state, expected_resources = _run(
+        _OFF_ALIASES.get(arm, arm),
+        seed=seed,
+        horizon=horizon,
+        phase_length=phase_length,
+    )
+    expected_resources["timing_telemetry_ns"] = timing
+    errors = np.asarray(trajectory["td_errors"], dtype=np.float64)
+    rewards = np.asarray(trajectory["rewards"], dtype=np.float64)
+    expected_record = dict(record)
+    execution_arm = _OFF_ALIASES.get(arm, arm)
+    expected_record["schema"] = SCHEMA
+    expected_record["arm"] = record["arm"]
+    expected_record["seed"] = record["seed"]
+    expected_record["execution_arm"] = execution_arm
+    expected_record["config"] = {
+        "horizon": config["horizon"],
+        "phase_length": config["phase_length"],
+        "discount": 0.95,
+        "trace_decay": 0.0 if execution_arm.endswith("td0") else 0.8,
+        "fixed_step_size": 0.05,
+        "intentional_fraction": 0.5,
+        "epsilon_greedy": 0.1,
+    }
+    expected_record["references"] = {
+        "paper": PAPER_REVISION,
+        "official_code": OFFICIAL_CODE_REVISION,
+        "protocol_difference": (
+            "linear two-state ASI consumer with fixed float32 arithmetic; not the "
+            "author neural-network benchmark or publication-equivalent"
+        ),
+    }
+    expected_record["information"] = {"boundary_information": [], "task_information": []}
+    expected_record["identity"] = {
+        "agent_rng_impl": _AGENT_RNG_IMPL,
+        "source_sha256": _source_identity(),
+        "runtime": _runtime_identity(),
+        "workload": "asi.recurring-two-state-continuing-mdp.v1",
+    }
+    expected_record["policy"] = {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "negative_outcome_retention_required": True,
+        "publication_equivalent": False,
+    }
+    expected_record["resources"] = expected_resources
+    expected_record["trajectory"] = trajectory
+    expected_record["final_state"] = final_state
+    expected_record["metrics"] = {
+        "mean_reward": float(np.mean(rewards)),
+        "mean_squared_td_error": float(np.mean(np.square(errors))),
+    }
+    if record != expected_record:
+        raise ValueError("control shard differs from exact current reexecution")
+    return record
+
+
+def _current_source() -> dict[str, object]:
+    return _screening_source_provenance(_REPO_ROOT)
+
+
+def _current_runtime() -> dict[str, object]:
+    return _screening_runtime_environment()
+
+
+def _digest(value: object, *, length: int, context: str) -> str:
+    hexdigits = frozenset("0123456789abcdef")
+    if (
+        type(value) is not str
+        or len(value) != length
+        or any(character not in hexdigits for character in value)
+    ):
+        raise ValueError(f"{context} must be one lowercase hexadecimal digest")
+    return value
+
+
+def _mean(values: object, *, context: str) -> float:
+    if type(values) is not list or not values:
+        raise ValueError(f"{context} must be one nonempty exact list")
+    converted: list[float] = []
+    for value in values:
+        if type(value) is not float or not math.isfinite(value):
+            raise ValueError(f"{context} must contain exact finite floats")
+        converted.append(value)
+    return math.fsum(converted) / len(converted)
+
+
+def _paired(deltas: list[float]) -> dict[str, object]:
+    if len(deltas) != len(SEEDS) or any(not math.isfinite(value) for value in deltas):
+        raise ValueError("paired deltas must cover the exact seed roster")
+    mean = math.fsum(deltas) / len(deltas)
+    centered = math.fsum((value - mean) ** 2 for value in deltas)
+    standard_error = math.sqrt(centered / (len(deltas) - 1)) / math.sqrt(len(deltas))
+    lower = mean - BONFERRONI_T_DF3 * standard_error
+    upper = mean + BONFERRONI_T_DF3 * standard_error
+    outcome = "supported" if lower > 0.0 else "rejected" if upper <= 0.0 else "inconclusive"
+    return {
+        "deltas": deltas,
+        "mean_delta": mean,
+        "standard_error": standard_error,
+        "ci9875_lower": lower,
+        "ci9875_upper": upper,
+        "outcome": outcome,
+    }
+
+
+def _validated_runs(
+    supervised_records: object, control_records: object
+) -> list[dict[str, object]]:
+    if type(supervised_records) is not list or len(supervised_records) != 2 * len(SEEDS):
+        raise ValueError("supervised records must contain the complete paired schedule")
+    if type(control_records) is not list or len(control_records) != len(CONTROL_ARMS) * len(SEEDS):
+        raise ValueError("control records must contain the complete paired schedule")
+    supervised_by_key: dict[tuple[int, str], dict[str, object]] = {}
+    for raw in supervised_records:
+        record = validate_intentional_updates_development_record(raw)
+        seed = record["seed"]
+        arm = record["arm"]
+        if (
+            type(seed) is not int
+            or seed not in SEEDS
+            or type(arm) is not str
+            or arm not in {"intentional_updates_off", "intentional_updates_ipmnist"}
+            or record["config"] != SUPERVISED_CONFIG.to_config()
+            or (seed, arm) in supervised_by_key
+        ):
+            raise ValueError("supervised record identity/configuration drift")
+        supervised_by_key[seed, arm] = record
+    control_by_key: dict[tuple[int, str], dict[str, object]] = {}
+    for raw in control_records:
+        record = validate_control_shard(raw)
+        seed = record["seed"]
+        arm = record["arm"]
+        config = cast(dict[str, object], record["config"])
+        if (
+            type(seed) is not int
+            or seed not in SEEDS
+            or type(arm) is not str
+            or arm not in CONTROL_ARMS
+            or config["horizon"] != 512
+            or config["phase_length"] != 64
+            or (seed, arm) in control_by_key
+        ):
+            raise ValueError("control record identity/configuration drift")
+        control_by_key[seed, arm] = record
+    expected_supervised = {
+        (seed, arm)
+        for seed in SEEDS
+        for arm in ("intentional_updates_off", "intentional_updates_ipmnist")
+    }
+    expected_control = {(seed, arm) for seed in SEEDS for arm in CONTROL_ARMS}
+    if set(supervised_by_key) != expected_supervised or set(control_by_key) != expected_control:
+        raise ValueError("records must contain the complete frozen seed-by-arm matrix")
+    return [
+        {
+            "seed": seed,
+            "supervised": [
+                supervised_by_key[seed, "intentional_updates_off"],
+                supervised_by_key[seed, "intentional_updates_ipmnist"],
+            ],
+            "control": [control_by_key[seed, arm] for arm in CONTROL_ARMS],
+        }
+        for seed in SEEDS
+    ]
+
+
+def _comparisons(runs: list[dict[str, object]]) -> dict[str, object]:
+    supervised_deltas: list[float] = []
+    td0_deltas: list[float] = []
+    trace_deltas: list[float] = []
+    q_deltas: list[float] = []
+    for run in runs:
+        supervised = cast(list[dict[str, object]], run["supervised"])
+        supervised_deltas.append(
+            _mean(
+                cast(dict[str, object], supervised[1]["metrics"])["per_task_accuracy"],
+                context="candidate supervised accuracy",
+            )
+            - _mean(
+                cast(dict[str, object], supervised[0]["metrics"])["per_task_accuracy"],
+                context="control supervised accuracy",
+            )
+        )
+        controls = {
+            cast(str, record["arm"]): record
+            for record in cast(list[dict[str, object]], run["control"])
+        }
+
+        def metric(arm: str, name: str) -> float:
+            value = cast(dict[str, object], controls[arm]["metrics"])[name]
+            if type(value) is not float or not math.isfinite(value):
+                raise ValueError("control primary metric must be an exact finite float")
+            return value
+
+        td0_deltas.append(
+            metric("fixed_td0", "mean_squared_td_error")
+            - metric("intentional_td0", "mean_squared_td_error")
+        )
+        trace_deltas.append(
+            metric("fixed_trace", "mean_squared_td_error")
+            - metric("intentional_trace", "mean_squared_td_error")
+        )
+        q_deltas.append(
+            metric("intentional_q_lambda", "mean_reward")
+            - metric("fixed_q_lambda", "mean_reward")
+        )
+    return {
+        "supervised_ipmnist": _paired(supervised_deltas),
+        "td0": _paired(td0_deltas),
+        "trace": _paired(trace_deltas),
+        "q_lambda": _paired(q_deltas),
+    }
+
+
+def build_report(
+    supervised_records: object,
+    control_records: object,
+    *,
+    dataset_file_sha256: object,
+    dataset_semantic_sha256: object,
+    execution_source_commit: object,
+) -> dict[str, object]:
+    """Build the complete two-family development report without cross-family ranking."""
+    file_digest = _digest(dataset_file_sha256, length=64, context="dataset file")
+    semantic_digest = _digest(dataset_semantic_sha256, length=64, context="dataset semantic")
+    commit = _digest(execution_source_commit, length=40, context="execution source commit")
+    if file_digest != DATASET_FILE_SHA256 or semantic_digest != DATASET_SEMANTIC_SHA256:
+        raise ValueError("dataset identity does not match the frozen plan")
+    runs = _validated_runs(supervised_records, control_records)
+    report: dict[str, object] = {
+        "schema": REPORT_SCHEMA,
+        "plan": frozen_plan(),
+        "dataset_file_sha256": file_digest,
+        "dataset_semantic_sha256": semantic_digest,
+        "execution_source_commit": commit,
+        "source_provenance": _current_source(),
+        "runtime_environment": _current_runtime(),
+        "runs": runs,
+        "paired_comparisons": _comparisons(runs),
+        "development_disposition": "four_separate_nonpromoting_outcomes",
+        "policy": {
+            "development_only": True,
+            "scientific_promotion_allowed": False,
+            "negative_outcomes_retained": True,
+            "timing_is_telemetry_only": True,
+            "cross_family_ranking_allowed": False,
+        },
+    }
+    return validate_report(report, require_current_source=True)
+
+
+def validate_report(value: object, *, require_current_source: bool = True) -> dict[str, object]:
+    """Fail closed over identities, complete children, and exact paired arithmetic."""
+    if type(require_current_source) is not bool:
+        raise ValueError("require_current_source must be an exact bool")
+    if type(value) is not dict:
+        raise ValueError("report must be an exact object")
+    report = cast(dict[str, object], _bounded_json(value, context="report"))
+    _exact_object(
+        report,
+        frozenset(
+            {
+                "schema", "plan", "dataset_file_sha256", "dataset_semantic_sha256",
+                "execution_source_commit", "source_provenance", "runtime_environment",
+                "runs", "paired_comparisons", "development_disposition", "policy",
+            }
+        ),
+        context="report",
+    )
+    if type(report["schema"]) is not str or report["schema"] != REPORT_SCHEMA:
+        raise ValueError("report schema drift")
+    if json.dumps(report["plan"], sort_keys=True, separators=(",", ":")) != json.dumps(
+        frozen_plan(), sort_keys=True, separators=(",", ":")
+    ):
+        raise ValueError("report plan differs from the literal prospective plan")
+    if (
+        _digest(report["dataset_file_sha256"], length=64, context="dataset file")
+        != DATASET_FILE_SHA256
+        or _digest(report["dataset_semantic_sha256"], length=64, context="dataset semantic")
+        != DATASET_SEMANTIC_SHA256
+    ):
+        raise ValueError("report dataset identity drift")
+    commit = _digest(report["execution_source_commit"], length=40, context="execution commit")
+    source = _bounded_json(report["source_provenance"], context="source provenance")
+    runtime = _bounded_json(report["runtime_environment"], context="runtime environment")
+    if type(source) is not dict or source.get("git_commit") != commit:
+        raise ValueError("execution commit does not match source provenance")
+    if require_current_source and source != _current_source():
+        raise ValueError("source provenance does not match current source")
+    if require_current_source and runtime != _current_runtime():
+        raise ValueError("runtime environment does not match current runtime")
+    runs_raw = report["runs"]
+    if type(runs_raw) is not list or len(runs_raw) != len(SEEDS):
+        raise ValueError("runs must contain the complete frozen schedule")
+    supervised: list[dict[str, object]] = []
+    control: list[dict[str, object]] = []
+    for index, raw_run in enumerate(runs_raw):
+        run = _exact_object(
+            raw_run, frozenset({"seed", "supervised", "control"}), context="run"
+        )
+        if type(run["seed"]) is not int or run["seed"] != SEEDS[index]:
+            raise ValueError("runs must use deterministic seed ordering")
+        if type(run["supervised"]) is not list or type(run["control"]) is not list:
+            raise ValueError("run children must be exact lists")
+        supervised.extend(cast(list[dict[str, object]], run["supervised"]))
+        control.extend(cast(list[dict[str, object]], run["control"]))
+    normalized_runs = _validated_runs(supervised, control)
+    if normalized_runs != runs_raw:
+        raise ValueError("runs differ from exact child validation")
+    paired = _bounded_json(report["paired_comparisons"], context="paired comparisons")
+    if paired != _comparisons(normalized_runs):
+        raise ValueError("paired arithmetic does not match retained runs")
+    policy = _exact_object(
+        report["policy"],
+        frozenset(
+            {
+                "development_only", "scientific_promotion_allowed",
+                "negative_outcomes_retained", "timing_is_telemetry_only",
+                "cross_family_ranking_allowed",
+            }
+        ),
+        context="report policy",
+    )
+    if policy != {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "negative_outcomes_retained": True,
+        "timing_is_telemetry_only": True,
+        "cross_family_ranking_allowed": False,
+    } or any(type(item) is not bool for item in policy.values()):
+        raise ValueError("report policy must remain permanently nonpromoting")
+    if (
+        type(report["development_disposition"]) is not str
+        or report["development_disposition"] != "four_separate_nonpromoting_outcomes"
+    ):
+        raise ValueError("report must not manufacture a cross-family disposition")
+    return report
+
+
+def _open_parent(path: Path) -> int:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        return os.open(path.parent, flags)
+    except FileNotFoundError:
+        parent_fd = os.open(path.parent.parent, flags)
+        try:
+            try:
+                os.mkdir(path.parent.name, 0o755, dir_fd=parent_fd)
+                os.fsync(parent_fd)
+            except FileExistsError:
+                pass
+            return os.open(path.parent.name, flags, dir_fd=parent_fd)
+        finally:
+            os.close(parent_fd)
+
+
+def _reserve(path: Path) -> _Reservation:
+    if type(path) is not type(Path()) or path.absolute() != OUTPUT_PATH.absolute():
+        raise ValueError(f"output must be the exact reserved NEW path {OUTPUT_PATH}")
+    directory_fd = _open_parent(path)
+    reservation_name = f".{path.name}.reservation"
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            reservation_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o400,
+            dir_fd=directory_fd,
+        )
+        marker = f"reserved:{path.name}\n".encode("ascii")
+        if os.write(descriptor, marker) != len(marker):
+            raise OSError("short immutable-output reservation write")
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.fsync(directory_fd)
+        try:
+            os.stat(path.name, dir_fd=directory_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(f"refusing to overwrite immutable output: {path}")
+        return _Reservation(directory_fd, path.name, reservation_name)
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(reservation_name, dir_fd=directory_fd)
+            os.fsync(directory_fd)
+        except FileNotFoundError:
+            pass
+        os.close(directory_fd)
+        raise
+
+
+def _release(reservation: _Reservation) -> None:
+    try:
+        os.unlink(reservation.reservation_name, dir_fd=reservation.directory_fd)
+        os.fsync(reservation.directory_fd)
+    except FileNotFoundError:
+        pass
+    finally:
+        os.close(reservation.directory_fd)
+
+
+def _strict_reread(reservation: _Reservation, expected: bytes) -> object:
+    descriptor = os.open(
+        reservation.destination_name,
+        os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        dir_fd=reservation.directory_fd,
+    )
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or not 0 < metadata.st_size <= _MAX_REPORT_BYTES:
+            raise ValueError("published report must be one bounded regular file")
+        chunks: list[bytes] = []
+        remaining = metadata.st_size
+        while remaining:
+            chunk = os.read(descriptor, min(remaining, 1024 * 1024))
+            if not chunk:
+                raise ValueError("published report ended before its pinned size")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        if os.read(descriptor, 1):
+            raise ValueError("published report grew during strict reread")
+    finally:
+        os.close(descriptor)
+    actual = b"".join(chunks)
+    if actual != expected:
+        raise ValueError("published bytes differ from the validated generation")
+    try:
+        return _bounded_json(json.loads(actual), context="published report")
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("published report is not strict JSON") from error
+
+
+def _publish_reserved(reservation: _Reservation, report: dict[str, object]) -> None:
+    encoded = (
+        json.dumps(report, allow_nan=False, ensure_ascii=True, indent=2, sort_keys=True) + "\n"
+    ).encode("ascii")
+    if len(encoded) > _MAX_REPORT_BYTES:
+        raise ValueError("validated report exceeds its publication bound")
+    temporary_name = f".{reservation.destination_name}.{secrets.token_hex(16)}.tmp"
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            temporary_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o400,
+            dir_fd=reservation.directory_fd,
+        )
+        view = memoryview(encoded)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("immutable report write made no progress")
+            view = view[written:]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.link(
+            temporary_name,
+            reservation.destination_name,
+            src_dir_fd=reservation.directory_fd,
+            dst_dir_fd=reservation.directory_fd,
+            follow_symlinks=False,
+        )
+        os.fsync(reservation.directory_fd)
+        if _strict_reread(reservation, encoded) != report:
+            raise ValueError("published semantic payload differs from validated report")
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary_name, dir_fd=reservation.directory_fd)
+            os.fsync(reservation.directory_fd)
+        except FileNotFoundError:
+            pass
+
+
+def publish_report(path: Path, report: object) -> Path:
+    """Reserve, validate, hard-link no-replace, fsync, and strictly reread."""
+    reservation = _reserve(path)
+    try:
+        validated = validate_report(report, require_current_source=True)
+        _publish_reserved(reservation, validated)
+    finally:
+        _release(reservation)
+    return path
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _execution_commit() -> str:
+    completed = subprocess.run(
+        ("git", "rev-parse", "HEAD"),
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return _digest(completed.stdout.strip(), length=40, context="execution commit")
+
+
+def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[str, object]:
+    """Run both frozen subprotocols exactly once after separate authorization."""
+    if not _EXECUTION_AUTHORIZED:
+        raise RuntimeError("Intentional Updates matched-development execution is not authorized")
+    if type(dataset_path) is not type(Path()) or type(output_path) is not type(Path()):
+        raise ValueError("dataset and output must be exact pathlib.Path values")
+    reservation = _reserve(output_path)
+    try:
+        file_digest = _sha256_file(dataset_path)
+        if file_digest != DATASET_FILE_SHA256:
+            raise ValueError("dataset file does not match the frozen reviewed input")
+        source_before = _current_source()
+        runtime_before = _current_runtime()
+        inputs, labels = _load_dataset(dataset_path)
+        semantic_digest = _sha256_arrays(inputs, labels)
+        if semantic_digest != DATASET_SEMANTIC_SHA256:
+            raise ValueError("dataset numeric payload does not match the frozen reviewed input")
+        supervised_records = [
+            intentional_updates_development_record(
+                run_screening_config(
+                    inputs,
+                    labels,
+                    screening_spec(arm),
+                    seed,
+                    SUPERVISED_CONFIG,
+                )
+            )
+            for seed in SEEDS
+            for arm in ("intentional_updates_off", "intentional_updates_ipmnist")
+        ]
+        control_records = [
+            run_control_shard(arm, seed=seed) for seed in SEEDS for arm in CONTROL_ARMS
+        ]
+        if source_before != _current_source():
+            raise RuntimeError("source identity changed during matched execution")
+        if runtime_before != _current_runtime():
+            raise RuntimeError("runtime identity changed during matched execution")
+        report = build_report(
+            supervised_records,
+            control_records,
+            dataset_file_sha256=file_digest,
+            dataset_semantic_sha256=semantic_digest,
+            execution_source_commit=_execution_commit(),
+        )
+        _publish_reserved(reservation, report)
+        return report
+    finally:
+        _release(reservation)
+
+
+__all__ = [
+    "BONFERRONI_T_DF3",
+    "CONTROL_ARMS",
+    "DATASET_FILE_SHA256",
+    "DATASET_SEMANTIC_SHA256",
+    "SEEDS",
+    "SUPERVISED_CONFIG",
+    "build_report",
+    "frozen_plan",
+    "publish_report",
+    "run_campaign",
+    "run_control_shard",
+    "validate_control_shard",
+    "validate_report",
+]

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -195,6 +195,10 @@ def frozen_plan() -> dict[str, object]:
         "development_only": True,
         "scientific_promotion_allowed": False,
         "negative_outcomes_retained": True,
+        "execution_failure_policy": (
+            "a failure after consumer dispatch leaves the immutable reservation as a "
+            "consumed-without-result tombstone and forbids retry"
+        ),
     }
 
 
@@ -1005,7 +1009,9 @@ def _reserve(path: Path) -> _Reservation:
             dir_fd=directory_fd,
         )
         reservation_acquired = True
-        marker = f"reserved:{path.name}\n".encode("ascii")
+        marker = (
+            f"reserved:{path.name}; retained as consumed-without-result after dispatch\n"
+        ).encode("ascii")
         view = memoryview(marker)
         while view:
             written = os.write(descriptor, view)
@@ -1057,6 +1063,26 @@ def _release(reservation: _Reservation) -> None:
             os.fsync(reservation.directory_fd)
     except FileNotFoundError:
         pass
+    finally:
+        os.close(reservation.directory_fd)
+
+
+def _retain_consumed_reservation(reservation: _Reservation) -> None:
+    """Close a dispatched reservation without making the consumed schedule reusable."""
+    try:
+        marker = os.stat(
+            reservation.reservation_name,
+            dir_fd=reservation.directory_fd,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(marker.st_mode)
+            or marker.st_nlink != 1
+            or (marker.st_dev, marker.st_ino)
+            != (reservation.reservation_device, reservation.reservation_inode)
+        ):
+            raise RuntimeError("consumed reservation identity changed")
+        os.fsync(reservation.directory_fd)
     finally:
         os.close(reservation.directory_fd)
 
@@ -1249,6 +1275,8 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
     if type(dataset_path) is not type(Path()) or type(output_path) is not type(Path()):
         raise ValueError("dataset and output must be exact pathlib.Path values")
     reservation = _reserve(output_path)
+    execution_started = False
+    report_published = False
     try:
         source_before = _current_source()
         runtime_before = _current_runtime()
@@ -1256,6 +1284,7 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
         dataset_provenance = _screening_dataset_provenance(inputs, labels)
         if dataset_provenance != frozen_plan()["dataset"]:
             raise ValueError("dataset numeric payload does not match the frozen reviewed input")
+        execution_started = True
         supervised_records = [
             intentional_updates_development_record(
                 run_screening_config(
@@ -1289,9 +1318,13 @@ def run_campaign(dataset_path: Path, output_path: Path = OUTPUT_PATH) -> dict[st
             execution_source_commit=_execution_commit(),
         )
         _publish_reserved(reservation, report)
+        report_published = True
         return report
     finally:
-        _release(reservation)
+        if report_published or not execution_started:
+            _release(reservation)
+        else:
+            _retain_consumed_reservation(reservation)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/alberta_framework/benchmarks/intentional_updates_control.py
+++ b/alberta_framework/benchmarks/intentional_updates_control.py
@@ -313,7 +313,7 @@ def _transition(state: int, action: int, step: int, phase_length: int) -> tuple[
 
 def _behavior_action(key: jax.Array) -> int:
     """Return one arm-independent action from the paired behavior stream."""
-    return int(jr.randint(key, (), 0, 2))
+    return int(jr.randint(key, (), 0, 2, dtype=np.int32))
 
 
 def _intentional_update(
@@ -372,7 +372,7 @@ def _run(
     sigma = np.float32(0.0)
     clip_ema = np.float32(0.0)
     root = jr.key(seed, impl=_AGENT_RNG_IMPL)
-    state = int(jr.randint(jr.fold_in(root, _MAX_HORIZON), (), 0, 2))
+    state = int(jr.randint(jr.fold_in(root, _MAX_HORIZON), (), 0, 2, dtype=np.int32))
     states = [state]
     actions: list[int] = []
     rewards: list[float] = []

--- a/docs/research/intentional-updates-matched-development.md
+++ b/docs/research/intentional-updates-matched-development.md
@@ -20,11 +20,11 @@ counts within each pair, and asks four two-sided paired questions with a Bonferr
 bytes, data/environment steps, updates, model/action queries, RNG operations, and optimizer solves
 are explicit in every child record.
 
-The supervised pair shares its example schedule and the prediction pairs share their realized
-transition schedule. The Q(lambda) pair instead shares the environment dynamics plus the agent RNG
-root/index schedule: learned policies can choose different actions and therefore produce different
-realized trajectories. Those policy-dependent trajectories are deliberately not described as a
-matched axis.
+The supervised pair shares its example schedule. All three linear pairs consume one seed-derived
+uniform behavior stream within a pair, so states, actions, rewards, observations, and update counts
+remain matched while learner parameters may differ. Q(lambda) is assessed by learner-sensitive
+mean squared TD error rather than the common behavior stream's necessarily identical reward. Each
+seed derives a distinct behavior schedule; nominal roots are not duplicate parity aliases.
 
 Seeds `31561001..31561004` are quarantined because contract tests consumed them. Contract tests
 use a distinct test-only capability and roster. Execution and public publication are

--- a/docs/research/intentional-updates-matched-development.md
+++ b/docs/research/intentional-updates-matched-development.md
@@ -1,0 +1,32 @@
+# Intentional Updates matched development
+
+Issue #1561 is split into two compatible-within-family subprotocols: the existing batch-size-one
+IPMNIST adapter, and a recurring two-state continuing-MDP consumer for linear TD(0), TD(lambda),
+and Q(lambda). Metrics are paired only inside each family; the report does not rank supervised
+accuracy against prediction error or control reward.
+
+The mechanism is pinned to `arXiv:2604.19033v1` and author code revision
+`sharifnassab/Intentional_RL@e86e26fd8613ac212e9a52c3fed8a01d0a31f685`. The control consumer
+specializes the author optimizer's entrywise RMS statistic, eligibility trace, global normalizer,
+adaptive error clipping, and update to a float32 linear learner. It is not the authors' neural
+benchmark and is not publication-equivalent. The supervised adapter remains a documented
+lambda-zero protocol extension rather than an RL reproduction.
+
+The literal plan reserves four globally searched seeds, binds the canonical materialized OpenML
+MNIST training-array digests already retained by ASI, requires equal observation and update
+schedules within each pair, and asks four two-sided paired questions with a Bonferroni-adjusted
+98.75% interval (`t(3) = 5.391949071934058`). Timing is retained as telemetry only. Persistent
+bytes, data/environment steps, updates, model/action queries, RNG operations, and optimizer solves
+are explicit in every child record.
+
+Execution is deliberately disabled in the initial merge. Inspecting the catalog is read-only:
+
+```bash
+.venv/bin/asi-intentional-updates-matched-development --catalog
+```
+
+A separate independently reviewed change must authorize execution. An authorized run may use only
+the frozen input identity and reserved NEW output path. It acquires an exclusive reservation before
+dataset loading, pins every directory segment without following symlinks, publishes by no-replace
+hard link, fsyncs, and strictly rereads and revalidates the report. Every supported, rejected, or
+inconclusive outcome remains development-only and permanently nonpromoting.

--- a/docs/research/intentional-updates-matched-development.md
+++ b/docs/research/intentional-updates-matched-development.md
@@ -15,10 +15,14 @@ lambda-zero protocol extension rather than an RL reproduction.
 The literal plan reserves four globally searched campaign seeds that no test executes, binds the
 canonical materialized OpenML
 MNIST training-array digests already retained by ASI, requires equal observation and update
-schedules within each pair, and asks four two-sided paired questions with a Bonferroni-adjusted
+counts within each pair, and asks four two-sided paired questions with a Bonferroni-adjusted
 98.75% interval (`t(3) = 5.391949071934058`). Timing is retained as telemetry only. Persistent
 bytes, data/environment steps, updates, model/action queries, RNG operations, and optimizer solves
 are explicit in every child record.
+
+Prediction pairs share their prescribed transition schedule. Q(lambda) pairs share the
+environment, seed, and exogenous exploration variates; their learned policies may produce
+different actions and transitions.
 
 The earlier draft roster was consumed by contract tests and is explicitly quarantined. Contract
 tests use a distinct test-only capability and roster. Execution and public publication are

--- a/docs/research/intentional-updates-matched-development.md
+++ b/docs/research/intentional-updates-matched-development.md
@@ -20,6 +20,11 @@ counts within each pair, and asks four two-sided paired questions with a Bonferr
 bytes, data/environment steps, updates, model/action queries, RNG operations, and optimizer solves
 are explicit in every child record.
 
+Execution provenance binds the exact `pyproject.toml` and `uv.lock` bytes alongside all consumed
+Python sources. Runtime provenance records every direct project dependency version, Python and
+platform identity, JAX backend, devices and configuration, and relevant JAX/XLA environment. Both
+identities are checked throughout execution and again during strict report validation.
+
 The supervised pair shares its example schedule. All three linear pairs consume one seed-derived
 uniform behavior stream within a pair, so states, actions, rewards, observations, and update counts
 remain matched while learner parameters may differ. Q(lambda) is assessed by learner-sensitive

--- a/docs/research/intentional-updates-matched-development.md
+++ b/docs/research/intentional-updates-matched-development.md
@@ -38,4 +38,6 @@ A separate independently reviewed change must authorize execution. An authorized
 the frozen input identity and reserved NEW output path. It acquires an exclusive reservation before
 dataset loading, pins every directory segment without following symlinks, publishes by no-replace
 hard link, fsyncs, and strictly rereads and revalidates the report. Every supported, rejected, or
-inconclusive outcome remains development-only and permanently nonpromoting.
+inconclusive completed comparison remains development-only and permanently nonpromoting. A failure
+after the first consumer dispatch leaves the immutable reservation as a consumed-without-result
+tombstone, so a partially consumed schedule cannot be retried or represented as a retained result.

--- a/docs/research/intentional-updates-matched-development.md
+++ b/docs/research/intentional-updates-matched-development.md
@@ -3,7 +3,7 @@
 Issue #1561 is split into two compatible-within-family subprotocols: the existing batch-size-one
 IPMNIST adapter, and a recurring two-state continuing-MDP consumer for linear TD(0), TD(lambda),
 and Q(lambda). Metrics are paired only inside each family; the report does not rank supervised
-accuracy against prediction error or control reward.
+accuracy against TD prediction or control error.
 
 The mechanism is pinned to `arXiv:2604.19033v1` and author code revision
 `sharifnassab/Intentional_RL@e86e26fd8613ac212e9a52c3fed8a01d0a31f685`. The control consumer

--- a/docs/research/intentional-updates-matched-development.md
+++ b/docs/research/intentional-updates-matched-development.md
@@ -20,9 +20,11 @@ counts within each pair, and asks four two-sided paired questions with a Bonferr
 bytes, data/environment steps, updates, model/action queries, RNG operations, and optimizer solves
 are explicit in every child record.
 
-Prediction pairs share their prescribed transition schedule. Q(lambda) pairs share the
-environment, seed, and exogenous exploration variates; their learned policies may produce
-different actions and transitions.
+The supervised pair shares its example schedule and the prediction pairs share their realized
+transition schedule. The Q(lambda) pair instead shares the environment dynamics plus the agent RNG
+root/index schedule: learned policies can choose different actions and therefore produce different
+realized trajectories. Those policy-dependent trajectories are deliberately not described as a
+matched axis.
 
 The earlier draft roster was consumed by contract tests and is explicitly quarantined. Contract
 tests use a distinct test-only capability and roster. Execution and public publication are

--- a/docs/research/intentional-updates-matched-development.md
+++ b/docs/research/intentional-updates-matched-development.md
@@ -12,14 +12,19 @@ adaptive error clipping, and update to a float32 linear learner. It is not the a
 benchmark and is not publication-equivalent. The supervised adapter remains a documented
 lambda-zero protocol extension rather than an RL reproduction.
 
-The literal plan reserves four globally searched seeds, binds the canonical materialized OpenML
+The literal plan reserves four globally searched campaign seeds that no test executes, binds the
+canonical materialized OpenML
 MNIST training-array digests already retained by ASI, requires equal observation and update
 schedules within each pair, and asks four two-sided paired questions with a Bonferroni-adjusted
 98.75% interval (`t(3) = 5.391949071934058`). Timing is retained as telemetry only. Persistent
 bytes, data/environment steps, updates, model/action queries, RNG operations, and optimizer solves
 are explicit in every child record.
 
-Execution is deliberately disabled in the initial merge. Inspecting the catalog is read-only:
+The earlier draft roster was consumed by contract tests and is explicitly quarantined. Contract
+tests use a distinct test-only capability and roster. Execution and public publication are
+deliberately disabled in the initial merge; both a literal reviewed-transition flag and a separate
+runtime authorization flag must become exact `true` before reservation, dataset loading, or a
+consumer call. Inspecting the catalog is read-only:
 
 ```bash
 .venv/bin/asi-intentional-updates-matched-development --catalog

--- a/docs/research/intentional-updates-matched-development.md
+++ b/docs/research/intentional-updates-matched-development.md
@@ -26,8 +26,8 @@ root/index schedule: learned policies can choose different actions and therefore
 realized trajectories. Those policy-dependent trajectories are deliberately not described as a
 matched axis.
 
-The earlier draft roster was consumed by contract tests and is explicitly quarantined. Contract
-tests use a distinct test-only capability and roster. Execution and public publication are
+Seeds `31561001..31561004` are quarantined because contract tests consumed them. Contract tests
+use a distinct test-only capability and roster. Execution and public publication are
 deliberately disabled in the initial merge; both a literal reviewed-transition flag and a separate
 runtime authorization flag must become exact `true` before reservation, dataset loading, or a
 consumer call. Inspecting the catalog is read-only:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ asi-native-supervised-catalog = "alberta_framework.benchmarks.native_supervised_
 asi-plasticity-diagnostic = "alberta_framework.benchmarks.plasticity_diagnostics:main"
 asi-nap-ipmnist = "alberta_framework.benchmarks.nap_ipmnist:main"
 asi-adamo-diagnostic = "alberta_framework.benchmarks.adamo_diagnostic:main"
+asi-intentional-updates-matched-development = "alberta_framework.benchmarks.intentional_updates_control:main"
 asi-activation-feature-ipmnist = "alberta_framework.benchmarks.activation_feature_ipmnist:main"
 asi-coom-qualification-smoke = "alberta_framework.benchmarks.coom_qualification:main"
 asi-clear-qualification = "alberta_framework.benchmarks.clear_qualification:main"

--- a/tests/test_console_entrypoints.py
+++ b/tests/test_console_entrypoints.py
@@ -32,6 +32,9 @@ _ASI_SCRIPTS = {
         "alberta_framework.benchmarks.activation_feature_ipmnist:main"
     ),
     "asi-adamo-diagnostic": "alberta_framework.benchmarks.adamo_diagnostic:main",
+    "asi-intentional-updates-matched-development": (
+        "alberta_framework.benchmarks.intentional_updates_control:main"
+    ),
     "asi-clear-qualification": (
         "alberta_framework.benchmarks.clear_qualification:main"
     ),

--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -49,6 +49,7 @@ _EXPECTED_SCRIPT_NAMES = {
     "asi-action-conditioned-latent",
     "asi-activation-feature-ipmnist",
     "asi-adamo-diagnostic",
+    "asi-intentional-updates-matched-development",
     "asi-clear-qualification",
     "asi-coom-qualification-smoke",
     "asi-cora-catalog",

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -6,8 +6,8 @@ import copy
 from pathlib import Path
 from typing import Never
 
-import pytest
 import numpy as np
+import pytest
 
 from alberta_framework.benchmarks import intentional_updates_control as lane
 from alberta_framework.benchmarks.ipmnist_screening import (

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -208,6 +208,36 @@ def test_report_rejects_missing_shard_arithmetic_and_promotion(
         lane.validate_report(promoting, require_current_source=True)
 
 
+def test_report_publication_is_no_replace_and_rejects_symlink_parent(
+    tmp_path: Path,
+    complete_records: tuple[list[dict[str, object]], list[dict[str, object]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(lane, "_current_source", lambda: {"git_commit": "c" * 40})
+    monkeypatch.setattr(lane, "_current_runtime", lambda: {"backend": "cpu"})
+    report = lane.build_report(
+        *complete_records,
+        dataset_file_sha256=lane.DATASET_FILE_SHA256,
+        dataset_semantic_sha256=lane.DATASET_SEMANTIC_SHA256,
+        execution_source_commit="c" * 40,
+    )
+    destination = tmp_path / "new" / "report.json"
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    assert lane.publish_report(destination, report) == destination
+    with pytest.raises(FileExistsError):
+        lane.publish_report(destination, report)
+
+    target = tmp_path / "target"
+    target.mkdir()
+    linked = tmp_path / "linked"
+    linked.symlink_to(target, target_is_directory=True)
+    linked_destination = linked / "report.json"
+    monkeypatch.setattr(lane, "OUTPUT_PATH", linked_destination)
+    with pytest.raises(OSError):
+        lane.publish_report(linked_destination, report)
+    assert not (target / "report.json").exists()
+
+
 @pytest.mark.parametrize(
     ("horizon", "phase_length"),
     [(0, 1), (10_001, 1), (8, 0), (8, 9), (True, 1)],

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import copy
 import json
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Iterator, Never
+from typing import Never
 
 import numpy as np
 import pytest

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -478,6 +478,46 @@ def test_strict_reread_converts_deep_json_recursion(
         lane._release(reservation)
 
 
+def test_campaign_failure_after_dispatch_retains_consumed_reservation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "consumed" / "report.json"
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(lane, "CAMPAIGN_SEEDS", lane.TEST_ONLY_SEEDS)
+    monkeypatch.setattr(lane, "SEEDS", lane.TEST_ONLY_SEEDS)
+    monkeypatch.setattr(lane, "_REVIEWED_EXECUTION_TRANSITION", True)
+    monkeypatch.setattr(lane, "_EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(lane, "_current_source", lambda: {"git_commit": "c" * 40})
+    monkeypatch.setattr(lane, "_current_runtime", lambda: {"backend": "cpu"})
+    monkeypatch.setattr(
+        lane,
+        "_load_dataset",
+        lambda _path: (
+            np.zeros((1, 1), dtype=np.float32),
+            np.zeros(1, dtype=np.int32),
+        ),
+    )
+    monkeypatch.setattr(
+        lane,
+        "_screening_dataset_provenance",
+        lambda _inputs, _labels: lane.frozen_plan()["dataset"],
+    )
+
+    def fail_first_consumer(*_args: object, **_kwargs: object) -> Never:
+        raise RuntimeError("injected consumer failure")
+
+    monkeypatch.setattr(lane, "run_screening_config", fail_first_consumer)
+    with pytest.raises(RuntimeError, match="injected consumer failure"):
+        lane.run_campaign(Path("unused.npz"), destination)
+    marker = destination.parent / ".report.json.reservation"
+    assert marker.read_text(encoding="ascii") == (
+        "reserved:report.json; retained as consumed-without-result after dispatch\n"
+    )
+    assert not destination.exists()
+    with pytest.raises(FileExistsError):
+        lane.run_campaign(Path("unused.npz"), destination)
+
+
 @pytest.mark.parametrize(
     ("horizon", "phase_length"),
     [(0, 1), (10_001, 1), (8, 0), (8, 9), (True, 1)],

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 import json
 from pathlib import Path
-from typing import Never
+from typing import Iterator, Never
 
 import numpy as np
 import pytest
@@ -20,6 +20,14 @@ from alberta_framework.benchmarks.ipmnist_screening import (
 pytestmark = pytest.mark.integration
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _test_only_seed_roster() -> Iterator[None]:
+    patch = pytest.MonkeyPatch()
+    patch.setattr(lane, "SEEDS", lane.TEST_ONLY_SEEDS)
+    yield
+    patch.undo()
+
+
 def _control(
     arm: str, *, seed: int, horizon: int = 512, phase_length: int = 64
 ) -> dict[str, object]:
@@ -28,14 +36,17 @@ def _control(
         seed=seed,
         horizon=horizon,
         phase_length=phase_length,
-        _capability=lane._EXECUTION_CAPABILITY,
+        _capability=lane._TEST_EXECUTION_CAPABILITY,
     )
 
 
 def test_plan_is_fresh_prospective_and_permanently_nonpromoting() -> None:
     plan = lane.frozen_plan()
-    assert plan["seeds"] == [31_561_001, 31_561_002, 31_561_003, 31_561_004]
+    assert plan["seeds"] == [41_562_001, 41_562_002, 41_562_003, 41_562_004]
+    assert lane.QUARANTINED_SEEDS == (31_561_001, 31_561_002, 31_561_003, 31_561_004)
+    assert set(lane.CAMPAIGN_SEEDS).isdisjoint(lane.TEST_ONLY_SEEDS)
     assert plan["execution_authorized"] is False
+    assert plan["reviewed_execution_transition"] is False
     assert plan["scientific_promotion_allowed"] is False
     assert plan["negative_outcomes_retained"] is True
     assert plan["confidence_critical"] == 5.391949071934058
@@ -152,6 +163,23 @@ def test_campaign_execution_is_closed_before_independent_review() -> None:
         lane.run_control_shard("fixed_td0", seed=lane.SEEDS[0])
     with pytest.raises(RuntimeError, match="not authorized"):
         lane.run_campaign(Path("unused.npz"), Path("unused.json"))
+
+
+def test_runtime_flag_alone_cannot_bypass_reviewed_transition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("reservation occurred without reviewed transition")
+
+    monkeypatch.setattr(lane, "_EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(lane, "_reserve", forbidden)
+    with pytest.raises(RuntimeError, match="not authorized"):
+        lane.run_campaign(Path("unused.npz"), lane.OUTPUT_PATH)
+    assert calls == 0
 
 
 def test_execution_cli_fails_before_dataset_or_consumer(
@@ -285,9 +313,13 @@ def test_report_publication_is_no_replace_and_rejects_symlink_parent(
     )
     destination = tmp_path / "new" / "report.json"
     monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
-    assert lane.publish_report(destination, report) == destination
+    assert lane._publish_report_authorized(
+        destination, report, _capability=lane._TEST_EXECUTION_CAPABILITY
+    ) == destination
     with pytest.raises(FileExistsError):
-        lane.publish_report(destination, report)
+        lane._publish_report_authorized(
+            destination, report, _capability=lane._TEST_EXECUTION_CAPABILITY
+        )
 
     target = tmp_path / "target"
     target.mkdir()
@@ -296,8 +328,29 @@ def test_report_publication_is_no_replace_and_rejects_symlink_parent(
     linked_destination = linked / "report.json"
     monkeypatch.setattr(lane, "OUTPUT_PATH", linked_destination)
     with pytest.raises(OSError):
-        lane.publish_report(linked_destination, report)
+        lane._publish_report_authorized(
+            linked_destination, report, _capability=lane._TEST_EXECUTION_CAPABILITY
+        )
     assert not (target / "report.json").exists()
+
+
+def test_public_publisher_is_closed_without_creating_output(
+    tmp_path: Path,
+    complete_records: tuple[list[dict[str, object]], list[dict[str, object]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(lane, "_current_source", lambda: {"git_commit": "c" * 40})
+    monkeypatch.setattr(lane, "_current_runtime", lambda: {"backend": "cpu"})
+    report = lane.build_report(
+        *complete_records,
+        dataset_provenance=lane.frozen_plan()["dataset"],
+        execution_source_commit="c" * 40,
+    )
+    destination = tmp_path / "never" / "report.json"
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    with pytest.raises(RuntimeError, match="not authorized"):
+        lane.publish_report(destination, report)
+    assert not destination.parent.exists()
 
 
 def test_reservation_is_exclusive_and_parent_swap_stays_descriptor_pinned(
@@ -340,5 +393,5 @@ def test_control_bounds_fail_before_execution(horizon: int, phase_length: int) -
             seed=lane.SEEDS[0],
             horizon=horizon,
             phase_length=phase_length,
-            _capability=lane._EXECUTION_CAPABILITY,
+            _capability=lane._TEST_EXECUTION_CAPABILITY,
         )

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -7,8 +7,14 @@ from pathlib import Path
 from typing import Never
 
 import pytest
+import numpy as np
 
 from alberta_framework.benchmarks import intentional_updates_control as lane
+from alberta_framework.benchmarks.ipmnist_screening import (
+    ScreeningRunResult,
+    intentional_updates_development_record,
+    screening_spec,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -118,6 +124,88 @@ def test_validator_rejects_resource_result_identity_and_policy_forgery() -> None
 def test_campaign_execution_is_closed_before_independent_review() -> None:
     with pytest.raises(RuntimeError, match="not authorized"):
         lane.run_campaign(Path("unused.npz"), Path("unused.json"))
+
+
+def _synthetic_supervised_records() -> list[dict[str, object]]:
+    records = []
+    for seed in lane.SEEDS:
+        for arm, offset in (
+            ("intentional_updates_off", 0.0),
+            ("intentional_updates_ipmnist", 0.01),
+        ):
+            spec = screening_spec(arm)
+            result = ScreeningRunResult(
+                config_name=arm,
+                base_learner=spec.base_learner,
+                hyperparameters=spec.hyperparameters,
+                seed=seed,
+                config=lane.SUPERVISED_CONFIG,
+                per_task_accuracy=np.full(8, 0.5 + offset, dtype=np.float64),
+                per_task_loss=np.full(8, 0.7 - offset, dtype=np.float64),
+                per_task_plasticity=np.full(8, 0.4 + offset, dtype=np.float64),
+                wall_clock_seconds=0.125,
+            )
+            records.append(intentional_updates_development_record(result))
+    return records
+
+
+@pytest.fixture(scope="module")
+def complete_records() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    supervised = _synthetic_supervised_records()
+    control = [
+        lane.run_control_shard(arm, seed=seed)
+        for seed in lane.SEEDS
+        for arm in lane.CONTROL_ARMS
+    ]
+    return supervised, control
+
+
+def test_report_recomputes_all_four_bonferroni_paired_questions(
+    complete_records: tuple[list[dict[str, object]], list[dict[str, object]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(lane, "_current_source", lambda: {"git_commit": "c" * 40})
+    monkeypatch.setattr(lane, "_current_runtime", lambda: {"backend": "cpu"})
+    report = lane.build_report(
+        *complete_records,
+        dataset_file_sha256=lane.DATASET_FILE_SHA256,
+        dataset_semantic_sha256=lane.DATASET_SEMANTIC_SHA256,
+        execution_source_commit="c" * 40,
+    )
+    assert set(report["paired_comparisons"]) == {
+        "supervised_ipmnist", "td0", "trace", "q_lambda"
+    }
+    assert all(
+        item["outcome"] in {"supported", "rejected", "inconclusive"}
+        for item in report["paired_comparisons"].values()
+    )
+    assert lane.validate_report(report, require_current_source=True) == report
+
+
+def test_report_rejects_missing_shard_arithmetic_and_promotion(
+    complete_records: tuple[list[dict[str, object]], list[dict[str, object]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(lane, "_current_source", lambda: {"git_commit": "c" * 40})
+    monkeypatch.setattr(lane, "_current_runtime", lambda: {"backend": "cpu"})
+    report = lane.build_report(
+        *complete_records,
+        dataset_file_sha256=lane.DATASET_FILE_SHA256,
+        dataset_semantic_sha256=lane.DATASET_SEMANTIC_SHA256,
+        execution_source_commit="c" * 40,
+    )
+    missing = copy.deepcopy(report)
+    missing["runs"][0]["control"].pop()
+    with pytest.raises(ValueError, match="complete"):
+        lane.validate_report(missing, require_current_source=True)
+    forged = copy.deepcopy(report)
+    forged["paired_comparisons"]["td0"]["mean_delta"] = 9.0
+    with pytest.raises(ValueError, match="paired arithmetic"):
+        lane.validate_report(forged, require_current_source=True)
+    promoting = copy.deepcopy(report)
+    promoting["policy"]["scientific_promotion_allowed"] = True
+    with pytest.raises(ValueError, match="nonpromoting"):
+        lane.validate_report(promoting, require_current_source=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -39,8 +39,13 @@ def test_mechanism_off_reduces_bit_exactly_to_fixed_consumer(
     actual = lane.run_control_shard(off, seed=25610, horizon=48, phase_length=12)
     assert actual["arm"] == off
     assert actual["execution_arm"] == fixed
-    for key in ("trajectory", "final_state", "metrics", "resources"):
+    for key in ("trajectory", "final_state", "metrics"):
         assert actual[key] == expected[key]
+    expected_resources = dict(expected["resources"])
+    actual_resources = dict(actual["resources"])
+    expected_resources.pop("timing_telemetry_ns")
+    actual_resources.pop("timing_telemetry_ns")
+    assert actual_resources == expected_resources
 
 
 @pytest.mark.parametrize("arm", lane.CONTROL_ARMS)

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -112,6 +112,14 @@ def test_runtime_identity_binds_dependencies_jax_devices_config_and_environment(
     )
 
 
+def test_current_runtime_rejects_oversized_environment_before_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XLA_FLAGS", "x" * 16_385)
+    with pytest.raises(ValueError, match="bounded exact JSON string"):
+        lane._current_runtime()
+
+
 @pytest.mark.parametrize(
     ("fixed", "off"),
     [

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -114,10 +114,10 @@ def test_each_control_arm_runs_end_to_end_with_exact_resources(arm: str) -> None
 @pytest.mark.parametrize(
     ("arm", "expected_bytes"),
     [
-        ("fixed_td0", 16),
-        ("intentional_td0", 36),
-        ("fixed_trace", 16),
-        ("intentional_trace", 36),
+        ("fixed_td0", 24),
+        ("intentional_td0", 44),
+        ("fixed_trace", 24),
+        ("intentional_trace", 44),
         ("fixed_q_lambda", 40),
         ("intentional_q_lambda", 68),
     ],
@@ -137,15 +137,41 @@ def test_prediction_and_control_information_and_rng_are_explicit() -> None:
         "intentional_q_lambda", seed=lane.SEEDS[2], horizon=16, phase_length=4
     )
     assert prediction["resources"]["action_queries"] == 0
-    assert prediction["resources"]["rng_fold_ins"] == 0
-    assert control["resources"]["action_queries"] == 16
-    assert control["resources"]["rng_fold_ins"] == 16
-    assert control["resources"]["rng_splits"] == 16
-    assert control["resources"]["rng_uniform_draws"] == 16
-    assert 0 <= control["resources"]["rng_integer_draws"] <= 16
-    assert control["identity"]["agent_rng_impl"] == "threefry2x32"
+    assert prediction["resources"]["rng_fold_ins"] == 17
+    assert control["resources"]["action_queries"] == 0
+    assert control["resources"]["rng_fold_ins"] == 17
+    assert control["resources"]["rng_splits"] == 0
+    assert control["resources"]["rng_uniform_draws"] == 0
+    assert control["resources"]["rng_integer_draws"] == 17
+    assert control["identity"]["behavior_rng_impl"] == "threefry2x32"
+    assert prediction["final_state"]["behavior_rng_root"]
     assert prediction["information"]["boundary_information"] == []
     assert prediction["information"]["task_information"] == []
+
+
+@pytest.mark.parametrize(
+    ("fixed", "candidate"),
+    [
+        ("fixed_td0", "intentional_td0"),
+        ("fixed_trace", "intentional_trace"),
+        ("fixed_q_lambda", "intentional_q_lambda"),
+    ],
+)
+def test_pairs_share_one_exogenous_behavior_trajectory(
+    fixed: str, candidate: str
+) -> None:
+    control = _control(fixed, seed=lane.SEEDS[0], horizon=64, phase_length=8)
+    intentional = _control(candidate, seed=lane.SEEDS[0], horizon=64, phase_length=8)
+    for field in ("states", "actions", "rewards"):
+        assert control["trajectory"][field] == intentional["trajectory"][field]
+
+
+def test_seed_roster_produces_independent_behavior_schedules() -> None:
+    schedules = {
+        tuple(_control("fixed_td0", seed=seed, horizon=64)["trajectory"]["actions"])
+        for seed in lane.SEEDS
+    }
+    assert len(schedules) == len(lane.SEEDS)
 
 
 def test_validator_rejects_nested_subclasses_without_hooks() -> None:

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -154,6 +154,26 @@ def test_campaign_execution_is_closed_before_independent_review() -> None:
         lane.run_campaign(Path("unused.npz"), Path("unused.json"))
 
 
+def test_execution_cli_fails_before_dataset_or_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"dataset": 0, "consumer": 0}
+
+    def forbidden_dataset(*args: object, **kwargs: object) -> object:
+        calls["dataset"] += 1
+        raise AssertionError("dataset load occurred before authorization")
+
+    def forbidden_consumer(*args: object, **kwargs: object) -> object:
+        calls["consumer"] += 1
+        raise AssertionError("consumer ran before authorization")
+
+    monkeypatch.setattr(lane, "_load_dataset", forbidden_dataset)
+    monkeypatch.setattr(lane, "_run", forbidden_consumer)
+    with pytest.raises(RuntimeError, match="not authorized"):
+        lane.main(["--dataset", "unused.npz"])
+    assert calls == {"dataset": 0, "consumer": 0}
+
+
 def test_validator_bounds_config_before_reexecution(monkeypatch: pytest.MonkeyPatch) -> None:
     record = _control("fixed_td0", seed=lane.SEEDS[0], horizon=16, phase_length=4)
     hostile = copy.deepcopy(record)
@@ -213,8 +233,7 @@ def test_report_recomputes_all_four_bonferroni_paired_questions(
     monkeypatch.setattr(lane, "_current_runtime", lambda: {"backend": "cpu"})
     report = lane.build_report(
         *complete_records,
-        dataset_file_sha256=lane.DATASET_FILE_SHA256,
-        dataset_semantic_sha256=lane.DATASET_SEMANTIC_SHA256,
+        dataset_provenance=lane.frozen_plan()["dataset"],
         execution_source_commit="c" * 40,
     )
     assert set(report["paired_comparisons"]) == {
@@ -235,8 +254,7 @@ def test_report_rejects_missing_shard_arithmetic_and_promotion(
     monkeypatch.setattr(lane, "_current_runtime", lambda: {"backend": "cpu"})
     report = lane.build_report(
         *complete_records,
-        dataset_file_sha256=lane.DATASET_FILE_SHA256,
-        dataset_semantic_sha256=lane.DATASET_SEMANTIC_SHA256,
+        dataset_provenance=lane.frozen_plan()["dataset"],
         execution_source_commit="c" * 40,
     )
     missing = copy.deepcopy(report)
@@ -262,8 +280,7 @@ def test_report_publication_is_no_replace_and_rejects_symlink_parent(
     monkeypatch.setattr(lane, "_current_runtime", lambda: {"backend": "cpu"})
     report = lane.build_report(
         *complete_records,
-        dataset_file_sha256=lane.DATASET_FILE_SHA256,
-        dataset_semantic_sha256=lane.DATASET_SEMANTIC_SHA256,
+        dataset_provenance=lane.frozen_plan()["dataset"],
         execution_source_commit="c" * 40,
     )
     destination = tmp_path / "new" / "report.json"
@@ -281,6 +298,35 @@ def test_report_publication_is_no_replace_and_rejects_symlink_parent(
     with pytest.raises(OSError):
         lane.publish_report(linked_destination, report)
     assert not (target / "report.json").exists()
+
+
+def test_reservation_is_exclusive_and_parent_swap_stays_descriptor_pinned(
+    tmp_path: Path,
+    complete_records: tuple[list[dict[str, object]], list[dict[str, object]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(lane, "_current_source", lambda: {"git_commit": "c" * 40})
+    monkeypatch.setattr(lane, "_current_runtime", lambda: {"backend": "cpu"})
+    report = lane.build_report(
+        *complete_records,
+        dataset_provenance=lane.frozen_plan()["dataset"],
+        execution_source_commit="c" * 40,
+    )
+    requested = tmp_path / "requested"
+    destination = requested / "report.json"
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    reservation = lane._reserve(destination)
+    try:
+        with pytest.raises(FileExistsError):
+            lane._reserve(destination)
+        moved = tmp_path / "moved"
+        requested.rename(moved)
+        requested.mkdir()
+        lane._publish_reserved(reservation, report)
+    finally:
+        lane._release(reservation)
+    assert (moved / "report.json").is_file()
+    assert not destination.exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -20,15 +20,33 @@ from alberta_framework.benchmarks.ipmnist_screening import (
 pytestmark = pytest.mark.integration
 
 
+def _control(
+    arm: str, *, seed: int, horizon: int = 512, phase_length: int = 64
+) -> dict[str, object]:
+    return lane._run_control_shard_authorized(
+        arm,
+        seed=seed,
+        horizon=horizon,
+        phase_length=phase_length,
+        _capability=lane._EXECUTION_CAPABILITY,
+    )
+
+
 def test_plan_is_fresh_prospective_and_permanently_nonpromoting() -> None:
     plan = lane.frozen_plan()
-    assert plan["seeds"] == [25610, 25611, 25612, 25613]
+    assert plan["seeds"] == [31_561_001, 31_561_002, 31_561_003, 31_561_004]
     assert plan["execution_authorized"] is False
     assert plan["scientific_promotion_allowed"] is False
     assert plan["negative_outcomes_retained"] is True
     assert plan["confidence_critical"] == 5.391949071934058
     assert plan["confidence_critical"].hex() == "0x1.5915b18f69e09p+2"
     assert plan["protocol_families"] == ["supervised_ipmnist", "td_control"]
+    assert plan["dataset"]["x"]["sha256"] == (
+        "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313"
+    )
+    assert plan["dataset"]["y"]["sha256"] == (
+        "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a"
+    )
 
 
 def test_catalog_cli_is_read_only_and_execution_stays_closed(
@@ -49,8 +67,8 @@ def test_catalog_cli_is_read_only_and_execution_stays_closed(
 def test_mechanism_off_reduces_bit_exactly_to_fixed_consumer(
     fixed: str, off: str,
 ) -> None:
-    expected = lane.run_control_shard(fixed, seed=25610, horizon=48, phase_length=12)
-    actual = lane.run_control_shard(off, seed=25610, horizon=48, phase_length=12)
+    expected = _control(fixed, seed=lane.SEEDS[0], horizon=48, phase_length=12)
+    actual = _control(off, seed=lane.SEEDS[0], horizon=48, phase_length=12)
     assert actual["arm"] == off
     assert actual["execution_arm"] == fixed
     for key in ("trajectory", "final_state", "metrics"):
@@ -64,7 +82,7 @@ def test_mechanism_off_reduces_bit_exactly_to_fixed_consumer(
 
 @pytest.mark.parametrize("arm", lane.CONTROL_ARMS)
 def test_each_control_arm_runs_end_to_end_with_exact_resources(arm: str) -> None:
-    record = lane.run_control_shard(arm, seed=25611, horizon=48, phase_length=12)
+    record = _control(arm, seed=lane.SEEDS[1], horizon=48, phase_length=12)
     assert lane.validate_control_shard(record) == record
     assert len(record["trajectory"]["rewards"]) == 48
     assert record["resources"]["environment_steps"] == 48
@@ -77,11 +95,11 @@ def test_each_control_arm_runs_end_to_end_with_exact_resources(arm: str) -> None
 
 
 def test_prediction_and_control_information_and_rng_are_explicit() -> None:
-    prediction = lane.run_control_shard(
-        "intentional_trace", seed=25612, horizon=16, phase_length=4
+    prediction = _control(
+        "intentional_trace", seed=lane.SEEDS[2], horizon=16, phase_length=4
     )
-    control = lane.run_control_shard(
-        "intentional_q_lambda", seed=25612, horizon=16, phase_length=4
+    control = _control(
+        "intentional_q_lambda", seed=lane.SEEDS[2], horizon=16, phase_length=4
     )
     assert prediction["resources"]["action_queries"] == 0
     assert prediction["resources"]["rng_fold_ins"] == 0
@@ -93,8 +111,8 @@ def test_prediction_and_control_information_and_rng_are_explicit() -> None:
 
 
 def test_validator_rejects_nested_subclasses_without_hooks() -> None:
-    record = lane.run_control_shard(
-        "intentional_trace", seed=25613, horizon=16, phase_length=4
+    record = _control(
+        "intentional_trace", seed=lane.SEEDS[3], horizon=16, phase_length=4
     )
 
     class HostileDict(dict[object, object]):
@@ -116,7 +134,7 @@ def test_validator_rejects_nested_subclasses_without_hooks() -> None:
 
 
 def test_validator_rejects_resource_result_identity_and_policy_forgery() -> None:
-    record = lane.run_control_shard("intentional_td0", seed=25610, horizon=16, phase_length=4)
+    record = _control("intentional_td0", seed=lane.SEEDS[0], horizon=16, phase_length=4)
     for path, replacement in (
         (("resources", "updates"), 15),
         (("trajectory", "rewards"), [99.0] * 16),
@@ -131,7 +149,26 @@ def test_validator_rejects_resource_result_identity_and_policy_forgery() -> None
 
 def test_campaign_execution_is_closed_before_independent_review() -> None:
     with pytest.raises(RuntimeError, match="not authorized"):
+        lane.run_control_shard("fixed_td0", seed=lane.SEEDS[0])
+    with pytest.raises(RuntimeError, match="not authorized"):
         lane.run_campaign(Path("unused.npz"), Path("unused.json"))
+
+
+def test_validator_bounds_config_before_reexecution(monkeypatch: pytest.MonkeyPatch) -> None:
+    record = _control("fixed_td0", seed=lane.SEEDS[0], horizon=16, phase_length=4)
+    hostile = copy.deepcopy(record)
+    hostile["config"]["horizon"] = 1 << 40
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("validator reexecuted before exact bounds")
+
+    monkeypatch.setattr(lane, "_run", forbidden)
+    with pytest.raises(ValueError, match="horizon"):
+        lane.validate_control_shard(hostile)
+    assert calls == 0
 
 
 def _synthetic_supervised_records() -> list[dict[str, object]]:
@@ -161,7 +198,7 @@ def _synthetic_supervised_records() -> list[dict[str, object]]:
 def complete_records() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
     supervised = _synthetic_supervised_records()
     control = [
-        lane.run_control_shard(arm, seed=seed)
+        _control(arm, seed=seed)
         for seed in lane.SEEDS
         for arm in lane.CONTROL_ARMS
     ]
@@ -252,6 +289,10 @@ def test_report_publication_is_no_replace_and_rejects_symlink_parent(
 )
 def test_control_bounds_fail_before_execution(horizon: int, phase_length: int) -> None:
     with pytest.raises(ValueError):
-        lane.run_control_shard(
-            "fixed_td0", seed=25610, horizon=horizon, phase_length=phase_length
+        lane._run_control_shard_authorized(
+            "fixed_td0",
+            seed=lane.SEEDS[0],
+            horizon=horizon,
+            phase_length=phase_length,
+            _capability=lane._EXECUTION_CAPABILITY,
         )

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -41,7 +41,9 @@ def _control(
     )
 
 
-def test_plan_is_fresh_prospective_and_permanently_nonpromoting() -> None:
+def test_plan_is_fresh_prospective_and_permanently_nonpromoting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     plan = lane.frozen_plan()
     assert plan["seeds"] == [41_562_001, 41_562_002, 41_562_003, 41_562_004]
     assert lane.QUARANTINED_SEEDS == (31_561_001, 31_561_002, 31_561_003, 31_561_004)
@@ -59,6 +61,9 @@ def test_plan_is_fresh_prospective_and_permanently_nonpromoting() -> None:
     assert plan["dataset"]["y"]["sha256"] == (
         "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a"
     )
+    monkeypatch.setattr(lane, "_REVIEWED_EXECUTION_TRANSITION", True)
+    monkeypatch.setattr(lane, "_EXECUTION_AUTHORIZED", True)
+    assert lane.frozen_plan() == plan
 
 
 def test_catalog_cli_is_read_only_and_execution_stays_closed(
@@ -104,6 +109,24 @@ def test_each_control_arm_runs_end_to_end_with_exact_resources(arm: str) -> None
     assert record["resources"]["timing_is_selection_metric"] is False
     assert type(record["resources"]["timing_telemetry_ns"]) is int
     assert record["policy"]["scientific_promotion_allowed"] is False
+
+
+@pytest.mark.parametrize(
+    ("arm", "expected_bytes"),
+    [
+        ("fixed_td0", 16),
+        ("intentional_td0", 36),
+        ("fixed_trace", 16),
+        ("intentional_trace", 36),
+        ("fixed_q_lambda", 40),
+        ("intentional_q_lambda", 68),
+    ],
+)
+def test_control_persistent_numeric_bytes_are_exact(
+    arm: str, expected_bytes: int
+) -> None:
+    record = _control(arm, seed=lane.SEEDS[0], horizon=8, phase_length=2)
+    assert record["resources"]["persistent_numeric_bytes"] == expected_bytes
 
 
 def test_prediction_and_control_information_and_rng_are_explicit() -> None:

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -120,6 +120,24 @@ def test_current_runtime_rejects_oversized_environment_before_use(
         lane._current_runtime()
 
 
+def test_runtime_identity_bounds_device_inventory_before_attribute_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    class HostileDevice:
+        def __getattribute__(self, name: str) -> object:
+            nonlocal calls
+            calls += 1
+            raise AssertionError(f"device attribute accessed before bound: {name}")
+
+    oversized = [HostileDevice() for _ in range(lane._MAX_RUNTIME_DEVICES + 1)]
+    monkeypatch.setattr(lane.jax, "devices", lambda: oversized)
+    with pytest.raises(RuntimeError, match="device inventory is out of bounds"):
+        lane._runtime_identity()
+    assert calls == 0
+
+
 @pytest.mark.parametrize(
     ("fixed", "off"),
     [

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -117,6 +117,9 @@ def test_prediction_and_control_information_and_rng_are_explicit() -> None:
     assert prediction["resources"]["rng_fold_ins"] == 0
     assert control["resources"]["action_queries"] == 16
     assert control["resources"]["rng_fold_ins"] == 16
+    assert control["resources"]["rng_splits"] == 16
+    assert control["resources"]["rng_uniform_draws"] == 16
+    assert 0 <= control["resources"]["rng_integer_draws"] <= 16
     assert control["identity"]["agent_rng_impl"] == "threefry2x32"
     assert prediction["information"]["boundary_information"] == []
     assert prediction["information"]["task_information"] == []
@@ -381,6 +384,98 @@ def test_reservation_is_exclusive_and_parent_swap_stays_descriptor_pinned(
         lane._release(reservation)
     assert (moved / "report.json").is_file()
     assert not destination.exists()
+
+
+def test_post_link_validation_failure_removes_only_the_published_inode(
+    tmp_path: Path,
+    complete_records: tuple[list[dict[str, object]], list[dict[str, object]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(lane, "_current_source", lambda: {"git_commit": "c" * 40})
+    monkeypatch.setattr(lane, "_current_runtime", lambda: {"backend": "cpu"})
+    report = lane.build_report(
+        *complete_records,
+        dataset_provenance=lane.frozen_plan()["dataset"],
+        execution_source_commit="c" * 40,
+    )
+    destination = tmp_path / "failed" / "report.json"
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    reservation = lane._reserve(destination)
+    original = lane.validate_report
+    calls = 0
+
+    def fail_after_publish(value: object, *, require_current_source: bool = True) -> object:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ValueError("injected post-link validation failure")
+        return original(value, require_current_source=require_current_source)
+
+    monkeypatch.setattr(lane, "validate_report", fail_after_publish)
+    try:
+        with pytest.raises(ValueError, match="injected post-link"):
+            lane._publish_reserved(reservation, report)
+    finally:
+        lane._release(reservation)
+    assert not destination.exists()
+
+
+def test_extra_hard_link_is_rejected_and_rolled_back(
+    tmp_path: Path,
+    complete_records: tuple[list[dict[str, object]], list[dict[str, object]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(lane, "_current_source", lambda: {"git_commit": "c" * 40})
+    monkeypatch.setattr(lane, "_current_runtime", lambda: {"backend": "cpu"})
+    report = lane.build_report(
+        *complete_records,
+        dataset_provenance=lane.frozen_plan()["dataset"],
+        execution_source_commit="c" * 40,
+    )
+    destination = tmp_path / "links" / "report.json"
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    reservation = lane._reserve(destination)
+    original_unlink = lane.os.unlink
+    skipped = False
+
+    def leave_first_temporary_link(
+        path: str, *, dir_fd: int | None = None
+    ) -> None:
+        nonlocal skipped
+        if not skipped and path.startswith(".report.json.") and path.endswith(".tmp"):
+            skipped = True
+            return
+        original_unlink(path, dir_fd=dir_fd)
+
+    monkeypatch.setattr(lane.os, "unlink", leave_first_temporary_link)
+    try:
+        with pytest.raises(ValueError, match="unique regular-file link"):
+            lane._publish_reserved(reservation, report)
+    finally:
+        lane._release(reservation)
+    assert not destination.exists()
+    assert not list(destination.parent.glob("*.tmp"))
+
+
+def test_strict_reread_converts_deep_json_recursion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "deep" / "report.json"
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    reservation = lane._reserve(destination)
+    raw = ("[" * 10_000 + "0" + "]" * 10_000).encode("ascii")
+    destination.write_bytes(raw)
+    metadata = destination.stat()
+    try:
+        with pytest.raises(ValueError, match="not strict JSON"):
+            lane._strict_reread(
+                reservation,
+                raw,
+                expected_identity=(metadata.st_dev, metadata.st_ino),
+            )
+    finally:
+        destination.unlink()
+        lane._release(reservation)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Never
 
+import jax
 import numpy as np
 import pytest
 
@@ -138,6 +139,7 @@ def test_prediction_and_control_information_and_rng_are_explicit() -> None:
     )
     assert prediction["resources"]["action_queries"] == 0
     assert prediction["resources"]["rng_fold_ins"] == 17
+    assert prediction["resources"]["rng_integer_draws"] == 17
     assert control["resources"]["action_queries"] == 0
     assert control["resources"]["rng_fold_ins"] == 17
     assert control["resources"]["rng_splits"] == 0
@@ -166,12 +168,19 @@ def test_pairs_share_one_exogenous_behavior_trajectory(
         assert control["trajectory"][field] == intentional["trajectory"][field]
 
 
-def test_seed_roster_produces_independent_behavior_schedules() -> None:
+def test_test_seed_roster_produces_distinct_behavior_schedules() -> None:
     schedules = {
         tuple(_control("fixed_td0", seed=seed, horizon=64)["trajectory"]["actions"])
         for seed in lane.SEEDS
     }
     assert len(schedules) == len(lane.SEEDS)
+
+
+def test_behavior_trajectory_is_invariant_to_jax_x64_mode() -> None:
+    expected = _control("fixed_td0", seed=lane.SEEDS[0], horizon=64, phase_length=8)
+    with jax.enable_x64():
+        actual = _control("fixed_td0", seed=lane.SEEDS[0], horizon=64, phase_length=8)
+    assert actual["trajectory"] == expected["trajectory"]
 
 
 def test_validator_rejects_nested_subclasses_without_hooks() -> None:
@@ -324,6 +333,16 @@ def test_report_recomputes_all_four_bonferroni_paired_questions(
         item["outcome"] in {"supported", "rejected", "inconclusive"}
         for item in report["paired_comparisons"].values()
     )
+    expected_q_deltas = []
+    for run in report["runs"]:
+        controls = {record["arm"]: record for record in run["control"]}
+        fixed = controls["fixed_q_lambda"]["metrics"]
+        intentional = controls["intentional_q_lambda"]["metrics"]
+        assert fixed["mean_reward"] == intentional["mean_reward"]
+        expected_q_deltas.append(
+            fixed["mean_squared_td_error"] - intentional["mean_squared_td_error"]
+        )
+    assert report["paired_comparisons"]["q_lambda"]["deltas"] == expected_q_deltas
     assert lane.validate_report(report, require_current_source=True) == report
 
 

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -1,0 +1,126 @@
+"""Prospective end-to-end Intentional Updates TD/control contract."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Never
+
+import pytest
+
+from alberta_framework.benchmarks import intentional_updates_control as lane
+
+pytestmark = pytest.mark.integration
+
+
+def test_plan_is_fresh_prospective_and_permanently_nonpromoting() -> None:
+    plan = lane.frozen_plan()
+    assert plan["seeds"] == [25610, 25611, 25612, 25613]
+    assert plan["execution_authorized"] is False
+    assert plan["scientific_promotion_allowed"] is False
+    assert plan["negative_outcomes_retained"] is True
+    assert plan["confidence_critical"] == 5.391949071934058
+    assert plan["confidence_critical"].hex() == "0x1.5915b18f69e09p+2"
+    assert plan["protocol_families"] == ["supervised_ipmnist", "td_control"]
+
+
+@pytest.mark.parametrize(
+    ("fixed", "off"),
+    [
+        ("fixed_td0", "intentional_td0_off"),
+        ("fixed_trace", "intentional_trace_off"),
+        ("fixed_q_lambda", "intentional_q_lambda_off"),
+    ],
+)
+def test_mechanism_off_reduces_bit_exactly_to_fixed_consumer(
+    fixed: str, off: str,
+) -> None:
+    expected = lane.run_control_shard(fixed, seed=25610, horizon=48, phase_length=12)
+    actual = lane.run_control_shard(off, seed=25610, horizon=48, phase_length=12)
+    assert actual["arm"] == off
+    assert actual["execution_arm"] == fixed
+    for key in ("trajectory", "final_state", "metrics", "resources"):
+        assert actual[key] == expected[key]
+
+
+@pytest.mark.parametrize("arm", lane.CONTROL_ARMS)
+def test_each_control_arm_runs_end_to_end_with_exact_resources(arm: str) -> None:
+    record = lane.run_control_shard(arm, seed=25611, horizon=48, phase_length=12)
+    assert lane.validate_control_shard(record) == record
+    assert len(record["trajectory"]["rewards"]) == 48
+    assert record["resources"]["environment_steps"] == 48
+    assert record["resources"]["observations"] == 48
+    assert record["resources"]["updates"] == 48
+    assert record["resources"]["model_queries"] == 96
+    assert record["resources"]["timing_is_selection_metric"] is False
+    assert type(record["resources"]["timing_telemetry_ns"]) is int
+    assert record["policy"]["scientific_promotion_allowed"] is False
+
+
+def test_prediction_and_control_information_and_rng_are_explicit() -> None:
+    prediction = lane.run_control_shard(
+        "intentional_trace", seed=25612, horizon=16, phase_length=4
+    )
+    control = lane.run_control_shard(
+        "intentional_q_lambda", seed=25612, horizon=16, phase_length=4
+    )
+    assert prediction["resources"]["action_queries"] == 0
+    assert prediction["resources"]["rng_fold_ins"] == 0
+    assert control["resources"]["action_queries"] == 16
+    assert control["resources"]["rng_fold_ins"] == 16
+    assert control["identity"]["agent_rng_impl"] == "threefry2x32"
+    assert prediction["information"]["boundary_information"] == []
+    assert prediction["information"]["task_information"] == []
+
+
+def test_validator_rejects_nested_subclasses_without_hooks() -> None:
+    record = lane.run_control_shard(
+        "intentional_trace", seed=25613, horizon=16, phase_length=4
+    )
+
+    class HostileDict(dict[object, object]):
+        calls = 0
+
+        def __iter__(self) -> Never:
+            type(self).calls += 1
+            raise AssertionError("must not iterate")
+
+        def __eq__(self, other: object) -> Never:
+            type(self).calls += 1
+            raise AssertionError("must not compare")
+
+    hostile = copy.deepcopy(record)
+    hostile["trajectory"] = HostileDict(hostile["trajectory"])
+    with pytest.raises(ValueError, match="exact JSON"):
+        lane.validate_control_shard(hostile)
+    assert HostileDict.calls == 0
+
+
+def test_validator_rejects_resource_result_identity_and_policy_forgery() -> None:
+    record = lane.run_control_shard("intentional_td0", seed=25610, horizon=16, phase_length=4)
+    for path, replacement in (
+        (("resources", "updates"), 15),
+        (("trajectory", "rewards"), [99.0] * 16),
+        (("identity", "source_sha256"), {"forged": "0" * 64}),
+        (("policy", "scientific_promotion_allowed"), True),
+    ):
+        hostile = copy.deepcopy(record)
+        hostile[path[0]][path[1]] = replacement
+        with pytest.raises(ValueError):
+            lane.validate_control_shard(hostile)
+
+
+def test_campaign_execution_is_closed_before_independent_review() -> None:
+    with pytest.raises(RuntimeError, match="not authorized"):
+        lane.run_campaign(Path("unused.npz"), Path("unused.json"))
+
+
+@pytest.mark.parametrize(
+    ("horizon", "phase_length"),
+    [(0, 1), (10_001, 1), (8, 0), (8, 9), (True, 1)],
+)
+def test_control_bounds_fail_before_execution(horizon: int, phase_length: int) -> None:
+    with pytest.raises(ValueError):
+        lane.run_control_shard(
+            "fixed_td0", seed=25610, horizon=horizon, phase_length=phase_length
+        )

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from pathlib import Path
 from typing import Never
 
@@ -28,6 +29,13 @@ def test_plan_is_fresh_prospective_and_permanently_nonpromoting() -> None:
     assert plan["confidence_critical"] == 5.391949071934058
     assert plan["confidence_critical"].hex() == "0x1.5915b18f69e09p+2"
     assert plan["protocol_families"] == ["supervised_ipmnist", "td_control"]
+
+
+def test_catalog_cli_is_read_only_and_execution_stays_closed(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert lane.main(["--catalog"]) == 0
+    assert json.loads(capsys.readouterr().out) == lane.frozen_plan()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_intentional_updates_control.py
+++ b/tests/test_intentional_updates_control.py
@@ -74,6 +74,44 @@ def test_catalog_cli_is_read_only_and_execution_stays_closed(
     assert json.loads(capsys.readouterr().out) == lane.frozen_plan()
 
 
+@pytest.mark.parametrize("dependency_input", ["pyproject.toml", "uv.lock"])
+def test_source_identity_binds_exact_dependency_inputs(
+    monkeypatch: pytest.MonkeyPatch, dependency_input: str,
+) -> None:
+    plan_files = lane.frozen_plan()["source_identity_policy"]["hashed_files"]
+    assert "pyproject.toml" in plan_files
+    assert "uv.lock" in plan_files
+    original = lane._source_identity()
+    read_bytes = Path.read_bytes
+
+    def mutated(path: Path) -> bytes:
+        payload = read_bytes(path)
+        return payload + b"\nmutation" if path.name == dependency_input else payload
+
+    monkeypatch.setattr(Path, "read_bytes", mutated)
+    changed = lane._source_identity()
+    assert changed[dependency_input] != original[dependency_input]
+
+
+def test_runtime_identity_binds_dependencies_jax_devices_config_and_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = lane._runtime_identity()
+    assert set(original["packages"]) == {
+        "chex", "jax", "jaxlib", "jaxtyping", "numpy", "orbax-checkpoint",
+        "scikit-learn", "scipy",
+    }
+    assert original["jax"]["devices"]
+    assert "jax_default_prng_impl" in original["jax"]["config"]
+    assert "XLA_FLAGS" in original["process_environment"]
+    monkeypatch.setenv("JAX_RANDOM_SEED_OFFSET", "provenance-mutation")
+    changed = lane._runtime_identity()
+    assert changed != original
+    assert changed["process_environment"]["JAX_RANDOM_SEED_OFFSET"] == (
+        "provenance-mutation"
+    )
+
+
 @pytest.mark.parametrize(
     ("fixed", "off"),
     [
@@ -344,6 +382,27 @@ def test_report_recomputes_all_four_bonferroni_paired_questions(
         )
     assert report["paired_comparisons"]["q_lambda"]["deltas"] == expected_q_deltas
     assert lane.validate_report(report, require_current_source=True) == report
+
+
+def test_report_rejects_runtime_identity_drift(
+    complete_records: tuple[list[dict[str, object]], list[dict[str, object]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(lane, "_current_source", lambda: {"git_commit": "c" * 40})
+    runtime = {"backend": "cpu", "dependency_lock": "a" * 64}
+    monkeypatch.setattr(lane, "_current_runtime", lambda: runtime)
+    report = lane.build_report(
+        *complete_records,
+        dataset_provenance=lane.frozen_plan()["dataset"],
+        execution_source_commit="c" * 40,
+    )
+    monkeypatch.setattr(
+        lane,
+        "_current_runtime",
+        lambda: {"backend": "cpu", "dependency_lock": "b" * 64},
+    )
+    with pytest.raises(ValueError, match="runtime environment"):
+        lane.validate_report(report, require_current_source=True)
 
 
 def test_report_rejects_missing_shard_arithmetic_and_promotion(


### PR DESCRIPTION
## Summary

Prospective, permanently nonpromoting #1561 infrastructure only. This PR does not execute a campaign, create an output, or close the issue.

- retains the existing batch-size-one supervised adapter and adds end-to-end linear TD(0), TD(lambda), and Q(lambda) consumers using the pinned author equations
- pins `arXiv:2604.19033v1` and official code commit `e86e26fd8613ac212e9a52c3fed8a01d0a31f685`, while recording all supervised and linear-control protocol differences
- provides exact mechanism-off reductions to fixed-step TD/control consumers
- freezes separate within-family matched schedules and paired Bonferroni questions with explicit persistent-byte, environment/data, model/action, RNG, solve, and telemetry accounting
- binds current source/runtime identities and ASI's retained canonical OpenML materialization digests
- explicitly quarantines draft seeds `31561001..31561004`, which contract tests consumed; replacement campaign seeds `41562001..41562004` had no fetched-history or local-worktree occurrence before freeze and tests never execute them
- gives tests a distinct test-only roster and identity-checked private capability
- requires both an exact literal reviewed-transition flag and a separate runtime authorization flag before reservation, dataset loading, consumer dispatch, or public publication; changing only the runtime flag remains fail-closed
- bounds validator-controlled reexecution before loops and recomputes all child identities and paired arithmetic
- reserves the exact NEW output through per-segment pinned no-follow dirfds, uses deterministic `O_EXCL` reservation, inode-safe cleanup, no-replace unique-link publication, fsync, stable bounded reread, duplicate-key rejection, `RecursionError` translation, and strict report revalidation

The issue remains open because no retained matched campaign has run.

## Verification

- failing-test-first commits precede both implementation and audit corrections
- final focused campaign suite: 28 passed
- related campaign/supervised/comparator/entrypoint/package suite before correction: 67 passed; correction only further closes public execution/publication and separates test seeds
- Ruff clean for the campaign and dedicated tests
- strict mypy clean for the campaign
- `git diff --check` clean

## Overlap audit

No open PR modifies the new campaign module, dedicated test, or research note. Shared entrypoint inventory and project metadata receive additive registrations only.
