### PR TITLE
fix(utils): use Cohen's d_z for paired comparisons

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -428,6 +428,56 @@ def cohens_d(
     return float((mean_a - mean_b) / pooled_std)
 
 
+def _paired_cohens_d(
+    values_a: NDArray[np.float64] | list[float],
+    values_b: NDArray[np.float64] | list[float],
+) -> float:
+    """Compute Cohen's d_z for paired/matched samples.
+
+    A paired design shares the between-seed variance across both groups,
+    and the paired test itself cancels it out. The correct effect size is
+    therefore d_z = mean(differences) / std(differences, ddof=1), not the
+    pooled independent-groups formula. Using pooled Cohen's d on paired
+    data can understate a real, consistent within-pair shift by orders of
+    magnitude.
+
+    Args:
+        values_a: Values for first method (paired with ``values_b``)
+        values_b: Values for second method (paired with ``values_a``)
+
+    Returns:
+        Cohen's d_z (positive means a > b on average within pairs).
+
+    Raises:
+        ValueError: If either sample is not a finite one-dimensional
+            vector, the samples differ in length, hold fewer than 2 pairs,
+            or the within-pair differences have zero variance.
+    """
+    a = _require_sample_vector(values_a, name="values_a")
+    b = _require_sample_vector(values_b, name="values_b")
+    _require_finite_values(a, name="values_a")
+    _require_finite_values(b, name="values_b")
+
+    if len(a) != len(b):
+        raise ValueError(
+            f"paired d_z requires equal-length samples (got {len(a)} and {len(b)})"
+        )
+    if len(a) < 2:
+        raise ValueError(
+            f"paired d_z requires at least 2 pairs (got {len(a)})"
+        )
+
+    differences = a - b
+    std_differences = np.std(differences, ddof=1)
+    if std_differences == 0:
+        mean_difference = np.mean(differences)
+        if mean_difference == 0:
+            return 0.0
+        return float(np.copysign(np.inf, mean_difference))
+
+    return float(np.mean(differences) / std_differences)
+
+
 def ttest_comparison(
     values_a: NDArray[np.float64] | list[float],
     values_b: NDArray[np.float64] | list[float],
@@ -503,7 +553,10 @@ def ttest_comparison(
     except ImportError:
         raise ImportError("scipy is required for t-test. Install with: pip install scipy")
 
-    effect = cohens_d(a, b)
+    if paired:
+        effect = _paired_cohens_d(a, b)
+    else:
+        effect = cohens_d(a, b)
 
     return SignificanceResult(
         test_name=test_name,
@@ -657,7 +710,7 @@ def wilcoxon_comparison(
     except ImportError:
         raise ImportError("scipy is required for Wilcoxon test. Install with: pip install scipy")
 
-    effect = cohens_d(a, b)
+    effect = _paired_cohens_d(a, b)
 
     return SignificanceResult(
         test_name="Wilcoxon signed-rank",

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -1179,3 +1179,33 @@ class TestPairwiseComparisons:
     def test_common_final_window_requires_positive_integer(self, window: object) -> None:
         with pytest.raises(ValueError, match="window must be a positive integer"):
             common_final_window({"learner": 10}, window, "squared_error")
+
+
+class TestPairedEffectSize:
+    """Paired comparisons must report Cohen's d_z, not pooled Cohen's d (#2154)."""
+
+    def test_paired_ttest_reports_dz(self) -> None:
+        """A consistent within-pair shift must not be swamped by between-seed variance."""
+        a = np.array([101.0, 202.0, 303.0, 404.0])
+        b = np.array([100.0, 200.0, 300.0, 400.0])
+        result = ttest_comparison(a, b, paired=True)
+        differences = a - b
+        expected = np.mean(differences) / np.std(differences, ddof=1)
+        assert result.effect_size == pytest.approx(expected)
+        assert result.effect_size > 1.0  # the issue's ~1.94, not ~0.02
+
+    def test_wilcoxon_reports_dz(self) -> None:
+        """Wilcoxon is always paired; its effect size must also be d_z."""
+        a = np.array([101.0, 202.0, 303.0, 404.0])
+        b = np.array([100.0, 200.0, 300.0, 400.0])
+        result = wilcoxon_comparison(a, b)
+        differences = a - b
+        expected = np.mean(differences) / np.std(differences, ddof=1)
+        assert result.effect_size == pytest.approx(expected)
+
+    def test_independent_ttest_still_uses_pooled_d(self) -> None:
+        """Unpaired comparisons keep the pooled Cohen's d formula."""
+        a = np.array([101.0, 202.0, 303.0, 404.0])
+        b = np.array([100.0, 200.0, 300.0, 400.0])
+        result = ttest_comparison(a, b, paired=False)
+        assert result.effect_size == pytest.approx(cohens_d(a, b))


### PR DESCRIPTION
## Problem
`ttest_comparison(..., paired=True)` and `wilcoxon_comparison(...)` (always paired) both report `effect_size` via `cohens_d(a, b)` — the pooled independent-groups formula — even though the test statistic (`scipy.stats.ttest_rel` / `scipy.stats.wilcoxon`) is computed on paired/matched samples.

Pooled Cohen's d denominates by the between-seed variance in each group. A paired design shares that variance across both groups and the paired test itself cancels it out — so the correct effect size is Cohen's d_z: `mean(differences) / std(differences, ddof=1)`. The issue's repro shows the pooled formula reporting ~0.02 (negligible) where d_z correctly reports ~1.94 (large).

## Fix
- Add `_paired_cohens_d` computing d_z from within-pair differences
- `ttest_comparison` uses it when `paired=True` (keeps pooled d for independent)
- `wilcoxon_comparison` uses it unconditionally (always a paired test)
- Add tests: d_z for paired t-test, d_z for Wilcoxon, pooled d preserved for independent t-test

Closes #2154

---
AI provider/model: deepseek-v4-flash
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi