### PR TITLE
fix(evaluation): recover the FLAD divisor when its squares underflow

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -277,24 +277,6 @@ def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tu
     )
     safe = jnp.where(valid, candidate, jnp.zeros_like(candidate))
     return safe, valid
-    numerator = jnp.vdot(scaled, delta).real
-    active = squared_norm > 0.0
-    denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
-    coefficient = numerator / denominator
-    projection = scaled * coefficient * active.astype(delta.dtype)
-    candidate = delta - projection
-    valid = (
-        jnp.all(jnp.isfinite(delta))
-        & jnp.all(jnp.isfinite(direction))
-        & jnp.all(jnp.isfinite(scaled))
-        & jnp.isfinite(squared_norm)
-        & jnp.isfinite(numerator)
-        & jnp.isfinite(coefficient)
-        & jnp.all(jnp.isfinite(projection))
-        & jnp.all(jnp.isfinite(candidate))
-    )
-    safe = jnp.where(valid, candidate, jnp.zeros_like(candidate))
-    return safe, valid
 
 
 def muon_ogd_dual_update_transaction(

--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -197,22 +197,96 @@ def spectral_matrix_sign(matrix: Array, *, steps: int = 5) -> Array:
     )
 
 
+def _subnormal_entry_present(value: Array) -> Array:
+    """Report whether any entry is a nonzero subnormal.
+
+    A power-of-two rescale cannot move such an entry. ``jnp.ldexp`` returns a
+    subnormal operand bit-for-bit unmodified on a backend that flushes subnormal
+    arithmetic operands, so rescaling a vector that mixes normal and subnormal
+    entries shifts only the normal ones and silently changes the direction the
+    vector points in. No float comparison detects the condition, because
+    ``x != 0.0`` is ``False`` for every float32 subnormal, so the exponent field
+    is read directly and the sign bit masked off to keep both signed zeros
+    reading as normal.
+    """
+    width = value.dtype.itemsize
+    unsigned = np.dtype(f"uint{8 * width}")
+    magnitude = jnp.bitwise_and(
+        jax.lax.bitcast_convert_type(value, unsigned),
+        jnp.asarray((1 << (8 * width - 1)) - 1, dtype=unsigned),
+    )
+    # An IEEE binary exponent field is one wider at 2.0 than at 1.0, so the gap
+    # between their bit patterns is the smallest normal magnitude for this dtype
+    # without asking an untyped introspection helper for the mantissa width.
+    landmarks = jax.lax.bitcast_convert_type(jnp.asarray([1.0, 2.0], dtype=value.dtype), unsigned)
+    smallest_normal = landmarks[1] - landmarks[0]
+    return jnp.any((magnitude != 0) & (magnitude < smallest_normal))
+
+
 def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tuple[Array, Array]:
-    """Return a finite FLAD noise component and caller-visible validity bit."""
+    """Return a finite FLAD noise component and caller-visible validity bit.
+
+    The projection onto the gradient's span does not depend on the gradient's
+    magnitude, so when the raw divisor is unusable the inner products are retaken
+    against an exactly power-of-two rescaled copy. Every gradient whose divisor is
+    already a positive finite number is answered from that divisor unchanged, and
+    the zero-gradient reduction stays exact.
+    """
     delta = _trusted_array(perturbation, name="perturbation")
     direction = _trusted_array(gradient, name="gradient")
     if delta.shape != direction.shape or delta.ndim != 1 or delta.size < 1:
         raise ValueError("perturbation and gradient must be non-empty equal-width vectors")
-    squared_norm = jnp.vdot(direction, direction).real
-    numerator = jnp.vdot(direction, delta).real
+    # `active` below is the protocol's zero-gradient reduction, so it must answer
+    # whether the gradient is zero and nothing else. Taken on the raw gradient it
+    # cannot: for float32 entries at or below roughly 1e-20 the squares land under
+    # the subnormal floor and `jnp.vdot` accumulates exactly zero, which sent a
+    # well-conditioned direction down the zero-gradient branch and returned the
+    # perturbation with its whole gradient component still in it. The numerator
+    # survives at those scales, so only the divisor was lost. Rescaling by an exact
+    # power of two recovers it without changing the projection, because the span
+    # being projected onto is invariant to the gradient's magnitude, and the same
+    # rescale keeps the squares finite for gradients large enough to overflow them.
+    #
+    # Two conditions narrow that rescale to the gradients it repairs. It runs only
+    # where the raw divisor is unusable, so every gradient that already produced an
+    # answer keeps producing bit-for-bit that answer instead of one re-rounded on a
+    # different grid. It is also withheld from a gradient holding subnormal entries,
+    # which a power-of-two rescale moves the normal entries of while leaving the
+    # subnormal ones in place, quietly changing the direction being projected onto.
+    raw_squared_norm = jnp.vdot(direction, direction).real
+    unusable = (raw_squared_norm == 0.0) | jnp.logical_not(jnp.isfinite(raw_squared_norm))
+    _, exponent = jnp.frexp(jnp.max(jnp.abs(direction)))
+    rescale = unusable & jnp.logical_not(_subnormal_entry_present(direction))
+    scaled = jnp.where(rescale, jnp.ldexp(direction, -exponent), direction)
+    squared_norm = jnp.vdot(scaled, scaled).real
+    numerator = jnp.vdot(scaled, delta).real
     active = squared_norm > 0.0
     denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
     coefficient = numerator / denominator
-    projection = direction * coefficient * active.astype(delta.dtype)
+    projection = scaled * coefficient * active.astype(delta.dtype)
     candidate = delta - projection
     valid = (
         jnp.all(jnp.isfinite(delta))
         & jnp.all(jnp.isfinite(direction))
+        & jnp.all(jnp.isfinite(scaled))
+        & jnp.isfinite(squared_norm)
+        & jnp.isfinite(numerator)
+        & jnp.isfinite(coefficient)
+        & jnp.all(jnp.isfinite(projection))
+        & jnp.all(jnp.isfinite(candidate))
+    )
+    safe = jnp.where(valid, candidate, jnp.zeros_like(candidate))
+    return safe, valid
+    numerator = jnp.vdot(scaled, delta).real
+    active = squared_norm > 0.0
+    denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
+    coefficient = numerator / denominator
+    projection = scaled * coefficient * active.astype(delta.dtype)
+    candidate = delta - projection
+    valid = (
+        jnp.all(jnp.isfinite(delta))
+        & jnp.all(jnp.isfinite(direction))
+        & jnp.all(jnp.isfinite(scaled))
         & jnp.isfinite(squared_norm)
         & jnp.isfinite(numerator)
         & jnp.isfinite(coefficient)

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -87,6 +87,123 @@ def test_flad_jit_removes_gradient_aligned_component() -> None:
     np.testing.assert_allclose(result, [0.0, 4.0])
 
 
+FLAD_PERTURBATION = np.array([1.0, -2.0, 0.5, 3.0], dtype=np.float32)
+FLAD_GRADIENT = np.array([2.0, 1.0, -1.0, 0.5], dtype=np.float32)
+
+
+def _flad_reference(perturbation: np.ndarray, gradient: np.ndarray) -> np.ndarray:
+    """Project the perturbation away from the gradient in float64."""
+    delta = perturbation.astype(np.float64)
+    direction = gradient.astype(np.float64)
+    squared_norm = float(direction @ direction)
+    if squared_norm == 0.0:
+        return delta
+    return delta - direction * (float(direction @ delta) / squared_norm)
+
+
+@pytest.mark.parametrize("scale", [1e-20, 1e-25, 1e-30])
+def test_flad_underflowing_squared_norm_still_removes_the_component(scale: float) -> None:
+    gradient = FLAD_GRADIENT * np.float32(scale)
+    assert float(jnp.vdot(jnp.asarray(gradient), jnp.asarray(gradient)).real) == 0.0
+    safe, valid = jax.jit(flad_noise_component_transaction)(
+        jnp.asarray(FLAD_PERTURBATION), jnp.asarray(gradient)
+    )
+    assert bool(valid)
+    np.testing.assert_allclose(
+        np.asarray(safe, dtype=np.float64),
+        _flad_reference(FLAD_PERTURBATION, gradient),
+        atol=1e-6,
+    )
+
+
+@pytest.mark.parametrize("scale", [1e19, 1e20, 1e30, 1.7e38])
+def test_flad_overflowing_squared_norm_is_answered_from_the_rescaled_gradient(
+    scale: float,
+) -> None:
+    gradient = FLAD_GRADIENT * np.float32(scale)
+    assert not bool(jnp.isfinite(jnp.vdot(jnp.asarray(gradient), jnp.asarray(gradient)).real))
+    safe, valid = jax.jit(flad_noise_component_transaction)(
+        jnp.asarray(FLAD_PERTURBATION), jnp.asarray(gradient)
+    )
+    assert bool(valid)
+    np.testing.assert_allclose(
+        np.asarray(safe, dtype=np.float64),
+        _flad_reference(FLAD_PERTURBATION, gradient),
+        atol=1e-6,
+    )
+
+
+def test_flad_unrepresentable_coefficient_stays_invalid() -> None:
+    maximum = np.float32(np.finfo(np.float32).max)
+    safe, valid = jax.jit(flad_noise_component_transaction)(
+        jnp.full((4,), maximum), jnp.full((4,), maximum)
+    )
+    assert bool(jnp.all(jnp.isfinite(safe)))
+    assert not bool(valid)
+
+
+@pytest.mark.parametrize("scale", [1e-38, 2.938736e-39])
+def test_flad_subnormal_gradient_entries_are_left_at_their_own_scale(scale: float) -> None:
+    gradient = FLAD_GRADIENT * np.float32(scale)
+    magnitudes = np.abs(gradient).view(np.uint32) & np.uint32(0x7FFFFFFF)
+    assert bool(np.any((magnitudes > 0) & (magnitudes < np.uint32(0x00800000))))
+    safe, valid = jax.jit(flad_noise_component_transaction)(
+        jnp.asarray(FLAD_PERTURBATION), jnp.asarray(gradient)
+    )
+    assert bool(valid)
+    np.testing.assert_array_equal(safe, jnp.asarray(FLAD_PERTURBATION))
+
+
+@pytest.mark.parametrize(
+    ("scale", "expected_words"),
+    [
+        (1.0, [0x3F2E147B, 0xC00A3D71, 0x3F28F5C2, 0x403AE148]),
+        (1e-10, [0x3F2E147B, 0xC00A3D71, 0x3F28F5C2, 0x403AE148]),
+        (1e-19, [0x3F1E79E8, 0xC00C30C3, 0x3F30C30C, 0x4039E79E]),
+    ],
+)
+def test_flad_usable_squared_norm_answers_are_bit_for_bit_unchanged(
+    scale: float, expected_words: list[int]
+) -> None:
+    """Pin the answers recorded before the rescale was introduced.
+
+    A gradient whose squared norm is already a positive finite number is answered
+    from that divisor, so its result must not be re-rounded onto the grid the
+    rescaled inner products would land on. The 1e-19 row keeps the precision it
+    loses to a divisor assembled from subnormal partial products.
+    """
+    direction = jnp.asarray(FLAD_GRADIENT * np.float32(scale))
+    squared_norm = jnp.vdot(direction, direction).real
+    assert bool(squared_norm > 0.0) and bool(jnp.isfinite(squared_norm))
+    safe, valid = jax.jit(flad_noise_component_transaction)(
+        jnp.asarray(FLAD_PERTURBATION), direction
+    )
+    assert bool(valid)
+    words = np.asarray(safe, dtype=np.float32).view(np.uint32)
+    assert [int(word) for word in words] == expected_words
+
+
+def test_flad_zero_gradient_reduces_to_the_perturbation_bit_for_bit() -> None:
+    delta = jnp.asarray(FLAD_PERTURBATION)
+    safe, valid = jax.jit(flad_noise_component_transaction)(
+        delta, jnp.zeros(4, dtype=jnp.float32)
+    )
+    assert bool(valid)
+    np.testing.assert_array_equal(safe, delta)
+
+
+def test_flad_bfloat16_underflow_is_repaired_within_its_own_precision() -> None:
+    gradient = jnp.asarray(FLAD_GRADIENT * np.float32(1e-20), dtype=jnp.bfloat16)
+    delta = jnp.asarray(FLAD_PERTURBATION, dtype=jnp.bfloat16)
+    assert float(jnp.vdot(gradient, gradient).real) == 0.0
+    safe, valid = jax.jit(flad_noise_component_transaction)(delta, gradient)
+    assert bool(valid)
+    reference = _flad_reference(
+        np.asarray(delta, dtype=np.float32), np.asarray(gradient, dtype=np.float32)
+    )
+    np.testing.assert_allclose(np.asarray(safe, dtype=np.float64), reference, atol=1e-2)
+
+
 def test_streaming_matrix_evaluation_is_frozen_matched_and_nonpromoting() -> None:
     result = run_streaming_matrix_evaluation()
     assert result["schema"] == GEOMETRY_RESULT_SCHEMA


### PR DESCRIPTION
Fixes #2393.

## What this fixes

`flad_noise_component_transaction` took its inner products on the raw gradient.
For a float32 gradient whose entries sit at or below roughly `1e-20` every square
lands under the subnormal floor, `jnp.vdot` accumulates exactly zero, and
`squared_norm > 0.0` — the protocol's zero-gradient reduction — fires on a
perfectly well-conditioned direction. The function then returned the perturbation
with its whole gradient component still in it, reporting `valid=True`.

The component that should have been removed is exactly the size of the thing the
function exists to compute. For the reproduction input the projection is
`3.20000e-01` and none of it was removed.

The numerator survives at those scales, so only the divisor was lost. When the
raw divisor is unusable the inner products are retaken against an exactly
power-of-two rescaled copy of the gradient. That is a reformulation rather than an
approximation: the span being projected onto does not depend on the gradient's
magnitude.

## Reproduction

`perturbation = [1.0, -2.0, 0.5, 3.0]`, `gradient = [2.0, 1.0, -1.0, 0.5] × scale`,
error measured as the maximum absolute difference against the same projection in
float64. JAX 0.11.0, CPU, x64 disabled, identical eagerly and under `jax.jit`.
The `before` column is `c9aba7b5`.

| gradient scale | `g @ g` (float32) | before | after | disposition |
| --- | --- | --- | --- | --- |
| 1.0 | 6.25000e+00 | 8.58307e-08 | 8.58307e-08 | bit-identical |
| 1e-10 | 6.25000e-20 | 8.58307e-08 | 8.58307e-08 | bit-identical |
| 1e-19 | 6.25000e-38 | 6.09524e-02 | 6.09524e-02 | bit-identical |
| 1e-20 | 0.00000e+00 | **3.20000e-01** | **8.58307e-08** | repaired |
| 1e-25 | 0.00000e+00 | **3.20000e-01** | **8.58307e-08** | repaired |
| 1e-30 | 0.00000e+00 | **3.20000e-01** | **8.58307e-08** | repaired |
| 1e-38 (mixed subnormal) | 0.00000e+00 | 3.20000e-01 | 3.20000e-01 | bit-identical, rescale withheld |
| 2.938736e-39 (all subnormal) | 0.00000e+00 | 3.20000e-01 | 3.20000e-01 | bit-identical, rescale withheld |
| 1e19 | inf | refused | **8.58307e-08** | now answered |
| 1e20 | inf | refused | **8.58307e-08** | now answered |
| 1e30 | inf | refused | **8.58307e-08** | now answered |
| 1.7e38 | inf | refused | **8.58307e-08** | now answered |

No row is made worse. The zero gradient still returns the perturbation bit for
bit, and `nan` or `inf` in either argument is still reported invalid with a zeroed
result.

## Why the rescale is gated twice

**It runs only where the raw divisor is dead — exactly zero, or non-finite.** A
gradient whose divisor is already a positive finite number is answered from that
divisor, so its result is not re-rounded onto the grid the rescaled inner
products land on. Three scales are pinned by their recorded bit patterns to hold
that line.

**It is withheld from any gradient holding a subnormal entry.** This is the part
that is not obvious, and it is the correction I posted on #2393 after measuring
rather than assuming. `jnp.ldexp` returns a subnormal operand **bit-for-bit
unmodified**, at every shift amount, identically eagerly and under `jax.jit`:

| operand | `ldexp(x, 125)` returned | mathematically correct result |
| --- | --- | --- |
| `0x00800000` smallest normal | `0x3f000000` | `0x3f000000` |
| `0x00400000` subnormal | `0x00400000` | `0x3e800000` |
| `0x00000001` subnormal floor | `0x00000001` | `0x33800000` |

Both correct results are ordinary normal floats, so the shift does not underflow —
it does not happen. Rescaling a vector that mixes normal and subnormal entries
therefore moves only the normal ones:

```
scale = 1e-38, frexp exponent = -125
  input  bits : ['0x00d9c7dc', '0x006ce3ee', '0x806ce3ee', '0x003671f7']
  scaled bits : ['0x3f59c7dc', '0x006ce3ee', '0x806ce3ee', '0x003671f7']
  moved       : [True, False, False, False]
```

An ungated rescale takes that row from `3.20e-01` to `6.80e-01`, because the
vector it normalizes points somewhere the input did not. Withholding it keeps
that input's previous answer instead.

## Why detection has to be bitwise

No float comparison can see a subnormal on this backend. For a float32
subnormal operand, measured identically eagerly and under `jax.jit`:

| operation | subnormal operand |
| --- | --- |
| `x > 0.0`, `x != 0.0` | `False` |
| `x * 1.0`, `x + 0.0` | flushed to `0x00000000` |
| `jnp.abs` | bits preserved |
| `jnp.frexp` | `(0.5, -149)` for every subnormal |
| `jnp.ldexp` | operand returned unmodified |
| bitcast, mask sign bit, compare | correct |

The round trip `jnp.ldexp(*jnp.frexp(x))` also *appears* exact for subnormals,
which is a trap: the reassembled value is `0x00000000` and the equality that
checks it flushes `x`, so `0x00000000 == subnormal` evaluates `True`. The
exponent field has to be read from the bits.

The helper masks the sign bit so both signed zeros read as normal, and derives
the smallest normal magnitude from the gap between the bit patterns of `1.0` and
`2.0`, which is one mantissa width for any IEEE binary format. That keeps it
correct for `float16`, `bfloat16` and `float32` alike without an untyped
introspection call, which matters because `mypy` runs strict here.

## Disposition change

Overflowing gradients now answer instead of refusing. Refusal is keyed on whether
the resulting coefficient is representable rather than on whether the gradient's
squared norm overflowed, so a huge gradient against an ordinary perturbation is
answered and a huge gradient against a huge perturbation still refuses. Both
halves are pinned by tests. If you would rather keep the refusal, that is a
two-line change to the gate.

## Boundaries this does not cross

Named rather than silently inherited:

- **A degraded divisor is not repaired, only a dead one.** At float32 scale
  `1e-19` the divisor is a barely-normal `6.25e-38` assembled from subnormal
  partial products, and roughly 19% of the projection is already gone. Repairing
  it means re-rounding an input that answers today, which is a disposition call
  rather than a bug fix. The same row exists in `float16` at scale `2e-4`, where
  the divisor is `2.38e-07`.
- **A gradient spanning more than the float32 exponent range loses its smallest
  entries to the rescale.** Their contribution to both inner products is far
  below the rounding of the dominant terms, so the projection is unaffected, but
  the entries are gone.
- **The flushed-operand class stays as it was.** A gradient carrying subnormal
  entries keeps its previous answer here; whether that should instead fail closed
  is #2391's question and #2392's proposal, and duplicating that judgement in a
  second function before it is reviewed seemed worse than leaving it.

The bit witness overlaps `_nonzero_magnitude_bits` from #2392. They answer
different questions — "any magnitude bit set" versus "any entry below the
smallest normal" — but if both land, one should absorb the other.

## Verification

| check | command | result |
| --- | --- | --- |
| geometry suite | `pytest tests/test_optimizer_geometry.py` | 41 passed, 2 failed |
| same suite on `c9aba7b5` | `pytest tests/test_optimizer_geometry.py` | 26 passed, 2 failed |
| lint | `ruff check .` | all checks passed |
| types | `mypy` | 108 errors, unchanged from `c9aba7b5` |

The two failures are `test_geometry_result_has_canonical_bytes_and_exclusive_retention`
and `test_geometry_retention_rejects_namespace_symlink`. Both require an absolute
POSIX repository root and fail identically on the pristine revision on this host;
they are not attributable to this change. The 15 added nodes are the 41 minus the
26 the pristine revision passes.

`mypy` sits at 108 on both revisions. An earlier revision of this branch reached
109 by calling an untyped `finfo` helper in a typed context; that call was removed
rather than suppressed.

The existing `jax.jacrev` test over the zero-gradient path still passes, so the
bitwise gate did not break the derivative, and the change stays outer-`jit` safe.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [fix]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0S955N75V5WWFYYA4N0Y8CG","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T07:01:02.760Z","completed_at":"2026-08-24T07:38:25.546Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T07:01:10.850Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f556d422d0e7bfdd4d93b41cdfbd4ecfe2475c947b9d4639a328cdde529e5b2d","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b1235edd-dc28-4990-b535-ce56a650fd1b","object_id":"sha256:f556d422d0e7bfdd4d93b41cdfbd4ecfe2475c947b9d4639a328cdde529e5b2d","sha256":"f556d422d0e7bfdd4d93b41cdfbd4ecfe2475c947b9d4639a328cdde529e5b2d"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"HeiLG2_S6qKb2dDr5XTaxpuSnhBzkYVt2R6pJ_H_SrmxXLPN6Hkj7y-twQVWy1x-o38x2oiKpo3dbR_HF1C3BQ"}} -->
