### PR TITLE
qualify(benchmarks): bind DreamerV3 source identity (#1576)

### DIFF
--- a/alberta_framework/benchmarks/dreamerv3_external_qualification.py
+++ b/alberta_framework/benchmarks/dreamerv3_external_qualification.py
@@ -1,0 +1,129 @@
+"""Read-only source qualification for the pinned DreamerV3 baseline.
+
+This closes only the source-availability and license-review gate for issue
+#1576. It does not build a runtime, acquire an environment, execute DreamerV3,
+or authorize a development comparison.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from alberta_framework.benchmarks.external_qualification import COMMON_GATES, qualification_plan
+
+SCHEMA = "asi.dreamerv3_source_qualification.v1"
+OFFICIAL_REPOSITORY = "https://github.com/danijar/dreamerv3.git"
+OFFICIAL_COMMIT = "e3f02248693a79dc8b0ebd62c93683888ddaccfe"
+OFFICIAL_GIT_TREE = "a6611dd5cca395eebcd387ebcad2685bb2d9dbdf"
+SOURCE_ARCHIVE_SHA256 = "bf7a237bd345e200f895943145b33e0296d40a8b90b2b7144c57985bd30698f4"
+SOURCE_ARCHIVE_BYTES = 6_312_430
+LICENSE_SPDX = "MIT"
+LICENSE_SHA256 = "9a0db563b71a42110ce6e52c066ec957ca908dd2fbff91e85df09d81a43076d2"
+REQUIREMENTS_SHA256 = "7825675c0866933f2d879320d842bcd781c8b2f29bd3b5b9091329e476d32487"
+CONFIG_SHA256 = "9dff9c7062e3e33951cb54c6dd4b598aaf7e56e18e2cff39c812eaa797bcfcfc"
+DOCKERFILE_SHA256 = "a6e6fd84abaf9e11f836d9cb1446261a8bc4b523668bf54d4858422de2772587"
+COMPLETED_GATES = ("external_code_available_and_license_reviewed",)
+UNRESOLVED_DEPENDENCIES = (
+    "official Dockerfile installs mutable apt/PPA inputs",
+    "official Dockerfile downloads and executes a mutable gist",
+    "official requirements leave most Python packages unpinned",
+    "official requirements request CUDA while the bounded slice is CPU-only",
+    "dm_control and MuJoCo runtime and asset identities are not locked",
+)
+
+
+def _exact_text(value: object, *, name: str, maximum: int = 512) -> str:
+    if type(value) is not str or not value or len(value.encode("utf-8")) > maximum:
+        raise ValueError(f"{name} must be bounded exact text")
+    return value
+
+
+def _sha256(value: object, *, name: str) -> str:
+    text = _exact_text(value, name=name, maximum=64)
+    if len(text) != 64 or any(character not in "0123456789abcdef" for character in text):
+        raise ValueError(f"{name} must be one lowercase SHA-256 digest")
+    return text
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class DreamerV3SourceQualification:
+    schema: str = SCHEMA
+    repository: str = OFFICIAL_REPOSITORY
+    commit: str = OFFICIAL_COMMIT
+    git_tree: str = OFFICIAL_GIT_TREE
+    source_archive_sha256: str = SOURCE_ARCHIVE_SHA256
+    source_archive_bytes: int = SOURCE_ARCHIVE_BYTES
+    license_spdx: str = LICENSE_SPDX
+    license_sha256: str = LICENSE_SHA256
+    requirements_sha256: str = REQUIREMENTS_SHA256
+    config_sha256: str = CONFIG_SHA256
+    dockerfile_sha256: str = DOCKERFILE_SHA256
+    config_overlays: tuple[str, ...] = ("dmc_proprio", "debug")
+    observation_mode: str = "proprioceptive_state"
+    completed_gates: tuple[str, ...] = COMPLETED_GATES
+    unresolved_dependencies: tuple[str, ...] = UNRESOLVED_DEPENDENCIES
+    source_acquired_read_only: bool = True
+    runtime_built: bool = False
+    workload_executed: bool = False
+    paper_parity_claimed: bool = False
+    scientific_promotion_allowed: bool = False
+
+    def __post_init__(self) -> None:
+        plan = qualification_plan(1576)
+        if self.schema != SCHEMA:
+            raise ValueError("schema drifted")
+        if self.repository != plan.code_revisions[0].repository:
+            raise ValueError("repository drifted from the issue catalog")
+        if self.commit != plan.code_revisions[0].commit:
+            raise ValueError("commit drifted from the issue catalog")
+        if self.git_tree != OFFICIAL_GIT_TREE:
+            raise ValueError("git tree drifted")
+        for name in (
+            "source_archive_sha256",
+            "license_sha256",
+            "requirements_sha256",
+            "config_sha256",
+            "dockerfile_sha256",
+        ):
+            _sha256(getattr(self, name), name=name)
+        if type(self.source_archive_bytes) is not int or self.source_archive_bytes != 6_312_430:
+            raise ValueError("source archive byte count drifted")
+        if self.license_spdx != "MIT":
+            raise ValueError("license review drifted")
+        if self.config_overlays != ("dmc_proprio", "debug"):
+            raise ValueError("state-observation configuration drifted")
+        if self.observation_mode != "proprioceptive_state":
+            raise ValueError("observation mode drifted")
+        if self.completed_gates != COMPLETED_GATES:
+            raise ValueError("only the source/license gate is complete")
+        if (
+            type(self.unresolved_dependencies) is not tuple
+            or not self.unresolved_dependencies
+            or len(self.unresolved_dependencies) > 16
+            or any(type(item) is not str or not item for item in self.unresolved_dependencies)
+        ):
+            raise ValueError("unresolved dependencies must remain explicit")
+        if self.source_acquired_read_only is not True:
+            raise ValueError("source audit must remain read-only")
+        if self.runtime_built is not False or self.workload_executed is not False:
+            raise ValueError("source qualification cannot claim external execution")
+        if self.paper_parity_claimed is not False:
+            raise ValueError("source qualification cannot claim paper parity")
+        if self.scientific_promotion_allowed is not False:
+            raise ValueError("scientific promotion must remain forbidden")
+
+    @property
+    def blockers(self) -> tuple[str, ...]:
+        completed = set(self.completed_gates)
+        return tuple(gate for gate in COMMON_GATES if gate not in completed)
+
+    def require_execution_ready(self) -> None:
+        raise RuntimeError(
+            "DreamerV3 is source-qualified only; runtime, workload, parity, and execution "
+            "authorization remain blocked"
+        )
+
+
+SOURCE_QUALIFICATION = DreamerV3SourceQualification()
+
+__all__ = ["DreamerV3SourceQualification", "SOURCE_QUALIFICATION"]

--- a/docs/research/dreamer-continual-development.md
+++ b/docs/research/dreamer-continual-development.md
@@ -26,3 +26,17 @@ selective-replay variants, evaluation matrices, published compute budgets, and o
 parity. Before comparison, locate and pin the Continual-Dreamer source snapshot, implement those
 components, match environment/dependency versions and all information boundaries, validate hardware
 accounting, reproduce official single-task controls, and freeze untouched scientific seeds.
+
+## External DreamerV3 source qualification
+
+The read-only `dreamerv3_external_qualification` record binds the official DreamerV3 commit and
+Git tree, the observed 6,312,430-byte source archive and its SHA-256 digest, the MIT license bytes,
+and the official requirements, configuration, and Dockerfile bytes. The prospective first slice is
+the official `dmc_proprio` configuration combined with `debug`, which uses proprioceptive state and
+the smallest published model overlay.
+
+This closes only the external-source availability and license-review gate. The official Dockerfile
+uses mutable apt/PPA inputs and executes a mutable gist; most Python dependencies are not pinned;
+the requirements select CUDA; and the dm_control/MuJoCo runtime and assets are not content-closed.
+No runtime was built, no environment or workload was executed, and no parity, performance,
+execution-attestation, development-result, or scientific claim is made.

--- a/tests/test_dreamerv3_external_qualification.py
+++ b/tests/test_dreamerv3_external_qualification.py
@@ -1,0 +1,58 @@
+"""Contracts for the read-only DreamerV3 source qualification."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from alberta_framework.benchmarks.dreamerv3_external_qualification import (
+    SOURCE_QUALIFICATION,
+)
+from alberta_framework.benchmarks.external_qualification import qualification_plan
+
+pytestmark = pytest.mark.unit
+
+
+def test_source_qualification_binds_catalog_and_content_identities() -> None:
+    plan = qualification_plan(1576)
+    qualification = SOURCE_QUALIFICATION
+    assert qualification.repository == plan.code_revisions[0].repository
+    assert qualification.commit == plan.code_revisions[0].commit
+    assert qualification.git_tree == "a6611dd5cca395eebcd387ebcad2685bb2d9dbdf"
+    assert qualification.source_archive_sha256 == (
+        "bf7a237bd345e200f895943145b33e0296d40a8b90b2b7144c57985bd30698f4"
+    )
+    assert qualification.source_archive_bytes == 6_312_430
+    assert qualification.license_spdx == "MIT"
+    assert qualification.license_sha256 == (
+        "9a0db563b71a42110ce6e52c066ec957ca908dd2fbff91e85df09d81a43076d2"
+    )
+
+
+def test_state_observation_slice_is_prospective_and_fail_closed() -> None:
+    qualification = SOURCE_QUALIFICATION
+    assert qualification.config_overlays == ("dmc_proprio", "debug")
+    assert qualification.observation_mode == "proprioceptive_state"
+    assert qualification.completed_gates == (
+        "external_code_available_and_license_reviewed",
+    )
+    assert "isolated_runtime_locked" in qualification.blockers
+    assert "assets_checksums_and_storage_approved" in qualification.blockers
+    assert "external_execution_separately_authorized" in qualification.blockers
+    assert qualification.source_acquired_read_only
+    assert not qualification.runtime_built
+    assert not qualification.workload_executed
+    assert not qualification.paper_parity_claimed
+    assert not qualification.scientific_promotion_allowed
+    with pytest.raises(RuntimeError, match="source-qualified only"):
+        qualification.require_execution_ready()
+
+
+def test_qualification_rejects_claim_and_identity_drift() -> None:
+    with pytest.raises(ValueError, match="commit"):
+        dataclasses.replace(SOURCE_QUALIFICATION, commit="0" * 40)
+    with pytest.raises(ValueError, match="promotion"):
+        dataclasses.replace(SOURCE_QUALIFICATION, scientific_promotion_allowed=True)
+    with pytest.raises(ValueError, match="unresolved dependencies"):
+        dataclasses.replace(SOURCE_QUALIFICATION, unresolved_dependencies=())


### PR DESCRIPTION
## Summary

Advances #1576 with the issue's next safe prerequisite: a read-only, content-addressed and
license-reviewed qualification of the pinned official DreamerV3 source.

- Binds the official commit, Git tree, observed source archive bytes/SHA-256, MIT license
  bytes/SHA-256, and requirements/configuration/Dockerfile bytes.
- Identifies the official `dmc_proprio + debug` overlays as the prospective smallest
  state-observation slice.
- Closes only `external_code_available_and_license_reviewed`.
- Keeps runtime, assets, boundary/budget matching, parity, result registration, and external
  authorization explicitly blocked.
- Records that no runtime was built and no workload, parity, performance, or scientific claim
  exists.

## Verification

- `.venv/bin/python -m pytest tests/test_dreamerv3_external_qualification.py tests/test_external_qualification.py tests/test_dreamer_continual_development.py -q` — 32 passed
- `.venv/bin/python -m ruff check alberta_framework/benchmarks/dreamerv3_external_qualification.py tests/test_dreamerv3_external_qualification.py` — passed
- `.venv/bin/python -m mypy` — passed (225 source files)
- `git diff --check` — passed

Verified head: `85c6c9a9deeef0f2af0f275ecb7eb19625be22aa`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex

This is a source-qualification slice only and does not close #1576.
