### PR TITLE
fix(core): domain-separate guarded dreaming RNG

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -179,6 +179,7 @@ _PROTOTYPE_CHECKPOINT_SCHEMA_V2 = "alberta.prototype_agent.v2"
 _PROTOTYPE_CHECKPOINT_SCHEMA_V1 = "alberta.prototype_agent.v1"
 _PROTOTYPE_EMPTY_ARRAY_CODEC = "alberta.prototype_agent.empty_array_projection.v1"
 _PROTOTYPE_SUPPORTED_PRNG_IMPLS = frozenset({"threefry2x32", "rbg"})
+_GUARDED_DREAM_STREAM_TAG = 0x44524D53
 _DREAM_NEXT_OBSERVATION_STREAM_TAG = 0x44524D4F
 _PROTOTYPE_V2_REPLAY_MIGRATION_TAG = 0x50525632
 _PROTOTYPE_FEATURE_LIFECYCLE_KEY_TAG = 0x50464C43
@@ -188,6 +189,11 @@ _INT32_MAX = 2**31 - 1
 # ---------------------------------------------------------------------------
 # Standalone utility
 # ---------------------------------------------------------------------------
+
+
+def _guarded_dream_rng_root(stored_real_key: Array) -> Array:
+    """Derive dreaming randomness without consuming the future real stream."""
+    return jr.fold_in(stored_real_key, _GUARDED_DREAM_STREAM_TAG)
 
 
 def feature_to_subtask_specs(
@@ -5457,13 +5463,14 @@ class PrototypeAgent:
         rng_key: Array,
     ) -> tuple[OaKState, Float[Array, " n_dreams"]]:
         n_prim = self._config.oak.n_primitive_actions
+        dream_root = _guarded_dream_rng_root(rng_key)
         sample_one_hot = (
             self._config.dream_next_observation_mode == "sample_one_hot"
         )
         dream_observation_root = (
-            jr.fold_in(rng_key, _DREAM_NEXT_OBSERVATION_STREAM_TAG)
+            jr.fold_in(dream_root, _DREAM_NEXT_OBSERVATION_STREAM_TAG)
             if sample_one_hot
-            else rng_key
+            else dream_root
         )
 
         def _dream_step(
@@ -5536,7 +5543,7 @@ class PrototypeAgent:
 
         (new_oak_state, _), dream_td_errors = jax.lax.scan(
             _dream_step,
-            (oak_state, rng_key),
+            (oak_state, dream_root),
             jnp.arange(self._config.n_dreams_per_step),
         )
         return new_oak_state, dream_td_errors

--- a/tests/test_prototype_dream_isolation.py
+++ b/tests/test_prototype_dream_isolation.py
@@ -18,12 +18,38 @@ from alberta_framework.core.options import STOMPConfig, SubtaskSpec
 from alberta_framework.core.prototype_agent import (
     PrototypeAgent,
     PrototypeAgentConfig,
+    _guarded_dream_rng_root,
     _sample_one_hot_dream_observation,
 )
 from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
 
 OBS = jnp.array([1.0, -0.5], dtype=jnp.float32)
 N_DREAMS = 3
+
+
+def test_guarded_dream_rng_root_is_disjoint_from_future_real_stream() -> None:
+    stored_real_key = jr.key(5474)
+    dream_root = _guarded_dream_rng_root(stored_real_key)
+
+    assert not bool(jnp.array_equal(dream_root, stored_real_key))
+    dream_keys = []
+    dream_key = dream_root
+    for _ in range(N_DREAMS):
+        dream_key, sample_key, action_key = jr.split(dream_key, 3)
+        dream_keys.extend((sample_key, action_key))
+
+    future_real_key = stored_real_key
+    for _ in range(N_DREAMS + 1):
+        future_real_key, explore_key, noise_key = jr.split(future_real_key, 3)
+        assert not bool(jnp.array_equal(dream_root, future_real_key))
+        for dream_key in dream_keys:
+            assert not bool(jnp.array_equal(dream_key, explore_key))
+            assert not bool(jnp.array_equal(dream_key, noise_key))
+
+    chex.assert_trees_all_equal(
+        dream_root,
+        _guarded_dream_rng_root(stored_real_key),
+    )
 
 
 def _dream_config(
@@ -275,7 +301,7 @@ def test_sample_mode_does_not_shift_legacy_anchor_or_action_streams(
     )
 
     expected = []
-    key = root_key
+    key = _guarded_dream_rng_root(root_key)
     for _ in range(N_DREAMS):
         key, sample_key, action_key = jr.split(key, 3)
         anchor_index = jr.randint(

--- a/tests/test_prototype_transition_contract.py
+++ b/tests/test_prototype_transition_contract.py
@@ -24,6 +24,7 @@ from alberta_framework.core.prototype_agent import (
     PrototypeAgentState,
     PrototypeTransition,
     PrototypeUpdateResult,
+    _guarded_dream_rng_root,
     _sample_one_hot_dream_observation,
 )
 from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
@@ -704,7 +705,9 @@ def test_dream_backup_is_caused_by_predicted_discount(discount: float) -> None:
     assert agent._buffer is not None
     buffer_state = agent._buffer.add(state.buffer_state, initial_obs)
     state = state.replace(buffer_state=buffer_state)
-    action = jnp.array(0, dtype=jnp.int32)
+    dream_root = _guarded_dream_rng_root(jr.key(6))
+    _, _, action_key = jr.split(dream_root, 3)
+    action = jr.randint(action_key, (), 0, 2, dtype=jnp.int32)
     reward = jnp.array(1.2, dtype=jnp.float32)
     transition = DreamTransition(
         observation=initial_obs,


### PR DESCRIPTION
## Summary

- domain-separate guarded Dyna dreaming from STOMP's stored real-action RNG stream
- preserve the stored real key and its future exploration sequence
- add a primitive key-branch regression plus update the transition expectation that had depended on the old alias

## Reproduction

Verified head: `9a3ace748db3c3adc5bc8e6021b4c9d88e75955e`

At base `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, `_run_dreams` and the next real epsilon-greedy selection both begin with `jr.split(stored_key, 3)`. With Threefry seed 5474 and `n=3` offsets:

- baseline: 6/6 dream sample/action branches were bitwise equal to the corresponding future real explore/noise branches
- candidate: 0/6 branches were equal after `jr.fold_in(stored_key, 0x44524D53)`

The candidate derives and advances a private dream root. It does not replace or advance `stomp_state.rng_key`, so the real exploration stream is unchanged.

## Verification

```bash
env PYTHONHASHSEED=0 XLA_PYTHON_CLIENT_PREALLOCATE=false /usr/bin/time -v \
  /root/asi/.venv/bin/python -m pytest \
  tests/test_prototype_dream_isolation.py \
  tests/test_prototype_transition_contract.py -q
```

`38 passed in 59.49s`; wall 62.38 s, user 112.21 s, system 4.17 s, maximum RSS 1,331,852 KiB.

```bash
/root/asi/.venv/bin/python -m ruff check \
  alberta_framework/core/prototype_agent.py \
  tests/test_prototype_dream_isolation.py \
  tests/test_prototype_transition_contract.py
/root/asi/.venv/bin/python -m mypy alberta_framework/core/prototype_agent.py
```

Both passed. The focused regression was written first and initially failed collection because `_guarded_dream_rng_root` did not exist.

## Evidence

<!-- evidence-head:9a3ace748db3c3adc5bc8e6021b4c9d88e75955e -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/user-attachments/files/31371604/prototype-dream-rng-verification.log
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/user-attachments/files/31371605/prototype-dream-rng-domain-artifact.json

Local upload files and SHA-256 digests:

- `prototype-dream-rng-verification.log`: `a8d3d8a068519e65d6b19fb9c29bcd76258cce06f9a8d36dc1e80b052c261db7`
- `prototype-dream-rng-domain-artifact.json`: `38efb2d3e613cfa14ee7076d6ef612ef3ca9ffec37164ff0625a99713f9c0c67`

## Scope and limitations

This is deterministic development-only defect evidence, permanently nonpromoting. It uses seed 5474 and three offsets; no benchmark, held-out, scientific, or promoted-evidence seeds were consumed. It proves removal of a structural key alias, not a performance improvement. `tests/test_prototype_agent.py -k dream` was interrupted after seven displayed passes when its existing JAX-heavy tail produced no output for several minutes, and is not claimed as passing.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-asi
Attribution status: self-reported
— [prototype-dream-key-domain]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0SKFPGHXD8D0FS9BDKF13X7","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T10:01:33.458Z","completed_at":"2026-08-24T10:33:19.838Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T10:01:33.637Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"6c449e282f312d36250d65d8ddb3b5b3f97911b7d829bc1c5d53218d979561de","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"25ad886d-b3ec-45bb-bef5-f1980474ffe2","object_id":"sha256:6c449e282f312d36250d65d8ddb3b5b3f97911b7d829bc1c5d53218d979561de","sha256":"6c449e282f312d36250d65d8ddb3b5b3f97911b7d829bc1c5d53218d979561de"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"rpAEf8tyZf-Hc2nI0gBm4-AOFL14M8mSW9tCg7654r7Boff5pLef5U9gRlSLZAH1XtG12SY5IIYbqFJ0dGt7DA"}} -->
