### PR TITLE
fix(nexting): promote integer/boolean cumulants to float in forward-view returns

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -155,8 +155,22 @@ def forward_view_returns(
     _require_leading_length(
         "cumulants", cumulants, ndim=1, maximum=_NEXTING_MAX_STEPS
     )
-    gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
-    init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
+    # Promote to a floating computation dtype so an integer/boolean cumulant
+    # series does not truncate gamma (``asarray(0.9, int32) == 0``) or the
+    # terminal value, which would collapse the bootstrap and degenerate the
+    # reverse scan into a raw cumulant echo (or a logical-OR for booleans).
+    # Promotion is over static dtypes only, so it stays traceable under
+    # jit + vmap.
+    compute_dtype = jnp.result_type(
+        cumulants.dtype,
+        jnp.asarray(gamma).dtype,
+        jnp.asarray(terminal_value).dtype,
+    )
+    if not jnp.issubdtype(compute_dtype, jnp.floating):
+        compute_dtype = jnp.float32
+    cumulants = cumulants.astype(compute_dtype)
+    gamma_s = jnp.asarray(gamma, dtype=compute_dtype)
+    init = jnp.asarray(terminal_value, dtype=compute_dtype)
 
     def step(carry: Array, c: Array) -> tuple[Array, Array]:
         # gamma=0 must not multiply an inf later return (0*inf).

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -114,6 +114,90 @@ class TestForwardViewReturns:
         actual = jax.jit(forward_view_returns)(c, jnp.array(0.5, dtype=jnp.float32))
         chex.assert_trees_all_close(actual, jnp.array([2.75, 3.5, 3.0]))
 
+    def test_float32_output_is_byte_identical_to_expected(self) -> None:
+        """Guard the promotion fix against silently altering float32 arithmetic."""
+        c = jnp.array([1.0, 0.0, 0.0, 0.0, 1.0], dtype=jnp.float32)
+        g = forward_view_returns(c, gamma=0.9)
+        assert g.dtype == jnp.float32
+        expected = jnp.array(
+            [1.6560999, 0.7289999, 0.80999994, 0.9, 1.0], dtype=jnp.float32
+        )
+        chex.assert_trees_all_equal(g, expected)
+
+    @pytest.mark.parametrize(
+        "dtype", [jnp.int16, jnp.int32, jnp.uint8, jnp.uint32]
+    )
+    def test_integer_cumulants_match_float_and_are_not_the_echo(self, dtype) -> None:
+        """int/uint series used to truncate gamma to 0 and echo the raw cumulants."""
+        c_int = jnp.array([1, 0, 0, 0, 1], dtype=dtype)
+        g_int = forward_view_returns(c_int, gamma=0.9)
+        g_float = forward_view_returns(c_int.astype(jnp.float32), gamma=0.9)
+        assert jnp.issubdtype(g_int.dtype, jnp.floating)
+        chex.assert_trees_all_close(g_int, g_float, atol=1e-6)
+        # The pre-fix degenerate result was a raw cumulant echo [1,0,0,0,1].
+        echo = c_int.astype(jnp.float32)
+        assert not bool(jnp.allclose(g_int, echo))
+        chex.assert_trees_all_close(
+            g_int,
+            jnp.array([1.6561, 0.729, 0.81, 0.9, 1.0], dtype=jnp.float32),
+            atol=1e-4,
+        )
+
+    def test_boolean_cumulants_are_promoted_not_logical_or(self) -> None:
+        """Boolean series used to collapse to all-True via the bootstrap OR."""
+        c_bool = jnp.array([True, False, False, False, True])
+        g_bool = forward_view_returns(c_bool, gamma=0.9)
+        g_float = forward_view_returns(
+            c_bool.astype(jnp.float32), gamma=0.9
+        )
+        assert jnp.issubdtype(g_bool.dtype, jnp.floating)
+        chex.assert_trees_all_close(g_bool, g_float, atol=1e-6)
+        # Pre-fix collapse produced all-True (1.0 everywhere); reject it.
+        assert not bool(jnp.all(g_bool == 1.0))
+
+    def test_fractional_terminal_value_not_truncated_with_integer_cumulants(
+        self,
+    ) -> None:
+        c_int = jnp.array([1, 2, 3], dtype=jnp.int32)
+        g = forward_view_returns(c_int, gamma=1.0, terminal_value=7.6)
+        # G_2 = 3 + 7.6 = 10.6, G_1 = 2 + 10.6 = 12.6, G_0 = 1 + 12.6 = 13.6.
+        chex.assert_trees_all_close(
+            g, jnp.array([13.6, 12.6, 10.6], dtype=jnp.float32), atol=1e-5
+        )
+
+    def test_integer_multi_horizon_gives_distinct_decay_per_horizon(self) -> None:
+        c_int = jnp.array([1, 0, 0, 0, 1], dtype=jnp.int32)
+        gammas = jnp.array([0.5, 0.9], dtype=jnp.float32)
+        g_int = multi_horizon_returns(c_int, gammas)
+        g_float = multi_horizon_returns(c_int.astype(jnp.float32), gammas)
+        chex.assert_shape(g_int, (5, 2))
+        chex.assert_trees_all_close(g_int, g_float, atol=1e-6)
+        # Distinct decay per horizon -- not the degenerate echo in both columns.
+        assert not bool(jnp.allclose(g_int[:, 0], g_int[:, 1]))
+
+    def test_integer_multi_channel_matches_float(self) -> None:
+        c_int = jnp.array(
+            [[1, 0], [0, 0], [0, 1]], dtype=jnp.int32
+        )
+        gammas = jnp.array([0.9], dtype=jnp.float32)
+        g_int = multi_channel_horizon_returns(c_int, gammas)
+        g_float = multi_channel_horizon_returns(
+            c_int.astype(jnp.float32), gammas
+        )
+        chex.assert_shape(g_int, (3, 2, 1))
+        chex.assert_trees_all_close(g_int, g_float, atol=1e-6)
+        # Channel 1 (delayed pulse) decays distinctly from channel 0.
+        assert not bool(jnp.allclose(g_int[:, 0, 0], g_int[:, 1, 0]))
+
+    def test_per_horizon_rmse_verdict_not_inverted_by_integer_returns(self) -> None:
+        """A perfect predictor must not score worse than a degenerate echo."""
+        c_int = jnp.array([1, 0, 0, 0, 1], dtype=jnp.int32)
+        truth = forward_view_returns(c_int, gamma=0.9).reshape(-1, 1)
+        echo = c_int.astype(jnp.float32).reshape(-1, 1)
+        perfect_rmse = per_horizon_rmse(truth, truth)
+        echo_rmse = per_horizon_rmse(echo, truth)
+        assert float(perfect_rmse[0]) < float(echo_rmse[0])
+
 
 class TestMultiHorizon:
     def test_shape(self) -> None:


### PR DESCRIPTION
## What was broken and its measurement consequence

`forward_view_returns` in `alberta_framework/utils/nexting.py` cast the discount
`gamma` and `terminal_value` into the **cumulant series' dtype**:

```python
gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
```

When a caller passes an integer or boolean cumulant series, `jnp.asarray(0.9,
dtype=int32)` truncates `gamma` to `0` (or `True` for bool), so the reverse
`jax.lax.scan` runs entirely in the integer/boolean dtype and the bootstrap term
vanishes:

- **int32** at `gamma=0.9` degenerates to a raw cumulant echo `[1,0,0,0,1]`
  instead of the correct float `[1.6561, 0.729, 0.81, 0.9, 1.0]`.
- **boolean** collapses (`gamma → True`, bootstrap becomes logical OR → all-True).
- a **fractional `terminal_value`** (e.g. `7.6`) alongside integer cumulants is
  truncated to its integer part.

The validator `_concrete_numeric_array` admits any dtype of kind `b i u f`, so
integer/boolean series flow through validation straight into the truncated cast.
This **inverts evaluation verdicts** through the public `per_horizon_rmse` API: a
perfect predictor scores no better than a degenerate echo predictor because the
ground-truth forward-view return is itself corrupted. All three public entry
points (`forward_view_returns`, `multi_horizon_returns`,
`multi_channel_horizon_returns`) funnel through the same cast and are affected.

## The fix (scoped to `nexting.py`)

In `forward_view_returns`, the dtype-truncating casts are replaced with a
**promoted floating computation dtype** derived from *static* dtypes only, so it
stays traceable under `jit` + `vmap`:

```python
compute_dtype = jnp.result_type(
    cumulants.dtype, jnp.asarray(gamma).dtype, jnp.asarray(terminal_value).dtype
)
if not jnp.issubdtype(compute_dtype, jnp.floating):
    compute_dtype = jnp.float32
cumulants = cumulants.astype(compute_dtype)
gamma_s = jnp.asarray(gamma, dtype=compute_dtype)
init = jnp.asarray(terminal_value, dtype=compute_dtype)
```

- Integer / unsigned / boolean series promote to `float32` and now produce the
  mathematically-correct float returns.
- Float32 output is **byte-identical** to the prior output (guarded by a test),
  and float64 under x64 is preserved (promote, never downcast an already-wider
  float).
- The existing `gamma == 0.0` guard is untouched and correct in the new dtype.
- `multi_horizon_returns` and `multi_channel_horizon_returns` delegate to
  `forward_view_returns`, so they are fixed by delegation (verified under
  jit+vmap in the new tests).

## Failing-then-passing reproduction

New regression tests in `tests/test_nexting.py` are **red on `main` (`c9aba7b5`)
with the fix reverted** and **green with the fix** — see the FAILING/PASSING
blocks below. The `per_horizon_rmse` verdict-inversion test fails on old code with
`assert 0.0 < 0.0` (perfect predictor tied with echo because the truth was
corrupted).

## Verification commands and results

```
################ BEFORE (degenerate int32 echo on main c9aba7b5) ################
int32 : [1 0 0 0 1]
float : [1.6560999  0.7289999  0.80999994 0.9        1.        ]
bool  : [ True  True  True  True  True]

################ FAILING TESTS ON MAIN (fix reverted) ################
tests/test_nexting.py:199: AssertionError
=========================== short test summary info ============================
FAILED tests/test_nexting.py::TestForwardViewReturns::test_integer_cumulants_match_float_and_are_not_the_echo[int16]
FAILED tests/test_nexting.py::TestForwardViewReturns::test_integer_cumulants_match_float_and_are_not_the_echo[int32]
FAILED tests/test_nexting.py::TestForwardViewReturns::test_integer_cumulants_match_float_and_are_not_the_echo[uint8]
FAILED tests/test_nexting.py::TestForwardViewReturns::test_integer_cumulants_match_float_and_are_not_the_echo[uint32]
FAILED tests/test_nexting.py::TestForwardViewReturns::test_boolean_cumulants_are_promoted_not_logical_or
FAILED tests/test_nexting.py::TestForwardViewReturns::test_fractional_terminal_value_not_truncated_with_integer_cumulants
FAILED tests/test_nexting.py::TestForwardViewReturns::test_integer_multi_horizon_gives_distinct_decay_per_horizon
FAILED tests/test_nexting.py::TestForwardViewReturns::test_integer_multi_channel_matches_float
FAILED tests/test_nexting.py::TestForwardViewReturns::test_per_horizon_rmse_verdict_not_inverted_by_integer_returns
9 failed, 10 passed, 80 deselected in 6.15s

################ AFTER (corrected float returns, fix applied) ################
int32 : [1.6560999  0.7289999  0.80999994 0.9        1.        ]
float : [1.6560999  0.7289999  0.80999994 0.9        1.        ]
bool  : [1.6560999  0.7289999  0.80999994 0.9        1.        ]
frac tv: [13.6 12.6 10.6]

################ PASSING TESTS (fix applied) ################
104 passed in 35.03s     # pytest tests/test_nexting.py tests/test_nexting_series_length.py -q -o addopts=""

################ RUFF ################
All checks passed!       # .venv/bin/python -m ruff check .

################ MYPY (full, strict py312) ################
Success: no issues found in 224 source files   # .venv/bin/python -m mypy
```

Exact commands run (from repo root, project venv):

- `.venv/bin/python -m pytest tests/test_nexting.py tests/test_nexting_series_length.py -q -o addopts=""` → `104 passed`
- `.venv/bin/python -m ruff check .` → `All checks passed!`
- `.venv/bin/python -m mypy` → `Success: no issues found in 224 source files`

`alberta-evidence-status`'s five registered claims are unaffected: `nexting.py`
is not a registered evidence source.

## What remains open

- Nothing in scope for this defect. The `_concrete_numeric_array` validator still
  intentionally admits integer/boolean series (they are now handled correctly by
  promotion rather than rejected), matching the issue's guidance that boolean
  cumulants should yield correct `0.0/1.0` arithmetic rather than be refused.

## Evidence tooling note

The immutable `github.com/user-attachments` minting tool (`attach.mjs`) was
unavailable in this environment (persistent GitHub login interstitial), so the
full captured evidence log is embedded inline above as fenced blocks bound to the
measured head rather than as an attachment URL.

Closes #2368

<!-- evidence-head:e4041976ed8ad539c8fb282625631f346cc8e8cb -->
<!-- evidence-row:logs -->
- [ ] logs: attachment minting blocked (GitHub login interstitial); full log embedded inline in the fenced blocks above, bound to the measured head.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi"} -->
