### PR TITLE
fix(core): cap temporal-context periods before walk hang

### DIFF
--- a/alberta_framework/core/temporal_context.py
+++ b/alberta_framework/core/temporal_context.py
@@ -42,6 +42,7 @@ from jaxtyping import Float
 from alberta_framework._float32 import round_real_to_float32_with_ratio
 
 _INT32_MAX: int = 2**31 - 1
+_MAX_TEMPORAL_CONTEXT_PERIODS = 4_096
 # Public last-fit in tests is 3 array steps. Origin scanned the leading
 # observation axis with no reject — hang/OOM, not an INT32 leftover.
 _TEMPORAL_CONTEXT_LOOP_MAX_STEPS = 10_000
@@ -330,6 +331,11 @@ class TemporalContextConfig:
             raw = payload["periods"]
             if type(raw) not in (list, tuple):
                 raise ValueError("periods must be a list or tuple")
+            if len(raw) > _MAX_TEMPORAL_CONTEXT_PERIODS:
+                raise ValueError(
+                    "periods length must be an integer in "
+                    f"[0, {_MAX_TEMPORAL_CONTEXT_PERIODS}]"
+                )
             payload["periods"] = tuple(raw)
         return cls(**payload)
 
@@ -424,6 +430,11 @@ def _validate_config(config: TemporalContextConfig) -> None:
     if type(config.periods) is not tuple:
         raise ValueError(
             "periods must be an actual tuple"
+        )
+    if len(config.periods) > _MAX_TEMPORAL_CONTEXT_PERIODS:
+        raise ValueError(
+            "periods length must be an integer in "
+            f"[0, {_MAX_TEMPORAL_CONTEXT_PERIODS}]"
         )
     canonical_periods = tuple(
         _require_positive_real("period", p) for p in config.periods

--- a/tests/test_temporal_context_period_count_cap.py
+++ b/tests/test_temporal_context_period_count_cap.py
@@ -1,0 +1,37 @@
+"""Reject oversized temporal-context period lists before per-period validation hangs."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.temporal_context import (
+    _MAX_TEMPORAL_CONTEXT_PERIODS,
+    TemporalContextConfig,
+)
+
+
+def test_temporal_period_cap_constant() -> None:
+    assert _MAX_TEMPORAL_CONTEXT_PERIODS == 4096
+
+
+def test_temporal_accepts_max_period_count() -> None:
+    TemporalContextConfig(
+        input_dim=1,
+        include_phase_products=False,
+        periods=(50.0,) * _MAX_TEMPORAL_CONTEXT_PERIODS,
+    )
+
+
+def test_temporal_rejects_oversized_period_count() -> None:
+    with pytest.raises(ValueError, match="periods length"):
+        TemporalContextConfig(
+            input_dim=1,
+            periods=(50.0,) * (_MAX_TEMPORAL_CONTEXT_PERIODS + 1),
+        )
+
+
+def test_temporal_from_config_rejects_oversized_period_list() -> None:
+    payload = TemporalContextConfig(input_dim=1).to_config()
+    payload["periods"] = [50.0] * (_MAX_TEMPORAL_CONTEXT_PERIODS + 1)
+    with pytest.raises(ValueError, match="periods length"):
+        TemporalContextConfig.from_config(payload)


### PR DESCRIPTION
## Summary
- Reject TemporalContextConfig period lists above 4096 before per-period validation so INT32-legal lengths fail closed.

## Test plan
- [x] pytest for the new test file plus existing module tests
- [x] ruff check on the touched files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FVM4G296T0CABKM30HFDYT","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T15:11:23.138Z","completed_at":"2026-08-20T15:16:15.987Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T15:11:25.567Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"1c4b27128f3f0f4b4dd0eac89b0658677d3db45f1e4cae9d8625d192186f4c03","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"837bc5bd-ae70-420f-b77a-289b40f1bb62","object_id":"sha256:1c4b27128f3f0f4b4dd0eac89b0658677d3db45f1e4cae9d8625d192186f4c03","sha256":"1c4b27128f3f0f4b4dd0eac89b0658677d3db45f1e4cae9d8625d192186f4c03"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"mNdGtQJW_u6s332UeOW0142gt6Afi-knRVQpVR3QRjJAEElg0sCWRLoZ_eRezYztE18KhBLDZeKUBexm8sXvCg"}} -->
