### PR TITLE
fix(evaluation): reject deep JSON nests before evidence-manifest parse

### DIFF
--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from types import FunctionType
 from typing import Literal, NoReturn, Protocol, cast
 
+from alberta_framework._bounded_containers import require_json_text_nesting
 from alberta_framework.evaluation.continual_ia import (
     ContinualIAConfig,
     IAAcceptanceThresholds,
@@ -147,6 +148,7 @@ from alberta_framework.recurring_feature_gate import (
 _STRICT_IA_ARTIFACT_VALIDATOR = validate_ia_evidence_artifact
 
 MANIFEST_SCHEMA_VERSION = "alberta.evidence_claim_manifest.v1"
+_MAX_JSON_NESTING_DEPTH = 64
 CLAIM_CONTRACT_VERSION = "alberta.evidence_claim_contract.v1"
 DIRTY_STATE_POLICY_VERSION = "alberta.registered_source_dirty_policy.v1"
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -934,12 +936,21 @@ def _reject_duplicate_json_keys(
 def _load_strict_json_object(path: Path) -> dict[str, object]:
     """Load a finite UTF-8 JSON object while rejecting duplicate keys."""
 
-    parsed = json.loads(
-        path.read_bytes(),
-        parse_constant=_reject_json_constant,
-        parse_float=_parse_finite_json_float,
-        object_pairs_hook=_reject_duplicate_json_keys,
+    text = path.read_text(encoding="utf-8")
+    require_json_text_nesting(
+        text,
+        max_depth=_MAX_JSON_NESTING_DEPTH,
+        name="evidence manifest",
     )
+    try:
+        parsed = json.loads(
+            text,
+            parse_constant=_reject_json_constant,
+            parse_float=_parse_finite_json_float,
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
+    except RecursionError as exc:
+        raise ValueError("evidence manifest exceeds the JSON nesting limit") from exc
     if not isinstance(parsed, dict):
         raise ValueError(f"{path} must contain a JSON object")
     return parsed

--- a/tests/test_evidence_manifest_json_nest.py
+++ b/tests/test_evidence_manifest_json_nest.py
@@ -1,0 +1,54 @@
+"""Origin-complete: deep evidence-manifest JSON must fail closed before RecursionError."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.evaluation.evidence_manifest import (
+    _MAX_JSON_NESTING_DEPTH,
+    _load_strict_json_object,
+)
+
+
+def _deep_object_bytes(depth: int) -> bytes:
+    return (b'{"k":' * depth) + b"0" + (b"}" * depth)
+
+
+def test_load_strict_json_object_rejects_origin_recursion_fixture(
+    tmp_path: Path,
+) -> None:
+    """60,001-byte depth-10000 object RecursionError'd origin json.loads."""
+    raw = _deep_object_bytes(10_000)
+    assert len(raw) == 60_001
+    path = tmp_path / "deep-object.json"
+    path.write_bytes(raw)
+    with pytest.raises(ValueError, match="JSON nesting limit"):
+        _load_strict_json_object(path)
+
+
+def test_load_strict_json_object_rejects_first_over_depth_object(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "over.json"
+    path.write_bytes(_deep_object_bytes(_MAX_JSON_NESTING_DEPTH + 1))
+    with pytest.raises(ValueError, match="JSON nesting limit"):
+        _load_strict_json_object(path)
+
+
+def test_load_strict_json_object_rejects_deep_array_nest(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "deep-array.json"
+    path.write_text("[" * 10_000 + "0" + "]" * 10_000, encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON nesting limit"):
+        _load_strict_json_object(path)
+
+
+def test_load_strict_json_object_accepts_bounded_object(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "ok.json"
+    path.write_text('{"schema": "x"}\n', encoding="utf-8")
+    assert _load_strict_json_object(path) == {"schema": "x"}


### PR DESCRIPTION
Outcome: **Fix** — reproduced decoder/loader defect that corrupts execution or measurement. Not a Climb / Port / Close.

No `mission-ready` issue. Operator-authorized occupancy-FREE input-boundary audit on a live evaluation host. No new issue filed.

# Change

`alberta_framework/evaluation/evidence_manifest.py` `_load_strict_json_object` on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` calls `json.loads(path.read_bytes())` with no nesting preflight. A 60,001-byte depth-10000 object RecursionError's the parser in ~0.0006s.


This head preflights bracket depth (cap 64) via `require_json_text_nesting` before `json.loads` and catches leftover RecursionError as ValueError. Bounded objects still load.

Not leftover-tax. Not `forager*` / IA / FTL / clocks. Not `upgd.py` / horde / dreaming / delight / #1874 `ipmnist_*`. Not a twin of #2157–#2168 (those hosts stay-off; this file is `evaluation/evidence_manifest.py`). Occupancy-FREE.

# Scope

- `alberta_framework/evaluation/evidence_manifest.py`
- `tests/test_evidence_manifest_json_nest.py` (new; leftover-identity tests untouched)

# Why this is unowned

Live occupancy: no open SlopDotCash/asi PR touches `evaluation/evidence_manifest.py`. Absent from factory occupancy JSON (`scannedAt=2026-08-20T22:15:06.479Z`). Not HARD_SKIP. Not ALWAYS-ON stay-off.

# Verification

Exact candidate head: `600b705832d5fdcc1f99891395c26e7a92b2bce8`
Base: `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (`origin/main`; this branch is 0 commits behind that base)

All output below was captured on this machine on 2026-08-21 by an independent
reviewer (Anthropic / claude-opus-5, Claude Code), re-running the proof from
scratch in two clean detached worktrees on external storage:

- base worktree `/Volumes/thescoho_1TB/Developer/worktrees/asi-evid-batchB-main-20260821` at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`
- candidate worktree `/Volumes/thescoho_1TB/Developer/worktrees/asi-evid-batchB-20260821` at `600b705832d5fdcc1f99891395c26e7a92b2bce8`

Both sides used the same interpreter, `/Volumes/thescoho_1TB/Developer/asi/.venv/bin/python`
(CPython 3.12, project venv), with `PYTHONPATH` pinned to the worktree under test so the
import resolves to that exact tree.

## Before/after reproduction (paired, same fixture, same interpreter)

Fixture: `(b'{"k":' * 10000) + b"0" + (b"}" * 10000)` — a depth-10000 JSON object,
60,001 bytes, asserted byte-exact in the probe.

```text
$ git rev-parse HEAD            # base worktree
c9aba7b54dedd647f8bd5f5c7bf6780b1413b676
$ python probe.py               # depth-10000 object, 60,001 bytes
target alberta_framework.evaluation.evidence_manifest._load_strict_json_object
RESULT RecursionError in 0.0010s: maximum recursion depth exceeded while decoding a JSON object from a unicode string

$ git rev-parse HEAD            # candidate worktree
600b705832d5fdcc1f99891395c26e7a92b2bce8
$ python probe.py               # same fixture
target alberta_framework.evaluation.evidence_manifest._load_strict_json_object
RESULT ValueError in 0.0001s: evidence manifest exceeds the JSON nesting limit
```

## Focused tests at the candidate head

```text
$ .venv/bin/python -m pytest tests/test_evidence_manifest_json_nest.py -q -o addopts=""
....                                                                     [100%]
4 passed in 0.69s
```

## Lint on the changed files at the candidate head

```text
$ .venv/bin/python -m ruff check alberta_framework/evaluation/evidence_manifest.py tests/test_evidence_manifest_json_nest.py
All checks passed!
```

## Not run

- `.venv/bin/python -m mypy` (strict, whole project): N/A - not run in this evidence pass; cost was out of budget. Not claimed.
- Full `pytest` suite: N/A - not run in this evidence pass. Only the focused module above is claimed.
- Hosted CI checks: N/A - this pull request comes from a fork without upstream write access, so no exact-head hosted check run exists and none is claimed.
- Benchmark shards / `outputs/` artifacts: N/A - none written, none read, none overwritten. This change touches no shard, seed, or campaign directory.

# Measurement gate (why this is a Fix, not a Climb)

- Lane / host: `alberta_framework/evaluation/evidence_manifest.py`
- Metric: decoder nest-depth fail-closed behaviour (not a hill-climb metric)
- Seeds / n: N/A - no benchmark shard, screen, or held-out seed was run or consumed
- Baseline vs candidate mean/spread: N/A - this is a fail-closed input validator, not a paired `average_online_accuracy` delta
- `outputs/` artifacts: none written; pinned campaign shards untouched
- Evidence tier: development-grade reproduction of a hostile parse; nonpromoting, and never presented as promoted
- Pre-registration deviations: none — there is no pre-registered climb here
- Remains open: `mypy` and the full suite are not claimed on this head (see "Not run")

# Evidence

<!-- evidence-head:600b705832d5fdcc1f99891395c26e7a92b2bce8 -->
<!-- evidence-row:before-screenshots -->
- [ ] before-screenshots: N/A - Python library change with no user interface surface, so no pre-fix screen state exists to capture.
<!-- evidence-row:after-screenshots -->
- [ ] after-screenshots: N/A - Python library change with no user interface surface, so no post-fix screen state exists to capture.
<!-- evidence-row:walkthrough-video -->
- [ ] walkthrough-video: N/A - Python library change with no user interface surface, so there is no interaction to record.
<!-- evidence-row:backend-logs -->
- [x] backend-logs: paired before/after reproduction of the hostile 60,001-byte depth-10000 JSON fixture against `alberta_framework.evaluation.evidence_manifest._load_strict_json_object`, run in two clean worktrees on the same interpreter — `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` raises `RecursionError` in 0.0010s; this head `600b705832d5fdcc1f99891395c26e7a92b2bce8` rejects it as `ValueError: evidence manifest exceeds the JSON nesting limit` before `json.loads`. Transcript below. Hosted artifact link: N/A - transcript captured locally in two detached worktrees on this machine, so no uploaded log artifact URL exists for it.

```text
$ git rev-parse HEAD            # base worktree
c9aba7b54dedd647f8bd5f5c7bf6780b1413b676
$ python probe.py               # depth-10000 object, 60,001 bytes
target alberta_framework.evaluation.evidence_manifest._load_strict_json_object
RESULT RecursionError in 0.0010s: maximum recursion depth exceeded while decoding a JSON object from a unicode string

$ git rev-parse HEAD            # candidate worktree
600b705832d5fdcc1f99891395c26e7a92b2bce8
$ python probe.py               # same fixture
target alberta_framework.evaluation.evidence_manifest._load_strict_json_object
RESULT ValueError in 0.0001s: evidence manifest exceeds the JSON nesting limit
```
<!-- evidence-row:frontend-logs -->
- [ ] frontend-logs: N/A - no browser or client surface is exercised by this change, so no console or network log exists.
<!-- evidence-row:llm-trajectory -->
- [ ] llm-trajectory: N/A - no agent trajectory was produced for this evidence pass.
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifacts: focused test run at `600b705832d5fdcc1f99891395c26e7a92b2bce8` — `.venv/bin/python -m pytest tests/test_evidence_manifest_json_nest.py -q -o addopts=""` → `4 passed in 0.69s`, plus `.venv/bin/python -m ruff check alberta_framework/evaluation/evidence_manifest.py tests/test_evidence_manifest_json_nest.py` → `All checks passed!`. Full captured output is inline under **Verification** above. Hosted artifact link: N/A - the pytest and ruff output was captured locally in a detached worktree, so no uploaded artifact URL exists for it.
Evidence-capture note: the code in this pull request was authored by the agent named in
the attribution footer below. The Verification and Evidence sections above were
independently re-run and rewritten from real captured output by Anthropic /
claude-opus-5 (Claude Code) on 2026-08-21; nothing above is quoted from the original
draft. No commit on this branch was changed, so the evidence head marker still names the
original head `600b705832d5fdcc1f99891395c26e7a92b2bce8`.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6 (implementation commits); anthropic/claude-opus-5 (independent evidence capture and this body)
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app (implementation); Claude Code (evidence capture)
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi"} -->

