### PR TITLE
fix(core): cap working-memory decay lists before walk hang

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -124,9 +124,19 @@ class WorkingMemoryConfig:
             if key in payload:
                 value = payload[key]
                 if type(value) is list:
+                    if len(value) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                        raise ValueError(
+                            f"{key} length must be an integer in "
+                            f"[0, {_MAX_WORKING_MEMORY_DECAY_RATES}]"
+                        )
                     payload[key] = tuple(value)
                 elif type(value) is not tuple:
                     raise ValueError(f"{key} must be an actual list or tuple")
+                if len(payload[key]) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                    raise ValueError(
+                        f"{key} length must be an integer in "
+                        f"[0, {_MAX_WORKING_MEMORY_DECAY_RATES}]"
+                    )
                 if any(type(item) is not float for item in payload[key]):
                     raise ValueError(f"serialized {key} values must be JSON numbers")
         for key in ("observation_dim", "action_dim", "reward_dim"):
@@ -216,6 +226,7 @@ class WorkingMemoryArrayResult:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_WORKING_MEMORY_DECAY_RATES = 4_096
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
@@ -287,6 +298,10 @@ def _require_array(
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(rates) > _MAX_WORKING_MEMORY_DECAY_RATES:
+        raise ValueError(
+            f"{name} length must be an integer in [0, {_MAX_WORKING_MEMORY_DECAY_RATES}]"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",

--- a/tests/test_working_memory_decay_count_cap.py
+++ b/tests/test_working_memory_decay_count_cap.py
@@ -1,0 +1,40 @@
+"""Reject oversized working-memory decay lists before per-rate validation hangs."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.working_memory import (
+    _MAX_WORKING_MEMORY_DECAY_RATES,
+    WorkingMemoryConfig,
+)
+
+
+def test_working_memory_decay_cap_constant() -> None:
+    assert _MAX_WORKING_MEMORY_DECAY_RATES == 4096
+
+
+def test_working_memory_accepts_max_observation_decay_count() -> None:
+    WorkingMemoryConfig(
+        observation_dim=1,
+        observation_decay_rates=(0.5,) * _MAX_WORKING_MEMORY_DECAY_RATES,
+        action_decay_rates=(),
+        reward_decay_rates=(),
+    )
+
+
+def test_working_memory_rejects_oversized_observation_decay_count() -> None:
+    with pytest.raises(ValueError, match="observation_decay_rates length"):
+        WorkingMemoryConfig(
+            observation_dim=1,
+            observation_decay_rates=(0.5,) * (_MAX_WORKING_MEMORY_DECAY_RATES + 1),
+            action_decay_rates=(),
+            reward_decay_rates=(),
+        )
+
+
+def test_working_memory_from_config_rejects_oversized_decay_list() -> None:
+    payload = WorkingMemoryConfig(observation_dim=1).to_config()
+    payload["action_decay_rates"] = [0.5] * (_MAX_WORKING_MEMORY_DECAY_RATES + 1)
+    with pytest.raises(ValueError, match="action_decay_rates length"):
+        WorkingMemoryConfig.from_config(payload)


### PR DESCRIPTION
## Summary
- Reject decay-rate lists above 4096 before per-element validation so INT32-legal lengths fail closed.

## Test plan
- [x] pytest for the new test file plus the existing module tests
- [x] ruff check on the touched files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FNYWJ5AS72NK67D9BZDBZ2","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T13:32:24.006Z","completed_at":"2026-08-20T13:35:36.565Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T13:32:24.505Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"834a1d5606b827d7622fe8350e7b2127a06bf9379a54759f4e30c71646c9e20a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"289e202f-6b96-47a1-9249-30c6aeef2f47","object_id":"sha256:834a1d5606b827d7622fe8350e7b2127a06bf9379a54759f4e30c71646c9e20a","sha256":"834a1d5606b827d7622fe8350e7b2127a06bf9379a54759f4e30c71646c9e20a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"OblmQD3Lbtp5QYoVTUZogbrX29Hp0bvRl2rpDCd6c_Fln3wFlFGUrqslndRsMswWvpvUYtbDog4VMDkH3si0Bg"}} -->
