### PR TITLE
fix(core): make UPGD gradient alignment scale free

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1983,12 +1983,31 @@ class UPGDLearner:
         return total
 
     @staticmethod
-    def _tuple_norm(xs: tuple[Array, ...]) -> Array:
-        """L2 norm over a static tuple of arrays."""
-        total = jnp.array(0.0, dtype=jnp.float32)
+    def _tuple_unit(xs: tuple[Array, ...]) -> tuple[tuple[Array, ...], Array]:
+        """Unit-norm copy of a tuple of arrays, plus whether a direction exists.
+
+        The tuple is rescaled by an exact power of two before its squares are
+        accumulated, and the divisor is the norm of that rescaled copy, so the
+        divisor stays representable at every input magnitude.
+        """
+        largest = jnp.array(0.0, dtype=jnp.float32)
         for x in xs:
+            largest = jnp.maximum(largest, jnp.max(jnp.abs(x), initial=0.0))
+        # A fixed magnitude floor cannot stand in for this rescale: a floor above
+        # the true norm makes the floor the divisor, and in float32 the squares of
+        # entries near 1e-20 underflow to zero before any floor is consulted, so
+        # both ends report a direction that the gradients do not have. Dividing by
+        # the largest entry is also unsafe, because its float32 reciprocal is
+        # subnormal for entries above ~1e38 and flushes the quotient to zero.
+        _, exponent = jnp.frexp(largest)
+        rescaled = tuple(jnp.ldexp(x, -exponent) for x in xs)
+        total = jnp.array(0.0, dtype=jnp.float32)
+        for x in rescaled:
             total = total + jnp.sum(jnp.square(x))
-        return jnp.sqrt(total + 1e-12)
+        norm = jnp.sqrt(total)
+        exists = jnp.isfinite(norm) & (norm > 0.0)
+        safe_norm = jnp.where(exists, norm, jnp.ones_like(norm))
+        return tuple(x / safe_norm for x in rescaled), exists
 
     @staticmethod
     def _gradient_alignment(
@@ -1996,11 +2015,11 @@ class UPGDLearner:
         current: tuple[Array, ...],
     ) -> Array:
         """Cosine alignment of two gradient tuples, zero for empty gradients."""
-        previous_norm = UPGDLearner._tuple_norm(previous)
-        current_norm = UPGDLearner._tuple_norm(current)
+        previous_unit, previous_exists = UPGDLearner._tuple_unit(previous)
+        current_unit, current_exists = UPGDLearner._tuple_unit(current)
         return jnp.where(
-            (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
+            previous_exists & current_exists,
+            UPGDLearner._tuple_dot(previous_unit, current_unit),
             jnp.array(0.0, dtype=jnp.float32),
         )
 

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -1804,6 +1804,157 @@ class TestUtilityTracking:
 
 
 # =============================================================================
+# Gradient-alignment scale freedom
+# =============================================================================
+
+_ALIGNMENT_SCALES = [1.0, 1e-4, 1e-6, 1e-8, 1e-10, 1e-19, 1e-23]
+_ALIGNMENT_DIRECTION = [1.0, -2.0, 0.5, 1.5]
+_ALIGNMENT_ORTHOGONAL = [2.0, 1.0, -1.5, 0.5]
+
+
+def _alignment_tuple(entries, scale):
+    return (jnp.array(entries, dtype=jnp.float32) * scale,)
+
+
+def _alignment_learner(meta_step_size=0.5):
+    """A learner whose parameters never move, so consecutive gradients are comparable."""
+    return UPGDLearner(
+        n_heads=1,
+        hidden_sizes=(),
+        sparsity=0.0,
+        step_size=0.0,
+        perturbation_sigma=0.0,
+        meta_plasticity_mode="gradient_alignment",
+        meta_plasticity_step_size=meta_step_size,
+        meta_plasticity_min_multiplier=0.1,
+        meta_plasticity_max_multiplier=10.0,
+    )
+
+
+def _two_updates(learner, obs, first_target, second_target):
+    state = learner.init(feature_dim=obs.shape[0], key=jr.key(16))
+    state = learner.update(state, obs, first_target).state
+    return learner.update(state, obs, second_target).state
+
+
+class TestGradientAlignmentScaleFreedom:
+    """A cosine is scale free: rescaling both gradient tuples must not change it.
+
+    The alignment feeds ``meta_*_log_scale`` and ``adaptive_kappa_log_scale``, so a
+    magnitude-dependent cosine silently turns meta-plasticity off for a problem
+    expressed in smaller units and reports a direction that is not there.
+    """
+
+    @pytest.mark.parametrize("scale", _ALIGNMENT_SCALES)
+    def test_repeated_gradient_aligns_with_itself_at_every_scale(self, scale):
+        gradient = _alignment_tuple(_ALIGNMENT_DIRECTION, scale)
+        alignment = UPGDLearner._gradient_alignment(gradient, gradient)
+        assert float(alignment) == pytest.approx(1.0, abs=1e-6)
+
+    @pytest.mark.parametrize("scale", _ALIGNMENT_SCALES)
+    def test_reversed_gradient_anti_aligns_at_every_scale(self, scale):
+        gradient = _alignment_tuple(_ALIGNMENT_DIRECTION, scale)
+        reversed_gradient = (-gradient[0],)
+        alignment = UPGDLearner._gradient_alignment(gradient, reversed_gradient)
+        assert float(alignment) == pytest.approx(-1.0, abs=1e-6)
+
+    @pytest.mark.parametrize("scale", _ALIGNMENT_SCALES)
+    def test_orthogonal_gradients_report_no_alignment_at_every_scale(self, scale):
+        gradient = _alignment_tuple(_ALIGNMENT_DIRECTION, scale)
+        orthogonal = _alignment_tuple(_ALIGNMENT_ORTHOGONAL, scale)
+        alignment = UPGDLearner._gradient_alignment(gradient, orthogonal)
+        assert float(alignment) == pytest.approx(0.0, abs=1e-6)
+
+    @pytest.mark.parametrize("scale", [1.0, 1e-6, 1e-12, 1e-20, 1e20])
+    def test_alignment_matches_the_analytic_cosine_at_every_scale(self, scale):
+        first = _alignment_tuple([1.0, 0.0], scale)
+        second = _alignment_tuple([1.0, 1.0], scale)
+        alignment = UPGDLearner._gradient_alignment(first, second)
+        assert float(alignment) == pytest.approx(0.7071067811865476, abs=1e-6)
+
+    @pytest.mark.parametrize("scale", [1e19, 1e20, 1e30])
+    def test_alignment_stays_finite_when_the_squared_norm_overflows(self, scale):
+        gradient = _alignment_tuple(_ALIGNMENT_DIRECTION, scale)
+        assert bool(jnp.all(jnp.isfinite(gradient[0])))
+        assert float(UPGDLearner._gradient_alignment(gradient, gradient)) == pytest.approx(
+            1.0, abs=1e-6
+        )
+        assert float(UPGDLearner._gradient_alignment(gradient, (-gradient[0],))) == pytest.approx(
+            -1.0, abs=1e-6
+        )
+
+    def test_alignment_is_scale_free_across_a_shared_rescale(self):
+        first = jnp.array([1.0, -2.0, 0.5, 1.5], dtype=jnp.float32)
+        second = jnp.array([0.5, 1.0, 2.0, -0.25], dtype=jnp.float32)
+        reference = float(UPGDLearner._gradient_alignment((first,), (second,)))
+        for scale in (1e-3, 1e-9, 1e-15, 1e-21, 1e9):
+            rescaled = UPGDLearner._gradient_alignment((first * scale,), (second * scale,))
+            assert float(rescaled) == pytest.approx(reference, abs=1e-6)
+
+    def test_alignment_is_zero_for_gradients_that_carry_no_direction(self):
+        zero = (jnp.zeros(4, dtype=jnp.float32),)
+        unit = _alignment_tuple(_ALIGNMENT_DIRECTION, 1.0)
+        assert float(UPGDLearner._gradient_alignment(zero, zero)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(zero, unit)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(unit, zero)) == 0.0
+        assert float(UPGDLearner._gradient_alignment((), ())) == 0.0
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_alignment_is_zero_rather_than_nonfinite_for_a_broken_gradient(self, bad):
+        broken = (jnp.array([bad, 1.0, 0.5, -1.0], dtype=jnp.float32),)
+        unit = _alignment_tuple(_ALIGNMENT_DIRECTION, 1.0)
+        assert float(UPGDLearner._gradient_alignment(broken, unit)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(unit, broken)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(broken, broken)) == 0.0
+
+    @pytest.mark.parametrize("scale", [1.0, 1e-4, 1e-6, 1e-8, 1e-10])
+    def test_meta_plasticity_signal_does_not_depend_on_input_units(self, scale):
+        learner = _alignment_learner()
+        obs = jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32) * scale
+        target = jnp.array([1.0], dtype=jnp.float32) * scale
+
+        state = _two_updates(learner, obs, target, target)
+
+        assert float(state.meta_head_weight_log_scale) == pytest.approx(0.5, abs=1e-6)
+        assert float(state.meta_head_bias_log_scale) == pytest.approx(0.5, abs=1e-6)
+
+    @pytest.mark.parametrize("scale", [1.0, 1e-4, 1e-6, 1e-8, 1e-10])
+    def test_meta_plasticity_signal_reverses_for_reversed_gradients(self, scale):
+        learner = _alignment_learner()
+        obs = jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32) * scale
+        first = jnp.array([1.0], dtype=jnp.float32) * scale
+        initial = learner.init(feature_dim=3, key=jr.key(16))
+        second = 2.0 * learner.predict(initial, obs) - first
+
+        state = _two_updates(learner, obs, first, second)
+
+        assert float(state.meta_head_weight_log_scale) == pytest.approx(-0.5, abs=1e-6)
+        assert float(state.meta_head_bias_log_scale) == pytest.approx(-0.5, abs=1e-6)
+
+    def test_meta_plasticity_state_stays_finite_for_large_finite_gradients(self):
+        learner = _alignment_learner()
+        obs = jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32) * 1e10
+        target = jnp.array([1.0], dtype=jnp.float32) * 1e10
+
+        state = _two_updates(learner, obs, target, target)
+
+        for gradient in state.previous_head_weight_grads:
+            assert bool(jnp.all(jnp.isfinite(gradient)))
+        assert bool(jnp.isfinite(state.meta_head_weight_log_scale))
+        assert float(state.meta_head_weight_log_scale) == pytest.approx(0.5, abs=1e-6)
+
+    def test_first_update_leaves_the_meta_scales_untouched(self):
+        learner = _alignment_learner()
+        obs = jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32)
+        initial = learner.init(feature_dim=3, key=jr.key(16))
+
+        state = learner.update(initial, obs, jnp.array([1.0], dtype=jnp.float32)).state
+
+        assert float(state.meta_head_weight_log_scale) == 0.0
+        assert float(state.meta_head_bias_log_scale) == 0.0
+
+
+# =============================================================================
 # Perturbation magnitude
 # =============================================================================
 


### PR DESCRIPTION
Fixes #2389.

## What was wrong

`UPGDLearner._gradient_alignment` is a cosine, so it must satisfy `cos(c·a, c·b) == cos(a, b)` for
every `c > 0`. Three fixed absolute constants made it a function of input magnitude instead:
`+ 1e-12` inside `_tuple_norm`'s `sqrt` (which floors the reported norm at exactly `1e-6`), a
`> 1e-6` magnitude gate that then inspects that floor rather than the gradient, and `+ 1e-12` added
to the divisor.

## Measured, before and after

The strongest case needs no tolerance argument: feed the **identical** tuple twice and the true
cosine is exactly `1.0`; feed the exactly negated tuple and it is exactly `−1.0`.

| element scale | true norm | `main` reported norm | `main` cos(g, g) | this branch reported norm | this branch cos(g, g) |
| --- | --- | --- | --- | --- | --- |
| `1e+00` | 2.7386e+00 | 2.738613e+00 | 1.000000 | 2.738613e+00 | 1.000000 |
| `1e-04` | 2.7386e-04 | 2.738631e-04 | 0.999973 | 2.738613e-04 | 1.000000 |
| `1e-05` | 2.7386e-05 | 2.740438e-05 | 0.997341 | 2.738613e-05 | 1.000000 |
| `1e-06` | 2.7386e-06 | 2.915476e-06 | 0.789474 | 2.738613e-06 | 1.000000 |
| `1e-07` | 2.7386e-07 | 1.036822e-06 | 0.036145 | 2.738613e-07 | 1.000000 |
| `1e-08` | 2.7386e-08 | 1.000375e-06 | 0.000375 | 2.738613e-08 | 1.000000 |
| `1e-10` | 2.7386e-10 | 1.000000e-06 | **0.000000** | 2.738613e-10 | 1.000000 |
| `1e-19` | 2.7386e-19 | 1.000000e-06 | **0.000000** | 2.738613e-19 | 1.000000 |
| `1e-23` | 2.7386e-23 | 1.000000e-06 | **0.000000** | 2.738613e-23 | 1.000000 |

`cos(g, −g)` degrades and recovers identically. The exactly orthogonal case (`[1, −2, 0.5, 1.5]`
against `[2, 1, −1.5, 0.5]`, dot product exactly `0.0`) is `0.000000` at every scale on both sides,
so the defect is one-sided: it erases alignment, it never invents it.

End to end through the public API, with `step_size=0.0` so the parameters never move and two updates
on the same `(obs, target)` produce identical consecutive gradients. With
`meta_plasticity_step_size=0.5` the correct value of `meta_head_weight_log_scale` is exactly `+0.5`
at every row:

| obs/target scale | `main` head-weight | `main` head-bias | this branch head-weight | this branch head-bias |
| --- | --- | --- | --- | --- |
| `1e+10` | **nan** | 0.50000000 | 0.50000000 | 0.50000000 |
| `1e+08` | 0.50000006 | 0.50000000 | 0.50000000 | 0.50000000 |
| `1e+04` | 0.50000000 | 0.50000000 | 0.49999997 | 0.50000000 |
| `1e+00` | 0.50000006 | 0.50000000 | 0.50000012 | 0.50000000 |
| `1e-04` | **0.00002768** | 0.49988154 | 0.50000000 | 0.50000000 |
| `1e-06` | **0.00000000** | 0.14832717 | 0.50000000 | 0.50000000 |
| `1e-08` | **0.00000000** | 0.00002109 | 0.49999997 | 0.50000000 |
| `1e-10` | **0.00000000** | 0.00000000 | 0.49999997 | 0.50000000 |

The `nan` at `1e+10` is produced from **finite** gradients (max magnitude `9.1845e+19`,
`jnp.isfinite` true on every stored entry): the squares overflow inside `_tuple_norm`, so no
caller-side finiteness check can see it coming, and `jnp.clip(nan, min_log, max_log)` does not repair
it — the multiplier is `jnp.exp(nan)` for the rest of the run.

Reversing the second gradient exactly (`second_target = 2·predict(state, obs) − first_target`, which
flips the error sign) makes the true alignment `−1.0`, so the correct log-scale is `−0.5`:

| obs/target scale | `main` head-weight | `main` head-bias | this branch head-weight | this branch head-bias |
| --- | --- | --- | --- | --- |
| `1e+00` | −0.50000006 | −0.50000000 | −0.50000006 | −0.50000000 |
| `1e-04` | **−0.00002768** | −0.49988154 | −0.50000000 | −0.50000000 |
| `1e-06` | **0.00000000** | −0.14832717 | −0.49999997 | −0.50000000 |
| `1e-08` | **0.00000000** | −0.00002109 | −0.49999997 | −0.50000000 |
| `1e-10` | **0.00000000** | 0.00000000 | −0.49999997 | −0.50000000 |

A gradient reversal is the event this signal exists to detect, and below `1e-6` `main` records it as
"nothing happened".

## What the repair does

`_tuple_norm` is replaced by `_tuple_unit`, which returns a unit-norm copy of the tuple plus a boolean
saying whether a direction exists. It takes the `jnp.frexp` exponent of the largest absolute entry,
rescales the tuple by that exact power of two with `jnp.ldexp`, accumulates the squares of the
**rescaled** copy, and divides by that norm — so the divisor is within a small factor of `1` at every
input magnitude. Existence becomes `jnp.isfinite(norm) & (norm > 0.0)`, a property of the data rather
than a comparison against a hard-coded magnitude, and the divisor is swapped for `1` inside the same
`jnp.where` that selects the result, so no branch divides by zero. `_gradient_alignment` then dots the
two unit copies. All three constants are gone; `_tuple_dot` is untouched.

Two things this deliberately does **not** do, both because they were measured rather than assumed:

- **It does not just lower the constant.** Squaring doubles the exponent, so a tuple whose entries are
  near `1e-20` has a sum of squares of exactly `0.0` in float32 (float64: `7.5e-40`) *before* any
  constant is consulted. The rescale has to happen before the accumulation, not after it.
- **It does not divide by `max|entry|`.** That variant returns exactly zero at element scale `1e38`,
  because the float32 reciprocal of a divisor near `2e38` is subnormal and flushes. The power-of-two
  rescale never forms a reciprocal. The reason is stated in the code comment so the shortcut is not
  reintroduced later.

## Tests

`TestGradientAlignmentScaleFreedom` in `tests/test_upgd.py`, **46 nodes**: self-alignment, reversal and
orthogonality across seven scales from `1e0` to `1e-23`; the analytic cosine of an exactly 45° pair at
five scales including `1e20` and `1e-20`; finiteness and correctness where the raw sum of squares
overflows (`1e19`, `1e20`, `1e30`); invariance under a shared rescale of both tuples; the no-direction
cases (all-zero, mixed, and the empty tuple); non-finite gradients returning `0.0` rather than
propagating; end-to-end invariance of both meta log-scales through two public updates at five scales;
the end-to-end reversal case; the large-finite-gradient case; and the first-update pin.

Failing-first, with the source file restored to `main`'s revision and the tests left in place:

```
31 failed, 15 passed
```

The 15 that pass at both revisions are deliberate no-drift pins — the orthogonal cases, the zero and
empty tuples, the non-finite cases, and the first update whose stored previous gradients are all zero.
They exist so this change cannot quietly alter behavior that was already correct.

The unit-level tests call the private static method, which has precedent in this suite
(`tests/test_optimizer_nonfinite_transactions.py:402`); every consumer-level test goes through the
public `update` only.

## Gates

Same host and interpreter for both columns. The right column is a detached worktree at `origin/main`
`c9aba7b5` with no new tests present, so any status difference is attributable to this change.

| gate | this branch | pristine `main` |
| --- | --- | --- |
| `python -m pytest tests/test_upgd.py -k TestGradientAlignmentScaleFreedom -q` | 46 passed | class does not exist |
| `python -m pytest tests/test_upgd.py -q` | 134 passed | 88 passed |
| `python -m pytest $(cat upgd-importers.txt) -q` | **595 passed** | **549 passed** |
| `python -m ruff check .` | all checks passed | all checks passed |
| `python -m mypy` | 108 errors in 17 files | 108 errors in 17 files |

`549 + 46 == 595`, so **no pre-existing node changed status**, and mypy's error count is byte-identical
— none of the 108 is in `upgd.py`; they are all the pre-existing POSIX-only-attribute categories this
host reports at every revision. The importer list is the 17 test files that reach the changed module:

```
tests/test_core_trust_ordering.py           tests/test_upgd.py
tests/test_forgetting_gate.py               tests/test_upgd_hostile_validation.py
tests/test_late_wave_transactions.py        tests/test_upgd_leftover_constructor_identities.py
tests/test_memory_scan_bounds_validation.py tests/test_upgd_lifetime_clock.py
tests/test_optimizer_nonfinite_transactions.py  tests/test_upgd_loop_steps.py
tests/test_plasticity_gate.py               tests/test_upgd_memory.py
tests/test_step2_theory_invariants.py       tests/test_upgd_memory_grad.py
tests/test_step_scan_bounds_validation.py   tests/test_upgd_memory_validation.py
                                            tests/test_upgd_validation.py
```

## Out of scope

`jnp.frexp` reports exponent `-149` for **every** float32 subnormal (numpy reports the true exponent),
and `jnp.ldexp` returns a subnormal operand unchanged for any shift. A gradient tuple whose largest
entry is itself subnormal therefore is not rescaled, and returns `0.0` — the same answer `main` gives,
and the same answer the all-zero tuple gives. XLA flushes subnormals in arithmetic on this backend, so
such a tuple can only arrive from outside; the case is neither improved nor regressed here. Stated
rather than left for a reviewer to find.

No behavior outside `_tuple_norm`/`_gradient_alignment` is touched, and no threshold, validator, or
test elsewhere was relaxed.

Environment for every number above: JAX 0.11.0, jaxlib 0.11.0, numpy 2.5.1, CPython 3.13.14,
Windows 11 AMD64, `jax_enable_x64` False (default), CPU backend.

Produced with claude-opus-5-w1 / anthropic / claude-opus-5.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-opus-5-w1
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [claude-opus-5-w1]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-opus-5-w1","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0QZ8HSTMC75X9G64A32548P","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-23T18:48:53.307Z","completed_at":"2026-08-24T05:08:11.832Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T18:48:54.456Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d58708fc4c04a555abf4871d5524105aec3398f47f3a8b3c265ad140a22991f4","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"fb6da41b-7022-4c30-a1a4-fdc1071aced3","object_id":"sha256:d58708fc4c04a555abf4871d5524105aec3398f47f3a8b3c265ad140a22991f4","sha256":"d58708fc4c04a555abf4871d5524105aec3398f47f3a8b3c265ad140a22991f4"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"2xhCEYIPq1e3y_VnUl23KjvI6E7XhFtBGyzOIen2deYwLanFzVXv6-UhR7pAJ1Xap3hYWyWQxvoDzGfRFPCLBw"}} -->
