### PR TITLE
fix(core): cap UPGD hidden_sizes before layer-walk hang

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -74,6 +74,7 @@ def _require_exact_str(name: object, value: object) -> str:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_UPGD_HIDDEN_LAYERS = 4_096
 # Public last-fit in tests is 5_000 array steps / 50 stream steps. Origin handed
 # ``10**12`` to ``jnp.arange`` with no reject — hang/OOM, not an INT32 leftover.
 _UPGD_LOOP_MAX_STEPS = 10_000
@@ -675,6 +676,11 @@ class UPGDLearner:
             raise ValueError("hidden_sizes must be a tuple of integers")
         if not isinstance(hidden_sizes, (tuple, list)):
             raise ValueError("hidden_sizes must be a tuple of integers")
+        if len(hidden_sizes) > _MAX_UPGD_HIDDEN_LAYERS:
+            raise ValueError(
+                "hidden_sizes length must be an integer in "
+                f"[0, {_MAX_UPGD_HIDDEN_LAYERS}]"
+            )
         canonical_hidden: list[int] = []
         for idx, size in enumerate(hidden_sizes):
             canonical_hidden.append(
@@ -1561,6 +1567,11 @@ class UPGDLearner:
             raise ValueError("hidden_sizes must be a tuple of integers")
         if not isinstance(raw_hidden, (tuple, list)):
             raise ValueError("hidden_sizes must be a tuple of integers")
+        if len(raw_hidden) > _MAX_UPGD_HIDDEN_LAYERS:
+            raise ValueError(
+                "hidden_sizes length must be an integer in "
+                f"[0, {_MAX_UPGD_HIDDEN_LAYERS}]"
+            )
         hidden_list: list[int] = []
         for idx, value in enumerate(raw_hidden):
             hidden_list.append(_require_int(f"hidden_sizes[{idx}]", value, minimum=1))

--- a/tests/test_upgd_hidden_layer_count_cap.py
+++ b/tests/test_upgd_hidden_layer_count_cap.py
@@ -1,0 +1,27 @@
+"""Reject oversized UPGD hidden-size lists before per-layer validation hangs."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.upgd import _MAX_UPGD_HIDDEN_LAYERS, UPGDLearner
+
+
+def test_upgd_hidden_layer_cap_constant() -> None:
+    assert _MAX_UPGD_HIDDEN_LAYERS == 4096
+
+
+def test_upgd_accepts_max_hidden_layer_count() -> None:
+    UPGDLearner(n_heads=1, hidden_sizes=(1,) * _MAX_UPGD_HIDDEN_LAYERS)
+
+
+def test_upgd_rejects_oversized_hidden_layer_count() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        UPGDLearner(n_heads=1, hidden_sizes=(1,) * (_MAX_UPGD_HIDDEN_LAYERS + 1))
+
+
+def test_upgd_from_config_rejects_oversized_hidden_list() -> None:
+    payload = UPGDLearner(n_heads=1, hidden_sizes=(4,)).to_config()
+    payload["hidden_sizes"] = [1] * (_MAX_UPGD_HIDDEN_LAYERS + 1)
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        UPGDLearner.from_config(payload)


### PR DESCRIPTION
## Summary
- Reject UPGDLearner hidden-layer lists above 4096 before per-layer validation so INT32-legal depths fail closed.

## Test plan
- [x] pytest for the new test file plus existing module tests
- [x] ruff check on the touched files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FSMV8X7R77N1GGDHHH5QW7","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T14:36:49.309Z","completed_at":"2026-08-20T14:42:19.972Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T14:36:51.108Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f7f57fcb4e1924f6aef41d51134dd60dbe6f7cc5d496c367223d7a93c723c8e1","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"f174cd07-4d42-4713-a2b3-3a2654d849a9","object_id":"sha256:f7f57fcb4e1924f6aef41d51134dd60dbe6f7cc5d496c367223d7a93c723c8e1","sha256":"f7f57fcb4e1924f6aef41d51134dd60dbe6f7cc5d496c367223d7a93c723c8e1"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"fbn92X_ki9WwJlni29rETXXbfGOzcDCmSxFhyTisonhiBPUESId5PXnrJm8498tuwbC6Bi4pcJa1PhpVh6D5Bw"}} -->
