### PR TITLE
fix(core): enforce equal-width latent invariant in BoundedPolicyArchive (#2322)

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        latent_width: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if latent_width is None:
+                latent_width = len(entry.latent)
+            elif len(entry.latent) != latent_width:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -66,3 +66,43 @@ def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")
     assert POLICY_ARCHIVE_PROTOCOL["scientific_promotion_allowed"] is False
+
+
+class TestEqualWidthInvariant:
+    """Enforce archive-wide equal latent width and control arm isolation (#2322)."""
+
+    def test_constructor_rejects_mixed_latent_widths(self) -> None:
+        narrow = _entry("a", (0.0,), 0.0)
+        wide = _entry("b", (3.0, 3.0), 9.0)
+        for mode in ("diverse_archive", "one_model", "fixed_snapshot"):
+            with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+                BoundedPolicyArchive(
+                    byte_budget=4096,
+                    min_latent_distance=1.0,
+                    mode=mode,
+                    entries=(narrow, wide),
+                )
+
+    def test_diverse_archive_add_rejects_mismatched_latent_width(self) -> None:
+        archive = BoundedPolicyArchive(byte_budget=4096, min_latent_distance=1.0).add(
+            _entry("a", (0.0,), 1.0)
+        )
+        with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+            archive.add(_entry("b", (1.0, 2.0), 2.0))
+
+    def test_controls_accept_different_latent_width(self) -> None:
+        narrow = _entry("a", (0.0,), 1.0)
+        wide = _entry("b", (1.0, 2.0), 2.0)
+
+        fixed = BoundedPolicyArchive(
+            byte_budget=4096, min_latent_distance=0.0, mode="fixed_snapshot"
+        ).add(narrow)
+        assert fixed.add(wide) is fixed
+        assert [entry.identity for entry in fixed.entries] == ["a"]
+
+        one = BoundedPolicyArchive(
+            byte_budget=4096, min_latent_distance=0.0, mode="one_model"
+        ).add(narrow)
+        updated = one.add(wide)
+        assert [entry.identity for entry in updated.entries] == ["b"]
+        assert updated.entries[0].latent == (1.0, 2.0)


### PR DESCRIPTION
Resolves #2322.

### Problem
`BoundedPolicyArchive.add` assumed all entries in the archive share equal latent width, but `BoundedPolicyArchive.__post_init__` never validated this invariant across directly constructed `entries`. If an archive was constructed with mixed descriptor widths, `np.asarray(entry.latent) - np.asarray(old.latent)` broadcasted mismatched dimensions and produced spurious 0-distance values that silently discarded valid candidate policies. Additionally, the equal-width guard in `add()` fired unconditionally before checking the archive mode, causing single-policy controls (`fixed_snapshot` and `one_model`) to reject descriptors with different widths even though they never compute latent distances.

### Fix
1. Validate equal latent width across all entries in `BoundedPolicyArchive.__post_init__`.
2. Move the descriptor width check in `BoundedPolicyArchive.add()` into the branch performing distance calculation, allowing single-policy control modes (`fixed_snapshot`, `one_model`) to function without superfluous shape restrictions.
3. Add unit test coverage in `tests/test_policy_archive.py` covering constructor rejection of mixed widths, control arm isolation, and diverse archive width validation.

## Measured project receipt
Post-hoc / same-window receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0Q1TV8B23XT1EQ452M929FD","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-23T10:14:35.531Z","completed_at":"2026-08-23T10:27:40.909Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T10:14:36.474Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fa0d53b9a166793fbc950f8cb2d48829a601742b32db3e6e6f0bece960095a25","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"f9e42c2a-dee1-46b9-8b1a-298d1624966a","object_id":"sha256:fa0d53b9a166793fbc950f8cb2d48829a601742b32db3e6e6f0bece960095a25","sha256":"fa0d53b9a166793fbc950f8cb2d48829a601742b32db3e6e6f0bece960095a25"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"zr25ni3xRrvGMD4KFcIMbvn8tXJvG_vvfOAl9B6Q61O1oSwthH47uA8DVuq_idM4X1kinpB76n6Qo4TJ6dUKAA"}} -->
