### PR TITLE
fix(core): cap HordeLearner hidden_sizes before layer-walk hang

### DIFF
--- a/alberta_framework/core/horde.py
+++ b/alberta_framework/core/horde.py
@@ -58,6 +58,9 @@ _ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
 # ``cumulants``, and ``next_observations`` straight to ``jax.lax.scan`` with
 # no other cap on the scanned sequence length.
 _HORDE_SEQUENCE_MAX_STEPS = 10_000
+# Public last-fit in tests is two hidden layers. Origin walked unbounded
+# ``hidden_sizes`` before INT32 leftover math — hang, not a width overflow.
+_MAX_HORDE_HIDDEN_LAYERS = 4_096
 
 
 def _require_float32(
@@ -76,6 +79,20 @@ def _require_exact_bool(name: str, value: object) -> bool:
     if type(value) is not bool:
         raise ValueError(f"{name} must be an exact bool")
     return value
+
+
+def _require_hidden_layer_count(hidden_sizes: object) -> None:
+    if type(hidden_sizes) in (tuple, list) and len(hidden_sizes) > _MAX_HORDE_HIDDEN_LAYERS:
+        raise ValueError(
+            "hidden_sizes length must be an integer in "
+            f"[0, {_MAX_HORDE_HIDDEN_LAYERS}]"
+        )
+
+
+def _pop_hidden_sizes(config: dict[str, Any]) -> tuple[Any, ...]:
+    hidden_sizes = config.pop("hidden_sizes")
+    _require_hidden_layer_count(hidden_sizes)
+    return tuple(hidden_sizes)
 
 
 def _require_horde_sequence_length(name: str, value: object) -> int:
@@ -305,6 +322,7 @@ class HordeLearner:
         step_size, sparsity, leaky_relu_slope, use_layer_norm = _canonical_horde_host_scalars(
             step_size, sparsity, leaky_relu_slope, use_layer_norm
         )
+        _require_hidden_layer_count(hidden_sizes)
         self._horde_spec = horde_spec
         self._hidden_sizes = hidden_sizes
         self._step_size = step_size
@@ -423,7 +441,7 @@ class HordeLearner:
 
         return cls(
             horde_spec=horde_spec,
-            hidden_sizes=tuple(config.pop("hidden_sizes")),
+            hidden_sizes=_pop_hidden_sizes(config),
             optimizer=optimizer,
             bounder=bounder,
             normalizer=normalizer,
@@ -670,6 +688,7 @@ class MixedHorde:
         step_size, sparsity, leaky_relu_slope, use_layer_norm = _canonical_horde_host_scalars(
             step_size, sparsity, leaky_relu_slope, use_layer_norm
         )
+        _require_hidden_layer_count(hidden_sizes)
         self._horde_spec = horde_spec
         self._hidden_sizes = hidden_sizes
         self._optimizer = optimizer
@@ -812,7 +831,7 @@ class MixedHorde:
         )
         return cls(
             horde_spec=horde_spec,
-            hidden_sizes=tuple(config.pop("hidden_sizes")),
+            hidden_sizes=_pop_hidden_sizes(config),
             optimizer=optimizer,
             bounder=bounder,
             normalizer=normalizer,

--- a/tests/test_horde_learner_hidden_layer_count_cap.py
+++ b/tests/test_horde_learner_hidden_layer_count_cap.py
@@ -1,0 +1,45 @@
+"""Reject oversized HordeLearner hidden-size lists before layer-walk hang."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.horde import _MAX_HORDE_HIDDEN_LAYERS, HordeLearner
+from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
+
+
+def _spec():
+    return create_horde_spec(
+        (
+            GVFSpec(
+                name="demon_0",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=0,
+            ),  # type: ignore[call-arg]
+        )
+    )
+
+
+def test_horde_hidden_layer_cap_constant() -> None:
+    assert _MAX_HORDE_HIDDEN_LAYERS == 4096
+
+
+def test_horde_accepts_max_hidden_layer_count() -> None:
+    HordeLearner(horde_spec=_spec(), hidden_sizes=(1,) * _MAX_HORDE_HIDDEN_LAYERS)
+
+
+def test_horde_rejects_oversized_hidden_layer_count() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        HordeLearner(
+            horde_spec=_spec(),
+            hidden_sizes=(1,) * (_MAX_HORDE_HIDDEN_LAYERS + 1),
+        )
+
+
+def test_horde_from_config_rejects_oversized_hidden_list() -> None:
+    payload = HordeLearner(horde_spec=_spec(), hidden_sizes=(4,)).to_config()
+    payload["hidden_sizes"] = [1] * (_MAX_HORDE_HIDDEN_LAYERS + 1)
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        HordeLearner.from_config(payload)


### PR DESCRIPTION
## Summary
- Cap `HordeLearner` / `MixedHorde` `hidden_sizes` at 4096 layers so oversized lists reject before per-layer walks hang.
- Last-fit in tests is two hidden layers; this is a hang-cap, not leftover INT32 width math.
- Permanently nonpromoting Fix.

## Test plan
- [x] `pytest tests/test_horde_learner_hidden_layer_count_cap.py -q`
- [x] `ruff check` on the two files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0M05WPM5S6CVPR25RKMRMF0","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-22T05:47:57.012Z","completed_at":"2026-08-22T05:48:54.517Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T05:47:57.669Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"efb8a3187d7f5c36fed4fa18e6180695484a378646d40b655304108c45418ef3","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"80a593e7-67a8-4ba2-91e9-b8f47e2f9533","object_id":"sha256:efb8a3187d7f5c36fed4fa18e6180695484a378646d40b655304108c45418ef3","sha256":"efb8a3187d7f5c36fed4fa18e6180695484a378646d40b655304108c45418ef3"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"3s9jXQkJU1B_QhEFVwPyH5mc8I0ypLsJIErQGNwc6EbnAfMEq2wqlaZbeSe4zwqAZU6g5W71oMSYYvVk60CAAA"}} -->
