### PR TITLE
qualify(cora): bind isolated Procgen runtime plan

### DIFF
--- a/alberta_framework/benchmarks/cora_development.py
+++ b/alberta_framework/benchmarks/cora_development.py
@@ -23,6 +23,13 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework.benchmarks.cora_procgen_qualification import (
+    ProcgenQualificationPlan,
+)
+from alberta_framework.benchmarks.cora_procgen_qualification import (
+    plan_sha256 as procgen_plan_sha256,
+)
+
 SCHEMA = "asi.cora_development.v1"
 PAPER = "Powers et al., CoLLAs 2022; arXiv:2110.10067v2"
 OFFICIAL_CODE = "AGI-Labs/continual_rl@f2754bb282757829765beb4703f24b87efa13ff9"
@@ -451,13 +458,20 @@ def validate_result(value: object) -> CORADevelopmentResult:
 
 
 def catalog_payload() -> dict[str, object]:
+    procgen_plan = ProcgenQualificationPlan()
+    procgen_plan.validate()
+    procgen_payload = json.loads(json.dumps(dataclasses.asdict(procgen_plan)))
     return {
-        "schema": "asi.cora_qualification_catalog.v1",
+        "schema": "asi.cora_qualification_catalog.v2",
         "paper": PAPER,
         "official_code": OFFICIAL_CODE,
         "external_execution_ready": False,
         "development_only": True,
         "families": [dataclasses.asdict(family) for family in CORA_CATALOG],
+        "procgen_qualification": {
+            "plan": procgen_payload,
+            "plan_sha256": procgen_plan_sha256(),
+        },
     }
 
 

--- a/alberta_framework/benchmarks/cora_procgen_qualification.py
+++ b/alberta_framework/benchmarks/cora_procgen_qualification.py
@@ -1,0 +1,236 @@
+"""Fail-closed qualification plan for CORA's external Procgen family.
+
+This module imports and executes no CORA or Procgen code.  It binds audited
+source and wheel identities and defines the create-only receipt accepted after
+a separately authorized isolated-runtime check.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+from typing import Literal
+
+SCHEMA = "asi.cora_procgen_create_qualification.development.v1"
+CORA_PROCGEN_TASKS = (
+    "climber-v0",
+    "dodgeball-v0",
+    "ninja-v0",
+    "starpilot-v0",
+    "bigfish-v0",
+    "fruitbot-v0",
+)
+
+
+def _digest(value: object, name: str) -> str:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256")
+    return value
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ProcgenQualificationPlan:
+    issue: int = 1581
+    paper_revision: str = "arXiv:2110.10067v2"
+    cora_repository: str = "https://github.com/AGI-Labs/continual_rl.git"
+    cora_commit: str = "f2754bb282757829765beb4703f24b87efa13ff9"
+    cora_tree: str = "3c296057e717401053ce0acfe362adeef395aede"
+    cora_archive_sha256: str = (
+        "d634325bd7cc450e68ee55fd5b83118fa4b8d11c0e5e6284daa6bff0a60436db"
+    )
+    cora_license_sha256: str = (
+        "37df918c349040efba06271ed929ffd623506ef2d4a0a7e4ce46e7749ba0cad7"
+    )
+    procgen_repository: str = "https://github.com/openai/procgen.git"
+    procgen_version: str = "0.10.7"
+    procgen_commit: str = "5e1dbf341d291eff40d1f9e0c0a0d5003643aebf"
+    procgen_tree: str = "0cb587203bb4d55e001283ad6550f6bc1ef95ad4"
+    procgen_archive_sha256: str = (
+        "22940ad0f1fdb4ad1eab3303ce23d3a0ea536700bb1d7c299bee64dbc7c57e9b"
+    )
+    procgen_wheel_filename: str = (
+        "procgen-0.10.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+    )
+    procgen_wheel_sha256: str = (
+        "4b594d14e42f0f2166e59a9e294477b906eb99c90c3343b570b7124cbc865f53"
+    )
+    procgen_license_sha256: str = (
+        "62fead824b483f3dbba9ffc2074d8ffb5420839481dfa883b91de6f5ae68bc45"
+    )
+    procgen_asset_licenses_sha256: str = (
+        "2d8857c3fe4252eb19eaf1187274a0aa4ea8c4ca0bea389268f7b118c0c72141"
+    )
+    platform_tag: str = "manylinux2014_x86_64"
+    python_version: str = "3.10"
+    compatibility_matrix: tuple[str, ...] = (
+        "CPython==3.10.x",
+        "torch==1.13.1+cpu (proposal; artifact unbound)",
+        "torchvision==0.14.1+cpu (proposal; artifact unbound)",
+        "gym==0.25.2 (official CORA upper bound; artifact unbound)",
+        "procgen==0.10.7 (Linux wheel bound above)",
+    )
+    tasks: tuple[str, ...] = CORA_PROCGEN_TASKS
+    cycles: int = 5
+    train_steps_per_task: int = 5_000_000
+    train_levels: int = 200
+    eval_levels: int = 0
+    start_level: int = 0
+    distribution_mode: str = "easy"
+    official_seed_semantics: str = "os.urandom-derived seed_to_set"
+    compatibility_seed_semantics: str = "caller-injected exact uint32 seed_to_set"
+    compatibility_smoke_has_official_seed_parity: bool = False
+    dependency_lock_complete: bool = False
+    runtime_qualified: bool = False
+    execution_authorized: bool = False
+    promotion_policy: str = "permanently_nonpromoting_qualification"
+
+    def validate(self) -> None:
+        if type(self.issue) is not int or self.issue != 1581:
+            raise ValueError("issue identity drift")
+        expected = ProcgenQualificationPlan()
+        if self != expected:
+            raise ValueError("Procgen qualification plan differs from the audited registry")
+        for name in (
+            "cora_archive_sha256",
+            "cora_license_sha256",
+            "procgen_archive_sha256",
+            "procgen_wheel_sha256",
+            "procgen_license_sha256",
+            "procgen_asset_licenses_sha256",
+        ):
+            _digest(getattr(self, name), name)
+        if (
+            type(self.compatibility_matrix) is not tuple
+            or type(self.tasks) is not tuple
+            or self.tasks != CORA_PROCGEN_TASKS
+            or self.dependency_lock_complete is not False
+            or self.runtime_qualified is not False
+            or self.execution_authorized is not False
+            or self.compatibility_smoke_has_official_seed_parity is not False
+        ):
+            raise ValueError("external runtime gates must remain closed")
+
+
+def plan_sha256() -> str:
+    plan = ProcgenQualificationPlan()
+    plan.validate()
+    payload = json.dumps(
+        dataclasses.asdict(plan), sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+Outcome = Literal["success", "failure"]
+Phase = Literal["train", "evaluation"]
+SeedMode = Literal["official_os_random", "deterministic_compatibility"]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ProcgenCreateReceipt:
+    plan_sha256: str
+    outcome: Outcome
+    task_id: str
+    phase: Phase
+    seed_mode: SeedMode
+    injected_seed: int | None = None
+    observation_sha256: str | None = None
+    reward_payload: None = None
+    termination_payload: None = None
+    failure_kind: str | None = None
+    environment_instances_created: int = 0
+    environment_steps: int = 0
+    policy_queries: int = 0
+    model_queries: int = 0
+    elapsed_ns: int = 0
+    timing_telemetry_only: bool = True
+    schema: str = SCHEMA
+    development_only: bool = True
+    scientific_promotion_allowed: bool = False
+
+
+def validate_create_receipt(value: object) -> ProcgenCreateReceipt:
+    if type(value) is not ProcgenCreateReceipt:
+        raise ValueError("receipt must be an exact ProcgenCreateReceipt")
+    receipt = value
+    if receipt.schema != SCHEMA or receipt.plan_sha256 != plan_sha256():
+        raise ValueError("receipt plan identity mismatch")
+    if (
+        type(receipt.task_id) is not str
+        or receipt.task_id not in CORA_PROCGEN_TASKS
+        or type(receipt.phase) is not str
+        or receipt.phase not in ("train", "evaluation")
+        or type(receipt.outcome) is not str
+        or receipt.outcome not in ("success", "failure")
+        or type(receipt.seed_mode) is not str
+        or receipt.seed_mode not in ("official_os_random", "deterministic_compatibility")
+    ):
+        raise ValueError("receipt categorical identity mismatch")
+    if receipt.seed_mode == "official_os_random":
+        if receipt.injected_seed is not None:
+            raise ValueError("official seed mode cannot carry an injected seed")
+    elif (
+        type(receipt.injected_seed) is not int
+        or not 0 <= receipt.injected_seed <= 2**32 - 1
+    ):
+        raise ValueError("deterministic seed mode requires an exact uint32 seed")
+    counters = (
+        receipt.environment_instances_created,
+        receipt.environment_steps,
+        receipt.policy_queries,
+        receipt.model_queries,
+        receipt.elapsed_ns,
+    )
+    if any(type(counter) is not int or not 0 <= counter <= 2**63 - 1 for counter in counters):
+        raise ValueError("receipt counters must be nonnegative signed-int64 integers")
+    if (
+        receipt.environment_steps != 0
+        or receipt.policy_queries != 0
+        or receipt.model_queries != 0
+        or receipt.reward_payload is not None
+        or receipt.termination_payload is not None
+    ):
+        raise ValueError("qualification receipt must remain create-only")
+    if receipt.outcome == "success":
+        if (
+            receipt.environment_instances_created != 1
+            or receipt.observation_sha256 is None
+            or receipt.failure_kind is not None
+        ):
+            raise ValueError("success receipt must contain one observation and no failure")
+        _digest(receipt.observation_sha256, "observation_sha256")
+    else:
+        failure_kind = receipt.failure_kind
+        if type(failure_kind) is not str or not failure_kind:
+            raise ValueError("failure receipt must retain one bounded failure kind")
+        try:
+            failure_bytes = failure_kind.encode("utf-8")
+        except UnicodeEncodeError as error:
+            raise ValueError("failure kind must be valid bounded UTF-8") from error
+        if (
+            receipt.environment_instances_created != 0
+            or receipt.observation_sha256 is not None
+            or len(failure_bytes) > 128
+        ):
+            raise ValueError("failure receipt must retain one bounded failure kind")
+    if (
+        receipt.timing_telemetry_only is not True
+        or receipt.development_only is not True
+        or receipt.scientific_promotion_allowed is not False
+    ):
+        raise ValueError("receipt must remain telemetry-only and nonpromoting")
+    return receipt
+
+
+__all__ = [
+    "CORA_PROCGEN_TASKS",
+    "SCHEMA",
+    "ProcgenCreateReceipt",
+    "ProcgenQualificationPlan",
+    "plan_sha256",
+    "validate_create_receipt",
+]

--- a/docs/research/cora-qualification.md
+++ b/docs/research/cora-qualification.md
@@ -38,3 +38,30 @@ normalization; independent run aggregation; official checkpoint/result parity; f
 budgets; matched ASI controls; hardware timing; and untouched preregistered scientific seeds. The
 native slice's unnormalized binary metrics only test equations and information flow. No CORA result,
 performance claim, or SOTA claim exists.
+
+## Procgen compatibility qualification
+
+`cora_procgen_qualification.py` binds the official CORA commit to Git tree
+`3c296057e717401053ce0acfe362adeef395aede`, source archive SHA-256
+`d634325bd7cc450e68ee55fd5b83118fa4b8d11c0e5e6284daa6bff0a60436db`, and MIT
+license SHA-256 `37df918c349040efba06271ed929ffd623506ef2d4a0a7e4ce46e7749ba0cad7`.
+It separately binds OpenAI Procgen 0.10.7 at commit
+`5e1dbf341d291eff40d1f9e0c0a0d5003643aebf`, tree
+`0cb587203bb4d55e001283ad6550f6bc1ef95ad4`, source archive SHA-256
+`22940ad0f1fdb4ad1eab3303ce23d3a0ea536700bb1d7c299bee64dbc7c57e9b`, and the
+36,395,959-byte CPython 3.10 manylinux2014 x86-64 wheel SHA-256
+`4b594d14e42f0f2166e59a9e294477b906eb99c90c3343b570b7124cbc865f53`.
+The Procgen MIT license and multi-license asset inventory are independently bound.
+
+This is a proposed isolated Python 3.10 compatibility runtime, not an in-process ASI dependency.
+The proposed Torch, torchvision, and Gym artifacts and their transitive dependencies are not yet
+content-closed, so dependency locking, runtime qualification, and execution authorization remain
+false. Procgen itself documents CPython support only through 3.10 for this release; ASI remains
+Python 3.12.
+
+The official CORA constructor normally derives `seed_to_set` from `os.urandom`. A deterministic
+compatibility smoke must instead inject an exact uint32 seed and explicitly records that it lacks
+official seed parity. The retained receipt schema is create-only: it may report either one initial
+observation digest or one bounded failure kind, but always records zero environment steps, rewards,
+terminations, policy queries, and model queries. This contract does not authorize a run or create a
+CORA result.

--- a/tests/test_cora_procgen_qualification.py
+++ b/tests/test_cora_procgen_qualification.py
@@ -1,0 +1,105 @@
+"""Fail-closed contracts for the proposed isolated CORA Procgen runtime."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from alberta_framework.benchmarks.cora_development import catalog_payload
+from alberta_framework.benchmarks.cora_procgen_qualification import (
+    CORA_PROCGEN_TASKS,
+    ProcgenCreateReceipt,
+    ProcgenQualificationPlan,
+    plan_sha256,
+    validate_create_receipt,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_plan_binds_source_wheel_assets_runtime_and_cora_protocol() -> None:
+    plan = ProcgenQualificationPlan()
+    plan.validate()
+    assert plan.cora_tree == "3c296057e717401053ce0acfe362adeef395aede"
+    assert plan.procgen_commit == "5e1dbf341d291eff40d1f9e0c0a0d5003643aebf"
+    assert plan.procgen_wheel_sha256 == (
+        "4b594d14e42f0f2166e59a9e294477b906eb99c90c3343b570b7124cbc865f53"
+    )
+    assert plan.python_version == "3.10"
+    assert plan.platform_tag == "manylinux2014_x86_64"
+    assert plan.tasks == CORA_PROCGEN_TASKS
+    assert plan.train_levels == 200
+    assert plan.eval_levels == 0
+    assert plan.execution_authorized is False
+    assert plan.runtime_qualified is False
+    catalog = catalog_payload()
+    assert catalog["schema"] == "asi.cora_qualification_catalog.v2"
+    procgen = catalog["procgen_qualification"]
+    assert isinstance(procgen, dict)
+    assert procgen["plan_sha256"] == plan_sha256()
+
+
+def test_seed_semantics_distinguish_official_randomness_from_compatibility_smoke() -> None:
+    plan = ProcgenQualificationPlan()
+    assert plan.official_seed_semantics == "os.urandom-derived seed_to_set"
+    assert plan.compatibility_seed_semantics == "caller-injected exact uint32 seed_to_set"
+    assert plan.compatibility_smoke_has_official_seed_parity is False
+
+
+def test_future_success_receipt_is_create_only_and_content_bound() -> None:
+    receipt = ProcgenCreateReceipt(
+        plan_sha256=plan_sha256(),
+        outcome="success",
+        task_id=CORA_PROCGEN_TASKS[0],
+        phase="train",
+        seed_mode="deterministic_compatibility",
+        injected_seed=1581000,
+        observation_sha256="1" * 64,
+        environment_instances_created=1,
+        elapsed_ns=10,
+    )
+    assert validate_create_receipt(receipt) is receipt
+    assert receipt.environment_steps == 0
+    assert receipt.policy_queries == 0
+    assert receipt.reward_payload is None
+    assert receipt.termination_payload is None
+
+
+def test_future_failure_receipt_retains_bounded_failure_without_fake_payload() -> None:
+    receipt = ProcgenCreateReceipt(
+        plan_sha256=plan_sha256(),
+        outcome="failure",
+        task_id=CORA_PROCGEN_TASKS[1],
+        phase="evaluation",
+        seed_mode="official_os_random",
+        failure_kind="RuntimeError",
+        elapsed_ns=10,
+    )
+    assert validate_create_receipt(receipt) is receipt
+    with pytest.raises(ValueError, match="success receipt"):
+        validate_create_receipt(
+            dataclasses.replace(receipt, outcome="success", observation_sha256="2" * 64)
+        )
+
+
+def test_receipt_rejects_execution_or_identity_forgery() -> None:
+    receipt = ProcgenCreateReceipt(
+        plan_sha256=plan_sha256(),
+        outcome="failure",
+        task_id=CORA_PROCGEN_TASKS[0],
+        phase="train",
+        seed_mode="official_os_random",
+        failure_kind="ImportError",
+        elapsed_ns=0,
+    )
+    with pytest.raises(ValueError, match="plan identity"):
+        validate_create_receipt(dataclasses.replace(receipt, plan_sha256="0" * 64))
+    with pytest.raises(ValueError, match="create-only"):
+        validate_create_receipt(dataclasses.replace(receipt, environment_steps=1))
+    with pytest.raises(ValueError, match="seed mode"):
+        validate_create_receipt(dataclasses.replace(receipt, injected_seed=7))
+    with pytest.raises(ValueError, match="signed-int64"):
+        validate_create_receipt(dataclasses.replace(receipt, elapsed_ns=2**80))
+    with pytest.raises(ValueError, match="failure kind"):
+        validate_create_receipt(dataclasses.replace(receipt, failure_kind="\ud800"))


### PR DESCRIPTION
## Summary

Advances #1581 by turning the audited CORA Procgen blocker into a machine-readable, fail-closed
isolated-runtime qualification plan.

- Binds `AGI-Labs/continual_rl@f2754bb282757829765beb4703f24b87efa13ff9`, exact Git tree,
  observed source archive, and MIT license SHA-256 identities.
- Binds OpenAI Procgen 0.10.7 at its exact commit/tree/source archive, MIT license, asset-license
  inventory, and 36,395,959-byte CPython 3.10 manylinux2014 x86-64 wheel SHA-256.
- Freezes the official six-game order, five cycles, 5M steps/task, 200 training levels,
  full-distribution evaluation, start level, and easy distribution mode.
- Records a proposed Python 3.10/Torch/torchvision/Gym/Procgen compatibility matrix while keeping
  incomplete dependency locks, runtime qualification, and execution authorization false.
- Separates official `os.urandom`-derived `seed_to_set` semantics from deterministic caller-injected
  compatibility seeds and forbids claiming seed parity.
- Defines strict future create-only success/failure receipts: either one initial-observation digest
  or one bounded failure kind, with zero steps, rewards, terminations, policy/model queries, and
  telemetry-only timing.
- Integrates the plan and its canonical digest into the primitive-only `asi-cora-catalog` v2 output.

No external package was installed or executed, no environment was created, and no result/output was
produced. This does not qualify Procgen, reproduce CORA, authorize a smoke, or make a performance or
scientific claim. Content-closing the proposed Torch/Gym dependency graph and an independently
reviewed isolated build remain prerequisites to execution.

## Verification

- `.venv/bin/python -m pytest tests/test_cora_procgen_qualification.py tests/test_cora_development.py tests/test_cora_evaluation_matrix_hang.py tests/test_console_entrypoints.py -q -o addopts=''` — 28 passed
- Ruff on touched Python files — passed
- `.venv/bin/python -m mypy` — passed (225 source files)
- `git diff --check origin/main...HEAD` — passed

Verified head: `b6b83d4abb119f35ba0b8a61477c01b470ccf82e`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex

Refs #1581.
