### PR TITLE
fix(core): cap fixed-trace decay lists before walk hang

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -70,6 +70,7 @@ from alberta_framework.core.working_memory import (
 )
 
 _INT32_MAX = 2**31 - 1
+_MAX_STATE_BUILDER_DECAY_RATES = 4_096
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -119,6 +120,10 @@ def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
     rates = cast(tuple[object, ...], value)
+    if len(rates) > _MAX_STATE_BUILDER_DECAY_RATES:
+        raise ValueError(
+            f"{name} length must be an integer in [0, {_MAX_STATE_BUILDER_DECAY_RATES}]"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",
@@ -1042,6 +1047,15 @@ class FixedTraceStateBuilderConfig:
             or not isinstance(out_decays, (list, tuple))
         ):
             raise ValueError("decay rates must be lists or tuples")
+        if (
+            len(obs_decays) > _MAX_STATE_BUILDER_DECAY_RATES
+            or len(act_decays) > _MAX_STATE_BUILDER_DECAY_RATES
+            or len(out_decays) > _MAX_STATE_BUILDER_DECAY_RATES
+        ):
+            raise ValueError(
+                "decay-rate length must be an integer in "
+                f"[0, {_MAX_STATE_BUILDER_DECAY_RATES}]"
+            )
         return cls(
             observation_dim=data["observation_dim"],
             n_actions=data["n_actions"],

--- a/tests/test_state_builder_decay_count_cap.py
+++ b/tests/test_state_builder_decay_count_cap.py
@@ -1,0 +1,40 @@
+"""Reject oversized fixed-trace decay lists before per-rate validation hangs."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.state_builder import (
+    _MAX_STATE_BUILDER_DECAY_RATES,
+    FixedTraceStateBuilderConfig,
+)
+
+
+def test_state_builder_decay_cap_constant() -> None:
+    assert _MAX_STATE_BUILDER_DECAY_RATES == 4096
+
+
+def test_fixed_trace_accepts_max_observation_decay_count() -> None:
+    FixedTraceStateBuilderConfig(
+        observation_dim=1,
+        observation_decay_rates=(0.5,) * _MAX_STATE_BUILDER_DECAY_RATES,
+        action_decay_rates=(),
+        outcome_decay_rates=(),
+    )
+
+
+def test_fixed_trace_rejects_oversized_observation_decay_count() -> None:
+    with pytest.raises(ValueError, match="observation_decay_rates length"):
+        FixedTraceStateBuilderConfig(
+            observation_dim=1,
+            observation_decay_rates=(0.5,) * (_MAX_STATE_BUILDER_DECAY_RATES + 1),
+            action_decay_rates=(),
+            outcome_decay_rates=(),
+        )
+
+
+def test_fixed_trace_from_config_rejects_oversized_decay_list() -> None:
+    payload = FixedTraceStateBuilderConfig(observation_dim=1).to_config()
+    payload["action_decay_rates"] = [0.5] * (_MAX_STATE_BUILDER_DECAY_RATES + 1)
+    with pytest.raises(ValueError, match="decay-rate length"):
+        FixedTraceStateBuilderConfig.from_config(payload)


### PR DESCRIPTION
## Summary
- Reject FixedTraceStateBuilder decay-rate lists above 4096 before per-element validation so INT32-legal lengths fail closed.

## Test plan
- [x] pytest for the new test file plus the existing module tests
- [x] ruff check on the touched files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FP6VCPAYWWA9ETH85201GC","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T13:36:44.950Z","completed_at":"2026-08-20T13:41:02.216Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T13:36:45.598Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ef44414581ac0e0fac4fe2670aaaa026a4476bee146fb6c2445cf5915913f665","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"d10ac523-bdbe-4c09-832d-6a367245243a","object_id":"sha256:ef44414581ac0e0fac4fe2670aaaa026a4476bee146fb6c2445cf5915913f665","sha256":"ef44414581ac0e0fac4fe2670aaaa026a4476bee146fb6c2445cf5915913f665"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"Tuo3jK8Vp8cBqaZfd-6iP8s9eqX89Ecutn7REpiDOmOx3KVubuj8KJ_3Hwz-1_kD13HA0O9HGV4pj0_UthrnDQ"}} -->
