### PR TITLE
fix(benchmarks): pin IPMNIST runner to Threefry

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -146,7 +146,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, fields, replace
 from pathlib import Path
 from types import FunctionType, MappingProxyType
-from typing import Any, cast
+from typing import Any, Final, cast
 
 import chex
 import jax
@@ -325,6 +325,8 @@ from alberta_framework.evaluation.replay_frozen_ipmnist_nonpromoting import (
 )
 
 logger = logging.getLogger(__name__)
+
+_SCREENING_RNG_IMPL: Final[str] = "threefry2x32"
 
 LEGACY_SHARD_SCHEMA = "alberta.ipmnist_screening.shard.v1"
 SHARD_SCHEMA = "alberta.ipmnist_screening.shard.v2"
@@ -10369,6 +10371,13 @@ def noise_curvature_development_result_payload(
     return validate_noise_curvature_development_result(payload)
 
 
+def _screening_root_key(seed: object) -> Array:
+    """Return the runner-owned Threefry root independent of ambient JAX config."""
+
+    resolved_seed = require_jax_seed(seed, name="seed")
+    return jr.key(jnp.uint32(resolved_seed), impl=_SCREENING_RNG_IMPL)
+
+
 def run_screening_config(
     data_x: np.ndarray | Array,
     data_y: np.ndarray | Array,
@@ -10449,7 +10458,7 @@ def run_screening_config(
     else:
         init_fn, step_fn = spec.factory(spec.hyperparameters)
 
-    root = jr.key(jnp.uint32(resolved_seed))
+    root = _screening_root_key(resolved_seed)
     key_init, key_schedule, key_noise = jr.split(root, 3)
     params = init_mlp_params(key_init, config)
     schedule = build_schedule(key_schedule, config, n_train)

--- a/tests/test_ipmnist_screening_explicit_threefry.py
+++ b/tests/test_ipmnist_screening_explicit_threefry.py
@@ -1,0 +1,53 @@
+"""The shared IPMNIST runner owns an explicit Threefry RNG root."""
+
+from __future__ import annotations
+
+import jax
+import numpy as np
+
+from alberta_framework.benchmarks.ipmnist_screening import (
+    run_screening_config,
+    screening_spec,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+
+
+def test_screening_trajectory_is_independent_of_ambient_prng_default() -> None:
+    data_x = np.linspace(-1.0, 1.0, 72, dtype=np.float32).reshape(12, 6)
+    data_y = np.arange(12, dtype=np.int32) % 3
+    config = IPMNISTConfig(
+        n_tasks=2,
+        task_length=4,
+        input_dim=6,
+        hidden1=5,
+        hidden2=4,
+        n_classes=3,
+    )
+    spec = screening_spec("upgd_w_control")
+
+    with jax.default_prng_impl("threefry2x32"):
+        threefry_default = run_screening_config(
+            data_x,
+            data_y,
+            spec,
+            seed=156_700_901,
+            config=config,
+        )
+    with jax.default_prng_impl("rbg"):
+        rbg_default = run_screening_config(
+            data_x,
+            data_y,
+            spec,
+            seed=156_700_901,
+            config=config,
+        )
+
+    np.testing.assert_array_equal(
+        rbg_default.per_task_accuracy,
+        threefry_default.per_task_accuracy,
+    )
+    np.testing.assert_array_equal(rbg_default.per_task_loss, threefry_default.per_task_loss)
+    np.testing.assert_array_equal(
+        rbg_default.per_task_plasticity,
+        threefry_default.per_task_plasticity,
+    )


### PR DESCRIPTION
## Summary

- make the shared `run_screening_config` RNG root explicitly `threefry2x32` instead of inheriting mutable ambient JAX configuration
- expose one internal root helper so future matched-development plans can bind the exact execution root they actually consume
- add an end-to-end regression proving identical initialization, schedule, perturbation, and metric trajectories under ambient `threefry2x32` and `rbg`

This is a shared execution-integrity prerequisite for the existing mechanism lanes, including #1563 and #1567. It does not introduce a second mechanism or campaign, execute a workload, write an output, consume a frozen prospective campaign roster, or make a performance/scientific claim. Both issues remain open for protocol consolidation, fresh-seed authorization, retained execution, and acceptance.

## Verification

- pre-fix regression: failed with exact per-task accuracy `[0.25, 0.25]` under ambient `rbg` versus `[0.5, 0.5]` under Threefry
- post-fix regression: 1 passed
- adjacent #1560–#1567 mechanism panel: 131 passed
- scoped Ruff: passed
- strict mypy on `ipmnist_screening.py`: passed
- `git diff --check`: passed

No campaign, benchmark output, workflow, or frozen evidence artifact was run or modified.