### PR TITLE
Fix paired effect_size to report Cohen's d_z, not pooled d (#2154)

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -428,6 +428,60 @@ def cohens_d(
     return float((mean_a - mean_b) / pooled_std)
 
 
+def _paired_cohens_d(
+    values_a: NDArray[np.float64] | list[float],
+    values_b: NDArray[np.float64] | list[float],
+) -> float:
+    """Compute paired Cohen's d_z effect size from within-pair differences.
+
+    Unlike pooled :func:`cohens_d`, this denominates by the standard deviation
+    of the within-pair differences ``a - b`` rather than the between-seed
+    spread of each group. That matches ``ttest_rel``/``wilcoxon``, which cancel
+    the shared between-seed variance a matched (same-seed) design induces.
+
+    Args:
+        values_a: Values for first group (paired by position with values_b).
+        values_b: Values for second group.
+
+    Returns:
+        Cohen's d_z = mean(a - b) / std(a - b, ddof=1) (positive means a > b).
+        Paired samples whose differences have zero spread but a nonzero mean
+        have a signed-infinite standardized difference, matching
+        :func:`cohens_d`'s zero-variance convention.
+
+    Raises:
+        ValueError: If either group is not a finite one-dimensional sample
+            vector, the two groups differ in length, or hold fewer than 2
+            pairs.
+    """
+    a = _require_sample_vector(values_a, name="values_a")
+    b = _require_sample_vector(values_b, name="values_b")
+    _require_finite_values(a, name="values_a")
+    _require_finite_values(b, name="values_b")
+
+    n_a = len(a)
+    n_b = len(b)
+    if n_a != n_b:
+        raise ValueError(
+            f"paired Cohen's d_z requires equal-length samples (got n_a={n_a}, n_b={n_b})"
+        )
+    if n_a < 2:
+        raise ValueError(
+            f"paired Cohen's d_z requires at least 2 pairs (got {n_a})"
+        )
+
+    differences = a - b
+    mean_difference = np.mean(differences)
+    std_difference = np.std(differences, ddof=1)
+
+    if std_difference == 0:
+        if mean_difference == 0:
+            return 0.0
+        return float(np.copysign(np.inf, mean_difference))
+
+    return float(mean_difference / std_difference)
+
+
 def ttest_comparison(
     values_a: NDArray[np.float64] | list[float],
     values_b: NDArray[np.float64] | list[float],
@@ -503,7 +557,10 @@ def ttest_comparison(
     except ImportError:
         raise ImportError("scipy is required for t-test. Install with: pip install scipy")
 
-    effect = cohens_d(a, b)
+    # Paired designs share the between-seed variance across both groups, which
+    # the paired statistic cancels; report Cohen's d_z (within-pair differences)
+    # there and the pooled independent-groups d only for the unpaired path.
+    effect = _paired_cohens_d(a, b) if paired else cohens_d(a, b)
 
     return SignificanceResult(
         test_name=test_name,
@@ -601,10 +658,11 @@ def wilcoxon_comparison(
 ) -> SignificanceResult:
     """Perform Wilcoxon signed-rank test (paired non-parametric).
 
-    Caveat: the reported ``effect_size`` is Cohen's d computed on the raw
-    values, not a rank-based effect size.  The standard companion to this
-    test is the matched-pairs rank-biserial correlation; interpret the
-    parametric d alongside a rank test with care.
+    Caveat: the reported ``effect_size`` is paired Cohen's d_z, computed from
+    the within-pair differences ``a - b`` (mean divided by the ddof=1 standard
+    deviation of those differences), not a rank-based effect size.  The
+    standard companion to this test is the matched-pairs rank-biserial
+    correlation; interpret the parametric d_z alongside a rank test with care.
 
     Args:
         values_a: Values for first method
@@ -657,7 +715,9 @@ def wilcoxon_comparison(
     except ImportError:
         raise ImportError("scipy is required for Wilcoxon test. Install with: pip install scipy")
 
-    effect = cohens_d(a, b)
+    # Wilcoxon is always paired; report Cohen's d_z from the within-pair
+    # differences rather than the pooled independent-groups d.
+    effect = _paired_cohens_d(a, b)
 
     return SignificanceResult(
         test_name="Wilcoxon signed-rank",

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -668,7 +668,10 @@ class TestIdenticalWilcoxonRejection:
         assert result.test_name == "Wilcoxon signed-rank"
         assert result.statistic == pytest.approx(0.0)
         assert result.p_value < 1.0
-        assert result.effect_size == cohens_d([1.0, 2.0, 3.0], [0.5, 1.5, 2.5])
+        # Paired d_z of a perfectly constant +0.5 shift has zero within-pair
+        # difference spread, so the standardized difference is +inf (not the
+        # pooled independent-groups d of 0.5).
+        assert np.isposinf(result.effect_size)
 
 
 class TestOneSampleRejection:
@@ -927,6 +930,57 @@ class TestEffectSizes:
         res = mann_whitney_comparison([3.0, 5.0], [1.0, 4.0])
         assert res.statistic == pytest.approx(3.0)
         assert res.effect_size == pytest.approx(0.5)
+
+
+class TestPairedCohensDz:
+    """Paired tests must report Cohen's d_z, not the pooled independent-groups d.
+
+    A consistent per-pair shift buried under large shared between-seed variance
+    is negligible under the pooled formula (the shared variance swamps the
+    denominator) but large under d_z (which the paired test actually reflects).
+    """
+
+    # a is consistently ~1 unit above b, per pair, on top of a large shared level.
+    _A = np.array([101.0, 202.0, 303.0, 404.0])
+    _B = np.array([100.0, 200.0, 300.0, 400.0])
+    # differences = [1, 2, 3, 4]; mean 2.5, std(ddof=1) = sqrt(5/3) -> d_z ~ 1.9365.
+    _EXPECTED_DZ = 2.5 / np.sqrt(5.0 / 3.0)
+    _POOLED_D = float(np.mean(_A) - np.mean(_B)) / np.sqrt(
+        (np.var(_A, ddof=1) + np.var(_B, ddof=1)) / 2.0
+    )
+
+    def test_paired_ttest_reports_dz_not_pooled(self) -> None:
+        res = ttest_comparison(self._A, self._B, paired=True)
+        assert res.test_name == "paired t-test"
+        assert res.effect_size == pytest.approx(self._EXPECTED_DZ, rel=1e-9)
+        assert res.effect_size == pytest.approx(1.9364916731, abs=1e-9)
+        # The pooled d (~0.0193) must NOT be what a paired test reports.
+        assert self._POOLED_D == pytest.approx(0.0193, abs=1e-3)
+        assert abs(res.effect_size - self._POOLED_D) > 1.0
+
+    def test_wilcoxon_reports_dz_not_pooled(self) -> None:
+        res = wilcoxon_comparison(self._A, self._B)
+        assert res.test_name == "Wilcoxon signed-rank"
+        assert res.effect_size == pytest.approx(self._EXPECTED_DZ, rel=1e-9)
+        assert res.effect_size != pytest.approx(self._POOLED_D, abs=1e-3)
+
+    def test_unpaired_ttest_still_reports_pooled_d(self) -> None:
+        res = ttest_comparison(self._A, self._B, paired=False)
+        assert res.test_name == "independent t-test"
+        assert res.effect_size == pytest.approx(cohens_d(self._A, self._B), rel=1e-12)
+        assert res.effect_size == pytest.approx(self._POOLED_D, rel=1e-9)
+
+    def test_paired_dz_sign_follows_difference_direction(self) -> None:
+        # b consistently above a -> negative d_z under the same magnitude.
+        res = ttest_comparison(self._B, self._A, paired=True)
+        assert res.effect_size == pytest.approx(-self._EXPECTED_DZ, rel=1e-9)
+
+    def test_paired_dz_constant_shift_is_signed_infinity(self) -> None:
+        # A perfectly constant nonzero per-pair shift has zero difference spread.
+        res = ttest_comparison([1.0, 2.0, 3.0], [0.5, 1.5, 2.5], paired=True)
+        assert np.isposinf(res.effect_size)
+        neg = ttest_comparison([0.5, 1.5, 2.5], [1.0, 2.0, 3.0], paired=True)
+        assert np.isneginf(neg.effect_size)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What was broken and its measurement consequence

`alberta_framework/utils/statistics.py` computed the reported `effect_size`
for **paired** significance tests using the pooled independent-groups Cohen's d:

- `ttest_comparison(..., paired=True)` — and `paired=True` is the **default** —
  reported `effect = cohens_d(a, b)`.
- `wilcoxon_comparison(...)` — which is *always* a paired signed-rank test —
  reported `effect = cohens_d(a, b)`.

But the underlying statistics (`scipy.stats.ttest_rel` / `scipy.stats.wilcoxon`)
operate on the within-pair differences and cancel the between-seed variance a
matched (same-seed) design shares across both groups. Pooled Cohen's d
denominates by that shared spread, so for a consistent per-pair shift sitting on
top of a large shared level the pooled formula reports a **negligible** effect
while the paired test is decisive. The correct paired effect size is Cohen's
**d_z** = `mean(a - b) / std(a - b, ddof=1)`.

This is a **measurement/correctness fix only**. It changes *only* the reported
paired effect size. No test statistic, p-value, `SignificanceResult` shape, the
`paired=False` path, or `mann_whitney_comparison` behavior changes. It makes **no
benchmark-improvement or scientific-promotion claim**.

## The fix (one lane, one variable)

- Added module-level `_paired_cohens_d(a, b) -> float` next to `cohens_d`,
  reusing the existing `_require_sample_vector` / `_require_finite_values` guards
  and `cohens_d`'s signed-infinity zero-spread convention (return `0.0` when the
  difference mean and spread are both zero, else `copysign(inf, mean)`).
- Wired it into the paired t-test branch (`_paired_cohens_d(a, b) if paired else
  cohens_d(a, b)`) and into Wilcoxon (always paired).
- Updated the Wilcoxon docstring "Caveat" to describe paired d_z from the
  within-pair differences.
- `cohens_d`'s pooled formula, the `paired=False` path, and Mann-Whitney are
  untouched.

## Failing-then-passing reproduction

Repro arrays: `a = [101, 202, 303, 404]`, `b = [100, 200, 300, 400]` — `a` is a
consistent +1..+4 above `b` per pair; the analytic d_z is `2.5 / sqrt(5/3) =
1.9364916731…`.

```
### BEFORE FIX (pre-fix statistics.py) — paired tests report pooled Cohen's d, not d_z
pooled cohens_d              : 0.019268335399609073
ttest paired effect_size     : 0.019268335399609073   # WRONG (pooled)
wilcoxon effect_size         : 0.019268335399609073   # WRONG (pooled)
correct d_z = mean/std(ddof1): 1.9364916731037085

### AFTER FIX
pooled cohens_d              : 0.019268335399609073
ttest paired effect_size     : 1.9364916731037085   # now d_z
wilcoxon effect_size         : 1.9364916731037085   # now d_z
ttest UNPAIRED effect_size   : 0.019268335399609073   # still pooled d
correct d_z = mean/std(ddof1): 1.9364916731037085
```

New regression tests (`TestPairedCohensDz` in `tests/test_statistics_validation.py`,
plus the updated `test_constant_nonzero_shift_stays_defined`) fail on the pre-fix
code and pass after. Failing run captured pre-fix:

```
FAILED tests/test_statistics_validation.py::TestIdenticalWilcoxonRejection::test_constant_nonzero_shift_stays_defined
FAILED tests/test_statistics_validation.py::TestPairedCohensDz::test_paired_ttest_reports_dz_not_pooled
FAILED tests/test_statistics_validation.py::TestPairedCohensDz::test_wilcoxon_reports_dz_not_pooled
FAILED tests/test_statistics_validation.py::TestPairedCohensDz::test_paired_dz_sign_follows_difference_direction
FAILED tests/test_statistics_validation.py::TestPairedCohensDz::test_paired_dz_constant_shift_is_signed_infinity
5 failed, 1 passed
```

## Verification commands and results (run on this CPU-only ARM machine)

```
$ .venv/bin/python -m pytest tests/test_statistics_validation.py tests/test_statistics_hostile_validation.py -q -o addopts=""
256 passed, 3 warnings in 10.44s

$ .venv/bin/python -m pytest tests/test_statistics_validation.py -o addopts="" -k "PairedCohensDz" -v
tests/test_statistics_validation.py::TestPairedCohensDz::test_paired_ttest_reports_dz_not_pooled PASSED
tests/test_statistics_validation.py::TestPairedCohensDz::test_wilcoxon_reports_dz_not_pooled PASSED
tests/test_statistics_validation.py::TestPairedCohensDz::test_unpaired_ttest_still_reports_pooled_d PASSED
tests/test_statistics_validation.py::TestPairedCohensDz::test_paired_dz_sign_follows_difference_direction PASSED
tests/test_statistics_validation.py::TestPairedCohensDz::test_paired_dz_constant_shift_is_signed_infinity PASSED
5 passed, 239 deselected, 1 warning in 2.04s

$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy            # CI scope: files = ["alberta_framework"]
Success: no issues found in 224 source files
```

(The 3 pytest warnings are pre-existing scipy catastrophic-cancellation notices
emitted by the near-identical test fixtures, not new to this change.)

## What remains open

Nothing for this defect. The matched-pairs rank-biserial correlation remains the
canonical *rank-based* companion for Wilcoxon; this PR keeps the parametric d_z
that the module already reported for that slot, now computed correctly.

## Evidence note

Immutable attachment-URL minting (the `attach.mjs` GitHub upload flow) is blocked
in this environment by a GitHub device-verification interstitial the headless
session cannot clear; no credentials were exposed. Per the work order's "fenced
logs in the PR body" allowance, the complete BEFORE/AFTER reproduction and all
verification command outputs are embedded inline above, bound to the pushed head
below.

Closes #2154

<!-- evidence-head:cba21b795797ee251b140b9ee53375f6e94eacd7 -->
<!-- evidence-row:logs -->
- [x] logs: embedded as fenced blocks above (attachment minting blocked by a GitHub device-verification interstitial; no session could be established)

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@51ee9f1b1e88ced844e28ae09184c65e8bed223c:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@51ee9f1b1e88ced844e28ae09184c65e8bed223c:skills/contribute-to-asi"} -->
