### PR TITLE
Fix ArrayValue and SpaceSpec walking unbounded shape rank

### DIFF
--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -383,14 +383,14 @@ class ArrayValue:
             raise ValueError(f"unsupported dtype '{host_dtype}'") from exc
         if dtype.name not in _SUPPORTED_DTYPES or dtype.name != self.dtype:
             raise ValueError("ArrayValue dtype must be a portable canonical numeric dtype")
-        if type(self.shape) is not tuple or any(
-            type(dimension) is not int or dimension <= 0 for dimension in self.shape
-        ):
+        if type(self.shape) is not tuple:
+            raise ValueError("ArrayValue shape must be a tuple of positive dimensions or ()")
+        if len(self.shape) > _MAX_ARRAY_RANK:
+            raise ValueError(f"ArrayValue rank must be <= {_MAX_ARRAY_RANK}")
+        if any(type(dimension) is not int or dimension <= 0 for dimension in self.shape):
             raise ValueError("ArrayValue shape must be a tuple of positive dimensions or ()")
         if not isinstance(self.payload, bytes):
             raise ValueError("ArrayValue payload must be immutable bytes")
-        if len(self.shape) > _MAX_ARRAY_RANK:
-            raise ValueError(f"ArrayValue rank must be <= {_MAX_ARRAY_RANK}")
         elements = _shape_size(self.shape)
         if elements > _MAX_ARRAY_ELEMENTS:
             raise ValueError(f"ArrayValue must contain <= {_MAX_ARRAY_ELEMENTS} elements")
@@ -439,9 +439,11 @@ class SpaceSpec:
 
     def __post_init__(self) -> None:
         _require_safe_id(self.semantic_id, name="semantic_id")
-        if type(self.shape) is not tuple or any(
-            type(dimension) is not int or dimension <= 0 for dimension in self.shape
-        ):
+        if type(self.shape) is not tuple:
+            raise ValueError("shape must be a tuple of positive integer dimensions or ()")
+        if len(self.shape) > _MAX_ARRAY_RANK:
+            raise ValueError(f"space rank must be <= {_MAX_ARRAY_RANK}")
+        if any(type(dimension) is not int or dimension <= 0 for dimension in self.shape):
             raise ValueError("shape must be a tuple of positive integer dimensions or ()")
         host_dtype = _require_exact_str("dtype", self.dtype)
         try:
@@ -453,8 +455,6 @@ class SpaceSpec:
         if dtype.name != self.dtype:
             host_canonical = _require_exact_str("dtype.name", dtype.name)
             raise ValueError(f"dtype must use canonical spelling '{host_canonical}'")
-        if len(self.shape) > _MAX_ARRAY_RANK:
-            raise ValueError(f"space rank must be <= {_MAX_ARRAY_RANK}")
         if _shape_size(self.shape) > _MAX_ARRAY_ELEMENTS:
             raise ValueError(f"space must contain <= {_MAX_ARRAY_ELEMENTS} elements")
 

--- a/tests/test_reference_agent_array_rank_cap.py
+++ b/tests/test_reference_agent_array_rank_cap.py
@@ -1,0 +1,36 @@
+"""ArrayValue and SpaceSpec reject oversized rank before walking axes."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from alberta_framework.reference_agent import _MAX_ARRAY_RANK, ArrayValue, SpaceSpec
+
+pytestmark = pytest.mark.unit
+
+
+def test_array_value_rejects_oversized_rank_before_axis_walk() -> None:
+    assert _MAX_ARRAY_RANK == 8
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="ArrayValue rank must be <= 8"):
+        ArrayValue(
+            semantic_id="a.b",
+            dtype="float32",
+            shape=(1,) * (_MAX_ARRAY_RANK + 1),
+            payload=b"",
+        )
+    assert time.perf_counter() - started < 0.25
+
+
+def test_space_spec_rejects_oversized_rank_before_axis_walk() -> None:
+    started = time.perf_counter()
+    with pytest.raises(ValueError, match="space rank must be <= 8"):
+        SpaceSpec(
+            kind="box",
+            shape=(1,) * (_MAX_ARRAY_RANK + 1),
+            dtype="float32",
+            semantic_id="a.b",
+        )
+    assert time.perf_counter() - started < 0.25

--- a/tests/test_reference_agent_array_rank_cap.py
+++ b/tests/test_reference_agent_array_rank_cap.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import time
-
 import pytest
 
 from alberta_framework.reference_agent import _MAX_ARRAY_RANK, ArrayValue, SpaceSpec
@@ -13,24 +11,20 @@ pytestmark = pytest.mark.unit
 
 def test_array_value_rejects_oversized_rank_before_axis_walk() -> None:
     assert _MAX_ARRAY_RANK == 8
-    started = time.perf_counter()
     with pytest.raises(ValueError, match="ArrayValue rank must be <= 8"):
         ArrayValue(
             semantic_id="a.b",
             dtype="float32",
-            shape=(1,) * (_MAX_ARRAY_RANK + 1),
+            shape=(0,) + (1,) * _MAX_ARRAY_RANK,
             payload=b"",
         )
-    assert time.perf_counter() - started < 0.25
 
 
 def test_space_spec_rejects_oversized_rank_before_axis_walk() -> None:
-    started = time.perf_counter()
     with pytest.raises(ValueError, match="space rank must be <= 8"):
         SpaceSpec(
             kind="box",
-            shape=(1,) * (_MAX_ARRAY_RANK + 1),
+            shape=(0,) + (1,) * _MAX_ARRAY_RANK,
             dtype="float32",
             semantic_id="a.b",
         )
-    assert time.perf_counter() - started < 0.25


### PR DESCRIPTION
## Summary
- `ArrayValue` and `SpaceSpec` walked every axis with `any(...)` before the existing rank last-fit (`_MAX_ARRAY_RANK = 8`), so a huge host tuple could hang the constructor.
- Check `type` and `len` first, then validate dimensions. `SpaceSpec.box` already rejected oversized rank; the dataclass constructor now matches.
- Keep the existing rank-8 ceiling; this is fail-closed ordering, not a new bound.

## Test plan
- [x] `ruff check` on the two touched files
- [x] `pytest tests/test_reference_agent_array_rank_cap.py tests/test_reference_agent_box_bounds_hang.py tests/test_reference_agent_hostile_validation.py` (CPU JAX)
- [ ] CI on this PR

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0MN6C63NK1898G7SCAJHKPA","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T11:55:12.964Z","completed_at":"2026-08-22T12:49:53.013Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T11:55:14.140Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"69931780108d099259b460f80cf88d71f19f9a1a1991bdff5b117de98402f8ca","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"046578ef-db6f-48b9-aa49-4c589ddbf361","object_id":"sha256:69931780108d099259b460f80cf88d71f19f9a1a1991bdff5b117de98402f8ca","sha256":"69931780108d099259b460f80cf88d71f19f9a1a1991bdff5b117de98402f8ca"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"wUQjbxI-75JOZL8n_dDam4pCGz1Jy-U0Cfm4iWaUZcBgnwCE8uiwiTArp3EH9p8skyKGeJYqKreEeJ-hdQq2Ag"}} -->
