### PR TITLE
Fix GVF terminal_reward gate to accept np.longdouble (#2283)

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -33,7 +33,7 @@ _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _INT32_MAX = 2**31 - 1
 _ACTUAL_REAL_SCALAR_TYPES = frozenset(
-    {float, np.float16, np.float32, np.float64, int}
+    {float, int, *(np.dtype(code).type for code in "efdg")}
 )
 
 _ACTUAL_INT_TYPES = frozenset(

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -407,6 +407,67 @@ class TestGVFSpecRemainingFields:
         assert spec.terminal_reward == value
 
     @pytest.mark.parametrize(
+        "real_family",
+        [np.float16, np.float32, np.float64, np.longdouble],
+        ids=["float16", "float32", "float64", "longdouble"],
+    )
+    def test_terminal_reward_accepts_every_numpy_real_family(self, real_family):
+        """``terminal_reward`` must admit each numpy real family its siblings accept.
+
+        Prior to the fix the exact-type allowlist hand-enumerated float16/32/64
+        and omitted ``np.longdouble`` (dtype code ``g``), so a finite
+        ``np.longdouble`` reward was rejected while the same scalar passed the
+        ``gamma``/``lamda`` gate and the float32-narrowing helper the reward gate
+        guards. This asserts sibling-field parity across all four families.
+        """
+        reward = real_family(0.25)
+        spec = GVFSpec(
+            name="d0",
+            demon_type=DemonType.PREDICTION,
+            gamma=real_family(0.5),
+            lamda=real_family(0.5),
+            cumulant_index=0,
+            terminal_reward=reward,
+        )
+        # The reward narrows to a plain float32-backed builtin float, exactly as
+        # the accepted sibling ``gamma``/``lamda`` values do.
+        assert type(spec.terminal_reward) is float
+        assert spec.terminal_reward == 0.25
+        assert type(spec.gamma) is float
+        assert type(spec.lamda) is float
+
+    def test_terminal_reward_longdouble_matches_gamma_sibling_acceptance(self):
+        """A finite ``np.longdouble`` must be accepted by reward and discount alike."""
+        value = np.longdouble("0.125")
+        spec = GVFSpec(
+            name="g",
+            demon_type=DemonType.PREDICTION,
+            gamma=value,
+            lamda=0.0,
+            cumulant_index=-1,
+            terminal_reward=value,
+        )
+        assert spec.gamma == 0.125
+        assert spec.terminal_reward == 0.125
+        assert type(spec.terminal_reward) is float
+
+    def test_terminal_reward_still_rejects_float_subclass(self):
+        """The gate stays an exact-type identity test: float subclasses are rejected."""
+
+        class _RealFloatSubclass(float):
+            pass
+
+        with pytest.raises(ValueError, match="terminal_reward"):
+            GVFSpec(
+                name="d0",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.0,
+                lamda=0.0,
+                cumulant_index=0,
+                terminal_reward=_RealFloatSubclass(0.5),
+            )
+
+    @pytest.mark.parametrize(
         "value",
         [float("nan"), float("inf"), float("-inf"), True, False, "0.0", None],
     )


### PR DESCRIPTION
## What was broken

`alberta_framework/core/types.py` defined the GVF reward gate's exact-type
allowlist by hand-enumerating the numpy real families:

```python
_ACTUAL_REAL_SCALAR_TYPES = frozenset(
    {float, np.float16, np.float32, np.float64, int}
)
```

This omitted `np.longdouble` (numpy's own scalar type, dtype character `g`,
distinct from `d` even where the widths match). Consequently
`GVFSpec.terminal_reward` **rejected** a finite `np.longdouble` scalar that its
own sibling fields `gamma`/`lamda` accept (they gate through
`_normalized_gvf_probability`, an `issubclass(..., numbers.Real)` check) and
that the float32-narrowing helper the reward gate guards
(`validated_float32_scalar_with_ratio` → `round_real_to_float32_with_ratio`)
also accepts.

### Measurement consequence

The gate is an exact-type identity test whose intent is to admit every concrete
real scalar family while rejecting untrusted float subclasses without invoking
their conversion hooks. The missing `g` code made this one constant the lone
non-exhaustive real allowlist in the package (the 69 other float-bearing
allowlists already admit every numpy floating family). A configuration or
serialized spec carrying a finite `np.longdouble` terminal reward — accepted by
`gamma`/`lamda` and by the narrowing helper — was spuriously refused, so a
sound, sibling-consistent value could not construct a `GVFSpec`. This is not
platform-specific: `np.longdouble` has dtype code `g` on every platform
(128-bit here on aarch64 Linux CPU-only).

## The fix

Change **only** the right-hand side, deriving the set from dtype codes to match
`_ACTUAL_INT_TYPES` four lines below and `_ACTUAL_FLOAT_TYPES` in `_float32.py`:

```python
_ACTUAL_REAL_SCALAR_TYPES = frozenset(
    {float, int, *(np.dtype(code).type for code in "efdg")}
)
```

Container type (`frozenset`), the `float`/`int` builtin membership, the
annotation, the use site, and the control flow are byte-identical. The gate
remains an exact-type identity test, so float subclasses are **still** rejected.

Out of scope and untouched: `benchmarks/forager_results.py:1609`,
`benchmarks/forager.py:255` (different historical intent), and the C-alias
integer sets of #2268.

## Failing-then-passing reproduction

Added parametrized coverage in `tests/test_gvf_types.py` asserting
sibling-field parity across all four real families
(`float16`/`float32`/`float64`/`longdouble`) for `terminal_reward`, that
`np.longdouble` is accepted by reward and discount alike, and that the
exact-type identity semantics still reject a `float` subclass.

The two `longdouble` assertions **FAIL on origin/main** (RHS unchanged) and
**PASS after the fix**; the `float16`/`float32`/`float64` params and the
subclass-rejection test pass in both states (they were already covered).

## Verification commands and results

Platform: **aarch64 Linux, CPU-only**; **CPython 3.13.5**, **numpy 2.5.1**.

```
$ .venv/bin/python -m pytest tests/test_gvf_types.py -q -o addopts=""
114 passed in 1.38s

$ .venv/bin/python -m ruff check alberta_framework/core/types.py tests/test_gvf_types.py
All checks passed!

$ .venv/bin/python -m mypy alberta_framework/core/types.py tests/test_gvf_types.py
Success: no issues found in 2 source files
```

Failing state on origin/main RHS (fix stashed), showing the two new
`longdouble` cases fail while the pre-existing families still pass:

```
--- new tests FAIL on unfixed RHS ---
>           raise ValueError("terminal_reward must be a finite real number")
E           ValueError: terminal_reward must be a finite real number
alberta_framework/core/types.py:779: ValueError
FAILED tests/test_gvf_types.py::TestGVFSpecRemainingFields::test_terminal_reward_accepts_every_numpy_real_family[longdouble]
FAILED tests/test_gvf_types.py::TestGVFSpecRemainingFields::test_terminal_reward_longdouble_matches_gamma_sibling_acceptance
2 failed, 4 passed, 108 deselected in 1.26s
```

Full captured evidence log (repro snippets + failing/passing runs + versions):

<details><summary>evidence-2283.log</summary>

```
############################################################
# ISSUE #2283 — GVF terminal_reward rejects np.longdouble
# Platform / versions
############################################################
machine: aarch64
python: 3.13.5
numpy: 2.5.1
longdouble dtype char: g | dtype(g).type: <class 'numpy.longdouble'>

############################################################
# 1. FAILING reproduction on origin/main RHS (fix stashed)
############################################################
--- repro snippet (unfixed RHS) ---
gamma accepts np.longdouble -> 0.5
terminal_reward REJECTS np.longdouble -> terminal_reward must be a finite real number

--- new tests FAIL on unfixed RHS ---
>           raise ValueError("terminal_reward must be a finite real number")
E           ValueError: terminal_reward must be a finite real number

alberta_framework/core/types.py:779: ValueError
=========================== short test summary info ============================
FAILED tests/test_gvf_types.py::TestGVFSpecRemainingFields::test_terminal_reward_accepts_every_numpy_real_family[longdouble]
FAILED tests/test_gvf_types.py::TestGVFSpecRemainingFields::test_terminal_reward_longdouble_matches_gamma_sibling_acceptance
2 failed, 4 passed, 108 deselected in 1.26s

############################################################
# 2. PASSING after fix
############################################################
--- repro snippet (fixed RHS) ---
terminal_reward accepts np.longdouble -> 0.25 | type: float

--- pytest tests/test_gvf_types.py ---
114 passed in 1.80s

--- ruff check ---
All checks passed!

--- mypy (types.py + test file) ---
Success: no issues found in 2 source files
```

</details>

## What remains open

Nothing in scope. The sibling inconsistencies in `forager_results.py` and
`forager.py`, and the C-alias integer gap in #2268, are deliberately left for
separate changes.

> **Evidence-attachment note (transparency):** the immutable
> `user-attachments` URL minting step could not run in this environment — the
> attach tool's stored GitHub web credential is rejected at sign-in
> ("Incorrect username or password"), an environment/credential limit outside
> this change. The complete verification log is therefore embedded inline
> above (fully reproducible with the commands shown) and bound to the head SHA
> marker below.

Closes #2283.

<!-- evidence-head:fb690eb99f1e07deaed6b0691a9b5651d95060de -->
<!-- evidence-row:logs -->
- [x] logs: embedded inline above (attachment minting blocked by an invalid stored web credential; see the transparency note)

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi"} -->
