### PR TITLE
fix(benchmarks): cap Forager CLI seed and size lists before walk hang

### DIFF
--- a/alberta_framework/forager_cli.py
+++ b/alberta_framework/forager_cli.py
@@ -86,6 +86,9 @@ from alberta_framework.benchmarks.historical_forager_provenance import (
 LOGGER = logging.getLogger("alberta.forager")
 REPO_ROOT = Path(__file__).resolve().parents[1]
 _HISTORICAL_CLI_SCHEMA = "alberta.historical_numpy_forager.cli.v1"
+# Public last-fit is one comma-separated field. Origin split then walked
+# unbounded int/float lists before leftover INT32 math — hang, not a width overflow.
+_MAX_FORAGER_CLI_SEQUENCE = 4_096
 
 
 def _configure_logging() -> None:
@@ -105,6 +108,11 @@ def _parse_ints(value: str) -> tuple[int, ...]:
         raise argparse.ArgumentTypeError("expected comma-separated integers") from exc
     if not values:
         raise argparse.ArgumentTypeError("at least one integer is required")
+    if len(values) > _MAX_FORAGER_CLI_SEQUENCE:
+        raise argparse.ArgumentTypeError(
+            "sequence length must be an integer in "
+            f"[1, {_MAX_FORAGER_CLI_SEQUENCE}]"
+        )
     if len(set(values)) != len(values):
         raise argparse.ArgumentTypeError("seed values must be unique")
     return values
@@ -117,6 +125,11 @@ def _parse_floats(value: str) -> tuple[float, ...]:
         raise argparse.ArgumentTypeError("expected comma-separated numbers") from exc
     if not values:
         raise argparse.ArgumentTypeError("at least one number is required")
+    if len(values) > _MAX_FORAGER_CLI_SEQUENCE:
+        raise argparse.ArgumentTypeError(
+            "sequence length must be an integer in "
+            f"[1, {_MAX_FORAGER_CLI_SEQUENCE}]"
+        )
     return values
 
 

--- a/tests/test_forager_cli_sequence_cap.py
+++ b/tests/test_forager_cli_sequence_cap.py
@@ -1,0 +1,34 @@
+"""Reject oversized Forager CLI comma-separated lists before walk hang."""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from alberta_framework.forager_cli import (
+    _MAX_FORAGER_CLI_SEQUENCE,
+    _parse_floats,
+    _parse_ints,
+)
+
+
+def test_forager_cli_sequence_cap_constant() -> None:
+    assert _MAX_FORAGER_CLI_SEQUENCE == 4096
+
+
+def test_forager_cli_accepts_max_unique_int_sequence() -> None:
+    payload = ",".join(str(index) for index in range(_MAX_FORAGER_CLI_SEQUENCE))
+    assert _parse_ints(payload) == tuple(range(_MAX_FORAGER_CLI_SEQUENCE))
+
+
+def test_forager_cli_rejects_oversized_int_sequence() -> None:
+    payload = ",".join(str(index) for index in range(_MAX_FORAGER_CLI_SEQUENCE + 1))
+    with pytest.raises(argparse.ArgumentTypeError, match="sequence length"):
+        _parse_ints(payload)
+
+
+def test_forager_cli_rejects_oversized_float_sequence() -> None:
+    payload = ",".join(["0.5"] * (_MAX_FORAGER_CLI_SEQUENCE + 1))
+    with pytest.raises(argparse.ArgumentTypeError, match="sequence length"):
+        _parse_floats(payload)


### PR DESCRIPTION
## Summary

- **Fix:** Forager CLI `_parse_ints` / `_parse_floats` split comma-separated flags (`--seeds`, hidden-size lists, `--reward-trace-decays`) into unbounded tuples, then uniqueness (`set`) and later config walks could hang on a legal-width but huge list.
- Reject `len > 4096` after nonempty parse and before uniqueness. Empty input still fails the existing "at least one" check. Unique 4096-int lists still parse.
- One source file + one test file. Distinct from the `AlbertaForagerConfig.hidden_sizes` cap. Editing `forager_cli.py` changes CLI provenance hashes; `FORAGER_BENCHMARK.md` is unchanged.

## Test plan

```text
<!-- evidence-head:d01b9aa61f1b238a2384ca3cb4a9fd3c39527c61 -->
<!-- evidence-row:logs -->
- [x] logs: focused pytest + ruff on the touched files (see commands)
```

```bash
JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m ruff check \
  alberta_framework/forager_cli.py tests/test_forager_cli_sequence_cap.py
JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m pytest \
  tests/test_forager_cli_sequence_cap.py -q -o addopts=""
# 4 passed
```

Validator-only Fix. No Forager campaign shard, seed, or threshold was changed.

Source HEAD: `d01b9aa61f1b238a2384ca3cb4a9fd3c39527c61`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0MDC9JG90S8QZG54E8GQ18V","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T09:38:38.289Z","completed_at":"2026-08-22T09:48:55.381Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T09:38:38.870Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"9dfc7a264388ada0a2f48898c92c5e9a2c6802e700722e5da0c8f9a88fea3e47","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5d523272-43f5-497e-b7c1-023f7e591074","object_id":"sha256:9dfc7a264388ada0a2f48898c92c5e9a2c6802e700722e5da0c8f9a88fea3e47","sha256":"9dfc7a264388ada0a2f48898c92c5e9a2c6802e700722e5da0c8f9a88fea3e47"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"uWjT1LqdgyCSkV2UMhNPTXZMKY3grgwHpVKQoqT-jJjlKKhFZIlg-nPFTvtRNVWLA1LuyCFNfGYEXF6nmMwUAA"}} -->
