### PR TITLE
fix(core): cap Horde actor-critic hidden_sizes before layer-walk hang

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -65,6 +65,9 @@ from alberta_framework.core.update_safety import (
 )
 
 _INT32_MAX = 2**31 - 1
+# Public last-fit in tests is one hidden layer. Origin walked unbounded
+# ``hidden_sizes`` before INT32 leftover math — hang, not a width overflow.
+_MAX_HORDE_ACTOR_HIDDEN_LAYERS = 4_096
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -97,6 +100,11 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 def _validate_hidden_sizes(sizes: object) -> tuple[int, ...]:
     if type(sizes) is not tuple:
         raise ValueError("hidden_sizes must be an actual tuple")
+    if len(sizes) > _MAX_HORDE_ACTOR_HIDDEN_LAYERS:
+        raise ValueError(
+            "hidden_sizes length must be an integer in "
+            f"[0, {_MAX_HORDE_ACTOR_HIDDEN_LAYERS}]"
+        )
     return tuple(
         _require_int32(f"hidden_sizes[{index}]", size, minimum=1)
         for index, size in enumerate(sizes)
@@ -1476,6 +1484,11 @@ class NonlinearHordeActorCriticConfig:
         )
         if type(c["hidden_sizes"]) is not list:
             raise ValueError("serialized hidden_sizes must be an exact built-in list")
+        if len(c["hidden_sizes"]) > _MAX_HORDE_ACTOR_HIDDEN_LAYERS:
+            raise ValueError(
+                "hidden_sizes length must be an integer in "
+                f"[0, {_MAX_HORDE_ACTOR_HIDDEN_LAYERS}]"
+            )
         c["hidden_sizes"] = tuple(c["hidden_sizes"])
         return cls(**c)
 
@@ -2232,6 +2245,11 @@ class NonlinearQHordeActorCriticConfig:
         )
         if type(payload["hidden_sizes"]) is not list:
             raise ValueError("serialized hidden_sizes must be an exact built-in list")
+        if len(payload["hidden_sizes"]) > _MAX_HORDE_ACTOR_HIDDEN_LAYERS:
+            raise ValueError(
+                "hidden_sizes length must be an integer in "
+                f"[0, {_MAX_HORDE_ACTOR_HIDDEN_LAYERS}]"
+            )
         payload["hidden_sizes"] = tuple(payload["hidden_sizes"])
         return cls(**payload)
 

--- a/tests/test_horde_actor_critic_hidden_layer_count_cap.py
+++ b/tests/test_horde_actor_critic_hidden_layer_count_cap.py
@@ -1,0 +1,36 @@
+"""Reject oversized Horde actor-critic hidden-size lists before layer-walk hang."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.horde_actor_critic import (
+    _MAX_HORDE_ACTOR_HIDDEN_LAYERS,
+    NonlinearHordeActorCriticConfig,
+)
+
+
+def test_horde_actor_hidden_layer_cap_constant() -> None:
+    assert _MAX_HORDE_ACTOR_HIDDEN_LAYERS == 4096
+
+
+def test_horde_actor_accepts_max_hidden_layer_count() -> None:
+    NonlinearHordeActorCriticConfig(
+        n_actions=2,
+        hidden_sizes=(1,) * _MAX_HORDE_ACTOR_HIDDEN_LAYERS,
+    )
+
+
+def test_horde_actor_rejects_oversized_hidden_layer_count() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        NonlinearHordeActorCriticConfig(
+            n_actions=2,
+            hidden_sizes=(1,) * (_MAX_HORDE_ACTOR_HIDDEN_LAYERS + 1),
+        )
+
+
+def test_horde_actor_from_config_rejects_oversized_hidden_list() -> None:
+    payload = NonlinearHordeActorCriticConfig(n_actions=2, hidden_sizes=(4,)).to_config()
+    payload["hidden_sizes"] = [1] * (_MAX_HORDE_ACTOR_HIDDEN_LAYERS + 1)
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        NonlinearHordeActorCriticConfig.from_config(payload)


### PR DESCRIPTION
## Summary
- Cap nonlinear Horde actor-critic `hidden_sizes` at 4096 layers so oversized lists reject before per-layer resource walks hang.
- Last-fit in tests is a one-layer MLP actor; this is a hang-cap, not leftover INT32 width math.
- Permanently nonpromoting Fix.

## Test plan
- [x] `pytest tests/test_horde_actor_critic_hidden_layer_count_cap.py -q`
- [x] `ruff check` on the two files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0KZYBQS2YJRYP19Z1DB3VD0","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-22T05:43:50.266Z","completed_at":"2026-08-22T05:45:32.252Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T05:43:50.876Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e183a29101a04df489e3d9263b10dd970f256b112660bc5bba3bf99e32a5f5f2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"86438634-f682-41c5-b641-2f876fac1133","object_id":"sha256:e183a29101a04df489e3d9263b10dd970f256b112660bc5bba3bf99e32a5f5f2","sha256":"e183a29101a04df489e3d9263b10dd970f256b112660bc5bba3bf99e32a5f5f2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"pFxgHN628AOXpU4Hv0jZZs9yq2kS3-jnGHW2ivT7UxC3oGJyKfZw-zj3UQznUJq_1tdjgvH4uEeslayjQw-YCA"}} -->
