### PR TITLE
fix: make published Wilson intervals host-independent

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent_artifact.py
+++ b/alberta_framework/evaluation/continual_multiagent_artifact.py
@@ -42,6 +42,10 @@ PROTOCOL_VERSION = "recurring-two-agent-contextual-bandit-aba.v1"
 DIGEST_ALGORITHM = "sha256"
 DIGEST_SCOPE = "$.content"
 CANONICALIZATION = "utf8-json-sort-keys-compact-no-nan"
+# Exact, separately-rounded AS241 value for inv_cdf(0.975).  The default
+# published interval must not depend on whether a host C compiler contracts
+# the polynomial's multiply-adds.
+_WILSON_95_Z_SCORE = float.fromhex("0x1.f5c0331eeff82p+0")
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SOURCE_PATHS = (
@@ -209,10 +213,15 @@ def wilson_score_interval(
     if not 0.0 < confidence_level < 1.0:
         raise ValueError("confidence_level must lie in (0, 1)")
 
-    from statistics import NormalDist
-
     proportion = successes / sample_size
-    z_score = NormalDist().inv_cdf(0.5 + confidence_level / 2.0)
+    if confidence_level == 0.95:
+        z_score = _WILSON_95_Z_SCORE
+    else:
+        # Non-protocol confidence levels retain the general convenience path;
+        # only 95% intervals are serialized by the frozen protocol.
+        from statistics import NormalDist
+
+        z_score = NormalDist().inv_cdf(0.5 + confidence_level / 2.0)
     z_squared = z_score * z_score
     denominator = 1.0 + z_squared / sample_size
     center = (proportion + z_squared / (2.0 * sample_size)) / denominator

--- a/alberta_framework/evaluation/recurring_feature_artifact.py
+++ b/alberta_framework/evaluation/recurring_feature_artifact.py
@@ -33,7 +33,6 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from statistics import NormalDist
 from typing import NoReturn
 
 import jax
@@ -64,6 +63,10 @@ CANONICALIZATION = "utf8-json-sort-keys-compact-no-nan"
 BOOTSTRAP_RESAMPLES = 10_000
 BOOTSTRAP_CONFIDENCE_LEVEL = 0.95
 BOOTSTRAP_SEED = 2_026_073_002
+# Exact, separately-rounded AS241 value for inv_cdf(0.975).  Do not obtain
+# this through statistics.NormalDist: its C accelerator may contract Horner
+# multiply-adds on FMA-capable hosts and return the adjacent lower float.
+_WILSON_95_Z_SCORE = float.fromhex("0x1.f5c0331eeff82p+0")
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SOURCE_PATHS = (
@@ -430,7 +433,7 @@ def wilson_score_interval(successes: int, sample_size: int) -> dict[str, object]
     if sample_size < 1 or not 0 <= successes <= sample_size:
         raise ValueError("invalid Wilson interval counts")
     proportion = successes / sample_size
-    z_score = NormalDist().inv_cdf(0.5 + BOOTSTRAP_CONFIDENCE_LEVEL / 2.0)
+    z_score = _WILSON_95_Z_SCORE
     z_squared = z_score**2
     denominator = 1.0 + z_squared / sample_size
     center = (proportion + z_squared / (2.0 * sample_size)) / denominator

--- a/tests/test_wilson_quantile_determinism.py
+++ b/tests/test_wilson_quantile_determinism.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import statistics
+
+import pytest
+
+from alberta_framework.evaluation.continual_multiagent_artifact import (
+    wilson_score_interval as multiagent_wilson,
+)
+from alberta_framework.evaluation.recurring_feature_artifact import (
+    wilson_score_interval as recurring_wilson,
+)
+
+
+def test_published_wilson_intervals_do_not_call_host_normal_quantile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail(*_args: object, **_kwargs: object) -> float:
+        raise AssertionError("published 95% quantile must not use the host accelerator")
+
+    monkeypatch.setattr(statistics.NormalDist, "inv_cdf", fail)
+
+    recurring = recurring_wilson(1, 1)
+    multiagent = multiagent_wilson(1, 1)
+    expected_lower = float.fromhex("0x1.a70353b217770p-3")
+    assert recurring["lower"] == expected_lower
+    assert multiagent["lower"] == expected_lower
+    assert recurring["upper"] == multiagent["upper"] == 1.0
+
+
+def test_nonpublished_confidence_level_retains_general_quantile_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[float] = []
+
+    def fixed(_self: statistics.NormalDist, probability: float) -> float:
+        calls.append(probability)
+        return 1.0
+
+    monkeypatch.setattr(statistics.NormalDist, "inv_cdf", fixed)
+    interval = multiagent_wilson(1, 2, confidence_level=0.8)
+
+    assert calls == [0.9]
+    assert interval["confidence_level"] == 0.8


### PR DESCRIPTION
Closes #2240.

## Outcome

This fixes a reproduced measurement-integrity defect in both registered Wilson-interval
serialization paths. The base implementation computed the published 95% normal quantile
through the host runtime; an adjacent-lower quantile changed the serialized `1/1` lower
endpoint. The candidate freezes the exact separately rounded AS241 binary64 value and
keeps the general runtime path only for nonprotocol confidence levels.

<!-- evidence-head:ae45c43f0b605bae7a8985534182308f8cd9d830 -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/user-attachments/files/31362426/pr2279-verification.log
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/user-attachments/files/31362427/pr2279-domain-artifact.json

## Exact measurement

- Commit: candidate `ae45c43f0b605bae7a8985534182308f8cd9d830`; base
  `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`.
- Baseline: executing the exact base with AS241 `z = 0x1.f5c0331eeff82p+0`
  produced `1/1 lower = 0x1.a70353b217770p-3`; injecting its adjacent lower binary64
  value `0x1.f5c0331eeff81p+0` produced `0x1.a70353b217772p-3` in both registered
  implementations.
- Candidate: both exact-head published paths return `0x1.a70353b217770p-3` and pass
  while `NormalDist.inv_cdf` is replaced by a raising function. The nonpublished 80%
  path still invokes the general quantile at probability `0.9`.
- Delta: `5.551115123125783e-17`, two ULP at the fixed `1/1` endpoint. The frozen
  `30/30` endpoint is `0x1.c5e1929151d35p-1` in both controlled base executions and
  the candidate, so its delta is zero and existing serialized endpoints remain unchanged.
- Seeds, statistical `n`, means, and spreads: not applicable. This is a deterministic
  floating-point boundary check, not a stochastic benchmark. Two exact count cases were
  checked; stochastic samples = 0. The baseline and candidate are exact endpoints, not
  estimated means.

## Reproduction and validation

Untrusted source was archived directly from both Git objects and executed in a disposable
container with `--network none --cpus 2 --memory 4g --pids-limit 512`. Because the archive
contains no `.git` directory, a narrow provenance shim returned the verified candidate SHA
for `git rev-parse HEAD` and a clean result for `git status`; all other invocations failed.

```bash
PYTHONPATH=/tmp/review:/tmp/venv/lib/python3.12/site-packages python -m pytest \
  tests/test_wilson_quantile_determinism.py \
  tests/test_recurring_feature_artifact.py \
  tests/test_continual_multiagent_benchmark.py -q
# 52 passed in 37.49s

PYTHONPATH=/tmp/review:/tmp/venv/lib/python3.12/site-packages python -m ruff check \
  alberta_framework/evaluation/continual_multiagent_artifact.py \
  alberta_framework/evaluation/recurring_feature_artifact.py \
  tests/test_wilson_quantile_determinism.py
# All checks passed!
```

The domain artifact also records the direct controlled execution of the exact base and
candidate. Source archive SHA-256 values are
`998391be1b16a5f511d4fde3cfba29a32b50e077e6c54af187e4ae6cb5269506` (candidate)
and `5fd5df80b8dfcfcbcebbad068726fb7d8a8243ba65db929452f900dafad9740f`
(base). The isolated image was
`sha256:5d22d9a5b0c7d01313da1c7096c90406e78ffe9c1fbc7d93fb5a0777a799bb3e`.

Author-reported but not part of this independent run: `.venv/bin/python -m mypy` passed
for 224 source files. The live triage check passes.

## Resources, artifacts, and limits

- Resource cap: 2 CPUs, 4 GiB memory, 512 PIDs, no network; focused test wall time
  37.49 seconds; data queries = 0, environment steps = 0, model queries = 0.
- Local evidence paths before GitHub attachment: `slopcash/pr2279-verification.log` and
  `slopcash/pr2279-domain-artifact.json`.
- Evidence-file SHA-256:
  `f1cf7c899ef45d35efd3a6f58ee989cdd554e5524aebde9bfee1fb5c4fd2e865` (log) and
  `214b5ef3f35c122dea27e44293bd70ecfa71c50952dff9166754e1714320cd96`
  (domain artifact).
- No pinned output artifact was edited or regenerated. The evidence registry remains
  `invalid` by design; this PR neither suppresses nor reinterprets that state.
- Limitation: this runner's native `NormalDist` already returns the fixed AS241 value.
  Cross-host corruption was therefore reproduced by injecting the adjacent-lower value
  into the exact base. The `30/30` endpoint does not diverge for that adjacent input; the
  demonstrated corruption is the `1/1` endpoint.
- Status: development/nonpromoting measurement-integrity verification only. This is not
  a benchmark win, scientific result, evidence promotion, integrated-agent claim, or
  robotics-readiness claim.

## Change

- Freeze the published 95% quantile as `float.fromhex("0x1.f5c0331eeff82p+0")` in both
  registered serialization modules.
- Preserve the general `NormalDist` route for nonprotocol confidence levels.
- Add regression coverage that proves the published path is independent of the host
  quantile implementation and pins its exact serialized endpoint.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-asi
Attribution status: self-reported
— [pr-2279-evidence-conversion]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0S36A82B3G8WE6Z7FB7S2J3","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T05:16:48.770Z","completed_at":"2026-08-24T05:25:20.137Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T05:16:49.456Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f728fab92301e83fd75ddf562918b8336879ba48f137e8a2c1c6153e75d43b33","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"517f9991-02e3-4598-8bbe-5cb8e8ce1c78","object_id":"sha256:f728fab92301e83fd75ddf562918b8336879ba48f137e8a2c1c6153e75d43b33","sha256":"f728fab92301e83fd75ddf562918b8336879ba48f137e8a2c1c6153e75d43b33"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"R2IWcLncXLjnffZPe0ZHDcgOAKedJUpWVNAOcyoY8QAQMKrFuwyGo_z7c9mGQSOzlRVgbyLlb3TvjHtQ8mOjAw"}} -->
