### PR TITLE
fix(utils): reject divergent infinite traces across continual metrics

### DIFF
--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -338,6 +338,8 @@ def _performance_matrix(
         raise ValueError("performance_matrix must have shape (checkpoints, tasks)")
     if matrix.shape[0] < 1 or matrix.shape[1] < 1:
         raise ValueError("performance_matrix must be non-empty")
+    if np.any(np.isinf(matrix)):
+        raise ValueError("performance_matrix has an infinite evaluation")
     return matrix
 
 
@@ -487,6 +489,8 @@ def compute_prequential_performance(
     values = _numeric_array(online_performance, name="online_performance")
     if values.ndim != 1 or values.size == 0:
         raise ValueError("online_performance must be a non-empty one-dimensional trace")
+    if np.any(np.isinf(values)):
+        raise ValueError("online_performance must not contain infinity")
     finite = values[np.isfinite(values)]
     if finite.size == 0:
         raise ValueError("online_performance must contain at least one finite value")
@@ -524,6 +528,10 @@ def compute_stability_gap(
         raise ValueError(
             "reference_performance must be scalar or match online_performance"
         ) from exc
+    if np.any(np.isinf(values)):
+        raise ValueError("online_performance must not contain infinity")
+    if np.any(np.isinf(broadcast_reference)):
+        raise ValueError("reference_performance must not contain infinity")
 
     valid = np.isfinite(values) & np.isfinite(broadcast_reference)
     if not np.any(valid):
@@ -562,6 +570,8 @@ def compute_recovery_lengths(
     threshold_value = _require_finite_real("threshold", threshold)
     if values.ndim != 1 or values.size == 0:
         raise ValueError("online_performance must be a non-empty one-dimensional trace")
+    if np.any(np.isinf(values)):
+        raise ValueError("online_performance must not contain infinity")
     if points.ndim != 1 or points.size == 0:
         raise ValueError("change_points must be a non-empty one-dimensional array")
     if np.any(points < 0) or np.any(points >= values.size):

--- a/tests/test_continual_metrics.py
+++ b/tests/test_continual_metrics.py
@@ -403,3 +403,37 @@ def test_continual_learning_summary_rejects_leftover_identities() -> None:
     )
     assert '"final_performance": 0.8' in dumped
     assert '"final_performance": true' not in dumped
+
+
+@pytest.mark.parametrize("value", [np.inf, -np.inf])
+def test_prequential_performance_rejects_infinite_trace(value: float) -> None:
+    with pytest.raises(ValueError, match="online_performance must not contain infinity"):
+        compute_prequential_performance([0.5, value, 0.7])
+
+
+@pytest.mark.parametrize("value", [np.inf, -np.inf])
+def test_stability_gap_rejects_infinite_online_trace(value: float) -> None:
+    with pytest.raises(ValueError, match="online_performance must not contain infinity"):
+        compute_stability_gap([0.5, value, 0.7], 0.8)
+
+
+@pytest.mark.parametrize("value", [np.inf, -np.inf])
+def test_stability_gap_rejects_infinite_reference_trace(value: float) -> None:
+    with pytest.raises(ValueError, match="reference_performance must not contain infinity"):
+        compute_stability_gap([0.5, 0.6, 0.7], [0.8, value, 0.8])
+
+
+@pytest.mark.parametrize("value", [np.inf, -np.inf])
+def test_recovery_lengths_reject_infinite_online_trace(value: float) -> None:
+    with pytest.raises(ValueError, match="online_performance must not contain infinity"):
+        compute_recovery_lengths([0.1, value, 0.9], change_points=[0], threshold=0.8, window_size=1)
+
+
+@pytest.mark.parametrize("value", [np.inf, -np.inf])
+def test_forward_transfer_rejects_infinite_pre_exposure(value: float) -> None:
+    with pytest.raises(ValueError, match="infinite evaluation"):
+        compute_forward_transfer(
+            [[value, np.nan], [0.5, 0.6]],
+            first_exposure=[1, 1],
+            baseline_performance=[0.5, 0.5],
+        )


### PR DESCRIPTION
### Summary

In `alberta_framework/utils/metrics.py`, `NaN` values represent unevaluated or missing probe checkpoints (e.g. before task exposure), whereas `inf` values denote numerical divergence / arithmetic overflow errors in the learning process.

Previously:
1. `_performance_matrix` did not check for `np.isinf`, which allowed `compute_forward_transfer` to silently filter out `inf` before first exposure rather than failing closed on corrupted performance evaluations.
2. `compute_prequential_performance` filtered out non-finites via `values[np.isfinite(values)]`, silently ignoring divergent infinite evaluations and returning a finite mean.
3. `compute_stability_gap` masked `inf` values as `NaN` via `np.isfinite()`, concealing explosive instability during online learning.
4. `compute_recovery_lengths` failed to reject infinite values in the online performance stream before searching for sustained threshold recovery.

This PR fixes these measurement-trust gaps across continual metrics:
- Rejects `np.isinf` in `_performance_matrix` with an `"infinite evaluation"` error.
- Fails closed on infinite values in `compute_prequential_performance`, `compute_stability_gap` (for both `online_performance` and `reference_performance`), and `compute_recovery_lengths`.
- Adds unit tests in `tests/test_continual_metrics.py` covering positive and negative infinite inputs across each metric.

### Validation
- `pytest tests/test_continual_metrics.py tests/test_metrics_hostile_validation.py tests/test_metrics_boolean_trace_width_hang.py tests/test_metrics_key_hostile.py tests/test_statistics_hostile_validation.py tests/test_statistics_validation.py` (346 passed)
- `ruff check .` (passed)
- `mypy alberta_framework` (Success: no issues found in 224 source files)
- `git diff --check` (clean)

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash
Client / agent tooling: antigravity-cli
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-asi-agy-worker]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"antigravity-cli","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0GKFHVVYXKDC3CJTRPMWM68","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T22:08:18.811Z","completed_at":"2026-08-20T22:08:45.170Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T22:08:19.177Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"02033a9ea4bafa7112f67ca8ef7f6dfe3a5738687068cbb1ff511892f8a2a0bd","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3008df9f-ca51-42e7-9137-395a48fcc043","object_id":"sha256:02033a9ea4bafa7112f67ca8ef7f6dfe3a5738687068cbb1ff511892f8a2a0bd","sha256":"02033a9ea4bafa7112f67ca8ef7f6dfe3a5738687068cbb1ff511892f8a2a0bd"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"2xtbPML2-5SRY0cNVDSq-Dix8lGrGgB4VTsSgRHbsFT3-Lnwhz3nNoW77Mag_qK4d6h3q9IsuIo9OuIMKWGUCQ"}} -->
