### PR TITLE
fix(core): admit every numpy float family at the GVF reward gate

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -33,7 +33,7 @@ _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _INT32_MAX = 2**31 - 1
 _ACTUAL_REAL_SCALAR_TYPES = frozenset(
-    {float, np.float16, np.float32, np.float64, int}
+    {float, int, *(np.dtype(code).type for code in "efdg")}
 )
 
 _ACTUAL_INT_TYPES = frozenset(

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -406,6 +406,45 @@ class TestGVFSpecRemainingFields:
         )
         assert spec.terminal_reward == value
 
+    @pytest.mark.parametrize("code", list("efdg"))
+    def test_terminal_reward_accepts_every_numpy_float_family(self, code):
+        """Each numpy floating family narrows once and stores an exact float."""
+        value = np.dtype(code).type(1.5)
+        spec = GVFSpec(
+            name="d0",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=0,
+            terminal_reward=value,
+        )
+        assert spec.terminal_reward == 1.5
+        assert type(spec.terminal_reward) is float
+        restored = GVFSpec.from_config(
+            {
+                "name": "d0",
+                "demon_type": "prediction",
+                "gamma": 0.0,
+                "lamda": 0.0,
+                "cumulant_index": 0,
+                "terminal_reward": value,
+            }
+        )
+        assert restored.terminal_reward == 1.5
+
+    @pytest.mark.parametrize("code", list("efdg"))
+    def test_terminal_reward_accepts_what_the_discount_fields_accept(self, code):
+        """One spelling of a legal value must not pass one field and fail its sibling."""
+        value = np.dtype(code).type(0.5)
+        fields = {
+            "name": "d0",
+            "demon_type": DemonType.PREDICTION,
+            "lamda": 0.0,
+            "cumulant_index": 0,
+        }
+        assert GVFSpec(gamma=value, **fields).gamma == 0.5
+        assert GVFSpec(gamma=0.0, terminal_reward=value, **fields).terminal_reward == 0.5
+
     @pytest.mark.parametrize(
         "value",
         [float("nan"), float("inf"), float("-inf"), True, False, "0.0", None],


### PR DESCRIPTION
Fixes #2283.

## What was wrong

`GVFSpec.terminal_reward` is validated by an exact-type membership test,
`type(value) not in _ACTUAL_REAL_SCALAR_TYPES`
(`alberta_framework/core/types.py:776`). That set hand-enumerated
`float16`, `float32`, `float64` and omitted `np.longdouble`, so one dataclass
disagreed with itself about what a real number is:

```
terminal_reward=np.float16(1.5)     -> accepted, terminal_reward=1.5
terminal_reward=np.float32(1.5)     -> accepted, terminal_reward=1.5
terminal_reward=np.float64(1.5)     -> accepted, terminal_reward=1.5
terminal_reward=np.longdouble(1.5)  -> ValueError: terminal_reward must be a finite real number
gamma=np.longdouble(0.5)            -> accepted, gamma=0.5
lamda=np.longdouble(0.5)            -> accepted, lamda=0.5
```

`gamma` and `lamda` are checked by `_normalized_gvf_probability` (`:707`), whose
test is `issubclass(actual_type, Real)` at `:711` and therefore admits the
family. The value was also not rejected because it could not be handled: the
gate guards `validated_float32_scalar_with_ratio`, and the allowlist that helper
consults is already complete — `alberta_framework/_float32.py:26` builds
`_ACTUAL_FLOAT_TYPES` from the dtype codes `e`, `f`, `d`, `g`.
`round_real_to_float32(np.longdouble(1.5))` returns `1.5`, and
`tests/test_float32.py:59` already parametrizes `np.longdouble(-0.0)` as a
supported input.

Unlike the C-alias integer gap in #2268, this is not platform-specific.
`np.dtype("g").type is not np.dtype("d").type` whether long double is 8 bytes
(Windows, arm64 macOS) or 16 (Linux x86-64).

## What this changes

One right-hand side, using the idiom four lines below it in the same file:

```python
_ACTUAL_REAL_SCALAR_TYPES = frozenset({float, int, *(np.dtype(code).type for code in "efdg")})
```

The container, annotation, use site, and control flow are unchanged, and no
import moved. The gate stays an exact-type identity test, so the spoofed float
subclass in `tests/test_gvf_types.py:435` is still rejected, and the value
policies behind it still fire: an exact nonzero that would underflow to float32
zero is still refused, and non-finite values are still refused. Nothing
extended-precision can reach stored state — `_float32_scalars.py:189` stores
`value if type(value) is float else narrowed`, so a numpy scalar is stored as
its binary32 narrowing as a builtin `float`.

`git grep _ACTUAL_REAL_SCALAR_TYPES` returns exactly two hits, the definition
and that one membership test; nothing imports or re-exports it.

## Tests

Two parametrizations over all four families in `TestGVFSpecRemainingFields`:

- `test_terminal_reward_accepts_every_numpy_float_family` — each family narrows
  once and stores an exact builtin `float`, through both `GVFSpec` and
  `GVFSpec.from_config`.
- `test_terminal_reward_accepts_what_the_discount_fields_accept` — one spelling
  of a legal value cannot pass `gamma` and fail `terminal_reward`.

Failing-test-first, at `main` with the tests applied and the fix not:

```
FAILED tests/test_gvf_types.py::TestGVFSpecRemainingFields::test_terminal_reward_accepts_every_numpy_float_family[g]
FAILED tests/test_gvf_types.py::TestGVFSpecRemainingFields::test_terminal_reward_accepts_what_the_discount_fields_accept[g]
2 failed, 6 passed
```

The `e`, `f`, `d` parametrizations pass at `main`, which is the point: the
defect is exactly one family wide. With the fix, 8 passed.

No existing test asserted the old rejection. The only `longdouble` in
`tests/test_gvf_types.py` is at `:146`, and it travels the `gamma`/`lamda` path
where it is rejected on **value** for exceeding 1, not on type; it is still
rejected. The eight GVF and horde suites go from 251 passed at `main` to 259
passed here, the difference being exactly the eight added parametrizations.

## Scope

`alberta_framework/core/types.py` is not a registered evidence source.
Introspecting `EVIDENCE_SPECS` (`alberta_framework/evaluation/evidence_manifest.py:642`)
lists six `core` modules — `average_reward.py`, `ftl_world_model.py`,
`intelligence_amplification.py`, `interaction_features.py`, `oak.py`,
`options.py` — and this file is not among them. No pinned artifact is touched.

Two adjacent real-scalar gates admit `float64` only and are deliberately left
alone, because both carry a comment stating they preserve the acceptance of
"NumPy's concrete float64 scalar" from a historical `isinstance` gate, so
widening them restates a different intent:
`alberta_framework/benchmarks/forager_results.py:1609` and
`alberta_framework/benchmarks/forager.py:255`. They are described in #2283 for
whoever picks them up.

## Verification

Interpreter `.venv/Scripts/python.exe`, CPython 3.13.14, numpy 2.5.1, pytest
9.1.1, AMD64 Windows-11-10.0.22631. Head SHA
`0ff8523eddd32aaae9c9bdacbe43b228832484ae`, based on `origin/main`
`c9aba7b5`. The "at `main`" column was measured in a separate worktree checked
out at `origin/main`, because an editable-install `.pth` and pytest's rootdir
insertion can otherwise import the repaired package.

| check | at `main` | with this change |
| --- | --- | --- |
| float-bearing type allowlists admitting every numpy float family | 69 of 70 | 70 of 70 |
| the two new tests | 2 failed, 6 passed | 8 passed |
| `tests/test_gvf_types.py` | 108 passed | 116 passed |
| GVF and horde suites, 8 files | 251 passed | 259 passed |
| registered evidence sources modified | — | 0 |

The whole non-slow selection was then run in both trees,
`-m "not slow and not package" --continue-on-collection-errors`:

| | at `main` | with this change |
| --- | --- | --- |
| failed | 363 | 363 |
| passed | 14793 | 14801 |
| skipped / deselected | 53 / 1059 | 53 / 1059 |
| collection errors | 37 | 37 |

The two `FAILED` sets are identical — 363 node ids each, zero difference in
either direction — so **no test fails on this branch that passes at `main`**,
and none of the pre-existing failures is fixed or newly broken by this change.
The `ERROR` sets are the same 37 files. The `+8 passed` is the whole delta and
is exactly the eight added parametrizations: `14793 + 363 = 15156` at `main`
against `14801 + 363 = 15164` here.

The 37 collection errors are Windows-environment blockers with nothing to do
with this change, and identical in both trees: `No module named 'fcntl'`, POSIX
descriptor and permission requirements (`immutable output publication requires
Linux descriptor support`, `trust anchor key file must not be accessible to
group or other users`, `repository_root must be an exact absolute POSIX Path`),
Windows temp-directory `PermissionError`, and missing optional extras `joblib`
and `matplotlib`. A maintainer on Linux should see far fewer; the `FAILED`-set
comparison is the load-bearing result, not the absolute counts.

`ruff check` passes on both changed files and repository-wide.
`mypy alberta_framework` output is byte-for-byte identical before and after —
108 errors in 17 files, 224 source files, none in either changed file, all
pre-existing POSIX-only attribute lookups on Windows.
`ruff format --check` reports the identical verdict and the same 8 hunks in both
trees; the hunk covering this constant exists at `main` too and asks to collapse
it and its `_ACTUAL_INT_TYPES` neighbour onto one line, so I kept the file's
existing split form. CI does not run `ruff format`.

The inventory figure was measured by importing every module in the package and
inspecting each module-level container of types, deduplicated by object
identity: 216 modules imported, 8 not importable on Windows (six `fcntl`, two
benchmark output-root validation), 70 float-bearing containers, one omitting
`np.longdouble`.

Produced with claude-code / anthropic / claude-opus-5.

## Evidence

Captured locally, one recorded run per pull request: the pinned test is
executed first in a clean `origin/main` checkout at
`c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, then unchanged at this head
`0ff8523eddd32aaae9c9bdacbe43b228832484ae`. CPython 3.13.14, numpy 2.5.1, pytest 9.1 on AMD64
Windows-11-10.0.22631, where `np.longdouble` is a distinct real type from `np.float64`. Every line after a `PS>` prompt
in the capture is a real command in the tree named in its banner; the commit
each result belongs to is printed on screen by `git rev-parse HEAD`
immediately above it.

<!-- evidence-head:0ff8523eddd32aaae9c9bdacbe43b228832484ae -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: ![before-pr2292.png](https://github.com/user-attachments/assets/ff488861-26c4-4ec1-bfb4-9738c2aee20e) — the pull request's test at `origin/main` `c9aba7b5`: **2 failed, 6 passed, 108 deselected**

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: ![after-pr2292.png](https://github.com/user-attachments/assets/3bdb83e5-5a45-41e2-b863-60ec56044cec) — the identical test at this head: **8 passed, 108 deselected**

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video — one continuous recording of the whole before/after run, commands included:
  https://github.com/user-attachments/assets/270bd1a2-ba46-44e1-a546-ff1dc04a68ff

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [backend-logs-pr2292.txt](https://github.com/user-attachments/files/31366728/backend-logs-pr2292.txt) — complete pytest stdout and stderr from both trees

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - this change is a Python library gate with no browser surface`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - the changed path performs no model call, so no trajectory exists`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [domain-artifact-pr2292.json](https://github.com/user-attachments/files/31366732/domain-artifact-pr2292.json) — machine-readable per-surface admission matrix measured in both trees

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [claude-opus-5-w1]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0M9ZHPNTK4QQ36R4FGCKRZS","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T08:39:14.901Z","completed_at":"2026-08-22T10:24:18.168Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T08:39:18.034Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c84e443572958fd7d21324c130457f6c27c2b255748f930efc0fcdd38da397a7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4cfacad9-1c6a-4b14-ab8f-f2ab91d4d682","object_id":"sha256:c84e443572958fd7d21324c130457f6c27c2b255748f930efc0fcdd38da397a7","sha256":"c84e443572958fd7d21324c130457f6c27c2b255748f930efc0fcdd38da397a7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"jkB131rksKILkNDNKcHVtTooQs08E-ARUWPkInP4MRcwQ0C-HqjSpfNXLWwNGjof5Opgdh1ToVEfqUddvtXWBQ"}} -->
