### PR TITLE
test(benchmarks): run every registered noise-curvature arm end to end

### DIFF
--- a/tests/test_noise_curvature_ipmnist.py
+++ b/tests/test_noise_curvature_ipmnist.py
@@ -234,6 +234,71 @@ def test_end_to_end_registered_arm_and_receipt_accounting() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "arm_name",
+    [
+        "noise_curvature_fixed_adam_l2",
+        "noise_curvature_gradient_only",
+        "noise_curvature_volatility_only",
+    ],
+)
+def test_every_registered_arm_runs_end_to_end_through_the_screening_harness(
+    arm_name: str,
+) -> None:
+    """Each registered controller-mode arm must survive a real screening run.
+
+    ``noise_curvature_combined`` is the only arm exercised end to end through
+    ``run_screening_config`` elsewhere in this file. The other three modes
+    (``fixed``, ``gradient_only``, ``volatility_only``) were previously
+    reachable only through ``screening_spec``/config-construction assertions
+    or through the isolated ``noise_curvature_safe_bound`` unit math — never
+    through the real registered-arm screening entrypoint that a live
+    development run would actually invoke for these Literal-typed
+    ``controller_mode`` values.
+    """
+    data_x = np.linspace(-1.0, 1.0, 160, dtype=np.float32).reshape(40, 4)
+    data_y = np.asarray([index % 2 for index in range(40)], dtype=np.int32)
+    config = IPMNISTConfig(
+        n_tasks=1, task_length=40, input_dim=4, hidden1=3, hidden2=2, n_classes=2
+    )
+    result = run_screening_config(
+        data_x,
+        data_y,
+        screening_spec(arm_name),
+        seed=0,
+        config=config,
+    )
+    assert isinstance(result, ScreeningRunResult)
+    assert np.isfinite(result.per_task_loss).all()
+    payload = noise_curvature_development_result_payload(result, outcome="inconclusive")
+    assert payload["development_only"] is True
+    assert payload["scientific_promotion_allowed"] is False
+    assert payload["development_seed_protocol"] == list(DEVELOPMENT_SEEDS)
+    resources = payload["resources"]
+    assert isinstance(resources, dict)
+    # Query/byte accounting is architecture-driven and must not depend on
+    # which controller mode the arm's Literal selects.
+    reference = run_screening_config(
+        data_x,
+        data_y,
+        screening_spec("noise_curvature_combined"),
+        seed=0,
+        config=config,
+    )
+    reference_resources = noise_curvature_development_result_payload(
+        reference, outcome="inconclusive"
+    )["resources"]
+    assert isinstance(reference_resources, dict)
+    # `timing_seconds` is wall-clock telemetry (CLAUDE.md: "timing remains
+    # telemetry-only until a separately qualified timing protocol exists")
+    # and is expected to vary run to run; every other counter is exact.
+    assert resources.keys() == reference_resources.keys()
+    for key, value in resources.items():
+        if key == "timing_seconds":
+            continue
+        assert value == reference_resources[key], key
+
+
 def test_receipt_validator_rejects_hostile_and_derived_counter_drift() -> None:
     result = ScreeningRunResult(
         config_name="noise_curvature_combined",


### PR DESCRIPTION
noise_curvature_ipmnist.py registers four screening arms
(fixed_adam_l2, gradient_only, volatility_only, combined) selected by
the ControllerMode Literal. Only "combined" was ever exercised through
the real run_screening_config entrypoint that a live IPMNIST
development screen would actually invoke; the other three modes were
reachable only through config-construction/screening_spec assertions
or through noise_curvature_safe_bound's isolated unit math, never
through the registered arm's full runtime path (noise_curvature_step /
_controller_update / the online IPMNIST loop).

Manually probed all four arms through run_screening_config before
writing this test: all produce finite losses and no diagnostic
failures, so this is a coverage gap, not a live bug. Adds a
parametrized end-to-end test for the three previously-unexercised arms
and asserts their resource/query accounting matches the already-tested
"combined" arm exactly (query counts are architecture-driven and must
not depend on which controller_mode a Literal selects), excluding the
wall-clock-only timing_seconds field.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019iH5eAgc3gCKcxdGZHdhjT

## Verification

- `pytest tests/test_noise_curvature_ipmnist.py` — 12 passed
- `ruff check` — all checks passed

## Collision check

`gh pr list --repo SlopDotCash/asi --state open --json files` confirmed no open PR touches `noise_curvature_ipmnist.py` or its test file.

## Attribution

- Client: claude-code
- Provider: anthropic
- Model: claude-sonnet-5
- Lane: rama0x1-asi-claude-worker-2

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0HK4SN79PZQ10RHJKPH0X2V","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-21T07:21:40.776Z","completed_at":"2026-08-21T07:22:15.799Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T07:21:41.540Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f24dbc96879c8cb3b0600a83d2cdc0d11cd6304d967f22b4f6605f64dd265e80","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"80d21ac4-6b9b-43f2-aab3-140b02f9a341","object_id":"sha256:f24dbc96879c8cb3b0600a83d2cdc0d11cd6304d967f22b4f6605f64dd265e80","sha256":"f24dbc96879c8cb3b0600a83d2cdc0d11cd6304d967f22b4f6605f64dd265e80"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"ALmFAckBGrnVGVW5iE9RBrtkx0Dtf4v6aIeq6-MJRSFSYcwwitrT_WxDwBSSps2SSKLUX5k7rCgizrmpM0mQCA"}} -->
