### PR TITLE
fix(core): keep the error out of Adam/RMSprop gradient-path steps

### DIFF
--- a/alberta_framework/core/baseline_optimizers.py
+++ b/alberta_framework/core/baseline_optimizers.py
@@ -512,8 +512,11 @@ class Adam(Optimizer[Any]):
 
     For the MLP path (:meth:`update_from_gradient`), the gradient is
     pre-computed by the caller (e.g. an eligibility trace or a VJP
-    cotangent), and the returned step does NOT include the error --
-    callers apply ``param += step`` directly.
+    cotangent), and the returned step never includes the error: with
+    ``error=None`` the gradient is the loss gradient and callers apply
+    ``param -= step``; with ``error`` supplied the gradient is the
+    prediction gradient and callers apply ``param += error * step``,
+    the same convention as the LMS/IDBD/Autostep error paths.
 
     With nonzero ``weight_decay``, the MLP path implements decoupled
     weight decay (AdamW; Loshchilov & Hutter 2019): the returned step
@@ -649,22 +652,26 @@ class Adam(Optimizer[Any]):
     ) -> ParamOptimizerUpdate:
         """Compute Adam step from a pre-computed gradient (MLP path).
 
-        The returned step has the SAME sign as the descent step, i.e.
-        callers apply ``param -= step`` to minimize loss when the
-        gradient is the loss gradient. When the gradient is the
-        prediction gradient ``dy/dw`` and the caller wants to do
-        ``param += error * step``, ``error`` should be passed so it is
-        folded into the moment EMAs.
+        With ``error=None`` the gradient is the loss gradient: the
+        returned step points along it and callers apply ``param -= step``
+        to minimize.
 
-        When ``error`` is ``None``, the gradient is assumed to already
-        be the loss gradient and is used as-is.
+        With ``error`` supplied the gradient is the prediction gradient
+        ``dy/dw`` and the base ``Optimizer.update_from_gradient``
+        contract applies: the returned step excludes the error, and the
+        caller multiplies ``error * step`` before applying. The moment
+        EMAs therefore condition the prediction gradient only; the
+        applied update scales linearly with the error, exactly like the
+        LMS/IDBD/Autostep error paths. Folding the error into the
+        moments here would reverse the applied update's sign under the
+        caller's multiplication.
 
         Args:
             state: Current per-parameter Adam state
             gradient: Pre-computed gradient (any shape matching state)
-            error: Optional prediction error scalar. When provided, the
-                effective gradient becomes ``-error * gradient`` (loss
-                gradient direction for ``loss = 0.5 * error^2``).
+            error: Optional prediction error scalar. Never enters the
+                returned step (the caller multiplies ``error * step``);
+                it still gates the checked-update transaction.
             param: Current parameter values; required when the optimizer
                 was constructed with nonzero ``weight_decay`` so the
                 decoupled decay term ``step_size * weight_decay * param``
@@ -680,10 +687,7 @@ class Adam(Optimizer[Any]):
         if self._weight_decay != 0.0 and param is None:
             raise ValueError("nonzero weight_decay requires passing param")
 
-        if error is not None:
-            g = -jnp.squeeze(error) * gradient
-        else:
-            g = gradient
+        g = gradient
 
         new_t = state.t + 1.0
         new_m = _skip_zero_scale(self._beta1, state.beta1, state.m) + (
@@ -952,22 +956,24 @@ class RMSprop(Optimizer[Any]):
     ) -> ParamOptimizerUpdate:
         """Compute RMSprop step from a pre-computed gradient (MLP path).
 
-        When ``error`` is supplied, the effective gradient is treated as
-        ``-error * gradient`` (loss gradient for squared error); when it
-        is ``None`` the gradient is used as-is (already a loss gradient).
+        With ``error=None`` the gradient is the loss gradient and
+        callers apply ``param -= step``. With ``error`` supplied the
+        gradient is the prediction gradient and the returned step
+        excludes the error (the base ``Optimizer.update_from_gradient``
+        contract): the caller multiplies ``error * step``, so the
+        second-moment normalizer conditions the prediction gradient
+        only. ``error`` still gates the checked-update transaction.
 
         Args:
             state: Current per-parameter RMSprop state
             gradient: Pre-computed gradient (any shape matching state)
-            error: Optional prediction error scalar
+            error: Optional prediction error scalar (never enters the
+                returned step)
 
         Returns:
             ``(step, new_state)`` -- step has the same shape as gradient
         """
-        if error is not None:
-            g = -jnp.squeeze(error) * gradient
-        else:
-            g = gradient
+        g = gradient
 
         new_v = _skip_zero_scale(self._decay, state.decay, state.v) + (
             1.0 - state.decay

--- a/tests/test_baseline_optimizers.py
+++ b/tests/test_baseline_optimizers.py
@@ -577,3 +577,98 @@ class TestNADALINE:
         chex.assert_tree_all_finite(result.new_state)
         chex.assert_tree_all_finite(result.weight_delta)
         chex.assert_tree_all_finite(result.bias_delta)
+
+
+# =============================================================================
+# The error-path contract shared with LMS/IDBD/Autostep
+# =============================================================================
+
+
+class TestErrorPathDescentContract:
+    """``update_from_gradient`` with ``error`` must honour the base contract.
+
+    ``Optimizer.update_from_gradient`` documents that the returned delta
+    does NOT include the error: every MLP/multi-head/Horde caller applies
+    ``param += error * step``. A step that folds the error in (or points
+    along the loss gradient) therefore reverses the applied update's sign
+    and scales it by ``error**2`` -- the update ascends the squared error
+    instead of descending it.
+    """
+
+    @pytest.mark.parametrize("optimizer", [Adam(step_size=0.01), RMSprop(step_size=0.01)])
+    def test_applied_update_descends_like_lms(self, optimizer):
+        """sign(error * step) must match the LMS descent direction."""
+        gradient = jnp.asarray([1.0], dtype=jnp.float32)
+        for error_value in (1.0, -1.0):
+            state = optimizer.init_for_shape((1,))
+            error = jnp.asarray(error_value, dtype=jnp.float32)
+            step, _ = optimizer.update_from_gradient(state, gradient, error=error)
+            applied = float(error * step[0])
+            # LMS applies error * (step_size * gradient): sign(error * gradient).
+            expected_sign = error_value * float(gradient[0])
+            assert applied * expected_sign > 0.0, (
+                f"{type(optimizer).__name__} applied update {applied} opposes the "
+                f"descent direction for error={error_value}"
+            )
+
+    @pytest.mark.parametrize("optimizer", [Adam(step_size=0.01), RMSprop(step_size=0.01)])
+    def test_step_excludes_the_error(self, optimizer):
+        """The returned step must be identical for any supplied error value."""
+        gradient = jnp.asarray([0.3, -0.7], dtype=jnp.float32)
+        steps = []
+        for error_value in (0.5, 2.0, -3.0):
+            state = optimizer.init_for_shape((2,))
+            error = jnp.asarray(error_value, dtype=jnp.float32)
+            step, _ = optimizer.update_from_gradient(state, gradient, error=error)
+            steps.append(step)
+        chex.assert_trees_all_equal(steps[0], steps[1])
+        chex.assert_trees_all_equal(steps[0], steps[2])
+
+    @pytest.mark.parametrize(
+        "optimizer", [Adam(step_size=0.05), RMSprop(step_size=0.05)]
+    )
+    def test_linear_unit_converges_under_caller_convention(self, optimizer):
+        """200 ``param += error * step`` updates must reduce the squared error."""
+        x = jnp.asarray(1.0, dtype=jnp.float32)
+        target = 1.0
+        w = jnp.asarray(0.0, dtype=jnp.float32)
+        state = optimizer.init_for_shape((1,))
+        first_error = None
+        for _ in range(200):
+            error = jnp.asarray(target - float(w * x), dtype=jnp.float32)
+            if first_error is None:
+                first_error = float(error) ** 2
+            step, state = optimizer.update_from_gradient(
+                state, jnp.asarray([x], dtype=jnp.float32), error=error
+            )
+            w = w + error * step[0]
+        final_error = (target - float(w * x)) ** 2
+        assert first_error is not None
+        assert final_error < 1e-2, (
+            f"{type(optimizer).__name__} did not converge: squared error "
+            f"{first_error} -> {final_error}"
+        )
+
+    def test_error_none_loss_gradient_path_is_unchanged(self):
+        """``error=None`` keeps the documented loss-gradient step exactly."""
+        optimizer = Adam(step_size=0.01, beta1=0.9, beta2=0.999, eps=1e-8)
+        state = optimizer.init_for_shape((2,))
+        gradient = jnp.asarray([2.0, -0.5], dtype=jnp.float32)
+        step, new_state = optimizer.update_from_gradient(state, gradient, error=None)
+        m_hat = ((1.0 - 0.9) * gradient) / (1.0 - 0.9)
+        v_hat = ((1.0 - 0.999) * gradient**2) / (1.0 - 0.999)
+        expected = 0.01 * m_hat / (jnp.sqrt(v_hat) + 1e-8)
+        chex.assert_trees_all_close(step, expected, atol=1e-7)
+        assert float(new_state.t) == pytest.approx(1.0)
+
+    def test_error_still_gates_the_transaction(self):
+        """A non-finite error must still veto the checked update."""
+        optimizer = Adam(step_size=0.01)
+        state = optimizer.init_for_shape((1,))
+        result = optimizer.update_from_gradient_checked(
+            state,
+            jnp.asarray([1.0], dtype=jnp.float32),
+            error=jnp.asarray(jnp.nan, dtype=jnp.float32),
+        )
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_close(result.step, jnp.zeros(1))


### PR DESCRIPTION
## Issue

`Optimizer.update_from_gradient` documents that the returned delta excludes the error — the caller multiplies `error * delta` before applying (`alberta_framework/core/optimizers.py:522`), and every consumer does exactly that (`learners.py:1599`, `multi_head_learner.py:1338`, the Horde/actor-critic learners via `_update_from_gradient_with_diagnostics`). `Adam.update_from_gradient_checked` and `RMSprop.update_from_gradient_checked` instead folded `-error * gradient` into their moment statistics and returned a loss-direction step. Under the caller's multiplication the applied update collapses to `-alpha * |error| * sign(gradient)`: an anti-gradient step whose sign no longer depends on the error's sign and whose magnitude applies the error twice. The class docstring ("callers apply `param += step`"), the method docstring ("callers apply `param -= step`"), and the base contract stated three mutually incompatible conventions; the consumers follow the base contract.

## Symptoms

One linear unit, `error=+1, x=+1` (LMS moves `w` by `+0.010000`): Adam moved `w` by `-0.010000`, RMSprop by `-0.100000`. Squared error over 200 identical steps: LMS `1.0 -> 3.2e-4`, Adam `1.0 -> 2.95e6`, RMSprop `1.0 -> 1.48e13`. End-to-end, `MultiHeadMLPLearner` with `head_optimizer=Adam(...)` reached squared error `4.07e14` after 300 steps on a trivially learnable linear target (`CBPMultiHeadMLPLearner` + Adam: `7.61e14`). `supported_for_mlp()` returns `True` and the config round-trips, so an "MLP + Adam/RMSprop" baseline silently reports divergence that is an implementation artifact — with `update_applied=True` throughout, because every intermediate stays finite for hundreds of steps and the fail-closed machinery has nothing to veto.

The active benchmark lanes are unaffected: `upgd_ipmnist.py`, `ipmnist_screening.py`, `noise_curvature_ipmnist.py`, and `core/adamo.py` use the `error=None` loss-gradient path, which is byte-identical before and after this change.

## New state

Both optimizers feed their moment statistics the caller's gradient unchanged, so the returned step excludes the error exactly as the base contract requires, and the applied `param += error * step` descends `0.5 * error**2`: with `error=+1, x=+1` Adam now moves `w` by `+0.010000`; 200-step squared error is `1.0 -> 3.2e-4` (Adam) and `1.0 -> 2e-6` (RMSprop); the multi-head Adam probe lands at `0.47`, in line with LMS on the same noisy stream. Under this interface the error path conditions the prediction gradient and scales linearly with the error — textbook Adam over the loss gradient is not expressible when the caller owns the error multiplication — and the docstrings now say exactly that. The `error=None` path is pinned unchanged by a hand-computed test, and a non-finite error still vetoes the checked transaction.

Verification, all at head `0cfb3943fc4904d92de455c88c41d342c13b635a` (on `c9aba7b5`):

- Red phase: the six new contract tests (descent direction, bitwise error-exclusion, 200-step convergence; Adam and RMSprop each) fail on the pre-fix tree exactly as predicted; after the fix all pass. Reverting only the source change reproduces the six failures (mutation check).
- `tests/test_baseline_optimizers.py` 41 passed; consumers `test_learners.py` + `test_multi_head_learner.py` + `test_optimizer_nonfinite_transactions.py` 290 passed; `test_horde_actor_critic.py` + `test_adamo.py` + `test_independent_demon_horde.py` + `test_average_reward.py` 255 passed. Ruff and mypy clean on the changed files.
- No existing test encoded the buggy sign; the prior error-path tests asserted finiteness only.

Open question for the maintainer: the alternative fix is to reject `error != None` in Adam/RMSprop and drop `supported_for_mlp()`; that removes a config surface that round-trips today, so this PR takes the contract-honouring repair instead. Nothing in-tree depends on the old behaviour.

## Agent disclosure

- client: Claude Code
- provider: anthropic
- model: claude-fable-5
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
- Slop run `run_01M0PXVHJ7EMV716R8V1KPESZB` is active; the signed receipt + private-trace footer will be appended when the measured run finalizes.
