### PR TITLE
fix(core): rank CBP replacement by the published bias-corrected utility (#2343)

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -44,12 +44,21 @@ contribution via outgoing-weight magnitudes; the gradient form here
 is mathematically related (via the chain rule) and is what the
 original Dohare implementation uses in practice.
 
+Ranking uses the paper's Eq. 8 warm-up debias,
+``u_hat_l[i] = u_l[i] / (1 - decay ** age_l[i])``, exactly as the released
+reference does (``lop/algos/gnt.py``: ``bias_correction = 1 -
+self.decay_rate ** self.ages[layer_idx]``, then ``topk`` over
+``bias_corrected_util``). The ``age`` exponent is per unit and every replaced
+unit restarts at ``age = 0``, so this correction does not cancel across units:
+ranking on the raw EMA understates recently reset units and re-replaces them.
+
 Replacement
 -----------
 On every step, ``replacement_rate * num_mature_units`` fractional
 replacements accrue per layer (units younger than ``maturity_threshold``
 earn no budget), and at most one accumulated replacement is delivered per
-step: the mature unit with the lowest utility in the layer is replaced. Replaced units have their
+step: the mature unit with the lowest bias-corrected utility in the layer is
+replaced. Replaced units have their
 incoming weights re-drawn via :func:`sparse_init` and their outgoing
 weights zeroed (so a freshly initialized unit does not destabilize the
 prediction immediately). The unit's age and utility are reset to 0.
@@ -137,6 +146,7 @@ _CBP_SINGLE_CONFIG_FIELDS = _CBP_MULTI_CONFIG_FIELDS - {
     "per_head_gamma_lamda",
 }
 _INT32_MAX = 2**31 - 1
+_FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES: frozenset[type] = frozenset(
     {
         int,
@@ -479,25 +489,49 @@ def update_utility(
     )
 
 
+def _bias_corrected_utility(utility: Array, age: Array, decay_rate: float) -> Array:
+    """Return the warm-up-debiased utility EMA of Dohare et al. 2024, Eq. 8.
+
+    ``u_hat[i] = u[i] / (1 - decay ** age[i])``. The ``age`` exponent is
+    per unit, so the correction does not cancel across units: every replaced
+    unit restarts its EMA at 0 with ``age = 0``, and without the correction a
+    recently reset unit reads systematically lower than an equally useful
+    long-lived one.
+
+    ``1 - decay ** age`` is 0 only at ``age == 0`` (and for ``decay == 0`` it
+    is 1 for every ``age >= 1``). Age-0 units are never eligible for
+    replacement unless ``maturity_threshold == 0``; the denominator is floored
+    at the smallest positive normal float32 so that case stays finite instead
+    of producing NaN.
+    """
+    decay = jnp.asarray(decay_rate, dtype=jnp.float32)
+    correction = 1.0 - decay ** age.astype(jnp.float32)
+    return utility / jnp.maximum(correction, _FLOAT32_MIN_NORMAL)
+
+
 def _select_replacement_index(
     utility: Array,
     age: Array,
     maturity_threshold: int,
+    decay_rate: float,
 ) -> tuple[Array, Array]:
     """Pick the index of the lowest-utility mature unit, if any.
 
-    A unit is "mature" iff ``age >= maturity_threshold``. Among mature
-    units we pick the one with the smallest utility. If no mature unit
-    exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
-    ``False``.
+    A unit is "mature" iff ``age >= maturity_threshold``. Among mature units
+    we pick the one with the smallest **bias-corrected** utility
+    (:func:`_bias_corrected_utility`). If no mature unit exists, ``selected``
+    is ``-1`` (sentinel) and ``has_candidate`` is ``False``.
 
     Implementation: replace the utility of immature or non-finite units
     with ``+inf`` before taking ``argmin`` so they are never chosen.
+    Eligibility is decided on the raw EMA's finiteness so the existing
+    NaN/inf fail-closed behaviour is unchanged.
 
     Args:
-        utility: Per-unit utility array, shape ``(num_units,)``.
+        utility: Per-unit raw utility EMA, shape ``(num_units,)``.
         age: Per-unit age array (same shape).
         maturity_threshold: Minimum age for eligibility.
+        decay_rate: Utility EMA decay ``eta``, used for the warm-up debias.
 
     Returns:
         Tuple ``(index, has_candidate)`` where ``index`` is the chosen
@@ -505,7 +539,9 @@ def _select_replacement_index(
     """
     mature = age >= jnp.asarray(maturity_threshold, dtype=age.dtype)
     eligible = mature & jnp.isfinite(utility)
-    masked_utility = jnp.where(eligible, utility, jnp.inf)
+    corrected = _bias_corrected_utility(utility, age, decay_rate)
+    eligible = eligible & jnp.isfinite(corrected)
+    masked_utility = jnp.where(eligible, corrected, jnp.inf)
     has_candidate = jnp.any(eligible)
     idx = jnp.argmin(masked_utility)
     selected = jnp.where(has_candidate, idx, jnp.int32(-1))
@@ -682,11 +718,13 @@ def replace_units_with_flags(
         accum = accum_arr[layer_idx] + rate * n_eligible
         # Will we replace one unit this step?
         do_replace = accum >= 1.0
-        # Pick lowest-utility mature unit from the *current* CBP state.
+        # Pick the mature unit with the lowest bias-corrected utility from the
+        # *current* CBP state.
         unit_idx, has_candidate = _select_replacement_index(
             new_cbp_state.utilities[layer_idx],
             new_cbp_state.ages[layer_idx],
             config.maturity_threshold,
+            config.decay_rate,
         )
         # Only replace if we both budgeted for it AND found a mature unit.
         gated = jnp.logical_and(do_replace, has_candidate)

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -222,7 +222,7 @@ class TestUtilityUpdate:
         new = update_utility(cbp_state, activations, grads, 0.9)
         assert bool(jnp.all(jnp.isfinite(new.utilities[0])))
         chex.assert_trees_all_close(new.utilities[0][0], cbp_state.utilities[0][0])
-        idx, has = _select_replacement_index(new.utilities[0], new.ages[0], 10)
+        idx, has = _select_replacement_index(new.utilities[0], new.ages[0], 10, 0.9)
         assert bool(has)
         assert int(idx) == 1
 
@@ -988,3 +988,140 @@ class TestCBPWrapperConstructorIdentities:
         payload[field] = value
         with pytest.raises(ValueError, match="serialized"):
             CBPMultiHeadMLPLearner.from_config(payload)
+
+
+# =============================================================================
+# Published bias-corrected utility (Dohare et al. 2024, Eq. 8)
+# =============================================================================
+
+
+def _warm_utility_ema(steps: int, contribution: float, decay: float) -> tuple[float, int]:
+    """Drive ``update_utility`` for ``steps`` steps on one unit.
+
+    Returns the resulting ``(utility, age)`` for a unit that saw the same
+    ``|activation * gradient|`` product on every step.
+    """
+    state = ContinualBackpropState(  # type: ignore[call-arg]
+        utilities=(jnp.zeros(1, dtype=jnp.float32),),
+        ages=(jnp.zeros(1, dtype=jnp.int32),),
+        replacement_accumulators=jnp.zeros(1, dtype=jnp.float32),
+        rng_key=jr.key(0),
+    )
+    activations = (jnp.array([contribution], dtype=jnp.float32),)
+    grads = (jnp.ones(1, dtype=jnp.float32),)
+    for _ in range(steps):
+        state = update_utility(state, activations, grads, decay)
+    return float(state.utilities[0][0]), int(state.ages[0][0])
+
+
+class TestPublishedBiasCorrectedUtility:
+    """Replacement must rank units by the *bias-corrected* utility.
+
+    Dohare, Hernandez-Garcia, Lan, Rahman, Mahmood & Sutton (2024), "Loss of
+    plasticity in deep continual learning", *Nature* 632, pp. 768-774,
+    Eq. 8::
+
+        u_hat[l, i, t] = u[l, i, t] / (1 - eta ** a[l, i, t])
+
+    where ``a`` is the *per-unit* age.  The authors' released implementation
+    (https://github.com/shibhansh/loss-of-plasticity,
+    ``lop/algos/gnt.py::GnT.update_utility`` /
+    ``GnT.test_features``) computes
+
+        bias_correction = 1 - self.decay_rate ** self.ages[layer_idx]
+        self.bias_corrected_util[layer_idx] = self.util[layer_idx] / bias_correction
+
+    and then selects with
+    ``torch.topk(-self.bias_corrected_util[i][eligible_feature_indices], ...)``.
+    ``lop/algos/cbp_linear.py`` and ``lop/algos/cbp_conv.py`` use the same
+    per-unit-age correction.
+
+    The correction does not cancel across units: every replaced unit has its
+    age reset to 0, so eligible units genuinely differ in age and therefore in
+    warm-up bias.  Ranking on the raw EMA systematically understates the
+    utility of the youngest eligible units -- exactly the units the maturity
+    threshold exists to protect (paper, Section "Continual backpropagation":
+    "initializing the outgoing weight to zero makes the new unit vulnerable to
+    immediate reinitialized as it has zero utility").
+    """
+
+    DECAY = 0.99
+    MATURITY = 100
+    # Steps chosen so the two units are genuinely distinguishable: the young
+    # unit is at exactly the maturity threshold (warm-up factor 1 - 0.99**100
+    # = 0.6340), the old unit is effectively fully warm (1 - 0.99**700
+    # = 0.99909).
+    YOUNG_STEPS = 100
+    OLD_STEPS = 700
+    YOUNG_CONTRIBUTION = 1.0
+    OLD_CONTRIBUTION = 0.9
+
+    def _crafted_layer(self) -> tuple[jnp.ndarray, jnp.ndarray, float, float]:
+        young_util, young_age = _warm_utility_ema(
+            self.YOUNG_STEPS, self.YOUNG_CONTRIBUTION, self.DECAY
+        )
+        old_util, old_age = _warm_utility_ema(
+            self.OLD_STEPS, self.OLD_CONTRIBUTION, self.DECAY
+        )
+        assert young_age == self.YOUNG_STEPS
+        assert old_age == self.OLD_STEPS
+        utility = jnp.array([young_util, old_util], dtype=jnp.float32)
+        age = jnp.array([young_age, old_age], dtype=jnp.int32)
+        return utility, age, young_util, old_util
+
+    def test_raw_and_published_rankings_actually_disagree(self) -> None:
+        """Pin that this fixture discriminates -- it cannot pass by coincidence."""
+        utility, age, young_util, old_util = self._crafted_layer()
+
+        # Raw EMAs: the young unit reads LOWER even though its steady-state
+        # contribution (1.0) is strictly larger than the old unit's (0.9).
+        assert young_util < old_util
+        assert int(jnp.argmin(utility)) == 0
+
+        # Bias-corrected utilities recover the true steady-state contributions
+        # and reverse the ranking.
+        corrected = utility / (1.0 - self.DECAY ** age.astype(jnp.float32))
+        assert float(corrected[0]) == pytest.approx(self.YOUNG_CONTRIBUTION, abs=2e-3)
+        assert float(corrected[1]) == pytest.approx(self.OLD_CONTRIBUTION, abs=2e-3)
+        assert float(corrected[0]) > float(corrected[1])
+        assert int(jnp.argmin(corrected)) == 1
+
+    def test_selector_uses_bias_corrected_utility(self) -> None:
+        utility, age, _, _ = self._crafted_layer()
+
+        idx, has_candidate = _select_replacement_index(
+            utility, age, self.MATURITY, self.DECAY
+        )
+        assert bool(has_candidate)
+        # Published rule replaces unit 1 (lowest bias-corrected utility, 0.9).
+        # The raw-EMA rule would have replaced unit 0 (see the test above).
+        assert int(idx) == 1
+
+    def test_replacement_path_reinitializes_the_published_unit(self) -> None:
+        utility, age, _, _ = self._crafted_layer()
+
+        learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(2,), sparsity=0.0)
+        mlp_state = learner.init(feature_dim=3, key=jr.key(0))
+        cbp_state = ContinualBackpropState(  # type: ignore[call-arg]
+            utilities=(utility,),
+            ages=(age,),
+            # Full budget so the single allowed replacement fires this step.
+            replacement_accumulators=jnp.ones(1, dtype=jnp.float32),
+            rng_key=jr.key(1),
+        )
+        config = ContinualBackpropConfig(
+            decay_rate=self.DECAY,
+            replacement_rate=0.0,
+            maturity_threshold=self.MATURITY,
+            enabled=True,
+        )
+
+        _new_mlp, new_cbp, replaced = replace_units_with_flags(
+            mlp_state, cbp_state, config, sparsity=0.0
+        )
+        assert bool(replaced[0])
+        # A replaced unit has its age and utility reset to 0.
+        assert int(new_cbp.ages[0][1]) == 0
+        assert float(new_cbp.utilities[0][1]) == 0.0
+        # The younger, higher-true-utility unit is untouched.
+        assert int(new_cbp.ages[0][0]) == self.YOUNG_STEPS


### PR DESCRIPTION
Closes #2343.

<!-- evidence-head:0356b494a8da809f6d755fb33fc3b285e517d788 -->

## Problem

`alberta_framework/core/continual_backprop.py::_select_replacement_index` ranked mature units by the **raw** utility EMA:

```python
masked_utility = jnp.where(eligible, utility, jnp.inf)
idx = jnp.argmin(masked_utility)
```

The cited algorithm ranks by the **bias-corrected** EMA.

**Reference:** Dohare, Hernandez-Garcia, Lan, Rahman, Mahmood & Sutton (2024), ["Loss of plasticity in deep continual learning"](https://www.nature.com/articles/s41586-024-07711-7), *Nature* **632**, 768–774 (preprint [arXiv:2306.13812](https://arxiv.org/abs/2306.13812v3)), **Eq. 7–8**:

```
u[l,i,t]     = eta * u[l,i,t-1] + (1 - eta) * y[l,i,t]        (7)
u_hat[l,i,t] = u[l,i,t] / (1 - eta ** a[l,i,t])               (8)
```

`a[l,i,t]` is the **per-unit age**. Algorithm 1 selects the eligible units "with the smallest utility", i.e. smallest `u_hat`.

The authors' released implementation ([shibhansh/loss-of-plasticity](https://github.com/shibhansh/loss-of-plasticity), `lop/algos/gnt.py`) agrees:

```python
# GnT.update_utility
bias_correction = 1 - self.decay_rate ** self.ages[layer_idx]
self.bias_corrected_util[layer_idx] = self.util[layer_idx] / bias_correction

# GnT.test_features
new_features_to_replace = torch.topk(-self.bias_corrected_util[i][eligible_feature_indices],
                                     num_new_features_to_replace)[1]
```

`lop/algos/cbp_linear.py` and `lop/algos/cbp_conv.py` use the same per-unit-age correction.

## Impact

The correction is **per unit** and does not cancel: `_replace_one_unit` resets a replaced unit's `age` *and* `utility` to 0, so eligible units in one layer genuinely differ in warm-up bias. At the module defaults (`decay_rate=0.99`, `maturity_threshold=100`) a unit that has just become eligible reads at `1 - 0.99**100 = 0.6340` of its true utility while a long-lived unit reads at ~1.0. Ranking on the raw EMA therefore targets the youngest eligible units — the ones the maturity threshold exists to protect. The paper is explicit about the mechanism:

> "initializing the outgoing weight to zero makes the new unit vulnerable to immediate reinitialized as it has zero utility. To protect new units from a reinitialization for maturity threshold m number of updates."

The maturity threshold only defers that by `m` steps; without Eq. 8 the freshly reset unit is still lowest-ranked the moment it matures.

## Fix

Rank on `utility / max(1 - decay_rate ** age, FLT_MIN_NORMAL)`. Eligibility (`age >= maturity_threshold`, finite raw EMA) and the existing NaN/inf fail-closed behaviour of #84 are unchanged; the floor keeps the `age == 0, maturity_threshold == 0` corner finite instead of producing NaN.

## Verification — paired before/after on this head

Same script, same seeds, on `origin/main` (`c9aba7b5`, source restored via `git stash`) and on this branch. Both scenarios drive the real `update_utility` EMA; `decay_rate=0.99`, `maturity_threshold=100`, replacement budget forced to fire once.

**A — young-strong vs old-weak.** Unit 0: constant contribution `1.0` for 100 steps. Unit 1: constant `0.9` for 700 steps.

```
raw EMA        : unit0=0.633967 (age 100)   unit1=0.899209 (age 700)
Eq. 8 corrected: unit0=1.000000             unit1=0.900001
true steady-state contributions: unit0=1.0  unit1=0.9

BEFORE (main)   REPLACED UNIT: [0]   <- the strictly more useful unit
AFTER  (branch) REPLACED UNIT: [1]
```

**B — repeat victim.** Four units with *identical* true contribution `1.0`; unit 2 was reset 100 steps ago, i.e. it is the unit CBP replaced last time and has only just matured.

```
raw EMA        : [0.999997, 0.999997, 0.633967, 0.999997]
Eq. 8 corrected: [0.999997, 0.999997, 1.000000, 0.999997]

BEFORE (main)   REPLACED UNIT: [2]   <- re-replaces its own fresh unit
AFTER  (branch) REPLACED UNIT: [0]
```

## Tests

Failing-test-first. New `TestPublishedBiasCorrectedUtility` in `tests/test_continual_backprop.py`:

- `test_raw_and_published_rankings_actually_disagree` — asserts the fixture is discriminating (`young_util < old_util`, `argmin(raw) == 0`, `argmin(corrected) == 1`) so the two behavioural tests cannot pass by coincidence. **Passes on `main` too** — that is the point.
- `test_selector_uses_bias_corrected_utility` — `_select_replacement_index` returns unit 1.
- `test_replacement_path_reinitializes_the_published_unit` — end-to-end through `replace_units_with_flags`: unit 1's age/utility reset to 0, unit 0 untouched.

```
.venv/bin/python -m pytest tests/test_continual_backprop.py -q -o addopts=""
  against origin/main's continual_backprop.py : 3 failed, 95 passed
  on this branch                              : 98 passed
```

The third pre-fix failure is `TestUtilityUpdate::test_inf_activation_silent_grad_holds_finite_utility`, an existing test whose `_select_replacement_index` call gained the `decay_rate` argument; its expectation (`idx == 1`) is unchanged because both units there share `age == 100`.

Also run:

```
.venv/bin/python -m pytest tests/test_continual_backprop.py tests/test_continual_backprop_validation.py \
    tests/test_plasticity_gate.py tests/test_scan_sequence_bounds_validation.py -q -o addopts=""
  -> 142 passed
.venv/bin/python -m ruff check .   -> All checks passed!
.venv/bin/python -m mypy           -> Success: no issues found in 224 source files
```

## Evidence and lane scope

- `core/continual_backprop.py` is **not** a registered evidence source. `alberta_framework/evaluation/*` registers `average_reward`, `baseline_optimizers`, `canonical_upgd`, `ftl_world_model`, `intelligence_amplification`, `interaction_features`, `normalizers`, `oak`, `options`, `optimizers`, `types`, `update_safety` — not this file. `alberta-evidence-status` per-claim validity is byte-identical before and after (all five claims `valid: false` on `origin/main` already, unchanged here; `overall_status: invalid`, exit 2, both).
- `benchmarks/ipmnist_screening.py` carries its own CBP implementation (`_init_cbp_state`, its own bias-corrected sigmoid utility) and does **not** import `core.continual_backprop`. No screening shard, merged summary, or incumbent number moves. No `outputs/` artifact is written, edited, or deleted by this PR.
- In-tree consumers are the public `alberta_framework` API (the robot track's `core/{...,continual_backprop,...}` import per `CLAUDE.md`) and the four test files above.

## Precedent

Same defect class as #480 (`fix(features): bias-correct EMA utility outputs`, merged) and issue #431, which corrected the warm-up debias for `future_utility` / `feature_discovery`. `core/continual_backprop.py` was outside that change.

## What remains open

Eligibility uses `age >= maturity_threshold`; the paper says "units with age **more than** m" and `gnt.py` uses `torch.where(self.ages > self.maturity_threshold)`. That is a separate one-step off-by-one and a second moving part, so it is deliberately **not** in this PR. The utility signal itself (`|a * g|` rather than the paper's Eq. 5–6 outgoing-weight/adaptation product) is a pre-existing declared deviation and is likewise untouched.

Not measured here: whether the corrected ranking changes any downstream continual-learning number. No lane in this repository currently climbs on `core.continual_backprop`, so there is no baseline to move; this PR makes the replacement rule match its cited source, nothing more.

## Collision check

`gh issue list --state open --limit 100` and `gh pr list --state open --json number,title,files --limit 200` (182 open PRs) run before selecting and again immediately before commit. Three open PRs touch `continual_backprop.py` and all are disjoint from `_select_replacement_index`: #2272 and #2275 (`_ACTUAL_INT_TYPES` integer gates), #2261 (`hidden_sizes` layer-walk cap). Sibling worktrees checked with `git status`: both are on unrelated files (`benchmarks/activation_feature_ipmnist.py`, `pipeline.py`).

## Attribution

- Client: claude-code
- Provider: anthropic
- Model: claude-opus-5
- Lane: rama0x1-asi-claude-worker

---

<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0PWMBT0TZ6N3FKCD8JZX09Z","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-23T08:43:40.225Z","completed_at":"2026-08-23T08:44:20.877Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T08:43:42.178Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2fc07012f363b3f061a118a5ec9197a83b2d2bdd041532e9911d3f3764f3c4d5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"6c6bdf57-6120-4a1b-a0fd-ed650eb6489b","object_id":"sha256:2fc07012f363b3f061a118a5ec9197a83b2d2bdd041532e9911d3f3764f3c4d5","sha256":"2fc07012f363b3f061a118a5ec9197a83b2d2bdd041532e9911d3f3764f3c4d5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"W_8vhNQpBcjxV_mFnvdYMfeweE-mr7sZlIiX4EGFz18HHIhM95CNpI2x98rCieeWkkEUh1bigQbBilPZEc_tCQ"}} -->
