### PR TITLE
Fix fixed-width numpy integer allowlists rejecting a valid integer family in two benchmarks

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -59,15 +59,8 @@ CAUSAL_MAP_VARIANT_KIND = "alberta_causal_map"
 _CAUSAL_MAP_RNG_NAMESPACE = 0xCA05A14
 _CAUSAL_MAP_PRNG_IMPL = "threefry2x32"
 _CAUSAL_MAP_ENVIRONMENT_PRNG_IMPL = "threefry2x32"
-_EXACT_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
+_EXACT_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 _EXACT_INTEGER_TYPES = (int, *_EXACT_NUMPY_INTEGER_TYPES)
 _EXACT_REAL_TYPES = (

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -43,17 +43,8 @@ _MAX_RUN_STEPS = 1_000_000
 _PRNG_IMPLEMENTATION = "threefry2x32"
 _PAIR_RESULT_SCHEMA = "asi.ipmnist.gradual-input-pair.result.v1"
 _ADAMW_IDENTITY = tuple(sorted(ADAMW_PROTOCOL_HYPERPARAMETERS.items()))
-_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.longlong,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.ulonglong,
+_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 
 GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(

--- a/tests/test_causal_map_forager.py
+++ b/tests/test_causal_map_forager.py
@@ -244,6 +244,38 @@ def test_config_rejects_respawn_factor_below_float32_one() -> None:
         CausalMapForagerConfig(respawn_safety_factor=below_one)
 
 
+@pytest.mark.parametrize("code", ["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"])
+def test_config_accepts_every_numpy_integer_family(code: str) -> None:
+    # A fixed-width scalar-name allowlist cannot cover all five signed (and all
+    # five unsigned) C integer families numpy exposes: on any platform exactly
+    # one signed and one unsigned family is orphaned (on aarch64 Linux that is
+    # np.longlong / np.ulonglong).  The dtype-code derivation admits all ten,
+    # so an integer of any family is accepted and canonicalized to int.
+    scalar = np.dtype(code).type(3)
+    assert type(scalar) is np.dtype(code).type
+    config = CausalMapForagerConfig(
+        initial_retry_delay=scalar,
+        maximum_retry_exponent=scalar,
+    )
+    assert type(config.initial_retry_delay) is int
+    assert config.initial_retry_delay == 3
+    assert type(config.maximum_retry_exponent) is int
+    assert config.maximum_retry_exponent == 3
+
+
+def test_config_rejects_int_subclass_bool_and_float_for_integer_field() -> None:
+    class ForgedInt(np.int64):
+        def __index__(self) -> int:
+            raise AssertionError("must not execute __index__")
+
+    with pytest.raises(ValueError, match="integer"):
+        CausalMapForagerConfig(initial_retry_delay=ForgedInt(3))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="integer"):
+        CausalMapForagerConfig(initial_retry_delay=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="integer"):
+        CausalMapForagerConfig(initial_retry_delay=3.0)  # type: ignore[arg-type]
+
+
 @pytest.mark.parametrize(
     "field",
     [

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -99,6 +99,41 @@ def test_transition_config_rejects_forged_and_hostile_values_without_index_hooks
     assert HostileMeta.calls == 0
 
 
+@pytest.mark.parametrize("code", ["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"])
+def test_config_accepts_every_numpy_integer_family(code: str) -> None:
+    # Every signed and unsigned C integer family numpy exposes must be admitted
+    # by the exact-type gate.  On any platform exactly one signed and one
+    # unsigned family has no fixed-width alias, so a hand-written fixed-width
+    # allowlist orphans it; the dtype-code derivation covers all ten families.
+    scalar = np.dtype(code).type(2)
+    assert type(scalar) is np.dtype(code).type
+    config = GradualTransitionConfig(mode="input_interpolation", transition_steps=scalar)
+    assert type(config.transition_steps) is int
+    assert config.transition_steps == 2
+
+
+def test_config_rejects_int_subclass_bool_and_float_without_index_hooks() -> None:
+    class ForgedInt(np.int64):
+        def __index__(self) -> int:
+            raise AssertionError("must not execute __index__")
+
+    with pytest.raises(ValueError, match="integer"):
+        GradualTransitionConfig(
+            mode="input_interpolation",
+            transition_steps=ForgedInt(2),  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="integer"):
+        GradualTransitionConfig(
+            mode="input_interpolation",
+            transition_steps=True,  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="integer"):
+        GradualTransitionConfig(
+            mode="input_interpolation",
+            transition_steps=2.0,  # type: ignore[arg-type]
+        )
+
+
 def test_task_sampling_mask_is_matched_deterministic_and_monotone() -> None:
     first = task_sampling_mask(seed=7, transition_id=3, count=10, alpha=0.3)
     second = task_sampling_mask(seed=7, transition_id=3, count=10, alpha=0.3)


### PR DESCRIPTION
## What was broken and its measurement consequence

Two exact-type numpy-integer allowlists in the benchmarks were hand-written as
fixed-width scalar-type names:

- `alberta_framework/benchmarks/ipmnist_gradual.py` — `_NUMPY_INTEGER_TYPES`
  (10 fixed-width names + `np.longlong`/`np.ulonglong`), used by the
  `_exact_index` gate covering every ipmnist call site.
- `alberta_framework/benchmarks/causal_map_forager.py` —
  `_EXACT_NUMPY_INTEGER_TYPES` (8 fixed-width names), splatted into
  `_EXACT_INTEGER_TYPES` and `_EXACT_REAL_TYPES`, reaching ~19
  `CausalMapForagerConfig` fields plus
  `validate_causal_map_state(observation_channels=)`,
  `CausalMapForagerAgent(seed=)`, and `run_causal_map_forager_seeds(seeds=)`.

numpy exposes **five** signed C integer scalar families (`b h i l q`) and five
unsigned (`B H I L Q`), but only four fixed-width signed aliases exist. On every
platform exactly one signed and one unsigned family has **no** fixed-width alias
— which one is the "orphan" is platform-dependent and invisible to CI. A valid
numpy integer of the orphan family is therefore rejected by these strict-identity
gates with `ValueError`, corrupting the config-validation surface for callers
that pass an ordinary numpy integer.

On this aarch64 Linux worker C `long` is 64-bit, so `np.int64` binds to `l`,
leaving `q`/`np.longlong` (and `Q`/`np.ulonglong`) with no fixed-width alias —
so `causal_map_forager` rejected `np.longlong(1)` here.

## Fix

Derive both constants from the ten numpy dtype codes, exactly as the sibling
modules already do (`benchmarks/upgd_ipmnist.py`, `benchmarks/forager.py`,
`core/normalizers.py`). `p`/`P` are pointer-width aliases that would duplicate an
existing family in a tuple, so they are excluded:

```python
tuple(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))
```

Container shape (tuple), annotations, all use sites, and the strict
`is` / `type(...) not in ...` identity semantics are unchanged. A forged
`np.int64` subclass, a Python `bool`, and a `float` are still rejected without
invoking `__index__`/`__eq__`/`__hash__`. `steps/step5.py` is untouched; no new
exports were added.

## Failing-then-passing reproduction

Platform: **aarch64 Linux, CPython 3.13.5, numpy 2.5.1**.

BEFORE the fix (source reverted, tests kept) — the orphan family raises:

```
### BEFORE FIX — failing reproduction (source reverted to pre-fix)
int64 -> ok
longlong -> ValueError: initial_retry_delay must be a positive integer
```

AFTER the fix — every orphan family is accepted and canonicalized to `int`,
while forged subclass / bool / float stay rejected:

```
causal_map int64(1) -> initial_retry_delay=1 type=int
causal_map longlong(1) -> initial_retry_delay=1 type=int
causal_map ulonglong(1) -> initial_retry_delay=1 type=int
causal_map intc(1) -> initial_retry_delay=1 type=int
causal_map uintc(1) -> initial_retry_delay=1 type=int
ipmnist_gradual: all 10 dtype codes accepted and canonicalized to int
rejected True
rejected 3.0
rejected forged np.int64 subclass (no __index__ call)
```

The new regression tests fail before the fix on the orphan family
(`test_config_accepts_every_numpy_integer_family[q]` / `[Q]` on this box) and
pass after it.

## Verification commands and results

New parametrized acceptance + negative regression tests (all 23 selected pass):

```
$ .venv/bin/python -m pytest \
    tests/test_causal_map_forager.py::test_config_accepts_every_numpy_integer_family \
    tests/test_causal_map_forager.py::test_config_rejects_int_subclass_bool_and_float_for_integer_field \
    tests/test_ipmnist_gradual.py::test_config_accepts_every_numpy_integer_family \
    tests/test_ipmnist_gradual.py::test_config_rejects_int_subclass_bool_and_float_without_index_hooks \
    tests/test_ipmnist_gradual.py::test_transition_config_rejects_forged_and_hostile_values_without_index_hooks \
    -v -o addopts=""
...
============================== 23 passed in 2.26s ==============================
```

Full touched test files:

```
$ .venv/bin/python -m pytest tests/test_causal_map_forager.py tests/test_ipmnist_gradual.py -q -o addopts=""
201 passed, 4 skipped in 408.82s (0:06:48)
```

Lint / types (repo CI invocations):

```
$ .venv/bin/python -m ruff check .
All checks passed!

$ .venv/bin/python -m mypy
Success: no issues found in 224 source files
```

(mypy CI config is `files = ["alberta_framework"]`; the two edited source files
also pass a scoped `mypy` run.)

## What remains open

Nothing in scope for this fix. The change is a bounded correctness repair of the
two integer allowlists; benchmark campaigns, frozen lifecycles, and pinned
`outputs/` artifacts were not touched.

## Evidence attachment note

The repository's immutable-attachment tooling (`attach.mjs`, which drives a
headless GitHub web-upload session) could not authenticate on this run — GitHub
returned `Incorrect username or password` for the browser-upload account, so no
`user-attachments` URLs could be minted. Per policy that stored credential was
not altered or revealed. All evidence above is therefore inlined verbatim from
the commands run against the pushed head; each number is shown with the exact
command that produced it.

<!-- evidence-head:69fa56a01aedeb99553d8847aa48c738c582ad6d -->

Closes #2295

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi"} -->
