### PR TITLE
fix(core): cap working-memory and fixed-trace decay rate cardinality

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -115,9 +115,17 @@ def _require_int32(name: str, value: object, *, minimum: int) -> int:
     return _require_integer(name, value, minimum=minimum, maximum=_INT32_MAX)
 
 
+_MAX_FIXED_TRACE_CONFIGURATION_ITEMS = 1 << 12
+_MAX_FIXED_TRACE_DECAY_RATES = _MAX_FIXED_TRACE_CONFIGURATION_ITEMS
+
+
 def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(value) > _MAX_FIXED_TRACE_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_FIXED_TRACE_DECAY_RATES} decay rates"
+        )
     rates = cast(tuple[object, ...], value)
     return tuple(
         validated_float32_scalar(
@@ -1036,12 +1044,24 @@ class FixedTraceStateBuilderConfig:
         obs_decays = data["observation_decay_rates"]
         act_decays = data["action_decay_rates"]
         out_decays = data["outcome_decay_rates"]
-        if (
-            not isinstance(obs_decays, (list, tuple))
-            or not isinstance(act_decays, (list, tuple))
-            or not isinstance(out_decays, (list, tuple))
+        for name, value in (
+            ("observation_decay_rates", obs_decays),
+            ("action_decay_rates", act_decays),
+            ("outcome_decay_rates", out_decays),
         ):
-            raise ValueError("decay rates must be lists or tuples")
+            if type(value) is list:
+                if len(value) > _MAX_FIXED_TRACE_DECAY_RATES:
+                    raise ValueError(
+                        f"{name} must contain at most "
+                        f"{_MAX_FIXED_TRACE_DECAY_RATES} decay rates"
+                    )
+            elif type(value) is not tuple:
+                raise ValueError("decay rates must be lists or tuples")
+            elif len(value) > _MAX_FIXED_TRACE_DECAY_RATES:
+                raise ValueError(
+                    f"{name} must contain at most "
+                    f"{_MAX_FIXED_TRACE_DECAY_RATES} decay rates"
+                )
         return cls(
             observation_dim=data["observation_dim"],
             n_actions=data["n_actions"],

--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -29,6 +29,9 @@ from alberta_framework.core.update_safety import (
     select_transaction,
 )
 
+_MAX_WORKING_MEMORY_CONFIGURATION_ITEMS = 1 << 12
+_MAX_WORKING_MEMORY_DECAY_RATES = _MAX_WORKING_MEMORY_CONFIGURATION_ITEMS
+
 
 @dataclass(frozen=True)
 class WorkingMemoryConfig:
@@ -124,9 +127,19 @@ class WorkingMemoryConfig:
             if key in payload:
                 value = payload[key]
                 if type(value) is list:
+                    if len(value) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                        raise ValueError(
+                            f"{key} must contain at most "
+                            f"{_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+                        )
                     payload[key] = tuple(value)
                 elif type(value) is not tuple:
                     raise ValueError(f"{key} must be an actual list or tuple")
+                elif len(value) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                    raise ValueError(
+                        f"{key} must contain at most "
+                        f"{_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+                    )
                 if any(type(item) is not float for item in payload[key]):
                     raise ValueError(f"serialized {key} values must be JSON numbers")
         for key in ("observation_dim", "action_dim", "reward_dim"):
@@ -287,6 +300,10 @@ def _require_array(
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(rates) > _MAX_WORKING_MEMORY_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",

--- a/tests/test_working_memory_cardinality_bounds.py
+++ b/tests/test_working_memory_cardinality_bounds.py
@@ -1,0 +1,210 @@
+"""Cardinality preflights for working-memory and fixed-trace decay rates."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from alberta_framework.core.state_builder import (
+    _MAX_FIXED_TRACE_DECAY_RATES,
+    FixedTraceStateBuilderConfig,
+)
+from alberta_framework.core.working_memory import (
+    _MAX_WORKING_MEMORY_DECAY_RATES,
+    WorkingMemoryConfig,
+)
+
+
+class _HostileList(list[object]):
+    calls = 0
+
+    def __len__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("list length hook executed")
+
+
+def test_documented_protocol_ceilings() -> None:
+    assert _MAX_WORKING_MEMORY_DECAY_RATES == 4096
+    assert _MAX_FIXED_TRACE_DECAY_RATES == 4096
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "observation_decay_rates",
+        "action_decay_rates",
+        "reward_decay_rates",
+    ],
+)
+def test_working_memory_last_fit_decay_count_is_accepted(field: str) -> None:
+    kwargs: dict[str, Any] = {
+        "observation_dim": 1,
+        "action_dim": 0,
+        "reward_dim": 0,
+        "observation_decay_rates": (),
+        "action_decay_rates": (),
+        "reward_decay_rates": (),
+        "include_current_action": False,
+        "include_current_reward": False,
+        "include_traces": True,
+        field: (0.5,) * _MAX_WORKING_MEMORY_DECAY_RATES,
+    }
+    if field == "action_decay_rates":
+        kwargs["action_dim"] = 1
+    elif field == "reward_decay_rates":
+        kwargs["reward_dim"] = 1
+
+    cfg = WorkingMemoryConfig(**kwargs)
+    assert len(getattr(cfg, field)) == _MAX_WORKING_MEMORY_DECAY_RATES
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "observation_decay_rates",
+        "action_decay_rates",
+        "reward_decay_rates",
+    ],
+)
+def test_working_memory_rejects_oversized_decay_rates_before_per_rate_walk(field: str) -> None:
+    calls = 0
+
+    class HostileFloat:
+        def __float__(self) -> float:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("oversized decay tuple walked an element")
+
+    hostile: Any = HostileFloat()
+    kwargs: dict[str, Any] = {
+        "observation_dim": 1,
+        "action_dim": 1,
+        "reward_dim": 1,
+        field: (hostile,) * (_MAX_WORKING_MEMORY_DECAY_RATES + 1),
+    }
+    with pytest.raises(ValueError, match="at most 4096"):
+        WorkingMemoryConfig(**kwargs)
+    assert calls == 0
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "observation_decay_rates",
+        "action_decay_rates",
+        "reward_decay_rates",
+    ],
+)
+def test_working_memory_from_config_rejects_oversized_lists_before_tuple_copy(
+    field: str,
+) -> None:
+    config = WorkingMemoryConfig(observation_dim=1, action_dim=1, reward_dim=1).to_config()
+    config[field] = [0.5] * (_MAX_WORKING_MEMORY_DECAY_RATES + 1)
+    with pytest.raises(ValueError, match="at most 4096"):
+        WorkingMemoryConfig.from_config(config)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "observation_decay_rates",
+        "action_decay_rates",
+        "reward_decay_rates",
+    ],
+)
+def test_working_memory_from_config_rejects_list_subclasses_before_length_hooks(
+    field: str,
+) -> None:
+    config = WorkingMemoryConfig(observation_dim=1, action_dim=1, reward_dim=1).to_config()
+    config[field] = _HostileList()
+    _HostileList.calls = 0
+    with pytest.raises(ValueError, match="actual list or tuple"):
+        WorkingMemoryConfig.from_config(config)
+    assert _HostileList.calls == 0
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "observation_decay_rates",
+        "action_decay_rates",
+        "outcome_decay_rates",
+    ],
+)
+def test_fixed_trace_last_fit_decay_count_is_accepted(field: str) -> None:
+    kwargs: dict[str, Any] = {
+        "observation_dim": 1,
+        "n_actions": 1 if field == "action_decay_rates" else 0,
+        "observation_decay_rates": (),
+        "action_decay_rates": (),
+        "outcome_decay_rates": (),
+        "include_raw_observation": False,
+        field: (0.5,) * _MAX_FIXED_TRACE_DECAY_RATES,
+    }
+    cfg = FixedTraceStateBuilderConfig(**kwargs)
+    assert len(getattr(cfg, field)) == _MAX_FIXED_TRACE_DECAY_RATES
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "observation_decay_rates",
+        "action_decay_rates",
+        "outcome_decay_rates",
+    ],
+)
+def test_fixed_trace_rejects_oversized_decay_rates_before_per_rate_walk(field: str) -> None:
+    calls = 0
+
+    class HostileFloat:
+        def __float__(self) -> float:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("oversized decay tuple walked an element")
+
+    hostile: Any = HostileFloat()
+    kwargs: dict[str, Any] = {
+        "observation_dim": 1,
+        "n_actions": 1,
+        field: (hostile,) * (_MAX_FIXED_TRACE_DECAY_RATES + 1),
+    }
+    with pytest.raises(ValueError, match="at most 4096"):
+        FixedTraceStateBuilderConfig(**kwargs)
+    assert calls == 0
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "observation_decay_rates",
+        "action_decay_rates",
+        "outcome_decay_rates",
+    ],
+)
+def test_fixed_trace_from_config_rejects_oversized_lists_before_tuple_copy(
+    field: str,
+) -> None:
+    config = FixedTraceStateBuilderConfig(observation_dim=1, n_actions=1).to_config()
+    config[field] = [0.5] * (_MAX_FIXED_TRACE_DECAY_RATES + 1)
+    with pytest.raises(ValueError, match="at most 4096"):
+        FixedTraceStateBuilderConfig.from_config(config)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "observation_decay_rates",
+        "action_decay_rates",
+        "outcome_decay_rates",
+    ],
+)
+def test_fixed_trace_from_config_rejects_list_subclasses_before_length_hooks(
+    field: str,
+) -> None:
+    config = FixedTraceStateBuilderConfig(observation_dim=1, n_actions=1).to_config()
+    config[field] = _HostileList()
+    _HostileList.calls = 0
+    with pytest.raises(ValueError, match="decay rates must be lists or tuples"):
+        FixedTraceStateBuilderConfig.from_config(config)
+    assert _HostileList.calls == 0


### PR DESCRIPTION
Fixes #2220

## Summary

- Capped `observation_decay_rates`, `action_decay_rates`, and `reward_decay_rates` cardinality to 4096 (`_MAX_WORKING_MEMORY_DECAY_RATES = 1 << 12`) in `WorkingMemoryConfig` and `_validate_decay_rates` in `alberta_framework/core/working_memory.py`.
- Capped `observation_decay_rates`, `action_decay_rates`, and `outcome_decay_rates` cardinality to 4096 (`_MAX_FIXED_TRACE_DECAY_RATES = 1 << 12`) in `FixedTraceStateBuilderConfig` and `_require_decay_rates` in `alberta_framework/core/state_builder.py`.
- Enforced list length bounds and rejected list subclasses prior to element walks and tuple conversions in `WorkingMemoryConfig.from_config` and `FixedTraceStateBuilderConfig.from_config`.
- Added failing-test-first test suite in `tests/test_working_memory_cardinality_bounds.py` asserting boundary acceptance at 4096, rejection of 4097 elements before element iteration, and rejection of hostile list subclasses without invoking length hooks.

Mode: Fix. Permanently nonpromoting.

## Verification

<!-- evidence-head:7435e55db37c561dc63fb455bdf8d6bc4f399400 -->
<!-- evidence-row:logs -->
- [x] logs: `.venv/bin/python -m pytest tests/test_working_memory_cardinality_bounds.py tests/test_working_memory_validation.py tests/test_working_memory.py tests/test_state_builder.py tests/test_state_builder_hostile_validation.py tests/test_history_feature_list_hang.py tests/test_history_features.py -q -o addopts=""` → 335 passed; `.venv/bin/python -m ruff check .` → all checks passed; `.venv/bin/python -m mypy` → 0 issues across 224 source files.

## Disclosure

AI provider/model: google / antigravity
Client / agent tooling: antigravity-cli
Lane: working-memory-decay-bound