### PR TITLE
fix(core): cap latent world-model hidden_sizes before layer-walk hang

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -79,6 +79,7 @@ from alberta_framework.core.update_safety import (
 EVIDENCE_LEVEL = "L0"
 SCIENTIFIC_PROMOTION_ALLOWED = False
 _INT32_MAX = 2**31 - 1
+_MAX_LATENT_HIDDEN_LAYERS = 4_096
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -108,6 +109,11 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 def _validate_hidden_sizes(sizes: object) -> tuple[int, ...]:
     if type(sizes) is not tuple:
         raise ValueError("hidden_sizes must be an actual tuple")
+    if len(sizes) > _MAX_LATENT_HIDDEN_LAYERS:
+        raise ValueError(
+            "hidden_sizes length must be an integer in "
+            f"[0, {_MAX_LATENT_HIDDEN_LAYERS}]"
+        )
     return tuple(
         _require_int32(f"hidden_sizes[{index}]", size, minimum=1)
         for index, size in enumerate(sizes)
@@ -395,6 +401,11 @@ class LatentWorldModelConfig:
         if "hidden_sizes" in payload:
             if type(payload["hidden_sizes"]) is not list:
                 raise ValueError("hidden_sizes must be a list in serialized config")
+            if len(payload["hidden_sizes"]) > _MAX_LATENT_HIDDEN_LAYERS:
+                raise ValueError(
+                    "hidden_sizes length must be an integer in "
+                    f"[0, {_MAX_LATENT_HIDDEN_LAYERS}]"
+                )
             payload["hidden_sizes"] = tuple(payload["hidden_sizes"])
         if "observation_scale" in payload and payload["observation_scale"] is not None:
             if type(payload["observation_scale"]) is not list:

--- a/tests/test_latent_hidden_layer_count_cap.py
+++ b/tests/test_latent_hidden_layer_count_cap.py
@@ -1,0 +1,38 @@
+"""Reject oversized latent world-model hidden-size lists before layer-walk hang."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.latent_world_model import (
+    _MAX_LATENT_HIDDEN_LAYERS,
+    LatentWorldModelConfig,
+)
+
+
+def test_latent_hidden_layer_cap_constant() -> None:
+    assert _MAX_LATENT_HIDDEN_LAYERS == 4096
+
+
+def test_latent_accepts_max_hidden_layer_count() -> None:
+    LatentWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        hidden_sizes=(1,) * _MAX_LATENT_HIDDEN_LAYERS,
+    )
+
+
+def test_latent_rejects_oversized_hidden_layer_count() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=(1,) * (_MAX_LATENT_HIDDEN_LAYERS + 1),
+        )
+
+
+def test_latent_from_config_rejects_oversized_hidden_list() -> None:
+    payload = LatentWorldModelConfig(observation_dim=2, n_actions=2, hidden_sizes=(4,)).to_config()
+    payload["hidden_sizes"] = [1] * (_MAX_LATENT_HIDDEN_LAYERS + 1)
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        LatentWorldModelConfig.from_config(payload)


### PR DESCRIPTION
## Summary
- Reject LatentWorldModelConfig hidden-layer lists above 4096 before per-layer validation so INT32-legal depths fail closed.

## Test plan
- [x] pytest for the new test file plus existing module tests
- [x] ruff check on the touched files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FTJH9GDDFPGJKC3Q9BSDM8","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T14:53:02.128Z","completed_at":"2026-08-20T14:56:16.747Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T14:53:02.687Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"605d6f2fa158d564146e94f210dbae87ba29b0eae8802b8db683eb9d8fe28b76","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"679f504c-95b9-47ec-a541-600a56eef1f9","object_id":"sha256:605d6f2fa158d564146e94f210dbae87ba29b0eae8802b8db683eb9d8fe28b76","sha256":"605d6f2fa158d564146e94f210dbae87ba29b0eae8802b8db683eb9d8fe28b76"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"bvGzjn3QeXcnr4LPGUkx1E_gydHdaV-k1asyX4CVEVhiuXyI6Ylcab6nXKQvDUDJWrI7Jbvmplb6nFF0AhHyCQ"}} -->
