### PR TITLE
fix(world-model): divide observation targets by the scale the decode multiplies

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -94,6 +94,24 @@ def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
     return validated_float32_scalar(name, value, **bounds)
 
 
+_SMALLEST_NORMAL_FLOAT32 = float(np.finfo(np.float32).tiny)
+
+
+def _validated_normalizing_scale(name: str, value: object) -> float:
+    """Accept only a scale that still divides and multiplies once narrowed to float32.
+
+    A subnormal float32 is returned as an exact zero by every arithmetic operand on
+    the accelerator backends this runs on, so a scale below the smallest normal
+    cannot rescale anything: the head it belongs to is structurally unable to
+    express a change, whatever it predicts. Refusing it here keeps that a
+    construction error rather than a model that converges and predicts nothing.
+    """
+    scale = _validated_config_float(name, value, positive=True)
+    if abs(float(np.float32(scale))) < _SMALLEST_NORMAL_FLOAT32:
+        raise ValueError(f"{name} must remain a normal float32 once narrowed, not a subnormal")
+    return scale
+
+
 def _validated_step_size(name: str, value: object) -> float:
     """Accept an exact zero freeze without silently underflowing learning to zero."""
     if type(value) not in (_ACTUAL_INT_TYPES | _ACTUAL_FLOAT_TYPES):
@@ -304,7 +322,10 @@ class ActionConditionedWorldModelConfig:
         gamma: Maximum environment discount used for clipping predicted
             discounts.
         observation_scale: Per-observation-dimension scale for normalized delta
-            targets. When ``None``, all dimensions use scale ``1``.
+            targets, dividing on encode and multiplying on decode. When ``None``,
+            all dimensions use scale ``1``. Each entry must narrow to a normal
+            float32; a subnormal is flushed by the decode multiply, leaving that
+            head unable to express any change.
         reward_scale: Scalar reward target scale.
         predict_delta: When ``True`` (default), the observation heads are
             trained on the normalized change ``next_obs - obs`` and decoded
@@ -364,9 +385,7 @@ class ActionConditionedWorldModelConfig:
             if len(observation_scale) != observation_dim:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
-                _validated_config_float(
-                    f"observation_scale[{index}]", scale, positive=True
-                )
+                _validated_normalizing_scale(f"observation_scale[{index}]", scale)
                 for index, scale in enumerate(observation_scale)
             )
 
@@ -794,7 +813,12 @@ class ActionConditionedWorldModel:
         discount: Array,
         next_observation: Array,
     ) -> Array:
-        """Build normalized ``[delta_obs, reward, discount]`` targets."""
+        """Build normalized ``[delta_obs, reward, discount]`` targets.
+
+        The observation divisor here is the same ``observation_scale`` the decode in
+        :meth:`_prediction_and_raw_diagnostics` multiplies by, so a head that fits
+        its target reconstructs the delta it was shown.
+        """
         obs = _float32_operand(
             "observation", observation, (self._config.observation_dim,)
         )
@@ -805,12 +829,17 @@ class ActionConditionedWorldModel:
         )
         reward_arr = _float32_operand("reward", reward, ())
         discount_arr = _float32_operand("discount", discount, ())
+        # The divisor is the raw declared scale, not a floored one: the decode in
+        # `_prediction_and_raw_diagnostics` multiplies by the raw value, and a head
+        # that fits a target divided by anything else reconstructs that ratio of the
+        # delta it trained on while still reporting a converged fit. Construction
+        # refuses a scale that does not narrow to a normal float32, which is the only
+        # way this divisor reaches zero.
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
             self._config.predict_delta,
-            (next_obs - obs) / safe_scale,
-            next_obs / safe_scale,
+            (next_obs - obs) / obs_scale,
+            next_obs / obs_scale,
         )
         reward_target = jnp.reshape(
             reward_arr / self._config.reward_scale,

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -204,6 +204,189 @@ def test_action_conditioned_world_model_update_and_prediction_shapes() -> None:
     chex.assert_tree_all_finite(result.prediction_error)
 
 
+_SMALLEST_NORMAL_FLOAT32 = float(np.finfo(np.float32).tiny)
+_BELOW_THE_OLD_FLOOR = [1e-7, 1e-9, 1e-12, 1e-20, 1e-30, _SMALLEST_NORMAL_FLOAT32]
+_PAIRING_SCALES = [1.0, 1e-3, 1e-6, *_BELOW_THE_OLD_FLOOR]
+
+# Every factor below is a power of two and each dimension's observation shares one with
+# its delta, so obs, delta and their sum are exact float32 at any scale the config
+# accepts and no intermediate lands in the subnormal range the backends flush.
+_PAIRING_DIM_FACTORS = (1.0, 2.0)
+_PAIRING_NORMALIZED_OBS = (1.0, 4.0)
+_PAIRING_NORMALIZED_DELTA = (1.0, 4.0)
+
+
+def _pairing_scales(scale: float) -> tuple[float, ...]:
+    return tuple(scale * factor for factor in _PAIRING_DIM_FACTORS)
+
+
+def _scale_matched_transition(scale: float) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Return ``(obs, delta, next_obs)`` sized to the per-dimension declared scale.
+
+    The delta is the declared scale times :data:`_PAIRING_NORMALIZED_DELTA`, which is
+    what ``observation_scale`` means: the size of the change the heads are asked to
+    predict, expressed in normalized units.
+    """
+    dim_scales = np.asarray(_pairing_scales(scale), dtype=np.float32)
+    obs = np.asarray(_PAIRING_NORMALIZED_OBS, dtype=np.float32) * dim_scales
+    delta = np.asarray(_PAIRING_NORMALIZED_DELTA, dtype=np.float32) * dim_scales
+    return (
+        jnp.asarray(obs, dtype=jnp.float32),
+        jnp.asarray(delta, dtype=jnp.float32),
+        jnp.asarray(obs + delta, dtype=jnp.float32),
+    )
+
+
+def _pairing_model(scale: float) -> ActionConditionedWorldModel:
+    return ActionConditionedWorldModel(
+        ActionConditionedWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            observation_scale=_pairing_scales(scale),
+            hidden_sizes=(),
+            step_size=0.05,
+            use_layer_norm=False,
+        )
+    )
+
+
+@pytest.mark.parametrize("scale", _PAIRING_SCALES)
+def test_observation_targets_rescale_back_to_the_delta_they_encode(scale: float) -> None:
+    """A head that emits its target exactly must decode to the delta it was shown."""
+    model = _pairing_model(scale)
+    obs, delta, next_obs = _scale_matched_transition(scale)
+    target = model.targets(
+        obs,
+        jnp.asarray(0.25, dtype=jnp.float32),
+        jnp.asarray(0.9, dtype=jnp.float32),
+        next_obs,
+    )
+    decoded = target[:2] * jnp.asarray(_pairing_scales(scale), dtype=jnp.float32)
+    np.testing.assert_array_equal(np.asarray(decoded), np.asarray(delta))
+
+
+@pytest.mark.parametrize("scale", _PAIRING_SCALES)
+def test_observation_targets_are_scale_free(scale: float) -> None:
+    """Declaring the scale of the transition must put the heads on the same targets."""
+    model = _pairing_model(scale)
+    obs, _, next_obs = _scale_matched_transition(scale)
+    target = model.targets(
+        obs,
+        jnp.asarray(0.25, dtype=jnp.float32),
+        jnp.asarray(0.9, dtype=jnp.float32),
+        next_obs,
+    )
+    np.testing.assert_array_equal(
+        np.asarray(target[:2]),
+        np.asarray(_PAIRING_NORMALIZED_DELTA, dtype=np.float32),
+    )
+
+
+@pytest.mark.parametrize("scale", _PAIRING_SCALES)
+def test_observation_targets_stay_finite_across_the_validated_domain(scale: float) -> None:
+    """No accepted scale may turn a representable delta into an infinity or a NaN."""
+    model = _pairing_model(scale)
+    obs, _, next_obs = _scale_matched_transition(scale)
+    chex.assert_tree_all_finite(
+        model.targets(
+            obs,
+            jnp.asarray(0.25, dtype=jnp.float32),
+            jnp.asarray(0.9, dtype=jnp.float32),
+            next_obs,
+        )
+    )
+
+
+def test_converged_prediction_recovers_a_delta_far_below_the_old_floor() -> None:
+    """End-to-end through the real learner: the old floor lost all but 1e-3 of this."""
+    scale = 1e-9
+    model = _pairing_model(scale)
+    state = model.init(jr.key(0))
+    obs, delta, next_obs = _scale_matched_transition(scale)
+    action = jnp.asarray(0, dtype=jnp.float32)
+    reward = jnp.asarray(0.0, dtype=jnp.float32)
+    discount = jnp.asarray(0.0, dtype=jnp.float32)
+    for _ in range(3000):
+        state = model.update(state, obs, action, reward, discount, next_obs).state
+
+    reconstructed = np.asarray(
+        model.predict(state, obs, action).next_observation, dtype=np.float64
+    ) - np.asarray(obs, dtype=np.float64)
+    relative = np.abs(reconstructed / np.asarray(delta, dtype=np.float64) - 1.0)
+    assert float(np.max(relative)) < 1e-4
+
+
+@pytest.mark.parametrize(
+    ("scale", "expected_words"),
+    [
+        ((1.0, 2.0), [0x3DCCCCCE, 0x3DCCCCCD, 0x3E000000, 0x3F733333]),
+        ((1e-3, 2e-3), [0x42C80000, 0x42C7FFFF, 0x3E000000, 0x3F733333]),
+        ((1e-6, 2e-6), [0x47C35001, 0x47C35000, 0x3E000000, 0x3F733333]),
+    ],
+)
+def test_targets_at_and_above_the_old_floor_are_bit_for_bit_unchanged(
+    scale: tuple[float, float], expected_words: list[int]
+) -> None:
+    """Scales the removed floor never touched must not be re-rounded by the change."""
+    model = ActionConditionedWorldModel(
+        ActionConditionedWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            observation_scale=scale,
+            hidden_sizes=(),
+            reward_scale=4.0,
+        )
+    )
+    target = model.targets(
+        jnp.asarray([0.2, -0.1], dtype=jnp.float32),
+        jnp.asarray(0.5, dtype=jnp.float32),
+        jnp.asarray(0.95, dtype=jnp.float32),
+        jnp.asarray([0.3, 0.1], dtype=jnp.float32),
+    )
+    words = np.asarray(target, dtype=np.float32).view(np.uint32)
+    assert [int(word) for word in words] == expected_words
+
+
+@pytest.mark.parametrize("scale", [1e-40, 1e-44, 1.4e-45])
+def test_config_rejects_an_observation_scale_that_narrows_to_a_subnormal(
+    scale: float,
+) -> None:
+    """The decode multiply flushes a subnormal operand, so the head could never move."""
+    assert 0.0 < abs(float(np.float32(scale))) < _SMALLEST_NORMAL_FLOAT32
+    with pytest.raises(ValueError, match="must remain a normal float32 once narrowed"):
+        ActionConditionedWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=(),
+            observation_scale=(scale, 1.0),
+        )
+
+
+def test_config_accepts_the_smallest_normal_observation_scale() -> None:
+    """The rejected boundary is representability, so the smallest normal still builds."""
+    config = ActionConditionedWorldModelConfig(
+        observation_dim=1,
+        n_actions=2,
+        hidden_sizes=(),
+        observation_scale=(_SMALLEST_NORMAL_FLOAT32,),
+    )
+    assert config.observation_scale == (_SMALLEST_NORMAL_FLOAT32,)
+
+
+def test_reward_and_discount_targets_are_untouched_by_the_observation_scale() -> None:
+    """The reward leg was already paired on the raw config value and must stay put."""
+    model = _pairing_model(1e-9)
+    obs, _, next_obs = _scale_matched_transition(1e-9)
+    target = model.targets(
+        obs,
+        jnp.asarray(0.25, dtype=jnp.float32),
+        jnp.asarray(0.9, dtype=jnp.float32),
+        next_obs,
+    )
+    assert float(target[2]) == 0.25 / model.config.reward_scale
+    assert float(target[3]) == float(np.float32(0.9))
+
+
 def test_action_conditioned_world_model_config_roundtrip() -> None:
     config = ActionConditionedWorldModelConfig(
         observation_dim=3,


### PR DESCRIPTION
Fixes #2398.

`ActionConditionedWorldModel.targets()` divides the observation delta by
`jnp.maximum(observation_scale, 1e-6)`, but `_prediction_and_raw_diagnostics()`
multiplies the decoded prediction by the raw `observation_scale`. The two ends of
one normalization use different divisors, so for any declared scale below `1e-6`
a head that fits its target perfectly reconstructs

```
scale / max(scale, 1e-6)
```

of the delta it was trained on — and reports a converged fit while doing it. The
reward leg of the same function already divides and multiplies by the raw
`reward_scale`, so the observation leg is the outlier inside a single function.

## Reproduction

A linear model (`hidden_sizes=()`, `use_layer_norm=False`, `step_size=0.05`,
`predict_delta=True`), trained 3000 steps through the real `update()` and read
back through the real `predict()`, on a transition sized to the scale the field
declares (`obs = 1.0 × scale`, `delta = 2.0 × scale`). Measured on pristine
`c9aba7b5`:

| observation_scale | class | `targets()[0]` | reconstructed delta | true delta | ratio | reported error |
| --- | --- | --- | --- | --- | --- | --- |
| `1e+00` | normal | `2.00000e+00` | `2.00000e+00` | `2.00000e+00` | `1.00000e+00` | `2.27374e-13` |
| `1e-03` | normal | `2.00000e+00` | `2.00000e-03` | `2.00000e-03` | `1.00000e+00` | `4.87891e-19` |
| `1e-06` | normal | `2.00000e+00` | `2.00000e-06` | `2.00000e-06` | `1.00000e+00` | `2.06795e-25` |
| `1e-07` | normal | `2.00000e-01` | `2.00000e-08` | `2.00000e-07` | `1.00000e-01` | `3.24000e-14` |
| `1e-09` | normal | `2.00000e-03` | `1.99996e-12` | `2.00000e-09` | `9.99978e-04` | `3.99200e-18` |
| `1e-12` | normal | `2.00000e-06` | `1.95156e-18` | `2.00000e-12` | `9.75782e-07` | `3.99999e-24` |
| `1e-20` | normal | `2.00000e-14` | `0.00000e+00` | `2.00000e-20` | `0.00000e+00` | `0.00000e+00` |
| `1e-30` | normal | `2.00000e-24` | `0.00000e+00` | `2.00000e-30` | `0.00000e+00` | `0.00000e+00` |
| `1.17549435e-38` | normal | `2.35099e-32` | `0.00000e+00` | `2.35099e-38` | `0.00000e+00` | `0.00000e+00` |
| `1e-38` | subnormal | `2.00000e-32` | `-1.00000e-38` | `2.00000e-38` | `-5.00000e-01` | `0.00000e+00` |
| `1.4e-45` | subnormal | `0.00000e+00` | `-1.40130e-45` | `2.80260e-45` | `-5.00000e-01` | `0.00000e+00` |

The ratio column equals `scale / max(scale, 1e-6)` exactly at every normal
scale, so the two divisors account for the whole loss with nothing left over.
Below roughly `1e-19` the decode product `normalized_delta * obs_scale`
underflows and the head predicts no change at all; the last two rows predict a
next observation of exactly `0.0`, which is why their reconstructed delta is
`-obs`.

### Why it is silent

The normalized fit is exact at every scale in the table. The reported error is
`0.0` on the rows where the head is completely dead. The config validator accepts
the input, no warning is emitted, and no assertion fires — the model, its
diagnostics and its validation all agree that the fit converged. Only comparing
the reconstructed delta against the delta that was fed in exposes it.

### Why the range is reachable

`observation_scale` is validated with `positive=True` and no lower bound, so it
accepts every positive float32 from `3.4e38` down to `1.4e-45`. The floored span
is about 32 decades. The config guards the upper end explicitly ten lines later
and leaves the lower end open. Existing coverage only used `(1.0, 2.0)` and
`(1.0, 2.0, 3.0)`.

## The fix

**Divisor: the raw declared scale.** The field documents a per-dimension scale
for normalized delta targets whose decode adds the predicted change back to the
current observation, so the encode divisor and the decode multiplier are the same
quantity by definition. The reward leg of the same function already works that
way.

Rejected alternatives:

- *Floor the decode multiplier to match the encode.* It would make the decoded
  change larger than the declared scale allows and changes learned behaviour for
  scales that work today.
- *Remove the floor only.* Measured: a subnormal scale then divides by a flushed
  zero and the target becomes `inf`, which is worse than the current silent zero.
- *Clamp the target after dividing.* It hides the same disagreement one layer
  further out and still trains the head on a number the decode cannot invert.

**Domain: each entry must narrow to a normal float32.** On this backend
(`jax 0.11.0`, CPU, x64 disabled) `jnp.asarray` preserves the bits of a float32
subnormal, but any arithmetic flushes a subnormal operand to exact zero. So a
subnormal scale means the decode multiply is already dead and the head cannot
express any change whatever the encode does — a construction error, not a
runtime degradation. `observation_scale=(1e-100,)` already receives that
disposition and is already pinned by an existing test, so this extends a
precedent rather than inventing one.

Note the mechanism is specific: a Python `float` config scalar is not narrowed
(weak typing keeps the double) whereas `jnp.asarray(v, dtype=jnp.float32)` is.
That is why `reward_scale` overflows its quotient at the same boundary while
`observation_scale` flushes its operand.

Two implementation details worth flagging for review:

- The new bound is a separate explicit check rather than a `lower=` argument to
  the shared config-float validator. That validator reports `positive` before
  consulting `lower`, so passing the smallest normal through it would have
  changed the existing `1e-100` rejection message and broken a pinned test.
- `np.finfo(np.float32).tiny` is used rather than `jnp.finfo`, which is an
  untyped call under mypy strict. `np` is already imported and typed in this
  module.

There is no extra runtime work: the jitted target path loses one elementwise
maximum, and the new check runs at construction.

## Verification

Fail-first: the new tests run against pristine `c9aba7b5` in its own tree give
**16 failed, 20 passed** — the pairing identity at all six scales below the
floor, the scale-free target at all six, the trained reconstruction, and all
three subnormal rejections. The finiteness test passes on pristine too, which is
the point: finiteness alone never catches this.

On this branch the ratio is `1.00000e+00` and the target is `2.00000e+00` at
every normal scale down to the smallest normal. Reported error at the scales
where the head was previously alive but wrong:

| observation_scale | before | after |
| --- | --- | --- |
| `1e-07` | `3.24000e-14` | `8.07794e-28` |
| `1e-09` | `3.99200e-18` | `4.43734e-31` |
| `1e-12` | `3.99999e-24` | `1.88079e-37` |

At `1e-20`, `1e-30` and the smallest normal the reported error is `0.0` in both
trees — zero before because the head was dead, zero after because the fit is
exact. The reconstructed-delta column is what separates them, not the reported
error. `1e-38` and `1.4e-45` now raise `ValueError` at construction naming the
offending entry.

`1e+00`, `1e-03` and `1e-06` are identical to all printed digits, and the target
words are bit-identical. Those bit patterns were recorded from the pristine
revision and are pinned in the test as literals rather than recomputed from the
implementation (inputs `obs [0.2, -0.1]`, `next_obs [0.3, 0.1]`, `reward 0.5`,
`discount 0.95`, `reward_scale 4.0`):

| observation_scale | target words |
| --- | --- |
| `(1.0, 2.0)` | `0X3DCCCCCE 0X3DCCCCCD 0X3E000000 0X3F733333` |
| `(1e-3, 2e-3)` | `0X42C80000 0X42C7FFFF 0X3E000000 0X3F733333` |
| `(1e-6, 2e-6)` | `0X47C35001 0X47C35000 0X3E000000 0X3F733333` |

Gates:

- `pytest tests/test_action_conditioned_world_model.py` — 104 passed
- dreaming, latent and ftl world-model suites (12 files) — 339 passed
- world-model, ensemble and qualification suites (12 files) — 285 passed
- `ruff check .` — all checks passed
- `mypy` — 108 errors on this branch, 108 on pristine `main`; unchanged

Consumer sweep across every Python, JSON, YAML, TOML and Markdown file: no
configuration outside `world_model.py`, `latent_world_model.py` and their tests
sets `observation_scale`, so the new refusal cannot break a shipped
configuration.

## Tests added

8 tests, 27 parametrized cases:

- `targets()[:obs_dim] * scale` equals the delta at nine scales
- the normalized target is the same numbers at every scale
- an end-to-end trained reconstruction below the old floor
- the recorded bit patterns at and above the old floor
- subnormal scales refused at construction
- the smallest normal still builds
- the reward and discount target entries unchanged
- targets finite across the validated domain

All factors in the test transition are powers of two and each dimension's
observation factor equals its delta factor, so `obs`, `delta` and their sum are
exact float32 at any accepted scale and no intermediate lands in the flushed
subnormal range. That is what lets the assertions be exact equalities instead of
tolerances.

## Behaviour changes

- A subnormal `observation_scale` entry is now a construction `ValueError`
  instead of a silently dead observation head. Scope: the two subnormal rows of
  the table above.
- For normal scales below `1e-6`, the observation heads now reconstruct the delta
  they were trained on instead of a fraction of it. That is the repair, and no
  shipped configuration is in that range.

## Boundaries deliberately not crossed

- **`reward_scale` at the same boundary.** Its leg is paired, but it stays a
  Python `float` and is not narrowed, so the quotient overflows instead of the
  operand flushing: `reward_scale=1.4e-45` with `reward=0.5` gives an `inf`
  reward target and no complaint. Different mechanism, and an upper bound on
  `|reward| / reward_scale` is not derivable from the config alone, so it wants
  its own disposition.
- **The same `1e-6` floor in the latent encoder** (`latent_world_model.py`).
  That encoder has no decode counterpart, so no pairing is violated; below the
  floor the declared scale is silently ignored and the tanh encoder sees inputs
  it was not conditioned for. Changing it alters learned behaviour for existing
  configurations with no round trip to appeal to, so it must not ride along with
  a pairing fix.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [fix]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0SCHTYH6W591M174KW1XH3G","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T08:00:23.505Z","completed_at":"2026-08-24T10:41:52.804Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T08:00:24.027Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a4ab73d7796f2287b77ca4b034a5c3e90239824bac98d1a26b15a2a098e2f512","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"702bf66a-fa5d-4879-a1b0-876f16a33777","object_id":"sha256:a4ab73d7796f2287b77ca4b034a5c3e90239824bac98d1a26b15a2a098e2f512","sha256":"a4ab73d7796f2287b77ca4b034a5c3e90239824bac98d1a26b15a2a098e2f512"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"EGRB1yMrG4_p5XGpzThgWn8xkEVVYlx2G1jMD-K-igCNxcuUJOe9sCfdhdVx0cFultVTf79bfT4j46VFtUvXCQ"}} -->
