### PR TITLE
research(plasticity): add random-label MNIST lane

### DIFF
--- a/alberta_framework/benchmarks/plasticity_diagnostics.py
+++ b/alberta_framework/benchmarks/plasticity_diagnostics.py
@@ -1,8 +1,8 @@
 """Bounded hidden-network diagnostics for canonical loss of plasticity.
 
-The implemented workload is input-permuted MNIST.  Labels never change.  It
-is a deliberately short development diagnostic, not a reproduction of the
-800-task paper experiment and not a random-label benchmark.
+The official-paper workload is input-permuted MNIST.  A separate random-label
+protocol extension advances issue #1583 without claiming paper parity.  Both
+are short development diagnostics, not reproductions of the 800-task paper.
 """
 
 from __future__ import annotations
@@ -26,11 +26,14 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
-SCHEMA = "asi.loss_of_plasticity_mnist_development.v1"
+SCHEMA = "asi.loss_of_plasticity_mnist_development.v2"
 PAPER_REVISION = "arXiv:2306.13812v3"
 OFFICIAL_CODE_COMMIT = "a6b79580d85f3025bdb601566d3627c5f489f13b"
 FROZEN_SEEDS = (15830, 15831, 15832, 15833)
 ARM_IDS = ("sgd_control", "cbp_mechanism_off", "cbp_bounded")
+CUMULATIVE_INPUT_PROTOCOL = "cumulative-input-permutation"
+RANDOM_LABEL_PROTOCOL = "independent-random-labels"
+TASK_PROTOCOLS = (CUMULATIVE_INPUT_PROTOCOL, RANDOM_LABEL_PROTOCOL)
 MAX_DATASET_EXAMPLES = 60_000
 INPUT_DIM = 784
 N_CLASSES = 10
@@ -308,6 +311,7 @@ class DiagnosticResult:
     development_only: bool = True
     scientific_promotion_allowed: bool = False
     negative_results_must_be_retained: bool = True
+    paper_parity_claimed: bool = False
 
     def __post_init__(self) -> None:
         if (
@@ -338,17 +342,18 @@ class DiagnosticResult:
             raise ValueError("current ASI source identity drift")
         if self.runtime_identity != _runtime_identity():
             raise ValueError("current runtime identity drift")
-        if (
-            self.task_protocol != "cumulative-input-permutation"
-            or self.labels_permuted is not False
-        ):
-            raise ValueError("the lane must not be described as random-label MNIST")
+        if type(self.task_protocol) is not str or self.task_protocol not in TASK_PROTOCOLS:
+            raise ValueError("unknown task protocol")
+        expected_labels_permuted = self.task_protocol == RANDOM_LABEL_PROTOCOL
+        if self.labels_permuted is not expected_labels_permuted:
+            raise ValueError("random-label protocol semantics disagree with labels_permuted")
         flags = (
             self.task_boundary_available_to_learner is False,
             self.task_id_available_to_learner is False,
             self.development_only is True,
             self.scientific_promotion_allowed is False,
             self.negative_results_must_be_retained is True,
+            self.paper_parity_claimed is False,
         )
         if not all(flags):
             raise ValueError("information or nonpromotion boundary drift")
@@ -396,6 +401,32 @@ def _schedule(
         tasks.append(
             (np.ascontiguousarray(images[indices][:, permutation]), labels[indices].copy())
         )
+    return tuple(tasks)
+
+
+def _random_label_schedule(
+    images: np.ndarray, labels: np.ndarray, profile: DiagnosticProfile, seed: int
+) -> tuple[tuple[np.ndarray, np.ndarray], ...]:
+    """Build bounded tasks with fresh per-example random labels and unchanged pixels."""
+    if labels.shape != (images.shape[0],):
+        raise ValueError("images and labels must retain matched rows")
+    key = jr.key(seed)
+    tasks: list[tuple[np.ndarray, np.ndarray]] = []
+    for _ in range(profile.n_tasks):
+        key, data_key, label_key = jr.split(key, 3)
+        order = np.asarray(jr.permutation(data_key, images.shape[0]), dtype=np.int32)
+        indices = order[: profile.examples_per_task]
+        random_labels = np.asarray(
+            jr.randint(
+                label_key,
+                (profile.examples_per_task,),
+                minval=0,
+                maxval=N_CLASSES,
+                dtype=jnp.int32,
+            ),
+            dtype=np.int32,
+        )
+        tasks.append((np.ascontiguousarray(images[indices]), random_labels))
     return tuple(tasks)
 
 
@@ -497,17 +528,28 @@ def _run_arm(
 
 
 def run_diagnostic(
-    images: object, labels: object, *, seed: object, profile_id: object = "contract-smoke"
+    images: object,
+    labels: object,
+    *,
+    seed: object,
+    profile_id: object = "contract-smoke",
+    task_protocol: object = CUMULATIVE_INPUT_PROTOCOL,
 ) -> DiagnosticResult:
     data, targets = _arrays(images, labels)
     if type(seed) is not int or seed not in FROZEN_SEEDS:
         raise ValueError("seed is outside the frozen development schedule")
     if type(profile_id) is not str or profile_id not in PROFILES:
         raise ValueError("unknown diagnostic profile")
+    if type(task_protocol) is not str or task_protocol not in TASK_PROTOCOLS:
+        raise ValueError("unknown task protocol")
     profile = PROFILES[profile_id]
     if data.shape[0] < profile.examples_per_task:
         raise ValueError("dataset has too few examples for the frozen profile")
-    tasks = _schedule(data, targets, profile, seed)
+    tasks = (
+        _schedule(data, targets, profile, seed)
+        if task_protocol == CUMULATIVE_INPUT_PROTOCOL
+        else _random_label_schedule(data, targets, profile, seed)
+    )
     result = DiagnosticResult(
         SCHEMA,
         PAPER_REVISION,
@@ -518,8 +560,8 @@ def run_diagnostic(
         _dataset_sha(data, targets),
         hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
         _runtime_identity(),
-        "cumulative-input-permutation",
-        False,
+        task_protocol,
+        task_protocol == RANDOM_LABEL_PROTOCOL,
         False,
         False,
         tuple(_run_arm(arm, tasks, profile, seed) for arm in ARM_IDS),
@@ -619,12 +661,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--dataset", type=Path)
     parser.add_argument("--seed", type=int, default=FROZEN_SEEDS[0])
     parser.add_argument("--profile", choices=tuple(PROFILES), default="contract-smoke")
+    parser.add_argument(
+        "--task-protocol", choices=TASK_PROTOCOLS, default=CUMULATIVE_INPUT_PROTOCOL
+    )
     parser.add_argument("--catalog", action="store_true")
     args = parser.parse_args(argv)
     if args.catalog:
         print(
             json.dumps(
-                {"schema": SCHEMA, "costly_lane_gates": costly_lane_gates()},
+                {
+                    "schema": SCHEMA,
+                    "task_protocols": TASK_PROTOCOLS,
+                    "costly_lane_gates": costly_lane_gates(),
+                },
                 sort_keys=True,
             )
         )
@@ -641,7 +690,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         if set(payload.files) != {"images", "labels"}:
             raise ValueError("dataset NPZ must contain exactly images and labels")
         result = run_diagnostic(
-            payload["images"], payload["labels"], seed=args.seed, profile_id=args.profile
+            payload["images"],
+            payload["labels"],
+            seed=args.seed,
+            profile_id=args.profile,
+            task_protocol=args.task_protocol,
         )
     print(_json_result(result))
     return 0

--- a/docs/research/plasticity-diagnostics.md
+++ b/docs/research/plasticity-diagnostics.md
@@ -13,13 +13,13 @@ commit `a6b79580d85f3025bdb601566d3627c5f489f13b`, inspected 18 August 2026.
 That tip postdates the paper and includes later fixes, including an Adam/GnT
 change, so code-tip parity is not automatically paper parity.
 
-The MNIST experiment is **input-permuted**, not random-label MNIST. The labels
+The official MNIST experiment is **input-permuted**, not random-label MNIST. The labels
 remain the digits 0–9. In each of 800 paper tasks, one pixel permutation is
 shared by all 60,000 training images, the images are presented one at a time in
 random order for one pass, and no task-switch indication is given to the
 network. The official current code applies each new pixel permutation to the
 already permuted array, so the adapter freezes the equivalent cumulative
-permutation. Calling this lane random-label MNIST is rejected by its validator.
+permutation. The official-paper protocol cannot be relabeled as random-label MNIST.
 
 The paper network has three hidden ReLU layers with 2,000 units, Kaiming
 initialization, batch size one, SGD/cross entropy, up to 800 tasks, and 10 runs
@@ -36,6 +36,15 @@ eight tasks, 64 examples per task, two hidden ReLU layers of width 64, learning
 rate 0.003, maturity 100, and replacement rate 1e-4. This is a mechanism
 diagnostic, not paper-scale parity: depth, width, task count, observations, and
 run count differ.
+
+The runner also exposes `independent-random-labels`, a #1583 protocol extension.
+For every task it selects a Threefry-rooted example order from the same bounded
+caller array and independently draws one label in `[0,9]` for every consumed
+example. Pixels are not permuted in this arm. The dataset identity still binds
+the complete caller images and original labels, even though original labels are
+not learner targets in this protocol. This extension uses the same frozen seeds,
+arms, updates, observations, queries, diagnostics, and resource accounting as
+the input-permutation lane. It explicitly sets `paper_parity_claimed=false`.
 
 The matched roster is SGD, CBP with replacement disabled, and bounded CBP.
 Every arm gets identical Threefry-rooted permutations, example orders,
@@ -63,6 +72,11 @@ backend identities. Negative results must be retained and no result can promote.
 .venv/bin/asi-plasticity-diagnostic --catalog
 .venv/bin/asi-plasticity-diagnostic \
   --dataset /approved/mnist-train.npz \
+  --profile bounded-development \
+  --seed 15830
+.venv/bin/asi-plasticity-diagnostic \
+  --dataset /approved/mnist-train.npz \
+  --task-protocol independent-random-labels \
   --profile bounded-development \
   --seed 15830
 ```

--- a/tests/test_plasticity_diagnostics.py
+++ b/tests/test_plasticity_diagnostics.py
@@ -18,6 +18,8 @@ from alberta_framework.benchmarks.plasticity_diagnostics import (
     OFFICIAL_CODE_COMMIT,
     PAPER_REVISION,
     PROFILES,
+    RANDOM_LABEL_PROTOCOL,
+    _random_label_schedule,
     costly_lane_gates,
     main,
     require_costly_lane,
@@ -133,6 +135,45 @@ def test_random_label_and_privileged_task_claims_fail_closed() -> None:
         validate_result(dataclasses.replace(result, scientific_promotion_allowed=True))
 
 
+def test_random_label_mnist_runs_matched_end_to_end_without_paper_parity_claim() -> None:
+    images, labels = _fixture()
+    result = run_diagnostic(
+        images,
+        labels,
+        seed=FROZEN_SEEDS[0],
+        task_protocol=RANDOM_LABEL_PROTOCOL,
+    )
+    assert result.task_protocol == RANDOM_LABEL_PROTOCOL
+    assert result.labels_permuted is True
+    control, mechanism_off, candidate = result.arms
+    assert control.task_accuracy == mechanism_off.task_accuracy
+    assert control.task_loss == mechanism_off.task_loss
+    assert control.final_state_sha256 == mechanism_off.final_state_sha256
+    assert candidate.receipt.replacements > 0
+    assert result.paper_parity_claimed is False
+
+
+def test_random_label_schedule_is_deterministic_and_relabels_each_task() -> None:
+    images, labels = _fixture()
+    profile = PROFILES["contract-smoke"]
+    first = _random_label_schedule(images, labels, profile, FROZEN_SEEDS[0])
+    second = _random_label_schedule(images, labels, profile, FROZEN_SEEDS[0])
+    for (left_images, left_labels), (right_images, right_labels) in zip(
+        first, second, strict=True
+    ):
+        np.testing.assert_array_equal(left_images, right_images)
+        np.testing.assert_array_equal(left_labels, right_labels)
+    assert not np.array_equal(first[0][1], first[1][1])
+
+
+def test_random_label_protocol_rejects_forged_label_semantics() -> None:
+    result = run_diagnostic(
+        *_fixture(), seed=FROZEN_SEEDS[0], task_protocol=RANDOM_LABEL_PROTOCOL
+    )
+    with pytest.raises(ValueError, match="protocol semantics"):
+        validate_result(dataclasses.replace(result, labels_permuted=False))
+
+
 @pytest.mark.parametrize(
     ("images_mutation", "labels_mutation"),
     [
@@ -167,6 +208,7 @@ def test_catalog_cli_does_not_load_or_execute_data(capsys: pytest.CaptureFixture
     assert main(("--catalog",)) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["schema"].startswith("asi.loss_of_plasticity")
+    assert RANDOM_LABEL_PROTOCOL in payload["task_protocols"]
     assert payload["costly_lane_gates"]["execution_authorized"] is False
 
 
@@ -181,3 +223,25 @@ def test_cli_runs_only_caller_supplied_bounded_npz(
     assert payload["task_protocol"] == "cumulative-input-permutation"
     assert payload["labels_permuted"] is False
     assert payload["scientific_promotion_allowed"] is False
+
+
+def test_cli_runs_random_label_protocol_from_caller_data(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    images, labels = _fixture()
+    dataset = tmp_path / "mnist.npz"
+    np.savez(dataset, images=images, labels=labels)
+    assert main(
+        (
+            "--dataset",
+            str(dataset),
+            "--seed",
+            str(FROZEN_SEEDS[0]),
+            "--task-protocol",
+            RANDOM_LABEL_PROTOCOL,
+        )
+    ) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["task_protocol"] == RANDOM_LABEL_PROTOCOL
+    assert payload["labels_permuted"] is True
+    assert payload["paper_parity_claimed"] is False


### PR DESCRIPTION
## Summary

Adds the missing bounded random-label MNIST protocol to the existing loss-of-plasticity
diagnostic while preserving the official paper's cumulative input-permutation lane.

- Adds `independent-random-labels`: each task uses a Threefry-rooted example order and fresh
  per-example labels in `[0,9]`, with unchanged pixels.
- Runs the existing matched `sgd_control`, `cbp_mechanism_off`, and `cbp_bounded` arms on the
  identical generated schedule, initialization, observations, updates, and query budget.
- Preserves exact SGD/mechanism-off curve and final-state parity.
- Reuses exact data-step, byte, model-query, update, MAC, replacement, persistent-state, and
  telemetry-only timing receipts.
- Advances the unpersisted result schema to v2 and adds a fail-closed
  `paper_parity_claimed=false` field so this extension cannot be confused with the pinned
  official input-permutation experiment.
- Exposes the protocol through the existing caller-supplied bounded-NPZ CLI and documents the
  protocol difference.

No dataset was downloaded, no long campaign was executed, and no output was retained. This is a
permanently nonpromoting protocol implementation, not the paper's 800-task result or a performance
claim. Canonical dataset binding, execution authorization, a retained matched outcome, full
paper-scale MNIST, ImageNet, and reinforcement-learning diagnostics remain open.

## Verification

- `.venv/bin/python -m pytest tests/test_plasticity_diagnostics.py tests/test_loss_of_plasticity_external_runtime.py tests/test_nap_ipmnist.py -q -o addopts=''` — 43 passed
- `.venv/bin/python -m ruff check alberta_framework/benchmarks/plasticity_diagnostics.py tests/test_plasticity_diagnostics.py` — passed
- `.venv/bin/python -m mypy` — passed (224 source files)
- `git diff --check origin/main...HEAD` — passed

Verified head: `1ee9e17bb19af3a587f29fd39a07713fd5f96717`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex

Refs #1583.
