### PR TITLE
fix(core): canonicalize square interaction pairs

### DIFF
--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -1502,8 +1502,6 @@ class FixedBudgetInteractionLearner:
         return self._canonicalize(left, right)
 
     def _canonicalize(self, left: Array, right: Array) -> tuple[Array, Array]:
-        if self._include_squares:
-            return left, right
         return jnp.minimum(left, right), jnp.maximum(left, right)
 
     def _live_descriptor_mask(

--- a/tests/test_feature_discovery.py
+++ b/tests/test_feature_discovery.py
@@ -1448,6 +1448,27 @@ class TestFixedBudgetInteractionLearner:
         chex.assert_tree_all_finite(result.metrics)
         assert int(result.state.step_count) == 1
 
+    def test_square_enabled_init_produces_live_pairs_and_accepts_updates(self) -> None:
+        learner = FixedBudgetInteractionLearner(
+            n_features=8,
+            n_tasks=2,
+            candidate_count=3,
+            replacement_interval=10,
+            include_squares=True,
+        )
+        state = learner.init(feature_dim=4, key=jr.key(10))
+
+        result = learner.update(
+            state,
+            jnp.array([0.1, -0.2, 0.3, 0.4], dtype=jnp.float32),
+            jnp.array([1.0, -1.0], dtype=jnp.float32),
+        )
+
+        assert not bool(result.update_rejected)
+        assert bool(jnp.all(state.feature_left <= state.feature_right))
+        assert bool(jnp.all(state.candidate_left <= state.candidate_right))
+        assert int(result.state.step_count) == 1
+
     def test_max_utility_aggregation_does_not_dilute_rare_task_head(self) -> None:
         mean_learner = FixedBudgetInteractionLearner(
             n_features=1,


### PR DESCRIPTION
## Outcome

Fixes `FixedBudgetInteractionLearner(include_squares=True)` initializing unordered active descriptors that its own live mask rejects, freezing the learner before its first update.

At parent `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, deterministic key 10 produced 2/8 unordered active pairs; `state_valid=False`, the first update was rejected, and `step_count` remained 0. Exact head `8dbf0cba96c0f36c43bb8d36b4304a8ada31a981` canonicalizes those pairs; all 8 are live, the update succeeds, and `step_count` advances to 1.

## Change

- Canonicalize random interaction descriptors with component-wise min/max whether squares are enabled or disabled.
- Add a failing-test-first initialized-state regression that requires ordered active/candidate pairs and successful first-update progress.

## Exact-head verification

<!-- evidence-head:8dbf0cba96c0f36c43bb8d36b4304a8ada31a981 -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/user-attachments/files/31369595/interaction-square-verification.log (`sha256:53bb99f2ada0bbfba5949394663cc2466b74d53cccc5a5066c953e6834dc16e1`)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/user-attachments/files/31369593/interaction-square-domain-artifact.json (`sha256:2d8a7359111707de1227c913aefb9de5d2b638a02556d91b03e35ecbb2550087`)

Commands:

```bash
PYTHONPATH=. .venv/bin/python /tmp/asi-interaction-square-reproduce.py
.venv/bin/python -m pytest tests/test_feature_discovery.py::TestFixedBudgetInteractionLearner tests/test_interaction_feature_validation.py tests/test_interaction_features_update_working_set.py tests/test_interaction_features_candidate_str_hostile.py tests/test_interaction_feature_loop_steps.py -q -o addopts=""
.venv/bin/python -m ruff check alberta_framework/core/interaction_features.py tests/test_feature_discovery.py
.venv/bin/python -m mypy alberta_framework/core/interaction_features.py
```

Measured parent → head outcome:

- Unordered active descriptors: `2/8` → `0/8`.
- Initialized state valid: `False` → `True`.
- First update applied: `False` → `True`.
- First-update step count: `0` → `1`.
- Counted verification: 123 passed in 38.38 s; 40.89 s wall; 857,660 KiB maximum RSS.
- Ruff and targeted mypy passed.

## Evidence status, deviations, and limitations

This is a deterministic initialization/validity defect, not a stochastic benchmark. Key 10 constructs one transaction (`n=1`); it is neither tuning nor evaluation and consumes no scientific seed. Baseline/candidate mean and spread are not applicable. No `outputs/` artifact was created or modified.

Two broader horizon/throughput invocations were interrupted after several minutes without completion and are excluded from passing evidence; neither printed a failure before interruption. The bounded 123-test result above is the claimed verification.

Development-only and nonpromoting. `interaction_features.py` is registered by `recurring_pair_features` and `scale_robust_pair_features`; changing it deliberately leaves persisted evidence fail-closed until independently frozen reruns. This PR does not regenerate, ratify, or promote either claim, and it establishes first-update liveness rather than learning or benchmark benefit.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-asi
Attribution status: self-reported
— [interaction-square-order]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0SH5HKWWAS2GYXZX47YWX4M","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T09:21:03.612Z","completed_at":"2026-08-24T09:34:31.311Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T09:21:03.817Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"40ed603b1e58c8550ce95bfd9b7dda592d801a0330f67562b81471acb63f417a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"643beff3-9a11-4136-9ca9-95feeb7d7861","object_id":"sha256:40ed603b1e58c8550ce95bfd9b7dda592d801a0330f67562b81471acb63f417a","sha256":"40ed603b1e58c8550ce95bfd9b7dda592d801a0330f67562b81471acb63f417a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"zh7lUkEaPkw_am-CBKC4_XOXXnNpE8R_XfrnD6G-e298ZlSk3y4l59c3SGbu3idlEaJHE2kdlvwPZmt3eklBDA"}} -->
