### PR TITLE
fix(benchmarks): validate rule-discovery shards through the screening loader

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery_summary.py
+++ b/alberta_framework/benchmarks/rule_discovery_summary.py
@@ -12,8 +12,8 @@ from typing import Any
 import numpy as np
 
 import alberta_framework.benchmarks.rule_discovery as rule_discovery_module
-from alberta_framework._seed_validation import require_jax_seed, require_unique_jax_seeds
-from alberta_framework._strict_json import load_strict_json_object
+from alberta_framework._seed_validation import require_unique_jax_seeds
+from alberta_framework.benchmarks import ipmnist_screening
 from alberta_framework.benchmarks.ipmnist_provenance import analysis_provenance
 from alberta_framework.benchmarks.rule_discovery import NONPROMOTING_POLICY
 
@@ -36,29 +36,51 @@ DISCOVERY_ARMS = (
 )
 CHAMPION = "sigma0_shiftnorm_d099"
 
+# Rule-discovery shards belong to a single IPMNIST protocol with two stages: a
+# 60-task development screen and a 200-task confirmation, both at 5,000 steps per
+# task.  The arm identity, the stage task count, and the task length are all
+# load-bearing: without them a shard from the wrong arm or the wrong stage would
+# be aggregated and republished under valid-looking provenance (issue #2134).
+_SCREEN_TASK_COUNT = 60
+_CONFIRM_TASK_COUNT = 200
+_REQUIRED_TASK_LENGTH = 5000
 
-def _arm(directory: Path, name: str, seeds: Sequence[int]) -> dict[str, Any]:
+
+def _arm(
+    directory: Path,
+    name: str,
+    seeds: Sequence[int],
+    *,
+    expected_task_count: int,
+) -> dict[str, Any]:
     values = []
     for seed in seeds:
         path = directory / f"{name}_seed{seed}.json"
         if not path.exists():
             raise ValueError(f"{name} is missing seed {seed} in {directory}")
-        payload = load_strict_json_object(path)
-        if (
-            type(payload.get("per_task_accuracy")) is not list
-            or not payload["per_task_accuracy"]
-        ):
-            raise ValueError(f"{path} lacks per_task_accuracy")
-        payload_seed = require_jax_seed(payload.get("seed"), name=f"{path} seed")
-        if payload_seed != seed:
+        # ``load_shard`` is the strict screening boundary: it validates the
+        # schema, registered arm membership, curve domain/length, seed, and the
+        # registered-compatible noise mode before we trust any measurement.
+        shard = ipmnist_screening.load_shard(path)
+        if shard["config_name"] != name:
+            raise ValueError(
+                f"{path} reports arm {shard['config_name']!r}, not the expected "
+                f"{name!r}"
+            )
+        if shard["seed"] != seed:
             raise ValueError(f"{path} seed does not match requested seed {seed}")
-        accuracy = np.asarray(payload["per_task_accuracy"], dtype=np.float64)
-        if (
-            accuracy.ndim != 1
-            or not bool(np.all(np.isfinite(accuracy)))
-            or not bool(np.all((0.0 <= accuracy) & (accuracy <= 1.0)))
-        ):
-            raise ValueError(f"{path} has invalid per_task_accuracy")
+        config = shard["config"]
+        if config["n_tasks"] != expected_task_count:
+            raise ValueError(
+                f"{path} has {config['n_tasks']} tasks, not the {expected_task_count} "
+                "required for this stage"
+            )
+        if config["task_length"] != _REQUIRED_TASK_LENGTH:
+            raise ValueError(
+                f"{path} has task_length {config['task_length']}, not the required "
+                f"{_REQUIRED_TASK_LENGTH}"
+            )
+        accuracy = np.asarray(shard["per_task_accuracy"], dtype=np.float64)
         values.append(float(np.mean(accuracy)))
     return {"per_seed": values, "mean": float(np.mean(values))}
 
@@ -71,7 +93,10 @@ def build_legacy_rule_discovery_summary(
 ) -> dict[str, Any]:
     """Reconstruct the exact legacy v1 payload for compatibility checks."""
     seeds = require_unique_jax_seeds(seeds)
-    screen = {name: _arm(screen_dir, name, seeds) for name in SCREEN_ARMS}
+    screen = {
+        name: _arm(screen_dir, name, seeds, expected_task_count=_SCREEN_TASK_COUNT)
+        for name in SCREEN_ARMS
+    }
     confirm_names = ("disc_r1_pscale_norms", CHAMPION)
     present = [
         (confirm_dir / f"{name}_seed{seed}.json").exists()
@@ -81,7 +106,10 @@ def build_legacy_rule_discovery_summary(
     if any(present) and not all(present):
         raise ValueError("rule-discovery confirmation seeds are incomplete")
     full = (
-        {name: _arm(confirm_dir, name, seeds) for name in confirm_names}
+        {
+            name: _arm(confirm_dir, name, seeds, expected_task_count=_CONFIRM_TASK_COUNT)
+            for name in confirm_names
+        }
         if all(present)
         else {}
     )
@@ -155,6 +183,9 @@ def build_rule_discovery_summary(
         sources={
             "rule_discovery": Path(rule_discovery_module.__file__),
             "rule_discovery_summary": Path(__file__),
+            # The screening loader is now part of the trusted validation path,
+            # so its source is bound into the maintained analysis provenance.
+            "ipmnist_screening": Path(ipmnist_screening.__file__),
         },
         repository_root=Path(__file__).resolve().parents[2],
     )

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -24,6 +24,7 @@ from alberta_framework.benchmarks.ipmnist_ceiling import (
     run_arm_per_step,
     run_batch_reference,
 )
+from alberta_framework.benchmarks.ipmnist_screening import LEGACY_SHARD_SCHEMA
 from alberta_framework.benchmarks.rule_discovery_summary import (
     CHAMPION,
     SCREEN_ARMS,
@@ -51,6 +52,50 @@ def _shard(path: Path, *, seed: int, accuracy: float) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps({"seed": seed, "per_task_accuracy": [accuracy, accuracy]}),
+        encoding="utf-8",
+    )
+
+
+def _rule_shard(
+    path: Path, *, config_name: str, seed: int, accuracy: float, n_tasks: int = 60
+) -> None:
+    """Write a strictly valid legacy-v1 screening shard the loader accepts.
+
+    The maintained rule-discovery summary now validates every shard through
+    ``ipmnist_screening.load_shard``, so its fixtures must be complete v1 shards
+    rather than the bare seed/accuracy stub used by the other analyzers.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": LEGACY_SHARD_SCHEMA,
+                "config_name": config_name,
+                "base_learner": "upgd_w",
+                "seed": seed,
+                "noise_mode": "step",
+                "hyperparameters": {},
+                "config": {
+                    "input_dim": 784,
+                    "hidden1": 300,
+                    "hidden2": 150,
+                    "n_classes": 10,
+                    "n_tasks": n_tasks,
+                    "task_length": 5000,
+                },
+                "per_task_accuracy": [accuracy] * n_tasks,
+                "per_task_loss": [0.5] * n_tasks,
+                "per_task_plasticity": [0.5] * n_tasks,
+                "wall_clock_seconds": 12.0,
+                "created_unix": 1785805898.0,
+                "environment": {
+                    "jax": "0.7.1",
+                    "numpy": "1.26.0",
+                    "python": "3.12.3",
+                    "platform": "linux",
+                },
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -677,7 +722,12 @@ def test_rule_discovery_summary_uses_explicit_directories(tmp_path: Path) -> Non
     for name in SCREEN_ARMS:
         for seed in (0, 1, 2):
             accuracy = 0.8 if name == CHAMPION else 0.79
-            _shard(screen / f"{name}_seed{seed}.json", seed=seed, accuracy=accuracy)
+            _rule_shard(
+                screen / f"{name}_seed{seed}.json",
+                config_name=name,
+                seed=seed,
+                accuracy=accuracy,
+            )
 
     summary = build_rule_discovery_summary(screen, confirm)
 
@@ -740,7 +790,12 @@ def test_rule_summary_requires_payload_seed_to_match_requested_seed(
     tmp_path: Path,
 ) -> None:
     screen = tmp_path / "screen"
-    _shard(screen / f"{SCREEN_ARMS[0]}_seed0.json", seed=1, accuracy=0.8)
+    _rule_shard(
+        screen / f"{SCREEN_ARMS[0]}_seed0.json",
+        config_name=SCREEN_ARMS[0],
+        seed=1,
+        accuracy=0.8,
+    )
     with pytest.raises(ValueError, match="does not match requested seed"):
         build_legacy_rule_discovery_summary(
             screen, tmp_path / "confirm", seeds=(0,)
@@ -752,9 +807,18 @@ def test_rule_summary_rejects_partial_confirmation_seed_set(tmp_path: Path) -> N
     confirm = tmp_path / "confirm"
     for name in SCREEN_ARMS:
         for seed in (0, 1):
-            _shard(screen / f"{name}_seed{seed}.json", seed=seed, accuracy=0.8)
-    _shard(
-        confirm / "disc_r1_pscale_norms_seed0.json", seed=0, accuracy=0.8
+            _rule_shard(
+                screen / f"{name}_seed{seed}.json",
+                config_name=name,
+                seed=seed,
+                accuracy=0.8,
+            )
+    _rule_shard(
+        confirm / "disc_r1_pscale_norms_seed0.json",
+        config_name="disc_r1_pscale_norms",
+        seed=0,
+        accuracy=0.8,
+        n_tasks=200,
     )
     with pytest.raises(ValueError, match="confirmation seeds are incomplete"):
         build_legacy_rule_discovery_summary(screen, confirm, seeds=(0, 1))

--- a/tests/test_rule_discovery_summary.py
+++ b/tests/test_rule_discovery_summary.py
@@ -1,0 +1,156 @@
+"""Regression tests for the maintained rule-discovery summary builder.
+
+Issue #2134: `_arm` selected shards by filename but validated only the payload
+seed and accuracy curve.  A shard from a different arm, or a 60-task screen shard
+dropped into the 200-task confirmation directory, was accepted and republished
+under valid-looking provenance.  The builder now routes every shard through
+`ipmnist_screening.load_shard` and requires the arm identity, the stage task
+count, and the task length to match before aggregation.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from alberta_framework.benchmarks import rule_discovery_summary as summary
+from alberta_framework.benchmarks.ipmnist_screening import LEGACY_SHARD_SCHEMA
+
+_CONFIRM_ARMS = ("disc_r1_pscale_norms", summary.CHAMPION)
+
+
+def _make_shard(
+    config_name: str, seed: int, n_tasks: int, *, task_length: int = 5000
+) -> dict[str, Any]:
+    """A minimal but strictly valid legacy-v1 screening shard with flat curves."""
+    return {
+        "schema": LEGACY_SHARD_SCHEMA,
+        "config_name": config_name,
+        "base_learner": "upgd_w",
+        "seed": seed,
+        "noise_mode": "step",
+        "hyperparameters": {},
+        "config": {
+            "input_dim": 784,
+            "hidden1": 300,
+            "hidden2": 150,
+            "n_classes": 10,
+            "n_tasks": n_tasks,
+            "task_length": task_length,
+        },
+        "per_task_accuracy": [0.5] * n_tasks,
+        "per_task_loss": [0.5] * n_tasks,
+        "per_task_plasticity": [0.5] * n_tasks,
+        "wall_clock_seconds": 12.0,
+        "created_unix": 1785805898.0,
+        "environment": {
+            "jax": "0.7.1",
+            "numpy": "1.26.0",
+            "python": "3.12.3",
+            "platform": "linux",
+        },
+    }
+
+
+def _write(directory: Path, shard: dict[str, Any]) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{shard['config_name']}_seed{shard['seed']}.json"
+    path.write_text(json.dumps(shard), encoding="utf-8")
+
+
+def _populate_valid(screen_dir: Path, confirm_dir: Path, seed: int = 0) -> None:
+    for name in summary.SCREEN_ARMS:
+        _write(screen_dir, _make_shard(name, seed, summary._SCREEN_TASK_COUNT))
+    for name in _CONFIRM_ARMS:
+        _write(confirm_dir, _make_shard(name, seed, summary._CONFIRM_TASK_COUNT))
+
+
+@pytest.mark.unit
+def test_valid_shards_build_summary(tmp_path: Path) -> None:
+    """A correctly-staged set of shards builds and aggregates as expected."""
+    screen_dir, confirm_dir = tmp_path / "screen", tmp_path / "confirm"
+    _populate_valid(screen_dir, confirm_dir)
+
+    result = summary.build_rule_discovery_summary(screen_dir, confirm_dir, seeds=(0,))
+
+    assert result["schema"] == "asi.rule_discovery.real_screen.v2"
+    assert result["screen_60_task"]["disc_r1"]["mean"] == pytest.approx(0.5)
+    assert result["confirm_200_task"][summary.CHAMPION]["mean"] == pytest.approx(0.5)
+    # The screening loader is bound into maintained provenance now that it is
+    # part of the trusted validation path.
+    assert "ipmnist_screening" in result["provenance"]["sources"]
+
+
+@pytest.mark.unit
+def test_arm_substitution_is_rejected(tmp_path: Path) -> None:
+    """A champion payload renamed into the disc_r1 slot must be rejected."""
+    screen_dir, confirm_dir = tmp_path / "screen", tmp_path / "confirm"
+    _populate_valid(screen_dir, confirm_dir)
+    # Overwrite disc_r1_seed0.json with a shard whose config_name is the champion.
+    impostor = _make_shard(summary.CHAMPION, 0, summary._SCREEN_TASK_COUNT)
+    (screen_dir / "disc_r1_seed0.json").write_text(json.dumps(impostor), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="expected 'disc_r1'"):
+        summary.build_rule_discovery_summary(screen_dir, confirm_dir, seeds=(0,))
+
+
+@pytest.mark.unit
+def test_stage_substitution_is_rejected(tmp_path: Path) -> None:
+    """60-task screen shards placed in the confirmation directory must be rejected."""
+    screen_dir, confirm_dir = tmp_path / "screen", tmp_path / "confirm"
+    _populate_valid(screen_dir, confirm_dir)
+    # Replace the 200-task confirmation shards with 60-task screen shards.
+    for name in _CONFIRM_ARMS:
+        _write(confirm_dir, _make_shard(name, 0, summary._SCREEN_TASK_COUNT))
+
+    with pytest.raises(ValueError, match="not the 200 required for this stage"):
+        summary.build_rule_discovery_summary(screen_dir, confirm_dir, seeds=(0,))
+
+
+@pytest.mark.unit
+def test_task_length_mismatch_is_rejected(tmp_path: Path) -> None:
+    """A shard whose task_length is not 5,000 must be rejected."""
+    screen_dir, confirm_dir = tmp_path / "screen", tmp_path / "confirm"
+    _populate_valid(screen_dir, confirm_dir)
+    _write(screen_dir, _make_shard("disc_r1", 0, summary._SCREEN_TASK_COUNT, task_length=4000))
+
+    with pytest.raises(ValueError, match="task_length 4000"):
+        summary.build_rule_discovery_summary(screen_dir, confirm_dir, seeds=(0,))
+
+
+@pytest.mark.unit
+def test_wrong_seed_in_payload_is_rejected(tmp_path: Path) -> None:
+    """A shard whose payload seed disagrees with its filename slot is rejected."""
+    screen_dir, confirm_dir = tmp_path / "screen", tmp_path / "confirm"
+    _populate_valid(screen_dir, confirm_dir)
+    mismatched = _make_shard("disc_r1", 0, summary._SCREEN_TASK_COUNT)
+    mismatched["seed"] = 7  # filename still says seed0
+    (screen_dir / "disc_r1_seed0.json").write_text(json.dumps(mismatched), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="seed does not match"):
+        summary.build_rule_discovery_summary(screen_dir, confirm_dir, seeds=(0,))
+
+
+@pytest.mark.unit
+def test_legacy_reconstruction_matches_genuine_shards(tmp_path: Path) -> None:
+    """The legacy v1 payload is reconstructed identically from valid shards.
+
+    Guards that the added validation does not perturb the historical numbers for
+    genuine, correctly-staged inputs (only the aggregation output is checked here;
+    values come from the flat synthetic curves).
+    """
+    screen_dir, confirm_dir = tmp_path / "screen", tmp_path / "confirm"
+    _populate_valid(screen_dir, confirm_dir)
+
+    legacy = summary.build_legacy_rule_discovery_summary(screen_dir, confirm_dir, seeds=(0,))
+
+    assert legacy["schema"] == "alberta.rule_discovery.real_screen.v1"
+    # Every paired-vs-champion difference is zero for identical flat curves.
+    for name in summary.DISCOVERY_ARMS:
+        assert legacy["paired_vs_champion_60_task"][name]["mean"] == pytest.approx(0.0)
+    # Copy is defensive; the builder must not mutate caller inputs.
+    assert copy.deepcopy(legacy) == legacy


### PR DESCRIPTION
## Summary

Fixes #2134. `alberta_framework.benchmarks.rule_discovery_summary._arm` selected
each shard by its expected filename but validated only the payload `seed` and the
`per_task_accuracy` curve. It never required the payload `config_name` to match
the expected arm, nor distinguished the 60-task development screen from the
200-task confirmation stage. The maintained v2 summary then attached
valid-looking input hashes and analysis provenance to **semantically
misclassified measurements**.

Reproduced on the pre-fix builder:

- a champion (`sigma0_shiftnorm_d099`) payload renamed to `disc_r1_seed0.json` is
  accepted and published under `disc_r1`;
- genuine 60-task screen shards copied into the confirmation directory are
  published under `confirm_200_task`.

## Change (all inside `rule_discovery_summary.py`)

- Route every shard through `ipmnist_screening.load_shard`, the strict screening
  boundary (schema, registered-arm membership, curve domain/length, seed, and
  registered-compatible noise mode).
- On top of the loader, require per slot: `config_name` == expected arm, the
  stage task count (60 for the screen, 200 for confirmation), and `task_length`
  == 5,000. The existing payload-seed-vs-requested-seed check is preserved.
- Bind `ipmnist_screening` into the maintained analysis provenance `sources`,
  since its validator is now on the trusted path.

The legacy v1 payload is reconstructed identically for genuine shards — the
`build_rule_discovery_summary` compatibility hash is computed from the v1 payload,
which carries no provenance, so it is unchanged.

## Tests

- New `tests/test_rule_discovery_summary.py`: arm-substitution rejection,
  stage-substitution rejection, task-length mismatch, seed mismatch, a valid
  build, and a legacy-reconstruction check. All `@pytest.mark.unit`, hermetic
  (synthetic valid v1 shards, no JAX execution).
- `tests/test_ipmnist_campaign_tools.py`: the three rule-summary tests that
  previously wrote bare seed/accuracy stubs now use a valid-v1-shard helper, so
  their fixtures pass the stricter loader. `test_current_rule_discovery_legacy_
  payload_reconstructs_exactly` (which rebuilds from the real pinned shards and
  asserts byte-equality with `outputs/rule_discovery/real_screen_v1.json`) is
  unchanged and still passes — confirming exact reconstruction on real data.

Failing-test-first confirmed: the pre-fix builder accepts both substitutions;
the new tests reject them. `ruff` (line-length 100) and `mypy` are clean on the
changed source; the campaign-tools + rule-discovery suites pass. `rule_discovery_
summary.py` is not a registered evidence source, so this change does not affect
the evidence registry.

## Non-goals honored

No benchmark/seed/JAX/campaign execution; no edits to pinned or append-only
outputs; no refactor of other campaign analyzers.

## Verification evidence

Verified exact head: `26a445ee7a14d8f2f2a9e770ef6e86869f73f82e`.

- Focused rule-discovery suites: 88 passed in 2.69s.
- Ruff on the changed source and test directory: passed.
- Strict mypy on `rule_discovery_summary.py`: passed.
- `git diff --check origin/main...HEAD`: passed.

<!-- evidence-head:26a445ee7a14d8f2f2a9e770ef6e86869f73f82e -->
<!-- evidence-row:screenshot -->
- [x] screenshot: https://github.com/user-attachments/assets/1d6627b9-d9f1-4614-ac7c-d155429224e2