### PR TITLE
fix(utils): report Cohen's d_z for paired comparisons

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -428,6 +428,32 @@ def cohens_d(
     return float((mean_a - mean_b) / pooled_std)
 
 
+def _paired_cohens_d(
+    values_a: NDArray[np.float64],
+    values_b: NDArray[np.float64],
+) -> float:
+    """Cohen's d_z for paired/matched samples.
+
+    The paired design shares between-seed variance across both groups and the
+    paired test statistic cancels it out, so the correct effect size
+    denominates by the within-pair differences only:
+    ``mean(differences) / std(differences, ddof=1)``. The pooled
+    independent-groups formula can be off by orders of magnitude when the
+    shared variance swamps the pooled denominator.
+
+    Zero-variance differences return a signed-infinite standardized
+    difference, mirroring ``cohens_d``'s zero-pooled-std convention.
+    """
+    differences = values_a - values_b
+    mean_difference = float(np.mean(differences))
+    std_difference = float(np.std(differences, ddof=1))
+    if std_difference == 0:
+        if mean_difference == 0:
+            return 0.0
+        return float(np.copysign(np.inf, mean_difference))
+    return mean_difference / std_difference
+
+
 def ttest_comparison(
     values_a: NDArray[np.float64] | list[float],
     values_b: NDArray[np.float64] | list[float],
@@ -503,7 +529,7 @@ def ttest_comparison(
     except ImportError:
         raise ImportError("scipy is required for t-test. Install with: pip install scipy")
 
-    effect = cohens_d(a, b)
+    effect = _paired_cohens_d(a, b) if paired else cohens_d(a, b)
 
     return SignificanceResult(
         test_name=test_name,
@@ -601,10 +627,10 @@ def wilcoxon_comparison(
 ) -> SignificanceResult:
     """Perform Wilcoxon signed-rank test (paired non-parametric).
 
-    Caveat: the reported ``effect_size`` is Cohen's d computed on the raw
-    values, not a rank-based effect size.  The standard companion to this
-    test is the matched-pairs rank-biserial correlation; interpret the
-    parametric d alongside a rank test with care.
+    Caveat: the reported ``effect_size`` is Cohen's d_z computed on the
+    within-pair differences, not a rank-based effect size.  The standard
+    companion to this test is the matched-pairs rank-biserial correlation;
+    interpret the parametric d_z alongside a rank test with care.
 
     Args:
         values_a: Values for first method
@@ -657,7 +683,7 @@ def wilcoxon_comparison(
     except ImportError:
         raise ImportError("scipy is required for Wilcoxon test. Install with: pip install scipy")
 
-    effect = cohens_d(a, b)
+    effect = _paired_cohens_d(a, b)
 
     return SignificanceResult(
         test_name="Wilcoxon signed-rank",

--- a/tests/test_paired_effect_size_dz.py
+++ b/tests/test_paired_effect_size_dz.py
@@ -1,0 +1,60 @@
+"""Regression: paired comparisons must report Cohen's d_z, not pooled d.
+
+`ttest_comparison(..., paired=True)` and `wilcoxon_comparison(...)` (always
+paired) both reported `effect_size` via the pooled independent-groups formula
+even though the test statistic is computed on paired/matched samples. The
+correct paired effect size is d_z: mean(differences) / std(differences, ddof=1).
+Issue #2154.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.utils.statistics import (
+    cohens_d,
+    ttest_comparison,
+    wilcoxon_comparison,
+)
+
+pytestmark = pytest.mark.unit
+
+# Every pair shows a consistent +1 shift; between-seed variance swamps the
+# pooled denominator, so pooled d looks negligible while d_z is large.
+A = np.array([101.0, 202.0, 303.0, 404.0])
+B = np.array([100.0, 200.0, 300.0, 400.0])
+D_Z = float(np.mean(A - B) / np.std(A - B, ddof=1))
+
+
+def test_paired_ttest_reports_dz_not_pooled_d() -> None:
+    result = ttest_comparison(A, B, paired=True)
+    assert result.effect_size == pytest.approx(D_Z)
+    # The pooled formula would report ~0.019; d_z is ~1.94.
+    assert result.effect_size != pytest.approx(cohens_d(A, B))
+
+
+def test_unpaired_ttest_still_reports_pooled_d() -> None:
+    result = ttest_comparison(A, B, paired=False)
+    assert result.effect_size == pytest.approx(cohens_d(A, B))
+
+
+def test_wilcoxon_reports_dz() -> None:
+    result = wilcoxon_comparison(A, B)
+    assert result.effect_size == pytest.approx(D_Z)
+
+
+def test_paired_dz_sign_convention() -> None:
+    # Positive means a > b, matching cohens_d's convention.
+    assert ttest_comparison(A, B, paired=True).effect_size > 0
+    assert ttest_comparison(B, A, paired=True).effect_size < 0
+    assert wilcoxon_comparison(A, B).effect_size > 0
+
+
+def test_paired_dz_zero_variance_differences() -> None:
+    # Constant nonzero differences: std(d)=0 -> signed-infinite d_z,
+    # mirroring cohens_d's zero-pooled-std convention.
+    a = np.array([2.0, 3.0, 4.0])
+    b = np.array([1.0, 2.0, 3.0])
+    assert ttest_comparison(a, b, paired=True).effect_size == float("inf")
+    assert ttest_comparison(b, a, paired=True).effect_size == float("-inf")

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -668,7 +668,9 @@ class TestIdenticalWilcoxonRejection:
         assert result.test_name == "Wilcoxon signed-rank"
         assert result.statistic == pytest.approx(0.0)
         assert result.p_value < 1.0
-        assert result.effect_size == cohens_d([1.0, 2.0, 3.0], [0.5, 1.5, 2.5])
+        # Paired effect size is d_z on the within-pair differences (#2154):
+        # constant +0.5 shift -> zero-variance differences -> signed infinity.
+        assert result.effect_size == float("inf")
 
 
 class TestOneSampleRejection:


### PR DESCRIPTION
Fixes #2154.

## Problem

`ttest_comparison(..., paired=True)` and `wilcoxon_comparison(...)` (always paired) both reported `effect_size` via `cohens_d(a, b)` — the pooled independent-groups formula — even though the test statistic itself (`scipy.stats.ttest_rel` / `scipy.stats.wilcoxon`) is computed on paired/matched samples.

The pooled denominator is swamped by the between-seed variance the paired design shares across both groups, so a consistent per-pair shift can read as a negligible effect when the correct paired d_z is large. Reproduced on `origin/main` @ `c9aba7b5`, Python 3.12.14, numpy 2.4.6, Windows AMD64:

```python
a = np.array([101.0, 202.0, 303.0, 404.0])
b = np.array([100.0, 200.0, 300.0, 400.0])  # consistent +1 shift per pair

ttest_comparison(a, b, paired=True).effect_size   # 0.0193 (pooled, looks negligible)
np.mean(a-b) / np.std(a-b, ddof=1)                # 1.9365 (correct d_z)
```

This matters directly for this repo's benchmark/evaluation reporting: paired comparisons (same seeds across two methods) are the common case — `paired=True` is the function's own default — and an effect size off by two orders of magnitude can make a real, consistent improvement look negligible.

## Fix

Add `_paired_cohens_d` computing `mean(differences) / std(differences, ddof=1)`, used by `ttest_comparison` when `paired=True` and unconditionally by `wilcoxon_comparison`. Zero-variance differences return a signed-infinite standardized difference, mirroring `cohens_d`'s zero-pooled-std convention. The unpaired path and `cohens_d` itself are unchanged.

## Tests

New regression module `tests/test_paired_effect_size_dz.py` (5 tests):
- paired t-test reports d_z, not pooled d
- unpaired t-test still reports pooled d
- Wilcoxon reports d_z
- sign convention preserved (positive means a > b)
- zero-variance differences -> signed infinity

One existing test updated: `test_constant_nonzero_shift_stays_defined` asserted the old pooled value for a constant-shift Wilcoxon; it now asserts the correct d_z (signed infinity for zero-variance differences), with a comment referencing this issue.

Local results:
- New tests: 5 passed (3 failed on `main` with the pooled value)
- Existing neighbors: `test_statistics_validation.py`, `test_statistics_hostile_validation.py`, `test_significance_result_leftover_identities.py`, `test_forager_matched_statistics.py` - 310 passed total

AI provider/model: stealth / ox-alpha (Hermes Agent)
Client / agent tooling: Hermes desktop app
Attribution status: self-reported