### PR TITLE
test(slow-lane): declare the Linux-only renameat2 publication requirement

### DIFF
--- a/tests/test_forager_matched_final_analysis.py
+++ b/tests/test_forager_matched_final_analysis.py
@@ -52,8 +52,9 @@ from alberta_framework.benchmarks import (
 from alberta_framework.benchmarks import forager_matched_statistics as statistics
 from tests import test_forager_matched_executor as executor_fixtures
 from tests import test_forager_matched_open_protocol as protocol_fixtures
+from tests._forager_matched_platform import requires_renameat2
 
-pytestmark = [pytest.mark.integration, pytest.mark.slow]
+pytestmark = [pytest.mark.integration, pytest.mark.slow, requires_renameat2]
 
 
 def _sha(label: str) -> str:

--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -34,6 +34,7 @@ from alberta_framework.reference_life_checkpoint import (
     save_reference_life_checkpoint,
 )
 from alberta_framework.streams.closed_loop import SwitchingTwoStateConfig
+from tests._forager_matched_platform import HAS_RENAMEAT2, requires_renameat2
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
@@ -199,6 +200,7 @@ def saved_case(
     return runner, state, barrier_state, checkpoint
 
 
+@requires_renameat2
 def test_quiescent_checkpoint_restores_exact_continuation(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
 ) -> None:
@@ -257,6 +259,7 @@ def _rehash_bundle(path: Path) -> None:
     (path / "COMMITTED").write_text(f"{bundle_id}\n", encoding="ascii")
 
 
+@requires_renameat2
 def test_restore_rejects_incomplete_tampered_unknown_and_symlink_bundles(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -343,6 +346,7 @@ def test_restore_rejects_incomplete_tampered_unknown_and_symlink_bundles(
         load_reference_life_checkpoint(symlinked)
 
 
+@requires_renameat2
 def test_restore_rejects_rehashed_duplicate_prototype_metadata_key(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -363,6 +367,7 @@ def test_restore_rejects_rehashed_duplicate_prototype_metadata_key(
         load_reference_life_checkpoint(duplicate)
 
 
+@requires_renameat2
 def test_publish_failure_and_existing_generation_leave_runner_unchanged(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -394,6 +399,7 @@ def test_publish_failure_and_existing_generation_leave_runner_unchanged(
     assert not tuple(parent.glob(".*.staging-*"))
 
 
+@requires_renameat2
 def test_post_commit_lock_cleanup_failure_returns_committed_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -428,6 +434,7 @@ def _bundle_bytes(path: Path) -> dict[str, bytes | None]:
     }
 
 
+@requires_renameat2
 @pytest.mark.parametrize("stale", [False, True], ids=["current", "stale"])
 def test_save_to_existing_generation_is_rejected_without_mutation(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
@@ -459,6 +466,7 @@ def test_save_to_existing_generation_is_rejected_without_mutation(
     assert restored_runner.current_state is restored_state
 
 
+@requires_renameat2
 def test_save_inside_existing_generation_is_rejected_without_mutation(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -480,6 +488,7 @@ def test_save_inside_existing_generation_is_rejected_without_mutation(
     assert restored_runner.current_state is restored_state
 
 
+@requires_renameat2
 def test_save_through_ancestor_symlink_into_generation_is_rejected(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -503,6 +512,21 @@ def test_save_through_ancestor_symlink_into_generation_is_rejected(
     assert restored_runner.current_state is restored_state
 
 
+@pytest.mark.skipif(HAS_RENAMEAT2, reason="Linux publishes the generation instead of refusing")
+def test_save_fails_closed_without_renameat2_and_publishes_nothing(tmp_path: Path) -> None:
+    """Off Linux the publisher refuses before any generation becomes visible."""
+
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+    assert state.phase is LifePhase.QUIESCENT
+    with pytest.raises(OSError, match="atomic no-replace rename requires Linux renameat2"):
+        save_reference_life_checkpoint(runner, state, tmp_path)
+
+    published = [entry for entry in tmp_path.iterdir() if not entry.name.startswith(".")]
+    assert published == []
+
+
+@requires_renameat2
 def test_checkpoint_filesystem_publication_stays_inside_runner_barrier(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_reference_life_riverswim_checkpoint.py
+++ b/tests/test_reference_life_riverswim_checkpoint.py
@@ -30,6 +30,7 @@ from alberta_framework.reference_life_checkpoint import (
     save_reference_life_checkpoint,
 )
 from alberta_framework.streams.closed_loop import RiverSwimConfig, RiverSwimMDP
+from tests._forager_matched_platform import requires_renameat2
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
@@ -189,6 +190,7 @@ def _rehash_bundle(path: Path) -> None:
     (path / "COMMITTED").write_text(f"{bundle_id}\n", encoding="ascii")
 
 
+@requires_renameat2
 def test_riverswim_quiescent_checkpoint_restores_exact_stochastic_continuation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Fixes #2323.

Three slow-marked files drive Linux-only no-replace publication without declaring it, leaving 44 items permanently red on macOS. The slow lane runs `ubuntu-latest` only (`slow.yml`), so CI never sees them. This declares the requirement with the helper built for exactly this (#1981/#1985), and adds the inverse test the checkpoint publisher was missing.

## The change

Test-only, additive:

1. `tests/test_forager_matched_final_analysis.py` — all 33 items reach `_publish_verified_no_replace` through the module fixture, so `requires_renameat2` joins the existing module-level `pytestmark`.
2. `tests/test_reference_life_checkpoint.py` — per-test `@requires_renameat2` on the nine functions (ten items) that reach the checkpoint publisher; the two pure-computation tests stay unguarded and keep running on macOS.
3. `tests/test_reference_life_riverswim_checkpoint.py` — one guard on the one publishing test.
4. New `test_save_fails_closed_without_renameat2_and_publishes_nothing` (inverse `skipif(HAS_RENAMEAT2)`): asserts `save_reference_life_checkpoint` raises the documented `OSError` off Linux and that **no visible generation is published** — measured, a failed save leaves only the hidden `.reference-life-checkpoint.lock`.

## Measured

macOS arm64 (Darwin), CPython 3.13.5, three files together:

| | `origin/main` @ `c9aba7b5` | this branch |
|---|---|---|
| outcome | **44 red** (35 failed + 8 fixture errors + 1), 4 passed | **5 passed**, 44 skipped, 0 failed |
| collected (strict flags) | 48 | 49 |

`ruff check tests/` passes. Linux is unaffected: `HAS_RENAMEAT2` probes the same `dlsym` lookup the seal publisher performs, so the marker never fires where CI runs, and the new inverse test skips there.

## Caveats, stated rather than left to be found

- **Two different library guards are being stood in for.** The seal path probes `dlsym` for `renameat2` (the helper's own probe, exact match). The checkpoint path guards on `sys.platform != "linux"` (`reference_life_checkpoint.py:1733`) before its own `dlsym` lookup. `requires_renameat2` coincides with both on every real platform — and on a hypothetical Linux libc without the symbol it skips exactly where the checkpoint's next line would refuse — but it is not literally the checkpoint's predicate. An exact `sys.platform` marker is a two-line swap if preferred.
- **Eight of the gated checkpoint items fail today at fixture setup**, not in test bodies: the module-scoped `saved_case` fixture itself publishes. Gating the consuming tests is what prevents the fixture from running off Linux; no fixture code is modified.
- The inverse test covers the **checkpoint** publisher's refusal. The seal publisher's refusal is already pinned by the existing inverse tests added with #1985 (`test_forager_matched_campaign.py:1383`), so it is not duplicated here.

Measured with `claude-code` / `anthropic` / `claude-fable-5` on arm64 Darwin, CPython 3.13.5.

---

This measured run also produced #2324 / #2326; the receipt is posted once, here.

Compute receipt: 10404912 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi
Attribution status: self-reported
— [asi]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0NA2AJ5C3YGPQV9VGNCP7XS","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-22T18:00:00.326Z","completed_at":"2026-08-22T20:46:06.322Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T18:00:02.134Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":76,"output_tokens":37889,"cache_creation_tokens":298820,"cache_read_tokens":10068127,"total_tokens":10404912,"cost_micro_usd":"17939737","session_count":1},"trajectory_sha256":"fa1c7f96936f9685fb0cdbc1189bd1c396b70dcaea066a9327300beeda99bc09","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"d116ebb0-cfb6-4048-a793-d86a137e5009","object_id":"sha256:fa1c7f96936f9685fb0cdbc1189bd1c396b70dcaea066a9327300beeda99bc09","sha256":"fa1c7f96936f9685fb0cdbc1189bd1c396b70dcaea066a9327300beeda99bc09"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAHBoGfBNRJEhRkQvHY6AcB2oVJyScySjClifWLRVPl28","device_key_id":"e6f31ab600bfb4b6612dfa8af8aec495ea789bb7fa02be582d03179b4a835899","device_signature":"upCF87a_iIUpfZlbvDFiKJNZQG0soGm8nRXTrR7gOMOViG0TAV9X4QGGye2NIN9Sq_49FaS3TUhDPrAR89yHAg"}} -->
