### PR TITLE
Fix CBP replacement to rank by bias-corrected utility (Eq. 8) — Closes #2343

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -483,21 +483,51 @@ def _select_replacement_index(
     utility: Array,
     age: Array,
     maturity_threshold: int,
+    decay_rate: float,
 ) -> tuple[Array, Array]:
-    """Pick the index of the lowest-utility mature unit, if any.
+    """Pick the index of the lowest bias-corrected-utility mature unit, if any.
 
     A unit is "mature" iff ``age >= maturity_threshold``. Among mature
-    units we pick the one with the smallest utility. If no mature unit
-    exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
-    ``False``.
+    units we rank by the *bias-corrected* utility of Dohare et al. 2024
+    (Nature 632, 768-774), Eq. 8:
 
-    Implementation: replace the utility of immature or non-finite units
-    with ``+inf`` before taking ``argmin`` so they are never chosen.
+        u_hat_l[i] = u_l[i] / (1 - decay_rate ** age_l[i])
+
+    and pick the unit with the smallest ``u_hat``. The raw utility EMA
+    ``u`` (Eq. 7) starts at 0 and warms up as ``(1 - decay_rate ** age)``,
+    so a freshly matured unit reads far below its true utility (e.g. at
+    ``decay_rate=0.99`` a unit of age 100 reads only ``1 - 0.99**100 =
+    0.634`` of it) while a long-lived unit reads at ~1.0. Because
+    :func:`_replace_one_unit` resets a replaced unit's age *and* utility
+    to 0, eligible units in a layer genuinely differ in age, so this
+    warm-up bias does not cancel: ranking on the raw EMA systematically
+    targets the youngest eligible units -- the very units the maturity
+    threshold exists to protect -- and in the pathological case CBP
+    re-replaces its own freshly reset unit every cycle. Dividing by the
+    per-unit bias correction before selection removes this, matching the
+    reference GnT implementation (``lop/algos/gnt.py``).
+
+    If no mature unit exists, ``selected`` is ``-1`` (sentinel) and
+    ``has_candidate`` is ``False``.
+
+    Implementation: replace the corrected utility of immature or
+    non-finite units with ``+inf`` before taking ``argmin`` so they are
+    never chosen. Eligibility semantics (``age >= maturity_threshold &
+    isfinite(utility)``) are unchanged. When ``maturity_threshold >= 1``
+    every eligible unit has ``age >= 1``, so its bias correction
+    ``1 - decay_rate ** age`` is strictly positive and the corrected
+    utility is finite; the degenerate ``maturity_threshold == 0`` case can
+    make an age-0 unit eligible with a zero correction (``0 / 0`` = NaN),
+    so the ``+inf`` mask also drops any non-finite corrected utility to
+    keep ``argmin`` from selecting it.
 
     Args:
-        utility: Per-unit utility array, shape ``(num_units,)``.
+        utility: Per-unit raw utility EMA array, shape ``(num_units,)``.
         age: Per-unit age array (same shape).
         maturity_threshold: Minimum age for eligibility.
+        decay_rate: EMA decay ``eta`` forming the per-unit bias correction
+            ``1 - decay_rate ** age`` (Eq. 8). Matches the ``decay_rate``
+            passed to :func:`update_utility`; cast to float32 as there.
 
     Returns:
         Tuple ``(index, has_candidate)`` where ``index`` is the chosen
@@ -505,7 +535,11 @@ def _select_replacement_index(
     """
     mature = age >= jnp.asarray(maturity_threshold, dtype=age.dtype)
     eligible = mature & jnp.isfinite(utility)
-    masked_utility = jnp.where(eligible, utility, jnp.inf)
+    decay = jnp.asarray(decay_rate, dtype=jnp.float32)
+    bias_correction = 1.0 - decay ** age.astype(jnp.float32)
+    corrected_utility = utility.astype(jnp.float32) / bias_correction
+    selectable = eligible & jnp.isfinite(corrected_utility)
+    masked_utility = jnp.where(selectable, corrected_utility, jnp.inf)
     has_candidate = jnp.any(eligible)
     idx = jnp.argmin(masked_utility)
     selected = jnp.where(has_candidate, idx, jnp.int32(-1))
@@ -687,6 +721,7 @@ def replace_units_with_flags(
             new_cbp_state.utilities[layer_idx],
             new_cbp_state.ages[layer_idx],
             config.maturity_threshold,
+            config.decay_rate,
         )
         # Only replace if we both budgeted for it AND found a mature unit.
         gated = jnp.logical_and(do_replace, has_candidate)

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -222,7 +222,7 @@ class TestUtilityUpdate:
         new = update_utility(cbp_state, activations, grads, 0.9)
         assert bool(jnp.all(jnp.isfinite(new.utilities[0])))
         chex.assert_trees_all_close(new.utilities[0][0], cbp_state.utilities[0][0])
-        idx, has = _select_replacement_index(new.utilities[0], new.ages[0], 10)
+        idx, has = _select_replacement_index(new.utilities[0], new.ages[0], 10, 0.9)
         assert bool(has)
         assert int(idx) == 1
 
@@ -243,6 +243,139 @@ class TestUtilityUpdate:
         assert bool(jnp.all(jnp.isfinite(new.utilities[0])))
         expected = jnp.abs(activations[0] * grads[0])
         chex.assert_trees_all_close(new.utilities[0], expected)
+
+
+class TestBiasCorrectedSelection:
+    """Replacement must rank by the bias-corrected utility (Dohare et al. 2024, Eq. 8).
+
+    The raw utility EMA of :func:`update_utility` (Eq. 7) starts at 0 and
+    warms up as ``(1 - decay_rate ** age)``, so a freshly matured unit
+    reads far below its true utility while a long-lived unit reads at
+    ~1.0. Ranking on that raw EMA systematically targets the youngest
+    eligible units. Both scenarios below drive the real ``update_utility``
+    EMA and would replace the wrong (younger, strictly more useful) unit
+    under raw-EMA ranking; the bias-corrected ranking must not.
+    """
+
+    @staticmethod
+    def _drive_single_unit(contribution: float, steps: int, decay: float) -> tuple[float, int]:
+        """Run the real ``update_utility`` EMA for one unit and return (utility, age).
+
+        A one-unit layer with constant post-activation ``contribution`` and
+        unit gradient makes ``|act * grad| == contribution`` each step, so the
+        raw EMA after ``steps`` updates is ``contribution * (1 - decay**steps)``.
+        """
+        state = ContinualBackpropState(  # type: ignore[call-arg]
+            utilities=(jnp.zeros(1, dtype=jnp.float32),),
+            ages=(jnp.zeros(1, dtype=jnp.int32),),
+            replacement_accumulators=jnp.zeros(1, dtype=jnp.float32),
+            rng_key=jr.key(0),
+        )
+        acts = (jnp.array([contribution], dtype=jnp.float32),)
+        grads = (jnp.array([1.0], dtype=jnp.float32),)
+        for _ in range(steps):
+            state = update_utility(state, acts, grads, decay)
+        return float(state.utilities[0][0]), int(state.ages[0][0])
+
+    def test_young_strong_unit_not_replaced_over_old_weak_unit(self) -> None:
+        """Falsifier A: a just-matured strong unit must not be replaced.
+
+        unit0 sees constant contribution 1.0 for 100 steps (age 100);
+        unit1 sees constant 0.9 for 700 steps (age 700). The raw EMA reads
+        unit0 (~0.6340) below unit1 (~0.8992) purely from warm-up bias, so
+        raw-EMA ranking replaces the strictly more useful unit0. Corrected
+        (Eq. 8), unit0 (~1.0) > unit1 (~0.9), so the fix replaces unit1.
+        """
+        decay = 0.99
+        u0, a0 = self._drive_single_unit(1.0, 100, decay)
+        u1, a1 = self._drive_single_unit(0.9, 700, decay)
+        assert a0 == 100 and a1 == 700
+        # Documented buggy premise: raw EMA depresses the younger, stronger unit.
+        assert u0 == pytest.approx(0.6340, abs=1e-3)
+        assert u1 == pytest.approx(0.8992, abs=1e-3)
+        assert u0 < u1
+        utility = jnp.array([u0, u1], dtype=jnp.float32)
+        age = jnp.array([a0, a1], dtype=jnp.int32)
+        # Raw-EMA argmin (the buggy statistic) would pick the younger unit0.
+        raw_masked = jnp.where(age >= 100, utility, jnp.inf)
+        assert int(jnp.argmin(raw_masked)) == 0
+        # The bias-corrected selection must pick unit1 instead.
+        idx, has = _select_replacement_index(utility, age, 100, decay)
+        assert bool(has)
+        assert int(idx) == 1
+
+    def test_repeat_victim_freshly_reset_unit_not_re_replaced(self) -> None:
+        """Falsifier B: a freshly reset unit must not be re-replaced by warm-up bias.
+
+        Four units. unit2 was reset 100 steps ago (age 100) yet carries the
+        largest true contribution (1.0); the three long-lived units (age 700)
+        carry a smaller true contribution (0.9). The raw EMA reads unit2
+        (~0.6340) below the long-lived units (~0.8992), so raw-EMA ranking
+        re-replaces the freshly reset unit2. Corrected (Eq. 8), unit2 recovers
+        to ~1.0 (the maximum) and the argmin falls on a long-lived unit --
+        index 0 -- never the repeat victim unit2.
+        """
+        decay = 0.99
+        u_young, a_young = self._drive_single_unit(1.0, 100, decay)
+        u_old, a_old = self._drive_single_unit(0.9, 700, decay)
+        utility = jnp.array([u_old, u_old, u_young, u_old], dtype=jnp.float32)
+        age = jnp.array([a_old, a_old, a_young, a_old], dtype=jnp.int32)
+        # Buggy raw-EMA statistic singles out the freshly reset unit2.
+        raw_masked = jnp.where(age >= 100, utility, jnp.inf)
+        assert int(jnp.argmin(raw_masked)) == 2
+        # The fix must not single out unit2; the argmin falls on index 0.
+        idx, has = _select_replacement_index(utility, age, 100, decay)
+        assert bool(has)
+        assert int(idx) != 2
+        assert int(idx) == 0
+
+    def test_decay_rate_threaded_from_config_into_selection(self) -> None:
+        """The replacement loop must rank by the config's ``decay_rate``.
+
+        End-to-end guard on falsifier A through ``replace_units_with_flags``:
+        a saturated accumulator forces one replacement, and the freshly reset
+        row must be unit1 (old-weak), not unit0 (young-strong).
+        """
+        decay = 0.99
+        u0, a0 = self._drive_single_unit(1.0, 100, decay)
+        u1, a1 = self._drive_single_unit(0.9, 700, decay)
+        learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(2,), sparsity=0.0)
+        mlp_state = learner.init(feature_dim=3, key=jr.key(1))
+        cbp_state = ContinualBackpropState(  # type: ignore[call-arg]
+            utilities=(jnp.array([u0, u1], dtype=jnp.float32),),
+            ages=(jnp.array([a0, a1], dtype=jnp.int32),),
+            # Accumulator already >= 1.0 so exactly one replacement fires.
+            replacement_accumulators=jnp.array([1.0], dtype=jnp.float32),
+            rng_key=jr.key(2),
+        )
+        config = ContinualBackpropConfig(
+            decay_rate=decay,
+            replacement_rate=1.0,
+            maturity_threshold=100,
+            enabled=True,
+        )
+        _, new_cbp, replaced = replace_units_with_flags(mlp_state, cbp_state, config, sparsity=0.0)
+        assert bool(replaced[0])
+        # The replaced unit's age/utility are reset to 0; unit1 must be the victim.
+        assert int(new_cbp.ages[0][1]) == 0
+        assert int(new_cbp.ages[0][0]) != 0
+
+    def test_zero_maturity_threshold_age_zero_gives_no_nan_selection(self) -> None:
+        """Guard: the bias correction's ``0/0`` NaN must not be picked by argmin.
+
+        With ``maturity_threshold == 0`` an age-0 unit is eligible, but its
+        bias correction ``1 - decay_rate ** 0 == 0`` makes the corrected
+        utility ``0 / 0 == NaN``. The +inf mask must drop that non-finite
+        value so a genuinely mature, finite-corrected unit is chosen instead.
+        """
+        decay = 0.99
+        u_old, a_old = self._drive_single_unit(0.5, 300, decay)
+        # unit0 is age-0 (NaN correction); unit1 is a mature finite candidate.
+        utility = jnp.array([0.0, u_old], dtype=jnp.float32)
+        age = jnp.array([0, a_old], dtype=jnp.int32)
+        idx, has = _select_replacement_index(utility, age, 0, decay)
+        assert bool(has)
+        assert int(idx) == 1
 
 
 class TestWrapperUtilityGradients:


### PR DESCRIPTION
Closes #2343

## What was broken and its measurement consequence

`alberta_framework/core/continual_backprop.py::_select_replacement_index` ranked mature hidden
units by the **raw** utility EMA `u` (Dohare et al. 2024, *Loss of plasticity in deep continual
learning*, Nature 632, 768–774, Eq. 7) and picked the smallest via `argmin`. The Continual
Backprop / GnT algorithm it implements ranks by the **bias-corrected** utility (Eq. 8):

```
u[l,i,t]     = eta * u[l,i,t-1] + (1 - eta) * y[l,i,t]     (7)
u_hat[l,i,t] = u[l,i,t] / (1 - eta ** a[l,i,t])            (8)
```

The raw EMA starts at 0 and warms up as `(1 - decay_rate ** age)`. Because `_replace_one_unit`
resets a replaced unit's age **and** utility to 0, eligible units in a layer genuinely differ in
age, so the warm-up bias does **not** cancel across units. At defaults (`decay_rate=0.99`,
`maturity_threshold=100`) a just-matured unit reads at `1 - 0.99**100 = 0.6340` of its true
utility while a long-lived unit reads at ~1.0. Ranking on the raw EMA therefore systematically
targets the youngest eligible units — the very units the maturity threshold exists to protect —
and in the pathological case CBP re-replaces its own freshly reset unit every cycle. This corrupts
the replacement selection that plasticity-injection depends on (same defect class as #480, #431).

## The fix (one moving part: the selection statistic)

Thread `config.decay_rate` into `_select_replacement_index` and rank by the per-unit
bias-corrected utility `u / (1 - decay_rate ** age)` (float32, matching `update_utility`), masking
non-finite corrected values to `+inf` before `argmin`, exactly as the reference implementation
(`shibhansh/loss-of-plasticity`, `lop/algos/gnt.py`) divides `util` by
`1 - decay_rate ** ages` per unit before selecting. Eligibility semantics
(`age >= maturity_threshold & isfinite(utility)`) are unchanged; `update_utility`,
`_replace_one_unit`, budgeting, and the public config surface are untouched. The `>=` vs `>`
maturity off-by-one is explicitly left out of scope per the issue. The degenerate
`maturity_threshold == 0` case (age-0 unit eligible → `1 - decay**0 == 0` → `0/0 == NaN`) is
guarded by the same `+inf` mask so `argmin` never selects the NaN.

Diff is confined to `core/continual_backprop.py` (selection statistic + call site) and
`tests/test_continual_backprop.py` (new regression coverage). `core/continual_backprop.py` is not
a registered evidence source and `alberta-evidence-status` output is byte-identical before/after
(verified against the stashed tree), so no screening/incumbent number moves.

## Before/after of the two falsifier numbers (issue's deterministic scenarios)

```
decay_rate=0.99, maturity_threshold=100

== Falsifier A: young-strong (unit0) vs old-weak (unit1) ==
  raw EMA (Eq.7):        unit0=0.6340 (age 100)  unit1=0.8992 (age 700)
  bias-corrected (Eq.8): unit0=1.0000  unit1=0.9000
  BUGGY raw argmin -> REPLACED UNIT [0] (the strictly more useful unit)
  FIXED  Eq.8 argmin -> REPLACED UNIT [1]

== Falsifier B: repeat victim (unit2 reset 100 steps ago, most useful) ==
  raw EMA (Eq.7):        [0.8992, 0.8992, 0.634, 0.8992]  ages [700, 700, 100, 700]
  bias-corrected (Eq.8): [0.9, 0.9, 1.0, 0.9]
  BUGGY raw argmin -> REPLACED UNIT [2] (re-replaces its own freshly reset unit)
  FIXED  Eq.8 argmin -> REPLACED UNIT [0]
```

Both scenarios drive the **real** `update_utility` EMA. Note on Falsifier B: with *identical* true
contribution 1.0 across all four units the bias-corrected values tie to within float32 noise
(~1e-7) and the `argmin` tiebreak is arbitrary; to keep the "repeat victim" falsifier deterministic
and float-robust the committed test gives the freshly-reset unit2 the *strictly largest* true
contribution (1.0) and the long-lived units a smaller one (0.9). Raw-EMA ranking still re-replaces
unit2 (warm-up bias), while the fix returns a long-lived unit (index 0) and never unit2 — the
issue's expected `REPLACED UNIT [0]`.

## Failing-then-passing reproduction

New class `TestBiasCorrectedSelection` (4 tests: falsifier A, falsifier B, an end-to-end
`replace_units_with_flags` guard confirming `config.decay_rate` is threaded through, and a
`maturity_threshold==0` NaN guard) **fails on pristine `main` (`c9aba7b5`)** and **passes after the
fix**. On pristine `main` the end-to-end test shows the buggy victim directly
(`assert 700 == 0` — the old-weak unit1 was NOT reset, so unit0 was wrongly replaced); the
`_select_replacement_index` tests fail on the 3-arg pristine signature.

```
########## 1. FAILING ON PRISTINE main (c9aba7b5) ##########
>       assert int(new_cbp.ages[0][1]) == 0
E       assert 700 == 0
E        +  where 700 = int(Array(700, dtype=int32))
tests/test_continual_backprop.py:360: AssertionError
...
FAILED tests/test_continual_backprop.py::TestBiasCorrectedSelection::test_young_strong_unit_not_replaced_over_old_weak_unit
FAILED tests/test_continual_backprop.py::TestBiasCorrectedSelection::test_repeat_victim_freshly_reset_unit_not_re_replaced
FAILED tests/test_continual_backprop.py::TestBiasCorrectedSelection::test_decay_rate_threaded_from_config_into_selection
FAILED tests/test_continual_backprop.py::TestBiasCorrectedSelection::test_zero_maturity_threshold_age_zero_gives_no_nan_selection
============================== 4 failed in 9.78s ===============================

########## 2. PASSING AFTER FIX — full CBP + validation suites ##########
tests/test_continual_backprop.py .......................................
............................................................
tests/test_continual_backprop_validation.py ............................
......
======================== 133 passed in 73.65s (0:01:13) ========================
```

## Exact verification commands and results (run on CPU-only ARM, this HEAD)

- `.venv/bin/python -m pytest tests/test_continual_backprop.py tests/test_continual_backprop_validation.py -q -o addopts=""` → **133 passed**
- `.venv/bin/python -m ruff check .` → **All checks passed!**
- `.venv/bin/python -m mypy` (full, strict py312) → **Success: no issues found in 224 source files**
- `.venv/bin/alberta-evidence-status` → byte-identical claim validity vs. the stashed pristine tree (this file is not a registered evidence source)

```
########## RUFF (repo-wide, CI form) ##########
All checks passed!

########## MYPY (full, strict py312, CI form) ##########
Success: no issues found in 224 source files
```

## What remains open

- The `>=` vs `>` maturity off-by-one is deliberately untouched (out of scope per #2343).
- `benchmarks/ipmnist_screening.py` carries its own separate CBP copy and is intentionally not
  modified here.

## Evidence note

The immutable attachment-URL minting tool (`attach.mjs`) could not complete its GitHub login in
this environment (a persistent auth/verification interstitial), so the failing-then-passing
pytest output, the falsifier before/after numbers, and the ruff/mypy output are embedded inline
above and are reproducible verbatim against the head SHA below.

<!-- evidence-head:ce7ca3d477990d582d5325046819eb4bc30b4b5c -->
<!-- evidence-row:logs -->
- [x] logs: embedded inline above (attachment-URL minting blocked by an environment auth interstitial; logs reproducible at the head SHA)

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi"} -->
