### PR TITLE
fix(nexting): enforce channel limits across concrete array types and validate inputs in multi-channel nexting

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -215,16 +215,32 @@ def multi_channel_horizon_returns(
     Returns:
         Array of shape ``(T, C, H)`` of forward-view returns.
     """
+    gammas = _require_host_discount("gammas", gammas, ndim=1)
+    terminal_value = _require_host_finite_real("terminal_value", terminal_value)
     _require_leading_length(
         "cumulants", cumulants, ndim=2, maximum=_NEXTING_MAX_STEPS
     )
-    if isinstance(cumulants, jax.Array) and not isinstance(cumulants, jax.core.Tracer):
+    if isinstance(cumulants, jax.core.Tracer):
+        if cumulants.ndim != 2:
+            raise ValueError("cumulants must be 2-dimensional")
+    elif isinstance(cumulants, jax.Array):
+        if cumulants.ndim != 2:
+            raise ValueError("cumulants must be 2-dimensional")
         channel_count = int(cumulants.shape[1])
         if channel_count < 1 or channel_count > _NEXTING_MAX_CHANNELS:
             raise ValueError(
                 "cumulants channel count must be an integer in "
                 f"[1, {_NEXTING_MAX_CHANNELS}]"
             )
+    else:
+        array = _concrete_numeric_array("cumulants", cumulants, ndim=2)
+        if array is not None:
+            channel_count = int(array.shape[1])
+            if channel_count < 1 or channel_count > _NEXTING_MAX_CHANNELS:
+                raise ValueError(
+                    "cumulants channel count must be an integer in "
+                    f"[1, {_NEXTING_MAX_CHANNELS}]"
+                )
     _require_leading_length("gammas", gammas, ndim=1, maximum=_NEXTING_MAX_HORIZONS)
     # Vmap over channels: for each channel apply multi_horizon_returns
     def per_channel(c_series: Array) -> Array:

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -169,6 +169,33 @@ class TestMultiChannel:
         # Channel 1: G_0 = 0 + 0.9*0 + 0.81*1 = 0.81; G_1 = 0.9; G_2 = 1
         chex.assert_trees_all_close(g[:, 1, 0], jnp.array([0.81, 0.9, 1.0]), atol=1e-6)
 
+    @pytest.mark.parametrize("array_type", [np.zeros, jnp.zeros])
+    def test_channel_count_limits_checked_for_numpy_and_jax(self, array_type) -> None:
+        cumulants_legal = array_type((5, 8), dtype=np.float32)
+        gammas = jnp.array([0.5], dtype=jnp.float32)
+        g = multi_channel_horizon_returns(cumulants_legal, gammas)
+        chex.assert_shape(g, (5, 8, 1))
+
+        cumulants_too_many = array_type((5, 9), dtype=np.float32)
+        with pytest.raises(
+            ValueError,
+            match=r"cumulants channel count must be an integer in \[1, 8\]",
+        ):
+            multi_channel_horizon_returns(cumulants_too_many, gammas)
+
+    @pytest.mark.parametrize("gamma_val", [True, float("nan"), float("inf"), -0.1, 1.1])
+    def test_multi_channel_rejects_invalid_gammas(self, gamma_val: object) -> None:
+        cumulants = jnp.zeros((3, 2), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="gammas"):
+            multi_channel_horizon_returns(cumulants, [cast(float, gamma_val)])
+
+    @pytest.mark.parametrize("term_val", [True, float("nan"), float("inf")])
+    def test_multi_channel_rejects_invalid_terminal_value(self, term_val: object) -> None:
+        cumulants = jnp.zeros((3, 2), dtype=jnp.float32)
+        gammas = jnp.array([0.5], dtype=jnp.float32)
+        with pytest.raises(ValueError, match="terminal_value"):
+            multi_channel_horizon_returns(cumulants, gammas, terminal_value=cast(float, term_val))
+
 
 class TestRMSE:
     def test_large_finite_errors_do_not_overflow(self) -> None:


### PR DESCRIPTION
### Summary
In `alberta_framework/utils/nexting.py`, `multi_channel_horizon_returns` previously checked the channel count limit (`_NEXTING_MAX_CHANNELS = 8`) exclusively when `isinstance(cumulants, jax.Array)`. Non-JAX array inputs such as NumPy arrays or nested sequences skipped this validation, allowing channel counts beyond the documented capacity to proceed into `vmap`. Additionally, `multi_channel_horizon_returns` omitted upfront host validation for `gammas` and `terminal_value` before initiating JAX mapping.

### Changes
1. Added upfront validation of `gammas` with `_require_host_discount` and `terminal_value` with `_require_host_finite_real` in `multi_channel_horizon_returns`.
2. Extended channel count validation to all concrete numeric array types (both `jax.Array` and non-JAX array types via `_concrete_numeric_array`), rejecting channel counts exceeding `_NEXTING_MAX_CHANNELS` or below 1 uniformly.
3. Added unit tests in `tests/test_nexting.py` covering NumPy and JAX channel limits, as well as invalid `gammas` and `terminal_value` rejections.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0Q3876ST4JGKSZ3FQG6M7NR","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-23T10:39:22.329Z","completed_at":"2026-08-23T10:40:11.875Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T10:39:22.857Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"02eae664889c63d3d732b8c362af85f9cbea7185e518bc65a1945557829e3ff2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"940789d7-d15f-49e8-a401-5664f7bf9d17","object_id":"sha256:02eae664889c63d3d732b8c362af85f9cbea7185e518bc65a1945557829e3ff2","sha256":"02eae664889c63d3d732b8c362af85f9cbea7185e518bc65a1945557829e3ff2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"CJY0zfiVrl17QtmzJyUo4BeGD-_BacQVZdW4MMp-iXlQu23HOGTq3RYDzWFq1Li87wi-6cX_KAteAR4NOHg-Cw"}} -->
