### PR TITLE
test(core): pin sigreg's Epps-Pulley statistic to the closed-form BHEP equation

### DIFF
--- a/tests/test_sigreg.py
+++ b/tests/test_sigreg.py
@@ -124,6 +124,56 @@ def test_sigreg_diagnostics_std_is_finite_at_float32_extremes() -> None:
     chex.assert_tree_all_finite(diagnostics)
 
 
+def _bhep_reference_statistic(samples: np.ndarray, kernel_width: float) -> float:
+    """Independent float64 reimplementation of the closed-form BHEP statistic.
+
+    Transcribes ``BHEP_{n,beta}`` exactly as given in Henze, N. (2021), "Tests
+    for multivariate normality -- a critical review with emphasis on
+    weighted L^2-statistics" (arXiv:2004.07332), Section 2.1:
+
+        BHEP_{n,beta} = (1/n) * sum_{j,k} exp(-beta^2 ||Y_j - Y_k||^2 / 2)
+            - 2 / (1 + beta^2)^(d/2) * sum_j exp(-beta^2 ||Y_j||^2 / (2 (1 + beta^2)))
+            + n / (1 + 2 beta^2)^(d/2)
+
+    for the univariate case ``d = 1``, citing that Baringhaus, L. & Henze, N.
+    (1988), "A Consistent Test for Multivariate Normality Based on the
+    Empirical Characteristic Function," studied the special case ``beta =
+    1``. ``epps_pulley_gaussian_statistic`` uses ``kernel_width = 1 / beta``
+    and reports ``BHEP_{n,beta} / n`` (a per-sample normalization suited to
+    use as a bounded loss rather than a raw n-scaled test statistic), clipped
+    at zero for floating-point safety.
+    """
+    x = np.asarray(samples, dtype=np.float64)
+    n = x.shape[0]
+    beta = 1.0 / kernel_width
+    diffs = x[:, None] - x[None, :]
+    term_a = np.sum(np.exp(-(beta**2) * diffs**2 / 2.0)) / n
+    term_b = (2.0 / (1.0 + beta**2) ** 0.5) * np.sum(
+        np.exp(-(beta**2) * x**2 / (2.0 * (1.0 + beta**2)))
+    )
+    term_c = n / (1.0 + 2.0 * beta**2) ** 0.5
+    return float(max((term_a - term_b + term_c) / n, 0.0))
+
+
+@pytest.mark.parametrize("kernel_width", [1.0, 0.75, 2.0])
+def test_epps_pulley_matches_closed_form_bhep_statistic(kernel_width: float) -> None:
+    """Cross-check against the published closed form, not just relative ordering.
+
+    ``kernel_width=1.0`` is beta=1, the exact case Baringhaus & Henze (1988)
+    studied; the other widths exercise the general beta dependence given in
+    Henze (2021, arXiv:2004.07332, Sec. 2.1). See
+    ``_bhep_reference_statistic`` for the transcribed formula.
+    """
+    samples = np.asarray([-1.5, 0.3, 2.0, -0.7], dtype=np.float64)
+    expected = _bhep_reference_statistic(samples, kernel_width)
+
+    actual = epps_pulley_gaussian_statistic(
+        jnp.asarray(samples, dtype=jnp.float32), kernel_width=kernel_width
+    )
+
+    assert float(actual) == pytest.approx(expected, abs=1.0e-6)
+
+
 def test_epps_pulley_statistic_penalizes_collapsed_samples() -> None:
     gaussian = jr.normal(jr.key(1), (128,), dtype=jnp.float32)
     collapsed = jnp.zeros((128,), dtype=jnp.float32)


### PR DESCRIPTION
alberta_framework/core/sigreg.py implements SIGReg's Epps-Pulley/BHEP
normality statistic (LeJEPA, Balestriero & LeCun 2025). The existing
suite only checked relative ordering (collapsed > gaussian, shifted >
gaussian), never a value tied to the published formula.

Verified the implementation algebraically against the closed form in
Henze, N. (2021), "Tests for multivariate normality -- a critical
review with emphasis on weighted L^2-statistics" (arXiv:2004.07332),
Sec. 2.1:

  BHEP_{n,beta} = (1/n) sum_{j,k} exp(-beta^2 ||Y_j-Y_k||^2/2)
      - 2/(1+beta^2)^(d/2) sum_j exp(-beta^2 ||Y_j||^2/(2(1+beta^2)))
      + n/(1+2beta^2)^(d/2)

which for d=1 attributes to Baringhaus & Henze (1988) at beta=1. With
kernel_width = 1/beta, epps_pulley_gaussian_statistic computes exactly
BHEP_{n,beta}/n (clipped at 0 for float noise) -- confirmed term-by-term
by hand and numerically against an independent float64 numpy
transcription of the formula. No discrepancy found; the implementation
is correct.

Adds a parametrized regression (kernel_width in {1.0, 0.75, 2.0}, the
1.0 case being Baringhaus & Henze's original beta=1) that cross-checks
the JAX statistic against that independent closed-form reimplementation,
so a future edit that silently drifts a constant or exponent in the
BHEP formula is caught instead of passing on ordering checks alone.

## Verification

- `pytest tests/test_sigreg.py` — 49 passed
- `ruff check` — all checks passed

## Collision check

`gh pr list --repo SlopDotCash/asi --state open --json files` confirmed no open PR touches `sigreg.py` or `tests/test_sigreg.py`.

## Attribution

- Client: claude-code
- Provider: anthropic
- Model: claude-sonnet-5
- Lane: rama0x1-asi-claude-worker

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0HK38DWEBRNCB6M7XNVZS7W","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-21T07:20:50.365Z","completed_at":"2026-08-21T07:21:25.929Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T07:20:52.154Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"25ba416f421c8ca920cc01d64bce528a8181de5998796f1fb57b511f3760c413","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"1f9a245e-34ae-4be6-9ca4-acb75190e07d","object_id":"sha256:25ba416f421c8ca920cc01d64bce528a8181de5998796f1fb57b511f3760c413","sha256":"25ba416f421c8ca920cc01d64bce528a8181de5998796f1fb57b511f3760c413"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"eSty8ndPaop2RZruHBzK9HVR0hhTnTPN_YbyUfiLAAN-dl4QToj8NwDWdWp1wYpnd2syv7gB4s-r9LILWo8YDw"}} -->
