### PR TITLE
fix(core): cap SARSA env-loop steps before range hang

### DIFF
--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -126,6 +126,21 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
     return canonical
 
 
+def _require_sarsa_host_steps(name: str, value: object) -> int:
+    """Reject an oversized host loop count before ``range`` materializes it.
+
+    ``run_sarsa_episode`` and ``run_sarsa_continuing`` are Python env loops.
+    Origin accepted any signed-int32 count and handed it to ``range`` — hang,
+    not leftover INT32 arithmetic. Public last-fit matches the array-scan
+    ceiling ``_SARSA_SEQUENCE_MAX_STEPS``.
+    """
+    if type(value) is not int or not 1 <= value <= _SARSA_SEQUENCE_MAX_STEPS:
+        raise ValueError(
+            f"{name} must be an integer in [1, {_SARSA_SEQUENCE_MAX_STEPS}]"
+        )
+    return value
+
+
 def _require_sarsa_sequence_length(name: str, value: object) -> int:
     """Reject an oversized or malformed leading axis before it drives a scan.
 
@@ -1089,6 +1104,7 @@ def run_sarsa_episode(
     Returns:
         SARSAEpisodeResult with episode metrics
     """
+    max_steps = _require_sarsa_host_steps("max_steps", max_steps)
     obs, _info = env.reset()
     obs = jnp.asarray(obs, dtype=jnp.float32).flatten()
 
@@ -1161,6 +1177,7 @@ def run_sarsa_continuing(
     Returns:
         SARSAContinuingResult with step-level metrics
     """
+    num_steps = _require_sarsa_host_steps("num_steps", num_steps)
     obs, _info = env.reset()
     obs = jnp.asarray(obs, dtype=jnp.float32).flatten()
 

--- a/tests/test_sarsa_host_step_cap.py
+++ b/tests/test_sarsa_host_step_cap.py
@@ -1,0 +1,66 @@
+"""Protocol ceilings for SARSA Python env loops.
+
+Public last-fit is max_steps/num_steps=10_000 (tests use 500). Origin accepted
+INT32-legal counts and handed them to range() — hang, not leftover INT32 math.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.sarsa import (
+    _SARSA_SEQUENCE_MAX_STEPS,
+    _require_sarsa_host_steps,
+    run_sarsa_continuing,
+    run_sarsa_episode,
+)
+
+
+class _HostileInt(int):
+    def __index__(self) -> int:  # pragma: no cover
+        raise AssertionError("index hook executed")
+
+    def __int__(self) -> int:  # pragma: no cover
+        raise AssertionError("int hook executed")
+
+
+class _BoomEnv:
+    def reset(self, *args: object, **kwargs: object) -> tuple[Any, dict[str, object]]:
+        raise AssertionError("env.reset must not run after an oversized step count")
+
+    def step(self, action: object) -> tuple[Any, float, bool, bool, dict[str, object]]:
+        raise AssertionError("env.step must not run after an oversized step count")
+
+
+def test_documented_protocol_ceiling() -> None:
+    assert _SARSA_SEQUENCE_MAX_STEPS == 10_000
+
+
+def test_last_fit_host_steps_are_accepted() -> None:
+    assert _require_sarsa_host_steps("max_steps", _SARSA_SEQUENCE_MAX_STEPS) == 10_000
+
+
+@pytest.mark.parametrize("value", [True, False, 0, -1, 1.0, 10_000.0, 10_001, 10**12, 2**31 - 1])
+def test_rejects_non_exact_or_oversized_host_steps(value: object) -> None:
+    with pytest.raises(ValueError, match="max_steps must be an integer in"):
+        _require_sarsa_host_steps("max_steps", value)
+
+
+def test_rejects_numpy_and_subclass_host_steps_without_index_hooks() -> None:
+    with pytest.raises(ValueError, match="max_steps must be an integer in"):
+        _require_sarsa_host_steps("max_steps", np.int64(10))
+    with pytest.raises(ValueError, match="max_steps must be an integer in"):
+        _require_sarsa_host_steps("max_steps", _HostileInt(10))
+
+
+def test_episode_rejects_overflow_before_env_reset() -> None:
+    with pytest.raises(ValueError, match="max_steps must be an integer in"):
+        run_sarsa_episode(None, None, _BoomEnv(), max_steps=10_001)  # type: ignore[arg-type]
+
+
+def test_continuing_rejects_overflow_before_env_reset() -> None:
+    with pytest.raises(ValueError, match="num_steps must be an integer in"):
+        run_sarsa_continuing(None, None, _BoomEnv(), num_steps=2**31 - 1)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- `run_sarsa_episode` / `run_sarsa_continuing` accepted any signed-int32 step count and handed it to `range()` before talking to the env.
- Reuse the existing public last-fit `_SARSA_SEQUENCE_MAX_STEPS = 10_000` (array scans already use it). Exact builtin `int` only; numpy/int subclasses fail without `__index__` hooks.

Mode: **Fix**. Permanently nonpromoting.

<!-- evidence-head:23803ebf7039ce6f52050b476b8e29a9f9b1b652 -->
<!-- evidence-row:logs -->
- [x] logs: `pytest tests/test_sarsa_host_step_cap.py tests/test_sarsa.py -q` → 161 passed, 2 skipped; `ruff check` clean on the touched files.

AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor 3.16.29
Lane: cursor-grok-4-6
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FHPDZ9VQ4SR53R7EWXF151","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T12:17:52.617Z","completed_at":"2026-08-20T12:21:40.877Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T12:17:54.525Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b5017c33964fb359df21b95509411409d808e06b0aea995382f2589a993776b0","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"029457c8-ab3e-43d0-b778-a4ec12508376","object_id":"sha256:b5017c33964fb359df21b95509411409d808e06b0aea995382f2589a993776b0","sha256":"b5017c33964fb359df21b95509411409d808e06b0aea995382f2589a993776b0"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"GzjD-g03zzUVnRZqrv22l23kxJUERxOYD1tHdRuimdB8VrZErjxhfkaD6XCZemLi9cdyc-FiBsb8yUV6kCYkBA"}} -->
