### PR TITLE
test(pavlovian): skip longdouble double-rounding probes on equal-width platforms (#2324)

### DIFF
--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -485,6 +485,17 @@ def test_construct_canonicalizes_noise_std_to_float32() -> None:
     assert stream._noise_std == float(np.float32(0.1))  # noqa: SLF001
 
 
+# Probing double-rounding via longdouble requires that longdouble has more mantissa
+# bits than binary64 (e.g. x86-64 80-bit float). On platforms where longdouble has
+# the same width as float64 (such as aarch64 macOS/Linux), these probes cannot be
+# constructed in longdouble and the Fraction-parametrized tests below cover single-rounding.
+_requires_wider_longdouble = pytest.mark.skipif(
+    np.finfo(np.longdouble).nmant <= np.finfo(np.float64).nmant,
+    reason="requires np.longdouble to be wider than float64 (nmant > 53)",
+)
+
+
+@_requires_wider_longdouble
 def test_construct_narrows_original_noise_real_once() -> None:
     midpoint_plus = (
         np.longdouble(1.0)
@@ -500,6 +511,7 @@ def test_construct_narrows_original_noise_real_once() -> None:
     assert stream._noise_std == float(np.float32(midpoint_plus))  # noqa: SLF001
 
 
+@_requires_wider_longdouble
 def test_construct_rejects_negative_real_that_rounds_to_zero() -> None:
     below_zero = -np.nextafter(np.longdouble(0.0), np.longdouble(1.0))
     assert float(below_zero) == 0.0


### PR DESCRIPTION
### Summary

In `tests/test_pavlovian_stream.py`, two slow-marked unit tests (`test_construct_narrows_original_noise_real_once` and `test_construct_rejects_negative_real_that_rounds_to_zero`) verify single-rounding behavior for `ClassicalConditioningStream`'s `noise_std` using `np.longdouble` fixtures whose properties require `np.longdouble` to have more mantissa bits than binary64 (`float64`).

On platforms where `np.longdouble` has the same width/precision as `float64` (e.g. aarch64 macOS/Linux where `np.finfo(np.longdouble).nmant == 52`), both tests fail in their own fixture assertions before exercising library code (#2324):
1. `midpoint_plus = 1 + 2⁻²⁴ + 2⁻⁶⁰` loses the `2⁻⁶⁰` term during `longdouble` construction, causing `np.float32(midpoint_plus) == np.float32(float(midpoint_plus)) == 1.0` (failing `assert ... != ...`).
2. `-np.nextafter(np.longdouble(0.0), np.longdouble(1.0))` is the binary64 subnormal `-5e-324` which survives `float()` conversion unchanged (failing `assert float(below_zero) == 0.0`).

The single-rounding behavior of the `noise_std` parameter is already comprehensively tested across all platforms by the exact `Fraction`-parametrized test cases in `test_construct_rounds_fraction_noise_midpoints_once`.

### Changes

- Added `_requires_wider_longdouble` skipif marker checking `np.finfo(np.longdouble).nmant <= np.finfo(np.float64).nmant`.
- Decorated `test_construct_narrows_original_noise_real_once` and `test_construct_rejects_negative_real_that_rounds_to_zero` with `@_requires_wider_longdouble`.

Closes #2324

## Measured project receipt
Post-hoc / same-window receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0RD1RYHJJC4BN3NG625C3MJ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-23T22:49:51.313Z","completed_at":"2026-08-23T22:50:04.207Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T22:49:51.763Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3e53d9ea1a57aad9d025b9dab751d3d48fed66c2a82a78978b5188b88006ba4c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ea09e98e-1cc8-491f-8fa0-65419745b1bc","object_id":"sha256:3e53d9ea1a57aad9d025b9dab751d3d48fed66c2a82a78978b5188b88006ba4c","sha256":"3e53d9ea1a57aad9d025b9dab751d3d48fed66c2a82a78978b5188b88006ba4c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"cQnwGUSccUQFfI5g-1OwDwGJJD_IWPxYRAmdg0JopKdP_jT7on3VMgKbV45wPg4nBet2RizxQEYIHCGlm4BZDg"}} -->
