### PR TITLE
Fix JSON text nesting preflight walking unbounded host strings

### DIFF
--- a/alberta_framework/_bounded_containers.py
+++ b/alberta_framework/_bounded_containers.py
@@ -13,6 +13,10 @@ from collections.abc import Callable, Iterable, Iterator
 
 ContainerChildren = Callable[[object], Iterable[object] | None]
 
+# Match the 16 MiB JSON byte last-fit used by `_strict_json` and checkpoint
+# codecs so this scanner cannot walk an arbitrarily large host string.
+_MAX_JSON_TEXT_CHARS = 16 * 1024 * 1024
+
 
 def require_bounded_container_tree(
     root: object,
@@ -89,6 +93,10 @@ def require_json_text_nesting(
         raise ValueError("max_depth must be a positive exact integer")
     if type(name) is not str or not name:
         raise ValueError("name must be a non-empty exact string")
+    if len(text) > _MAX_JSON_TEXT_CHARS:
+        raise ValueError(
+            f"{name} length must be an integer in [0, {_MAX_JSON_TEXT_CHARS}]"
+        )
 
     depth = 0
     in_string = False

--- a/tests/test_bounded_containers.py
+++ b/tests/test_bounded_containers.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import pytest
 
 from alberta_framework._bounded_containers import (
+    _MAX_JSON_TEXT_CHARS,
     require_bounded_container_tree,
     require_json_text_nesting,
 )
@@ -63,6 +64,21 @@ def test_tree_preflight_rejects_cycle_depth_and_node_budget() -> None:
             name="payload",
             kind="JSON",
         )
+
+
+def test_json_text_scanner_rejects_oversized_host_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _MAX_JSON_TEXT_CHARS == 16 * 1024 * 1024
+    monkeypatch.setattr(
+        "alberta_framework._bounded_containers._MAX_JSON_TEXT_CHARS", 8
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"payload length must be an integer in \[0, 8\]",
+    ):
+        require_json_text_nesting("[" * 9, max_depth=3, name="payload")
+    require_json_text_nesting("[]", max_depth=3, name="payload")
 
 
 def test_json_text_scanner_ignores_brackets_inside_escaped_strings() -> None:


### PR DESCRIPTION
## Summary
- `require_json_text_nesting` scanned every character of a host string with no length last-fit, so an oversized JSON blob could hang the preflight that exists to bound nesting.
- Cap the scan at `16 * 1024 * 1024` characters, matching the 16 MiB JSON last-fit already used by `_strict_json` and the reference-life checkpoint codec.
- Reject oversized input before the bracket walk; keep the existing string-escape nesting behavior.

## Test plan
- [x] `ruff check` on the two touched files
- [x] `pytest tests/test_bounded_containers.py` (CPU JAX)
- [ ] CI on this PR

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0MKMXBHGT6T5J6P09F9ME5F","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T11:28:12.146Z","completed_at":"2026-08-22T11:42:28.567Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T11:28:12.987Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ac0ad906a4f7e7154272bbf252e4348332965b4d01668fab9f7f4d918d07c07f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"548cba29-3b73-43cb-8c2f-8b82151b0240","object_id":"sha256:ac0ad906a4f7e7154272bbf252e4348332965b4d01668fab9f7f4d918d07c07f","sha256":"ac0ad906a4f7e7154272bbf252e4348332965b4d01668fab9f7f4d918d07c07f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"erxVonmlbm6hMWO7A0EvQvDhctSzz2NDxt74LYxQMmp9ZSgNFeFneBmpj7R1d0bG0suSf5Mgtc6mzQ3BRs_MBA"}} -->
