### PR TITLE
fix(core): keep the label prior outside the evidence weight normalization

### DIFF
--- a/alberta_framework/core/associative_memory.py
+++ b/alberta_framework/core/associative_memory.py
@@ -867,11 +867,17 @@ class AssociativeMemoryLearner:
         # The decayed label-frequency prior enters with a small fixed weight:
         # it dominates only when no feature rows match (evidence is zero, so
         # the prediction falls back to base rates) and is otherwise a weak
-        # tiebreak against feature evidence scaled by ``logit_scale``.
-        logits = 0.05 * state.prior + self._config.logit_scale * evidence
+        # tiebreak against feature evidence scaled by ``logit_scale``. The
+        # weight normalization applies to the evidence sum alone, so the
+        # prior's coefficient stays fixed instead of scaling with
+        # ``1 / total_weight``.
+        scaled_evidence = self._config.logit_scale * evidence
         total_weight = jnp.sum(weights)
         if self._config.normalize_by_weight:
-            logits = jnp.where(total_weight > 0.0, logits / total_weight, logits)
+            scaled_evidence = jnp.where(
+                total_weight > 0.0, scaled_evidence / total_weight, scaled_evidence
+            )
+        logits = 0.05 * state.prior + scaled_evidence
         probabilities = _softmax(logits)
         return AssociativeMemoryPrediction(
             logits=logits,

--- a/tests/test_associative_memory.py
+++ b/tests/test_associative_memory.py
@@ -908,3 +908,55 @@ def test_associative_memory_json_roundtrip() -> None:
 
     assert restored == config
     assert restored.feature_family == "token_suffix_pair"
+
+
+def test_prior_coefficient_is_independent_of_feature_weight_mass() -> None:
+    """The prior enters with a small fixed weight (its documented contract).
+
+    Two states with identical priors and identical weighted-average feature
+    evidence, differing only in matched-row utility (hence total weight
+    mass), must rank the labels identically: the weight normalization
+    applies to the evidence average, never to the prior term.
+    """
+
+    def build(utility_value: float):
+        config = AssociativeMemoryConfig(
+            vocab_size=4,
+            block_size=2,
+            suffix_length=2,
+            feature_family="position_token",
+            max_features=8,
+        )
+        learner = AssociativeMemoryLearner(config)
+        state = learner.init()
+        context = jnp.asarray([0, 1], dtype=jnp.int32)
+        keys, _mask = learner.feature_keys(context)
+        keys_arr = state.keys.at[0].set(keys[0]).at[1].set(keys[1])
+        row = jnp.asarray([0.0, 0.5, 0.0, 0.0], dtype=jnp.float32)
+        values = state.values.at[0].set(row).at[1].set(row)
+        counts = state.counts.at[0].set(1).at[1].set(1)
+        utility = state.utility.at[0].set(utility_value).at[1].set(utility_value)
+        prior = jnp.asarray([10.0, 0.0, 0.0, 0.0], dtype=jnp.float32)
+        state = state.replace(
+            keys=keys_arr,
+            values=values,
+            counts=counts,
+            utility=utility,
+            prior=prior,
+            step_count=jnp.asarray(1, dtype=jnp.int32),
+            last_update=state.last_update.at[0].set(1).at[1].set(1),
+        )
+        return learner, state, context
+
+    predictions = {}
+    for utility_value in (0.0, -8.0):
+        learner, state, context = build(utility_value)
+        predictions[utility_value] = learner.predict(state, context)
+
+    high = predictions[0.0]
+    low = predictions[-8.0]
+    assert int(jnp.argmax(high.logits)) == 1
+    assert int(jnp.argmax(low.logits)) == int(jnp.argmax(high.logits))
+    prior_term_high = high.logits[0]
+    prior_term_low = low.logits[0]
+    chex.assert_trees_all_close(prior_term_high, prior_term_low, atol=1e-6)


### PR DESCRIPTION
## Issue

`AssociativeMemoryLearner`'s prediction composed `logits = 0.05 * prior + logit_scale * evidence` and then, under `normalize_by_weight=True` (the default in the core config, `steps/step2.py`, and `pipeline.py`), divided the **whole sum** by `total_weight`. The comment directly above documents the prior as entering "with a small fixed weight … otherwise a weak tiebreak"; its effective coefficient was actually `0.05 / total_weight`, a free function of the matched rows' learned utilities. The module's own counterfactual `_weighted_feature_loss` already composes it the other way (evidence-only, then normalize), so the family/window/budget scope controllers were optimising a surrogate whose logit composition differed from the model's actual prediction.

## Symptoms

Two states with identical priors and identical weighted-average feature evidence — differing only in matched-row utility, both inside the module's own ±8 utility clip and both accepted by the learner's validity predicate — produced opposite argmaxes: at row utility 0.0 the prior coefficient was 0.025 and the feature evidence won; at −8.0 (the clip bound) the coefficient was 1.25 (50x) and the prior won. On a plain default run the effective coefficient spanned 15.2x purely with weight mass, flipping 0.4–2.2% of predictions with matched rows. Reaches the public Step 2 associative kernel and `pipeline.py` `step2="associative"`.

## New state

The weight normalization applies to the scaled evidence term alone — turning the weighted evidence *sum* into the weighted *average* the option documents — and the prior is added afterwards with its fixed 0.05 coefficient, exactly as `_weighted_feature_loss` already does. The no-match fallback (zero evidence → prior-only base rates) and `normalize_by_weight=False` configs are unchanged. New test pins that the prior term of the logits is identical across the two utility regimes and that the ranking no longer flips; it fails on the pre-fix tree (mutation-checked by reverting only the source file). `tests/test_associative_memory.py` + `test_step2_loop_steps.py` + `test_step2_theory_invariants.py` + `test_pipeline.py`: 392 passed; ruff and mypy clean. Head `b0c905d7ebcfe476a0d348eda0c9659aad3c7621` on `c9aba7b5`.

Related but distinct: #2355 fixes the within-step self-eviction in the same module; the two changes touch different functions and merge independently.

## Agent disclosure

- client: Claude Code
- provider: anthropic
- model: claude-fable-5
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
- Slop run `run_01M0PXVHJ7EMV716R8V1KPESZB` is active; the signed receipt + private-trace footer follows when the measured run finalizes.
