### PR TITLE
fix(core): enforce BoundedPolicyArchive equal-width invariant in the …

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        latent_width: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if latent_width is None:
+                latent_width = len(entry.latent)
+            elif len(entry.latent) != latent_width:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,12 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            # The constructor holds the equal-width invariant, so one
+            # comparison against entries[0] is the archive-wide check; the
+            # single-policy controls above never read `latent` and must not
+            # reject a descriptor they do not use.
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive_equal_width.py
+++ b/tests/test_policy_archive_equal_width.py
@@ -1,0 +1,96 @@
+"""Regression: BoundedPolicyArchive must enforce its declared equal-width
+invariant in the constructor, and the single-policy controls must not reject
+a descriptor they never read.
+
+Issue #2322: the width guard lived in `add` before the mode short-circuits, so
+(1) a directly constructed mixed-width archive violated the declared invariant
+and numpy broadcasting fabricated zero distances that silently discarded valid
+candidates, and (2) the one_model/fixed_snapshot controls raised on entries
+whose latent they never use.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.policy_archive import BoundedPolicyArchive, PolicyEntry
+
+pytestmark = pytest.mark.unit
+
+
+def _entry(identity: str, latent: tuple[float, ...], score: float = 0.0) -> PolicyEntry:
+    return PolicyEntry(
+        identity=identity, policy_bytes=b"x", latent=latent, score=score
+    )
+
+
+def test_constructor_rejects_mixed_width_entries() -> None:
+    narrow = _entry("a", (0.0,))
+    wide = _entry("b", (3.0, 3.0))
+    with pytest.raises(ValueError, match="equal width"):
+        BoundedPolicyArchive(
+            byte_budget=4096, min_latent_distance=1.0, entries=(narrow, wide)
+        )
+
+
+def test_constructor_rejects_mixed_width_in_any_mode() -> None:
+    narrow = _entry("a", (0.0,))
+    wide = _entry("b", (3.0, 3.0))
+    for mode in ("diverse_archive", "one_model", "fixed_snapshot"):
+        with pytest.raises(ValueError, match="equal width"):
+            BoundedPolicyArchive(
+                byte_budget=4096,
+                min_latent_distance=1.0,
+                mode=mode,
+                entries=(narrow, wide),
+            )
+
+
+def test_one_model_control_accepts_wider_entry() -> None:
+    archive = BoundedPolicyArchive(
+        byte_budget=4096,
+        min_latent_distance=1.0,
+        mode="one_model",
+        entries=(_entry("a", (0.0,)),),
+    )
+    successor = archive.add(_entry("b", (3.0, 3.0), score=9.0))
+    assert tuple(e.identity for e in successor.entries) == ("b",)
+
+
+def test_fixed_snapshot_control_accepts_wider_entry() -> None:
+    archive = BoundedPolicyArchive(
+        byte_budget=4096,
+        min_latent_distance=1.0,
+        mode="fixed_snapshot",
+        entries=(_entry("a", (0.0,)),),
+    )
+    assert archive.add(_entry("b", (3.0, 3.0), score=9.0)) is archive
+
+
+def test_diverse_add_still_rejects_mismatched_candidate_width() -> None:
+    archive = BoundedPolicyArchive(
+        byte_budget=4096,
+        min_latent_distance=1.0,
+        entries=(_entry("a", (0.0,)),),
+    )
+    with pytest.raises(ValueError, match="equal width"):
+        archive.add(_entry("b", (3.0, 3.0)))
+
+
+def test_diverse_add_retains_distant_candidate() -> None:
+    archive = BoundedPolicyArchive(
+        byte_budget=4096,
+        min_latent_distance=1.0,
+        entries=(_entry("a", (0.0,)),),
+    )
+    successor = archive.add(_entry("c", (3.0,), score=1.0))
+    assert tuple(e.identity for e in successor.entries) == ("a", "c")
+
+
+def test_diverse_add_rejects_close_low_score_candidate() -> None:
+    archive = BoundedPolicyArchive(
+        byte_budget=4096,
+        min_latent_distance=1.0,
+        entries=(_entry("a", (0.0,), score=5.0),),
+    )
+    assert archive.add(_entry("c", (0.5,), score=1.0)) is archive


### PR DESCRIPTION
Fixes #2322.

## Problem

`BoundedPolicyArchive.add` declared an archive-wide equal-width invariant but compared against `entries[0]` alone, and `__post_init__` never compared widths. Two consequences, both reproduced on `origin/main` @ `c9aba7b5` (Python 3.12.14, numpy 2.4.6, Windows AMD64):

1. **A shape violation becomes a wrong result.** A directly constructed mixed-width archive violates the invariant the error message asserts. numpy broadcasts mismatched widths rather than raising — `(3.0,) - (3.0, 3.0)` is `[0.0, 0.0]`, norm `0.0` — so `add` fabricated a zero distance and silently discarded a candidate that was 3.0 from every entry of its own width and cleared `min_latent_distance=1.0` outright. No exception, no diagnostic; `persistent_bytes` and the entry count stay self-consistent, so nothing downstream can detect the loss.

2. **The guard fires on the two control arms.** The check ran before the mode short-circuits, so `one_model` and `fixed_snapshot` — declared controls in `POLICY_ARCHIVE_PROTOCOL["controls"]` that never read `latent` — rejected entries whose descriptor they do not use. A control that raises where its diverse counterpart proceeds cannot hold the matched axes the protocol promises.

## Fix

Per the issue's proposed approach:

1. Enforce the invariant where it is declared: compare every entry's width in `__post_init__`, inside the existing loop and after the per-entry type check (so an ill-typed element still reports the exact-tuple message). `add` builds successors with `replace`, which re-runs `__post_init__`, so successors are validated on the same path.
2. Move the guard in `add` into the branch that actually computes distances. Once the constructor holds the invariant, one comparison against `entries[0]` *is* the archive-wide check, and the two control arms stop rejecting a descriptor they never read.

Neither step relaxes an existing rejection: a mismatched candidate against a well-formed `diverse_archive` still raises the same message.

## Tests

New regression module `tests/test_policy_archive_equal_width.py` (7 tests) covering both consequences plus the unchanged rejection paths:
- constructor rejects mixed widths (all three modes)
- `one_model` and `fixed_snapshot` controls accept a wider entry
- diverse `add` still rejects a mismatched candidate width
- diverse `add` retains a distant candidate and rejects a close low-score one

Local results:
- New tests: 7 passed (4 failed on `main`)
- Existing: `tests/test_policy_archive.py` - 6 passed

AI provider/model: stealth / ox-alpha (Hermes Agent)
Client / agent tooling: Hermes desktop app
Attribution status: self-reported