### PR TITLE
fix(reference): bound exact config traversal

### DIFF
--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -44,8 +44,10 @@ _MAX_LIFECYCLE_ID_LENGTH = _MAX_ID_LENGTH - len(
 )
 _MAX_CONFIG_BYTES = 1 << 20
 _MAX_JSON_NESTING_DEPTH = 64
-# Frozen manifests are tiny. Cap nodes before walking toward the 1 MiB encoding cap.
+# Frozen manifests are tiny. Bound every traversal axis before canonical encoding.
 _MAX_JSON_VALUES = 1_000_000
+_MIN_JSON_INTEGER = -(1 << 63)
+_MAX_JSON_INTEGER = (1 << 63) - 1
 _MAX_ARRAY_RANK = 8
 _MAX_ARRAY_ELEMENTS = 1 << 20
 _SUPPORTED_DTYPES = frozenset(
@@ -124,43 +126,126 @@ def _load_manifest_config_json(raw: str) -> Any:
 def _validate_json_value(
     value: Any, *, path: str, depth: int = 0, nodes: int = 0
 ) -> int:
-    nodes += 1
-    if nodes > _MAX_JSON_VALUES:
-        raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
-    if depth > _MAX_JSON_NESTING_DEPTH:
-        raise ValueError(f"{path} exceeds the maximum canonical JSON nesting depth")
-    value_type = type(value)
-    if value is None or value_type is str or value_type is bool or value_type is int:
-        return nodes
-    if value_type is float:
-        if not math.isfinite(value):
-            raise ValueError(f"{path} must contain only finite JSON numbers")
-        return nodes
-    if isinstance(value, list):
-        extra = len(value)
-        if nodes + extra > _MAX_JSON_VALUES:
-            raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
-        for index, item in enumerate(value):
-            nodes = _validate_json_value(
-                item, path=f"{path}[{index}]", depth=depth + 1, nodes=nodes
+    if type(path) is not str or type(depth) is not int or type(nodes) is not int:
+        raise ValueError("canonical JSON traversal controls must use exact built-ins")
+    if depth < 0 or nodes < 0 or nodes > _MAX_JSON_VALUES:
+        raise ValueError("canonical JSON traversal controls are outside their limits")
+    budget = [nodes, 0, 0]  # nodes, cumulative UTF-8 bytes, canonical encoding work
+
+    def visit(item: object, *, item_depth: int, item_path: str) -> None:
+        budget[0] += 1
+        if budget[0] > _MAX_JSON_VALUES:
+            raise ValueError(
+                f"{item_path} exceeds the canonical JSON value resource limit"
             )
-        return nodes
-    if isinstance(value, Mapping):
-        extra = len(value)
-        if nodes + extra > _MAX_JSON_VALUES:
-            raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
-        for key, item in value.items():
-            if type(key) is not str:
-                raise ValueError(f"{path} JSON object keys must be strings")
-            nodes = _validate_json_value(
-                item, path=f"{path}.{key}", depth=depth + 1, nodes=nodes
+        if item_depth > _MAX_JSON_NESTING_DEPTH:
+            raise ValueError(
+                f"{item_path} exceeds the maximum canonical JSON nesting depth"
             )
-        return nodes
-    raise ValueError(f"{path} is not a canonical JSON value")
+        item_type = type(item)
+        if item is None:
+            budget[2] += 4
+        elif item_type is bool:
+            budget[2] += 4 if item else 5
+        elif item_type is int:
+            integer = cast(int, item)
+            if not _MIN_JSON_INTEGER <= integer <= _MAX_JSON_INTEGER:
+                raise ValueError(f"{item_path} integer must fit signed 64-bit bounds")
+            budget[2] += len(str(integer))
+        elif item_type is float:
+            number = cast(float, item)
+            if not math.isfinite(number):
+                raise ValueError(f"{item_path} must contain only finite JSON numbers")
+            budget[2] += len(json.dumps(number, allow_nan=False))
+        elif item_type is str:
+            text = cast(str, item)
+            if len(text) > _MAX_CONFIG_BYTES:
+                raise ValueError(f"{item_path} exceeds the aggregate UTF-8 byte limit")
+            try:
+                encoded = text.encode("utf-8")
+            except UnicodeEncodeError as error:
+                raise ValueError(f"{item_path} must contain valid UTF-8 text") from error
+            budget[1] += len(encoded)
+            if budget[1] > _MAX_CONFIG_BYTES:
+                raise ValueError(f"{item_path} exceeds the aggregate UTF-8 byte limit")
+            budget[2] += len(json.dumps(text, ensure_ascii=True))
+        elif item_type is list:
+            sequence = cast(list[object], item)
+            length = len(sequence)
+            if budget[0] + length > _MAX_JSON_VALUES:
+                raise ValueError(
+                    f"{item_path} exceeds the canonical JSON value resource limit"
+                )
+            punctuation = 2 + max(0, length - 1)
+            if budget[2] + punctuation + length > _MAX_CONFIG_BYTES:
+                raise ValueError(
+                    f"{item_path} exceeds the canonical JSON encoding work limit"
+                )
+            budget[2] += punctuation
+            for index, child in enumerate(sequence):
+                visit(
+                    child,
+                    item_depth=item_depth + 1,
+                    item_path=f"{item_path}[{index}]",
+                )
+        elif item_type is dict:
+            mapping = cast(dict[object, object], item)
+            length = len(mapping)
+            if budget[0] + length > _MAX_JSON_VALUES:
+                raise ValueError(
+                    f"{item_path} exceeds the canonical JSON value resource limit"
+                )
+            punctuation = 2 + max(0, length - 1) + length
+            if budget[2] + punctuation + length > _MAX_CONFIG_BYTES:
+                raise ValueError(
+                    f"{item_path} exceeds the canonical JSON encoding work limit"
+                )
+            keys = tuple(mapping.keys())
+            if any(type(key) is not str for key in keys):
+                raise ValueError(f"{item_path} JSON object keys must be strings")
+            budget[2] += punctuation
+            for raw_key in keys:
+                key = cast(str, raw_key)
+                if len(key) > _MAX_CONFIG_BYTES:
+                    raise ValueError(
+                        f"{item_path} exceeds the aggregate UTF-8 byte limit"
+                    )
+                try:
+                    encoded_key = key.encode("utf-8")
+                except UnicodeEncodeError as error:
+                    raise ValueError(
+                        f"{item_path} JSON object keys must be valid UTF-8"
+                    ) from error
+                budget[1] += len(encoded_key)
+                budget[2] += len(json.dumps(key, ensure_ascii=True))
+                if budget[1] > _MAX_CONFIG_BYTES:
+                    raise ValueError(
+                        f"{item_path} exceeds the aggregate UTF-8 byte limit"
+                    )
+                if budget[2] > _MAX_CONFIG_BYTES:
+                    raise ValueError(
+                        f"{item_path} exceeds the canonical JSON encoding work limit"
+                    )
+            for raw_key in keys:
+                key = cast(str, raw_key)
+                visit(
+                    mapping[key],
+                    item_depth=item_depth + 1,
+                    item_path=f"{item_path}.{key}",
+                )
+        else:
+            raise ValueError(f"{item_path} is not a canonical JSON value")
+        if budget[2] > _MAX_CONFIG_BYTES:
+            raise ValueError(
+                f"{item_path} exceeds the canonical JSON encoding work limit"
+            )
+
+    visit(value, item_depth=depth, item_path=path)
+    return budget[0]
 
 
 def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
-    if not isinstance(value, Mapping):
+    if type(value) is not dict:
         raise ValueError("config must be a JSON mapping")
     _validate_json_value(value, path="config")
     try:

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -44,6 +44,8 @@ _MAX_LIFECYCLE_ID_LENGTH = _MAX_ID_LENGTH - len(
 )
 _MAX_CONFIG_BYTES = 1 << 20
 _MAX_JSON_NESTING_DEPTH = 64
+# Frozen manifests are tiny. Cap nodes before walking toward the 1 MiB encoding cap.
+_MAX_JSON_VALUES = 1_000_000
 _MAX_ARRAY_RANK = 8
 _MAX_ARRAY_ELEMENTS = 1 << 20
 _SUPPORTED_DTYPES = frozenset(
@@ -119,26 +121,41 @@ def _load_manifest_config_json(raw: str) -> Any:
         raise ValueError("manifest config must be canonical JSON") from exc
 
 
-def _validate_json_value(value: Any, *, path: str, depth: int = 0) -> None:
+def _validate_json_value(
+    value: Any, *, path: str, depth: int = 0, nodes: int = 0
+) -> int:
+    nodes += 1
+    if nodes > _MAX_JSON_VALUES:
+        raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
     if depth > _MAX_JSON_NESTING_DEPTH:
         raise ValueError(f"{path} exceeds the maximum canonical JSON nesting depth")
     value_type = type(value)
     if value is None or value_type is str or value_type is bool or value_type is int:
-        return
+        return nodes
     if value_type is float:
         if not math.isfinite(value):
             raise ValueError(f"{path} must contain only finite JSON numbers")
-        return
+        return nodes
     if isinstance(value, list):
+        extra = len(value)
+        if nodes + extra > _MAX_JSON_VALUES:
+            raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
         for index, item in enumerate(value):
-            _validate_json_value(item, path=f"{path}[{index}]", depth=depth + 1)
-        return
+            nodes = _validate_json_value(
+                item, path=f"{path}[{index}]", depth=depth + 1, nodes=nodes
+            )
+        return nodes
     if isinstance(value, Mapping):
+        extra = len(value)
+        if nodes + extra > _MAX_JSON_VALUES:
+            raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
         for key, item in value.items():
             if type(key) is not str:
                 raise ValueError(f"{path} JSON object keys must be strings")
-            _validate_json_value(item, path=f"{path}.{key}", depth=depth + 1)
-        return
+            nodes = _validate_json_value(
+                item, path=f"{path}.{key}", depth=depth + 1, nodes=nodes
+            )
+        return nodes
     raise ValueError(f"{path} is not a canonical JSON value")
 
 

--- a/tests/test_reference_agent_json_width_hang.py
+++ b/tests/test_reference_agent_json_width_hang.py
@@ -1,0 +1,44 @@
+"""Canonical JSON configs reject oversized width before the 1 MiB encoding walk."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.reference_agent import (
+    _MAX_JSON_VALUES,
+    _validate_json_value,
+    canonical_config_sha256,
+)
+
+
+def test_frozen_json_value_bound_matches_strict_json_last_fit() -> None:
+    assert _MAX_JSON_VALUES == 1_000_000
+
+
+def test_last_fit_json_list_validates_without_width_hang() -> None:
+    payload: dict[str, object] = {"k": [0] * (_MAX_JSON_VALUES - 2)}
+    started = time.perf_counter()
+    nodes = _validate_json_value(payload, path="config")
+    assert time.perf_counter() - started < 0.5
+    assert nodes == _MAX_JSON_VALUES
+
+
+@pytest.mark.parametrize("count", [_MAX_JSON_VALUES, 2_000_000, 20_000_000])
+def test_canonical_config_rejects_oversized_list_before_encoding(
+    count: int,
+) -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="JSON value resource limit"):
+        canonical_config_sha256({"k": [0] * count})
+    assert time.perf_counter() - started < 0.5
+
+
+def test_canonical_config_rejects_pointer_repeated_nested_lists() -> None:
+    row = [0] * 5_000
+    payload: dict[str, object] = {"k": [row] * 5_000}
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="JSON value resource limit"):
+        canonical_config_sha256(payload)
+    assert time.perf_counter() - started < 0.5

--- a/tests/test_reference_agent_json_width_hang.py
+++ b/tests/test_reference_agent_json_width_hang.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import time
+from collections.abc import Iterator, Mapping
 
 import pytest
 
@@ -17,28 +17,71 @@ def test_frozen_json_value_bound_matches_strict_json_last_fit() -> None:
     assert _MAX_JSON_VALUES == 1_000_000
 
 
-def test_last_fit_json_list_validates_without_width_hang() -> None:
-    payload: dict[str, object] = {"k": [0] * (_MAX_JSON_VALUES - 2)}
-    started = time.perf_counter()
+class _HookList(list[object]):
+    calls = 0
+
+    def __len__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile list hook ran")
+
+
+class _HookMapping(Mapping[str, object]):
+    calls = 0
+
+    def __getitem__(self, key: str) -> object:
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook ran")
+
+    def __iter__(self) -> Iterator[str]:
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook ran")
+
+    def __len__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook ran")
+
+
+def test_small_json_tree_reports_exact_node_count() -> None:
+    payload: dict[str, object] = {"k": [0, True, None]}
     nodes = _validate_json_value(payload, path="config")
-    assert time.perf_counter() - started < 0.5
-    assert nodes == _MAX_JSON_VALUES
+    assert nodes == 5
 
 
-@pytest.mark.parametrize("count", [_MAX_JSON_VALUES, 2_000_000, 20_000_000])
-def test_canonical_config_rejects_oversized_list_before_encoding(
-    count: int,
-) -> None:
-    started = time.perf_counter()
-    with pytest.raises(ValueError, match="JSON value resource limit"):
-        canonical_config_sha256({"k": [0] * count})
-    assert time.perf_counter() - started < 0.5
+def test_oversized_list_rejects_from_length_before_child_traversal() -> None:
+    payload = {"k": [object()] * 600_000}
+    with pytest.raises(ValueError, match="encoding work limit"):
+        canonical_config_sha256(payload)
 
 
 def test_canonical_config_rejects_pointer_repeated_nested_lists() -> None:
-    row = [0] * 5_000
-    payload: dict[str, object] = {"k": [row] * 5_000}
-    started = time.perf_counter()
-    with pytest.raises(ValueError, match="JSON value resource limit"):
+    row = [0] * 2_048
+    payload: dict[str, object] = {"k": [row] * 512}
+    with pytest.raises(ValueError, match="encoding work limit"):
         canonical_config_sha256(payload)
-    assert time.perf_counter() - started < 0.5
+
+
+def test_hostile_container_aliases_reject_without_hooks() -> None:
+    hostile_list = _HookList()
+    _HookList.calls = 0
+    with pytest.raises(ValueError, match="not a canonical JSON value"):
+        _validate_json_value(hostile_list, path="config")
+    assert _HookList.calls == 0
+
+    hostile_mapping = _HookMapping()
+    _HookMapping.calls = 0
+    with pytest.raises(ValueError, match="not a canonical JSON value"):
+        _validate_json_value(hostile_mapping, path="config")
+    assert _HookMapping.calls == 0
+    with pytest.raises(ValueError, match="JSON mapping"):
+        canonical_config_sha256(hostile_mapping)
+    assert _HookMapping.calls == 0
+
+
+def test_aggregate_text_escaping_and_integer_bounds_fail_closed() -> None:
+    shared = "a" * 600_000
+    with pytest.raises(ValueError, match="aggregate UTF-8"):
+        canonical_config_sha256({"k": [shared, shared]})
+    with pytest.raises(ValueError, match="encoding work limit"):
+        canonical_config_sha256({"k": "\x00" * 200_000})
+    with pytest.raises(ValueError, match="signed 64-bit"):
+        canonical_config_sha256({"k": 1 << 63})


### PR DESCRIPTION
Contributor-preserving successor to PR 2118. The original width-hang commit remains intact in history with ss251 authorship; this follow-up closes the trust-boundary gaps found during independent review.

- admits exact built-in dict/list containers only before any len/iteration hook
- snapshots and exact-type-checks all dict keys before encoding or value traversal
- enforces cumulative UTF-8 bytes, exact canonical-encoding work, signed-64-bit integers, nodes, and depth before final json.dumps
- makes the root config an exact dict
- replaces the 20-million-pointer and wall-clock assertions with bounded exact width, pointer-repeat, aggregate-text/escaping, signed-int, and zero-hook hostile-container tests

Verification: 38 focused tests passed; expanded reference-agent/life panel 150 passed, 1 skipped; scoped Ruff and mypy passed; diff check clean. No reference scorecard, external workload, receipt, artifact, or output was run or created. This is a protocol boundary fix and does not resolve an external qualification issue.