### PR TITLE
fix(evaluation): harden bounded-elastic campaign transaction

### DIFF
--- a/alberta_framework/evaluation/bounded_elastic_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/bounded_elastic_ipmnist_nonpromoting.py
@@ -28,6 +28,8 @@ BOUNDED_ELASTIC_PROTOCOL = MappingProxyType(
             "ASI begins with half of hidden layer 1 active and caps growth at its configured width",
             "growth and pruning occur at each known 5,000-example boundary",
             "elastic pruning uses the prior task's online activation sums, not a future 5% sample",
+            "ASI elastic events prune exactly one least-active unit and grow exactly one unit; "
+            "the paper removes zero or more units estimated dead at a boundary",
             "a pruned slot is freshly initialized before it is reactivated",
             "ASI uses 5,000 MNIST examples per task, not the paper's 10,000/40,000 lanes",
             "ASI inputs are [-1,1], while the paper uses [0,1] MNIST/FMNIST",

--- a/alberta_framework/evaluation/bounded_elastic_matched_runner.py
+++ b/alberta_framework/evaluation/bounded_elastic_matched_runner.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import argparse
+import ctypes
+import errno
 import hashlib
 import importlib.metadata
 import json
 import math
 import os
 import platform
-import secrets
 import stat
 import sys
 from pathlib import Path
@@ -101,6 +102,16 @@ def frozen_plan() -> dict[str, object]:
         ),
         "matched_axes": ["seed", "observations", "updates", "example_schedule",
                          "allowed_boundary_information", "allowed_task_information"],
+        "decision_rule": {
+            "metric": "mean_online_accuracy",
+            "baseline": "bounded_fixed_cbp",
+            "candidates": ["bounded_growth", "bounded_elastic"],
+            "candidate_supported": "all five paired deltas are strictly positive",
+            "candidate_rejected": "all five paired deltas are nonpositive",
+            "campaign_supported": "at least one candidate is supported",
+            "campaign_rejected": "both candidates are rejected",
+            "otherwise": "inconclusive",
+        },
         "reviewed_execution_transition": _REVIEWED_EXECUTION_TRANSITION,
         "execution_authorized": _EXECUTION_AUTHORIZED,
         "development_only": True,
@@ -385,7 +396,51 @@ def _aggregate(rows: list[dict[str, object]]) -> dict[str, object]:
             "mean_plasticity": math.fsum(item["mean_plasticity"] for item in metrics)
             / len(metrics),
         }
-    return {"arms": arms, "row_count": len(rows)}
+    comparisons: list[dict[str, object]] = []
+    for candidate in ("bounded_growth", "bounded_elastic"):
+        deltas: list[float] = []
+        for seed in sorted({cast(int, row["seed"]) for row in rows}):
+            by_arm = {
+                cast(str, row["arm"]): cast(
+                    dict[str, float], cast(dict[str, object], row["result"])["metrics"]
+                )
+                for row in rows
+                if row["seed"] == seed
+            }
+            deltas.append(
+                by_arm[candidate]["mean_online_accuracy"]
+                - by_arm["bounded_fixed_cbp"]["mean_online_accuracy"]
+            )
+        outcome = (
+            "supported"
+            if all(delta > 0.0 for delta in deltas)
+            else "rejected"
+            if all(delta <= 0.0 for delta in deltas)
+            else "inconclusive"
+        )
+        comparisons.append(
+            {
+                "candidate": candidate,
+                "baseline": "bounded_fixed_cbp",
+                "paired_accuracy_deltas": deltas,
+                "mean_accuracy_delta": math.fsum(deltas) / len(deltas),
+                "outcome": outcome,
+            }
+        )
+    outcomes = [cast(str, comparison["outcome"]) for comparison in comparisons]
+    campaign_outcome = (
+        "supported"
+        if "supported" in outcomes
+        else "rejected"
+        if all(outcome == "rejected" for outcome in outcomes)
+        else "inconclusive"
+    )
+    return {
+        "arms": arms,
+        "primary_comparisons": comparisons,
+        "outcome": campaign_outcome,
+        "row_count": len(rows),
+    }
 
 
 def run_bounded_elastic_matched(
@@ -412,8 +467,14 @@ def _run_bounded_elastic_matched_authorized(
     )
     if expected_seeds is None or type(seeds) is not tuple or seeds != expected_seeds:
         raise RuntimeError("private bounded-elastic execution capability or seeds are invalid")
+    if _capability is _EXECUTION_CAPABILITY and (
+        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
+    ):
+        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
     checked_config = _checked_config(config)
     x, y = _validated_arrays(data_x, data_y, checked_config)
+    execution_source = _source_identity()
+    execution_runtime = _runtime_identity()
     if _capability is _EXECUTION_CAPABILITY:
         if checked_config != CAMPAIGN_CONFIG:
             raise ValueError("campaign config differs from the frozen reviewed plan")
@@ -425,6 +486,8 @@ def _run_bounded_elastic_matched_authorized(
         for arm in ARMS:
             spec = screening_spec(arm)
             arm_result = run_screening_config(x, y, spec, seed, checked_config)
+            if _source_identity() != execution_source or _runtime_identity() != execution_runtime:
+                raise RuntimeError("source or runtime changed during matched execution")
             rows.append(
                 {
                     "seed": seed,
@@ -443,8 +506,8 @@ def _run_bounded_elastic_matched_authorized(
         "arms": list(ARMS),
         "identity": {
             "dataset_sha256": _dataset_sha256(x, y),
-            "source_sha256": _source_identity(),
-            "runtime": _runtime_identity(),
+            "source_sha256": execution_source,
+            "runtime": execution_runtime,
             "consistency_not_attestation": True,
         },
         "policy": dict(_POLICY),
@@ -481,6 +544,10 @@ def _validate_bounded_elastic_matched_authorized(
     )
     if expected_seeds is None or type(seeds) is not tuple or seeds != expected_seeds:
         raise RuntimeError("private bounded-elastic validation capability or seeds are invalid")
+    if _capability is _EXECUTION_CAPABILITY and (
+        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
+    ):
+        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
     _validate_bounded_elastic_matched(
         value, data_x, data_y, config=config, seeds=seeds, reexecute=True
     )
@@ -574,6 +641,8 @@ def _validate_bounded_elastic_matched(
     if type(claimed) is not str or claimed != hashlib.sha256(_canonical(unsigned)).hexdigest():
         raise ValueError("matched result digest drifted")
     if reexecute:
+        replay_source = _source_identity()
+        replay_runtime = _runtime_identity()
         for row in rows:
             claimed_payload = cast(dict[str, object], row["result"])
             replay = run_screening_config(
@@ -583,6 +652,8 @@ def _validate_bounded_elastic_matched(
                 cast(int, row["seed"]),
                 checked_config,
             )
+            if _source_identity() != replay_source or _runtime_identity() != replay_runtime:
+                raise RuntimeError("source or runtime changed during strict reexecution")
             expected_payload = bounded_elastic_development_result_payload(
                 replay, outcome="inconclusive"
             )
@@ -635,9 +706,14 @@ def _open_output_parent(path: Path) -> int:
         raise
 
 
-def _reserve_output(path: Path) -> tuple[int, str, str, int, int]:
+OutputReservation = tuple[int, str, str, int, int, int]
+
+
+def _reserve_output(path: Path) -> OutputReservation:
     if type(path) is not type(Path()):
         raise TypeError("destination must be an exact Path")
+    if not all(hasattr(os, name) for name in ("O_DIRECTORY", "O_NOFOLLOW", "O_TMPFILE")):
+        raise OSError("immutable output publication requires Linux descriptor support")
     if path.absolute() != OUTPUT_PATH.absolute() or path.name in {"", ".", ".."}:
         raise ValueError(f"output must be the exact reserved NEW path {OUTPUT_PATH}")
     directory_fd = _open_output_parent(path)
@@ -669,10 +745,15 @@ def _reserve_output(path: Path) -> tuple[int, str, str, int, int]:
         os.fsync(marker_fd)
         metadata = os.fstat(marker_fd)
         marker_identity = (metadata.st_dev, metadata.st_ino)
-        os.close(marker_fd)
-        marker_fd = -1
         os.fsync(directory_fd)
-        return directory_fd, path.name, reservation_name, metadata.st_dev, metadata.st_ino
+        return (
+            directory_fd,
+            path.name,
+            reservation_name,
+            marker_fd,
+            metadata.st_dev,
+            metadata.st_ino,
+        )
     except BaseException:
         if marker_fd >= 0:
             os.close(marker_fd)
@@ -690,8 +771,21 @@ def _reserve_output(path: Path) -> tuple[int, str, str, int, int]:
         raise
 
 
-def _release_output(reservation: tuple[int, str, str, int, int]) -> None:
-    directory_fd, _name, marker_name, device, inode = reservation
+def _require_owned_reservation(reservation: OutputReservation) -> None:
+    directory_fd, _name, marker_name, marker_fd, device, inode = reservation
+    held = os.fstat(marker_fd)
+    visible = os.stat(marker_name, dir_fd=directory_fd, follow_symlinks=False)
+    if (
+        not stat.S_ISREG(held.st_mode)
+        or held.st_nlink != 1
+        or (held.st_dev, held.st_ino) != (device, inode)
+        or (visible.st_dev, visible.st_ino) != (device, inode)
+    ):
+        raise ValueError("output reservation is not the owned visible regular marker")
+
+
+def _release_output(reservation: OutputReservation) -> None:
+    directory_fd, _name, marker_name, marker_fd, device, inode = reservation
     try:
         metadata = os.stat(marker_name, dir_fd=directory_fd, follow_symlinks=False)
         if (metadata.st_dev, metadata.st_ino) == (device, inode):
@@ -700,7 +794,19 @@ def _release_output(reservation: tuple[int, str, str, int, int]) -> None:
     except FileNotFoundError:
         pass
     finally:
+        os.close(marker_fd)
         os.close(directory_fd)
+
+
+def _link_unnamed_file(file_fd: int, directory_fd: int, name: str) -> None:
+    linkat = ctypes.CDLL(None, use_errno=True).linkat
+    linkat.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_int]
+    linkat.restype = ctypes.c_int
+    if linkat(file_fd, b"", directory_fd, os.fsencode(name), 0x1000) != 0:
+        error_number = ctypes.get_errno()
+        if error_number == errno.EEXIST:
+            raise FileExistsError(error_number, os.strerror(error_number), name)
+        raise OSError(error_number, os.strerror(error_number), name)
 
 
 def _write_bounded_elastic_matched_authorized(
@@ -714,19 +820,24 @@ def _write_bounded_elastic_matched_authorized(
     )
     if expected_seeds is None or seeds != expected_seeds:
         raise RuntimeError("private bounded-elastic publication capability is invalid")
+    if _capability is _EXECUTION_CAPABILITY and (
+        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
+    ):
+        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
     reservation = _reserve_output(destination)
-    directory_fd, destination_name, _marker, _device, _inode = reservation
-    temporary_name = f".{destination_name}.{secrets.token_hex(16)}.tmp"
+    directory_fd, destination_name, _marker, _marker_fd, _device, _inode = reservation
     descriptor = -1
     try:
+        _require_owned_reservation(reservation)
         _validate_bounded_elastic_matched(
             value, data_x, data_y, config=config, seeds=seeds, reexecute=True
         )
+        _require_owned_reservation(reservation)
         encoded = _canonical(value) + b"\n"
         descriptor = os.open(
-            temporary_name,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
-            0o400,
+            ".",
+            os.O_WRONLY | os.O_TMPFILE | os.O_CLOEXEC,
+            0o600,
             dir_fd=directory_fd,
         )
         view = memoryview(encoded)
@@ -736,11 +847,15 @@ def _write_bounded_elastic_matched_authorized(
                 raise OSError("immutable output write made no progress")
             view = view[written:]
         os.fsync(descriptor)
-        os.close(descriptor)
-        descriptor = -1
-        os.link(temporary_name, destination_name, src_dir_fd=directory_fd,
-                dst_dir_fd=directory_fd, follow_symlinks=False)
-        os.unlink(temporary_name, dir_fd=directory_fd)
+        os.fchmod(descriptor, 0o400)
+        os.fsync(descriptor)
+        _require_owned_reservation(reservation)
+        try:
+            _link_unnamed_file(descriptor, directory_fd, destination_name)
+        except FileExistsError as error:
+            raise FileExistsError(
+                "refusing to replace immutable bounded-elastic output"
+            ) from error
         os.fsync(directory_fd)
         read_fd = os.open(destination_name, os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
                           dir_fd=directory_fd)
@@ -776,10 +891,6 @@ def _write_bounded_elastic_matched_authorized(
     finally:
         if descriptor >= 0:
             os.close(descriptor)
-        try:
-            os.unlink(temporary_name, dir_fd=directory_fd)
-        except FileNotFoundError:
-            pass
         _release_output(reservation)
 
 

--- a/alberta_framework/evaluation/bounded_elastic_matched_runner.py
+++ b/alberta_framework/evaluation/bounded_elastic_matched_runner.py
@@ -54,8 +54,9 @@ _POLICY: Final = {
     "scientific_promotion_allowed": False,
     "sota_claim_allowed": False,
     "completed_outcomes_retained_in_result": True,
-    "atomic_execution_and_publication": True,
-    "execution_failure_receipts_retained": True,
+    "reservation_precedes_execution_and_publication": True,
+    "pre_dispatch_failure_receipts_retained": False,
+    "post_dispatch_failure_tombstone_retained": True,
     "post_start_retry_prevention": True,
 }
 _MAX_STEPS: Final = 2_000_000
@@ -124,8 +125,9 @@ def frozen_plan() -> dict[str, object]:
         "development_only": True,
         "scientific_promotion_allowed": False,
         "completed_outcomes_retained_in_result": True,
-        "atomic_execution_and_publication": True,
-        "execution_failure_receipts_retained": True,
+        "reservation_precedes_execution_and_publication": True,
+        "pre_dispatch_failure_receipts_retained": False,
+        "post_dispatch_failure_tombstone_retained": True,
         "post_start_retry_prevention": True,
         "output_path": "outputs/bounded_elastic_matched_development/report.v1.json",
     }
@@ -727,12 +729,21 @@ def _require_live_output_parent(path: Path, directory_fd: int) -> None:
 OutputReservation = tuple[int, str, str, int, int, int]
 
 
-def _reserve_output(path: Path) -> OutputReservation:
+def _reserve_output(path: Path, *, _capability: object) -> OutputReservation:
+    if _capability is _EXECUTION_CAPABILITY:
+        if _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True:
+            raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
+    elif _capability is not _TEST_EXECUTION_CAPABILITY:
+        raise RuntimeError("private bounded-elastic reservation capability is invalid")
     if type(path) is not type(Path()):
         raise TypeError("destination must be an exact Path")
     if not all(hasattr(os, name) for name in ("O_DIRECTORY", "O_NOFOLLOW", "O_TMPFILE")):
         raise OSError("immutable output publication requires Linux descriptor support")
-    if path.absolute() != OUTPUT_PATH.absolute() or path.name in {"", ".", ".."}:
+    if (
+        path.name in {"", ".", ".."}
+        or (_capability is _EXECUTION_CAPABILITY and path.absolute() != OUTPUT_PATH.absolute())
+        or (_capability is _TEST_EXECUTION_CAPABILITY and path.absolute() == OUTPUT_PATH.absolute())
+    ):
         raise ValueError(f"output must be the exact reserved NEW path {OUTPUT_PATH}")
     directory_fd = _open_output_parent(path)
     reservation_name = f".{path.name}.reservation"
@@ -861,7 +872,7 @@ def _write_bounded_elastic_matched_authorized(
         )
     if type(seeds) is not tuple or seeds != TEST_ONLY_SEEDS:
         raise RuntimeError("private bounded-elastic publication capability is invalid")
-    reservation = _reserve_output(destination)
+    reservation = _reserve_output(destination, _capability=_capability)
     try:
         _publish_bounded_elastic_matched_reserved(
             reservation,
@@ -871,6 +882,7 @@ def _write_bounded_elastic_matched_authorized(
             data_y,
             config=config,
             seeds=seeds,
+            _capability=_capability,
         )
     finally:
         _release_output(reservation)
@@ -885,15 +897,19 @@ def _publish_bounded_elastic_matched_reserved(
     *,
     config: IPMNISTConfig,
     seeds: tuple[int, ...],
+    _capability: object,
 ) -> None:
-    if type(seeds) is not tuple:
+    if _capability is _EXECUTION_CAPABILITY:
+        if _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True:
+            raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
+    elif _capability is not _TEST_EXECUTION_CAPABILITY:
         raise RuntimeError("private bounded-elastic publication capability is invalid")
     expected_seeds = (
-        CAMPAIGN_SEEDS if seeds == CAMPAIGN_SEEDS
-        else TEST_ONLY_SEEDS if seeds == TEST_ONLY_SEEDS
+        CAMPAIGN_SEEDS if _capability is _EXECUTION_CAPABILITY
+        else TEST_ONLY_SEEDS if _capability is _TEST_EXECUTION_CAPABILITY
         else None
     )
-    if expected_seeds is None:
+    if expected_seeds is None or type(seeds) is not tuple or seeds != expected_seeds:
         raise RuntimeError("private bounded-elastic publication capability is invalid")
     directory_fd, destination_name, _marker, _marker_fd, _device, _inode = reservation
     descriptor = -1
@@ -1023,7 +1039,7 @@ def _run_and_publish_bounded_elastic_matched_authorized(
         _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
     ):
         raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
-    reservation = _reserve_output(destination)
+    reservation = _reserve_output(destination, _capability=_capability)
     consumer_started = False
     published = False
 
@@ -1052,6 +1068,7 @@ def _run_and_publish_bounded_elastic_matched_authorized(
             data_y,
             config=config,
             seeds=seeds,
+            _capability=_capability,
         )
         published = True
         return report

--- a/alberta_framework/evaluation/bounded_elastic_matched_runner.py
+++ b/alberta_framework/evaluation/bounded_elastic_matched_runner.py
@@ -13,6 +13,7 @@ import os
 import platform
 import stat
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Final, cast
 
@@ -31,6 +32,7 @@ from alberta_framework.benchmarks.upgd_ipmnist import (
     build_schedule,
     default_openml_data_home,
     init_mlp_params,
+    load_mnist_train,
 )
 from alberta_framework.evaluation.bounded_elastic_ipmnist_nonpromoting import (
     bounded_elastic_resource_expectations,
@@ -52,9 +54,9 @@ _POLICY: Final = {
     "scientific_promotion_allowed": False,
     "sota_claim_allowed": False,
     "completed_outcomes_retained_in_result": True,
-    "atomic_execution_and_publication": False,
-    "execution_failure_receipts_retained": False,
-    "post_start_retry_prevention": False,
+    "atomic_execution_and_publication": True,
+    "execution_failure_receipts_retained": True,
+    "post_start_retry_prevention": True,
 }
 _MAX_STEPS: Final = 2_000_000
 _MAX_PERSISTENT_BYTES: Final = 256 * 1024 * 1024
@@ -122,9 +124,9 @@ def frozen_plan() -> dict[str, object]:
         "development_only": True,
         "scientific_promotion_allowed": False,
         "completed_outcomes_retained_in_result": True,
-        "atomic_execution_and_publication": False,
-        "execution_failure_receipts_retained": False,
-        "post_start_retry_prevention": False,
+        "atomic_execution_and_publication": True,
+        "execution_failure_receipts_retained": True,
+        "post_start_retry_prevention": True,
         "output_path": "outputs/bounded_elastic_matched_development/report.v1.json",
     }
 
@@ -454,18 +456,17 @@ def _aggregate(rows: list[dict[str, object]]) -> dict[str, object]:
 def run_bounded_elastic_matched(
     data_x: object, data_y: object, *, config: IPMNISTConfig
 ) -> dict[str, object]:
-    """Fail closed pending a separately reviewed authorization transition."""
-    if (_REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True):
-        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
-    return _run_bounded_elastic_matched_authorized(
-        data_x, data_y, config=config, seeds=CAMPAIGN_SEEDS,
-        _capability=_EXECUTION_CAPABILITY,
+    """Permanently reject execution outside the reservation-first transaction."""
+    del data_x, data_y, config
+    raise RuntimeError(
+        "standalone bounded-elastic execution is disabled; use the reserved transaction"
     )
 
 
 def _run_bounded_elastic_matched_authorized(
     data_x: object, data_y: object, *, config: IPMNISTConfig,
     seeds: tuple[int, ...], _capability: object,
+    _on_first_dispatch: Callable[[], None] | None = None,
 ) -> dict[str, object]:
     """Capability-private full runner used by tests or an authorized campaign."""
     expected_seeds = (
@@ -493,6 +494,8 @@ def _run_bounded_elastic_matched_authorized(
         execution_identity = _execution_identity(seed, checked_config, x.shape[0])
         for arm in ARMS:
             spec = screening_spec(arm)
+            if not rows and _on_first_dispatch is not None:
+                _on_first_dispatch()
             arm_result = run_screening_config(x, y, spec, seed, checked_config)
             if _source_identity() != execution_source or _runtime_identity() != execution_runtime:
                 raise RuntimeError("source or runtime changed during matched execution")
@@ -532,12 +535,10 @@ def _run_bounded_elastic_matched_authorized(
 def validate_bounded_elastic_matched(
     value: object, data_x: object, data_y: object, *, config: IPMNISTConfig
 ) -> None:
-    """Fail closed because validation reexecutes the reserved campaign roster."""
-    if (_REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True):
-        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
-    _validate_bounded_elastic_matched_authorized(
-        value, data_x, data_y, config=config, seeds=CAMPAIGN_SEEDS,
-        _capability=_EXECUTION_CAPABILITY,
+    """Permanently reject reexecution outside the reservation-first transaction."""
+    del value, data_x, data_y, config
+    raise RuntimeError(
+        "standalone bounded-elastic reexecution is disabled; use the reserved transaction"
     )
 
 
@@ -680,12 +681,10 @@ def write_bounded_elastic_matched(
     *,
     config: IPMNISTConfig,
 ) -> None:
-    """Fail closed until a reviewed authorization enables publication."""
-    if (_REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True):
-        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
-    _write_bounded_elastic_matched_authorized(
-        destination, value, data_x, data_y, config=config, seeds=CAMPAIGN_SEEDS,
-        _capability=_EXECUTION_CAPABILITY,
+    """Permanently reject publication outside the reservation-first transaction."""
+    del destination, value, data_x, data_y, config
+    raise RuntimeError(
+        "standalone bounded-elastic publication is disabled; use the reserved transaction"
     )
 
 
@@ -818,6 +817,28 @@ def _release_output(reservation: OutputReservation) -> None:
         os.close(directory_fd)
 
 
+def _retain_consumed_output(reservation: OutputReservation) -> None:
+    """Retain the owned marker permanently after the first consumer dispatch."""
+    directory_fd, _name, _marker_name, marker_fd, _device, _inode = reservation
+    try:
+        _require_owned_reservation(reservation)
+        marker = b"asi-bounded-elastic-consumed-without-result-v1\n"
+        os.ftruncate(marker_fd, 0)
+        os.lseek(marker_fd, 0, os.SEEK_SET)
+        view = memoryview(marker)
+        while view:
+            written = os.write(marker_fd, view)
+            if written <= 0:
+                raise OSError("consumed reservation write made no progress")
+            view = view[written:]
+        os.fsync(marker_fd)
+        os.fsync(directory_fd)
+        _require_owned_reservation(reservation)
+    finally:
+        os.close(marker_fd)
+        os.close(directory_fd)
+
+
 def _link_unnamed_file(file_fd: int, directory_fd: int, name: str) -> None:
     linkat = ctypes.CDLL(None, use_errno=True).linkat
     linkat.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_int]
@@ -833,18 +854,47 @@ def _write_bounded_elastic_matched_authorized(
     destination: Path, value: object, data_x: object, data_y: object, *,
     config: IPMNISTConfig, seeds: tuple[int, ...], _capability: object,
 ) -> None:
+    """Test-only convenience publisher; campaign publication is transactional."""
+    if _capability is not _TEST_EXECUTION_CAPABILITY:
+        raise RuntimeError(
+            "campaign publication requires the reservation-first transaction"
+        )
+    if type(seeds) is not tuple or seeds != TEST_ONLY_SEEDS:
+        raise RuntimeError("private bounded-elastic publication capability is invalid")
+    reservation = _reserve_output(destination)
+    try:
+        _publish_bounded_elastic_matched_reserved(
+            reservation,
+            destination,
+            value,
+            data_x,
+            data_y,
+            config=config,
+            seeds=seeds,
+        )
+    finally:
+        _release_output(reservation)
+
+
+def _publish_bounded_elastic_matched_reserved(
+    reservation: OutputReservation,
+    destination: Path,
+    value: object,
+    data_x: object,
+    data_y: object,
+    *,
+    config: IPMNISTConfig,
+    seeds: tuple[int, ...],
+) -> None:
+    if type(seeds) is not tuple:
+        raise RuntimeError("private bounded-elastic publication capability is invalid")
     expected_seeds = (
-        CAMPAIGN_SEEDS if _capability is _EXECUTION_CAPABILITY
-        else TEST_ONLY_SEEDS if _capability is _TEST_EXECUTION_CAPABILITY
+        CAMPAIGN_SEEDS if seeds == CAMPAIGN_SEEDS
+        else TEST_ONLY_SEEDS if seeds == TEST_ONLY_SEEDS
         else None
     )
-    if expected_seeds is None or seeds != expected_seeds:
+    if expected_seeds is None:
         raise RuntimeError("private bounded-elastic publication capability is invalid")
-    if _capability is _EXECUTION_CAPABILITY and (
-        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
-    ):
-        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
-    reservation = _reserve_output(destination)
     directory_fd, destination_name, _marker, _marker_fd, _device, _inode = reservation
     descriptor = -1
     published_identity: tuple[int, int] | None = None
@@ -931,7 +981,85 @@ def _write_bounded_elastic_matched_authorized(
     finally:
         if descriptor >= 0:
             os.close(descriptor)
-        _release_output(reservation)
+
+
+def run_and_publish_bounded_elastic_matched(
+    data_home: Path,
+    destination: Path = OUTPUT_PATH,
+) -> dict[str, object]:
+    """Run only as one reviewed reservation-first campaign transaction."""
+    if _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True:
+        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
+    return _run_and_publish_bounded_elastic_matched_authorized(
+        data_home,
+        destination,
+        config=CAMPAIGN_CONFIG,
+        seeds=CAMPAIGN_SEEDS,
+        _capability=_EXECUTION_CAPABILITY,
+    )
+
+
+def _run_and_publish_bounded_elastic_matched_authorized(
+    data_home: Path,
+    destination: Path,
+    *,
+    config: IPMNISTConfig,
+    seeds: tuple[int, ...],
+    _capability: object,
+) -> dict[str, object]:
+    expected_seeds = (
+        CAMPAIGN_SEEDS if _capability is _EXECUTION_CAPABILITY
+        else TEST_ONLY_SEEDS if _capability is _TEST_EXECUTION_CAPABILITY
+        else None
+    )
+    if (
+        expected_seeds is None
+        or type(seeds) is not tuple
+        or seeds != expected_seeds
+        or type(data_home) is not type(Path())
+    ):
+        raise RuntimeError("private bounded-elastic transaction capability is invalid")
+    if _capability is _EXECUTION_CAPABILITY and (
+        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
+    ):
+        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
+    reservation = _reserve_output(destination)
+    consumer_started = False
+    published = False
+
+    def note_first_dispatch() -> None:
+        nonlocal consumer_started
+        consumer_started = True
+
+    try:
+        _require_live_output_parent(destination, reservation[0])
+        _require_owned_reservation(reservation)
+        data_x, data_y = load_mnist_train(data_home)
+        report = _run_bounded_elastic_matched_authorized(
+            data_x,
+            data_y,
+            config=config,
+            seeds=seeds,
+            _capability=_capability,
+            _on_first_dispatch=note_first_dispatch,
+        )
+        _require_owned_reservation(reservation)
+        _publish_bounded_elastic_matched_reserved(
+            reservation,
+            destination,
+            report,
+            data_x,
+            data_y,
+            config=config,
+            seeds=seeds,
+        )
+        published = True
+        return report
+    finally:
+        if published or not consumer_started:
+            _release_output(reservation)
+        else:
+            _retain_consumed_output(reservation)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -942,7 +1070,8 @@ def main(argv: list[str] | None = None) -> int:
     if args.catalog:
         print(json.dumps(frozen_plan(), sort_keys=True))
         return 0
-    raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
+    run_and_publish_bounded_elastic_matched(args.data_home)
+    return 0
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/alberta_framework/evaluation/bounded_elastic_matched_runner.py
+++ b/alberta_framework/evaluation/bounded_elastic_matched_runner.py
@@ -706,6 +706,17 @@ def _open_output_parent(path: Path) -> int:
         raise
 
 
+def _require_live_output_parent(path: Path, directory_fd: int) -> None:
+    held = os.fstat(directory_fd)
+    visible = os.stat(path.parent, follow_symlinks=False)
+    if (
+        not stat.S_ISDIR(held.st_mode)
+        or not stat.S_ISDIR(visible.st_mode)
+        or (held.st_dev, held.st_ino) != (visible.st_dev, visible.st_ino)
+    ):
+        raise RuntimeError("bounded-elastic output parent changed during publication")
+
+
 OutputReservation = tuple[int, str, str, int, int, int]
 
 
@@ -746,6 +757,7 @@ def _reserve_output(path: Path) -> OutputReservation:
         metadata = os.fstat(marker_fd)
         marker_identity = (metadata.st_dev, metadata.st_ino)
         os.fsync(directory_fd)
+        _require_live_output_parent(path, directory_fd)
         return (
             directory_fd,
             path.name,
@@ -827,7 +839,9 @@ def _write_bounded_elastic_matched_authorized(
     reservation = _reserve_output(destination)
     directory_fd, destination_name, _marker, _marker_fd, _device, _inode = reservation
     descriptor = -1
+    published_identity: tuple[int, int] | None = None
     try:
+        _require_live_output_parent(destination, directory_fd)
         _require_owned_reservation(reservation)
         _validate_bounded_elastic_matched(
             value, data_x, data_y, config=config, seeds=seeds, reexecute=True
@@ -849,6 +863,7 @@ def _write_bounded_elastic_matched_authorized(
         os.fsync(descriptor)
         os.fchmod(descriptor, 0o400)
         os.fsync(descriptor)
+        _require_live_output_parent(destination, directory_fd)
         _require_owned_reservation(reservation)
         try:
             _link_unnamed_file(descriptor, directory_fd, destination_name)
@@ -856,6 +871,8 @@ def _write_bounded_elastic_matched_authorized(
             raise FileExistsError(
                 "refusing to replace immutable bounded-elastic output"
             ) from error
+        prepared = os.fstat(descriptor)
+        published_identity = (prepared.st_dev, prepared.st_ino)
         os.fsync(directory_fd)
         read_fd = os.open(destination_name, os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
                           dir_fd=directory_fd)
@@ -888,6 +905,21 @@ def _write_bounded_elastic_matched_authorized(
             )
         finally:
             os.close(read_fd)
+        _require_live_output_parent(destination, directory_fd)
+    except BaseException:
+        if published_identity is not None:
+            try:
+                visible = os.stat(
+                    destination_name,
+                    dir_fd=directory_fd,
+                    follow_symlinks=False,
+                )
+                if (visible.st_dev, visible.st_ino) == published_identity:
+                    os.unlink(destination_name, dir_fd=directory_fd)
+                    os.fsync(directory_fd)
+            except FileNotFoundError:
+                pass
+        raise
     finally:
         if descriptor >= 0:
             os.close(descriptor)

--- a/alberta_framework/evaluation/bounded_elastic_matched_runner.py
+++ b/alberta_framework/evaluation/bounded_elastic_matched_runner.py
@@ -57,7 +57,7 @@ _POLICY: Final = {
     "reservation_precedes_execution_and_publication": True,
     "pre_dispatch_failure_receipts_retained": False,
     "post_dispatch_failure_tombstone_retained": True,
-    "post_start_retry_prevention": True,
+    "post_dispatch_retry_prevention": True,
 }
 _MAX_STEPS: Final = 2_000_000
 _MAX_PERSISTENT_BYTES: Final = 256 * 1024 * 1024
@@ -128,7 +128,7 @@ def frozen_plan() -> dict[str, object]:
         "reservation_precedes_execution_and_publication": True,
         "pre_dispatch_failure_receipts_retained": False,
         "post_dispatch_failure_tombstone_retained": True,
-        "post_start_retry_prevention": True,
+        "post_dispatch_retry_prevention": True,
         "output_path": "outputs/bounded_elastic_matched_development/report.v1.json",
     }
 

--- a/alberta_framework/evaluation/bounded_elastic_matched_runner.py
+++ b/alberta_framework/evaluation/bounded_elastic_matched_runner.py
@@ -51,7 +51,10 @@ _POLICY: Final = {
     "development_only": True,
     "scientific_promotion_allowed": False,
     "sota_claim_allowed": False,
-    "negative_results_retained": True,
+    "completed_outcomes_retained_in_result": True,
+    "atomic_execution_and_publication": False,
+    "execution_failure_receipts_retained": False,
+    "post_start_retry_prevention": False,
 }
 _MAX_STEPS: Final = 2_000_000
 _MAX_PERSISTENT_BYTES: Final = 256 * 1024 * 1024
@@ -112,11 +115,16 @@ def frozen_plan() -> dict[str, object]:
             "campaign_rejected": "both candidates are rejected",
             "otherwise": "inconclusive",
         },
-        "reviewed_execution_transition": _REVIEWED_EXECUTION_TRANSITION,
-        "execution_authorized": _EXECUTION_AUTHORIZED,
+        # These are immutable properties of this reviewed plan. A future source
+        # transition must not rewrite the historical plan that preceded it.
+        "reviewed_execution_transition": False,
+        "execution_authorized": False,
         "development_only": True,
         "scientific_promotion_allowed": False,
-        "negative_results_retained": True,
+        "completed_outcomes_retained_in_result": True,
+        "atomic_execution_and_publication": False,
+        "execution_failure_receipts_retained": False,
+        "post_start_retry_prevention": False,
         "output_path": "outputs/bounded_elastic_matched_development/report.v1.json",
     }
 

--- a/alberta_framework/evaluation/bounded_elastic_matched_runner.py
+++ b/alberta_framework/evaluation/bounded_elastic_matched_runner.py
@@ -1,0 +1,753 @@
+"""Run the complete, resource-matched issue #1562 development comparison."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+import platform
+import secrets
+import stat
+import sys
+from pathlib import Path
+from typing import Final, cast
+
+import jax
+import jax.random as jr
+import numpy as np
+
+from alberta_framework.benchmarks.ipmnist_screening import (
+    _screening_dataset_provenance,
+    bounded_elastic_development_result_payload,
+    run_screening_config,
+    screening_spec,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import (
+    IPMNISTConfig,
+    build_schedule,
+    default_openml_data_home,
+    init_mlp_params,
+)
+from alberta_framework.evaluation.bounded_elastic_ipmnist_nonpromoting import (
+    bounded_elastic_resource_expectations,
+    validate_bounded_elastic_development_result,
+    validate_matched_bounded_elastic_results,
+)
+
+RESULT_SCHEMA: Final = "asi.bounded-elastic-ipmnist.matched-development.v1"
+CAMPAIGN_SEEDS: Final = (51_562_001, 51_562_002, 51_562_003, 51_562_004, 51_562_005)
+TEST_ONLY_SEEDS: Final = (201, 202, 203, 204, 205)
+ARMS: Final = (
+    "bounded_structure_off",
+    "bounded_growth",
+    "bounded_elastic",
+    "bounded_fixed_cbp",
+)
+_POLICY: Final = {
+    "development_only": True,
+    "scientific_promotion_allowed": False,
+    "sota_claim_allowed": False,
+    "negative_results_retained": True,
+}
+_MAX_STEPS: Final = 2_000_000
+_MAX_PERSISTENT_BYTES: Final = 256 * 1024 * 1024
+_MAX_DATASET_BYTES: Final = 256 * 1024 * 1024
+_MAX_SCHEDULE_BYTES: Final = 256 * 1024 * 1024
+_REVIEWED_EXECUTION_TRANSITION: Final = False
+_EXECUTION_AUTHORIZED: Final = False
+_EXECUTION_CAPABILITY: Final = object()
+_TEST_EXECUTION_CAPABILITY: Final = object()
+CAMPAIGN_CONFIG: Final = IPMNISTConfig(n_tasks=8, task_length=5000)
+OUTPUT_PATH: Final = (
+    Path(__file__).resolve().parents[2]
+    / "outputs/bounded_elastic_matched_development/report.v1.json"
+)
+
+
+def frozen_plan() -> dict[str, object]:
+    config = CAMPAIGN_CONFIG
+    return {
+        "schema": "asi.bounded-elastic-ipmnist.matched-plan.v1",
+        "paper_revision": "arXiv:2608.01475v1",
+        "official_code": None,
+        "seeds": list(CAMPAIGN_SEEDS),
+        "arms": list(ARMS),
+        "config": _config_payload(config),
+        "dataset": {
+            "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
+            "source": {"provider": "openml", "name": "mnist_784", "version": 1,
+                       "row_start": 0, "row_stop_exclusive": 60_000},
+            "materialization": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
+            "x": {"dtype": "<f4", "shape": [60_000, 784],
+                  "sha256": "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313"},
+            "y": {"dtype": "<i4", "shape": [60_000],
+                  "sha256": "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a"},
+        },
+        "source_identity": _source_identity(),
+        "runtime_identity": _runtime_identity(),
+        "per_arm_resources": {
+            arm: bounded_elastic_resource_expectations(
+                arm=arm, n_tasks=config.n_tasks, input_dim=config.input_dim,
+                hidden1=config.hidden1, hidden2=config.hidden2, n_classes=config.n_classes,
+            )
+            for arm in ARMS
+        },
+        "matched_axes": ["seed", "observations", "updates", "example_schedule",
+                         "allowed_boundary_information", "allowed_task_information"],
+        "reviewed_execution_transition": _REVIEWED_EXECUTION_TRANSITION,
+        "execution_authorized": _EXECUTION_AUTHORIZED,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "negative_results_retained": True,
+        "output_path": "outputs/bounded_elastic_matched_development/report.v1.json",
+    }
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False
+    ).encode("ascii")
+
+
+def _json_preflight(value: object) -> None:
+    pending: list[tuple[object, int]] = [(value, 0)]
+    seen: set[int] = set()
+    nodes = 0
+    while pending:
+        current, depth = pending.pop()
+        nodes += 1
+        if nodes > 100_000 or depth > 16:
+            raise ValueError("matched result exceeds its JSON structure bound")
+        if current is None or type(current) in {bool, int}:
+            continue
+        if type(current) is float:
+            if not math.isfinite(current):
+                raise ValueError("matched result contains a non-finite float")
+            continue
+        if type(current) is str:
+            if len(current.encode("utf-8")) > 16_384:
+                raise ValueError("matched result contains an oversized string")
+            continue
+        if type(current) not in {dict, list}:
+            raise ValueError("matched result must contain only exact JSON values")
+        identity = id(current)
+        if identity in seen:
+            raise ValueError("matched result contains an aliased or cyclic container")
+        seen.add(identity)
+        if type(current) is dict:
+            mapping = cast(dict[object, object], current)
+            if len(mapping) > 4096 or any(type(key) is not str for key in mapping):
+                raise ValueError("matched result object exceeds its field bound")
+            pending.extend((item, depth + 1) for item in mapping.values())
+        else:
+            sequence = cast(list[object], current)
+            if len(sequence) > 4096:
+                raise ValueError("matched result list exceeds its item bound")
+            pending.extend((item, depth + 1) for item in sequence)
+
+
+def _exact_object(value: object, fields: set[str], label: str) -> dict[str, object]:
+    if type(value) is not dict or set(cast(dict[object, object], value)) != fields:
+        raise ValueError(f"{label} fields drifted")
+    return cast(dict[str, object], value)
+
+
+def _source_identity() -> dict[str, str]:
+    root = Path(__file__).resolve().parents[2]
+    relative_paths = (
+        "alberta_framework/_seed_validation.py",
+        "alberta_framework/benchmarks/ipmnist_screening.py",
+        "alberta_framework/benchmarks/upgd_ipmnist.py",
+        "alberta_framework/evaluation/bounded_elastic_ipmnist_nonpromoting.py",
+        "alberta_framework/evaluation/bounded_elastic_matched_runner.py",
+    )
+    return {
+        relative: hashlib.sha256((root / relative).read_bytes()).hexdigest()
+        for relative in relative_paths
+    }
+
+
+def _runtime_identity() -> dict[str, object]:
+    environment_names = (
+        "JAX_DEFAULT_MATMUL_PRECISION",
+        "JAX_DEFAULT_PRNG_IMPL",
+        "JAX_ENABLE_X64",
+        "JAX_NUM_CPU_DEVICES",
+        "JAX_PLATFORMS",
+        "JAX_PLATFORM_NAME",
+        "JAX_RANDOM_SEED_OFFSET",
+        "XLA_FLAGS",
+    )
+    return {
+        "schema": "asi.bounded-elastic-ipmnist.runtime.v1",
+        "python": list(sys.version_info[:3]),
+        "python_implementation": platform.python_implementation(),
+        "byteorder": sys.byteorder,
+        "platform": sys.platform,
+        "platform_release": platform.release(),
+        "machine": platform.machine(),
+        "packages": {
+            name: importlib.metadata.version(name)
+            for name in ("chex", "jax", "jaxlib", "numpy", "scikit-learn")
+        },
+        "backend": jax.default_backend(),
+        "devices": [
+            {
+                "platform": device.platform,
+                "device_kind": device.device_kind,
+                "id": device.id,
+                "process_index": device.process_index,
+            }
+            for device in jax.devices()
+        ],
+        "jax_config": {
+            "jax_default_matmul_precision": str(jax.config.jax_default_matmul_precision),
+            "jax_default_prng_impl": str(jax.config.jax_default_prng_impl),
+            "jax_disable_jit": bool(jax.config.jax_disable_jit),
+            "jax_enable_x64": bool(jax.config.jax_enable_x64),
+            "jax_numpy_dtype_promotion": str(jax.config.jax_numpy_dtype_promotion.value),
+            "jax_numpy_rank_promotion": str(jax.config.jax_numpy_rank_promotion),
+            "jax_random_seed_offset": int(jax.config.jax_random_seed_offset),
+            "jax_threefry_partitionable": bool(jax.config.jax_threefry_partitionable),
+        },
+        "environment": {name: os.environ.get(name) for name in environment_names},
+    }
+
+
+def _checked_config(value: object) -> IPMNISTConfig:
+    if type(value) is not IPMNISTConfig:
+        raise ValueError("config must be an exact IPMNISTConfig")
+    try:
+        config = IPMNISTConfig(
+            **{
+                name: getattr(value, name)
+                for name in (
+                    "n_tasks",
+                    "task_length",
+                    "input_dim",
+                    "hidden1",
+                    "hidden2",
+                    "n_classes",
+                )
+            }
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError("config is invalid") from error
+    if config.task_length != 5000:
+        raise ValueError("bounded-elastic campaign requires task_length=5000")
+    if config.n_tasks * config.task_length > _MAX_STEPS:
+        raise ValueError("bounded-elastic campaign exceeds its 2000000-step bound")
+    resources = bounded_elastic_resource_expectations(
+        arm="bounded_fixed_cbp",
+        n_tasks=config.n_tasks,
+        input_dim=config.input_dim,
+        hidden1=config.hidden1,
+        hidden2=config.hidden2,
+        n_classes=config.n_classes,
+    )
+    if resources["peak_persistent_bytes_budget"] > _MAX_PERSISTENT_BYTES:
+        raise ValueError("bounded-elastic campaign exceeds its persistent-memory bound")
+    return config
+
+
+def _validated_arrays(
+    data_x: object, data_y: object, config: IPMNISTConfig
+) -> tuple[np.ndarray, np.ndarray]:
+    if type(data_x) is not np.ndarray or data_x.dtype != np.dtype(np.float32):
+        raise ValueError("data_x must be an exact float32 NumPy array")
+    if type(data_y) is not np.ndarray or data_y.dtype != np.dtype(np.int32):
+        raise ValueError("data_y must be an exact int32 NumPy array")
+    if (
+        data_x.ndim != 2
+        or data_y.ndim != 1
+        or data_x.shape[0] != data_y.shape[0]
+        or data_x.shape[0] < config.task_length
+        or data_x.shape[1] != config.input_dim
+    ):
+        raise ValueError("dataset shape does not match the campaign config")
+    if data_x.nbytes + data_y.nbytes > _MAX_DATASET_BYTES:
+        raise ValueError("dataset exceeds the campaign's 256 MiB byte bound")
+    schedule_bytes = config.n_tasks * (data_x.shape[0] + config.input_dim) * 4
+    if schedule_bytes > _MAX_SCHEDULE_BYTES:
+        raise ValueError("schedule exceeds the campaign's 256 MiB byte bound")
+    if not np.isfinite(data_x).all():
+        raise ValueError("data_x must be finite")
+    if np.any(data_y < 0) or np.any(data_y >= config.n_classes):
+        raise ValueError("data_y is outside the configured class range")
+    return np.array(data_x, copy=True, order="C"), np.array(data_y, copy=True, order="C")
+
+
+def _dataset_sha256(data_x: np.ndarray, data_y: np.ndarray) -> str:
+    digest = hashlib.sha256(b"asi-bounded-elastic-dataset-v1\0")
+    for value in (data_x, data_y):
+        digest.update(np.asarray(value.shape, dtype="<i8").tobytes())
+        digest.update(value.dtype.str.encode("ascii"))
+        digest.update(value.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+def _array_tree_sha256(value: object) -> str:
+    digest = hashlib.sha256(b"asi-bounded-elastic-initial-parameters-v1\0")
+    leaves, structure = jax.tree.flatten(value)
+    digest.update(str(structure).encode("ascii"))
+    for leaf in leaves:
+        host = np.asarray(leaf)
+        digest.update(np.asarray(host.shape, dtype="<i8").tobytes())
+        digest.update(host.dtype.str.encode("ascii"))
+        digest.update(host.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+def _execution_identity(seed: int, config: IPMNISTConfig, n_train: int) -> dict[str, str]:
+    root = jr.key(np.uint32(seed), impl="threefry2x32")
+    key_init, key_schedule, _ = jr.split(root, 3)
+    parameters = init_mlp_params(key_init, config)
+    schedule = build_schedule(key_schedule, config, n_train)
+    digest = hashlib.sha256(b"asi-bounded-elastic-schedule-v1\0")
+    for value in (schedule.permutations, schedule.example_indices):
+        host = np.asarray(value, dtype=np.int32)
+        digest.update(np.asarray(host.shape, dtype="<i8").tobytes())
+        digest.update(host.astype("<i4", copy=False).tobytes(order="C"))
+    return {
+        "schedule_sha256": digest.hexdigest(),
+        "initial_parameters_sha256": _array_tree_sha256(parameters),
+        "prng_implementation": "threefry2x32",
+    }
+
+
+def _config_payload(config: IPMNISTConfig) -> dict[str, int]:
+    return {
+        name: getattr(config, name)
+        for name in ("n_tasks", "task_length", "input_dim", "hidden1", "hidden2", "n_classes")
+    }
+
+
+def _aggregate(rows: list[dict[str, object]]) -> dict[str, object]:
+    arms: dict[str, object] = {}
+    for arm in ARMS:
+        metrics = [
+            cast(dict[str, float], cast(dict[str, object], row["result"])["metrics"])
+            for row in rows
+            if row["arm"] == arm
+        ]
+        arms[arm] = {
+            "mean_accuracy": math.fsum(item["mean_online_accuracy"] for item in metrics)
+            / len(metrics),
+            "mean_loss": math.fsum(item["mean_loss"] for item in metrics) / len(metrics),
+            "mean_plasticity": math.fsum(item["mean_plasticity"] for item in metrics)
+            / len(metrics),
+        }
+    return {"arms": arms, "row_count": len(rows)}
+
+
+def run_bounded_elastic_matched(
+    data_x: object, data_y: object, *, config: IPMNISTConfig
+) -> dict[str, object]:
+    """Fail closed pending a separately reviewed authorization transition."""
+    if (_REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True):
+        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
+    return _run_bounded_elastic_matched_authorized(
+        data_x, data_y, config=config, seeds=CAMPAIGN_SEEDS,
+        _capability=_EXECUTION_CAPABILITY,
+    )
+
+
+def _run_bounded_elastic_matched_authorized(
+    data_x: object, data_y: object, *, config: IPMNISTConfig,
+    seeds: tuple[int, ...], _capability: object,
+) -> dict[str, object]:
+    """Capability-private full runner used by tests or an authorized campaign."""
+    expected_seeds = (
+        CAMPAIGN_SEEDS if _capability is _EXECUTION_CAPABILITY
+        else TEST_ONLY_SEEDS if _capability is _TEST_EXECUTION_CAPABILITY
+        else None
+    )
+    if expected_seeds is None or type(seeds) is not tuple or seeds != expected_seeds:
+        raise RuntimeError("private bounded-elastic execution capability or seeds are invalid")
+    checked_config = _checked_config(config)
+    x, y = _validated_arrays(data_x, data_y, checked_config)
+    if _capability is _EXECUTION_CAPABILITY:
+        if checked_config != CAMPAIGN_CONFIG:
+            raise ValueError("campaign config differs from the frozen reviewed plan")
+        if _screening_dataset_provenance(x, y) != frozen_plan()["dataset"]:
+            raise ValueError("campaign dataset differs from the frozen reviewed identity")
+    rows: list[dict[str, object]] = []
+    for seed in seeds:
+        execution_identity = _execution_identity(seed, checked_config, x.shape[0])
+        for arm in ARMS:
+            spec = screening_spec(arm)
+            arm_result = run_screening_config(x, y, spec, seed, checked_config)
+            rows.append(
+                {
+                    "seed": seed,
+                    "arm": arm,
+                    "execution_identity": dict(execution_identity),
+                    "result": bounded_elastic_development_result_payload(
+                        arm_result, outcome="inconclusive"
+                    ),
+                }
+            )
+    campaign: dict[str, object] = {
+        "schema": RESULT_SCHEMA,
+        "status": "complete",
+        "config": _config_payload(checked_config),
+        "development_seeds": list(seeds),
+        "arms": list(ARMS),
+        "identity": {
+            "dataset_sha256": _dataset_sha256(x, y),
+            "source_sha256": _source_identity(),
+            "runtime": _runtime_identity(),
+            "consistency_not_attestation": True,
+        },
+        "policy": dict(_POLICY),
+        "rows": rows,
+        "aggregate": _aggregate(rows),
+    }
+    campaign["result_sha256"] = hashlib.sha256(_canonical(campaign)).hexdigest()
+    _validate_bounded_elastic_matched(
+        campaign, x, y, config=checked_config, seeds=seeds, reexecute=False
+    )
+    return campaign
+
+
+def validate_bounded_elastic_matched(
+    value: object, data_x: object, data_y: object, *, config: IPMNISTConfig
+) -> None:
+    """Fail closed because validation reexecutes the reserved campaign roster."""
+    if (_REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True):
+        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
+    _validate_bounded_elastic_matched_authorized(
+        value, data_x, data_y, config=config, seeds=CAMPAIGN_SEEDS,
+        _capability=_EXECUTION_CAPABILITY,
+    )
+
+
+def _validate_bounded_elastic_matched_authorized(
+    value: object, data_x: object, data_y: object, *, config: IPMNISTConfig,
+    seeds: tuple[int, ...], _capability: object,
+) -> None:
+    expected_seeds = (
+        CAMPAIGN_SEEDS if _capability is _EXECUTION_CAPABILITY
+        else TEST_ONLY_SEEDS if _capability is _TEST_EXECUTION_CAPABILITY
+        else None
+    )
+    if expected_seeds is None or type(seeds) is not tuple or seeds != expected_seeds:
+        raise RuntimeError("private bounded-elastic validation capability or seeds are invalid")
+    _validate_bounded_elastic_matched(
+        value, data_x, data_y, config=config, seeds=seeds, reexecute=True
+    )
+
+
+def _validate_bounded_elastic_matched(
+    value: object,
+    data_x: object,
+    data_y: object,
+    *,
+    config: IPMNISTConfig,
+    seeds: tuple[int, ...],
+    reexecute: bool,
+) -> None:
+    """Validate the full roster, identities, and optionally current execution."""
+    _json_preflight(value)
+    root = _exact_object(
+        value,
+        {
+            "schema",
+            "status",
+            "config",
+            "development_seeds",
+            "arms",
+            "identity",
+            "policy",
+            "rows",
+            "aggregate",
+            "result_sha256",
+        },
+        "matched result",
+    )
+    if root["schema"] != RESULT_SCHEMA or root["status"] != "complete":
+        raise ValueError("matched result identity drifted")
+    checked_config = _checked_config(config)
+    x, y = _validated_arrays(data_x, data_y, checked_config)
+    if root["config"] != _config_payload(checked_config):
+        raise ValueError("matched result config drifted")
+    if root["development_seeds"] != list(seeds) or root["arms"] != list(ARMS):
+        raise ValueError("matched result protocol roster drifted")
+    expected_identity = {
+        "dataset_sha256": _dataset_sha256(x, y),
+        "source_sha256": _source_identity(),
+        "runtime": _runtime_identity(),
+        "consistency_not_attestation": True,
+    }
+    if root["identity"] != expected_identity:
+        raise ValueError("matched result identity drifted")
+    if root["policy"] != _POLICY:
+        raise ValueError("matched result must remain permanently nonpromoting")
+    expected_roster = [(seed, arm) for seed in seeds for arm in ARMS]
+    raw_rows = root["rows"]
+    if type(raw_rows) is not list or len(raw_rows) != len(expected_roster):
+        raise ValueError("matched result roster is incomplete")
+    rows = cast(list[dict[str, object]], raw_rows)
+    observed: list[tuple[object, object]] = []
+    identities = {
+        seed: _execution_identity(seed, checked_config, x.shape[0]) for seed in seeds
+    }
+    for row in rows:
+        checked_row = _exact_object(
+            row, {"seed", "arm", "execution_identity", "result"}, "matched row"
+        )
+        seed = checked_row["seed"]
+        arm = checked_row["arm"]
+        if (
+            type(seed) is not int
+            or seed not in identities
+            or type(arm) is not str
+            or arm not in ARMS
+        ):
+            raise ValueError("matched row roster identity drifted")
+        if checked_row["execution_identity"] != identities[seed]:
+            raise ValueError("matched row execution identity drifted")
+        payload = validate_bounded_elastic_development_result(checked_row["result"])
+        if payload["outcome"] != "inconclusive":
+            raise ValueError("matched campaign outcomes must remain inconclusive")
+        if payload["seed"] != seed or payload["arm"] != arm:
+            raise ValueError("matched row result identity drifted")
+        observed.append((seed, arm))
+    if observed != expected_roster:
+        raise ValueError("matched result roster order drifted")
+    for offset in range(0, len(rows), len(ARMS)):
+        validate_matched_bounded_elastic_results(
+            [row["result"] for row in rows[offset : offset + len(ARMS)]]
+        )
+    if root["aggregate"] != _aggregate(rows):
+        raise ValueError("matched result aggregate drifted")
+    unsigned = dict(root)
+    claimed = unsigned.pop("result_sha256")
+    if type(claimed) is not str or claimed != hashlib.sha256(_canonical(unsigned)).hexdigest():
+        raise ValueError("matched result digest drifted")
+    if reexecute:
+        for row in rows:
+            claimed_payload = cast(dict[str, object], row["result"])
+            replay = run_screening_config(
+                x,
+                y,
+                screening_spec(cast(str, row["arm"])),
+                cast(int, row["seed"]),
+                checked_config,
+            )
+            expected_payload = bounded_elastic_development_result_payload(
+                replay, outcome="inconclusive"
+            )
+            expected_resources = cast(dict[str, object], expected_payload["resources"])
+            claimed_resources = cast(dict[str, object], claimed_payload["resources"])
+            expected_resources["timing_seconds"] = claimed_resources["timing_seconds"]
+            if expected_payload != claimed_payload:
+                raise ValueError("matched row disagrees with strict current-source reexecution")
+
+
+def write_bounded_elastic_matched(
+    destination: Path,
+    value: object,
+    data_x: object,
+    data_y: object,
+    *,
+    config: IPMNISTConfig,
+) -> None:
+    """Fail closed until a reviewed authorization enables publication."""
+    if (_REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True):
+        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
+    _write_bounded_elastic_matched_authorized(
+        destination, value, data_x, data_y, config=config, seeds=CAMPAIGN_SEEDS,
+        _capability=_EXECUTION_CAPABILITY,
+    )
+
+
+def _open_output_parent(path: Path) -> int:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    absolute = Path(os.path.abspath(os.fspath(path)))
+    descriptor = os.open(os.path.sep, flags)
+    try:
+        for component in absolute.parent.parts[1:]:
+            if component in {"", ".", ".."}:
+                raise ValueError("output path contains an unsafe component")
+            created = False
+            try:
+                os.mkdir(component, 0o755, dir_fd=descriptor)
+                created = True
+            except FileExistsError:
+                pass
+            if created:
+                os.fsync(descriptor)
+            next_descriptor = os.open(component, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _reserve_output(path: Path) -> tuple[int, str, str, int, int]:
+    if type(path) is not type(Path()):
+        raise TypeError("destination must be an exact Path")
+    if path.absolute() != OUTPUT_PATH.absolute() or path.name in {"", ".", ".."}:
+        raise ValueError(f"output must be the exact reserved NEW path {OUTPUT_PATH}")
+    directory_fd = _open_output_parent(path)
+    reservation_name = f".{path.name}.reservation"
+    marker_fd = -1
+    acquired = False
+    marker_identity: tuple[int, int] | None = None
+    try:
+        try:
+            os.stat(path.name, dir_fd=directory_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError("refusing to replace immutable bounded-elastic output")
+        marker_fd = os.open(
+            reservation_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o400,
+            dir_fd=directory_fd,
+        )
+        acquired = True
+        marker = b"asi-bounded-elastic-output-reservation-v1\n"
+        view = memoryview(marker)
+        while view:
+            written = os.write(marker_fd, view)
+            if written <= 0:
+                raise OSError("short reservation write")
+            view = view[written:]
+        os.fsync(marker_fd)
+        metadata = os.fstat(marker_fd)
+        marker_identity = (metadata.st_dev, metadata.st_ino)
+        os.close(marker_fd)
+        marker_fd = -1
+        os.fsync(directory_fd)
+        return directory_fd, path.name, reservation_name, metadata.st_dev, metadata.st_ino
+    except BaseException:
+        if marker_fd >= 0:
+            os.close(marker_fd)
+        if acquired:
+            try:
+                current = os.stat(
+                    reservation_name, dir_fd=directory_fd, follow_symlinks=False
+                )
+                if (current.st_dev, current.st_ino) == marker_identity:
+                    os.unlink(reservation_name, dir_fd=directory_fd)
+                    os.fsync(directory_fd)
+            except FileNotFoundError:
+                pass
+        os.close(directory_fd)
+        raise
+
+
+def _release_output(reservation: tuple[int, str, str, int, int]) -> None:
+    directory_fd, _name, marker_name, device, inode = reservation
+    try:
+        metadata = os.stat(marker_name, dir_fd=directory_fd, follow_symlinks=False)
+        if (metadata.st_dev, metadata.st_ino) == (device, inode):
+            os.unlink(marker_name, dir_fd=directory_fd)
+            os.fsync(directory_fd)
+    except FileNotFoundError:
+        pass
+    finally:
+        os.close(directory_fd)
+
+
+def _write_bounded_elastic_matched_authorized(
+    destination: Path, value: object, data_x: object, data_y: object, *,
+    config: IPMNISTConfig, seeds: tuple[int, ...], _capability: object,
+) -> None:
+    expected_seeds = (
+        CAMPAIGN_SEEDS if _capability is _EXECUTION_CAPABILITY
+        else TEST_ONLY_SEEDS if _capability is _TEST_EXECUTION_CAPABILITY
+        else None
+    )
+    if expected_seeds is None or seeds != expected_seeds:
+        raise RuntimeError("private bounded-elastic publication capability is invalid")
+    reservation = _reserve_output(destination)
+    directory_fd, destination_name, _marker, _device, _inode = reservation
+    temporary_name = f".{destination_name}.{secrets.token_hex(16)}.tmp"
+    descriptor = -1
+    try:
+        _validate_bounded_elastic_matched(
+            value, data_x, data_y, config=config, seeds=seeds, reexecute=True
+        )
+        encoded = _canonical(value) + b"\n"
+        descriptor = os.open(
+            temporary_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o400,
+            dir_fd=directory_fd,
+        )
+        view = memoryview(encoded)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("immutable output write made no progress")
+            view = view[written:]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.link(temporary_name, destination_name, src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd, follow_symlinks=False)
+        os.unlink(temporary_name, dir_fd=directory_fd)
+        os.fsync(directory_fd)
+        read_fd = os.open(destination_name, os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                          dir_fd=directory_fd)
+        try:
+            metadata = os.fstat(read_fd)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                raise ValueError("published output must be one unique regular file")
+            actual = os.read(read_fd, len(encoded) + 1)
+            final = os.fstat(read_fd)
+            if actual != encoded or metadata.st_size != len(encoded) or (
+                metadata.st_dev, metadata.st_ino, metadata.st_size, metadata.st_mtime_ns
+            ) != (final.st_dev, final.st_ino, final.st_size, final.st_mtime_ns):
+                raise ValueError("published output changed during strict reread")
+            def exact_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+                result: dict[str, object] = {}
+                for key, item in pairs:
+                    if key in result:
+                        raise ValueError("published output contains a duplicate JSON key")
+                    result[key] = item
+                return result
+
+            try:
+                reread = json.loads(
+                    actual.decode("utf-8"), object_pairs_hook=exact_object
+                )
+            except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
+                raise ValueError("published output is not bounded strict JSON") from error
+            _validate_bounded_elastic_matched(
+                reread, data_x, data_y, config=config, seeds=seeds, reexecute=False
+            )
+        finally:
+            os.close(read_fd)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary_name, dir_fd=directory_fd)
+        except FileNotFoundError:
+            pass
+        _release_output(reservation)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", action="store_true")
+    parser.add_argument("--data-home", type=Path, default=default_openml_data_home())
+    args = parser.parse_args(argv)
+    if args.catalog:
+        print(json.dumps(frozen_plan(), sort_keys=True))
+        return 0
+    raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/alberta_framework/evaluation/bounded_elastic_matched_runner.py
+++ b/alberta_framework/evaluation/bounded_elastic_matched_runner.py
@@ -64,6 +64,13 @@ _MAX_PERSISTENT_BYTES: Final = 256 * 1024 * 1024
 _MAX_DATASET_BYTES: Final = 256 * 1024 * 1024
 _MAX_SCHEDULE_BYTES: Final = 256 * 1024 * 1024
 _MAX_COMBINED_NUMERIC_BYTES: Final = 256 * 1024 * 1024
+_MAX_RESULT_BYTES: Final = 16 * 1024 * 1024
+_MAX_JSON_NODES: Final = 100_000
+_MAX_JSON_DEPTH: Final = 16
+_MAX_JSON_STRING_BYTES: Final = 16_384
+_MAX_JSON_KEY_BYTES: Final = 256
+_MAX_PATH_BYTES: Final = 4096
+_MAX_PATH_COMPONENT_BYTES: Final = 240
 _REVIEWED_EXECUTION_TRANSITION: Final = False
 _EXECUTION_AUTHORIZED: Final = False
 _EXECUTION_CAPABILITY: Final = object()
@@ -75,6 +82,30 @@ OUTPUT_PATH: Final = (
 )
 
 
+def _frozen_dataset_provenance() -> dict[str, object]:
+    return {
+        "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
+        "source": {
+            "provider": "openml",
+            "name": "mnist_784",
+            "version": 1,
+            "row_start": 0,
+            "row_stop_exclusive": 60_000,
+        },
+        "materialization": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
+        "x": {
+            "dtype": "<f4",
+            "shape": [60_000, 784],
+            "sha256": "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313",
+        },
+        "y": {
+            "dtype": "<i4",
+            "shape": [60_000],
+            "sha256": "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a",
+        },
+    }
+
+
 def frozen_plan() -> dict[str, object]:
     config = CAMPAIGN_CONFIG
     return {
@@ -84,16 +115,7 @@ def frozen_plan() -> dict[str, object]:
         "seeds": list(CAMPAIGN_SEEDS),
         "arms": list(ARMS),
         "config": _config_payload(config),
-        "dataset": {
-            "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
-            "source": {"provider": "openml", "name": "mnist_784", "version": 1,
-                       "row_start": 0, "row_stop_exclusive": 60_000},
-            "materialization": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
-            "x": {"dtype": "<f4", "shape": [60_000, 784],
-                  "sha256": "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313"},
-            "y": {"dtype": "<i4", "shape": [60_000],
-                  "sha256": "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a"},
-        },
+        "dataset": _frozen_dataset_provenance(),
         "source_identity": _source_identity(),
         "runtime_identity": _runtime_identity(),
         "per_arm_resources": {
@@ -106,6 +128,14 @@ def frozen_plan() -> dict[str, object]:
         "numeric_resource_envelope": _numeric_resource_envelope(
             config=config, dataset_rows=60_000
         ),
+        "numeric_resource_scope": (
+            "one caller-owned C-contiguous host dataset, one materialized schedule, and "
+            "learner parameters plus persistent learner state; backend copies, compiler "
+            "state, gradients, and transient execution buffers are excluded"
+        ),
+        "transaction_resource_accounting": _transaction_resource_accounting(
+            config=config, seeds=CAMPAIGN_SEEDS
+        ),
         "matched_axes": ["seed", "observations", "updates", "example_schedule",
                          "allowed_boundary_information", "allowed_task_information"],
         "decision_rule": {
@@ -117,6 +147,11 @@ def frozen_plan() -> dict[str, object]:
             "campaign_supported": "at least one candidate is supported",
             "campaign_rejected": "both candidates are rejected",
             "otherwise": "inconclusive",
+        },
+        "seed_policy": {
+            "campaign_roster_status": "reserved_unconsumed",
+            "test_only_seeds": list(TEST_ONLY_SEEDS),
+            "campaign_and_test_rosters_disjoint": True,
         },
         # These are immutable properties of this reviewed plan. A future source
         # transition must not rewrite the historical plan that preceded it.
@@ -143,21 +178,42 @@ def _json_preflight(value: object) -> None:
     pending: list[tuple[object, int]] = [(value, 0)]
     seen: set[int] = set()
     nodes = 0
+    scalar_bytes = 0
     while pending:
         current, depth = pending.pop()
         actual_type = type(current)
         nodes += 1
-        if nodes > 100_000 or depth > 16:
+        if nodes > _MAX_JSON_NODES or depth > _MAX_JSON_DEPTH:
             raise ValueError("matched result exceeds its JSON structure bound")
-        if current is None or actual_type is bool or actual_type is int:
+        scalar_bytes += 8
+        if scalar_bytes > _MAX_RESULT_BYTES:
+            raise ValueError("matched result exceeds its JSON byte bound")
+        if current is None or actual_type is bool:
+            continue
+        if actual_type is int:
+            if not -(1 << 63) <= cast(int, current) <= (1 << 63) - 1:
+                raise ValueError("matched result contains an out-of-range integer")
+            scalar_bytes += 24
+            if scalar_bytes > _MAX_RESULT_BYTES:
+                raise ValueError("matched result exceeds its JSON byte bound")
             continue
         if actual_type is float:
             if not math.isfinite(cast(float, current)):
                 raise ValueError("matched result contains a non-finite float")
+            scalar_bytes += 32
+            if scalar_bytes > _MAX_RESULT_BYTES:
+                raise ValueError("matched result exceeds its JSON byte bound")
             continue
         if actual_type is str:
-            if len(cast(str, current).encode("utf-8")) > 16_384:
+            try:
+                string_bytes = len(cast(str, current).encode("utf-8"))
+            except UnicodeEncodeError as error:
+                raise ValueError("matched result contains invalid Unicode") from error
+            if string_bytes > _MAX_JSON_STRING_BYTES:
                 raise ValueError("matched result contains an oversized string")
+            scalar_bytes += 6 * string_bytes
+            if scalar_bytes > _MAX_RESULT_BYTES:
+                raise ValueError("matched result exceeds its JSON byte bound")
             continue
         if actual_type is not dict and actual_type is not list:
             raise ValueError("matched result must contain only exact JSON values")
@@ -169,6 +225,15 @@ def _json_preflight(value: object) -> None:
             mapping = cast(dict[object, object], current)
             if len(mapping) > 4096 or any(type(key) is not str for key in mapping):
                 raise ValueError("matched result object exceeds its field bound")
+            try:
+                encoded_keys = [cast(str, key).encode("utf-8") for key in mapping]
+            except UnicodeEncodeError as error:
+                raise ValueError("matched result contains an invalid Unicode field") from error
+            if any(len(key) > _MAX_JSON_KEY_BYTES for key in encoded_keys):
+                raise ValueError("matched result contains an oversized field name")
+            scalar_bytes += 6 * sum(map(len, encoded_keys))
+            if scalar_bytes > _MAX_RESULT_BYTES:
+                raise ValueError("matched result exceeds its JSON byte bound")
             pending.extend((item, depth + 1) for item in mapping.values())
         else:
             sequence = cast(list[object], current)
@@ -296,7 +361,7 @@ def _numeric_resource_envelope(
     *, config: IPMNISTConfig, dataset_rows: int
 ) -> dict[str, int]:
     dataset_bytes = dataset_rows * (config.input_dim * 4 + 4)
-    schedule_bytes = config.n_tasks * (dataset_rows + config.input_dim) * 4
+    schedule_bytes = config.n_tasks * (config.task_length + config.input_dim) * 4
     peak_persistent_bytes = max(
         bounded_elastic_resource_expectations(
             arm=arm,
@@ -312,8 +377,29 @@ def _numeric_resource_envelope(
         "dataset_bytes": dataset_bytes,
         "schedule_bytes": schedule_bytes,
         "peak_persistent_bytes_budget": peak_persistent_bytes,
-        "combined_numeric_bytes": dataset_bytes + schedule_bytes + peak_persistent_bytes,
-        "combined_numeric_bytes_limit": _MAX_COMBINED_NUMERIC_BYTES,
+        "static_accounted_numeric_bytes": (
+            dataset_bytes + schedule_bytes + peak_persistent_bytes
+        ),
+        "static_accounted_numeric_bytes_limit": _MAX_COMBINED_NUMERIC_BYTES,
+    }
+
+
+def _transaction_resource_accounting(
+    *, config: IPMNISTConfig, seeds: tuple[int, ...]
+) -> dict[str, int]:
+    rows = len(seeds) * len(ARMS)
+    observations_per_dispatch = config.n_tasks * config.task_length
+    runner_dispatches = 2 * rows
+    return {
+        "campaign_rows": rows,
+        "initial_runner_dispatches": rows,
+        "strict_reexecution_dispatches": rows,
+        "total_runner_dispatches": runner_dispatches,
+        "total_observations": runner_dispatches * observations_per_dispatch,
+        "total_optimizer_updates": runner_dispatches * observations_per_dispatch,
+        "total_data_steps": runner_dispatches * observations_per_dispatch,
+        "total_environment_steps": 0,
+        "total_model_queries": 2 * runner_dispatches * observations_per_dispatch,
     }
 
 
@@ -332,20 +418,22 @@ def _validated_arrays(
         or data_x.shape[1] != config.input_dim
     ):
         raise ValueError("dataset shape does not match the campaign config")
+    if not data_x.flags.c_contiguous or not data_y.flags.c_contiguous:
+        raise ValueError("dataset arrays must be C-contiguous to avoid an unaccounted copy")
     dataset_bytes = data_x.nbytes + data_y.nbytes
     if dataset_bytes > _MAX_DATASET_BYTES:
         raise ValueError("dataset exceeds the campaign's 256 MiB byte bound")
-    schedule_bytes = config.n_tasks * (data_x.shape[0] + config.input_dim) * 4
+    schedule_bytes = config.n_tasks * (config.task_length + config.input_dim) * 4
     if schedule_bytes > _MAX_SCHEDULE_BYTES:
         raise ValueError("schedule exceeds the campaign's 256 MiB byte bound")
     envelope = _numeric_resource_envelope(config=config, dataset_rows=data_x.shape[0])
-    if envelope["combined_numeric_bytes"] > _MAX_COMBINED_NUMERIC_BYTES:
-        raise ValueError("campaign exceeds its combined 256 MiB numeric allocation bound")
+    if envelope["static_accounted_numeric_bytes"] > _MAX_COMBINED_NUMERIC_BYTES:
+        raise ValueError("campaign exceeds its static 256 MiB numeric accounting bound")
     if not np.isfinite(data_x).all():
         raise ValueError("data_x must be finite")
     if np.any(data_y < 0) or np.any(data_y >= config.n_classes):
         raise ValueError("data_y is outside the configured class range")
-    return np.array(data_x, copy=True, order="C"), np.array(data_y, copy=True, order="C")
+    return data_x, data_y
 
 
 def _dataset_sha256(data_x: np.ndarray, data_y: np.ndarray) -> str:
@@ -391,6 +479,42 @@ def _config_payload(config: IPMNISTConfig) -> dict[str, int]:
         name: getattr(config, name)
         for name in ("n_tasks", "task_length", "input_dim", "hidden1", "hidden2", "n_classes")
     }
+
+
+def _result_identity(data_x: np.ndarray, data_y: np.ndarray) -> dict[str, object]:
+    return {
+        "dataset_sha256": _dataset_sha256(data_x, data_y),
+        "source_sha256": _source_identity(),
+        "runtime": _runtime_identity(),
+        "consistency_not_attestation": True,
+    }
+
+
+def _seed_roster_matches(value: object, expected: tuple[int, ...]) -> bool:
+    return (
+        type(value) is tuple
+        and len(cast(tuple[object, ...], value)) == len(expected)
+        and all(
+            type(item) is int and item == expected_item
+            for item, expected_item in zip(cast(tuple[object, ...], value), expected, strict=True)
+        )
+    )
+
+
+def _require_capability_roster(
+    seeds: object, capability: object, *, operation: str
+) -> tuple[int, ...]:
+    if capability is _EXECUTION_CAPABILITY:
+        if _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True:
+            raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
+        expected = CAMPAIGN_SEEDS
+    elif capability is _TEST_EXECUTION_CAPABILITY:
+        expected = TEST_ONLY_SEEDS
+    else:
+        raise RuntimeError(f"private bounded-elastic {operation} capability is invalid")
+    if not _seed_roster_matches(seeds, expected):
+        raise RuntimeError(f"private bounded-elastic {operation} seed roster is invalid")
+    return expected
 
 
 def _aggregate(rows: list[dict[str, object]]) -> dict[str, object]:
@@ -471,29 +595,22 @@ def _run_bounded_elastic_matched_authorized(
     _on_first_dispatch: Callable[[], None] | None = None,
 ) -> dict[str, object]:
     """Capability-private full runner used by tests or an authorized campaign."""
-    expected_seeds = (
-        CAMPAIGN_SEEDS if _capability is _EXECUTION_CAPABILITY
-        else TEST_ONLY_SEEDS if _capability is _TEST_EXECUTION_CAPABILITY
-        else None
+    checked_seeds = _require_capability_roster(
+        seeds, _capability, operation="execution"
     )
-    if expected_seeds is None or type(seeds) is not tuple or seeds != expected_seeds:
-        raise RuntimeError("private bounded-elastic execution capability or seeds are invalid")
-    if _capability is _EXECUTION_CAPABILITY and (
-        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
-    ):
-        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
     checked_config = _checked_config(config)
     x, y = _validated_arrays(data_x, data_y, checked_config)
-    execution_source = _source_identity()
-    execution_runtime = _runtime_identity()
+    execution_identity = _result_identity(x, y)
+    execution_source = execution_identity["source_sha256"]
+    execution_runtime = execution_identity["runtime"]
     if _capability is _EXECUTION_CAPABILITY:
         if checked_config != CAMPAIGN_CONFIG:
             raise ValueError("campaign config differs from the frozen reviewed plan")
-        if _screening_dataset_provenance(x, y) != frozen_plan()["dataset"]:
+        if _screening_dataset_provenance(x, y) != _frozen_dataset_provenance():
             raise ValueError("campaign dataset differs from the frozen reviewed identity")
     rows: list[dict[str, object]] = []
-    for seed in seeds:
-        execution_identity = _execution_identity(seed, checked_config, x.shape[0])
+    for seed in checked_seeds:
+        row_execution_identity = _execution_identity(seed, checked_config, x.shape[0])
         for arm in ARMS:
             spec = screening_spec(arm)
             if not rows and _on_first_dispatch is not None:
@@ -505,31 +622,32 @@ def _run_bounded_elastic_matched_authorized(
                 {
                     "seed": seed,
                     "arm": arm,
-                    "execution_identity": dict(execution_identity),
+                    "execution_identity": dict(row_execution_identity),
                     "result": bounded_elastic_development_result_payload(
                         arm_result, outcome="inconclusive"
                     ),
                 }
             )
+    if _result_identity(x, y) != execution_identity:
+        raise RuntimeError("source, runtime, or dataset changed during matched execution")
+    if _capability is _EXECUTION_CAPABILITY and (
+        _screening_dataset_provenance(x, y) != _frozen_dataset_provenance()
+    ):
+        raise RuntimeError("campaign dataset changed during matched execution")
     campaign: dict[str, object] = {
         "schema": RESULT_SCHEMA,
         "status": "complete",
         "config": _config_payload(checked_config),
-        "development_seeds": list(seeds),
+        "development_seeds": list(checked_seeds),
         "arms": list(ARMS),
-        "identity": {
-            "dataset_sha256": _dataset_sha256(x, y),
-            "source_sha256": execution_source,
-            "runtime": execution_runtime,
-            "consistency_not_attestation": True,
-        },
+        "identity": execution_identity,
         "policy": dict(_POLICY),
         "rows": rows,
         "aggregate": _aggregate(rows),
     }
     campaign["result_sha256"] = hashlib.sha256(_canonical(campaign)).hexdigest()
     _validate_bounded_elastic_matched(
-        campaign, x, y, config=checked_config, seeds=seeds, reexecute=False
+        campaign, x, y, config=checked_config, seeds=checked_seeds, reexecute=False
     )
     return campaign
 
@@ -548,19 +666,11 @@ def _validate_bounded_elastic_matched_authorized(
     value: object, data_x: object, data_y: object, *, config: IPMNISTConfig,
     seeds: tuple[int, ...], _capability: object,
 ) -> None:
-    expected_seeds = (
-        CAMPAIGN_SEEDS if _capability is _EXECUTION_CAPABILITY
-        else TEST_ONLY_SEEDS if _capability is _TEST_EXECUTION_CAPABILITY
-        else None
+    checked_seeds = _require_capability_roster(
+        seeds, _capability, operation="validation"
     )
-    if expected_seeds is None or type(seeds) is not tuple or seeds != expected_seeds:
-        raise RuntimeError("private bounded-elastic validation capability or seeds are invalid")
-    if _capability is _EXECUTION_CAPABILITY and (
-        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
-    ):
-        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
     _validate_bounded_elastic_matched(
-        value, data_x, data_y, config=config, seeds=seeds, reexecute=True
+        value, data_x, data_y, config=config, seeds=checked_seeds, reexecute=True
     )
 
 
@@ -574,6 +684,17 @@ def _validate_bounded_elastic_matched(
     reexecute: bool,
 ) -> None:
     """Validate the full roster, identities, and optionally current execution."""
+    if type(reexecute) is not bool:
+        raise TypeError("reexecute must be an exact bool")
+    if not (
+        _seed_roster_matches(seeds, TEST_ONLY_SEEDS)
+        or _seed_roster_matches(seeds, CAMPAIGN_SEEDS)
+    ):
+        raise RuntimeError("matched validation seed roster is invalid")
+    if reexecute and _seed_roster_matches(seeds, CAMPAIGN_SEEDS) and (
+        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
+    ):
+        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
     _json_preflight(value)
     root = _exact_object(
         value,
@@ -595,16 +716,16 @@ def _validate_bounded_elastic_matched(
         raise ValueError("matched result identity drifted")
     checked_config = _checked_config(config)
     x, y = _validated_arrays(data_x, data_y, checked_config)
+    if _seed_roster_matches(seeds, CAMPAIGN_SEEDS) and (
+        checked_config != CAMPAIGN_CONFIG
+        or _screening_dataset_provenance(x, y) != _frozen_dataset_provenance()
+    ):
+        raise ValueError("campaign inputs differ from the frozen reviewed plan")
     if root["config"] != _config_payload(checked_config):
         raise ValueError("matched result config drifted")
     if root["development_seeds"] != list(seeds) or root["arms"] != list(ARMS):
         raise ValueError("matched result protocol roster drifted")
-    expected_identity = {
-        "dataset_sha256": _dataset_sha256(x, y),
-        "source_sha256": _source_identity(),
-        "runtime": _runtime_identity(),
-        "consistency_not_attestation": True,
-    }
+    expected_identity = _result_identity(x, y)
     if root["identity"] != expected_identity:
         raise ValueError("matched result identity drifted")
     if root["policy"] != _POLICY:
@@ -673,6 +794,8 @@ def _validate_bounded_elastic_matched(
             expected_resources["timing_seconds"] = claimed_resources["timing_seconds"]
             if expected_payload != claimed_payload:
                 raise ValueError("matched row disagrees with strict current-source reexecution")
+        if _result_identity(x, y) != expected_identity:
+            raise RuntimeError("source, runtime, or dataset changed during strict reexecution")
 
 
 def write_bounded_elastic_matched(
@@ -690,9 +813,25 @@ def write_bounded_elastic_matched(
     )
 
 
+def _validated_output_path(path: object) -> Path:
+    if type(path) is not type(Path()):
+        raise TypeError("destination must be an exact Path")
+    absolute = Path(os.path.abspath(os.fspath(path)))
+    if len(os.fsencode(absolute)) > _MAX_PATH_BYTES:
+        raise ValueError("output path exceeds its byte bound")
+    components = absolute.parts[1:]
+    if any(
+        component in {"", ".", ".."}
+        or len(os.fsencode(component)) > _MAX_PATH_COMPONENT_BYTES
+        for component in components
+    ):
+        raise ValueError("output path contains an unsafe or oversized component")
+    return absolute
+
+
 def _open_output_parent(path: Path) -> int:
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
-    absolute = Path(os.path.abspath(os.fspath(path)))
+    absolute = _validated_output_path(path)
     descriptor = os.open(os.path.sep, flags)
     try:
         for component in absolute.parent.parts[1:]:
@@ -735,24 +874,24 @@ def _reserve_output(path: Path, *, _capability: object) -> OutputReservation:
             raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
     elif _capability is not _TEST_EXECUTION_CAPABILITY:
         raise RuntimeError("private bounded-elastic reservation capability is invalid")
-    if type(path) is not type(Path()):
-        raise TypeError("destination must be an exact Path")
+    absolute = _validated_output_path(path)
+    output_absolute = _validated_output_path(OUTPUT_PATH)
     if not all(hasattr(os, name) for name in ("O_DIRECTORY", "O_NOFOLLOW", "O_TMPFILE")):
         raise OSError("immutable output publication requires Linux descriptor support")
     if (
-        path.name in {"", ".", ".."}
-        or (_capability is _EXECUTION_CAPABILITY and path.absolute() != OUTPUT_PATH.absolute())
-        or (_capability is _TEST_EXECUTION_CAPABILITY and path.absolute() == OUTPUT_PATH.absolute())
+        path != absolute
+        or (_capability is _EXECUTION_CAPABILITY and absolute != output_absolute)
+        or (_capability is _TEST_EXECUTION_CAPABILITY and absolute == output_absolute)
     ):
         raise ValueError(f"output must be the exact reserved NEW path {OUTPUT_PATH}")
-    directory_fd = _open_output_parent(path)
-    reservation_name = f".{path.name}.reservation"
+    directory_fd = _open_output_parent(absolute)
+    reservation_name = f".{absolute.name}.reservation"
     marker_fd = -1
     acquired = False
     marker_identity: tuple[int, int] | None = None
     try:
         try:
-            os.stat(path.name, dir_fd=directory_fd, follow_symlinks=False)
+            os.stat(absolute.name, dir_fd=directory_fd, follow_symlinks=False)
         except FileNotFoundError:
             pass
         else:
@@ -775,10 +914,10 @@ def _reserve_output(path: Path, *, _capability: object) -> OutputReservation:
         metadata = os.fstat(marker_fd)
         marker_identity = (metadata.st_dev, metadata.st_ino)
         os.fsync(directory_fd)
-        _require_live_output_parent(path, directory_fd)
+        _require_live_output_parent(absolute, directory_fd)
         return (
             directory_fd,
-            path.name,
+            absolute.name,
             reservation_name,
             marker_fd,
             metadata.st_dev,
@@ -861,6 +1000,51 @@ def _link_unnamed_file(file_fd: int, directory_fd: int, name: str) -> None:
         raise OSError(error_number, os.strerror(error_number), name)
 
 
+def _strict_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, item in pairs:
+        if key in result:
+            raise ValueError("prepared output contains a duplicate JSON key")
+        result[key] = item
+    return result
+
+
+def _strict_reread_prepared_output(
+    descriptor: int,
+    encoded: bytes,
+    data_x: object,
+    data_y: object,
+    *,
+    config: IPMNISTConfig,
+    seeds: tuple[int, ...],
+) -> tuple[int, int]:
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    before = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or before.st_nlink != 0
+        or before.st_size != len(encoded)
+    ):
+        raise ValueError("prepared output must be one unnamed regular file")
+    actual = os.read(descriptor, len(encoded) + 1)
+    after = os.fstat(descriptor)
+    if actual != encoded or (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+    ) != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns):
+        raise ValueError("prepared output changed during strict reread")
+    try:
+        reread = json.loads(actual.decode("utf-8"), object_pairs_hook=_strict_json_object)
+    except (UnicodeDecodeError, ValueError, RecursionError) as error:
+        raise ValueError("prepared output is not bounded strict JSON") from error
+    _validate_bounded_elastic_matched(
+        reread, data_x, data_y, config=config, seeds=seeds, reexecute=False
+    )
+    return before.st_dev, before.st_ino
+
+
 def _write_bounded_elastic_matched_authorized(
     destination: Path, value: object, data_x: object, data_y: object, *,
     config: IPMNISTConfig, seeds: tuple[int, ...], _capability: object,
@@ -870,9 +1054,12 @@ def _write_bounded_elastic_matched_authorized(
         raise RuntimeError(
             "campaign publication requires the reservation-first transaction"
         )
-    if type(seeds) is not tuple or seeds != TEST_ONLY_SEEDS:
-        raise RuntimeError("private bounded-elastic publication capability is invalid")
+    checked_seeds = _require_capability_roster(
+        seeds, _capability, operation="publication"
+    )
+    _json_preflight(value)
     reservation = _reserve_output(destination, _capability=_capability)
+    published = False
     try:
         _publish_bounded_elastic_matched_reserved(
             reservation,
@@ -881,11 +1068,15 @@ def _write_bounded_elastic_matched_authorized(
             data_x,
             data_y,
             config=config,
-            seeds=seeds,
+            seeds=checked_seeds,
             _capability=_capability,
         )
+        published = True
     finally:
-        _release_output(reservation)
+        if published:
+            _release_output(reservation)
+        else:
+            _retain_consumed_output(reservation)
 
 
 def _publish_bounded_elastic_matched_reserved(
@@ -899,18 +1090,9 @@ def _publish_bounded_elastic_matched_reserved(
     seeds: tuple[int, ...],
     _capability: object,
 ) -> None:
-    if _capability is _EXECUTION_CAPABILITY:
-        if _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True:
-            raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
-    elif _capability is not _TEST_EXECUTION_CAPABILITY:
-        raise RuntimeError("private bounded-elastic publication capability is invalid")
-    expected_seeds = (
-        CAMPAIGN_SEEDS if _capability is _EXECUTION_CAPABILITY
-        else TEST_ONLY_SEEDS if _capability is _TEST_EXECUTION_CAPABILITY
-        else None
+    checked_seeds = _require_capability_roster(
+        seeds, _capability, operation="publication"
     )
-    if expected_seeds is None or type(seeds) is not tuple or seeds != expected_seeds:
-        raise RuntimeError("private bounded-elastic publication capability is invalid")
     directory_fd, destination_name, _marker, _marker_fd, _device, _inode = reservation
     descriptor = -1
     published_identity: tuple[int, int] | None = None
@@ -918,13 +1100,15 @@ def _publish_bounded_elastic_matched_reserved(
         _require_live_output_parent(destination, directory_fd)
         _require_owned_reservation(reservation)
         _validate_bounded_elastic_matched(
-            value, data_x, data_y, config=config, seeds=seeds, reexecute=True
+            value, data_x, data_y, config=config, seeds=checked_seeds, reexecute=True
         )
         _require_owned_reservation(reservation)
         encoded = _canonical(value) + b"\n"
+        if len(encoded) > _MAX_RESULT_BYTES:
+            raise ValueError("encoded matched result exceeds its byte bound")
         descriptor = os.open(
             ".",
-            os.O_WRONLY | os.O_TMPFILE | os.O_CLOEXEC,
+            os.O_RDWR | os.O_TMPFILE | os.O_CLOEXEC,
             0o600,
             dir_fd=directory_fd,
         )
@@ -937,49 +1121,45 @@ def _publish_bounded_elastic_matched_reserved(
         os.fsync(descriptor)
         os.fchmod(descriptor, 0o400)
         os.fsync(descriptor)
+        prepared_identity = _strict_reread_prepared_output(
+            descriptor,
+            encoded,
+            data_x,
+            data_y,
+            config=config,
+            seeds=checked_seeds,
+        )
         _require_live_output_parent(destination, directory_fd)
         _require_owned_reservation(reservation)
+        # Arm rollback before linkat: an asynchronous exception can arrive after
+        # linkat succeeds but before Python resumes at the following statement.
+        published_identity = prepared_identity
         try:
             _link_unnamed_file(descriptor, directory_fd, destination_name)
         except FileExistsError as error:
             raise FileExistsError(
                 "refusing to replace immutable bounded-elastic output"
             ) from error
-        prepared = os.fstat(descriptor)
-        published_identity = (prepared.st_dev, prepared.st_ino)
+        visible = os.stat(destination_name, dir_fd=directory_fd, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(visible.st_mode)
+            or visible.st_nlink != 1
+            or visible.st_size != len(encoded)
+            or (visible.st_dev, visible.st_ino) != prepared_identity
+        ):
+            raise ValueError("published output is not the strictly checked prepared inode")
         os.fsync(directory_fd)
-        read_fd = os.open(destination_name, os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
-                          dir_fd=directory_fd)
-        try:
-            metadata = os.fstat(read_fd)
-            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
-                raise ValueError("published output must be one unique regular file")
-            actual = os.read(read_fd, len(encoded) + 1)
-            final = os.fstat(read_fd)
-            if actual != encoded or metadata.st_size != len(encoded) or (
-                metadata.st_dev, metadata.st_ino, metadata.st_size, metadata.st_mtime_ns
-            ) != (final.st_dev, final.st_ino, final.st_size, final.st_mtime_ns):
-                raise ValueError("published output changed during strict reread")
-            def exact_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
-                result: dict[str, object] = {}
-                for key, item in pairs:
-                    if key in result:
-                        raise ValueError("published output contains a duplicate JSON key")
-                    result[key] = item
-                return result
-
-            try:
-                reread = json.loads(
-                    actual.decode("utf-8"), object_pairs_hook=exact_object
-                )
-            except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
-                raise ValueError("published output is not bounded strict JSON") from error
-            _validate_bounded_elastic_matched(
-                reread, data_x, data_y, config=config, seeds=seeds, reexecute=False
-            )
-        finally:
-            os.close(read_fd)
         _require_live_output_parent(destination, directory_fd)
+        final_visible = os.stat(
+            destination_name, dir_fd=directory_fd, follow_symlinks=False
+        )
+        if (
+            not stat.S_ISREG(final_visible.st_mode)
+            or final_visible.st_nlink != 1
+            or final_visible.st_size != len(encoded)
+            or (final_visible.st_dev, final_visible.st_ino) != prepared_identity
+        ):
+            raise ValueError("published output name changed after directory synchronization")
     except BaseException:
         if published_identity is not None:
             try:
@@ -1023,22 +1203,11 @@ def _run_and_publish_bounded_elastic_matched_authorized(
     seeds: tuple[int, ...],
     _capability: object,
 ) -> dict[str, object]:
-    expected_seeds = (
-        CAMPAIGN_SEEDS if _capability is _EXECUTION_CAPABILITY
-        else TEST_ONLY_SEEDS if _capability is _TEST_EXECUTION_CAPABILITY
-        else None
+    checked_seeds = _require_capability_roster(
+        seeds, _capability, operation="transaction"
     )
-    if (
-        expected_seeds is None
-        or type(seeds) is not tuple
-        or seeds != expected_seeds
-        or type(data_home) is not type(Path())
-    ):
+    if type(data_home) is not type(Path()):
         raise RuntimeError("private bounded-elastic transaction capability is invalid")
-    if _capability is _EXECUTION_CAPABILITY and (
-        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
-    ):
-        raise RuntimeError("bounded-elastic matched campaign execution is not authorized")
     reservation = _reserve_output(destination, _capability=_capability)
     consumer_started = False
     published = False
@@ -1055,7 +1224,7 @@ def _run_and_publish_bounded_elastic_matched_authorized(
             data_x,
             data_y,
             config=config,
-            seeds=seeds,
+            seeds=checked_seeds,
             _capability=_capability,
             _on_first_dispatch=note_first_dispatch,
         )
@@ -1067,7 +1236,7 @@ def _run_and_publish_bounded_elastic_matched_authorized(
             data_x,
             data_y,
             config=config,
-            seeds=seeds,
+            seeds=checked_seeds,
             _capability=_capability,
         )
         published = True

--- a/alberta_framework/evaluation/bounded_elastic_matched_runner.py
+++ b/alberta_framework/evaluation/bounded_elastic_matched_runner.py
@@ -56,6 +56,7 @@ _MAX_STEPS: Final = 2_000_000
 _MAX_PERSISTENT_BYTES: Final = 256 * 1024 * 1024
 _MAX_DATASET_BYTES: Final = 256 * 1024 * 1024
 _MAX_SCHEDULE_BYTES: Final = 256 * 1024 * 1024
+_MAX_COMBINED_NUMERIC_BYTES: Final = 256 * 1024 * 1024
 _REVIEWED_EXECUTION_TRANSITION: Final = False
 _EXECUTION_AUTHORIZED: Final = False
 _EXECUTION_CAPABILITY: Final = object()
@@ -95,6 +96,9 @@ def frozen_plan() -> dict[str, object]:
             )
             for arm in ARMS
         },
+        "numeric_resource_envelope": _numeric_resource_envelope(
+            config=config, dataset_rows=60_000
+        ),
         "matched_axes": ["seed", "observations", "updates", "example_schedule",
                          "allowed_boundary_information", "allowed_task_information"],
         "reviewed_execution_transition": _REVIEWED_EXECUTION_TRANSITION,
@@ -118,26 +122,27 @@ def _json_preflight(value: object) -> None:
     nodes = 0
     while pending:
         current, depth = pending.pop()
+        actual_type = type(current)
         nodes += 1
         if nodes > 100_000 or depth > 16:
             raise ValueError("matched result exceeds its JSON structure bound")
-        if current is None or type(current) in {bool, int}:
+        if current is None or actual_type is bool or actual_type is int:
             continue
-        if type(current) is float:
-            if not math.isfinite(current):
+        if actual_type is float:
+            if not math.isfinite(cast(float, current)):
                 raise ValueError("matched result contains a non-finite float")
             continue
-        if type(current) is str:
-            if len(current.encode("utf-8")) > 16_384:
+        if actual_type is str:
+            if len(cast(str, current).encode("utf-8")) > 16_384:
                 raise ValueError("matched result contains an oversized string")
             continue
-        if type(current) not in {dict, list}:
+        if actual_type is not dict and actual_type is not list:
             raise ValueError("matched result must contain only exact JSON values")
         identity = id(current)
         if identity in seen:
             raise ValueError("matched result contains an aliased or cyclic container")
         seen.add(identity)
-        if type(current) is dict:
+        if actual_type is dict:
             mapping = cast(dict[object, object], current)
             if len(mapping) > 4096 or any(type(key) is not str for key in mapping):
                 raise ValueError("matched result object exceeds its field bound")
@@ -163,6 +168,8 @@ def _source_identity() -> dict[str, str]:
         "alberta_framework/benchmarks/upgd_ipmnist.py",
         "alberta_framework/evaluation/bounded_elastic_ipmnist_nonpromoting.py",
         "alberta_framework/evaluation/bounded_elastic_matched_runner.py",
+        "pyproject.toml",
+        "uv.lock",
     )
     return {
         relative: hashlib.sha256((root / relative).read_bytes()).hexdigest()
@@ -191,7 +198,16 @@ def _runtime_identity() -> dict[str, object]:
         "machine": platform.machine(),
         "packages": {
             name: importlib.metadata.version(name)
-            for name in ("chex", "jax", "jaxlib", "numpy", "scikit-learn")
+            for name in (
+                "chex",
+                "jax",
+                "jaxlib",
+                "jaxtyping",
+                "numpy",
+                "orbax-checkpoint",
+                "scikit-learn",
+                "scipy",
+            )
         },
         "backend": jax.default_backend(),
         "devices": [
@@ -253,6 +269,31 @@ def _checked_config(value: object) -> IPMNISTConfig:
     return config
 
 
+def _numeric_resource_envelope(
+    *, config: IPMNISTConfig, dataset_rows: int
+) -> dict[str, int]:
+    dataset_bytes = dataset_rows * (config.input_dim * 4 + 4)
+    schedule_bytes = config.n_tasks * (dataset_rows + config.input_dim) * 4
+    peak_persistent_bytes = max(
+        bounded_elastic_resource_expectations(
+            arm=arm,
+            n_tasks=config.n_tasks,
+            input_dim=config.input_dim,
+            hidden1=config.hidden1,
+            hidden2=config.hidden2,
+            n_classes=config.n_classes,
+        )["peak_persistent_bytes_budget"]
+        for arm in ARMS
+    )
+    return {
+        "dataset_bytes": dataset_bytes,
+        "schedule_bytes": schedule_bytes,
+        "peak_persistent_bytes_budget": peak_persistent_bytes,
+        "combined_numeric_bytes": dataset_bytes + schedule_bytes + peak_persistent_bytes,
+        "combined_numeric_bytes_limit": _MAX_COMBINED_NUMERIC_BYTES,
+    }
+
+
 def _validated_arrays(
     data_x: object, data_y: object, config: IPMNISTConfig
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -268,11 +309,15 @@ def _validated_arrays(
         or data_x.shape[1] != config.input_dim
     ):
         raise ValueError("dataset shape does not match the campaign config")
-    if data_x.nbytes + data_y.nbytes > _MAX_DATASET_BYTES:
+    dataset_bytes = data_x.nbytes + data_y.nbytes
+    if dataset_bytes > _MAX_DATASET_BYTES:
         raise ValueError("dataset exceeds the campaign's 256 MiB byte bound")
     schedule_bytes = config.n_tasks * (data_x.shape[0] + config.input_dim) * 4
     if schedule_bytes > _MAX_SCHEDULE_BYTES:
         raise ValueError("schedule exceeds the campaign's 256 MiB byte bound")
+    envelope = _numeric_resource_envelope(config=config, dataset_rows=data_x.shape[0])
+    if envelope["combined_numeric_bytes"] > _MAX_COMBINED_NUMERIC_BYTES:
+        raise ValueError("campaign exceeds its combined 256 MiB numeric allocation bound")
     if not np.isfinite(data_x).all():
         raise ValueError("data_x must be finite")
     if np.any(data_y < 0) or np.any(data_y >= config.n_classes):

--- a/docs/research/bounded-elastic-matched-development.md
+++ b/docs/research/bounded-elastic-matched-development.md
@@ -7,11 +7,13 @@ the protocol records the architecture, task-length, input-scaling, boundary, and
 differences. It is not a paper reproduction.
 
 The prospective plan binds the canonical materialized OpenML MNIST training-array digests,
-current source/runtime identity, an exact 8-task by 5,000-example configuration, all four arms,
-and five globally searched campaign seeds. Tests use a separate test-only capability and seed
-roster, so they never execute the campaign schedule. Each result retains observations, updates,
-data and environment steps, model queries, persistent bytes, peak budget, active final size,
-structural events, and telemetry-only timing.
+current source/runtime identity, exact `pyproject.toml` and `uv.lock` bytes, an exact 8-task by
+5,000-example configuration, all four arms, and five globally searched campaign seeds. Tests use
+a separate test-only capability and seed roster, so they never execute the campaign schedule.
+Each result retains observations, updates, data and environment steps, model queries, persistent
+bytes, peak budget, active final size, structural events, and telemetry-only timing. One aggregate
+256 MiB numeric envelope covers retained dataset, schedule, and peak persistent bytes and is
+checked before dataset copying, schedule construction, parameter initialization, or execution.
 
 Execution, strict reexecution, and publication are hard-disabled until both a separately reviewed
 source transition and runtime authorization become exact `true`. The future output path is NEW.

--- a/docs/research/bounded-elastic-matched-development.md
+++ b/docs/research/bounded-elastic-matched-development.md
@@ -24,10 +24,15 @@ development-selection outcome only; it is not a significance test or scientific 
 
 Execution, strict reexecution, and publication are hard-disabled until both a separately reviewed
 source transition and runtime authorization become exact `true`. The future output path is NEW.
-Before any dataset load or runner dispatch, the campaign publisher must reserve that path through
-per-segment no-follow directory descriptors. Publication is create-only, fsynced, uniquely linked,
-bounded-reread, duplicate-key rejected, and strictly revalidated. Every result is development-only,
-permanently nonpromoting, and retains negative or inconclusive outcomes.
+The reviewed plan records both authorization fields as literal `false`; a later transition cannot
+retroactively change that plan identity. The current runner and publisher are separate primitives,
+not an atomic campaign transaction: an in-memory run can precede output reservation, execution
+failures produce no durable receipt, and a failed attempt does not prevent retry. A future
+authorization must either add a reserve-before-execution coordinator with explicit failure
+semantics or retain these limitations. The existing publisher reserves its NEW path before strict
+reexecution, then publishes create-only via a fsynced unique link with bounded reread, duplicate-key
+rejection, and strict revalidation. Completed results retain their outcome in the returned or
+published object. Every outcome remains development-only and permanently nonpromoting.
 
 The read-only catalog is available without loading MNIST:
 

--- a/docs/research/bounded-elastic-matched-development.md
+++ b/docs/research/bounded-elastic-matched-development.md
@@ -9,12 +9,18 @@ differences. It is not a paper reproduction.
 
 The prospective plan binds the canonical materialized OpenML MNIST training-array digests,
 current source/runtime identity, exact `pyproject.toml` and `uv.lock` bytes, an exact 8-task by
-5,000-example configuration, all four arms, and five globally searched campaign seeds. Tests use
-a separate test-only capability and seed roster, so they never execute the campaign schedule.
+5,000-example configuration, all four arms, and five repository-history-checked campaign seeds.
+The catalog records the distinct test-only roster; the two literal rosters are disjoint, and the
+authorization gate rejects the campaign roster even through private helpers while authorization
+remains false.
 Each result retains observations, updates, data and environment steps, model queries, persistent
-bytes, peak-persistent budget, active final size, structural events, and telemetry-only timing. One aggregate
-256 MiB numeric envelope covers retained dataset, schedule, and peak persistent bytes and is
-checked before dataset copying, schedule construction, parameter initialization, or execution.
+bytes, peak budget, active final size, structural events, and telemetry-only timing. One static
+256 MiB accounting envelope covers one caller-owned C-contiguous host dataset, the exact
+task-length schedule, and peak learner-persistent bytes. It is checked before schedule
+construction, parameter initialization, or execution; backend copies, compiler state, gradients,
+and transient execution buffers are explicitly outside that arithmetic envelope. The plan also
+charges the transaction's 20 initial runner dispatches and 20 strict reexecution dispatches:
+1,600,000 observations, optimizer updates, and data steps plus 3,200,000 model queries in total.
 
 The preregistered primary comparison is paired whole-stream mean online accuracy for
 `bounded_growth` and `bounded_elastic` against `bounded_fixed_cbp`. A candidate is supported only
@@ -28,13 +34,16 @@ run-and-publish transaction remains hard-disabled until both a separately review
 and runtime authorization become exact `true`. The reviewed plan records both authorization fields
 as literal `false`; a later transition cannot retroactively change that plan identity. The future
 output path is NEW. Before any dataset load or runner dispatch, the transaction reserves the path
-through per-segment no-follow directory descriptors. A failure after the first runner dispatch
-permanently retains the inode-owned marker as a consumed-without-result tombstone, so the five-seed
-roster cannot be retried. A failure before the first dispatch has no structured receipt and releases
+through per-segment no-follow directory descriptors. It strictly rereads and validates an unnamed
+staged inode before linking it into the output namespace. Post-link failure removes only that exact
+inode. A failure after the first runner dispatch permanently retains the inode-owned marker as a
+consumed-without-result tombstone, so the five-seed roster cannot be retried; a successful linked
+output is itself the immutable retention barrier before the marker is released. Publication is
+create-only and fsynced. A failure before the first dispatch has no structured receipt and releases
 the reservation. Process death leaves the owned reservation marker in place and also prevents an
-implicit retry. Publication is create-only, fsynced, uniquely linked, bounded-reread,
-duplicate-key rejected, and strictly revalidated. Every result is development-only, permanently
-nonpromoting, and retains negative or inconclusive outcomes.
+implicit retry. Source, runtime, and dataset identities are checked again after both initial
+execution and strict reexecution. Every result is development-only and permanently nonpromoting;
+negative, inconclusive, supported, and rejected development outcomes remain subject to retention.
 
 The read-only catalog is available without loading MNIST:
 

--- a/docs/research/bounded-elastic-matched-development.md
+++ b/docs/research/bounded-elastic-matched-development.md
@@ -1,7 +1,8 @@
 # Bounded elastic matched development
 
 Issue #1562 compares the existing bounded structure-off, bounded growth, bounded elastic, and
-fixed-capacity CBP arms under one peak-memory and final-size budget. This is an ASI fixed-shape
+fixed-capacity CBP arms under one learner-owned persistent-memory and final-size budget. This is
+an ASI fixed-shape
 IPMNIST adaptation of `arXiv:2608.01475v1`; the paper discloses no official code repository, and
 the protocol records the architecture, task-length, input-scaling, boundary, and pruning-sample
 differences. It is not a paper reproduction.
@@ -11,7 +12,7 @@ current source/runtime identity, exact `pyproject.toml` and `uv.lock` bytes, an 
 5,000-example configuration, all four arms, and five globally searched campaign seeds. Tests use
 a separate test-only capability and seed roster, so they never execute the campaign schedule.
 Each result retains observations, updates, data and environment steps, model queries, persistent
-bytes, peak budget, active final size, structural events, and telemetry-only timing. One aggregate
+bytes, peak-persistent budget, active final size, structural events, and telemetry-only timing. One aggregate
 256 MiB numeric envelope covers retained dataset, schedule, and peak persistent bytes and is
 checked before dataset copying, schedule construction, parameter initialization, or execution.
 
@@ -29,7 +30,9 @@ as literal `false`; a later transition cannot retroactively change that plan ide
 output path is NEW. Before any dataset load or runner dispatch, the transaction reserves the path
 through per-segment no-follow directory descriptors. A failure after the first runner dispatch
 permanently retains the inode-owned marker as a consumed-without-result tombstone, so the five-seed
-roster cannot be retried. Publication is create-only, fsynced, uniquely linked, bounded-reread,
+roster cannot be retried. A failure before the first dispatch has no structured receipt and releases
+the reservation. Process death leaves the owned reservation marker in place and also prevents an
+implicit retry. Publication is create-only, fsynced, uniquely linked, bounded-reread,
 duplicate-key rejected, and strictly revalidated. Every result is development-only, permanently
 nonpromoting, and retains negative or inconclusive outcomes.
 

--- a/docs/research/bounded-elastic-matched-development.md
+++ b/docs/research/bounded-elastic-matched-development.md
@@ -1,0 +1,29 @@
+# Bounded elastic matched development
+
+Issue #1562 compares the existing bounded structure-off, bounded growth, bounded elastic, and
+fixed-capacity CBP arms under one peak-memory and final-size budget. This is an ASI fixed-shape
+IPMNIST adaptation of `arXiv:2608.01475v1`; the paper discloses no official code repository, and
+the protocol records the architecture, task-length, input-scaling, boundary, and pruning-sample
+differences. It is not a paper reproduction.
+
+The prospective plan binds the canonical materialized OpenML MNIST training-array digests,
+current source/runtime identity, an exact 8-task by 5,000-example configuration, all four arms,
+and five globally searched campaign seeds. Tests use a separate test-only capability and seed
+roster, so they never execute the campaign schedule. Each result retains observations, updates,
+data and environment steps, model queries, persistent bytes, peak budget, active final size,
+structural events, and telemetry-only timing.
+
+Execution, strict reexecution, and publication are hard-disabled until both a separately reviewed
+source transition and runtime authorization become exact `true`. The future output path is NEW.
+Before any dataset load or runner dispatch, the campaign publisher must reserve that path through
+per-segment no-follow directory descriptors. Publication is create-only, fsynced, uniquely linked,
+bounded-reread, duplicate-key rejected, and strictly revalidated. Every result is development-only,
+permanently nonpromoting, and retains negative or inconclusive outcomes.
+
+The read-only catalog is available without loading MNIST:
+
+```bash
+.venv/bin/python -m alberta_framework.evaluation.bounded_elastic_matched_runner --catalog
+```
+
+No campaign run or result artifact is included with this plan.

--- a/docs/research/bounded-elastic-matched-development.md
+++ b/docs/research/bounded-elastic-matched-development.md
@@ -22,17 +22,16 @@ and otherwise inconclusive. The campaign is supported when either candidate is s
 rejected when both are rejected, and otherwise inconclusive. This conservative sign rule is a
 development-selection outcome only; it is not a significance test or scientific evidence.
 
-Execution, strict reexecution, and publication are hard-disabled until both a separately reviewed
-source transition and runtime authorization become exact `true`. The future output path is NEW.
-The reviewed plan records both authorization fields as literal `false`; a later transition cannot
-retroactively change that plan identity. The current runner and publisher are separate primitives,
-not an atomic campaign transaction: an in-memory run can precede output reservation, execution
-failures produce no durable receipt, and a failed attempt does not prevent retry. A future
-authorization must either add a reserve-before-execution coordinator with explicit failure
-semantics or retain these limitations. The existing publisher reserves its NEW path before strict
-reexecution, then publishes create-only via a fsynced unique link with bounded reread, duplicate-key
-rejection, and strict revalidation. Completed results retain their outcome in the returned or
-published object. Every outcome remains development-only and permanently nonpromoting.
+Standalone execution, strict reexecution, and publication are permanently disabled. One public
+run-and-publish transaction remains hard-disabled until both a separately reviewed source transition
+and runtime authorization become exact `true`. The reviewed plan records both authorization fields
+as literal `false`; a later transition cannot retroactively change that plan identity. The future
+output path is NEW. Before any dataset load or runner dispatch, the transaction reserves the path
+through per-segment no-follow directory descriptors. A failure after the first runner dispatch
+permanently retains the inode-owned marker as a consumed-without-result tombstone, so the five-seed
+roster cannot be retried. Publication is create-only, fsynced, uniquely linked, bounded-reread,
+duplicate-key rejected, and strictly revalidated. Every result is development-only, permanently
+nonpromoting, and retains negative or inconclusive outcomes.
 
 The read-only catalog is available without loading MNIST:
 

--- a/docs/research/bounded-elastic-matched-development.md
+++ b/docs/research/bounded-elastic-matched-development.md
@@ -15,6 +15,13 @@ bytes, peak budget, active final size, structural events, and telemetry-only tim
 256 MiB numeric envelope covers retained dataset, schedule, and peak persistent bytes and is
 checked before dataset copying, schedule construction, parameter initialization, or execution.
 
+The preregistered primary comparison is paired whole-stream mean online accuracy for
+`bounded_growth` and `bounded_elastic` against `bounded_fixed_cbp`. A candidate is supported only
+when all five paired deltas are strictly positive, rejected only when all five are nonpositive,
+and otherwise inconclusive. The campaign is supported when either candidate is supported,
+rejected when both are rejected, and otherwise inconclusive. This conservative sign rule is a
+development-selection outcome only; it is not a significance test or scientific evidence.
+
 Execution, strict reexecution, and publication are hard-disabled until both a separately reviewed
 source transition and runtime authorization become exact `true`. The future output path is NEW.
 Before any dataset load or runner dispatch, the campaign publisher must reserve that path through

--- a/tests/test_bounded_elastic_ipmnist.py
+++ b/tests/test_bounded_elastic_ipmnist.py
@@ -263,6 +263,7 @@ def test_protocol_fails_closed_on_missing_official_code_and_records_adaptation()
     assert BOUNDED_ELASTIC_PROTOCOL["official_repository"] is None
     differences = BOUNDED_ELASTIC_PROTOCOL["protocol_differences"]
     assert isinstance(differences, tuple)
-    assert len(differences) == 9
+    assert len(differences) == 10
+    assert any("exactly one least-active unit" in difference for difference in differences)
     assert BOUNDED_ELASTIC_PROTOCOL["development_only"] is True
     assert BOUNDED_ELASTIC_PROTOCOL["scientific_promotion_allowed"] is False

--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -72,7 +72,9 @@ def _fake_run(
 ) -> ScreeningRunResult:
     del data_x, data_y
     resolved = cast(Any, spec)
-    value = float(seed + tuple(runner.ARMS).index(resolved.name)) / 100.0
+    value = 0.5 + float(
+        runner.TEST_ONLY_SEEDS.index(seed) + tuple(runner.ARMS).index(resolved.name)
+    ) / 100.0
     return ScreeningRunResult(
         config_name=resolved.name,
         base_learner="upgd_w",
@@ -176,6 +178,7 @@ def test_writer_is_create_only_and_retains_negative_outcomes(
     monkeypatch.setattr(runner, "run_screening_config", _fake_run)
     result = _run_for_test(*_data(), config=SMALL)
     destination = tmp_path / "bounded-elastic.json"
+    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
     runner._write_bounded_elastic_matched_authorized(
         destination, result, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
         _capability=runner._TEST_EXECUTION_CAPABILITY,

--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -38,8 +38,9 @@ def test_plan_is_prospective_and_public_execution_is_hard_disabled(
     assert plan["seeds"] == [51_562_001, 51_562_002, 51_562_003, 51_562_004, 51_562_005]
     assert plan["reviewed_execution_transition"] is False
     assert plan["execution_authorized"] is False
-    assert plan["atomic_execution_and_publication"] is True
-    assert plan["execution_failure_receipts_retained"] is True
+    assert plan["reservation_precedes_execution_and_publication"] is True
+    assert plan["pre_dispatch_failure_receipts_retained"] is False
+    assert plan["post_dispatch_failure_tombstone_retained"] is True
     assert plan["post_start_retry_prevention"] is True
     monkeypatch.setattr(runner, "_REVIEWED_EXECUTION_TRANSITION", True)
     monkeypatch.setattr(runner, "_EXECUTION_AUTHORIZED", True)
@@ -228,7 +229,6 @@ def test_writer_is_create_only_and_retains_negative_outcomes(
     monkeypatch.setattr(runner, "run_screening_config", _fake_run)
     result = _run_for_test(*_data(), config=SMALL)
     destination = tmp_path / "bounded-elastic.json"
-    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
     runner._write_bounded_elastic_matched_authorized(
         destination, result, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
         _capability=runner._TEST_EXECUTION_CAPABILITY,
@@ -251,7 +251,6 @@ def test_writer_rejects_replaced_visible_reservation_before_publication(
     monkeypatch.setattr(runner, "run_screening_config", _fake_run)
     result = _run_for_test(*_data(), config=SMALL)
     destination = tmp_path / "bounded-elastic.json"
-    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
     original_validate = runner._validate_bounded_elastic_matched
 
     def replace_marker(*args: object, **kwargs: object) -> None:
@@ -285,7 +284,6 @@ def test_writer_parent_swap_does_not_publish_through_replacement(
     destination = requested / "bounded-elastic.json"
     retired = tmp_path / "retired"
     competitor = b"replacement-directory"
-    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
     original_link = runner._link_unnamed_file
 
     def swap_parent(file_fd: int, directory_fd: int, name: str) -> None:
@@ -316,6 +314,21 @@ def test_public_writer_is_closed_before_creating_output(tmp_path: Path) -> None:
         )
     with pytest.raises(RuntimeError, match="reservation-first transaction"):
         runner._write_bounded_elastic_matched_authorized(
+            destination,
+            {},
+            *_data(),
+            config=SMALL,
+            seeds=runner.CAMPAIGN_SEEDS,
+            _capability=runner._EXECUTION_CAPABILITY,
+        )
+    with pytest.raises(RuntimeError, match="not authorized"):
+        runner._reserve_output(
+            destination,
+            _capability=runner._EXECUTION_CAPABILITY,
+        )
+    with pytest.raises(RuntimeError, match="not authorized"):
+        runner._publish_bounded_elastic_matched_reserved(
+            (-1, "unused", "unused", -1, -1, -1),
             destination,
             {},
             *_data(),
@@ -363,7 +376,6 @@ def test_transaction_reserves_before_dataset_load_or_runner(
         calls += 1
         raise AssertionError("consumer work preceded reservation")
 
-    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
     monkeypatch.setattr(runner, "load_mnist_train", forbidden)
     monkeypatch.setattr(runner, "run_screening_config", forbidden)
     with pytest.raises(FileExistsError):
@@ -390,7 +402,6 @@ def test_transaction_retains_owned_tombstone_after_first_dispatch_failure(
         calls += 1
         raise RuntimeError("injected consumer failure")
 
-    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
     monkeypatch.setattr(runner, "load_mnist_train", lambda _home: (x, y))
     monkeypatch.setattr(runner, "run_screening_config", fail_after_dispatch)
     with pytest.raises(RuntimeError, match="injected consumer failure"):
@@ -427,7 +438,6 @@ def test_transaction_publishes_only_after_strict_reexecution(
         calls += 1
         return _fake_run(*args, **kwargs)
 
-    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
     monkeypatch.setattr(runner, "load_mnist_train", lambda _home: (x, y))
     monkeypatch.setattr(runner, "run_screening_config", counted_run)
     report = runner._run_and_publish_bounded_elastic_matched_authorized(

--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -48,6 +48,21 @@ def test_plan_is_prospective_and_public_execution_is_hard_disabled(
     monkeypatch.setattr(runner, "run_screening_config", forbidden)
     with pytest.raises(RuntimeError, match="not authorized"):
         runner.run_bounded_elastic_matched(*_data(), config=SMALL)
+    with pytest.raises(RuntimeError, match="not authorized"):
+        runner._run_bounded_elastic_matched_authorized(
+            *_data(),
+            config=SMALL,
+            seeds=runner.CAMPAIGN_SEEDS,
+            _capability=runner._EXECUTION_CAPABILITY,
+        )
+    with pytest.raises(RuntimeError, match="not authorized"):
+        runner._validate_bounded_elastic_matched_authorized(
+            {},
+            *_data(),
+            config=SMALL,
+            seeds=runner.CAMPAIGN_SEEDS,
+            _capability=runner._EXECUTION_CAPABILITY,
+        )
     assert calls == 0
 
 
@@ -99,10 +114,37 @@ def test_campaign_runs_all_four_arms_across_frozen_seeds(monkeypatch: pytest.Mon
         (seed, arm) for seed in runner.TEST_ONLY_SEEDS for arm in runner.ARMS
     ]
     assert all(row["result"]["outcome_retained"] is True for row in result["rows"])
+    assert result["aggregate"]["outcome"] == "rejected"
+    comparisons = result["aggregate"]["primary_comparisons"]
+    assert [comparison["candidate"] for comparison in comparisons] == [
+        "bounded_growth",
+        "bounded_elastic",
+    ]
+    assert all(comparison["baseline"] == "bounded_fixed_cbp" for comparison in comparisons)
     for seed in runner.TEST_ONLY_SEEDS:
         rows = [row for row in result["rows"] if row["seed"] == seed]
         assert len({row["execution_identity"]["schedule_sha256"] for row in rows}) == 1
         assert len({row["execution_identity"]["initial_parameters_sha256"] for row in rows}) == 1
+
+
+def test_campaign_rejects_source_drift_during_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_source = runner._source_identity()
+    calls = 0
+
+    def drift_after_first_run(*args: object, **kwargs: object) -> ScreeningRunResult:
+        nonlocal calls
+        calls += 1
+        drifted = dict(original_source)
+        drifted["alberta_framework/benchmarks/ipmnist_screening.py"] = "0" * 64
+        monkeypatch.setattr(runner, "_source_identity", lambda: drifted)
+        return _fake_run(*args, **kwargs)
+
+    monkeypatch.setattr(runner, "run_screening_config", drift_after_first_run)
+    with pytest.raises(RuntimeError, match="changed during matched execution"):
+        _run_for_test(*_data(), config=SMALL)
+    assert calls == 1
 
 
 def test_validator_rejects_identity_resource_and_roster_forgery(
@@ -195,11 +237,52 @@ def test_writer_is_create_only_and_retains_negative_outcomes(
         )
 
 
+def test_writer_rejects_replaced_visible_reservation_before_publication(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = _run_for_test(*_data(), config=SMALL)
+    destination = tmp_path / "bounded-elastic.json"
+    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
+    original_validate = runner._validate_bounded_elastic_matched
+
+    def replace_marker(*args: object, **kwargs: object) -> None:
+        original_validate(*args, **kwargs)
+        marker = destination.with_name(f".{destination.name}.reservation")
+        marker.unlink()
+        marker.write_text("replacement", encoding="ascii")
+
+    monkeypatch.setattr(runner, "_validate_bounded_elastic_matched", replace_marker)
+    with pytest.raises(ValueError, match="owned visible regular marker"):
+        runner._write_bounded_elastic_matched_authorized(
+            destination,
+            result,
+            *_data(),
+            config=SMALL,
+            seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    assert not destination.exists()
+    marker = destination.with_name(f".{destination.name}.reservation")
+    assert marker.read_text(encoding="ascii") == "replacement"
+    marker.unlink()
+
+
 def test_public_writer_is_closed_before_creating_output(tmp_path: Path) -> None:
     destination = tmp_path / "never" / "report.json"
     with pytest.raises(RuntimeError, match="not authorized"):
         runner.write_bounded_elastic_matched(
             destination, {}, *_data(), config=SMALL
+        )
+    assert not destination.parent.exists()
+    with pytest.raises(RuntimeError, match="not authorized"):
+        runner._write_bounded_elastic_matched_authorized(
+            destination,
+            {},
+            *_data(),
+            config=SMALL,
+            seeds=runner.CAMPAIGN_SEEDS,
+            _capability=runner._EXECUTION_CAPABILITY,
         )
     assert not destination.parent.exists()
 

--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -41,7 +41,7 @@ def test_plan_is_prospective_and_public_execution_is_hard_disabled(
     assert plan["reservation_precedes_execution_and_publication"] is True
     assert plan["pre_dispatch_failure_receipts_retained"] is False
     assert plan["post_dispatch_failure_tombstone_retained"] is True
-    assert plan["post_start_retry_prevention"] is True
+    assert plan["post_dispatch_retry_prevention"] is True
     monkeypatch.setattr(runner, "_REVIEWED_EXECUTION_TRANSITION", True)
     monkeypatch.setattr(runner, "_EXECUTION_AUTHORIZED", True)
     assert runner.frozen_plan() == plan

--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -38,9 +38,9 @@ def test_plan_is_prospective_and_public_execution_is_hard_disabled(
     assert plan["seeds"] == [51_562_001, 51_562_002, 51_562_003, 51_562_004, 51_562_005]
     assert plan["reviewed_execution_transition"] is False
     assert plan["execution_authorized"] is False
-    assert plan["atomic_execution_and_publication"] is False
-    assert plan["execution_failure_receipts_retained"] is False
-    assert plan["post_start_retry_prevention"] is False
+    assert plan["atomic_execution_and_publication"] is True
+    assert plan["execution_failure_receipts_retained"] is True
+    assert plan["post_start_retry_prevention"] is True
     monkeypatch.setattr(runner, "_REVIEWED_EXECUTION_TRANSITION", True)
     monkeypatch.setattr(runner, "_EXECUTION_AUTHORIZED", True)
     assert runner.frozen_plan() == plan
@@ -54,7 +54,7 @@ def test_plan_is_prospective_and_public_execution_is_hard_disabled(
         raise AssertionError("runner dispatched before authorization")
 
     monkeypatch.setattr(runner, "run_screening_config", forbidden)
-    with pytest.raises(RuntimeError, match="not authorized"):
+    with pytest.raises(RuntimeError, match="standalone.*disabled"):
         runner.run_bounded_elastic_matched(*_data(), config=SMALL)
     with pytest.raises(RuntimeError, match="not authorized"):
         runner._run_bounded_elastic_matched_authorized(
@@ -310,12 +310,11 @@ def test_writer_parent_swap_does_not_publish_through_replacement(
 
 def test_public_writer_is_closed_before_creating_output(tmp_path: Path) -> None:
     destination = tmp_path / "never" / "report.json"
-    with pytest.raises(RuntimeError, match="not authorized"):
+    with pytest.raises(RuntimeError, match="standalone.*disabled"):
         runner.write_bounded_elastic_matched(
             destination, {}, *_data(), config=SMALL
         )
-    assert not destination.parent.exists()
-    with pytest.raises(RuntimeError, match="not authorized"):
+    with pytest.raises(RuntimeError, match="reservation-first transaction"):
         runner._write_bounded_elastic_matched_authorized(
             destination,
             {},
@@ -325,6 +324,122 @@ def test_public_writer_is_closed_before_creating_output(tmp_path: Path) -> None:
             _capability=runner._EXECUTION_CAPABILITY,
         )
     assert not destination.parent.exists()
+
+
+def test_standalone_paths_remain_disabled_after_flag_transition(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    destination = tmp_path / "never" / "report.json"
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("standalone path dispatched a runner")
+
+    monkeypatch.setattr(runner, "_REVIEWED_EXECUTION_TRANSITION", True)
+    monkeypatch.setattr(runner, "_EXECUTION_AUTHORIZED", True)
+    monkeypatch.setattr(runner, "run_screening_config", forbidden)
+    with pytest.raises(RuntimeError, match="standalone.*disabled"):
+        runner.run_bounded_elastic_matched(*_data(), config=SMALL)
+    with pytest.raises(RuntimeError, match="standalone.*disabled"):
+        runner.validate_bounded_elastic_matched({}, *_data(), config=SMALL)
+    with pytest.raises(RuntimeError, match="standalone.*disabled"):
+        runner.write_bounded_elastic_matched(destination, {}, *_data(), config=SMALL)
+    assert calls == 0
+    assert not destination.parent.exists()
+
+
+def test_transaction_reserves_before_dataset_load_or_runner(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    destination = tmp_path / "report.json"
+    marker = destination.with_name(f".{destination.name}.reservation")
+    marker.write_bytes(b"prior reservation")
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("consumer work preceded reservation")
+
+    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(runner, "load_mnist_train", forbidden)
+    monkeypatch.setattr(runner, "run_screening_config", forbidden)
+    with pytest.raises(FileExistsError):
+        runner._run_and_publish_bounded_elastic_matched_authorized(
+            tmp_path,
+            destination,
+            config=SMALL,
+            seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    assert calls == 0
+    assert marker.read_bytes() == b"prior reservation"
+
+
+def test_transaction_retains_owned_tombstone_after_first_dispatch_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    destination = tmp_path / "report.json"
+    x, y = _data()
+    calls = 0
+
+    def fail_after_dispatch(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("injected consumer failure")
+
+    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(runner, "load_mnist_train", lambda _home: (x, y))
+    monkeypatch.setattr(runner, "run_screening_config", fail_after_dispatch)
+    with pytest.raises(RuntimeError, match="injected consumer failure"):
+        runner._run_and_publish_bounded_elastic_matched_authorized(
+            tmp_path,
+            destination,
+            config=SMALL,
+            seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    marker = destination.with_name(f".{destination.name}.reservation")
+    assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
+    assert not destination.exists()
+    with pytest.raises(FileExistsError):
+        runner._run_and_publish_bounded_elastic_matched_authorized(
+            tmp_path,
+            destination,
+            config=SMALL,
+            seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    assert calls == 1
+
+
+def test_transaction_publishes_only_after_strict_reexecution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    destination = tmp_path / "report.json"
+    x, y = _data()
+    calls = 0
+
+    def counted_run(*args: object, **kwargs: object) -> ScreeningRunResult:
+        nonlocal calls
+        calls += 1
+        return _fake_run(*args, **kwargs)
+
+    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(runner, "load_mnist_train", lambda _home: (x, y))
+    monkeypatch.setattr(runner, "run_screening_config", counted_run)
+    report = runner._run_and_publish_bounded_elastic_matched_authorized(
+        tmp_path,
+        destination,
+        config=SMALL,
+        seeds=runner.TEST_ONLY_SEEDS,
+        _capability=runner._TEST_EXECUTION_CAPABILITY,
+    )
+    assert json.loads(destination.read_bytes()) == report
+    assert calls == 2 * len(runner.TEST_ONLY_SEEDS) * len(runner.ARMS)
+    assert not destination.with_name(f".{destination.name}.reservation").exists()
 
 
 def test_preflight_rejects_unbounded_or_wrong_dataset_before_execution(

--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -237,6 +237,50 @@ def test_preflight_rejects_unbounded_or_wrong_dataset_before_execution(
     assert calls == 0
 
 
+def test_combined_numeric_preflight_precedes_copy_schedule_and_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    x, y = _data()
+    monkeypatch.setattr(runner, "_MAX_COMBINED_NUMERIC_BYTES", 1_000)
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("allocation or execution preceded aggregate preflight")
+
+    monkeypatch.setattr(runner.np, "array", forbidden)
+    monkeypatch.setattr(runner, "build_schedule", forbidden)
+    monkeypatch.setattr(runner, "init_mlp_params", forbidden)
+    monkeypatch.setattr(runner, "run_screening_config", forbidden)
+    with pytest.raises(ValueError, match="combined 256 MiB numeric allocation"):
+        _run_for_test(x, y, config=SMALL)
+    assert calls == 0
+
+
+def test_json_preflight_rejects_nested_hostile_type_without_dispatching_hooks() -> None:
+    calls = 0
+
+    class HostileMeta(type):
+        def __hash__(cls) -> int:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("hostile type was hashed")
+
+        def __eq__(cls, other: object) -> bool:
+            del other
+            nonlocal calls
+            calls += 1
+            raise AssertionError("hostile type was compared")
+
+    class Hostile(metaclass=HostileMeta):
+        pass
+
+    with pytest.raises(ValueError, match="exact JSON values"):
+        runner._json_preflight({"outer": [{"inner": Hostile()}]})
+    assert calls == 0
+
+
 def test_registered_controls_are_exact() -> None:
     for arm in runner.ARMS:
         assert screening_spec(arm).hyperparameters == registered_bounded_elastic_hyperparameters(
@@ -251,4 +295,29 @@ def test_source_identity_uses_only_installed_package_files() -> None:
         "alberta_framework/benchmarks/upgd_ipmnist.py",
         "alberta_framework/evaluation/bounded_elastic_ipmnist_nonpromoting.py",
         "alberta_framework/evaluation/bounded_elastic_matched_runner.py",
+        "pyproject.toml",
+        "uv.lock",
     }
+
+
+@pytest.mark.parametrize("dependency_input", ["pyproject.toml", "uv.lock"])
+def test_source_identity_detects_dependency_input_mutation(
+    monkeypatch: pytest.MonkeyPatch, dependency_input: str
+) -> None:
+    original = runner._source_identity()
+    read_bytes = Path.read_bytes
+
+    def mutated(path: Path) -> bytes:
+        payload = read_bytes(path)
+        if path.name == dependency_input:
+            return payload + b"\nprospective-mutation"
+        return payload
+
+    monkeypatch.setattr(Path, "read_bytes", mutated)
+    changed = runner._source_identity()
+    assert changed[dependency_input] != original[dependency_input]
+    assert all(
+        changed[path] == digest
+        for path, digest in original.items()
+        if path != dependency_input
+    )

--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import alberta_framework.evaluation.bounded_elastic_matched_runner as runner
+from alberta_framework.benchmarks.ipmnist_screening import ScreeningRunResult, screening_spec
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+from alberta_framework.evaluation.bounded_elastic_ipmnist_nonpromoting import (
+    registered_bounded_elastic_hyperparameters,
+)
+
+SMALL = IPMNISTConfig(n_tasks=1, task_length=5000, input_dim=2, hidden1=4, hidden2=2, n_classes=2)
+
+
+def _run_for_test(
+    data_x: object, data_y: object, *, config: IPMNISTConfig
+) -> dict[str, object]:
+    return runner._run_bounded_elastic_matched_authorized(
+        data_x,
+        data_y,
+        config=config,
+        seeds=runner.TEST_ONLY_SEEDS,
+        _capability=runner._TEST_EXECUTION_CAPABILITY,
+    )
+
+
+def test_plan_is_prospective_and_public_execution_is_hard_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = runner.frozen_plan()
+    assert plan["seeds"] == [51_562_001, 51_562_002, 51_562_003, 51_562_004, 51_562_005]
+    assert plan["reviewed_execution_transition"] is False
+    assert plan["execution_authorized"] is False
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("runner dispatched before authorization")
+
+    monkeypatch.setattr(runner, "run_screening_config", forbidden)
+    with pytest.raises(RuntimeError, match="not authorized"):
+        runner.run_bounded_elastic_matched(*_data(), config=SMALL)
+    assert calls == 0
+
+
+def _data() -> tuple[np.ndarray, np.ndarray]:
+    x = np.arange(10_000, dtype=np.float32).reshape(5000, 2) / 10_000.0
+    y = np.arange(5000, dtype=np.int32) % 2
+    return x, y
+
+
+def _resign(value: dict[str, Any]) -> None:
+    unsigned = dict(value)
+    unsigned.pop("result_sha256", None)
+    value["result_sha256"] = hashlib.sha256(runner._canonical(unsigned)).hexdigest()
+
+
+def _fake_run(
+    data_x: np.ndarray,
+    data_y: np.ndarray,
+    spec: object,
+    seed: int,
+    config: IPMNISTConfig,
+) -> ScreeningRunResult:
+    del data_x, data_y
+    resolved = cast(Any, spec)
+    value = float(seed + tuple(runner.ARMS).index(resolved.name)) / 100.0
+    return ScreeningRunResult(
+        config_name=resolved.name,
+        base_learner="upgd_w",
+        hyperparameters=registered_bounded_elastic_hyperparameters(resolved.name),
+        seed=seed,
+        config=config,
+        per_task_accuracy=np.asarray([value], dtype=np.float64),
+        per_task_loss=np.asarray([1.0 - value], dtype=np.float64),
+        per_task_plasticity=np.asarray([value], dtype=np.float64),
+        wall_clock_seconds=1.0,
+    )
+
+
+def test_campaign_runs_all_four_arms_across_frozen_seeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = cast(dict[str, Any], _run_for_test(*_data(), config=SMALL))
+    runner._validate_bounded_elastic_matched_authorized(
+        result, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+        _capability=runner._TEST_EXECUTION_CAPABILITY,
+    )
+    assert [(row["seed"], row["arm"]) for row in result["rows"]] == [
+        (seed, arm) for seed in runner.TEST_ONLY_SEEDS for arm in runner.ARMS
+    ]
+    assert all(row["result"]["outcome_retained"] is True for row in result["rows"])
+    for seed in runner.TEST_ONLY_SEEDS:
+        rows = [row for row in result["rows"] if row["seed"] == seed]
+        assert len({row["execution_identity"]["schedule_sha256"] for row in rows}) == 1
+        assert len({row["execution_identity"]["initial_parameters_sha256"] for row in rows}) == 1
+
+
+def test_validator_rejects_identity_resource_and_roster_forgery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = cast(dict[str, Any], _run_for_test(*_data(), config=SMALL))
+
+    forged = copy.deepcopy(result)
+    forged["rows"][0]["execution_identity"]["schedule_sha256"] = "0" * 64
+    _resign(forged)
+    with pytest.raises(ValueError, match="execution identity"):
+        runner._validate_bounded_elastic_matched_authorized(
+            forged, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+
+    forged = copy.deepcopy(result)
+    forged["rows"][0]["result"]["resources"]["data_steps"] = 1
+    _resign(forged)
+    with pytest.raises(ValueError, match="step/query"):
+        runner._validate_bounded_elastic_matched_authorized(
+            forged, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+
+    missing = copy.deepcopy(result)
+    missing["rows"].pop()
+    _resign(missing)
+    with pytest.raises(ValueError, match="roster"):
+        runner._validate_bounded_elastic_matched_authorized(
+            missing, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+
+
+def test_validator_reexecutes_and_rejects_self_consistent_metric_forgery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = cast(dict[str, Any], _run_for_test(*_data(), config=SMALL))
+    forged = copy.deepcopy(result)
+    forged["rows"][0]["result"]["metrics"]["mean_online_accuracy"] = 0.99
+    forged["aggregate"] = runner._aggregate(forged["rows"])
+    _resign(forged)
+
+    with pytest.raises(ValueError, match="reexecution"):
+        runner._validate_bounded_elastic_matched_authorized(
+            forged, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+
+
+def test_campaign_rejects_unregistered_outcome_decisions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = cast(dict[str, Any], _run_for_test(*_data(), config=SMALL))
+    forged = copy.deepcopy(result)
+    forged["rows"][0]["result"]["outcome"] = "supported"
+    _resign(forged)
+
+    with pytest.raises(ValueError, match="inconclusive"):
+        runner._validate_bounded_elastic_matched_authorized(
+            forged, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+
+
+def test_writer_is_create_only_and_retains_negative_outcomes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = _run_for_test(*_data(), config=SMALL)
+    destination = tmp_path / "bounded-elastic.json"
+    runner._write_bounded_elastic_matched_authorized(
+        destination, result, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+        _capability=runner._TEST_EXECUTION_CAPABILITY,
+    )
+    retained = json.loads(destination.read_bytes())
+    runner._validate_bounded_elastic_matched_authorized(
+        retained, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+        _capability=runner._TEST_EXECUTION_CAPABILITY,
+    )
+    with pytest.raises(FileExistsError):
+        runner._write_bounded_elastic_matched_authorized(
+            destination, result, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+
+
+def test_public_writer_is_closed_before_creating_output(tmp_path: Path) -> None:
+    destination = tmp_path / "never" / "report.json"
+    with pytest.raises(RuntimeError, match="not authorized"):
+        runner.write_bounded_elastic_matched(
+            destination, {}, *_data(), config=SMALL
+        )
+    assert not destination.parent.exists()
+
+
+def test_preflight_rejects_unbounded_or_wrong_dataset_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("screening must not execute")
+
+    monkeypatch.setattr(runner, "run_screening_config", forbidden)
+    x, y = _data()
+    with pytest.raises(ValueError, match="float32"):
+        runner._run_bounded_elastic_matched_authorized(
+            x.astype(np.float64), y, config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    huge = IPMNISTConfig(
+        n_tasks=1,
+        task_length=5000,
+        input_dim=8_000,
+        hidden1=10_000,
+        hidden2=1,
+        n_classes=2,
+    )
+    with pytest.raises(ValueError, match="persistent-memory"):
+        runner._run_bounded_elastic_matched_authorized(
+            x, y, config=huge, seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    assert calls == 0
+
+
+def test_registered_controls_are_exact() -> None:
+    for arm in runner.ARMS:
+        assert screening_spec(arm).hyperparameters == registered_bounded_elastic_hyperparameters(
+            arm
+        )
+
+
+def test_source_identity_uses_only_installed_package_files() -> None:
+    assert set(runner._source_identity()) == {
+        "alberta_framework/_seed_validation.py",
+        "alberta_framework/benchmarks/ipmnist_screening.py",
+        "alberta_framework/benchmarks/upgd_ipmnist.py",
+        "alberta_framework/evaluation/bounded_elastic_ipmnist_nonpromoting.py",
+        "alberta_framework/evaluation/bounded_elastic_matched_runner.py",
+    }

--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -38,6 +38,14 @@ def test_plan_is_prospective_and_public_execution_is_hard_disabled(
     assert plan["seeds"] == [51_562_001, 51_562_002, 51_562_003, 51_562_004, 51_562_005]
     assert plan["reviewed_execution_transition"] is False
     assert plan["execution_authorized"] is False
+    assert plan["atomic_execution_and_publication"] is False
+    assert plan["execution_failure_receipts_retained"] is False
+    assert plan["post_start_retry_prevention"] is False
+    monkeypatch.setattr(runner, "_REVIEWED_EXECUTION_TRANSITION", True)
+    monkeypatch.setattr(runner, "_EXECUTION_AUTHORIZED", True)
+    assert runner.frozen_plan() == plan
+    monkeypatch.setattr(runner, "_REVIEWED_EXECUTION_TRANSITION", False)
+    monkeypatch.setattr(runner, "_EXECUTION_AUTHORIZED", False)
     calls = 0
 
     def forbidden(*args: object, **kwargs: object) -> object:

--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import stat
 from pathlib import Path
 from typing import Any, cast
 
@@ -42,6 +43,12 @@ def test_plan_is_prospective_and_public_execution_is_hard_disabled(
     assert plan["pre_dispatch_failure_receipts_retained"] is False
     assert plan["post_dispatch_failure_tombstone_retained"] is True
     assert plan["post_dispatch_retry_prevention"] is True
+    assert plan["seed_policy"] == {
+        "campaign_roster_status": "reserved_unconsumed",
+        "test_only_seeds": [201, 202, 203, 204, 205],
+        "campaign_and_test_rosters_disjoint": True,
+    }
+    assert set(runner.CAMPAIGN_SEEDS).isdisjoint(runner.TEST_ONLY_SEEDS)
     monkeypatch.setattr(runner, "_REVIEWED_EXECUTION_TRANSITION", True)
     monkeypatch.setattr(runner, "_EXECUTION_AUTHORIZED", True)
     assert runner.frozen_plan() == plan
@@ -71,6 +78,28 @@ def test_plan_is_prospective_and_public_execution_is_hard_disabled(
             config=SMALL,
             seeds=runner.CAMPAIGN_SEEDS,
             _capability=runner._EXECUTION_CAPABILITY,
+        )
+    assert calls == 0
+
+
+def test_direct_internal_reexecution_cannot_bypass_campaign_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("campaign dispatch bypassed authorization")
+
+    monkeypatch.setattr(runner, "run_screening_config", forbidden)
+    with pytest.raises(RuntimeError, match="not authorized"):
+        runner._validate_bounded_elastic_matched(
+            {},
+            *_data(),
+            config=SMALL,
+            seeds=runner.CAMPAIGN_SEEDS,
+            reexecute=True,
         )
     assert calls == 0
 
@@ -154,6 +183,45 @@ def test_campaign_rejects_source_drift_during_execution(
     with pytest.raises(RuntimeError, match="changed during matched execution"):
         _run_for_test(*_data(), config=SMALL)
     assert calls == 1
+
+
+def test_campaign_and_reexecution_reject_dataset_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    x, y = _data()
+    calls = 0
+
+    def mutate_once(
+        data_x: np.ndarray,
+        data_y: np.ndarray,
+        spec: object,
+        seed: int,
+        config: IPMNISTConfig,
+    ) -> ScreeningRunResult:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            data_x[0, 0] += np.float32(0.25)
+        return _fake_run(data_x, data_y, spec, seed, config)
+
+    monkeypatch.setattr(runner, "run_screening_config", mutate_once)
+    with pytest.raises(RuntimeError, match="dataset changed during matched execution"):
+        _run_for_test(x, y, config=SMALL)
+
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    clean_x, clean_y = _data()
+    result = _run_for_test(clean_x, clean_y, config=SMALL)
+    calls = 0
+    monkeypatch.setattr(runner, "run_screening_config", mutate_once)
+    with pytest.raises(RuntimeError, match="dataset changed during strict reexecution"):
+        runner._validate_bounded_elastic_matched_authorized(
+            result,
+            clean_x,
+            clean_y,
+            config=SMALL,
+            seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
 
 
 def test_validator_rejects_identity_resource_and_roster_forgery(
@@ -243,6 +311,127 @@ def test_writer_is_create_only_and_retains_negative_outcomes(
             destination, result, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
             _capability=runner._TEST_EXECUTION_CAPABILITY,
         )
+    assert not destination.with_name(f".{destination.name}.reservation").exists()
+
+
+def test_writer_strictly_rereads_before_link_and_retains_failed_attempt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = _run_for_test(*_data(), config=SMALL)
+    destination = tmp_path / "bounded-elastic.json"
+    marker = destination.with_name(f".{destination.name}.reservation")
+
+    def fail_strict_stage(*_args: object, **_kwargs: object) -> tuple[int, int]:
+        raise ValueError("strict stage failed")
+
+    monkeypatch.setattr(runner, "_strict_reread_prepared_output", fail_strict_stage)
+
+    with pytest.raises(ValueError, match="strict stage failed"):
+        runner._write_bounded_elastic_matched_authorized(
+            destination,
+            result,
+            *_data(),
+            config=SMALL,
+            seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    assert not destination.exists()
+    assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
+
+
+def test_writer_retains_reservation_after_reexecution_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = _run_for_test(*_data(), config=SMALL)
+    destination = tmp_path / "bounded-elastic.json"
+    marker = destination.with_name(f".{destination.name}.reservation")
+
+    def fail_dispatch(*_args: object, **_kwargs: object) -> ScreeningRunResult:
+        raise RuntimeError("dispatch failed")
+
+    monkeypatch.setattr(runner, "run_screening_config", fail_dispatch)
+
+    with pytest.raises(RuntimeError, match="dispatch failed"):
+        runner._write_bounded_elastic_matched_authorized(
+            destination,
+            result,
+            *_data(),
+            config=SMALL,
+            seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    assert not destination.exists()
+    assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
+
+
+@pytest.mark.parametrize("replace_linked_inode", [False, True])
+def test_post_link_failure_rolls_back_only_the_exact_published_inode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    replace_linked_inode: bool,
+) -> None:
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = _run_for_test(*_data(), config=SMALL)
+    destination = tmp_path / "bounded-elastic.json"
+    marker = destination.with_name(f".{destination.name}.reservation")
+    original_fsync = runner.os.fsync
+    directory_fsyncs = 0
+
+    def fail_after_link(descriptor: int) -> None:
+        nonlocal directory_fsyncs
+        if stat.S_ISDIR(runner.os.fstat(descriptor).st_mode):
+            directory_fsyncs += 1
+            if directory_fsyncs == 2:
+                if replace_linked_inode:
+                    destination.unlink()
+                    destination.write_bytes(b"foreign replacement")
+                raise OSError("post-link directory fsync failed")
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(runner.os, "fsync", fail_after_link)
+    with pytest.raises(OSError, match="post-link"):
+        runner._write_bounded_elastic_matched_authorized(
+            destination,
+            result,
+            *_data(),
+            config=SMALL,
+            seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    if replace_linked_inode:
+        assert destination.read_bytes() == b"foreign replacement"
+    else:
+        assert not destination.exists()
+    assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
+
+
+def test_link_success_followed_by_exception_rolls_back_exact_inode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = _run_for_test(*_data(), config=SMALL)
+    destination = tmp_path / "bounded-elastic.json"
+    original_link = runner._link_unnamed_file
+
+    def link_then_interrupt(file_fd: int, directory_fd: int, name: str) -> None:
+        original_link(file_fd, directory_fd, name)
+        raise KeyboardInterrupt("interrupted after link")
+
+    monkeypatch.setattr(runner, "_link_unnamed_file", link_then_interrupt)
+    with pytest.raises(KeyboardInterrupt, match="interrupted after link"):
+        runner._write_bounded_elastic_matched_authorized(
+            destination,
+            result,
+            *_data(),
+            config=SMALL,
+            seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    assert not destination.exists()
+    marker = destination.with_name(f".{destination.name}.reservation")
+    assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
 
 
 def test_writer_rejects_replaced_visible_reservation_before_publication(
@@ -485,7 +674,7 @@ def test_preflight_rejects_unbounded_or_wrong_dataset_before_execution(
     assert calls == 0
 
 
-def test_combined_numeric_preflight_precedes_copy_schedule_and_initialization(
+def test_static_numeric_preflight_precedes_schedule_and_initialization(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     x, y = _data()
@@ -497,12 +686,48 @@ def test_combined_numeric_preflight_precedes_copy_schedule_and_initialization(
         calls += 1
         raise AssertionError("allocation or execution preceded aggregate preflight")
 
-    monkeypatch.setattr(runner.np, "array", forbidden)
     monkeypatch.setattr(runner, "build_schedule", forbidden)
     monkeypatch.setattr(runner, "init_mlp_params", forbidden)
     monkeypatch.setattr(runner, "run_screening_config", forbidden)
-    with pytest.raises(ValueError, match="combined 256 MiB numeric allocation"):
+    with pytest.raises(ValueError, match="static 256 MiB numeric accounting"):
         _run_for_test(x, y, config=SMALL)
+    assert calls == 0
+
+
+def test_resource_envelope_uses_task_length_and_rejects_unaccounted_dataset_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    envelope = runner._numeric_resource_envelope(config=SMALL, dataset_rows=5000)
+    assert envelope["schedule_bytes"] == SMALL.n_tasks * (
+        SMALL.task_length + SMALL.input_dim
+    ) * 4
+    assert "combined_numeric_bytes" not in envelope
+    plan = runner.frozen_plan()
+    assert "backend copies" in cast(str, plan["numeric_resource_scope"])
+    transaction = cast(dict[str, int], plan["transaction_resource_accounting"])
+    assert transaction == {
+        "campaign_rows": 20,
+        "initial_runner_dispatches": 20,
+        "strict_reexecution_dispatches": 20,
+        "total_runner_dispatches": 40,
+        "total_observations": 1_600_000,
+        "total_optimizer_updates": 1_600_000,
+        "total_data_steps": 1_600_000,
+        "total_environment_steps": 0,
+        "total_model_queries": 3_200_000,
+    }
+
+    x, y = _data()
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("noncontiguous dataset reached execution")
+
+    monkeypatch.setattr(runner, "run_screening_config", forbidden)
+    with pytest.raises(ValueError, match="C-contiguous"):
+        _run_for_test(x[:, ::-1], y, config=SMALL)
     assert calls == 0
 
 
@@ -529,6 +754,53 @@ def test_json_preflight_rejects_nested_hostile_type_without_dispatching_hooks() 
     assert calls == 0
 
 
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ({"field": 1 << 80}, "out-of-range integer"),
+        ({"x" * 257: 1}, "oversized field name"),
+        ({"field": "\ud800"}, "invalid Unicode"),
+    ],
+)
+def test_json_preflight_rejects_hostile_scalar_bounds(
+    value: object, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        runner._json_preflight(value)
+
+
+def test_seed_roster_validation_does_not_dispatch_hostile_equality(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    class HostileInt(int):
+        def __eq__(self, other: object) -> bool:
+            del other
+            nonlocal calls
+            calls += 1
+            raise AssertionError("hostile seed equality dispatched")
+
+    hostile = (HostileInt(201), *runner.TEST_ONLY_SEEDS[1:])
+    with pytest.raises(RuntimeError, match="seed roster"):
+        runner._run_bounded_elastic_matched_authorized(
+            *_data(),
+            config=SMALL,
+            seeds=cast(Any, hostile),
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    assert calls == 0
+
+
+def test_output_path_bounds_fail_before_directory_creation(tmp_path: Path) -> None:
+    destination = tmp_path / "never" / ("x" * 241) / "report.json"
+    with pytest.raises(ValueError, match="oversized component"):
+        runner._reserve_output(
+            destination, _capability=runner._TEST_EXECUTION_CAPABILITY
+        )
+    assert not (tmp_path / "never").exists()
+
+
 def test_registered_controls_are_exact() -> None:
     for arm in runner.ARMS:
         assert screening_spec(arm).hyperparameters == registered_bounded_elastic_hyperparameters(
@@ -536,7 +808,7 @@ def test_registered_controls_are_exact() -> None:
         )
 
 
-def test_source_identity_uses_only_installed_package_files() -> None:
+def test_source_identity_uses_exact_audited_sources_and_dependency_inputs() -> None:
     assert set(runner._source_identity()) == {
         "alberta_framework/_seed_validation.py",
         "alberta_framework/benchmarks/ipmnist_screening.py",

--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -268,6 +268,38 @@ def test_writer_rejects_replaced_visible_reservation_before_publication(
     marker.unlink()
 
 
+def test_writer_parent_swap_does_not_publish_through_replacement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = _run_for_test(*_data(), config=SMALL)
+    requested = tmp_path / "requested"
+    destination = requested / "bounded-elastic.json"
+    retired = tmp_path / "retired"
+    competitor = b"replacement-directory"
+    monkeypatch.setattr(runner, "OUTPUT_PATH", destination)
+    original_link = runner._link_unnamed_file
+
+    def swap_parent(file_fd: int, directory_fd: int, name: str) -> None:
+        requested.rename(retired)
+        requested.mkdir()
+        destination.write_bytes(competitor)
+        original_link(file_fd, directory_fd, name)
+
+    monkeypatch.setattr(runner, "_link_unnamed_file", swap_parent)
+    with pytest.raises(RuntimeError, match="parent changed"):
+        runner._write_bounded_elastic_matched_authorized(
+            destination,
+            result,
+            *_data(),
+            config=SMALL,
+            seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+    assert destination.read_bytes() == competitor
+    assert not (retired / destination.name).exists()
+
+
 def test_public_writer_is_closed_before_creating_output(tmp_path: Path) -> None:
     destination = tmp_path / "never" / "report.json"
     with pytest.raises(RuntimeError, match="not authorized"):


### PR DESCRIPTION
## Summary

Strict successor to closed-unmerged #2115. This branch preserves its full contributor lineage through `7b8fb020` and adds one focused hardening commit. No campaign workload or output was run; issue #1562 remains open.

The successor:

- validates and strictly rereads the anonymous staged inode before linking, with exact-inode rollback across asynchronous and post-link failures
- retains the owned consumed-without-result tombstone after every post-dispatch failure and prevents retry
- rechecks dataset/source/runtime identity after initial execution and strict reexecution
- keeps campaign and test capability/seed rosters disjoint and blocks campaign helpers while authorization remains false
- corrects task-length schedule accounting, records the full 20-primary + 20-replay transaction counters, requires C-contiguous caller arrays, and honestly scopes the static numeric envelope
- bounds JSON integers, aggregate bytes, keys, Unicode, paths, and path components before expensive or filesystem work

All results remain development-only and permanently nonpromoting. The standalone execution/reexecution/publication helpers remain closed; the single reservation-first transaction remains gated by two literal false authorization fields.

## Verification

- 44 focused and adjacent tests passed on exact head `922de144`
- scoped Ruff clean
- strict mypy clean (222 source files)
- `git diff --check` clean

## Supersession

#2115 is closed unmerged. Exactly this stronger successor should survive.