### PR TITLE
feat: freeze fail-closed calibrated partial reset campaign

### DIFF
--- a/alberta_framework/benchmarks/calibrated_partial_reset_ipmnist.py
+++ b/alberta_framework/benchmarks/calibrated_partial_reset_ipmnist.py
@@ -1,0 +1,266 @@
+"""Calibrated Partial Reset arms for the prospective issue #1563 IPMNIST lane."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Final, Literal
+
+import chex
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from alberta_framework.benchmarks.ipmnist_screening import (
+    ScreeningSpec,
+    ScreeningStepFn,
+    StepMetrics,
+    _step_metrics,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import LearnerInitFn, cross_entropy_loss
+
+PAPER_REVISION: Final = "arXiv:2607.24996v1"
+OFFICIAL_CODE_REVISION: Final = "LucMc/continual-learning@6fc2af34783159f5dda50c6915dda32c2d443604"
+ARMS: Final = (
+    "cpr_off",
+    "cpr_utility",
+    "cpr_utility_free",
+    "cpr_l2_init",
+    "cpr_hard_reset",
+)
+_MODES: Final = ("off", "utility", "utility_free", "l2_init", "hard_reset")
+
+
+@chex.dataclass(frozen=True)
+class CPRState:
+    """Matched Adam state, retained initialization, and per-neuron utility."""
+
+    first_moment: dict[str, Array]
+    second_moment: dict[str, Array]
+    initial_params: dict[str, Array]
+    utility1: Array
+    utility2: Array
+    step: Array
+
+
+def _checked_hyperparameters(value: Mapping[str, float]) -> dict[str, float]:
+    expected = {
+        "step_size",
+        "beta1",
+        "beta2",
+        "epsilon",
+        "utility_decay",
+        "replacement_rate",
+        "sharpness",
+        "update_frequency",
+        "l2_init_strength",
+    }
+    if (
+        type(value) is not dict
+        or len(value) != len(expected)
+        or any(type(name) is not str for name in value)
+        or set(value) != expected
+    ):
+        raise ValueError("CPR hyperparameters differ from the exact contract")
+    result: dict[str, float] = {}
+    for name in sorted(expected):
+        item = value[name]
+        if type(item) is not float or not math.isfinite(item):
+            raise ValueError("CPR hyperparameters must be exact finite floats")
+        result[name] = item
+    if not 0.0 < result["step_size"] <= 1.0:
+        raise ValueError("CPR step size is out of bounds")
+    if not 0.0 <= result["beta1"] < 1.0 or not 0.0 <= result["beta2"] < 1.0:
+        raise ValueError("CPR Adam decays are out of bounds")
+    if not 0.0 <= result["utility_decay"] < 1.0:
+        raise ValueError("CPR utility decay is out of bounds")
+    if not 0.0 <= result["replacement_rate"] <= 1.0:
+        raise ValueError("CPR replacement rate is out of bounds")
+    if not 0.0 < result["epsilon"] <= 1.0 or not 0.0 < result["sharpness"] <= 64.0:
+        raise ValueError("CPR numeric stabilizers are out of bounds")
+    frequency = result["update_frequency"]
+    if not frequency.is_integer() or not 1 <= frequency <= 1_000_000:
+        raise ValueError("CPR update frequency is out of bounds")
+    if not 0.0 <= result["l2_init_strength"] <= 1.0:
+        raise ValueError("CPR L2-init strength is out of bounds")
+    return result
+
+
+def _normalized_utility(gradient: Array, previous: Array, decay: float) -> Array:
+    score = jnp.mean(jnp.abs(gradient), axis=0)
+    normalized = score / (jnp.mean(score) + jnp.asarray(1e-8, dtype=score.dtype))
+    return decay * previous + (1.0 - decay) * normalized
+
+
+def _partial_reset(
+    params: dict[str, Array],
+    initial: dict[str, Array],
+    utility1: Array,
+    utility2: Array,
+    *,
+    replacement_rate: float,
+    sharpness: float,
+    mode: Literal["utility", "utility_free", "hard_reset"],
+) -> dict[str, Array]:
+    def rate(utility: Array) -> Array:
+        if mode == "utility":
+            shape = jnp.minimum(2.0 * jax.nn.sigmoid(-sharpness * (utility - 1.0)), 1.0)
+            return replacement_rate * shape
+        if mode == "utility_free":
+            return jnp.full_like(utility, replacement_rate)
+        return jnp.where(utility <= 1.0, 1.0, 0.0)
+
+    rate1 = rate(utility1)
+    rate2 = rate(utility2)
+    result = dict(params)
+    result["w1"] = params["w1"] + rate1[None, :] * (initial["w1"] - params["w1"])
+    result["w2"] = params["w2"] * (1.0 - rate1[:, None])
+    result["w2"] = result["w2"] + rate2[None, :] * (initial["w2"] - result["w2"])
+    result["w3"] = params["w3"] * (1.0 - rate2[:, None])
+    return result
+
+
+def _make_cpr_learner(
+    hp: Mapping[str, float],
+    *,
+    mode: Literal["off", "utility", "utility_free", "l2_init", "hard_reset"],
+) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    if type(mode) is not str or mode not in _MODES:
+        raise ValueError("unknown CPR reduction")
+    checked = _checked_hyperparameters(hp)
+
+    def init_fn(params: dict[str, Array]) -> CPRState:
+        return CPRState(
+            first_moment={name: jnp.zeros_like(value) for name, value in params.items()},
+            second_moment={name: jnp.zeros_like(value) for name, value in params.items()},
+            initial_params=dict(params),
+            utility1=jnp.ones(params["w1"].shape[1], dtype=jnp.float32),
+            utility2=jnp.ones(params["w2"].shape[1], dtype=jnp.float32),
+            step=jnp.asarray(0, dtype=jnp.int32),
+        )
+
+    def step_fn(
+        params: dict[str, Array], state: CPRState, x: Array, y: Array, key: Array
+    ) -> tuple[dict[str, Array], CPRState, StepMetrics]:
+        del key
+        (loss, logits), grads = jax.value_and_grad(cross_entropy_loss, has_aux=True)(params, x, y)
+        step = state.step + jnp.asarray(1, dtype=jnp.int32)
+        first = {
+            name: checked["beta1"] * state.first_moment[name]
+            + (1.0 - checked["beta1"]) * grads[name]
+            for name in params
+        }
+        second = {
+            name: checked["beta2"] * state.second_moment[name]
+            + (1.0 - checked["beta2"]) * jnp.square(grads[name])
+            for name in params
+        }
+        correction1 = 1.0 - jnp.power(checked["beta1"], step.astype(jnp.float32))
+        correction2 = 1.0 - jnp.power(checked["beta2"], step.astype(jnp.float32))
+        updated = {
+            name: params[name]
+            - checked["step_size"]
+            * (first[name] / correction1)
+            / (jnp.sqrt(second[name] / correction2) + checked["epsilon"])
+            for name in params
+        }
+        utility1 = _normalized_utility(grads["w1"], state.utility1, checked["utility_decay"])
+        utility2 = _normalized_utility(grads["w2"], state.utility2, checked["utility_decay"])
+        if mode == "l2_init":
+            updated = {
+                name: value + checked["l2_init_strength"] * (state.initial_params[name] - value)
+                for name, value in updated.items()
+            }
+        elif mode != "off":
+            should_reset = step % int(checked["update_frequency"]) == 0
+            reset = _partial_reset(
+                updated,
+                state.initial_params,
+                utility1,
+                utility2,
+                replacement_rate=checked["replacement_rate"],
+                sharpness=checked["sharpness"],
+                mode=mode,
+            )
+            updated = {
+                name: jnp.where(should_reset, reset[name], value) for name, value in updated.items()
+            }
+            utility1 = jnp.where(should_reset, jnp.ones_like(utility1), utility1)
+            utility2 = jnp.where(should_reset, jnp.ones_like(utility2), utility2)
+        new_state = CPRState(
+            first_moment=first,
+            second_moment=second,
+            initial_params=state.initial_params,
+            utility1=utility1,
+            utility2=utility2,
+            step=step,
+        )
+        return updated, new_state, _step_metrics(updated, x, y, loss, logits)
+
+    return init_fn, step_fn
+
+
+def _make_off(hp: Mapping[str, float]) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    return _make_cpr_learner(hp, mode="off")
+
+
+def _make_utility(hp: Mapping[str, float]) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    return _make_cpr_learner(hp, mode="utility")
+
+
+def _make_utility_free(hp: Mapping[str, float]) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    return _make_cpr_learner(hp, mode="utility_free")
+
+
+def _make_l2_init(hp: Mapping[str, float]) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    return _make_cpr_learner(hp, mode="l2_init")
+
+
+def _make_hard_reset(hp: Mapping[str, float]) -> tuple[LearnerInitFn, ScreeningStepFn]:
+    return _make_cpr_learner(hp, mode="hard_reset")
+
+
+def _hyperparameters() -> dict[str, float]:
+    return {
+        "step_size": 0.001,
+        "beta1": 0.9,
+        "beta2": 0.999,
+        "epsilon": 1e-8,
+        "utility_decay": 0.99,
+        "replacement_rate": 0.01,
+        "sharpness": 16.0,
+        "update_frequency": 1000.0,
+        "l2_init_strength": 1e-5,
+    }
+
+
+_FACTORIES: Final = {
+    "cpr_off": _make_off,
+    "cpr_utility": _make_utility,
+    "cpr_utility_free": _make_utility_free,
+    "cpr_l2_init": _make_l2_init,
+    "cpr_hard_reset": _make_hard_reset,
+}
+
+
+def calibrated_partial_reset_spec(name: str) -> ScreeningSpec:
+    if type(name) is not str or name not in ARMS:
+        raise ValueError("unknown calibrated partial reset arm")
+    return ScreeningSpec(
+        name=name,
+        base_learner="adamw",
+        mechanism="calibrated_partial_reset",
+        hyperparameters=_hyperparameters(),
+        factory=_FACTORIES[name],
+        description=f"CPR matched-development reduction: {name}",
+    )
+
+
+def persistent_numeric_bytes(*, input_dim: int, hidden1: int, hidden2: int, n_classes: int) -> int:
+    values = input_dim * hidden1 + hidden1 + hidden1 * hidden2 + hidden2
+    values += hidden2 * n_classes + n_classes
+    # Parameters + retained initialization + Adam first/second moments.
+    values *= 4
+    # Two per-neuron utility vectors plus one int32 step.
+    values += hidden1 + hidden2 + 1
+    return values * 4

--- a/alberta_framework/evaluation/calibrated_partial_reset_campaign.py
+++ b/alberta_framework/evaluation/calibrated_partial_reset_campaign.py
@@ -76,6 +76,10 @@ def _runtime_identity() -> dict[str, object]:
     devices = tuple(jax.devices())
     if len(devices) == 0 or len(devices) > _MAX_RUNTIME_DEVICES:
         raise RuntimeError("CPR runtime device inventory is out of bounds")
+    default_prng = str(jax.config.jax_default_prng_impl)
+    random_seed_offset = int(jax.config.jax_random_seed_offset)
+    if default_prng != "threefry2x32" or random_seed_offset != 0:
+        raise RuntimeError("CPR execution requires unoffset Threefry RNG roots")
     environment = (
         "JAX_DEFAULT_MATMUL_PRECISION",
         "JAX_DEFAULT_PRNG_IMPL",
@@ -122,12 +126,12 @@ def _runtime_identity() -> dict[str, object]:
             ],
             "config": {
                 "jax_default_matmul_precision": str(jax.config.jax_default_matmul_precision),
-                "jax_default_prng_impl": str(jax.config.jax_default_prng_impl),
+                "jax_default_prng_impl": default_prng,
                 "jax_disable_jit": bool(jax.config.jax_disable_jit),
                 "jax_enable_x64": bool(jax.config.jax_enable_x64),
                 "jax_numpy_dtype_promotion": str(jax.config.jax_numpy_dtype_promotion.value),
                 "jax_numpy_rank_promotion": str(jax.config.jax_numpy_rank_promotion),
-                "jax_random_seed_offset": int(jax.config.jax_random_seed_offset),
+                "jax_random_seed_offset": random_seed_offset,
                 "jax_threefry_partitionable": bool(jax.config.jax_threefry_partitionable),
             },
         },

--- a/alberta_framework/evaluation/calibrated_partial_reset_campaign.py
+++ b/alberta_framework/evaluation/calibrated_partial_reset_campaign.py
@@ -1,0 +1,924 @@
+"""Prospective, hard-disabled matched campaign for issue #1563."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import errno
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+import platform
+import stat
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Final, cast
+
+import jax
+import jax.random as jr
+import numpy as np
+
+from alberta_framework.benchmarks.calibrated_partial_reset_ipmnist import (
+    ARMS,
+    OFFICIAL_CODE_REVISION,
+    PAPER_REVISION,
+    calibrated_partial_reset_spec,
+    persistent_numeric_bytes,
+)
+from alberta_framework.benchmarks.ipmnist_screening import (
+    ScreeningRunResult,
+    _screening_dataset_provenance,
+    run_screening_config,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import (
+    IPMNISTConfig,
+    build_schedule,
+    default_openml_data_home,
+    init_mlp_params,
+    load_mnist_train,
+)
+
+SCHEMA: Final = "asi.calibrated-partial-reset.matched-development.v1"
+CAMPAIGN_SEEDS: Final = (61_563_001, 61_563_002, 61_563_003, 61_563_004, 61_563_005)
+TEST_ONLY_SEEDS: Final = (301, 302, 303, 304, 305)
+CAMPAIGN_CONFIG: Final = IPMNISTConfig(n_tasks=8, task_length=5000)
+_REVIEWED_EXECUTION_TRANSITION: Final = False
+_EXECUTION_AUTHORIZED: Final = False
+_EXECUTION_CAPABILITY: Final = object()
+_TEST_EXECUTION_CAPABILITY: Final = object()
+_MAX_JSON_NODES: Final = 100_000
+_MAX_JSON_DEPTH: Final = 16
+_MAX_STRING_BYTES: Final = 16_384
+_MAX_INTEGER_ABS: Final = 2**63 - 1
+_MAX_REPORT_BYTES: Final = 64 * 1024 * 1024
+_MAX_NUMERIC_BYTES: Final = 256 * 1024 * 1024
+_MAX_RUNTIME_DEVICES: Final = 64
+_ROOT: Final = Path(__file__).resolve().parents[2]
+OUTPUT_PATH: Final = _ROOT / "outputs/calibrated_partial_reset_matched/report.v1.json"
+
+
+def _source_identity() -> dict[str, str]:
+    paths = (
+        "alberta_framework/benchmarks/calibrated_partial_reset_ipmnist.py",
+        "alberta_framework/benchmarks/ipmnist_screening.py",
+        "alberta_framework/benchmarks/upgd_ipmnist.py",
+        "alberta_framework/evaluation/calibrated_partial_reset_campaign.py",
+        "pyproject.toml",
+        "uv.lock",
+    )
+    return {path: hashlib.sha256((_ROOT / path).read_bytes()).hexdigest() for path in paths}
+
+
+def _runtime_identity() -> dict[str, object]:
+    devices = tuple(jax.devices())
+    if len(devices) == 0 or len(devices) > _MAX_RUNTIME_DEVICES:
+        raise RuntimeError("CPR runtime device inventory is out of bounds")
+    environment = (
+        "JAX_DEFAULT_MATMUL_PRECISION",
+        "JAX_DEFAULT_PRNG_IMPL",
+        "JAX_ENABLE_X64",
+        "JAX_NUM_CPU_DEVICES",
+        "JAX_PLATFORMS",
+        "JAX_PLATFORM_NAME",
+        "JAX_RANDOM_SEED_OFFSET",
+        "XLA_FLAGS",
+    )
+    return {
+        "schema": "asi.calibrated-partial-reset.runtime.v1",
+        "python": list(sys.version_info[:3]),
+        "implementation": platform.python_implementation(),
+        "byteorder": sys.byteorder,
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "packages": {
+            name: importlib.metadata.version(name)
+            for name in (
+                "chex",
+                "jax",
+                "jaxlib",
+                "jaxtyping",
+                "numpy",
+                "orbax-checkpoint",
+                "scikit-learn",
+                "scipy",
+            )
+        },
+        "jax": {
+            "backend": jax.default_backend(),
+            "devices": [
+                {
+                    "id": int(device.id),
+                    "platform": str(device.platform),
+                    "device_kind": str(device.device_kind),
+                    "process_index": int(device.process_index),
+                }
+                for device in devices
+            ],
+            "config": {
+                "jax_default_matmul_precision": str(jax.config.jax_default_matmul_precision),
+                "jax_default_prng_impl": str(jax.config.jax_default_prng_impl),
+                "jax_disable_jit": bool(jax.config.jax_disable_jit),
+                "jax_enable_x64": bool(jax.config.jax_enable_x64),
+                "jax_numpy_dtype_promotion": str(jax.config.jax_numpy_dtype_promotion.value),
+                "jax_numpy_rank_promotion": str(jax.config.jax_numpy_rank_promotion),
+                "jax_random_seed_offset": int(jax.config.jax_random_seed_offset),
+                "jax_threefry_partitionable": bool(jax.config.jax_threefry_partitionable),
+            },
+        },
+        "environment": {name: os.environ.get(name) for name in environment},
+    }
+
+
+def _resource_envelope(config: IPMNISTConfig, rows: int) -> dict[str, int]:
+    dataset = rows * (config.input_dim * 4 + 4)
+    schedule = config.n_tasks * (config.task_length + config.input_dim) * 4
+    persistent = persistent_numeric_bytes(
+        input_dim=config.input_dim,
+        hidden1=config.hidden1,
+        hidden2=config.hidden2,
+        n_classes=config.n_classes,
+    )
+    return {
+        "dataset_bytes": dataset,
+        "schedule_bytes": schedule,
+        "peak_persistent_numeric_bytes": persistent,
+        "combined_numeric_bytes": dataset + schedule + persistent,
+        "combined_numeric_bytes_limit": _MAX_NUMERIC_BYTES,
+    }
+
+
+def _transaction_resources(config: IPMNISTConfig, seeds: tuple[int, ...]) -> dict[str, int]:
+    rows = len(seeds) * len(ARMS)
+    dispatches = 2 * rows
+    steps = config.n_tasks * config.task_length
+    return {
+        "campaign_rows": rows,
+        "initial_runner_dispatches": rows,
+        "strict_reexecution_dispatches": rows,
+        "total_runner_dispatches": dispatches,
+        "total_observations": dispatches * steps,
+        "total_updates": dispatches * steps,
+        "total_data_steps": dispatches * steps,
+        "total_environment_steps": 0,
+        "total_model_queries": 2 * dispatches * steps,
+    }
+
+
+def frozen_plan() -> dict[str, object]:
+    return {
+        "schema": "asi.calibrated-partial-reset.matched-plan.v1",
+        "paper_revision": PAPER_REVISION,
+        "official_code_revision": OFFICIAL_CODE_REVISION,
+        "adaptation": {
+            "workload": "ASI online IPMNIST instead of the paper RL suites",
+            "optimizer": "matched float32 Adam",
+            "initialization": "retained seed initialization, not fresh reset draws",
+            "biases": "unchanged at reset, matching official code",
+            "utility": "incoming-weight gradient magnitude normalized per hidden layer",
+        },
+        "seeds": list(CAMPAIGN_SEEDS),
+        "test_only_seeds": list(TEST_ONLY_SEEDS),
+        "arms": list(ARMS),
+        "config": CAMPAIGN_CONFIG.to_config(),
+        "dataset": {
+            "schema": "alberta.ipmnist_screening.dataset_provenance.v1",
+            "source": {
+                "provider": "openml",
+                "name": "mnist_784",
+                "version": 1,
+                "row_start": 0,
+                "row_stop_exclusive": 60_000,
+            },
+            "materialization": "alberta.ipmnist.float32-neg1-pos1-int32-labels.v1",
+            "x": {
+                "dtype": "<f4",
+                "shape": [60_000, 784],
+                "sha256": "b8078cd833f53d89828a5e28d728517be9add34076f13fe973399f1f16381313",
+            },
+            "y": {
+                "dtype": "<i4",
+                "shape": [60_000],
+                "sha256": "4f1dd9551f104f8153409e0add59f0a71568f7bad5a5f8e2274480c186fe219a",
+            },
+        },
+        "source_identity_policy": {"hashed_files": list(_source_identity())},
+        "runtime_identity_policy": "exact dependencies/JAX devices/config/environment at execution",
+        "resources": _resource_envelope(CAMPAIGN_CONFIG, 60_000),
+        "resource_scope": (
+            "one caller-owned C-contiguous host dataset, one materialized schedule, and "
+            "parameters plus retained learner state; backend/compiler copies, gradients, "
+            "and transient execution buffers are excluded from the static byte envelope"
+        ),
+        "transaction_resources": _transaction_resources(CAMPAIGN_CONFIG, CAMPAIGN_SEEDS),
+        "matched_axes": [
+            "seed",
+            "initial_parameters",
+            "example_schedule",
+            "observations",
+            "updates",
+            "allowed_boundary_information",
+            "allowed_task_information",
+        ],
+        "allowed_boundary_information": [],
+        "allowed_task_information": ["current_example_label"],
+        "reviewed_execution_transition": False,
+        "execution_authorized": False,
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "negative_outcomes_retained": True,
+        "output_path": "outputs/calibrated_partial_reset_matched/report.v1.json",
+    }
+
+
+def _bounded_json(value: object) -> object:
+    nodes = 0
+    seen: set[int] = set()
+
+    def visit(item: object, depth: int) -> object:
+        nonlocal nodes
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > _MAX_JSON_DEPTH:
+            raise ValueError("CPR result exceeds its JSON structure bound")
+        actual_type = type(item)
+        if item is None or actual_type is bool:
+            return item
+        if actual_type is int:
+            if abs(cast(int, item)) > _MAX_INTEGER_ABS:
+                raise ValueError("CPR result contains an out-of-bounds integer")
+            return item
+        if actual_type is float:
+            if not math.isfinite(cast(float, item)):
+                raise ValueError("CPR result contains a non-finite float")
+            return item
+        if actual_type is str:
+            if len(cast(str, item).encode("utf-8")) > _MAX_STRING_BYTES:
+                raise ValueError("CPR result contains an oversized string")
+            return item
+        if actual_type is not dict and actual_type is not list:
+            raise ValueError("CPR result must contain only exact JSON values")
+        identity = id(item)
+        if identity in seen:
+            raise ValueError("CPR result contains an aliased or cyclic container")
+        seen.add(identity)
+        if actual_type is list:
+            sequence = cast(list[object], item)
+            if len(sequence) > 4096:
+                raise ValueError("CPR result list exceeds its item bound")
+            return [visit(child, depth + 1) for child in sequence]
+        mapping = cast(dict[object, object], item)
+        if len(mapping) > 4096 or any(type(key) is not str for key in mapping):
+            raise ValueError("CPR result object exceeds its field bound")
+        return {cast(str, key): visit(child, depth + 1) for key, child in mapping.items()}
+
+    return visit(value, 0)
+
+
+def _validated_arrays(x: object, y: object, config: IPMNISTConfig) -> tuple[np.ndarray, np.ndarray]:
+    if type(x) is not np.ndarray or x.dtype != np.dtype(np.float32):
+        raise ValueError("inputs must be an exact float32 NumPy array")
+    if type(y) is not np.ndarray or y.dtype != np.dtype(np.int32):
+        raise ValueError("labels must be an exact int32 NumPy array")
+    if x.ndim != 2 or y.ndim != 1 or x.shape != (y.shape[0], config.input_dim):
+        raise ValueError("dataset shape differs from the CPR config")
+    if x.shape[0] < config.task_length:
+        raise ValueError("dataset has too few rows for the CPR schedule")
+    if not x.flags.c_contiguous or not y.flags.c_contiguous:
+        raise ValueError("dataset arrays must be C-contiguous to avoid an unaccounted copy")
+    envelope = _resource_envelope(config, x.shape[0])
+    if envelope["combined_numeric_bytes"] > _MAX_NUMERIC_BYTES:
+        raise ValueError("CPR campaign exceeds its combined numeric allocation bound")
+    if not np.isfinite(x).all() or np.any(y < 0) or np.any(y >= config.n_classes):
+        raise ValueError("dataset numeric domain differs from the CPR contract")
+    return x, y
+
+
+def _tree_digest(value: object) -> str:
+    digest = hashlib.sha256(b"asi-cpr-tree-v1\0")
+    leaves, structure = jax.tree.flatten(value)
+    digest.update(str(structure).encode("ascii"))
+    for leaf in leaves:
+        array = np.asarray(leaf)
+        digest.update(np.asarray(array.shape, dtype="<i8").tobytes())
+        digest.update(array.dtype.str.encode("ascii"))
+        digest.update(array.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+def _dataset_identity(x: np.ndarray, y: np.ndarray) -> dict[str, object]:
+    if x.shape == (60_000, 784) and y.shape == (60_000,):
+        return _screening_dataset_provenance(x, y)
+    return {
+        "schema": "asi.calibrated-partial-reset.test-dataset.v1",
+        "x": {
+            "dtype": x.dtype.str,
+            "shape": list(x.shape),
+            "sha256": hashlib.sha256(x.tobytes(order="C")).hexdigest(),
+        },
+        "y": {
+            "dtype": y.dtype.str,
+            "shape": list(y.shape),
+            "sha256": hashlib.sha256(y.tobytes(order="C")).hexdigest(),
+        },
+    }
+
+
+def _execution_identity(seed: int, config: IPMNISTConfig, rows: int) -> dict[str, str]:
+    root = jr.key(np.uint32(seed), impl="threefry2x32")
+    init_key, schedule_key, _ = jr.split(root, 3)
+    schedule = build_schedule(schedule_key, config, rows)
+    return {
+        "initial_parameters_sha256": _tree_digest(init_mlp_params(init_key, config)),
+        "schedule_sha256": _tree_digest(schedule),
+        "prng_implementation": "threefry2x32",
+    }
+
+
+def _record(result: ScreeningRunResult) -> dict[str, object]:
+    steps = result.config.n_tasks * result.config.task_length
+    return {
+        "metrics": {
+            "per_task_accuracy": result.per_task_accuracy.tolist(),
+            "per_task_loss": result.per_task_loss.tolist(),
+            "per_task_plasticity": result.per_task_plasticity.tolist(),
+            "mean_online_accuracy": math.fsum(result.per_task_accuracy.tolist())
+            / result.config.n_tasks,
+        },
+        "resources": {
+            "observations": steps,
+            "data_steps": steps,
+            "environment_steps": 0,
+            "updates": steps,
+            "model_queries": 2 * steps,
+            "persistent_numeric_bytes": persistent_numeric_bytes(
+                input_dim=result.config.input_dim,
+                hidden1=result.config.hidden1,
+                hidden2=result.config.hidden2,
+                n_classes=result.config.n_classes,
+            ),
+            "timing_telemetry_seconds": result.wall_clock_seconds,
+            "timing_is_selection_metric": False,
+        },
+        "outcome": "inconclusive",
+        "outcome_retained": True,
+    }
+
+
+def _aggregate(rows: list[dict[str, object]]) -> dict[str, object]:
+    means: dict[str, float] = {}
+    for arm in ARMS:
+        values = [
+            cast(
+                float,
+                cast(dict[str, object], cast(dict[str, object], row["result"])["metrics"])[
+                    "mean_online_accuracy"
+                ],
+            )
+            for row in rows
+            if row["arm"] == arm
+        ]
+        means[arm] = math.fsum(values) / len(values)
+    return {"mean_online_accuracy": means, "row_count": len(rows), "outcome": "inconclusive"}
+
+
+def _run(
+    x: object,
+    y: object,
+    *,
+    config: IPMNISTConfig,
+    seeds: tuple[int, ...],
+    capability: object,
+    on_dispatch: Callable[[], None] | None = None,
+) -> dict[str, object]:
+    expected = (
+        CAMPAIGN_SEEDS
+        if capability is _EXECUTION_CAPABILITY
+        else TEST_ONLY_SEEDS
+        if capability is _TEST_EXECUTION_CAPABILITY
+        else None
+    )
+    if (
+        expected is None
+        or type(seeds) is not tuple
+        or len(seeds) != len(expected)
+        or any(type(seed) is not int for seed in seeds)
+        or any(seed != expected[index] for index, seed in enumerate(seeds))
+    ):
+        raise RuntimeError("CPR private execution capability is invalid")
+    if capability is _EXECUTION_CAPABILITY and (
+        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
+    ):
+        raise RuntimeError("CPR campaign execution is not authorized")
+    if type(config) is not IPMNISTConfig:
+        raise ValueError("CPR config must be an exact IPMNISTConfig")
+    checked_x, checked_y = _validated_arrays(x, y, config)
+    source = _source_identity()
+    runtime = _runtime_identity()
+    dataset = _dataset_identity(checked_x, checked_y)
+    _bounded_json(source)
+    _bounded_json(runtime)
+    _bounded_json(frozen_plan())
+    if capability is _EXECUTION_CAPABILITY:
+        if (
+            config != CAMPAIGN_CONFIG
+            or _screening_dataset_provenance(checked_x, checked_y) != frozen_plan()["dataset"]
+        ):
+            raise ValueError("CPR campaign inputs differ from the frozen plan")
+    rows: list[dict[str, object]] = []
+    for seed in seeds:
+        identity = _execution_identity(seed, config, checked_x.shape[0])
+        for arm in ARMS:
+            if not rows and on_dispatch is not None:
+                on_dispatch()
+            result = run_screening_config(
+                checked_x, checked_y, calibrated_partial_reset_spec(arm), seed, config
+            )
+            if (
+                _source_identity() != source
+                or _runtime_identity() != runtime
+                or _dataset_identity(checked_x, checked_y) != dataset
+            ):
+                raise RuntimeError("CPR source, runtime, or dataset changed during execution")
+            rows.append(
+                {
+                    "seed": seed,
+                    "arm": arm,
+                    "execution_identity": dict(identity),
+                    "result": _record(result),
+                }
+            )
+    report: dict[str, object] = {
+        "schema": SCHEMA,
+        "plan": frozen_plan(),
+        "identity": {
+            "source": source,
+            "runtime": runtime,
+            "dataset": dataset,
+        },
+        "rows": rows,
+        "aggregate": _aggregate(rows),
+        "policy": {
+            "development_only": True,
+            "scientific_promotion_allowed": False,
+            "negative_outcomes_retained": True,
+        },
+    }
+    report["sha256"] = hashlib.sha256(_canonical(report)).hexdigest()
+    validate_report(report, checked_x, checked_y, config=config, seeds=seeds, reexecute=False)
+    return report
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("ascii")
+
+
+def _exact_object(value: object, fields: tuple[str, ...], label: str) -> dict[str, object]:
+    if type(value) is not dict:
+        raise ValueError(f"CPR {label} must be an exact object")
+    result = cast(dict[str, object], value)
+    if len(result) != len(fields) or any(field not in result for field in fields):
+        raise ValueError(f"CPR {label} fields drifted")
+    return result
+
+
+def _exact_float_list(value: object, length: int, label: str) -> list[float]:
+    if type(value) is not list or len(cast(list[object], value)) != length:
+        raise ValueError(f"CPR {label} shape drifted")
+    values = cast(list[object], value)
+    if any(type(item) is not float or not math.isfinite(item) for item in values):
+        raise ValueError(f"CPR {label} numeric domain drifted")
+    return cast(list[float], values)
+
+
+def _validate_record(value: object, config: IPMNISTConfig) -> None:
+    record = _exact_object(value, ("metrics", "resources", "outcome", "outcome_retained"), "result")
+    metrics = _exact_object(
+        record["metrics"],
+        ("per_task_accuracy", "per_task_loss", "per_task_plasticity", "mean_online_accuracy"),
+        "metrics",
+    )
+    accuracy = _exact_float_list(metrics["per_task_accuracy"], config.n_tasks, "accuracy")
+    loss = _exact_float_list(metrics["per_task_loss"], config.n_tasks, "loss")
+    plasticity = _exact_float_list(metrics["per_task_plasticity"], config.n_tasks, "plasticity")
+    if any(item < 0.0 or item > 1.0 for item in accuracy + plasticity) or any(
+        item < 0.0 for item in loss
+    ):
+        raise ValueError("CPR metric numeric domain drifted")
+    mean = metrics["mean_online_accuracy"]
+    if type(mean) is not float or mean != math.fsum(accuracy) / config.n_tasks:
+        raise ValueError("CPR metric arithmetic drifted")
+    resources = _exact_object(
+        record["resources"],
+        (
+            "observations",
+            "data_steps",
+            "environment_steps",
+            "updates",
+            "model_queries",
+            "persistent_numeric_bytes",
+            "timing_telemetry_seconds",
+            "timing_is_selection_metric",
+        ),
+        "resources",
+    )
+    steps = config.n_tasks * config.task_length
+    exact_resources = {
+        "observations": steps,
+        "data_steps": steps,
+        "environment_steps": 0,
+        "updates": steps,
+        "model_queries": 2 * steps,
+        "persistent_numeric_bytes": persistent_numeric_bytes(
+            input_dim=config.input_dim,
+            hidden1=config.hidden1,
+            hidden2=config.hidden2,
+            n_classes=config.n_classes,
+        ),
+        "timing_is_selection_metric": False,
+    }
+    if any(
+        type(resources[name]) is not type(expected) or resources[name] != expected
+        for name, expected in exact_resources.items()
+    ):
+        raise ValueError("CPR exact resource accounting drifted")
+    timing = resources["timing_telemetry_seconds"]
+    if type(timing) is not float or not math.isfinite(timing) or timing < 0.0 or timing > 604_800.0:
+        raise ValueError("CPR timing telemetry drifted")
+    if record["outcome"] != "inconclusive" or record["outcome_retained"] is not True:
+        raise ValueError("CPR nonpromoting outcome policy drifted")
+
+
+def validate_report(
+    value: object,
+    x: object,
+    y: object,
+    *,
+    config: IPMNISTConfig,
+    seeds: tuple[int, ...],
+    reexecute: bool,
+) -> None:
+    if type(config) is not IPMNISTConfig:
+        raise ValueError("CPR config must be an exact IPMNISTConfig")
+    if type(seeds) is not tuple or any(type(seed) is not int for seed in seeds):
+        raise ValueError("CPR seeds must be an exact integer tuple")
+    if type(reexecute) is not bool:
+        raise ValueError("CPR reexecution selector must be an exact bool")
+    report = cast(dict[str, object], _bounded_json(value))
+    report = _exact_object(
+        report, ("schema", "plan", "identity", "rows", "aggregate", "policy", "sha256"), "report"
+    )
+    if report["schema"] != SCHEMA:
+        raise ValueError("CPR report fields or schema drifted")
+    if report["plan"] != frozen_plan():
+        raise ValueError("CPR report plan drifted")
+    checked_x, checked_y = _validated_arrays(x, y, config)
+    identity = _exact_object(report["identity"], ("source", "runtime", "dataset"), "identity")
+    if identity != {
+        "source": _source_identity(),
+        "runtime": _runtime_identity(),
+        "dataset": _dataset_identity(checked_x, checked_y),
+    }:
+        raise ValueError("CPR report identity drifted")
+    if type(report["rows"]) is not list:
+        raise ValueError("CPR rows must be an exact list")
+    rows = cast(list[dict[str, object]], report["rows"])
+    roster = [(seed, arm) for seed in seeds for arm in ARMS]
+    if len(rows) != len(roster):
+        raise ValueError("CPR report roster drifted")
+    expected_identity = {
+        seed: _execution_identity(seed, config, checked_x.shape[0]) for seed in seeds
+    }
+    source = _source_identity()
+    runtime = _runtime_identity()
+    dataset = _dataset_identity(checked_x, checked_y)
+    for index, raw_row in enumerate(rows):
+        row = _exact_object(raw_row, ("seed", "arm", "execution_identity", "result"), "row")
+        seed, arm = roster[index]
+        if (
+            type(row["seed"]) is not int
+            or row["seed"] != seed
+            or type(row["arm"]) is not str
+            or row["arm"] != arm
+        ):
+            raise ValueError("CPR report roster drifted")
+        if row["execution_identity"] != expected_identity[seed]:
+            raise ValueError("CPR row identity drifted")
+        _validate_record(row["result"], config)
+        if reexecute:
+            replay = _record(
+                run_screening_config(
+                    checked_x, checked_y, calibrated_partial_reset_spec(arm), seed, config
+                )
+            )
+            replay_resources = cast(dict[str, object], replay["resources"])
+            claimed_resources = cast(
+                dict[str, object], cast(dict[str, object], row["result"])["resources"]
+            )
+            replay_resources["timing_telemetry_seconds"] = claimed_resources[
+                "timing_telemetry_seconds"
+            ]
+            if replay != row["result"]:
+                raise ValueError("CPR row differs from strict current reexecution")
+            if (
+                _source_identity() != source
+                or _runtime_identity() != runtime
+                or _dataset_identity(checked_x, checked_y) != dataset
+            ):
+                raise RuntimeError("CPR identity changed during strict reexecution")
+    _exact_object(
+        report["aggregate"], ("mean_online_accuracy", "row_count", "outcome"), "aggregate"
+    )
+    if report["aggregate"] != _aggregate(rows):
+        raise ValueError("CPR aggregate arithmetic drifted")
+    policy = _exact_object(
+        report["policy"],
+        ("development_only", "scientific_promotion_allowed", "negative_outcomes_retained"),
+        "policy",
+    )
+    if policy != {
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "negative_outcomes_retained": True,
+    }:
+        raise ValueError("CPR result policy drifted")
+    unsigned = dict(report)
+    claimed = unsigned.pop("sha256")
+    if type(claimed) is not str or claimed != hashlib.sha256(_canonical(unsigned)).hexdigest():
+        raise ValueError("CPR report digest drifted")
+
+
+Reservation = tuple[int, str, str, int, int, int]
+
+
+def _open_parent(path: Path) -> int:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    absolute = Path(os.path.abspath(os.fspath(path)))
+    descriptor = os.open(os.path.sep, flags)
+    try:
+        for component in absolute.parent.parts[1:]:
+            if component in {"", ".", ".."}:
+                raise ValueError("CPR output contains an unsafe path segment")
+            try:
+                os.mkdir(component, 0o755, dir_fd=descriptor)
+                os.fsync(descriptor)
+            except FileExistsError:
+                pass
+            next_descriptor = os.open(component, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _reserve(path: Path) -> Reservation:
+    if type(path) is not type(Path()) or path.absolute() != OUTPUT_PATH.absolute():
+        raise ValueError("CPR output must be the exact frozen NEW path")
+    directory = _open_parent(path)
+    marker_name = f".{path.name}.reservation"
+    marker_fd = -1
+    try:
+        probe = os.open(".", os.O_RDWR | os.O_TMPFILE | os.O_CLOEXEC, 0o600, dir_fd=directory)
+        os.close(probe)
+        try:
+            os.stat(path.name, dir_fd=directory, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError("CPR output already exists")
+        marker_fd = os.open(
+            marker_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o400,
+            dir_fd=directory,
+        )
+        os.write(marker_fd, b"asi-cpr-reserved-v1\n")
+        os.fsync(marker_fd)
+        metadata = os.fstat(marker_fd)
+        os.fsync(directory)
+        return directory, path.name, marker_name, marker_fd, metadata.st_dev, metadata.st_ino
+    except BaseException:
+        if marker_fd >= 0:
+            try:
+                metadata = os.fstat(marker_fd)
+                visible = os.stat(marker_name, dir_fd=directory, follow_symlinks=False)
+                if (visible.st_dev, visible.st_ino) == (metadata.st_dev, metadata.st_ino):
+                    os.unlink(marker_name, dir_fd=directory)
+                    os.fsync(directory)
+            except FileNotFoundError:
+                pass
+            os.close(marker_fd)
+        os.close(directory)
+        raise
+
+
+def _owned(reservation: Reservation) -> None:
+    directory, _name, marker, marker_fd, device, inode = reservation
+    held = os.fstat(marker_fd)
+    visible = os.stat(marker, dir_fd=directory, follow_symlinks=False)
+    if (
+        not stat.S_ISREG(held.st_mode)
+        or held.st_nlink != 1
+        or (held.st_dev, held.st_ino) != (device, inode)
+        or (visible.st_dev, visible.st_ino) != (device, inode)
+    ):
+        raise RuntimeError("CPR output reservation identity changed")
+
+
+def _finish_reservation(reservation: Reservation, *, consumed: bool) -> None:
+    directory, _name, marker, marker_fd, device, inode = reservation
+    try:
+        _owned(reservation)
+        if consumed:
+            os.ftruncate(marker_fd, 0)
+            os.lseek(marker_fd, 0, os.SEEK_SET)
+            os.write(marker_fd, b"asi-cpr-consumed-without-result-v1\n")
+            os.fsync(marker_fd)
+            os.fsync(directory)
+        else:
+            current = os.stat(marker, dir_fd=directory, follow_symlinks=False)
+            if (current.st_dev, current.st_ino) == (device, inode):
+                os.unlink(marker, dir_fd=directory)
+                os.fsync(directory)
+    finally:
+        os.close(marker_fd)
+        os.close(directory)
+
+
+def _link_tmpfile(file_fd: int, directory_fd: int, name: str) -> None:
+    linkat = ctypes.CDLL(None, use_errno=True).linkat
+    linkat.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_int]
+    linkat.restype = ctypes.c_int
+    if linkat(file_fd, b"", directory_fd, os.fsencode(name), 0x1000) != 0:
+        number = ctypes.get_errno()
+        if number == errno.EEXIST:
+            raise FileExistsError(number, os.strerror(number), name)
+        raise OSError(number, os.strerror(number), name)
+
+
+def _publish(
+    reservation: Reservation,
+    report: dict[str, object],
+    x: np.ndarray,
+    y: np.ndarray,
+    config: IPMNISTConfig,
+    seeds: tuple[int, ...],
+    capability: object,
+) -> None:
+    if capability is not _EXECUTION_CAPABILITY and capability is not _TEST_EXECUTION_CAPABILITY:
+        raise RuntimeError("CPR publication capability is invalid")
+    directory, name, _marker, _marker_fd, _device, _inode = reservation
+    _owned(reservation)
+    validate_report(report, x, y, config=config, seeds=seeds, reexecute=True)
+    encoded = _canonical(report) + b"\n"
+    if len(encoded) > _MAX_REPORT_BYTES:
+        raise ValueError("CPR report exceeds its byte bound")
+    descriptor = os.open(".", os.O_RDWR | os.O_TMPFILE | os.O_CLOEXEC, 0o600, dir_fd=directory)
+    published_identity: tuple[int, int] | None = None
+    try:
+        view = memoryview(encoded)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("CPR report write made no progress")
+            view = view[written:]
+        os.fsync(descriptor)
+        os.fchmod(descriptor, 0o400)
+        staged = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(staged.st_mode)
+            or staged.st_nlink != 0
+            or staged.st_size != len(encoded)
+        ):
+            raise ValueError("CPR staged report inode is invalid")
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        staged_raw = os.read(descriptor, len(encoded) + 1)
+        if staged_raw != encoded:
+            raise ValueError("CPR staged report changed during bounded reread")
+
+        def exact(pairs: list[tuple[str, object]]) -> dict[str, object]:
+            result: dict[str, object] = {}
+            for key, item in pairs:
+                if key in result:
+                    raise ValueError("CPR published JSON contains duplicate keys")
+                result[key] = item
+            return result
+
+        try:
+            staged_report = json.loads(staged_raw.decode("utf-8"), object_pairs_hook=exact)
+        except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
+            raise ValueError("CPR staged report is not strict bounded JSON") from error
+        validate_report(staged_report, x, y, config=config, seeds=seeds, reexecute=False)
+        _owned(reservation)
+        published_identity = (staged.st_dev, staged.st_ino)
+        _link_tmpfile(descriptor, directory, name)
+        metadata = os.fstat(descriptor)
+        if metadata.st_nlink != 1 or (metadata.st_dev, metadata.st_ino) != published_identity:
+            raise RuntimeError("CPR published inode identity drifted")
+        os.fsync(directory)
+        read_fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC, dir_fd=directory)
+        try:
+            before = os.fstat(read_fd)
+            raw = os.read(read_fd, len(encoded) + 1)
+            after = os.fstat(read_fd)
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or before.st_nlink != 1
+                or raw != encoded
+                or (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
+                != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+            ):
+                raise ValueError("CPR published report changed during bounded reread")
+
+            try:
+                reread = json.loads(raw.decode("utf-8"), object_pairs_hook=exact)
+            except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
+                raise ValueError("CPR published report is not strict bounded JSON") from error
+            validate_report(reread, x, y, config=config, seeds=seeds, reexecute=False)
+        finally:
+            os.close(read_fd)
+    except BaseException:
+        if published_identity is not None:
+            try:
+                visible = os.stat(name, dir_fd=directory, follow_symlinks=False)
+                if (visible.st_dev, visible.st_ino) == published_identity:
+                    os.unlink(name, dir_fd=directory)
+                    os.fsync(directory)
+            except FileNotFoundError:
+                pass
+        raise
+    finally:
+        os.close(descriptor)
+
+
+def run_and_publish(data_home: Path, destination: Path = OUTPUT_PATH) -> dict[str, object]:
+    if _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True:
+        raise RuntimeError("CPR campaign execution is not authorized")
+    return _run_and_publish(
+        data_home, destination, CAMPAIGN_CONFIG, CAMPAIGN_SEEDS, _EXECUTION_CAPABILITY
+    )
+
+
+def _run_and_publish(
+    data_home: Path,
+    destination: Path,
+    config: IPMNISTConfig,
+    seeds: tuple[int, ...],
+    capability: object,
+) -> dict[str, object]:
+    expected = (
+        CAMPAIGN_SEEDS
+        if capability is _EXECUTION_CAPABILITY
+        else TEST_ONLY_SEEDS
+        if capability is _TEST_EXECUTION_CAPABILITY
+        else None
+    )
+    if (
+        expected is None
+        or type(seeds) is not tuple
+        or seeds != expected
+        or type(data_home) is not type(Path())
+    ):
+        raise RuntimeError("CPR transaction capability is invalid")
+    if capability is _EXECUTION_CAPABILITY and (
+        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
+    ):
+        raise RuntimeError("CPR campaign execution is not authorized")
+    reservation = _reserve(destination)
+    dispatched = False
+    published = False
+
+    def note() -> None:
+        nonlocal dispatched
+        dispatched = True
+
+    try:
+        x, y = load_mnist_train(data_home)
+        report = _run(x, y, config=config, seeds=seeds, capability=capability, on_dispatch=note)
+        _publish(reservation, report, x, y, config, seeds, capability)
+        published = True
+        return report
+    finally:
+        _finish_reservation(reservation, consumed=dispatched and not published)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", action="store_true")
+    parser.add_argument("--data-home", type=Path, default=default_openml_data_home())
+    args = parser.parse_args(argv)
+    if args.catalog:
+        print(json.dumps(frozen_plan(), sort_keys=True))
+        return 0
+    run_and_publish(args.data_home)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/alberta_framework/evaluation/calibrated_partial_reset_campaign.py
+++ b/alberta_framework/evaluation/calibrated_partial_reset_campaign.py
@@ -52,7 +52,9 @@ _TEST_EXECUTION_CAPABILITY: Final = object()
 _MAX_JSON_NODES: Final = 100_000
 _MAX_JSON_DEPTH: Final = 16
 _MAX_STRING_BYTES: Final = 16_384
-_MAX_INTEGER_ABS: Final = 2**63 - 1
+_MAX_TOTAL_UTF8_BYTES: Final = 8 * 1024 * 1024
+_MIN_INTEGER: Final = -(2**63)
+_MAX_INTEGER: Final = 2**63 - 1
 _MAX_REPORT_BYTES: Final = 64 * 1024 * 1024
 _MAX_NUMERIC_BYTES: Final = 256 * 1024 * 1024
 _MAX_RUNTIME_DEVICES: Final = 64
@@ -231,6 +233,16 @@ def frozen_plan() -> dict[str, object]:
         ],
         "allowed_boundary_information": [],
         "allowed_task_information": ["current_example_label"],
+        "primary_paired_question": {
+            "candidate": "cpr_utility",
+            "control": "cpr_off",
+            "metric": "mean_online_accuracy",
+            "direction": "higher_is_better",
+            "decision_rule": "advance iff mean_delta > 0 and at least 4 of 5 seed deltas > 0",
+            "advance_outcome": "advance_for_nonpromoting_followup",
+            "reject_outcome": "do_not_advance",
+            "ablation_policy": "utility-free, L2-init, and hard-reset arms are descriptive only",
+        },
         "reviewed_execution_transition": False,
         "execution_authorized": False,
         "development_only": True,
@@ -242,10 +254,11 @@ def frozen_plan() -> dict[str, object]:
 
 def _bounded_json(value: object) -> object:
     nodes = 0
+    utf8_bytes = 0
     seen: set[int] = set()
 
     def visit(item: object, depth: int) -> object:
-        nonlocal nodes
+        nonlocal nodes, utf8_bytes
         nodes += 1
         if nodes > _MAX_JSON_NODES or depth > _MAX_JSON_DEPTH:
             raise ValueError("CPR result exceeds its JSON structure bound")
@@ -253,7 +266,7 @@ def _bounded_json(value: object) -> object:
         if item is None or actual_type is bool:
             return item
         if actual_type is int:
-            if abs(cast(int, item)) > _MAX_INTEGER_ABS:
+            if cast(int, item) < _MIN_INTEGER or cast(int, item) > _MAX_INTEGER:
                 raise ValueError("CPR result contains an out-of-bounds integer")
             return item
         if actual_type is float:
@@ -261,7 +274,9 @@ def _bounded_json(value: object) -> object:
                 raise ValueError("CPR result contains a non-finite float")
             return item
         if actual_type is str:
-            if len(cast(str, item).encode("utf-8")) > _MAX_STRING_BYTES:
+            size = len(cast(str, item).encode("utf-8"))
+            utf8_bytes += size
+            if size > _MAX_STRING_BYTES or utf8_bytes > _MAX_TOTAL_UTF8_BYTES:
                 raise ValueError("CPR result contains an oversized string")
             return item
         if actual_type is not dict and actual_type is not list:
@@ -278,7 +293,15 @@ def _bounded_json(value: object) -> object:
         mapping = cast(dict[object, object], item)
         if len(mapping) > 4096 or any(type(key) is not str for key in mapping):
             raise ValueError("CPR result object exceeds its field bound")
-        return {cast(str, key): visit(child, depth + 1) for key, child in mapping.items()}
+        result: dict[str, object] = {}
+        for key, child in mapping.items():
+            checked_key = cast(str, key)
+            key_size = len(checked_key.encode("utf-8"))
+            utf8_bytes += key_size
+            if key_size > _MAX_STRING_BYTES or utf8_bytes > _MAX_TOTAL_UTF8_BYTES:
+                raise ValueError("CPR result contains oversized aggregate UTF-8")
+            result[checked_key] = visit(child, depth + 1)
+        return result
 
     return visit(value, 0)
 
@@ -368,7 +391,7 @@ def _record(result: ScreeningRunResult) -> dict[str, object]:
             "timing_telemetry_seconds": result.wall_clock_seconds,
             "timing_is_selection_metric": False,
         },
-        "outcome": "inconclusive",
+        "outcome": "descriptive_only",
         "outcome_retained": True,
     }
 
@@ -387,7 +410,47 @@ def _aggregate(rows: list[dict[str, object]]) -> dict[str, object]:
             if row["arm"] == arm
         ]
         means[arm] = math.fsum(values) / len(values)
-    return {"mean_online_accuracy": means, "row_count": len(rows), "outcome": "inconclusive"}
+    by_pair = {
+        (cast(int, row["seed"]), cast(str, row["arm"])): cast(
+            float,
+            cast(dict[str, object], cast(dict[str, object], row["result"])["metrics"])[
+                "mean_online_accuracy"
+            ],
+        )
+        for row in rows
+    }
+    paired_deltas = [
+        {
+            "seed": seed,
+            "utility_minus_off": by_pair[(seed, "cpr_utility")] - by_pair[(seed, "cpr_off")],
+        }
+        for seed in sorted({seed for seed, _arm in by_pair})
+    ]
+    delta_values = [item["utility_minus_off"] for item in paired_deltas]
+    mean_delta = math.fsum(delta_values) / len(delta_values)
+    positive_count = sum(delta > 0.0 for delta in delta_values)
+    outcome = (
+        "advance_for_nonpromoting_followup"
+        if mean_delta > 0.0 and positive_count >= 4
+        else "do_not_advance"
+    )
+    return {
+        "mean_online_accuracy": means,
+        "row_count": len(rows),
+        "primary_paired_question": {
+            "candidate": "cpr_utility",
+            "control": "cpr_off",
+            "metric": "mean_online_accuracy",
+            "direction": "higher_is_better",
+            "paired_deltas": paired_deltas,
+            "mean_delta": mean_delta,
+            "positive_seed_count": positive_count,
+            "decision_rule": "advance iff mean_delta > 0 and at least 4 of 5 seed deltas > 0",
+            "outcome": outcome,
+        },
+        "ablation_policy": "utility-free, L2-init, and hard-reset arms are descriptive only",
+        "outcome": outcome,
+    }
 
 
 def _run(
@@ -478,7 +541,32 @@ def _run(
 
 
 def _canonical(value: object) -> bytes:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("ascii")
+    bounded = _bounded_json(value)
+    encoded = json.dumps(bounded, sort_keys=True, separators=(",", ":"), allow_nan=False).encode(
+        "ascii"
+    )
+    if len(encoded) > _MAX_REPORT_BYTES:
+        raise ValueError("CPR canonical JSON exceeds its byte bound")
+    return encoded
+
+
+def _exact_json_equal(left: object, right: object) -> bool:
+    if type(left) is not type(right):
+        return False
+    actual_type = type(left)
+    if actual_type is dict:
+        left_map = cast(dict[str, object], left)
+        right_map = cast(dict[str, object], right)
+        if len(left_map) != len(right_map) or any(key not in right_map for key in left_map):
+            return False
+        return all(_exact_json_equal(left_map[key], right_map[key]) for key in left_map)
+    if actual_type is list:
+        left_list = cast(list[object], left)
+        right_list = cast(list[object], right)
+        return len(left_list) == len(right_list) and all(
+            _exact_json_equal(a, b) for a, b in zip(left_list, right_list, strict=True)
+        )
+    return bool(left == right)
 
 
 def _exact_object(value: object, fields: tuple[str, ...], label: str) -> dict[str, object]:
@@ -553,7 +641,7 @@ def _validate_record(value: object, config: IPMNISTConfig) -> None:
     timing = resources["timing_telemetry_seconds"]
     if type(timing) is not float or not math.isfinite(timing) or timing < 0.0 or timing > 604_800.0:
         raise ValueError("CPR timing telemetry drifted")
-    if record["outcome"] != "inconclusive" or record["outcome_retained"] is not True:
+    if record["outcome"] != "descriptive_only" or record["outcome_retained"] is not True:
         raise ValueError("CPR nonpromoting outcome policy drifted")
 
 
@@ -570,6 +658,11 @@ def validate_report(
         raise ValueError("CPR config must be an exact IPMNISTConfig")
     if type(seeds) is not tuple or any(type(seed) is not int for seed in seeds):
         raise ValueError("CPR seeds must be an exact integer tuple")
+    if len(seeds) != 5 or not any(
+        all(seed == roster[index] for index, seed in enumerate(seeds))
+        for roster in (CAMPAIGN_SEEDS, TEST_ONLY_SEEDS)
+    ):
+        raise ValueError("CPR seed roster differs from the campaign or test-only contract")
     if type(reexecute) is not bool:
         raise ValueError("CPR reexecution selector must be an exact bool")
     report = cast(dict[str, object], _bounded_json(value))
@@ -578,15 +671,18 @@ def validate_report(
     )
     if report["schema"] != SCHEMA:
         raise ValueError("CPR report fields or schema drifted")
-    if report["plan"] != frozen_plan():
+    if not _exact_json_equal(report["plan"], frozen_plan()):
         raise ValueError("CPR report plan drifted")
     checked_x, checked_y = _validated_arrays(x, y, config)
     identity = _exact_object(report["identity"], ("source", "runtime", "dataset"), "identity")
-    if identity != {
-        "source": _source_identity(),
-        "runtime": _runtime_identity(),
-        "dataset": _dataset_identity(checked_x, checked_y),
-    }:
+    if not _exact_json_equal(
+        identity,
+        {
+            "source": _source_identity(),
+            "runtime": _runtime_identity(),
+            "dataset": _dataset_identity(checked_x, checked_y),
+        },
+    ):
         raise ValueError("CPR report identity drifted")
     if type(report["rows"]) is not list:
         raise ValueError("CPR rows must be an exact list")
@@ -610,7 +706,7 @@ def validate_report(
             or row["arm"] != arm
         ):
             raise ValueError("CPR report roster drifted")
-        if row["execution_identity"] != expected_identity[seed]:
+        if not _exact_json_equal(row["execution_identity"], expected_identity[seed]):
             raise ValueError("CPR row identity drifted")
         _validate_record(row["result"], config)
         if reexecute:
@@ -626,7 +722,7 @@ def validate_report(
             replay_resources["timing_telemetry_seconds"] = claimed_resources[
                 "timing_telemetry_seconds"
             ]
-            if replay != row["result"]:
+            if not _exact_json_equal(replay, row["result"]):
                 raise ValueError("CPR row differs from strict current reexecution")
             if (
                 _source_identity() != source
@@ -635,20 +731,31 @@ def validate_report(
             ):
                 raise RuntimeError("CPR identity changed during strict reexecution")
     _exact_object(
-        report["aggregate"], ("mean_online_accuracy", "row_count", "outcome"), "aggregate"
+        report["aggregate"],
+        (
+            "mean_online_accuracy",
+            "row_count",
+            "primary_paired_question",
+            "ablation_policy",
+            "outcome",
+        ),
+        "aggregate",
     )
-    if report["aggregate"] != _aggregate(rows):
+    if not _exact_json_equal(report["aggregate"], _aggregate(rows)):
         raise ValueError("CPR aggregate arithmetic drifted")
     policy = _exact_object(
         report["policy"],
         ("development_only", "scientific_promotion_allowed", "negative_outcomes_retained"),
         "policy",
     )
-    if policy != {
-        "development_only": True,
-        "scientific_promotion_allowed": False,
-        "negative_outcomes_retained": True,
-    }:
+    if not _exact_json_equal(
+        policy,
+        {
+            "development_only": True,
+            "scientific_promotion_allowed": False,
+            "negative_outcomes_retained": True,
+        },
+    ):
         raise ValueError("CPR result policy drifted")
     unsigned = dict(report)
     claimed = unsigned.pop("sha256")

--- a/alberta_framework/evaluation/calibrated_partial_reset_campaign.py
+++ b/alberta_framework/evaluation/calibrated_partial_reset_campaign.py
@@ -658,13 +658,20 @@ def validate_report(
         raise ValueError("CPR config must be an exact IPMNISTConfig")
     if type(seeds) is not tuple or any(type(seed) is not int for seed in seeds):
         raise ValueError("CPR seeds must be an exact integer tuple")
-    if len(seeds) != 5 or not any(
-        all(seed == roster[index] for index, seed in enumerate(seeds))
-        for roster in (CAMPAIGN_SEEDS, TEST_ONLY_SEEDS)
-    ):
+    campaign_roster = len(seeds) == len(CAMPAIGN_SEEDS) and all(
+        seed == CAMPAIGN_SEEDS[index] for index, seed in enumerate(seeds)
+    )
+    test_roster = len(seeds) == len(TEST_ONLY_SEEDS) and all(
+        seed == TEST_ONLY_SEEDS[index] for index, seed in enumerate(seeds)
+    )
+    if not campaign_roster and not test_roster:
         raise ValueError("CPR seed roster differs from the campaign or test-only contract")
     if type(reexecute) is not bool:
         raise ValueError("CPR reexecution selector must be an exact bool")
+    if reexecute and campaign_roster and (
+        _REVIEWED_EXECUTION_TRANSITION is not True or _EXECUTION_AUTHORIZED is not True
+    ):
+        raise RuntimeError("CPR campaign reexecution is not authorized")
     report = cast(dict[str, object], _bounded_json(value))
     report = _exact_object(
         report, ("schema", "plan", "identity", "rows", "aggregate", "policy", "sha256"), "report"
@@ -788,6 +795,26 @@ def _open_parent(path: Path) -> int:
         raise
 
 
+def _require_live_parent(path: Path, directory: int) -> None:
+    held = os.fstat(directory)
+    visible = os.stat(path.parent, follow_symlinks=False)
+    if (
+        not stat.S_ISDIR(held.st_mode)
+        or not stat.S_ISDIR(visible.st_mode)
+        or (held.st_dev, held.st_ino) != (visible.st_dev, visible.st_ino)
+    ):
+        raise RuntimeError("CPR output parent changed during publication")
+
+
+def _write_all(descriptor: int, raw: bytes, *, label: str) -> None:
+    view = memoryview(raw)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise OSError(f"CPR {label} write made no progress")
+        view = view[written:]
+
+
 def _reserve(path: Path) -> Reservation:
     if type(path) is not type(Path()) or path.absolute() != OUTPUT_PATH.absolute():
         raise ValueError("CPR output must be the exact frozen NEW path")
@@ -809,10 +836,11 @@ def _reserve(path: Path) -> Reservation:
             0o400,
             dir_fd=directory,
         )
-        os.write(marker_fd, b"asi-cpr-reserved-v1\n")
+        _write_all(marker_fd, b"asi-cpr-reserved-v1\n", label="reservation")
         os.fsync(marker_fd)
         metadata = os.fstat(marker_fd)
         os.fsync(directory)
+        _require_live_parent(path, directory)
         return directory, path.name, marker_name, marker_fd, metadata.st_dev, metadata.st_ino
     except BaseException:
         if marker_fd >= 0:
@@ -849,9 +877,15 @@ def _finish_reservation(reservation: Reservation, *, consumed: bool) -> None:
         if consumed:
             os.ftruncate(marker_fd, 0)
             os.lseek(marker_fd, 0, os.SEEK_SET)
-            os.write(marker_fd, b"asi-cpr-consumed-without-result-v1\n")
+            _write_all(
+                marker_fd,
+                b"asi-cpr-consumed-without-result-v1\n",
+                label="consumed tombstone",
+            )
             os.fsync(marker_fd)
             os.fsync(directory)
+            _require_live_parent(OUTPUT_PATH, directory)
+            _owned(reservation)
         else:
             current = os.stat(marker, dir_fd=directory, follow_symlinks=False)
             if (current.st_dev, current.st_ino) == (device, inode):
@@ -885,6 +919,7 @@ def _publish(
     if capability is not _EXECUTION_CAPABILITY and capability is not _TEST_EXECUTION_CAPABILITY:
         raise RuntimeError("CPR publication capability is invalid")
     directory, name, _marker, _marker_fd, _device, _inode = reservation
+    _require_live_parent(OUTPUT_PATH, directory)
     _owned(reservation)
     validate_report(report, x, y, config=config, seeds=seeds, reexecute=True)
     encoded = _canonical(report) + b"\n"
@@ -926,6 +961,7 @@ def _publish(
         except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
             raise ValueError("CPR staged report is not strict bounded JSON") from error
         validate_report(staged_report, x, y, config=config, seeds=seeds, reexecute=False)
+        _require_live_parent(OUTPUT_PATH, directory)
         _owned(reservation)
         published_identity = (staged.st_dev, staged.st_ino)
         _link_tmpfile(descriptor, directory, name)
@@ -941,6 +977,7 @@ def _publish(
             if (
                 not stat.S_ISREG(before.st_mode)
                 or before.st_nlink != 1
+                or (before.st_dev, before.st_ino) != published_identity
                 or raw != encoded
                 or (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
                 != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
@@ -954,6 +991,15 @@ def _publish(
             validate_report(reread, x, y, config=config, seeds=seeds, reexecute=False)
         finally:
             os.close(read_fd)
+        os.fsync(directory)
+        _require_live_parent(OUTPUT_PATH, directory)
+        visible = os.stat(name, dir_fd=directory, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(visible.st_mode)
+            or visible.st_nlink != 1
+            or (visible.st_dev, visible.st_ino) != published_identity
+        ):
+            raise RuntimeError("CPR published output name changed after synchronization")
     except BaseException:
         if published_identity is not None:
             try:

--- a/docs/research/calibrated-partial-reset-matched-development.md
+++ b/docs/research/calibrated-partial-reset-matched-development.md
@@ -1,0 +1,64 @@
+# Calibrated Partial Reset matched development plan
+
+This is the prospective, permanently nonpromoting plan for issue #1563. It does not
+authorize a run, contain a result, close the issue, or create scientific evidence.
+
+## Mechanism and provenance
+
+The hypothesis is that scaling a partial pull toward initialization by a hidden unit's
+incoming-gradient utility preserves useful features while restoring low-utility capacity.
+The paper is *Calibrated Partial Resets* (`arXiv:2607.24996v1`). The audited official
+implementation is `LucMc/continual-learning` at
+`6fc2af34783159f5dda50c6915dda32c2d443604`.
+
+The official implementation periodically normalizes each hidden layer's mean absolute
+incoming-weight gradients, maintains an exponential utility trace, pulls incoming weights
+toward a newly sampled initialization, and pulls outgoing weights toward zero. This ASI
+IPMNIST adaptation instead uses the run's retained seed initialization so all matched arms
+share an exact target; uses float32 Adam; leaves biases unchanged, matching the official
+code; and evaluates online permuted MNIST rather than the paper's reinforcement-learning
+suites. It therefore tests the mechanism in ASI and does not claim paper-protocol parity.
+
+The five matched arms are mechanism-off Adam, utility-scaled CPR, utility-free uniform
+partial reset, continuous L2 pull to initialization, and thresholded hard reset. Unit tests
+pin the mechanism-off trajectory and show that each named reduction changes the end-to-end
+trajectory.
+
+## Frozen matching and resources
+
+The unexecuted campaign roster is `61563001` through `61563005`. Repository and Git history
+searches found these seeds globally absent before this plan exposed them. Tests use the
+separate `301` through `305` roster and never execute campaign seeds.
+
+Every arm shares seed-derived initial parameters and example schedule, 8 tasks of 5,000
+updates, observations, current-example labels, and no task-boundary signal. Each initial
+row is strictly reexecuted before publication. The 25 rows and 25 reexecutions total 50
+runner dispatches, 2,000,000 observations/data steps/updates, zero environment steps, and
+4,000,000 model queries.
+
+The static numeric envelope counts one caller-owned C-contiguous float32 dataset and int32
+labels, one materialized permutation/index schedule, and the peak retained learner state:
+parameters, initialization target, both Adam moments, utility traces, and step counter. Its
+256 MiB ceiling excludes backend/compiler copies, gradients, and transient execution
+buffers; those exclusions prevent this byte envelope from being presented as total process
+memory. Timing is bounded telemetry only and cannot select an outcome.
+
+The report binds exact source bytes, including `pyproject.toml` and `uv.lock`, installed
+direct dependency versions, Python/platform identity, JAX backend/config/device inventory,
+selected JAX environment, canonical dataset digests, and per-seed initialization and
+schedule digests. Validators require exact bounded JSON containers and scalars and reject
+resource, arithmetic, roster, identity, reexecution, or policy drift.
+
+## Authorization and publication
+
+Two separate literal flags are frozen `False`. Public execution fails before output
+reservation, dataset loading, or runner dispatch. A later reviewed transition must change
+both literals. The single run-and-publish transaction pins each output-directory component
+with `O_DIRECTORY|O_NOFOLLOW`, acquires the canonical NEW-path reservation with `O_EXCL`
+before dataset work, and publishes a strictly validated anonymous inode by no-replace link
+plus directory `fsync`. After the first runner dispatch, any failure leaves an inode-owned
+`consumed-without-result` tombstone, permanently preventing retry at that namespace.
+
+All accepted and negative outcomes remain development-only and nonpromoting. Negative
+outcomes are retained. No result can populate `reference-dev`, support a performance or
+scientific claim, or authorize promotion without a separate protocol and untouched seeds.

--- a/docs/research/calibrated-partial-reset-matched-development.md
+++ b/docs/research/calibrated-partial-reset-matched-development.md
@@ -36,6 +36,14 @@ row is strictly reexecuted before publication. The 25 rows and 25 reexecutions t
 runner dispatches, 2,000,000 observations/data steps/updates, zero environment steps, and
 4,000,000 model queries.
 
+The prospectively frozen primary question is whether utility-scaled CPR improves each
+seed's mean online accuracy relative to mechanism-off Adam. The report retains all five
+paired `utility - off` deltas and their exact `math.fsum` mean. It advances only to another
+nonpromoting development follow-up when the mean delta is positive and at least four of
+five seed deltas are positive; otherwise the outcome is `do_not_advance`. The utility-free,
+L2-init, and hard-reset reductions are descriptive ablations and cannot change that primary
+outcome. This directional development rule has no scientific threshold or promotion force.
+
 The static numeric envelope counts one caller-owned C-contiguous float32 dataset and int32
 labels, one materialized permutation/index schedule, and the peak retained learner state:
 parameters, initialization target, both Adam moments, utility traces, and step counter. Its

--- a/docs/research/calibrated-partial-reset-matched-development.md
+++ b/docs/research/calibrated-partial-reset-matched-development.md
@@ -61,10 +61,15 @@ resource, arithmetic, roster, identity, reexecution, or policy drift.
 
 Two separate literal flags are frozen `False`. Public execution fails before output
 reservation, dataset loading, or runner dispatch. A later reviewed transition must change
-both literals. The single run-and-publish transaction pins each output-directory component
+both literals. Public strict reexecution of the campaign roster is closed by the same gate;
+the disjoint test-only roster remains available for regression tests. The single
+run-and-publish transaction pins each output-directory component
 with `O_DIRECTORY|O_NOFOLLOW`, acquires the canonical NEW-path reservation with `O_EXCL`
-before dataset work, and publishes a strictly validated anonymous inode by no-replace link
-plus directory `fsync`. After the first runner dispatch, any failure leaves an inode-owned
+before dataset work, proves that its held parent remains the visible registered parent, and
+publishes a strictly validated anonymous inode by no-replace link plus directory `fsync`.
+The linked and reread file must remain that exact prepared inode; same-byte replacement is
+rejected. Reservation, output, and tombstone writes require complete progress. After the
+first runner dispatch, any failure leaves an inode-owned
 `consumed-without-result` tombstone, permanently preventing retry at that namespace.
 
 All accepted and negative outcomes remain development-only and nonpromoting. Negative

--- a/tests/test_calibrated_partial_reset_campaign.py
+++ b/tests/test_calibrated_partial_reset_campaign.py
@@ -114,6 +114,11 @@ def test_private_runner_covers_complete_roster_and_strict_reexecution(
     assert [(row["seed"], row["arm"]) for row in report["rows"]] == [
         (seed, arm) for seed in lane.TEST_ONLY_SEEDS for arm in lane.ARMS
     ]
+    primary = report["aggregate"]["primary_paired_question"]
+    assert [item["seed"] for item in primary["paired_deltas"]] == list(lane.TEST_ONLY_SEEDS)
+    assert primary["mean_delta"] == pytest.approx(0.01)
+    assert primary["positive_seed_count"] == 5
+    assert primary["outcome"] == "advance_for_nonpromoting_followup"
     lane.validate_report(
         report,
         *_data(),
@@ -193,8 +198,46 @@ def test_runtime_device_bound_precedes_device_attribute_access(
 
 
 def test_json_boundary_rejects_unbounded_integer() -> None:
-    with pytest.raises(ValueError, match="out-of-bounds integer"):
-        lane._bounded_json({"nested": [2**64]})
+    assert lane._bounded_json({"values": [-(2**63), 2**63 - 1]}) == {
+        "values": [-(2**63), 2**63 - 1]
+    }
+    for value in (-(2**63) - 1, 2**63):
+        with pytest.raises(ValueError, match="out-of-bounds integer"):
+            lane._bounded_json({"nested": [value]})
+
+
+def test_json_boundary_enforces_aggregate_utf8_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(lane, "_MAX_TOTAL_UTF8_BYTES", 7)
+    with pytest.raises(ValueError, match="UTF-8|oversized string"):
+        lane._canonical({"a": "1234", "b": "5678"})
+
+
+def test_validator_rejects_bool_int_aliases_in_nested_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report = _run_for_test(monkeypatch)
+    forged = copy.deepcopy(report)
+    forged["plan"]["execution_authorized"] = 0
+    _resign(forged)
+    with pytest.raises(ValueError, match="plan"):
+        lane.validate_report(
+            forged,
+            *_data(),
+            config=SMALL,
+            seeds=lane.TEST_ONLY_SEEDS,
+            reexecute=False,
+        )
+    forged = copy.deepcopy(report)
+    forged["policy"]["development_only"] = 1
+    _resign(forged)
+    with pytest.raises(ValueError, match="policy"):
+        lane.validate_report(
+            forged,
+            *_data(),
+            config=SMALL,
+            seeds=lane.TEST_ONLY_SEEDS,
+            reexecute=False,
+        )
 
 
 def test_combined_numeric_bound_precedes_dataset_copy_and_runner(

--- a/tests/test_calibrated_partial_reset_campaign.py
+++ b/tests/test_calibrated_partial_reset_campaign.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import alberta_framework.evaluation.calibrated_partial_reset_campaign as lane
+from alberta_framework.benchmarks.ipmnist_screening import ScreeningRunResult
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+
+SMALL = IPMNISTConfig(n_tasks=1, task_length=8, input_dim=4, hidden1=3, hidden2=2, n_classes=2)
+
+
+def _data() -> tuple[np.ndarray, np.ndarray]:
+    return (
+        np.arange(32, dtype=np.float32).reshape(8, 4) / 32.0,
+        np.arange(8, dtype=np.int32) % 2,
+    )
+
+
+def _fake_run(
+    data_x: np.ndarray,
+    data_y: np.ndarray,
+    spec: object,
+    seed: int,
+    config: IPMNISTConfig,
+) -> ScreeningRunResult:
+    del data_x, data_y
+    checked = cast(Any, spec)
+    value = 0.4 + 0.01 * (lane.TEST_ONLY_SEEDS.index(seed) + lane.ARMS.index(checked.name))
+    return ScreeningRunResult(
+        config_name=checked.name,
+        base_learner=checked.base_learner,
+        hyperparameters=checked.hyperparameters,
+        seed=seed,
+        config=config,
+        per_task_accuracy=np.full(config.n_tasks, value, dtype=np.float64),
+        per_task_loss=np.full(config.n_tasks, 1.0 - value, dtype=np.float64),
+        per_task_plasticity=np.full(config.n_tasks, value, dtype=np.float64),
+        wall_clock_seconds=1.0,
+    )
+
+
+def _run_for_test(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    monkeypatch.setattr(lane, "run_screening_config", _fake_run)
+    return lane._run(
+        *_data(),
+        config=SMALL,
+        seeds=lane.TEST_ONLY_SEEDS,
+        capability=lane._TEST_EXECUTION_CAPABILITY,
+    )
+
+
+def _resign(report: dict[str, object]) -> None:
+    unsigned = dict(report)
+    unsigned.pop("sha256", None)
+    report["sha256"] = hashlib.sha256(lane._canonical(unsigned)).hexdigest()
+
+
+def test_plan_is_prospective_exact_and_nonpromoting() -> None:
+    plan = lane.frozen_plan()
+    assert plan["seeds"] == [61_563_001, 61_563_002, 61_563_003, 61_563_004, 61_563_005]
+    assert set(plan["seeds"]).isdisjoint(plan["test_only_seeds"])
+    assert plan["reviewed_execution_transition"] is False
+    assert plan["execution_authorized"] is False
+    assert plan["scientific_promotion_allowed"] is False
+    assert plan["arms"] == list(lane.ARMS)
+    assert "pyproject.toml" in plan["source_identity_policy"]["hashed_files"]
+    assert "uv.lock" in plan["source_identity_policy"]["hashed_files"]
+    assert plan["resources"]["combined_numeric_bytes"] <= 256 * 1024 * 1024
+    assert plan["transaction_resources"] == {
+        "campaign_rows": 25,
+        "initial_runner_dispatches": 25,
+        "strict_reexecution_dispatches": 25,
+        "total_runner_dispatches": 50,
+        "total_observations": 2_000_000,
+        "total_updates": 2_000_000,
+        "total_data_steps": 2_000_000,
+        "total_environment_steps": 0,
+        "total_model_queries": 4_000_000,
+    }
+
+
+def test_public_transaction_is_closed_before_reservation_or_consumer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("consumer or reservation ran before authorization")
+
+    monkeypatch.setattr(lane, "_reserve", forbidden)
+    monkeypatch.setattr(lane, "load_mnist_train", forbidden)
+    monkeypatch.setattr(lane, "run_screening_config", forbidden)
+    with pytest.raises(RuntimeError, match="not authorized"):
+        lane.run_and_publish(tmp_path, tmp_path / "report.json")
+    assert calls == 0
+
+
+def test_private_runner_covers_complete_roster_and_strict_reexecution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report = _run_for_test(monkeypatch)
+    assert [(row["seed"], row["arm"]) for row in report["rows"]] == [
+        (seed, arm) for seed in lane.TEST_ONLY_SEEDS for arm in lane.ARMS
+    ]
+    lane.validate_report(
+        report,
+        *_data(),
+        config=SMALL,
+        seeds=lane.TEST_ONLY_SEEDS,
+        reexecute=True,
+    )
+
+
+def test_validator_rejects_resource_and_aggregate_forgery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report = _run_for_test(monkeypatch)
+    forged = copy.deepcopy(report)
+    forged["rows"][0]["result"]["resources"]["updates"] = 1
+    _resign(forged)
+    with pytest.raises(ValueError, match="resource"):
+        lane.validate_report(
+            forged,
+            *_data(),
+            config=SMALL,
+            seeds=lane.TEST_ONLY_SEEDS,
+            reexecute=False,
+        )
+    forged = copy.deepcopy(report)
+    forged["aggregate"]["row_count"] = 1
+    _resign(forged)
+    with pytest.raises(ValueError, match="aggregate"):
+        lane.validate_report(
+            forged,
+            *_data(),
+            config=SMALL,
+            seeds=lane.TEST_ONLY_SEEDS,
+            reexecute=False,
+        )
+
+
+def test_json_boundary_rejects_hostile_nested_type_without_hooks() -> None:
+    calls = 0
+
+    class Meta(type):
+        def __hash__(cls) -> int:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("hostile type hash dispatched")
+
+        def __eq__(cls, other: object) -> bool:
+            del other
+            nonlocal calls
+            calls += 1
+            raise AssertionError("hostile type equality dispatched")
+
+    class Hostile(metaclass=Meta):
+        pass
+
+    with pytest.raises(ValueError, match="exact JSON"):
+        lane._bounded_json({"nested": [Hostile()]})
+    assert calls == 0
+
+
+def test_runtime_device_bound_precedes_device_attribute_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    class Device:
+        def __getattribute__(self, name: str) -> object:
+            del name
+            nonlocal calls
+            calls += 1
+            raise AssertionError("device attribute accessed before inventory bound")
+
+    monkeypatch.setattr(lane.jax, "devices", lambda: [Device()] * 65)
+    with pytest.raises(RuntimeError, match="inventory"):
+        lane._runtime_identity()
+    assert calls == 0
+
+
+def test_json_boundary_rejects_unbounded_integer() -> None:
+    with pytest.raises(ValueError, match="out-of-bounds integer"):
+        lane._bounded_json({"nested": [2**64]})
+
+
+def test_combined_numeric_bound_precedes_dataset_copy_and_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    x, y = _data()
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("allocation or runner preceded aggregate bound")
+
+    monkeypatch.setattr(lane, "_MAX_NUMERIC_BYTES", 1)
+    monkeypatch.setattr(lane.np, "array", forbidden)
+    monkeypatch.setattr(lane, "run_screening_config", forbidden)
+    with pytest.raises(ValueError, match="combined numeric allocation"):
+        lane._run(
+            x,
+            y,
+            config=SMALL,
+            seeds=lane.TEST_ONLY_SEEDS,
+            capability=lane._TEST_EXECUTION_CAPABILITY,
+        )
+    assert calls == 0
+
+
+def test_noncontiguous_dataset_is_rejected_before_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    x, y = _data()
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("runner preceded dataset allocation validation")
+
+    monkeypatch.setattr(lane, "run_screening_config", forbidden)
+    with pytest.raises(ValueError, match="C-contiguous"):
+        lane._run(
+            x[:, ::-1],
+            y,
+            config=SMALL,
+            seeds=lane.TEST_ONLY_SEEDS,
+            capability=lane._TEST_EXECUTION_CAPABILITY,
+        )
+    assert calls == 0
+
+
+def test_transaction_reserves_before_load_and_retains_tombstone_after_dispatch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    destination = tmp_path / "report.json"
+    marker = destination.with_name(f".{destination.name}.reservation")
+    marker.write_bytes(b"occupied")
+    calls = 0
+
+    def fail(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("consumer failure")
+
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(lane, "load_mnist_train", fail)
+    with pytest.raises(FileExistsError):
+        lane._run_and_publish(
+            tmp_path,
+            destination,
+            SMALL,
+            lane.TEST_ONLY_SEEDS,
+            lane._TEST_EXECUTION_CAPABILITY,
+        )
+    assert calls == 0
+    marker.unlink()
+    monkeypatch.setattr(lane, "load_mnist_train", lambda _home: _data())
+    monkeypatch.setattr(lane, "run_screening_config", fail)
+    with pytest.raises(RuntimeError, match="consumer failure"):
+        lane._run_and_publish(
+            tmp_path,
+            destination,
+            SMALL,
+            lane.TEST_ONLY_SEEDS,
+            lane._TEST_EXECUTION_CAPABILITY,
+        )
+    assert marker.read_bytes() == b"asi-cpr-consumed-without-result-v1\n"
+    with pytest.raises(FileExistsError):
+        lane._run_and_publish(
+            tmp_path,
+            destination,
+            SMALL,
+            lane.TEST_ONLY_SEEDS,
+            lane._TEST_EXECUTION_CAPABILITY,
+        )
+    assert calls == 1
+
+
+def test_transaction_strictly_publishes_and_removes_reservation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    destination = tmp_path / "report.json"
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(lane, "load_mnist_train", lambda _home: _data())
+    monkeypatch.setattr(lane, "run_screening_config", _fake_run)
+    report = lane._run_and_publish(
+        tmp_path,
+        destination,
+        SMALL,
+        lane.TEST_ONLY_SEEDS,
+        lane._TEST_EXECUTION_CAPABILITY,
+    )
+    assert json.loads(destination.read_bytes()) == report
+    assert not destination.with_name(f".{destination.name}.reservation").exists()

--- a/tests/test_calibrated_partial_reset_campaign.py
+++ b/tests/test_calibrated_partial_reset_campaign.py
@@ -84,6 +84,9 @@ def test_plan_is_prospective_exact_and_nonpromoting() -> None:
         "total_environment_steps": 0,
         "total_model_queries": 4_000_000,
     }
+    runtime = lane._runtime_identity()
+    assert runtime["jax"]["config"]["jax_default_prng_impl"] == "threefry2x32"
+    assert runtime["jax"]["config"]["jax_random_seed_offset"] == 0
 
 
 def test_public_transaction_is_closed_before_reservation_or_consumer(

--- a/tests/test_calibrated_partial_reset_campaign.py
+++ b/tests/test_calibrated_partial_reset_campaign.py
@@ -107,6 +107,30 @@ def test_public_transaction_is_closed_before_reservation_or_consumer(
     assert calls == 0
 
 
+def test_campaign_reexecution_is_closed_before_validation_or_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("campaign work preceded reexecution authorization")
+
+    monkeypatch.setattr(lane, "_bounded_json", forbidden)
+    monkeypatch.setattr(lane, "run_screening_config", forbidden)
+    with pytest.raises(RuntimeError, match="reexecution is not authorized"):
+        lane.validate_report(
+            {},
+            object(),
+            object(),
+            config=lane.CAMPAIGN_CONFIG,
+            seeds=lane.CAMPAIGN_SEEDS,
+            reexecute=True,
+        )
+    assert calls == 0
+
+
 def test_private_runner_covers_complete_roster_and_strict_reexecution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -349,3 +373,99 @@ def test_transaction_strictly_publishes_and_removes_reservation(
     )
     assert json.loads(destination.read_bytes()) == report
     assert not destination.with_name(f".{destination.name}.reservation").exists()
+
+
+def test_transaction_handles_short_marker_and_output_writes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    destination = tmp_path / "report.json"
+    original_write = lane.os.write
+
+    def short_write(descriptor: int, value: object) -> int:
+        view = memoryview(cast(Any, value))
+        return original_write(descriptor, view[: max(1, min(3, len(view)))])
+
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(lane, "load_mnist_train", lambda _home: _data())
+    monkeypatch.setattr(lane, "run_screening_config", _fake_run)
+    monkeypatch.setattr(lane.os, "write", short_write)
+    report = lane._run_and_publish(
+        tmp_path,
+        destination,
+        SMALL,
+        lane.TEST_ONLY_SEEDS,
+        lane._TEST_EXECUTION_CAPABILITY,
+    )
+    assert json.loads(destination.read_bytes()) == report
+    assert not destination.with_name(f".{destination.name}.reservation").exists()
+
+
+def test_publication_rejects_replaced_visible_parent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    parent = tmp_path / "visible"
+    parent.mkdir()
+    destination = parent / "report.json"
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(lane, "run_screening_config", _fake_run)
+    report = _run_for_test(monkeypatch)
+    reservation = lane._reserve(destination)
+    moved = tmp_path / "moved"
+    parent.rename(moved)
+    parent.mkdir()
+    try:
+        with pytest.raises(RuntimeError, match="output parent changed"):
+            lane._publish(
+                reservation,
+                report,
+                *_data(),
+                SMALL,
+                lane.TEST_ONLY_SEEDS,
+                lane._TEST_EXECUTION_CAPABILITY,
+            )
+        assert not destination.exists()
+    finally:
+        lane._finish_reservation(reservation, consumed=False)
+
+
+def test_publication_rejects_same_byte_foreign_link_replacement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    destination = tmp_path / "report.json"
+    monkeypatch.setattr(lane, "OUTPUT_PATH", destination)
+    monkeypatch.setattr(lane, "run_screening_config", _fake_run)
+    report = _run_for_test(monkeypatch)
+    encoded = lane._canonical(report) + b"\n"
+    reservation = lane._reserve(destination)
+    original_open = lane.os.open
+    replaced = False
+
+    def replace_before_read(
+        path: object,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal replaced
+        if path == destination.name and not replaced:
+            replaced = True
+            destination.unlink()
+            destination.write_bytes(encoded)
+            destination.chmod(0o400)
+        return original_open(cast(Any, path), flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(lane.os, "open", replace_before_read)
+    try:
+        with pytest.raises(ValueError, match="changed during bounded reread"):
+            lane._publish(
+                reservation,
+                report,
+                *_data(),
+                SMALL,
+                lane.TEST_ONLY_SEEDS,
+                lane._TEST_EXECUTION_CAPABILITY,
+            )
+        assert destination.read_bytes() == encoded
+    finally:
+        lane._finish_reservation(reservation, consumed=False)

--- a/tests/test_calibrated_partial_reset_ipmnist.py
+++ b/tests/test_calibrated_partial_reset_ipmnist.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.calibrated_partial_reset_ipmnist import (
+    ARMS,
+    _make_cpr_learner,
+    calibrated_partial_reset_spec,
+    persistent_numeric_bytes,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig, init_mlp_params
+
+SMALL = IPMNISTConfig(n_tasks=1, task_length=8, input_dim=4, hidden1=3, hidden2=2, n_classes=2)
+
+
+def _hp() -> dict[str, float]:
+    result = dict(calibrated_partial_reset_spec("cpr_utility").hyperparameters)
+    result["update_frequency"] = 2.0
+    return result
+
+
+def _trajectory(mode: str) -> dict[str, jnp.ndarray]:
+    init_fn, step_fn = _make_cpr_learner(_hp(), mode=mode)  # type: ignore[arg-type]
+    params = init_mlp_params(jr.key(7), SMALL)
+    state = init_fn(params)
+    for index in range(4):
+        params, state, _ = step_fn(
+            params,
+            state,
+            jnp.asarray([0.2, -0.1, 0.3, 0.5], dtype=jnp.float32),
+            jnp.asarray(index % 2, dtype=jnp.int32),
+            jr.key(index),
+        )
+    return params
+
+
+def test_registered_arm_roster_and_resource_formula_are_exact() -> None:
+    assert tuple(calibrated_partial_reset_spec(name).name for name in ARMS) == ARMS
+    parameter_values = 4 * 3 + 3 + 3 * 2 + 2 + 2 * 2 + 2
+    assert persistent_numeric_bytes(input_dim=4, hidden1=3, hidden2=2, n_classes=2) == (
+        (4 * parameter_values + 3 + 2 + 1) * 4
+    )
+
+
+def test_mechanism_off_is_bit_exact_when_reset_strengths_are_inert() -> None:
+    off = _trajectory("off")
+    hp = _hp()
+    hp["replacement_rate"] = 0.0
+    init_fn, step_fn = _make_cpr_learner(hp, mode="utility")
+    params = init_mlp_params(jr.key(7), SMALL)
+    state = init_fn(params)
+    for index in range(4):
+        params, state, _ = step_fn(
+            params,
+            state,
+            jnp.asarray([0.2, -0.1, 0.3, 0.5], dtype=jnp.float32),
+            jnp.asarray(index % 2, dtype=jnp.int32),
+            jr.key(100 + index),
+        )
+    for name in off:
+        np.testing.assert_array_equal(np.asarray(params[name]), np.asarray(off[name]))
+
+
+@pytest.mark.parametrize("mode", ["utility", "utility_free", "l2_init", "hard_reset"])
+def test_each_reduction_changes_the_end_to_end_parameter_trajectory(mode: str) -> None:
+    off = _trajectory("off")
+    changed = _trajectory(mode)
+    assert any(not np.array_equal(np.asarray(off[name]), np.asarray(changed[name])) for name in off)
+
+
+def test_hard_reset_is_a_full_below_mean_reduction() -> None:
+    changed = _trajectory("hard_reset")
+    assert all(np.isfinite(np.asarray(value)).all() for value in changed.values())

--- a/tests/test_calibrated_partial_reset_ipmnist.py
+++ b/tests/test_calibrated_partial_reset_ipmnist.py
@@ -8,6 +8,7 @@ import pytest
 from alberta_framework.benchmarks.calibrated_partial_reset_ipmnist import (
     ARMS,
     _make_cpr_learner,
+    _partial_reset,
     calibrated_partial_reset_spec,
     persistent_numeric_bytes,
 )
@@ -74,3 +75,28 @@ def test_each_reduction_changes_the_end_to_end_parameter_trajectory(mode: str) -
 def test_hard_reset_is_a_full_below_mean_reduction() -> None:
     changed = _trajectory("hard_reset")
     assert all(np.isfinite(np.asarray(value)).all() for value in changed.values())
+
+
+def test_partial_reset_uses_hidden1_rows_then_hidden2_columns_at_unequal_widths() -> None:
+    params = {
+        "w1": jnp.ones((2, 3), dtype=jnp.float32),
+        "b1": jnp.arange(3, dtype=jnp.float32),
+        "w2": jnp.asarray([[1, 2], [3, 4], [5, 6]], dtype=jnp.float32),
+        "b2": jnp.arange(2, dtype=jnp.float32),
+        "w3": jnp.asarray([[7], [8]], dtype=jnp.float32),
+        "b3": jnp.asarray([9], dtype=jnp.float32),
+    }
+    initial = {name: jnp.full_like(value, 10) for name, value in params.items()}
+    reset = _partial_reset(
+        params,
+        initial,
+        jnp.asarray([0, 2, 0], dtype=jnp.float32),
+        jnp.asarray([2, 0], dtype=jnp.float32),
+        replacement_rate=0.01,
+        sharpness=16.0,
+        mode="hard_reset",
+    )
+    np.testing.assert_array_equal(reset["w2"], np.asarray([[0, 10], [3, 10], [0, 10]]))
+    np.testing.assert_array_equal(reset["w3"], np.asarray([[7], [0]]))
+    for name in ("b1", "b2", "b3"):
+        np.testing.assert_array_equal(reset[name], params[name])


### PR DESCRIPTION
Authoritative successor to #2125. It preserves that PR’s complete contributor lineage and its corrected CPR axes, explicit Threefry roots, paired decision rule, exact JSON boundaries, and nonpromoting policy, then closes the remaining fail-closed gaps.

The successor denies public campaign-roster reexecution while both authorization gates are false; verifies the held output parent remains the visible registered parent after reservation, before link, and after fsync; loops marker/tombstone writes to completion; binds the reread name to the exact prepared inode; and rejects same-byte foreign replacement. The test-only roster remains available for regression.

Exact verification: 25 focused CPR tests passed; Ruff and strict mypy passed; diff and Markdown conflict checks passed. No campaign seed, campaign CLI, dataset download, benchmark, or output was executed.