### PR TITLE
fix(core): align STOMP importance ratios with Gumbel behavior policy

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1069,7 +1069,7 @@ def _epsilon_greedy_action_probabilities(q_values: Array, epsilon: Array) -> Arr
     n_actions = q.shape[0]
     eps = jnp.asarray(epsilon, dtype=jnp.float32)
     scale = jnp.asarray(_GUMBEL_TIE_BREAK_SCALE, dtype=jnp.float32)
-    greedy = jax.nn.softmax(q / scale)
+    greedy = jax.nn.softmax((q - jnp.max(q)) / scale)
     return eps / n_actions + (1.0 - eps) * greedy
 
 

--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -972,6 +972,14 @@ def check_option_terminated(
 # ---------------------------------------------------------------------------
 
 
+# Scale of the Gumbel perturbation used for greedy tie-breaking in action
+# selection.  ``argmax(q + _GUMBEL_TIE_BREAK_SCALE * Gumbel(0, 1))`` draws the
+# greedy action from ``softmax(q / _GUMBEL_TIE_BREAK_SCALE)`` (the Gumbel-max
+# identity), so the importance-ratio probabilities must use the same scale to
+# describe the policy that actually generated the action.
+_GUMBEL_TIE_BREAK_SCALE = 1e-6
+
+
 def _q_values_for_obs(q_weights: Array, observation: Array) -> Array:
     """Compute Q(s, ·) = q_weights @ obs for all actions."""
     return q_weights @ observation
@@ -987,7 +995,9 @@ def _select_action_epsilon_greedy(
     """ε-greedy action selection with Gumbel tie-breaking."""
     key, explore_key, noise_key = jr.split(key, 3)
     q_vals = _q_values_for_obs(q_weights, observation)
-    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(jnp.int32)
+    greedy = jnp.argmax(
+        q_vals + _GUMBEL_TIE_BREAK_SCALE * jr.gumbel(noise_key, (n_actions,))
+    ).astype(jnp.int32)
     random_action = jr.randint(explore_key, (), 0, n_actions).astype(jnp.int32)
     explore = jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32)
     action = jnp.where(explore, random_action, greedy)
@@ -1002,7 +1012,9 @@ def _select_action_epsilon_greedy_from_q(
 ) -> tuple[Array, Array]:
     """ε-greedy action selection from pre-computed Q values."""
     key, explore_key, noise_key = jr.split(key, 3)
-    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(jnp.int32)
+    greedy = jnp.argmax(
+        q_vals + _GUMBEL_TIE_BREAK_SCALE * jr.gumbel(noise_key, (n_actions,))
+    ).astype(jnp.int32)
     random_action = jr.randint(explore_key, (), 0, n_actions).astype(jnp.int32)
     explore = jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32)
     action = jnp.where(explore, random_action, greedy)
@@ -1024,7 +1036,7 @@ def _select_action_epsilon_greedy_from_q_masked(
 
     n_actions = q_vals.shape[0]
     key, explore_key, noise_key = jr.split(key, 3)
-    noisy = q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))
+    noisy = q_vals + _GUMBEL_TIE_BREAK_SCALE * jr.gumbel(noise_key, (n_actions,))
     masked_noisy = jnp.where(action_mask, noisy, -jnp.inf)
     greedy = jnp.argmax(masked_noisy).astype(jnp.int32)
     eligible_count = jnp.sum(action_mask.astype(jnp.int32))
@@ -1042,14 +1054,23 @@ def _select_action_epsilon_greedy_from_q_masked(
 
 
 def _epsilon_greedy_action_probabilities(q_values: Array, epsilon: Array) -> Array:
-    """Return epsilon-greedy probabilities with uniform tie handling."""
+    """Return epsilon-greedy probabilities matching Gumbel-max action selection.
+
+    Action selection draws ``argmax(q + _GUMBEL_TIE_BREAK_SCALE * Gumbel(0, 1))``,
+    whose greedy component is distributed as
+    ``softmax(q / _GUMBEL_TIE_BREAK_SCALE)`` by the Gumbel-max identity.  Using
+    that exact distribution keeps the importance-ratio numerator and denominator
+    on the same policy that generated the action: exactly tied values collapse to
+    a uniform split over the maximisers, well-separated values collapse to a hard
+    greedy choice, and near-ties within the tie-break scale receive the smooth
+    Gumbel-max weights instead of the previous hard ``isclose`` uniform split.
+    """
     q = jnp.asarray(q_values, dtype=jnp.float32)
     n_actions = q.shape[0]
     eps = jnp.asarray(epsilon, dtype=jnp.float32)
-    max_q = jnp.max(q)
-    greedy_mask = jnp.isclose(q, max_q, atol=1e-6, rtol=0.0).astype(jnp.float32)
-    n_greedy = jnp.maximum(jnp.sum(greedy_mask), jnp.array(1.0, dtype=jnp.float32))
-    return eps / n_actions + (1.0 - eps) * greedy_mask / n_greedy
+    scale = jnp.asarray(_GUMBEL_TIE_BREAK_SCALE, dtype=jnp.float32)
+    greedy = jax.nn.softmax(q / scale)
+    return eps / n_actions + (1.0 - eps) * greedy
 
 
 def _clipped_epsilon_greedy_importance_ratio(

--- a/tests/test_stomp_gumbel_importance_ratio.py
+++ b/tests/test_stomp_gumbel_importance_ratio.py
@@ -80,6 +80,27 @@ def test_exact_ties_remain_uniform() -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("q_values", "expected"),
+    [
+        ([1.0e38, 1.0e38], [0.5, 0.5]),
+        ([3.0e38, 3.1e38], [0.0, 1.0]),
+    ],
+)
+def test_float32_boundary_values_remain_finite(
+    q_values: list[float], expected: list[float]
+) -> None:
+    """Centering before scaling prevents overflow for large finite Q-values."""
+    greedy = _epsilon_greedy_action_probabilities(
+        jnp.asarray(q_values, dtype=jnp.float32), jnp.asarray(0.0)
+    )
+
+    probabilities = np.asarray(greedy)
+    assert np.all(np.isfinite(probabilities))
+    np.testing.assert_allclose(probabilities, expected, rtol=0.0, atol=1e-6)
+
+
+@pytest.mark.unit
 def test_well_separated_values_are_hard_greedy() -> None:
     """Q-values separated far beyond the tie-break scale act like a hard argmax."""
     q_values = jnp.asarray([0.0, 5.0], dtype=jnp.float32)

--- a/tests/test_stomp_gumbel_importance_ratio.py
+++ b/tests/test_stomp_gumbel_importance_ratio.py
@@ -1,0 +1,127 @@
+"""Regression tests: STOMP importance ratios must match the Gumbel behavior policy.
+
+Action selection draws ``argmax(q + _GUMBEL_TIE_BREAK_SCALE * Gumbel(0, 1))``,
+whose greedy component is ``softmax(q / _GUMBEL_TIE_BREAK_SCALE)``.  The
+importance-ratio helper previously treated any values within ``1e-6`` of the
+maximum as a hard uniform tie, which disagreed with the policy that actually
+generated the action for near-tied Q-values.  These tests pin the exact
+Gumbel-max probabilities while preserving exact-tie and well-separated limits.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.options import (
+    _GUMBEL_TIE_BREAK_SCALE,
+    _clipped_epsilon_greedy_importance_ratio,
+    _epsilon_greedy_action_probabilities,
+)
+
+
+def _reference_probabilities(q_values: np.ndarray, epsilon: float) -> np.ndarray:
+    """Independent NumPy reference for softmax-based epsilon-greedy probabilities."""
+    q = np.asarray(q_values, dtype=np.float64)
+    scaled = q / _GUMBEL_TIE_BREAK_SCALE
+    scaled = scaled - scaled.max()
+    greedy = np.exp(scaled) / np.exp(scaled).sum()
+    n = q.shape[0]
+    return epsilon / n + (1.0 - epsilon) * greedy
+
+
+@pytest.mark.unit
+def test_near_tie_probabilities_match_gumbel_max_distribution() -> None:
+    """Near-tied Q-values follow softmax(q / scale), not a hard uniform split."""
+    q_values = jnp.asarray([0.0, 5.0e-7], dtype=jnp.float32)
+
+    greedy = _epsilon_greedy_action_probabilities(q_values, jnp.asarray(0.0))
+
+    # The old hard-tie helper returned [0.5, 0.5] here; the correct Gumbel-max
+    # greedy distribution is markedly asymmetric.
+    np.testing.assert_allclose(
+        np.asarray(greedy), [0.37754068, 0.62245935], rtol=0.0, atol=1e-6
+    )
+
+
+@pytest.mark.unit
+def test_near_tie_importance_ratio_matches_issue_example() -> None:
+    """The #2136 example: ratios must be [~0.939, ~1.041], not [1.0, 1.0]."""
+    # q_weights @ observation = [0, 5e-7] with a single scalar feature.
+    q_weights = jnp.asarray([[0.0], [5.0e-7]], dtype=jnp.float32)
+    observation = jnp.asarray([1.0], dtype=jnp.float32)
+
+    ratios = [
+        float(
+            _clipped_epsilon_greedy_importance_ratio(
+                q_weights,
+                observation,
+                jnp.asarray(action, dtype=jnp.int32),
+                behavior_epsilon=0.2,
+                target_epsilon=0.0,
+                clip=10.0,
+            )
+        )
+        for action in (0, 1)
+    ]
+
+    np.testing.assert_allclose(ratios, [0.9390799, 1.0409585], rtol=0.0, atol=1e-6)
+    # The regression being fixed: these must not collapse to the uniform-tie ratio.
+    assert not np.allclose(ratios, [1.0, 1.0], atol=1e-3)
+
+
+@pytest.mark.unit
+def test_exact_ties_remain_uniform() -> None:
+    """Exactly equal Q-values still split greedy mass uniformly."""
+    q_values = jnp.asarray([1.0, 1.0, 1.0], dtype=jnp.float32)
+
+    greedy = _epsilon_greedy_action_probabilities(q_values, jnp.asarray(0.0))
+
+    np.testing.assert_allclose(np.asarray(greedy), [1 / 3, 1 / 3, 1 / 3], atol=1e-6)
+
+
+@pytest.mark.unit
+def test_well_separated_values_are_hard_greedy() -> None:
+    """Q-values separated far beyond the tie-break scale act like a hard argmax."""
+    q_values = jnp.asarray([0.0, 5.0], dtype=jnp.float32)
+
+    greedy = _epsilon_greedy_action_probabilities(q_values, jnp.asarray(0.0))
+
+    np.testing.assert_allclose(np.asarray(greedy), [0.0, 1.0], atol=1e-6)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("epsilon", [0.0, 0.1, 0.35, 1.0])
+def test_probabilities_are_normalised_and_match_reference(epsilon: float) -> None:
+    """Probabilities sum to one and match an independent NumPy reference."""
+    q_np = np.asarray([0.0, 2.0e-7, -3.0e-7, 1.0], dtype=np.float32)
+    q_values = jnp.asarray(q_np, dtype=jnp.float32)
+
+    probs = np.asarray(
+        _epsilon_greedy_action_probabilities(q_values, jnp.asarray(epsilon))
+    )
+
+    np.testing.assert_allclose(probs.sum(), 1.0, atol=1e-6)
+    assert np.all(probs >= 0.0)
+    np.testing.assert_allclose(
+        probs, _reference_probabilities(q_np, epsilon), rtol=0.0, atol=1e-6
+    )
+
+
+@pytest.mark.unit
+def test_importance_ratio_respects_clip() -> None:
+    """A tight clip bounds the returned ratio."""
+    q_weights = jnp.asarray([[0.0], [5.0e-7]], dtype=jnp.float32)
+    observation = jnp.asarray([1.0], dtype=jnp.float32)
+
+    ratio = float(
+        _clipped_epsilon_greedy_importance_ratio(
+            q_weights,
+            observation,
+            jnp.asarray(1, dtype=jnp.int32),
+            behavior_epsilon=0.2,
+            target_epsilon=0.0,
+            clip=1.02,
+        )
+    )
+
+    assert ratio == pytest.approx(1.02, abs=1e-6)


### PR DESCRIPTION
## Summary

Fixes #2136. STOMP's intra-option behavior selector draws the greedy action with
Gumbel tie-breaking, `argmax(q + 1e-6 · Gumbel(0, 1))`. By the Gumbel-max
identity this samples from `softmax(q / 1e-6)`, but `_epsilon_greedy_action_probabilities`
computed the greedy component with a hard `isclose(atol=1e-6)` tie mask. For
near-tied Q-values the two disagree, so the importance ratio scaled eligibility
traces, weight updates, and the differential average-reward update with
probabilities from a **different policy than the one that generated the action**.

Concretely, for `q = [0, 5e-7]`, behavior ε = 0.2, target ε = 0:

| quantity | before (buggy) | after (this PR) |
|---|---|---|
| greedy probs | `[0.5, 0.5]` | `[0.37754068, 0.62245935]` |
| target/behavior ratio | `[1.0, 1.0]` | `[0.9390799, 1.0409585]` |

## Change

- Replace the hard-tie mask with the exact Gumbel-max distribution
  `jax.nn.softmax(q / scale)`.
- Introduce a shared module constant `_GUMBEL_TIE_BREAK_SCALE = 1e-6`, now used
  by both the three action-selection sites and the probability helper, so the
  selection policy and its importance-ratio model can never drift apart again.
  Substituting the constant for the `1e-6` literal is bit-identical, so action
  selection (and its RNG parity) is unchanged.

Limiting behavior is preserved: exact ties collapse to a uniform split,
well-separated values collapse to a hard greedy choice, and only near-ties
within the tie-break scale change — to the correct smooth weights.

## Tests

New `tests/test_stomp_gumbel_importance_ratio.py` (all `@pytest.mark.unit`):

- pins the issue's exact greedy probabilities and ratios, and asserts they do
  **not** collapse to the old `[1.0, 1.0]`;
- exact-tie uniform and well-separated hard-greedy limits;
- normalization + an independent NumPy reference across ε ∈ {0, 0.1, 0.35, 1.0};
- clip is respected.

Failing-test-first confirmed: the pre-fix helper yields `[0.5, 0.5]` / `[1.0, 1.0]`,
which the new tests reject. `ruff` (line-length 100) and `mypy` (strict) are
clean; the existing STOMP/OaK/options/off-policy suites (372 tests) pass.

## ⚠️ Evidence registry impact (by design — needs maintainer action)

`alberta_framework/core/options.py` is a registered source for the
`continual_intelligence_amplification` claim (evidence_manifest.py). Per the
fail-closed rules in `CLAUDE.md`, changing its bytes changes the source hash, so
`alberta-evidence-status` will report that claim `invalid` (exit 2) until its
frozen protocol is rerun. I intentionally did **not** modify any pinned artifact,
snapshot, or manifest to mask this — it is the documented, correct consequence of
a library fix to a registered file. A maintainer should rerun the IA protocol to
re-pin provenance.

## Review-blocker resolution

Resolved at exact head `eeb70d80f7d452372526e572b05eb1cd0a98a7a1`. Following the changes-requested review, the implementation now centers finite float32 Q-values before scaling:

```python
greedy = jax.nn.softmax((q - jnp.max(q)) / scale)
```

This preserves the near-tie probabilities while preventing overflow for large finite inputs. Added boundary regressions cover `[1e38, 1e38] -> [0.5, 0.5]` and `[3e38, 3.1e38] -> [0.0, 1.0]`, with finite-output assertions. Current-head verification reported 37 focused tests and 452 broader STOMP/OaK/options/off-policy tests passing, plus ruff, strict mypy, and `git diff --check`. A renewed independent review of this head remains required.