### PR TITLE
fix(evaluation): reconstruct multiagent evidence aggregates

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent_artifact.py
+++ b/alberta_framework/evaluation/continual_multiagent_artifact.py
@@ -78,6 +78,11 @@ _EXPECTED_LEARNING_MASKS = {
     "learner_only": [True, False],
     "joint_adaptive": [True, True],
 }
+_EXPECTED_CONTROLLER_BUDGET = {
+    "state_scalars": 10,
+    "state_bytes": 48,
+    "action_scalars_per_step": 2,
+}
 _REQUIRED_CONDITION_FIELDS = frozenset(
     {
         "learning_mask",
@@ -97,6 +102,29 @@ _REQUIRED_CONDITION_FIELDS = frozenset(
         "recurrence_recovery_steps",
         "interference_forgetting",
         "controller_budget",
+    }
+)
+_REQUIRED_AGGREGATE_FIELDS = frozenset(
+    {
+        "seed_count",
+        "seeds",
+        "mean_prequential_reward",
+        "reward_uplift_over_frozen",
+        "reward_uplift_over_frozen_paired_interval",
+        "coadaptation_uplift_over_learner_only",
+        "coadaptation_uplift_over_learner_only_paired_interval",
+        "joint_adaptive_phase_rewards",
+        "joint_adaptive_read_only_probe_matrix",
+        "recurrent_a_probe_reward",
+        "mean_forgetting",
+        "maximum_forgetting",
+        "mean_interference_forgetting",
+        "recurrence_recovery_fraction",
+        "recurrence_recovery_fraction_interval",
+        "mean_recurrence_recovery_steps_among_recovered_seeds",
+        "mean_stability_gap",
+        "resource_budget",
+        "all_scientific_and_timing_values_finite",
     }
 )
 
@@ -751,6 +779,95 @@ def _numbers_match(first: object, second: object) -> bool:
     )
 
 
+def _finite_vector(
+    value: object,
+    *,
+    length: int,
+    location: str,
+    errors: list[str],
+) -> list[float] | None:
+    if type(value) is not list or len(value) != length:
+        errors.append(f"{location} must be an array of {length} finite numbers")
+        return None
+    parsed = [_finite_number(item) for item in value]
+    if any(item is None for item in parsed):
+        errors.append(f"{location} must contain only finite numbers")
+        return None
+    return [float(item) for item in parsed if item is not None]
+
+
+def _finite_matrix(
+    value: object,
+    *,
+    rows: int,
+    columns: int,
+    location: str,
+    errors: list[str],
+) -> list[list[float]] | None:
+    if type(value) is not list or len(value) != rows:
+        errors.append(f"{location} must be a {rows}x{columns} finite matrix")
+        return None
+    parsed: list[list[float]] = []
+    for row_index, row in enumerate(value):
+        parsed_row = _finite_vector(
+            row,
+            length=columns,
+            location=f"{location}[{row_index}]",
+            errors=errors,
+        )
+        if parsed_row is None:
+            return None
+        parsed.append(parsed_row)
+    return parsed
+
+
+def _controller_budget(
+    value: object,
+    *,
+    location: str,
+    errors: list[str],
+) -> tuple[int, int, int] | None:
+    if type(value) is not dict or set(value) != set(_EXPECTED_CONTROLLER_BUDGET):
+        errors.append(f"{location} keys do not match the v1 controller budget")
+        return None
+    parsed: list[int] = []
+    for field_name in _EXPECTED_CONTROLLER_BUDGET:
+        field = value.get(field_name)
+        if type(field) is not int or field < 0:
+            errors.append(f"{location}.{field_name} must be a nonnegative integer")
+            return None
+        parsed.append(field)
+    if parsed[2] < 1:
+        errors.append(f"{location}.action_scalars_per_step must be positive")
+        return None
+    if value != _EXPECTED_CONTROLLER_BUDGET:
+        errors.append(f"{location} does not match the frozen v1 controller budget")
+    return parsed[0], parsed[1], parsed[2]
+
+
+def _aggregate_array_matches(actual: object, expected: np.ndarray) -> bool:
+    if expected.ndim == 1:
+        parsed_vector = _finite_vector(
+            actual,
+            length=int(expected.shape[0]),
+            location="content.aggregate array",
+            errors=[],
+        )
+        if parsed_vector is None:
+            return False
+        return bool(np.allclose(parsed_vector, expected, rtol=0.0, atol=1e-12))
+    parsed_matrix = _finite_matrix(
+        actual,
+        rows=int(expected.shape[0]),
+        columns=int(expected.shape[1]),
+        location="content.aggregate matrix",
+        errors=[],
+    )
+    return parsed_matrix is not None and bool(
+        np.allclose(parsed_matrix, expected, rtol=0.0, atol=1e-12)
+    )
+
+
 def _validate_interval_record(
     value: object,
     *,
@@ -805,12 +922,21 @@ def _validate_seed_and_aggregate_consistency(
         return
     if not isinstance(aggregate, Mapping) or not isinstance(config, Mapping):
         return
+    if set(aggregate) != _REQUIRED_AGGREGATE_FIELDS:
+        errors.append("content.aggregate keys do not match the v1 schema")
 
     observed_seeds: list[int] = []
     prequential: dict[str, list[float]] = {
         condition: [] for condition in _EXPECTED_CONDITIONS
     }
     recurrence_steps: list[int] = []
+    joint_phase_rewards: list[list[float]] = []
+    joint_probe_matrices: list[list[list[float]]] = []
+    joint_mean_forgetting: list[float] = []
+    joint_maximum_forgetting: list[float] = []
+    joint_interference_forgetting: list[float] = []
+    joint_mean_stability_gap: list[float] = []
+    budgets: list[tuple[int, int, int]] = []
     for index, raw_seed in enumerate(seed_summaries):
         location = f"content.seed_summaries[{index}]"
         if not isinstance(raw_seed, Mapping):
@@ -845,6 +971,12 @@ def _validate_seed_and_aggregate_consistency(
                     f"{result_location} is missing fields: "
                     + ", ".join(missing_fields)
                 )
+            extra_fields = sorted(set(result) - _REQUIRED_CONDITION_FIELDS)
+            if extra_fields:
+                errors.append(
+                    f"{result_location} has unsupported fields: "
+                    + ", ".join(extra_fields)
+                )
             if result.get("learning_mask") != _EXPECTED_LEARNING_MASKS[condition]:
                 errors.append(
                     f"{result_location}.learning_mask is inconsistent "
@@ -857,6 +989,107 @@ def _validate_seed_and_aggregate_consistency(
                 )
             else:
                 prequential[condition].append(reward)
+            for field_name in (
+                "final_probe_reward",
+                "mean_forgetting",
+                "maximum_forgetting",
+                "backward_transfer",
+                "mean_stability_gap",
+                "maximum_stability_gap",
+                "interference_forgetting",
+            ):
+                if _finite_number(result.get(field_name)) is None:
+                    errors.append(f"{result_location}.{field_name} must be finite")
+            phase_rewards = _finite_vector(
+                result.get("phase_mean_rewards"),
+                length=3,
+                location=f"{result_location}.phase_mean_rewards",
+                errors=errors,
+            )
+            probe_matrix = _finite_matrix(
+                result.get("read_only_probe_matrix"),
+                rows=3,
+                columns=2,
+                location=f"{result_location}.read_only_probe_matrix",
+                errors=errors,
+            )
+            per_task_vectors: dict[str, list[float] | None] = {}
+            for field_name in (
+                "per_task_final_performance",
+                "per_task_forgetting",
+                "per_task_backward_transfer",
+            ):
+                per_task_vectors[field_name] = _finite_vector(
+                    result.get(field_name),
+                    length=2,
+                    location=f"{result_location}.{field_name}",
+                    errors=errors,
+                )
+            if probe_matrix is not None:
+                matrix = np.asarray(probe_matrix, dtype=np.float64)
+                trajectories = (matrix[:, 0], matrix[1:, 1])
+                expected_final = np.asarray(
+                    [trajectory[-1] for trajectory in trajectories]
+                )
+                expected_forgetting = np.asarray(
+                    [
+                        max(0.0, float(np.max(trajectory) - trajectory[-1]))
+                        for trajectory in trajectories
+                    ]
+                )
+                expected_backward_transfer = np.asarray(
+                    [trajectory[-1] - trajectory[0] for trajectory in trajectories]
+                )
+                expected_vectors = {
+                    "per_task_final_performance": expected_final,
+                    "per_task_forgetting": expected_forgetting,
+                    "per_task_backward_transfer": expected_backward_transfer,
+                }
+                for field_name, expected in expected_vectors.items():
+                    actual = per_task_vectors[field_name]
+                    if actual is not None and not np.allclose(
+                        actual, expected, rtol=0.0, atol=1e-12
+                    ):
+                        errors.append(
+                            f"{result_location}.{field_name} is inconsistent "
+                            "with read_only_probe_matrix"
+                        )
+                expected_scalars = {
+                    "final_probe_reward": float(np.mean(expected_final)),
+                    "mean_forgetting": float(np.mean(expected_forgetting)),
+                    "maximum_forgetting": float(np.max(expected_forgetting)),
+                    "backward_transfer": float(np.mean(expected_backward_transfer)),
+                    "interference_forgetting": max(
+                        0.0, float(matrix[0, 0] - matrix[1, 0])
+                    ),
+                }
+                for field_name, expected_scalar in expected_scalars.items():
+                    if not _numbers_match(result.get(field_name), expected_scalar):
+                        errors.append(
+                            f"{result_location}.{field_name} is inconsistent "
+                            "with read_only_probe_matrix"
+                        )
+            recovery_lengths = result.get("recovery_lengths")
+            if (
+                type(recovery_lengths) is not list
+                or len(recovery_lengths) != 2
+                or any(type(item) is not int for item in recovery_lengths)
+            ):
+                errors.append(
+                    f"{result_location}.recovery_lengths must be two integers"
+                )
+            elif result.get("recurrence_recovery_steps") != recovery_lengths[1]:
+                errors.append(
+                    f"{result_location}.recurrence_recovery_steps is inconsistent "
+                    "with recovery_lengths"
+                )
+            budget = _controller_budget(
+                result.get("controller_budget"),
+                location=f"{result_location}.controller_budget",
+                errors=errors,
+            )
+            if budget is not None:
+                budgets.append(budget)
             if condition == "joint_adaptive":
                 recovery = result.get("recurrence_recovery_steps")
                 if type(recovery) is not int:
@@ -866,6 +1099,19 @@ def _validate_seed_and_aggregate_consistency(
                     )
                 else:
                     recurrence_steps.append(recovery)
+                if phase_rewards is not None:
+                    joint_phase_rewards.append(phase_rewards)
+                if probe_matrix is not None:
+                    joint_probe_matrices.append(probe_matrix)
+                for field_name, destination in (
+                    ("mean_forgetting", joint_mean_forgetting),
+                    ("maximum_forgetting", joint_maximum_forgetting),
+                    ("interference_forgetting", joint_interference_forgetting),
+                    ("mean_stability_gap", joint_mean_stability_gap),
+                ):
+                    numeric = _finite_number(result.get(field_name))
+                    if numeric is not None:
+                        destination.append(numeric)
 
     if tuple(observed_seeds) != _EXPECTED_EVIDENCE_SEEDS:
         errors.append(
@@ -896,6 +1142,79 @@ def _validate_seed_and_aggregate_consistency(
                 )
     else:
         errors.append("content.aggregate.mean_prequential_reward must be an object")
+
+    seed_count = len(_EXPECTED_EVIDENCE_SEEDS)
+    if len(joint_phase_rewards) == seed_count:
+        expected_phase_rewards = np.mean(
+            np.asarray(joint_phase_rewards, dtype=np.float64), axis=0
+        )
+        if not _aggregate_array_matches(
+            aggregate.get("joint_adaptive_phase_rewards"), expected_phase_rewards
+        ):
+            errors.append(
+                "content.aggregate.joint_adaptive_phase_rewards is inconsistent "
+                "with seed summaries"
+            )
+    if len(joint_probe_matrices) == seed_count:
+        expected_probe_matrix = np.mean(
+            np.asarray(joint_probe_matrices, dtype=np.float64), axis=0
+        )
+        if not _aggregate_array_matches(
+            aggregate.get("joint_adaptive_read_only_probe_matrix"),
+            expected_probe_matrix,
+        ):
+            errors.append(
+                "content.aggregate.joint_adaptive_read_only_probe_matrix is "
+                "inconsistent with seed summaries"
+            )
+        if not _numbers_match(
+            aggregate.get("recurrent_a_probe_reward"),
+            float(expected_probe_matrix[-1, 0]),
+        ):
+            errors.append(
+                "content.aggregate.recurrent_a_probe_reward is inconsistent "
+                "with seed summaries"
+            )
+    scalar_reductions = (
+        ("mean_forgetting", joint_mean_forgetting, np.mean),
+        ("maximum_forgetting", joint_maximum_forgetting, np.max),
+        ("mean_interference_forgetting", joint_interference_forgetting, np.mean),
+        ("mean_stability_gap", joint_mean_stability_gap, np.mean),
+    )
+    for field_name, values, reduction in scalar_reductions:
+        if len(values) == seed_count and not _numbers_match(
+            aggregate.get(field_name), float(reduction(values))
+        ):
+            errors.append(
+                f"content.aggregate.{field_name} is inconsistent with seed summaries"
+            )
+
+    expected_result_count = seed_count * len(_EXPECTED_CONDITIONS)
+    resources = aggregate.get("resource_budget")
+    if not isinstance(resources, Mapping) or set(resources) != {
+        *_EXPECTED_CONTROLLER_BUDGET,
+        "identical_across_conditions",
+    }:
+        errors.append("content.aggregate.resource_budget keys do not match the v1 schema")
+    elif len(budgets) == expected_result_count:
+        expected_identical = all(budget == budgets[0] for budget in budgets[1:])
+        for index, field_name in enumerate(_EXPECTED_CONTROLLER_BUDGET):
+            if resources.get(field_name) != budgets[0][index]:
+                errors.append(
+                    f"content.aggregate.resource_budget.{field_name} is inconsistent "
+                    "with seed summaries"
+                )
+        if resources.get("identical_across_conditions") is not expected_identical:
+            errors.append(
+                "content.aggregate.resource_budget identical-across-conditions "
+                "declaration is inconsistent with seed summaries"
+            )
+    finite_declaration = aggregate.get("all_scientific_and_timing_values_finite")
+    if finite_declaration is not True:
+        errors.append(
+            "content.aggregate finiteness declaration is inconsistent with "
+            "validated seed summaries"
+        )
 
     confidence = _finite_number(config.get("confidence_level"))
     resamples = config.get("bootstrap_resamples")
@@ -1039,6 +1358,67 @@ def _validate_seed_and_aggregate_consistency(
                 )
 
 
+def _validate_operational_timing_primitives(
+    value: object,
+    *,
+    maximum_update_latency_ms: object,
+    errors: list[str],
+) -> None:
+    location = "operational_diagnostics.condition_timings"
+    if type(value) is not list:
+        errors.append(f"{location} must be an array")
+        return
+    expected_pairs = [
+        (seed, condition)
+        for seed in _EXPECTED_EVIDENCE_SEEDS
+        for condition in _EXPECTED_CONDITIONS
+    ]
+    if len(value) != len(expected_pairs):
+        errors.append(f"{location} must contain exactly 90 condition records")
+    observed_pairs: list[tuple[int, str]] = []
+    p95_latencies: list[float] = []
+    expected_fields = {
+        "seed",
+        "condition",
+        "wall_seconds",
+        "mean_step_latency_ms",
+        "mean_update_latency_ms",
+        "p95_update_latency_ms",
+    }
+    for index, raw_timing in enumerate(value):
+        record_location = f"{location}[{index}]"
+        if type(raw_timing) is not dict or set(raw_timing) != expected_fields:
+            errors.append(f"{record_location} keys do not match the v1 schema")
+            continue
+        seed = raw_timing.get("seed")
+        condition = raw_timing.get("condition")
+        if type(seed) is not int or type(condition) is not str:
+            errors.append(f"{record_location} seed/condition identity is invalid")
+        else:
+            observed_pairs.append((seed, condition))
+        for field_name in (
+            "wall_seconds",
+            "mean_step_latency_ms",
+            "mean_update_latency_ms",
+            "p95_update_latency_ms",
+        ):
+            numeric = _finite_number(raw_timing.get(field_name))
+            if numeric is None or numeric < 0.0:
+                errors.append(
+                    f"{record_location}.{field_name} must be finite and nonnegative"
+                )
+            elif field_name == "p95_update_latency_ms":
+                p95_latencies.append(numeric)
+    if observed_pairs != expected_pairs:
+        errors.append(f"{location} must match the held-out seed/condition schedule")
+    if len(p95_latencies) == len(expected_pairs) and not _numbers_match(
+        maximum_update_latency_ms,
+        float(np.max(p95_latencies)),
+    ):
+        errors.append(
+            "operational_diagnostics.maximum_update_latency_ms is inconsistent "
+            "with condition timing primitives"
+        )
 def _validate_scientific_check_bindings(
     checks: Mapping[str, Mapping[str, object]],
     *,
@@ -1362,6 +1742,14 @@ def validate_evidence_artifact(
                 "operational_diagnostics.passed is inconsistent with its checks"
             )
         operational_passed = computed_passed
+
+        _validate_operational_timing_primitives(
+            operational.get("condition_timings"),
+            maximum_update_latency_ms=operational.get(
+                "maximum_update_latency_ms"
+            ),
+            errors=errors,
+        )
 
         latency = _finite_number(
             operational.get("maximum_update_latency_ms")

--- a/tests/test_continual_multiagent_aggregate_reconstruction.py
+++ b/tests/test_continual_multiagent_aggregate_reconstruction.py
@@ -1,0 +1,128 @@
+"""Fail-closed reconstruction regressions for continual-multiagent evidence."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+import alberta_framework.evaluation.continual_multiagent_artifact as artifact_module
+
+pytestmark = pytest.mark.unit
+
+_PINNED_ARTIFACT = (
+    Path(__file__).resolve().parents[1] / "outputs/continual_multiagent/evidence.json"
+)
+
+
+def _source_projected_scratch() -> dict[str, object]:
+    """Return a nonpromoting scratch copy bound to the current validator source."""
+
+    artifact = json.loads(_PINNED_ARTIFACT.read_text(encoding="utf-8"))
+    content = artifact["content"]
+    content["source_provenance"] = artifact_module._source_provenance()
+    artifact["content_digest"]["sha256"] = artifact_module.scientific_content_sha256(content)
+    assert artifact_module.validate_evidence_artifact(artifact).accepted
+    return artifact
+
+
+def _rehash(artifact: dict[str, object]) -> None:
+    content = artifact["content"]
+    artifact["content_digest"]["sha256"] = artifact_module.scientific_content_sha256(content)
+
+
+def test_rehashed_primitive_summary_corruption_fails_closed() -> None:
+    fabricated = copy.deepcopy(_source_projected_scratch())
+    content = fabricated["content"]
+    summaries = content["seed_summaries"]
+    for seed in summaries:
+        joint = seed["conditions"]["joint_adaptive"]
+        joint["phase_mean_rewards"][0] = -999.0
+        joint["read_only_probe_matrix"][2][0] = -999.0
+        joint["mean_forgetting"] = 999.0
+        joint["maximum_forgetting"] = 999.0
+        joint["interference_forgetting"] = 999.0
+        joint["mean_stability_gap"] = -999.0
+        joint["controller_budget"] = {
+            "state_scalars": 999,
+            "state_bytes": 999,
+            "action_scalars_per_step": 999,
+        }
+    _rehash(fabricated)
+
+    validation = artifact_module.validate_evidence_artifact(fabricated)
+
+    assert not validation.valid
+    assert not validation.accepted
+    assert any("inconsistent with seed summaries" in error for error in validation.errors)
+
+
+def test_rehashed_coordinated_aggregate_forgery_fails_closed() -> None:
+    fabricated = copy.deepcopy(_source_projected_scratch())
+    content = fabricated["content"]
+    aggregate = content["aggregate"]
+    aggregate.update(
+        {
+            "recurrent_a_probe_reward": 0.95,
+            "mean_forgetting": 0.04,
+            "maximum_forgetting": 999.0,
+            "mean_stability_gap": 0.19,
+        }
+    )
+    aggregate["resource_budget"] = {
+        "state_scalars": 999,
+        "state_bytes": 999,
+        "action_scalars_per_step": 999,
+        "identical_across_conditions": True,
+    }
+    forged_actuals = {
+        "recurrent_a_probe_reward": 0.95,
+        "mean_forgetting": 0.04,
+        "mean_stability_gap": 0.19,
+        "budgets_identical": 1.0,
+    }
+    for check in content["acceptance"]["checks"]:
+        if check["name"] in forged_actuals:
+            check["actual"] = forged_actuals[check["name"]]
+    _rehash(fabricated)
+
+    validation = artifact_module.validate_evidence_artifact(fabricated)
+
+    assert not validation.valid
+    assert not validation.accepted
+    assert any("inconsistent with seed summaries" in error for error in validation.errors)
+
+
+def test_rehashed_finiteness_and_budget_declarations_are_reconstructed() -> None:
+    fabricated = copy.deepcopy(_source_projected_scratch())
+    content = fabricated["content"]
+    aggregate = content["aggregate"]
+    aggregate["all_scientific_and_timing_values_finite"] = False
+    aggregate["resource_budget"]["identical_across_conditions"] = False
+    for check in content["acceptance"]["checks"]:
+        if check["name"] in {"all_values_finite", "budgets_identical"}:
+            check["actual"] = 0.0
+            check["passed"] = False
+    content["acceptance"]["passed"] = False
+    fabricated["operational_diagnostics"]["overall_acceptance_passed"] = False
+    _rehash(fabricated)
+
+    validation = artifact_module.validate_evidence_artifact(fabricated)
+
+    assert not validation.valid
+    assert not validation.accepted
+    assert any("finiteness" in error or "resource budget" in error for error in validation.errors)
+
+
+def test_operational_finiteness_is_reconstructed_from_condition_timings() -> None:
+    fabricated = copy.deepcopy(_source_projected_scratch())
+    timings = fabricated["operational_diagnostics"]["condition_timings"]
+    timings[0]["p95_update_latency_ms"] = None
+
+    validation = artifact_module.validate_evidence_artifact(fabricated)
+
+    assert not validation.valid
+    assert not validation.accepted
+    assert any("must be finite and nonnegative" in error for error in validation.errors)


### PR DESCRIPTION
## Outcome

Makes the `recurring_multiagent_coadaptation` v1 evidence validator fail closed by reconstructing declared aggregates and integrity booleans from serialized seed/condition records.

The defect was reproduced failing-test-first on an in-memory scratch copy of the pinned artifact: primitive summaries could be corrupted to extreme values while untouched aggregates remained accepted, and aggregate/check values could be forged while untouched seed summaries remained accepted. At exact head `aecc6cadb97170306e949e29ab5c230518a6a4d6`, both directions are rejected.

## Changes

- Enforces exact v1 aggregate, condition, controller-budget, and timing schemas.
- Reconstructs per-seed final performance, forgetting, backward transfer, interference, and recurrence fields from probe matrices/recovery vectors.
- Reconstructs aggregate phase/probe arrays, forgetting/stability summaries, resource declarations, recurrence statistics, paired intervals, and maximum timing from lower-level records.
- Rejects nonfinite/malformed scientific and operational primitives.
- Adds focused hostile regressions for primitive corruption, aggregate forgery, boolean forgery, and nonfinite timing.

## Exact-head verification

<!-- evidence-head:aecc6cadb97170306e949e29ab5c230518a6a4d6 -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/user-attachments/files/31367960/multiagent-validator-verification.log (`sha256:d169f2661f7f2b022d00293ec496b08ab19bf62fecaac736e6ab81294ecc6188`)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/user-attachments/files/31367963/multiagent-validator-domain-artifact.json (`sha256:65e5d63cf30686adf7675d18ac5ff145aceb43e02a6d91a3d9db695d8c1223a0`)

Commands:

```bash
.venv/bin/python -m pytest tests/test_continual_multiagent_aggregate_reconstruction.py tests/test_continual_multiagent_sha256_hostile.py tests/test_continual_multiagent_cli.py tests/test_continual_multiagent_validation.py tests/test_continual_multiagent_seed_recovery_hostile.py tests/test_continual_multiagent_finite_number_hostile.py tests/test_continual_multiagent_name_hostile.py tests/test_continual_multiagent_benchmark.py tests/test_evidence_manifest.py -q -o addopts=""
.venv/bin/python -m ruff check alberta_framework/evaluation/continual_multiagent_artifact.py tests/test_continual_multiagent_aggregate_reconstruction.py
.venv/bin/python -m mypy alberta_framework/evaluation/continual_multiagent_artifact.py
PYTHONPATH=. .venv/bin/python /tmp/asi-multiagent-reproduce.py
sha256sum outputs/continual_multiagent/evidence.json
```

Results:

- Relevant matrix: 263 passed, 2 skipped in 26.12 s; 27.65 s wall; 478,240 KiB maximum RSS.
- Ruff: passed. Targeted mypy: passed.
- Scratch source-projected baseline: `valid=True accepted=True`.
- Primitive-only corruption: before `valid=True accepted=True`; after `valid=False accepted=False`.
- Aggregate-only forgery: before `valid=True accepted=True`; after `valid=False accepted=False`.
- False acceptances across the two reproduced directions: 2/2 → 0/2 (delta -2).
- Pinned artifact SHA-256 before/after: `5ed1410e77e8c140e9e381f272c630b9fe88d9c16880447ab3b47a8a85613bd8`; it was not modified.

## Evidence status and limitations

This is a deterministic measurement-integrity repair, not a benchmark comparison. Baseline/candidate mean and spread are therefore not applicable; the measured response is validator acceptance in two forgery directions. No scientific run occurred and no new seeds were consumed. The scratch reproduction only inspected the artifact's historical held-out schedule, seeds 30–59 (`n=30`).

Development-only and nonpromoting. Because this validator is a registered source, changing it deliberately leaves persisted evidence invalid until an independently frozen protocol is run and ratified; this PR does not regenerate or promote the claim. The v1 artifact lacks full online reward traces, so phase and stability summaries cannot be reconstructed from per-step observations. Digests/source hashes establish consistency, not authenticated execution.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-asi
Attribution status: self-reported
— [multiagent-validator-fail-closed]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0SF4C80FT9XAJ83ATYFD4MT","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T08:45:28.192Z","completed_at":"2026-08-24T08:46:32.535Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T08:45:28.856Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b4578716b95e46a00222545d6d4076eaa942853114de6f1b076873e83970b3b7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"57d7d377-2a23-4363-973d-956428a2bda8","object_id":"sha256:b4578716b95e46a00222545d6d4076eaa942853114de6f1b076873e83970b3b7","sha256":"b4578716b95e46a00222545d6d4076eaa942853114de6f1b076873e83970b3b7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"uIxo16CDQAKD-NlKi3v6PkWF9KQaat6xLqdbfvgNWM_Yq44fKu4MpBxgQqtLzEHDZGexcTSUZeeAC65oBMmaCA"}} -->
