### PR TITLE
fix(benchmarks): bound NTK threshold rank by singular dimension

### DIFF
--- a/alberta_framework/benchmarks/cchain_ipmnist.py
+++ b/alberta_framework/benchmarks/cchain_ipmnist.py
@@ -600,7 +600,10 @@ def cchain_ntk_diagnostics(
     cumulative = jnp.cumsum(eigenvalues)
     rank = jnp.where(
         total > 0.0,
-        jnp.searchsorted(cumulative, threshold * total, side="left") + 1,
+        jnp.minimum(
+            jnp.searchsorted(cumulative, threshold * total, side="left") + 1,
+            rows,
+        ),
         0,
     ).astype(jnp.int32)
     diagonal = jnp.diag(gram)

--- a/alberta_framework/benchmarks/plasticity_comparators.py
+++ b/alberta_framework/benchmarks/plasticity_comparators.py
@@ -567,7 +567,7 @@ def ntk_threshold_rank(jacobian: Array, *, threshold: float = 0.99) -> Array:
     total = jnp.sum(singular)
     cumulative = jnp.cumsum(singular)
     rank = jnp.searchsorted(cumulative, target * total, side="left") + 1
-    return jnp.where(total > 0, rank, 0)
+    return jnp.where(total > 0, jnp.minimum(rank, singular.shape[0]), 0)
 
 
 def smooth_leaky(value: Array, *, alpha: float, power: float, curvature: float) -> Array:

--- a/tests/test_cchain_ipmnist.py
+++ b/tests/test_cchain_ipmnist.py
@@ -256,6 +256,8 @@ def test_full_logit_ntk_diagnostics_are_bounded_and_jittable() -> None:
     assert 0 <= int(eager["ntk_threshold_rank"]) <= 8
     assert float(eager["ntk_off_diagonal_abs_mean"]) >= 0.0
     assert float(eager["ntk_diagonal_mean"]) >= 0.0
+    eager_full = cchain_ntk_diagnostics(_params(), examples, energy_threshold=1.0)
+    assert 0 <= int(eager_full["ntk_threshold_rank"]) <= 8
     with pytest.raises(ValueError, match="1..4"):
         cchain_ntk_diagnostics(_params(), jnp.zeros((5, 4), dtype=jnp.float32))
 

--- a/tests/test_plasticity_comparators.py
+++ b/tests/test_plasticity_comparators.py
@@ -130,6 +130,13 @@ def test_c_chain_churn_loss_and_off_reduction() -> None:
     assert int(ntk_threshold_rank(jnp.eye(3), threshold=0.66)) == 2
 
 
+def test_ntk_threshold_rank_never_exceeds_singular_dimension() -> None:
+    mat = jr.normal(jr.key(0), (20, 20), dtype=jnp.float32)
+    rank = int(ntk_threshold_rank(mat, threshold=1.0))
+    assert 1 <= rank <= 20
+    assert int(ntk_threshold_rank(jnp.zeros((10, 10), dtype=jnp.float32), threshold=1.0)) == 0
+
+
 def test_low_cost_activation_and_feature_controls() -> None:
     value = jnp.asarray([-2.0, 0.0, 2.0])
     assert jnp.allclose(smooth_leaky(value, alpha=1, power=3, curvature=5), value)


### PR DESCRIPTION
## Summary
Ships leftover Antigravity work that was implemented locally but not opened as a PR.

## Evidence
- Rebased onto current origin/main before push.

N/A - leftover ship of already-implemented local commit; re-run focused tests in CI.