### PR TITLE
fix(core): zero ceil(sparsity * fan_in) inputs in sparse_init

### DIFF
--- a/alberta_framework/core/initializers.py
+++ b/alberta_framework/core/initializers.py
@@ -84,17 +84,21 @@ def sparse_init(
 ) -> Float[Array, "fan_out fan_in"]:
     """Create a sparsely initialized weight matrix.
 
-    Applies the paper-specified SparseInit distribution and then zeros out a
-    fraction of weights per output neuron. This creates sparser gradient flows
-    that improve stability in streaming learning settings.
+    Applies the paper-specified SparseInit distribution and then zeros out
+    ``ceil(sparsity * fan_in)`` inputs per output neuron. This creates sparser
+    gradient flows that improve stability in streaming learning settings.
 
-    Reference: Elsayed et al. 2024, sparse_init.py
+    Reference: Elsayed, Vasan, and Mahmood 2024, "Streaming Deep Reinforcement
+    Learning Finally Works" (arXiv:2410.14606v2), Algorithm 1 (SparseInit), and
+    the authors' reference ``sparse_init.py`` at commit ``40bd4a61``
+    (https://github.com/mohmdelsayed/streaming-drl/blob/40bd4a61/sparse_init.py).
 
     Args:
         key: JAX random key
         shape: Weight matrix shape (fan_out, fan_in)
-        sparsity: Fraction of input connections to zero out per output neuron
-            (default: 0.9 means 90% sparse)
+        sparsity: Fraction of input connections to zero out per output neuron.
+            The zeroed count is ``ceil(sparsity * fan_in)``, exactly as in the
+            reference implementation (default: 0.9 means 90% sparse)
         init_type: Initialization distribution, "uniform" or "normal"
             (default: the uniform bound specified by SparseInit Algorithm 1)
 
@@ -131,7 +135,13 @@ def sparse_init(
     if fan_out > _INT32_MAX // max(1, fan_in) or 4 * fan_out * fan_in > _INT32_MAX:
         raise ValueError("shape byte count must fit signed int32")
     sparsity_validated = _require_float32_in_unit("sparsity", sparsity)
-    num_zeros = int(sparsity_validated * fan_in + 0.5)  # round to nearest int
+    # SparseInit zeros ``ceil(sparsity * fan_in)`` inputs per output neuron:
+    # Elsayed et al. 2024 (arXiv:2410.14606v2) Algorithm 1 takes ``n <- s x
+    # fan_in`` as a count, and the authors' reference implementation resolves it
+    # as ``num_zeros = int(math.ceil(sparsity * fan_in))``.  Evaluated in the same
+    # binary64 arithmetic as the reference so a decimal literal such as 0.9 gives
+    # the published count rather than one more.
+    num_zeros = math.ceil(sparsity_validated * fan_in)
 
     # Split key for init and sparsity mask
     init_key, mask_key = jr.split(key)

--- a/tests/test_initializers.py
+++ b/tests/test_initializers.py
@@ -1,11 +1,34 @@
 """Tests for sparse initialization."""
 
+import math
+
 import chex
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
 
 from alberta_framework import sparse_init
+
+# SparseInit is Algorithm 1 of Elsayed, Vasan, and Mahmood, "Streaming Deep
+# Reinforcement Learning Finally Works" (arXiv:2410.14606v2).  Algorithm 1
+# writes the per-output-neuron zero count as ``n <- s x fan_in``; the authors'
+# reference implementation resolves that real-valued count with a ceiling:
+#
+#     num_zeros = int(math.ceil(sparsity * fan_in))
+#
+# (https://github.com/mohmdelsayed/streaming-drl/blob/40bd4a61/sparse_init.py).
+# These pairs are exactly the ones where the ceiling and a round-to-nearest
+# count disagree, so they are what separates the published rule from a
+# look-alike.
+_CEILING_DISAGREEMENT_CASES = [
+    (0.9, 8, 8),
+    (0.9, 16, 15),
+    (0.9, 128, 116),
+    (0.9, 256, 231),
+    (0.8, 64, 52),
+    (0.2, 32, 7),
+    (0.95, 32, 31),
+]
 
 
 class TestSparseInit:
@@ -31,10 +54,58 @@ class TestSparseInit:
 
         # Count zeros per row
         zeros_per_row = jnp.sum(weights == 0, axis=1)
-        expected_zeros = int(sparsity * fan_in + 0.5)
+        expected_zeros = math.ceil(sparsity * fan_in)
 
         # Each row should have exactly expected_zeros zeros
         chex.assert_trees_all_close(zeros_per_row, jnp.full(fan_out, expected_zeros))
+
+    @pytest.mark.parametrize(("sparsity", "fan_in", "expected_zeros"), _CEILING_DISAGREEMENT_CASES)
+    def test_zero_count_is_the_published_ceiling(self, sparsity, fan_in, expected_zeros):
+        """Zeros per output neuron equal ceil(sparsity * fan_in), per SparseInit.
+
+        Elsayed et al. 2024 (arXiv:2410.14606v2) Algorithm 1 with the authors'
+        reference ``sparse_init.py`` line ``num_zeros = int(math.ceil(sparsity *
+        fan_in))``.  Every pair here is one where a round-to-nearest count would
+        be one lower, so this pins the published rule and not a coincidence.
+        """
+        assert expected_zeros == math.ceil(sparsity * fan_in)
+        assert expected_zeros != int(sparsity * fan_in + 0.5)
+
+        weights = sparse_init(jr.key(7), (24, fan_in), sparsity=sparsity)
+        zeros_per_row = jnp.sum(weights == 0, axis=1)
+        chex.assert_trees_all_close(zeros_per_row, jnp.full(24, expected_zeros))
+
+    @pytest.mark.parametrize(("sparsity", "fan_in"), [(0.8, 50), (0.9, 100), (0.5, 64), (0.2, 25)])
+    def test_ceiling_uses_binary64_like_the_reference(self, sparsity, fan_in):
+        """A whole-number ``sparsity * fan_in`` must not round up to one extra zero.
+
+        The reference ``sparse_init.py`` evaluates ``math.ceil(sparsity *
+        fan_in)`` in binary64, where ``0.9 * 100`` is exactly ``90.0``. Taking
+        the ceiling of the *exact* value of the decimal literal instead would
+        give 91, because binary64 ``0.9`` is slightly above nine tenths. This
+        pins the reference's arithmetic, not just its ceiling.
+        """
+        expected_zeros = math.ceil(sparsity * fan_in)
+        assert expected_zeros * 1.0 == sparsity * fan_in
+
+        weights = sparse_init(jr.key(11), (16, fan_in), sparsity=sparsity)
+        zeros_per_row = jnp.sum(weights == 0, axis=1)
+        chex.assert_trees_all_close(zeros_per_row, jnp.full(16, expected_zeros))
+
+    def test_ceiling_saturating_sparsity_zeros_every_input(self):
+        """ceil(0.99 * 64) == 64 zeroes the whole row, unlike a rounded count.
+
+        Reference: Elsayed et al. 2024 (arXiv:2410.14606v2) Algorithm 1 and
+        ``sparse_init.py``; ``row_indices[:num_zeros]`` covers the full fan-in
+        once the ceiling saturates, while round-to-nearest would leave one live
+        input per output neuron.
+        """
+        fan_in = 64
+        assert math.ceil(0.99 * fan_in) == fan_in
+        assert int(0.99 * fan_in + 0.5) == fan_in - 1
+
+        weights = sparse_init(jr.key(3), (16, fan_in), sparsity=0.99)
+        assert jnp.all(weights == 0)
 
     def test_nonzero_values_within_paper_sparse_init_bounds(self):
         """Non-zero values should stay within SparseInit Algorithm 1 bounds."""
@@ -75,7 +146,7 @@ class TestSparseInit:
 
         # Check sparsity
         zeros_per_row = jnp.sum(weights == 0, axis=1)
-        expected_zeros = int(0.5 * 16 + 0.5)
+        expected_zeros = math.ceil(0.5 * 16)
         chex.assert_trees_all_close(zeros_per_row, jnp.full(32, expected_zeros))
 
     def test_invalid_init_type_raises(self):


### PR DESCRIPTION
## Problem

`sparse_init` resolved its per-output-neuron zero count with round-to-nearest:

```python
num_zeros = int(sparsity_validated * fan_in + 0.5)  # round to nearest int
```

SparseInit's published rule is a **ceiling**.

**Reference:** Elsayed, Vasan, and Mahmood 2024, ["Streaming Deep Reinforcement Learning Finally Works"](https://arxiv.org/abs/2410.14606) (arXiv:2410.14606v2), Algorithm 1 — which takes `n <- s x fan_in` as a count — and the authors' reference implementation [`sparse_init.py` at commit `40bd4a61`](https://github.com/mohmdelsayed/streaming-drl/blob/40bd4a61/sparse_init.py), which resolves it as:

```python
num_zeros = int(math.ceil(sparsity * fan_in))
```

## Impact

The two rules disagree whenever the fractional part of `sparsity * fan_in` falls below 0.5 — which includes this module's own **default** `sparsity=0.9` at common fan-in widths:

| sparsity | fan_in | published (ceil) | previous (round) |
|---|---|---|---|
| 0.9 | 16 | 15 | 14 |
| 0.9 | 128 | 116 | 115 |
| 0.9 | 256 | 231 | 230 |
| 0.8 | 64 | 52 | 51 |
| 0.2 | 32 | 7 | 6 |

At a saturating sparsity the gap is qualitative rather than off-by-one: `ceil(0.99 * 64) == 64` zeroes the row outright, while round-to-nearest leaves one live input per output neuron.

## Fix

Uses `math.ceil`, evaluated in the same binary64 arithmetic as the reference so a whole-number product such as `0.9 * 100` stays `90` rather than rounding up to `91` (binary64 `0.9` is slightly above nine tenths, so taking the ceiling of the exact decimal value would give 91).

## Verification

- **Failing-test-first**: 8 new/updated tests fail against the unpatched source (`8 failed, 35 passed`), all pass after the fix (`43 passed`). The parametrized cases are chosen to be exactly the `(sparsity, fan_in)` pairs where ceiling and round-to-nearest disagree, and each asserts `expected != int(sparsity * fan_in + 0.5)` so it pins the published rule rather than a coincidence.
- `pytest tests/test_initializers.py` — 43 passed
- `ruff check` — all checks passed
- `mypy` — no issues

## Collision check

`gh pr list --repo SlopDotCash/asi --state open --json files` re-run before commit. Open PR #2272 also touches `initializers.py`, but only lines 21-38 (deriving `_ACTUAL_INT_TYPES` from dtype codes); this change is confined to lines 84-141 (`sparse_init`'s docstring and `num_zeros`). Verified disjoint via `gh pr diff 2272`.

## Attribution

- Client: claude-code
- Provider: anthropic
- Model: claude-opus-5
- Lane: rama0x1-asi-claude-worker

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0M7AY7P4W05TAZFQGDGESTA","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-22T07:53:02.454Z","completed_at":"2026-08-22T07:53:43.774Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T07:53:03.625Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c880aba986633b9edaf6166889d074a5eb039231accd66b8bc07366f14bb0561","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ab4ee419-1d09-4347-b703-0daeb392de48","object_id":"sha256:c880aba986633b9edaf6166889d074a5eb039231accd66b8bc07366f14bb0561","sha256":"c880aba986633b9edaf6166889d074a5eb039231accd66b8bc07366f14bb0561"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"Am9sqq5-cEcOAwO1LXdS4ZDkeyZawhO_KQUHfEnk-2KvrO7k3fyuHKb-V4vBU38-lb-ahyIK7t1VjoHCwKU5BQ"}} -->
