### PR TITLE
research: freeze prospective CLEAR-100 provider assets

### DIFF
--- a/alberta_framework/benchmarks/clear_qualification.py
+++ b/alberta_framework/benchmarks/clear_qualification.py
@@ -21,10 +21,14 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path, PurePosixPath
 
 SCHEMA = "asi.clear.qualification.v1"
+PROSPECTIVE_ASSET_SCHEMA = "asi.clear100.prospective-assets.v1"
 PAPER_REVISION = "arXiv:2201.06289v3"
 CURATION_COMMIT = "620cab4a7d99921fde73b67b53879470533cb39a"
 REFERENCE_COMMIT = "75d5d2e7d412a787e0decf0417a4868c56691252"
 AVALANCHE_COMMIT = "eb075be393e1f458b2c352514ff6c17b5a2c0f4e"
+OFFICIAL_SITE_COMMIT = "fa2f22e6bcaa47d4512acbcf4ec1643ad9dc66b2"
+OFFICIAL_SITE_TREE = "19c7f8a68d867dab7e6b7236227797773873eec7"
+PROVIDER_REVISION = "b518a845a98f1c913497ab98a19727cb65b74e65"
 DATASET_NAME = "clear100"
 BUCKETS = tuple(range(1, 11))
 YEARS = tuple(range(2005, 2015))
@@ -38,6 +42,104 @@ MAX_RESULT_BYTES = 1 << 20
 
 class ClearQualificationError(ValueError):
     """A CLEAR setup or result record failed closed."""
+
+
+def prospective_clear100_asset_plan() -> Mapping[str, object]:
+    """Return the reviewed source/asset freeze without fetching or executing anything."""
+    assets = [
+        {
+            "role": "provider-labeled-clear100-train-images-only",
+            "path": "clear100-train-image-only.zip",
+            "size_bytes": 3_289_951_359,
+            "lfs_sha256": "0376b952674e6ef55c3923ee4ce61e5b299fea4e29bbc4780530636e8988fd72",
+            "pointer_git_oid": "e441ed603eef45715947fe06567206bd90b26cf9",
+            "xet_hash": "f09eba2c90ad5295187b77a4af788629a908f2ea70ae2a33886ed55b9abecfb5",
+        },
+        {
+            "role": "provider-labeled-clear100-test",
+            "path": "clear100-test.zip",
+            "size_bytes": 1_640_361_665,
+            "lfs_sha256": "c939753be4e62dc7732347e5e636ea599022c82f45443ea9e7166167e467abd0",
+            "pointer_git_oid": "3a57c37f5b8beaf478b5e9a00fd38ed2454f5d6c",
+            "xet_hash": "a5fdd88c13d87116b6f1c10b41407bd68ca459ea67fb7b7df351fd07fec2ae86",
+        },
+    ]
+    return {
+        "schema_version": PROSPECTIVE_ASSET_SCHEMA,
+        "issue": 1579,
+        "classification": "prospective-source-and-asset-freeze-only",
+        "dataset": DATASET_NAME,
+        "protocol": "streaming-near-future",
+        "paper_revision": PAPER_REVISION,
+        "source_revisions": {
+            "curation": CURATION_COMMIT,
+            "reference_runner": REFERENCE_COMMIT,
+            "avalanche": AVALANCHE_COMMIT,
+            "official_site_commit": OFFICIAL_SITE_COMMIT,
+            "official_site_tree": OFFICIAL_SITE_TREE,
+        },
+        "provider": {
+            "repository": "https://huggingface.co/datasets/elvishelvis6/"
+            "CLEAR-Continual_Learning_Benchmark",
+            "revision": PROVIDER_REVISION,
+            "access_observed_utc_date": "2026-08-20",
+            "public_at_observation": True,
+            "gated_at_observation": False,
+            "disabled_at_observation": False,
+            "declared_license": "CC-BY-4.0",
+            "license_metadata_path": "README.md",
+            "license_metadata_git_oid": "b187bb7e7d837a367ccd0862441947ad412c77f7",
+            "license_metadata_size_bytes": 27,
+            "license_declaration_source": "https://clear-benchmark.github.io/",
+            "license_deed": "https://creativecommons.org/licenses/by/4.0/",
+        },
+        "assets": assets,
+        "provider_archive_bytes": 4_930_313_024,
+        "selected_semantics": {
+            "labeled_buckets": list(BUCKETS),
+            "years": list(YEARS),
+            "bucket_zero_pretraining": "excluded",
+            "sample_counts": "unverified-until-bounded-local-inspection",
+            "class_bucket_split": "unverified-until-bounded-local-inspection",
+        },
+        "claims": {
+            "archives_downloaded": False,
+            "local_size_and_sha256_verified": False,
+            "archive_contents_inspected": False,
+            "rights_and_takedown_reviewed": False,
+            "split_semantics_verified": False,
+            "runtime_qualified": False,
+            "workload_executed": False,
+            "receipt_created": False,
+            "parity_verified": False,
+            "execution_authorized": False,
+            "performance_claimed": False,
+            "promotion_authorized": False,
+            "authenticated_execution_attested": False,
+        },
+        "blockers": [
+            "Review YFCC/Flickr asset rights, takedown behavior, privacy and moral-rights "
+            "limits, and approved storage before acquisition.",
+            "Obtain explicit owner authorization before any multi-gigabyte download.",
+            "Download both revision-pinned archives into approved storage and reverify each "
+            "exact local size and SHA-256.",
+            "Safely inventory bounded regular archive members and independently verify image, "
+            "label, class, bucket, year, and train/test split semantics.",
+            "Qualify the exact runtime and dependency lock before building or importing "
+            "a provider.",
+            "Implement and review a prospective runner with exact image decoding, transforms, "
+            "normalization, task boundaries, metrics, and control/mechanism-off parity.",
+            "Freeze matched development seeds, arms, budgets, failure retention, and resource "
+            "ceilings before execution.",
+            "Require bounded resource receipts for archive, persistent state, accelerator, "
+            "preprocessing, observations, updates, model queries, and telemetry-only timing.",
+            "Require durable create-only success or failure receipts bound to source, assets, "
+            "runtime, plan, and execution identity.",
+            "Review any future run plan and grant exact execution authorization separately.",
+            "Keep untouched scientific seeds and all promotion gates outside this "
+            "prospective lane.",
+        ],
+    }
 
 
 def _canonical(value: object) -> bytes:
@@ -535,9 +637,21 @@ def validate_result(
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("manifest", type=Path)
-    parser.add_argument("--dataset-root", required=True, type=Path)
+    parser.add_argument("manifest", nargs="?", type=Path)
+    parser.add_argument("--dataset-root", type=Path)
+    parser.add_argument(
+        "--prospective-assets",
+        action="store_true",
+        help="print the nonexecuting revision-pinned CLEAR-100 asset plan",
+    )
     args = parser.parse_args(argv)
+    if args.prospective_assets:
+        if args.manifest is not None or args.dataset_root is not None:
+            parser.error("--prospective-assets does not accept a manifest or dataset root")
+        print(_canonical(prospective_clear100_asset_plan()).decode())
+        return 0
+    if args.manifest is None or args.dataset_root is None:
+        parser.error("manifest and --dataset-root are required for local verification")
     raw = load_dataset_manifest(args.manifest)
     receipt = verify_dataset_manifest(raw, root=args.dataset_root)
     print(_canonical(qualification_plan(receipt)).decode())

--- a/docs/runbooks/clear-qualification.md
+++ b/docs/runbooks/clear-qualification.md
@@ -14,6 +14,12 @@ nonpromoting, and retained when negative.
   at `75d5d2e7d412a787e0decf0417a4868c56691252`.
 - Avalanche adapter and metric implementation: `ContinualAI/avalanche` at
   `eb075be393e1f458b2c352514ff6c17b5a2c0f4e`.
+- Official project site source: `clear-benchmark/clear-benchmark.github.io` at
+  commit `fa2f22e6bcaa47d4512acbcf4ec1643ad9dc66b2`, tree
+  `19c7f8a68d867dab7e6b7236227797773873eec7`.
+- Public, ungated provider repository:
+  `elvishelvis6/CLEAR-Continual_Learning_Benchmark` at revision
+  `b518a845a98f1c913497ab98a19727cb65b74e65`.
 
 CLEAR derives natural temporal buckets from YFCC100M imagery spanning
 2004–2014. Bucket 0 is the optional unlabeled/pretraining bucket; the selected
@@ -22,15 +28,22 @@ streaming: the accuracy matrix is used to measure the near future, including
 the superdiagonal `next_domain` metric. It is not the alternate within-bucket
 70:30 IID protocol.
 
-The project site labels its material CC BY, and the two codebases have their
-own repository licenses. That is not sufficient evidence that every underlying
-Flickr/YFCC asset is redistributable or still available. The current Avalanche
-adapter downloads archives from a mutable Hugging Face `main` URL with
-`checksum=None`; the authors' download script instead names S3 archives. No
-reviewed provider revision or provider-published archive SHA-256 was found.
-Those are explicit blockers, not values to infer. A local qualification receipt
-therefore records caller-computed archive SHA-256 values while preserving
-`provider_archive_checksums_published: false`.
+The project site declares CC BY 4.0, and the provider repository carries the
+`license:cc-by-4.0` tag. That does not establish that every underlying
+Flickr/YFCC asset remains redistributable or available: privacy, publicity,
+moral-rights, takedown, and approved-storage review remain explicit blockers.
+The revision above exposes exact Git LFS identities for the selected archives:
+
+- `clear100-train-image-only.zip`: 3,289,951,359 bytes, SHA-256
+  `0376b952674e6ef55c3923ee4ce61e5b299fea4e29bbc4780530636e8988fd72`.
+- `clear100-test.zip`: 1,640,361,665 bytes, SHA-256
+  `c939753be4e62dc7732347e5e636ea599022c82f45443ea9e7166167e467abd0`.
+
+These are provider metadata identities, not local download verification or
+proof of archive contents and split semantics. The existing v1 local manifest
+field remains `provider_archive_checksums_published: false` because changing
+that historical schema would silently change its meaning; a separate
+prospective asset-plan schema records the newly reviewed provider identities.
 
 ## Frozen development comparison
 
@@ -50,6 +63,17 @@ summaries: accuracy, in-domain, next-domain, forward transfer, and backward
 transfer.
 
 ## Local manifest and CLI
+
+Print the content-closed prospective source/asset freeze without reading a
+dataset manifest or archive, accessing the network, or executing a workload:
+
+```bash
+.venv/bin/asi-clear-qualification --prospective-assets
+```
+
+This output is a plan-only prerequisite record. It is not a download receipt,
+runtime qualification, execution authorization, run result, parity result, or
+authenticated attestation.
 
 Create a JSON file with this exact shape and locally computed byte identities:
 
@@ -84,13 +108,16 @@ hash drift, and oversized manifests. It never extracts or writes data.
 
 ## Remaining comparability gates
 
-- Resolve a content-addressed provider snapshot and published checksums, or
-  archive an independently reviewed acquisition receipt.
-- Review YFCC/Flickr asset terms, takedown behavior, and approved storage.
+- Review YFCC/Flickr asset terms, privacy/publicity/moral-rights limits,
+  takedown behavior, and approved storage; obtain explicit acquisition
+  authorization.
+- Download both revision-pinned archives only into approved storage, then
+  independently verify their exact local sizes and SHA-256 values.
 - Parse the prepared metadata and independently verify class and bucket counts;
-  archive-byte identity alone does not prove semantic split parity.
-- Implement a runner outside the #1578 native-suite adapter, then add image,
-  label, transform, metric, JIT/parity, and end-to-end tests.
+  provider metadata identity alone does not prove semantic split parity.
+- Qualify the exact runtime and implement a reviewed runner outside the #1578
+  native-suite adapter, then add image, label, transform, metric, JIT/parity,
+  and end-to-end tests before seeking separate execution authorization.
 - Receipt exact model, optimizer, accelerator, preprocessing, and optional
   bucket-0 pretraining costs. The selected control excludes bucket-0
   pretraining; any use needs a separately matched no-pretraining ablation.

--- a/tests/test_clear_qualification.py
+++ b/tests/test_clear_qualification.py
@@ -14,6 +14,10 @@ from alberta_framework.benchmarks.clear_qualification import (
     BUCKETS,
     CURATION_COMMIT,
     DEV_SEEDS,
+    OFFICIAL_SITE_COMMIT,
+    OFFICIAL_SITE_TREE,
+    PROSPECTIVE_ASSET_SCHEMA,
+    PROVIDER_REVISION,
     REFERENCE_COMMIT,
     SCHEMA,
     ArchiveIdentity,
@@ -23,6 +27,7 @@ from alberta_framework.benchmarks.clear_qualification import (
     execution_config,
     load_dataset_manifest,
     main,
+    prospective_clear100_asset_plan,
     qualification_plan,
     validate_result,
     verify_dataset_manifest,
@@ -126,6 +131,74 @@ def test_cli_verifies_local_data_and_emits_only_a_nonexecuting_plan(
     assert payload["classification"] == "development-only-permanently-nonpromoting"
     assert payload["execution_authorized"] is False
     assert payload["promotion_authorized"] is False
+
+
+def test_prospective_asset_plan_binds_provider_assets_and_every_open_gate() -> None:
+    plan = prospective_clear100_asset_plan()
+    assert plan["schema_version"] == PROSPECTIVE_ASSET_SCHEMA
+    assert plan["classification"] == "prospective-source-and-asset-freeze-only"
+    assert plan["source_revisions"] == {
+        "curation": CURATION_COMMIT,
+        "reference_runner": REFERENCE_COMMIT,
+        "avalanche": AVALANCHE_COMMIT,
+        "official_site_commit": OFFICIAL_SITE_COMMIT,
+        "official_site_tree": OFFICIAL_SITE_TREE,
+    }
+    provider = plan["provider"]
+    assert isinstance(provider, dict)
+    assert provider["revision"] == PROVIDER_REVISION
+    assert provider["public_at_observation"] is True
+    assert provider["gated_at_observation"] is False
+    assert provider["license_metadata_git_oid"] == "b187bb7e7d837a367ccd0862441947ad412c77f7"
+    assets = plan["assets"]
+    assert isinstance(assets, list)
+    assert assets == [
+        {
+            "role": "provider-labeled-clear100-train-images-only",
+            "path": "clear100-train-image-only.zip",
+            "size_bytes": 3_289_951_359,
+            "lfs_sha256": "0376b952674e6ef55c3923ee4ce61e5b299fea4e29bbc4780530636e8988fd72",
+            "pointer_git_oid": "e441ed603eef45715947fe06567206bd90b26cf9",
+            "xet_hash": "f09eba2c90ad5295187b77a4af788629a908f2ea70ae2a33886ed55b9abecfb5",
+        },
+        {
+            "role": "provider-labeled-clear100-test",
+            "path": "clear100-test.zip",
+            "size_bytes": 1_640_361_665,
+            "lfs_sha256": "c939753be4e62dc7732347e5e636ea599022c82f45443ea9e7166167e467abd0",
+            "pointer_git_oid": "3a57c37f5b8beaf478b5e9a00fd38ed2454f5d6c",
+            "xet_hash": "a5fdd88c13d87116b6f1c10b41407bd68ca459ea67fb7b7df351fd07fec2ae86",
+        },
+    ]
+    assert plan["provider_archive_bytes"] == 4_930_313_024
+    assert sum(asset["size_bytes"] for asset in assets) == plan["provider_archive_bytes"]
+    claims = plan["claims"]
+    assert isinstance(claims, dict)
+    assert claims and all(value is False for value in claims.values())
+    blockers = plan["blockers"]
+    assert isinstance(blockers, list)
+    assert len(blockers) == 11
+    assert any("rights" in blocker and "takedown" in blocker for blocker in blockers)
+    assert any("split semantics" in blocker for blocker in blockers)
+    assert any("execution authorization" in blocker for blocker in blockers)
+
+
+def test_prospective_asset_cli_is_consumed_without_local_manifest(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "alberta_framework.benchmarks.clear_qualification.load_dataset_manifest",
+        lambda _path: pytest.fail("prospective asset plan touched a local manifest"),
+    )
+    assert main(("--prospective-assets",)) == 0
+    assert json.loads(capsys.readouterr().out) == prospective_clear100_asset_plan()
+
+
+def test_prospective_asset_cli_rejects_local_verification_arguments(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        main(("--prospective-assets", str(tmp_path / "manifest.json")))
+    with pytest.raises(SystemExit):
+        main(("--prospective-assets", "--dataset-root", str(tmp_path)))
 
 
 def test_manifest_path_read_is_metadata_gated_bounded_and_does_not_use_read_bytes(


### PR DESCRIPTION
Issue 1579 remains unresolved. This narrow prerequisite change gives the existing CLEAR qualification CLI a real, nonexecuting consumer for a content-addressed prospective source/asset plan.

It binds the official site commit/tree and public provider revision, the revision-bound CC-BY-4.0 metadata file, and exact size/LFS SHA-256/pointer/Xet identities for the provider-labeled CLEAR-100 train-image-only and test archives. The legacy local-manifest v1 semantics are unchanged.

Every acquisition and qualification boundary remains literal: underlying YFCC/Flickr rights, takedown/privacy/publicity/moral-rights review, storage approval, multi-gigabyte download authorization, local rehash, safe content/split inspection, runtime, runner, receipts, parity, execution authorization, authentication, performance, and promotion are all false or blockers. No archive was downloaded, no runtime was built, no workload executed, and no repository output was created.

Gates after rebase on current main:
- 42 focused tests passed
- Ruff passed
- mypy passed (221 source files)
- diff check passed