### PR TITLE
fix(core): enforce the policy archive equal-width invariant where it is declared

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        latent_width: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if latent_width is None:
+                latent_width = len(entry.latent)
+            elif len(entry.latent) != latent_width:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from alberta_framework.core.policy_archive import (
@@ -59,6 +60,71 @@ def test_archive_preflights_host_dimensions() -> None:
             byte_budget=256 * 1024 * 1024,
             min_latent_distance=0.0,
             entries=(entry,) * 4097,
+        )
+
+
+@pytest.mark.parametrize("mode", ("diverse_archive", "one_model", "fixed_snapshot"))
+def test_constructor_enforces_the_declared_equal_width_invariant(mode: str) -> None:
+    """``add`` states the invariant archive-wide, so construction must hold it."""
+    with pytest.raises(ValueError, match="equal width"):
+        BoundedPolicyArchive(
+            byte_budget=4096,
+            min_latent_distance=1.0,
+            mode=mode,  # type: ignore[arg-type]
+            entries=(_entry("a", (0.0,), 0.0), _entry("b", (3.0, 3.0), 9.0)),
+        )
+
+
+def test_mixed_width_entries_cannot_reach_the_distance_computation() -> None:
+    """A width-1 latent broadcasts against a width-2 latent to a distance of 0.0.
+
+    Reaching ``add``'s nearest-neighbour search with a mixed-width archive turns a
+    shape violation into a wrong result: the candidate below is 3.0 away from every
+    entry of its own width, yet the broadcast pairing reports 0.0 and discards it.
+    """
+    wide = _entry("b", (3.0, 3.0), 9.0)
+    assert float(np.linalg.norm(np.asarray((3.0,)) - np.asarray(wide.latent))) == 0.0
+    with pytest.raises(ValueError, match="equal width"):
+        BoundedPolicyArchive(
+            byte_budget=4096,
+            min_latent_distance=1.0,
+            entries=(_entry("a", (0.0,), 0.0), wide),
+        )
+    well_formed = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=1.0, entries=(_entry("a", (0.0,), 0.0),)
+    )
+    assert [entry.identity for entry in well_formed.add(_entry("c", (3.0,), 1.0)).entries] == [
+        "a",
+        "c",
+    ]
+
+
+@pytest.mark.parametrize(("mode", "retained"), (("fixed_snapshot", "a"), ("one_model", "b")))
+def test_single_policy_controls_accept_a_wider_entry(mode: str, retained: str) -> None:
+    """Neither control compares descriptors, so neither can hold a mixed-width state."""
+    archive = BoundedPolicyArchive(
+        byte_budget=4096,
+        min_latent_distance=0.0,
+        mode=mode,  # type: ignore[arg-type]
+    ).add(_entry("a", (0.0,), 1.0))
+    successor = archive.add(_entry("b", (0.0, 0.0), 2.0))
+    assert [entry.identity for entry in successor.entries] == [retained]
+
+
+def test_width_guard_still_rejects_a_mismatched_candidate() -> None:
+    archive = BoundedPolicyArchive(byte_budget=4096, min_latent_distance=0.5).add(
+        _entry("a", (0.0, 0.0), 1.0)
+    )
+    with pytest.raises(ValueError, match="equal width"):
+        archive.add(_entry("b", (0.0,), 2.0))
+
+
+def test_entry_type_is_checked_before_its_latent_width() -> None:
+    with pytest.raises(ValueError, match="exact tuple"):
+        BoundedPolicyArchive(
+            byte_budget=4096,
+            min_latent_distance=0.0,
+            entries=("a",),  # type: ignore[arg-type]
         )
 
 


### PR DESCRIPTION
Closes #2322.

`BoundedPolicyArchive.add` raises `"all latent descriptors must have equal width"` —
an archive-wide claim — while comparing the candidate against `self.entries[0]`
alone. `__post_init__` validates the byte budget, identity uniqueness, and entry
type, but never compares widths. `entries` is a directly constructible field on a
public frozen dataclass, so the invariant the error message asserts is not a
property the archive holds.

That matters because the distance computation subtracts two `np.asarray` values,
and numpy broadcasts a width mismatch instead of raising: `(3.0,) - (3.0, 3.0)`
is `[0.0, 0.0]`, norm `0.0`. A candidate that is genuinely far from every entry of
its own width therefore reports a fabricated `0.0` distance, loses the
nearest-neighbour replacement test, and is discarded with no exception and no
diagnostic. `persistent_bytes` and the entry count stay self-consistent, so
nothing downstream can detect the loss.

The same check also ran ahead of the mode short-circuits, so `one_model` and
`fixed_snapshot` rejected an entry over a descriptor width neither arm reads —
`fixed_snapshot` returns `self`, and `one_model` replaces the whole tuple with
`(entry,)`. Both are declared controls in `POLICY_ARCHIVE_PROTOCOL["controls"]`,
so a matched comparison against a diverse arm aborted where its counterpart
proceeded.

## The change

1. `__post_init__` compares every entry's latent width, inside the existing loop
   and after the per-entry exact-type check, so an ill-typed element still
   reports `"exact tuple"` rather than raising `AttributeError` on `.latent`.
   `add` builds successors with `replace`, which re-runs `__post_init__`, so
   successors are validated on the same path.
2. The guard in `add` moves into the branch that actually computes distances.
   With the constructor holding the invariant, that single `entries[0]`
   comparison *is* the archive-wide check, and the two control arms stop
   rejecting a width they never use.

Nothing is relaxed: a mismatched candidate against a well-formed
`diverse_archive` still raises the same message, now covered by
`test_width_guard_still_rejects_a_mismatched_candidate`.

## Before and after

One tree-agnostic probe script, run unmodified against `main` at `c9aba7b5` and
against this branch.

<table>
<tr><th>probe</th><th><code>main</code></th><th>this branch</th></tr>
<tr><td>constructor with <code>entries=(width 1, width 2)</code>, all three modes</td>
<td>CONSTRUCTED ×3 — declared invariant not enforced</td>
<td>REJECT ×3 — <code>all latent descriptors must have equal width</code></td></tr>
<tr><td><code>add</code> a width-1 candidate <code>3.0</code> from every width-1 entry, <code>min_latent_distance=1.0</code></td>
<td>broadcast &quot;distance&quot; <code>0.0</code> vs the true <code>3.0</code>; <code>add</code> returned the same archive; identities stayed <code>('a', 'b')</code></td>
<td>unreachable — the mixed-width archive cannot be constructed</td></tr>
<tr><td><code>fixed_snapshot</code> / <code>one_model</code> handed a wider entry</td>
<td>REJECT / REJECT</td>
<td><code>identities=('a',) widths=(1,)</code> / <code>identities=('b',) widths=(2,)</code></td></tr>
<tr><td>tally</td>
<td>2 rejections, <strong>1 silently discarded valid candidate</strong></td>
<td>3 rejections, <strong>0 silently discarded</strong></td></tr>
</table>

## Verification

| check | command | result |
| --- | --- | --- |
| failing test first | `pytest tests/test_policy_archive.py -q`, new tests copied into a pristine `main` worktree | **6 failed, 8 passed** — every new behavioural case fails at `main` |
| this branch | same command | **14 passed** |
| lint | `ruff check .`, both trees | identical output, `All checks passed!` |
| types | `mypy`, both trees | **byte-for-byte identical**, 13568 bytes each, 108 pre-existing host-platform errors (`fcntl.LOCK_NB`, `os.uname`), **0** mentioning `policy_archive` |
| only production consumer | `pytest tests/test_telapa_qualification.py tests/test_console_entrypoints.py tests/test_historical_forager_cli_package.py -q`, both trees | identical 2-failure set on both (`ModuleNotFoundError: No module named 'fcntl'`, POSIX-only on this Windows host); 29 passed at `main`, 43 on the branch — the difference is exactly this module's 14 cases |
| full suite | `pytest -m "not slow and not package" --continue-on-collection-errors -q`, sequentially, one tree after the other | `main` **363 failed / 14793 passed** / 53 skipped / 1059 deselected / 37 errors in 1:26:43; branch **363 failed / 14801 passed** / 53 skipped / 1059 deselected / 37 errors in 1:22:52 |
| failure-set diff | sorted-diff over the `FAILED` and `ERROR` node-id sets of the two full runs | **identical 363-test failure set** and **identical 37-error set**; the branch adds exactly its 8 new passing cases (14801 vs 14793) and **zero** failures involve `tests/test_package_import_boundaries.py` on either side |

`alberta_framework/benchmarks/telapa_qualification.py` is the only production
consumer in the tree. It constructs the archive empty and only ever adds entries
whose latent is the fixed four-statistic rollout descriptor, so every descriptor
on that path is width 4: the new constructor invariant cannot fire there, and the
relocated guard is behaviour-identical for uniform widths in every arm.

Environment: CPython 3.13.14, numpy 2.5.1, pytest 9.1.1, AMD64
Windows-11-10.0.22631. The broadcasting result is platform-independent numpy
semantics; the `fcntl` and `os.uname` failures above are host-only and present at
`main`.

---

— [claude-opus-5-w1]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0MVQSRTV8PXX64WKCMWJPB1","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-22T13:49:35.386Z","completed_at":"2026-08-23T11:15:16.195Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T13:49:39.638Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"7dbd286b76061fe315d225f05599f1812453c1698dd2b6ee37f32a49b5cd81f0","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"8b8c660e-1a39-4ccf-97cb-a7767219afca","object_id":"sha256:7dbd286b76061fe315d225f05599f1812453c1698dd2b6ee37f32a49b5cd81f0","sha256":"7dbd286b76061fe315d225f05599f1812453c1698dd2b6ee37f32a49b5cd81f0"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"i72FYlPuI0rNaYGt9ITvrTzC3tAN7tKLmSyimOYGIfyas9H6RomYqlzTTJgQ89LLPenBuMPKcl0uDslGW75hDA"}} -->
