### PR TITLE
fix(core): use exact Gumbel-max probabilities for epsilon-greedy ratios

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1042,14 +1042,19 @@ def _select_action_epsilon_greedy_from_q_masked(
 
 
 def _epsilon_greedy_action_probabilities(q_values: Array, epsilon: Array) -> Array:
-    """Return epsilon-greedy probabilities with uniform tie handling."""
+    """Return epsilon-greedy probabilities with the exact Gumbel-max greedy law.
+
+    Action selection is ``argmax(q + 1e-6 * Gumbel(0, 1))``, whose greedy
+    probabilities are ``softmax(q / 1e-6)``.  Using that exact distribution
+    keeps the importance ratio on-policy for near-tied values, and an exact
+    tie still yields uniform greedy probabilities because softmax is
+    shift-invariant.
+    """
     q = jnp.asarray(q_values, dtype=jnp.float32)
     n_actions = q.shape[0]
     eps = jnp.asarray(epsilon, dtype=jnp.float32)
-    max_q = jnp.max(q)
-    greedy_mask = jnp.isclose(q, max_q, atol=1e-6, rtol=0.0).astype(jnp.float32)
-    n_greedy = jnp.maximum(jnp.sum(greedy_mask), jnp.array(1.0, dtype=jnp.float32))
-    return eps / n_actions + (1.0 - eps) * greedy_mask / n_greedy
+    greedy = jax.nn.softmax(q / jnp.asarray(1e-6, dtype=jnp.float32))
+    return eps / n_actions + (1.0 - eps) * greedy
 
 
 def _clipped_epsilon_greedy_importance_ratio(

--- a/tests/test_epsilon_greedy_gumbel_ratio.py
+++ b/tests/test_epsilon_greedy_gumbel_ratio.py
@@ -1,0 +1,71 @@
+"""Regression: epsilon-greedy importance ratios must use the exact Gumbel-max
+greedy distribution, not a uniform tie over values within atol=1e-6.
+
+_select_action_epsilon_greedy selects argmax(q + 1e-6 * Gumbel(0,1)), whose
+greedy-component probabilities are softmax(q / 1e-6). The probability helper
+instead treated every value within absolute tolerance 1e-6 of the maximum as
+an exactly uniform tie, so near-tied Q values produced ratio 1.0 where the
+true target/behavior ratio differs. Issue #2136.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.options import (
+    _clipped_epsilon_greedy_importance_ratio,
+    _epsilon_greedy_action_probabilities,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_near_tied_q_values_use_gumbel_max_probabilities() -> None:
+    q = jnp.array([0.0, 5e-7], dtype=jnp.float32)
+    greedy = jax.nn.softmax(q / 1e-6)
+
+    behavior = _epsilon_greedy_action_probabilities(q, jnp.asarray(0.2))
+    target = _epsilon_greedy_action_probabilities(q, jnp.asarray(0.0))
+
+    expected_behavior = 0.2 / 2 + (1 - 0.2) * greedy
+    expected_target = 0.0 / 2 + (1 - 0.0) * greedy
+    assert jnp.allclose(behavior, expected_behavior, atol=1e-5)
+    assert jnp.allclose(target, expected_target, atol=1e-5)
+
+
+def test_near_tied_importance_ratio_matches_true_ratio() -> None:
+    # q_weights @ observation reproduces q = [0, 5e-7].
+    q_weights = jnp.array([[0.0, 0.0], [0.0, 5e-7]], dtype=jnp.float32)
+    observation = jnp.array([1.0, 1.0], dtype=jnp.float32)
+
+    greedy = jax.nn.softmax(jnp.array([0.0, 5e-7]) / 1e-6)
+    behavior = 0.2 / 2 + (1 - 0.2) * greedy
+    target = 0.0 / 2 + (1 - 0.0) * greedy
+    expected = target / jnp.maximum(behavior, 1e-6)
+
+    for action in (0, 1):
+        ratio = _clipped_epsilon_greedy_importance_ratio(
+            q_weights,
+            observation,
+            jnp.asarray(action, dtype=jnp.int32),
+            behavior_epsilon=0.2,
+            target_epsilon=0.0,
+            clip=10.0,
+        )
+        assert float(ratio) == pytest.approx(float(expected[action]), abs=1e-5)
+
+
+def test_exact_tie_stays_uniform() -> None:
+    q = jnp.array([1.0, 1.0], dtype=jnp.float32)
+    probs = _epsilon_greedy_action_probabilities(q, jnp.asarray(0.2))
+    assert jnp.allclose(probs, jnp.array([0.5, 0.5]), atol=1e-6)
+
+
+def test_clear_winner_stays_greedy() -> None:
+    q = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    probs = _epsilon_greedy_action_probabilities(q, jnp.asarray(0.0))
+    # softmax([0,1]/1e-6) is effectively [0, 1]
+    assert float(probs[1]) == pytest.approx(1.0, abs=1e-4)
+    assert float(probs[0]) == pytest.approx(0.0, abs=1e-4)


### PR DESCRIPTION
Fixes #2136.

## Problem

STOMP's intra-option behavior selector (`_select_action_epsilon_greedy`) picks `argmax(q + 1e-6 * Gumbel(0,1))`, whose greedy-component probabilities are `softmax(q / 1e-6)`. But `_epsilon_greedy_action_probabilities` (used by `_clipped_epsilon_greedy_importance_ratio`) treated every value within absolute tolerance `1e-6` of the maximum as an exactly uniform tie.

For `q_values = [0, 5e-7]`, behavior epsilon `0.2`, target epsilon `0`, reproduced on `origin/main` (Python 3.12.14, JAX CPU, Windows AMD64):

- actual Gumbel greedy probabilities: `[0.37754068, 0.62245935]`
- correct target/behavior ratios: `[0.9390799, 1.0409585]`
- current helper ratios: `[1.0, 1.0]`

The wrong ratio is consumed by `_update_intra_option_policy`, scaling eligibility traces, weight updates, and the differential average-reward update with probabilities from a different policy than generated the action.

## Fix

Compute the greedy-component probabilities from the exact Gumbel-max distribution (`softmax(q / 1e-6)`) and mix in uniform epsilon exploration. Exact ties retain uniform greedy probabilities because softmax is shift-invariant, so the exact-tie behavior the old code intended is preserved.

## Tests

New `tests/test_epsilon_greedy_gumbel_ratio.py` (4 tests):
- near-tied Q values produce the exact Gumbel-max probabilities
- the clipped importance ratio matches the true target/behavior ratio for both actions
- exact ties stay uniform
- a clear winner stays greedy

Local results:
- New tests: 4 passed (2 failed on `main` with ratio 1.0 vs true 0.939)
- Neighbors: `test_options.py` - 105 passed; STOMP suites (`test_stomp_degeneracy.py`, `test_stomp_execution_boundaries.py`, `test_oak_authoritative_stomp_adoption.py`, `test_oak_stomp_adoption_resource_budget.py`) - 42 passed

AI provider/model: stealth / ox-alpha (Hermes Agent)
Client / agent tooling: Hermes desktop app
Attribution status: self-reported