### PR TITLE
Cap normalizer persist-byte pytree host width at 4096

### DIFF
--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -23,7 +23,7 @@ import dataclasses
 import math
 import operator
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from numbers import Real
 from typing import Any, SupportsIndex, cast
 
@@ -34,6 +34,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
+from alberta_framework._bounded_containers import require_bounded_container_tree
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite as _floating_tree_is_finite,
 )
@@ -86,6 +87,8 @@ NORMALIZER_LIFETIME_COUNTER_NBYTES = 12
 NORMALIZER_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
 _INT32_MAX = 2**31 - 1
+_MAX_NORMALIZER_STATE_LEAVES = 4096
+_MAX_NORMALIZER_STATE_DEPTH = 32
 _UINT32_MAX = 2**32 - 1
 _FLOAT32_CONSECUTIVE_INTEGER_LIMIT = 2**24
 
@@ -973,9 +976,38 @@ def _preflight_normalizer_update_working_set(
         )
 
 
+def _normalizer_state_children(node: object) -> Iterable[object] | None:
+    node_type = type(node)
+    if node_type is dict:
+        values = cast(dict[Any, Any], node)
+        if len(values) > _MAX_NORMALIZER_STATE_LEAVES:
+            raise ValueError(
+                "normalizer state length must be an integer in "
+                f"[0, {_MAX_NORMALIZER_STATE_LEAVES}]"
+            )
+        return values.values()
+    if node_type is list or node_type is tuple:
+        sequence = cast(list[Any] | tuple[Any, ...], node)
+        if len(sequence) > _MAX_NORMALIZER_STATE_LEAVES:
+            raise ValueError(
+                "normalizer state length must be an integer in "
+                f"[0, {_MAX_NORMALIZER_STATE_LEAVES}]"
+            )
+        return sequence
+    return None
+
+
 def measure_normalizer_state_nbytes(state: AnyNormalizerState) -> int:
     """Measure persistent JAX-array bytes in one concrete normalizer state."""
 
+    require_bounded_container_tree(
+        state,
+        children=_normalizer_state_children,
+        max_depth=_MAX_NORMALIZER_STATE_DEPTH,
+        max_nodes=_MAX_NORMALIZER_STATE_LEAVES,
+        name="normalizer state",
+        kind="pytree",
+    )
     return sum(
         int(leaf.size) * int(leaf.dtype.itemsize)
         for leaf in jax.tree.leaves(state)

--- a/tests/test_normalizer_state_leaf_cap.py
+++ b/tests/test_normalizer_state_leaf_cap.py
@@ -1,0 +1,27 @@
+"""Reject oversized host pytrees before measuring normalizer persist bytes."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.normalizers import (
+    _MAX_NORMALIZER_STATE_LEAVES,
+    EMANormalizer,
+    measure_normalizer_state_nbytes,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_measure_nbytes_rejects_oversized_host_tuple() -> None:
+    assert _MAX_NORMALIZER_STATE_LEAVES == 4096
+    with pytest.raises(
+        ValueError,
+        match=r"normalizer state length must be an integer in \[0, 4096\]",
+    ):
+        measure_normalizer_state_nbytes((0,) * (_MAX_NORMALIZER_STATE_LEAVES + 1))
+
+
+def test_measure_nbytes_still_counts_ema_state() -> None:
+    state = EMANormalizer().init(4)
+    assert measure_normalizer_state_nbytes(state) > 0


### PR DESCRIPTION
## Summary
- `measure_normalizer_state_nbytes` walked `jax.tree.leaves(state)` with no last-fit on host list/tuple/dict width, so a hostile persist-byte call could hang before INT32 resource checks.
- Preflight exact `list`/`tuple`/`dict` nodes with `len` then iterate the original sequence (no `tuple(list)` copy), last-fit 4096, and reject with `normalizer state length must be an integer in [0, 4096]`.
- Real chex dataclass states still measure; last-fit tuple of 4097 host values is rejected.

Verified head: `109838b79246a9047e41fa22df9a539e77bd54ea`

## Test plan
- [x] `JAX_PLATFORMS=cpu /root/asi-venv/bin/python -m pytest tests/test_normalizer_state_leaf_cap.py tests/test_normalizers_hostile_validation.py -q`
- [x] ruff on the two files