### PR TITLE
fix(core): cap option-search n_options before arange hang

### DIFF
--- a/alberta_framework/core/option_search_control.py
+++ b/alberta_framework/core/option_search_control.py
@@ -423,17 +423,21 @@ class OptionSearchControl:
     ) -> None:
         self._agent = stomp_agent
         self._config = config or OptionSearchControlConfig()
-        if self._agent.config.n_options < 1:
-            raise ValueError("option search control requires at least one option")
-        if (
-            type(self._agent.config.n_options) is not int
-            or self._agent.config.n_options > _MAX_BACKUP_BUDGET
-        ):
+        n_options = self._agent.config.n_options
+        if type(n_options) is not int:
             raise ValueError(
                 f"n_options must be an integer in [1, {_MAX_BACKUP_BUDGET}] "
                 "for option-search arange work"
             )
-        candidate_slots = self._agent.config.n_options * self._config.backup_budget
+        if n_options < 1:
+            raise ValueError("option search control requires at least one option")
+        if n_options > _MAX_BACKUP_BUDGET:
+            raise ValueError(
+                f"n_options must be an integer in [1, {_MAX_BACKUP_BUDGET}] "
+                "for option-search arange work"
+            )
+        self._n_options = n_options
+        candidate_slots = n_options * self._config.backup_budget
         if candidate_slots > _MAX_CANDIDATE_DIAGNOSTIC_SLOTS:
             raise ValueError(
                 "backup_budget * n_options exceeds the option-search "
@@ -450,7 +454,7 @@ class OptionSearchControl:
     def resource_budget(self) -> OptionSearchControlResourceBudget:
         """Return exact logical work maxima for one call."""
 
-        n_options = self._agent.config.n_options
+        n_options = self._n_options
         backup_budget = self._config.backup_budget
         candidate_slots = n_options * backup_budget
         # Dense logical payload: decision observation; eighteen boolean scalar
@@ -597,7 +601,7 @@ class OptionSearchControl:
         models = state.option_models
         if not isinstance(models, OptionModelsState):
             return False
-        n_options = self._agent.config.n_options
+        n_options = self._n_options
         observation_dim = self._agent.config.observation_dim
         return (
             _array_has_contract(models.cumreward_ema, (n_options,), jnp.float32)
@@ -655,7 +659,7 @@ class OptionSearchControl:
             jnp.isfinite(observation)
         )
         budget = self._config.backup_budget
-        n_options = self._agent.config.n_options
+        n_options = self._n_options
         matrix_shape = (budget, n_options)
         return OptionSearchControlDiagnostics(
             decision_observation=jnp.where(values_finite, observation, 0.0),
@@ -717,7 +721,7 @@ class OptionSearchControl:
         """Evaluate all option targets and residuals from one learner state."""
 
         models = state.option_models
-        n_options = self._agent.config.n_options
+        n_options = self._n_options
         base_values = self._agent.base_learner.predict(
             learner_state,
             observation,
@@ -877,7 +881,7 @@ class OptionSearchControl:
         )
 
         budget = self._config.backup_budget
-        n_options = self._agent.config.n_options
+        n_options = self._n_options
         matrix_shape = (budget, n_options)
         completion_supported_log = jnp.zeros(matrix_shape, dtype=jnp.bool_)
         semantics_valid_log = jnp.zeros(matrix_shape, dtype=jnp.bool_)

--- a/alberta_framework/core/option_search_control.py
+++ b/alberta_framework/core/option_search_control.py
@@ -425,6 +425,14 @@ class OptionSearchControl:
         self._config = config or OptionSearchControlConfig()
         if self._agent.config.n_options < 1:
             raise ValueError("option search control requires at least one option")
+        if (
+            type(self._agent.config.n_options) is not int
+            or self._agent.config.n_options > _MAX_BACKUP_BUDGET
+        ):
+            raise ValueError(
+                f"n_options must be an integer in [1, {_MAX_BACKUP_BUDGET}] "
+                "for option-search arange work"
+            )
         candidate_slots = self._agent.config.n_options * self._config.backup_budget
         if candidate_slots > _MAX_CANDIDATE_DIAGNOSTIC_SLOTS:
             raise ValueError(

--- a/tests/test_option_search_option_count_cap.py
+++ b/tests/test_option_search_option_count_cap.py
@@ -20,7 +20,21 @@ from alberta_framework.core.option_search_control import (
 
 class _Agent:
     def __init__(self, n_options: object) -> None:
-        self.config = SimpleNamespace(n_options=n_options)
+        self.config = SimpleNamespace(n_options=n_options, observation_dim=1)
+
+
+class _HostileInt(int):
+    calls = 0
+
+    def __lt__(self, other: object) -> bool:
+        del other
+        type(self).calls += 1
+        raise AssertionError("hostile less-than hook executed")
+
+    def __gt__(self, other: object) -> bool:
+        del other
+        type(self).calls += 1
+        raise AssertionError("hostile greater-than hook executed")
 
 
 def test_documented_protocol_ceiling() -> None:
@@ -35,3 +49,18 @@ def test_last_fit_option_count_is_accepted() -> None:
 def test_rejects_oversized_option_counts_before_slot_product(value: int) -> None:
     with pytest.raises(ValueError, match="n_options must be an integer in"):
         OptionSearchControl(_Agent(value), OptionSearchControlConfig())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", [True, False, _HostileInt(2)])
+def test_rejects_non_exact_option_count_before_comparison_hooks(value: object) -> None:
+    _HostileInt.calls = 0
+    with pytest.raises(ValueError, match="n_options must be an integer in"):
+        OptionSearchControl(_Agent(value), OptionSearchControlConfig())  # type: ignore[arg-type]
+    assert _HostileInt.calls == 0
+
+
+def test_resource_budget_uses_admitted_option_count_snapshot() -> None:
+    agent = _Agent(2)
+    control = OptionSearchControl(agent, OptionSearchControlConfig())  # type: ignore[arg-type]
+    agent.config.n_options = 2**31 - 1
+    assert control.resource_budget.n_options == 2

--- a/tests/test_option_search_option_count_cap.py
+++ b/tests/test_option_search_option_count_cap.py
@@ -1,0 +1,37 @@
+"""Option-search n_options ceiling before jnp.arange hang.
+
+Public last-fit is 4096 (same as backup_budget). Tests construct 65 options.
+Origin accepted INT32-legal n_options whenever backup_budget * n_options
+stayed under 262_144 diagnostic slots, then scanned jnp.arange(n_options).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from alberta_framework.core.option_search_control import (
+    _MAX_BACKUP_BUDGET,
+    OptionSearchControl,
+    OptionSearchControlConfig,
+)
+
+
+class _Agent:
+    def __init__(self, n_options: object) -> None:
+        self.config = SimpleNamespace(n_options=n_options)
+
+
+def test_documented_protocol_ceiling() -> None:
+    assert _MAX_BACKUP_BUDGET == 4096
+
+
+def test_last_fit_option_count_is_accepted() -> None:
+    OptionSearchControl(_Agent(_MAX_BACKUP_BUDGET), OptionSearchControlConfig())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", [4097, 10_001, 2**31 - 1])
+def test_rejects_oversized_option_counts_before_slot_product(value: int) -> None:
+    with pytest.raises(ValueError, match="n_options must be an integer in"):
+        OptionSearchControl(_Agent(value), OptionSearchControlConfig())  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- `OptionSearchControl` allowed INT32-legal `n_options` whenever `backup_budget * n_options <= 262_144`, then scanned `jnp.arange(n_options)`.
- Cap at 4096, matching `_MAX_BACKUP_BUDGET`. Existing tests construct 65 options.

Mode: **Fix**. Permanently nonpromoting.

<!-- evidence-head:5506b71fc634e537044bb553ff87e5aed6d0038c -->
<!-- evidence-row:logs -->
- [x] logs: `pytest tests/test_option_search_option_count_cap.py tests/test_option_search_control.py tests/test_option_search_control_resource_budget.py -q` → 48 passed; ruff clean.

AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor 3.16.29
Lane: cursor-grok-4-6
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FJ7T1116WSNTC65H7RNSEN","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T12:27:22.017Z","completed_at":"2026-08-20T12:30:48.329Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T12:27:22.567Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"8c64f445df9e739a50b0e1e8e19b3b844ba244f96a6366a40a67902e0ccebeaa","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"e0431251-93f2-441c-8542-b025b67d6495","object_id":"sha256:8c64f445df9e739a50b0e1e8e19b3b844ba244f96a6366a40a67902e0ccebeaa","sha256":"8c64f445df9e739a50b0e1e8e19b3b844ba244f96a6366a40a67902e0ccebeaa"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"5NBziosF63r3KTq8rd6e0sgGlBx0BIVbVrRfJRGEMD8mpRTutGZuEeOUQO3PNsDPxktsXXTmAhevs-SVXt1VBQ"}} -->
