### PR TITLE
fix(core): fall back to uniform distribution when probability mass is zero or underflowing in floor_and_renormalize_probabilities

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -225,11 +225,11 @@ def floor_and_renormalize_probabilities(
     if min_probability * n_actions >= 1.0:
         return jnp.ones_like(probs) / n_actions
     clipped = jnp.maximum(probs, 0.0)
-    normalizer = jnp.maximum(
-        jnp.sum(clipped, axis=-1, keepdims=True),
-        jnp.asarray(1e-12, dtype=jnp.float32),
-    )
-    normalized = clipped / normalizer
+    total_mass = jnp.sum(clipped, axis=-1, keepdims=True)
+    has_mass = total_mass > 0.0
+    safe_normalizer = jnp.where(has_mass, total_mass, 1.0)
+    uniform = jnp.ones_like(probs) / n_actions
+    normalized = jnp.where(has_mass, clipped / safe_normalizer, uniform)
     floor_mass = jnp.asarray(min_probability * n_actions, dtype=jnp.float32)
     return jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
 

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -389,6 +389,60 @@ def test_probability_simplex_and_helper_invariants() -> None:
     chex.assert_trees_all_close(logs, jnp.log(selected))
 
 
+def test_floor_and_renormalize_probabilities_degenerate_and_batch() -> None:
+    """Verify simplex invariant holds even for all-zero, negative, or underflowing mass."""
+    # Zero mass
+    zero_mass = floor_and_renormalize_probabilities(
+        jnp.array([0.0, 0.0, 0.0], dtype=jnp.float32),
+        min_probability=1e-6,
+    )
+    chex.assert_trees_all_close(
+        zero_mass,
+        jnp.array([1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0], dtype=jnp.float32),
+        atol=1e-6,
+    )
+    chex.assert_trees_all_close(jnp.sum(zero_mass), 1.0, atol=1e-6)
+    assert float(jnp.min(zero_mass)) >= 1e-6
+
+    # Negative mass (clipped to zero)
+    neg_mass = floor_and_renormalize_probabilities(
+        jnp.array([-5.0, -2.0, -10.0, -1.0], dtype=jnp.float32),
+        min_probability=1e-4,
+    )
+    chex.assert_trees_all_close(neg_mass, jnp.full((4,), 0.25, dtype=jnp.float32), atol=1e-6)
+    chex.assert_trees_all_close(jnp.sum(neg_mass), 1.0, atol=1e-6)
+
+    # Sub-epsilon float32 mass that would previously collapse under max(sum, 1e-12)
+    small_mass = floor_and_renormalize_probabilities(
+        jnp.array([1e-30, 2e-30, 1e-30], dtype=jnp.float32),
+        min_probability=1e-6,
+    )
+    chex.assert_trees_all_close(jnp.sum(small_mass), 1.0, atol=1e-6)
+    assert float(jnp.min(small_mass)) >= 1e-6 - 1e-9
+
+    # Batched input with mixed zero-mass and valid-mass rows
+    batch = jnp.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.2, 0.3, 0.5],
+            [-1.0, -2.0, -3.0],
+        ],
+        dtype=jnp.float32,
+    )
+    floored_batch = floor_and_renormalize_probabilities(batch, min_probability=0.01)
+    chex.assert_shape(floored_batch, (3, 3))
+    sums = jnp.sum(floored_batch, axis=-1)
+    chex.assert_trees_all_close(sums, jnp.ones(3, dtype=jnp.float32), atol=1e-6)
+    chex.assert_trees_all_close(
+        floored_batch[0], jnp.full((3,), 1.0 / 3.0, dtype=jnp.float32), atol=1e-6
+    )
+    chex.assert_trees_all_close(
+        floored_batch[2], jnp.full((3,), 1.0 / 3.0, dtype=jnp.float32), atol=1e-6
+    )
+    assert float(jnp.min(floored_batch)) >= 0.01 - 1e-7
+
+
+
 @pytest.mark.parametrize(
     "action",
     [


### PR DESCRIPTION
### Summary
In `alberta_framework/core/behavior_model.py`, `floor_and_renormalize_probabilities` documents that it returns a valid probability simplex along the last axis with entries floored to at least `min_probability`.

However, when input probabilities held zero mass (e.g. `[0.0, 0.0, 0.0]`, all-negative inputs clipped to zero, or sub-epsilon float32 values), `normalizer = jnp.maximum(jnp.sum(clipped, axis=-1, keepdims=True), 1e-12)` resulted in `normalized = 0.0`, causing the affine combination `min_probability + (1.0 - floor_mass) * normalized` to return `[min_probability, min_probability, ...]`. For $n$ actions, this summed to $n \cdot \text{min\_probability}$ (`3e-6` for 3 actions) rather than a valid probability simplex summing to `1.0` (#2238).

### Changes
1. Updated `floor_and_renormalize_probabilities` in `alberta_framework/core/behavior_model.py` to check `total_mass > 0.0` and fall back to the uniform distribution `jnp.ones_like(probs) / n_actions` whenever the clipped mass is zero or underflowing, guaranteeing a proper simplex across both 1D and batched inputs.
2. Added comprehensive unit tests in `tests/test_behavior_model.py` verifying the simplex invariant on all-zero, negative, sub-epsilon, and mixed batched inputs.

Resolves #2238

## Measured project receipt
Post-hoc / same-window receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0Q4D1VJC0BY2NXH36NWQQXC","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-23T10:59:29.266Z","completed_at":"2026-08-23T11:02:54.636Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T10:59:29.784Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"92a681d8dba7cdd92556bf42f099480acd93e39a3e3c4a9671af02f7ed82a07e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"648278a5-cac4-4a11-a24a-65c9cdcf58de","object_id":"sha256:92a681d8dba7cdd92556bf42f099480acd93e39a3e3c4a9671af02f7ed82a07e","sha256":"92a681d8dba7cdd92556bf42f099480acd93e39a3e3c4a9671af02f7ed82a07e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"PSddF7zYRWKiPDhKLGQy2fomviLKK-5jaM7DrcYgb6eerPV2OuyLum6Q93iqD6HlJY4iCEN-jJKx5lKAx7KqCA"}} -->