### PR TITLE
fix(reference-life): reject deep oracle-control JSON nests before parse

### DIFF
--- a/alberta_framework/reference_life_controls.py
+++ b/alberta_framework/reference_life_controls.py
@@ -23,6 +23,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._bounded_containers import require_json_text_nesting
 from alberta_framework.core.average_reward import (
     DifferentialSARSAAgent,
     DifferentialSARSAConfig,
@@ -86,6 +87,9 @@ _THREEFRY_IMPLEMENTATION = REFERENCE_LIFE_PRNG_IMPLEMENTATION
 _SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9._:-]*$")
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _MAX_ID_LENGTH = 256
+# Same ceiling as reference_agent string-fed JSON. Origin json.loads
+# RecursionErrors a 16_000-deep object nest before the oracle schema runs.
+_MAX_JSON_NESTING_DEPTH = 64
 _RANDOM_DOMAIN = 0x4354524C
 
 EnvironmentKind = Literal["switching_two_state", "riverswim"]
@@ -225,6 +229,26 @@ def _canonical_json(value: dict[str, Any]) -> str:
         separators=(",", ":"),
         sort_keys=True,
     )
+
+
+def _require_oracle_config_json(raw: object) -> str:
+    """Reject nesting that would RecursionError json.loads before it runs."""
+
+    if type(raw) is not str:
+        raise ValueError("oracle environment config must be canonical JSON")
+    try:
+        require_json_text_nesting(
+            raw,
+            max_depth=_MAX_JSON_NESTING_DEPTH,
+            name="oracle environment config",
+        )
+    except ValueError as exc:
+        if "nesting limit" not in str(exc):
+            raise
+        raise ValueError(
+            "oracle environment config exceeds the JSON nesting limit"
+        ) from exc
+    return raw
 
 
 def _canonical_switching_environment(
@@ -736,10 +760,13 @@ class AnalyticOracleReferenceConfig:
             self.policy_sha256
         ) is None:
             raise ValueError("oracle policy_sha256 must be a lowercase SHA-256 digest")
-        if type(self.environment_config_json) is not str:
-            raise ValueError("oracle environment config must be canonical JSON")
+        _require_oracle_config_json(self.environment_config_json)
         try:
             decoded = json.loads(self.environment_config_json)
+        except RecursionError as exc:
+            raise ValueError(
+                "oracle environment config exceeds the JSON nesting limit"
+            ) from exc
         except (TypeError, json.JSONDecodeError) as exc:
             raise ValueError("oracle environment config must be canonical JSON") from exc
         if (
@@ -845,7 +872,13 @@ class AnalyticOracleReferenceConfig:
 
     @property
     def environment_config(self) -> dict[str, Any]:
-        decoded = json.loads(self.environment_config_json)
+        _require_oracle_config_json(self.environment_config_json)
+        try:
+            decoded = json.loads(self.environment_config_json)
+        except RecursionError as exc:
+            raise ValueError(
+                "oracle environment config exceeds the JSON nesting limit"
+            ) from exc
         assert isinstance(decoded, dict)
         return decoded
 

--- a/tests/test_reference_life_controls_json_nest.py
+++ b/tests/test_reference_life_controls_json_nest.py
@@ -1,0 +1,67 @@
+"""Reject deep oracle environment JSON before json.loads RecursionError.
+
+Origin ``AnalyticOracleReferenceConfig`` loads ``environment_config_json``
+with ``json.loads`` and no nesting preflight. A 16_000-deep object nest
+RecursionError's the C decoder on origin/main. Overlay fail-closes at the
+shared 64-deep JSON ceiling before parse.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from alberta_framework.reference_life_controls import (
+    _MAX_JSON_NESTING_DEPTH,
+    AnalyticOracleReferenceConfig,
+    _require_oracle_config_json,
+)
+from alberta_framework.streams.closed_loop import SwitchingTwoStateConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _nested_json(depth: int) -> str:
+    return '{"k":' * depth + "0" + "}" * depth
+
+
+def test_frozen_oracle_config_json_nest_bound() -> None:
+    assert _MAX_JSON_NESTING_DEPTH == 64
+
+
+def test_last_fit_oracle_config_still_validates() -> None:
+    environment = SwitchingTwoStateConfig(phase_length=2)  # type: ignore[call-arg]
+    config = AnalyticOracleReferenceConfig.for_switching(environment, horizon=2)
+    assert config.environment_kind == "switching_two_state"
+    assert config.environment_config["phase_length"] == 2
+
+
+def test_last_fit_json_text_still_encodes() -> None:
+    _require_oracle_config_json(_nested_json(_MAX_JSON_NESTING_DEPTH))
+
+
+def test_first_overflow_nest_is_value_error_not_recursion_error() -> None:
+    with pytest.raises(ValueError, match="nesting limit"):
+        _require_oracle_config_json(_nested_json(_MAX_JSON_NESTING_DEPTH + 1))
+
+
+def test_origin_recursion_class_rejects_before_loads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_loads(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("json.loads ran before the oracle-config nest gate")
+
+    monkeypatch.setattr(json, "loads", fail_loads)
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="nesting limit"):
+        AnalyticOracleReferenceConfig(
+            environment_kind="switching_two_state",
+            observation_dim=2,
+            n_actions=2,
+            horizon=2,
+            policy_sha256="0" * 64,
+            environment_config_json=_nested_json(16_000),
+        )
+    assert time.perf_counter() - started < 0.25


### PR DESCRIPTION
Outcome: **Fix** — reproduced decoder/loader defect that corrupts execution or measurement. Not a Climb / Port / Close.

No `mission-ready` issue. Operator-authorized occupancy-FREE input-boundary audit on a live reference-life oracle-control host. No new issue filed.

# Change

`alberta_framework/reference_life_controls.py` `AnalyticOracleReferenceConfig` on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` loads caller `environment_config_json` with `json.loads` and no nesting preflight. A 16,000-deep object nest RecursionError's the C decoder in ~0.0006s before the exact switching/RiverSwim schema can fail closed.

Independent origin proof:

```text
ORIGIN RecursionError in 0.0006s
OVERLAY ValueError oracle environment config exceeds the JSON nesting limit in 0.0000s
```

This head preflights JSON bracket depth (cap 64, same ceiling as `reference_agent` string-fed JSON) via `require_json_text_nesting` before `json.loads` and catches leftover RecursionError as ValueError. Honest last-fit SwitchingTwoState oracle controls still validate.

Not leftover-tax. Not `forager*` / IA / FTL / clocks. Not `upgd.py` / horde / dreaming / delight / #1874 / feature_discovery pair-cap. Not a nest/`np.load` twin of #2157–#2173 (those hosts stay-off; this file is `reference_life_controls.py` and the walker is constructor-time string-fed `json.loads` of `environment_config_json`, not path-fed file parse and not validator-time `json.dumps` of a caller mapping). Occupancy-FREE.

# Scope

- `alberta_framework/reference_life_controls.py`
- `tests/test_reference_life_controls_json_nest.py` (new; leftover-identity tests untouched)

# Why this is unowned

Live occupancy: no open SlopDotCash/asi PR touches `reference_life_controls.py`. Absent from factory occupancy JSON (`scannedAt=2026-08-20T23:19:48.766Z`). Not HARD_SKIP. Not ALWAYS-ON stay-off.

# Verification

Exact candidate head: `6c20a829288b3821288eb921a4bf43f44353b007`
Base measured against: `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`
Environment: macOS (Darwin 25.5.0), CPU-only JAX, project venv CPython 3.12.4. Every transcript below is verbatim stdout from a run made at the two shas named above, in two clean worktrees.

## Hosted checks at the exact head

Hosted `ci` workflow run at this exact head: https://github.com/SlopDotCash/asi/actions/runs/32429088582

```text
gh pr checks 2174 --repo SlopDotCash/asi
-> 56 checks, all SUCCESS
gh api repos/SlopDotCash/asi/actions/runs/32429088582 --jq '{head_sha,conclusion,event}'
-> {"head_sha":"6c20a829288b3821288eb921a4bf43f44353b007","conclusion":"success","event":"pull_request"}
```

## Focused tests at the exact head

```bash
.venv/bin/python -m pytest tests/test_reference_life_controls_json_nest.py -q -o addopts=""
```

```text
.....                                                                    [100%]
5 passed in 0.64s
```

## Before/after reproduction against origin/main

Reviewer-runnable script (depends only on the package; no fixture files):

```python
"""Hostile-nest reproduction: AnalyticOracleReferenceConfig environment_config_json."""
import time
from reprolog import log
from alberta_framework.reference_life_controls import AnalyticOracleReferenceConfig

TAG = "ReferenceLifeControls"
nested = '{"k":' * 16_000 + "0" + "}" * 16_000
log("INFO", TAG, f"hostile environment_config_json built: {len(nested)} bytes, object nest depth 16000")
started = time.perf_counter()
try:
    AnalyticOracleReferenceConfig(environment_kind="switching_two_state", observation_dim=2,
        n_actions=2, horizon=2, policy_sha256="0" * 64, environment_config_json=nested)
    log("ERROR", TAG, "NO GATE - AnalyticOracleReferenceConfig accepted the hostile nest")
except RecursionError:
    log("ERROR", TAG, f"AnalyticOracleReferenceConfig raised RecursionError after {time.perf_counter()-started:.4f}s - json.loads recursed before the schema check")
except ValueError as exc:
    log("INFO", TAG, f"AnalyticOracleReferenceConfig fail-closed with ValueError: {exc} after {time.perf_counter()-started:.4f}s")
```

Run once per tree:

```bash
PYTHONPATH=<tree> .venv/bin/python repro.py
```

It imports the sibling logger `reprolog.py`:

```python
"""Structured stdout logger for the hostile-nest reproduction harness."""
import datetime, os, subprocess, sys

def _sha() -> str:
    try:
        return subprocess.run(["git", "rev-parse", "HEAD"], cwd=os.environ.get("TREE", "."),
                              capture_output=True, text=True, check=True).stdout.strip()[:12]
    except Exception:
        return "unknown"

TREE_SHA = _sha()

def log(level: str, tag: str, message: str) -> None:
    stamp = datetime.datetime.now(datetime.UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
    print(f"{stamp} {level} [{tag}] tree={TREE_SHA} {message}", flush=True)
```

Both transcripts — `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` raising `RecursionError`, and this head raising `ValueError` — are quoted verbatim in the `backend-logs` evidence row below.

# Measurement gate (why this is a Fix, not a Climb)

- Lane / host: `alberta_framework/reference_life_controls.py`
- Metric: decoder/encoder nest-depth fail-closed at the input boundary. Not a hill-climb metric.
- Seeds / n: N/A - no benchmark shard, screen, wave, or held-out seed was run or consumed by this change.
- Baseline vs candidate mean/spread: N/A - this is a fail-closed validator, not a paired `average_online_accuracy` delta. The paired quantity is the exception class on the same hostile input: `RecursionError` on origin/main, `ValueError` here.
- `outputs/` artifacts: none written, none edited, none deleted. No pinned campaign shard, receipt, or sealed directory was touched.
- Evidence tier: development-grade reproduction of a hostile parse/encode path. Nonpromoting.
- Pre-registration deviations: none - there is no pre-registered climb attached to this change.
- Remains open: No benchmark number moves and none is claimed. The hosted run above is the only full-suite evidence; no `alberta-evidence-status` claim is made, since no registered artifact source is touched.

# Evidence

Row ids below are the seven the ASI contribution skill's own gate requires
(`REQUIRED_EVIDENCE_ROWS` in `scripts/live-report.mjs`); the two category rows
the SKILL.md prose names (`logs`, `domain-artifact`) follow them for human
readers.

<!-- evidence-head:6c20a829288b3821288eb921a4bf43f44353b007 -->
<!-- evidence-row:before-screenshots -->
- [ ] before-screenshots: N/A - headless Python and JAX library change with no user interface or rendered surface to capture
<!-- evidence-row:after-screenshots -->
- [ ] after-screenshots: N/A - headless Python and JAX library change with no user interface or rendered surface to capture
<!-- evidence-row:walkthrough-video -->
- [ ] walkthrough-video: N/A - the entire reproduction is two stdout lines from a headless script, quoted verbatim in the backend log row below
<!-- evidence-row:backend-logs -->
- [x] backend-logs: stdout of the hostile-nest reproduction harness, captured once in a worktree at `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` and once in a worktree at this exact head `6c20a829288b3821288eb921a4bf43f44353b007`.

<details><summary>reproduction harness stdout — origin/main then this head</summary>

```text
2026-08-21T04:47:49.548Z INFO [ReferenceLifeControls] tree=c9aba7b54ded hostile environment_config_json built: 96001 bytes, object nest depth 16000
2026-08-21T04:47:49.549Z ERROR [ReferenceLifeControls] tree=c9aba7b54ded AnalyticOracleReferenceConfig raised RecursionError after 0.0009s - json.loads recursed before the schema check
2026-08-21T04:47:50.740Z INFO [ReferenceLifeControls] tree=6c20a829288b hostile environment_config_json built: 96001 bytes, object nest depth 16000
2026-08-21T04:47:50.741Z INFO [ReferenceLifeControls] tree=6c20a829288b AnalyticOracleReferenceConfig fail-closed with ValueError: oracle environment config exceeds the JSON nesting limit after 0.0000s
```

</details>
<!-- evidence-row:frontend-logs -->
- [ ] frontend-logs: N/A - no browser, client, or renderer takes part in this change
<!-- evidence-row:llm-trajectory -->
- [ ] llm-trajectory: N/A - no finalized private trace was produced for this contribution, so no trace digest is claimed
<!-- evidence-row:domain-artifacts -->
- [ ] domain-artifacts: N/A - no immutable GitHub attachment upload was available from this headless session, and the gate accepts repository blob links only from the eliza repository; the regression test and its focused pytest transcript are quoted in full below instead.

<details><summary>focused pytest at the exact head</summary>

```text
$ .venv/bin/python -m pytest tests/test_reference_life_controls_json_nest.py -q -o addopts=""
.....                                                                    [100%]
5 passed in 0.64s
```

Test source at this head: https://github.com/SlopDotCash/asi/blob/6c20a829288b3821288eb921a4bf43f44353b007/tests/test_reference_life_controls_json_nest.py
Changed host at this head: https://github.com/SlopDotCash/asi/blob/6c20a829288b3821288eb921a4bf43f44353b007/alberta_framework/reference_life_controls.py

</details>
<!-- evidence-row:logs -->
- [x] logs: hosted `ci` workflow run at the exact evidence head — https://github.com/SlopDotCash/asi/actions/runs/32429088582 — 56/56 checks SUCCESS (ruff, mypy strict, and the full sharded runtime suite on Linux). Local focused-pytest and before/after reproduction transcripts are quoted verbatim in the Verification section above.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: hostile-nest regression test pinned at the exact head — https://github.com/SlopDotCash/asi/blob/6c20a829288b3821288eb921a4bf43f44353b007/tests/test_reference_life_controls_json_nest.py — and the changed host at the same sha — https://github.com/SlopDotCash/asi/blob/6c20a829288b3821288eb921a4bf43f44353b007/alberta_framework/reference_life_controls.py

# Attribution

Implementation and branch authorship: xAI / grok-4.6 via Grok Bot.app. Its rows and footer are preserved verbatim below.
Evidence re-verification and this body rewrite (2026-08-21): Anthropic / claude-opus-5 via Claude Code. Its footer is the last block.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi"} -->
