### PR TITLE
fix(core): align STOMP importance ratios with Gumbel behavior policy

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1042,14 +1042,12 @@ def _select_action_epsilon_greedy_from_q_masked(
 
 
 def _epsilon_greedy_action_probabilities(q_values: Array, epsilon: Array) -> Array:
-    """Return epsilon-greedy probabilities with uniform tie handling."""
+    """Return epsilon-greedy probabilities matching Gumbel tie-breaking."""
     q = jnp.asarray(q_values, dtype=jnp.float32)
     n_actions = q.shape[0]
     eps = jnp.asarray(epsilon, dtype=jnp.float32)
-    max_q = jnp.max(q)
-    greedy_mask = jnp.isclose(q, max_q, atol=1e-6, rtol=0.0).astype(jnp.float32)
-    n_greedy = jnp.maximum(jnp.sum(greedy_mask), jnp.array(1.0, dtype=jnp.float32))
-    return eps / n_actions + (1.0 - eps) * greedy_mask / n_greedy
+    greedy_probs = jax.nn.softmax(q / 1e-6)
+    return eps / n_actions + (1.0 - eps) * greedy_probs
 
 
 def _clipped_epsilon_greedy_importance_ratio(

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -21,8 +21,10 @@ from alberta_framework.core.options import (
     STOMPSpecArrays,
     STOMPState,
     SubtaskSpec,
+    _clipped_epsilon_greedy_importance_ratio,
     _differential_q_update,
     _differential_semidp_q_update,
+    _epsilon_greedy_action_probabilities,
     _stomp_direct_array_scalars,
     load_stomp_state_with_migration,
     replace_dispatched_primitive_action,
@@ -547,3 +549,83 @@ def test_stomp_from_config_preserves_historical_mapping_and_sequence_compatibili
     ):
         with pytest.raises(ValueError, match=match):
             STOMPConfig.from_config({"subtask_specs": (bad_spec,)})
+
+
+@pytest.mark.unit
+class TestEpsilonGreedyImportanceRatios:
+    """Intra-option importance ratios must align with Gumbel tie-breaking behavior policy."""
+
+    def test_epsilon_greedy_action_probabilities_exact_ties(self) -> None:
+        q_tied = jnp.array([1.0, 1.0], dtype=jnp.float32)
+        probs_tied = _epsilon_greedy_action_probabilities(
+            q_tied, jnp.asarray(0.2, dtype=jnp.float32)
+        )
+        np.testing.assert_allclose(probs_tied, [0.5, 0.5], rtol=1e-5)
+
+        q_three = jnp.array([0.0, 0.0, 0.0], dtype=jnp.float32)
+        probs_three = _epsilon_greedy_action_probabilities(
+            q_three, jnp.asarray(0.0, dtype=jnp.float32)
+        )
+        np.testing.assert_allclose(probs_three, [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0], rtol=1e-5)
+
+    def test_epsilon_greedy_action_probabilities_distinct(self) -> None:
+        q_distinct = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        probs_distinct = _epsilon_greedy_action_probabilities(
+            q_distinct, jnp.asarray(0.0, dtype=jnp.float32)
+        )
+        np.testing.assert_allclose(probs_distinct, [0.0, 1.0], atol=1e-6)
+
+    def test_epsilon_greedy_action_probabilities_near_ties(self) -> None:
+        # q = [0, 5e-7], behavior epsilon = 0.2, target epsilon = 0
+        q_near = jnp.array([0.0, 5e-7], dtype=jnp.float32)
+        behavior_probs = _epsilon_greedy_action_probabilities(
+            q_near, jnp.asarray(0.2, dtype=jnp.float32)
+        )
+        target_probs = _epsilon_greedy_action_probabilities(
+            q_near, jnp.asarray(0.0, dtype=jnp.float32)
+        )
+
+        expected_greedy = jax.nn.softmax(q_near / 1e-6)
+        expected_behavior = 0.2 / 2.0 + 0.8 * expected_greedy
+        expected_target = expected_greedy
+
+        np.testing.assert_allclose(behavior_probs, expected_behavior, rtol=1e-5)
+        np.testing.assert_allclose(target_probs, expected_target, rtol=1e-5)
+
+        # Action 0 ratio and action 1 ratio
+        ratio_0 = float(target_probs[0] / behavior_probs[0])
+        ratio_1 = float(target_probs[1] / behavior_probs[1])
+        assert ratio_0 < 1.0
+        assert ratio_1 > 1.0
+        expected_ratio_0 = float(expected_target[0] / expected_behavior[0])
+        expected_ratio_1 = float(expected_target[1] / expected_behavior[1])
+        np.testing.assert_allclose(ratio_0, expected_ratio_0, rtol=1e-5)
+        np.testing.assert_allclose(ratio_1, expected_ratio_1, rtol=1e-5)
+
+    def test_clipped_epsilon_greedy_importance_ratio_near_ties(self) -> None:
+        # q_weights @ obs gives q = [0, 5e-7]
+        q_weights = jnp.array([[0.0, 0.0], [5e-7, 0.0]], dtype=jnp.float32)
+        obs = jnp.array([1.0, 0.0], dtype=jnp.float32)
+
+        ratio_act0 = _clipped_epsilon_greedy_importance_ratio(
+            q_weights,
+            obs,
+            action=jnp.asarray(0, dtype=jnp.int32),
+            behavior_epsilon=0.2,
+            target_epsilon=0.0,
+            clip=2.0,
+        )
+        ratio_act1 = _clipped_epsilon_greedy_importance_ratio(
+            q_weights,
+            obs,
+            action=jnp.asarray(1, dtype=jnp.int32),
+            behavior_epsilon=0.2,
+            target_epsilon=0.0,
+            clip=2.0,
+        )
+
+        # Verify not flat 1.0
+        assert float(ratio_act0) < 1.0
+        assert float(ratio_act1) > 1.0
+        np.testing.assert_allclose(float(ratio_act0), 0.9390799, rtol=1e-4)
+        np.testing.assert_allclose(float(ratio_act1), 1.0409585, rtol=1e-4)


### PR DESCRIPTION
Fixes #2136.

## What's wrong

STOMP's intra-option behavior selector and its importance-ratio calculation disagreed for near-tied Q-values.

 selects the non-exploratory action with:
```python
argmax(q_values + 1e-6 * Gumbel(0, 1))
```
Its greedy-component selection probabilities are therefore the Gumbel-max categorical distribution `softmax(q_values / 1e-6)`.

However, `_clipped_epsilon_greedy_importance_ratio` called `_epsilon_greedy_action_probabilities`, which used `jnp.isclose(q, max_q, atol=1e-6)` to treat every value within absolute tolerance `1e-6` of the maximum as an exactly uniform tie.

For `q_values = [0, 5e-7]`, behavior epsilon `0.2`, and target epsilon `0`:
- actual Gumbel greedy probabilities: approximately `[0.37754068, 0.62245935]`
- actual behavior probabilities: approximately `[0.40203254, 0.59796748]`
- correct target/behavior ratios: approximately `[0.9390799, 1.0409585]`
- previous helper ratios: `[1.0, 1.0]`

The incorrect ratio was consumed by `_update_intra_option_policy`, scaling eligibility traces, weight updates, and the differential average-reward update with probabilities from a different policy than generated the action.

## Fix

Updated `_epsilon_greedy_action_probabilities` to compute the greedy-component action probabilities via `jax.nn.softmax(q / 1e-6)`, matching the Gumbel tie-breaking mechanism.

This correctly:
1. Retains uniform probability distribution `1 / n_tied` on exact ties (`q = [1.0, 1.0]` -> `[0.5, 0.5]`).
2. Correctly assigns the smooth Gumbel-max probability on near ties (`q = [0.0, 5e-7]` -> `[0.37754068, 0.62245935]`).
3. Correctly concentrates probability 1.0 on distinct maximal actions (`q = [0.0, 1.0]` -> `[0.0, 1.0]`).

## Verification

- Added `TestEpsilonGreedyImportanceRatios` in `tests/test_options.py` covering exact ties, near ties, distinct values, and computed importance ratios.
- **Mutation testing**: temporarily reverted the fix to the old `isclose` implementation and re-ran tests. `test_epsilon_greedy_action_probabilities_near_ties` and `test_clipped_epsilon_greedy_importance_ratio_near_ties` failed with exact predicted values (reported `0.5` instead of `0.402033`; `1.0` instead of `< 1.0`). Restoring the fix passed all tests.
- Full suite passing: 161/161 tests across `tests/test_options.py`, `tests/test_stomp_option_planning.py`, `tests/test_oak_authoritative_stomp_adoption.py`, `tests/test_oak_stomp_adoption_resource_budget.py`.
- `ruff check .` and `mypy alberta_framework` clean (0 issues across 224 files); `git diff --check` clean.

This is a control/importance-sampling correctness fix; it does not claim benchmark improvement or scientific promotion.

---
Agent: Antigravity CLI + Gemini (Google DeepMind)

## Measured project receipt
Post-hoc / same-window receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0GM8GM2VMGFRC4TB2JZB35M","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-20T22:21:56.738Z","completed_at":"2026-08-23T09:08:44.066Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-20T22:21:58.530Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5fa92ede942fd646dd4005d60e7874c8ee16f72f002881fa6637f5bca49584f0","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"8a7dc8ff-7c82-4fad-b4b8-492ab199e2ba","object_id":"sha256:5fa92ede942fd646dd4005d60e7874c8ee16f72f002881fa6637f5bca49584f0","sha256":"5fa92ede942fd646dd4005d60e7874c8ee16f72f002881fa6637f5bca49584f0"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"6SNNt6yKL5RVekqIPYGp2uMhhf1MwIFKa7a4QgW9qO-ucICxkb34YIcRsB_CRy1o41r8K5EEliqUZNtQvQ4UAQ"}} -->
