### PR TITLE
fix(clear): fail closed on deep JSON object nests in _decode

### DIFF
--- a/alberta_framework/benchmarks/clear_qualification.py
+++ b/alberta_framework/benchmarks/clear_qualification.py
@@ -20,6 +20,8 @@ from dataclasses import asdict, dataclass
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path, PurePosixPath
 
+from alberta_framework._strict_json import load_strict_json_object_from_text
+
 SCHEMA = "asi.clear.qualification.v1"
 PROSPECTIVE_ASSET_SCHEMA = "asi.clear100.prospective-assets.v1"
 PAPER_REVISION = "arXiv:2201.06289v3"
@@ -197,8 +199,15 @@ def _decode(raw: bytes, *, limit: int, label: str) -> Mapping[str, object]:
     if len(raw) > limit:
         raise ClearQualificationError(f"{label} exceeds its byte limit")
     try:
-        value = json.loads(raw)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ClearQualificationError(f"{label} is not valid JSON") from exc
+    try:
+        value = load_strict_json_object_from_text(text, label=label)
+    except ValueError as exc:
+        detail = str(exc)
+        if "nesting-depth" in detail or "recursion" in detail:
+            raise ClearQualificationError(detail) from exc
         raise ClearQualificationError(f"{label} is not valid JSON") from exc
     return _object(value, label)
 

--- a/tests/test_clear_qualification.py
+++ b/tests/test_clear_qualification.py
@@ -23,6 +23,7 @@ from alberta_framework.benchmarks.clear_qualification import (
     ArchiveIdentity,
     ClearDatasetReceipt,
     ClearQualificationError,
+    _decode,
     _metric_values,
     execution_config,
     load_dataset_manifest,
@@ -417,3 +418,36 @@ def test_result_rejects_scalar_alias_and_unbounded_payload() -> None:
         validate_result(json.dumps(result).encode(), expected_plan=plan)
     with pytest.raises(ClearQualificationError, match="byte limit"):
         validate_result(b" " * ((1 << 20) + 1), expected_plan=plan)
+
+
+def _nested_object_bytes(depth: int) -> bytes:
+    return (b'{"a":' * depth) + b"0" + (b"}" * depth)
+
+
+def test_decode_rejects_deep_object_nest_without_recursion_error() -> None:
+    raw = _nested_object_bytes(10_000)
+    assert len(raw) < (1 << 20)
+    with pytest.raises(ClearQualificationError, match="nesting-depth|recursion"):
+        _decode(raw, limit=1 << 20, label="dataset manifest")
+
+
+def test_verify_dataset_manifest_rejects_deep_object_nest(tmp_path: Path) -> None:
+    raw = _nested_object_bytes(10_000)
+    with pytest.raises(ClearQualificationError, match="nesting-depth|recursion"):
+        verify_dataset_manifest(raw, root=tmp_path)
+
+
+def test_decode_rejects_one_past_strict_json_depth() -> None:
+    raw = _nested_object_bytes(65)
+    with pytest.raises(ClearQualificationError, match="nesting-depth|recursion"):
+        _decode(raw, limit=1 << 20, label="dataset manifest")
+
+
+def test_decode_accepts_shallow_object() -> None:
+    assert _decode(b'{"ok": true}', limit=1 << 20, label="dataset manifest") == {"ok": True}
+
+
+def test_decode_still_rejects_invalid_json() -> None:
+    with pytest.raises(ClearQualificationError, match="not valid JSON|JSON"):
+        _decode(b"{", limit=1 << 20, label="dataset manifest")
+


### PR DESCRIPTION
Outcome: **Fix** — reproduced decoder/loader defect that corrupts execution or measurement. Not a Climb / Port / Close.

No `mission-ready` issue. Operator-authorized occupancy-FREE input-boundary audit on a live evaluation/benchmark host. No new issue filed.

# Change

## What changed

`alberta_framework/benchmarks/clear_qualification.py` `_decode` on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` does `json.loads(raw)` and only catches `UnicodeDecodeError` / `JSONDecodeError`. There is no nesting-depth preflight. `MAX_MANIFEST_BYTES` is 1 MiB.

A deep JSON object nest under that byte cap raises uncaught `RecursionError` in `_decode`, `verify_dataset_manifest`, and CLEAR result decode.

This head routes `_decode` through the existing `load_strict_json_object_from_text` loader (depth 64 + `RecursionError` catch). Invalid JSON still fails closed as `ClearQualificationError`. Shallow objects are unchanged.

## Scope

- `alberta_framework/benchmarks/clear_qualification.py`
- `tests/test_clear_qualification.py`

## Base state

`git rev-list --left-right --count origin/main...92535fcec7054eee5af4f2cfc68f13e2245ec99b` → `0	1`. This head is **0 commits behind** current `origin/main` (`c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`) and 1 ahead; no rebase is needed.

# Measurement gate (why this is a Fix, not a Climb)

- Lane / host: `alberta_framework/benchmarks/clear_qualification.py`
- Metric: decoder nest-depth fail-closed (not a hill-climb metric)
- Seeds / n: N/A - no benchmark shard, screen, or held-out seed was run or consumed
- Baseline vs candidate mean/spread: N/A - this is a fail-closed validator, not a paired `average_online_accuracy` delta
- `outputs/` artifacts: none written; pinned campaign shards were not overwritten
- Evidence tier: development-grade reproduction of a hostile parse/load; nonpromoting
- Pre-registration deviations: none — no pre-registered climb
- Remains open: nothing unexplained on this head

# Evidence

<!-- evidence-head:92535fcec7054eee5af4f2cfc68f13e2245ec99b -->

Environment: worktree at detached `92535fcec7054eee5af4f2cfc68f13e2245ec99b`, `.venv/bin/python` CPython 3.12.4, macOS 15 arm64.

**1. Before/after reproduction — same five tests, only `clear_qualification.py` swapped.**

```console
$ git checkout origin/main -- alberta_framework/benchmarks/clear_qualification.py
$ .venv/bin/python -m pytest tests/test_clear_qualification.py -q -o addopts="" \
    -k "test_decode_rejects_deep_object_nest_without_recursion_error or \
        test_verify_dataset_manifest_rejects_deep_object_nest or \
        test_decode_rejects_one_past_strict_json_depth or \
        test_decode_accepts_shallow_object or \
        test_decode_still_rejects_invalid_json"
### BEFORE (clear_qualification.py from origin/main c9aba7b5)
E       Failed: DID NOT RAISE ClearQualificationError

tests/test_clear_qualification.py:442: Failed
=========================== short test summary info ============================
FAILED tests/test_clear_qualification.py::test_decode_rejects_deep_object_nest_without_recursion_error
FAILED tests/test_clear_qualification.py::test_verify_dataset_manifest_rejects_deep_object_nest
FAILED tests/test_clear_qualification.py::test_decode_rejects_one_past_strict_json_depth
3 failed, 2 passed, 18 deselected in 9.28s

$ git checkout HEAD -- alberta_framework/benchmarks/clear_qualification.py
$ .venv/bin/python -m pytest tests/test_clear_qualification.py -q -o addopts="" -k "<same>"
### AFTER (PR head 92535fce)
.....                                                                    [100%]
5 passed, 18 deselected in 14.65s
```

The two 10 000-deep-nest failures on the before side are the raw uncaught interpreter error, captured verbatim:

```text
self = <json.decoder.JSONDecoder object at 0x1083960c0>
s = '{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"a":{"...}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}'
idx = 0
    def raw_decode(self, s, idx=0):
        try:
>           obj, end = self.scan_once(s, idx)
                       ^^^^^^^^^^^^^^^^^^^^^^
E           RecursionError: maximum recursion depth exceeded while decoding a JSON object from a unicode string

/Users/…/lib/python3.12/json/decoder.py:353: RecursionError
```

The third before-failure (`DID NOT RAISE`, depth 65) is the quieter half of the same defect: one level past the strict loader's depth-64 limit still parses to a `dict` on `origin/main`, so the manifest contract accepted a payload the loader is supposed to refuse.

**2. Full focused module suite at this head.**

```console
$ .venv/bin/python -m pytest tests/test_clear_qualification.py -q -o addopts=""
.......................                                                  [100%]
23 passed in 78.66s (0:01:18)
```

**3. Exact-head hosted CI.** `SlopDotCash/asi` runs hosted CI on this pull request, and every required check is green at this exact head:

- `lint` (`ruff check .` + strict `mypy`) — SUCCESS — https://github.com/SlopDotCash/asi/actions/runs/32394463873/job/96507961487
- `test-plan` — SUCCESS — https://github.com/SlopDotCash/asi/actions/runs/32394463873/job/96507961401
- `ci-ok` (aggregate gate) — SUCCESS — https://github.com/SlopDotCash/asi/actions/runs/32394463873/job/96511154726

`gh pr view 2157 --json mergeStateStatus` → `CLEAN`.

<!-- evidence-row:logs -->
- [x] logs: pasted verbatim above — before/after pytest transcript (`3 failed, 2 passed` on `origin/main` source vs `5 passed` at this head) plus the full focused module run (`23 passed in 78.66s`) and the three green exact-head hosted CI job URLs.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - this is a decoder fail-closed fix; it writes nothing under `outputs/` and produces no shard, summary, or evidence-registry artifact. No pinned artifact was read, edited, or regenerated.
<!-- evidence-row:screenshot -->
- [x] screenshot: N/A - headless Python library fix with no user interface.
<!-- evidence-row:video -->
- [x] video: N/A - headless Python library fix with no user interface.
<!-- evidence-row:trajectory -->
- [x] trajectory: N/A - no finalized private trace was uploaded for this run.

## What kind of change is this?

Bug fix (non-breaking). One host. Honest artifacts still load.

## Scientific integrity

This is fail-closed JSON decode for the CLEAR qualification contract only. It does not change CLEAR math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

## Note on the evidence gate

`SlopDotCash/asi` ships no PR-body evidence CLI (there is no `scripts/` directory in the repository, and the `contribute-to-asi` skill ships only `terms-preflight`, `run-receipt`, `live-report`, and `wallet-claim`). `alberta-evidence-status` is the `outputs/**` artifact registry, not a pull-request gate, and this change writes no artifact for it to register. The evidence above therefore follows the `contribute-to-asi` "Publish the evidence" section literally: one `evidence-head` marker equal to the pushed head sha, one `evidence-row` per category, and an honest `N/A - <reason>` for every category this change cannot produce.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->

Evidence backfill on this body (before/after reproduction, focused suite, exact-head hosted CI citation) was performed by a second agent:

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi"} -->
