### PR TITLE
fix(core): enforce BoundedPolicyArchive equal-width invariant and relocate add() width guard

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -116,6 +116,8 @@ class BoundedPolicyArchive:
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +136,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +143,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -62,6 +62,70 @@ def test_archive_preflights_host_dimensions() -> None:
         )
 
 
+def test_constructor_enforces_equal_latent_width() -> None:
+    narrow = _entry("narrow", (3.0,), 1.0)
+    wide = _entry("wide", (3.0, 3.0), 2.0)
+    for mode in ("diverse_archive", "one_model", "fixed_snapshot"):
+        with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+            BoundedPolicyArchive(
+                byte_budget=4096,
+                min_latent_distance=1.0,
+                mode=mode,  # type: ignore[arg-type]
+                entries=(narrow, wide),
+            )
+    # A same-width tuple of entries still constructs cleanly.
+    ok = BoundedPolicyArchive(
+        byte_budget=4096,
+        min_latent_distance=1.0,
+        entries=(narrow, _entry("other", (9.0,), 2.0)),
+    )
+    assert [entry.identity for entry in ok.entries] == ["narrow", "other"]
+
+
+def test_diverse_archive_retains_distant_candidate() -> None:
+    # Reproduction from the issue: two same-width entries and a candidate that is
+    # genuinely 3.0 away from every existing descriptor and clears the distance gate.
+    diverse_archive = BoundedPolicyArchive(byte_budget=4096, min_latent_distance=1.0)
+    diverse_archive = diverse_archive.add(_entry("a", (0.0,), 1.0))
+    diverse_archive = diverse_archive.add(_entry("b", (1.0,), 1.0))
+    updated = diverse_archive.add(_entry("far", (4.0,), 0.5))
+    assert updated is not diverse_archive
+    assert "far" in [entry.identity for entry in updated.entries]
+    assert len(updated.entries) == 3
+
+
+def test_control_arms_accept_wider_entry() -> None:
+    wide = _entry("wide", (3.0, 3.0), 2.0)
+    fixed = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=0.0, mode="fixed_snapshot"
+    ).add(_entry("a", (0.0,), 1.0))
+    assert fixed.add(wide) is fixed
+    one = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=0.0, mode="one_model"
+    ).add(_entry("a", (0.0,), 1.0))
+    replaced = one.add(wide)
+    assert tuple(entry.identity for entry in replaced.entries) == ("wide",)
+    assert len(replaced.entries) == 1
+
+
+def test_diverse_archive_still_rejects_mismatched_width() -> None:
+    diverse_archive = BoundedPolicyArchive(byte_budget=4096, min_latent_distance=1.0)
+    diverse_archive = diverse_archive.add(_entry("a", (0.0,), 1.0))
+    diverse_archive = diverse_archive.add(_entry("b", (1.0,), 1.0))
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        diverse_archive.add(_entry("wide", (3.0, 3.0), 2.0))
+
+
+def test_ill_typed_entry_reports_tuple_message_before_width() -> None:
+    good = _entry("a", (0.0,), 1.0)
+    with pytest.raises(ValueError, match="exact tuple of PolicyEntry values"):
+        BoundedPolicyArchive(
+            byte_budget=4096,
+            min_latent_distance=0.0,
+            entries=(good, "not-an-entry"),  # type: ignore[arg-type]
+        )
+
+
 def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")


### PR DESCRIPTION
## What was broken and its measurement consequence

`BoundedPolicyArchive.add` raises `ValueError("all latent descriptors must have equal width")`, asserting an **archive-wide** invariant, but that invariant was never enforced and the guard was mispositioned:

1. **Constructor never enforced it.** `BoundedPolicyArchive.__post_init__` validated byte budget, identity uniqueness, and entry type, but never compared latent widths across `entries`. Because `BoundedPolicyArchive` is a public frozen dataclass with a directly-constructible `entries` tuple, a mixed-width archive the error message calls impossible could be built (e.g. `entries=(narrow, wide)`). On such an archive the distance loop does `np.asarray(entry.latent) - np.asarray(old.latent)`, and numpy **broadcasts** mismatched widths instead of raising: `(3.0,) - (3.0, 3.0)` → `[0.0, 0.0]`, norm `0.0` — a fabricated "distance". A candidate genuinely `3.0` away from every same-width entry (clearing `min_latent_distance=1.0`) is then **silently discarded** because the broadcast pairing reports the nearest distance as `0.0` and it loses the score test. A MAP-Elites-style illumination archive drops a policy it was built to retain, with no exception or diagnostic.

2. **The guard fired on the two control arms that never read `latent`.** The guard ran *before* the mode short-circuits. `fixed_snapshot` returns `self` and `one_model` replaces the tuple with `(entry,)` — neither reads `latent`. Both are declared controls in `POLICY_ARCHIVE_PROTOCOL["controls"]`, and `matched_axes` promises they proceed where the diverse arm proceeds; yet a wider entry was rejected on `fixed_snapshot`/`one_model` with the width error even though those arms never use the descriptor.

## The fix (one variable, one lane: `alberta_framework/core/policy_archive.py`)

1. **Enforce the invariant where it is declared.** `__post_init__` now compares every entry's latent width against `entries[0]`, inside the existing `for entry in self.entries:` loop and **after** the per-entry `type(entry) is not PolicyEntry` check (so an ill-typed element still reports the existing "exact tuple of PolicyEntry values" message). `add` builds successors with `dataclasses.replace`, which re-runs `__post_init__`, so successors are validated on the same path.
2. **Relocate the `add` guard into the `else` branch that actually computes distances.** With the constructor holding the invariant, a single comparison against `entries[0]` in that branch is the archive-wide check, and `fixed_snapshot`/`one_model` stop rejecting a descriptor they never read.

The existing rejection is preserved unchanged: a mismatched candidate against a well-formed same-width `diverse_archive` still raises the identical `"all latent descriptors must have equal width"` message.

## Failing-then-passing reproduction

Before the fix, the two new contract tests fail and the issue's silent-discard reproduces; after the fix all 11 tests pass and the mixed-width construction is rejected at the constructor (silent-discard path unreachable). Verbatim runs below.

### Verification commands and results (measured head `9f8ae2f4848fbcf46708d133f514048fc6502cd7`)

- `.venv/bin/python -m pytest tests/test_policy_archive.py -q -o addopts=""` → **11 passed**
- `.venv/bin/python -m ruff check alberta_framework/core/policy_archive.py tests/test_policy_archive.py` → **All checks passed!**
- `.venv/bin/python -m mypy alberta_framework/core/policy_archive.py` → **Success: no issues found in 1 source file**

```text
--- (1) PRE-FIX: new tests failing (constructor never enforces; control arms wrongly reject wider entry) ---
F.F.                                                                     [100%]
=================================== FAILURES ===================================
_________________ test_constructor_enforces_equal_latent_width _________________
>           with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
E           Failed: DID NOT RAISE ValueError
tests/test_policy_archive.py:69: Failed
_____________________ test_control_arms_accept_wider_entry _____________________
>       assert fixed.add(wide) is fixed
        if self.entries and len(entry.latent) != len(self.entries[0].latent):
>           raise ValueError("all latent descriptors must have equal width")
E           ValueError: all latent descriptors must have equal width
alberta_framework/core/policy_archive.py:138: ValueError
=========================== short test summary info ============================
FAILED tests/test_policy_archive.py::test_constructor_enforces_equal_latent_width
FAILED tests/test_policy_archive.py::test_control_arms_accept_wider_entry
2 failed, 2 passed, 7 deselected in 3.06s

--- (2) PRE-FIX reproduction of the SILENT DISCARD (issue consequence #1):
        candidate 3.0 away from the same-width entry is dropped because a wider entry broadcasts to 0.0 ---
mixed-width archive constructed: ['narrow', 'wide']
candidate retained? False
silently discarded (result is self)? True

--- (3) POST-FIX: mixed-width construction now rejected at the constructor (silent-discard path unreachable) ---
POST-FIX constructor rejects mixed-width: all latent descriptors must have equal width

--- (4) POST-FIX: full pytest for tests/test_policy_archive.py ---
...........                                                              [100%]
11 passed in 1.40s

--- (5) ruff check alberta_framework/core/policy_archive.py tests/test_policy_archive.py ---
All checks passed!

--- (6) mypy alberta_framework/core/policy_archive.py (strict, py312) ---
Success: no issues found in 1 source file
```

## What remains open

Nothing further for this defect. The change is confined to the module that owns the surface plus its test file; no validator, threshold, or test was weakened, and no frozen resource, benchmark lane, or pinned `outputs/` artifact was touched.

## Evidence-tooling note (transparency)

The repo's immutable-attachment minting tool (`attach.mjs`, the only fork-accessible evidence-URL family) could not authenticate in this environment — GitHub returned a verification interstitial that the headless login flow could not clear (credentials were present; the session simply never reached an authenticated state across repeated attempts). The full verification logs are therefore reproduced inline above and are byte-for-byte reproducible by re-running the three commands at the measured head. No number here appears without its command.

Closes #2322

<!-- evidence-head:9f8ae2f4848fbcf46708d133f514048fc6502cd7 -->
<!-- evidence-row:logs -->
- [ ] logs: immutable attachment URL could not be minted (attach.mjs GitHub login interstitial); full logs inlined above, reproducible at the measured head via the three verification commands.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi"} -->
