### PR TITLE
fix(reference): bound canonical config preflight

### DIFF
--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -138,7 +138,7 @@ def _charge_json_string(encoded_bytes: list[int], text: str) -> None:
             size += 2
         elif codepoint < 32:
             size += 6
-        elif codepoint < 128:
+        elif codepoint <= 0x7E:
             size += 1
         elif codepoint <= 0xFFFF:
             size += 6
@@ -176,8 +176,11 @@ def _validate_json_value(
         _charge_json_bytes(_encoded_bytes, 4 if value else 5)
         return nodes
     if value_type is int:
+        integer = cast(int, value)
+        if integer.bit_length() > (_MAX_CONFIG_BYTES * 10) // 3 + 1:
+            raise ValueError(f"canonical config exceeds {_MAX_CONFIG_BYTES} bytes")
         try:
-            _charge_json_bytes(_encoded_bytes, len(str(value)))
+            _charge_json_bytes(_encoded_bytes, len(str(integer)))
         except ValueError as exc:
             raise ValueError(f"{path} must have a finite canonical JSON encoding") from exc
         return nodes
@@ -228,7 +231,7 @@ def _validate_json_value(
 
 def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
     if type(value) is not dict:
-        raise ValueError("config must be a JSON mapping")
+        raise ValueError("config must be an exact JSON object")
     _validate_json_value(value, path="config")
     try:
         encoded = json.dumps(

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -46,6 +46,8 @@ _MAX_CONFIG_BYTES = 1 << 20
 _MAX_JSON_NESTING_DEPTH = 64
 # Frozen manifests are tiny. Cap nodes before walking toward the 1 MiB encoding cap.
 _MAX_JSON_VALUES = 1_000_000
+_MIN_JSON_INTEGER = -(1 << 63)
+_MAX_JSON_INTEGER = (1 << 63) - 1
 _MAX_ARRAY_RANK = 8
 _MAX_ARRAY_ELEMENTS = 1 << 20
 _SUPPORTED_DTYPES = frozenset(
@@ -177,12 +179,9 @@ def _validate_json_value(
         return nodes
     if value_type is int:
         integer = cast(int, value)
-        if integer.bit_length() > (_MAX_CONFIG_BYTES * 10) // 3 + 1:
-            raise ValueError(f"canonical config exceeds {_MAX_CONFIG_BYTES} bytes")
-        try:
-            _charge_json_bytes(_encoded_bytes, len(str(integer)))
-        except ValueError as exc:
-            raise ValueError(f"{path} must have a finite canonical JSON encoding") from exc
+        if not _MIN_JSON_INTEGER <= integer <= _MAX_JSON_INTEGER:
+            raise ValueError(f"{path} integer must fit signed 64-bit bounds")
+        _charge_json_bytes(_encoded_bytes, len(str(integer)))
         return nodes
     if value_type is float:
         if not math.isfinite(value):

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -121,46 +121,113 @@ def _load_manifest_config_json(raw: str) -> Any:
         raise ValueError("manifest config must be canonical JSON") from exc
 
 
+def _charge_json_bytes(encoded_bytes: list[int], amount: int) -> None:
+    if amount > _MAX_CONFIG_BYTES - encoded_bytes[0]:
+        raise ValueError(f"canonical config exceeds {_MAX_CONFIG_BYTES} bytes")
+    encoded_bytes[0] += amount
+
+
+def _charge_json_string(encoded_bytes: list[int], text: str) -> None:
+    remaining = _MAX_CONFIG_BYTES - encoded_bytes[0]
+    if len(text) > remaining - 2:
+        raise ValueError(f"canonical config exceeds {_MAX_CONFIG_BYTES} bytes")
+    size = 2
+    for character in text:
+        codepoint = ord(character)
+        if character in {'"', "\\"} or codepoint in {8, 9, 10, 12, 13}:
+            size += 2
+        elif codepoint < 32:
+            size += 6
+        elif codepoint < 128:
+            size += 1
+        elif codepoint <= 0xFFFF:
+            size += 6
+        else:
+            size += 12
+        if size > remaining:
+            raise ValueError(f"canonical config exceeds {_MAX_CONFIG_BYTES} bytes")
+    _charge_json_bytes(encoded_bytes, size)
+
+
 def _validate_json_value(
-    value: Any, *, path: str, depth: int = 0, nodes: int = 0
+    value: Any,
+    *,
+    path: str,
+    depth: int = 0,
+    nodes: int = 0,
+    _encoded_bytes: list[int] | None = None,
 ) -> int:
+    if _encoded_bytes is None:
+        _encoded_bytes = [0]
+
     nodes += 1
     if nodes > _MAX_JSON_VALUES:
         raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
     if depth > _MAX_JSON_NESTING_DEPTH:
         raise ValueError(f"{path} exceeds the maximum canonical JSON nesting depth")
     value_type = type(value)
-    if value is None or value_type is str or value_type is bool or value_type is int:
+    if value is None:
+        _charge_json_bytes(_encoded_bytes, 4)
+        return nodes
+    if value_type is str:
+        _charge_json_string(_encoded_bytes, value)
+        return nodes
+    if value_type is bool:
+        _charge_json_bytes(_encoded_bytes, 4 if value else 5)
+        return nodes
+    if value_type is int:
+        try:
+            _charge_json_bytes(_encoded_bytes, len(str(value)))
+        except ValueError as exc:
+            raise ValueError(f"{path} must have a finite canonical JSON encoding") from exc
         return nodes
     if value_type is float:
         if not math.isfinite(value):
             raise ValueError(f"{path} must contain only finite JSON numbers")
+        _charge_json_bytes(_encoded_bytes, len(repr(value)))
         return nodes
-    if isinstance(value, list):
+    if value_type is list:
         extra = len(value)
         if nodes + extra > _MAX_JSON_VALUES:
             raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
+        structural_bytes = 2 + max(0, extra - 1)
+        if structural_bytes + extra > _MAX_CONFIG_BYTES - _encoded_bytes[0]:
+            raise ValueError(f"canonical config exceeds {_MAX_CONFIG_BYTES} bytes")
+        _charge_json_bytes(_encoded_bytes, structural_bytes)
         for index, item in enumerate(value):
             nodes = _validate_json_value(
-                item, path=f"{path}[{index}]", depth=depth + 1, nodes=nodes
+                item,
+                path=f"{path}[{index}]",
+                depth=depth + 1,
+                nodes=nodes,
+                _encoded_bytes=_encoded_bytes,
             )
         return nodes
-    if isinstance(value, Mapping):
+    if value_type is dict:
         extra = len(value)
         if nodes + extra > _MAX_JSON_VALUES:
             raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
+        structural_bytes = 2 + max(0, extra - 1) + extra
+        if structural_bytes + extra > _MAX_CONFIG_BYTES - _encoded_bytes[0]:
+            raise ValueError(f"canonical config exceeds {_MAX_CONFIG_BYTES} bytes")
+        _charge_json_bytes(_encoded_bytes, structural_bytes)
         for key, item in value.items():
             if type(key) is not str:
                 raise ValueError(f"{path} JSON object keys must be strings")
+            _charge_json_string(_encoded_bytes, key)
             nodes = _validate_json_value(
-                item, path=f"{path}.{key}", depth=depth + 1, nodes=nodes
+                item,
+                path=f"{path}.{key}",
+                depth=depth + 1,
+                nodes=nodes,
+                _encoded_bytes=_encoded_bytes,
             )
         return nodes
     raise ValueError(f"{path} is not a canonical JSON value")
 
 
 def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
-    if not isinstance(value, Mapping):
+    if type(value) is not dict:
         raise ValueError("config must be a JSON mapping")
     _validate_json_value(value, path="config")
     try:

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -44,6 +44,8 @@ _MAX_LIFECYCLE_ID_LENGTH = _MAX_ID_LENGTH - len(
 )
 _MAX_CONFIG_BYTES = 1 << 20
 _MAX_JSON_NESTING_DEPTH = 64
+# Frozen manifests are tiny. Cap nodes before walking toward the 1 MiB encoding cap.
+_MAX_JSON_VALUES = 1_000_000
 _MAX_ARRAY_RANK = 8
 _MAX_ARRAY_ELEMENTS = 1 << 20
 _SUPPORTED_DTYPES = frozenset(
@@ -119,26 +121,41 @@ def _load_manifest_config_json(raw: str) -> Any:
         raise ValueError("manifest config must be canonical JSON") from exc
 
 
-def _validate_json_value(value: Any, *, path: str, depth: int = 0) -> None:
+def _validate_json_value(
+    value: Any, *, path: str, depth: int = 0, nodes: int = 0
+) -> int:
+    nodes += 1
+    if nodes > _MAX_JSON_VALUES:
+        raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
     if depth > _MAX_JSON_NESTING_DEPTH:
         raise ValueError(f"{path} exceeds the maximum canonical JSON nesting depth")
     value_type = type(value)
     if value is None or value_type is str or value_type is bool or value_type is int:
-        return
+        return nodes
     if value_type is float:
         if not math.isfinite(value):
             raise ValueError(f"{path} must contain only finite JSON numbers")
-        return
+        return nodes
     if isinstance(value, list):
+        extra = len(value)
+        if nodes + extra > _MAX_JSON_VALUES:
+            raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
         for index, item in enumerate(value):
-            _validate_json_value(item, path=f"{path}[{index}]", depth=depth + 1)
-        return
+            nodes = _validate_json_value(
+                item, path=f"{path}[{index}]", depth=depth + 1, nodes=nodes
+            )
+        return nodes
     if isinstance(value, Mapping):
+        extra = len(value)
+        if nodes + extra > _MAX_JSON_VALUES:
+            raise ValueError(f"{path} exceeds the canonical JSON value resource limit")
         for key, item in value.items():
             if type(key) is not str:
                 raise ValueError(f"{path} JSON object keys must be strings")
-            _validate_json_value(item, path=f"{path}.{key}", depth=depth + 1)
-        return
+            nodes = _validate_json_value(
+                item, path=f"{path}.{key}", depth=depth + 1, nodes=nodes
+            )
+        return nodes
     raise ValueError(f"{path} is not a canonical JSON value")
 
 

--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -46,8 +46,6 @@ _MAX_CONFIG_BYTES = 1 << 20
 _MAX_JSON_NESTING_DEPTH = 64
 # Frozen manifests are tiny. Cap nodes before walking toward the 1 MiB encoding cap.
 _MAX_JSON_VALUES = 1_000_000
-_MIN_JSON_INTEGER = -(1 << 63)
-_MAX_JSON_INTEGER = (1 << 63) - 1
 _MAX_ARRAY_RANK = 8
 _MAX_ARRAY_ELEMENTS = 1 << 20
 _SUPPORTED_DTYPES = frozenset(
@@ -179,9 +177,17 @@ def _validate_json_value(
         return nodes
     if value_type is int:
         integer = cast(int, value)
-        if not _MIN_JSON_INTEGER <= integer <= _MAX_JSON_INTEGER:
-            raise ValueError(f"{path} integer must fit signed 64-bit bounds")
-        _charge_json_bytes(_encoded_bytes, len(str(integer)))
+        # Preserve the public canonical-JSON domain, including unsigned-64
+        # protocol values, while rejecting integers that cannot possibly fit
+        # the 1 MiB encoded-byte budget before decimal conversion.  Since
+        # 2**10 > 10**3, an integer beyond this bit bound necessarily needs
+        # more than _MAX_CONFIG_BYTES decimal digits.
+        if integer.bit_length() > (_MAX_CONFIG_BYTES * 10) // 3 + 1:
+            raise ValueError(f"canonical config exceeds {_MAX_CONFIG_BYTES} bytes")
+        try:
+            _charge_json_bytes(_encoded_bytes, len(str(integer)))
+        except ValueError as exc:
+            raise ValueError(f"{path} must have a finite canonical JSON encoding") from exc
         return nodes
     if value_type is float:
         if not math.isfinite(value):

--- a/tests/test_reference_agent_json_width_hang.py
+++ b/tests/test_reference_agent_json_width_hang.py
@@ -1,0 +1,44 @@
+"""Canonical JSON configs reject oversized width before the 1 MiB encoding walk."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.reference_agent import (
+    _MAX_JSON_VALUES,
+    _validate_json_value,
+    canonical_config_sha256,
+)
+
+
+def test_frozen_json_value_bound_matches_strict_json_last_fit() -> None:
+    assert _MAX_JSON_VALUES == 1_000_000
+
+
+def test_last_fit_json_list_validates_without_width_hang() -> None:
+    payload: dict[str, object] = {"k": [0] * (_MAX_JSON_VALUES - 2)}
+    started = time.perf_counter()
+    nodes = _validate_json_value(payload, path="config")
+    assert time.perf_counter() - started < 0.5
+    assert nodes == _MAX_JSON_VALUES
+
+
+@pytest.mark.parametrize("count", [_MAX_JSON_VALUES, 2_000_000, 20_000_000])
+def test_canonical_config_rejects_oversized_list_before_encoding(
+    count: int,
+) -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="JSON value resource limit"):
+        canonical_config_sha256({"k": [0] * count})
+    assert time.perf_counter() - started < 0.5
+
+
+def test_canonical_config_rejects_pointer_repeated_nested_lists() -> None:
+    row = [0] * 5_000
+    payload: dict[str, object] = {"k": [row] * 5_000}
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="JSON value resource limit"):
+        canonical_config_sha256(payload)
+    assert time.perf_counter() - started < 0.5

--- a/tests/test_reference_agent_json_width_hang.py
+++ b/tests/test_reference_agent_json_width_hang.py
@@ -11,9 +11,8 @@ import pytest
 import alberta_framework.reference_agent as reference_agent
 from alberta_framework.reference_agent import (
     _MAX_CONFIG_BYTES,
-    _MAX_JSON_INTEGER,
     _MAX_JSON_VALUES,
-    _MIN_JSON_INTEGER,
+    MAX_DECISION_INDEX,
     _validate_json_value,
     canonical_config_sha256,
 )
@@ -81,20 +80,20 @@ def test_canonical_config_counts_del_escape_before_encoding(
         canonical_config_sha256({"k": "\x7f" * count})
 
 
-@pytest.mark.parametrize("integer", [_MIN_JSON_INTEGER, _MAX_JSON_INTEGER])
-def test_canonical_config_accepts_signed_64_bit_boundaries(integer: int) -> None:
+@pytest.mark.parametrize("integer", [1 << 63, MAX_DECISION_INDEX, MAX_DECISION_INDEX + 1])
+def test_canonical_config_preserves_large_protocol_integer_domain(integer: int) -> None:
     assert len(canonical_config_sha256({"k": integer})) == 64
 
 
-@pytest.mark.parametrize("integer", [_MIN_JSON_INTEGER - 1, _MAX_JSON_INTEGER + 1])
-def test_canonical_config_rejects_first_integer_overflow_before_decimal_conversion(
-    integer: int, monkeypatch: pytest.MonkeyPatch
+def test_canonical_config_rejects_huge_integer_before_decimal_conversion(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def decimal_conversion_must_not_run(_value: object) -> str:
-        raise AssertionError("out-of-range integer reached decimal conversion")
+        raise AssertionError("oversized integer reached decimal conversion")
 
     monkeypatch.setattr(reference_agent, "str", decimal_conversion_must_not_run, raising=False)
-    with pytest.raises(ValueError, match="signed 64-bit"):
+    integer = 1 << (((_MAX_CONFIG_BYTES * 10) // 3) + 2)
+    with pytest.raises(ValueError, match="canonical config exceeds"):
         _validate_json_value(integer, path="config.k")
 
 

--- a/tests/test_reference_agent_json_width_hang.py
+++ b/tests/test_reference_agent_json_width_hang.py
@@ -1,12 +1,15 @@
-"""Canonical JSON configs reject oversized width before the 1 MiB encoding walk."""
+"""Canonical JSON configs enforce resource bounds before encoding."""
 
 from __future__ import annotations
 
-import time
+import json
+from collections.abc import Iterator, Mapping
+from typing import Any
 
 import pytest
 
 from alberta_framework.reference_agent import (
+    _MAX_CONFIG_BYTES,
     _MAX_JSON_VALUES,
     _validate_json_value,
     canonical_config_sha256,
@@ -17,28 +20,91 @@ def test_frozen_json_value_bound_matches_strict_json_last_fit() -> None:
     assert _MAX_JSON_VALUES == 1_000_000
 
 
-def test_last_fit_json_list_validates_without_width_hang() -> None:
-    payload: dict[str, object] = {"k": [0] * (_MAX_JSON_VALUES - 2)}
-    started = time.perf_counter()
-    nodes = _validate_json_value(payload, path="config")
-    assert time.perf_counter() - started < 0.5
-    assert nodes == _MAX_JSON_VALUES
+def test_json_value_counter_accepts_small_builtin_containers() -> None:
+    assert _validate_json_value({"k": [0, None, True]}, path="config") == 5
 
 
-@pytest.mark.parametrize("count", [_MAX_JSON_VALUES, 2_000_000, 20_000_000])
-def test_canonical_config_rejects_oversized_list_before_encoding(
-    count: int,
+def test_canonical_config_rejects_oversized_width_before_encoding(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    started = time.perf_counter()
-    with pytest.raises(ValueError, match="JSON value resource limit"):
+    def encoding_must_not_run(*args: object, **kwargs: object) -> str:
+        raise AssertionError("oversized config reached json.dumps")
+
+    monkeypatch.setattr(json, "dumps", encoding_must_not_run)
+    count = _MAX_CONFIG_BYTES // 2 + 1
+    with pytest.raises(ValueError, match="canonical config exceeds"):
         canonical_config_sha256({"k": [0] * count})
-    assert time.perf_counter() - started < 0.5
 
 
-def test_canonical_config_rejects_pointer_repeated_nested_lists() -> None:
-    row = [0] * 5_000
-    payload: dict[str, object] = {"k": [row] * 5_000}
-    started = time.perf_counter()
-    with pytest.raises(ValueError, match="JSON value resource limit"):
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"k": "x" * (_MAX_CONFIG_BYTES + 1)},
+        {"x" * (_MAX_CONFIG_BYTES + 1): 0},
+    ],
+)
+def test_canonical_config_rejects_oversized_text_before_encoding(
+    payload: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def encoding_must_not_run(*args: object, **kwargs: object) -> str:
+        raise AssertionError("oversized config reached json.dumps")
+
+    monkeypatch.setattr(json, "dumps", encoding_must_not_run)
+    with pytest.raises(ValueError, match="canonical config exceeds"):
         canonical_config_sha256(payload)
-    assert time.perf_counter() - started < 0.5
+
+
+def test_canonical_config_counts_escaped_string_bytes_before_encoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def encoding_must_not_run(*args: object, **kwargs: object) -> str:
+        raise AssertionError("oversized config reached json.dumps")
+
+    monkeypatch.setattr(json, "dumps", encoding_must_not_run)
+    payload = {"k": "\N{GRINNING FACE}" * (_MAX_CONFIG_BYTES // 12 + 1)}
+    with pytest.raises(ValueError, match="canonical config exceeds"):
+        canonical_config_sha256(payload)
+
+
+def test_canonical_config_preserves_exact_byte_limit_boundary() -> None:
+    assert len(canonical_config_sha256({"k": "x" * (_MAX_CONFIG_BYTES - 8)})) == 64
+    with pytest.raises(ValueError, match="canonical config exceeds"):
+        canonical_config_sha256({"k": "x" * (_MAX_CONFIG_BYTES - 7)})
+
+
+class _HostileList(list[object]):
+    def __len__(self) -> int:
+        raise AssertionError("hostile list length hook ran")
+
+    def __iter__(self) -> Iterator[object]:
+        raise AssertionError("hostile list iterator hook ran")
+
+
+class _HostileMapping(Mapping[str, object]):
+    def __getitem__(self, key: str) -> object:
+        raise AssertionError("hostile mapping item hook ran")
+
+    def __iter__(self) -> Iterator[str]:
+        raise AssertionError("hostile mapping iterator hook ran")
+
+    def __len__(self) -> int:
+        raise AssertionError("hostile mapping length hook ran")
+
+
+class _HostileDict(dict[str, object]):
+    def __len__(self) -> int:
+        raise AssertionError("hostile dict length hook ran")
+
+    def items(self) -> Any:
+        raise AssertionError("hostile dict items hook ran")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [{"k": _HostileList()}, _HostileMapping(), _HostileDict()],
+)
+def test_canonical_config_rejects_hook_bearing_containers_without_dispatch(
+    payload: Any,
+) -> None:
+    with pytest.raises(ValueError, match="canonical JSON value|JSON mapping"):
+        canonical_config_sha256(payload)

--- a/tests/test_reference_agent_json_width_hang.py
+++ b/tests/test_reference_agent_json_width_hang.py
@@ -66,6 +66,24 @@ def test_canonical_config_counts_escaped_string_bytes_before_encoding(
         canonical_config_sha256(payload)
 
 
+def test_canonical_config_counts_del_escape_before_encoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def encoding_must_not_run(*args: object, **kwargs: object) -> str:
+        raise AssertionError("oversized config reached json.dumps")
+
+    monkeypatch.setattr(json, "dumps", encoding_must_not_run)
+    count = ((_MAX_CONFIG_BYTES - 8) // 6) + 1
+    with pytest.raises(ValueError, match="canonical config exceeds"):
+        canonical_config_sha256({"k": "\x7f" * count})
+
+
+def test_canonical_config_rejects_huge_integer_before_decimal_conversion() -> None:
+    integer = 1 << (((_MAX_CONFIG_BYTES * 10) // 3) + 2)
+    with pytest.raises(ValueError, match="canonical config exceeds"):
+        canonical_config_sha256({"k": integer})
+
+
 def test_canonical_config_preserves_exact_byte_limit_boundary() -> None:
     assert len(canonical_config_sha256({"k": "x" * (_MAX_CONFIG_BYTES - 8)})) == 64
     with pytest.raises(ValueError, match="canonical config exceeds"):
@@ -106,5 +124,5 @@ class _HostileDict(dict[str, object]):
 def test_canonical_config_rejects_hook_bearing_containers_without_dispatch(
     payload: Any,
 ) -> None:
-    with pytest.raises(ValueError, match="canonical JSON value|JSON mapping"):
+    with pytest.raises(ValueError, match="canonical JSON value|exact JSON object"):
         canonical_config_sha256(payload)

--- a/tests/test_reference_agent_json_width_hang.py
+++ b/tests/test_reference_agent_json_width_hang.py
@@ -8,9 +8,12 @@ from typing import Any
 
 import pytest
 
+import alberta_framework.reference_agent as reference_agent
 from alberta_framework.reference_agent import (
     _MAX_CONFIG_BYTES,
+    _MAX_JSON_INTEGER,
     _MAX_JSON_VALUES,
+    _MIN_JSON_INTEGER,
     _validate_json_value,
     canonical_config_sha256,
 )
@@ -78,10 +81,21 @@ def test_canonical_config_counts_del_escape_before_encoding(
         canonical_config_sha256({"k": "\x7f" * count})
 
 
-def test_canonical_config_rejects_huge_integer_before_decimal_conversion() -> None:
-    integer = 1 << (((_MAX_CONFIG_BYTES * 10) // 3) + 2)
-    with pytest.raises(ValueError, match="canonical config exceeds"):
-        canonical_config_sha256({"k": integer})
+@pytest.mark.parametrize("integer", [_MIN_JSON_INTEGER, _MAX_JSON_INTEGER])
+def test_canonical_config_accepts_signed_64_bit_boundaries(integer: int) -> None:
+    assert len(canonical_config_sha256({"k": integer})) == 64
+
+
+@pytest.mark.parametrize("integer", [_MIN_JSON_INTEGER - 1, _MAX_JSON_INTEGER + 1])
+def test_canonical_config_rejects_first_integer_overflow_before_decimal_conversion(
+    integer: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def decimal_conversion_must_not_run(_value: object) -> str:
+        raise AssertionError("out-of-range integer reached decimal conversion")
+
+    monkeypatch.setattr(reference_agent, "str", decimal_conversion_must_not_run, raising=False)
+    with pytest.raises(ValueError, match="signed 64-bit"):
+        _validate_json_value(integer, path="config.k")
 
 
 def test_canonical_config_preserves_exact_byte_limit_boundary() -> None:


### PR DESCRIPTION
Supersedes #2118 while preserving its contributor commit.\n\nThe original width cap still admitted oversized string/key payloads to json.dumps, dispatched hooks on list/Mapping subclasses, and used a 20-million-element timing test. This successor keeps the contributor node/depth protection, computes the exact canonical byte charge before encoding, admits only exact built-in dict/list containers before len/iteration, and replaces memory-heavy wall-clock assertions with encoder non-entry and hostile-hook tests.\n\nOrdinary canonical bytes/hashes and the exact 1 MiB boundary are unchanged. No outputs or workflows were changed or run.\n\nVerification: 177 passed, 1 skipped in the adjacent reference-agent/reference-life panel; 38 focused passed after final cleanup; full Ruff clean; strict mypy clean (221 files); diff check clean.\n\nCo-authored-by: ss251 <ss251@uw.edu>