### PR TITLE
test(world-model): refute transition-only FTL control (#1575)

### DIFF
--- a/docs/evidence/negative-results.md
+++ b/docs/evidence/negative-results.md
@@ -247,6 +247,20 @@ postmortem.
     complete-prototype manifest and the not-assessed WP2 matrix: source presence
     was not an empirical gate.
 
+14. **A transition-only FTL prediction cannot truthfully supply the immediate-
+    reward control required by the action-conditioned latent lane.** In
+    `SwitchingTwoStateMDP`, phase A and phase B admit the same learner
+    observation, action, and next observation while returning rewards 0 and 1.
+    Therefore no adapter from `SparseFTLWorldModel`'s predicted next observation
+    to immediate reward can identify the correct control value without
+    privileged phase information. This closes only the environment-payoff-table
+    adapter route: an FTL control with a separately learned reward head, with its
+    state, updates, queries, and bytes charged, remains open under issue #1575.
+    The exact counterexample is retained in
+    `tests/test_action_conditioned_latent.py`; the permanently nonpromoting
+    protocol scope is recorded in
+    [`action-conditioned-latent-protocol.md`](../research/action-conditioned-latent-protocol.md).
+
 ## EMNIST transfer results
 
 1. **Bare input conditioning does not solve label permutation.**

--- a/docs/research/action-conditioned-latent-protocol.md
+++ b/docs/research/action-conditioned-latent-protocol.md
@@ -40,7 +40,18 @@ exploration schedule are matched. The roster is:
 4. a trained model behind a disabled decision interface;
 5. exact no-model mechanism-off control; and
 6. the repository's live SARSA control agent as a stronger non-world-model
-   comparator.
+comparator.
+
+The existing `SparseFTLWorldModel` is not yet a valid seventh arm. It predicts
+only the next observation, while this environment switches its reward matrix
+without changing transition dynamics and does not expose the active phase to
+the learner. The same current observation, action, and next observation can
+therefore carry reward 0 in phase A and reward 1 in phase B. Applying the
+environment payoff table to an FTL state prediction would require privileged
+phase information and violate the matched information boundary. A valid FTL
+arm needs an online learned reward head (with its updates, queries, and bytes
+charged) or a separately justified decision objective; next-observation
+prediction alone cannot drive the existing immediate-reward selector.
 
 The decision-off and mechanism-off arms must have identical action/reward
 transcript hashes. Receipts count real environment steps, model updates,

--- a/docs/research/action-conditioned-latent-protocol.md
+++ b/docs/research/action-conditioned-latent-protocol.md
@@ -40,7 +40,7 @@ exploration schedule are matched. The roster is:
 4. a trained model behind a disabled decision interface;
 5. exact no-model mechanism-off control; and
 6. the repository's live SARSA control agent as a stronger non-world-model
-comparator.
+   comparator.
 
 The existing `SparseFTLWorldModel` is not yet a valid seventh arm. It predicts
 only the next observation, while this environment switches its reward matrix

--- a/tests/test_action_conditioned_latent.py
+++ b/tests/test_action_conditioned_latent.py
@@ -8,6 +8,7 @@ import dataclasses
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from alberta_framework.benchmarks.action_conditioned_latent import (
@@ -20,6 +21,11 @@ from alberta_framework.benchmarks.action_conditioned_latent import (
     validate_action_latent_payload,
 )
 from alberta_framework.core.latent_world_model import LatentWorldModel, LatentWorldModelConfig
+from alberta_framework.streams.closed_loop import (
+    SwitchingTwoStateConfig,
+    SwitchingTwoStateMDP,
+    SwitchingTwoStateState,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -79,6 +85,24 @@ def test_live_model_action_selector_is_jittable_and_action_conditioned() -> None
     )
     assert int(eager) in (0, 1)
     assert int(compiled) == int(eager)
+
+
+def test_next_observation_cannot_identify_phase_switched_immediate_reward() -> None:
+    """Refute an oracle-free reward adapter for the transition-only FTL model."""
+    environment = SwitchingTwoStateMDP(SwitchingTwoStateConfig(phase_length=4))
+    phase_a = SwitchingTwoStateState(
+        state_index=jnp.asarray(0, dtype=jnp.int32),
+        step_count=jnp.asarray(0, dtype=jnp.int32),
+    )
+    phase_b = phase_a.replace(step_count=jnp.asarray(4, dtype=jnp.int32))
+    action = jnp.asarray(0, dtype=jnp.int32)
+    next_a, reward_a, _ = environment.step(phase_a, action, jr.key(0))
+    next_b, reward_b, _ = environment.step(phase_b, action, jr.key(1))
+
+    np.testing.assert_array_equal(environment.observe(phase_a), environment.observe(phase_b))
+    np.testing.assert_array_equal(next_a, next_b)
+    assert float(reward_a) == 0.0
+    assert float(reward_b) == 1.0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Advances and narrows #1575 by machine-checking why the existing transition-only
`SparseFTLWorldModel` cannot be inserted as a truthful control in the current immediate-reward
decision lane.

`SwitchingTwoStateMDP` keeps transition dynamics fixed while switching an unobserved reward phase.
The regression constructs phase-A and phase-B states with the same learner observation and action,
then verifies they produce byte-equal next observations but rewards 0 and 1 respectively. Therefore
no function of the FTL model's predicted next observation can recover the action reward.

Using the environment payoff table would require privileged phase information and violate the
matched learner information boundary. The protocol now records the honest implementation path: add
an online learned reward head and charge its updates, queries, and bytes, or justify a different
decision objective.

This does not add the FTL arm or close #1575. It rejects one invalid implementation route without
changing benchmark results or making a scientific claim.

## Verification

- `.venv/bin/python -m pytest tests/test_action_conditioned_latent.py -q` — 14 passed
- `.venv/bin/python -m ruff check tests/test_action_conditioned_latent.py` — passed
- `git diff --check` — passed

Verified head: `ac3dc56b589268a69862287a827725d1d77418ca`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
