### PR TITLE
fix(core): cap FeatureBankRouter consumer leaves before walk hang

### DIFF
--- a/alberta_framework/core/feature_bank_router.py
+++ b/alberta_framework/core/feature_bank_router.py
@@ -40,6 +40,9 @@ from jaxtyping import Bool, Int
 CONFIG_SCHEMA_VERSION = "alberta.feature_bank_router.config.v1"
 INACTIVE_DESCRIPTOR = (-1, -1)
 _INT32_MAX = 2**31 - 1
+# Public last-fit is a small consumer PyTree. Origin flattened then walked
+# unbounded leaves before leftover INT32 math — hang, not a width overflow.
+_MAX_CONSUMER_LEAVES = 4_096
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -522,6 +525,11 @@ class FeatureBankRouter:
         leaves, tree_definition = jax.tree_util.tree_flatten(consumers)
         if not leaves:
             raise ValueError("consumers must contain at least one array leaf")
+        if len(leaves) > _MAX_CONSUMER_LEAVES:
+            raise ValueError(
+                "consumer leaf count must be an integer in "
+                f"[1, {_MAX_CONSUMER_LEAVES}]"
+            )
         if feature_axes is None:
             raw_axes = [-1] * len(leaves)
         else:

--- a/tests/test_feature_bank_router_leaf_count_cap.py
+++ b/tests/test_feature_bank_router_leaf_count_cap.py
@@ -1,0 +1,37 @@
+"""Reject oversized FeatureBankRouter consumer PyTrees before leaf-walk hang."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.core.feature_bank_router import (
+    _MAX_CONSUMER_LEAVES,
+    FeatureBankRouter,
+    FeatureBankRouterConfig,
+)
+
+
+def _router() -> FeatureBankRouter:
+    return FeatureBankRouter(FeatureBankRouterConfig(base_dim=2, active_slots=1))
+
+
+def test_feature_bank_router_leaf_cap_constant() -> None:
+    assert _MAX_CONSUMER_LEAVES == 4096
+
+
+def test_feature_bank_router_accepts_max_consumer_leaves() -> None:
+    width = _router()._config.total_feature_dim
+    consumers = tuple(np.zeros((width,), dtype=np.float32) for _ in range(_MAX_CONSUMER_LEAVES))
+    arrays, _, axes = _router()._consumer_layout(consumers, None)
+    assert len(arrays) == _MAX_CONSUMER_LEAVES
+    assert axes == (0,) * _MAX_CONSUMER_LEAVES
+
+
+def test_feature_bank_router_rejects_oversized_consumer_leaves() -> None:
+    width = _router()._config.total_feature_dim
+    consumers = tuple(
+        np.zeros((width,), dtype=np.float32) for _ in range(_MAX_CONSUMER_LEAVES + 1)
+    )
+    with pytest.raises(ValueError, match="consumer leaf count"):
+        _router()._consumer_layout(consumers, None)


### PR DESCRIPTION
## Summary

- **Fix:** `FeatureBankRouter._consumer_layout` flattened an arbitrary consumer PyTree and walked every leaf with no count bound, so a legal-width but huge tuple hung before leftover INT32 math.
- Reject `len(leaves) > 4096` after nonempty flatten and before axis walks. Last-fit 4096 still routes. Empty consumers still fail the existing check.
- One source file + one test file. Not a frozen evidence-registry source and not on #2272/#2275.

## Test plan

```text
<!-- evidence-head:08030c469af08a84c2f58b89ac566084c3a47ab9 -->
<!-- evidence-row:logs -->
- [x] logs: focused pytest + ruff on the touched files (see commands)
```

```bash
JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m ruff check \
  alberta_framework/core/feature_bank_router.py \
  tests/test_feature_bank_router_leaf_count_cap.py
JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m pytest \
  tests/test_feature_bank_router_leaf_count_cap.py \
  tests/test_feature_bank_router_int_hostile.py -q -o addopts=""
# 5 passed
```

Validator-only Fix. No campaign shard, seed, or threshold was changed.

Source HEAD: `08030c469af08a84c2f58b89ac566084c3a47ab9`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0MGBDSQCQS9TX69M11MSX23","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T10:30:35.576Z","completed_at":"2026-08-22T10:42:28.403Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T10:30:36.191Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"6f5c422f560dfdd85ba544f747ab9066e1b06dfddc30419ad4c525873ec9bb82","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"6a8cc612-e1c0-4561-a496-94b29cf7d99a","object_id":"sha256:6f5c422f560dfdd85ba544f747ab9066e1b06dfddc30419ad4c525873ec9bb82","sha256":"6f5c422f560dfdd85ba544f747ab9066e1b06dfddc30419ad4c525873ec9bb82"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"hHMEezoGegJ_INRTZFJVR9v8Ikll25-1G2B7gs6pZa6fejToxeD1cL53m-XuCHtSw1BMLphjxpOthLKeiUnzBA"}} -->
