### PR TITLE
fix(core): bound candidate rebound depth

### DIFF
--- a/alberta_framework/core/compositional_features.py
+++ b/alberta_framework/core/compositional_features.py
@@ -4315,7 +4315,7 @@ class CompositionalFeatureLearner:
                 references_later_cascade,
                 references_active_change,
             )
-            rebound_depth = (
+            rebound_depth = jnp.minimum(
                 jnp.maximum(
                     depth[safe_candidate_pa],
                     jnp.where(
@@ -4324,7 +4324,8 @@ class CompositionalFeatureLearner:
                         jnp.asarray(0, dtype=jnp.int32),
                     ),
                 )
-                + 1
+                + 1,
+                self._max_depth,
             ).astype(jnp.int32)
             candidate_depth = jnp.where(
                 candidate_rebound_mask,

--- a/tests/test_compositional_features.py
+++ b/tests/test_compositional_features.py
@@ -515,6 +515,47 @@ class TestCompositionalFeatureLearner:
         assert int(result.promoted_candidate) == 0
         assert int(result.state.ops[2]) == OP_TANH
 
+    def test_candidate_rebound_at_depth_limit_does_not_poison_future_updates(self) -> None:
+        """Rebinding through a promoted max-depth parent must remain valid."""
+        learner = CompositionalFeatureLearner(
+            n_features=5,
+            n_tasks=1,
+            candidate_count=2,
+            step_size_output=0.0,
+            utility_decay=0.99,
+            replacement_interval=1,
+            min_feature_age=0,
+            candidate_min_age=0,
+            promotion_margin=0.0,
+            max_depth=2,
+            use_obgd=False,
+        )
+        state = learner.init(feature_dim=2, key=jr.key(27)).replace(  # type: ignore[attr-defined]
+            ops=jnp.array([OP_RAW, OP_RAW, OP_PRODUCT, OP_PRODUCT, OP_PRODUCT]),
+            parent_a=jnp.array([0, 1, 0, 0, 2], dtype=jnp.int32),
+            parent_b=jnp.array([-1, -1, 1, 1, 1], dtype=jnp.int32),
+            depth=jnp.array([0, 0, 1, 1, 2], dtype=jnp.int32),
+            utilities=jnp.array([0.0, 0.0, 10.0, 0.0, 10.0], dtype=jnp.float32),
+            ages=jnp.full((5,), 10, dtype=jnp.int32),
+            candidate_ops=jnp.array([OP_PRODUCT, OP_PRODUCT], dtype=jnp.int32),
+            candidate_parent_a=jnp.array([2, 3], dtype=jnp.int32),
+            candidate_parent_b=jnp.array([0, 1], dtype=jnp.int32),
+            candidate_depth=jnp.array([2, 2], dtype=jnp.int32),
+            candidate_utilities=jnp.array([100.0, 1.0], dtype=jnp.float32),
+            candidate_ages=jnp.full((2,), 10, dtype=jnp.int32),
+        )
+        observation = jnp.array([1.0, -1.0], dtype=jnp.float32)
+        target = jnp.array([0.0], dtype=jnp.float32)
+
+        promotion = learner.update(state, observation, target)
+        subsequent = learner.update(promotion.state, observation, target)
+
+        assert bool(promotion.update_applied)
+        assert bool(promotion.curation_trace.candidate_rebound_mask[1])
+        assert int(promotion.state.candidate_depth[1]) <= learner.max_depth
+        assert bool(subsequent.update_applied)
+        assert int(subsequent.state.step_count) == int(promotion.state.step_count) + 1
+
     def test_tanh_family_quota_protects_smooth_scaffold(self) -> None:
         """Family protection can keep the last smooth basis from early churn."""
         learner = CompositionalFeatureLearner(


### PR DESCRIPTION
## Outcome

Prevents a candidate rebound from committing `max_depth + 1` and permanently freezing `CompositionalFeatureLearner` at its own source-state validity gate.

The failure was reproduced before the fix with one deterministic promotion transaction at `max_depth=2`: a candidate referencing the replaced slot rebounded from depth 2 to depth 3, the invalid depth was committed, and the immediately subsequent update returned `update_applied=False` without advancing `step_count`. Head `7d4295e87820b7559d28ea5dd9b40ac5dd189d9c` bounds the recomputed depth, so the same next update succeeds and advances.

## Change

- Clamp candidate rebound depth to the configured `max_depth` before committing state.
- Add a failing-test-first regression covering the promotion, rebound, committed bound, and next-update progress.

Promotion compatibility still independently recomputes depth from current parents, so a rebound candidate whose parents imply an over-limit active composition remains ineligible for promotion.

## Exact-head verification

<!-- evidence-head:7d4295e87820b7559d28ea5dd9b40ac5dd189d9c -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/user-attachments/files/31368811/compositional-depth-verification.log (`sha256:628f6cf9081b708162c25054144768cdb0884d64c274557e4de71d8fb119a4b2`)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/user-attachments/files/31368809/compositional-depth-domain-artifact.json (`sha256:aab35cf70668edbfd4a5057c3b5267049400c83006db57356c8a3dd3ab043709`)

Commands:

```bash
PYTHONPATH=. .venv/bin/python /tmp/asi-compositional-depth-reproduce.py
.venv/bin/python -m pytest tests/test_compositional_features.py tests/test_compositional_features_str_hostile.py tests/test_compositional_feature_scalar_residuals.py -q -o addopts=""
.venv/bin/python -m ruff check alberta_framework/core/compositional_features.py tests/test_compositional_features.py
.venv/bin/python -m mypy alberta_framework/core/compositional_features.py
```

Measured parent → head outcome:

- Committed rebound depth: `3` → `2` under `max_depth=2`.
- Depth-limit violations: `1` → `0`.
- Immediately subsequent update accepted: `False` → `True`.
- Immediately subsequent step progress: `0` → `1`.
- Relevant tests: 93 passed in 55.90 s; 58.92 s wall; 1,237,376 KiB maximum RSS.
- Ruff and targeted mypy passed.

## Evidence status and limitations

This is a deterministic state-machine defect, not a stochastic benchmark comparison. The reproduction uses JAX key 27 solely to construct one transaction (`n=1`); it is neither a tuning nor evaluation seed and consumes no scientific resource. Baseline/candidate mean and spread are not applicable. No `outputs/` artifact was created or modified.

Development-only and nonpromoting. The supplied 9/12 (`max_depth=2`) and 3/8 (`max_depth=4`) incidence figures did not include an exact learner configuration, so this PR does not claim them. It establishes the exact overflow/stall transition and its immediate recovery, not a benchmark benefit or scientific result.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-asi
Attribution status: self-reported
— [compositional-depth-stall]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0SFYC7WTE6S30F6KER29EQ3","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T08:59:40.157Z","completed_at":"2026-08-24T09:11:54.946Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T08:59:40.362Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0439cfd9e9826e42d3ddad77bf2859ddab9e829a0a5e1a4759ad68d14cffd855","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b4550728-f2cb-44c3-bc7e-6f28fb5aec0a","object_id":"sha256:0439cfd9e9826e42d3ddad77bf2859ddab9e829a0a5e1a4759ad68d14cffd855","sha256":"0439cfd9e9826e42d3ddad77bf2859ddab9e829a0a5e1a4759ad68d14cffd855"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"oqGf6_C4y28VylXEJwk8aho2LyBtA8T3vQaKzco4eVcRV9kkO_Z7OLnsDxCDSuRIvAPsLxKs852f5rv9ahRFBQ"}} -->
