### PR TITLE
fix(core): bound stacked-horde demon count and reject oversized sequences in deserializer

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -132,6 +132,8 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_STACKED_HORDE_CONFIGURATION_ITEMS = 1 << 12
+_MAX_STACKED_HORDE_DEMONS = _MAX_STACKED_HORDE_CONFIGURATION_ITEMS
 _CONFIG_FIELDS = {
     "type",
     "n_demons",
@@ -174,9 +176,19 @@ def _require_sequence(name: str, value: object) -> tuple[object, ...]:
 
 
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
-    if type(value) not in (list, tuple):
+    if type(value) is list:
+        if len(value) > _MAX_STACKED_HORDE_DEMONS:
+            raise ValueError(
+                f"{name} must contain at most {_MAX_STACKED_HORDE_DEMONS} items"
+            )
+        return tuple(value)
+    elif type(value) is not tuple:
         raise ValueError(f"{name} must be an actual list or tuple")
-    return tuple(cast(list[object] | tuple[object, ...], value))
+    elif len(value) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_STACKED_HORDE_DEMONS} items"
+        )
+    return cast(tuple[object, ...], value)
 
 
 def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
@@ -257,7 +269,9 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        n_demons = _require_int32(
+            "n_demons", self.n_demons, minimum=1, maximum=_MAX_STACKED_HORDE_DEMONS
+        )
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
         raw_sequences = {
@@ -365,8 +379,10 @@ def nexting_spec(
     )
     canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
     n_demons = len(canonical_indices) * len(canonical_gammas)
-    if n_demons < 1 or n_demons > _INT32_MAX:
-        raise ValueError("derived n_demons must be in the signed int32 domain")
+    if n_demons < 1 or n_demons > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"derived nexting demon count ({n_demons}) must be in [1, {_MAX_STACKED_HORDE_DEMONS}]"
+        )
     _preflight_horde_resources(n_demons, feature_dim)
     _preflight_stacked_horde_update_working_set(n_demons, feature_dim)
     idxs: list[int] = []

--- a/tests/test_stacked_horde_cardinality_bounds.py
+++ b/tests/test_stacked_horde_cardinality_bounds.py
@@ -1,0 +1,113 @@
+"""Cardinality preflights for StackedLinearHorde demons and sequences."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from alberta_framework.core.stacked_horde import (
+    _MAX_STACKED_HORDE_DEMONS,
+    StackedHordeConfig,
+    nexting_spec,
+)
+
+
+class _HostileList(list[object]):
+    calls = 0
+
+    def __len__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("list length hook executed")
+
+
+def test_documented_protocol_ceilings() -> None:
+    assert _MAX_STACKED_HORDE_DEMONS == 4096
+
+
+def test_last_fit_demon_count_is_accepted() -> None:
+    config = StackedHordeConfig(
+        n_demons=_MAX_STACKED_HORDE_DEMONS,
+        feature_dim=1,
+        gammas=(0.9,) * _MAX_STACKED_HORDE_DEMONS,
+        lamdas=(0.5,) * _MAX_STACKED_HORDE_DEMONS,
+        cumulant_indices=(0,) * _MAX_STACKED_HORDE_DEMONS,
+        step_size=0.05,
+    )
+    assert config.n_demons == _MAX_STACKED_HORDE_DEMONS
+    assert len(config.gammas) == _MAX_STACKED_HORDE_DEMONS
+
+
+def test_rejects_oversized_demon_count_before_element_walk() -> None:
+    calls = 0
+
+    class HostileFloat:
+        def __float__(self) -> float:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("oversized sequence walked an element")
+
+    hostile: Any = HostileFloat()
+    with pytest.raises(ValueError, match="n_demons"):
+        StackedHordeConfig(
+            n_demons=_MAX_STACKED_HORDE_DEMONS + 1,
+            feature_dim=1,
+            gammas=(hostile,) * (_MAX_STACKED_HORDE_DEMONS + 1),
+            lamdas=(0.5,) * (_MAX_STACKED_HORDE_DEMONS + 1),
+            cumulant_indices=(0,) * (_MAX_STACKED_HORDE_DEMONS + 1),
+            step_size=0.05,
+        )
+    assert calls == 0
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "gammas",
+        "lamdas",
+        "cumulant_indices",
+    ],
+)
+def test_from_config_rejects_oversized_lists_before_tuple_copy(field: str) -> None:
+    base = StackedHordeConfig(
+        n_demons=1,
+        feature_dim=1,
+        gammas=(0.9,),
+        lamdas=(0.5,),
+        cumulant_indices=(0,),
+    ).to_config()
+    base[field] = [0.5 if field != "cumulant_indices" else 0] * (_MAX_STACKED_HORDE_DEMONS + 1)
+    with pytest.raises(ValueError, match="at most 4096"):
+        StackedHordeConfig.from_config(base)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "gammas",
+        "lamdas",
+        "cumulant_indices",
+    ],
+)
+def test_from_config_rejects_list_subclasses_before_length_hooks(field: str) -> None:
+    base = StackedHordeConfig(
+        n_demons=1,
+        feature_dim=1,
+        gammas=(0.9,),
+        lamdas=(0.5,),
+        cumulant_indices=(0,),
+    ).to_config()
+    base[field] = _HostileList()
+    _HostileList.calls = 0
+    with pytest.raises(ValueError, match="actual list or tuple"):
+        StackedHordeConfig.from_config(base)
+    assert _HostileList.calls == 0
+
+
+def test_nexting_spec_rejects_oversized_combinations() -> None:
+    with pytest.raises(ValueError, match="demon count"):
+        nexting_spec(
+            feature_dim=1,
+            cumulant_indices=tuple(range(1025)),
+            gammas=(0.0, 0.5, 0.9, 0.99),  # 1025 * 4 = 4100 > 4096
+        )


### PR DESCRIPTION
Fixes #2225

## Summary

- Defined `_MAX_STACKED_HORDE_DEMONS = 1 << 12` (4096) in `alberta_framework/core/stacked_horde.py`.
- Enforced upper bound on `n_demons` in `StackedHordeConfig.__post_init__`.
- Capped sequence lengths to 4096 and rejected list subclasses prior to element copying in `_decode_sequence`.
- Added cardinality preflight on demon product in `nexting_spec`.
- Added failing-test-first test suite in `tests/test_stacked_horde_cardinality_bounds.py` asserting boundary acceptance at 4096, rejection of 4097 demons, rejection of oversized serialized lists, rejection of hostile list subclasses without invoking length hooks, and preflight rejection in `nexting_spec`.

Mode: Fix. Permanently nonpromoting.

## Verification

<!-- evidence-head:478414622d03a14157d110f29840af216f7da8f5 -->
<!-- evidence-row:logs -->
- [x] logs: `.venv/bin/python -m pytest tests/test_stacked_horde_cardinality_bounds.py tests/test_stacked_horde.py tests/test_stacked_horde_update_working_set.py tests/test_multi_head_stacked_horde_label_emnist_scan_bounds.py tests/test_horde.py tests/test_horde_actor_critic.py tests/test_baird_horde.py -q -o addopts=""` → 299 passed; `.venv/bin/python -m ruff check .` → all checks passed; `.venv/bin/python -m mypy` → 0 issues across 224 source files.

## Disclosure

AI provider/model: google / antigravity
Client / agent tooling: antigravity-cli
Lane: stacked-horde-demon-bound