### PR TITLE
fix(benchmarks): score activation-lane plasticity under the step's own activation mask

### DIFF
--- a/alberta_framework/benchmarks/activation_feature_ipmnist.py
+++ b/alberta_framework/benchmarks/activation_feature_ipmnist.py
@@ -122,7 +122,13 @@ def _metrics(
     key: Array,
 ) -> tuple[Array, Array, Array]:
     accuracy = (jnp.argmax(logits) == y).astype(jnp.float32)
-    after = _loss(forward(params, x, key, False), y)
+    # ``loss`` came from the training-mode forward that produced the gradient.
+    # The runner's ``_step_metrics`` applies one forward function to both sides
+    # of the plasticity ratio, so the post-update loss is scored in the same
+    # mode from the same per-step key: for ``aid`` and ``ordinary_dropout`` that
+    # re-derives the identical activation mask, leaving the parameter update as
+    # the only thing that moved.  Every mode-independent arm is unaffected.
+    after = _loss(forward(params, x, key, True), y)
     plasticity = jnp.clip(1.0 - after / jnp.maximum(loss, _PLASTICITY_LOSS_FLOOR), 0.0, 1.0)
     return accuracy, loss, plasticity
 
@@ -672,7 +678,9 @@ def _activation_feature_result_payload(
             "gradient_evaluations": steps,
             "optimizer_scalar_updates": steps * allocated,
             "model_queries": 2 * steps,
-            "random_bernoulli_variates": steps * activation_width if stochastic else 0,
+            # Both metric forwards run in training mode, so a stochastic arm
+            # draws one mask per hidden unit in each of them.
+            "random_bernoulli_variates": 2 * steps * activation_width if stochastic else 0,
             "activation_scalar_evaluations": 2 * steps * activation_width,
             "allocated_parameter_scalars": allocated,
             "active_parameter_scalars": active,
@@ -885,7 +893,7 @@ def _validate_activation_feature_result(
         "gradient_evaluations": steps,
         "optimizer_scalar_updates": steps * allocated,
         "model_queries": 2 * steps,
-        "random_bernoulli_variates": steps * (hidden1 + hidden2) if stochastic else 0,
+        "random_bernoulli_variates": 2 * steps * (hidden1 + hidden2) if stochastic else 0,
         "activation_scalar_evaluations": 2 * steps * (hidden1 + hidden2),
         "allocated_parameter_scalars": allocated,
         "active_parameter_scalars": active,

--- a/tests/test_activation_feature_ipmnist.py
+++ b/tests/test_activation_feature_ipmnist.py
@@ -11,6 +11,7 @@ from alberta_framework.benchmarks.activation_feature_ipmnist import (
     ACTIVATION_FEATURE_SOURCES,
     ACTIVATION_FEATURE_SPECS,
     DEVELOPMENT_SEEDS,
+    _aid_forward,
     _preflight_activation_feature_resources,
     activation_feature_result_payload,
     activation_feature_spec,
@@ -18,8 +19,12 @@ from alberta_framework.benchmarks.activation_feature_ipmnist import (
     validate_activation_feature_result,
     validate_matched_activation_feature_results,
 )
-from alberta_framework.benchmarks.ipmnist_screening import run_screening_config, screening_spec
-from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+from alberta_framework.benchmarks.ipmnist_screening import (
+    ema_normalize,
+    run_screening_config,
+    screening_spec,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import _PLASTICITY_LOSS_FLOOR, IPMNISTConfig
 
 SMALL = IPMNISTConfig(n_tasks=2, task_length=4, input_dim=4, hidden1=4, hidden2=4, n_classes=2)
 
@@ -169,6 +174,56 @@ def test_factories_are_jittable_and_aid_is_deterministic_per_seed() -> None:
     np.testing.assert_array_equal(compiled[2][1], eager[2][1])
 
 
+def _stochastic_probe_params() -> dict[str, jnp.ndarray]:
+    keys = jax.random.split(jax.random.key(2), 6)
+    shapes = ((6, 8), (8,), (8, 8), (8,), (8, 3), (3,))
+    widths = (0.9, 0.3, 0.9, 0.3, 0.9, 0.3)
+    names = ("w1", "b1", "w2", "b2", "w3", "b3")
+    return {
+        name: jax.random.normal(key, shape) * width
+        for name, key, shape, width in zip(names, keys, shapes, widths, strict=True)
+    }
+
+
+@pytest.mark.parametrize("arm", ["aid", "ordinary_dropout"])
+def test_stochastic_arm_plasticity_holds_the_step_activation_mask_fixed(arm: str) -> None:
+    """Both sides of the plasticity ratio must use one activation rule.
+
+    The lane keeps ``run_screening_config``'s online metrics, and that runner's
+    ``_step_metrics`` evaluates ``loss`` and ``loss_after`` with a single
+    forward function, so plasticity isolates the parameter update.  ``aid`` and
+    ``ordinary_dropout`` are the only registered arms whose forward depends on
+    ``training``: their pre-update loss comes from a sampled mask, so the
+    post-update loss has to be scored under that same sampled mask rather than
+    under the deterministic evaluation rule.
+    """
+    params = _stochastic_probe_params()
+    x = jnp.asarray([1.0, -2.0, 0.5, 0.25, -0.75, 1.5], dtype=jnp.float32)
+    y = jnp.asarray(2, dtype=jnp.int32)
+    key = jax.random.key(2)
+    spec = activation_feature_spec(arm)
+    init, step = spec.factory(spec.hyperparameters)
+    state = init(params)
+    params_after, _next_state, (_accuracy, loss, plasticity) = step(params, state, x, y, key)
+
+    x_norm, _next_norm = ema_normalize(state.norm, x, 0.99, 1e-8)
+    ordinary = arm == "ordinary_dropout"
+    denominator = jnp.maximum(loss, _PLASTICITY_LOSS_FLOOR)
+
+    def ratio(training: bool) -> float:
+        after = -jax.nn.log_softmax(
+            _aid_forward(params_after, x_norm, key, training, expected=False, ordinary=ordinary)
+        )[y]
+        return float(jnp.clip(1.0 - after / denominator, 0.0, 1.0))
+
+    mask_matched = ratio(True)
+    evaluation_rule = ratio(False)
+    # The two rules must actually disagree here, or this pins nothing.
+    assert abs(mask_matched - evaluation_rule) > 0.5
+    assert 0.0 < mask_matched < 1.0 and 0.0 < evaluation_rule < 1.0
+    assert float(plasticity) == pytest.approx(mask_matched, abs=1e-6)
+
+
 def test_activation_shard_is_independent_of_ambient_default_prng() -> None:
     x, y = _data()
     with jax.default_prng_impl("threefry2x32"):
@@ -190,7 +245,8 @@ def test_result_receipt_is_exact_bounded_and_permanently_nonpromoting() -> None:
     assert payload["development_seed_protocol"] == list(DEVELOPMENT_SEEDS)
     assert payload["resources"]["data_steps"] == 8
     assert payload["resources"]["model_queries"] == 16
-    assert payload["resources"]["random_bernoulli_variates"] == 64
+    # Two training-mode forwards per step, each masking hidden1 + hidden2 units.
+    assert payload["resources"]["random_bernoulli_variates"] == 128
     assert validate_activation_feature_result(copy.deepcopy(payload)) == payload
 
     hostile = copy.deepcopy(payload)


### PR DESCRIPTION
<!-- evidence-head:7ec78078ce7f8a169c4231f64ce2ab7098f7dd3b -->

## What is wrong

`alberta_framework/benchmarks/activation_feature_ipmnist.py::_metrics` builds the
lane's per-step protocol metrics:

```python
accuracy = (jnp.argmax(logits) == y).astype(jnp.float32)
after = _loss(forward(params, x, key, False), y)          # evaluation rule
plasticity = jnp.clip(1.0 - after / jnp.maximum(loss, _PLASTICITY_LOSS_FLOOR), 0.0, 1.0)
```

`loss` and `logits` are whatever `jax.value_and_grad(objective)` returned, and
`objective` runs `forward(current, x_norm, key, True)` — **training** mode.
So the numerator of the plasticity ratio is scored under the deterministic
evaluation rule while its denominator was scored under a sampled activation
mask. Two things move at once, and the result is not a plasticity.

The module's own docstring says the lane "deliberately runs through
`run_screening_config`, so ... online metrics ... remain those of the live
IPMNIST screening runner". That runner does the opposite
(`ipmnist_screening.py::_step_metrics`):

```python
def _step_metrics(params_after, x, y, loss, logits) -> StepMetrics:
    """Protocol metrics: pre-update accuracy, loss, post-update plasticity."""
    accuracy = (jnp.argmax(logits) == y).astype(jnp.float32)
    loss_after, _ = cross_entropy_loss(params_after, x, y)
```

One forward function, both sides. The parameter update is the only thing that
differs between `loss` and `loss_after`.

### Why no test caught it

Nine of the eleven registered arms are mode-independent: `_smooth_forward` and
`_fourier_forward` both `del key, training`, and `aid_expected` ignores
`training` too. For those arms `forward(..., False)` and `forward(..., True)`
are the same function, so the defect is invisible. Only `aid` and
`ordinary_dropout` — the two arms whose forward branches on `training` — are
affected, and no test compared their reported plasticity against an
independently computed value.

## Why it corrupts measurement

`aid` is the lane's port of AID (arXiv:2502.01342v2, Algorithm 2) and
`ordinary_dropout` is its registered `aid_ablation` control. Their whole
purpose is to be compared against `aid_expected` (the deterministic-expectation
ablation) and `aid_off` (the exact `sgd_ema_norm_d099` control), which is how
the lane isolates whether *sampling* the mask, rather than applying its
expectation, is what matters. Under the current rule the two sampled arms are
the only ones whose plasticity is scored by a different function than the one
that produced their loss, so the comparison confounds the mechanism under test
with a measurement artefact.

`outputs/activation_feature_ipmnist/` does not exist yet — the registered
`cheap_screen.v2` / `full_confirmation.v2` campaign in
`alberta_framework/evaluation/activation_feature_campaign.py` is prospective and
unexecuted. Nothing pinned has to be re-run; this is the moment to fix the
metric.

## Point measurement, one step

`aid` and `ordinary_dropout`, `params` from `jr.split(jr.key(2), 6)` scaled
`(0.9, 0.3)` per layer, `x = [1.0, -2.0, 0.5, 0.25, -0.75, 1.5]`, `y = 2`,
step key `jr.key(2)` (this is the new regression test):

| arm | reported (evaluation rule) | correct (mask held fixed) |
|---|---|---|
| `aid` | 0.778277 | 0.114859 |
| `ordinary_dropout` | 0.771824 | 0.068130 |

A 6.8x and 11.3x overstatement on that step. In the earlier probe at
`jr.key(11)`/`jr.key(3)` the sign flips: the update genuinely removed 3.2% of
the example's loss under its own mask, and the current rule reports exactly
`0.0` because the evaluation-mode post-update loss exceeded the training-mode
pre-update loss and clipped.

## Stream measurement, all eleven arms

Same commit, same synthetic stream, same seeds, baseline and candidate differing
only by this change. MNIST is not cached in this sandbox, so the stream is
`np.random.default_rng(20260823).normal(size=(3000, 784))` with uniform labels;
it is byte-identical on both sides, which is all the paired comparison needs.
`IPMNISTConfig(n_tasks=2, task_length=500)`, seeds 0 and 1, every arm driven
through the real `run_activation_feature_arm` entrypoint and its
`activation_feature_result_payload` receipt.

| arm \| seed | plasticity (baseline) | plasticity (candidate) | delta | accuracy + loss identical |
|---|---|---|---|---|
| `aid` \| 0 | 0.071044 | 0.102837 | **+0.031793** | yes |
| `aid` \| 1 | 0.075830 | 0.108602 | **+0.032772** | yes |
| `ordinary_dropout` \| 0 | 0.066134 | 0.082690 | **+0.016556** | yes |
| `ordinary_dropout` \| 1 | 0.072351 | 0.090057 | **+0.017705** | yes |
| `aid_expected` \| 0 | 0.072653 | 0.072653 | +0.000000 | yes |
| `aid_expected` \| 1 | 0.078198 | 0.078198 | +0.000000 | yes |
| `aid_off` \| 0 | 0.097813 | 0.097813 | +0.000000 | yes |
| `aid_off` \| 1 | 0.104632 | 0.104632 | +0.000000 | yes |
| `smooth_leaky` \| 0 | 0.063534 | 0.063534 | +0.000000 | yes |
| `smooth_leaky` \| 1 | 0.064421 | 0.064421 | +0.000000 | yes |
| `smooth_leaky_off` \| 0 | 0.097813 | 0.097813 | +0.000000 | yes |
| `smooth_leaky_off` \| 1 | 0.104632 | 0.104632 | +0.000000 | yes |
| `smooth_leaky_fixed_leak` \| 0 | 0.105802 | 0.105802 | +0.000000 | yes |
| `smooth_leaky_fixed_leak` \| 1 | 0.111528 | 0.111528 | +0.000000 | yes |
| `deep_fourier` \| 0 | 0.382541 | 0.382541 | +0.000000 | yes |
| `deep_fourier` \| 1 | 0.379100 | 0.379100 | +0.000000 | yes |
| `deep_fourier_off` \| 0 | 0.097813 | 0.097813 | +0.000000 | yes |
| `deep_fourier_off` \| 1 | 0.104632 | 0.104632 | +0.000000 | yes |
| `deep_fourier_first_layer` \| 0 | 0.090807 | 0.090807 | +0.000000 | yes |
| `deep_fourier_first_layer` \| 1 | 0.082814 | 0.082814 | +0.000000 | yes |
| `deep_fourier_sine_only` \| 0 | 0.097188 | 0.097188 | +0.000000 | yes |
| `deep_fourier_sine_only` \| 1 | 0.098400 | 0.098400 | +0.000000 | yes |

Read the two invariants off that table:

- **Bit-exact reduction.** Every one of the nine mode-independent arms is
  unchanged to the last printed digit on both seeds. The change touches exactly
  the two arms whose forward depends on `training`, and nothing else.
- **No learning changed.** `asi_whole_stream_mean_accuracy` and
  `asi_whole_stream_mean_loss` are identical for all 22 runs. The gradient path
  is untouched — `after` never feeds back into `params` — so this is purely a
  measurement correction, not a new learner.

The baseline understates `aid`'s plasticity by 31% and 30% of the corrected
value on the two seeds, and `ordinary_dropout`'s by 20% and 20%.

## The change

One variable. `_metrics` now scores the post-update loss with the same forward
mode and the same per-step key as the pre-update loss:

```python
after = _loss(forward(params, x, key, True), y)
```

`_aid_forward` derives its masks with `key1, key2 = jr.split(key)`, so the same
`key` re-derives the *identical* mask. Only the parameters differ between the
two evaluations, which is exactly what `_step_metrics` guarantees for the
runner's own arms.

### Resource receipt

Both metric forwards are now stochastic for the two masked arms, so each step
draws one Bernoulli per hidden unit twice instead of once:

```python
"random_bernoulli_variates": 2 * steps * activation_width if stochastic else 0,
```

updated in both the payload builder and the validator's independent derivation,
which must agree exactly or `validate_activation_feature_result` fails closed.
This also removes an inconsistency: `random_bernoulli_variates` was the only
per-forward counter in the receipt billed once, while `model_queries`
(`2 * steps`), `activation_scalar_evaluations`, `forward_affine_weight_applications`
and `sigmoid_evaluations` are all billed twice for the lane's two forwards.
`model_queries` stays at `2 * steps` — no forward was added.

## Verification

Failing-test-first. The new
`test_stochastic_arm_plasticity_holds_the_step_activation_mask_fixed[aid, ordinary_dropout]`
recomputes the ratio from `_aid_forward` at the post-update parameters and
asserts the reported value matches the mask-matched one; it also asserts the two
rules disagree by more than 0.5 at those parameter values, so the pin cannot
silently degenerate. On `origin/main` both parametrizations fail:

```
E       assert 0.7718241810798645 == 0.06812989711761475 ± 1.0e-06
```

- `.venv/bin/python -m pytest tests/test_activation_feature_ipmnist.py -q -o addopts=""` — 16 passed
- `.venv/bin/python -m pytest tests/test_activation_feature_campaign.py tests/test_plasticity_comparators.py tests/test_console_entrypoints.py -q -o addopts=""` — 42 passed
- `.venv/bin/python -m ruff check alberta_framework/benchmarks/activation_feature_ipmnist.py tests/test_activation_feature_ipmnist.py` — All checks passed
- `.venv/bin/python -m mypy` — Success: no issues found in 224 source files

Baseline/candidate separation was produced by reverting only the two changed
files, re-running the same 22-run script, and restoring them; both sides ran on
the same machine, same JAX build, same `OMP_NUM_THREADS=1`.

## What this does not claim

- The lane stays permanently nonpromoting: `development_only: True`,
  `scientific_promotion_allowed: False`, unchanged.
- No benchmark result. The 22 runs above are a synthetic-stream measurement
  identity check, not an IPMNIST number, and the corrected plasticity values are
  not a claim about AID.
- Online **accuracy** for `aid` and `ordinary_dropout` is still scored from the
  sampled training-mode forward, exactly as before. Whether a stochastic arm
  should commit its scored online prediction through a sampled mask or through
  AID's deterministic evaluation rule is a separate protocol question; changing
  it would need a third forward per step and would move every arm's
  `model_queries`. Not in scope here — this PR only makes the two sides of the
  plasticity ratio use one rule.
- Paper parity is still not claimed; `comparability_gaps` are unchanged.

## Collision check

`gh pr list --repo SlopDotCash/asi --state open --json number,title,files --limit 200`
and `gh issue list --repo SlopDotCash/asi --state open --limit 100`, run before
picking the target and again immediately before commit (182 open PRs at the
second check): no open pull request or issue touches
`alberta_framework/benchmarks/activation_feature_ipmnist.py` or
`tests/test_activation_feature_ipmnist.py`. #2145 touches
`alberta_framework/evaluation/activation_feature_campaign.py`, a different file,
and does not overlap this diff.

## Attribution

- Client: claude-code
- Provider: anthropic
- Model: claude-opus-5
- Lane: rama0x1-asi-claude-worker-2

Refs #1566
