### PR TITLE
Fix horde_ac control path dropping terminated flag (#2344)

### DIFF
--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -1573,11 +1573,23 @@ class AlbertaPipeline:
                 dtype=jnp.int32,
             )
             auxiliary_cumulants = horde_cumulants[aux_indices] if aux_indices.size else None
+            # Only the value head's discount is a per-transition control
+            # quantity. Zero it at episode boundaries so the value head does
+            # not bootstrap through termination and the actor eligibility
+            # trace decays to zero; auxiliary GVF demons keep their configured
+            # gammas. At ``terminated == 0.0`` this reproduces the value head's
+            # configured gamma bit-for-bit, so the non-terminal path is
+            # unchanged versus omitting ``discount``.
+            value_gamma = self._horde.horde_spec.gammas[value_index]
+            control_discount = jnp.where(
+                terminated == 0.0, value_gamma, jnp.zeros_like(value_gamma)
+            )
             ac_result = ac.update(
                 ac_state,
                 reward,
                 features,
                 auxiliary_cumulants=auxiliary_cumulants,
+                discount=control_discount,
             )
             new_control_state: SARSAState | HordeActorCriticState = ac_result.state
             q_values_or_policy = ac_result.policy

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -431,6 +431,92 @@ def test_pipeline_with_horde_ac_control_smoke() -> None:
     assert smoke.q_values_shape == (4, 2)
 
 
+def _terminating_horde_ac_config() -> AlbertaPipelineConfig:
+    """Horde-AC config with a bootstrapping value head and a live actor trace."""
+    return AlbertaPipelineConfig(
+        features=Step2FeatureConfig.identity(observation_dim=3),
+        horde=Step3HordeConfig(
+            gammas=(0.9, 0.5),
+            lamdas=(0.0, 0.0),
+            hidden_sizes=(),
+            step_size=0.05,
+            use_obgd=True,
+            obgd_kappa=1.0,
+        ),
+        control=Step4SARSAConfig(
+            n_actions=2,
+            hidden_sizes=(),
+            epsilon_start=0.0,
+            epsilon_end=0.0,
+            step_size=0.05,
+            bounder_kappa=1.0,
+        ),
+        horde_ac=HordeActorCriticPipelineConfig(
+            n_actions=2,
+            actor_step_size=0.02,
+            actor_lamda=0.8,
+            value_head_index=0,
+        ),
+        control_mode="horde_ac",
+    )
+
+
+def test_pipeline_horde_ac_honors_terminated_discount() -> None:
+    """Regression for #2344: ``horde_ac`` must honor ``terminated``.
+
+    On the ``control_mode="horde_ac"`` path the pipeline previously dropped the
+    ``terminated`` flag, so the value head bootstrapped through episode
+    boundaries and the actor eligibility trace survived every termination. This
+    checks that at a terminal transition the value head's TD target collapses to
+    the bare reward and the actor trace is zeroed, that the auxiliary demon keeps
+    its own configured gamma, and that the non-terminal path is bit-identical to
+    the pre-fix behavior.
+    """
+    config = _terminating_horde_ac_config()
+    pipeline = make_alberta_pipeline(config)
+    value_index = config.horde_ac.value_head_index
+
+    state = pipeline.init(jr.key(0), jnp.asarray([0.2, -0.1, 0.4], dtype=jnp.float32))
+    obs = jnp.asarray([0.1, 0.3, -0.2], dtype=jnp.float32)
+    reward = jnp.asarray(0.5, dtype=jnp.float32)
+    cumulants = jnp.asarray([0.5, -0.2], dtype=jnp.float32)
+
+    non_terminal = pipeline.update(
+        state, obs, reward, jnp.asarray(0.0, dtype=jnp.float32), cumulants
+    )
+    terminal = pipeline.update(
+        state, obs, reward, jnp.asarray(1.0, dtype=jnp.float32), cumulants
+    )
+
+    # (a) At termination the value head does not bootstrap: target == reward.
+    assert float(terminal.horde_td_targets[value_index]) == float(reward)
+    # The non-terminal value target genuinely bootstraps (target != reward),
+    # so the terminal collapse is a real behavioral change, not a no-op.
+    assert float(non_terminal.horde_td_targets[value_index]) != float(reward)
+
+    # (b) The actor eligibility trace is zeroed at the episode boundary.
+    terminal_trace = terminal.state.control_state.actor_trace_weights
+    np.testing.assert_array_equal(terminal_trace, jnp.zeros_like(terminal_trace))
+    # The non-terminal trace still carries accumulated eligibility.
+    non_terminal_trace = non_terminal.state.control_state.actor_trace_weights
+    assert float(jnp.max(jnp.abs(non_terminal_trace))) > 0.0
+
+    # Only the value head's discount is a per-transition control quantity:
+    # the auxiliary demon keeps its configured gamma across the boundary.
+    aux_index = 1 - value_index
+    chex.assert_trees_all_equal(
+        terminal.horde_td_targets[aux_index],
+        non_terminal.horde_td_targets[aux_index],
+    )
+
+    # (c) The ``terminated=0.0`` path is bit-exact with the pre-fix behavior:
+    # passing the value head's own gamma reduces to omitting ``discount``.
+    np.testing.assert_array_equal(
+        np.asarray(non_terminal.horde_td_targets),
+        np.asarray([0.34537804, -0.18965168], dtype=np.float32),
+    )
+
+
 def test_pipeline_with_associative_step2_smoke() -> None:
     """Associative Step 2 exposes finite probability features and updates."""
     config = _small_associative_config()


### PR DESCRIPTION
## Summary

Closes #2344.

`AlbertaPipeline.update` documents and validates a `terminated` scalar flag
(`{0.0, 1.0}` float32). On the default `control_mode="sarsa"` path it flows into
`SARSAAgent.update`, which correctly skips bootstrapping and zeroes eligibility
traces at terminal transitions. On the `control_mode="horde_ac"` path, however,
`terminated` was **dropped entirely** — the call to
`HordeActorCriticAgent.update` passed no `discount`, so the agent fell back to
the value head's configured demon gamma on *every* step. Two measurement bugs
resulted at a terminal transition:

1. **The value head bootstrapped through termination** — its TD target was
   `r + γ·V(s')` instead of `r`.
2. **The actor eligibility trace survived the episode boundary** — with a
   non-zero discount, `carry_traces = value_discount != 0.0` never fired, so the
   trace bled into the next episode.

This is a measurement-trustworthiness fix: any Horde-AC run crossing episode
boundaries was learning a value function and policy that leak reward and credit
across terminations. **No benchmark climb, no `outputs/` change, no frozen
lifecycle or registered evidence source is touched.**

## Fix

The correct plumbing already existed: `HordeActorCriticAgent.update` accepts an
optional `discount` and routes to `HordeLearner.update_with_discounts`, which is
designed for control adapters to zero the value head at episode boundaries while
keeping fixed GVF metadata and per-head trace decay intact. The pipeline is such
a control adapter and was the only in-tree one not using it.

In the `horde_ac` branch of `alberta_framework/pipeline.py` we now compute a
terminal-aware value-head discount and pass it through:

```python
value_gamma = self._horde.horde_spec.gammas[value_index]
control_discount = jnp.where(terminated == 0.0, value_gamma, jnp.zeros_like(value_gamma))
ac_result = ac.update(..., discount=control_discount)
```

**Scope constraint honored:** only the value head's per-transition discount
changes. Auxiliary GVF demons keep their own configured gammas — `update` sets
`discounts = gammas.at[value_head_index].set(value_discount)`, so every other
head is untouched.

**Bit-exact at `terminated == 0.0`:** `update_with_discounts` computes
`bootstrap = jnp.where(discounts == 0.0, 0.0, discounts * next_preds)` from the
same `gammas` vector the `discount is None` branch uses, and passing
`value_gamma` reproduces `value_discount = value_gamma` exactly. The reproduction
confirms the non-terminal line is byte-identical before and after
(`0.34537804`, `-0.18965168`).

`run_arrays` / `run_pipeline_smoke` delegate to `update`, so they inherit the fix.

## Reproduction (failing → passing)

Identity Step 2 features, `horde.gammas=(0.9, 0.5)`, `value_head_index=0`,
`actor_lamda=0.8`; one `update` from `init` for each `terminated` value.

**Pre-fix — `terminated` has no effect (both lines byte-identical):**
```
0.0 td_targets= [ 0.34537804 -0.18965168] trace= [ 0.1  -0.05  0.2  -0.1   0.05 -0.2 ]
1.0 td_targets= [ 0.34537804 -0.18965168] trace= [ 0.1  -0.05  0.2  -0.1   0.05 -0.2 ]
```

**Post-fix — terminal case honors `terminated`:**
```
0.0 td_targets= [ 0.34537804 -0.18965168] trace= [ 0.1  -0.05  0.2  -0.1   0.05 -0.2 ]
1.0 td_targets= [ 0.5        -0.18965168] trace= [0. 0. 0. 0. 0. 0.]
```

At `terminated=1.0` the value-head target (index 0) collapses to the bare reward
`0.5`, the actor trace is zeroed, and the auxiliary demon target (`-0.18965168`)
is unchanged. At `terminated=0.0` everything is bit-identical to pre-fix.

## Verification commands and results

Focused regression (`tests/test_pipeline.py::test_pipeline_horde_ac_honors_terminated_discount`):
```
# pre-fix
1 failed, 183 deselected in 5.90s
    assert float(terminal.horde_td_targets[value_index]) == float(reward)
E   assert 0.345378041267395 == 0.5
# post-fix
1 passed, 183 deselected in 5.68s
```

Full pipeline suite:
```
.venv/bin/python -m pytest tests/test_pipeline.py -q -o addopts=""
184 passed in 122.34s (0:02:02)
```

Lint:
```
.venv/bin/python -m ruff check .
All checks passed!
```

Types (CI mypy scope is `files = ["alberta_framework"]`):
```
.venv/bin/python -m mypy alberta_framework/pipeline.py
Success: no issues found in 1 source file
```

## What remains open

The SARSA path was already correct; this only closes the Horde-AC control
adapter gap. No performance claim, no frozen protocol, and no `outputs/`
artifact is involved.

> Note on evidence hosting: the `github.com/user-attachments` minting service
> was blocked by a GitHub verification interstitial in this environment, so the
> captured failing-then-passing and verification logs are hosted as an immutable
> public gist instead; the full command transcripts are also embedded inline
> above.

<!-- evidence-head:81465c1b91317dcbbcdb743658f5fa56f4a0d1df -->
<!-- evidence-row:logs -->
- [x] logs: https://gist.github.com/agent-cortex/c3f77a68c4ca09da1a61cd84f7c8b9d2

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi"} -->
