### PR TITLE
fix(utils): store p-values and alpha at full float64 precision

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -230,20 +230,30 @@ def _require_sample_vector(values: object, *, name: str) -> NDArray[np.float64]:
 
 
 def _require_probability(value: object, *, name: str, strict: bool) -> float:
+    """Return ``value`` as the exact host double after checking its domain.
+
+    Probabilities here are measurement outputs (p-values) or preregistered
+    decision thresholds (alpha), not float32-consumed configuration, so the
+    stored value keeps full float64 precision; narrowing a p-value to
+    binary32 flushes anything below ~1.4e-45 to an impossible exact 0 and
+    perturbs every stored value and verdict boundary by the container type.
+    """
+    domain = "strictly between 0 and 1" if strict else "in [0, 1]"
+    message = f"{name} must be a finite real {domain}"
     if type(value) not in _ALLOWED_REAL_TYPES:
-        domain = "strictly between 0 and 1" if strict else "in [0, 1]"
-        raise ValueError(f"{name} must be a finite real {domain}")
+        raise ValueError(message)
     try:
-        if strict:
-            return validated_float32_scalar(
-                name, value, positive=True, upper=1.0, upper_inclusive=False
-            )
-        return validated_float32_scalar(
-            name, value, lower=0.0, upper=1.0, upper_inclusive=True
-        )
-    except ValueError:
-        domain = "strictly between 0 and 1" if strict else "in [0, 1]"
-        raise ValueError(f"{name} must be a finite real {domain}") from None
+        converted = float(cast(Any, value))
+    except (OverflowError, ValueError):
+        raise ValueError(message) from None
+    if not math.isfinite(converted):
+        raise ValueError(message)
+    if strict:
+        if not 0.0 < converted < 1.0:
+            raise ValueError(message)
+    elif not 0.0 <= converted <= 1.0:
+        raise ValueError(message)
+    return converted
 
 
 def _require_alpha(alpha: object) -> float:

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -1179,3 +1179,55 @@ class TestPairwiseComparisons:
     def test_common_final_window_requires_positive_integer(self, window: object) -> None:
         with pytest.raises(ValueError, match="window must be a positive integer"):
             common_final_window({"learner": 10}, window, "squared_error")
+
+
+class TestProbabilityPrecision:
+    """Stored p-values and alphas keep full float64 precision.
+
+    p-values are measurement outputs and alpha is a preregistered decision
+    threshold; neither has a float32 consumer, so narrowing them to binary32
+    corrupts the recorded artifact (anything below ~1.4e-45 flushes to an
+    impossible exact 0) and makes verdicts depend on the host container type
+    of the same real number.
+    """
+
+    def test_ttest_p_value_matches_scipy_exactly(self) -> None:
+        scipy_stats = pytest.importorskip("scipy.stats")
+        rng = np.random.default_rng(11)
+        x = rng.normal(0.0, 1.0, 20)
+        y = x + 0.9 + rng.normal(0.0, 0.05, 20)
+        expected = float(scipy_stats.ttest_rel(x, y).pvalue)
+        result = ttest_comparison(x, y, paired=True)
+        assert result.p_value == expected
+
+    def test_extreme_p_value_is_not_flushed_to_zero(self) -> None:
+        scipy_stats = pytest.importorskip("scipy.stats")
+        rng = np.random.default_rng(20260823)
+        a = 0.010 + rng.normal(0.0, 0.00008, 20)
+        b = 0.500 + rng.normal(0.0, 0.00080, 20)
+        expected = float(scipy_stats.ttest_rel(a, b).pvalue)
+        assert 0.0 < expected < 1e-45
+        result = ttest_comparison(a, b, paired=True)
+        assert result.p_value == expected
+        assert result.p_value > 0.0
+
+    def test_alpha_is_recorded_exactly(self) -> None:
+        result = ttest_comparison(
+            np.asarray([1.0, 2.0, 4.0, 8.0]),
+            np.asarray([1.5, 2.5, 3.5, 6.0]),
+            paired=True,
+            alpha=np.float64(0.01),
+        )
+        assert result.alpha == 0.01
+
+    @pytest.mark.parametrize("correction", [bonferroni_correction, holm_correction])
+    def test_correction_verdicts_do_not_depend_on_host_container(
+        self, correction: Any
+    ) -> None:
+        boundary = 0.016666666666666663
+        assert boundary < 0.05 / 3
+        from_double = correction([np.float64(boundary)] * 3, alpha=0.05)
+        from_builtin = correction([boundary] * 3, alpha=0.05)
+        assert from_double == from_builtin
+        significant = from_double[0] if correction is bonferroni_correction else from_double
+        assert list(significant) == [True, True, True]


### PR DESCRIPTION
## Issue

`_require_probability` (`alberta_framework/utils/statistics.py`) returned the value produced by `validated_float32_scalar`, whose documented contract stores non-builtin-float reals "as the validated binary32 value". scipy returns `np.float64` p-values, so every p-value flowing through `ttest_comparison` / `mann_whitney_comparison` / `wilcoxon_comparison`, and every caller-supplied p-value or alpha in `bonferroni_correction` / `holm_correction` / `pairwise_comparisons`, was silently narrowed to float32 before being stored or compared. The helper exists for float32-consumed *configuration* scalars; a p-value is a measurement output with no float32 consumer, and the same module already knows this — `_validate_confidence_level` calls the identical helper and deliberately discards its return, and `ttest_comparison` stores the test *statistic* as an unnarrowed `float(result[0])` two lines above the narrowed p-value.

## Symptoms

- A 20-seed paired comparison with a clearly diverging baseline (t = −4139) has scipy p = `4.82e-58`; the recorded `SignificanceResult.p_value` was exactly `0.0` — an impossible p-value; everything below ~1.4e-45 flushed, and the subnormal band 1e-45..1e-38 quantized to ~2 digits (`1e-44` stored as `9.81e-45`, 1.9% relative error).
- Ordinary magnitudes lost nine significant digits (scipy `8.937228798519006e-27` stored as `8.937228603122392e-27`, relative error 2.2e-8 = binary32 eps) in every stored p-value.
- Host-container-dependent verdicts: with `alpha=0.05, n=3`, the p-value `0.016666666666666663` (strictly below the Bonferroni cut) was ruled significant as a builtin `float` and not significant as the identical `np.float64` — same real number, opposite decision, in both `bonferroni_correction` and `holm_correction`.
- A preregistered `alpha=np.float64(0.01)` was recorded (and re-exported into LaTeX/markdown/JSON artifacts via `export.py`) as `0.009999999776482582` — a strictly different decision threshold than the one preregistered.

These reach every consumer of `SignificanceResult` — `export.generate_significance_table` / `generate_latex_table` / `generate_markdown_table` / `save_experiment_report` and `visualization._get_significance_marker_for_plot` — all public API. No pinned campaign artifact is affected: the active screening/forager lanes use the separate exact-rational `benchmarks/forager_matched_statistics.py`.

## New state

`_require_probability` validates the documented domain in exact float64 arithmetic (same exact-type gate, finiteness, and strict/inclusive bounds) and returns the host double, so stored p-values are bit-identical to scipy's, alpha round-trips exactly, and correction verdicts are independent of the container type. Every existing rejection is preserved: the parametrized contract suites (`nan`, `inf`, `0.0`, `1.0`, `-0.1`, `1.1`, `True`, strings, `None`, float-class spoofs, hostile scalars) pass unchanged — 256 tests across `test_statistics_validation.py` + `test_statistics_hostile_validation.py`, plus 153 in `test_export.py` + `test_export_hostile_validation.py`. Five new tests pin exact scipy equality, the sub-1e-45 non-flush, exact alpha recording, and container-independent correction verdicts; all five fail on the pre-fix tree (red phase) and reverting only `statistics.py` reproduces the failures. Ruff and mypy clean. Head `04ab3d204286f6c115bf2017936c8010a35da3f8` on `c9aba7b5`.

One deliberate domain consequence, stated plainly: the old float32-space check rejected a strict-domain alpha whose binary32 rounding hit an excluded endpoint (e.g. `1e-46`, or `1 - 2**-30`); the exact check accepts such values because they genuinely lie strictly between 0 and 1, which is the documented domain. No in-tree caller or test relied on those boundary rejections.

## Agent disclosure

- client: Claude Code
- provider: anthropic
- model: claude-fable-5
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
- Slop run `run_01M0PXVHJ7EMV716R8V1KPESZB` is active; the signed receipt + private-trace footer follows when the measured run finalizes.
