### PR TITLE
research(adalin): add matched PMNIST transaction

### DIFF
--- a/alberta_framework/benchmarks/adalin.py
+++ b/alberta_framework/benchmarks/adalin.py
@@ -22,7 +22,9 @@ ADALIN_PAPER_URL = "https://arxiv.org/abs/2505.09486v1"
 ADALIN_OFFICIAL_REPOSITORY = "https://github.com/RoozbehRazavi/AdaLin"
 ADALIN_OFFICIAL_COMMIT = "011469138bc22bf82955b16d68f33e4fbd04e3f8"
 ADALIN_OFFICIAL_TREE_AUDIT = "single README.md blob containing '# AdaLin'; no runnable code"
-ADALIN_RESULT_SCHEMA = "asi.adalin.pmnist-development-result.v1"
+ADALIN_RESULT_SCHEMA = "asi.adalin.pmnist-development-result.v2"
+ADALIN_MATCHED_RESULT_SCHEMA = "asi.adalin.pmnist-matched-development-result.v1"
+ADALIN_MATCHED_DEVELOPMENT_SEEDS = (1_571_001, 1_571_002, 1_571_003)
 
 ADALIN_PROTOCOL = MappingProxyType(
     {
@@ -485,6 +487,20 @@ def _state_hash(state: AdaLinState) -> str:
     return _hash_arrays(*(np.asarray(leaf) for leaf in leaves))
 
 
+def _shared_parameter_hash(parameters: AdaLinParameters) -> str:
+    """Hash the matched initialization surface, excluding mechanism-owned alpha."""
+    return _hash_arrays(
+        *(np.asarray(value) for value in (
+            parameters.weight1,
+            parameters.bias1,
+            parameters.weight2,
+            parameters.bias2,
+            parameters.weight3,
+            parameters.bias3,
+        ))
+    )
+
+
 def _implementation_hash() -> str:
     return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
 
@@ -540,6 +556,7 @@ def run_adalin_development(
         mechanism_enabled=mechanism_enabled,
     )
     initial_hash = _state_hash(state)
+    initial_shared_hash = _shared_parameter_hash(state.parameters)
     initial_bytes = _parameter_bytes(state.parameters) + int(np.asarray(state.updates).nbytes)
     task_online: list[float] = []
     task_test: list[float] = []
@@ -608,6 +625,7 @@ def run_adalin_development(
             "implementation_sha256": _implementation_hash(),
             "schedule_sha256": schedule_hash,
             "initial_state_sha256": initial_hash,
+            "initial_shared_parameters_sha256": initial_shared_hash,
             "final_state_sha256": _state_hash(state),
         },
         "metrics": {
@@ -790,6 +808,7 @@ def validate_adalin_result(value: object) -> None:
             "implementation_sha256",
             "schedule_sha256",
             "initial_state_sha256",
+            "initial_shared_parameters_sha256",
             "final_state_sha256",
         },
         "provenance",
@@ -807,6 +826,7 @@ def validate_adalin_result(value: object) -> None:
     for field in (
         "schedule_sha256",
         "initial_state_sha256",
+        "initial_shared_parameters_sha256",
         "final_state_sha256",
         "implementation_sha256",
     ):
@@ -962,3 +982,212 @@ def validate_adalin_result(value: object) -> None:
         "negative_outcomes_retained": True,
     }:
         raise ValueError("result policy is not permanently nonpromoting")
+
+
+_MATCHED_RESULT_KEYS = {
+    "schema",
+    "arms",
+    "matched_axes",
+    "comparison",
+    "resources",
+    "policy",
+}
+_MATCHED_RESOURCE_FIELDS = (
+    "environment_data_steps",
+    "observations",
+    "label_queries",
+    "optimizer_updates",
+    "model_queries",
+    "model_forward_calls",
+)
+
+
+def run_adalin_matched_development(
+    train_inputs: object,
+    train_labels: object,
+    test_inputs: object,
+    test_labels: object,
+    *,
+    config: AdaLinConfig = PAPER_PMNIST_CONFIG,
+    seed: int,
+) -> dict[str, object]:
+    """Run AdaLin and its exact alpha-zero reduction on one matched PMNIST schedule."""
+    if type(seed) is not int or seed not in ADALIN_MATCHED_DEVELOPMENT_SEEDS:
+        raise ValueError("seed is not in the frozen AdaLin matched-development roster")
+    enabled = run_adalin_development(
+        train_inputs,
+        train_labels,
+        test_inputs,
+        test_labels,
+        config=config,
+        seed=seed,
+        mechanism_enabled=True,
+    )
+    disabled = run_adalin_development(
+        train_inputs,
+        train_labels,
+        test_inputs,
+        test_labels,
+        config=config,
+        seed=seed,
+        mechanism_enabled=False,
+    )
+    enabled_metric = cast(dict[str, object], enabled["metrics"])[
+        "asi_whole_stream_preupdate_online_accuracy"
+    ]
+    disabled_metric = cast(dict[str, object], disabled["metrics"])[
+        "asi_whole_stream_preupdate_online_accuracy"
+    ]
+    delta = float(cast(float, enabled_metric)) - float(cast(float, disabled_metric))
+    outcome = "positive" if delta > 0.0 else "negative" if delta < 0.0 else "tied"
+    enabled_resources = cast(dict[str, object], enabled["resources"])
+    disabled_resources = cast(dict[str, object], disabled["resources"])
+    result: dict[str, object] = {
+        "schema": ADALIN_MATCHED_RESULT_SCHEMA,
+        "arms": [enabled, disabled],
+        "matched_axes": {
+            "seed": enabled["seed"],
+            "config": enabled["config"],
+            "dataset_sha256": cast(dict[str, object], enabled["dataset"])["sha256"],
+            "schedule_sha256": cast(dict[str, object], enabled["provenance"])[
+                "schedule_sha256"
+            ],
+            "initial_shared_parameters_sha256": cast(
+                dict[str, object], enabled["provenance"]
+            )["initial_shared_parameters_sha256"],
+            "learner_observes_task_boundary": False,
+        },
+        "comparison": {
+            "primary_metric": "asi_whole_stream_preupdate_online_accuracy",
+            "adalin_minus_mechanism_off": delta,
+            "outcome": outcome,
+            "claim_threshold": None,
+        },
+        "resources": {
+            field: cast(int, enabled_resources[field]) + cast(int, disabled_resources[field])
+            for field in _MATCHED_RESOURCE_FIELDS
+        }
+        | {
+            "wall_clock_seconds_telemetry": float(
+                cast(float, enabled_resources["wall_clock_seconds_telemetry"])
+            )
+            + float(cast(float, disabled_resources["wall_clock_seconds_telemetry"])),
+            "timing_qualified": False,
+        },
+        "policy": {
+            "status": "development-only-nonpromoting",
+            "development_only": True,
+            "scientific_promotion_allowed": False,
+            "negative_outcomes_retained": True,
+            "automatic_reference_selection_allowed": False,
+        },
+    }
+    validate_adalin_matched_result(result)
+    return result
+
+
+def validate_adalin_matched_result(value: object) -> None:
+    """Strictly validate one matched AdaLin/mechanism-off development result."""
+    _require_builtin_json(value)
+    result = _exact_dict(value, "matched result")
+    _require_keys(result, _MATCHED_RESULT_KEYS, "matched result")
+    if result["schema"] != ADALIN_MATCHED_RESULT_SCHEMA:
+        raise ValueError("unexpected matched AdaLin result schema")
+    raw_arms = result["arms"]
+    if type(raw_arms) is not list or len(raw_arms) != 2:
+        raise ValueError("matched result must contain exactly two arms")
+    arms = cast(list[object], raw_arms)
+    for arm in arms:
+        validate_adalin_result(arm)
+    enabled = _exact_dict(arms[0], "enabled arm")
+    disabled = _exact_dict(arms[1], "disabled arm")
+    if enabled["arm"] != "adalin" or disabled["arm"] != "relu_alpha_zero_mechanism_off":
+        raise ValueError("matched arms are out of order or unsupported")
+    if type(enabled["seed"]) is not int or enabled["seed"] not in ADALIN_MATCHED_DEVELOPMENT_SEEDS:
+        raise ValueError("seed is not in the frozen AdaLin matched-development roster")
+
+    enabled_dataset = _exact_dict(enabled["dataset"], "enabled dataset")
+    disabled_dataset = _exact_dict(disabled["dataset"], "disabled dataset")
+    enabled_provenance = _exact_dict(enabled["provenance"], "enabled provenance")
+    disabled_provenance = _exact_dict(disabled["provenance"], "disabled provenance")
+    if (
+        enabled["seed"] != disabled["seed"]
+        or enabled["config"] != disabled["config"]
+        or enabled_dataset != disabled_dataset
+        or enabled_provenance["schedule_sha256"] != disabled_provenance["schedule_sha256"]
+        or enabled_provenance["initial_shared_parameters_sha256"]
+        != disabled_provenance["initial_shared_parameters_sha256"]
+    ):
+        raise ValueError("AdaLin arms do not share the matched execution axes")
+
+    expected_axes = {
+        "seed": enabled["seed"],
+        "config": enabled["config"],
+        "dataset_sha256": enabled_dataset["sha256"],
+        "schedule_sha256": enabled_provenance["schedule_sha256"],
+        "initial_shared_parameters_sha256": enabled_provenance[
+            "initial_shared_parameters_sha256"
+        ],
+        "learner_observes_task_boundary": False,
+    }
+    axes = _exact_dict(result["matched_axes"], "matched axes")
+    if axes != expected_axes:
+        raise ValueError("matched axes disagree with arm receipts")
+
+    enabled_resources = _exact_dict(enabled["resources"], "enabled resources")
+    disabled_resources = _exact_dict(disabled["resources"], "disabled resources")
+    for field in _MATCHED_RESOURCE_FIELDS:
+        if enabled_resources[field] != disabled_resources[field]:
+            raise ValueError(f"matched arm resource {field} differs")
+    resources = _exact_dict(result["resources"], "matched resources")
+    expected_resources: dict[str, object] = {
+        field: cast(int, enabled_resources[field]) + cast(int, disabled_resources[field])
+        for field in _MATCHED_RESOURCE_FIELDS
+    }
+    expected_resources.update(
+        {
+            "wall_clock_seconds_telemetry": float(
+                cast(float, enabled_resources["wall_clock_seconds_telemetry"])
+            )
+            + float(cast(float, disabled_resources["wall_clock_seconds_telemetry"])),
+            "timing_qualified": False,
+        }
+    )
+    if resources != expected_resources:
+        raise ValueError("matched resources are not the exact arm totals")
+
+    comparison = _exact_dict(result["comparison"], "matched comparison")
+    _require_keys(
+        comparison,
+        {"primary_metric", "adalin_minus_mechanism_off", "outcome", "claim_threshold"},
+        "matched comparison",
+    )
+    enabled_metric = _exact_finite_number(
+        _exact_dict(enabled["metrics"], "enabled metrics")[
+            "asi_whole_stream_preupdate_online_accuracy"
+        ],
+        "enabled primary metric",
+    )
+    disabled_metric = _exact_finite_number(
+        _exact_dict(disabled["metrics"], "disabled metrics")[
+            "asi_whole_stream_preupdate_online_accuracy"
+        ],
+        "disabled primary metric",
+    )
+    delta = enabled_metric - disabled_metric
+    expected_outcome = "positive" if delta > 0.0 else "negative" if delta < 0.0 else "tied"
+    if comparison != {
+        "primary_metric": "asi_whole_stream_preupdate_online_accuracy",
+        "adalin_minus_mechanism_off": delta,
+        "outcome": expected_outcome,
+        "claim_threshold": None,
+    }:
+        raise ValueError("matched comparison is not derived from arm metrics")
+    if result["policy"] != {
+        "status": "development-only-nonpromoting",
+        "development_only": True,
+        "scientific_promotion_allowed": False,
+        "negative_outcomes_retained": True,
+        "automatic_reference_selection_allowed": False,
+    }:
+        raise ValueError("matched result policy is not permanently nonpromoting")

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,8 @@ The package overview and development entry points are in
   the current status authority.
 - [`research/ipmnist-theory.md`](research/ipmnist-theory.md) — mechanistic interpretation of
   the development-only IPMNIST campaign.
+- [`research/adalin-matched-development.md`](research/adalin-matched-development.md) — strict
+  permanently nonpromoting AdaLin versus alpha-zero matched PMNIST contract.
 - [`research/ipmnist-campaign-index.md`](research/ipmnist-campaign-index.md) — mutable pointer
   to the current IPMNIST summary and the supersession status of append-only records.
 - [`research/sota-landscape.md`](research/sota-landscape.md) — current protocol-aware external

--- a/docs/research/adalin-matched-development.md
+++ b/docs/research/adalin-matched-development.md
@@ -1,0 +1,28 @@
+# AdaLin matched PMNIST development lane
+
+This lane integrates the existing AdaLin learner into one matched,
+permanently nonpromoting PMNIST transaction. It compares learnable per-neuron
+alpha against the exact alpha-zero ReLU reduction using consumed development
+seeds `1571001`–`1571003`.
+
+Both arms receive identical caller-supplied data, pixel and example schedules,
+non-alpha parameter initialization, observations, labels, update counts, and
+evaluation queries. The learner receives neither task identity nor boundary
+events. The strict matched validator reloads both complete arm receipts,
+requires their dataset, configuration, schedule, shared initialization, and
+resource axes to agree, and derives the whole-stream pre-update accuracy delta.
+There is no claim threshold and no automatic reference selection.
+
+The arm receipt counts data steps, observations, label queries, optimizer
+updates, model queries, forward calls, persistent parameter and alpha bytes,
+and telemetry-only wall time. The matched receipt reports exact sums across
+both arms. Alpha state remains allocated in the mechanism-off arm but is
+initialized to zero, has identically zero gradients, and remains exactly zero.
+
+This is not the paper's 400-task result, a reproduction, scientific evidence,
+or a promotion protocol. The official pinned repository contains no runnable
+implementation or experiment configuration. ASI uses caller-supplied data and
+does not know the paper's exact MNIST sample selection, permutation seeds, or
+dataloader order. Any retained campaign result requires a separately reviewed
+transaction, canonical dataset identity, explicit execution authorization,
+and a new append-only output path.

--- a/docs/research/sota-landscape.md
+++ b/docs/research/sota-landscape.md
@@ -60,7 +60,10 @@ local same-runner development ranking, not a paper-level SOTA claim.
   permuted-MNIST tasks using 10,000 images per task, one epoch, batch size 16,
   and a 100-by-100 MLP. Its curves are relevant evidence about adaptive
   activations and plasticity, but its data budget, batching, network, and
-  reporting do not define an exact-protocol leaderboard entry.
+  reporting do not define an exact-protocol leaderboard entry. ASI's
+  [matched development lane](adalin-matched-development.md) compares learnable
+  alpha with its exact alpha-zero reduction under shared development axes; it
+  remains permanently nonpromoting and does not reproduce the paper.
 - [Plasticity of Growing and Elastic Neural Networks
   (2026)](https://arxiv.org/abs/2608.01475) studies online permuted MNIST and
   FashionMNIST with 10,000 or 40,000 examples per task, per-example SGD at

--- a/tests/test_adalin.py
+++ b/tests/test_adalin.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from alberta_framework.benchmarks.adalin import (
+    ADALIN_MATCHED_RESULT_SCHEMA,
     ADALIN_OFFICIAL_COMMIT,
     ADALIN_PROTOCOL,
     AdaLinConfig,
@@ -22,6 +23,8 @@ from alberta_framework.benchmarks.adalin import (
     initialize_adalin_state,
     make_pmnist_schedule,
     run_adalin_development,
+    run_adalin_matched_development,
+    validate_adalin_matched_result,
     validate_adalin_result,
 )
 
@@ -180,6 +183,92 @@ def test_mechanism_off_runner_keeps_alpha_zero() -> None:
     assert result["arm"] == "relu_alpha_zero_mechanism_off"
     assert result["state"]["final_alpha_l2"] == 0.0
     validate_adalin_result(json.loads(json.dumps(result)))
+
+
+def test_matched_runner_binds_schedule_initialization_resources_and_nonpromotion() -> None:
+    inputs = np.eye(4, dtype=np.float32)
+    labels = np.array([0, 1, 0, 1], np.int32)
+    config = AdaLinConfig(
+        tasks=2, examples_per_task=4, batch_size=2, hidden_widths=(3, 2), classes=2
+    )
+    result = run_adalin_matched_development(
+        inputs, labels, inputs, labels, config=config, seed=1_571_001
+    )
+    validate_adalin_matched_result(json.loads(json.dumps(result)))
+
+    assert result["schema"] == ADALIN_MATCHED_RESULT_SCHEMA
+    assert [arm["arm"] for arm in result["arms"]] == [
+        "adalin",
+        "relu_alpha_zero_mechanism_off",
+    ]
+    enabled, disabled = result["arms"]
+    assert enabled["provenance"]["schedule_sha256"] == disabled["provenance"][
+        "schedule_sha256"
+    ]
+    assert enabled["provenance"]["initial_shared_parameters_sha256"] == disabled[
+        "provenance"
+    ]["initial_shared_parameters_sha256"]
+    assert enabled["resources"]["optimizer_updates"] == disabled["resources"][
+        "optimizer_updates"
+    ]
+    assert disabled["state"]["final_alpha_l2"] == 0.0
+    assert result["policy"]["scientific_promotion_allowed"] is False
+    assert result["policy"]["automatic_reference_selection_allowed"] is False
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "replacement"),
+    [
+        ("matched_axes", "schedule_sha256", "0" * 64),
+        ("matched_axes", "initial_shared_parameters_sha256", "1" * 64),
+        ("comparison", "adalin_minus_mechanism_off", 1.0),
+        ("resources", "optimizer_updates", 1),
+        ("policy", "automatic_reference_selection_allowed", True),
+    ],
+)
+def test_matched_validator_rejects_forged_derived_fields(
+    section: str, field: str, replacement: object
+) -> None:
+    inputs = np.eye(4, dtype=np.float32)
+    labels = np.array([0, 1, 0, 1], np.int32)
+    config = AdaLinConfig(
+        tasks=1, examples_per_task=4, batch_size=2, hidden_widths=(3, 2), classes=2
+    )
+    result = run_adalin_matched_development(
+        inputs, labels, inputs, labels, config=config, seed=1_571_002
+    )
+    forged = copy.deepcopy(result)
+    forged[section][field] = replacement
+    with pytest.raises(ValueError):
+        validate_adalin_matched_result(forged)
+
+
+def test_matched_validator_rejects_arm_schedule_or_shared_initialization_substitution() -> None:
+    inputs = np.eye(4, dtype=np.float32)
+    labels = np.array([0, 1, 0, 1], np.int32)
+    config = AdaLinConfig(
+        tasks=1, examples_per_task=4, batch_size=2, hidden_widths=(3, 2), classes=2
+    )
+    result = run_adalin_matched_development(
+        inputs, labels, inputs, labels, config=config, seed=1_571_003
+    )
+    for field in ("schedule_sha256", "initial_shared_parameters_sha256"):
+        forged = copy.deepcopy(result)
+        forged["arms"][1]["provenance"][field] = "f" * 64
+        with pytest.raises(ValueError):
+            validate_adalin_matched_result(forged)
+
+
+def test_matched_runner_rejects_seed_outside_frozen_development_roster() -> None:
+    inputs = np.eye(4, dtype=np.float32)
+    labels = np.array([0, 1, 0, 1], np.int32)
+    config = AdaLinConfig(
+        tasks=1, examples_per_task=4, batch_size=2, hidden_widths=(3, 2), classes=2
+    )
+    with pytest.raises(ValueError, match="frozen AdaLin matched-development roster"):
+        run_adalin_matched_development(
+            inputs, labels, inputs, labels, config=config, seed=1_571_999
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Implements the missing matched-runner prerequisite for #1571 around the existing AdaLin learner:

- runs learnable-alpha AdaLin and its exact alpha-zero ReLU mechanism-off reduction on the same caller-supplied PMNIST data, seed, pixel/example schedule, non-alpha initialization, observations, labels, update count, and evaluation cadence;
- adds a shared-parameter initialization digest excluding mechanism-owned alpha, advancing the unpersisted arm receipt schema to v2 rather than silently changing v1;
- freezes consumed matched-development seeds `1571001`–`1571003`;
- adds a strict matched receipt/validator that reloads both complete arm receipts, enforces all matched axes and equal per-arm resource counts, derives the whole-stream pre-update accuracy delta/outcome, and reports exact combined steps/updates/queries plus telemetry-only timing;
- forbids scientific promotion and automatic reference selection;
- documents the matched contract and remaining paper/data/runtime/campaign gaps.

## Validation

- `pytest tests/test_adalin.py -q -o addopts=""` — 27 passed
- Ruff on touched Python files — passed
- strict mypy on `adalin.py` — passed
- `git diff --check origin/main...HEAD` — passed
- verified head: `2af0240316dacd0e5efddba7a4e368d2f11bf41a`

## Boundaries

No dataset was downloaded, no campaign or benchmark output was executed or retained, and no seed outside the consumed development roster is admitted. This is not the paper’s 400-task result, a reproduction, scientific evidence, or a promotion protocol. Canonical dataset binding, frozen production hyperparameters/reporting, transaction-safe retention, explicit execution authorization, and an actual nonpromoting matched result remain open before #1571 can close.

Refs #1571.