### PR TITLE
fix(core): decay off-policy TD traces with the prior transition's discount

### DIFF
--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -1099,7 +1099,9 @@ class GradientTDLinearLearner:
             & jnp.isfinite(rho_s)
         )
         previous_checked = state.replace(  # type: ignore[attr-defined]
-            eligibility_traces=_zero_if_unused(gamma_s * lam, state.eligibility_traces),
+            eligibility_traces=_zero_if_unused(
+                state.previous_gamma * lam, state.eligibility_traces
+            ),
         )
         candidate_metrics = jnp.array(
             [

--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -245,6 +245,11 @@ class OffPolicyTDState:
         bias: Bias term
         eligibility_traces: Per-feature importance-sampling trace ``z_t``
         bias_eligibility_trace: Bias importance-sampling trace
+        previous_gamma: Discount from the prior update call, carried so the
+            trace decays by ``gamma_t`` (the discount of the transition into
+            ``S_t``) while the TD error bootstraps with ``gamma_{t+1}``
+            (Sutton & Barto 2nd ed., eqs. 12.23/12.25). Seeded to 1.0,
+            which is inert against the zero initial traces.
         step_count: Number of updates applied
         birth_timestamp: Wall-clock seconds at init
         uptime_s: Cumulative wall-clock seconds spent in update calls
@@ -254,6 +259,7 @@ class OffPolicyTDState:
     bias: Float[Array, ""]
     eligibility_traces: Float[Array, " feature_dim"]
     bias_eligibility_trace: Float[Array, ""]
+    previous_gamma: Float[Array, ""] = None  # type: ignore[assignment]
     step_count: Int[Array, ""] = None  # type: ignore[assignment]
     birth_timestamp: float = 0.0
     uptime_s: float = 0.0
@@ -348,6 +354,7 @@ class GradientTDState:
     weights: Float[Array, " augmented_feature_dim"]
     secondary_weights: Float[Array, " augmented_feature_dim"]
     eligibility_traces: Float[Array, " augmented_feature_dim"]
+    previous_gamma: Float[Array, ""] = None  # type: ignore[assignment]
     step_count: Int[Array, ""] = None  # type: ignore[assignment]
     birth_timestamp: float = 0.0
     uptime_s: float = 0.0
@@ -389,6 +396,7 @@ def _off_policy_state_contract(state: object) -> tuple[OffPolicyTDState, int]:
     _array_metadata("state.bias", checked.bias, ())
     _array_metadata("state.eligibility_traces", checked.eligibility_traces, (feature_dim,))
     _array_metadata("state.bias_eligibility_trace", checked.bias_eligibility_trace, ())
+    _array_metadata("state.previous_gamma", checked.previous_gamma, ())
     try:
         step_shape = tuple(checked.step_count.shape)
         step_dtype = np.dtype(checked.step_count.dtype)
@@ -434,6 +442,7 @@ def _gradient_state_contract(state: object) -> tuple[GradientTDState, int]:
         raise ValueError("state augmented feature dimension must be at least two")
     for name in ("weights", "secondary_weights", "eligibility_traces"):
         _array_metadata(f"state.{name}", getattr(checked, name), (augmented_dim,))
+    _array_metadata("state.previous_gamma", checked.previous_gamma, ())
     try:
         step_shape = tuple(checked.step_count.shape)
         step_dtype = np.dtype(checked.step_count.dtype)
@@ -510,13 +519,14 @@ class OffPolicyTDLinearLearner:
     def init(self, feature_dim: int) -> OffPolicyTDState:
         """Initialize learner state with zero weights and zero traces."""
         feature_dim = _require_feature_dim(
-            feature_dim, vectors=2, fixed_scalars=3, update_vectors=9
+            feature_dim, vectors=2, fixed_scalars=4, update_vectors=9
         )
         return OffPolicyTDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
             eligibility_traces=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias_eligibility_trace=jnp.array(0.0, dtype=jnp.float32),
+            previous_gamma=jnp.array(1.0, dtype=jnp.float32),
             step_count=jnp.array(0, dtype=jnp.int32),
             birth_timestamp=time.time(),
             uptime_s=0.0,
@@ -597,8 +607,10 @@ class OffPolicyTDLinearLearner:
         td_error = reward_s + _skip_zero_scale(gamma_s, v_next) - v_t
 
         # Canonical per-decision IS trace.  Each transition's ratio enters once:
-        # the prior ratios are already represented in the stored trace.
-        decay = gamma_s * lam
+        # the prior ratios are already represented in the stored trace. The
+        # decay uses the PRIOR call's discount (state.previous_gamma = gamma_t,
+        # the discount into S_t); only the td_error bootstrap uses gamma_s.
+        decay = state.previous_gamma * lam
         new_e = _skip_zero_scale(
             rho_clipped, _skip_zero_scale(decay, state.eligibility_traces) + observation
         )
@@ -613,6 +625,7 @@ class OffPolicyTDLinearLearner:
             bias=state.bias + scaled_update * new_e_b,
             eligibility_traces=new_e,
             bias_eligibility_trace=new_e_b,
+            previous_gamma=gamma_s,
             step_count=jnp.minimum(state.step_count, _INT32_MAX - 1) + 1,
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
@@ -969,7 +982,7 @@ class GradientTDLinearLearner:
         feature_dim = _require_feature_dim(
             feature_dim,
             vectors=3,
-            fixed_scalars=1,
+            fixed_scalars=2,
             update_vectors=15,
             augmented=True,
         )
@@ -978,6 +991,7 @@ class GradientTDLinearLearner:
             weights=jnp.zeros(augmented_dim, dtype=jnp.float32),
             secondary_weights=jnp.zeros(augmented_dim, dtype=jnp.float32),
             eligibility_traces=jnp.zeros(augmented_dim, dtype=jnp.float32),
+            previous_gamma=jnp.array(1.0, dtype=jnp.float32),
             step_count=jnp.array(0, dtype=jnp.int32),
             birth_timestamp=time.time(),
             uptime_s=0.0,
@@ -1055,7 +1069,9 @@ class GradientTDLinearLearner:
         next_prediction = jnp.dot(state.weights, next_phi)
         td_error = reward_s + _skip_zero_scale(gamma_s, next_prediction) - prediction
 
-        traces = rho_clipped * (phi + _skip_zero_scale(gamma_s * lam, state.eligibility_traces))
+        traces = rho_clipped * (
+            phi + _skip_zero_scale(state.previous_gamma * lam, state.eligibility_traces)
+        )
         secondary_dot_trace = jnp.dot(state.secondary_weights, traces)
         secondary_dot_phi = jnp.dot(state.secondary_weights, phi)
 
@@ -1069,6 +1085,7 @@ class GradientTDLinearLearner:
             weights=state.weights + primary_step,
             secondary_weights=state.secondary_weights + secondary_step,
             eligibility_traces=traces,
+            previous_gamma=gamma_s,
             step_count=jnp.minimum(state.step_count, _INT32_MAX - 1) + 1,
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -1028,7 +1028,12 @@ class TestZeroGammaDoesNotMultiplyInfBootstrap:
         chex.assert_tree_all_finite(result.state.eligibility_traces)
 
     def test_gradient_td_does_not_multiply_inf_traces(self) -> None:
-        """previous_gamma*lam=0 drops leftover GTD traces; 0 * inf must not freeze."""
+        """previous_gamma*lam=0 drops leftover GTD traces; 0 * inf must not freeze.
+
+        The current transition's gamma is nonzero, so both the trace reset
+        and the acceptance guard must key on the prior transition's discount
+        (the episode-boundary state), not on the current call's.
+        """
         learner = GradientTDLinearLearner(step_size=0.1, trace_decay=0.9)
         state = learner.init(2).replace(  # type: ignore[attr-defined]
             eligibility_traces=jnp.full(3, jnp.inf, dtype=jnp.float32),
@@ -1041,12 +1046,13 @@ class TestZeroGammaDoesNotMultiplyInfBootstrap:
             state,
             jnp.array([0.5, -0.25], dtype=jnp.float32),
             jnp.array(1.0, dtype=jnp.float32),
-            jnp.array([jnp.inf, 0.0], dtype=jnp.float32),
-            jnp.array(0.0, dtype=jnp.float32),
+            jnp.array([0.25, 0.5], dtype=jnp.float32),
+            jnp.array(0.9, dtype=jnp.float32),
             jnp.array(1.0, dtype=jnp.float32),
         )
         assert bool(result.update_applied)
         chex.assert_tree_all_finite(result.state.eligibility_traces)
+        chex.assert_trees_all_close(result.state.previous_gamma, jnp.asarray(0.9))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -981,11 +981,12 @@ class TestZeroGammaDoesNotMultiplyInfBootstrap:
         chex.assert_tree_all_finite(result.state.weights)
 
     def test_off_policy_td_does_not_multiply_inf_traces(self) -> None:
-        """gamma*lam=0 drops leftover traces; 0 * inf must not freeze."""
+        """previous_gamma*lam=0 drops leftover traces; 0 * inf must not freeze."""
         learner = OffPolicyTDLinearLearner(step_size=0.1, trace_decay=0.9)
         state = learner.init(2).replace(  # type: ignore[attr-defined]
             eligibility_traces=jnp.full(2, jnp.inf, dtype=jnp.float32),
             bias_eligibility_trace=jnp.asarray(jnp.inf, dtype=jnp.float32),
+            previous_gamma=jnp.asarray(0.0, dtype=jnp.float32),
         )
         raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
         assert not bool(jnp.isfinite(raw))
@@ -1027,10 +1028,11 @@ class TestZeroGammaDoesNotMultiplyInfBootstrap:
         chex.assert_tree_all_finite(result.state.eligibility_traces)
 
     def test_gradient_td_does_not_multiply_inf_traces(self) -> None:
-        """gamma*lam=0 drops leftover GTD traces; 0 * inf must not freeze."""
+        """previous_gamma*lam=0 drops leftover GTD traces; 0 * inf must not freeze."""
         learner = GradientTDLinearLearner(step_size=0.1, trace_decay=0.9)
         state = learner.init(2).replace(  # type: ignore[attr-defined]
             eligibility_traces=jnp.full(3, jnp.inf, dtype=jnp.float32),
+            previous_gamma=jnp.asarray(0.0, dtype=jnp.float32),
         )
         raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
         assert not bool(jnp.isfinite(raw))
@@ -1268,4 +1270,69 @@ def test_gradient_scan_preflights_host_shapes_and_aggregate_resources() -> None:
             Oversized((steps, 2)),  # type: ignore[arg-type]
             Oversized((steps,)),  # type: ignore[arg-type]
             Oversized((steps,)),  # type: ignore[arg-type]
+        )
+
+
+class TestTraceDiscountUsesPriorTransition:
+    """The trace decays by gamma_t (into S_t), the TD error by gamma_{t+1}.
+
+    Sutton & Barto 2nd ed., eqs. 12.23/12.25: z_t = rho_t(gamma_t lambda_t
+    z_{t-1} + phi_t) while delta_t bootstraps with gamma_{t+1}. Decaying the
+    trace by the current call's discount wipes the accumulated trace exactly
+    on the terminal step, before the terminal reward is credited.
+    """
+
+    def test_off_policy_terminal_reward_credits_the_carried_trace(self) -> None:
+        learner = OffPolicyTDLinearLearner(step_size=0.1, trace_decay=1.0)
+        state = learner.init(2)
+        phi_a = jnp.array([1.0, 0.0], dtype=jnp.float32)
+        phi_b = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        one = jnp.array(1.0, dtype=jnp.float32)
+
+        first = learner.update(
+            state, phi_a, jnp.array(0.0, dtype=jnp.float32), phi_b,
+            jnp.array(0.9, dtype=jnp.float32), one,
+        )
+        assert bool(first.update_applied)
+        chex.assert_trees_all_close(first.state.previous_gamma, jnp.asarray(0.9))
+
+        last = learner.update(
+            first.state, phi_b, one, jnp.zeros(2, dtype=jnp.float32),
+            jnp.array(0.0, dtype=jnp.float32), one,
+        )
+        assert bool(last.update_applied)
+        chex.assert_trees_all_close(
+            last.state.weights, jnp.array([0.09, 0.1], dtype=jnp.float32), atol=1e-6
+        )
+
+        post = learner.update(
+            last.state, phi_a, jnp.array(0.0, dtype=jnp.float32), phi_b,
+            jnp.array(0.9, dtype=jnp.float32), one,
+        )
+        chex.assert_trees_all_close(
+            post.state.eligibility_traces, phi_a, atol=1e-6
+        )
+
+    def test_gradient_td_terminal_reward_credits_the_carried_trace(self) -> None:
+        learner = GradientTDLinearLearner(step_size=0.1, trace_decay=1.0)
+        state = learner.init(2)
+        phi_a = jnp.array([1.0, 0.0], dtype=jnp.float32)
+        phi_b = jnp.array([0.0, 1.0], dtype=jnp.float32)
+        one = jnp.array(1.0, dtype=jnp.float32)
+
+        first = learner.update(
+            state, phi_a, jnp.array(0.0, dtype=jnp.float32), phi_b,
+            jnp.array(0.9, dtype=jnp.float32), one,
+        )
+        assert bool(first.update_applied)
+
+        last = learner.update(
+            first.state, phi_b, one, jnp.zeros(2, dtype=jnp.float32),
+            jnp.array(0.0, dtype=jnp.float32), one,
+        )
+        assert bool(last.update_applied)
+        chex.assert_trees_all_close(
+            last.state.weights,
+            jnp.array([0.09, 0.1, 0.19], dtype=jnp.float32),
+            atol=1e-6,
         )


### PR DESCRIPTION
## Issue

`OffPolicyTDLinearLearner` and `GradientTDLinearLearner` decay their eligibility traces by the **current** call's discount — `decay = gamma_s * lam` — the same `gamma_{t+1}` the TD error bootstraps with. Sutton & Barto (2nd ed.) index the two discounts differently: the trace decays by the discount of the transition *into* `S_t` (`z_t = rho_t(gamma_t lambda_t z_{t-1} + phi_t)`, eq. 12.25) while the TD error bootstraps with the discount *out of* `S_t` (eq. 12.23). These learners accept genuinely per-call gammas, so the faithful fix is the one this file already uses for the identical index-shift in rho: the merged `ETDState.previous_rho` carries the prior call's ratio; `previous_gamma` now does the same for the discount.

## Symptoms

On a terminal transition (`gamma = 0`) the whole accumulated in-episode trace was multiplied by zero *before* the terminal reward was credited — lambda forced to 0 for the one update that carries the reward signal. A two-step episode (`lambda = 1, gamma = 0.9`, reward only at termination) left weights `[0, 0.1]` where the textbook recursion gives `[0.09, 0.1]`: the pre-terminal feature received exactly zero credit (GradientTD: `[0, 0.1, 0.19]` vs `[0.09, 0.1, 0.19]`). Same defect class as #2350's actor-critic sites; these two learners need the state-carried form because their gamma is legitimately per-call.

## New state

`OffPolicyTDState` and `GradientTDState` carry `previous_gamma`, seeded to 1.0 at init — provably inert, since the initial traces are zero — advanced to the call's validated gamma on every applied update, and validated by the state contracts alongside the other scalars (resource accounting updated: one more fixed scalar each). The trace decay reads `state.previous_gamma * lam`; the TD error keeps `gamma_s`. Episode boundaries now clear leftover traces one call later through `previous_gamma = 0` — exactly the S&B semantics — and the two tests that crafted `inf` leftover traces and relied on the current-call gamma dropping them now express the same scenario as a post-terminal state (`previous_gamma = 0`), which is what their comments described. ETD's own gamma index is left untouched: it is adjacent to the merged `previous_rho` decision and belongs to the maintainer.

Verification at head `fa663f7f0e6bcefaa8e544ed9fb17ceb1a7fda73` (on `c9aba7b5`): red phase — the two new terminal-credit tests (hand-computed weight expectations plus the post-terminal trace reset) fail on the pre-fix tree; reverting only the source file reproduces the failures. `tests/test_off_policy_td.py` + `test_off_policy_td_update_working_set.py` + `test_baird.py`: 136 passed; consumer `test_off_policy_horde.py`: 28 passed. Ruff and mypy clean.

## Agent disclosure

- client: Claude Code
- provider: anthropic
- model: claude-fable-5
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
- Slop run `run_01M0PXVHJ7EMV716R8V1KPESZB` is active; the signed receipt + private-trace footer follows when the measured run finalizes.


Compute receipt: 194908228 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-asi
Attribution status: self-reported
— [ipmnist-screening]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0PXVHJ7EMV716R8V1KPESZB","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-23T09:05:04.071Z","completed_at":"2026-08-23T10:31:40.703Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T09:05:07.859Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":1316,"output_tokens":766268,"cache_creation_tokens":2507670,"cache_read_tokens":191632974,"total_tokens":194908228,"cost_micro_usd":"197062891","session_count":1},"trajectory_sha256":"0079b6cc90d2c06bcc485d0b5e7ca83cd54f23e3a2a9ed5bcfdeca579985c32a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"bac77ed3-2b66-48ee-b329-574235abdca7","object_id":"sha256:0079b6cc90d2c06bcc485d0b5e7ca83cd54f23e3a2a9ed5bcfdeca579985c32a","sha256":"0079b6cc90d2c06bcc485d0b5e7ca83cd54f23e3a2a9ed5bcfdeca579985c32a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAqi07CPiDmDVOcxKGoxTxK8erAc6YjFvC7D48RM9HdJs","device_key_id":"08732235d7ed2a4c8448e031f00a275cb31fb6cf21faafb5911fdd74d42b2fb2","device_signature":"9NWArRtCMGzkaABLaWb9YKwHtTiCCiMJp__o3qK_c6xWL-3XxNM2hIP9j3oNxtsmaGYQfb8c_qpWRUfVUhF4DQ"}} -->
