### PR TITLE
fix(benchmarks): bill the post-task diagnostic forward in low-cost query accounting

### DIFF
--- a/alberta_framework/benchmarks/low_cost_controls_ipmnist.py
+++ b/alberta_framework/benchmarks/low_cost_controls_ipmnist.py
@@ -325,6 +325,10 @@ def _run_arm(
         # Evaluation forwards are deterministic: the stochastic arm uses its
         # declared test-time scaling rather than a fresh draw.
         _, hidden1, hidden2 = _forward(params, jnp.asarray(inputs), arm_id, eval_key, False)
+        # The post-task diagnostic is a real forward pass and is billed as one
+        # query per task boundary, matching `adamo_diagnostic`'s published
+        # `2 * observations + n_tasks` accounting for the same structure.
+        queries += 1
         host1, host2 = np.asarray(hidden1), np.asarray(hidden2)
         dead_units = int(np.sum(np.all(host1 == 0.0, axis=0))) + int(
             np.sum(np.all(host2 == 0.0, axis=0))

--- a/tests/test_low_cost_controls_ipmnist.py
+++ b/tests/test_low_cost_controls_ipmnist.py
@@ -9,9 +9,11 @@ from alberta_framework.benchmarks.low_cost_controls_ipmnist import (
     LowCostCatalogEntry,
     LowCostResult,
     _preactivation_width,
+    _run_arm,
     qualification_gates,
     run_comparator,
 )
+from alberta_framework.benchmarks.plasticity_diagnostics import PROFILES
 
 
 def _fixture(rows: int = 32):
@@ -149,3 +151,25 @@ class TestResultContract:
             "aid_off",
             "deep_fourier_off",
         }
+
+
+def test_model_queries_bill_the_post_task_diagnostic_forward() -> None:
+    """Each task boundary runs a real diagnostic forward that must be billed.
+
+    `adamo_diagnostic` publishes `2 * observations + n_tasks` for the same
+    per-example-plus-post-task-diagnostic structure; this lane must agree or its
+    reported resource usage understates the comparator by one query per task.
+    """
+    profile = PROFILES["contract-smoke"]
+    tasks = tuple(
+        (
+            np.zeros((profile.examples_per_task, 784), dtype=np.float32),
+            np.zeros((profile.examples_per_task,), dtype=np.int32),
+        )
+        for _ in range(profile.n_tasks)
+    )
+
+    result = _run_arm("sgd_current_control", tasks, profile, seed=15_660)
+
+    steps = profile.n_tasks * profile.examples_per_task
+    assert result.model_queries == 2 * steps + profile.n_tasks


### PR DESCRIPTION
## What's wrong

`_run_arm` bills two model queries per example — one training forward for the gradient, one evaluation forward for the reported prediction:

```python
queries += 2
```

It then runs a **third, real forward** at every task boundary to collect the dead-unit and effective-rank diagnostics:

```python
_, hidden1, hidden2 = _forward(params, jnp.asarray(inputs), arm_id, eval_key, False)
```

That forward is never counted. `model_queries` reports `2 * observations` and understates the comparator's own resource usage by exactly `n_tasks`. On the `contract-smoke` profile (2 tasks × 4 examples) it reports **16** where the executed work is **18**.

A resource number that is quietly short is worse than a missing one: it makes this arm look cheaper than it is when compared against lanes that count honestly.

## Why one query per boundary, not one per example

The boundary forward processes the whole task batch, so "one per example" was worth ruling out. This repository already publishes the convention for exactly this structure — per-example forwards plus one post-task diagnostic — in `adamo_diagnostic.py`:

```python
"model_queries": 2 * observations + config.n_tasks,
```

So the boundary forward is billed as one query per task. This lane now agrees with its sibling instead of contradicting it.

## Verification

| Gate | Result |
| --- | --- |
| `test_low_cost_controls_ipmnist.py` + `test_low_cost_controls_parity.py` | 30 passed |
| `ruff check` (both changed files) | passed |
| strict `mypy` on `low_cost_controls_ipmnist.py` | passed |

No recorded artifact under `outputs/` carries this lane's `model_queries`, and nothing recomputes the old formula, so **no immutable evidence is invalidated** by the corrected count.

## Mutation resistance

Reverting only the source change and keeping the test:

```
AssertionError: assert 16 == ((2 * 8) + 2)
  where 16 = LowCostArmResult(..., model_queries=16).model_queries
  and    2 = DiagnosticProfile(profile_id='contract-smoke', n_tasks=2, examples_per_task=4, ...).n_tasks
```

The failure names the undercount directly. Reapplying returns all 30 to green.

## Attribution

- Found by OpenAI `gpt-5.6-sol` via Codex (AgentRouter) during a review of the benchmark comparator surface.
- Independent verification, and confirmation that one-query-per-boundary (rather than one-per-example) is the repository's own established convention via `adamo_diagnostic`, by Claude Code (`claude-opus-5`).
