### PR TITLE
test(pavlovian): declare the extended-longdouble requirement of two double-rounding probes

### DIFF
--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -31,6 +31,19 @@ from alberta_framework.streams.pavlovian import (
     reacquisition_scenario,
 )
 
+# ``np.longdouble`` is only wider than float64 on platforms whose C long double
+# carries extra mantissa bits (x86-64 80-bit extended, or IEEE quad). On
+# aarch64 macOS it *is* float64, so no longdouble value can distinguish a
+# single narrowing from a double-rounded one, and the smallest longdouble
+# subnormal survives ``float()`` unchanged -- the two properties below become
+# untestable rather than false. The Fraction-parametrized cases keep the
+# double-rounding semantics covered on every platform.
+LONGDOUBLE_IS_EXTENDED = np.finfo(np.longdouble).nmant > np.finfo(np.float64).nmant
+requires_extended_longdouble = pytest.mark.skipif(
+    not LONGDOUBLE_IS_EXTENDED,
+    reason="requires np.longdouble wider than float64; on this platform they are identical",
+)
+
 pytestmark = pytest.mark.slow
 
 # ---------------------------------------------------------------------------
@@ -485,6 +498,7 @@ def test_construct_canonicalizes_noise_std_to_float32() -> None:
     assert stream._noise_std == float(np.float32(0.1))  # noqa: SLF001
 
 
+@requires_extended_longdouble
 def test_construct_narrows_original_noise_real_once() -> None:
     midpoint_plus = (
         np.longdouble(1.0)
@@ -500,6 +514,7 @@ def test_construct_narrows_original_noise_real_once() -> None:
     assert stream._noise_std == float(np.float32(midpoint_plus))  # noqa: SLF001
 
 
+@requires_extended_longdouble
 def test_construct_rejects_negative_real_that_rounds_to_zero() -> None:
     below_zero = -np.nextafter(np.longdouble(0.0), np.longdouble(1.0))
     assert float(below_zero) == 0.0


### PR DESCRIPTION
Fixes #2324.

Two double-rounding probes in `tests/test_pavlovian_stream.py` assume `np.longdouble` is wider than `float64`. On aarch64 macOS the two types are identical, so both tests fail in their own precondition asserts before touching the library — the tested property is untestable there, not false. Same class as #1979/#1983, in the slow lane CI never runs off `ubuntu-latest`.

## The change

Test-only. Adds a documented module predicate

```python
LONGDOUBLE_IS_EXTENDED = np.finfo(np.longdouble).nmant > np.finfo(np.float64).nmant
```

and gates `test_construct_narrows_original_noise_real_once` and `test_construct_rejects_negative_real_that_rounds_to_zero` on it, with a comment explaining *why* the property cannot be constructed when the widths coincide (direct and via-`float64` narrowing become bit-identical; every nonzero longdouble survives `float()`).

Coverage note: the validator's double-rounding semantics stay tested on every platform by the adjacent `Fraction`-parametrized cases — exact rationals don't depend on C `long double` width. What is skipped on aarch64 is only the np-scalar flavor of the same property, which that platform cannot express.

A #1983-style platform-honest fixture (adapting the value instead of skipping) is impossible here: no `np.longdouble` value distinguishes one narrowing from two when the type widths are equal. That's why this one is a declared skip.

## Measured

macOS arm64 (Darwin), CPython 3.13.5:

| | `origin/main` @ `c9aba7b5` | this branch |
|---|---|---|
| `tests/test_pavlovian_stream.py` | **2 failed**, 100 passed | 100 passed, **2 skipped**, 0 failed |
| collected (strict flags) | 102 | 102 |

`ruff check` passes. On Linux x86-64 (80-bit `long double`) the predicate holds and both tests keep running exactly as before — CI coverage is untouched.

Measured with `claude-code` / `anthropic` / `claude-fable-5` on arm64 Darwin, CPython 3.13.5.
