### PR TITLE
fix(core): decay actor-critic traces with the trace-side discount

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -764,8 +764,9 @@ class ActorCriticAgent:
         actor_grad_bias = (one_hot - old_policy) / cfg.temperature
         actor_grad_weights = actor_grad_bias[:, None] * prev_obs[None, :]
 
-        actor_decay = discount * cfg.actor_lamda
-        critic_decay = discount * cfg.critic_lamda
+        trace_discount = jnp.where(discount == 0.0, cfg.gamma, discount)
+        actor_decay = trace_discount * cfg.actor_lamda
+        critic_decay = trace_discount * cfg.critic_lamda
         actor_trace_weights = (
             jnp.where(
                 actor_decay == 0.0,
@@ -1586,8 +1587,9 @@ class ContinuousActorCriticAgent:
         mean_grad_weights = mean_grad_bias[:, None] * prev_obs[None, :]
         log_sigma_grad = (diff * diff) / sigma_sq - 1.0
 
-        actor_decay = discount * cfg.actor_lamda
-        critic_decay = discount * cfg.critic_lamda
+        trace_discount = jnp.where(discount == 0.0, cfg.gamma, discount)
+        actor_decay = trace_discount * cfg.actor_lamda
+        critic_decay = trace_discount * cfg.critic_lamda
         mean_trace_weights = (
             jnp.where(
                 actor_decay == 0.0,

--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -718,7 +718,8 @@ class QHordeActorCriticAgent:
             else sampled_actor_grad_bias
         )
         actor_grad_weights = actor_grad_bias[:, None] * prev_obs[None, :]
-        actor_decay = effective_gamma * cfg.actor_lamda
+        trace_discount = jnp.where(effective_gamma == 0.0, cfg.gamma, effective_gamma)
+        actor_decay = trace_discount * cfg.actor_lamda
         actor_trace_weights = (
             _skip_zero_scale(actor_decay, state.actor_trace_weights) + actor_grad_weights
         )
@@ -1041,7 +1042,8 @@ class HordeActorCriticAgent:
         one_hot = jax.nn.one_hot(safe_last_action, cfg.n_actions, dtype=jnp.float32)
         actor_grad_bias = (one_hot - old_policy) / cfg.temperature
         actor_grad_weights = actor_grad_bias[:, None] * prev_obs[None, :]
-        actor_decay = value_discount * cfg.actor_lamda
+        trace_discount = jnp.where(value_discount == 0.0, value_gamma, value_discount)
+        actor_decay = trace_discount * cfg.actor_lamda
         actor_trace_weights = (
             _skip_zero_scale(actor_decay, state.actor_trace_weights) + actor_grad_weights
         )
@@ -1861,7 +1863,8 @@ class NonlinearHordeActorCriticAgent:
             cfg.actor_gradient_clip_norm,
         )
 
-        actor_decay = value_discount * cfg.actor_lamda
+        trace_discount = jnp.where(value_discount == 0.0, value_gamma, value_discount)
+        actor_decay = trace_discount * cfg.actor_lamda
         n_hidden = len(cfg.hidden_sizes)
 
         new_trunk_traces: list[Array] = []
@@ -2547,7 +2550,8 @@ class NonlinearQHordeActorCriticAgent:
             cfg.actor_gradient_clip_norm,
         )
 
-        actor_decay = effective_gamma * cfg.actor_lamda
+        trace_discount = jnp.where(effective_gamma == 0.0, cfg.gamma, effective_gamma)
+        actor_decay = trace_discount * cfg.actor_lamda
         n_hidden = len(cfg.hidden_sizes)
         new_trunk_traces: list[Array] = []
         for i in range(n_hidden):

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -14,6 +14,8 @@ from alberta_framework.core import ActorCriticAgent as CoreActorCriticAgent
 from alberta_framework.core.actor_critic import (
     ActorCriticAgent,
     ActorCriticConfig,
+    ContinuousActorCriticAgent,
+    ContinuousActorCriticConfig,
     _require_discrete_state_resources,
     run_actor_critic_from_arrays,
 )
@@ -595,3 +597,107 @@ def test_actor_critic_state_contract_and_counter_saturation() -> None:
     )
     assert bool(result.update_applied)
     assert int(result.state.step_count) == 2**31 - 1
+
+
+def test_actor_critic_terminal_update_credits_in_episode_trace() -> None:
+    gamma, lam = 0.9, 0.9
+    agent = ActorCriticAgent(
+        ActorCriticConfig(
+            n_actions=2,
+            gamma=gamma,
+            actor_step_size=0.1,
+            critic_step_size=0.1,
+            actor_lamda=lam,
+            critic_lamda=lam,
+            temperature=1.0,
+        )
+    )
+    obs_a = jnp.array([1.0, 0.0], dtype=jnp.float32)
+    obs_b = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    state = agent.init(feature_dim=2, key=jr.key(0)).replace(  # type: ignore[attr-defined]
+        last_observation=obs_a,
+        last_action=jnp.array(0, dtype=jnp.int32),
+    )
+
+    first = agent.update(
+        state,
+        reward=jnp.array(0.0, dtype=jnp.float32),
+        observation=obs_b,
+        terminated=jnp.array(False),
+    )
+    assert bool(first.update_applied)
+    mid = first.state.replace(last_action=jnp.array(0, dtype=jnp.int32))  # type: ignore[attr-defined]
+    policy_at_b = agent.policy(mid, obs_b)
+
+    last = agent.update(
+        mid,
+        reward=jnp.array(1.0, dtype=jnp.float32),
+        observation=jnp.zeros(2, dtype=jnp.float32),
+        terminated=jnp.array(True),
+    )
+    assert bool(last.update_applied)
+    delta = last.td_error
+
+    # Backward view (Sutton & Barto 2nd ed, eq. 12.25): the trace carried into
+    # the terminal update decays by the discount of the transition INTO S_1,
+    # which was non-terminal, so phi(S_0) keeps gamma * lam credit.
+    expected_critic_trace = gamma * lam * jnp.array([1.0, 0.0]) + jnp.array([0.0, 1.0])
+    chex.assert_trees_all_close(
+        last.state.critic_weights, 0.1 * delta * expected_critic_trace, atol=1e-6
+    )
+
+    grad_a0_at_a = 1.0 - 0.5
+    grad_a0_at_b = (jnp.array([1.0, 0.0]) - policy_at_b)[0]
+    expected_actor_trace_row0 = jnp.array(
+        [gamma * lam * grad_a0_at_a, grad_a0_at_b], dtype=jnp.float32
+    )
+    chex.assert_trees_all_close(
+        last.state.actor_weights[0], 0.1 * delta * expected_actor_trace_row0, atol=1e-6
+    )
+
+    chex.assert_trees_all_close(
+        last.state.critic_trace_weights, jnp.zeros(2, dtype=jnp.float32)
+    )
+    chex.assert_trees_all_close(
+        last.state.actor_trace_weights, jnp.zeros((2, 2), dtype=jnp.float32)
+    )
+
+
+def test_continuous_actor_critic_terminal_update_credits_in_episode_trace() -> None:
+    gamma, lam = 0.9, 0.9
+    agent = ContinuousActorCriticAgent(
+        ContinuousActorCriticConfig(
+            action_dim=1,
+            gamma=gamma,
+            actor_step_size=0.1,
+            critic_step_size=0.1,
+            actor_lamda=lam,
+            critic_lamda=lam,
+        )
+    )
+    state = agent.init(feature_dim=2, key=jr.key(0)).replace(  # type: ignore[attr-defined]
+        last_observation=jnp.array([1.0, 0.0], dtype=jnp.float32),
+        last_action=jnp.zeros((1,), dtype=jnp.float32),
+    )
+    first = agent.update(
+        state,
+        reward=jnp.array(0.0, dtype=jnp.float32),
+        observation=jnp.array([0.0, 1.0], dtype=jnp.float32),
+        terminated=jnp.array(False),
+    )
+    assert bool(first.update_applied)
+    trace_before = first.state.critic_trace_weights
+
+    last = agent.update(
+        first.state,
+        reward=jnp.array(1.0, dtype=jnp.float32),
+        observation=jnp.zeros(2, dtype=jnp.float32),
+        terminated=jnp.array(True),
+    )
+    assert bool(last.update_applied)
+    delta = last.td_error
+    expected = 0.1 * delta * (gamma * lam * trace_before + jnp.array([0.0, 1.0]))
+    chex.assert_trees_all_close(last.state.critic_weights, expected, atol=1e-6)
+    chex.assert_trees_all_close(
+        last.state.critic_trace_weights, jnp.zeros(2, dtype=jnp.float32)
+    )

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -2019,3 +2019,118 @@ def test_all_horde_actor_critic_counters_saturate_and_rollback(
     assert applied.tolist() == [False, True]
     assert final_state.step_count.dtype == jnp.int32
     assert int(final_state.step_count) == 2**31 - 1
+
+
+def test_horde_ac_terminal_update_credits_pre_terminal_features() -> None:
+    gamma, lam = 0.9, 0.9
+    critic = HordeLearner(
+        create_horde_spec(
+            [
+                GVFSpec(  # type: ignore[call-arg]
+                    name="value",
+                    demon_type=DemonType.PREDICTION,
+                    gamma=gamma,
+                    lamda=0.8,
+                    cumulant_index=-1,
+                )
+            ]
+        ),
+        hidden_sizes=(),
+        step_size=0.1,
+        use_layer_norm=False,
+    )
+    agent = HordeActorCriticAgent(
+        HordeActorCriticConfig(n_actions=2, actor_step_size=0.1, actor_lamda=lam),
+        critic=critic,
+    )
+    state = agent.init(feature_dim=2, key=jr.key(0)).replace(  # type: ignore[attr-defined]
+        last_observation=jnp.array([1.0, 0.0], dtype=jnp.float32),
+        last_action=jnp.array(0, dtype=jnp.int32),
+    )
+    first = agent.update(
+        state,
+        reward=jnp.array(0.0, dtype=jnp.float32),
+        observation=jnp.array([0.0, 1.0], dtype=jnp.float32),
+        discount=jnp.array(gamma, dtype=jnp.float32),
+    )
+    mid = first.state.replace(last_action=jnp.array(0, dtype=jnp.int32))  # type: ignore[attr-defined]
+    trace_before = mid.actor_trace_weights
+
+    last = agent.update(
+        mid,
+        reward=jnp.array(1.0, dtype=jnp.float32),
+        observation=jnp.zeros(2, dtype=jnp.float32),
+        discount=jnp.array(0.0, dtype=jnp.float32),
+    )
+    assert bool(last.update_applied)
+    # The fresh actor gradient at S_1 has a zero column for phi(S_0), so any
+    # credit in that column comes from the carried trace; the backward view
+    # decays it by the value head's gamma, not by the terminal discount 0.
+    expected_col0 = 0.1 * last.td_error * (gamma * lam * trace_before[:, 0])
+    chex.assert_trees_all_close(last.state.actor_weights[:, 0], expected_col0, atol=1e-6)
+    assert bool(jnp.any(jnp.abs(last.state.actor_weights[:, 0]) > 1e-8))
+    chex.assert_trees_all_close(
+        last.state.actor_trace_weights,
+        jnp.zeros_like(last.state.actor_trace_weights),
+    )
+
+
+def test_qhorde_ac_terminal_update_credits_pre_terminal_features() -> None:
+    gamma, lam = 0.9, 0.9
+    critic = HordeLearner(
+        create_horde_spec(
+            [
+                GVFSpec(  # type: ignore[call-arg]
+                    name="q0",
+                    demon_type=DemonType.CONTROL,
+                    gamma=0.0,
+                    lamda=0.0,
+                    cumulant_index=-1,
+                ),
+                GVFSpec(  # type: ignore[call-arg]
+                    name="q1",
+                    demon_type=DemonType.CONTROL,
+                    gamma=0.0,
+                    lamda=0.0,
+                    cumulant_index=-1,
+                ),
+            ]
+        ),
+        hidden_sizes=(),
+        step_size=0.1,
+        use_layer_norm=False,
+    )
+    agent = QHordeActorCriticAgent(
+        QHordeActorCriticConfig(
+            n_actions=2, gamma=gamma, actor_step_size=0.1, actor_lamda=lam
+        ),
+        critic=critic,
+    )
+    state = agent.init(feature_dim=2, key=jr.key(0)).replace(  # type: ignore[attr-defined]
+        last_observation=jnp.array([1.0, 0.0], dtype=jnp.float32),
+        last_action=jnp.array(0, dtype=jnp.int32),
+    )
+    first = agent.update(
+        state,
+        reward=jnp.array(0.0, dtype=jnp.float32),
+        observation=jnp.array([0.0, 1.0], dtype=jnp.float32),
+        terminated=jnp.array(False),
+    )
+    mid = first.state.replace(last_action=jnp.array(0, dtype=jnp.int32))  # type: ignore[attr-defined]
+    trace_before = mid.actor_trace_weights
+
+    last = agent.update(
+        mid,
+        reward=jnp.array(1.0, dtype=jnp.float32),
+        observation=jnp.zeros(2, dtype=jnp.float32),
+        terminated=jnp.array(True),
+    )
+    assert bool(last.update_applied)
+    assert bool(jnp.any(jnp.abs(trace_before[:, 0]) > 1e-8))
+    expected_col0 = 0.1 * last.td_error * (gamma * lam * trace_before[:, 0])
+    chex.assert_trees_all_close(last.state.actor_weights[:, 0], expected_col0, atol=1e-6)
+    assert bool(jnp.any(jnp.abs(last.state.actor_weights[:, 0]) > 1e-8))
+    chex.assert_trees_all_close(
+        last.state.actor_trace_weights,
+        jnp.zeros_like(last.state.actor_trace_weights),
+    )


### PR DESCRIPTION
## Issue

Sutton & Barto (2nd ed.) make the two discount indices in TD(lambda) explicit and different: the eligibility trace decays by the discount of the transition *into* `S_t` — `z_t = rho_t (gamma_t lambda_t z_{t-1} + grad v(S_t))`, eq. 12.25 — while the TD error bootstraps with the discount of the transition *out of* `S_t` — `delta_t = R_{t+1} + gamma_{t+1} v(S_{t+1}) - v(S_t)`, eq. 12.23. Six actor-critic sites fed one per-transition `discount` (= `gamma_{t+1}`) into both roles: `ActorCriticAgent` and `ContinuousActorCriticAgent` (`actor_critic.py`), and the actor traces of `QHordeActorCriticAgent`, `HordeActorCriticAgent`, `NonlinearHordeActorCriticAgent`, `NonlinearQHordeActorCriticAgent` (`horde_actor_critic.py`). On a terminal transition (`discount = 0`) the accumulated in-episode trace is therefore multiplied by zero *before* the terminal reward is credited.

The repository already implements the correct rule twice: `recurrent_trace_actor_critic.py:2633` substitutes the constant gamma at boundaries ("the terminating reward must still credit traces accumulated within the episode"), and `sarsa.py:997` decays control-head traces by the spec `gamma * lamda`, clearing them only after the terminal update.

## Symptoms

Lambda is forced to 0 for the single most informative update of every episode. On a 5-state chain with reward only at termination (`gamma=1, lambda=0.9, alpha=0.1`), `ActorCriticAgent` learned `V = [0, 0, 0, 0.1]` — only the last visited state moved — where textbook AC(lambda) gives `[0.0729, 0.081, 0.09, 0.1]`. In a hand-computed two-step episode (`gamma=lambda=0.9`), the terminal update produced critic weights `[0, 0.1]` against the textbook `[0.081, 0.1]`: the pre-terminal state receives exactly zero credit for the terminal reward. All four linear variants reproduce this; `update_applied=True` throughout, so nothing fails closed. All 529 existing tests in the touched modules pass on the buggy tree — the one test pinning terminal behaviour asserts only that the *stored* traces end up zeroed, which is true before and after this change.

## New state

Each site decays its traces with the trace-side discount — the class constant `cfg.gamma` (or the value head's spec gamma) substituted exactly when the incoming per-transition discount is zero, the same rule `recurrent_trace_actor_critic.py` uses — and keeps the existing post-terminal trace clearing, so credit flows through the terminal update and traces still start the next episode at zero. Non-terminal steps are arithmetically identical to before (`where(d==0, gamma, d) == d` whenever `d != 0`). This is exact for the constant-gamma-with-termination case these agents document; genuinely per-step-variable gamma streams would need the previous transition's discount carried in state (the `ETDState.previous_rho` pattern) — noted for the maintainer, not done here to keep state schemas unchanged.

Verification at head `7dfb1a6ae000be6e499325cec7e571a253182de7` (on `c9aba7b5`):

- Red phase: four new tests (hand-computed textbook expectations for `ActorCriticAgent` and `ContinuousActorCriticAgent`; carried-trace column credit for `HordeActorCriticAgent` and `QHordeActorCriticAgent`) fail on the pre-fix tree and pass after; reverting only the two source files reproduces all four failures.
- `tests/test_actor_critic.py` + `test_horde_actor_critic.py` + `test_sarsa.py` + `test_recurrent_trace_actor_critic.py`: 403 passed. `tests/test_pipeline.py`: 183 passed. Ruff and mypy clean on all four changed files.
- The 5-state chain probe on the fixed tree credits all four visited states.

Two sibling sites are **deliberately not touched**, flagged for the maintainer:

1. `core/average_reward.py:2373` (`DifferentialSARSAAgent`, explicit-discounts path) has the same defect (the chain probe still shows `Q = [0, 0, 0, 0.1, 0]` there), but that file is a registered evidence source for the pinned five-claim registry — editing it invalidates persisted evidence until the frozen protocol reruns, which is a maintainer decision.
2. `core/off_policy_td.py:601`/`:1058` share the gamma-index conflation; those learners genuinely accept per-step gammas, so the faithful fix is a state-carried previous discount (the merged `previous_rho` pattern) — a separate focused change.

## Agent disclosure

- client: Claude Code
- provider: anthropic
- model: claude-fable-5
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
- Slop run `run_01M0PXVHJ7EMV716R8V1KPESZB` is active; the signed receipt + private-trace footer follows when the measured run finalizes.
