### PR TITLE
fix(core): cap policy-archive latent width before value-walk hang

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -13,7 +13,9 @@ _MAX_ARCHIVE_BYTES = 256 * 1024 * 1024
 _MAX_ARCHIVE_ENTRIES = 4096
 _MAX_IDENTITY_CHARACTERS = 1024
 _MAX_POLICY_BYTES = 64 * 1024 * 1024
-_MAX_LATENT_WIDTH = 65_536
+# Public last-fit is a compact latent descriptor. Origin walked 65_536
+# floats in PolicyEntry validation — hang, not leftover INT32 math.
+_MAX_LATENT_WIDTH = 4_096
 
 POLICY_ARCHIVE_PROTOCOL = MappingProxyType(
     {
@@ -59,12 +61,13 @@ class PolicyEntry:
             or len(self.policy_bytes) > _MAX_POLICY_BYTES
         ):
             raise ValueError("policy_bytes must be non-empty exact bytes")
-        if (
-            type(self.latent) is not tuple
-            or not self.latent
-            or len(self.latent) > _MAX_LATENT_WIDTH
-        ):
+        if type(self.latent) is not tuple or not self.latent:
             raise ValueError("latent must be a non-empty tuple")
+        if len(self.latent) > _MAX_LATENT_WIDTH:
+            raise ValueError(
+                "latent length must be an integer in "
+                f"[1, {_MAX_LATENT_WIDTH}]"
+            )
         if any(type(value) is not float or not math.isfinite(value) for value in self.latent):
             raise ValueError("latent values must be finite floats")
         if type(self.score) is not float or not math.isfinite(self.score):

--- a/tests/test_policy_archive_latent_width_cap.py
+++ b/tests/test_policy_archive_latent_width_cap.py
@@ -1,0 +1,26 @@
+"""Reject oversized policy-archive latents before per-element walk hang."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.policy_archive import (
+    _MAX_LATENT_WIDTH,
+    PolicyEntry,
+)
+
+
+def test_policy_archive_latent_width_cap_constant() -> None:
+    assert _MAX_LATENT_WIDTH == 4096
+
+
+def test_policy_archive_accepts_max_latent_width() -> None:
+    latent = tuple(0.0 for _ in range(_MAX_LATENT_WIDTH))
+    entry = PolicyEntry(identity="a", policy_bytes=b"abcd", latent=latent, score=1.0)
+    assert len(entry.latent) == _MAX_LATENT_WIDTH
+
+
+def test_policy_archive_rejects_oversized_latent_before_value_walk() -> None:
+    latent = tuple(0.0 for _ in range(_MAX_LATENT_WIDTH + 1))
+    with pytest.raises(ValueError, match="latent length"):
+        PolicyEntry(identity="a", policy_bytes=b"abcd", latent=latent, score=1.0)


### PR DESCRIPTION
## Summary

- **Fix:** `PolicyEntry` accepted latent tuples up to 65,536 floats, then walked every element. A last-fit-width list hung in per-value type checks.
- Reject `len(latent) > 4096` after the nonempty exact-tuple check and before the float walk. Last-fit 4096 still constructs. Empty/non-tuple latents keep the existing error.
- One source file + one test file. Not a frozen evidence-registry source and not on #2272/#2275.

## Test plan

```text
<!-- evidence-head:ff5fb3da0c5279cdf39fc136a400773b6e7baca7 -->
<!-- evidence-row:logs -->
- [x] logs: focused pytest + ruff on the touched files (see commands)
```

```bash
JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m ruff check \
  alberta_framework/core/policy_archive.py \
  tests/test_policy_archive_latent_width_cap.py tests/test_policy_archive.py
JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m pytest \
  tests/test_policy_archive_latent_width_cap.py tests/test_policy_archive.py \
  -q -o addopts=""
# 9 passed
```

Validator-only Fix. No campaign shard, seed, or threshold was changed.

Source HEAD: `ff5fb3da0c5279cdf39fc136a400773b6e7baca7`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0MJS2TMJ2N0TAFW84VVZE1T","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T11:13:00.244Z","completed_at":"2026-08-22T11:19:46.937Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T11:13:00.822Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4e19466fc733fe4b3fd4a3775f1ce54d4a47a43b2db20bd4bf71bacd7c6962f9","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"df8e9d47-ee63-4f7a-add6-70d0b433b441","object_id":"sha256:4e19466fc733fe4b3fd4a3775f1ce54d4a47a43b2db20bd4bf71bacd7c6962f9","sha256":"4e19466fc733fe4b3fd4a3775f1ce54d4a47a43b2db20bd4bf71bacd7c6962f9"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"5XOgOS6Z3uDA_kbLw7BtWmxoHX9ZAUZKIhwJOnGbTP5VsSicCfeq5ieMM7FkB5opEidNnCY7OHa4SZyyhYlNAQ"}} -->
