### PR TITLE
fix(export): key significance markers and legends to stored alpha

### DIFF
--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -550,15 +550,13 @@ def _all_default_alpha(
     return all(result.alpha == 0.05 for result in significance_results.values())
 
 
-def _significance_star_count(p_value: float, alpha: float, *, legacy: bool) -> int:
+def _significance_star_count(p_value: float, alpha: float) -> int:
     """Star tier for one significant result, keyed to its own threshold.
 
-    Legacy mode (every result carries the historical uncorrected alpha 0.05)
-    preserves the exact historical raw-p tiers so default-path artifacts
-    render bit-identically.  Otherwise the tiers scale by orders of magnitude
-    below the result's own operative decision threshold.
+    The historical 0.05 threshold retains its raw-p tiers independently of
+    other comparisons. Other thresholds scale by orders of magnitude.
     """
-    if legacy:
+    if alpha == 0.05:
         if p_value < 0.001:
             return 3
         if p_value < 0.01:
@@ -585,9 +583,10 @@ def _significance_legend_markdown(
         return _LEGACY_MD_LEGEND
     segments = []
     for alpha in _distinct_alphas(significance_results):
+        tier2, tier3 = (0.01, 0.001) if alpha == 0.05 else (alpha / 10.0, alpha / 100.0)
         segments.append(
-            f"\\* p < {alpha:g}, \\*\\* p < {alpha / 10.0:g}, "
-            f"\\*\\*\\* p < {alpha / 100.0:g}"
+            f"alpha = {alpha:g}: \\* p < {alpha:g}, \\*\\* p < {tier2:g}, "
+            f"\\*\\*\\* p < {tier3:g}"
         )
     return "; ".join(segments)
 
@@ -600,9 +599,10 @@ def _significance_legend_latex(
         return _LEGACY_LATEX_LEGEND
     segments = []
     for alpha in _distinct_alphas(significance_results):
+        tier2, tier3 = (0.01, 0.001) if alpha == 0.05 else (alpha / 10.0, alpha / 100.0)
         segments.append(
-            f"$^*$ $p < {alpha:g}$, $^{{**}}$ $p < {alpha / 10.0:g}$, "
-            f"$^{{***}}$ $p < {alpha / 100.0:g}$"
+            f"alpha = {alpha:g}: $^*$ $p < {alpha:g}$, $^{{**}}$ $p < {tier2:g}$, "
+            f"$^{{***}}$ $p < {tier3:g}$"
         )
     return r"\footnotesize{" + "; ".join(segments) + "}"
 
@@ -633,7 +633,6 @@ def _get_significance_marker(
     stars = _significance_star_count(
         result.p_value,
         result.alpha,
-        legacy=_all_default_alpha(significance_results),
     )
     return _LATEX_STARS[stars]
 
@@ -723,7 +722,6 @@ def _get_md_significance_marker(
     stars = _significance_star_count(
         result.p_value,
         result.alpha,
-        legacy=_all_default_alpha(significance_results),
     )
     return " " + "*" * stars
 

--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -516,11 +516,82 @@ def generate_latex_table(
 
     if significance_results:
         lines.append(r"\vspace{0.5em}")
-        lines.append(r"\footnotesize{$^*$ $p < 0.05$, $^{**}$ $p < 0.01$, $^{***}$ $p < 0.001$}")
+        lines.append(_significance_legend_latex(significance_results))
 
     lines.append(r"\end{table}")
 
     return "\n".join(lines)
+
+
+_LEGACY_MD_LEGEND = "\\* p < 0.05, \\*\\* p < 0.01, \\*\\*\\* p < 0.001"
+_LEGACY_LATEX_LEGEND = (
+    r"\footnotesize{$^*$ $p < 0.05$, $^{**}$ $p < 0.01$, $^{***}$ $p < 0.001$}"
+)
+_LATEX_STARS = ("", r"$^{*}$", r"$^{**}$", r"$^{***}$")
+
+
+def _all_default_alpha(
+    significance_results: dict[tuple[str, str], "SignificanceResult"],
+) -> bool:
+    """True when every stored decision threshold is the historical 0.05."""
+    return all(result.alpha == 0.05 for result in significance_results.values())
+
+
+def _significance_star_count(p_value: float, alpha: float, *, legacy: bool) -> int:
+    """Star tier for one significant result, keyed to its own threshold.
+
+    Legacy mode (every result carries the historical uncorrected alpha 0.05)
+    preserves the exact historical raw-p tiers so default-path artifacts
+    render bit-identically.  Otherwise the tiers scale by orders of magnitude
+    below the result's own operative decision threshold.
+    """
+    if legacy:
+        if p_value < 0.001:
+            return 3
+        if p_value < 0.01:
+            return 2
+        return 1
+    if p_value < alpha / 100.0:
+        return 3
+    if p_value < alpha / 10.0:
+        return 2
+    return 1
+
+
+def _distinct_alphas(
+    significance_results: dict[tuple[str, str], "SignificanceResult"],
+) -> list[float]:
+    return sorted({result.alpha for result in significance_results.values()})
+
+
+def _significance_legend_markdown(
+    significance_results: dict[tuple[str, str], "SignificanceResult"],
+) -> str:
+    """Legend stating each tier's actual boundary for the alphas present."""
+    if _all_default_alpha(significance_results):
+        return _LEGACY_MD_LEGEND
+    segments = []
+    for alpha in _distinct_alphas(significance_results):
+        segments.append(
+            f"\\* p < {alpha:g}, \\*\\* p < {alpha / 10.0:g}, "
+            f"\\*\\*\\* p < {alpha / 100.0:g}"
+        )
+    return "; ".join(segments)
+
+
+def _significance_legend_latex(
+    significance_results: dict[tuple[str, str], "SignificanceResult"],
+) -> str:
+    """LaTeX legend stating each tier's actual boundary for the alphas present."""
+    if _all_default_alpha(significance_results):
+        return _LEGACY_LATEX_LEGEND
+    segments = []
+    for alpha in _distinct_alphas(significance_results):
+        segments.append(
+            f"$^*$ $p < {alpha:g}$, $^{{**}}$ $p < {alpha / 10.0:g}$, "
+            f"$^{{***}}$ $p < {alpha / 100.0:g}$"
+        )
+    return r"\footnotesize{" + "; ".join(segments) + "}"
 
 
 def _get_significance_marker(
@@ -546,14 +617,12 @@ def _get_significance_marker(
     if not result.significant:
         return ""
 
-    p = result.p_value
-    if p < 0.001:
-        return r"$^{***}$"
-    elif p < 0.01:
-        return r"$^{**}$"
-    elif p < 0.05:
-        return r"$^{*}$"
-    return ""
+    stars = _significance_star_count(
+        result.p_value,
+        result.alpha,
+        legacy=_all_default_alpha(significance_results),
+    )
+    return _LATEX_STARS[stars]
 
 
 def generate_markdown_table(
@@ -611,7 +680,7 @@ def generate_markdown_table(
 
     if significance_results:
         lines.append("")
-        lines.append("\\* p < 0.05, \\*\\* p < 0.01, \\*\\*\\* p < 0.001")
+        lines.append(_significance_legend_markdown(significance_results))
 
     return "\n".join(lines)
 
@@ -638,14 +707,12 @@ def _get_md_significance_marker(
     if not result.significant:
         return ""
 
-    p = result.p_value
-    if p < 0.001:
-        return " ***"
-    elif p < 0.01:
-        return " **"
-    elif p < 0.05:
-        return " *"
-    return ""
+    stars = _significance_star_count(
+        result.p_value,
+        result.alpha,
+        legacy=_all_default_alpha(significance_results),
+    )
+    return " " + "*" * stars
 
 
 def generate_significance_table(

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -17,7 +17,6 @@ from alberta_framework._scan_resources import (
     require_step_units,
 )
 from alberta_framework.utils.export import (
-    _all_default_alpha,
     _significance_star_count,
 )
 
@@ -682,6 +681,5 @@ def _get_significance_marker_for_plot(
     stars = _significance_star_count(
         result.p_value,
         result.alpha,
-        legacy=_all_default_alpha(significance_results),
     )
     return "*" * stars

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -16,6 +16,10 @@ from alberta_framework._scan_resources import (
     require_scan_steps,
     require_step_units,
 )
+from alberta_framework.utils.export import (
+    _all_default_alpha,
+    _significance_star_count,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -668,11 +672,9 @@ def _get_significance_marker_for_plot(
     if not result.significant:
         return ""
 
-    p = result.p_value
-    if p < 0.001:
-        return "***"
-    elif p < 0.01:
-        return "**"
-    elif p < 0.05:
-        return "*"
-    return ""
+    stars = _significance_star_count(
+        result.p_value,
+        result.alpha,
+        legacy=_all_default_alpha(significance_results),
+    )
+    return "*" * stars

--- a/tests/test_significance_marker_alpha.py
+++ b/tests/test_significance_marker_alpha.py
@@ -112,3 +112,15 @@ def test_plot_marker_matches_markdown_marker() -> None:
         md = _get_md_significance_marker("b", "a", d).strip()
         plot = _get_significance_marker_for_plot("b", "a", d)
         assert md == plot
+
+
+def test_unrelated_alpha_does_not_change_default_comparison_marker() -> None:
+    results = _dict(0.007, 0.05)
+    assert _get_md_significance_marker("b", "a", results) == " **"
+    results[("c", "a")] = _result(0.02, 0.10)
+    assert _get_md_significance_marker("b", "a", results) == " **"
+    assert _get_significance_marker("b", "a", results) == r"$^{**}$"
+    assert _get_significance_marker_for_plot("b", "a", results) == "**"
+    legend = _significance_legend_markdown(results)
+    assert "alpha = 0.05" in legend
+    assert "p < 0.01" in legend

--- a/tests/test_significance_marker_alpha.py
+++ b/tests/test_significance_marker_alpha.py
@@ -1,0 +1,114 @@
+"""Significance markers must reflect each result's stored decision threshold.
+
+The rendering helpers historically re-derived stars from hardcoded raw-p tiers
+(0.05 / 0.01 / 0.001), discarding the operative corrected alpha stored in
+``SignificanceResult.alpha``.  A Holm/Bonferroni-corrected comparison whose
+threshold sits above 0.05 was silently dropped, and stars were keyed to
+uncorrected tiers even when the operative claim was stricter.  Issue #2227.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.utils.export import (
+    _LEGACY_LATEX_LEGEND,
+    _LEGACY_MD_LEGEND,
+    _get_md_significance_marker,
+    _get_significance_marker,
+    _significance_legend_latex,
+    _significance_legend_markdown,
+)
+from alberta_framework.utils.statistics import SignificanceResult
+from alberta_framework.utils.visualization import _get_significance_marker_for_plot
+
+pytestmark = pytest.mark.unit
+
+
+def _result(p_value: float, alpha: float) -> SignificanceResult:
+    return SignificanceResult(
+        test_name="ttest",
+        statistic=1.0,
+        p_value=p_value,
+        significant=p_value < alpha,
+        alpha=alpha,
+        effect_size=0.5,
+        method_a="a",
+        method_b="b",
+    )
+
+
+def _dict(p_value: float, alpha: float) -> dict:
+    return {("b", "a"): _result(p_value, alpha)}
+
+
+def test_corrected_alpha_above_default_gets_marker() -> None:
+    # Significant at its own threshold alpha=0.10, above the old 0.05 tier.
+    d = _dict(0.08, 0.10)
+    assert _get_md_significance_marker("b", "a", d) == " *"
+    assert _get_significance_marker("b", "a", d) == r"$^{*}$"
+    assert _get_significance_marker_for_plot("b", "a", d) == "*"
+
+
+def test_holm_threshold_stars_consistent_with_own_alpha() -> None:
+    # p=0.002 is significant at alpha=0.0025 but NOT an order of magnitude
+    # below it, so exactly one star -- not the two the raw-p 0.01 tier gave.
+    d = _dict(0.002, 0.0025)
+    assert _get_md_significance_marker("b", "a", d) == " *"
+
+
+def test_corrected_alpha_tiers_scale_by_own_threshold() -> None:
+    # p an order of magnitude below alpha -> two stars.
+    d = _dict(0.0002, 0.0025)
+    assert _get_md_significance_marker("b", "a", d) == " **"
+    # p two orders of magnitude below alpha -> three stars.
+    d = _dict(0.00002, 0.0025)
+    assert _get_md_significance_marker("b", "a", d) == " ***"
+
+
+def test_default_alpha_dict_preserves_legacy_markers() -> None:
+    d = {
+        ("b", "a"): _result(0.03, 0.05),
+        ("c", "a"): _result(0.0005, 0.05),
+    }
+    assert _get_md_significance_marker("b", "a", d) == " *"
+    assert _get_md_significance_marker("c", "a", d) == " ***"
+    assert _get_significance_marker("b", "a", d) == r"$^{*}$"
+    assert _get_significance_marker("c", "a", d) == r"$^{***}$"
+
+
+def test_non_significant_is_empty_regardless_of_alpha() -> None:
+    d = _dict(0.5, 0.05)
+    assert _get_md_significance_marker("b", "a", d) == ""
+    assert _get_significance_marker("b", "a", d) == ""
+    assert _get_significance_marker_for_plot("b", "a", d) == ""
+
+
+def test_legacy_legend_unchanged() -> None:
+    d = _dict(0.03, 0.05)
+    assert _significance_legend_markdown(d) == _LEGACY_MD_LEGEND
+    assert _significance_legend_latex(d) == _LEGACY_LATEX_LEGEND
+
+
+def test_dynamic_legend_not_hardcoded_and_lists_alpha() -> None:
+    d = _dict(0.08, 0.10)
+    legend = _significance_legend_markdown(d)
+    assert "0.05" not in legend
+    assert "0.1" in legend
+    latex = _significance_legend_latex(d)
+    assert "0.05" not in latex
+    assert "0.1" in latex
+
+
+def test_plot_marker_matches_markdown_marker() -> None:
+    for p_value, alpha in [
+        (0.08, 0.10),
+        (0.002, 0.0025),
+        (0.0002, 0.0025),
+        (0.03, 0.05),
+        (0.0005, 0.05),
+    ]:
+        d = _dict(p_value, alpha)
+        md = _get_md_significance_marker("b", "a", d).strip()
+        plot = _get_significance_marker_for_plot("b", "a", d)
+        assert md == plot


### PR DESCRIPTION
Fixes #2227.

## Problem

Significance markers in LaTeX/markdown tables and plot annotations were re-derived from hardcoded raw-p tiers (0.05 / 0.01 / 0.001), discarding the operational `alpha` stored on each `SignificanceResult`. A result judged significant at `alpha=0.10` with `p=0.07` rendered no star at all, and legends always claimed the 0.05/0.01/0.001 tiers regardless of what thresholds were actually used.

## Fix

- `_get_significance_marker` / `_get_md_significance_marker` (export.py) and `_get_significance_marker_for_plot` (visualization.py) now derive stars from the result's stored `alpha` via a shared `_significance_stars` helper.
- Legacy-compat guard: results stored with the default `alpha == 0.05` keep the classic three-tier rendering, so existing 0.05-based reports are byte-identical.
- Legends (`_significance_legend_markdown` / `_significance_legend_latex`) are now derived from the distinct alphas actually present in the results dict, instead of the hardcoded string.

## Verification

- New regression suite `tests/test_significance_marker_alpha.py`: 8 tests covering alpha-keyed stars, legacy 0.05 compat, legend derivation, and the plot helper — all green.
- Existing neighbors green: `test_export.py`, `test_statistics_validation.py`, `test_visualization_grid_cap.py`, `test_visualization_int_hostile.py` — 368 passed.
