### PR TITLE
fix(benchmarks): reject deep JSON nests before scorecard parse

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -32,6 +32,7 @@ from typing import Any, NoReturn, cast
 import jax
 import numpy as np
 
+from alberta_framework._bounded_containers import require_json_text_nesting
 from alberta_framework.core.oak import OaKConfig
 from alberta_framework.core.options import STOMPConfig
 from alberta_framework.core.prototype_agent import PrototypeAgentConfig
@@ -129,6 +130,7 @@ REFERENCE_LIFE_SCORECARD_PLAN_V1_SHA256 = (
 # A complete 144-shard aggregate is comfortably below this limit.  Keeping
 # the cap explicit prevents validation inputs from becoming an unbounded read.
 MAX_SCORECARD_JSON_INPUT_BYTES = 64 * 1024 * 1024
+_MAX_JSON_NESTING_DEPTH = 64
 MAX_SCORECARD_AGGREGATE_INPUT_BYTES = 256 * 1024 * 1024
 
 CONTROL_GATE_T_CRITICAL = 2.201
@@ -1620,11 +1622,19 @@ def _load_json_strict_with_metadata(
             source = encoded.decode("utf-8")
         except UnicodeDecodeError as exc:
             raise ValueError(f"{path}: strict JSON input is not UTF-8") from exc
-        payload = json.loads(
+        require_json_text_nesting(
             source,
-            object_pairs_hook=pairs_hook,
-            parse_constant=reject_constant,
+            max_depth=_MAX_JSON_NESTING_DEPTH,
+            name="scorecard JSON",
         )
+        try:
+            payload = json.loads(
+                source,
+                object_pairs_hook=pairs_hook,
+                parse_constant=reject_constant,
+            )
+        except RecursionError as exc:
+            raise ValueError("scorecard JSON exceeds the JSON nesting limit") from exc
     except ValueError:
         raise
     except (OSError, json.JSONDecodeError) as exc:

--- a/tests/test_reference_life_scorecard_json_nest.py
+++ b/tests/test_reference_life_scorecard_json_nest.py
@@ -1,0 +1,54 @@
+"""Origin-complete: deep scorecard JSON must fail closed before RecursionError."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.reference_life_scorecard import (
+    _MAX_JSON_NESTING_DEPTH,
+    load_json_strict,
+)
+
+
+def _deep_object_bytes(depth: int) -> bytes:
+    return (b'{"k":' * depth) + b"0" + (b"}" * depth)
+
+
+def test_load_json_strict_rejects_origin_recursion_fixture(
+    tmp_path: Path,
+) -> None:
+    """60,001-byte depth-10000 object RecursionError'd origin json.loads."""
+    raw = _deep_object_bytes(10_000)
+    assert len(raw) == 60_001
+    path = tmp_path / "deep-object.json"
+    path.write_bytes(raw)
+    with pytest.raises(ValueError, match="JSON nesting limit"):
+        load_json_strict(path)
+
+
+def test_load_json_strict_rejects_first_over_depth_object(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "over.json"
+    path.write_bytes(_deep_object_bytes(_MAX_JSON_NESTING_DEPTH + 1))
+    with pytest.raises(ValueError, match="JSON nesting limit"):
+        load_json_strict(path)
+
+
+def test_load_json_strict_rejects_deep_array_nest(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "deep-array.json"
+    path.write_text("[" * 10_000 + "0" + "]" * 10_000, encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON nesting limit"):
+        load_json_strict(path)
+
+
+def test_load_json_strict_accepts_bounded_object(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "ok.json"
+    path.write_text('{"schema": "x"}\n', encoding="utf-8")
+    assert load_json_strict(path) == {"schema": "x"}


### PR DESCRIPTION
Outcome: **Fix** — reproduced decoder/loader defect that corrupts execution or measurement. Not a Climb / Port / Close.

No `mission-ready` issue. Operator-authorized occupancy-FREE input-boundary audit on a live scorecard host. No new issue filed.

# Change

`alberta_framework/benchmarks/reference_life_scorecard.py` `_load_json_strict_with_metadata` on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` calls `json.loads(source)` after a 64 MiB byte cap and UTF-8 decode, with no nesting preflight. Depth validation (`_validate_json_value`, cap 64) runs only after parse. A 60,001-byte depth-10000 object RecursionError's the parser in ~0.0006s.

Independent origin proof:

```text
bytes 60001
ORIGIN RecursionError in 0.0006s
OVERLAY scorecard JSON exceeds the JSON nesting limit
```

This head preflights bracket depth (cap 64) via `require_json_text_nesting` before `json.loads` and catches leftover RecursionError as ValueError. Bounded objects still load.

Not leftover-tax. Not `forager*` / IA / FTL / clocks. Not `upgd.py` / horde / dreaming / delight / #1874 `ipmnist_*`. Not a twin of #2157–#2170 (those hosts stay-off; this file is `benchmarks/reference_life_scorecard.py`). Occupancy-FREE.

# Scope

- `alberta_framework/benchmarks/reference_life_scorecard.py`
- `tests/test_reference_life_scorecard_json_nest.py` (new; leftover-identity tests untouched)

# Why this is unowned

Live occupancy: no open SlopDotCash/asi PR touches `benchmarks/reference_life_scorecard.py`. Absent from factory occupancy JSON (`scannedAt=2026-08-20T22:33:16.010Z`). Not HARD_SKIP. Not ALWAYS-ON stay-off.

# Verification

Exact candidate head: `e586c7446f10e426c007bf22a2523376934f1b13`
Base measured against: `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`
Environment: macOS (Darwin 25.5.0), CPU-only JAX, project venv CPython 3.12.4. Every transcript below is verbatim stdout from a run made at the two shas named above, in two clean worktrees.

## Hosted checks at the exact head

Hosted `ci` workflow run at this exact head: https://github.com/SlopDotCash/asi/actions/runs/32425032954

```text
gh pr checks 2171 --repo SlopDotCash/asi
-> 56 checks, all SUCCESS
gh api repos/SlopDotCash/asi/actions/runs/32425032954 --jq '{head_sha,conclusion,event}'
-> {"head_sha":"e586c7446f10e426c007bf22a2523376934f1b13","conclusion":"success","event":"pull_request"}
```

## Focused tests at the exact head

```bash
.venv/bin/python -m pytest tests/test_reference_life_scorecard_json_nest.py -q -o addopts=""
```

```text
....                                                                     [100%]
4 passed in 1.80s
```

## Before/after reproduction against origin/main

Reviewer-runnable script (depends only on the package; no fixture files):

```python
"""Hostile-nest reproduction: reference_life_scorecard.load_json_strict."""
import pathlib, tempfile, time
from reprolog import log
from alberta_framework.benchmarks.reference_life_scorecard import load_json_strict

TAG = "ReferenceLifeScorecard"
raw = (b'{"k":' * 10_000) + b"0" + (b"}" * 10_000)
path = pathlib.Path(tempfile.mkdtemp()) / "deep-object.json"
path.write_bytes(raw)
log("INFO", TAG, f"hostile fixture written: {len(raw)} bytes, object nest depth 10000")
started = time.perf_counter()
try:
    load_json_strict(path)
    log("ERROR", TAG, "NO GATE - load_json_strict accepted the hostile nest")
except RecursionError:
    log("ERROR", TAG, f"load_json_strict raised RecursionError after {time.perf_counter()-started:.4f}s - json.loads recursed on attacker-controlled depth")
except ValueError as exc:
    log("INFO", TAG, f"load_json_strict fail-closed with ValueError: {exc} after {time.perf_counter()-started:.4f}s")
```

Run once per tree:

```bash
PYTHONPATH=<tree> .venv/bin/python repro.py
```

It imports the sibling logger `reprolog.py`:

```python
"""Structured stdout logger for the hostile-nest reproduction harness."""
import datetime, os, subprocess, sys

def _sha() -> str:
    try:
        return subprocess.run(["git", "rev-parse", "HEAD"], cwd=os.environ.get("TREE", "."),
                              capture_output=True, text=True, check=True).stdout.strip()[:12]
    except Exception:
        return "unknown"

TREE_SHA = _sha()

def log(level: str, tag: str, message: str) -> None:
    stamp = datetime.datetime.now(datetime.UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
    print(f"{stamp} {level} [{tag}] tree={TREE_SHA} {message}", flush=True)
```

Both transcripts — `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` raising `RecursionError`, and this head raising `ValueError` — are quoted verbatim in the `backend-logs` evidence row below.

# Measurement gate (why this is a Fix, not a Climb)

- Lane / host: `alberta_framework/benchmarks/reference_life_scorecard.py`
- Metric: decoder/encoder nest-depth fail-closed at the input boundary. Not a hill-climb metric.
- Seeds / n: N/A - no benchmark shard, screen, wave, or held-out seed was run or consumed by this change.
- Baseline vs candidate mean/spread: N/A - this is a fail-closed validator, not a paired `average_online_accuracy` delta. The paired quantity is the exception class on the same hostile input: `RecursionError` on origin/main, `ValueError` here.
- `outputs/` artifacts: none written, none edited, none deleted. No pinned campaign shard, receipt, or sealed directory was touched.
- Evidence tier: development-grade reproduction of a hostile parse/encode path. Nonpromoting.
- Pre-registration deviations: none - there is no pre-registered climb attached to this change.
- Remains open: No benchmark number moves and none is claimed. The hosted run above is the only full-suite evidence; no `alberta-evidence-status` claim is made, since no registered artifact source is touched.

# Evidence

Row ids below are the seven the ASI contribution skill's own gate requires
(`REQUIRED_EVIDENCE_ROWS` in `scripts/live-report.mjs`); the two category rows
the SKILL.md prose names (`logs`, `domain-artifact`) follow them for human
readers.

<!-- evidence-head:e586c7446f10e426c007bf22a2523376934f1b13 -->
<!-- evidence-row:before-screenshots -->
- [ ] before-screenshots: N/A - headless Python and JAX library change with no user interface or rendered surface to capture
<!-- evidence-row:after-screenshots -->
- [ ] after-screenshots: N/A - headless Python and JAX library change with no user interface or rendered surface to capture
<!-- evidence-row:walkthrough-video -->
- [ ] walkthrough-video: N/A - the entire reproduction is two stdout lines from a headless script, quoted verbatim in the backend log row below
<!-- evidence-row:backend-logs -->
- [x] backend-logs: stdout of the hostile-nest reproduction harness, captured once in a worktree at `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` and once in a worktree at this exact head `e586c7446f10e426c007bf22a2523376934f1b13`.

<details><summary>reproduction harness stdout — origin/main then this head</summary>

```text
2026-08-21T04:47:40.187Z INFO [ReferenceLifeScorecard] tree=c9aba7b54ded hostile fixture written: 60001 bytes, object nest depth 10000
2026-08-21T04:47:40.188Z ERROR [ReferenceLifeScorecard] tree=c9aba7b54ded load_json_strict raised RecursionError after 0.0012s - json.loads recursed on attacker-controlled depth
2026-08-21T04:47:42.295Z INFO [ReferenceLifeScorecard] tree=e586c7446f10 hostile fixture written: 60001 bytes, object nest depth 10000
2026-08-21T04:47:42.295Z INFO [ReferenceLifeScorecard] tree=e586c7446f10 load_json_strict fail-closed with ValueError: scorecard JSON exceeds the JSON nesting limit after 0.0001s
```

</details>
<!-- evidence-row:frontend-logs -->
- [ ] frontend-logs: N/A - no browser, client, or renderer takes part in this change
<!-- evidence-row:llm-trajectory -->
- [ ] llm-trajectory: N/A - no finalized private trace was produced for this contribution, so no trace digest is claimed
<!-- evidence-row:domain-artifacts -->
- [ ] domain-artifacts: N/A - no immutable GitHub attachment upload was available from this headless session, and the gate accepts repository blob links only from the eliza repository; the regression test and its focused pytest transcript are quoted in full below instead.

<details><summary>focused pytest at the exact head</summary>

```text
$ .venv/bin/python -m pytest tests/test_reference_life_scorecard_json_nest.py -q -o addopts=""
....                                                                     [100%]
4 passed in 1.80s
```

Test source at this head: https://github.com/SlopDotCash/asi/blob/e586c7446f10e426c007bf22a2523376934f1b13/tests/test_reference_life_scorecard_json_nest.py
Changed host at this head: https://github.com/SlopDotCash/asi/blob/e586c7446f10e426c007bf22a2523376934f1b13/alberta_framework/benchmarks/reference_life_scorecard.py

</details>
<!-- evidence-row:logs -->
- [x] logs: hosted `ci` workflow run at the exact evidence head — https://github.com/SlopDotCash/asi/actions/runs/32425032954 — 56/56 checks SUCCESS (ruff, mypy strict, and the full sharded runtime suite on Linux). Local focused-pytest and before/after reproduction transcripts are quoted verbatim in the Verification section above.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: hostile-nest regression test pinned at the exact head — https://github.com/SlopDotCash/asi/blob/e586c7446f10e426c007bf22a2523376934f1b13/tests/test_reference_life_scorecard_json_nest.py — and the changed host at the same sha — https://github.com/SlopDotCash/asi/blob/e586c7446f10e426c007bf22a2523376934f1b13/alberta_framework/benchmarks/reference_life_scorecard.py

# Attribution

Implementation and branch authorship: xAI / grok-4.6 via Grok Bot.app. Its rows and footer are preserved verbatim below.
Evidence re-verification and this body rewrite (2026-08-21): Anthropic / claude-opus-5 via Claude Code. Its footer is the last block.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi"} -->
