### PR TITLE
fix(core): cap Prototype n_dreams_per_step before arange hang

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -260,6 +260,7 @@ def feature_to_subtask_specs(
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_DREAMS_PER_STEP = 10_000
 _UINT32_MAX = 4_294_967_295
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
         int,
@@ -725,7 +726,7 @@ class PrototypeAgentConfig:
                 "n_dreams_per_step",
                 self.n_dreams_per_step,
                 minimum=0,
-                maximum=_INT32_MAX,
+                maximum=_MAX_DREAMS_PER_STEP,
             ),
         )
         # horde_hidden_sizes: hostile-safe per-element validation
@@ -1335,7 +1336,10 @@ class PrototypeAgentConfig:
             "buffer_capacity", data.pop("buffer_capacity", 200), minimum=1, maximum=_INT32_MAX
         )
         n_dreams_per_step = _require_int(
-            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=_INT32_MAX
+            "n_dreams_per_step",
+            data.pop("n_dreams_per_step", 0),
+            minimum=0,
+            maximum=_MAX_DREAMS_PER_STEP,
         )
         dream_next_observation_mode = data.pop(
             "dream_next_observation_mode",

--- a/tests/test_prototype_dream_count_cap.py
+++ b/tests/test_prototype_dream_count_cap.py
@@ -1,0 +1,54 @@
+"""Protocol ceiling for Prototype Dyna dream scans.
+
+Public last-fit is n_dreams_per_step=10_000 (tests use 0-4). Origin accepted
+INT32-legal counts and scanned jnp.arange(n_dreams) — hang, not leftover INT32.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.oak import OaKConfig
+from alberta_framework.core.options import STOMPConfig, SubtaskSpec
+from alberta_framework.core.prototype_agent import (
+    _MAX_DREAMS_PER_STEP,
+    PrototypeAgentConfig,
+)
+from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
+
+
+def _oak() -> OaKConfig:
+    return OaKConfig(
+        stomp=STOMPConfig(
+            subtask_specs=(SubtaskSpec(feature_index=0),),
+            observation_dim=4,
+            n_primitive_actions=2,
+        )
+    )
+
+
+def _world_model() -> ActionConditionedWorldModelConfig:
+    return ActionConditionedWorldModelConfig(
+        observation_dim=4,
+        n_actions=2,
+        hidden_sizes=(),
+    )
+
+
+def test_documented_protocol_ceiling() -> None:
+    assert _MAX_DREAMS_PER_STEP == 10_000
+
+
+def test_last_fit_dream_count_is_accepted() -> None:
+    cfg = PrototypeAgentConfig(
+        oak=_oak(),
+        world_model=_world_model(),
+        n_dreams_per_step=_MAX_DREAMS_PER_STEP,
+    )
+    assert cfg.n_dreams_per_step == 10_000
+
+
+@pytest.mark.parametrize("value", [10_001, 2**31 - 1])
+def test_rejects_oversized_dream_counts(value: int) -> None:
+    with pytest.raises(ValueError, match="n_dreams_per_step"):
+        PrototypeAgentConfig(oak=_oak(), n_dreams_per_step=value)


### PR DESCRIPTION
## Summary
- `PrototypeAgentConfig.n_dreams_per_step` accepted any signed-int32 count, then `jnp.arange(n_dreams_per_step)` scanned it.
- Public last-fit is 10_000 (tests use 0–4). Zero still disables dreaming. Numpy ints remain canonicalized.

Mode: **Fix**. Permanently nonpromoting.

<!-- evidence-head:c071ceaea42e9a435e7f908ed0aff1d7e71a2064 -->
<!-- evidence-row:logs -->
- [x] logs: `pytest tests/test_prototype_dream_count_cap.py tests/test_prototype_agent_validation.py -q` → 27 passed; ruff clean.

AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor 3.16.29
Lane: cursor-grok-4-6
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FJ2WK23NRQ57FPXSKRGD36","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T12:24:40.803Z","completed_at":"2026-08-20T12:26:41.300Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T12:24:41.635Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"9a0376e9050771d6fd253ac1e8a421749bdcce9ced64004d9ba7b8551368c5e0","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"79f6de29-3ac9-4517-9fe5-e2e52192156e","object_id":"sha256:9a0376e9050771d6fd253ac1e8a421749bdcce9ced64004d9ba7b8551368c5e0","sha256":"9a0376e9050771d6fd253ac1e8a421749bdcce9ced64004d9ba7b8551368c5e0"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"Bp4Y7Ac0nR3EHirdBOuaCZqksjRzIKzjAz2JDth3wp4rvZYbJhO1cIP8oNQCryZn-wUkzwDwj-2FkSHbFwEkAw"}} -->
