### PR TITLE
fix(core): cap UPGD-memory hidden_sizes before layer-walk hang

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -43,6 +43,7 @@ from alberta_framework.core.update_safety import (
 from alberta_framework.core.upgd import UPGDLearner, UPGDState
 
 _INT32_MAX: int = 2**31 - 1
+_MAX_UPGD_MEMORY_HIDDEN_LAYERS = 4_096
 _UINT32_MAX: int = 2**32 - 1
 _MAX_PERSISTENT_STATE_BYTES: int = 256 * 1024 * 1024
 _FLOAT32_MIN_NORMAL: float = float(np.finfo(np.float32).tiny)
@@ -402,6 +403,11 @@ class UPGDMemoryConfig:
             hidden = payload["hidden_sizes"]
             if type(hidden) not in {list, tuple}:
                 raise ValueError("hidden_sizes must be a list or tuple")
+            if len(hidden) > _MAX_UPGD_MEMORY_HIDDEN_LAYERS:
+                raise ValueError(
+                    "hidden_sizes length must be an integer in "
+                    f"[0, {_MAX_UPGD_MEMORY_HIDDEN_LAYERS}]"
+                )
             payload["hidden_sizes"] = tuple(hidden)
         return cls(**payload)
 
@@ -450,6 +456,11 @@ def _validate_config(config: UPGDMemoryConfig) -> None:
     if type(config.hidden_sizes) is not tuple:
         raise TypeError(
             f"hidden_sizes must be an actual tuple, got {type(config.hidden_sizes).__name__}"
+        )
+    if len(config.hidden_sizes) > _MAX_UPGD_MEMORY_HIDDEN_LAYERS:
+        raise ValueError(
+            "hidden_sizes length must be an integer in "
+            f"[0, {_MAX_UPGD_MEMORY_HIDDEN_LAYERS}]"
         )
     canonical_hidden = tuple(
         _require_int("hidden_sizes element", size, minimum=1, maximum=_INT32_MAX)

--- a/tests/test_upgd_memory_hidden_layer_count_cap.py
+++ b/tests/test_upgd_memory_hidden_layer_count_cap.py
@@ -1,0 +1,36 @@
+"""Reject oversized UPGD-memory hidden-size lists before per-layer validation hangs."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.upgd_memory import (
+    _MAX_UPGD_MEMORY_HIDDEN_LAYERS,
+    UPGDMemoryConfig,
+)
+
+
+def test_upgd_memory_hidden_layer_cap_constant() -> None:
+    assert _MAX_UPGD_MEMORY_HIDDEN_LAYERS == 4096
+
+
+def test_upgd_memory_accepts_max_hidden_layer_count() -> None:
+    UPGDMemoryConfig(
+        feature_dim=2, n_heads=2, hidden_sizes=(1,) * _MAX_UPGD_MEMORY_HIDDEN_LAYERS
+    )
+
+
+def test_upgd_memory_rejects_oversized_hidden_layer_count() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        UPGDMemoryConfig(
+            feature_dim=2,
+            n_heads=2,
+            hidden_sizes=(1,) * (_MAX_UPGD_MEMORY_HIDDEN_LAYERS + 1),
+        )
+
+
+def test_upgd_memory_from_config_rejects_oversized_hidden_list() -> None:
+    payload = UPGDMemoryConfig(feature_dim=2, n_heads=2, hidden_sizes=(4,)).to_config()
+    payload["hidden_sizes"] = [1] * (_MAX_UPGD_MEMORY_HIDDEN_LAYERS + 1)
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        UPGDMemoryConfig.from_config(payload)


### PR DESCRIPTION
## Summary
- Reject UPGDMemoryConfig hidden-layer lists above 4096 before per-layer validation so INT32-legal depths fail closed.

## Test plan
- [x] pytest for the new test file plus existing module tests
- [x] ruff check on the touched files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FTAJA3XAM4CKQ61GAN424B","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T14:48:41.027Z","completed_at":"2026-08-20T14:52:36.207Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T14:48:42.226Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"55b94b236857bec640da2dd4ae6fe35f0f4e6e5b799e21ef4bc649a8a37f56c4","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ee1191ae-c711-47b0-9a26-fc6d7c0839e0","object_id":"sha256:55b94b236857bec640da2dd4ae6fe35f0f4e6e5b799e21ef4bc649a8a37f56c4","sha256":"55b94b236857bec640da2dd4ae6fe35f0f4e6e5b799e21ef4bc649a8a37f56c4"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"fPfcWdviw1R3KlwU46hnSPn4NTC121Gk3OXDg5XHlj4_F3SpJzlXuhg-lQ-m28QGh6hbS6nUmp1kDBebHRSFCw"}} -->
