### PR TITLE
research: fail closed before Continual World external smoke

### DIFF
--- a/alberta_framework/benchmarks/continual_world_qualification.py
+++ b/alberta_framework/benchmarks/continual_world_qualification.py
@@ -22,6 +22,18 @@ OFFICIAL_COMMIT = "73f63bb4fa0b5d00bda973e20dfb783bfcf1b8aa"
 METAWORLD_COMMIT = "0875192baaa91c43523708f55866d98eaf3facaf"
 OFFICIAL_SETUP_BLOB = "125705947e810f8a41e7f9560d429d444c06694f"
 OFFICIAL_DOCKERFILE_BLOB = "6282da996f68e58549f3fcf15ba5d326b1f5ef50"
+OFFICIAL_TREE_SHA256 = "514f88bbf29ad64a4fbbc1bc403b6a4eca540e9f"
+OFFICIAL_ARCHIVE_SHA256 = "21ed7d404975be7ca12fbb315eeece14f25cc0580dc6b074a81eac791a2d03d9"
+OFFICIAL_LICENSE_STATUS = "blocked-no-license-file"
+METAWORLD_TREE_SHA256 = "3024851b45599fe678718b92156d6e004c17039c"
+METAWORLD_ARCHIVE_SHA256 = "fa1f0336719ef8110c7c22c411ace52c7936deacddce0a1f011ebde3989ec5a5"
+METAWORLD_LICENSE_SHA256 = "9d4c6640ecd8cb9e3fe55eb923517fb75a241b74949817121399260c8f549243"
+OBSERVED_MUJOCO_ARCHIVE_SHA256 = (
+    "ba8560040f6ca47dbd89e4731bc9e06080a99eba4583cda95cdedca802389153"
+)
+OBSERVED_MUJOCO_KEY_SHA256 = "bffe403bce6978d329239c83e874e0fd412740d149834b8c051689ba4a9adecc"
+LICENSE_DISPOSITION_APPROVED = False
+EXTERNAL_EXECUTION_AUTHORIZED = False
 FROZEN_DEVELOPMENT_SEED = 1_580_000
 FROZEN_STEPS_PER_TASK = 2
 CW10_TASKS = (
@@ -127,6 +139,19 @@ class ContinualWorldSmokePlan:
             "metaworld_commit": METAWORLD_COMMIT,
             "official_setup_blob": OFFICIAL_SETUP_BLOB,
             "official_dockerfile_blob": OFFICIAL_DOCKERFILE_BLOB,
+            "source_audit": {
+                "official_tree_sha256": OFFICIAL_TREE_SHA256,
+                "official_archive_sha256": OFFICIAL_ARCHIVE_SHA256,
+                "official_license_status": OFFICIAL_LICENSE_STATUS,
+                "metaworld_tree_sha256": METAWORLD_TREE_SHA256,
+                "metaworld_archive_sha256": METAWORLD_ARCHIVE_SHA256,
+                "metaworld_license_sha256": METAWORLD_LICENSE_SHA256,
+                "mujoco_archive_sha256": OBSERVED_MUJOCO_ARCHIVE_SHA256,
+                "mujoco_key_sha256": OBSERVED_MUJOCO_KEY_SHA256,
+                "official_runtime_reconstructible": False,
+            },
+            "license_disposition_approved": LICENSE_DISPOSITION_APPROVED,
+            "external_execution_authorized": EXTERNAL_EXECUTION_AUTHORIZED,
             "runtime": dataclasses.asdict(self.runtime),
             "seed": self.seed,
             "tasks": list(CW20_TASKS),
@@ -245,6 +270,11 @@ def build_smoke_receipt(
     outcome: str,
 ) -> ContinualWorldSmokeReceipt:
     """Snapshot one external official-runtime trace into a strict host receipt."""
+    if LICENSE_DISPOSITION_APPROVED is not True or EXTERNAL_EXECUTION_AUTHORIZED is not True:
+        raise PermissionError(
+            "Continual World license disposition and external execution authorization "
+            "must both be approved before trace admission"
+        )
     if type(plan) is not ContinualWorldSmokePlan:
         raise ValueError("plan must be exact")
     horizon = len(CW20_TASKS) * plan.steps_per_task

--- a/docs/research/continual-world-qualification.md
+++ b/docs/research/continual-world-qualification.md
@@ -13,6 +13,16 @@ transitive versions or downloaded archive bytes, so an ASI run must first build 
 separate image and bind its immutable image digest, MuJoCo archive SHA-256, and
 resolved package/runtime versions in `IsolatedRuntimeIdentity`.
 
+The pinned Continual World tree contains no license file, and its Dockerfile is
+not reconstructible as written: the base image, apt/Python dependencies, and
+download URLs are mutable, while the pinned patchelf URL no longer resolves.
+The observed source/tree, Meta-World, MuJoCo, key, and Meta-World license hashes
+are bound into every plan. `LICENSE_DISPOSITION_APPROVED` and
+`EXTERNAL_EXECUTION_AUTHORIZED` remain false, so the host rejects a trace before
+inspecting it. Changing both gates requires explicit maintainer review and
+changes the plan identity; the observed MuJoCo/key hashes are not presented as
+a frozen provider contract.
+
 The qualification smoke traverses all 20 official tasks for two steps each with
 the fixed float32 zero action. The evaluator may record the task index, boundary,
 and name; no learner exists and no task or boundary information reaches a learner.

--- a/tests/test_continual_world_qualification.py
+++ b/tests/test_continual_world_qualification.py
@@ -6,6 +6,7 @@ import dataclasses
 import numpy as np
 import pytest
 
+import alberta_framework.benchmarks.continual_world_qualification as qualification
 from alberta_framework.benchmarks.continual_world_qualification import (
     CW20_TASKS,
     ContinualWorldSmokePlan,
@@ -33,7 +34,9 @@ def runtime() -> IsolatedRuntimeIdentity:
 
 
 @pytest.fixture
-def receipt(runtime: IsolatedRuntimeIdentity):
+def receipt(runtime: IsolatedRuntimeIdentity, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(qualification, "LICENSE_DISPOSITION_APPROVED", True)
+    monkeypatch.setattr(qualification, "EXTERNAL_EXECUTION_AUTHORIZED", True)
     plan = ContinualWorldSmokePlan(runtime=runtime)
     horizon = 20 * plan.steps_per_task
     return build_smoke_receipt(
@@ -57,6 +60,25 @@ def test_protocol_pins_official_sequence_sources_and_nonpromotion(runtime) -> No
     assert payload["paper_revision"] == "arXiv:2105.10919v3"
     assert payload["official_commit"] == "73f63bb4fa0b5d00bda973e20dfb783bfcf1b8aa"
     assert payload["metaworld_commit"] == "0875192baaa91c43523708f55866d98eaf3facaf"
+    assert payload["source_audit"] == {
+        "official_tree_sha256": "514f88bbf29ad64a4fbbc1bc403b6a4eca540e9f",
+        "official_archive_sha256": (
+            "21ed7d404975be7ca12fbb315eeece14f25cc0580dc6b074a81eac791a2d03d9"
+        ),
+        "official_license_status": "blocked-no-license-file",
+        "metaworld_tree_sha256": "3024851b45599fe678718b92156d6e004c17039c",
+        "metaworld_archive_sha256": (
+            "fa1f0336719ef8110c7c22c411ace52c7936deacddce0a1f011ebde3989ec5a5"
+        ),
+        "metaworld_license_sha256": (
+            "9d4c6640ecd8cb9e3fe55eb923517fb75a241b74949817121399260c8f549243"
+        ),
+        "mujoco_archive_sha256": "ba8560040f6ca47dbd89e4731bc9e06080a99eba4583cda95cdedca802389153",
+        "mujoco_key_sha256": "bffe403bce6978d329239c83e874e0fd412740d149834b8c051689ba4a9adecc",
+        "official_runtime_reconstructible": False,
+    }
+    assert payload["license_disposition_approved"] is False
+    assert payload["external_execution_authorized"] is False
     assert payload["learner_boundary_information"] == []
     assert payload["scientific_promotion_allowed"] is False
 
@@ -71,7 +93,11 @@ def test_fixed_action_receipt_is_exact_mechanism_off_and_round_trips(receipt) ->
     assert checked.negative_outcome_retained is True
 
 
-def test_trace_builder_snapshots_and_rejects_wrong_boundary_schedule(runtime) -> None:
+def test_trace_builder_snapshots_and_rejects_wrong_boundary_schedule(
+    runtime: IsolatedRuntimeIdentity, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(qualification, "LICENSE_DISPOSITION_APPROVED", True)
+    monkeypatch.setattr(qualification, "EXTERNAL_EXECUTION_AUTHORIZED", True)
     plan = ContinualWorldSmokePlan(runtime=runtime)
     horizon = 40
     observations = np.zeros((horizon, 32), dtype=np.float32)
@@ -142,3 +168,31 @@ def test_runtime_and_plan_fail_closed(runtime) -> None:
     with pytest.raises(ValueError, match="development seed"):
         ContinualWorldSmokePlan(runtime=runtime, seed=0)
     assert len(protocol_gap_record()) >= 8
+
+
+def test_smoke_execution_fails_before_trace_access_while_license_is_blocked(
+    runtime: IsolatedRuntimeIdentity,
+) -> None:
+    class HostileArray:
+        calls = 0
+
+        def __getattribute__(self, name: str) -> object:
+            if name != "calls":
+                type(self).calls += 1
+                raise AssertionError("trace must not be inspected before authorization")
+            return object.__getattribute__(self, name)
+
+    hostile = HostileArray()
+    with pytest.raises(PermissionError, match="license.*authorization"):
+        build_smoke_receipt(
+            ContinualWorldSmokePlan(runtime=runtime),
+            actions=hostile,  # type: ignore[arg-type]
+            observations=hostile,  # type: ignore[arg-type]
+            rewards=hostile,  # type: ignore[arg-type]
+            successes=hostile,  # type: ignore[arg-type]
+            task_indices=hostile,  # type: ignore[arg-type]
+            persistent_environment_numeric_bytes=1,
+            timing_ns=0,
+            outcome="inconclusive",
+        )
+    assert HostileArray.calls == 0


### PR DESCRIPTION
Advances #1580.

## What changed

- binds the audited Continual World source tree/archive, Meta-World tree/archive/license, and observed MuJoCo/key hashes into every smoke plan
- records that the pinned Continual World tree has no license file and the official runtime recipe is not reconstructible
- adds separate license-disposition and external-execution authorization gates, both false by default
- rejects smoke trace admission before inspecting any trace array unless both gates are explicitly approved
- makes either authorization transition change the bound plan identity
- documents that observed MuJoCo/key hashes are audit observations, not a frozen provider contract

No external source was downloaded, built, redistributed, or executed. No smoke receipt or output artifact was created. The issue remains blocked on an explicit license disposition and a separately reviewed reconstructible runtime plan.

## Verification

- `/root/asi/.venv/bin/python -m pytest tests/test_continual_world_qualification.py tests/test_external_qualification.py -q` — 27 passed
- `/root/asi/.venv/bin/python -m ruff check alberta_framework/benchmarks/continual_world_qualification.py tests/test_continual_world_qualification.py` — passed
- `/root/asi/.venv/bin/python -m mypy` — passed (224 source files)