### PR TITLE
fix(benchmarks): score the FTL planner on the summed horizon return

### DIFF
--- a/alberta_framework/benchmarks/ftl_online_agent_development.py
+++ b/alberta_framework/benchmarks/ftl_online_agent_development.py
@@ -199,10 +199,16 @@ def _mpc_action(
     queries = 0
     for sequence in itertools.product(range(4), repeat=host_horizon):
         imagined = observation.copy()
+        # arXiv:2507.09177v1 Eq. 2 maximizes the summed H-step reward over the
+        # imagined rollout, and this lane's reported return accumulates the same
+        # per-step cost at every executed step.  Scoring only the terminal
+        # imagined state optimizes a different objective than the one measured,
+        # which stops the privileged-dynamics control from bounding the lane.
+        score = 0.0
         for action in sequence:
             imagined = np.asarray(predict(imagined, action), dtype=np.float32)
             queries += 1
-        score = -float(np.sum((imagined - goal) ** 2))
+            score -= float(np.sum((imagined - goal) ** 2))
         if score > best_score:
             best_score, best_action = score, sequence[0]
     return best_action, queries, candidate_count

--- a/docs/research/ftl-online-agent-development.md
+++ b/docs/research/ftl-online-agent-development.md
@@ -18,6 +18,15 @@ units (their sum plus environment transitions), persistent array bytes, and wall
 only). Logical units are an implementation-independent call count, not hardware FLOPs. Negative
 results must be retained.
 
+The planner maximizes the summed reward over the imagined rollout, matching the paper's Eq. 2
+`H`-step finite-horizon return and the per-step cost the lane actually reports. Scoring only the
+terminal imagined state optimizes a different objective than the one measured: under it the
+privileged-dynamics control degraded monotonically with deeper lookahead (-6, -22, -50, -82 at
+horizons 1-4) and lost to the learned online arm on two of four frozen seeds at the frozen default
+horizon of two, so it no longer bounded the lane. With the summed return the control holds the
+analytic optimum of -6 at every horizon on every frozen seed. Horizon one is a single imagined
+step, where the two objectives are identical.
+
 Every arm receives the same current goal for planning and no boundary or task identifier; the
 world model itself trains only on observation, action, and next observation. The validator derives
 the exact metric sequence length and persistent numeric bytes from the frozen execution contract,

--- a/tests/test_ftl_online_agent_development.py
+++ b/tests/test_ftl_online_agent_development.py
@@ -3,18 +3,26 @@ from __future__ import annotations
 import dataclasses
 
 import jax
+import numpy as np
 import pytest
 
 from alberta_framework.benchmarks.ftl_online_agent_development import (
     ACTION_DELTAS,
     ARM_IDS,
+    FROZEN_GOALS,
     FROZEN_SEEDS,
     OFFICIAL_CODE_REVISION,
+    _mpc_action,
     run_development_lane,
     validate_result,
 )
 
 pytestmark = pytest.mark.integration
+
+# Every frozen task starts at the origin, each goal sits two unit moves away,
+# and no action holds position.  The best reachable cost is therefore one per
+# odd step and zero per even step: exactly two per four-step task.
+_OPTIMAL_DEFAULT_RETURN = -2.0 * len(FROZEN_GOALS)
 
 
 def test_end_to_end_lane_has_matched_axes_controls_and_exact_receipts() -> None:
@@ -105,3 +113,68 @@ def test_mechanism_off_is_causal_and_does_not_adopt_updates() -> None:
 def test_workload_action_registry_is_read_only() -> None:
     with pytest.raises(ValueError):
         ACTION_DELTAS[0, 0] = 7
+
+
+def _grid_predict(observation: np.ndarray, action: int) -> np.ndarray:
+    return np.asarray(observation + ACTION_DELTAS[action], dtype=np.float32)
+
+
+def test_planner_maximizes_the_summed_horizon_return_not_the_terminal_state() -> None:
+    """arXiv:2507.09177v1 Eq. 2 sums the H-step reward over the imagined rollout.
+
+    This deterministic model separates the two objectives.  Action ``0`` is a
+    detour that is far from the goal after one step and exactly on it after two;
+    every other action parks one unit away.  Terminal-state scoring prefers the
+    detour, the summed horizon return prefers parking.
+    """
+
+    def detour_predict(observation: np.ndarray, action: int) -> np.ndarray:
+        if action == 0:
+            far = float(observation[0]) == 0.0
+            return np.asarray((10.0 if far else 0.0, 0.0), dtype=np.float32)
+        return np.asarray((1.0, 0.0), dtype=np.float32)
+
+    observation = np.zeros(2, dtype=np.float32)
+    goal = np.zeros(2, dtype=np.float32)
+    action, queries, candidates = _mpc_action(observation, goal, 2, detour_predict)
+    assert (queries, candidates) == (32, 16)
+    assert action == 1
+
+
+def test_planner_horizon_one_reduces_to_the_single_imagined_step() -> None:
+    """One imagined step makes the summed and terminal objectives identical."""
+    observation = np.zeros(2, dtype=np.float32)
+    for goal_tuple in FROZEN_GOALS:
+        goal = np.asarray(goal_tuple, dtype=np.float32)
+        action, queries, candidates = _mpc_action(observation, goal, 1, _grid_predict)
+        terminal_scores = [
+            -float(np.sum((_grid_predict(observation, candidate) - goal) ** 2))
+            for candidate in range(4)
+        ]
+        assert (queries, candidates) == (4, 4)
+        assert action == int(np.argmax(terminal_scores))
+
+
+def test_privileged_control_bounds_every_arm_at_the_frozen_default_horizon() -> None:
+    """The lane's defaults are its frozen protocol; run them, not a shrunk proxy."""
+    for seed in FROZEN_SEEDS:
+        result = run_development_lane(seed=seed)
+        returns = {arm.arm_id: sum(arm.task_returns) for arm in result.arms}
+        assert result.planning_horizon == 2
+        assert all(
+            arm.receipt.environment_steps == 4 * len(FROZEN_GOALS) for arm in result.arms
+        )
+        privileged = returns["privileged_dynamics_mpc"]
+        assert privileged == pytest.approx(_OPTIMAL_DEFAULT_RETURN)
+        assert privileged >= returns["sparse_ftl_online"]
+        assert privileged >= returns["sparse_ftl_frozen"]
+
+
+def test_deeper_planning_never_degrades_the_privileged_dynamics_control() -> None:
+    """Exact dynamics plus more lookahead cannot lower the control's own return."""
+    privileged_returns = []
+    for horizon in (1, 2, 3):
+        result = run_development_lane(seed=FROZEN_SEEDS[0], planning_horizon=horizon)
+        arm = next(x for x in result.arms if x.arm_id == "privileged_dynamics_mpc")
+        privileged_returns.append(sum(arm.task_returns))
+    assert privileged_returns == pytest.approx([_OPTIMAL_DEFAULT_RETURN] * 3)


### PR DESCRIPTION
<!-- evidence-head:dd00453e034a3069ac849478334cd133ae2676b4 -->

## What is wrong

`alberta_framework/benchmarks/ftl_online_agent_development.py::_mpc_action` scored a
candidate action sequence by the **terminal** imagined state only:

```python
for action in sequence:
    imagined = np.asarray(predict(imagined, action), dtype=np.float32)
    queries += 1
score = -float(np.sum((imagined - goal) ** 2))
```

The lane's reported metric does not measure that. `_run_arm` accumulates the
per-step cost at **every executed step** (`total -= float(np.sum((next_observation - goal) ** 2))`).
So the planner maximizes one objective while the receipt reports another.

The two objectives coincide when the rollout is one step long and diverge from
horizon 2 onward. `run_development_lane`'s frozen default is `planning_horizon=2`,
and every pre-existing test in the suite passes `planning_horizon=1` explicitly, so
nothing in CI ever ran the lane's own default — the defect was invisible.

It also silently deviates from the pinned method. Liu et al., *Continual
Reinforcement Learning by Planning with Online World Models*, ICML 2025
(arXiv:2507.09177v1, pinned by this lane and by
`docs/research/ftl-online-agent-development.md`), Section 3.2 Eq. 2 maximizes
`argmax_{a_{t:t+H}} Σ_{i=0}^{H} R(s_{t+i}, a_{t+i})` — the summed H-step
finite-horizon return, not a terminal-state score. The lane's doc declares its
deviations from the paper explicitly and this one was not among them.

## Why it corrupts measurement

`privileged_dynamics_mpc` is the lane's privileged control: it plans with exact
ground-truth dynamics (`obs + ACTION_DELTAS[action]`) and is
`candidate_eligible=False` precisely because it is meant to *bound* what a
learned model can reach. Under terminal-state scoring it does not bound anything.

Measured on all four frozen seeds at `steps_per_task=4` (total return, summed over
the three frozen goals):

| horizon | privileged control (4 seeds) | `sparse_ftl_online` (4 seeds) | control >= online |
|---|---|---|---|
| 1 | -6, -6, -6, -6 | -26, -24, -36, -50 | 4/4 |
| **2 (lane default)** | **-22, -22, -22, -22** | **-42, -14, -14, -34** | **2/4** |
| 3 | -50, -50, -50, -50 | -32, -50, -88, -46 | 2/4 |
| 4 | -82, -82, -82, -82 | -44, -64, -86, -104 | 2/4 |

A control with perfect dynamics gets **monotonically worse the more it plans**
(-6 -> -22 -> -50 -> -82) and is beaten by the learned online arm on half the
frozen seeds at the lane's own default horizon. Any comparison normalized against
that control is not trustworthy.

## The change

One variable: `_mpc_action` now accumulates the per-step cost over the imagined
rollout, which is exactly the quantity `_run_arm` reports and exactly Eq. 2's
summed finite-horizon return. Nothing else moves.

After the change, same commands, same seeds:

| horizon | privileged control (4 seeds) | `sparse_ftl_online` (4 seeds) | control >= online |
|---|---|---|---|
| 1 | -6, -6, -6, -6 | -26, -24, -36, -50 | 4/4 |
| **2 (lane default)** | **-6, -6, -6, -6** | **-38, -28, -40, -22** | **4/4** |
| 3 | -6, -6, -6, -6 | -22, -12, -44, -12 | 4/4 |
| 4 | -6, -6, -6, -6 | -22, -12, -36, -12 | 4/4 |

`-6.0` is the analytic optimum, not a tuned number: each of the three frozen
tasks resets to the origin with its goal two unit moves away, no action holds
position, so the best reachable four-step cost is `1 + 0 + 1 + 0 = 2` per task
and `-2 * 3 = -6` in total. The privileged control now attains it at every
horizon on every seed, and deeper lookahead also stops hurting the learned arm.

`sparse_ftl_frozen` is -138 on every seed at every horizon in both states.

### Reduction pin

At `planning_horizon=1` the rollout is a single imagined step, so the summed and
terminal objectives are identical and the change is exact. Verified: all twelve
pre-existing tests pass byte-for-byte unchanged, and `model_queries` /
`planner_candidates` / `logical_compute_units` / `persistent_bytes` receipts are
unchanged at **every** horizon (the number of `predict` calls is untouched), so
`validate_result`'s derived receipt contract still holds.

## Failing-test-first

Three tests added; all three fail on `origin/main` and pass with the fix.

```
$ git stash push -- alberta_framework/benchmarks/ftl_online_agent_development.py
$ .venv/bin/python -m pytest tests/test_ftl_online_agent_development.py \
    tests/test_ftl_mpc_enumeration_hang.py -q -o addopts=""
FAILED ...::test_planner_maximizes_the_summed_horizon_return_not_the_terminal_state
FAILED ...::test_privileged_control_bounds_every_arm_at_the_frozen_default_horizon
FAILED ...::test_deeper_planning_never_degrades_the_privileged_dynamics_control
3 failed, 12 passed in 16.45s

    assert privileged_returns == pytest.approx([_OPTIMAL_DEFAULT_RETURN] * 3)
E   assert [-6.0, -22.0, -50.0] == approx([-6.0 ... -6.0 +- 6.0e-06])
E     Index | Obtained | Expected
E     1     | -22.0    | -6.0 +- 6.0e-06
E     2     | -50.0    | -6.0 +- 6.0e-06

$ git stash pop
$ .venv/bin/python -m pytest tests/test_ftl_online_agent_development.py \
    tests/test_ftl_mpc_enumeration_hang.py -q -o addopts=""
15 passed in 14.66s
```

- `test_planner_maximizes_the_summed_horizon_return_not_the_terminal_state` — a
  deterministic two-state model with no JAX, where terminal scoring picks a
  detour that is far after one step and on-goal after two, and the summed return
  picks parking. Isolates the objective from the rest of the lane.
- `test_privileged_control_bounds_every_arm_at_the_frozen_default_horizon` — runs
  `run_development_lane(seed=seed)` with **no argument overrides**, i.e. the lane's
  own frozen defaults, on all four frozen seeds.
- `test_deeper_planning_never_degrades_the_privileged_dynamics_control` — horizons
  1/2/3 on one frozen seed.

## Verification

- `.venv/bin/python -m pytest tests/test_ftl_online_agent_development.py tests/test_ftl_mpc_enumeration_hang.py -q -o addopts=""` — **15 passed** (12 pre-existing + 3 new)
- `.venv/bin/python -m pytest tests -q -o addopts="" -k "ftl"` — **276 passed, 9 skipped**
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy` — success, no issues in 224 source files
- `.venv/bin/alberta-evidence-status` — `overall_status: invalid` both before and
  after this change on a clean `origin/main` checkout; pre-existing and unrelated.
  This lane registers no evidence source, writes no `outputs/` artifact, and has no
  console entry point, so no pinned artifact is invalidated.
- Compute: CPU only, a few minutes total.

## Scope

- Lane: `asi.ftl_online_agent_development.v1` (nonpromoting development lane, issue #1574)
- No promotion, no `outputs/` write, no seed consumed, no threshold or validator weakened.
- `alberta_framework/benchmarks/ftl_online_agent_development.py` is imported by nothing
  outside its own two test files.

## What remains open

- The lane's cost is undiscounted; Eq. 2 as written is also undiscounted over the
  finite horizon, so no discount factor was introduced. Whether this analogue should
  discount is a separate question.
- Ties are still broken by first-in-enumeration order, unchanged.
- This remains an ASI-native analogue: no MuJoCo, no CEM, no continuous actions, no
  paper parity claim. Everything listed as a deviation in
  `docs/research/ftl-online-agent-development.md` still stands.

## Collision check

`gh pr list --repo SlopDotCash/asi --state open --json number,title,files --limit 200`
run immediately before and after the work: no open PR touches
`alberta_framework/benchmarks/ftl_online_agent_development.py`,
`tests/test_ftl_online_agent_development.py`, `tests/test_ftl_mpc_enumeration_hang.py`,
or `docs/research/ftl-online-agent-development.md`.

## Attribution

- Client: claude-code
- Provider: anthropic
- Model: claude-opus-5
- Lane: rama0x1-asi-claude-worker-2

Refs #1574

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0HMFK9P8A87T9BFYBR04V83","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-21T07:45:03.286Z","completed_at":"2026-08-21T07:45:39.125Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T07:45:03.910Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"813f30ac0e4724615cea5a02b659deed81e633fb2fa1b70dec4ecb3e9bd63eb5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"db500a8d-5902-4d0b-a66c-bcf207253c93","object_id":"sha256:813f30ac0e4724615cea5a02b659deed81e633fb2fa1b70dec4ecb3e9bd63eb5","sha256":"813f30ac0e4724615cea5a02b659deed81e633fb2fa1b70dec4ecb3e9bd63eb5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"4uCgeou48qZeM9igJ573pGGbo_litIQfSy2Wil5JA6QLf5Kyib57pCnYQ2tNaNiQ-3TaHshFxtlCgV90JmSBDQ"}} -->
