### PR TITLE
fix(optimizer-geometry): normalize matrix sign by a rescaled norm

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -159,7 +159,9 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
 
     The pinned paper defines ``f(X) = 3/2 X - 1/2 XX^T X``. Frobenius
     normalization places every singular value in its convergence interval and
-    preserves an exact zero for a zero matrix.
+    preserves an exact zero for a zero matrix. The normalization divides an
+    exactly power-of-two rescaled copy by its own norm so the divisor stays
+    representable at every input magnitude.
     """
     value = _trusted_array(matrix, name="matrix")
     if (
@@ -173,7 +175,22 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
     valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    # `norm` remains the caller-visible overflow signal, but it cannot be the
+    # divisor: its squares underflow to zero for float32 entries near 1e-20, and
+    # a true norm under a fixed magnitude floor would divide by the floor, which
+    # leaves every singular value below the NS5 convergence interval and launders
+    # a nonzero matrix into a numerically zero sign. Rescaling by an exact power
+    # of two keeps the divisor representable without changing any quotient that
+    # was already correct, and an exact zero is preserved by the zero test.
+    _, exponent = jnp.frexp(jnp.max(jnp.abs(value)))
+    rescaled = jnp.ldexp(value, -exponent)
+    rescaled_norm = jnp.linalg.norm(rescaled)
+    positive = rescaled_norm > 0
+    x = jnp.where(
+        positive,
+        rescaled / jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm)),
+        jnp.zeros_like(rescaled),
+    )
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -333,6 +333,86 @@ def test_geometry_float32_overflow_is_invalid_not_laundered() -> None:
     assert not bool(dual_valid)
 
 
+def _floor_probe_matrix() -> jax.Array:
+    return jnp.array([[2.0, 1.0], [0.5, -1.0]], dtype=jnp.float32)
+
+
+@pytest.mark.parametrize("scale", [1e-13, 1e-15, 1e-20, 1e-25, 1e-30])
+def test_spectral_matrix_sign_is_scale_invariant_below_the_frobenius_floor(scale: float) -> None:
+    reference = _floor_probe_matrix()
+    tiny = reference * jnp.asarray(scale, dtype=jnp.float32)
+    sign, valid = spectral_matrix_sign_transaction(tiny, steps=5)
+    assert bool(valid)
+    np.testing.assert_allclose(sign, spectral_matrix_sign(reference, steps=5), rtol=1e-6)
+
+
+@pytest.mark.parametrize("exponent", [-120, -80, -45, 40])
+def test_spectral_matrix_sign_is_exactly_invariant_to_power_of_two_rescaling(
+    exponent: int,
+) -> None:
+    reference = _floor_probe_matrix()
+    np.testing.assert_array_equal(
+        spectral_matrix_sign(jnp.ldexp(reference, exponent), steps=5),
+        spectral_matrix_sign(reference, steps=5),
+    )
+
+
+def test_spectral_matrix_sign_below_the_floor_stays_orthogonal() -> None:
+    tiny = _floor_probe_matrix() * jnp.asarray(1e-20, dtype=jnp.float32)
+    assert 0.0 <= float(jnp.linalg.norm(tiny)) < 1e-12
+    assert float(jnp.max(jnp.abs(tiny))) > 0.0
+    sign, valid = spectral_matrix_sign_transaction(tiny, steps=5)
+    assert bool(valid)
+    singular = np.linalg.svd(np.asarray(sign, dtype=np.float64), compute_uv=False)
+    np.testing.assert_allclose(singular, np.ones_like(singular), rtol=1e-3)
+
+
+def test_spectral_matrix_sign_gradient_is_finite_below_the_frobenius_floor() -> None:
+    tiny = _floor_probe_matrix() * jnp.asarray(1e-25, dtype=jnp.float32)
+    jacobian = jax.jacrev(spectral_matrix_sign)(tiny)
+    assert bool(jnp.all(jnp.isfinite(jacobian)))
+
+
+def test_jit_spectral_matrix_sign_is_scale_invariant_below_the_floor() -> None:
+    reference = _floor_probe_matrix()
+    jitted = jax.jit(spectral_matrix_sign)
+    tiny = reference * jnp.asarray(1e-25, dtype=jnp.float32)
+    np.testing.assert_allclose(jitted(tiny), jitted(reference), rtol=1e-6)
+
+
+def test_muon_ogd_empty_constraints_reduces_to_ns5_below_the_floor() -> None:
+    reference = _floor_probe_matrix()
+    tiny = reference * jnp.asarray(1e-25, dtype=jnp.float32)
+    update, dual = muon_ogd_dual_update(
+        tiny,
+        jnp.zeros((0, 2, 2), dtype=jnp.float32),
+        jnp.zeros((0,), dtype=jnp.float32),
+        dual_learning_rate=0.25,
+        dual_steps=2,
+    )
+    np.testing.assert_array_equal(dual, jnp.zeros((0,), dtype=jnp.float32))
+    np.testing.assert_allclose(update, spectral_matrix_sign(reference), rtol=1e-6)
+
+
+def test_spectral_matrix_sign_zero_matrix_stays_exactly_zero_and_valid() -> None:
+    zero = jnp.zeros((3, 2), dtype=jnp.float32)
+    sign, valid = spectral_matrix_sign_transaction(zero, steps=5)
+    np.testing.assert_array_equal(sign, zero)
+    assert bool(valid)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16])
+def test_spectral_matrix_sign_narrow_dtype_below_the_floor_is_orthogonal(
+    dtype: jnp.dtype,
+) -> None:
+    tiny = (_floor_probe_matrix() * jnp.asarray(2.0**-20, dtype=jnp.float32)).astype(dtype)
+    sign, valid = spectral_matrix_sign_transaction(tiny, steps=5)
+    assert bool(valid)
+    assert sign.dtype == tiny.dtype
+    singular = np.linalg.svd(np.asarray(sign, dtype=np.float64), compute_uv=False)
+    np.testing.assert_allclose(singular, np.ones_like(singular), rtol=1e-2)
+
+
 def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "alberta_framework.evaluation.optimizer_geometry._frozen_stream",


### PR DESCRIPTION
Fixes #2379.

## Defect

`spectral_matrix_sign` normalized by `jnp.maximum(norm, 1e-12)`, so a matrix whose Frobenius norm fell below that fixed floor was divided by the floor instead of by its own norm. Its singular values then sat far below the NS5 convergence interval, and five cubic steps multiplied them by only ≈7.59 — the function returned a numerically zero matrix and still reported `valid=True`. The docstring promised the opposite: "Frobenius normalization places every singular value in its convergence interval and preserves an exact zero for a zero matrix."

In float32 the floor is reached sooner than the exponent range suggests, because the sum of squares underflows: for entries near `1e-20`, `jnp.linalg.norm` returns exactly `0.0` for a plainly nonzero matrix.

## Change

```python
_, exponent = jnp.frexp(jnp.max(jnp.abs(value)))
rescaled = jnp.ldexp(value, -exponent)
rescaled_norm = jnp.linalg.norm(rescaled)
positive = rescaled_norm > 0
x = jnp.where(
    positive,
    rescaled / jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm)),
    jnp.zeros_like(rescaled),
)
```

The largest entry lands in `[0.5, 1)`, so the sum of squares can neither overflow nor underflow; an exact zero is preserved by the zero test rather than by a magnitude floor; and the paired `jnp.where` keeps the unused branch from dividing by zero, matching the existing guarded denominator in `flad_noise_component_transaction`. This is the same power-of-two rescaling already used for this hazard in `nexting.py`, `oak.py`, `state_builder.py`, `representation_gradient_mixer.py`, `experiential_memory_policy.py`, and `ipmnist_screening.py`.

`norm` itself is untouched and still feeds `valid`, so it remains the overflow signal.

## Before and after

One fixed 2×2 float32 matrix, scaled by positive constants. The matrix sign is invariant to positive scaling, so every row must return the same value.

| input scale | input norm | `‖sign‖_F` before | `‖sign‖_F` after |
| --- | --- | --- | --- |
| `1.0` | `2.500000e+00` | `1.414202` | `1.414202` |
| `1e-12` | `2.500000e-12` | `1.414202` | `1.414202` |
| `1e-13` | `2.500000e-13` | `1.201002` | `1.414202` |
| `1e-15` | `2.500000e-15` | `0.018983` | `1.414202` |
| `1e-20` | `0.000000e+00` | `1.898437e-07` | `1.414202` |
| `1e-25` | `0.000000e+00` | `1.898438e-12` | `1.414202` |
| `1e-30` | `0.000000e+00` | `1.898437e-17` | `1.414202` |

Singular values of the returned sign at scale `1e-25`, computed in float64: `[1.698e-12, 8.490e-13]` before, `[0.99999999, 0.99998346]` after — to eight digits the values the same matrix returns at unit scale, i.e. the orthogonal factor the NS5 iteration is supposed to produce. For an exact power-of-two rescale the returned sign is bit-identical, which is what the new `assert_array_equal` node pins.

Under `jax.jit` the collapse was total rather than merely small:

| scale | jitted `‖sign‖_F` before | after |
| --- | --- | --- |
| `1.0` | `1.4142019` | `1.4142019` |
| `1e-13` | `1.2010021` | `1.4142019` |
| `1e-25` | `0.0000000` | `1.4142019` |

`jax.jacrev(spectral_matrix_sign)` was non-finite at scale `1e-25` and is now finite. The exact-zero input is unchanged: its Jacobian is non-finite before and after, because `jnp.linalg.norm` has no derivative at the origin; this PR does not claim to change that.

## The floor was also dtype-dependent

`_trusted_array` admits any floating dtype, and `jnp.asarray(1e-12, dtype=jnp.float16)` is exactly `0.0`. In float16 the "floor" was therefore zero, so a small matrix divided by zero and the transaction **rejected a finite, well-conditioned input**:

| input dtype at scale `2**-20` | `‖sign‖_F` before | `valid` before | after | `valid` after |
| --- | --- | --- | --- | --- |
| `float16` | `0.000000` | **False** | `1.414764` | True |
| `bfloat16` | `1.420554` | True | `1.420554` | True |
| `float32` | `1.414202` | True | `1.414202` | True |

bfloat16 escaped because its float32-like exponent range represents `1e-12` normally. One line produced three different behaviours across the three dtypes the function accepts; removing the absolute constant removes the dtype dependence rather than papering over it. Recorded in more detail in [#2379](https://github.com/SlopDotCash/asi/issues/2379#issuecomment-5387741104).

## Consumer impact

`muon_ogd_dual_update_transaction` uses the sign as its update direction. On the empty-constraint path that `test_muon_ogd_empty_constraints_reduces_exactly_to_ns5` pins as reducing exactly to NS5:

| gradient scale | `‖update‖_F` before | after |
| --- | --- | --- |
| `1.0` | `1.414202e+00` | `1.414202` |
| `1e-13` | `1.201002e+00` | `1.414202` |
| `1e-25` | `1.898438e-12` | `1.414202` |

A scale-free orthogonalized direction is the point of the Muon-OGD step, so before this change a small-magnitude momentum matrix silently produced no step.

## The large end is deliberately unchanged

`test_geometry_float32_overflow_is_invalid_not_laundered` pins the policy that an input whose own arithmetic overflows must be reported `valid=False` rather than rescued into a plausible-looking result. That test passes unchanged here: `valid` is still computed from the raw-dtype `norm`, which is still non-finite for a maximum-magnitude float32 matrix. Only the small end — which did the opposite of that policy, returning a fabricated near-zero matrix with `valid=True` — is repaired.

## No numeric drift

Because power-of-two scaling is exact, numerator and denominator are scaled by the same factor, so the quotient is unchanged wherever the original norm was representable. Verified two ways:

- **Bit-identity probe:** 200 random float32 matrices, shapes `1x1` through `5x5`, scale exponents from `2**-30` to `2**30` — the normalized matrix is bit-identical to the old expression for all 200.
- **Frozen benchmark parity:** `run_streaming_matrix_evaluation()` at `main` and at this branch produce byte-identical results after removing `timing_ns` (declared telemetry-only, `timing_qualified: false`) and `result_sha256` (which embeds the module source hash and therefore must change):

  ```
  main   sha256: 176ecd02a083161be2ff30535b08224a069c3653164d2419abd9d022ae1ad599
  branch sha256: 176ecd02a083161be2ff30535b08224a069c3653164d2419abd9d022ae1ad599
  ```

  All six arms' `final_target_mse`, `mean_protected_interference`, `mean_update_frobenius_norm`, and `persistent_numeric_bytes`, all three `comparisons` deltas and `outcome` values, and the stream digest `ad69d142…` are identical. The eight frozen stream matrices have norms between `1.146` and `2.587`, all far above the floor, which is why the published arms never exercised the defect.

## Verification

Run from the repository root with the repository virtual environment interpreter:

```
python -B -m pytest tests/test_optimizer_geometry.py -q -p no:cacheprovider
ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py
mypy
```

| check | this branch | unmodified `main`, new tests only |
| --- | --- | --- |
| `tests/test_optimizer_geometry.py` (44 nodes) | 42 passed, 2 failed | 29 passed, 15 failed |
| `ruff check` (repository config) | clean | clean |
| `mypy` (strict, `files=["alberta_framework"]`) | 108 errors in 17 files | 108 errors in 17 files |

The same 2 failures appear on both sides: `test_geometry_result_has_canonical_bytes_and_exclusive_retention` and `test_geometry_retention_rejects_namespace_symlink`. `retain_streaming_matrix_result` requires `type(repository_root) is PosixPath`, so both fail on Windows at every revision, including unmodified `main` with no test changes at all. They are unrelated to this change.

The other 13 failures in the right-hand column are the new nodes, and they are the failing-first evidence: all five scale-invariance scales, the three power-of-two exponents that actually cross the floor (`-120`, `-80`, `-45`), orthogonality, the gradient, the jitted path, the Muon-OGD consumer, and `float16`. Three new nodes pass at `main` on purpose, as no-drift pins: power-of-two exponent `40` (norm far above the floor), the zero matrix, and `bfloat16`.

Exponent `-40` was rejected while writing the power-of-two test because `2.5 * 2**-40` is `2.27e-12`, still above the floor, so it would have passed before the fix; `-45` is the first probed exponent that crosses it. Exponents below `-120` were rejected because the smallest entry becomes subnormal, so exact power-of-two equality would no longer be a legitimate assertion.

mypy reports the identical 108 errors in the identical 17 files on both trees. The four in this module are the same `PosixPath` attribute findings, shifted by the `+17` lines this change adds.

`ruff format --check` reports both files as needing reformatting at unmodified `main` as well, so it is left untouched here; the gated lint job runs `ruff check .` and `mypy` (`.github/workflows/ci.yml`).

## Environment

JAX 0.11.0, jaxlib 0.11.0, numpy 2.5.1, CPython 3.13.14, Windows 11 AMD64, `jax_enable_x64` False (default).

Produced with claude-opus-5-w1 / anthropic / claude-opus-5.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-opus-5-w1
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [claude-opus-5-w1]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-opus-5-w1","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0QXH77FVNHBBEDXN7D2VE9K","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-23T18:18:40.240Z","completed_at":"2026-08-23T18:43:48.543Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T18:18:40.754Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"81afdd2d2d6f14b80d4b1db2827b8f37f39b4f6dba8b78fdef7d01898b238148","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"be568f4e-bc54-4525-a2e7-c7ad3e71f106","object_id":"sha256:81afdd2d2d6f14b80d4b1db2827b8f37f39b4f6dba8b78fdef7d01898b238148","sha256":"81afdd2d2d6f14b80d4b1db2827b8f37f39b4f6dba8b78fdef7d01898b238148"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"ZZFZXOL5IGWQsO0h5fouQjYePIuOkpI012h5tphe8JsGm8Fc9ioO3MOlsn2Ja7xnQfl1SFts0r_7V078b93JAw"}} -->
