### PR TITLE
fix(reference-life): reject deep life-config JSON nests before parse

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -157,9 +157,9 @@ def _require_config_json(raw: object, *, name: str) -> str:
 
 
 def _load_config_json(raw: object, *, name: str) -> Any:
-    _require_config_json(raw, name=name)
+    text = _require_config_json(raw, name=name)
     try:
-        return json.loads(raw)
+        return json.loads(text)
     except RecursionError as exc:
         raise ValueError(f"{name} exceeds the JSON nesting limit") from exc
     except (TypeError, json.JSONDecodeError) as exc:

--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -30,6 +30,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._bounded_containers import require_json_text_nesting
 from alberta_framework.core.prototype_agent import PrototypeAgentConfig
 from alberta_framework.prototype_reference_adapter import (
     PrototypeReferenceAdapter,
@@ -80,6 +81,9 @@ _SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9._:-]*$")
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _PROTOTYPE_LIFECYCLE = re.compile(r"^prototype\.[0-9a-f]{16}$")
 _MAX_ID_LENGTH = 256
+# Same ceiling as reference_agent string-fed JSON. Origin json.loads
+# RecursionErrors a 16_000-deep object nest before life-config schema runs.
+_MAX_JSON_NESTING_DEPTH = 64
 _MAX_SWITCHING_EXECUTIONS = int(np.iinfo(np.int32).max)
 RIVERSWIM_REFERENCE_MAX_STATES = 12
 _CheckpointPublishResult = TypeVar("_CheckpointPublishResult")
@@ -135,6 +139,33 @@ def _require_prototype_lifecycle_id(value: str) -> None:
         )
 
 
+def _require_config_json(raw: object, *, name: str) -> str:
+    """Reject nesting that would RecursionError json.loads before it runs."""
+    if type(raw) is not str:
+        raise ValueError(f"{name} must be canonical JSON")
+    try:
+        require_json_text_nesting(
+            raw,
+            max_depth=_MAX_JSON_NESTING_DEPTH,
+            name=name,
+        )
+    except ValueError as exc:
+        if "nesting limit" not in str(exc):
+            raise
+        raise ValueError(f"{name} exceeds the JSON nesting limit") from exc
+    return raw
+
+
+def _load_config_json(raw: object, *, name: str) -> Any:
+    _require_config_json(raw, name=name)
+    try:
+        return json.loads(raw)
+    except RecursionError as exc:
+        raise ValueError(f"{name} exceeds the JSON nesting limit") from exc
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{name} must be canonical JSON") from exc
+
+
 def _canonical_json(value: Mapping[str, Any]) -> str:
     try:
         encoded = json.dumps(
@@ -144,9 +175,11 @@ def _canonical_json(value: Mapping[str, Any]) -> str:
             separators=(",", ":"),
             sort_keys=True,
         )
+    except RecursionError as exc:
+        raise ValueError("reference-life configuration exceeds the JSON nesting limit") from exc
     except (TypeError, ValueError) as exc:
         raise ValueError("reference-life configuration must be canonical finite JSON") from exc
-    decoded = json.loads(encoded)
+    decoded = _load_config_json(encoded, name="reference-life configuration")
     if not isinstance(decoded, dict):
         raise ValueError("reference-life configuration must be a JSON object")
     return encoded
@@ -287,7 +320,7 @@ class ReferenceEnvironmentManifest:
             "implementation_id": implementation_id,
             "state_schema": state_schema,
             "config_sha256": config_sha256,
-            "config": json.loads(config_json),
+            "config": _load_config_json(config_json, name="environment config"),
             "observation_spec": _space_descriptor(observation_spec),
             "action_spec": _space_descriptor(action_spec),
             "max_executions": max_executions,
@@ -306,7 +339,7 @@ class ReferenceEnvironmentManifest:
 
     @property
     def config(self) -> dict[str, Any]:
-        value = json.loads(self._config_json)
+        value = _load_config_json(self._config_json, name="environment config")
         assert isinstance(value, dict)
         return value
 
@@ -1551,7 +1584,7 @@ class ReferenceLifeConfig:
 
     @property
     def config(self) -> dict[str, Any]:
-        value = json.loads(self._config_json)
+        value = _load_config_json(self._config_json, name="life configuration")
         assert isinstance(value, dict)
         return value
 

--- a/tests/test_reference_life_config_json_nest.py
+++ b/tests/test_reference_life_config_json_nest.py
@@ -1,0 +1,92 @@
+"""Reject deep life-config JSON before json.loads RecursionError.
+
+Origin ``ReferenceLifeConfig`` loads ``_config_json`` with ``json.loads``
+and no nesting preflight. A 16_000-deep object nest RecursionErrors the
+C decoder on origin/main. Overlay fail-closes at the shared 64-deep JSON
+ceiling before parse.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import time
+
+import pytest
+
+from alberta_framework.core.oak import OaKConfig
+from alberta_framework.core.options import STOMPConfig
+from alberta_framework.core.prototype_agent import PrototypeAgentConfig
+from alberta_framework.reference_life import (
+    _MAX_JSON_NESTING_DEPTH,
+    _require_config_json,
+    build_prototype_switching_life,
+)
+from alberta_framework.streams.closed_loop import SwitchingTwoStateConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _nested_json(depth: int) -> str:
+    open_obj = chr(123) + chr(34) + "k" + chr(34) + ":"
+    return open_obj * depth + "0" + chr(125) * depth
+
+
+def _agent_config() -> PrototypeAgentConfig:
+    return PrototypeAgentConfig(
+        oak=OaKConfig(
+            stomp=STOMPConfig(
+                subtask_specs=(),
+                observation_dim=2,
+                n_primitive_actions=2,
+                base_step_size=0.05,
+                epsilon_base=0.0,
+            )
+        )
+    )
+
+
+def _last_fit_runner():
+    return build_prototype_switching_life(
+        agent_config=_agent_config(),
+        environment_config=SwitchingTwoStateConfig(phase_length=2),
+        lifecycle_id="prototype.0000000100000002",
+        seed=7,
+        max_accepted_events=3,
+    )
+
+
+def test_frozen_life_config_json_nest_bound() -> None:
+    assert _MAX_JSON_NESTING_DEPTH == 64
+
+
+def test_last_fit_life_config_still_validates() -> None:
+    runner = _last_fit_runner()
+    assert runner.config.config["environment"]["config"]["phase_length"] == 2
+
+
+def test_last_fit_json_text_still_encodes() -> None:
+    _require_config_json(_nested_json(_MAX_JSON_NESTING_DEPTH), name="life configuration")
+
+
+def test_first_overflow_nest_is_value_error_not_recursion_error() -> None:
+    with pytest.raises(ValueError, match="nesting limit"):
+        _require_config_json(
+            _nested_json(_MAX_JSON_NESTING_DEPTH + 1),
+            name="life configuration",
+        )
+
+
+def test_origin_recursion_class_rejects_before_loads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _last_fit_runner()
+
+    def fail_loads(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("json.loads ran before the life-config nest gate")
+
+    monkeypatch.setattr(json, "loads", fail_loads)
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="nesting limit"):
+        dataclasses.replace(runner.config, _config_json=_nested_json(16_000))
+    assert time.perf_counter() - started < 0.25


### PR DESCRIPTION
Outcome: **Fix** — reproduced decoder/loader defect that corrupts execution or measurement. Not a Climb / Port / Close.

No `mission-ready` issue. Operator-authorized occupancy-FREE input-boundary audit on a live reference-life config host. No new issue filed.

# Change

`alberta_framework/reference_life.py` `ReferenceLifeConfig` on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` loads caller `_config_json` with `json.loads` and no nesting preflight. A 16,000-deep object nest RecursionErrors the C decoder in ~0.0015s before the exact life-config schema can fail closed.

Independent origin proof:

```text
ORIGIN RecursionError in 0.0015s
OVERLAY ValueError life configuration exceeds the JSON nesting limit in 0.0001s
```

This head preflights JSON bracket depth (cap 64, same ceiling as `reference_agent` string-fed JSON) via `require_json_text_nesting` before `json.loads` and catches leftover RecursionError as ValueError. Honest last-fit SwitchingTwoState life configs still validate.

Not leftover-tax. Not `forager*` / IA / FTL / clocks. Not `upgd.py` / horde / dreaming / delight / #1874 / feature_discovery pair-cap. Not a nest/`np.load` twin of #2157–#2174 (those hosts stay-off; this file is `reference_life.py` and the walker is constructor-time string-fed `json.loads` of `_config_json`, not path-fed file parse, not validator-time `json.dumps` of a caller mapping, and not `reference_life_controls.py` `environment_config_json`). Occupancy-FREE.

# Scope

- `alberta_framework/reference_life.py`
- `tests/test_reference_life_config_json_nest.py` (new; leftover-identity tests untouched)

# Why this is unowned

Live occupancy: no open SlopDotCash/asi PR touches `reference_life.py`. Absent from factory occupancy JSON (`scannedAt=2026-08-20T23:45:19.733Z`). Not HARD_SKIP. Not ALWAYS-ON stay-off.

# Verification

Exact candidate head: `a35471ac282082b6bf21fe17f4a65ad77766c249`
Base measured against: `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`
Environment: macOS (Darwin 25.5.0), CPU-only JAX, project venv CPython 3.12.4. Every transcript below is verbatim stdout from a run made at the two shas named above, in two clean worktrees.

## Hosted checks at the exact head

Hosted `ci` workflow run at this exact head: https://github.com/SlopDotCash/asi/actions/runs/32447752643

```text
gh pr checks 2175 --repo SlopDotCash/asi
-> 56 checks, all SUCCESS
gh api repos/SlopDotCash/asi/actions/runs/32447752643 --jq '{head_sha,conclusion,event}'
-> {"head_sha":"a35471ac282082b6bf21fe17f4a65ad77766c249","conclusion":"success","event":"pull_request"}
```

## Focused tests at the exact head

```bash
.venv/bin/python -m pytest tests/test_reference_life_config_json_nest.py -q -o addopts=""
```

```text
.....                                                                    [100%]
5 passed in 0.95s
```

## BLOCKED cleared at this head

The previous head `9c5ba624d2b00985da0dc1743d6f5354002e3e27` was `BLOCKED`: the hosted `lint` job failed mypy strict with

```text
alberta_framework/reference_life.py:162: error: Argument 1 to "loads" has incompatible type "object"; expected "str | bytes | bytearray"  [arg-type]
Found 1 error in 1 file (checked 224 source files)
```

`_require_config_json` already proves the value is a `str` and returns it, so this head passes that narrowed return into `json.loads` instead of the unnarrowed parameter. No behaviour change; the nest gate is untouched. Locally at this head:

```text
$ .venv/bin/python -m mypy
alberta_framework/evaluation/bounded_elastic_matched_runner.py:1111: error: Module has no attribute "O_TMPFILE"  [attr-defined]
Found 1 error in 1 file (checked 224 source files)

$ .venv/bin/python -m ruff check alberta_framework/reference_life.py tests/test_reference_life_config_json_nest.py
All checks passed!
```

The single remaining local mypy error is `os.O_TMPFILE`, which does not exist on macOS and is pre-existing on `origin/main`; the hosted Linux `lint` job at this head is green, which is the authoritative result.

```text
$ .venv/bin/python -m pytest tests/test_reference_life_config_json_nest.py tests/test_reference_life.py -q -o addopts=""
48 passed in 24.34s
```

## Before/after reproduction against origin/main

Reviewer-runnable script (depends only on the package; no fixture files):

```python
"""Hostile-nest reproduction: ReferenceLifeConfig _config_json."""
import dataclasses, time
from reprolog import log
from alberta_framework.core.oak import OaKConfig
from alberta_framework.core.options import STOMPConfig
from alberta_framework.core.prototype_agent import PrototypeAgentConfig
from alberta_framework.reference_life import build_prototype_switching_life
from alberta_framework.streams.closed_loop import SwitchingTwoStateConfig

TAG = "ReferenceLife"
agent = PrototypeAgentConfig(oak=OaKConfig(stomp=STOMPConfig(
    subtask_specs=(), observation_dim=2, n_primitive_actions=2,
    base_step_size=0.05, epsilon_base=0.0)))
runner = build_prototype_switching_life(agent_config=agent,
    environment_config=SwitchingTwoStateConfig(phase_length=2),
    lifecycle_id="prototype.0000000100000002", seed=7, max_accepted_events=3)
nested = '{"k":' * 16_000 + "0" + "}" * 16_000
log("INFO", TAG, f"hostile _config_json built: {len(nested)} bytes, object nest depth 16000")
started = time.perf_counter()
try:
    dataclasses.replace(runner.config, _config_json=nested)
    log("ERROR", TAG, "NO GATE - ReferenceLifeConfig accepted the hostile nest")
except RecursionError:
    log("ERROR", TAG, f"ReferenceLifeConfig raised RecursionError after {time.perf_counter()-started:.4f}s - json.loads recursed before the life-config schema check")
except ValueError as exc:
    log("INFO", TAG, f"ReferenceLifeConfig fail-closed with ValueError: {exc} after {time.perf_counter()-started:.4f}s")
```

Run once per tree:

```bash
PYTHONPATH=<tree> .venv/bin/python repro.py
```

It imports the sibling logger `reprolog.py`:

```python
"""Structured stdout logger for the hostile-nest reproduction harness."""
import datetime, os, subprocess, sys

def _sha() -> str:
    try:
        return subprocess.run(["git", "rev-parse", "HEAD"], cwd=os.environ.get("TREE", "."),
                              capture_output=True, text=True, check=True).stdout.strip()[:12]
    except Exception:
        return "unknown"

TREE_SHA = _sha()

def log(level: str, tag: str, message: str) -> None:
    stamp = datetime.datetime.now(datetime.UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
    print(f"{stamp} {level} [{tag}] tree={TREE_SHA} {message}", flush=True)
```

Both transcripts — `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` raising `RecursionError`, and this head raising `ValueError` — are quoted verbatim in the `backend-logs` evidence row below.

# Measurement gate (why this is a Fix, not a Climb)

- Lane / host: `alberta_framework/reference_life.py`
- Metric: decoder/encoder nest-depth fail-closed at the input boundary. Not a hill-climb metric.
- Seeds / n: N/A - no benchmark shard, screen, wave, or held-out seed was run or consumed by this change.
- Baseline vs candidate mean/spread: N/A - this is a fail-closed validator, not a paired `average_online_accuracy` delta. The paired quantity is the exception class on the same hostile input: `RecursionError` on origin/main, `ValueError` here.
- `outputs/` artifacts: none written, none edited, none deleted. No pinned campaign shard, receipt, or sealed directory was touched.
- Evidence tier: development-grade reproduction of a hostile parse/encode path. Nonpromoting.
- Pre-registration deviations: none - there is no pre-registered climb attached to this change.
- Remains open: No benchmark number moves and none is claimed. The hosted run above is the only full-suite evidence; no `alberta-evidence-status` claim is made, since no registered artifact source is touched. Local `mypy` still reports the pre-existing macOS-only `os.O_TMPFILE` error, which is unrelated to this change and green on Linux.

# Evidence

Row ids below are the seven the ASI contribution skill's own gate requires
(`REQUIRED_EVIDENCE_ROWS` in `scripts/live-report.mjs`); the two category rows
the SKILL.md prose names (`logs`, `domain-artifact`) follow them for human
readers.

<!-- evidence-head:a35471ac282082b6bf21fe17f4a65ad77766c249 -->
<!-- evidence-row:before-screenshots -->
- [ ] before-screenshots: N/A - headless Python and JAX library change with no user interface or rendered surface to capture
<!-- evidence-row:after-screenshots -->
- [ ] after-screenshots: N/A - headless Python and JAX library change with no user interface or rendered surface to capture
<!-- evidence-row:walkthrough-video -->
- [ ] walkthrough-video: N/A - the entire reproduction is two stdout lines from a headless script, quoted verbatim in the backend log row below
<!-- evidence-row:backend-logs -->
- [x] backend-logs: stdout of the hostile-nest reproduction harness, captured once in a worktree at `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` and once in a worktree at this exact head `a35471ac282082b6bf21fe17f4a65ad77766c249`.

<details><summary>reproduction harness stdout — origin/main then this head</summary>

```text
2026-08-21T04:47:51.970Z INFO [ReferenceLife] tree=c9aba7b54ded hostile _config_json built: 96001 bytes, object nest depth 16000
2026-08-21T04:47:51.971Z ERROR [ReferenceLife] tree=c9aba7b54ded ReferenceLifeConfig raised RecursionError after 0.0009s - json.loads recursed before the life-config schema check
2026-08-21T04:47:53.300Z INFO [ReferenceLife] tree=a35471ac2820 hostile _config_json built: 96001 bytes, object nest depth 16000
2026-08-21T04:47:53.300Z INFO [ReferenceLife] tree=a35471ac2820 ReferenceLifeConfig fail-closed with ValueError: life configuration exceeds the JSON nesting limit after 0.0000s
```

</details>
<!-- evidence-row:frontend-logs -->
- [ ] frontend-logs: N/A - no browser, client, or renderer takes part in this change
<!-- evidence-row:llm-trajectory -->
- [ ] llm-trajectory: N/A - no finalized private trace was produced for this contribution, so no trace digest is claimed
<!-- evidence-row:domain-artifacts -->
- [ ] domain-artifacts: N/A - no immutable GitHub attachment upload was available from this headless session, and the gate accepts repository blob links only from the eliza repository; the regression test and its focused pytest transcript are quoted in full below instead.

<details><summary>focused pytest at the exact head</summary>

```text
$ .venv/bin/python -m pytest tests/test_reference_life_config_json_nest.py -q -o addopts=""
.....                                                                    [100%]
5 passed in 0.95s
```

Test source at this head: https://github.com/SlopDotCash/asi/blob/a35471ac282082b6bf21fe17f4a65ad77766c249/tests/test_reference_life_config_json_nest.py
Changed host at this head: https://github.com/SlopDotCash/asi/blob/a35471ac282082b6bf21fe17f4a65ad77766c249/alberta_framework/reference_life.py

</details>
<!-- evidence-row:logs -->
- [x] logs: hosted `ci` workflow run at the exact evidence head — https://github.com/SlopDotCash/asi/actions/runs/32447752643 — 56/56 checks SUCCESS including the `lint` job that was previously red (ruff, mypy strict, and the full sharded runtime suite on Linux). Local focused-pytest and before/after reproduction transcripts are quoted verbatim above.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: hostile-nest regression test pinned at the exact head — https://github.com/SlopDotCash/asi/blob/a35471ac282082b6bf21fe17f4a65ad77766c249/tests/test_reference_life_config_json_nest.py — and the changed host at the same sha — https://github.com/SlopDotCash/asi/blob/a35471ac282082b6bf21fe17f4a65ad77766c249/alberta_framework/reference_life.py

# Attribution

Implementation and branch authorship: xAI / grok-4.6 via Grok Bot.app. Its rows and footer are preserved verbatim below.
Evidence re-verification and this body rewrite (2026-08-21): Anthropic / claude-opus-5 via Claude Code. Its footer is the last block.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"elizaOS/slopdotcash@6000f7847387c3f046d2c4df071a7c0bb8ddc8d6:skills/contribute-to-asi"} -->

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi"} -->
