### PR TITLE
fix(core): bound decay-rate cardinality before per-item walks

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -70,6 +70,7 @@ from alberta_framework.core.working_memory import (
 )
 
 _INT32_MAX = 2**31 - 1
+_MAX_FIXED_TRACE_DECAY_RATES = 1 << 12
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -119,6 +120,10 @@ def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
     rates = cast(tuple[object, ...], value)
+    if len(rates) > _MAX_FIXED_TRACE_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_FIXED_TRACE_DECAY_RATES} decay rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",
@@ -1036,12 +1041,20 @@ class FixedTraceStateBuilderConfig:
         obs_decays = data["observation_decay_rates"]
         act_decays = data["action_decay_rates"]
         out_decays = data["outcome_decay_rates"]
-        if (
-            not isinstance(obs_decays, (list, tuple))
-            or not isinstance(act_decays, (list, tuple))
-            or not isinstance(out_decays, (list, tuple))
+        for name, value in (
+            ("observation_decay_rates", obs_decays),
+            ("action_decay_rates", act_decays),
+            ("outcome_decay_rates", out_decays),
         ):
-            raise ValueError("decay rates must be lists or tuples")
+            # Exact-type check rejects list subclasses before any length or
+            # iteration hook can run; the length cap bounds the tuple copy.
+            if type(value) not in (list, tuple):
+                raise ValueError("decay rates must be lists or tuples")
+            if len(value) > _MAX_FIXED_TRACE_DECAY_RATES:
+                raise ValueError(
+                    f"{name} must contain at most "
+                    f"{_MAX_FIXED_TRACE_DECAY_RATES} decay rates"
+                )
         return cls(
             observation_dim=data["observation_dim"],
             n_actions=data["n_actions"],

--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -124,9 +124,19 @@ class WorkingMemoryConfig:
             if key in payload:
                 value = payload[key]
                 if type(value) is list:
+                    if len(value) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                        raise ValueError(
+                            f"{key} must contain at most "
+                            f"{_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+                        )
                     payload[key] = tuple(value)
                 elif type(value) is not tuple:
                     raise ValueError(f"{key} must be an actual list or tuple")
+                elif len(value) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                    raise ValueError(
+                        f"{key} must contain at most "
+                        f"{_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+                    )
                 if any(type(item) is not float for item in payload[key]):
                     raise ValueError(f"serialized {key} values must be JSON numbers")
         for key in ("observation_dim", "action_dim", "reward_dim"):
@@ -216,6 +226,8 @@ class WorkingMemoryArrayResult:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_WORKING_MEMORY_CONFIGURATION_ITEMS = 1 << 12
+_MAX_WORKING_MEMORY_DECAY_RATES = _MAX_WORKING_MEMORY_CONFIGURATION_ITEMS
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
@@ -287,6 +299,10 @@ def _require_array(
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(rates) > _MAX_WORKING_MEMORY_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",

--- a/tests/test_working_memory_cardinality_bounds.py
+++ b/tests/test_working_memory_cardinality_bounds.py
@@ -1,0 +1,127 @@
+"""Cardinality bounds for working-memory and fixed-trace decay rate sequences.
+
+Peer modules bound configuration-item cardinalities before per-item walks
+(_MAX_HISTORY_CONFIGURATION_ITEMS in history_features.py, _MAX_HORDE_DEMONS in
+types.py), but WorkingMemoryConfig and FixedTraceStateBuilderConfig walked
+decay-rate sequences of any size before validation. Issue #2220.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core import working_memory
+from alberta_framework.core.state_builder import FixedTraceStateBuilderConfig
+from alberta_framework.core.working_memory import WorkingMemoryConfig
+
+pytestmark = pytest.mark.unit
+
+_MAX = 4096
+
+
+def test_max_working_memory_decay_rates_is_4096() -> None:
+    assert working_memory._MAX_WORKING_MEMORY_DECAY_RATES == _MAX
+
+
+def test_config_rejects_oversized_decay_rates() -> None:
+    with pytest.raises(ValueError, match="observation_decay_rates"):
+        WorkingMemoryConfig(
+            observation_dim=2,
+            observation_decay_rates=(0.5,) * (_MAX + 1),
+        )
+
+
+def test_config_accepts_boundary_decay_rates() -> None:
+    cfg = WorkingMemoryConfig(
+        observation_dim=2,
+        observation_decay_rates=(0.5,) * _MAX,
+    )
+    assert len(cfg.observation_decay_rates) == _MAX
+
+
+def _wm_payload(obs_rates: list[float]) -> dict:
+    return {
+        "type": "WorkingMemoryConfig",
+        "observation_dim": 2,
+        "action_dim": 0,
+        "reward_dim": 1,
+        "observation_decay_rates": obs_rates,
+        "action_decay_rates": [0.5],
+        "reward_decay_rates": [0.5],
+        "include_current_observation": True,
+        "include_current_action": False,
+        "include_current_reward": False,
+        "include_traces": True,
+        "include_innovations": False,
+        "gated_update": False,
+        "gate_threshold": 0.5,
+        "gate_temperature": 0.1,
+    }
+
+
+def test_from_config_rejects_oversized_serialized_list() -> None:
+    with pytest.raises(ValueError):
+        WorkingMemoryConfig.from_config(_wm_payload([0.5] * (_MAX + 1)))
+
+
+class _HostileList(list[object]):
+    calls = 0
+
+    def __len__(self) -> int:  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile list length")
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        type(self).calls += 1
+        raise AssertionError("hostile list iteration")
+
+
+def test_from_config_rejects_hostile_list_subclass_before_hooks() -> None:
+    _HostileList.calls = 0
+    payload = _wm_payload([0.5, 0.9])
+    payload["observation_decay_rates"] = _HostileList([0.5, 0.9])
+    with pytest.raises(ValueError, match="observation_decay_rates"):
+        WorkingMemoryConfig.from_config(payload)
+    assert _HostileList.calls == 0
+
+
+def test_fixed_trace_rejects_oversized_decay_rates() -> None:
+    with pytest.raises(ValueError, match="observation_decay_rates"):
+        FixedTraceStateBuilderConfig(
+            observation_dim=2,
+            observation_decay_rates=(0.5,) * (_MAX + 1),
+        )
+
+
+def test_fixed_trace_accepts_boundary_decay_rates() -> None:
+    cfg = FixedTraceStateBuilderConfig(
+        observation_dim=2,
+        observation_decay_rates=(0.5,) * _MAX,
+    )
+    assert len(cfg.observation_decay_rates) == _MAX
+
+
+def _ft_payload(obs_rates: list[float]) -> dict:
+    return {
+        "type": "FixedTraceStateBuilder",
+        "observation_dim": 2,
+        "n_actions": 0,
+        "observation_decay_rates": obs_rates,
+        "action_decay_rates": [0.5],
+        "outcome_decay_rates": [0.5],
+        "include_raw_observation": True,
+    }
+
+
+def test_fixed_trace_from_config_rejects_oversized_list() -> None:
+    with pytest.raises(ValueError):
+        FixedTraceStateBuilderConfig.from_config(_ft_payload([0.5] * (_MAX + 1)))
+
+
+def test_fixed_trace_from_config_rejects_hostile_list_subclass() -> None:
+    _HostileList.calls = 0
+    payload = _ft_payload([0.5, 0.9])
+    payload["observation_decay_rates"] = _HostileList([0.5, 0.9])
+    with pytest.raises(ValueError):
+        FixedTraceStateBuilderConfig.from_config(payload)
+    assert _HostileList.calls == 0


### PR DESCRIPTION
Fixes #2220.

## Problem

Peer modules bound configuration-item cardinalities before per-item walks (`_MAX_HISTORY_CONFIGURATION_ITEMS = 4096` in `history_features.py`, `_MAX_HORDE_DEMONS = 4096` in `types.py`), but `WorkingMemoryConfig` and `FixedTraceStateBuilderConfig` walked decay-rate sequences of any size before validation, and the `FixedTraceStateBuilderConfig.from_config` deserializer accepted list subclasses via loose `isinstance(..., (list, tuple))`.

## Fix

Per the issue's proposed approach:

1. Define `_MAX_WORKING_MEMORY_CONFIGURATION_ITEMS = 1 << 12` and `_MAX_WORKING_MEMORY_DECAY_RATES = _MAX_WORKING_MEMORY_CONFIGURATION_ITEMS` in `working_memory.py`; `_MAX_FIXED_TRACE_DECAY_RATES = 4096` in `state_builder.py`.
2. `_validate_decay_rates` checks the ceiling before the per-rate comprehension loop.
3. `WorkingMemoryConfig.from_config` checks the ceiling before the tuple copy and element-type walk; its exact-type check already rejects list subclasses before any length/iteration hook runs.
4. `_require_decay_rates` checks the ceiling before the per-rate loop.
5. `FixedTraceStateBuilderConfig.from_config` replaces the loose `isinstance` check with an exact-type check (rejecting list subclasses before hooks) plus the length cap before the tuple copy. The existing non-sequence rejection message is preserved.

## Tests

New `tests/test_working_memory_cardinality_bounds.py` (9 tests) per the issue's acceptance criteria:
- oversized decay-rate tuples (4097) rejected before the per-rate loop; boundary 4096 accepted (both configs)
- `from_config` rejects oversized serialized lists before copying (both configs)
- hostile list subclasses rejected without invoking their length/iteration hooks (both configs)

Local results (Python 3.12.14, numpy 2.4.6, Windows AMD64):
- New tests: 9 passed (6 failed on `main`)
- Neighbors: `test_working_memory.py`, `test_working_memory_validation.py`, `test_state_builder.py`, `test_state_builder_hostile_validation.py`, `test_state_builder_update_working_set.py` - 251 passed, no regressions

AI provider/model: stealth / ox-alpha (Hermes Agent)
Client / agent tooling: Hermes desktop app
Attribution status: self-reported