### PR TITLE
fix(core): cap independent-Horde hidden_sizes before layer-walk hang

### DIFF
--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -76,6 +76,7 @@ from alberta_framework.core.update_safety import (
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_INDEPENDENT_HORDE_HIDDEN_LAYERS = 4_096
 _ACTUAL_INT_TYPES = frozenset(
     {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
 )
@@ -117,6 +118,11 @@ def _read_mapping(name: str, value: object) -> dict[str, Any]:
 def _decode_tuple(name: str, value: object) -> tuple[Any, ...]:
     if type(value) not in {list, tuple}:
         raise ValueError(f"{name} must be an exact list or tuple")
+    if name == "hidden_sizes" and len(value) > _MAX_INDEPENDENT_HORDE_HIDDEN_LAYERS:
+        raise ValueError(
+            "hidden_sizes length must be an integer in "
+            f"[0, {_MAX_INDEPENDENT_HORDE_HIDDEN_LAYERS}]"
+        )
     return tuple(cast(list[Any] | tuple[Any, ...], value))
 
 
@@ -385,6 +391,11 @@ class IndependentDemonHorde:
             raise ValueError("horde_spec must be a nonempty HordeSpec")
         if type(hidden_sizes) is not tuple:
             raise ValueError("hidden_sizes must be an exact tuple")
+        if len(hidden_sizes) > _MAX_INDEPENDENT_HORDE_HIDDEN_LAYERS:
+            raise ValueError(
+                "hidden_sizes length must be an integer in "
+                f"[0, {_MAX_INDEPENDENT_HORDE_HIDDEN_LAYERS}]"
+            )
         hidden_sizes = tuple(
             _require_int32(f"hidden_sizes[{i}]", v, minimum=1) for i, v in enumerate(hidden_sizes)
         )

--- a/tests/test_independent_horde_hidden_layer_count_cap.py
+++ b/tests/test_independent_horde_hidden_layer_count_cap.py
@@ -1,0 +1,54 @@
+"""Reject oversized independent-Horde hidden-size lists before layer-walk hang."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.independent_demon_horde import (
+    _MAX_INDEPENDENT_HORDE_HIDDEN_LAYERS,
+    IndependentDemonHorde,
+)
+from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
+
+
+def _spec() -> object:
+    return create_horde_spec(
+        (
+            GVFSpec(
+                name="d0",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=0,
+            ),
+        )
+    )
+
+
+def test_independent_horde_hidden_layer_cap_constant() -> None:
+    assert _MAX_INDEPENDENT_HORDE_HIDDEN_LAYERS == 4096
+
+
+def test_independent_horde_accepts_max_hidden_layer_count() -> None:
+    IndependentDemonHorde(
+        horde_spec=_spec(),  # type: ignore[arg-type]
+        hidden_sizes=(1,) * _MAX_INDEPENDENT_HORDE_HIDDEN_LAYERS,
+        sparsity=0.0,
+    )
+
+
+def test_independent_horde_rejects_oversized_hidden_layer_count() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        IndependentDemonHorde(
+            horde_spec=_spec(),  # type: ignore[arg-type]
+            hidden_sizes=(1,) * (_MAX_INDEPENDENT_HORDE_HIDDEN_LAYERS + 1),
+            sparsity=0.0,
+        )
+
+
+def test_independent_horde_from_config_rejects_oversized_hidden_list() -> None:
+    horde = IndependentDemonHorde(horde_spec=_spec(), hidden_sizes=(4,), sparsity=0.0)  # type: ignore[arg-type]
+    payload = horde.to_config()
+    payload["hidden_sizes"] = [1] * (_MAX_INDEPENDENT_HORDE_HIDDEN_LAYERS + 1)
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        IndependentDemonHorde.from_config(payload)


### PR DESCRIPTION
## Summary
- Reject IndependentDemonHorde hidden-layer lists above 4096 before per-layer validation so INT32-legal depths fail closed.

## Test plan
- [x] pytest for the new test file plus existing module tests
- [x] ruff check on the touched files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0FVYQ2N5R7EQ5ERR8G2WT7S","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T15:17:09.846Z","completed_at":"2026-08-20T15:20:38.761Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T15:17:11.048Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e8654a5de6c4ec255c39fb57a931a7948e4dba2b91597dbc9ad0d9cb3a827593","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7721a2c9-04a1-461f-8673-15ed3559b14b","object_id":"sha256:e8654a5de6c4ec255c39fb57a931a7948e4dba2b91597dbc9ad0d9cb3a827593","sha256":"e8654a5de6c4ec255c39fb57a931a7948e4dba2b91597dbc9ad0d9cb3a827593"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"xoGktAtct7WmW4ag19IuHF5Ag1O2rsVKFehLHrZHT1Kab5KPzC64096n_IGk1u09OQz7ndlvrM2vv9lpT-cmAA"}} -->
