### PR TITLE
research: bind native supervised receipts to Avalanche plan

### DIFF
--- a/alberta_framework/benchmarks/native_supervised_suite.py
+++ b/alberta_framework/benchmarks/native_supervised_suite.py
@@ -25,6 +25,9 @@ from jax import Array
 
 SCHEMA = "asi.native_supervised_cl_development.v1"
 AVALANCHE_REVISION = "ContinualAI/avalanche@eb075be393e1f458b2c352514ff6c17b5a2c0f4e"
+AVALANCHE_QUALIFICATION_PLAN_SHA256 = (
+    "ee85d404886ec2ae3412f9bec888e36cb1a984b41185af90cd8d1e36f7975053"
+)
 FROZEN_SEEDS = (15780, 15781, 15782, 15783)
 BENCHMARK_IDS = ("split_mnist", "rotated_mnist", "split_cifar100", "ipmnist")
 ARM_IDS = ("online_sgd", "replay_sgd", "running_centroid", "frozen_no_learning")
@@ -321,6 +324,7 @@ class SuiteResult:
     dataset_sha256: str
     schedule_sha256: str
     source_sha256: str
+    avalanche_qualification_plan_sha256: str
     runtime_identity: tuple[str, str, str, str]
     arms: tuple[ArmResult, ...]
     development_only: bool = True
@@ -337,10 +341,17 @@ class SuiteResult:
         _exact_int(self.input_dim, "input_dim", 1, MAX_INPUT_DIM)
         if self.n_classes != spec.n_classes:
             raise ValueError("class count differs from the catalog")
-        for name in ("dataset_sha256", "schedule_sha256", "source_sha256"):
+        for name in (
+            "dataset_sha256",
+            "schedule_sha256",
+            "source_sha256",
+            "avalanche_qualification_plan_sha256",
+        ):
             _digest(getattr(self, name), name)
         if self.source_sha256 != _source_sha256():
             raise ValueError("current ASI source identity drift")
+        if self.avalanche_qualification_plan_sha256 != AVALANCHE_QUALIFICATION_PLAN_SHA256:
+            raise ValueError("Avalanche qualification plan identity drift")
         if self.runtime_identity != _runtime_identity():
             raise ValueError("current runtime identity drift")
         if type(self.arms) is not tuple or any(type(arm) is not ArmResult for arm in self.arms):
@@ -476,6 +487,7 @@ def run_native_suite(
         dataset_sha256=_dataset_sha256(data, targets),
         schedule_sha256=_schedule_sha256(tasks),
         source_sha256=_source_sha256(),
+        avalanche_qualification_plan_sha256=AVALANCHE_QUALIFICATION_PLAN_SHA256,
         runtime_identity=_runtime_identity(),
         arms=tuple(_run_arm(tasks, spec.n_classes, capacity, arm_id) for arm_id in ARM_IDS),
     )
@@ -538,6 +550,7 @@ def catalog_payload() -> dict[str, object]:
     return {
         "schema": "asi.native_supervised_cl_catalog.v1",
         "avalanche_revision": AVALANCHE_REVISION,
+        "avalanche_qualification_plan_sha256": AVALANCHE_QUALIFICATION_PLAN_SHA256,
         "development_only": True,
         "scientific_promotion_allowed": False,
         "frozen_seeds": list(FROZEN_SEEDS),
@@ -560,7 +573,8 @@ if __name__ == "__main__":
 
 
 __all__ = [
-    "ARM_IDS", "AVALANCHE_REVISION", "BENCHMARK_IDS", "CATALOG", "FROZEN_SEEDS",
+    "ARM_IDS", "AVALANCHE_QUALIFICATION_PLAN_SHA256", "AVALANCHE_REVISION",
+    "BENCHMARK_IDS", "CATALOG", "FROZEN_SEEDS",
     "ArmResult", "BenchmarkSpec", "ResourceReceipt", "SuiteResult", "TaskBatch",
     "benchmark_spec", "build_task_stream", "catalog_payload", "main", "run_native_suite",
     "validate_result",

--- a/docs/research/native-supervised-suite.md
+++ b/docs/research/native-supervised-suite.md
@@ -8,6 +8,15 @@ site (60,000 train and 10,000 test 28×28 images) and the University of Toronto 
 ICLR 2024, arXiv `2404.00781`, and its separately audited UPGD code revision; this suite does not
 replace the full `upgd_ipmnist` runner.
 
+Every native catalog and result also binds the complete prospective Avalanche
+qualification plan by SHA-256
+`ee85d404886ec2ae3412f9bec888e36cb1a984b41185af90cd8d1e36f7975053`.
+That plan owns the audited source tree/archive/license, hash-locked runtime,
+compatibility deviations, and ten unresolved execution blockers. The external
+runtime test recomputes this digest from the plan bytes, so those inputs cannot
+drift independently of native receipts. This binding does not authorize an
+image build, dataset download, scenario execution, or parity claim.
+
 The additive `asi.native_supervised_cl_development.v1` runner accepts caller-supplied exact
 float32 images and int32 labels; it never downloads or writes data. It deterministically constructs
 Split MNIST (five ascending class pairs), Rotated MNIST (fixed 0/45/90/135/180 degree rotations),

--- a/tests/test_avalanche_external_runtime.py
+++ b/tests/test_avalanche_external_runtime.py
@@ -12,6 +12,9 @@ from types import ModuleType
 import pytest
 
 from alberta_framework.benchmarks.external_qualification import qualification_plan
+from alberta_framework.benchmarks.native_supervised_suite import (
+    AVALANCHE_QUALIFICATION_PLAN_SHA256,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -43,6 +46,9 @@ def _plan() -> dict[str, object]:
 
 
 def test_plan_binds_official_source_license_and_every_runtime_input() -> None:
+    assert hashlib.sha256((ROOT / "qualification-plan.json").read_bytes()).hexdigest() == (
+        AVALANCHE_QUALIFICATION_PLAN_SHA256
+    )
     plan = _plan()
     authority = plan["authority"]
     inputs = plan["qualification_inputs"]

--- a/tests/test_native_supervised_suite.py
+++ b/tests/test_native_supervised_suite.py
@@ -9,6 +9,7 @@ import pytest
 
 from alberta_framework.benchmarks.native_supervised_suite import (
     ARM_IDS,
+    AVALANCHE_QUALIFICATION_PLAN_SHA256,
     BENCHMARK_IDS,
     FROZEN_SEEDS,
     build_task_stream,
@@ -44,6 +45,9 @@ def test_all_catalog_lanes_construct_and_run_end_to_end(benchmark_id: str) -> No
     assert len(result.schedule_sha256) == 64
     assert len(result.source_sha256) == 64
     assert len(result.runtime_identity) == 4
+    assert result.avalanche_qualification_plan_sha256 == (
+        AVALANCHE_QUALIFICATION_PLAN_SHA256
+    )
     for arm in result.arms:
         assert arm.receipt.data_steps == len(arm.task_accuracies) * 2
         assert arm.receipt.data_bytes_read > 0
@@ -89,6 +93,10 @@ def test_result_binds_dataset_schedule_source_and_runtime_identities() -> None:
     with pytest.raises(ValueError, match="runtime identity"):
         validate_result(
             dataclasses.replace(first, runtime_identity=("forged", *first.runtime_identity[1:]))
+        )
+    with pytest.raises(ValueError, match="qualification plan"):
+        validate_result(
+            dataclasses.replace(first, avalanche_qualification_plan_sha256="0" * 64)
         )
 
 
@@ -160,3 +168,6 @@ def test_catalog_cli_is_metadata_only(capsys: pytest.CaptureFixture[str]) -> Non
     payload = json.loads(capsys.readouterr().out)
     assert payload == catalog_payload()
     assert payload["avalanche_revision"].endswith("eb075be393e1f458b2c352514ff6c17b5a2c0f4e")
+    assert payload["avalanche_qualification_plan_sha256"] == (
+        "ee85d404886ec2ae3412f9bec888e36cb1a984b41185af90cd8d1e36f7975053"
+    )


### PR DESCRIPTION
Advances #1578.

## What changed

- binds every native supervised catalog and result to the complete prospective Avalanche qualification plan SHA-256
- validates that identity as part of the strict `SuiteResult` contract
- makes the external-runtime test recompute the digest from the actual plan bytes
- adds fail-closed regression coverage for forged plan identities
- documents that the bound plan owns the audited source tree/archive/license, runtime lock, compatibility deviations, and unresolved execution blockers

This closes an integration gap where native receipts named the Avalanche commit but did not bind the external qualification plan defining what that qualification meant. No image was built, no dataset was downloaded, and no external scenario or long benchmark was executed. The plan remains explicitly unauthorized and nonpromoting.

## Verification

- `/root/asi/.venv/bin/python -m pytest tests/test_native_supervised_suite.py tests/test_avalanche_external_runtime.py -q` — 24 passed
- `/root/asi/.venv/bin/python -m ruff check alberta_framework/benchmarks/native_supervised_suite.py tests/test_native_supervised_suite.py tests/test_avalanche_external_runtime.py` — passed
- `/root/asi/.venv/bin/python -m mypy` — passed (224 source files)