### PR TITLE
test(core): pin AutoTDIDBD to Kearney et al. 2019 Algorithm 6

### DIFF
--- a/tests/test_td_optimizers.py
+++ b/tests/test_td_optimizers.py
@@ -1,7 +1,10 @@
 """Tests for TDIDBD and AutoTDIDBD optimizers."""
 
+import math
+
 import chex
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from alberta_framework import TDIDBD, AutoTDIDBD
@@ -286,6 +289,241 @@ class TestAutoTDIDBD:
         assert bool(result.update_applied)
         assert bool(jnp.all(jnp.isfinite(result.weight_delta)))
         chex.assert_trees_all_close(result.new_state.eligibility_traces, obs)
+
+
+# ---------------------------------------------------------------------------
+# Published-algorithm pin: Kearney, Veeriah, Travnik, Pilarski & Sutton (2019),
+# "Learning Feature Relevance Through Step Size Adaptation in
+# Temporal-Difference Learning", arXiv:1903.03252, Section 6.2, Algorithm 6
+# ("AutoStep Style Normalized TIDBD(lambda)").  Lines as printed:
+#
+#   3   delta <- R + gamma w^T phi(s') - w^T phi(s)
+#   5-7 eta_i <- max[ |delta [gamma phi_i(s') - phi_i(s)] h_i|,
+#                     eta_i - 1/tau alpha_i [gamma phi_i(s') - phi_i(s)] z_i
+#                              (|delta phi_i(s) h_i| - eta_i) ]
+#   9   beta_i <- beta_i - theta 1/eta_i delta [gamma phi_i(s') - phi_i(s)] h_i
+#   10  M <- max(-e^{beta_i} [gamma phi_i(s') - phi_i(s)]^T z_i, 1)
+#   11  beta_i <- beta_i - log(M)
+#   12  alpha_i <- e^{beta_i}
+#   13  z_i <- z_i gamma lambda + phi_i(s)
+#   14  w_i <- w_i + alpha_i delta z_i
+#   15  h_i <- h_i [1 + alpha_i [gamma phi_i(s') - phi_i(s)] z_i]^+ + alpha_i delta z_i
+#
+# Note lines 5-7: the max's first argument uses the feature *difference*
+# [gamma phi(s') - phi(s)], while the exponential-average argument uses the raw
+# feature phi(s).  That asymmetry is the published text, not a transcription
+# slip, and a "consistency cleanup" of it silently changes the algorithm.
+# ---------------------------------------------------------------------------
+
+_ALG6_ALPHA0 = 0.4
+_ALG6_THETA = 0.5
+_ALG6_LAMBDA = 0.9
+_ALG6_TAU = 2.0
+_ALG6_GAMMA = 0.95
+
+# Mixed-sign transitions so that both branches of line 10's max and both
+# branches of line 15's positive part are exercised on this trajectory.
+_ALG6_OBS = np.array(
+    [
+        [1.6, 0.9, 1.2],
+        [2.0, 1.5, 0.5],
+        [0.8, 1.1, 1.9],
+        [1.7, 0.6, 1.0],
+        [1.8, 1.4, 0.6],
+        [1.4, 1.0, 0.8],
+    ],
+    dtype=np.float32,
+)
+_ALG6_NEXT_OBS = np.array(
+    [
+        [-1.2, -0.7, -1.5],
+        [5.0, -1.4, 0.2],
+        [-1.6, -0.8, -0.6],
+        [-0.7, -1.3, -1.7],
+        [5.5, -1.0, 0.3],
+        [-1.1, -1.6, -1.2],
+    ],
+    dtype=np.float32,
+)
+_ALG6_TD_ERRORS = np.array([1.2, -0.9, 0.7, -1.3, 1.1, -0.6], dtype=np.float32)
+
+# float32 agreement between the optimizer and the hand-transcribed reference.
+# Observed maximum absolute disagreement is ~2.4e-7 on weight deltas of
+# magnitude ~2.0.  Every deviation asserted below is at least 1e-3, i.e. more
+# than three orders of magnitude above this floor, so no assertion here can
+# pass or fail by float32 rounding.
+_ALG6_MATCH_ATOL = 2e-6
+_ALG6_DEVIATION_FLOOR = 1e-3
+
+
+def _algorithm_6_weight_deltas(variant: str = "published") -> tuple[np.ndarray, dict[str, int]]:
+    """Literal float32 transcription of Algorithm 6's weight path.
+
+    ``variant`` injects one deliberate departure from the printed algorithm so
+    a test can assert that the published choice is load-bearing:
+
+    ``symmetric_normalizer``
+        line 7 uses ``|delta [gamma phi(s') - phi(s)] h|`` instead of the
+        printed ``|delta phi(s) h|``;
+    ``eta_max_uses_phi``
+        line 6 uses ``|delta phi(s) h|`` instead of the printed feature
+        difference;
+    ``post_update_z_in_m``
+        line 10 uses the line-13 (post-update) eligibility trace instead of the
+        trace that line 10 actually sees;
+    ``no_plus_in_h``
+        line 15 drops the positive part ``[.]^+``.
+
+    The optimizer adds two numerical guards the paper does not state (a
+    ``[-10, 2]`` clamp on ``beta`` and a ``1e-8`` floor on ``eta``).  The
+    returned diagnostics record whether either guard ever binds; the pin below
+    requires that neither does, so the comparison is against the published
+    algorithm and not against a guard.
+    """
+    f32 = np.float32
+    n_features = _ALG6_OBS.shape[1]
+    h = np.zeros(n_features, dtype=f32)
+    z = np.zeros(n_features, dtype=f32)
+    beta = np.full(n_features, f32(math.log(_ALG6_ALPHA0)), dtype=f32)
+    # The paper does not state eta's initial value; AutoTDIDBD.init uses ones.
+    eta = np.ones(n_features, dtype=f32)
+    deltas: list[np.ndarray] = []
+    diagnostics = {"m_above_one": 0, "positive_part_clamps": 0, "guards_bound": 0}
+
+    for step in range(_ALG6_OBS.shape[0]):
+        phi = _ALG6_OBS[step]
+        phi_next = _ALG6_NEXT_OBS[step]
+        td_error = _ALG6_TD_ERRORS[step]
+        difference = (f32(_ALG6_GAMMA) * phi_next - phi).astype(f32)
+        alpha = np.exp(beta).astype(f32)
+
+        # Lines 5-7.
+        max_arm = np.abs(
+            td_error * (phi if variant == "eta_max_uses_phi" else difference) * h
+        ).astype(f32)
+        average_arm_signal = np.abs(
+            td_error * (difference if variant == "symmetric_normalizer" else phi) * h
+        ).astype(f32)
+        average_arm = (
+            eta
+            - (f32(1.0) / f32(_ALG6_TAU)) * alpha * difference * z * (average_arm_signal - eta)
+        ).astype(f32)
+        eta = np.maximum(max_arm, average_arm).astype(f32)
+        if bool(np.any(eta < f32(1e-8))):
+            diagnostics["guards_bound"] += 1
+        eta = np.maximum(eta, f32(1e-8)).astype(f32)
+
+        # Line 9.
+        beta = (
+            beta - f32(_ALG6_THETA) * (f32(1.0) / eta) * td_error * difference * h
+        ).astype(f32)
+
+        # Lines 10-12.  Line 10 sees the trace before line 13 advances it.
+        trace_for_m = z
+        if variant == "post_update_z_in_m":
+            trace_for_m = (z * f32(_ALG6_GAMMA * _ALG6_LAMBDA) + phi).astype(f32)
+        m_factor = max(float(-np.sum(np.exp(beta).astype(f32) * difference * trace_for_m)), 1.0)
+        if m_factor > 1.0:
+            diagnostics["m_above_one"] += 1
+        beta = (beta - f32(math.log(m_factor))).astype(f32)
+        if bool(np.any(beta < f32(-10.0)) or np.any(beta > f32(2.0))):
+            diagnostics["guards_bound"] += 1
+        beta = np.clip(beta, f32(-10.0), f32(2.0)).astype(f32)
+        alpha = np.exp(beta).astype(f32)
+
+        # Lines 13-15.
+        z = (z * f32(_ALG6_GAMMA * _ALG6_LAMBDA) + phi).astype(f32)
+        deltas.append((alpha * td_error * z).astype(f32))
+        positive_part = (f32(1.0) + alpha * difference * z).astype(f32)
+        if bool(np.any(positive_part < f32(0.0))):
+            diagnostics["positive_part_clamps"] += 1
+        if variant != "no_plus_in_h":
+            positive_part = np.maximum(f32(0.0), positive_part).astype(f32)
+        h = (h * positive_part + alpha * td_error * z).astype(f32)
+
+    return np.stack(deltas), diagnostics
+
+
+def _auto_tdidbd_weight_deltas() -> np.ndarray:
+    """Run :class:`AutoTDIDBD` over the pinned trajectory."""
+    optimizer = AutoTDIDBD(
+        initial_step_size=_ALG6_ALPHA0,
+        meta_step_size=_ALG6_THETA,
+        trace_decay=_ALG6_LAMBDA,
+        normalizer_decay=_ALG6_TAU,
+    )
+    state = optimizer.init(feature_dim=_ALG6_OBS.shape[1])
+    deltas: list[np.ndarray] = []
+    for step in range(_ALG6_OBS.shape[0]):
+        result = optimizer.update(
+            state,
+            jnp.asarray(_ALG6_TD_ERRORS[step]),
+            jnp.asarray(_ALG6_OBS[step]),
+            jnp.asarray(_ALG6_NEXT_OBS[step]),
+            jnp.asarray(_ALG6_GAMMA, dtype=jnp.float32),
+        )
+        assert bool(result.update_applied)
+        deltas.append(np.asarray(result.weight_delta))
+        state = result.new_state
+    return np.stack(deltas)
+
+
+class TestAutoTDIDBDPublishedAlgorithm:
+    """Pin AutoTDIDBD's numerics to Kearney et al. 2019 Algorithm 6.
+
+    The pre-existing AutoTDIDBD tests assert shapes, finiteness, JIT
+    compilation, and qualitative direction only. Nothing pinned the arithmetic,
+    so an edit could silently produce a different algorithm from the one the
+    docstring cites while every test still passed. These tests compare the
+    optimizer against a line-by-line transcription of the published algorithm
+    and then show that each published choice actually changes the trajectory.
+    """
+
+    def test_trajectory_exercises_the_published_branches_without_guards(self) -> None:
+        """The pinned trajectory must reach line 10's M>1 arm and line 15's clamp.
+
+        It must also stay clear of the two numerical guards the optimizer adds
+        beyond the paper, so the comparison below is against Algorithm 6 rather
+        than against a clamp or a floor.
+        """
+        _, diagnostics = _algorithm_6_weight_deltas()
+        assert diagnostics["m_above_one"] > 0
+        assert diagnostics["positive_part_clamps"] > 0
+        assert diagnostics["guards_bound"] == 0
+
+    def test_weight_deltas_match_published_algorithm_6(self) -> None:
+        """AutoTDIDBD reproduces Algorithm 6 lines 3-15 to float32."""
+        published, _ = _algorithm_6_weight_deltas()
+        chex.assert_trees_all_close(
+            _auto_tdidbd_weight_deltas(), published, atol=_ALG6_MATCH_ATOL, rtol=0.0
+        )
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            "symmetric_normalizer",
+            "eta_max_uses_phi",
+            "post_update_z_in_m",
+            "no_plus_in_h",
+        ],
+    )
+    def test_each_published_choice_changes_the_trajectory(self, variant: str) -> None:
+        """Each departure from Algorithm 6 must move the weight deltas.
+
+        Without this the match test above could pass for a trajectory on which
+        the published detail happens to be inert. The optimizer must track the
+        published branch and must not track the departed one.
+        """
+        published, _ = _algorithm_6_weight_deltas()
+        departed, _ = _algorithm_6_weight_deltas(variant)
+        separation = float(np.max(np.abs(published - departed)))
+        assert separation > _ALG6_DEVIATION_FLOOR, (
+            f"{variant} is inert on this trajectory; the pin would not detect it"
+        )
+
+        observed = _auto_tdidbd_weight_deltas()
+        assert float(np.max(np.abs(observed - published))) <= _ALG6_MATCH_ATOL
+        assert float(np.max(np.abs(observed - departed))) > _ALG6_DEVIATION_FLOOR
 
 
 class TestTDOptimizerComparison:


### PR DESCRIPTION
`AutoTDIDBD` (alberta_framework/core/optimizers.py) cites Kearney, Veeriah,
Travnik, Pilarski & Sutton (2019), "Learning Feature Relevance Through Step
Size Adaptation in Temporal-Difference Learning" (arXiv:1903.03252),
Section 6.2, Algorithm 6 "AutoStep Style Normalized TIDBD(lambda)".

I verified the implementation line by line against the paper's own HTML
rendering of Algorithm 6 (https://arxiv.org/html/1903.03252, Sec. 6.2):

```
 5-7  eta_i <- max[ |delta [gamma phi_i(s') - phi_i(s)] h_i|,
                    eta_i - 1/tau alpha_i [gamma phi_i(s') - phi_i(s)] z_i
                             (|delta phi_i(s) h_i| - eta_i) ]
 9    beta_i <- beta_i - theta 1/eta_i delta [gamma phi_i(s') - phi_i(s)] h_i
 10   M <- max(-e^{beta_i} [gamma phi_i(s') - phi_i(s)]^T z_i, 1)
 11   beta_i <- beta_i - log(M)
 12   alpha_i <- e^{beta_i}
 13   z_i <- z_i gamma lambda + phi_i(s)
 14   w_i <- w_i + alpha_i delta z_i
 15   h_i <- h_i [1 + alpha_i [gamma phi_i(s') - phi_i(s)] z_i]^+ + alpha_i delta z_i
```

**No discrepancy found — the implementation is faithful**, including the
paper's asymmetric normalizer (line 6's max argument uses the feature
difference; line 7's exponential-average argument uses the raw feature
`phi(s)`), the ordering that lets line 10 see the eligibility trace before
line 13 advances it, and line 15's positive part.

## What was untested

Nothing pinned the arithmetic. `tests/test_td_optimizers.py::TestAutoTDIDBD`
asserted shapes, finiteness, JIT compilation, terminal handling, and one
qualitative "normalization prevents overshoot" direction. Every one of those
passes for an optimizer implementing a *different* algorithm from the one the
docstring names. In particular the paper's line 5-7 asymmetry reads like a
transcription slip and is the obvious target of a well-meaning consistency
cleanup, which nothing would have caught.

## What this adds

A line-by-line float32 transcription of Algorithm 6 lines 3-15, pinned against
the optimizer's weight deltas over a six-step trajectory, plus a proof that
the pin discriminates. Four separate departures from the printed algorithm are
constructed and each is asserted to move the reference trajectory by more than
`1e-3` while the optimizer tracks the published branch:

| departure from Algorithm 6 | max |published - departed| |
|---|---|
| line 7 uses `\|delta [gamma phi(s')-phi(s)] h\|` (symmetric with line 6) | 7.1e-2 |
| line 6 uses `\|delta phi(s) h\|` (symmetric with line 7) | 4.1e-1 |
| line 10 uses the post-line-13 eligibility trace | 1.6e+0 |
| line 15 drops the positive part `[.]^+` | 7.8e-3 |

Observed optimizer-vs-paper disagreement on the same trajectory is **2.4e-7**
on weight deltas of magnitude ~2.0, i.e. float32 rounding — three to seven
orders of magnitude below every asserted deviation, so no assertion can pass
or fail by rounding.

The trajectory uses mixed-sign transitions on purpose, so that:

* line 10's `M > 1` arm fires (3 of 6 steps, max `M` = 10.4) rather than
  collapsing to `M = 1`;
* line 15's positive part actually clamps (2 of 6 steps). Unlike AutoStep,
  where `M = max(sum alpha_i x_i^2, 1)` makes `[.]^+` provably inert, here a
  single element's `alpha [gamma phi(s')-phi(s)] z` can fall below `-1` while
  the signed sum keeps `M = 1`;
* neither of the two numerical guards the optimizer adds beyond the paper (the
  `[-10, 2]` clamp on `beta`, the `1e-8` floor on `eta`) ever binds. A test
  asserts this, so the pin is against Algorithm 6 and not against a guard.

`eta`'s initial value is not stated in the paper; the reference uses
`AutoTDIDBD.init`'s `ones`, and that is documented in the helper's docstring
rather than claimed as published.

## Evidence: mutation check

Each of the four departures was applied to `alberta_framework/core/optimizers.py`
in the working tree, the new class was run, and the file restored to its
committed bytes (verified byte-equal afterwards). Production code is unchanged
in this PR.

```
symmetric_normalizer     exit=1  5 failed, 1 passed in 3.84s
eta_max_uses_phi         exit=1  5 failed, 1 passed in 3.94s
post_update_z_in_m       exit=1  5 failed, 1 passed in 4.09s
no_plus_in_h             exit=1  5 failed, 1 passed in 4.06s
```

(The 1 passing test in each run is the trajectory-diagnostics test, which
exercises the reference transcription only and does not call the optimizer.)

## Verification

Head SHA measured: `8f5df71e59bad6b08cbb0715e36a29b02102158a`

```
.venv/bin/python -m pytest tests/test_td_optimizers.py -q -o addopts=""
  -> 24 passed in 5.66s   (18 pre-existing + 6 new)

.venv/bin/python -m pytest tests/test_td_optimizers.py tests/test_optimizers.py \
    tests/test_td_learners.py tests/test_optimizer_nonfinite_transactions.py \
    tests/test_optimizers_update_working_set.py -q -o addopts=""
  -> 311 passed in 75.94s

.venv/bin/python -m ruff check .   -> All checks passed!
.venv/bin/python -m mypy           -> Success: no issues found in 224 source files
```

Test-only change; no registered evidence source is touched.

## Scope

This is a **Fix** in the "make a measurement trustworthy where it was not"
sense: a published algorithm this repository implements had no numerical
regression, so a silent deviation from it would not have been detected. It
does not move a benchmark number and does not claim to.

## Collision check

`gh pr list --repo SlopDotCash/asi --state open --json number,title,files --limit 200`
and `gh issue list --repo SlopDotCash/asi --state open --limit 200`, re-run
immediately before this push: no open PR touches
`tests/test_td_optimizers.py`, and no open PR or issue mentions TIDBD,
AutoTDIDBD, or Kearney. The two open PRs touching
`alberta_framework/core/optimizers.py` (#2272 `_ACTUAL_INT_TYPES`, #2275 numpy
C-alias integers) do not overlap with this file.

## Attribution

- Client: claude-code
- Provider: anthropic
- Model: claude-opus-5
- Lane: rama0x1-asi-claude-worker

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0M8YNAAWABCKS7Q8TRKWTQX","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-22T08:21:17.258Z","completed_at":"2026-08-22T08:21:59.768Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T08:21:19.185Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"272d4ea50f001d4ac279237bdb3c2f61d4e2936c23a49f1340f4bc5bdde38f5a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"1be1c17d-4f7d-48b4-a978-34b75f5d3068","object_id":"sha256:272d4ea50f001d4ac279237bdb3c2f61d4e2936c23a49f1340f4bc5bdde38f5a","sha256":"272d4ea50f001d4ac279237bdb3c2f61d4e2936c23a49f1340f4bc5bdde38f5a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"qCsZ3bDCsShIfdSrRih-Cs_E8hn35q5Jqp8NkfozEOnNNQ8l9IkjXbZofPREn8F-fLdUtmkcT78VT3W7hrFXCA"}} -->
