### PR TITLE
qualify(benchmarks): bind ContinualBench source

### DIFF
--- a/alberta_framework/benchmarks/external_qualification.py
+++ b/alberta_framework/benchmarks/external_qualification.py
@@ -158,7 +158,18 @@ def _revision(repository: str, commit: str) -> ExternalCodeRevision:
 # label.  Empty code revisions are an explicit blocker, never permission to
 # substitute an unofficial implementation.
 EXTERNAL_QUALIFICATION_PLANS: tuple[ExternalQualificationPlan, ...] = (
-    ExternalQualificationPlan(1574, "ftl-online-agent", ("arXiv:2507.09177v1",), (), COMMON_GATES),
+    ExternalQualificationPlan(
+        1574,
+        "ftl-online-agent",
+        ("arXiv:2507.09177v1",),
+        (
+            _revision(
+                "https://github.com/sail-sg/ContinualBench.git",
+                "a4fdb3b94a07a40d76e28d3aeab0f8ca97519dad",
+            ),
+        ),
+        COMMON_GATES,
+    ),
     ExternalQualificationPlan(
         1575,
         "action-conditioned-latent",

--- a/docs/research/ftl-online-agent-development.md
+++ b/docs/research/ftl-online-agent-development.md
@@ -4,7 +4,13 @@ This record pins Liu et al., *Continual Reinforcement Learning by Planning with 
 Models*, ICML 2025, PMLR 267:38397–38423, and arXiv `2507.09177v1` (12 July 2025). The official
 Continual Bench repository is pinned at
 `sail-sg/ContinualBench@a4fdb3b94a07a40d76e28d3aeab0f8ca97519dad` (the `main` revision audited
-on 17 August 2026). The paper uses a sparse shallow FTL world model, CEM MPC, known changing
+on 17 August 2026). A read-only source audit on 22 August 2026 additionally bound Git tree
+`ebf540dbac186f13858f97dfe12eb0b3c823ec43`, GitHub archive SHA-256
+`7726bc3badd6ad8752845b50a98e84e8d19c549c49bacf7bda84cd3933aa6e04`, and the repository's
+MIT `LICENSE.txt` bytes at SHA-256
+`854b88f1dd8df45fc717efc3926da5d10efb6b1122b47ddbea639eb2637a867f`. These identities do
+not qualify the runtime, dependencies, MuJoCo/Meta-World assets, or execution. The paper uses a
+sparse shallow FTL world model, CEM MPC, known changing
 reward functions, six 26-dimensional MuJoCo/Meta-World-derived tasks, 600 episodes, and reports
 10–15 hours per run on one A100 plus 16 CPUs.
 

--- a/external_runtimes/continual_bench/README.md
+++ b/external_runtimes/continual_bench/README.md
@@ -1,0 +1,14 @@
+# ContinualBench source qualification
+
+This directory records the content-addressed official source prerequisite for
+ASI issue #1574. It does not install or execute ContinualBench and cannot
+authorize a benchmark run.
+
+`qualification-plan.json` binds the official commit, Git tree, immutable GitHub
+archive, and MIT license bytes inspected on 2026-08-22. Runtime dependencies,
+MuJoCo/Meta-World environments and assets, observation/action semantics,
+continuous-action CEM, budgets, controls, metrics, and execution authorization
+remain open gates.
+
+The record is permanently nonpromoting coordination metadata, not a paper
+reproduction, benchmark result, or scientific evidence.

--- a/external_runtimes/continual_bench/qualification-plan.json
+++ b/external_runtimes/continual_bench/qualification-plan.json
@@ -1,0 +1,22 @@
+{
+  "schema": "asi.continual_bench_external_source_qualification.v1",
+  "policy": "read_only_nonexecuting_permanently_nonpromoting",
+  "paper_revision": "arXiv:2507.09177v1",
+  "source": {
+    "repository": "https://github.com/sail-sg/ContinualBench.git",
+    "commit": "a4fdb3b94a07a40d76e28d3aeab0f8ca97519dad",
+    "git_tree": "ebf540dbac186f13858f97dfe12eb0b3c823ec43",
+    "source_archive_sha256": "7726bc3badd6ad8752845b50a98e84e8d19c549c49bacf7bda84cd3933aa6e04",
+    "license": "MIT",
+    "license_path": "LICENSE.txt",
+    "license_sha256": "854b88f1dd8df45fc717efc3926da5d10efb6b1122b47ddbea639eb2637a867f"
+  },
+  "claims": {
+    "source_identity_content_bound": true,
+    "runtime_qualified": false,
+    "assets_qualified": false,
+    "external_execution_authorized": false,
+    "paper_parity_claimed": false,
+    "scientific_promotion_allowed": false
+  }
+}

--- a/tests/test_external_qualification.py
+++ b/tests/test_external_qualification.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from alberta_framework.benchmarks.external_qualification import (
@@ -52,6 +55,47 @@ def test_action_conditioned_lane_pins_official_dreamer_cdp_source() -> None:
         "a851fa3e3d70b624b094ee1810ad4bb602346092",
     )
     assert "isolated_runtime_locked" in plan.blockers
+
+
+def test_ftl_lane_pins_official_continual_bench_source_without_claiming_readiness() -> None:
+    plan = qualification_plan(1574)
+    assert plan.code_revisions == (
+        ExternalCodeRevision(
+            "https://github.com/sail-sg/ContinualBench.git",
+            "a4fdb3b94a07a40d76e28d3aeab0f8ca97519dad",
+        ),
+    )
+    assert plan.blockers == plan.required_gates
+    assert "external_code_available_and_license_reviewed" in plan.blockers
+    assert "external_execution_separately_authorized" in plan.blockers
+
+
+def test_ftl_source_manifest_content_binds_official_revision_without_execution_claims() -> None:
+    payload = json.loads(
+        Path("external_runtimes/continual_bench/qualification-plan.json").read_bytes()
+    )
+    assert payload["schema"] == "asi.continual_bench_external_source_qualification.v1"
+    assert payload["source"] == {
+        "repository": "https://github.com/sail-sg/ContinualBench.git",
+        "commit": "a4fdb3b94a07a40d76e28d3aeab0f8ca97519dad",
+        "git_tree": "ebf540dbac186f13858f97dfe12eb0b3c823ec43",
+        "source_archive_sha256": (
+            "7726bc3badd6ad8752845b50a98e84e8d19c549c49bacf7bda84cd3933aa6e04"
+        ),
+        "license": "MIT",
+        "license_path": "LICENSE.txt",
+        "license_sha256": (
+            "854b88f1dd8df45fc717efc3926da5d10efb6b1122b47ddbea639eb2637a867f"
+        ),
+    }
+    assert payload["claims"] == {
+        "source_identity_content_bound": True,
+        "runtime_qualified": False,
+        "assets_qualified": False,
+        "external_execution_authorized": False,
+        "paper_parity_claimed": False,
+        "scientific_promotion_allowed": False,
+    }
 
 
 def test_loss_of_plasticity_lane_preserves_protocol_and_cost_blockers() -> None:


### PR DESCRIPTION
## Summary

Closes the concrete metadata inconsistency identified in the current-main #1574 audit: the maintained FTL protocol document pinned the official ContinualBench revision, while `external_qualification.py` still carried an empty source roster.

- binds `sail-sg/ContinualBench@a4fdb3b94a07a40d76e28d3aeab0f8ca97519dad` in the external qualification registry;
- adds machine-readable, read-only source qualification metadata for exact Git tree `ebf540dbac186f13858f97dfe12eb0b3c823ec43`, immutable archive SHA-256 `7726bc3badd6ad8752845b50a98e84e8d19c549c49bacf7bda84cd3933aa6e04`, and MIT `LICENSE.txt` SHA-256 `854b88f1dd8df45fc717efc3926da5d10efb6b1122b47ddbea639eb2637a867f`;
- adds regression coverage that the registry and manifest agree and keep all readiness/execution gates closed;
- updates the maintained protocol record with the audited content identities.

## Validation

- `pytest tests/test_external_qualification.py -q -o addopts=""` — 23 passed
- Ruff on touched Python files — passed
- strict mypy on `external_qualification.py` — passed
- `git diff --check origin/main...HEAD` — passed
- verified head: `bcc18fe4a0223321b2f198b2a8d6d1483d78ce4d`

## Boundary

No external source was installed or executed. This does not qualify the Python/MuJoCo/Meta-World runtime, assets, environment semantics, continuous-action CEM, budgets, controls, metrics, or paper parity, and it does not authorize execution or scientific promotion. Those remain open in #1574.

Refs #1574.