### PR TITLE
test(package): declare the Linux-only publisher inside the wheel-install smoke

### DIFF
--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -240,6 +240,13 @@ def test_historical_cli_reports_provenance_and_validates_strict_pairing(
 
 
 @pytest.mark.package
+@pytest.mark.skipif(
+    not hasattr(os, "O_TMPFILE"),
+    reason=(
+        "the wheel-install smoke runs `alberta-historical-forager provenance`, "
+        "which publishes through the Linux-only write_new_json O_TMPFILE path"
+    ),
+)
 def test_wheel_and_sdist_are_complete_and_hard_link_safe(tmp_path: Path) -> None:
     uv = shutil.which("uv")
     if uv is None:


### PR DESCRIPTION
Fixes #2340.

The wheel-install smoke in `test_wheel_and_sdist_are_complete_and_hard_link_safe` runs `alberta-historical-forager provenance` from the installed wheel, which publishes through `write_new_json` — the Linux-only O_TMPFILE path — and asserts exit 0. On a fully provisioned macOS env the test therefore fails with the publisher's own designed refusal; the CI `package` job is ubuntu-only, so the requirement was never declared.

## The change

Test-only, one `skipif` in the same inline idiom `tests/test_reference_life_scorecard.py` (#1984) uses for the same publisher, with a reason naming the actual smoke path. No new inverse test: `write_new_json`'s fails-closed refusal is already pinned off Linux by `test_new_json_publication_fails_closed_without_o_tmpfile` (`test_reference_life_scorecard.py:400`).

## Measured

macOS arm64 (Darwin), CPython 3.13.5, dev extras installed (`uv==0.9.24`, `hatchling==1.32.0`, `editables==0.6`, `twine`):

| | `origin/main` @ `c9aba7b5` | this branch |
|---|---|---|
| `tests/test_historical_forager_cli_package.py` | **1 failed**, 3 passed | 3 passed, **1 skipped** |
| collected (strict flags) | 4 | 4 |

`ruff check` passes. The ubuntu `package` job is unaffected — `O_TMPFILE` exists there, so the marker never fires.

## Caveats

- **Without the dev extras the skip never fires**: the test still fails first on its own `uv is required` declaration (`:249`), which is correct fail-closed behavior and out of scope here.
- **macOS loses the wheel-completeness assertions along with the smoke.** They are bundled in one test whose probe cannot run off Linux as written. A platform-honest probe that expects the refusal off Linux while keeping the wheel checks is a viable follow-up if that coverage is wanted — flagged in #2340; this PR takes the #1984-consistent declaration.

Measured with `claude-code` / `anthropic` / `claude-fable-5` on arm64 Darwin, CPython 3.13.5.

---

Compute receipt: 5726357 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi
Attribution status: self-reported
— [asi]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0PDRQCQ2WRE8P03ZQYKPD6M","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-23T04:23:54.520Z","completed_at":"2026-08-23T13:00:10.303Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T04:23:56.809Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":36,"output_tokens":16468,"cache_creation_tokens":297681,"cache_read_tokens":5412172,"total_tokens":5726357,"cost_micro_usd":"12189552","session_count":1},"trajectory_sha256":"0278cbbbce714fb27365367aa77dec03839235a15d549b9db904b49452af1aa7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"f2a55a14-d78f-4f5d-a927-eaf9e7fb020c","object_id":"sha256:0278cbbbce714fb27365367aa77dec03839235a15d549b9db904b49452af1aa7","sha256":"0278cbbbce714fb27365367aa77dec03839235a15d549b9db904b49452af1aa7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAHBoGfBNRJEhRkQvHY6AcB2oVJyScySjClifWLRVPl28","device_key_id":"e6f31ab600bfb4b6612dfa8af8aec495ea789bb7fa02be582d03179b4a835899","device_signature":"88kwFhr8GhAOt3kR3EErRMN-6nx3_6tXIzb8qN2Q01MNq5MVw_zwaE6i3N-nFEFDx9NBc-JWWBQmH2l7P_87CA"}} -->
