### PR TITLE
fix(core): define UPGD fast-trunk VJP for softmax losses

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -2275,6 +2275,12 @@ class UPGDLearner:
             loss = 0.5 * jnp.sum(sq_masked) / denom
             return loss, (logits_for_loss, hidden_for_loss, loss)
 
+        def trunk_fn(
+            weights: tuple[Array, ...],
+            biases: tuple[Array, ...],
+        ) -> Array:
+            return self._trunk_forward(weights, biases, observation, slope, ln)
+
         if not use_direct_mse_loss:
             (_, (logits, hidden_for_readout, loss_value)), grads = jax.value_and_grad(
                 loss_and_aux_fn,
@@ -2288,13 +2294,6 @@ class UPGDLearner:
             )
             trunk_w_grads, trunk_b_grads, head_w_grads, head_b_grads = grads
         else:
-
-            def trunk_fn(
-                weights: tuple[Array, ...],
-                biases: tuple[Array, ...],
-            ) -> Array:
-                return self._trunk_forward(weights, biases, observation, slope, ln)
-
             raw_hidden, trunk_vjp_fn = jax.vjp(
                 trunk_fn,
                 state.trunk_params.weights,
@@ -2375,6 +2374,12 @@ class UPGDLearner:
             )
             fast_head_b_grads = tuple(fast_logit_grads[i : i + 1] for i in range(self._n_heads))
             if self._readout_fast_trunk_gradient_multiplier > 0.0:
+                if not use_direct_mse_loss:
+                    raw_hidden, trunk_vjp_fn = jax.vjp(
+                        trunk_fn,
+                        state.trunk_params.weights,
+                        state.trunk_params.biases,
+                    )
                 fast_head_cotangent = (
                     fast_head_matrix[:, : raw_hidden.shape[0]].T @ fast_logit_grads
                     if self._readout_input_mode == "hidden_plus_input" and n_trunk > 0

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -1310,6 +1310,39 @@ class TestUpdateMetrics:
         assert float(passive_delta) > 0.0
         assert float(active_delta) > 0.0
 
+    @pytest.mark.parametrize("readout_input_mode", ["hidden", "hidden_plus_input"])
+    def test_two_timescale_softmax_ce_fast_trunk_gradient_updates_on_first_step(
+        self,
+        readout_input_mode: str,
+    ):
+        common = {
+            "n_heads": 3,
+            "hidden_sizes": (4,),
+            "sparsity": 0.0,
+            "step_size": 0.1,
+            "perturbation_sigma": 0.0,
+            "readout_mode": "two_timescale_simplex",
+            "readout_loss_mode": "softmax_ce",
+            "readout_input_mode": readout_input_mode,
+        }
+        learner = UPGDLearner(**common, readout_fast_trunk_gradient_multiplier=1.0)
+        state = learner.init(feature_dim=3, key=jr.key(2383))
+        observation = jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32)
+        target = jnp.array([0.0, 1.0, 0.0], dtype=jnp.float32)
+
+        result = learner.update(state, observation, target)
+
+        assert any(
+            not bool(jnp.array_equal(before, after))
+            for before, after in zip(
+                state.trunk_params.weights,
+                result.state.trunk_params.weights,
+            )
+        )
+        chex.assert_tree_all_finite(result.state.trunk_params)
+        chex.assert_tree_all_finite(result.predictions)
+        chex.assert_tree_all_finite(result.metrics)
+
     def test_two_timescale_fast_head_uses_shared_bounder(self):
         common = {
             "n_heads": 3,


### PR DESCRIPTION
## Summary

- define the trunk forward/VJP path for non-direct readout losses that request a fast-head trunk gradient
- preserve the existing direct-MSE VJP path and avoid the extra VJP when the fast-trunk multiplier is zero
- cover first update for both legal readout-input modes

## Reproduction

Verified head: `f0c1b19930b13fd6fca7d7128d69e1fc19d6a33f`

At base `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, seed 2383, `two_timescale_simplex + softmax_ce + readout_fast_trunk_gradient_multiplier=1.0`:

- `hidden`: first update raises `UnboundLocalError` for `trunk_vjp_fn`
- `hidden_plus_input`: first update raises `UnboundLocalError` for `raw_hidden`
- baseline completion: 0/2; candidate completion: 2/2

Candidate mean losses are 0.8419613 and 0.7486447 respectively; predictions and metrics are finite, and both configurations produce nonzero trunk updates.

## Verification

```bash
env PYTHONHASHSEED=0 XLA_PYTHON_CLIENT_PREALLOCATE=false /usr/bin/time -v \
  /root/asi/.venv/bin/python -m pytest tests/test_upgd.py -q
```

`90 passed in 36.42s`; wall 38.49 s, user 78.86 s, system 3.23 s, maximum RSS 846,172 KiB.

```bash
/root/asi/.venv/bin/python -m ruff check \
  alberta_framework/core/upgd.py tests/test_upgd.py
/root/asi/.venv/bin/python -m mypy alberta_framework/core/upgd.py
```

Both passed. The regression was written first and failed at `core/upgd.py:2383` before the production fix.

## Evidence

<!-- evidence-head:f0c1b19930b13fd6fca7d7128d69e1fc19d6a33f -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/user-attachments/files/31372100/upgd-fast-trunk-vjp-verification.log
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/user-attachments/files/31372448/upgd-fast-trunk-vjp-domain-artifact.json

Local upload files and SHA-256 digests:

- `upgd-fast-trunk-vjp-verification.log`: `acfd4fffb16102af1e48d188c4b28f09b95a2716058fb087023a58cc3a456a62`
- `upgd-fast-trunk-vjp-domain-artifact.json`: `d07eda262ba14382e634fbd725904d21cc0222f18295560c10198faed44899bf`

## Scope and limitations

This is deterministic development-only defect evidence, permanently nonpromoting. It covers seed 2383, one first update, `softmax_ce`, and both legal readout-input modes. No benchmark, held-out, scientific, or promoted-evidence seeds were consumed. It establishes crash repair and finite update behavior, not a performance improvement.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-asi
Attribution status: self-reported
— [upgd-fast-trunk-vjp]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@89cf9ef4303a439291bf3f715bd4bf7175c3ddc0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0SP7RD5CE92N8PD83Q883V5","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T10:49:38.981Z","completed_at":"2026-08-24T10:55:44.359Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T10:49:39.748Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"23edf695614e1f719af1af61d171e330bf422a959337ebc017bd8275e8542dab","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"77b4fbe4-2152-42b0-9438-a6ec4e5ca129","object_id":"sha256:23edf695614e1f719af1af61d171e330bf422a959337ebc017bd8275e8542dab","sha256":"23edf695614e1f719af1af61d171e330bf422a959337ebc017bd8275e8542dab"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"I86TY8lALi4JUktZwdDZ8w8bPmv2_3-lWf5BS-qF1qJ8F4IZO8SwBuA-8_DJtV1I6laXcIOmgnXvvgP5R3cHAg"}} -->
