### PR TITLE
fix(nexting): promote the return computation dtype instead of truncating gamma into the cumulant dtype

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -155,8 +155,19 @@ def forward_view_returns(
     _require_leading_length(
         "cumulants", cumulants, ndim=1, maximum=_NEXTING_MAX_STEPS
     )
-    gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
-    init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
+    # The computation dtype is promoted across all three operands so an
+    # integer or boolean cumulant series yields float returns instead of
+    # truncating gamma / terminal_value into the series dtype (which would
+    # collapse the bootstrap to 0 and turn returns into a raw cumulant echo).
+    result_dtype = jnp.promote_types(
+        jnp.promote_types(cumulants.dtype, jnp.asarray(gamma).dtype),
+        jnp.asarray(terminal_value).dtype,
+    )
+    if not jnp.issubdtype(result_dtype, jnp.floating):
+        result_dtype = jnp.float32
+    gamma_s = jnp.asarray(gamma, dtype=result_dtype)
+    init = jnp.asarray(terminal_value, dtype=result_dtype)
+    series = cumulants.astype(result_dtype)
 
     def step(carry: Array, c: Array) -> tuple[Array, Array]:
         # gamma=0 must not multiply an inf later return (0*inf).
@@ -164,7 +175,7 @@ def forward_view_returns(
         new_carry = c + bootstrap
         return new_carry, new_carry
 
-    _, returns_reversed = jax.lax.scan(step, init, cumulants[::-1])
+    _, returns_reversed = jax.lax.scan(step, init, series[::-1])
     return returns_reversed[::-1]
 
 

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -114,6 +114,80 @@ class TestForwardViewReturns:
         actual = jax.jit(forward_view_returns)(c, jnp.array(0.5, dtype=jnp.float32))
         chex.assert_trees_all_close(actual, jnp.array([2.75, 3.5, 3.0]))
 
+    @pytest.mark.parametrize("make_series", [np.asarray, jnp.asarray])
+    def test_integer_cumulants_are_promoted_to_float_returns(self, make_series) -> None:
+        """Integer cumulants must not truncate gamma into the series dtype.
+
+        With gamma=0.9 truncated to 0 the recursion degenerates to a raw
+        cumulant echo; the return must instead be computed in float.
+        """
+        c = make_series([1, 0, 0, 0, 1], dtype=np.int32)
+        g = forward_view_returns(jnp.asarray(c), gamma=0.9)
+        assert jnp.issubdtype(g.dtype, jnp.floating)
+        expected = forward_view_returns(
+            jnp.asarray([1, 0, 0, 0, 1], dtype=jnp.float32), gamma=0.9
+        )
+        chex.assert_trees_all_close(g, expected)
+
+    def test_boolean_cumulants_are_promoted_to_float_returns(self) -> None:
+        """Boolean cumulants must not turn the bootstrap into a logical OR.
+
+        Casting gamma=True makes every return collapse to all-True.
+        """
+        c = jnp.array([True, False, False, False, True])
+        g = forward_view_returns(c, gamma=0.9)
+        assert jnp.issubdtype(g.dtype, jnp.floating)
+        expected = forward_view_returns(
+            jnp.asarray([1, 0, 0, 0, 1], dtype=jnp.float32), gamma=0.9
+        )
+        chex.assert_trees_all_close(g, expected)
+
+    def test_integer_cumulants_preserve_fractional_terminal_value(self) -> None:
+        """A fractional terminal_value must survive alongside int series."""
+        c = jnp.array([1, 0, 1], dtype=jnp.int32)
+        g = forward_view_returns(c, gamma=0.5, terminal_value=7.6)
+        assert jnp.issubdtype(g.dtype, jnp.floating)
+        # G_2 = 1 + 0.5*7.6 = 4.8; G_1 = 0 + 0.5*4.8 = 2.4; G_0 = 1 + 0.5*2.4 = 2.2
+        chex.assert_trees_all_close(g, jnp.array([2.2, 2.4, 4.8]), atol=1e-6)
+
+    @pytest.mark.parametrize("gamma", [0.9, 0.5])
+    def test_multi_horizon_integer_cumulants_decay_per_horizon(self, gamma: float) -> None:
+        gammas = jnp.array([gamma, gamma + 0.09], dtype=jnp.float32)
+        c_int = jnp.array([1, 0, 0, 0, 1], dtype=jnp.int32)
+        c_float = c_int.astype(jnp.float32)
+        g_int = multi_horizon_returns(c_int, gammas)
+        g_float = multi_horizon_returns(c_float, gammas)
+        assert jnp.issubdtype(g_int.dtype, jnp.floating)
+        chex.assert_trees_all_close(g_int, g_float, atol=1e-6)
+
+    def test_multi_channel_boolean_cumulants_match_float_channels(self) -> None:
+        cumulants_bool = jnp.array([[True, False], [False, True]])
+        cumulants_float = cumulants_bool.astype(jnp.float32)
+        gammas = jnp.array([0.0, 0.9], dtype=jnp.float32)
+        g_bool = multi_channel_horizon_returns(cumulants_bool, gammas)
+        g_float = multi_channel_horizon_returns(cumulants_float, gammas)
+        assert jnp.issubdtype(g_bool.dtype, jnp.floating)
+        chex.assert_trees_all_close(g_bool, g_float, atol=1e-6)
+
+    def test_jit_integer_cumulants_produce_float_returns(self) -> None:
+        c = jnp.array([1, 0, 1], dtype=jnp.int32)
+        actual = jax.jit(forward_view_returns)(c, jnp.array(0.9, dtype=jnp.float32))
+        expected = forward_view_returns(c.astype(jnp.float32), gamma=0.9)
+        assert jnp.issubdtype(actual.dtype, jnp.floating)
+        chex.assert_trees_all_close(actual, expected)
+
+    def test_float64_cumulant_series_keeps_float64_output_under_x64(self) -> None:
+        with jax.enable_x64():
+            c = jnp.array([1.0, 2.0, 3.0], dtype=jnp.float64)
+            g = forward_view_returns(c, gamma=0.5)
+            assert g.dtype == jnp.float64
+            # G_2 = 3; G_1 = 2 + 0.5*3 = 3.5; G_0 = 1 + 0.5*3.5 = 2.75
+            chex.assert_trees_all_close(g, jnp.array([2.75, 3.5, 3.0]))
+
+    def test_float32_series_dtype_is_unchanged(self) -> None:
+        c = jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)
+        assert forward_view_returns(c, gamma=0.5).dtype == jnp.float32
+
 
 class TestMultiHorizon:
     def test_shape(self) -> None:


### PR DESCRIPTION
Closes #2368

## Defect

`forward_view_returns` cast the discount and the terminal value into the **cumulant series' dtype**:

```python
gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
```

`jnp.asarray(0.9, dtype=int32)` truncates to `0`; `jnp.asarray(0.9, dtype=bool)` becomes `True`. Nothing rejected integer or boolean series before that cast — `_concrete_numeric_array` admits every dtype of kind `b i u f`, and the `Float[Array, " T"]` annotations are documentation, not a runtime gate. The whole `lax.scan` then ran in the series dtype, so the bootstrap term either vanished or turned into a logical OR.

## Change

Promote the computation dtype across all three operands and fall back to `float32` when the promotion is still not floating:

```python
result_dtype = jnp.promote_types(
    jnp.promote_types(cumulants.dtype, jnp.asarray(gamma).dtype),
    jnp.asarray(terminal_value).dtype,
)
if not jnp.issubdtype(result_dtype, jnp.floating):
    result_dtype = jnp.float32
gamma_s = jnp.asarray(gamma, dtype=result_dtype)
init = jnp.asarray(terminal_value, dtype=result_dtype)
series = cumulants.astype(result_dtype)
```

`multi_horizon_returns` and `multi_channel_horizon_returns` are fixed by the same three lines because both `vmap` over this function; no separate change was needed in either. The existing `gamma == 0` guard against `0 * inf` is untouched, and validation is not relaxed anywhere: `gamma`, `gammas`, `terminal_value`, series length, and channel count keep their existing host-side rejections.

## Before / after

Series `[1, 0, 0, 0, 1]`, `gamma=0.9`, one identical script on both trees:

| series dtype | main | this branch |
| --- | --- | --- |
| float32 | `[1.6561, 0.729, 0.81, 0.9, 1.0]` | `[1.6561, 0.729, 0.81, 0.9, 1.0]` (unchanged) |
| int32 | `[1, 0, 0, 0, 1]` int32 — raw cumulant echo | `[1.6561, 0.729, 0.81, 0.9, 1.0]` float32 |
| bool | `[True, True, True, True, True]` | `[1.6561, 0.729, 0.81, 0.9, 1.0]` float32 |
| int32, `gamma=0.5`, `terminal_value=7.6` | `G_0 = 1` (fraction truncated) | `G_0 = 1.2999999523162842` |
| int32 through `multi_channel_horizon_returns`, `gammas=(0.0, 0.9)` | every horizon column identical | per-horizon decay restored |

Why it matters beyond the dtype: with the int32 series above and `gammas=(0.9,)`, `per_horizon_rmse` scored a **perfect** predictor at `≈0.697` and a degenerate echo predictor at `0.0`. The harness rated the worst possible learner as flawless. That inversion is gone.

## Verification

| Check | Result |
| --- | --- |
| Failing-test-first, new cases at pristine `main` (`c9aba7b5`) | 8 failed / 2 passed — every behavioural case fails unpatched; the 2 that pass are the float32-unchanged and float64-under-x64 regression pins |
| `tests/test_nexting.py` on branch | 99 passed |
| `tests/test_nexting_series_length.py` on branch | 5 passed |
| `ruff check` (repo config: line-length 100, `E,F,I,N,W,UP`, ignore `F722`) | All checks passed, both files |
| `mypy` (`strict`, `files = ["alberta_framework"]`) | per-file error profile byte-identical to `main`; zero mentions of `nexting.py` on either tree |
| Full suite, pristine `main` + these tests | `371 failed, 14795 passed, 53 skipped, 1059 deselected` in 1:13:51 |
| Full suite, this branch | `363 failed, 14803 passed, 53 skipped, 1059 deselected` in 1:23:25 |
| Failure-set diff | the **only** difference is the 8 new nexting cases moving out of the failed set; −8 failed / +8 passed, nothing else changed |

Suites ran strictly sequentially in one shell on the same virtual environment, with node ids extracted and sorted before diffing. The 363 failures common to both trees are pre-existing on this host (POSIX-only `fcntl`, absent `joblib`, drive-root path semantics) and are unaffected by this change.

## New test coverage

`tests/test_nexting.py` had no integer or boolean cumulant coverage at all. Added to `TestForwardViewReturns`:

- `test_integer_cumulants_are_promoted_to_float_returns`, parametrized over `np.asarray` and `jnp.asarray` construction
- `test_boolean_cumulants_are_promoted_to_float_returns`
- `test_integer_cumulants_preserve_fractional_terminal_value`
- `test_multi_horizon_integer_cumulants_decay_per_horizon`, parametrized over two discounts
- `test_multi_channel_boolean_cumulants_match_float_channels`
- `test_jit_integer_cumulants_produce_float_returns`
- `test_float64_cumulant_series_keeps_float64_output_under_x64` — pins that promotion does not clamp a float64 series to float32
- `test_float32_series_dtype_is_unchanged` — pins the ordinary path

Each non-pin case asserts against the float32 reference computed by the same function, so the tests state the mathematical contract rather than hard-coded constants.

## Environment

CPython 3.13.14, JAX 0.11.0, NumPy 2.5.1, pytest 9.1.1, Windows 11 AMD64. Branch based on `main` at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`; `git merge-base` confirms no divergence.

---

— [claude-opus-5-w1]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-opus-5-w1","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0Q6S4D39R7TR50368VT9ME2","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-23T11:41:02.244Z","completed_at":"2026-08-23T15:55:33.742Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T11:41:02.737Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"7556014110b6990e148fe76c540d24bd14bb4b98099fe3e45018321942ebb184","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7d172924-dccc-4a2f-be4d-f5ac8ecb3313","object_id":"sha256:7556014110b6990e148fe76c540d24bd14bb4b98099fe3e45018321942ebb184","sha256":"7556014110b6990e148fe76c540d24bd14bb4b98099fe3e45018321942ebb184"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"IonXkCMuonNa08eAtMythuKpH1Y2PAtSLNVrqimAROmahUCugun1Sx3yG-Oo36DZl99B91rI9z2BiDEvSVGIBw"}} -->
