### PR TITLE
fix(core): emit the policy that produced each action from the horde array runners

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -395,7 +395,12 @@ class HordeActorCriticUpdateResult:
 
 @chex.dataclass(frozen=True)
 class HordeActorCriticArrayResult:
-    """Result from scan-based Horde actor-critic learning."""
+    """Result from scan-based Horde actor-critic learning.
+
+    ``policies[t]`` is the pre-update policy at ``observations[t]`` — the
+    distribution that produced ``actions[t]``, matching
+    :class:`~alberta_framework.core.actor_critic.ActorCriticArrayResult`.
+    """
 
     state: HordeActorCriticState
     actions: Int[Array, " num_steps"]
@@ -1199,8 +1204,9 @@ def run_horde_actor_critic_from_arrays(
                 last_action=fixed_action.astype(jnp.int32),
             )
             current_action = fixed_action.astype(jnp.int32)
+            current_policy = agent.policy(started_state, obs)
         else:
-            started_state, current_action, _policy = agent.start(carry, obs)
+            started_state, current_action, current_policy = agent.start(carry, obs)
         result = agent.update(
             started_state,
             reward,
@@ -1220,7 +1226,7 @@ def run_horde_actor_critic_from_arrays(
                 current_action,
                 jnp.asarray(0, dtype=jnp.int32),
             ),
-            jnp.where(update_applied, result.policy, jnp.zeros_like(result.policy)),
+            jnp.where(update_applied, current_policy, jnp.zeros_like(current_policy)),
             jnp.where(update_applied, result.value, 0.0),
             jnp.where(update_applied, result.td_error, 0.0),
             jnp.where(
@@ -1537,7 +1543,12 @@ class NonlinearHordeActorCriticUpdateResult:
 
 @chex.dataclass(frozen=True)
 class NonlinearHordeActorCriticArrayResult:
-    """Result from a scan-based nonlinear Horde actor-critic loop."""
+    """Result from a scan-based nonlinear Horde actor-critic loop.
+
+    ``policies[t]`` is the pre-update policy at ``observations[t]`` — the
+    distribution that produced ``actions[t]``, matching
+    :class:`~alberta_framework.core.actor_critic.ActorCriticArrayResult`.
+    """
 
     state: NonlinearHordeActorCriticState
     actions: Int[Array, " num_steps"]
@@ -2089,7 +2100,7 @@ def run_nonlinear_horde_actor_critic_from_arrays(
         tuple[Array, Array, Array, Array, Array, Array],
     ]:
         obs, reward, next_obs, aux, disc = inputs
-        started, current_action, _policy = agent.start(carry, obs)
+        started, current_action, current_policy = agent.start(carry, obs)
         result = agent.update(started, reward, next_obs, aux, disc)
         committed_state = jax.lax.cond(
             result.update_applied,
@@ -2102,7 +2113,7 @@ def run_nonlinear_horde_actor_critic_from_arrays(
                 current_action,
                 jnp.asarray(0, dtype=jnp.int32),
             ),
-            result.policy,
+            current_policy,
             result.value,
             result.td_error,
             result.critic_result.td_errors,

--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -398,7 +398,7 @@ class HordeActorCriticArrayResult:
     """Result from scan-based Horde actor-critic learning.
 
     ``policies[t]`` is the pre-update policy at ``observations[t]`` — the
-    distribution that produced ``actions[t]``, matching
+    sampling distribution (or the model policy when actions are supplied), matching
     :class:`~alberta_framework.core.actor_critic.ActorCriticArrayResult`.
     """
 
@@ -1546,7 +1546,7 @@ class NonlinearHordeActorCriticArrayResult:
     """Result from a scan-based nonlinear Horde actor-critic loop.
 
     ``policies[t]`` is the pre-update policy at ``observations[t]`` — the
-    distribution that produced ``actions[t]``, matching
+    sampling distribution (or the model policy when actions are supplied), matching
     :class:`~alberta_framework.core.actor_critic.ActorCriticArrayResult`.
     """
 
@@ -2113,7 +2113,7 @@ def run_nonlinear_horde_actor_critic_from_arrays(
                 current_action,
                 jnp.asarray(0, dtype=jnp.int32),
             ),
-            current_policy,
+            jnp.where(result.update_applied, current_policy, jnp.zeros_like(current_policy)),
             result.value,
             result.td_error,
             result.critic_result.td_errors,

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -2019,3 +2019,46 @@ def test_all_horde_actor_critic_counters_saturate_and_rollback(
     assert applied.tolist() == [False, True]
     assert final_state.step_count.dtype == jnp.int32
     assert int(final_state.step_count) == 2**31 - 1
+
+
+def test_array_runner_policies_align_with_actions() -> None:
+    critic = HordeLearner(
+        create_horde_spec(
+            [
+                GVFSpec(  # type: ignore[call-arg]
+                    name="value",
+                    demon_type=DemonType.PREDICTION,
+                    gamma=0.9,
+                    lamda=0.0,
+                    cumulant_index=-1,
+                )
+            ]
+        ),
+        hidden_sizes=(),
+        step_size=0.5,
+        use_layer_norm=False,
+    )
+    agent = HordeActorCriticAgent(
+        HordeActorCriticConfig(n_actions=3, actor_step_size=0.5, actor_lamda=0.0),
+        critic=critic,
+    )
+    state = agent.init(feature_dim=2, key=jr.key(0)).replace(  # type: ignore[attr-defined]
+        actor_weights=jnp.array([[2.0, -1.0], [0.0, 3.0], [-2.0, 0.5]], jnp.float32),
+    )
+    observations = jnp.array([[1.0, 0.0], [0.0, 1.0]], jnp.float32)
+    next_observations = jnp.array([[0.0, 1.0], [1.0, 1.0]], jnp.float32)
+    rewards = jnp.array([1.0, 1.0], jnp.float32)
+
+    result = run_horde_actor_critic_from_arrays(
+        agent, state, observations, rewards, next_observations
+    )
+
+    # ``policies[t]`` documents the pre-update distribution at
+    # ``observations[t]`` -- the one that produced ``actions[t]`` -- matching
+    # the discrete runner's contract.
+    chex.assert_trees_all_close(
+        result.policies[0], agent.policy(state, observations[0]), atol=1e-7
+    )
+    assert not bool(
+        jnp.allclose(result.policies[0], agent.policy(state, next_observations[0]))
+    )

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -2062,3 +2062,14 @@ def test_array_runner_policies_align_with_actions() -> None:
     assert not bool(
         jnp.allclose(result.policies[0], agent.policy(state, next_observations[0]))
     )
+
+
+def test_nonlinear_array_runner_neutralizes_policy_on_rejected_update() -> None:
+    agent = _make_nlhac_agent(hidden_sizes=())
+    state = _init_nlhac(agent)
+    obs = jnp.zeros((1, OBS_DIM))
+    result = run_nonlinear_horde_actor_critic_from_arrays(
+        agent, state, obs, jnp.array([jnp.nan]), obs
+    )
+    np.testing.assert_array_equal(result.policies, jnp.zeros_like(result.policies))
+    chex.assert_trees_all_equal(result.state, state)


### PR DESCRIPTION
## Issue

`run_horde_actor_critic_from_arrays` and `run_nonlinear_horde_actor_critic_from_arrays` sample `current_action` from `agent.start(carry, obs)`, discard the returned sampling distribution, and emit `result.policy` — the **post-update** policy evaluated at `next_observations[t]`. The sibling discrete runner (`actor_critic.py`, `ActorCriticArrayResult.policies`) documents the opposite contract for the same field: "per-step pre-update agent policy probabilities at `observations[t]` … the distribution that produced `actions[t]`" — and honours it.

## Symptoms

`policies[t]` from the horde runners is not the distribution that produced `actions[t]`: on a two-step probe with a non-uniform actor, the runner reported `[0.019, 0.903, 0.078]` for step 0 while the distribution that actually sampled `actions[0]` was `[0.867, 0.117, 0.016]` — the reported row tracks `next_observations` and the post-update weights. No learning dynamics are affected, but any consumer using `policies` as behaviour-policy provenance (importance-sampling ratios, entropy or action-probability diagnostics) silently reads the wrong state, one full step and one update out of phase.

## New state

Both runners emit the pre-update distribution that produced the action: the sampled path forwards `agent.start`'s policy, the fixed-actions path computes `agent.policy(started_state, obs)` explicitly (the same shape the discrete runner uses), and the linear runner's rejected-transition neutralisation applies to that value. The two array-result docstrings now state the contract and its equivalence to `ActorCriticArrayResult`. New test pins `policies[0] == agent.policy(initial_state, observations[0])` and that it differs from the post-update/next-obs policy; it fails on the pre-fix tree and passes after (mutation-checked by reverting only the source file). `tests/test_horde_actor_critic.py` + `test_pipeline.py`: 271 passed; ruff and mypy clean. Head `cd929fc66c9a8dab3a0594fdcf55487e71d29cdb` on `c9aba7b5`.

## Agent disclosure

- client: Claude Code
- provider: anthropic
- model: claude-fable-5
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
- Slop run `run_01M0PXVHJ7EMV716R8V1KPESZB` is active; the signed receipt + private-trace footer follows when the measured run finalizes.
