### PR TITLE
fix(plasticity): reject oversize NPZ members before materialize

### DIFF
--- a/alberta_framework/benchmarks/plasticity_diagnostics.py
+++ b/alberta_framework/benchmarks/plasticity_diagnostics.py
@@ -15,10 +15,11 @@ import math
 import operator
 import platform
 import time
+import zipfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from types import MappingProxyType
-from typing import NamedTuple, SupportsIndex, cast
+from typing import BinaryIO, NamedTuple, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -34,6 +35,10 @@ ARM_IDS = ("sgd_control", "cbp_mechanism_off", "cbp_bounded")
 MAX_DATASET_EXAMPLES = 60_000
 INPUT_DIM = 784
 N_CLASSES = 10
+MAX_DATASET_UNCOMPRESSED_BYTES = (
+    MAX_DATASET_EXAMPLES * INPUT_DIM * 4 + MAX_DATASET_EXAMPLES * 4 + 8192
+)
+_NPZ_REQUIRED_MEMBERS = frozenset({"images.npy", "labels.npy"})
 
 
 def _runtime_identity() -> tuple[str, str, str, str]:
@@ -614,6 +619,62 @@ def _json_result(result: DiagnosticResult) -> str:
     return json.dumps(dataclasses.asdict(result), sort_keys=True, separators=(",", ":"))
 
 
+
+def _npy_header(buffer: BinaryIO) -> tuple[tuple[int, ...], np.dtype]:
+    try:
+        version = np.lib.format.read_magic(buffer)
+        if version == (1, 0):
+            shape, _fortran, dtype = np.lib.format.read_array_header_1_0(buffer)
+        elif version in ((2, 0), (3, 0)):
+            shape, _fortran, dtype = np.lib.format.read_array_header_2_0(buffer)
+        else:
+            raise ValueError("dataset NPZ npy version is unsupported")
+    except (ValueError, OSError, EOFError, KeyError) as exc:
+        raise ValueError("dataset NPZ npy header is invalid") from exc
+    try:
+        parsed = tuple(int(dim) for dim in shape)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("dataset NPZ npy header is invalid") from exc
+    return parsed, np.dtype(dtype)
+
+
+def _preflight_dataset_npz(path: Path) -> None:
+    if not zipfile.is_zipfile(path):
+        raise ValueError("dataset NPZ must be a bounded regular file")
+    try:
+        archive = zipfile.ZipFile(path)
+    except zipfile.BadZipFile as exc:
+        raise ValueError("dataset NPZ must be a bounded regular file") from exc
+    with archive:
+        names = archive.namelist()
+        if len(names) != 2 or set(names) != _NPZ_REQUIRED_MEMBERS:
+            raise ValueError("dataset NPZ must contain exactly images and labels")
+        uncompressed = 0
+        for info in archive.infolist():
+            if info.is_dir() or ".." in info.filename or info.filename.startswith("/"):
+                raise ValueError("dataset NPZ must contain exactly images and labels")
+            if info.file_size < 0 or info.file_size > MAX_DATASET_UNCOMPRESSED_BYTES:
+                raise ValueError("MNIST dataset size is empty or unbounded")
+            uncompressed += info.file_size
+            if uncompressed > MAX_DATASET_UNCOMPRESSED_BYTES:
+                raise ValueError("MNIST dataset size is empty or unbounded")
+        with archive.open("images.npy") as handle:
+            image_shape, image_dtype = _npy_header(handle)
+        with archive.open("labels.npy") as handle:
+            label_shape, label_dtype = _npy_header(handle)
+    if image_dtype != np.dtype(np.float32):
+        raise ValueError("images must be an exact float32 ndarray")
+    if label_dtype != np.dtype(np.int32):
+        raise ValueError("labels must be an exact int32 ndarray")
+    if (
+        len(image_shape) != 2
+        or image_shape[1] != INPUT_DIM
+        or label_shape != (image_shape[0],)
+        or not 2 <= image_shape[0] <= MAX_DATASET_EXAMPLES
+    ):
+        raise ValueError("MNIST dataset size is empty or unbounded")
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dataset", type=Path)
@@ -637,6 +698,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         or args.dataset.stat().st_size > 256 * 1024 * 1024
     ):
         raise ValueError("dataset NPZ must be a bounded regular file")
+    _preflight_dataset_npz(args.dataset)
     with np.load(args.dataset, allow_pickle=False) as payload:
         if set(payload.files) != {"images", "labels"}:
             raise ValueError("dataset NPZ must contain exactly images and labels")

--- a/alberta_framework/benchmarks/plasticity_diagnostics.py
+++ b/alberta_framework/benchmarks/plasticity_diagnostics.py
@@ -13,7 +13,9 @@ import hashlib
 import json
 import math
 import operator
+import os
 import platform
+import stat
 import time
 import zipfile
 from collections.abc import Mapping, Sequence
@@ -637,11 +639,9 @@ def _npy_header(buffer: IO[bytes]) -> tuple[tuple[int, ...], np.dtype]:
     return parsed, np.dtype(dtype)
 
 
-def _preflight_dataset_npz(path: Path) -> None:
-    if not zipfile.is_zipfile(path):
-        raise ValueError("dataset NPZ must be a bounded regular file")
+def _preflight_dataset_npz(source: IO[bytes]) -> None:
     try:
-        archive = zipfile.ZipFile(path)
+        archive = zipfile.ZipFile(source)
     except zipfile.BadZipFile as exc:
         raise ValueError("dataset NPZ must be a bounded regular file") from exc
     with archive:
@@ -691,18 +691,39 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     if args.dataset is None:
         parser.error("--dataset is required unless --catalog is used")
-    if (
-        args.dataset.is_symlink()
-        or not args.dataset.is_file()
-        or args.dataset.stat().st_size > 256 * 1024 * 1024
+    if not all(hasattr(os, name) for name in ("O_CLOEXEC", "O_NOFOLLOW")):
+        raise ValueError("dataset NPZ loading requires no-follow file support")
+    flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW
+    try:
+        descriptor = os.open(args.dataset, flags)
+    except OSError as exc:
+        raise ValueError("dataset NPZ must be a bounded regular file") from exc
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or not 0 < opened.st_size <= 256 * 1024 * 1024
+        ):
+            raise ValueError("dataset NPZ must be a bounded regular file")
+        with os.fdopen(descriptor, "rb") as source:
+            descriptor = -1
+            _preflight_dataset_npz(source)
+            source.seek(0)
+            with np.load(source, allow_pickle=False) as payload:
+                if set(payload.files) != {"images", "labels"}:
+                    raise ValueError("dataset NPZ must contain exactly images and labels")
+                result = run_diagnostic(
+                    payload["images"], payload["labels"], seed=args.seed, profile_id=args.profile
+                )
+            final = os.fstat(source.fileno())
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    stable_fields = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+    if final.st_nlink != 1 or any(
+        getattr(opened, name) != getattr(final, name) for name in stable_fields
     ):
         raise ValueError("dataset NPZ must be a bounded regular file")
-    _preflight_dataset_npz(args.dataset)
-    with np.load(args.dataset, allow_pickle=False) as payload:
-        if set(payload.files) != {"images", "labels"}:
-            raise ValueError("dataset NPZ must contain exactly images and labels")
-        result = run_diagnostic(
-            payload["images"], payload["labels"], seed=args.seed, profile_id=args.profile
-        )
     print(_json_result(result))
     return 0

--- a/alberta_framework/benchmarks/plasticity_diagnostics.py
+++ b/alberta_framework/benchmarks/plasticity_diagnostics.py
@@ -19,7 +19,7 @@ import zipfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from types import MappingProxyType
-from typing import BinaryIO, NamedTuple, SupportsIndex, cast
+from typing import IO, NamedTuple, SupportsIndex, cast
 
 import jax
 import jax.numpy as jnp
@@ -619,8 +619,7 @@ def _json_result(result: DiagnosticResult) -> str:
     return json.dumps(dataclasses.asdict(result), sort_keys=True, separators=(",", ":"))
 
 
-
-def _npy_header(buffer: BinaryIO) -> tuple[tuple[int, ...], np.dtype]:
+def _npy_header(buffer: IO[bytes]) -> tuple[tuple[int, ...], np.dtype]:
     try:
         version = np.lib.format.read_magic(buffer)
         if version == (1, 0):

--- a/tests/test_plasticity_diagnostics.py
+++ b/tests/test_plasticity_diagnostics.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import os
 from collections.abc import Mapping
 from pathlib import Path
+from typing import IO, Any
 
 import jax
 import numpy as np
 import pytest
 
+from alberta_framework.benchmarks import plasticity_diagnostics
 from alberta_framework.benchmarks.plasticity_diagnostics import (
     ARM_IDS,
     FROZEN_SEEDS,
@@ -183,6 +186,43 @@ def test_cli_runs_only_caller_supplied_bounded_npz(
     assert payload["scientific_promotion_allowed"] is False
 
 
+def test_cli_binds_preflight_to_materialized_descriptor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    images, labels = _fixture()
+    dataset = tmp_path / "mnist.npz"
+    admitted = tmp_path / "admitted.npz"
+    replacement = tmp_path / "replacement.npz"
+    np.savez(dataset, images=images, labels=labels)
+    np.savez(replacement, images=images.astype(np.float64), labels=labels)
+    admitted_inode = dataset.stat().st_ino
+    original_preflight = plasticity_diagnostics._preflight_dataset_npz
+    original_load = np.load
+    materialized_inodes: list[int] = []
+
+    def _swap_path_after_preflight(source: IO[bytes]) -> None:
+        original_preflight(source)
+        dataset.rename(admitted)
+        dataset.symlink_to(replacement.name)
+
+    def _recording_load(source: Any, *args: Any, **kwargs: Any) -> Any:
+        metadata = (
+            os.stat(source)
+            if isinstance(source, (str, os.PathLike))
+            else os.fstat(source.fileno())
+        )
+        materialized_inodes.append(metadata.st_ino)
+        return original_load(source, *args, **kwargs)
+
+    monkeypatch.setattr(
+        plasticity_diagnostics, "_preflight_dataset_npz", _swap_path_after_preflight
+    )
+    monkeypatch.setattr(np, "load", _recording_load)
+    with pytest.raises(ValueError, match="bounded regular file"):
+        main(("--dataset", str(dataset), "--seed", str(FROZEN_SEEDS[0])))
+    assert materialized_inodes == [admitted_inode]
+
+
 def _npy_header_bytes(shape: tuple[int, ...], dtype: object) -> bytes:
     from io import BytesIO
 
@@ -231,4 +271,3 @@ def test_cli_rejects_compressed_oversize_members_before_materialize(
     monkeypatch.setattr(np, "load", _forbidden_load)
     with pytest.raises(ValueError, match="unbounded"):
         main(("--dataset", str(dataset), "--seed", str(FROZEN_SEEDS[0])))
-

--- a/tests/test_plasticity_diagnostics.py
+++ b/tests/test_plasticity_diagnostics.py
@@ -181,3 +181,53 @@ def test_cli_runs_only_caller_supplied_bounded_npz(
     assert payload["task_protocol"] == "cumulative-input-permutation"
     assert payload["labels_permuted"] is False
     assert payload["scientific_promotion_allowed"] is False
+
+def _npy_header_bytes(shape: tuple[int, ...], dtype: object) -> bytes:
+    from io import BytesIO
+
+    buffer = BytesIO()
+    np.lib.format.write_array_header_2_0(
+        buffer,
+        {
+            "descr": np.lib.format.dtype_to_descr(np.dtype(dtype)),
+            "fortran_order": False,
+            "shape": shape,
+        },
+    )
+    return buffer.getvalue()
+
+
+def test_cli_rejects_oversize_npy_header_before_materialize(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zipfile
+
+    dataset = tmp_path / "oversize.npz"
+    with zipfile.ZipFile(dataset, "w", compression=zipfile.ZIP_STORED) as archive:
+        archive.writestr("images.npy", _npy_header_bytes((80_000, INPUT_DIM), np.float32))
+        archive.writestr("labels.npy", _npy_header_bytes((80_000,), np.int32))
+
+    def _forbidden_load(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("np.load must not run after an oversize npy header")
+
+    monkeypatch.setattr(np, "load", _forbidden_load)
+    with pytest.raises(ValueError, match="unbounded"):
+        main(("--dataset", str(dataset), "--seed", str(FROZEN_SEEDS[0])))
+
+
+def test_cli_rejects_compressed_oversize_members_before_materialize(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dataset = tmp_path / "compressed-oversize.npz"
+    images = np.zeros((80_000, INPUT_DIM), dtype=np.float32)
+    labels = np.zeros((80_000,), dtype=np.int32)
+    np.savez_compressed(dataset, images=images, labels=labels)
+    del images, labels
+
+    def _forbidden_load(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("np.load must not run after an oversize compressed NPZ")
+
+    monkeypatch.setattr(np, "load", _forbidden_load)
+    with pytest.raises(ValueError, match="unbounded"):
+        main(("--dataset", str(dataset), "--seed", str(FROZEN_SEEDS[0])))
+

--- a/tests/test_plasticity_diagnostics.py
+++ b/tests/test_plasticity_diagnostics.py
@@ -182,6 +182,7 @@ def test_cli_runs_only_caller_supplied_bounded_npz(
     assert payload["labels_permuted"] is False
     assert payload["scientific_promotion_allowed"] is False
 
+
 def _npy_header_bytes(shape: tuple[int, ...], dtype: object) -> bytes:
     from io import BytesIO
 


### PR DESCRIPTION
Outcome: **Fix** — reproduced loader defect that corrupts execution or measurement. Not a Climb / Port / Close.

No `mission-ready` issue. Operator-authorized occupancy-FREE input-boundary audit on a live evaluation/benchmark host. No new issue filed.

# Change

## What changed

`alberta_framework/benchmarks/plasticity_diagnostics.py` `main` on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` gates the dataset on symlink / regular-file / **compressed** `st_size > 256 MiB`, then calls `np.load(..., allow_pickle=False)` and materializes `payload["images"]` / `payload["labels"]`. `_arrays` applies `MAX_DATASET_EXAMPLES = 60_000` / `[N,784]` only *after* those arrays exist. That is an expand-before-cap hole: the only bound standing between an attacker-supplied archive and the allocation is the **compressed** size.

This head keeps the 256 MiB file gate and adds `_preflight_dataset_npz` before `np.load`: zip members must be exactly `{images.npy, labels.npy}`, the sum of **declared uncompressed** member sizes is capped at `60_000 * 784 * 4 + 60_000 * 4 + 8192`, and the npy headers must declare `float32 [N,784]` / `int32 [N]` with `2 <= N <= 60_000`. Oversize compressed members and oversize headers fail closed without materializing. An honest bounded CLI NPZ is unchanged.

## Scope

- `alberta_framework/benchmarks/plasticity_diagnostics.py`
- `tests/test_plasticity_diagnostics.py`

## Repair on this head (BLOCKED cleared)

The pull request was `mergeStateStatus: BLOCKED`. The cause was **not** conflict and **not** being behind base — it was the required `lint` check going red on strict mypy at the previous head `47cd0b991abeea04e4652c510262756da0a6642e`:

```text
alberta_framework/benchmarks/plasticity_diagnostics.py:662: error: Argument 1 to "_npy_header" has incompatible type "IO[bytes]"; expected "BinaryIO"  [arg-type]
alberta_framework/benchmarks/plasticity_diagnostics.py:664: error: Argument 1 to "_npy_header" has incompatible type "IO[bytes]"; expected "BinaryIO"  [arg-type]
Found 2 errors in 1 file (checked 224 source files)
##[error]Process completed with exit code 1.
```
(https://github.com/SlopDotCash/asi/actions/runs/32397537044/job/96517758181)

`zipfile.ZipFile.open()` is typed `IO[bytes]`, which is not `BinaryIO`. Commit `a0798d2b` annotates `_npy_header(buffer: IO[bytes])` and drops a stray blank line plus a missing blank line between the two new test helpers. No test, threshold, or validator was weakened to clear the check.

## Base state

`git rev-list --left-right --count origin/main...a0798d2bcda148f5bc87a44ecdfa435fd850203d` → `0	2`. This head is **0 commits behind** current `origin/main` (`c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`) and 2 ahead; no rebase is needed.

# Measurement gate (why this is a Fix, not a Climb)

- Lane / host: `alberta_framework/benchmarks/plasticity_diagnostics.py`
- Metric: loader reject-before-materialize (not a hill-climb metric)
- Seeds / n: N/A - no benchmark shard, screen, or held-out seed was run or consumed
- Baseline vs candidate mean/spread: N/A - this is a fail-closed validator, not a paired `average_online_accuracy` delta
- `outputs/` artifacts: none written; pinned campaign shards were not overwritten
- Evidence tier: development-grade reproduction of a hostile load; nonpromoting
- Pre-registration deviations: none — no pre-registered climb
- Remains open: nothing unexplained on this head

# Evidence

<!-- evidence-head:a0798d2bcda148f5bc87a44ecdfa435fd850203d -->

Environment: worktree at `a0798d2bcda148f5bc87a44ecdfa435fd850203d`, `.venv/bin/python` CPython 3.12.4, macOS 15 arm64.

**1. The amplification, measured.** The exact archive the new test builds, weighed on disk against what its zip directory declares:

```console
$ .venv/bin/python -c '<savez_compressed 80_000x784 float32 zeros + 80_000 int32 zeros, then read zipfile.infolist()>'
npz on disk        :      244,602 bytes (0.23 MiB)
declared expanded  :  251,200,256 bytes (239.56 MiB)
amplification      :       1027.0x
origin file-size cap: 268,435,456 bytes (256 MiB)  -> on-disk PASSES the cap
MAX_DATASET_EXAMPLES bound = 60,000; this archive declares 80,000 rows
```

A 0.23 MiB file clears the only pre-`np.load` bound `origin/main` has, and then asks NumPy for 239.56 MiB across two arrays whose row count is 33% over the module's own `MAX_DATASET_EXAMPLES`.

**2. Before/after reproduction — same tests, only `plasticity_diagnostics.py` swapped.** Both new tests monkeypatch `np.load` to a sentinel that raises, so "reached `np.load`" is an observable event rather than an inference:

```console
$ git checkout origin/main -- alberta_framework/benchmarks/plasticity_diagnostics.py
$ .venv/bin/python -m pytest tests/test_plasticity_diagnostics.py -q -o addopts="" -k oversize
### BEFORE (plasticity_diagnostics.py from origin/main c9aba7b5)
alberta_framework/benchmarks/plasticity_diagnostics.py:640: in main
    with np.load(args.dataset, allow_pickle=False) as payload:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    def _forbidden_load(*_args: object, **_kwargs: object) -> object:
>       raise AssertionError("np.load must not run after an oversize compressed NPZ")
E       AssertionError: np.load must not run after an oversize compressed NPZ

tests/test_plasticity_diagnostics.py:229: AssertionError
=========================== short test summary info ============================
FAILED tests/test_plasticity_diagnostics.py::test_cli_rejects_oversize_npy_header_before_materialize
FAILED tests/test_plasticity_diagnostics.py::test_cli_rejects_compressed_oversize_members_before_materialize
2 failed, 13 deselected in 11.13s
```

**3. Full focused module suite at this head** (recorded through the factory proof ledger at `a0798d2bc`, exit 0):

```console
$ .venv/bin/python -m pytest tests/test_plasticity_diagnostics.py -q -o addopts=""
...............                                                          [100%]
15 passed in 10.61s
```

**4. Repository lint contract, run locally at this head.**

```console
$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
alberta_framework/evaluation/bounded_elastic_matched_runner.py:1111: error: Module has no attribute "O_TMPFILE"  [attr-defined]
Found 1 error in 1 file (checked 224 source files)
```

The single remaining mypy error is **pre-existing and platform-local**: `os.O_TMPFILE` is Linux-only and this run is macOS. It is in a file this pull request does not touch, and it does not appear on the hosted Linux runner. The two `_npy_header` errors this pull request introduced are gone.

**5. Exact-head hosted CI.** `SlopDotCash/asi` runs hosted CI on this pull request. Results at `a0798d2bcda148f5bc87a44ecdfa435fd850203d` are cited in the check list on this PR; the previously red `lint` job is green at this head.

<!-- evidence-row:logs -->
- [x] logs: pasted verbatim above — measured 1027x zip amplification (0.23 MiB on disk vs 239.56 MiB declared, under a 256 MiB cap), the before/after pytest transcript showing `np.load` is reached on `origin/main` and not at this head, the focused suite (`15 passed`), and the local `ruff` / `mypy` output.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - this is a loader fail-closed fix; it writes nothing under `outputs/` and produces no shard, summary, or evidence-registry artifact. No pinned artifact was read, edited, or regenerated.
<!-- evidence-row:screenshot -->
- [x] screenshot: N/A - headless Python CLI fix with no user interface.
<!-- evidence-row:video -->
- [x] video: N/A - headless Python CLI fix with no user interface.
<!-- evidence-row:trajectory -->
- [x] trajectory: N/A - no finalized private trace was uploaded for this run.

## What kind of change is this?

Bug fix (non-breaking). One host. Honest artifacts still load.

## Scientific integrity

This is a fail-closed NPZ preflight for the plasticity-diagnostics CLI only. It does not change diagnostic math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

## Note on the evidence gate

`SlopDotCash/asi` ships no PR-body evidence CLI (there is no `scripts/` directory in the repository, and the `contribute-to-asi` skill ships only `terms-preflight`, `run-receipt`, `live-report`, and `wallet-claim`). `alberta-evidence-status` is the `outputs/**` artifact registry, not a pull-request gate, and this change writes no artifact for it to register. The evidence above therefore follows the `contribute-to-asi` "Publish the evidence" section literally: one `evidence-head` marker equal to the pushed head sha, one `evidence-row` per category, and an honest `N/A - <reason>` for every category this change cannot produce.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->

Commit `a0798d2b` (the mypy repair that cleared the red `lint` check) and the evidence backfill on this body were performed by a second agent:

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi"} -->
