### PR TITLE
fix(core): return a simplex from floor_and_renormalize_probabilities …

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -230,6 +230,16 @@ def floor_and_renormalize_probabilities(
         jnp.asarray(1e-12, dtype=jnp.float32),
     )
     normalized = clipped / normalizer
+    # The affine step below is a simplex only when ``normalized`` sums to one.
+    # A zero clipped mass, or a float32 normalizer so large that the reciprocal
+    # underflows (XLA evaluates ``clipped / normalizer`` as multiply-by-reciprocal),
+    # leaves ``normalized`` all-zero, which would otherwise return
+    # ``min_probability`` in every slot instead of a distribution.  Fall back to
+    # uniform in that case; well-formed inputs keep ``normalized`` bit-for-bit.
+    normalized_sum = jnp.sum(normalized, axis=-1, keepdims=True)
+    usable = normalized_sum > jnp.asarray(0.5, dtype=jnp.float32)
+    uniform = jnp.ones_like(probs) / n_actions
+    normalized = jnp.where(usable, normalized, uniform)
     floor_mass = jnp.asarray(min_probability * n_actions, dtype=jnp.float32)
     return jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
 

--- a/tests/test_floor_renormalize_simplex.py
+++ b/tests/test_floor_renormalize_simplex.py
@@ -1,0 +1,52 @@
+"""Regression: floor_and_renormalize_probabilities must return a simplex.
+
+For zero-mass and float32-underflowing inputs the floored normalizer yields an
+all-zero ``normalized`` vector, so the affine step returned ``min_probability``
+in every slot (summing to ``n * min_probability``) instead of a valid simplex.
+Issue #2238.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.behavior_model import floor_and_renormalize_probabilities
+
+pytestmark = pytest.mark.unit
+
+
+def test_zero_mass_returns_simplex() -> None:
+    out = floor_and_renormalize_probabilities(jnp.asarray([0.0, 0.0, 0.0]))
+    assert float(out.sum()) == pytest.approx(1.0, abs=1e-6)
+    # Degenerate mass falls back to uniform.
+    assert jnp.allclose(out, jnp.ones(3) / 3, atol=1e-6)
+
+
+def test_float32_underflow_returns_simplex() -> None:
+    out = floor_and_renormalize_probabilities(jnp.asarray([1e38, 1.0, 1.0]))
+    assert float(out.sum()) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_well_formed_input_unchanged() -> None:
+    probs = jnp.asarray([0.2, 0.3, 0.5])
+    out = floor_and_renormalize_probabilities(probs)
+    assert float(out.sum()) == pytest.approx(1.0, abs=1e-6)
+    assert float(jnp.min(out)) >= 1e-6 - 1e-9
+    # Ordering preserved.
+    assert float(out[2]) > float(out[1]) > float(out[0])
+
+
+def test_negative_containing_input_still_simplex() -> None:
+    out = floor_and_renormalize_probabilities(jnp.asarray([-0.1, 0.4, 0.7]))
+    assert float(out.sum()) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_single_action_stays_one() -> None:
+    out = floor_and_renormalize_probabilities(jnp.asarray([1.0]))
+    assert float(out.sum()) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_already_floored_stays_simplex() -> None:
+    out = floor_and_renormalize_probabilities(jnp.asarray([1e-6, 1e-6, 1e-6]))
+    assert float(out.sum()) == pytest.approx(1.0, abs=1e-6)


### PR DESCRIPTION
Fixes #2238.

## Problem

`floor_and_renormalize_probabilities` documents that it returns "a valid simplex along the last axis", but for two classes of degenerate input it returned `min_probability` in every slot (summing to `n * min_probability`, e.g. `3e-6` for three actions) instead of `1.0`. Reproduced on `origin/main` (Python 3.12.14, JAX CPU, Windows AMD64):

```
[0.0, 0.0, 0.0]   -> [1e-06, 1e-06, 1e-06]  sum = 3.0e-06
[1e38, 1.0, 1.0]  -> [1e-06, 1e-06, 1e-06]  sum = 3.0e-06
```

## Mechanism

The affine step `min_probability + (1 - n*min_probability) * normalized` is a simplex only when `normalized` sums to one. The floored denominator breaks that two ways:

1. **Zero mass** — every clipped entry is zero, so the ratio over the floored `1e-12` denominator is all zeros.
2. **float32 underflow** — for `[1e38, 1, 1]` the normalizer is `~1e38`. XLA evaluates `clipped / normalizer` as multiply-by-reciprocal, and `1/1e38 = 1e-38` underflows to zero in float32, so every ratio — including `1e38/1e38` — vanishes. (Scalar element division does not hit this; only the vector path does.)

In both cases `normalized.sum()` is `0.0`, so the affine step returns `min_probability` in every slot.

## Fix

Fall back to the uniform distribution when the normalized vector carries no usable mass (`jnp.where(normalized_sum > 0.5, normalized, uniform)`). Well-formed inputs keep `normalized` bit-for-bit, so every previously-valid output is unchanged — verified on normal, negative-containing, single-action, and already-floored cases.

## Tests

New `tests/test_floor_renormalize_simplex.py` (6 tests):
- zero mass returns a simplex (uniform fallback)
- float32-underflow input returns a simplex
- well-formed, negative-containing, single-action, and already-floored inputs stay simplex with ordering/min-floor preserved

Local results:
- New tests: 6 passed (2 failed on `main` with sum = 3e-06)
- Neighbors: `test_behavior_model.py` - 64 passed; `test_dreaming.py` (the other in-tree caller) - 79 passed

AI provider/model: stealth / ox-alpha (Hermes Agent)
Client / agent tooling: Hermes desktop app
Attribution status: self-reported