### PR TITLE
fix(core): drive IDBD's MLP meta-update with the loss gradient

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -860,7 +860,9 @@ class IDBD(Optimizer[IDBDState]):
         Operation order (meta-update first, then new alpha for trace):
 
         1. Compute h_decay based on mode: ``z^2`` or ``(error * z)^2``
-        2. Meta-update with OLD traces: ``log_alpha += beta * z * h``
+        2. Meta-update with OLD traces: ``log_alpha += beta * g * h``
+           where ``g = -error * z`` (loss gradient direction; ``z``
+           itself when ``error`` is None)
         3. Clip log step-sizes to ``[-10.0, 2.0]``
         4. New step-sizes: ``alpha = exp(log_alpha)``
         5. Step: ``alpha * z`` (error applied externally by caller)
@@ -876,7 +878,8 @@ class IDBD(Optimizer[IDBDState]):
             gradient: Pre-computed prediction gradient / eligibility trace
                 (same shape as state arrays)
             error: Optional prediction error scalar. When provided,
-                used for h_decay (loss_grads mode) and h-trace sign.
+                used for the meta-update and h-trace loss-gradient
+                direction, and for h_decay in loss_grads mode.
 
         Returns:
             ``(step, new_state)`` where step has the same shape as gradient
@@ -891,9 +894,13 @@ class IDBD(Optimizer[IDBDState]):
             # prediction_grads mode, or loss_grads without error
             h_decay = z**2
 
-        # 2. Meta-update with OLD traces (Meyer: prediction_grads * h, no error).
+        # 2. Meta-update with OLD traces (Meyer: loss grad * h; the loss
+        # gradient is -error * z here, z itself on the error=None trunk path).
         # Skip 0 * inf when meta-learning is disabled.
-        meta_gradient = z * state.traces
+        if error is not None:
+            meta_gradient = -jnp.squeeze(error) * z * state.traces
+        else:
+            meta_gradient = z * state.traces
         meta_delta = _skip_zero_scale(beta, meta_gradient)
 
         # 3. Clip log step-sizes; a non-finite meta-gradient (inf z against a

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1018,8 +1018,15 @@ class TestIDBDParamState:
         expected_h = -0.01 * 2.0 * jnp.ones(5)
         chex.assert_trees_all_close(new_state.traces, expected_h, atol=1e-6)
 
-    def test_meta_update_uses_prediction_grads_only(self):
-        """Meta-update should use z * h (no error), matching Meyer."""
+    def test_meta_update_uses_loss_gradient_correlation(self):
+        """Meta-update should use (-error * z) * h, matching Meyer.
+
+        Meyer's reference (idbd.py line 206) advances beta with
+        ``meta_lr * grad * h`` where ``grad`` is the loss gradient, so a
+        repeated identical error/gradient pair -- perfectly correlated
+        successive loss gradients -- must GROW the step-size (Sutton 1992's
+        defining property for the linear case z = x).
+        """
         optimizer = IDBD(initial_step_size=0.1, meta_step_size=0.1)
         state = optimizer.init_for_shape((3,))
 
@@ -1030,13 +1037,54 @@ class TestIDBDParamState:
         _, state = optimizer.update_from_gradient(state, z, error=error)
         log_alpha_after_1 = state.log_step_sizes
 
-        # Step 2: h = -alpha * error * z < 0, meta = z * h < 0
-        # With negative h, meta-gradient z * h < 0 -> step-size decreases
+        # Step 2: h = -alpha * error * z < 0, meta = (-error * z) * h > 0
         _, state = optimizer.update_from_gradient(state, z, error=error)
         log_alpha_after_2 = state.log_step_sizes
 
-        # Step-sizes should decrease (meta-gradient is negative)
+        assert jnp.all(log_alpha_after_2 > log_alpha_after_1)
+
+    def test_meta_update_shrinks_on_alternating_errors(self):
+        """Anti-correlated successive loss gradients must shrink step-sizes."""
+        optimizer = IDBD(initial_step_size=0.1, meta_step_size=0.1)
+        state = optimizer.init_for_shape((3,))
+        z = jnp.ones(3)
+
+        _, state = optimizer.update_from_gradient(state, z, error=jnp.array(1.0))
+        log_alpha_after_1 = state.log_step_sizes
+        _, state = optimizer.update_from_gradient(state, z, error=jnp.array(-1.0))
+        log_alpha_after_2 = state.log_step_sizes
+
         assert jnp.all(log_alpha_after_2 < log_alpha_after_1)
+
+    def test_step_size_adaptation_is_invariant_to_target_sign(self):
+        """Relabelling y -> -y mirrors the problem; alphas must not change.
+
+        The error path's step-size dynamics may depend only on gradient
+        correlations, never on the arbitrary sign convention of the target
+        (the linear ``update`` path already has this invariance).
+        """
+        optimizer = IDBD(initial_step_size=0.05, meta_step_size=0.05)
+        errors = [0.7, -0.3, 1.1, 0.4, -0.9, 0.6]
+        gradients = [
+            jnp.array([1.0, -0.5], dtype=jnp.float32),
+            jnp.array([0.3, 0.8], dtype=jnp.float32),
+            jnp.array([-0.6, 0.2], dtype=jnp.float32),
+        ] * 2
+
+        state_pos = optimizer.init_for_shape((2,))
+        state_neg = optimizer.init_for_shape((2,))
+        for error, z in zip(errors, gradients, strict=True):
+            _, state_pos = optimizer.update_from_gradient(
+                state_pos, z, error=jnp.array(error, dtype=jnp.float32)
+            )
+            _, state_neg = optimizer.update_from_gradient(
+                state_neg, z, error=jnp.array(-error, dtype=jnp.float32)
+            )
+
+        chex.assert_trees_all_close(
+            state_pos.log_step_sizes, state_neg.log_step_sizes, atol=1e-7
+        )
+        chex.assert_trees_all_close(state_pos.traces, -state_neg.traces, atol=1e-7)
 
     def test_loss_grads_mode(self):
         """loss_grads h_decay_mode should produce finite results."""


### PR DESCRIPTION
## Issue

`IDBD.update_from_gradient_checked`'s error path advanced the meta-weights with `meta_gradient = z * traces` — the prediction gradient times the h-trace — while the h-trace itself accumulates `-error * z`, the loss gradient. The cited reference (Meyer, `ejmejm/phd_research`, `idbd.py`) updates beta with `meta_lr * grad * h` where `grad` is `p.grad`, the **loss** gradient (line 206); its only use of prediction gradients is the `h_decay_term` (line 156), which this module already replicates as `h_decay_mode="prediction_grads"`. Sutton (1992) is the same: the meta-update correlates successive loss gradients. Mixing one loss-side factor with one prediction-side factor makes `d(log alpha)` odd in the error's sign — a quantity that is not a gradient correlation at all. The `error=None` trunk path (cotangents already in loss-gradient direction) was and remains correct.

## Symptoms

Step-size adaptation depended on the arbitrary sign convention of the target. Relabelling `y -> -y` — an exactly mirrored problem — changed final per-weight alphas by up to **440x** (0.00101 vs 0.446) where the linear `IDBD.update` path is exactly invariant. With perfectly correlated successive gradients (identical error and gradient repeated), the step-size *shrank* for `y=+1` and grew for `y=-1`, contradicting the class docstring ("when successive gradients agree in sign, the step-size for that weight increases") and the module's own "recovers Sutton 1992" claim. A sign-relabelling sweep across LMS, IDBD-linear, Autostep (both paths), ObGD, AutostepGTDLambda, TDIDBD, AutoTDIDBD, and SwiftTD showed every one exactly invariant except this branch. Public reach: `optimizer="idbd"` in the Step 4 SARSA configuration and every MLP/multi-head/Horde learner accepting an IDBD per-parameter optimizer; `update_applied=True` throughout, so the fail-closed machinery cannot see it.

## New state

The error path multiplies the meta-gradient by `-error`, so the meta-update correlates loss gradients exactly as the reference and the linear path do; the trunk path is untouched. On the probe suite: relabelling invariance is exact (alpha gap 0, mirrored weights), and correlated gradients grow the step-size for both target signs (0.01 -> 0.109 in the fix-check probe). One existing test (`test_meta_update_uses_prediction_grads_only`) had pinned the old behaviour on a misreading of the reference — its own scenario (constant error, constant gradient) asserted *decreasing* step-sizes under perfect correlation; it is renamed `test_meta_update_uses_loss_gradient_correlation`, asserts the growth property, and is joined by an alternating-error shrink test and an exact sign-relabelling invariance test.

Verification at head `6ac003df9d4dfcfa5a064af8332e980d6abb1dfa` (on `c9aba7b5`):

- Red phase: the growth-under-correlation and sign-invariance tests fail on the pre-fix tree (the alternating-error test does not discriminate — both behaviours shrink there — and is kept as a property pin); reverting only `optimizers.py` reproduces the failures.
- `tests/test_optimizers.py` 136 passed; consumers `test_learners.py` + `test_mlp_learner.py` + `test_multi_head_learner.py` + `test_multi_head_learner_update_working_set.py` 344 passed; `test_sarsa.py` + `test_step4_production.py` + `test_horde_actor_critic.py` 302 passed. Ruff and mypy clean on the changed files.

## Agent disclosure

- client: Claude Code
- provider: anthropic
- model: claude-fable-5
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
- Slop run `run_01M0PXVHJ7EMV716R8V1KPESZB` is active; the signed receipt + private-trace footer follows when the measured run finalizes.
