### PR TITLE
fix(core): align STOMP importance ratios with Gumbel behavior policy

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1042,14 +1042,24 @@ def _select_action_epsilon_greedy_from_q_masked(
 
 
 def _epsilon_greedy_action_probabilities(q_values: Array, epsilon: Array) -> Array:
-    """Return epsilon-greedy probabilities with uniform tie handling."""
+    """Return epsilon-greedy probabilities matching the Gumbel tie-break.
+
+    The action selector draws greedy = argmax(q + t * Gumbel(0, 1)) with
+    t = 1e-6, so the greedy-component distribution is the Gumbel-max
+    distribution softmax(q / t), not a uniform split over an isclose
+    tolerance band. Using isclose(q, max_q, atol=1e-6) treated values
+    within the Gumbel scale as exact ties, giving [0.5, 0.5] for
+    q = [0, 5e-7] where the true greedy probabilities are
+    softmax([-0.5, 0]) = [0.3775, 0.6225]. Mix uniform epsilon exploration
+    over the exact greedy probabilities; exact ties still collapse to the
+    uniform split because softmax of equal logits is uniform.
+    """
     q = jnp.asarray(q_values, dtype=jnp.float32)
     n_actions = q.shape[0]
     eps = jnp.asarray(epsilon, dtype=jnp.float32)
-    max_q = jnp.max(q)
-    greedy_mask = jnp.isclose(q, max_q, atol=1e-6, rtol=0.0).astype(jnp.float32)
-    n_greedy = jnp.maximum(jnp.sum(greedy_mask), jnp.array(1.0, dtype=jnp.float32))
-    return eps / n_actions + (1.0 - eps) * greedy_mask / n_greedy
+    # Gumbel scale t matches the selector's 1e-6 noise multiplier.
+    greedy_probs = jax.nn.softmax(q / jnp.asarray(1e-6, dtype=jnp.float32))
+    return eps / n_actions + (1.0 - eps) * greedy_probs
 
 
 def _clipped_epsilon_greedy_importance_ratio(

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -23,6 +23,7 @@ from alberta_framework.core.options import (
     SubtaskSpec,
     _differential_q_update,
     _differential_semidp_q_update,
+    _epsilon_greedy_action_probabilities,
     _stomp_direct_array_scalars,
     load_stomp_state_with_migration,
     replace_dispatched_primitive_action,
@@ -547,3 +548,40 @@ def test_stomp_from_config_preserves_historical_mapping_and_sequence_compatibili
     ):
         with pytest.raises(ValueError, match=match):
             STOMPConfig.from_config({"subtask_specs": (bad_spec,)})
+
+
+@pytest.mark.unit
+class TestEpsilonGreedyGumbelProbabilities:
+    """Importance ratios must match the Gumbel-max selector (#2136)."""
+
+    def test_near_tied_values_use_gumbel_distribution(self) -> None:
+        """q = [0, 5e-7] must produce softmax(q/1e-6) greedy probabilities."""
+        q = jnp.array([0.0, 5e-7])
+        behavior = _epsilon_greedy_action_probabilities(q, jnp.array(0.2))
+        target = _epsilon_greedy_action_probabilities(q, jnp.array(0.0))
+        ratio = target / behavior
+        np.testing.assert_allclose(
+            np.asarray(ratio),
+            np.array([0.9390799, 1.0409585]),
+            atol=1e-5,
+        )
+
+    def test_exact_tie_stays_uniform(self) -> None:
+        """Exactly equal q-values must still split uniformly."""
+        q = jnp.array([1.0, 1.0])
+        probs = _epsilon_greedy_action_probabilities(q, jnp.array(0.1))
+        np.testing.assert_allclose(
+            np.asarray(probs),
+            np.array([0.5, 0.5]),
+            atol=1e-6,
+        )
+
+    def test_three_way_exact_tie(self) -> None:
+        """Three-way exact tie splits uniformly with epsilon."""
+        q = jnp.array([1.0, 1.0, 1.0])
+        probs = _epsilon_greedy_action_probabilities(q, jnp.array(0.3))
+        np.testing.assert_allclose(
+            np.asarray(probs),
+            np.array([1 / 3, 1 / 3, 1 / 3]),
+            atol=1e-6,
+        )


### PR DESCRIPTION
## Problem
The intra-option behavior selector draws `greedy = argmax(q + 1e-6 * Gumbel(0, 1))`, so its greedy-component probabilities are `softmax(q / 1e-6)`. However, `_clipped_epsilon_greedy_importance_ratio` calls `_epsilon_greedy_action_probabilities`, which treated every value within absolute tolerance `1e-6` of the maximum as an exactly uniform tie.

For `q_values = [0, 5e-7]`, behavior epsilon `0.2`, target epsilon `0`:
- actual Gumbel greedy probabilities: approx `[0.37754068, 0.62245935]`
- correct target/behavior ratios: approx `[0.9390799, 1.0409585]`
- current helper ratios: `[1.0, 1.0]` (wrong)

The wrong ratio scales eligibility traces, weight updates, and the differential average-reward update with probabilities from a different policy than generated the action.

## Fix
Compute greedy-component probabilities from the exact Gumbel-max distribution `softmax(q / 1e-6)`, then mix in uniform epsilon exploration. Exact ties still collapse to the uniform split because softmax of equal logits is uniform. Add regression tests for near-tied values and retained exact-tie uniform behavior.

Closes #2136

---
AI provider/model: deepseek-v4-flash
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-asi