### PR TITLE
fix(tests): guard longdouble-width precondition on platforms where it is float64

### DIFF
--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -491,7 +491,12 @@ def test_construct_narrows_original_noise_real_once() -> None:
         + np.longdouble(2.0) ** -24
         + np.longdouble(2.0) ** -60
     )
-    assert np.float32(midpoint_plus) != np.float32(float(midpoint_plus))
+    if np.float32(midpoint_plus) == np.float32(float(midpoint_plus)):
+        # np.longdouble is float64 on this platform (e.g. aarch64 macOS), so the
+        # 2^-60 term cannot survive to exercise the double-rounding path — the
+        # defining property of the fixture only exists where C long double is
+        # wider than float64. Skip instead of failing in the precondition.
+        pytest.skip("np.longdouble is not wider than float64 on this platform")
 
     stream = ClassicalConditioningStream(
         phases=(_valid_phase(),),
@@ -502,7 +507,10 @@ def test_construct_narrows_original_noise_real_once() -> None:
 
 def test_construct_rejects_negative_real_that_rounds_to_zero() -> None:
     below_zero = -np.nextafter(np.longdouble(0.0), np.longdouble(1.0))
-    assert float(below_zero) == 0.0
+    if float(below_zero) != 0.0:
+        # Same width caveat as above: where np.longdouble is float64 the
+        # nextafter step is too coarse to build a negative that rounds to zero.
+        pytest.skip("np.longdouble is not wider than float64 on this platform")
     with pytest.raises(ValueError, match="noise_std"):
         ClassicalConditioningStream(phases=(_valid_phase(),), noise_std=below_zero)
 


### PR DESCRIPTION
## Problem

Two slow-lane tests in `test_pavlovian_stream.py` assume `np.longdouble` is wider than `float64` — the `2^-60` term in the fixtures only survives where C `long double` is wider. On **aarch64 macOS** `np.longdouble` *is* `float64`, so both tests failed **in their own precondition asserts**, before the library was exercised (#2324, same class as #1979).

## Fix

- Detect the width collapse and `pytest.skip` with an explicit reason instead of failing in the precondition.
- Behavior unchanged on platforms where long double is wider.

## Verification

```text
$ /tmp/asi-venv/bin/python -m pytest tests/test_pavlovian_stream.py --noconftest -q
102 passed (x86_64 Linux; long double is wider here, so the guards stay dormant)
```

AI provider/model: deepseek / deepseek-v4-flash
<!-- eliza-computer-attribution:v1 -->