### PR TITLE
fix(core): cap stacked Horde n_demons before walk hang

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -132,6 +132,7 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_STACKED_HORDE_DEMONS = 4_096
 _CONFIG_FIELDS = {
     "type",
     "n_demons",
@@ -170,12 +171,20 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 def _require_sequence(name: str, value: object) -> tuple[object, ...]:
     if type(value) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(value) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"{name} length must be an integer in [0, {_MAX_STACKED_HORDE_DEMONS}]"
+        )
     return cast(tuple[object, ...], value)
 
 
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
     if type(value) not in (list, tuple):
         raise ValueError(f"{name} must be an actual list or tuple")
+    if len(value) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"{name} length must be an integer in [0, {_MAX_STACKED_HORDE_DEMONS}]"
+        )
     return tuple(cast(list[object] | tuple[object, ...], value))
 
 
@@ -257,7 +266,9 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        n_demons = _require_int32(
+            "n_demons", self.n_demons, minimum=1, maximum=_MAX_STACKED_HORDE_DEMONS
+        )
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
         raw_sequences = {
@@ -365,8 +376,11 @@ def nexting_spec(
     )
     canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
     n_demons = len(canonical_indices) * len(canonical_gammas)
-    if n_demons < 1 or n_demons > _INT32_MAX:
-        raise ValueError("derived n_demons must be in the signed int32 domain")
+    if n_demons < 1 or n_demons > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            "derived n_demons must be an integer in "
+            f"[1, {_MAX_STACKED_HORDE_DEMONS}]"
+        )
     _preflight_horde_resources(n_demons, feature_dim)
     _preflight_stacked_horde_update_working_set(n_demons, feature_dim)
     idxs: list[int] = []

--- a/tests/test_stacked_horde_demon_count_cap.py
+++ b/tests/test_stacked_horde_demon_count_cap.py
@@ -1,0 +1,47 @@
+"""Reject oversized stacked-Horde demon counts before per-demon walks hang."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.stacked_horde import (
+    _MAX_STACKED_HORDE_DEMONS,
+    StackedHordeConfig,
+    nexting_spec,
+)
+
+
+def test_stacked_horde_demon_cap_constant() -> None:
+    assert _MAX_STACKED_HORDE_DEMONS == 4096
+
+
+def test_stacked_horde_accepts_max_demon_count() -> None:
+    n = _MAX_STACKED_HORDE_DEMONS
+    StackedHordeConfig(
+        n_demons=n,
+        feature_dim=1,
+        gammas=(0.9,) * n,
+        lamdas=(0.8,) * n,
+        cumulant_indices=(0,) * n,
+    )
+
+
+def test_stacked_horde_rejects_oversized_demon_count() -> None:
+    n = _MAX_STACKED_HORDE_DEMONS + 1
+    with pytest.raises(ValueError, match="n_demons"):
+        StackedHordeConfig(
+            n_demons=n,
+            feature_dim=1,
+            gammas=(0.9,) * n,
+            lamdas=(0.8,) * n,
+            cumulant_indices=(0,) * n,
+        )
+
+
+def test_nexting_spec_rejects_oversized_derived_demon_count() -> None:
+    with pytest.raises(ValueError, match="derived n_demons"):
+        nexting_spec(
+            feature_dim=1,
+            cumulant_indices=tuple(range(65)),
+            gammas=tuple(i / 100.0 for i in range(65)),
+        )


### PR DESCRIPTION
## Summary
- Reject stacked-Horde demon counts above 4096 before per-demon walks so INT32-legal sizes fail closed.

## Test plan
- [x] pytest for the new test file plus the existing module tests
- [x] ruff check on the touched files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FQ0WF2G3R4P7606M548T67","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T13:50:58.019Z","completed_at":"2026-08-20T13:53:11.305Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T13:50:58.646Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"afa133b75f3eec0d3fcc78f55d5f9560b529b0fe5e0c16357f9ab26ff2cfcf56","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2b881baf-13ad-42dc-8ef2-6775b4894e32","object_id":"sha256:afa133b75f3eec0d3fcc78f55d5f9560b529b0fe5e0c16357f9ab26ff2cfcf56","sha256":"afa133b75f3eec0d3fcc78f55d5f9560b529b0fe5e0c16357f9ab26ff2cfcf56"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"MHJ93Tqp4V7Z7K-8iqAdRcfUikgzFKrTYFovsEEuQdn_abI6uhx6eyo-QMKDsonSo3XkYPYoOhmw6L-pXPf2Bg"}} -->
