### PR TITLE
fix(core): clip Autostep step-sizes before the overshoot normalization

### DIFF
--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -1262,14 +1262,16 @@ class Autostep(Optimizer[AutostepState]):
             state.step_sizes,
         )
 
-        # Eq. 6-7: M = max(Σ α_i*z_i², 1); α_i /= M
+        # Clip step-sizes for numerical safety
+        new_step_sizes = jnp.clip(new_step_sizes, 1e-8, 1.0)
+
+        # Eq. 6-7: M = max(Σ α_i*z_i², 1); α_i /= M. Normalization is the
+        # last operation on α so the overshoot bound Σ α_i*z_i² <= 1 holds
+        # at update time (Algorithm 5 lines 8-10).
         effective_terms = new_step_sizes * z_sq
         effective_step = jnp.sum(effective_terms)
         m_factor = jnp.maximum(effective_step, 1.0)
         new_step_sizes = new_step_sizes / m_factor
-
-        # Clip step-sizes for numerical safety
-        new_step_sizes = jnp.clip(new_step_sizes, 1e-8, 1.0)
 
         # Compute step: α_i * z_i (error applied externally)
         step = new_step_sizes * z
@@ -1403,17 +1405,19 @@ class Autostep(Optimizer[AutostepState]):
             state.bias_step_size,
         )
 
+        # Clip step-sizes for numerical safety
+        new_step_sizes = jnp.clip(new_step_sizes, 1e-8, 1.0)
+        new_bias_step_size = jnp.clip(new_bias_step_size, 1e-8, 1.0)
+
         # Eq. 6-7: Overshoot prevention (joint over weights + bias)
-        # M = max(Σ α_i*x_i² + α_bias*1², 1)
+        # M = max(Σ α_i*x_i² + α_bias*1², 1). Normalization is the last
+        # operation on α so the overshoot bound holds at update time
+        # (Algorithm 5 lines 8-10).
         effective_terms = new_step_sizes * x_sq
         effective_step = jnp.sum(effective_terms) + new_bias_step_size
         m_factor = jnp.maximum(effective_step, 1.0)
         new_step_sizes = new_step_sizes / m_factor
         new_bias_step_size = new_bias_step_size / m_factor
-
-        # Clip step-sizes for numerical safety
-        new_step_sizes = jnp.clip(new_step_sizes, 1e-8, 1.0)
-        new_bias_step_size = jnp.clip(new_bias_step_size, 1e-8, 1.0)
 
         # Weight update with NEW alpha: α_i * δ * x_i
         weight_delta = new_step_sizes * error_scalar * x

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -400,6 +400,47 @@ class TestAutostep:
         )
         assert float(effective) <= 1.0 + 1e-6
 
+    @pytest.mark.parametrize("magnitude", [3e3, 1e4, 1e5])
+    def test_overshoot_bound_holds_at_large_feature_scale(self, magnitude: float):
+        """The Algorithm 5 guarantee must survive the numerical-safety clip.
+
+        Normalization is the last operation on alpha in Mahmood et al. 2012
+        (Algorithm 5 lines 8-10), precisely so sum(alpha_i * x_i^2) <= 1 at
+        update time; a floor applied afterwards can raise alpha back above
+        the normalized value once sum(x_i^2) is large enough, turning the
+        overshoot guard into an error amplifier.
+        """
+        optimizer = Autostep(initial_step_size=0.01, meta_step_size=0.01)
+        feature_dim = 100
+        state = optimizer.init(feature_dim=feature_dim)
+
+        observation = jnp.ones(feature_dim) * magnitude
+        error = jnp.array(1.0)
+        result = optimizer.update(state, error, observation)
+
+        effective = (
+            jnp.sum(result.new_state.step_sizes * observation**2)
+            + result.new_state.bias_step_size
+        )
+        assert float(effective) <= 1.0 + 1e-4
+
+        prediction_change = float(
+            jnp.dot(result.weight_delta, observation) + result.bias_delta
+        )
+        assert abs(1.0 - prediction_change) <= 1.0 + 1e-4
+
+    def test_overshoot_bound_holds_on_gradient_path_at_large_scale(self):
+        """The shape-generic path shares the Algorithm 5 guarantee."""
+        optimizer = Autostep(initial_step_size=0.01, meta_step_size=0.01)
+        state = optimizer.init_for_shape((100,))
+        gradient = jnp.ones(100) * 1e4
+        error = jnp.array(1.0)
+
+        step, new_state = optimizer.update_from_gradient(state, gradient, error=error)
+
+        effective = float(jnp.sum(new_state.step_sizes * gradient**2))
+        assert effective <= 1.0 + 1e-4
+
     def test_normalizer_tracks_meta_gradient_not_primary(self):
         """v_i should track |δ*x*h| (meta-gradient), not |δ*x| (primary gradient)."""
         optimizer = Autostep(initial_step_size=0.1, meta_step_size=0.1)


### PR DESCRIPTION
## Issue

Autostep's defining guarantee is overshoot prevention: Mahmood et al. 2012 (restated as Algorithm 5 in Kearney et al., arXiv:1903.03252) normalizes the step-sizes by `M = max(sum(alpha_i x_i^2), 1)` as the **last** operation on alpha, so the effective step size `sum(alpha_i x_i^2) <= 1` holds at update time — the class docstring repeats the claim. Both Autostep paths (`update`, linear with bias, and `update_from_gradient_checked`, shape-generic) applied the numerical-safety clip `clip(alpha, 1e-8, 1.0)` *after* the division by `M`. Whenever `alpha / M < 1e-8` — with uniform alphas that reduces to `sum(x_i^2) > 1e8`, independent of `initial_step_size` — the floor raised alpha back above the normalized value.

## Symptoms

At large feature scales the overshoot guard became an error amplifier: the realized effective step is `1e-8 * sum(x_i^2)`, so one update on `|x| = 1e4, n = 100` moved the prediction 100x past its target (|error| 1 -> 99; at `|x| = 1e5, n = 10` -> 999), `update_applied=True` throughout. The algorithm performs strictly worse than fixed-step LMS in exactly the raw large-magnitude regime it exists to handle. The repository's own invariant test (`test_overshoot_prevention_bounds_effective_step_size`) asserts precisely this bound but only exercises `|x| = 5` (`sum(x^2) = 250`), so it never fired.

## New state

The clip runs before the normalization and the division by `M` is the final operation on the step-sizes in both paths, exactly as Algorithm 5 orders it; the effective step is bounded by 1 again at every probed scale (`3e3`, `1e4`, `1e5`, both paths — new parametrized tests assert the bound and that a single update cannot move the prediction past its target). Small-scale behaviour is unchanged: whenever the pre-clip alphas already lie in `[1e-8, 1]` and `M = 1`, both orderings are identical, which is why all 133 pre-existing optimizer tests pass untouched. Red phase: the four new large-scale assertions fail on the pre-fix tree; reverting only `optimizers.py` reproduces the failures. `tests/test_optimizers.py` 138 passed; consumers `test_learners.py` + `test_mlp_learner.py` + `test_optimizer_nonfinite_transactions.py` 242 passed; ruff and mypy clean. Head `5eb4d586a71efc68351f9316ce2617b9c0848527` on `c9aba7b5`.

## Agent disclosure

- client: Claude Code
- provider: anthropic
- model: claude-fable-5
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
- Slop run `run_01M0PXVHJ7EMV716R8V1KPESZB` is active; the signed receipt + private-trace footer follows when the measured run finalizes.
