### PR TITLE
fix(ipmnist): reject oversize ceiling NPZ members before materialize

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_campaign_tools.py
+++ b/alberta_framework/benchmarks/ipmnist_campaign_tools.py
@@ -13,9 +13,10 @@ import math
 import re
 import statistics
 import time
+import zipfile
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, BinaryIO, cast
 
 import numpy as np
 
@@ -51,6 +52,14 @@ BUCKETS = (
     (3500, 5000),
 )
 _IDENTIFIER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*\Z")
+MAX_CEILING_TASKS = 200
+MAX_CEILING_TASK_LENGTH = 5_000
+MAX_CEILING_METADATA_BYTES = 16 * 1024 * 1024
+MAX_CEILING_PER_STEP_BYTES = MAX_CEILING_TASKS * MAX_CEILING_TASK_LENGTH
+MAX_CEILING_UNCOMPRESSED_BYTES = (
+    MAX_CEILING_PER_STEP_BYTES + MAX_CEILING_METADATA_BYTES + 8192
+)
+_NPZ_REQUIRED_MEMBERS = frozenset({"metadata.npy", "per_step.npy"})
 
 
 def _safe_identifier(value: object, *, name: str) -> str:
@@ -212,6 +221,69 @@ def build_frontier(
     }
 
 
+def _npy_header(buffer: BinaryIO) -> tuple[tuple[int, ...], np.dtype]:
+    try:
+        version = np.lib.format.read_magic(buffer)
+        if version == (1, 0):
+            shape, _fortran, dtype = np.lib.format.read_array_header_1_0(buffer)
+        elif version in ((2, 0), (3, 0)):
+            shape, _fortran, dtype = np.lib.format.read_array_header_2_0(buffer)
+        else:
+            raise ValueError("ceiling NPZ npy version is unsupported")
+    except (ValueError, OSError, EOFError, KeyError) as exc:
+        raise ValueError("ceiling NPZ npy header is invalid") from exc
+    try:
+        parsed = tuple(int(dim) for dim in shape)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("ceiling NPZ npy header is invalid") from exc
+    return parsed, np.dtype(dtype)
+
+
+def _preflight_ceiling_npz(path: Path) -> None:
+    if not zipfile.is_zipfile(path):
+        raise ValueError(f"{path} ceiling NPZ size is empty or unbounded")
+    try:
+        archive = zipfile.ZipFile(path)
+    except zipfile.BadZipFile as exc:
+        raise ValueError(f"{path} ceiling NPZ size is empty or unbounded") from exc
+    with archive:
+        names = archive.namelist()
+        if len(names) != 2 or set(names) != _NPZ_REQUIRED_MEMBERS:
+            raise ValueError(f"{path} ceiling NPZ must contain exactly metadata and per_step")
+        uncompressed = 0
+        for info in archive.infolist():
+            if info.is_dir() or ".." in info.filename or info.filename.startswith("/"):
+                raise ValueError(
+                    f"{path} ceiling NPZ must contain exactly metadata and per_step"
+                )
+            if info.file_size < 0 or info.file_size > MAX_CEILING_UNCOMPRESSED_BYTES:
+                raise ValueError(f"{path} ceiling NPZ size is empty or unbounded")
+            uncompressed += info.file_size
+            if uncompressed > MAX_CEILING_UNCOMPRESSED_BYTES:
+                raise ValueError(f"{path} ceiling NPZ size is empty or unbounded")
+        with archive.open("per_step.npy") as handle:
+            step_shape, step_dtype = _npy_header(handle)
+        with archive.open("metadata.npy") as handle:
+            metadata_shape, metadata_dtype = _npy_header(handle)
+    if step_dtype != np.dtype(np.uint8):
+        raise ValueError(f"{path} per_step must be a uint8 binary matrix")
+    if (
+        len(step_shape) != 2
+        or step_shape[1] != MAX_CEILING_TASK_LENGTH
+        or not 1 <= step_shape[0] <= MAX_CEILING_TASKS
+    ):
+        raise ValueError(f"{path} ceiling NPZ size is empty or unbounded")
+    metadata_size = 1
+    for dim in metadata_shape:
+        metadata_size *= dim
+    if (
+        metadata_dtype.kind not in {"U", "S"}
+        or metadata_size != 1
+        or metadata_dtype.itemsize * metadata_size > MAX_CEILING_METADATA_BYTES
+    ):
+        raise ValueError(f"{path} ceiling NPZ size is empty or unbounded")
+
+
 def _ceiling_runs(
     ceiling_dir: Path,
     prefix: str,
@@ -240,6 +312,7 @@ def _ceiling_runs(
             input_paths.extend((path, per_step_path))
         runs[seed] = payload
     for path in sorted(ceiling_dir.glob(f"{prefix}_seed*.npz")):
+        _preflight_ceiling_npz(path)
         with np.load(path, allow_pickle=False) as archive:
             payload = load_strict_json_object_from_text(
                 archive["metadata"].item(),

--- a/alberta_framework/benchmarks/ipmnist_campaign_tools.py
+++ b/alberta_framework/benchmarks/ipmnist_campaign_tools.py
@@ -16,7 +16,7 @@ import time
 import zipfile
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, BinaryIO, cast
+from typing import IO, Any, cast
 
 import numpy as np
 
@@ -221,7 +221,7 @@ def build_frontier(
     }
 
 
-def _npy_header(buffer: BinaryIO) -> tuple[tuple[int, ...], np.dtype]:
+def _npy_header(buffer: IO[bytes]) -> tuple[tuple[int, ...], np.dtype]:
     try:
         version = np.lib.format.read_magic(buffer)
         if version == (1, 0):

--- a/tests/test_ipmnist_campaign_tools_npz_preflight.py
+++ b/tests/test_ipmnist_campaign_tools_npz_preflight.py
@@ -1,0 +1,104 @@
+"""Fail-closed NPZ preflight for maintained IPMNIST campaign ceiling runs."""
+
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.ipmnist_campaign_tools import build_ceiling_summary
+
+pytestmark = pytest.mark.unit
+
+
+def _valid_metadata(*, n_tasks: int = 1) -> str:
+    payload: dict[str, object] = {
+        "schema": "asi.ipmnist_ceiling.run.v2",
+        "evidence_class": "development_screening_diagnostic",
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "tag": "stationary_sigma0_ndecay099",
+        "spec_name": "sigma0_ndecay099",
+        "seed": 0,
+        "perm_mode": "identity",
+        "n_tasks": n_tasks,
+        "task_length": 5000,
+        "per_task_accuracy": [1.0] * n_tasks,
+        "mean_accuracy": 1.0,
+        "wall_clock_seconds": 1.0,
+        "provenance": {"schema": "asi.ipmnist.ceiling_run_provenance.v1"},
+    }
+    return json.dumps(payload)
+
+
+def _npy_header_bytes(shape: tuple[int, ...], dtype: object) -> bytes:
+    buffer = BytesIO()
+    np.lib.format.write_array_header_2_0(
+        buffer,
+        {
+            "descr": np.lib.format.dtype_to_descr(np.dtype(dtype)),
+            "fortran_order": False,
+            "shape": shape,
+        },
+    )
+    return buffer.getvalue()
+
+
+def test_ceiling_rejects_oversize_npy_header_before_materialize(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zipfile
+
+    ceiling = tmp_path / "ceiling"
+    ceiling.mkdir()
+    path = ceiling / "stationary_sigma0_ndecay099_seed0.npz"
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as archive:
+        archive.writestr("metadata.npy", _npy_header_bytes((), np.dtype("<U1")))
+        archive.writestr(
+            "per_step.npy", _npy_header_bytes((80_000, 5000), np.uint8)
+        )
+
+    def _forbidden_load(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("np.load must not run after an oversize npy header")
+
+    monkeypatch.setattr(np, "load", _forbidden_load)
+    with pytest.raises(ValueError, match="unbounded"):
+        build_ceiling_summary(ceiling, tmp_path / "confirm")
+
+
+def test_ceiling_rejects_compressed_oversize_members_before_materialize(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ceiling = tmp_path / "ceiling"
+    ceiling.mkdir()
+    path = ceiling / "stationary_sigma0_ndecay099_seed0.npz"
+    per_step = np.zeros((80_000, 5000), dtype=np.uint8)
+    np.savez_compressed(
+        path,
+        metadata=np.asarray(_valid_metadata()),
+        per_step=per_step,
+    )
+    del per_step
+
+    def _forbidden_load(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("np.load must not run after an oversize compressed NPZ")
+
+    monkeypatch.setattr(np, "load", _forbidden_load)
+    with pytest.raises(ValueError, match="unbounded"):
+        build_ceiling_summary(ceiling, tmp_path / "confirm")
+
+
+def test_ceiling_accepts_bounded_compressed_npz(tmp_path: Path) -> None:
+    ceiling = tmp_path / "ceiling"
+    ceiling.mkdir()
+    per_step = np.ones((1, 5000), dtype=np.uint8)
+    np.savez_compressed(
+        ceiling / "stationary_sigma0_ndecay099_seed0.npz",
+        metadata=np.asarray(_valid_metadata()),
+        per_step=per_step,
+    )
+    report = build_ceiling_summary(ceiling, tmp_path / "confirm")
+    assert report["stationary_sigma0_ndecay099"]["avg_online_mean"] == 1.0


### PR DESCRIPTION
Outcome: **Fix** — reproduced loader defect that corrupts execution or measurement. Not a Climb / Port / Close.

No `mission-ready` issue. Operator-authorized occupancy-FREE input-boundary audit on a live evaluation/benchmark host. No new issue filed.

# Change

## What changed

`alberta_framework/benchmarks/ipmnist_campaign_tools.py` `_ceiling_runs` on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` glob-loads `{prefix}_seed*.npz` with `np.load(..., allow_pickle=False)` and materializes `archive["per_step"]` **before** `_validated_ceiling_run` checks the `(n_tasks, 5000)` shape. That is an expand-before-cap hole: nothing bounds the declared array between the archive landing on disk and the allocation.

This head adds `_preflight_ceiling_npz` before `np.load`: zip members must be exactly `{metadata.npy, per_step.npy}`, declared uncompressed sizes are capped at `200 * 5000 + 16 MiB + 8192`, and the npy headers must declare uint8 `[N,5000]` with `1 <= N <= 200` plus a scalar `U`/`S` metadata string inside the existing 16 MiB JSON byte contract. Oversize compressed members fail closed without materializing. Bounded ceiling archives are unchanged.

## Scope

- `alberta_framework/benchmarks/ipmnist_campaign_tools.py`
- `tests/test_ipmnist_campaign_tools_npz_preflight.py` (new; the occupied `tests/test_ipmnist_campaign_tools.py` is untouched)

## Repair on this head (BLOCKED cleared)

The pull request was `mergeStateStatus: BLOCKED`. The cause was **not** conflict and **not** being behind base — it was the required `lint` check going red on strict mypy at the previous head `5223b3f3cc30451ced6d6cbee7030b3760e80dd2`:

```text
alberta_framework/benchmarks/ipmnist_campaign_tools.py:265: error: Argument 1 to "_npy_header" has incompatible type "IO[bytes]"; expected "BinaryIO"  [arg-type]
alberta_framework/benchmarks/ipmnist_campaign_tools.py:267: error: Argument 1 to "_npy_header" has incompatible type "IO[bytes]"; expected "BinaryIO"  [arg-type]
Found 2 errors in 1 file (checked 224 source files)
##[error]Process completed with exit code 1.
```
(https://github.com/SlopDotCash/asi/actions/runs/32403024010/job/96535469817)

`zipfile.ZipFile.open()` is typed `IO[bytes]`, which is not `BinaryIO`. Commit `11dd9a60` annotates `_npy_header(buffer: IO[bytes])`. No test, threshold, or validator was weakened to clear the check.

## Base state

`git rev-list --left-right --count origin/main...11dd9a6028d1fa90dcf5395adf6a8ed7af2df13a` → `0	2`. This head is **0 commits behind** current `origin/main` (`c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`) and 2 ahead; no rebase is needed.

# Measurement gate (why this is a Fix, not a Climb)

- Lane / host: `alberta_framework/benchmarks/ipmnist_campaign_tools.py`
- Metric: loader reject-before-materialize (not a hill-climb metric)
- Seeds / n: N/A - no benchmark shard, screen, or held-out seed was run or consumed
- Baseline vs candidate mean/spread: N/A - this is a fail-closed validator, not a paired `average_online_accuracy` delta
- `outputs/` artifacts: none written; pinned campaign shards were not overwritten or re-read
- Evidence tier: development-grade reproduction of a hostile load; nonpromoting
- Pre-registration deviations: none — no pre-registered climb
- Remains open: nothing unexplained on this head

# Evidence

<!-- evidence-head:11dd9a6028d1fa90dcf5395adf6a8ed7af2df13a -->

Environment: worktree at `11dd9a6028d1fa90dcf5395adf6a8ed7af2df13a`, `.venv/bin/python` CPython 3.12.4, macOS 15 arm64.

**1. The amplification, measured.** The exact ceiling archive the new test builds (`metadata` scalar + `per_step` uint8 zeros `(80_000, 5000)`), weighed on disk against what its zip directory declares:

```console
$ .venv/bin/python -c '<savez_compressed metadata + 80_000x5000 uint8 zeros, then read zipfile.infolist()>'
npz on disk       :       389,206 bytes (0.37 MiB)
declared expanded :   400,000,260 bytes (381.47 MiB)
amplification     :         1,028x
```

A 0.37 MiB file asks NumPy for 381.47 MiB, against a `_validated_ceiling_run` bound of `n_tasks <= 200` rows — 400x over the shape the module accepts — and that check only runs *after* the allocation.

**2. Before/after reproduction — same tests, only `ipmnist_campaign_tools.py` swapped.** The two hostile tests monkeypatch `np.load` to a sentinel that raises, so "reached `np.load`" is an observable event rather than an inference; the third test is a positive control proving a bounded archive still loads:

```console
$ git checkout origin/main -- alberta_framework/benchmarks/ipmnist_campaign_tools.py
$ .venv/bin/python -m pytest tests/test_ipmnist_campaign_tools_npz_preflight.py -q -o addopts=""
### BEFORE (ipmnist_campaign_tools.py from origin/main c9aba7b5)
_args = (PosixPath('.../ceiling/stationary_sigma0_ndecay099_seed0.npz'),)
_kwargs = {'allow_pickle': False}

    def _forbidden_load(*_args: object, **_kwargs: object) -> object:
>       raise AssertionError("np.load must not run after an oversize compressed NPZ")
E       AssertionError: np.load must not run after an oversize compressed NPZ

tests/test_ipmnist_campaign_tools_npz_preflight.py:87: AssertionError
=========================== short test summary info ============================
FAILED tests/test_ipmnist_campaign_tools_npz_preflight.py::test_ceiling_rejects_oversize_npy_header_before_materialize
FAILED tests/test_ipmnist_campaign_tools_npz_preflight.py::test_ceiling_rejects_compressed_oversize_members_before_materialize
2 failed, 1 passed in 2.40s
```

The `1 passed` on the before side is `test_ceiling_accepts_bounded_compressed_npz` — the positive control passes on both sides, which is what makes the two failures attributable to the preflight rather than to the fixture.

**3. New focused test file at this head** (recorded through the factory proof ledger at `11dd9a602`, exit 0):

```console
$ .venv/bin/python -m pytest tests/test_ipmnist_campaign_tools_npz_preflight.py -q -o addopts=""
...                                                                      [100%]
3 passed in 4.83s
```

**4. Repository lint contract, run locally at this head.**

```console
$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
alberta_framework/evaluation/bounded_elastic_matched_runner.py:1111: error: Module has no attribute "O_TMPFILE"  [attr-defined]
Found 1 error in 1 file (checked 224 source files)
```

The single remaining mypy error is **pre-existing and platform-local**: `os.O_TMPFILE` is Linux-only and this run is macOS. It is in a file this pull request does not touch, and it does not appear on the hosted Linux runner. The two `_npy_header` errors this pull request introduced are gone.

**5. Exact-head hosted CI.** `SlopDotCash/asi` runs hosted CI on this pull request. Results at `11dd9a6028d1fa90dcf5395adf6a8ed7af2df13a` are cited in the check list on this PR; the previously red `lint` job is green at this head.

<!-- evidence-row:logs -->
- [x] logs: pasted verbatim above — measured 1,028x zip amplification (0.37 MiB on disk vs 381.47 MiB declared, 400x over the accepted row count), the before/after pytest transcript showing `np.load` is reached on `origin/main` and not at this head with a positive control passing on both sides, the focused test file (`3 passed`), and the local `ruff` / `mypy` output.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - this is a loader fail-closed fix; it writes nothing under `outputs/` and produces no shard, summary, or evidence-registry artifact. The tests build their own throwaway archives under `tmp_path`; no pinned campaign artifact was read, edited, or regenerated.
<!-- evidence-row:screenshot -->
- [x] screenshot: N/A - headless Python library fix with no user interface.
<!-- evidence-row:video -->
- [x] video: N/A - headless Python library fix with no user interface.
<!-- evidence-row:trajectory -->
- [x] trajectory: N/A - no finalized private trace was uploaded for this run.

## What kind of change is this?

Bug fix (non-breaking). One host. Honest artifacts still load.

## Scientific integrity

This is a fail-closed NPZ preflight for the maintained IPMNIST campaign ceiling reader only. It does not change campaign math, registered evidence sources, frozen protocols, scientific claims, benchmark results, `CHANGELOG.md`, or any `outputs/**` artifact.

## Note on the evidence gate

`SlopDotCash/asi` ships no PR-body evidence CLI (there is no `scripts/` directory in the repository, and the `contribute-to-asi` skill ships only `terms-preflight`, `run-receipt`, `live-report`, and `wallet-claim`). `alberta-evidence-status` is the `outputs/**` artifact registry, not a pull-request gate, and this change writes no artifact for it to register. The evidence above therefore follows the `contribute-to-asi` "Publish the evidence" section literally: one `evidence-head` marker equal to the pushed head sha, one `evidence-row` per category, and an honest `N/A - <reason>` for every category this change cannot produce.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->

Commit `11dd9a60` (the mypy repair that cleared the red `lint` check) and the evidence backfill on this body were performed by a second agent:

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi"} -->
