### PR TITLE
fix(steps): cap Step 4 SARSA hidden_sizes before layer-walk hang

### DIFF
--- a/alberta_framework/steps/step4.py
+++ b/alberta_framework/steps/step4.py
@@ -57,6 +57,9 @@ from alberta_framework.steps._smoke_record_validation import require_step_shape
 Step4OptimizerName = Literal["lms", "idbd", "autostep"]
 Step4BounderName = Literal["none", "obgd"]
 _INT32_MAX = 2**31 - 1
+# Public last-fit in tests is one hidden layer. Origin walked unbounded
+# ``hidden_sizes`` before INT32 leftover math — hang, not a width overflow.
+_MAX_STEP4_HIDDEN_LAYERS = 4_096
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -118,6 +121,11 @@ class Step4SARSAConfig:
             raise ValueError("Step4SARSAConfig payload fields do not match the schema")
         if type(raw["hidden_sizes"]) is not list:
             raise ValueError("hidden_sizes must be an exact list")
+        if len(cast(list[object], raw["hidden_sizes"])) > _MAX_STEP4_HIDDEN_LAYERS:
+            raise ValueError(
+                "hidden_sizes length must be an integer in "
+                f"[0, {_MAX_STEP4_HIDDEN_LAYERS}]"
+            )
         config = dict(raw)
         config["hidden_sizes"] = tuple(cast(list[object], config["hidden_sizes"]))
         return cls(**cast(Any, config))
@@ -266,6 +274,11 @@ def _validate_sarsa_config(config: Step4SARSAConfig) -> None:
     n_actions = _require_positive_int("n_actions", config.n_actions)
     if type(config.hidden_sizes) is not tuple:
         raise ValueError("hidden_sizes must be an actual tuple")
+    if len(config.hidden_sizes) > _MAX_STEP4_HIDDEN_LAYERS:
+        raise ValueError(
+            "hidden_sizes length must be an integer in "
+            f"[0, {_MAX_STEP4_HIDDEN_LAYERS}]"
+        )
     hidden_sizes = tuple(
         _require_positive_int("hidden_sizes", size) for size in config.hidden_sizes
     )

--- a/tests/test_step4_hidden_layer_count_cap.py
+++ b/tests/test_step4_hidden_layer_count_cap.py
@@ -1,0 +1,30 @@
+"""Reject oversized Step 4 SARSA hidden-size lists before layer-walk hang."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.steps.step4 import _MAX_STEP4_HIDDEN_LAYERS, Step4SARSAConfig
+
+
+def test_step4_hidden_layer_cap_constant() -> None:
+    assert _MAX_STEP4_HIDDEN_LAYERS == 4096
+
+
+def test_step4_accepts_max_hidden_layer_count() -> None:
+    Step4SARSAConfig(n_actions=2, hidden_sizes=(1,) * _MAX_STEP4_HIDDEN_LAYERS)
+
+
+def test_step4_rejects_oversized_hidden_layer_count() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        Step4SARSAConfig(
+            n_actions=2,
+            hidden_sizes=(1,) * (_MAX_STEP4_HIDDEN_LAYERS + 1),
+        )
+
+
+def test_step4_from_dict_rejects_oversized_hidden_list() -> None:
+    payload = Step4SARSAConfig(n_actions=2, hidden_sizes=(4,)).to_dict()
+    payload["hidden_sizes"] = [1] * (_MAX_STEP4_HIDDEN_LAYERS + 1)
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        Step4SARSAConfig.from_dict(payload)


### PR DESCRIPTION
## Summary
- Cap Step 4 SARSA `hidden_sizes` at 4096 layers so oversized lists reject before per-layer walks hang.
- Last-fit in tests is one hidden layer; widths at INT32 max stay legal. This is a hang-cap, not leftover INT32 width math.
- Permanently nonpromoting Fix.

## Test plan
- [x] `pytest tests/test_step4_hidden_layer_count_cap.py tests/test_step4_production.py tests/test_step4_hostile_validation.py -q`
- [x] `ruff check` on the two files

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"elizaOS/slopdotcash@c6bb2ca44d65e232abbb8d40c0c1c8b9eec3ded8:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0M0C5YTA98PFKAJGRFK4HRE","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-22T05:51:23.099Z","completed_at":"2026-08-22T05:53:07.960Z","skill_sha256":"a7a2cd43183c129e8153cd69fc3313097af609a07f3b8b001eb07774ca508c35","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T05:51:23.828Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"9899a3d37e028e92e457b7f67f35f5714d07f346489052fd64e200ed67977d58","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9993a6e4-042f-4e33-a01d-7ba15d5afdf1","object_id":"sha256:9899a3d37e028e92e457b7f67f35f5714d07f346489052fd64e200ed67977d58","sha256":"9899a3d37e028e92e457b7f67f35f5714d07f346489052fd64e200ed67977d58"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"vjFXRQh5orjolGrhVbC6VZS8bXd1wt9zD4uEBVcWJWKnTWwucfvmnBrnCgy_a5NCESSReefRobIqTmEqmfpYCA"}} -->
