### PR TITLE
fix(core): cap checkpoint empty-array shape rank before dimension-walk hang

### DIFF
--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -59,6 +59,9 @@ _EMPTY_ARRAYS_KEY = "_empty_array_leaves"
 # on a 10_000-deep metadata nest and cannot reject it as ValueError.
 _JSON_MAX_DEPTH = 32
 _JSON_MAX_NODES = 4096
+# NumPy/JAX last-fit rank. Origin walked unbounded empty-leaf shape lists
+# during restore — hang, not leftover INT32 math.
+_MAX_ARRAY_RANK = 32
 
 
 def _is_empty_array(value: object) -> bool:
@@ -117,10 +120,15 @@ def _restore_empty_arrays(template: Any, restored: Any, manifest: object) -> Any
             raise ValueError("checkpoint empty array manifest is invalid")
         raw_shape = raw_spec["shape"]
         raw_dtype = raw_spec["dtype"]
+        if not _is_empty_array(expected) or type(raw_shape) is not list:
+            raise ValueError("checkpoint empty array leaf does not match the restore template")
+        if len(raw_shape) > _MAX_ARRAY_RANK:
+            raise ValueError(
+                "shape rank must be an integer in "
+                f"[0, {_MAX_ARRAY_RANK}]"
+            )
         if (
-            not _is_empty_array(expected)
-            or type(raw_shape) is not list
-            or any(type(dimension) is not int or dimension < 0 for dimension in raw_shape)
+            any(type(dimension) is not int or dimension < 0 for dimension in raw_shape)
             or type(raw_dtype) is not str
             or list(expected.shape) != raw_shape
             or str(expected.dtype) != raw_dtype

--- a/tests/test_checkpoint_empty_array_shape_rank_cap.py
+++ b/tests/test_checkpoint_empty_array_shape_rank_cap.py
@@ -1,0 +1,34 @@
+"""Reject oversized checkpoint empty-array shape ranks before walk hang."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.checkpoints import (
+    _MAX_ARRAY_RANK,
+    _restore_empty_arrays,
+)
+
+
+def test_checkpoint_empty_array_rank_cap_constant() -> None:
+    assert _MAX_ARRAY_RANK == 32
+
+
+def test_checkpoint_empty_array_accepts_max_rank() -> None:
+    template = {"x": jnp.empty((0,) * _MAX_ARRAY_RANK, dtype=jnp.float32)}
+    restored = {"x": jnp.zeros((1,), dtype=jnp.float32)}
+    manifest = [
+        {"shape": [0] * _MAX_ARRAY_RANK, "dtype": str(template["x"].dtype)},
+    ]
+    loaded = _restore_empty_arrays(template, restored, manifest)
+    assert loaded["x"].shape == (0,) * _MAX_ARRAY_RANK
+    assert loaded["x"].dtype == jnp.float32
+
+
+def test_checkpoint_empty_array_rejects_oversized_rank_before_dimension_walk() -> None:
+    template = {"x": jnp.empty((0,), dtype=jnp.float32)}
+    restored = {"x": jnp.zeros((1,), dtype=jnp.float32)}
+    manifest = [{"shape": [0] * (_MAX_ARRAY_RANK + 1), "dtype": "float32"}]
+    with pytest.raises(ValueError, match="shape rank"):
+        _restore_empty_arrays(template, restored, manifest)


### PR DESCRIPTION
## Summary

- **Fix:** Empty-array checkpoint restore walked `raw_shape` with no rank bound, so a legal-width but huge Python list hung in per-dimension type checks before the template comparison.
- Reject `len(raw_shape) > 32` after confirming an empty template leaf and an exact list. Rank 32 with matching zeros still restores. Non-list / nonempty-template mismatches keep the existing error.
- One source file + one test file. `checkpoints.py` is not a frozen evidence-registry source.

## Test plan

```text
<!-- evidence-head:072c007f3105c6a77ed60e2ae587d222fc8d49e6 -->
<!-- evidence-row:logs -->
- [x] logs: focused pytest + ruff on the touched files (see commands)
```

```bash
JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m ruff check \
  alberta_framework/core/checkpoints.py \
  tests/test_checkpoint_empty_array_shape_rank_cap.py
JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m pytest \
  tests/test_checkpoint_empty_array_shape_rank_cap.py \
  tests/test_checkpoints_validation.py -q -o addopts=""
# 15 passed
```

Validator-only Fix. No campaign shard, seed, or threshold was changed.

Source HEAD: `072c007f3105c6a77ed60e2ae587d222fc8d49e6`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0ME38T2FBN8ZCMW7B4NDMJ2","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T09:51:11.171Z","completed_at":"2026-08-22T10:12:55.477Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T09:51:11.774Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3520ca3ff34ecfc4c5427728457566951253279f13501ded44c733ee578b41d3","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"70d33698-b029-456b-abea-6500df2e5b06","object_id":"sha256:3520ca3ff34ecfc4c5427728457566951253279f13501ded44c733ee578b41d3","sha256":"3520ca3ff34ecfc4c5427728457566951253279f13501ded44c733ee578b41d3"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"9WRgRcXnlfiZ7SkdyvczhcypWOTxQwOIC0TTolTETB41qZeD4RDZ9ZTtmDM0uchx9Nd230Lr_xCX7OMQcD2XCg"}} -->
