### PR TITLE
test(bounded-elastic): declare the Linux-only publication requirement

### DIFF
--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -16,6 +16,7 @@ from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
 from alberta_framework.evaluation.bounded_elastic_ipmnist_nonpromoting import (
     registered_bounded_elastic_hyperparameters,
 )
+from tests._forager_matched_platform import HAS_O_TMPFILE, requires_o_tmpfile
 
 SMALL = IPMNISTConfig(n_tasks=1, task_length=5000, input_dim=2, hidden1=4, hidden2=2, n_classes=2)
 
@@ -291,6 +292,7 @@ def test_campaign_rejects_unregistered_outcome_decisions(
         )
 
 
+@requires_o_tmpfile
 def test_writer_is_create_only_and_retains_negative_outcomes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -314,6 +316,7 @@ def test_writer_is_create_only_and_retains_negative_outcomes(
     assert not destination.with_name(f".{destination.name}.reservation").exists()
 
 
+@requires_o_tmpfile
 def test_writer_strictly_rereads_before_link_and_retains_failed_attempt(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -340,6 +343,7 @@ def test_writer_strictly_rereads_before_link_and_retains_failed_attempt(
     assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
 
 
+@requires_o_tmpfile
 def test_writer_retains_reservation_after_reexecution_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -366,6 +370,7 @@ def test_writer_retains_reservation_after_reexecution_failure(
     assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
 
 
+@requires_o_tmpfile
 @pytest.mark.parametrize("replace_linked_inode", [False, True])
 def test_post_link_failure_rolls_back_only_the_exact_published_inode(
     monkeypatch: pytest.MonkeyPatch,
@@ -407,6 +412,7 @@ def test_post_link_failure_rolls_back_only_the_exact_published_inode(
     assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
 
 
+@requires_o_tmpfile
 def test_link_success_followed_by_exception_rolls_back_exact_inode(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -434,6 +440,7 @@ def test_link_success_followed_by_exception_rolls_back_exact_inode(
     assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
 
 
+@requires_o_tmpfile
 def test_writer_rejects_replaced_visible_reservation_before_publication(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -464,6 +471,7 @@ def test_writer_rejects_replaced_visible_reservation_before_publication(
     marker.unlink()
 
 
+@requires_o_tmpfile
 def test_writer_parent_swap_does_not_publish_through_replacement(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -493,6 +501,16 @@ def test_writer_parent_swap_does_not_publish_through_replacement(
         )
     assert destination.read_bytes() == competitor
     assert not (retired / destination.name).exists()
+
+
+@pytest.mark.skipif(HAS_O_TMPFILE, reason="Linux publishes the artifact instead of refusing")
+def test_reservation_fails_closed_without_linux_descriptor_support(tmp_path: Path) -> None:
+    destination = tmp_path / "never" / "bounded-elastic.json"
+    with pytest.raises(OSError, match="immutable output publication requires Linux"):
+        runner._reserve_output(destination, _capability=runner._TEST_EXECUTION_CAPABILITY)
+
+    assert not destination.parent.exists()
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_public_writer_is_closed_before_creating_output(tmp_path: Path) -> None:
@@ -552,6 +570,7 @@ def test_standalone_paths_remain_disabled_after_flag_transition(
     assert not destination.parent.exists()
 
 
+@requires_o_tmpfile
 def test_transaction_reserves_before_dataset_load_or_runner(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -579,6 +598,7 @@ def test_transaction_reserves_before_dataset_load_or_runner(
     assert marker.read_bytes() == b"prior reservation"
 
 
+@requires_o_tmpfile
 def test_transaction_retains_owned_tombstone_after_first_dispatch_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -615,6 +635,7 @@ def test_transaction_retains_owned_tombstone_after_first_dispatch_failure(
     assert calls == 1
 
 
+@requires_o_tmpfile
 def test_transaction_publishes_only_after_strict_reexecution(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Fixes #2251.

`tests/test_bounded_elastic_matched_runner.py` drives the Linux-only immutable-publication path but declares no platform requirement, so 11 of its 34 items are permanently red on macOS while passing in CI. This declares the requirement using the helper that already exists for exactly this purpose, and adds the inverse test the file was missing.

## The change

Test-only, purely additive (21 insertions, no deletions):

1. Applies `requires_o_tmpfile` from `tests/_forager_matched_platform.py` to the ten test functions (eleven items — one is parametrized) that reach `_reserve_output`.
2. Adds `test_reservation_fails_closed_without_linux_descriptor_support`, guarded by the inverse `skipif(HAS_O_TMPFILE)`, asserting that `_reserve_output` refuses off Linux *and* creates no directory — pinning that the guard fires before `_open_output_parent`.

No library code is touched, no test is deleted or renamed, and no assertion is weakened.

## Measured

macOS arm64 (Darwin), CPython 3.13.5:

| | `origin/main` @ `c9aba7b5` | this branch |
|---|---|---|
| `tests/test_bounded_elastic_matched_runner.py` | **11 failed**, 23 passed | **24 passed**, 11 skipped |
| collected (strict CI flags) | 34 | 35 |

`ruff check` passes on the changed file. mypy is scoped to `alberta_framework`, so a test-only change moves no registered source hash.

**CI coverage is unchanged.** `HAS_O_TMPFILE = bool(getattr(os, "O_TMPFILE", 0))` (`tests/_forager_matched_platform.py:45`) is truthy on Linux, so `requires_o_tmpfile` never fires there and all 34 original items continue to run and pass exactly as before; the one new test inverts and skips. The existing `macos-14` / `windows-latest` `portability` job runs a fixed panel that does not include this file, so these failures were local-dev-only and no CI signal changes in either direction.

## Why gate rather than port

`alberta_framework/evaluation/bounded_elastic_matched_runner.py:879-880` refuses off Linux by design:

```python
if not all(hasattr(os, name) for name in ("O_DIRECTORY", "O_NOFOLLOW", "O_TMPFILE")):
    raise OSError("immutable output publication requires Linux descriptor support")
```

That is a fail-closed guard, not an oversight — it refuses rather than publishing through a weaker path. Gating the tests to match keeps the test outcome faithful to the library's own contract, which is the rule `tests/_forager_matched_platform.py` was written to enforce (#1981 / #1985). These eleven items were never green on macOS and cannot be, so nothing that could pass is being skipped.

## Caveats, stated rather than left to be found

- **`O_TMPFILE` stands in for two primitives, not one.** The gated paths need both the `os.O_TMPFILE` open (`runner.py:1111`) and `linkat(fd, "", dirfd, name, AT_EMPTY_PATH)` — `0x1000` via `ctypes.CDLL(None)` at `runner.py:993-996`. The helper's docstring already bundles these in one bullet, and the byte-identical construct in `forager_matched_campaign._link_anonymous_no_replace` is gated by this same predicate, so this matches precedent.
- **The predicate probes one attribute; the guard is a three-way conjunction.** `O_DIRECTORY` and `O_NOFOLLOW` are POSIX-ubiquitous and are dereferenced unguarded at `runner.py:833`, so neither can ever be the missing conjunct in an environment where the module imports at all. `O_TMPFILE` is the sole discriminator. I reused the existing marker rather than adding a fourth near-duplicate predicate; happy to add an exact-conjunction one if you would prefer the probe mirror the guard literally.
- **Both guard and predicate are attribute checks, not runtime filesystem probes.** On a Linux host whose `tmp_path` is on a filesystem without `O_TMPFILE` support (NFS, some overlay/FUSE), the gated tests would still run and fail at `runner.py:1111` with `EOPNOTSUPP`. That imprecision is pre-existing in the library guard — this predicate is exactly as precise as the guard it stands in for — and tightening it would be a library edit, so it is out of scope here.
- **macOS coverage of the ten gated functions goes from "errors" to "skipped."** No coverage is lost, and the new inverse test converts part of that into one positive macOS assertion.

Measured with `claude-code` / `anthropic` / `claude-opus-5` on arm64 Darwin, CPython 3.13.5.

---

Compute receipt: 8747610 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi
Attribution status: self-reported
— [asi]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0JVS5NR66W2WE8ERH6M7RXF","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-21T19:11:51.480Z","completed_at":"2026-08-21T20:15:02.001Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T19:11:53.894Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":81,"output_tokens":38894,"cache_creation_tokens":68177,"cache_read_tokens":8640458,"total_tokens":8747610,"cost_micro_usd":"5974754","session_count":1},"trajectory_sha256":"d832c6861eca21f40afd80a1c0552aea72af29a2de119f820a8ecc9826bba595","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"13b5fd2c-ff70-4b1b-b8da-85ce00f3b576","object_id":"sha256:d832c6861eca21f40afd80a1c0552aea72af29a2de119f820a8ecc9826bba595","sha256":"d832c6861eca21f40afd80a1c0552aea72af29a2de119f820a8ecc9826bba595"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAHBoGfBNRJEhRkQvHY6AcB2oVJyScySjClifWLRVPl28","device_key_id":"e6f31ab600bfb4b6612dfa8af8aec495ea789bb7fa02be582d03179b4a835899","device_signature":"oPrHUc8usxWI4knKTYNHj5qEQHXJV4yJmvavbnDGtSWFa1JYDC1MirUIGq7cl-vgC5-p3SlfAJto8VgdO53oBw"}} -->
