### PR TITLE
fix(core): bound stacked Horde demon cardinality before element walks

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -362,6 +362,13 @@ def nexting_spec(
     feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
     raw_indices = _require_sequence("cumulant_indices", cumulant_indices)
     raw_gammas = _require_sequence("gammas", gammas)
+    # Bound the derived demon product on the raw lengths before the
+    # per-element validation walk, so an oversized input is rejected by the
+    # cardinality gate rather than walked element-by-element first.
+    if len(raw_indices) * len(raw_gammas) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"derived n_demons must be in [1, {_MAX_STACKED_HORDE_DEMONS}]"
+        )
     canonical_indices = tuple(
         _require_int32(f"cumulant_indices[{i}]", value, minimum=0)
         for i, value in enumerate(raw_indices)

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -132,6 +132,7 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_STACKED_HORDE_DEMONS = 1 << 12
 _CONFIG_FIELDS = {
     "type",
     "n_demons",
@@ -176,6 +177,10 @@ def _require_sequence(name: str, value: object) -> tuple[object, ...]:
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
     if type(value) not in (list, tuple):
         raise ValueError(f"{name} must be an actual list or tuple")
+    if len(value) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"{name} must have at most {_MAX_STACKED_HORDE_DEMONS} elements"
+        )
     return tuple(cast(list[object] | tuple[object, ...], value))
 
 
@@ -257,7 +262,9 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        n_demons = _require_int32(
+            "n_demons", self.n_demons, minimum=1, maximum=_MAX_STACKED_HORDE_DEMONS
+        )
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
         raw_sequences = {
@@ -365,8 +372,10 @@ def nexting_spec(
     )
     canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
     n_demons = len(canonical_indices) * len(canonical_gammas)
-    if n_demons < 1 or n_demons > _INT32_MAX:
-        raise ValueError("derived n_demons must be in the signed int32 domain")
+    if n_demons < 1 or n_demons > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"derived n_demons must be in [1, {_MAX_STACKED_HORDE_DEMONS}]"
+        )
     _preflight_horde_resources(n_demons, feature_dim)
     _preflight_stacked_horde_update_working_set(n_demons, feature_dim)
     idxs: list[int] = []

--- a/tests/test_stacked_horde_cardinality_bounds.py
+++ b/tests/test_stacked_horde_cardinality_bounds.py
@@ -1,0 +1,107 @@
+"""Cardinality bounds for StackedLinearHorde demon counts and sequences.
+
+Peer modules bound demon and demon-list cardinalities (e.g.
+``_MAX_HORDE_DEMONS = 4096`` in ``types.py``), but ``StackedHordeConfig``
+allowed ``n_demons`` up to ``_INT32_MAX`` and ``_decode_sequence`` accepted
+lists/tuples of any size and list subclasses. Issue #2225.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core import stacked_horde
+from alberta_framework.core.stacked_horde import (
+    StackedHordeConfig,
+    nexting_spec,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _config(n_demons: int) -> StackedHordeConfig:
+    return StackedHordeConfig(
+        n_demons=n_demons,
+        feature_dim=2,
+        gammas=(0.9,) * n_demons,
+        lamdas=(0.5,) * n_demons,
+        cumulant_indices=tuple(range(n_demons)),
+        step_size=0.1,
+    )
+
+
+def test_max_stacked_horde_demons_is_4096() -> None:
+    assert stacked_horde._MAX_STACKED_HORDE_DEMONS == 4096
+
+
+def test_config_rejects_oversized_n_demons() -> None:
+    with pytest.raises(ValueError, match="n_demons"):
+        _config(4097)
+
+
+def test_config_accepts_boundary_n_demons() -> None:
+    cfg = _config(4096)
+    assert cfg.n_demons == 4096
+
+
+def test_from_config_rejects_oversized_sequences() -> None:
+    n = 4097
+    payload = {
+        "type": "StackedHordeConfig",
+        "n_demons": n,
+        "feature_dim": 2,
+        "gammas": [0.9] * n,
+        "lamdas": [0.5] * n,
+        "cumulant_indices": list(range(n)),
+        "step_size": 0.1,
+    }
+    with pytest.raises(ValueError):
+        StackedHordeConfig.from_config(payload)
+
+
+class _HostileList(list[object]):
+    calls = 0
+
+    def __len__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile list length")
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        type(self).calls += 1
+        raise AssertionError("hostile list iteration")
+
+
+def test_from_config_rejects_hostile_list_subclass_before_hooks() -> None:
+    _HostileList.calls = 0
+    hostile = _HostileList([0.9, 0.9])
+    payload = {
+        "type": "StackedHordeConfig",
+        "n_demons": 2,
+        "feature_dim": 2,
+        "gammas": hostile,
+        "lamdas": [0.5, 0.5],
+        "cumulant_indices": [0, 1],
+        "step_size": 0.1,
+    }
+    with pytest.raises(ValueError, match="gammas"):
+        StackedHordeConfig.from_config(payload)
+    assert _HostileList.calls == 0
+
+
+def test_nexting_spec_rejects_oversized_product() -> None:
+    # 4097 cumulants x 1 gamma = 4097 demons > 4096
+    with pytest.raises(ValueError):
+        nexting_spec(
+            feature_dim=2,
+            cumulant_indices=tuple(range(4097)),
+            gammas=(0.9,),
+        )
+
+
+def test_nexting_spec_accepts_boundary_product() -> None:
+    cfg = nexting_spec(
+        feature_dim=2,
+        cumulant_indices=tuple(range(1024)),
+        gammas=(0.0, 0.5, 0.9, 0.99),
+    )
+    assert cfg.n_demons == 4096

--- a/tests/test_stacked_horde_cardinality_bounds.py
+++ b/tests/test_stacked_horde_cardinality_bounds.py
@@ -98,6 +98,16 @@ def test_nexting_spec_rejects_oversized_product() -> None:
         )
 
 
+def test_nexting_spec_bounds_before_per_element_walk() -> None:
+    # Every element is invalid (negative), so if the per-element validation
+    # walk ran first the rejection would be a per-element error. The
+    # cardinality gate must fire on the raw lengths before any element is
+    # inspected.
+    oversized = tuple(-1 for _ in range(4097))
+    with pytest.raises(ValueError, match="derived n_demons"):
+        nexting_spec(feature_dim=2, cumulant_indices=oversized, gammas=(0.9,))
+
+
 def test_nexting_spec_accepts_boundary_product() -> None:
     cfg = nexting_spec(
         feature_dim=2,


### PR DESCRIPTION
Fixes #2225.

## Problem

Peer modules bound demon and demon-list cardinalities (`_MAX_HORDE_DEMONS = 4096` in `types.py`, `_MAX_HISTORY_CONFIGURATION_ITEMS = 4096` in `history_features.py`, `_MAX_BACKUP_BUDGET = 4096` in `option_search_control.py`), but `StackedHordeConfig` allowed `n_demons` up to `_INT32_MAX` and `_decode_sequence` accepted sequences of any size — so oversized inputs walked millions of elements through `_require_sequence` and the per-demon float32 validation loops before the aggregate scalar preflight ran. `nexting_spec` also expanded the combinatorial demon grid before any cardinality check.

## Fix

Per the issue's proposed approach:

1. Define `_MAX_STACKED_HORDE_DEMONS = 1 << 12` (4096).
2. `StackedHordeConfig.__post_init__` validates `n_demons` with `maximum=_MAX_STACKED_HORDE_DEMONS`.
3. `_decode_sequence` rejects sequences exceeding the ceiling before the tuple copy. The existing exact-type check (`type(value) not in (list, tuple)`) already rejects list subclasses, so a hostile subclass with custom `__len__`/`__iter__` hooks is rejected before any hook runs.
4. `nexting_spec` preflights `len(cumulant_indices) * len(gammas) <= _MAX_STACKED_HORDE_DEMONS` before building the demon grid.

## Tests

New `tests/test_stacked_horde_cardinality_bounds.py` (7 tests) per the issue's acceptance criteria:
- `_MAX_STACKED_HORDE_DEMONS == 4096`
- `n_demons = 4097` rejected at config construction; boundary `4096` accepted
- `from_config` rejects oversized lists (> 4096) before tuple copy
- `from_config` rejects a hostile list subclass without invoking its length/iteration hooks
- `nexting_spec` rejects an oversized product (4097 x 1) and accepts the boundary product (1024 x 4 = 4096)

Local results (Python 3.12.14, numpy 2.4.6, Windows AMD64):
- New tests: 7 passed (4 failed on `main`)
- Neighbors: `test_stacked_horde.py` + `test_stacked_horde_update_working_set.py` + `test_multi_head_stacked_horde_label_emnist_scan_bounds.py` - 118 passed; the only 2 failures are the pre-existing `intc`/`uintc` parametrizations documented as red on `main` by issue #2268 (verified identical with this change stashed)

AI provider/model: stealth / ox-alpha (Hermes Agent)
Client / agent tooling: Hermes desktop app
Attribution status: self-reported