### PR TITLE
fix(core): size tracking histories for every recording

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -620,8 +620,8 @@ def run_learning_loop[StreamStateT](
     ss_interval = step_size_tracking.interval if step_size_tracking else num_steps + 1
     norm_interval = normalizer_tracking.interval if normalizer_tracking else num_steps + 1
 
-    ss_num_recordings = num_steps // ss_interval if step_size_tracking else 0
-    norm_num_recordings = num_steps // norm_interval if normalizer_tracking else 0
+    ss_num_recordings = -(-num_steps // ss_interval) if step_size_tracking else 0
+    norm_num_recordings = -(-num_steps // norm_interval) if normalizer_tracking else 0
 
     # Pre-allocate step-size history arrays
     ss_history = (
@@ -1764,7 +1764,7 @@ def run_mlp_learning_loop[StreamStateT](
 
     # Tracking enabled
     norm_interval = normalizer_tracking.interval
-    norm_num_recordings = num_steps // norm_interval
+    norm_num_recordings = -(-num_steps // norm_interval)
 
     norm_means = jnp.zeros((norm_num_recordings, feature_dim), dtype=jnp.float32)
     norm_vars = jnp.zeros((norm_num_recordings, feature_dim), dtype=jnp.float32)

--- a/tests/test_learners.py
+++ b/tests/test_learners.py
@@ -962,3 +962,45 @@ def test_linear_family_feature_dimensions_are_exact_and_preflighted(learner) -> 
 
     with pytest.raises(ValueError, match="resource"):
         learner.init(2**26)
+
+
+class TestTrackingKeepsEveryRecording:
+    """History arrays must hold every (idx % interval == 0) recording.
+
+    The recording predicate fires ceil(num_steps / interval) times over
+    idx in [0, num_steps); a floor-sized allocation silently drops the
+    trailing recordings (JAX scatters out-of-bounds writes to nowhere)
+    whenever the interval does not divide num_steps.
+    """
+
+    def test_step_size_history_keeps_the_tail_recording(self, rng_key):
+        step_size = 0.05
+        stream = RandomWalkStream(feature_dim=3)
+        learner = LinearLearner(optimizer=LMS(step_size=step_size))
+        config = StepSizeTrackingConfig(interval=3)
+
+        _, _, history = run_learning_loop(
+            learner, stream, num_steps=10, key=rng_key, step_size_tracking=config
+        )
+
+        chex.assert_shape(history.step_sizes, (4, 3))
+        chex.assert_trees_all_close(
+            history.recording_indices, jnp.array([0, 3, 6, 9], dtype=jnp.int32)
+        )
+        chex.assert_trees_all_close(
+            history.step_sizes[-1], jnp.full(3, step_size, dtype=jnp.float32)
+        )
+
+    def test_normalizer_history_keeps_the_tail_recording(self, rng_key):
+        stream = RandomWalkStream(feature_dim=3)
+        learner = LinearLearner(optimizer=IDBD(), normalizer=EMANormalizer())
+        config = NormalizerTrackingConfig(interval=4)
+
+        _, _, history = run_learning_loop(
+            learner, stream, num_steps=10, key=rng_key, normalizer_tracking=config
+        )
+
+        chex.assert_shape(history.means, (3, 3))
+        chex.assert_trees_all_close(
+            history.recording_indices, jnp.array([0, 4, 8], dtype=jnp.int32)
+        )


### PR DESCRIPTION
## Issue

`run_learning_loop` and `run_mlp_learning_loop` record step-size / normalizer diagnostics at every `idx % interval == 0` over `idx in [0, num_steps)` — `ceil(num_steps / interval)` events — but allocated their history arrays with `num_steps // interval` rows. JAX scatters drop out-of-bounds writes silently, so the surplus recordings vanished without any error.

## Symptoms

Whenever the tracking interval does not divide `num_steps`, the tail of every diagnostic history is silently missing: `num_steps=10, interval=3` allocates 3 rows for 4 events and records indices `[0, 3, 6]`, dropping the recording at step 9; `interval=4` drops step 8. Any step-size-adaptation or normalizer diagnostic whose sampling interval is not a divisor of the run length loses its most recent measurements — the ones closest to the reported final state.

## New state

All three allocation sites use the ceiling, so the histories hold exactly one row per recording event; runs whose interval divides `num_steps` are unchanged (floor == ceiling there, which is why all 197 pre-existing tests pass untouched). New tests pin the full recording-index sets `[0, 3, 6, 9]` and `[0, 4, 8]` and a populated final row; both fail on the pre-fix tree. `tests/test_learners.py` + `test_learners_learning_loop_steps.py` + `test_mlp_learner.py`: 199 passed; ruff and mypy clean. Head `9acb8ee78c7313798bb3281283d943d28afad511` on `c9aba7b5`.

## Agent disclosure

- client: Claude Code
- provider: anthropic
- model: claude-fable-5
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
- Slop run `run_01M0PXVHJ7EMV716R8V1KPESZB` is active; the signed receipt + private-trace footer follows when the measured run finalizes.
