### PR TITLE
fix(benchmarks): cap Forager hidden_sizes before layer-walk hang

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -208,6 +208,9 @@ FORAGER_FOV_EMA_SUBSAMPLE = 100
 FORAGER_FOV_TAIL_FRACTION = 0.10
 FORAGER_ENVIRONMENT_RNG_SCHEDULE = "dedicated_environment_split_chain_v1"
 _MAX_JAX_INT32 = 2**31 - 1
+# Public last-fit is one hidden layer. Origin walked unbounded actor/critic
+# ``hidden_sizes`` before leftover INT32 math — hang, not a width overflow.
+_MAX_FORAGER_HIDDEN_LAYERS = 4_096
 _ACTUAL_NUMPY_INT_TYPES = frozenset(
     np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
@@ -954,10 +957,14 @@ class AlbertaForagerConfig:
             ("actor_hidden_sizes", self.actor_hidden_sizes),
             ("critic_hidden_sizes", self.critic_hidden_sizes),
         ):
-            if type(widths) is not tuple or not widths or any(
-                type(width) is not int or width < 1
-                for width in widths
-            ):
+            if type(widths) is not tuple or not widths:
+                raise ValueError(f"{name} must contain positive integer widths")
+            if len(widths) > _MAX_FORAGER_HIDDEN_LAYERS:
+                raise ValueError(
+                    f"{name} length must be an integer in "
+                    f"[1, {_MAX_FORAGER_HIDDEN_LAYERS}]"
+                )
+            if any(type(width) is not int or width < 1 for width in widths):
                 raise ValueError(f"{name} must contain positive integer widths")
         unit_interval = {
             "gamma": self.gamma,

--- a/tests/test_forager_hidden_layer_count_cap.py
+++ b/tests/test_forager_hidden_layer_count_cap.py
@@ -1,0 +1,32 @@
+"""Reject oversized Forager hidden-size lists before layer-walk hang."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.forager import (
+    _MAX_FORAGER_HIDDEN_LAYERS,
+    AlbertaForagerConfig,
+)
+
+
+def test_forager_hidden_layer_cap_constant() -> None:
+    assert _MAX_FORAGER_HIDDEN_LAYERS == 4096
+
+
+def test_forager_accepts_max_actor_hidden_layer_count() -> None:
+    AlbertaForagerConfig(actor_hidden_sizes=(1,) * _MAX_FORAGER_HIDDEN_LAYERS)
+
+
+def test_forager_rejects_oversized_actor_hidden_layer_count() -> None:
+    with pytest.raises(ValueError, match="actor_hidden_sizes length"):
+        AlbertaForagerConfig(
+            actor_hidden_sizes=(1,) * (_MAX_FORAGER_HIDDEN_LAYERS + 1),
+        )
+
+
+def test_forager_rejects_oversized_critic_hidden_layer_count() -> None:
+    with pytest.raises(ValueError, match="critic_hidden_sizes length"):
+        AlbertaForagerConfig(
+            critic_hidden_sizes=(1,) * (_MAX_FORAGER_HIDDEN_LAYERS + 1),
+        )


### PR DESCRIPTION
## Summary

- **Fix:** `AlbertaForagerConfig` walked `actor_hidden_sizes` / `critic_hidden_sizes` with no layer-count bound, so a huge legal-width tuple hung in `any(...)` before leftover INT32 math.
- Reject `len > 4096` after the existing nonempty-tuple gate. Empty tuples still fail the original "positive integer widths" check. Widths stay un-capped beyond positivity (no INT32 last-fit change).
- One source file + one test file. Avoids the open `_ACTUAL_INT_TYPES` mega-PRs. Does not edit `FORAGER_BENCHMARK.md`.

## Test plan

```text
<!-- evidence-head:78bfc3b52d041b68d32fe0be80ac7ef210c13168 -->
<!-- evidence-row:logs -->
- [x] logs: focused pytest + ruff on the touched files
```

```bash
JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m pytest \
  tests/test_forager_hidden_layer_count_cap.py \
  tests/test_forager_int_hostile.py -q -o addopts=""
# 7 passed
/root/asi-venv/bin/python -m ruff check \
  alberta_framework/benchmarks/forager.py \
  tests/test_forager_hidden_layer_count_cap.py
```

Provider/model: spacexai / Cursor-Grok-4.6
Client: cursor / lane cursor-grok-4-6
Skill: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Permanently nonpromoting measurement-correctness fix; not a Forager campaign result.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0MC0K6QCRPEC5HJB3H815AJ","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T09:14:46.359Z","completed_at":"2026-08-22T09:22:16.289Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T09:14:46.908Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b362fdb00933095007022464646d1694dd66da947e80aaa80670da50b92abfb5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"59346271-0a7a-4e71-8b1f-caaa2a90661a","object_id":"sha256:b362fdb00933095007022464646d1694dd66da947e80aaa80670da50b92abfb5","sha256":"b362fdb00933095007022464646d1694dd66da947e80aaa80670da50b92abfb5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"VtmpLkKbgIzozuZ5IIIjMMuq3XtAEKUPVn-IzFumRtSxwY1XF9bg0uC1IZxDs4xhrVrzr_54o3zyIqEdlcp0CA"}} -->
