### PR TITLE
fix(utils): fail closed when export tables span unequal final windows

### DIFF
--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -19,7 +19,7 @@ from numpy.typing import NDArray
 
 from alberta_framework._seed_validation import require_unique_jax_seeds
 from alberta_framework.utils.experiments import AggregatedResults, MetricSummary
-from alberta_framework.utils.statistics import SignificanceResult
+from alberta_framework.utils.statistics import SignificanceResult, common_final_window
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -261,6 +261,19 @@ def _preflight_export_results(
             if actual_statistics != expected_statistics:
                 raise ValueError(f"{qualified_name} statistics do not match values")
             export_cells = _checked_export_cells(export_cells, int(summary.values.size))
+
+    if metric is not None:
+        # A metric-ranked export compares the configs' final-value summaries,
+        # each averaged over min(100, n_steps) steps by aggregate_metrics; the
+        # comparison is only meaningful when that window agrees across configs.
+        common_final_window(
+            {
+                name: int(aggregate.metric_arrays[metric].shape[1])
+                for name, aggregate in results.items()
+            },
+            100,
+            metric,
+        )
 
 
 def _write_text_atomically(filepath: Path, payload: str) -> None:

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -280,6 +280,13 @@ def plot_final_performance_bars(
     names = list(results.keys())
     if not names:
         raise ValueError("plot_final_performance_bars requires at least one result")
+    from alberta_framework.utils.statistics import common_final_window
+
+    common_final_window(
+        {name: int(results[name].metric_arrays[metric].shape[1]) for name in names},
+        100,
+        metric,
+    )
     means = [results[name].summary[metric].mean for name in names]
     stds = [results[name].summary[metric].std for name in names]
     means_arr = np.asarray(means, dtype=np.float64)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -8,6 +8,7 @@ import math
 import os
 from pathlib import Path
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
@@ -18,6 +19,7 @@ from alberta_framework.utils.export import (
     export_to_json,
     generate_latex_table,
     generate_markdown_table,
+    results_to_dataframe,
     save_experiment_report,
 )
 
@@ -581,3 +583,67 @@ def test_export_rejects_boolean_summary_statistics(
 
     with pytest.raises(ValueError, match="refusing to export boolean as numeric measurement"):
         generate_markdown_table(results)
+
+
+class TestCrossConfigFinalWindow:
+    """Metric-ranked exports must not compare means over different horizons."""
+
+    @staticmethod
+    def _aggregate(name: str, n_steps: int, settled: float):
+        from alberta_framework.core.optimizers import LMSState
+        from alberta_framework.core.types import LearnerState
+        from alberta_framework.utils import experiments as ex
+
+        state = LearnerState(
+            weights=jnp.zeros(1),
+            bias=jnp.zeros(()),
+            optimizer_state=LMSState(step_size=jnp.asarray(0.1)),
+            step_count=jnp.asarray(0),
+        )
+        trace = [5.0] * (n_steps - n_steps // 2) + [settled] * (n_steps // 2)
+        runs = [
+            ex.SingleRunResult(
+                config_name=name,
+                seed=seed,
+                metrics_history=[{"squared_error": float(v)} for v in trace],
+                final_state=state,
+            )
+            for seed in (0, 1, 2, 3)
+        ]
+        return ex.aggregate_metrics(runs)
+
+    def _unequal_results(self):
+        return {
+            "short": self._aggregate("short", 20, 0.10),
+            "long": self._aggregate("long", 500, 0.11),
+        }
+
+    def test_tables_fail_closed_on_unequal_final_windows(self) -> None:
+        results = self._unequal_results()
+        with pytest.raises(ValueError, match="final steps"):
+            generate_markdown_table(results, metric="squared_error")
+        with pytest.raises(ValueError, match="final steps"):
+            generate_latex_table(results, metric="squared_error")
+        with pytest.raises(ValueError, match="final steps"):
+            results_to_dataframe(results, metric="squared_error")
+
+    def test_plot_bars_fails_closed_on_unequal_final_windows(self) -> None:
+        pytest.importorskip("matplotlib")
+        from alberta_framework.utils.visualization import plot_final_performance_bars
+
+        with pytest.raises(ValueError, match="final steps"):
+            plot_final_performance_bars(self._unequal_results(), metric="squared_error")
+
+    def test_equal_windows_still_export(self) -> None:
+        results = {
+            "short": self._aggregate("short", 40, 0.10),
+            "long": self._aggregate("long", 60, 0.11),
+        }
+        with pytest.raises(ValueError, match="final steps"):
+            generate_markdown_table(results, metric="squared_error")
+        equal = {
+            "short": self._aggregate("short", 200, 0.10),
+            "long": self._aggregate("long", 500, 0.11),
+        }
+        table = generate_markdown_table(equal, metric="squared_error")
+        assert "short" in table and "long" in table


### PR DESCRIPTION
## Issue

`aggregate_metrics` fixes each config's "final value" summary to its own `min(100, n_steps)` window — a **per-config** horizon. `common_final_window` exists precisely because "a per-method minimum would silently compare methods over different horizons", and the two comparison surfaces that existed when it was added (`get_final_performance`, `pairwise_comparisons`) both fail closed through it. The metric-ranked export surfaces never got the guard: `generate_latex_table`, `generate_markdown_table`, `results_to_dataframe`, the summary/timeseries CSV exporters, and `visualization.plot_final_performance_bars` all read `AggregatedResults.summary[metric].mean` across configs and pick/bold/highlight a "best" method, with `ExperimentConfig.num_steps` legally differing per config.

## Symptoms

With a 20-step trace and a 500-step trace whose learners both settle at ~0.10/~0.11 (the short one genuinely better), the short config's summary mean is 2.55 (last 20 steps, mostly pre-settling) while the long one's is 0.11 (last 100 settled steps): the generated markdown and LaTeX tables bolded the *worse* learner by a 23x margin, and the bars plot gold-rimmed the same wrong winner — while `get_final_performance` and `pairwise_comparisons` rejected the identical input. The winner in a publication-export table was an artifact of trace length.

## New state

The shared `_preflight_export_results` derives the cross-config `common_final_window` for the requested metric, so every metric-ranked export path (both tables, the dataframe, both CSV modes, `save_experiment_report`) inherits exactly the guard its comparison siblings already had, and `plot_final_performance_bars` applies the same check; `export_to_json` (raw per-config dump, no ranking) is deliberately unguarded. Configs whose `min(100, n_steps)` windows agree — including unequal lengths both at or above 100 — export exactly as before (pinned by test).

Verification at head `d20393f929e626f1dc4d2f21f68a0d3d54a4b493` (on `c9aba7b5`): red phase — the three new fail-closed tests (tables/dataframe, bars plot, and the agree-vs-disagree window pair) fail on the pre-fix tree and pass after; reverting only the two source files reproduces the failures. `tests/test_export.py` + `test_export_hostile_validation.py` + both visualization suites: 163 passed; `test_experiments_validation.py` + `test_experiments_hostile_validation.py` + `test_statistics_validation.py`: 380 passed. Ruff and mypy clean.

## Agent disclosure

- client: Claude Code
- provider: anthropic
- model: claude-fable-5
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
- Slop run `run_01M0PXVHJ7EMV716R8V1KPESZB` is active; the signed receipt + private-trace footer follows when the measured run finalizes.
