### PR TITLE
fix(coom): bind qualification runtime identity

### DIFF
--- a/external_runtimes/coom/Dockerfile
+++ b/external_runtimes/coom/Dockerfile
@@ -23,6 +23,8 @@ COPY Dockerfile /opt/qualification/Dockerfile.source
 COPY qualification-manifest.json /opt/qualification/qualification-manifest.json
 COPY smoke.py /opt/qualification/smoke.py
 
-ENV PYTHONPATH=/opt/coom
+ENV HOME=/tmp \
+    PYTHONPATH=/opt/coom
+USER 65532:65532
 WORKDIR /opt/coom
 ENTRYPOINT ["python", "/opt/qualification/smoke.py"]

--- a/external_runtimes/coom/README.md
+++ b/external_runtimes/coom/README.md
@@ -24,13 +24,29 @@ Build and execute from this directory:
 ```bash
 docker build --tag asi-coom-qualification:development .
 receipt_dir="$(mktemp -d /tmp/asi-coom-receipts.XXXXXX)"
-docker run --rm -v "$receipt_dir:/output" asi-coom-qualification:development \
+chmod 0733 "$receipt_dir"
+docker run --rm --network none --read-only --user 65532:65532 \
+  --cap-drop ALL --security-opt no-new-privileges \
+  --cpus 2 --memory 2g --pids-limit 64 \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=16m \
+  -v "$receipt_dir:/output" asi-coom-qualification:development \
   --output /output/receipt.json
-docker run --rm -v "$receipt_dir:/input:ro" asi-coom-qualification:development \
+chmod 0755 "$receipt_dir"
+docker run --rm --network none --read-only --user 65532:65532 \
+  --cap-drop ALL --security-opt no-new-privileges \
+  --cpus 2 --memory 2g --pids-limit 64 \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=16m \
+  -v "$receipt_dir:/input:ro" asi-coom-qualification:development \
   --validate-receipt /input/receipt.json
+chmod 0700 "$receipt_dir"
 ```
 
 The host receipt directory above is explicitly outside the source checkout.
+The verifier refuses to start the engine unless it is UID/GID 65532, has no
+effective Linux capabilities, has `NoNewPrivs` set, and sees exactly the eleven
+reviewed Python distributions. The command also makes network, root filesystem,
+CPU, memory, process, and temporary-filesystem bounds explicit. The receipt does
+not claim that these caller-supplied limits are authenticated execution evidence.
 
 Compare `trace_sha256`, not the telemetry-only elapsed time or platform string.
 The smoke consumes seed 1582000, all eight official CO8 tasks, and two action-0

--- a/external_runtimes/coom/qualification-manifest.json
+++ b/external_runtimes/coom/qualification-manifest.json
@@ -1,8 +1,8 @@
 {
   "schema": "asi.coom_external_runtime.inputs.v1",
   "base_image_digest": "python:3.12.12-slim-bookworm@sha256:593bd06efe90efa80dc4eee3948be7c0fde4134606dd40d8dd8dbcade98e669c",
-  "dockerfile_sha256": "252cbabc7adbbabf7f53fdb859e2b6cc848a6612818e86429c1845449e832594",
+  "dockerfile_sha256": "dec91565d3b697d5065137a115229ee80ecd818d2e7351ecc7f80710d306b7f6",
   "requirements_lock_sha256": "300bfe63042bd684b6024d0fbf4ad13c475c8e83181cf84eaabe3e3aeb11b509",
-  "smoke_sha256": "1e68cb597d10b99ddcedb949f9aab69ded137ac0df83d7f0c51fb171db26e8ef",
+  "smoke_sha256": "4f38d839930fbc47ad8e690738fc5948a04f4e201651bbd3e9711eaeb7992c9e",
   "patch_sha256": "25bc846908e573ff1c7d02909a9bb895570e0beafe1a928dbd0d5fd4b63835a7"
 }

--- a/external_runtimes/coom/qualification-manifest.json
+++ b/external_runtimes/coom/qualification-manifest.json
@@ -3,6 +3,6 @@
   "base_image_digest": "python:3.12.12-slim-bookworm@sha256:593bd06efe90efa80dc4eee3948be7c0fde4134606dd40d8dd8dbcade98e669c",
   "dockerfile_sha256": "dec91565d3b697d5065137a115229ee80ecd818d2e7351ecc7f80710d306b7f6",
   "requirements_lock_sha256": "300bfe63042bd684b6024d0fbf4ad13c475c8e83181cf84eaabe3e3aeb11b509",
-  "smoke_sha256": "4f38d839930fbc47ad8e690738fc5948a04f4e201651bbd3e9711eaeb7992c9e",
+  "smoke_sha256": "6befb030d75a649aafe2762620b101c86b05ea015e006212b6de769ea0500969",
   "patch_sha256": "25bc846908e573ff1c7d02909a9bb895570e0beafe1a928dbd0d5fd4b63835a7"
 }

--- a/external_runtimes/coom/smoke.py
+++ b/external_runtimes/coom/smoke.py
@@ -36,6 +36,19 @@ PATCHED_REWARD_WRAPPER_SHA256 = (
     "0ab457a6bc95dc2551b2c81608d1619549e56ced47e2c85949c39b87b8b5a8cf"
 )
 EXPECTED_TRACE_SHA256 = "c74968494ccebaaeac4bc1e0c0f1db7546ac5091b831c05a4c0c727266da696f"
+EXPECTED_DISTRIBUTIONS = (
+    ("Farama-Notifications", "0.0.6"),
+    ("cloudpickle", "3.1.2"),
+    ("gymnasium", "0.28.1"),
+    ("jax-jumpy", "1.0.0"),
+    ("numpy", "1.26.4"),
+    ("opencv-python-headless", "4.11.0.86"),
+    ("pip", "25.0.1"),
+    ("pygame-ce", "2.5.8"),
+    ("scipy", "1.11.4"),
+    ("typing_extensions", "4.16.0"),
+    ("vizdoom", "1.3.0"),
+)
 TASK_NAMES = (
     "pitfall-default",
     "arms_dealer-default",
@@ -51,6 +64,7 @@ STEPS_PER_TASK = 2
 _QUALIFICATION_ROOT = Path("/opt/qualification")
 _MAX_MANIFEST_BYTES = 8192
 _MAX_RECEIPT_BYTES = 1024 * 1024
+_MAX_PROC_STATUS_BYTES = 64 * 1024
 
 
 def _array_sha256(value: np.ndarray) -> str:
@@ -81,6 +95,62 @@ def _asset_manifest() -> tuple[int, int, str]:
 
 def _file_sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _runtime_identity() -> dict[str, object]:
+    """Validate the exact non-root runtime before importing or starting COOM."""
+
+    if not hasattr(os, "getuid") or not hasattr(os, "getgid"):
+        raise ValueError("COOM qualification requires Linux process identities")
+    uid = os.getuid()
+    gid = os.getgid()
+    if uid != 65532 or gid != 65532:
+        raise ValueError("COOM qualification requires exact UID/GID 65532")
+
+    status_raw = Path("/proc/self/status").read_bytes()
+    if len(status_raw) > _MAX_PROC_STATUS_BYTES:
+        raise ValueError("process status exceeds its byte limit")
+    fields: dict[bytes, bytes] = {}
+    for line in status_raw.splitlines():
+        if b":" not in line:
+            continue
+        key, value = line.split(b":", 1)
+        if key in (b"CapEff", b"NoNewPrivs"):
+            if key in fields:
+                raise ValueError("process status contains duplicate security fields")
+            fields[key] = value.strip()
+    if fields != {b"CapEff": b"0000000000000000", b"NoNewPrivs": b"1"}:
+        raise ValueError("COOM qualification requires no capabilities and NoNewPrivs")
+
+    distributions: list[tuple[str, str]] = []
+    for distribution in importlib.metadata.distributions():
+        name = distribution.metadata["Name"]
+        version = distribution.version
+        distributions.append(
+            (
+                _exact_str(name, name="installed distribution name"),
+                _exact_str(version, name="installed distribution version"),
+            )
+        )
+    installed = tuple(sorted(distributions))
+    if len(installed) != len(set(installed)) or installed != EXPECTED_DISTRIBUTIONS:
+        raise ValueError("installed distributions differ from the exact runtime roster")
+
+    return {
+        "python": platform.python_version(),
+        "python_implementation": platform.python_implementation(),
+        "platform": platform.platform(),
+        "uid": uid,
+        "gid": gid,
+        "effective_capabilities_hex": fields[b"CapEff"].decode("ascii"),
+        "no_new_privileges": True,
+        "installed_distributions": [list(item) for item in installed],
+        "numpy": importlib.metadata.version("numpy"),
+        "scipy": importlib.metadata.version("scipy"),
+        "gymnasium": importlib.metadata.version("gymnasium"),
+        "vizdoom": importlib.metadata.version("vizdoom"),
+        "opencv_python_headless": importlib.metadata.version("opencv-python-headless"),
+    }
 
 
 def _git_object(kind: bytes, payload: bytes) -> bytes:
@@ -612,6 +682,11 @@ def validate_receipt(receipt: object) -> None:
             "gymnasium",
             "vizdoom",
             "opencv_python_headless",
+            "uid",
+            "gid",
+            "effective_capabilities_hex",
+            "no_new_privileges",
+            "installed_distributions",
         },
         name="runtime",
     )
@@ -625,9 +700,37 @@ def validate_receipt(receipt: object) -> None:
         "opencv_python_headless": "4.11.0.86",
     }
     for name in runtime:
-        _exact_str(runtime[name], name=f"runtime {name}", maximum=256)
+        if name not in {"uid", "gid", "no_new_privileges", "installed_distributions"}:
+            _exact_str(runtime[name], name=f"runtime {name}", maximum=256)
     if any(runtime[name] != value for name, value in expected_versions.items()):
         raise ValueError("runtime versions differ from the hash-locked qualification")
+    if (
+        _exact_int(runtime["uid"], name="runtime uid") != 65532
+        or _exact_int(runtime["gid"], name="runtime gid") != 65532
+        or _exact_str(
+            runtime["effective_capabilities_hex"], name="effective capabilities"
+        )
+        != "0000000000000000"
+        or _exact_bool(runtime["no_new_privileges"], name="no_new_privileges") is not True
+    ):
+        raise ValueError("runtime process security identity differs")
+    installed_value = runtime["installed_distributions"]
+    if type(installed_value) is not list or len(installed_value) != len(
+        EXPECTED_DISTRIBUTIONS
+    ):
+        raise ValueError("installed distributions differ from the exact runtime roster")
+    installed: list[tuple[str, str]] = []
+    for item in installed_value:
+        if type(item) is not list or len(item) != 2:
+            raise ValueError("installed distribution entries must be exact pairs")
+        installed.append(
+            (
+                _exact_str(item[0], name="installed distribution name"),
+                _exact_str(item[1], name="installed distribution version"),
+            )
+        )
+    if tuple(installed) != EXPECTED_DISTRIBUTIONS:
+        raise ValueError("installed distributions differ from the exact runtime roster")
     trace = _exact_keys(
         root["trace"],
         {"seed", "sequence", "steps_per_task", "fixed_action", "frame_skip", "resize", "records"},
@@ -768,6 +871,7 @@ def validate_receipt(receipt: object) -> None:
 
 def build_receipt() -> dict[str, object]:
     qualification_inputs = _load_qualification_manifest()
+    runtime = _runtime_identity()
     root = Path("/opt/coom")
     if _source_tree_sha1(root) != SOURCE_TREE:
         raise SystemExit("COOM source archive does not reconstruct the pinned Git tree")
@@ -813,16 +917,7 @@ def build_receipt() -> dict[str, object]:
             "patched_reward_wrapper_sha256": PATCHED_REWARD_WRAPPER_SHA256,
             "qualification_patch_scope": "gym RewardWrapper import only",
         },
-        "runtime": {
-            "python": platform.python_version(),
-            "python_implementation": platform.python_implementation(),
-            "platform": platform.platform(),
-            "numpy": importlib.metadata.version("numpy"),
-            "scipy": importlib.metadata.version("scipy"),
-            "gymnasium": importlib.metadata.version("gymnasium"),
-            "vizdoom": importlib.metadata.version("vizdoom"),
-            "opencv_python_headless": importlib.metadata.version("opencv-python-headless"),
-        },
+        "runtime": runtime,
         "trace": trace,
         "trace_sha256": hashlib.sha256(trace_bytes).hexdigest(),
         "resource_receipt": {

--- a/external_runtimes/coom/smoke.py
+++ b/external_runtimes/coom/smoke.py
@@ -123,7 +123,9 @@ def _runtime_identity() -> dict[str, object]:
         raise ValueError("COOM qualification requires no capabilities and NoNewPrivs")
 
     distributions: list[tuple[str, str]] = []
-    for distribution in importlib.metadata.distributions():
+    for index, distribution in enumerate(importlib.metadata.distributions()):
+        if index >= len(EXPECTED_DISTRIBUTIONS):
+            raise ValueError("installed distributions exceed the exact runtime roster")
         name = distribution.metadata["Name"]
         version = distribution.version
         distributions.append(

--- a/tests/test_coom_external_runtime.py
+++ b/tests/test_coom_external_runtime.py
@@ -62,6 +62,7 @@ def test_coom_runtime_is_source_dependency_and_base_image_pinned() -> None:
     assert hashlib.sha256(patch.read_bytes()).hexdigest() in dockerfile
     assert "--require-hashes" in dockerfile
     assert "apt-get" not in dockerfile
+    assert "USER 65532:65532" in dockerfile
     assert manifest["base_image_digest"] in dockerfile
     assert manifest["dockerfile_sha256"] == hashlib.sha256(
         (ROOT / "Dockerfile").read_bytes()
@@ -104,6 +105,25 @@ def test_coom_runtime_smoke_is_bounded_external_and_nonpromoting() -> None:
     assert "EXPECTED_TRACE_SHA256" in source
     assert '_exact_keys(reset_info, frozenset(), name="reset info")' in source
     assert '_exact_keys(info, frozenset(), name="step info")' in source
+    assert "EXPECTED_DISTRIBUTIONS" in source
+    assert "_runtime_identity()" in source
+
+
+def test_coom_runbook_requires_the_reviewed_sandbox_boundary() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    for required in (
+        "--network none",
+        "--read-only",
+        "--user 65532:65532",
+        "--cap-drop ALL",
+        "--security-opt no-new-privileges",
+        "--cpus 2",
+        "--memory 2g",
+        "--pids-limit 64",
+        "noexec",
+    ):
+        assert required in readme
 
 
 def test_coom_receipt_validator_rejects_hostile_provider_payloads(
@@ -170,6 +190,11 @@ def test_coom_receipt_validator_rejects_hostile_provider_payloads(
             "python": "3.12.12",
             "python_implementation": "CPython",
             "platform": "linux-test",
+            "uid": 65532,
+            "gid": 65532,
+            "effective_capabilities_hex": "0000000000000000",
+            "no_new_privileges": True,
+            "installed_distributions": [list(item) for item in smoke.EXPECTED_DISTRIBUTIONS],
             "numpy": "1.26.4",
             "scipy": "1.11.4",
             "gymnasium": "0.28.1",
@@ -247,6 +272,19 @@ def test_coom_receipt_validator_rejects_hostile_provider_payloads(
     hostile = copy.deepcopy(receipt)
     hostile["resource_receipt"]["environment_steps"] = True
     with pytest.raises(ValueError, match="resource receipt"):
+        smoke.validate_receipt(hostile)
+
+    hostile = copy.deepcopy(receipt)
+    hostile["runtime"]["uid"] = True
+    with pytest.raises(ValueError, match="runtime uid"):
+        smoke.validate_receipt(hostile)
+    hostile = copy.deepcopy(receipt)
+    hostile["runtime"]["no_new_privileges"] = False
+    with pytest.raises(ValueError, match="process security identity"):
+        smoke.validate_receipt(hostile)
+    hostile = copy.deepcopy(receipt)
+    hostile["runtime"]["installed_distributions"].append(["unreviewed", "1.0"])
+    with pytest.raises(ValueError, match="installed distributions"):
         smoke.validate_receipt(hostile)
 
     hostile = copy.deepcopy(receipt)
@@ -387,6 +425,49 @@ def test_reward_admission_matches_real_coom_scalar_without_coercion() -> None:
     with pytest.raises(ValueError, match="exact float scalar"):
         smoke._trusted_reward(HostileReward())
     assert _TypeEqualityHook.calls == 0
+
+
+def test_runtime_identity_requires_nonroot_sandbox_and_complete_distribution_roster(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    smoke = _smoke_module()
+
+    monkeypatch.setattr(smoke.os, "getuid", lambda: 0)
+    monkeypatch.setattr(smoke.os, "getgid", lambda: 0)
+    with pytest.raises(ValueError, match="UID/GID 65532"):
+        smoke._runtime_identity()
+
+    monkeypatch.setattr(smoke.os, "getuid", lambda: 65532)
+    monkeypatch.setattr(smoke.os, "getgid", lambda: 65532)
+    monkeypatch.setattr(
+        smoke.Path,
+        "read_bytes",
+        lambda _self: b"Name:\tpython\nCapEff:\t0000000000000000\nNoNewPrivs:\t1\n",
+    )
+    distributions = tuple(
+        SimpleNamespace(metadata={"Name": name}, version=version)
+        for name, version in smoke.EXPECTED_DISTRIBUTIONS
+    )
+    monkeypatch.setattr(smoke.importlib.metadata, "distributions", lambda: distributions)
+    versions = dict(smoke.EXPECTED_DISTRIBUTIONS)
+    monkeypatch.setattr(smoke.importlib.metadata, "version", versions.__getitem__)
+    identity = smoke._runtime_identity()
+    assert identity["uid"] == 65532
+    assert identity["gid"] == 65532
+    assert identity["effective_capabilities_hex"] == "0000000000000000"
+    assert identity["no_new_privileges"] is True
+    assert identity["installed_distributions"] == [
+        list(item) for item in smoke.EXPECTED_DISTRIBUTIONS
+    ]
+
+    monkeypatch.setattr(
+        smoke.importlib.metadata,
+        "distributions",
+        lambda: distributions
+        + (SimpleNamespace(metadata={"Name": "unreviewed"}, version="1.0"),),
+    )
+    with pytest.raises(ValueError, match="installed distributions"):
+        smoke._runtime_identity()
 
 
 def test_output_path_rejects_subclass_before_filesystem_hook(tmp_path: Path) -> None:

--- a/tests/test_coom_external_runtime.py
+++ b/tests/test_coom_external_runtime.py
@@ -470,6 +470,44 @@ def test_runtime_identity_requires_nonroot_sandbox_and_complete_distribution_ros
         smoke._runtime_identity()
 
 
+def test_runtime_identity_rejects_twelfth_distribution_before_metadata_or_thirteenth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    smoke = _smoke_module()
+    monkeypatch.setattr(smoke.os, "getuid", lambda: 65532)
+    monkeypatch.setattr(smoke.os, "getgid", lambda: 65532)
+    monkeypatch.setattr(
+        smoke.Path,
+        "read_bytes",
+        lambda _self: b"CapEff:\t0000000000000000\nNoNewPrivs:\t1\n",
+    )
+
+    class TwelfthDistribution:
+        metadata_reads = 0
+
+        @property
+        def metadata(self) -> object:
+            type(self).metadata_reads += 1
+            raise AssertionError("twelfth distribution metadata was traversed")
+
+    yielded = 0
+
+    def distributions() -> object:
+        nonlocal yielded
+        for name, version in smoke.EXPECTED_DISTRIBUTIONS:
+            yielded += 1
+            yield SimpleNamespace(metadata={"Name": name}, version=version)
+        yielded += 1
+        yield TwelfthDistribution()
+        raise AssertionError("thirteenth distribution was requested")
+
+    monkeypatch.setattr(smoke.importlib.metadata, "distributions", distributions)
+    with pytest.raises(ValueError, match="installed distributions"):
+        smoke._runtime_identity()
+    assert yielded == len(smoke.EXPECTED_DISTRIBUTIONS) + 1
+    assert TwelfthDistribution.metadata_reads == 0
+
+
 def test_output_path_rejects_subclass_before_filesystem_hook(tmp_path: Path) -> None:
     smoke = _smoke_module()
 


### PR DESCRIPTION
## Summary

Hardens the existing real-engine COOM qualification consumer after an exact current-main audit found that its receipt bound only five headline package versions and could validate with extra distributions, base-tool drift, or a root process.

The image and verifier now require UID/GID 65532, zero effective Linux capabilities, `NoNewPrivs`, and the complete observed eleven-distribution runtime roster (including base `pip`). The runbook supplies the matching networkless, read-only, non-root, capability-free, CPU/memory/PID/tmpfs invocation, and the manifest rebinds the changed Dockerfile and verifier bytes. The gate runs before COOM is imported or the engine starts.

## Evidence boundary

This PR does not build the image, start COOM/ViZDoom, download data, dispatch a workload, or write an output/receipt. The new identity helper was exercised read-only inside the already-present exact COOM image with network disabled and returned the expected UID/GID, capability, `NoNewPrivs`, and complete distribution roster. Caller-supplied resource limits remain unauthenticated; the full matched learner/control campaign, complete resource accounting, durable negative outcomes, and promotion gates remain open. Issue #1582 is not closed.

## Validation

- 51 focused/adjacent tests passed
- Ruff passed
- strict mypy passed (221 source files)
- diff check passed
- constrained read-only `_runtime_identity()` inspection passed without importing COOM or starting the engine

Refs #1582.