### PR TITLE
fix(steps): cap Step 8 hidden_sizes before layer-walk hang

### DIFF
--- a/alberta_framework/steps/step8.py
+++ b/alberta_framework/steps/step8.py
@@ -53,6 +53,9 @@ from alberta_framework.steps._float32_validation import (
 from alberta_framework.steps._smoke_record_validation import require_step_shape
 
 _STEP8_SMOKE_BUDGET = ScanBudget("Step 8 smoke", maximum_steps=10_000)
+# Public last-fit in tests is one hidden layer. Origin walked unbounded
+# ``hidden_sizes`` before INT32 leftover math — hang, not a width overflow.
+_MAX_STEP8_HIDDEN_LAYERS = 4_096
 
 
 @dataclass(frozen=True)
@@ -101,6 +104,11 @@ class Step8WorldModelConfig:
             raise ValueError("Step8WorldModelConfig payload fields do not match the schema")
         if type(raw["hidden_sizes"]) is not list:
             raise ValueError("hidden_sizes must be an exact list")
+        if len(cast(list[object], raw["hidden_sizes"])) > _MAX_STEP8_HIDDEN_LAYERS:
+            raise ValueError(
+                "hidden_sizes length must be an integer in "
+                f"[0, {_MAX_STEP8_HIDDEN_LAYERS}]"
+            )
         data = dict(raw)
         data["hidden_sizes"] = tuple(cast(list[object], data["hidden_sizes"]))
         return cls(**cast(Any, data))
@@ -228,6 +236,11 @@ def _validate_world_model_config(config: Step8WorldModelConfig) -> None:
     action_dim = _require_int("action_dim", config.action_dim, minimum=1, maximum=_INT32_MAX)
     if type(config.hidden_sizes) is not tuple:
         raise ValueError("hidden_sizes must be an actual tuple")
+    if len(config.hidden_sizes) > _MAX_STEP8_HIDDEN_LAYERS:
+        raise ValueError(
+            "hidden_sizes length must be an integer in "
+            f"[0, {_MAX_STEP8_HIDDEN_LAYERS}]"
+        )
     hidden_sizes = tuple(
         _require_int("hidden_sizes", size, minimum=1, maximum=_INT32_MAX)
         for size in config.hidden_sizes

--- a/tests/test_step8_hidden_layer_count_cap.py
+++ b/tests/test_step8_hidden_layer_count_cap.py
@@ -1,0 +1,27 @@
+"""Reject oversized Step 8 world-model hidden-size lists before layer-walk hang."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.steps.step8 import _MAX_STEP8_HIDDEN_LAYERS, Step8WorldModelConfig
+
+
+def test_step8_hidden_layer_cap_constant() -> None:
+    assert _MAX_STEP8_HIDDEN_LAYERS == 4096
+
+
+def test_step8_accepts_max_hidden_layer_count() -> None:
+    Step8WorldModelConfig(hidden_sizes=(1,) * _MAX_STEP8_HIDDEN_LAYERS)
+
+
+def test_step8_rejects_oversized_hidden_layer_count() -> None:
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        Step8WorldModelConfig(hidden_sizes=(1,) * (_MAX_STEP8_HIDDEN_LAYERS + 1))
+
+
+def test_step8_from_dict_rejects_oversized_hidden_list() -> None:
+    payload = Step8WorldModelConfig(hidden_sizes=(4,)).to_dict()
+    payload["hidden_sizes"] = [1] * (_MAX_STEP8_HIDDEN_LAYERS + 1)
+    with pytest.raises(ValueError, match="hidden_sizes length"):
+        Step8WorldModelConfig.from_dict(payload)


### PR DESCRIPTION
## Summary

- **Fix:** `Step8WorldModelConfig` walked `hidden_sizes` with no layer-count bound, so a legal-width but huge list hung in validation before INT32 leftover math.
- Reject `len(hidden_sizes) > 4096` in `_validate_world_model_config` and `from_dict` (exact `list` only). Empty tuple and INT32 last-fit widths stay accepted.
- One source file + one test file. No registered evidence sources.

## Test plan

```text
<!-- evidence-head:1d956599c837a96e385e91bc38b0deb10861e120 -->
<!-- evidence-row:logs -->
- [x] logs: focused pytest + ruff on the touched files (see commands)
```

```bash
JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m pytest \
  tests/test_step8_hidden_layer_count_cap.py \
  tests/test_step8_production.py \
  tests/test_step8_hostile_validation.py -q -o addopts=""
# 111 passed
/root/asi-venv/bin/python -m ruff check \
  alberta_framework/steps/step8.py tests/test_step8_hidden_layer_count_cap.py
```

Provider/model: spacexai / Cursor-Grok-4.6
Client: cursor / lane cursor-grok-4-6
Skill: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Permanently nonpromoting measurement-correctness fix; not a benchmark result.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0M15DK6BJB8KNG5NCPN9CSX","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T06:05:10.119Z","completed_at":"2026-08-22T06:12:34.518Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T06:05:11.196Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"021b5f46b0e71496fa2579a02c4bc0b27d48710a40d9833d558d9469feb1587c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"6ce84fbf-2ed5-46a4-830e-674db9295fa9","object_id":"sha256:021b5f46b0e71496fa2579a02c4bc0b27d48710a40d9833d558d9469feb1587c","sha256":"021b5f46b0e71496fa2579a02c4bc0b27d48710a40d9833d558d9469feb1587c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"vRKGNgzeve12M5RuRxCrnboZLTGMVslUQ1ZBxcNhOleO9Rc0Krh9arym0ARQQM8a8zrn1YhvlzpmHRW8dJddDw"}} -->
