### PR TITLE
fix(core): cap AdamO shape rank before dimension-walk hang

### DIFF
--- a/alberta_framework/core/adamo.py
+++ b/alberta_framework/core/adamo.py
@@ -49,6 +49,9 @@ ADAMO_PROTOCOL = MappingProxyType({
 _INT32_MAX = (1 << 31) - 1
 _MAX_ARRAY_ELEMENTS = 1_000_000
 _MAX_WORKING_BYTES = 256 * 1024 * 1024
+# Public last-fit is NumPy ndim. Origin walked unbounded ``shape`` rank
+# before leftover INT32 math — hang, not a per-axis overflow.
+_MAX_ADAMO_SHAPE_RANK = 32
 
 
 def _trusted_float_array(value: object, *, name: str) -> Array:
@@ -242,6 +245,11 @@ class AdamO:
     def init_for_shape(self, shape: tuple[int, ...]) -> AdamOState:
         if type(shape) is not tuple or not shape:
             raise ValueError("shape must be a non-empty tuple")
+        if len(shape) > _MAX_ADAMO_SHAPE_RANK:
+            raise ValueError(
+                "shape length must be an integer in "
+                f"[1, {_MAX_ADAMO_SHAPE_RANK}]"
+            )
         if any(type(dimension) is not int or dimension < 1 for dimension in shape):
             raise ValueError("shape dimensions must be positive built-in integers")
         return self._adam.init_for_shape(shape)

--- a/tests/test_adamo_shape_rank_cap.py
+++ b/tests/test_adamo_shape_rank_cap.py
@@ -1,0 +1,20 @@
+"""Reject oversized AdamO shape rank before dimension-walk hang."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.adamo import _MAX_ADAMO_SHAPE_RANK, AdamO
+
+
+def test_adamo_shape_rank_cap_constant() -> None:
+    assert _MAX_ADAMO_SHAPE_RANK == 32
+
+
+def test_adamo_accepts_max_shape_rank() -> None:
+    AdamO().init_for_shape((1,) * _MAX_ADAMO_SHAPE_RANK)
+
+
+def test_adamo_rejects_oversized_shape_rank() -> None:
+    with pytest.raises(ValueError, match="shape length"):
+        AdamO().init_for_shape((1,) * (_MAX_ADAMO_SHAPE_RANK + 1))


### PR DESCRIPTION
## Summary

- **Fix:** `AdamO.init_for_shape` walked an unbounded `shape` tuple with `any(...)`, so a huge legal-axis rank hung before leftover INT32 math.
- Reject `len(shape) > 32` (NumPy ndim last-fit) after the existing nonempty-tuple gate. Per-axis positivity and INT32 last-fit in `gram_working_bytes` are unchanged.
- One source file + one test file. Does not collide with open `_ACTUAL_INT_TYPES` PRs or the AdamO matched-plan PR (#2133).

## Test plan

```text
<!-- evidence-head:ce55481205b1077c3a907b1f6d0cab50d79db4bc -->
<!-- evidence-row:logs -->
- [x] logs: focused pytest + ruff on the touched files
```

```bash
JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m pytest \
  tests/test_adamo_shape_rank_cap.py tests/test_adamo.py -q -o addopts=""
# 23 passed
/root/asi-venv/bin/python -m ruff check \
  alberta_framework/core/adamo.py tests/test_adamo_shape_rank_cap.py
```

Provider/model: spacexai / Cursor-Grok-4.6
Client: cursor / lane cursor-grok-4-6
Skill: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Permanently nonpromoting measurement-correctness fix; not an IPMNIST or AdamO campaign result.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0MCJHAKM3SJNSF8WYX871SG","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T09:24:34.260Z","completed_at":"2026-08-22T09:35:40.134Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T09:24:34.771Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"40449fde763d8ba93f3ea0d3de29c60ed3166fed63e21cb419ae063f9a1998c8","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"918412cf-2b50-4064-b5d0-02d0644a5391","object_id":"sha256:40449fde763d8ba93f3ea0d3de29c60ed3166fed63e21cb419ae063f9a1998c8","sha256":"40449fde763d8ba93f3ea0d3de29c60ed3166fed63e21cb419ae063f9a1998c8"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"-azC2j5YH4GmzyT17hAFfstKzKuRPmS1vvBtCZdKVFNANmCMeQJs1sdlVr0ZYwKf6RAoRyM_8io6585M9ZYSDg"}} -->
