### PR TITLE
fix(core): cap history-feature decay and channel lists before walk hang

### DIFF
--- a/alberta_framework/core/history_features.py
+++ b/alberta_framework/core/history_features.py
@@ -64,10 +64,11 @@ class HistoryFeatureState:
 # =============================================================================
 
 _INT32_MAX = 2**31 - 1
-# Same list ceiling as HordeSpec demons / JAX seed-sequence length. Origin
-# enumerated every decay/channel before the INT32 feature_dim product.
-_MAX_HISTORY_DECAY_RATES = 4_096
-_MAX_HISTORY_CHANNELS = 4_096
+# One 12-bit cardinality budget bounds direct tuple validation, serialized-list
+# normalization, and the implicit all-channel expansion before per-item work.
+_MAX_HISTORY_CONFIGURATION_ITEMS = 1 << 12
+_MAX_HISTORY_DECAY_RATES = _MAX_HISTORY_CONFIGURATION_ITEMS
+_MAX_HISTORY_CHANNELS = _MAX_HISTORY_CONFIGURATION_ITEMS
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -253,6 +254,10 @@ class HistoryFeatureExtractor:
             n_channels=channel_count,
             feature_dim=feature_dim,
         )
+        if channel_count > _MAX_HISTORY_CHANNELS:
+            raise ValueError(
+                f"channels must contain at most {_MAX_HISTORY_CHANNELS} indices"
+            )
         if canonical_channels is None:
             canonical_channels = tuple(range(raw_dim))
 

--- a/alberta_framework/core/history_features.py
+++ b/alberta_framework/core/history_features.py
@@ -64,6 +64,10 @@ class HistoryFeatureState:
 # =============================================================================
 
 _INT32_MAX = 2**31 - 1
+# Same list ceiling as HordeSpec demons / JAX seed-sequence length. Origin
+# enumerated every decay/channel before the INT32 feature_dim product.
+_MAX_HISTORY_DECAY_RATES = 4_096
+_MAX_HISTORY_CHANNELS = 4_096
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -135,6 +139,10 @@ def _require_decay_rates(value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError("decay_rates must be an actual tuple")
     rates = cast(tuple[object, ...], value)
+    if len(rates) > _MAX_HISTORY_DECAY_RATES:
+        raise ValueError(
+            f"decay_rates must contain at most {_MAX_HISTORY_DECAY_RATES} rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"decay_rates[{index}]",
@@ -152,6 +160,11 @@ def _require_channels(value: object, raw_dim: int) -> tuple[int, ...] | None:
         return None
     if type(value) is not tuple:
         raise ValueError("channels must be an actual tuple or None")
+    channels = cast(tuple[object, ...], value)
+    if len(channels) > _MAX_HISTORY_CHANNELS:
+        raise ValueError(
+            f"channels must contain at most {_MAX_HISTORY_CHANNELS} indices"
+        )
     return tuple(
         _require_int32(
             f"channels[{index}]",
@@ -159,7 +172,7 @@ def _require_channels(value: object, raw_dim: int) -> tuple[int, ...] | None:
             minimum=0,
             maximum=raw_dim - 1,
         )
-        for index, channel in enumerate(cast(tuple[object, ...], value))
+        for index, channel in enumerate(channels)
     )
 
 

--- a/alberta_framework/core/history_features.py
+++ b/alberta_framework/core/history_features.py
@@ -389,9 +389,17 @@ class HistoryFeatureExtractor:
         config.pop("type", None)
         raw_rates = config["decay_rates"]
         if type(raw_rates) is list:
+            if len(raw_rates) > _MAX_HISTORY_DECAY_RATES:
+                raise ValueError(
+                    f"decay_rates must contain at most {_MAX_HISTORY_DECAY_RATES} rates"
+                )
             raw_rates = tuple(raw_rates)
         raw_channels = config["channels"]
         if type(raw_channels) is list:
+            if len(raw_channels) > _MAX_HISTORY_CHANNELS:
+                raise ValueError(
+                    f"channels must contain at most {_MAX_HISTORY_CHANNELS} indices"
+                )
             raw_channels = tuple(raw_channels)
         return cls(
             raw_dim=config["raw_dim"],

--- a/tests/test_history_feature_list_hang.py
+++ b/tests/test_history_feature_list_hang.py
@@ -1,0 +1,63 @@
+"""List ceilings for history-feature decay rates and channel indices.
+
+Origin enumerated every decay/channel before the INT32 feature_dim product.
+A cheap pointer-repeat still walks the validator; public last-fit is 4096.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.core.history_features import (
+    _MAX_HISTORY_CHANNELS,
+    _MAX_HISTORY_DECAY_RATES,
+    HistoryFeatureExtractor,
+)
+
+
+def test_documented_protocol_ceilings() -> None:
+    assert _MAX_HISTORY_DECAY_RATES == 4096
+    assert _MAX_HISTORY_CHANNELS == 4096
+
+
+def test_last_fit_decay_count_is_accepted() -> None:
+    extractor = HistoryFeatureExtractor(
+        raw_dim=1,
+        decay_rates=(0.5,) * _MAX_HISTORY_DECAY_RATES,
+        channels=(0,),
+        include_raw=False,
+    )
+    assert len(extractor.decay_rates) == _MAX_HISTORY_DECAY_RATES
+
+
+def test_last_fit_channel_count_is_accepted() -> None:
+    extractor = HistoryFeatureExtractor(
+        raw_dim=_MAX_HISTORY_CHANNELS,
+        decay_rates=(0.5,),
+        channels=tuple(range(_MAX_HISTORY_CHANNELS)),
+        include_raw=False,
+    )
+    assert extractor.channels is not None
+    assert len(extractor.channels) == _MAX_HISTORY_CHANNELS
+
+
+@pytest.mark.parametrize("count", [4097, 400_000])
+def test_rejects_oversized_decay_rates_before_per_rate_walk(count: int) -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="at most 4096"):
+        HistoryFeatureExtractor(raw_dim=1, decay_rates=(0.5,) * count)
+    assert time.perf_counter() - started < 0.5
+
+
+@pytest.mark.parametrize("count", [4097, 400_000])
+def test_rejects_oversized_channels_before_per_index_walk(count: int) -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="at most 4096"):
+        HistoryFeatureExtractor(
+            raw_dim=1,
+            decay_rates=(0.5,),
+            channels=(0,) * count,
+        )
+    assert time.perf_counter() - started < 0.5

--- a/tests/test_history_feature_list_hang.py
+++ b/tests/test_history_feature_list_hang.py
@@ -1,13 +1,12 @@
-"""List ceilings for history-feature decay rates and channel indices.
-
-Origin enumerated every decay/channel before the INT32 feature_dim product.
-A cheap pointer-repeat still walks the validator; public last-fit is 4096.
-"""
+"""Cardinality preflights for history-feature decay rates and channels."""
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
+import alberta_framework.core.history_features as history_features
 from alberta_framework.core.history_features import (
     _MAX_HISTORY_CHANNELS,
     _MAX_HISTORY_DECAY_RATES,
@@ -15,9 +14,12 @@ from alberta_framework.core.history_features import (
 )
 
 
-def test_documented_protocol_ceilings() -> None:
-    assert _MAX_HISTORY_DECAY_RATES == 4096
-    assert _MAX_HISTORY_CHANNELS == 4096
+class _HostileList(list[object]):
+    calls = 0
+
+    def __len__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("list length hook executed")
 
 
 def test_last_fit_decay_count_is_accepted() -> None:
@@ -50,7 +52,7 @@ def test_rejects_oversized_decay_rates_before_per_rate_walk() -> None:
             calls += 1
             raise AssertionError("oversized decay tuple walked an element")
 
-    hostile = HostileFloat()
+    hostile: Any = HostileFloat()
     with pytest.raises(ValueError, match="at most 4096"):
         HistoryFeatureExtractor(raw_dim=1, decay_rates=(hostile,) * 4097)
     assert calls == 0
@@ -65,7 +67,7 @@ def test_rejects_oversized_channels_before_per_index_walk() -> None:
             calls += 1
             raise AssertionError("oversized channel tuple walked an element")
 
-    hostile = HostileIndex()
+    hostile: Any = HostileIndex()
     with pytest.raises(ValueError, match="at most 4096"):
         HistoryFeatureExtractor(
             raw_dim=1,
@@ -73,6 +75,22 @@ def test_rejects_oversized_channels_before_per_index_walk() -> None:
             channels=(hostile,) * 4097,
         )
     assert calls == 0
+
+
+def test_default_channels_reject_before_range_expansion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def range_must_not_run(*args: object) -> range:
+        raise AssertionError("default channel range expanded before its count bound")
+
+    monkeypatch.setattr(history_features, "range", range_must_not_run, raising=False)
+    with pytest.raises(ValueError, match="channels must contain at most 4096"):
+        HistoryFeatureExtractor(
+            raw_dim=_MAX_HISTORY_CHANNELS + 1,
+            decay_rates=(0.5,),
+            channels=None,
+            include_raw=False,
+        )
 
 
 @pytest.mark.parametrize(
@@ -89,3 +107,13 @@ def test_from_config_rejects_oversized_lists_before_tuple_copy(
     config[field] = value
     with pytest.raises(ValueError, match="at most 4096"):
         HistoryFeatureExtractor.from_config(config)
+
+
+@pytest.mark.parametrize("field", ["decay_rates", "channels"])
+def test_from_config_rejects_list_subclasses_before_length_hooks(field: str) -> None:
+    config = HistoryFeatureExtractor(raw_dim=1).to_config()
+    config[field] = _HostileList()
+    _HostileList.calls = 0
+    with pytest.raises(ValueError, match="actual tuple"):
+        HistoryFeatureExtractor.from_config(config)
+    assert _HostileList.calls == 0

--- a/tests/test_history_feature_list_hang.py
+++ b/tests/test_history_feature_list_hang.py
@@ -61,3 +61,19 @@ def test_rejects_oversized_channels_before_per_index_walk(count: int) -> None:
             channels=(0,) * count,
         )
     assert time.perf_counter() - started < 0.5
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("decay_rates", [0.5] * 4097),
+        ("channels", [0] * 4097),
+    ],
+)
+def test_from_config_rejects_oversized_lists_before_tuple_copy(
+    field: str, value: list[object]
+) -> None:
+    config = HistoryFeatureExtractor(raw_dim=1).to_config()
+    config[field] = value
+    with pytest.raises(ValueError, match="at most 4096"):
+        HistoryFeatureExtractor.from_config(config)

--- a/tests/test_history_feature_list_hang.py
+++ b/tests/test_history_feature_list_hang.py
@@ -6,8 +6,6 @@ A cheap pointer-repeat still walks the validator; public last-fit is 4096.
 
 from __future__ import annotations
 
-import time
-
 import pytest
 
 from alberta_framework.core.history_features import (
@@ -43,24 +41,38 @@ def test_last_fit_channel_count_is_accepted() -> None:
     assert len(extractor.channels) == _MAX_HISTORY_CHANNELS
 
 
-@pytest.mark.parametrize("count", [4097, 400_000])
-def test_rejects_oversized_decay_rates_before_per_rate_walk(count: int) -> None:
-    started = time.perf_counter()
+def test_rejects_oversized_decay_rates_before_per_rate_walk() -> None:
+    calls = 0
+
+    class HostileFloat:
+        def __float__(self) -> float:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("oversized decay tuple walked an element")
+
+    hostile = HostileFloat()
     with pytest.raises(ValueError, match="at most 4096"):
-        HistoryFeatureExtractor(raw_dim=1, decay_rates=(0.5,) * count)
-    assert time.perf_counter() - started < 0.5
+        HistoryFeatureExtractor(raw_dim=1, decay_rates=(hostile,) * 4097)
+    assert calls == 0
 
 
-@pytest.mark.parametrize("count", [4097, 400_000])
-def test_rejects_oversized_channels_before_per_index_walk(count: int) -> None:
-    started = time.perf_counter()
+def test_rejects_oversized_channels_before_per_index_walk() -> None:
+    calls = 0
+
+    class HostileIndex:
+        def __index__(self) -> int:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("oversized channel tuple walked an element")
+
+    hostile = HostileIndex()
     with pytest.raises(ValueError, match="at most 4096"):
         HistoryFeatureExtractor(
             raw_dim=1,
             decay_rates=(0.5,),
-            channels=(0,) * count,
+            channels=(hostile,) * 4097,
         )
-    assert time.perf_counter() - started < 0.5
+    assert calls == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- `HistoryFeatureExtractor` enumerated every decay rate and channel index before the INT32 feature-dim product.
- Public last-fit is 4096 (same list ceiling as Horde demons / JAX seed-sequence length). Default `channels=None` still expands only after the working-set preflight.

Mode: **Fix**. Permanently nonpromoting.

<!-- evidence-head:7c0768c1d80a0459643c630c81e73aa6d617f463 -->
<!-- evidence-row:logs -->
- [x] logs: `pytest tests/test_history_feature_list_hang.py tests/test_history_features.py tests/test_history_features_trace_byte_preflight.py -q` → 70 passed; ruff clean.

AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor 3.16.29
Lane: cursor-grok-4-6
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FHZEXKZJ1WT81ETV2Q2ZBF","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T12:22:48.499Z","completed_at":"2026-08-20T12:24:27.641Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T12:22:49.045Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ec19244f404baa3f737b01ff5e76f2c00710620ab8da2eae6f832a278d67bde8","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"489a9fe9-30e4-4ae5-a206-d078d5728f75","object_id":"sha256:ec19244f404baa3f737b01ff5e76f2c00710620ab8da2eae6f832a278d67bde8","sha256":"ec19244f404baa3f737b01ff5e76f2c00710620ab8da2eae6f832a278d67bde8"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"HpJlf--LfalrxV-VYhwNsOLW90gaQp-q8jfF_kmhsyxVOrkxTM6bz9jM9qjhLDHWqENivRfBCs2JUOUzbUkPDg"}} -->
