### PR TITLE
test(experiments): actually suppress the longdouble parse warning the helper promises to hide

### DIFF
--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from decimal import Decimal
 from fractions import Fraction
@@ -536,9 +537,25 @@ class _NonfiniteFloatThatConvertsFinite(float):
 
 
 def _platform_longdouble_1e4000() -> np.longdouble:
-    """Parse the cross-platform boundary without leaking an expected warning."""
-    with np.errstate(over="ignore", invalid="ignore"):
-        return np.longdouble("1e4000")
+    """Parse the cross-platform boundary without leaking an expected warning.
+
+    Where longdouble is float64 (aarch64) the parse overflows and numpy reports
+    it through the Python ``warnings`` machinery, which ``np.errstate`` does not
+    govern -- ``errstate`` only scopes the floating-point error state. Both are
+    silenced so the expected overflow never leaks into collection output.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        with np.errstate(over="ignore", invalid="ignore"):
+            return np.longdouble("1e4000")
+
+
+def test_platform_longdouble_boundary_helper_does_not_leak_its_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        value = _platform_longdouble_1e4000()
+    assert isinstance(value, np.longdouble)
+    assert [str(entry.message) for entry in caught] == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #2387.

`_platform_longdouble_1e4000` promises to parse the overflow boundary "without leaking an expected warning", but `np.errstate` only scopes numpy's FP error state — the aarch64 string-parse overflow goes through the Python `warnings` module and leaks into every run and collection on the platforms the helper was written for.

## The change

Test-only, in `tests/test_experiments_validation.py`:

1. The helper silences both channels (`warnings.catch_warnings` + `simplefilter("ignore", RuntimeWarning)` around the existing `np.errstate`), with the docstring extended to say why both are needed.
2. New `test_platform_longdouble_boundary_helper_does_not_leak_its_warning` pins the contract: records all warnings across a helper call and asserts none are emitted. **Failing-test-first:** against main's helper on aarch64 it fails (the leak is recorded in #2387); with the fix it passes. On x86-64 the parse is finite and silent on both sides, so the test is vacuously green there — the assertion is about the helper's contract, which holds everywhere.

## Measured

macOS arm64 (Darwin), CPython 3.13.5, pristine `origin/main` @ `c9aba7b5` baseline:

| | main | this branch |
|---|---|---|
| `tests/test_experiments_validation.py` | 129 passed + leaked `RuntimeWarning` | **130 passed, zero warnings** |

`ruff check` passes. CI (`ubuntu-latest` x86-64) is unaffected: `1e4000` parses to a finite 80-bit value there, no warning exists to suppress, and the new test runs green.

Measured with `claude-code` / `anthropic` / `claude-fable-5` on arm64 Darwin, CPython 3.13.5.


---

Compute receipt: 4022593 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi
Attribution status: self-reported
— [asi]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0RJV894Y84WMF874ZB7K0ZX","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-24T00:31:09.093Z","completed_at":"2026-08-24T00:50:10.500Z","skill_sha256":"c94223908586136b106902f6be29bfeff822d0b036eb6d87590f729fdcb3be20","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T00:31:11.923Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":23,"output_tokens":7970,"cache_creation_tokens":9356,"cache_read_tokens":4005244,"total_tokens":4022593,"cost_micro_usd":"4591094","session_count":1},"trajectory_sha256":"ddabe2dfd32976a2b60d4d6261f5ed85abdf6adf047af0e3a241e5884567b3cf","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"8f2caf63-b8a9-4198-9bab-7afb2ac36276","object_id":"sha256:ddabe2dfd32976a2b60d4d6261f5ed85abdf6adf047af0e3a241e5884567b3cf","sha256":"ddabe2dfd32976a2b60d4d6261f5ed85abdf6adf047af0e3a241e5884567b3cf"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAHBoGfBNRJEhRkQvHY6AcB2oVJyScySjClifWLRVPl28","device_key_id":"e6f31ab600bfb4b6612dfa8af8aec495ea789bb7fa02be582d03179b4a835899","device_signature":"nnaI5FGaYfB7olLvBioGylYzHXxthrJuQ7PRoNwPS3BmAnNUZIaoJ--GDV3tqr2M59NTPC2CCWl8g2MjF045BQ"}} -->
