### PR TITLE
fix(core): admit np.longdouble in GVFSpec.terminal_reward

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -33,7 +33,7 @@ _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _INT32_MAX = 2**31 - 1
 _ACTUAL_REAL_SCALAR_TYPES = frozenset(
-    {float, np.float16, np.float32, np.float64, int}
+    {float, np.float16, np.float32, np.float64, np.longdouble, int}
 )
 
 _ACTUAL_INT_TYPES = frozenset(

--- a/tests/test_gvf_terminal_reward_longdouble.py
+++ b/tests/test_gvf_terminal_reward_longdouble.py
@@ -1,0 +1,64 @@
+"""Regression: GVFSpec.terminal_reward must admit np.longdouble like its sibling
+fields gamma/lamda.
+
+np.longdouble is numpy's own scalar type with dtype character 'g', distinct from
+'d' even where the two have the same width, so the rejection reproduces on every
+platform. Issue #2283.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework import DemonType, GVFSpec
+
+pytestmark = pytest.mark.unit
+
+
+def _base() -> dict:
+    return dict(
+        name="d",
+        demon_type=DemonType.PREDICTION,
+        gamma=0.0,
+        lamda=0.0,
+        cumulant_index=0,
+    )
+
+
+def test_terminal_reward_accepts_every_numpy_float_family() -> None:
+    for family in (np.float16, np.float32, np.float64, np.longdouble):
+        spec = GVFSpec(**_base(), terminal_reward=family(1.5))
+        assert spec.terminal_reward == pytest.approx(1.5)
+
+
+def test_terminal_reward_accepts_longdouble_zero_and_negative() -> None:
+    spec = GVFSpec(**_base(), terminal_reward=np.longdouble(0.0))
+    assert spec.terminal_reward == 0.0
+    spec = GVFSpec(**_base(), terminal_reward=np.longdouble(-2.5))
+    assert spec.terminal_reward == pytest.approx(-2.5)
+
+
+def test_gamma_lamda_still_accept_longdouble() -> None:
+    spec = GVFSpec(
+        name="d",
+        demon_type=DemonType.PREDICTION,
+        gamma=np.longdouble(0.5),
+        lamda=np.longdouble(0.5),
+        cumulant_index=0,
+    )
+    assert spec.gamma == pytest.approx(0.5)
+    assert spec.lamda == pytest.approx(0.5)
+
+
+def test_terminal_reward_still_rejects_non_finite_and_subclasses() -> None:
+    with pytest.raises(ValueError):
+        GVFSpec(**_base(), terminal_reward=np.longdouble("inf"))
+    with pytest.raises(ValueError):
+        GVFSpec(**_base(), terminal_reward=np.longdouble("nan"))
+
+    class _HostileFloat(float):
+        pass
+
+    with pytest.raises(ValueError):
+        GVFSpec(**_base(), terminal_reward=_HostileFloat(1.5))


### PR DESCRIPTION
Fixes #2283.

## Problem

`_ACTUAL_REAL_SCALAR_TYPES` in `alberta_framework/core/types.py:35` hand-enumerates `float16`, `float32`, `float64` and omits `np.longdouble`. So `GVFSpec.terminal_reward` rejects a finite real that its own sibling fields `gamma` and `lamda` accept (they check `issubclass(actual_type, Real)`), and that the float32 narrowing helper the gate guards accepts too.

Unlike the C-alias integer gap in #2268, this is not platform-specific: `np.longdouble` is numpy's own scalar type with dtype character `g`, distinct from `d` even where the two have the same width, so the rejection reproduces everywhere.

Reproduced on `origin/main` @ `c9aba7b5`, Python 3.12.14, numpy 2.4.6, Windows AMD64:

```python
GVFSpec(**base, terminal_reward=np.float64(1.5))      # -> 1.5
GVFSpec(**base, terminal_reward=np.longdouble(1.5))   # -> ValueError
GVFSpec(**base, gamma=np.longdouble(0.5))             # -> accepted
```

## Fix

Add `np.longdouble` to `_ACTUAL_REAL_SCALAR_TYPES`. The exact-type gate still rejects float subclasses and non-finite values; the float32 narrowing and nonzero-after-narrowing checks are unchanged.

## Tests

New regression module `tests/test_gvf_terminal_reward_longdouble.py`:
- all four numpy float families accepted for `terminal_reward`
- longdouble zero and negative values accepted
- `gamma`/`lamda` longdouble acceptance preserved
- inf/nan longdouble and float subclasses still rejected

Local results:
- New tests: 4 passed (2 failed on `main` with the exact `ValueError` from the issue)
- Existing neighbors: `test_gvf_types.py`, `test_horde.py`, `test_baird_horde.py` - 156 passed

AI provider/model: stealth / ox-alpha (Hermes Agent)
Client / agent tooling: Hermes desktop app
Attribution status: self-reported