### PR TITLE
fix(benchmarks): admit every numpy integer family at two exact-type gates

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -59,15 +59,8 @@ CAUSAL_MAP_VARIANT_KIND = "alberta_causal_map"
 _CAUSAL_MAP_RNG_NAMESPACE = 0xCA05A14
 _CAUSAL_MAP_PRNG_IMPL = "threefry2x32"
 _CAUSAL_MAP_ENVIRONMENT_PRNG_IMPL = "threefry2x32"
-_EXACT_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
+_EXACT_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 _EXACT_INTEGER_TYPES = (int, *_EXACT_NUMPY_INTEGER_TYPES)
 _EXACT_REAL_TYPES = (

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -43,17 +43,8 @@ _MAX_RUN_STEPS = 1_000_000
 _PRNG_IMPLEMENTATION = "threefry2x32"
 _PAIR_RESULT_SCHEMA = "asi.ipmnist.gradual-input-pair.result.v1"
 _ADAMW_IDENTITY = tuple(sorted(ADAMW_PROTOCOL_HYPERPARAMETERS.items()))
-_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.longlong,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.ulonglong,
+_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 
 GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(

--- a/tests/test_benchmark_integer_family_gates.py
+++ b/tests/test_benchmark_integer_family_gates.py
@@ -1,0 +1,101 @@
+"""Every numpy integer family reaching the two benchmark exact-type index gates.
+
+``ipmnist_gradual._NUMPY_INTEGER_TYPES`` and
+``causal_map_forager._EXACT_NUMPY_INTEGER_TYPES`` are the allowlists behind
+``GradualTransitionConfig``, ``transition_alpha``, ``output_interpolation``,
+``task_sampling_mask``, ``CausalMapForagerConfig`` and
+``CausalMapForagerAgent``.  Both enumerated fixed-width names, so wherever
+numpy's C aliases are distinct type objects -- 64-bit Windows, where
+``np.intc is np.int32`` is False -- a valid C ``int`` was rejected by these
+gates while every other spelling of the same width passed.  Neither constant is
+spelled ``_ACTUAL_INT_TYPES``, so no sweep over that name reaches them.
+
+The parametrization is over dtype codes rather than fixed-width names so the
+contract is stated on every platform, not only the one that exposed the gap.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.causal_map_forager import (
+    CausalMapForagerAgent,
+    CausalMapForagerConfig,
+)
+from alberta_framework.benchmarks.ipmnist_gradual import (
+    GradualTransitionConfig,
+    output_interpolation,
+    task_sampling_mask,
+    transition_alpha,
+)
+
+pytestmark = pytest.mark.unit
+
+_INTEGER_DTYPE_CODES = ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
+
+
+def test_dtype_codes_enumerate_every_distinct_integer_family() -> None:
+    """The parametrization must be an enumeration, not a hand-kept list of names."""
+    families = tuple(np.dtype(code).type for code in _INTEGER_DTYPE_CODES)
+    assert len(set(families)) == len(families)
+    assert set(families) == {np.dtype(code).type for code in "bBhHiIlLqQpP"}
+
+
+@pytest.mark.parametrize("code", _INTEGER_DTYPE_CODES)
+def test_gradual_index_arguments_accept_every_numpy_integer_family(code: str) -> None:
+    integer = np.dtype(code).type
+
+    config = GradualTransitionConfig(mode="task_sampling", transition_steps=integer(4))
+    assert type(config.transition_steps) is int
+    assert config.transition_steps == 4
+    assert transition_alpha(integer(2), config) == 0.5
+
+    np.testing.assert_array_equal(
+        output_interpolation(integer(0), integer(1), 0.25, n_classes=integer(3)),
+        output_interpolation(0, 1, 0.25, n_classes=3),
+    )
+    np.testing.assert_array_equal(
+        task_sampling_mask(seed=0, transition_id=integer(0), count=integer(4), alpha=0.5),
+        task_sampling_mask(seed=0, transition_id=0, count=4, alpha=0.5),
+    )
+
+
+@pytest.mark.parametrize("code", _INTEGER_DTYPE_CODES)
+def test_causal_map_scalars_accept_every_numpy_integer_family(code: str) -> None:
+    integer = np.dtype(code).type
+
+    config = CausalMapForagerConfig(
+        initial_retry_delay=integer(1),
+        maximum_retry_exponent=integer(0),
+        maximum_exact_interval_width=integer(0),
+        visit_penalty=integer(0),
+    )
+    assert type(config.initial_retry_delay) is int
+    assert type(config.maximum_retry_exponent) is int
+    assert type(config.maximum_exact_interval_width) is int
+    assert type(config.visit_penalty) is float
+
+    agent = CausalMapForagerAgent(seed=integer(3))
+    assert type(agent.seed) is int
+    assert agent.seed == 3
+
+
+def test_widened_families_do_not_soften_the_exact_type_gates() -> None:
+    """Admitting every family must not admit a subclass, a bool, or a float."""
+
+    class ForgedInt(np.int64):
+        def __index__(self) -> int:
+            raise AssertionError("must not execute")
+
+    with pytest.raises(ValueError, match="integer"):
+        GradualTransitionConfig(
+            mode="task_sampling",
+            transition_steps=ForgedInt(4),  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="integer"):
+        GradualTransitionConfig(mode="task_sampling", transition_steps=True)
+    with pytest.raises(ValueError, match="initial_retry_delay"):
+        CausalMapForagerConfig(initial_retry_delay=ForgedInt(1))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="initial_retry_delay"):
+        CausalMapForagerConfig(initial_retry_delay=np.float64(1.0))  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #2295.

Two exact-type integer allowlists in `benchmarks/` were spelled as fixed-width
names, and four fixed-width names cannot cover five numpy integer families. Nine
public entry points across the two modules rejected a valid numpy integer that
every sibling spelling of the same width accepted.

| allowlist | form at `main` | families admitted |
| --- | --- | --- |
| `benchmarks/ipmnist_gradual.py:46` `_NUMPY_INTEGER_TYPES` | 10 fixed-width names + `longlong`/`ulonglong` | 8 of 10 |
| `benchmarks/causal_map_forager.py:62` `_EXACT_NUMPY_INTEGER_TYPES` | 8 fixed-width names | 8 of 10 |

Head: `355597a6d9c03366a6ceed9796968e6db9771ae7`

## The counting argument

numpy exposes five signed C integer scalar types (`b h i l q`) and only four
fixed-width signed aliases, so on every platform exactly one signed family has no
fixed-width name, and the same for unsigned:

```
signed C scalar types (b h i l q)  : 5  ['int8', 'int16', 'int32', 'int64', 'intc']
signed fixed-width names           : 4  ['int8', 'int16', 'int32', 'int64']
signed family with no such name    : intc          (unsigned: uintc)
```

Which family is unnamed is the ABI's choice. Here `np.dtype("l").type is
np.int32` and `np.intc is np.int32` is False, so C `int` is the orphan; where C
`long` is 64 bits, `np.int64` binds to `l` and `np.longlong` is the orphan
instead. `ipmnist_gradual` lists `longlong`/`ulonglong` by name, which closes the
gap on the second ABI and leaves it open on the first; `causal_map_forager`
lists neither, so its gate is short a family on both.

## Reproduction

CPython 3.13.14, numpy 2.5.1, AMD64 Windows-11-10.0.22631, `origin/main` @
`c9aba7b5`. Each cell constructs the surface with one numpy integer family.

```
surface                                              int8   uint8  int16  uint16 intc   uintc  int32  uint32 int64  uint64
ipmnist  GradualTransitionConfig(transition_steps)    ok     ok     ok     ok     REJECT REJECT ok     ok     ok     ok
ipmnist  transition_alpha(step)                       ok     ok     ok     ok     REJECT REJECT ok     ok     ok     ok
ipmnist  output_interpolation(old,new,n_classes)      ok     ok     ok     ok     REJECT REJECT ok     ok     ok     ok
ipmnist  task_sampling_mask(transition_id,count)      ok     ok     ok     ok     REJECT REJECT ok     ok     ok     ok
causal   Config(initial_retry_delay)                  ok     ok     ok     ok     REJECT REJECT ok     ok     ok     ok
causal   Config(maximum_retry_exponent)               ok     ok     ok     ok     REJECT REJECT ok     ok     ok     ok
causal   Config(maximum_exact_interval_width)         ok     ok     ok     ok     REJECT REJECT ok     ok     ok     ok
causal   Config(visit_penalty)  [real gate]           ok     ok     ok     ok     REJECT REJECT ok     ok     ok     ok
causal   Agent(seed)                                  ok     ok     ok     ok     REJECT REJECT ok     ok     ok     ok

ValueError rejections across 9 surfaces x 10 families:  18   at c9aba7b5
                                                         0   on this branch
```

Two lines of it, standalone:

```python
import numpy as np
from alberta_framework.benchmarks.causal_map_forager import CausalMapForagerConfig

CausalMapForagerConfig(initial_retry_delay=np.int32(1))  # -> 1
CausalMapForagerConfig(initial_retry_delay=np.intc(1))   # -> ValueError at c9aba7b5
```

Nothing was rejected because it could not be handled: every one of these gates
normalizes with `operator.index` or `int()` immediately afterwards, and
`np.intc` satisfies both.

## The change

Two right-hand sides. Both become the dtype-code enumeration that the sibling
benchmark `benchmarks/upgd_ipmnist.py:288`, the same-directory
`benchmarks/forager.py:212` and the tuple-shaped `core/normalizers.py:92`
already use:

```python
_NUMPY_INTEGER_TYPES = tuple(
    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
)
```

Ten codes rather than the twelve `core/types.py:40` uses, because these
containers are tuples: `p` and `P` are pointer-width aliases of a family
`bhilq`/`BHILQ` already names, so in a `frozenset` they collapse and in a tuple
they would be duplicate entries. Measured, both forms yield the same 10 distinct
types.

The containers, annotations, use sites and control flow are untouched, so both
gates remain exact-type identity tests. `ipmnist_gradual` keeps
`any(actual_type is allowed for allowed in ...)` in `_exact_index`, which is what
makes `tests/test_ipmnist_gradual.py:59` pass: a forged `np.int64` subclass and a
hostile metaclass are still rejected without invoking `__index__`, type `__eq__`
or `__hash__`.

## Tests

`tests/test_benchmark_integer_family_gates.py`, 22 cases: a parametrization over
the ten dtype codes for each module, covering `GradualTransitionConfig`,
`transition_alpha`, `output_interpolation`, `task_sampling_mask`,
`CausalMapForagerConfig` and `CausalMapForagerAgent`; an assertion that the ten
codes are an enumeration rather than a hand-kept list; and a regression test that
the widened families do not admit a subclass, a `bool`, or a float.

Failing-test-first, `python -m pytest tests/test_benchmark_integer_family_gates.py -q`:

| tree | result |
| --- | --- |
| `origin/main` `c9aba7b5` | **4 failed**, 18 passed — `[i]` and `[I]` of both family tests |
| this branch | **22 passed** |

## Verification

| check | command | result |
| --- | --- | --- |
| new test at `main` | `pytest tests/test_benchmark_integer_family_gates.py -q` | 4 failed, 18 passed |
| new test on branch | same | 22 passed |
| reproduction, 9x10 | inline script, both trees | 18 rejections at `main`, 0 on branch |
| lint | `ruff check .` | All checks passed |
| types | `mypy` | 108 errors / 17 files / 224 sources on both trees, **output byte-for-byte identical**, 0 in the changed files |
| format | `ruff format --check --diff` on the two edited modules | 85 pre-existing hunks on both trees, identical verdict, none on the edited lines; CI runs `ruff check .` and `mypy`, not `ruff format` |
| full suite | `pytest -m "not slow and not package" --continue-on-collection-errors -q`, both trees | `main` **369 failed / 14787 passed** / 53 skipped / 1059 deselected / 37 errors; branch **367 failed / 14811 passed** / 53 skipped / 1059 deselected / 37 errors |
| failure-set diff | `comm` over the two `FAILED` sets | **identical 363-test failure set** and **identical 37-error set** once `tests/test_package_import_boundaries.py` is excluded; branch adds exactly the 22 new tests (14805 vs 14783 passed outside that file) |
| the one divergent file | `pytest tests/test_package_import_boundaries.py -q`, each tree alone | **10 passed** on both. Its 10 tests each `subprocess.run(..., timeout=30)`; the two full suites were run concurrently, so cold-start imports crossed 30 s nondeterministically on both sides — 4 in-file failures on the branch, 6 at `main`, 2 of them shared |
| focused suites | `pytest` over `test_ipmnist_gradual.py`, `test_causal_map_forager.py`, `test_causal_map_int_hostile.py`, `test_causal_map_hostile_validation.py`, `test_causal_map_state_string_identity_hostile.py`, `test_causal_map_chunk_cap.py` | **194 passed, 4 skipped on both trees** |

## Scope

Each constant is confined to the module that defines it:
`_EXACT_NUMPY_INTEGER_TYPES` has 3 hits, all in `causal_map_forager.py`;
`_NUMPY_INTEGER_TYPES` has 2 in `ipmnist_gradual.py`, and its only other
occurrence in `alberta_framework/` is an unrelated constant of the same name in
`steps/step5.py:69` that aliases that module's own `_ACTUAL_INT_TYPES`. Nothing
imports or re-exports either of the two.

Neither file is a registered evidence source, so no pinned artifact is touched:
introspecting `EVIDENCE_SPECS`
(`alberta_framework/evaluation/evidence_manifest.py:642`) yields 5 specs over 25
source paths, none of them under `benchmarks/`.

## Not in scope

This is the defect of #2268 in two constants that #2268 cannot reach. #2275 adds
`tests/test_actual_int_types_closure.py`, which checks the attribute literally
named `_ACTUAL_INT_TYPES`; these two are named `_NUMPY_INTEGER_TYPES` and
`_EXACT_NUMPY_INTEGER_TYPES`, so that sweep reports nothing about them before or
after it merges, and neither file is among its 68. The real-scalar gates at
`benchmarks/forager_results.py:1609` and `benchmarks/forager.py:255` admit
`float64` only and remain out of scope per #2283.

Measured with claude-code / anthropic / claude-opus-5.

## Evidence

Captured locally, one recorded run per pull request: the pinned test is
executed first in a clean `origin/main` checkout at
`c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, then unchanged at this head
`355597a6d9c03366a6ceed9796968e6db9771ae7`. CPython 3.13.14, numpy 2.5.1, pytest 9.1 on AMD64
Windows-11-10.0.22631, where `np.intc is np.int32` is False, so C `int` is the unnamed family. Every line after a `PS>` prompt
in the capture is a real command in the tree named in its banner; the commit
each result belongs to is printed on screen by `git rev-parse HEAD`
immediately above it.

<!-- evidence-head:355597a6d9c03366a6ceed9796968e6db9771ae7 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: ![before-pr2318.png](https://github.com/user-attachments/assets/2c3c6a01-20c7-4f11-aedd-61a0f7530428) — the pull request's test at `origin/main` `c9aba7b5`: **4 failed, 18 passed**

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: ![after-pr2318.png](https://github.com/user-attachments/assets/9160e155-c7c1-4485-bbe6-26b0e8c14b96) — the identical test at this head: **22 passed**

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video — one continuous recording of the whole before/after run, commands included:
  https://github.com/user-attachments/assets/57b0d65b-51c6-4c9c-95f0-c08db9e86032

<!-- evidence-row:backend-logs -->
- [x] Backend logs: [backend-logs-pr2318.txt](https://github.com/user-attachments/files/31366729/backend-logs-pr2318.txt) — complete pytest stdout and stderr from both trees

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - this change is a Python library gate with no browser surface`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - the changed path performs no model call, so no trajectory exists`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [domain-artifact-pr2318.json](https://github.com/user-attachments/files/31366733/domain-artifact-pr2318.json) — machine-readable per-surface admission matrix measured in both trees

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [claude-opus-5-w1]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0MGD0RT46DETZ5B7C641240","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T10:31:27.770Z","completed_at":"2026-08-22T13:35:55.753Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T10:31:30.685Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"aaf1a38f05262663cdacf45620f783b9442a94280e4d02263572734941ad20fe","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"71437fa8-7611-4fdd-bc52-70d54648b681","object_id":"sha256:aaf1a38f05262663cdacf45620f783b9442a94280e4d02263572734941ad20fe","sha256":"aaf1a38f05262663cdacf45620f783b9442a94280e4d02263572734941ad20fe"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"VnlK0fzlI87lDR8zgHXCeH2OdiuDs3RVS1Lp2SipJZv391vffkXrq8R3O_NYS414btcybZ1Otg_jOowT-aQYDg"}} -->
