### PR TITLE
fix(campaign): preflight output filesystem publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made activation/feature campaign output reservation probe the destination
+  filesystem's linkable-`O_TMPFILE` capability before plan admission, dataset
+  access, or execution, so partially supported Linux filesystems fail early
+  instead of losing a completed shard at publication time.
 - Canonicalized discounted-SARSA lifecycle timers at the exact-dispatch
   reference-control boundary. The first compiled update can no longer grow
   persistent numeric state by promoting two host floats into JAX leaves, so

--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -1495,7 +1495,8 @@ def _probe_linkable_tmpfile(parent_fd: int, destination_name: str) -> None:
     """Fail before campaign work when this output filesystem cannot publish atomically."""
     if not hasattr(os, "O_TMPFILE"):
         raise OSError("immutable publication requires Linux O_TMPFILE support")
-    probe_name = f".{destination_name}.publication-probe"
+    destination_digest = hashlib.sha256(destination_name.encode("utf-8")).hexdigest()[:16]
+    probe_name = f".publication-probe-{destination_digest}"
     probe_fd: int | None = None
     probe_identity: tuple[int, int] | None = None
     linked = False

--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -1454,6 +1454,7 @@ def _reserved_new_output(path: Path) -> Iterator[tuple[Path, int, str]]:
         os.close(reservation_fd)
         reservation_fd = None
         os.fsync(parent_fd)
+        _probe_linkable_tmpfile(parent_fd, destination.name)
         yield destination, parent_fd, reservation_name
     finally:
         if reservation_fd is not None:
@@ -1488,6 +1489,57 @@ def _link_unnamed_file(file_fd: int, parent_fd: int, name: str) -> None:
         if error == errno.EEXIST:
             raise FileExistsError(error, os.strerror(error), name)
         raise OSError(error, os.strerror(error), name)
+
+
+def _probe_linkable_tmpfile(parent_fd: int, destination_name: str) -> None:
+    """Fail before campaign work when this output filesystem cannot publish atomically."""
+    if not hasattr(os, "O_TMPFILE"):
+        raise OSError("immutable publication requires Linux O_TMPFILE support")
+    probe_name = f".{destination_name}.publication-probe"
+    probe_fd: int | None = None
+    probe_identity: tuple[int, int] | None = None
+    linked = False
+    try:
+        try:
+            os.stat(probe_name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise FileExistsError(f"publication capability probe already exists: {probe_name}")
+        probe_fd = os.open(
+            ".",
+            os.O_WRONLY | os.O_CLOEXEC | os.O_TMPFILE,
+            0o600,
+            dir_fd=parent_fd,
+        )
+        probe_stat = os.fstat(probe_fd)
+        probe_identity = (probe_stat.st_dev, probe_stat.st_ino)
+        try:
+            _link_unnamed_file(probe_fd, parent_fd, probe_name)
+        except OSError as error:
+            raise OSError(
+                "campaign output filesystem cannot link O_TMPFILE; "
+                "choose a filesystem with linkable unnamed-inode support"
+            ) from error
+        linked = True
+        linked_stat = os.stat(probe_name, dir_fd=parent_fd, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(linked_stat.st_mode)
+            or (linked_stat.st_dev, linked_stat.st_ino) != probe_identity
+        ):
+            raise OSError("campaign output filesystem linked the wrong probe inode")
+    finally:
+        if linked:
+            try:
+                current = os.stat(probe_name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                if (current.st_dev, current.st_ino) == probe_identity:
+                    os.unlink(probe_name, dir_fd=parent_fd)
+                    os.fsync(parent_fd)
+        if probe_fd is not None:
+            os.close(probe_fd)
 
 
 def _load_json_strict_at(

--- a/docs/research/activation-feature-comparison.md
+++ b/docs/research/activation-feature-comparison.md
@@ -119,6 +119,9 @@ Plan, shard, and aggregate publication pins every path segment with no-follow
 directory descriptors, reserves the destination with deterministic `O_EXCL`
 before dataset access or execution, publishes without replacement, fsyncs, and
 strictly rereads and validates the linked file. No retained campaign result exists.
+The output filesystem must support linking an unnamed inode created with
+`O_TMPFILE`; the reservation path probes that capability and fails before plan
+admission, dataset access, or campaign work when the filesystem cannot provide it.
 
 No campaign mutation is enabled by this freeze. `plan`, `run-shard`, and
 `summarize` all fail before output reservation or dataset access while the

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import errno
+import hashlib
 import json
 import os
 from collections.abc import Iterator
@@ -782,9 +783,12 @@ def test_publication_rejects_zero_write_and_nonregular_reread_swap(
 def test_reservation_rejects_unlinkable_tmpfile_before_work(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, authorized: None
 ) -> None:
-    destination = tmp_path / "result.json"
+    destination_name = f"{'x' * 232}.json"
+    destination = tmp_path / destination_name
+    linked_names: list[str] = []
 
-    def reject_link(_file_fd: int, _parent_fd: int, _name: str) -> None:
+    def reject_link(_file_fd: int, _parent_fd: int, name: str) -> None:
+        linked_names.append(name)
         raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
 
     monkeypatch.setattr(campaign, "_link_unnamed_file", reject_link)
@@ -793,5 +797,8 @@ def test_reservation_rejects_unlinkable_tmpfile_before_work(
         with campaign._reserved_new_output(destination):
             entered = True
     assert entered is False
+    assert linked_names == [
+        f".publication-probe-{hashlib.sha256(destination_name.encode()).hexdigest()[:16]}"
+    ]
     assert not destination.exists()
-    assert not (tmp_path / ".result.json.reservation").exists()
+    assert not (tmp_path / f".{destination_name}.reservation").exists()

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import errno
 import json
 import os
 from collections.abc import Iterator
@@ -605,13 +606,20 @@ def test_aggregate_rejects_missing_duplicate_and_self_consistent_statistic_forge
         campaign.validate_aggregate(aggregate)
 
 
-@pytest.mark.skipif(
-    not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_TMPFILE")),
-    reason="strict loader/publication requires Linux descriptor support",
-)
+def _require_publication_filesystem(tmp_path: Path, authorized: None) -> None:
+    try:
+        with campaign._reserved_new_output(tmp_path / "capability-probe.json"):
+            pass
+    except OSError as error:
+        if "requires Linux" in str(error) or "cannot link O_TMPFILE" in str(error):
+            pytest.skip(str(error))
+        raise
+
+
 def test_strict_file_admission_and_append_only_writer(
     cheap_plan: dict[str, object], tmp_path: Path, authorized: None
 ) -> None:
+    _require_publication_filesystem(tmp_path, authorized)
     destination = tmp_path / "plan.json"
     campaign.write_new_json(destination, cheap_plan)
     assert campaign.load_json_strict(destination, max_bytes=campaign._MAX_SHARD_BYTES) == cheap_plan
@@ -686,13 +694,10 @@ def test_summarizer_uses_metadata_from_the_descriptor_that_supplied_bytes(
     assert swapped is True
 
 
-@pytest.mark.skipif(
-    not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_TMPFILE")),
-    reason="descriptor-pinned publication requires Linux",
-)
 def test_reserved_publication_resists_parent_swap_and_occupied_race(
     cheap_plan: dict[str, object], tmp_path: Path, authorized: None
 ) -> None:
+    _require_publication_filesystem(tmp_path, authorized)
     requested_parent = tmp_path / "requested"
     requested_parent.mkdir()
     destination = requested_parent / "result.json"
@@ -712,16 +717,13 @@ def test_reserved_publication_resists_parent_swap_and_occupied_race(
     assert occupied.read_text(encoding="utf-8") == "do not replace"
 
 
-@pytest.mark.skipif(
-    not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_TMPFILE")),
-    reason="descriptor-pinned publication requires Linux",
-)
 def test_reservation_is_exclusive_before_work_and_publication_strictly_rereads(
     cheap_plan: dict[str, object],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     authorized: None,
 ) -> None:
+    _require_publication_filesystem(tmp_path, authorized)
     destination = tmp_path / "plan.json"
     with campaign._reserved_new_output(destination) as target:
         with pytest.raises(FileExistsError, match="reserved"):
@@ -744,16 +746,13 @@ def test_reservation_is_exclusive_before_work_and_publication_strictly_rereads(
     ) == cheap_plan
 
 
-@pytest.mark.skipif(
-    not all(hasattr(os, name) for name in ("O_NOFOLLOW", "O_TMPFILE")),
-    reason="descriptor-pinned publication requires Linux",
-)
 def test_publication_rejects_zero_write_and_nonregular_reread_swap(
     cheap_plan: dict[str, object],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     authorized: None,
 ) -> None:
+    _require_publication_filesystem(tmp_path, authorized)
     short_output = tmp_path / "short.json"
     with campaign._reserved_new_output(short_output) as target:
         monkeypatch.setattr(os, "write", lambda *_args, **_kwargs: 0)
@@ -774,3 +773,25 @@ def test_publication_rejects_zero_write_and_nonregular_reread_swap(
         monkeypatch.setattr(campaign, "_link_unnamed_file", link_then_swap)
         with pytest.raises(ValueError, match="regular file"):
             campaign._publish_reserved_json(target, cheap_plan)
+
+
+@pytest.mark.skipif(
+    not all(hasattr(os, name) for name in ("O_DIRECTORY", "O_NOFOLLOW", "O_TMPFILE")),
+    reason="unlinkable-O_TMPFILE regression requires Linux descriptor support",
+)
+def test_reservation_rejects_unlinkable_tmpfile_before_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, authorized: None
+) -> None:
+    destination = tmp_path / "result.json"
+
+    def reject_link(_file_fd: int, _parent_fd: int, _name: str) -> None:
+        raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
+
+    monkeypatch.setattr(campaign, "_link_unnamed_file", reject_link)
+    entered = False
+    with pytest.raises(OSError, match="cannot link O_TMPFILE"):
+        with campaign._reserved_new_output(destination):
+            entered = True
+    assert entered is False
+    assert not destination.exists()
+    assert not (tmp_path / ".result.json.reservation").exists()


### PR DESCRIPTION
## Summary

Follow-up for #1566 after merged #2109.

- probes the actual destination filesystem's ability to link an `O_TMPFILE` during output reservation, before plan admission, dataset access, or campaign execution
- fails early with an actionable filesystem error instead of completing work and then losing the result at publication
- cleans the linked probe through the pinned parent descriptor and verifies its inode identity before unlinking
- makes publication tests use the same runtime capability boundary and adds a regression proving an unlinkable unnamed inode prevents entry into protected work
- documents the required filesystem capability and records the fix in the changelog

No campaign workload or output was executed. This does not authorize execution, promote evidence, or close #1566.

## Reproduction and verification

Before the fix, exact #2109 head `bea0a04f0b69a7105679e424df124910498f8e44` produced 4 failures in the focused suite on this Linux filesystem: `O_TMPFILE` exists, but `linkat(..., AT_EMPTY_PATH)` returns `ENOENT`.

On this PR head:

- `python -m pytest tests/test_activation_feature_campaign.py tests/test_activation_feature_ipmnist.py tests/test_console_entrypoints.py tests/test_release_metadata.py -q` — **44 passed, 4 skipped**; the four successful-publication tests skip because this filesystem cannot provide the required capability, while the simulated early-failure regression passes
- scoped Ruff — passed
- strict mypy for `activation_feature_campaign.py` — passed
- `git diff --check origin/main...HEAD` — passed

The repository evidence registry remains invalid from pre-existing registered-source drift on current `main`; this patch does not edit any of the registered source files named by that report and does not alter pinned artifacts.

## Evidence

<!-- evidence-head:87dc1b33c9d67e0b7cd553cfb6e4a1dc96019474 -->
<!-- evidence-row:logs -->
- [x] logs: [current-head verification log](https://github.com/user-attachments/files/31577815/pr2145-current-head-verification.log)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [current-head domain artifact](https://github.com/user-attachments/files/31577817/pr2145-current-head-domain-artifact.json)

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Attribution status: self-reported
