### PR TITLE
test(package): skip wheel-install smoke off Linux O_TMPFILE — Closes #2340

### DIFF
--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -240,6 +240,10 @@ def test_historical_cli_reports_provenance_and_validates_strict_pairing(
 
 
 @pytest.mark.package
+@pytest.mark.skipif(
+    not hasattr(os, "O_TMPFILE"),
+    reason="write_new_json publishes through Linux O_TMPFILE and linkat(AT_EMPTY_PATH)",
+)
 def test_wheel_and_sdist_are_complete_and_hard_link_safe(tmp_path: Path) -> None:
     uv = shutil.which("uv")
     if uv is None:


### PR DESCRIPTION
## What was broken and its measurement consequence

The package-lane test `test_wheel_and_sdist_are_complete_and_hard_link_safe` in
`tests/test_historical_forager_cli_package.py` builds and installs the wheel, then runs
`alberta-historical-forager provenance` from the installed wheel as a subprocess smoke check and
asserts `loaded.returncode == 0` (~line 450). That `provenance` subcommand publishes its
provenance document through `write_new_json` in
`alberta_framework/benchmarks/reference_life_scorecard.py`, whose immutable-publication path is
intentionally fail-closed and **requires Linux `O_TMPFILE`** — off Linux it raises
`OSError("immutable publication requires Linux O_TMPFILE support")` (established by #1980).

Consequently, on a fully-provisioned (dev-extras installed) macOS/aarch64 checkout the subprocess
exits non-zero and `assert loaded.returncode == 0` fails, so the test is **permanently red**. CI
only runs the `package` job on `ubuntu-latest`, so upstream never observes this; the platform
mismatch silently corrupts the package lane's measurement off Linux. This is the same defect shape
as #1980, one layer removed through a wheel install.

## The fix

Declare the Linux-only requirement on the test using the **exact `skipif` idiom PR #1984 already
merged** for the same `write_new_json` publisher in `tests/test_reference_life_scorecard.py`
(lines 381–383), keeping the existing `@pytest.mark.package` marker:

```python
@pytest.mark.package
@pytest.mark.skipif(
    not hasattr(os, "O_TMPFILE"),
    reason="write_new_json publishes through Linux O_TMPFILE and linkat(AT_EMPTY_PATH)",
)
def test_wheel_and_sdist_are_complete_and_hard_link_safe(tmp_path: Path) -> None:
```

`os` is already imported in the file, so no new imports. **No production code changes.** On Linux
(`hasattr(os, "O_TMPFILE")` is True) the test runs unchanged and passes exactly as before; off
Linux it is cleanly skipped with the stated reason instead of failing.

No new inverse/negative test is added: the fails-closed refusal off Linux is already positively
asserted by `test_new_json_publication_fails_closed_without_o_tmpfile` in
`tests/test_reference_life_scorecard.py` (~line 400). This mirrors the merged #1984 declaration for
the same publisher.

## Failing-then-passing reproduction

The `skipif` predicate is evaluated at collection time, so the mechanism is demonstrated on Linux
by temporarily deleting `os.O_TMPFILE` in a throwaway harness (NOT committed) to simulate a
non-Linux platform. Under that simulation: **before** the decorator the test is *not* skipped (it
runs the wheel-install smoke that, on real macOS, drives `write_new_json` → the `OSError` and
fails the `returncode == 0` assertion); **after** the decorator it is cleanly *skipped*.

## Exact verification commands and results

```
=== [1] BEFORE fix: decorator absent, simulated non-O_TMPFILE platform ===
    (test is NOT skipped -> it runs the wheel-install smoke that drives
     write_new_json -> OSError('immutable publication requires Linux O_TMPFILE
     support') on real macOS, making assert loaded.returncode == 0 fail)
collecting ... collected 4 items / 3 deselected / 1 selected
tests/test_historical_forager_cli_package.py::test_wheel_and_sdist_are_complete_and_hard_link_safe PASSED [100%]
======================= 1 passed, 3 deselected in 12.39s =======================

=== [2] AFTER fix: decorator present, simulated non-O_TMPFILE platform ===
    (test is cleanly SKIPPED with the stated reason)
collecting ... collected 4 items / 3 deselected / 1 selected
tests/test_historical_forager_cli_package.py::test_wheel_and_sdist_are_complete_and_hard_link_safe SKIPPED [100%]
SKIPPED [1] tests/test_historical_forager_cli_package.py:242: write_new_json publishes through Linux O_TMPFILE and linkat(AT_EMPTY_PATH)
======================= 1 skipped, 3 deselected in 2.34s =======================

=== [3] AFTER fix: real Linux (O_TMPFILE present) -> test runs & PASSES ===
collecting ... collected 4 items / 3 deselected / 1 selected
tests/test_historical_forager_cli_package.py::test_wheel_and_sdist_are_complete_and_hard_link_safe PASSED [100%]
======================= 1 passed, 3 deselected in 12.16s =======================

=== [4] ruff (repo-wide) ===
All checks passed!

=== [5] mypy (repo-configured: files=[alberta_framework], strict, py312) ===
Success: no issues found in 224 source files
```

Commands run from repo root with the project venv (`.venv/bin/python`, CPU-only aarch64):
- `.venv/bin/python -m pytest tests/test_historical_forager_cli_package.py -k wheel_and_sdist -v -o addopts=""` → **1 passed** on Linux (run [3]). `UV_PYTHON` was pointed at the 3.13 venv interpreter for the run only, because the wheel-install subprocess otherwise auto-discovered a system CPython 3.11 that fails the `requires-python >= 3.12` floor — an interpreter-discovery detail of this box, unrelated to the change.
- Runs [1]/[2] delete `os.O_TMPFILE` in a throwaway harness (reverted, never committed) to prove skip-vs-run across the predicate.
- `.venv/bin/python -m ruff check .` → **All checks passed!**
- `.venv/bin/python -m mypy` (repo config: `files = ["alberta_framework"]`, strict, py312) → **Success: no issues found in 224 source files**. (The repo's configured mypy does not type-check `tests/`; a scoped single-file run surfaces 3 pre-existing errors at other lines that predate and are untouched by this one-line-region change.)

## What remains open

Nothing for this defect. The general `write_new_json` Linux-`O_TMPFILE` coupling is by design
(#1980) and out of scope here.

> Note on evidence attachments: the sanctioned immutable-attachment uploader could not authenticate
> in this environment (its browser login to GitHub did not reach an authenticated session), so the
> logs above are embedded inline verbatim rather than linked as `user-attachments` URLs. The output
> is fully reproducible with the commands listed.

Closes #2340

<!-- evidence-head:4ef3808c0aaadbf8eff5b64be5dc087c82fd2774 -->
<!-- evidence-row:logs -->
- [ ] logs: attach uploader unavailable in environment; logs embedded inline above (verbatim, reproducible)

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@a326de9b94722266d64688dcf4f18fcbd2bbe1b8:skills/contribute-to-asi"} -->
