### PR TITLE
Fix SIGReg walking unbounded host-list width before asarray

### DIFF
--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -42,6 +42,7 @@ from alberta_framework.core._float32_scalars import validated_float32_scalar
 _INT32_MAX = 2**31 - 1
 # Origin ``jnp.asarray`` still accepts depth 64 and RecursionErrors at 10_000.
 _MAX_ARRAY_NESTING_DEPTH = 64
+_MAX_HOST_ARRAY_CONTAINER_ITEMS = 4096
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -244,7 +245,12 @@ def _require_host_array_nesting(value: object, *, name: str) -> None:
     """Reject cycles and nesting that RecursionError ``jnp.asarray``."""
     def children(node: object) -> list[Any] | tuple[Any, ...] | None:
         if type(node) in (list, tuple):
-            return cast(list[Any] | tuple[Any, ...], node)
+            sequence = cast(list[Any] | tuple[Any, ...], node)
+            if len(sequence) > _MAX_HOST_ARRAY_CONTAINER_ITEMS:
+                raise ValueError(
+                    f"{name} length must be an integer in [0, {_MAX_HOST_ARRAY_CONTAINER_ITEMS}]"
+                )
+            return sequence
         return None
 
     require_bounded_container_tree(

--- a/tests/test_sigreg_host_array_width.py
+++ b/tests/test_sigreg_host_array_width.py
@@ -1,0 +1,41 @@
+"""Reject wide host arrays before SIGReg walks them for jnp.asarray."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from alberta_framework.core.sigreg import (
+    _MAX_HOST_ARRAY_CONTAINER_ITEMS,
+    _asarray_float32,
+    epps_pulley_gaussian_statistic,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_wide_host_list_rejects_before_asarray(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _MAX_HOST_ARRAY_CONTAINER_ITEMS == 4096
+    calls: list[int] = []
+
+    def spy(value: object, dtype: object = None) -> Any:
+        calls.append(1)
+        raise AssertionError("jnp.asarray must not run on oversized host lists")
+
+    monkeypatch.setattr("alberta_framework.core.sigreg.jnp.asarray", spy)
+    with pytest.raises(
+        ValueError,
+        match=r"samples length must be an integer in \[0, 4096\]",
+    ):
+        epps_pulley_gaussian_statistic(
+            cast(Any, [0.0] * (_MAX_HOST_ARRAY_CONTAINER_ITEMS + 1))
+        )
+    assert calls == []
+
+
+def test_last_fit_host_list_still_converts() -> None:
+    array = _asarray_float32(
+        [0.0] * _MAX_HOST_ARRAY_CONTAINER_ITEMS, name="samples"
+    )
+    assert array.shape == (_MAX_HOST_ARRAY_CONTAINER_ITEMS,)


### PR DESCRIPTION
## Summary
- SIGReg already rejected deep and cyclic host nests, but a length-1e7 list still walked every item before `jnp.asarray`.
- Fail closed at 4096 exact list/tuple items in the nesting preflight (`len` is O(1)), matching other host-collection last-fits.
- Depth-64 last-fit and cycle checks are unchanged.

## Test plan
- [x] `ruff check` on the two touched files
- [x] `pytest tests/test_sigreg_host_array_width.py tests/test_sigreg_host_array_depth.py` (CPU JAX)
- [ ] CI on this PR

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: spacexai / Cursor-Grok-4.6
Client / agent tooling: cursor
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [cursor-grok-4-6]
<!-- slop-contribution-attribution:v1 {"provider":"spacexai","model":"Cursor-Grok-4.6","client":"cursor","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0MRCB098REFHSAPXDB5HTTC","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T12:50:54.090Z","completed_at":"2026-08-23T02:23:40.038Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T12:50:54.936Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ffd51556afd59c64a8fcb80e7e5aa346dafe4001c4d1f9f70324670ca6d29181","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"44c47fab-4f6f-4da5-9bff-f8443387b2d3","object_id":"sha256:ffd51556afd59c64a8fcb80e7e5aa346dafe4001c4d1f9f70324670ca6d29181","sha256":"ffd51556afd59c64a8fcb80e7e5aa346dafe4001c4d1f9f70324670ca6d29181"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEARIERQaUpo5_ZmX7M4V1ncQDKjtDI2V_0CDRlM8ClTkk","device_key_id":"2fab4898afc5c534ce1e0c96922cc825a99e6b721189bcd8153f88a15ae09cd2","device_signature":"Nr_nRvISJsn5tpoVTkbSbyMJB3AgyhCYV5THuqueoi0ZKUGkFfktO1taRvsWHL6_lV22bCQNStPMMhOiuL8fBg"}} -->
