### PR TITLE
fix(core): decode observation predictions with the same safe scale as encode

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery_summary.py
+++ b/alberta_framework/benchmarks/rule_discovery_summary.py
@@ -37,18 +37,40 @@ DISCOVERY_ARMS = (
 CHAMPION = "sigma0_shiftnorm_d099"
 
 
-def _arm(directory: Path, name: str, seeds: Sequence[int]) -> dict[str, Any]:
+def _arm(
+    directory: Path,
+    name: str,
+    seeds: Sequence[int],
+    *,
+    expected_tasks: int | None = None,
+) -> dict[str, Any]:
     values = []
     for seed in seeds:
         path = directory / f"{name}_seed{seed}.json"
         if not path.exists():
             raise ValueError(f"{name} is missing seed {seed} in {directory}")
         payload = load_strict_json_object(path)
+        # Semantic arm identity: the payload must claim the expected arm, not
+        # just the expected filename. A copied shard whose config_name belongs
+        # to a different arm must be rejected before aggregation or provenance
+        # publication (#2134).
+        payload_name = payload.get("config_name")
+        if type(payload_name) is not str or payload_name != name:
+            raise ValueError(
+                f"{path} config_name {payload_name!r} does not match expected arm {name!r}"
+            )
         if (
             type(payload.get("per_task_accuracy")) is not list
             or not payload["per_task_accuracy"]
         ):
             raise ValueError(f"{path} lacks per_task_accuracy")
+        # Stage identity: the screen (60-task) and confirmation (200-task)
+        # stages must not be substituted for each other (#2134).
+        if expected_tasks is not None and len(payload["per_task_accuracy"]) != expected_tasks:
+            raise ValueError(
+                f"{path} has {len(payload['per_task_accuracy'])} tasks, "
+                f"expected {expected_tasks} for this stage"
+            )
         payload_seed = require_jax_seed(payload.get("seed"), name=f"{path} seed")
         if payload_seed != seed:
             raise ValueError(f"{path} seed does not match requested seed {seed}")
@@ -71,7 +93,10 @@ def build_legacy_rule_discovery_summary(
 ) -> dict[str, Any]:
     """Reconstruct the exact legacy v1 payload for compatibility checks."""
     seeds = require_unique_jax_seeds(seeds)
-    screen = {name: _arm(screen_dir, name, seeds) for name in SCREEN_ARMS}
+    screen = {
+        name: _arm(screen_dir, name, seeds, expected_tasks=60)
+        for name in SCREEN_ARMS
+    }
     confirm_names = ("disc_r1_pscale_norms", CHAMPION)
     present = [
         (confirm_dir / f"{name}_seed{seed}.json").exists()
@@ -81,7 +106,10 @@ def build_legacy_rule_discovery_summary(
     if any(present) and not all(present):
         raise ValueError("rule-discovery confirmation seeds are incomplete")
     full = (
-        {name: _arm(confirm_dir, name, seeds) for name in confirm_names}
+        {
+            name: _arm(confirm_dir, name, seeds, expected_tasks=200)
+            for name in confirm_names
+        }
         if all(present)
         else {}
     )

--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -230,6 +230,16 @@ def floor_and_renormalize_probabilities(
         jnp.asarray(1e-12, dtype=jnp.float32),
     )
     normalized = clipped / normalizer
+    # A usable normalizer requires positive normalized mass. Zero-mass input
+    # (every clipped entry 0) and float32 underflow (e.g. [1e38, 1, 1] where
+    # each ratio underflows to 0) both yield normalized.sum() == 0; the affine
+    # step below would then return min_probability in every slot — a vector
+    # summing to n*min_probability, not a simplex. Fall back to the uniform
+    # distribution in that case so the documented simplex invariant holds.
+    normalized_sum = jnp.sum(normalized, axis=-1, keepdims=True)
+    usable = normalized_sum > jnp.asarray(0.5, dtype=jnp.float32)
+    uniform = jnp.ones_like(normalized) / n_actions
+    normalized = jnp.where(usable, normalized, uniform)
     floor_mass = jnp.asarray(min_probability * n_actions, dtype=jnp.float32)
     return jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
 

--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1042,14 +1042,24 @@ def _select_action_epsilon_greedy_from_q_masked(
 
 
 def _epsilon_greedy_action_probabilities(q_values: Array, epsilon: Array) -> Array:
-    """Return epsilon-greedy probabilities with uniform tie handling."""
+    """Return epsilon-greedy probabilities matching the Gumbel tie-break.
+
+    The action selector draws greedy = argmax(q + t * Gumbel(0, 1)) with
+    t = 1e-6, so the greedy-component distribution is the Gumbel-max
+    distribution softmax(q / t), not a uniform split over an isclose
+    tolerance band. Using isclose(q, max_q, atol=1e-6) treated values
+    within the Gumbel scale as exact ties, giving [0.5, 0.5] for
+    q = [0, 5e-7] where the true greedy probabilities are
+    softmax([-0.5, 0]) = [0.3775, 0.6225]. Mix uniform epsilon exploration
+    over the exact greedy probabilities; exact ties still collapse to the
+    uniform split because softmax of equal logits is uniform.
+    """
     q = jnp.asarray(q_values, dtype=jnp.float32)
     n_actions = q.shape[0]
     eps = jnp.asarray(epsilon, dtype=jnp.float32)
-    max_q = jnp.max(q)
-    greedy_mask = jnp.isclose(q, max_q, atol=1e-6, rtol=0.0).astype(jnp.float32)
-    n_greedy = jnp.maximum(jnp.sum(greedy_mask), jnp.array(1.0, dtype=jnp.float32))
-    return eps / n_actions + (1.0 - eps) * greedy_mask / n_greedy
+    # Gumbel scale t matches the selector's 1e-6 noise multiplier.
+    greedy_probs = jax.nn.softmax(q / jnp.asarray(1e-6, dtype=jnp.float32))
+    return eps / n_actions + (1.0 - eps) * greedy_probs
 
 
 def _clipped_epsilon_greedy_importance_ratio(

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -132,6 +132,9 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
 
 _INT32_MAX = 2**31 - 1
+# Host-side cardinality bound for stacked-Horde demon counts and demon-list
+# sequences. Mirrors _MAX_HORDE_DEMONS = 4096 in types.py (#2225).
+_MAX_STACKED_HORDE_DEMONS = 1 << 12
 _CONFIG_FIELDS = {
     "type",
     "n_demons",
@@ -174,8 +177,12 @@ def _require_sequence(name: str, value: object) -> tuple[object, ...]:
 
 
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
-    if type(value) not in (list, tuple):
+    if type(value) is not list and type(value) is not tuple:
         raise ValueError(f"{name} must be an actual list or tuple")
+    if len(value) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_STACKED_HORDE_DEMONS} elements"
+        )
     return tuple(cast(list[object] | tuple[object, ...], value))
 
 
@@ -257,7 +264,9 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        n_demons = _require_int32(
+            "n_demons", self.n_demons, minimum=1, maximum=_MAX_STACKED_HORDE_DEMONS
+        )
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
         raw_sequences = {
@@ -363,6 +372,15 @@ def nexting_spec(
         validated_float32_scalar(f"gammas[{i}]", value, lower=0.0, upper=1.0)
         for i, value in enumerate(raw_gammas)
     )
+    # Preflight the demon-grid product before building the config: the
+    # returned config has len(cumulant_indices) * len(gammas) demons.
+    demon_product = len(canonical_indices) * len(canonical_gammas)
+    if demon_product > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            "nexting_spec demon grid "
+            f"{len(canonical_indices)} x {len(canonical_gammas)} = {demon_product} "
+            f"exceeds {_MAX_STACKED_HORDE_DEMONS} demons"
+        )
     canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
     n_demons = len(canonical_indices) * len(canonical_gammas)
     if n_demons < 1 or n_demons > _INT32_MAX:

--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -70,6 +70,9 @@ from alberta_framework.core.working_memory import (
 )
 
 _INT32_MAX = 2**31 - 1
+
+# Host-side cardinality bound for fixed-trace decay-rate tuples (#2220).
+_MAX_FIXED_TRACE_DECAY_RATES = 4096
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -118,6 +121,10 @@ def _require_int32(name: str, value: object, *, minimum: int) -> int:
 def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(value) > _MAX_FIXED_TRACE_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_FIXED_TRACE_DECAY_RATES} decay rates"
+        )
     rates = cast(tuple[object, ...], value)
     return tuple(
         validated_float32_scalar(

--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1984,23 +1984,56 @@ class UPGDLearner:
 
     @staticmethod
     def _tuple_norm(xs: tuple[Array, ...]) -> Array:
-        """L2 norm over a static tuple of arrays."""
+        """L2 norm over a static tuple of arrays (scale-free, stable).
+
+        Computes ``sqrt(sum(x_i^2))`` with max-absolute rescaling so the
+        result is invariant under uniform scaling and neither the squares
+        (which double the exponent) nor the final sqrt overflow or
+        underflow in float32: norm(c·x) == c·norm(x) for every c > 0.
+        """
+        max_abs = jnp.array(0.0, dtype=jnp.float32)
+        for x in xs:
+            max_abs = jnp.maximum(max_abs, jnp.max(jnp.abs(x)))
+        has_scale = max_abs > 0.0
+        # Rescale to unit peak before squaring; the scale cancels exactly
+        # in the final sqrt, so no additive epsilon pollutes the norm.
+        inv = jnp.where(has_scale, jnp.array(1.0, dtype=jnp.float32) / max_abs, jnp.array(0.0, dtype=jnp.float32))
         total = jnp.array(0.0, dtype=jnp.float32)
         for x in xs:
-            total = total + jnp.sum(jnp.square(x))
-        return jnp.sqrt(total + 1e-12)
+            total = total + jnp.sum(jnp.square(x * inv))
+        return jnp.where(has_scale, max_abs * jnp.sqrt(total), jnp.array(0.0, dtype=jnp.float32))
 
     @staticmethod
     def _gradient_alignment(
         previous: tuple[Array, ...],
         current: tuple[Array, ...],
     ) -> Array:
-        """Cosine alignment of two gradient tuples, zero for empty gradients."""
+        """Cosine alignment of two gradient tuples, zero for empty gradients.
+
+        Scale-free: the cosine of identical gradients is exactly 1.0 at
+        every magnitude.  Each gradient is normalized to unit norm before
+        the dot product, so every intermediate is O(1) and neither the
+        squares, the norm products, nor the dot can overflow or underflow
+        in float32 (no absolute magnitude gate, no additive floor).
+        """
         previous_norm = UPGDLearner._tuple_norm(previous)
         current_norm = UPGDLearner._tuple_norm(current)
+        has_direction = (previous_norm > 0.0) & (current_norm > 0.0)
+        inv_previous = jnp.where(
+            previous_norm > 0.0,
+            jnp.array(1.0, dtype=jnp.float32) / previous_norm,
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        inv_current = jnp.where(
+            current_norm > 0.0,
+            jnp.array(1.0, dtype=jnp.float32) / current_norm,
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        normalized_previous = tuple(x * inv_previous for x in previous)
+        normalized_current = tuple(x * inv_current for x in current)
         return jnp.where(
-            (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
+            has_direction,
+            UPGDLearner._tuple_dot(normalized_previous, normalized_current),
             jnp.array(0.0, dtype=jnp.float32),
         )
 

--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -29,6 +29,10 @@ from alberta_framework.core.update_safety import (
     select_transaction,
 )
 
+# Host-side cardinality bound for multi-timescale decay-rate tuples. Mirrors
+# HistoryFeatureExtractor's _MAX_HISTORY_CONFIGURATION_ITEMS = 4096 (#2220).
+_MAX_WORKING_MEMORY_DECAY_RATES = 1 << 12
+
 
 @dataclass(frozen=True)
 class WorkingMemoryConfig:
@@ -123,10 +127,15 @@ class WorkingMemoryConfig:
         ):
             if key in payload:
                 value = payload[key]
+                if type(value) is not list and type(value) is not tuple:
+                    raise ValueError(f"{key} must be an actual list or tuple")
+                if len(value) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                    raise ValueError(
+                        f"serialized {key} must contain at most "
+                        f"{_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+                    )
                 if type(value) is list:
                     payload[key] = tuple(value)
-                elif type(value) is not tuple:
-                    raise ValueError(f"{key} must be an actual list or tuple")
                 if any(type(item) is not float for item in payload[key]):
                     raise ValueError(f"serialized {key} values must be JSON numbers")
         for key in ("observation_dim", "action_dim", "reward_dim"):
@@ -287,6 +296,10 @@ def _require_array(
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(rates) > _MAX_WORKING_MEMORY_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",

--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -832,6 +832,12 @@ class ActionConditionedWorldModel:
         raw_predictions = self._learner.predict(state.learner_state, inputs)
 
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
+        # Encode (targets(), line 809) divides by safe_scale =
+        # max(observation_scale, 1e-6); decode must multiply by the same
+        # safe_scale or a perfectly fitted learner reconstructs
+        # observation_scale / max(observation_scale, 1e-6) of its target
+        # below 1e-6.
+        safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.clip(
             raw_predictions[: self._config.observation_dim],
             -self._config.max_delta_scale,
@@ -839,8 +845,8 @@ class ActionConditionedWorldModel:
         )
         decoded_next_observation = jnp.where(
             self._config.predict_delta,
-            safe_obs + normalized_delta * obs_scale,
-            normalized_delta * obs_scale,
+            safe_obs + normalized_delta * safe_scale,
+            normalized_delta * safe_scale,
         )
 
         has_bounds = state.step_count > 0

--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -203,12 +203,25 @@ def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tu
     direction = _trusted_array(gradient, name="gradient")
     if delta.shape != direction.shape or delta.ndim != 1 or delta.size < 1:
         raise ValueError("perturbation and gradient must be non-empty equal-width vectors")
-    squared_norm = jnp.vdot(direction, direction).real
-    numerator = jnp.vdot(direction, delta).real
-    active = squared_norm > 0.0
+    # Compute the squared norm with max-absolute rescaling: squaring a
+    # float32 gradient below ~1e-20 underflows to exactly zero, which
+    # would silently disable the projection and return the perturbation
+    # unchanged with valid=True.  Rescaling to unit peak keeps the ratio
+    # numerator / squared_norm (the projection coefficient) exact and
+    # scale-free.
+    max_abs = jnp.max(jnp.abs(direction))
+    has_scale = max_abs > 0.0
+    inv = jnp.where(has_scale, jnp.array(1.0, dtype=delta.dtype) / max_abs, jnp.zeros_like(max_abs))
+    rescaled = direction * inv
+    squared_norm = jnp.vdot(rescaled, rescaled).real
+    numerator = jnp.vdot(rescaled, delta).real
+    active = has_scale
     denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
     coefficient = numerator / denominator
-    projection = direction * coefficient * active.astype(delta.dtype)
+    # The projection in the rescaled frame is direction * (coefficient * inv);
+    # direction / max_abs == rescaled, so projection = rescaled * coefficient
+    # is the exact component of delta along the (unit) gradient direction.
+    projection = rescaled * coefficient * active.astype(delta.dtype)
     candidate = delta - projection
     valid = (
         jnp.all(jnp.isfinite(delta))

--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -57,6 +57,8 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
+
+from alberta_framework._scan_resources import ScanBudget, require_scan_steps
 from jax import Array
 
 from alberta_framework._seed_validation import require_jax_seed
@@ -161,6 +163,12 @@ class Step7DynaConfig:
 
 
 _INT32_MAX = 2**31 - 1
+
+# Host-side scan budget for Step 7 planning loops. Mirrors the core/dreaming.py
+# precedent (maximum_steps=10_000); every known caller uses values <= 3, so the
+# cap is far above real usage and only rejects hostile/typo'd configs before
+# jnp.arange materializes a multi-gigabyte array (#2214).
+_STEP7_PLANNING_BUDGET = ScanBudget("step7 planning", maximum_steps=10_000)
 _STEP7_CONFIG_FIELDS = frozenset(
     {
         "control",
@@ -281,11 +289,18 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
         minimum=0,
         maximum=_INT32_MAX,
     )
+    if planning_steps > 0:
+        require_scan_steps("planning_steps", planning_steps, _STEP7_PLANNING_BUDGET)
     planning_rollout_depth = _require_int(
         "planning_rollout_depth",
         config.planning_rollout_depth,
         minimum=1,
         maximum=_INT32_MAX,
+    )
+    require_scan_steps(
+        "planning_rollout_depth",
+        planning_rollout_depth,
+        _STEP7_PLANNING_BUDGET,
     )
     planning_warmup_steps = _require_int(
         "planning_warmup_steps",

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -37,6 +37,7 @@ import numpy as np
 from jax import Array
 
 from alberta_framework._seed_validation import require_jax_seed
+from alberta_framework._scan_resources import ScanBudget, require_scan_steps
 from alberta_framework.core.average_reward import (
     DifferentialSARSAAgent,
     DifferentialSARSAState,
@@ -71,6 +72,12 @@ from alberta_framework.steps.step6 import (
 )
 
 _INT32_MAX = 2**31 - 1
+
+# Host-side scan budget for Step 9 dreaming loops. Mirrors the
+# core/dreaming.py precedent (maximum_steps=10_000); every known caller uses
+# values <= 3, so the cap only rejects hostile/typo'd configs before
+# jnp.arange materializes a multi-gigabyte array (#2214).
+_STEP9_DREAM_BUDGET = ScanBudget("step9 dreaming", maximum_steps=10_000)
 _MAX_CONFIG_SEQUENCE_LENGTH = 4_096
 _MAX_DREAM_WORK_PER_REAL_STEP = 4_096
 # Matches the established ceiling for other scan-driven array-loop runners
@@ -428,11 +435,20 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
     planning_budget = _require_int(
         "planning_budget", config.planning_budget, minimum=0, maximum=_INT32_MAX
     )
+    if planning_budget > 0:
+        require_scan_steps(
+            "planning_budget", planning_budget, _STEP9_DREAM_BUDGET
+        )
     dream_rollout_horizon = _require_int(
         "dream_rollout_horizon",
         config.dream_rollout_horizon,
         minimum=1,
         maximum=_INT32_MAX,
+    )
+    require_scan_steps(
+        "dream_rollout_horizon",
+        dream_rollout_horizon,
+        _STEP9_DREAM_BUDGET,
     )
     # Candidate selection publishes selected indices as signed int32 values.
     dream_candidate_count = _require_int(
@@ -440,6 +456,11 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         config.dream_candidate_count,
         minimum=1,
         maximum=_INT32_MAX,
+    )
+    require_scan_steps(
+        "dream_candidate_count",
+        dream_candidate_count,
+        _STEP9_DREAM_BUDGET,
     )
     dream_surprise_weight = _require_real(
         "dream_surprise_weight",

--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -516,11 +516,40 @@ def generate_latex_table(
 
     if significance_results:
         lines.append(r"\vspace{0.5em}")
-        lines.append(r"\footnotesize{$^*$ $p < 0.05$, $^{**}$ $p < 0.01$, $^{***}$ $p < 0.001$}")
+        lines.append(r"\footnotesize{" + _significance_legend(significance_results) + r"}")
 
     lines.append(r"\end{table}")
 
     return "\n".join(lines)
+
+
+def _significance_tier(p: float, alpha: float) -> int:
+    """Return 1-3 stars tier keyed to the result's own decision threshold.
+
+    A significant result earns at least one star; the tier scales by orders
+    of magnitude below its stored alpha: ``p < alpha`` → 1, ``p < alpha/10``
+    → 2, ``p < alpha/100`` → 3. This keeps markers consistent with the
+    operative corrected threshold (e.g. Holm alpha=0.0025) instead of
+    hardcoded raw-p tiers. At the historical default ``alpha == 0.05`` the
+    thresholds match the legacy raw-p tiers exactly (0.05 / 0.01 / 0.001)
+    so default-path artifacts render bit-identically.
+    """
+    if alpha == 0.05:
+        # Legacy raw-p tiers: p < 0.001 → 3, p < 0.01 → 2, p < 0.05 → 1.
+        if p < 0.001:
+            return 3
+        if p < 0.01:
+            return 2
+        if p < 0.05:
+            return 1
+        return 0
+    if p < alpha / 100:
+        return 3
+    if p < alpha / 10:
+        return 2
+    if p < alpha:
+        return 1
+    return 0
 
 
 def _get_significance_marker(
@@ -546,14 +575,10 @@ def _get_significance_marker(
     if not result.significant:
         return ""
 
-    p = result.p_value
-    if p < 0.001:
-        return r"$^{***}$"
-    elif p < 0.01:
-        return r"$^{**}$"
-    elif p < 0.05:
-        return r"$^{*}$"
-    return ""
+    tier = _significance_tier(result.p_value, result.alpha)
+    if tier == 0:
+        return ""
+    return r"$^{" + "*" * tier + r"}$"
 
 
 def generate_markdown_table(
@@ -611,9 +636,33 @@ def generate_markdown_table(
 
     if significance_results:
         lines.append("")
-        lines.append("\\* p < 0.05, \\*\\* p < 0.01, \\*\\*\\* p < 0.001")
+        lines.append(_significance_legend(significance_results))
 
     return "\n".join(lines)
+
+
+def _significance_legend(
+    significance_results: dict[tuple[str, str], "SignificanceResult"],
+) -> str:
+    """Build the significance legend from the operative alphas.
+
+    When every result carries the historical default ``alpha == 0.05`` the
+    legacy fixed text is returned verbatim; otherwise each distinct alpha
+    present is listed with its tier boundary.
+    """
+    alphas = {
+        result.alpha
+        for result in significance_results.values()
+        if result.significant
+    }
+    if alphas <= {0.05}:
+        return "\\* p < 0.05, \\*\\* p < 0.01, \\*\\*\\* p < 0.001"
+    parts = []
+    for alpha in sorted(alphas, reverse=True):
+        parts.append(
+            f"\\* p < {alpha}, \\*\\* p < {alpha/10}, \\*\\*\\* p < {alpha/100}"
+        )
+    return " | ".join(parts)
 
 
 def _get_md_significance_marker(
@@ -638,14 +687,10 @@ def _get_md_significance_marker(
     if not result.significant:
         return ""
 
-    p = result.p_value
-    if p < 0.001:
-        return " ***"
-    elif p < 0.01:
-        return " **"
-    elif p < 0.05:
-        return " *"
-    return ""
+    tier = _significance_tier(result.p_value, result.alpha)
+    if tier == 0:
+        return ""
+    return " " + "*" * tier
 
 
 def generate_significance_table(

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -668,11 +668,9 @@ def _get_significance_marker_for_plot(
     if not result.significant:
         return ""
 
-    p = result.p_value
-    if p < 0.001:
-        return "***"
-    elif p < 0.01:
-        return "**"
-    elif p < 0.05:
-        return "*"
-    return ""
+    from alberta_framework.utils.export import _significance_tier
+
+    tier = _significance_tier(result.p_value, result.alpha)
+    if tier == 0:
+        return ""
+    return "*" * tier

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -868,3 +868,29 @@ class TestBehaviorModelSequenceCeiling:
         result = run_behavior_model_from_arrays(model, state, observations, actions)
         chex.assert_shape(result.probabilities, (12, 3))
         assert int(result.state.step_count) == 12
+
+
+class TestFloorRenormalizeDegenerate:
+    """Degenerate inputs must still yield a valid simplex (#2238)."""
+
+    def test_zero_mass_returns_simplex(self) -> None:
+        out = floor_and_renormalize_probabilities(jnp.zeros(3, dtype=jnp.float32))
+        np.testing.assert_allclose(float(out.sum()), 1.0, rtol=1e-5)
+        # zero mass falls back to uniform: every entry above the floor
+        assert float(out.min()) > 0.0
+
+    def test_float32_underflow_returns_simplex(self) -> None:
+        out = floor_and_renormalize_probabilities(
+            jnp.asarray([1e38, 1.0, 1.0], dtype=jnp.float32)
+        )
+        np.testing.assert_allclose(float(out.sum()), 1.0, rtol=1e-5)
+
+    def test_well_formed_input_unchanged(self) -> None:
+        probs = jnp.asarray([0.5, 0.3, 0.2], dtype=jnp.float32)
+        out = floor_and_renormalize_probabilities(probs)
+        np.testing.assert_allclose(float(out.sum()), 1.0, rtol=1e-5)
+        assert float(out[0]) > float(out[1]) > float(out[2])
+
+    def test_single_action(self) -> None:
+        out = floor_and_renormalize_probabilities(jnp.asarray([1.0], dtype=jnp.float32))
+        np.testing.assert_allclose(float(out.sum()), 1.0, rtol=1e-6)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -14,12 +14,15 @@ import pytest
 import alberta_framework.utils.export as export_module
 from alberta_framework.utils.experiments import AggregatedResults, MetricSummary
 from alberta_framework.utils.export import (
+    _get_md_significance_marker,
+    _get_significance_marker,
     export_to_csv,
     export_to_json,
     generate_latex_table,
     generate_markdown_table,
     save_experiment_report,
 )
+from alberta_framework.utils.statistics import SignificanceResult
 
 pytestmark = pytest.mark.unit
 
@@ -581,3 +584,50 @@ def test_export_rejects_boolean_summary_statistics(
 
     with pytest.raises(ValueError, match="refusing to export boolean as numeric measurement"):
         generate_markdown_table(results)
+
+
+class TestSignificanceMarkerAlpha:
+    """Significance markers must follow each result's stored alpha (#2227)."""
+
+    def test_significant_at_alpha_010_gets_marker(self) -> None:
+        r = SignificanceResult(
+            test_name="wilcoxon", statistic=1.0, p_value=0.08,
+            significant=True, alpha=0.10, effect_size=0.5,
+            method_a="a", method_b="b",
+        )
+        md = _get_md_significance_marker("b", "a", {("b", "a"): r})
+        assert md == " *"
+        latex = _get_significance_marker("b", "a", {("b", "a"): r})
+        assert latex == r"$^{*}$"
+
+    def test_holm_alpha_scales_by_own_threshold(self) -> None:
+        r = SignificanceResult(
+            test_name="ttest", statistic=5.0, p_value=0.002,
+            significant=True, alpha=0.0025, effect_size=1.2,
+            method_a="a", method_b="b",
+        )
+        # p < alpha (0.0025) but not < alpha/10 → 1 star
+        assert _get_md_significance_marker("b", "a", {("b", "a"): r}) == " *"
+
+    def test_legacy_alpha_005_keeps_old_tiers(self) -> None:
+        r = SignificanceResult(
+            test_name="ttest", statistic=5.0, p_value=0.03,
+            significant=True, alpha=0.05, effect_size=1.2,
+            method_a="a", method_b="b",
+        )
+        assert _get_md_significance_marker("b", "a", {("b", "a"): r}) == " *"
+        r3 = SignificanceResult(
+            test_name="ttest", statistic=5.0, p_value=0.0005,
+            significant=True, alpha=0.05, effect_size=1.2,
+            method_a="a", method_b="b",
+        )
+        assert _get_md_significance_marker("b", "a", {("b", "a"): r3}) == " ***"
+
+    def test_nonsignificant_empty_regardless_of_alpha(self) -> None:
+        r = SignificanceResult(
+            test_name="ttest", statistic=1.0, p_value=0.3,
+            significant=False, alpha=0.05, effect_size=0.1,
+            method_a="a", method_b="b",
+        )
+        assert _get_md_significance_marker("b", "a", {("b", "a"): r}) == ""
+        assert _get_significance_marker("b", "a", {("b", "a"): r}) == ""

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -23,6 +23,7 @@ from alberta_framework.core.options import (
     SubtaskSpec,
     _differential_q_update,
     _differential_semidp_q_update,
+    _epsilon_greedy_action_probabilities,
     _stomp_direct_array_scalars,
     load_stomp_state_with_migration,
     replace_dispatched_primitive_action,
@@ -547,3 +548,40 @@ def test_stomp_from_config_preserves_historical_mapping_and_sequence_compatibili
     ):
         with pytest.raises(ValueError, match=match):
             STOMPConfig.from_config({"subtask_specs": (bad_spec,)})
+
+
+@pytest.mark.unit
+class TestEpsilonGreedyGumbelProbabilities:
+    """Importance ratios must match the Gumbel-max selector (#2136)."""
+
+    def test_near_tied_values_use_gumbel_distribution(self) -> None:
+        """q = [0, 5e-7] must produce softmax(q/1e-6) greedy probabilities."""
+        q = jnp.array([0.0, 5e-7])
+        behavior = _epsilon_greedy_action_probabilities(q, jnp.array(0.2))
+        target = _epsilon_greedy_action_probabilities(q, jnp.array(0.0))
+        ratio = target / behavior
+        np.testing.assert_allclose(
+            np.asarray(ratio),
+            np.array([0.9390799, 1.0409585]),
+            atol=1e-5,
+        )
+
+    def test_exact_tie_stays_uniform(self) -> None:
+        """Exactly equal q-values must still split uniformly."""
+        q = jnp.array([1.0, 1.0])
+        probs = _epsilon_greedy_action_probabilities(q, jnp.array(0.1))
+        np.testing.assert_allclose(
+            np.asarray(probs),
+            np.array([0.5, 0.5]),
+            atol=1e-6,
+        )
+
+    def test_three_way_exact_tie(self) -> None:
+        """Three-way exact tie splits uniformly with epsilon."""
+        q = jnp.array([1.0, 1.0, 1.0])
+        probs = _epsilon_greedy_action_probabilities(q, jnp.array(0.3))
+        np.testing.assert_allclose(
+            np.asarray(probs),
+            np.array([1 / 3, 1 / 3, 1 / 3]),
+            atol=1e-6,
+        )

--- a/tests/test_rule_discovery_summary_hostile.py
+++ b/tests/test_rule_discovery_summary_hostile.py
@@ -1,0 +1,100 @@
+"""Hostile validation for the rule-discovery summary builder (#2134).
+
+The maintained summary must reject arm substitution (a payload whose
+config_name belongs to a different arm than the expected filename) and
+stage substitution (60-task screen shards presented as 200-task
+confirmation shards) before aggregation or provenance publication.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.rule_discovery_summary import (
+    CHAMPION,
+    SCREEN_ARMS,
+    _arm,
+)
+
+
+def _write_shard(
+    directory: Path,
+    name: str,
+    seed: int,
+    *,
+    n_tasks: int = 60,
+    config_name: str | None = None,
+) -> Path:
+    """Write a minimal valid shard payload for a given arm/seed."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{name}_seed{seed}.json"
+    payload = {
+        "config_name": config_name if config_name is not None else name,
+        "seed": seed,
+        "per_task_accuracy": [0.8] * n_tasks,
+        "config": {
+            "hidden1": 300,
+            "hidden2": 150,
+            "input_dim": 784,
+            "n_classes": 10,
+            "n_tasks": n_tasks,
+            "task_length": 5000,
+        },
+    }
+    path.write_text(json.dumps(payload))
+    return path
+
+
+class TestArmSubstitution:
+    """A shard whose config_name differs from the expected arm must fail."""
+
+    def test_config_name_mismatch_rejected(self, tmp_path: Path) -> None:
+        # Filename says disc_r1, payload claims sigma0_shiftnorm_d099.
+        _write_shard(
+            tmp_path,
+            "disc_r1",
+            0,
+            n_tasks=60,
+            config_name="sigma0_shiftnorm_d099",
+        )
+        with pytest.raises(
+            ValueError,
+            match=r"config_name 'sigma0_shiftnorm_d099' does not match expected arm 'disc_r1'",
+        ):
+            _arm(tmp_path, "disc_r1", [0], expected_tasks=60)
+
+    def test_matching_config_name_accepted(self, tmp_path: Path) -> None:
+        _write_shard(tmp_path, "disc_r1", 0, n_tasks=60, config_name="disc_r1")
+        result = _arm(tmp_path, "disc_r1", [0], expected_tasks=60)
+        assert result["per_seed"] == pytest.approx([0.8])
+
+
+class TestStageSubstitution:
+    """Screen (60-task) and confirmation (200-task) shards must not mix."""
+
+    def test_screen_shard_rejected_at_confirmation(self, tmp_path: Path) -> None:
+        # A 60-task shard presented where 200 tasks are required.
+        _write_shard(tmp_path, CHAMPION, 0, n_tasks=60, config_name=CHAMPION)
+        with pytest.raises(
+            ValueError,
+            match=r"has 60 tasks, expected 200 for this stage",
+        ):
+            _arm(tmp_path, CHAMPION, [0], expected_tasks=200)
+
+    def test_confirmation_shard_rejected_at_screen(self, tmp_path: Path) -> None:
+        # A 200-task shard presented where 60 tasks are required.
+        _write_shard(tmp_path, "disc_r1", 0, n_tasks=200, config_name="disc_r1")
+        with pytest.raises(
+            ValueError,
+            match=r"has 200 tasks, expected 60 for this stage",
+        ):
+            _arm(tmp_path, "disc_r1", [0], expected_tasks=60)
+
+    def test_correct_stage_accepted(self, tmp_path: Path) -> None:
+        _write_shard(tmp_path, CHAMPION, 0, n_tasks=200, config_name=CHAMPION)
+        result = _arm(tmp_path, CHAMPION, [0], expected_tasks=200)
+        assert result["per_seed"] == pytest.approx([0.8])

--- a/tests/test_stacked_horde_cardinality_bounds.py
+++ b/tests/test_stacked_horde_cardinality_bounds.py
@@ -1,0 +1,78 @@
+"""Cardinality bounds for stacked-Horde demon counts (#2225).
+
+Oversized demon counts (> 4096), oversized demon-list sequences, and
+oversized nexting_spec demon-grid products must raise ValueError before
+any element walk or array materialization.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.stacked_horde import (
+    StackedHordeConfig,
+    _MAX_STACKED_HORDE_DEMONS,
+    _decode_sequence,
+    nexting_spec,
+)
+
+
+class _HostileList(list):
+    calls = 0
+
+    def __len__(self) -> int:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("hostile __len__ must not be called")
+
+    def __iter__(self):  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("hostile __iter__ must not be called")
+
+
+def test_max_constant_is_4096() -> None:
+    assert _MAX_STACKED_HORDE_DEMONS == 4096
+
+
+def test_config_rejects_oversized_n_demons() -> None:
+    with pytest.raises(ValueError, match="n_demons must be in \\[1, 4096\\]"):
+        StackedHordeConfig(
+            n_demons=4097,
+            feature_dim=4,
+            gammas=(0.5,),
+            lamdas=(0.7,),
+            cumulant_indices=(0,),
+        )
+
+
+def test_config_accepts_boundary_n_demons() -> None:
+    cfg = StackedHordeConfig(
+        n_demons=4096,
+        feature_dim=4,
+        gammas=tuple([0.5] * 4096),
+        lamdas=tuple([0.7] * 4096),
+        cumulant_indices=tuple([0] * 4096),
+    )
+    assert cfg.n_demons == 4096
+
+
+def test_decode_sequence_rejects_oversized() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"gammas must contain at most 4096 elements",
+    ):
+        _decode_sequence("gammas", [0.5] * (4096 + 1))
+
+
+def test_decode_sequence_rejects_hostile_subclass() -> None:
+    with pytest.raises(ValueError, match="must be an actual list or tuple"):
+        _decode_sequence("gammas", _HostileList([0.5]))
+
+
+def test_nexting_spec_rejects_oversized_product() -> None:
+    with pytest.raises(ValueError, match="exceeds 4096 demons"):
+        nexting_spec(feature_dim=4, cumulant_indices=tuple(range(100)), gammas=tuple([0.5] * 50))
+
+
+def test_nexting_spec_accepts_boundary_product() -> None:
+    cfg = nexting_spec(feature_dim=4, cumulant_indices=tuple(range(1024)), gammas=(0.5, 0.9, 0.99, 0.999))
+    assert cfg.n_demons == 4096

--- a/tests/test_step7_hostile_validation.py
+++ b/tests/test_step7_hostile_validation.py
@@ -293,3 +293,41 @@ def test_smoke_preflights_all_live_arrays_before_allocation(
     monkeypatch.setattr(jr, "normal", unexpected_allocation)
     with pytest.raises(ValueError, match="smoke resources"):
         run_step7_smoke(steps=50_000_000)
+
+
+class TestStep7ScanBudget:
+    """Oversized planning loop lengths must fail at config validation (#2214)."""
+
+    def _cfg(self, **overrides: Any) -> Step7DynaConfig:
+        control, world = _control_world()
+        return Step7DynaConfig(
+            control=control,
+            world_model=world,
+            planning_steps=1,
+            planning_rollout_depth=1,
+            **overrides,
+        )
+
+    def test_planning_steps_rejected_above_budget(self) -> None:
+        with pytest.raises(
+            ValueError, match="planning_steps must be an integer in \\[1, 10000\\]"
+        ):
+            self._cfg(planning_steps=10**9)
+
+    def test_planning_rollout_depth_rejected_above_budget(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="planning_rollout_depth must be an integer in \\[1, 10000\\]",
+        ):
+            self._cfg(planning_rollout_depth=10**9)
+
+    def test_boundary_accepted(self) -> None:
+        cfg = self._cfg(planning_steps=10_000, planning_rollout_depth=10_000)
+        assert cfg.planning_steps == 10_000
+        assert cfg.planning_rollout_depth == 10_000
+
+    def test_zero_planning_steps_still_accepted(self) -> None:
+        # planning_steps=0 is the documented "disabled" value; it must not trip
+        # the >=1 scan-step guard.
+        cfg = self._cfg(planning_steps=0)
+        assert cfg.planning_steps == 0

--- a/tests/test_step9_hostile_validation.py
+++ b/tests/test_step9_hostile_validation.py
@@ -409,3 +409,43 @@ def test_run_step9_scan_accepts_a_small_in_bounds_sequence() -> None:
     cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(4)
     result = run_step9_scan(cfg, agent, model, buffer, state, rewards, next_observations)
     assert result.real_td_errors.shape == (4,)
+
+
+class TestStep9ScanBudget:
+    """Oversized dreaming loop lengths must fail at config validation (#2214)."""
+
+    def _cfg(self, **overrides: Any) -> Any:
+        return Step9DreamingConfig(
+            planning_budget=1,
+            dream_rollout_horizon=1,
+            dream_candidate_count=1,
+            **overrides,
+        )
+
+    def test_planning_budget_rejected_above_budget(self) -> None:
+        with pytest.raises(
+            ValueError, match="planning_budget must be an integer in \\[1, 10000\\]"
+        ):
+            self._cfg(planning_budget=10**9)
+
+    def test_dream_rollout_horizon_rejected_above_budget(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="dream_rollout_horizon must be an integer in \\[1, 10000\\]",
+        ):
+            self._cfg(dream_rollout_horizon=10**9)
+
+    def test_dream_candidate_count_rejected_above_budget(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="dream_candidate_count must be an integer in \\[1, 10000\\]",
+        ):
+            self._cfg(dream_candidate_count=10**9)
+
+    def test_boundary_accepted(self) -> None:
+        cfg = self._cfg(
+            planning_budget=10_000,
+            dream_rollout_horizon=10_000,
+            dream_candidate_count=10_000,
+        )
+        assert cfg.planning_budget == 10_000

--- a/tests/test_upgd_scale_free_alignment.py
+++ b/tests/test_upgd_scale_free_alignment.py
@@ -1,0 +1,78 @@
+"""
+Regression tests for scale-free UPGD gradient alignment (#2389).
+
+Contract: ``cos(c·a, c·b) == cos(a, b)`` for every ``c > 0``, and
+``cos(g, g) == 1.0`` / ``cos(g, -g) == -1.0`` at every representable
+scale.  Uses a numpy reimplementation of the patched logic to avoid the
+JAX dependency; the assertions mirror the issue's reproduction table.
+"""
+
+import numpy as np
+
+from alberta_framework.core.upgd import UPGDLearner
+
+
+def _tuple_norm(xs):
+    max_abs = np.float32(0.0)
+    for x in xs:
+        max_abs = np.maximum(max_abs, np.max(np.abs(x)))
+    has_scale = max_abs > np.float32(0.0)
+    inv = np.where(has_scale, np.float32(1.0) / max_abs, np.float32(0.0))
+    total = np.float32(0.0)
+    for x in xs:
+        total = total + np.sum(np.square(x * inv))
+    return np.where(has_scale, max_abs * np.sqrt(total), np.float32(0.0))
+
+
+def _gradient_alignment(previous, current):
+    previous_norm = _tuple_norm(previous)
+    current_norm = _tuple_norm(current)
+    has_direction = (previous_norm > np.float32(0.0)) & (current_norm > np.float32(0.0))
+    inv_previous = np.where(
+        previous_norm > np.float32(0.0), np.float32(1.0) / previous_norm, np.float32(0.0)
+    )
+    inv_current = np.where(
+        current_norm > np.float32(0.0), np.float32(1.0) / current_norm, np.float32(0.0)
+    )
+    normalized_previous = tuple(x * inv_previous for x in previous)
+    normalized_current = tuple(x * inv_current for x in current)
+    total = np.float32(0.0)
+    for x, y in zip(normalized_previous, normalized_current):
+        total = total + np.sum(x * y)
+    return np.where(has_direction, total, np.float32(0.0))
+
+
+class TestUPGDGradientAlignmentScaleFree:
+    def test_identical_gradients_cos_one_all_scales(self):
+        direction = np.array([1.0, -2.0, 0.5, 1.5], dtype=np.float32)
+        for exponent in (0, -2, -4, -5, -6, -7, -8, -10, -19, -23, 9):
+            scale = np.float32(10.0**exponent)
+            g = (direction * scale,)
+            val = float(_gradient_alignment(g, g))
+            assert abs(val - 1.0) < 1e-4, f"cos(g,g) = {val} at 1e{exponent}"
+
+    def test_negated_gradients_cos_minus_one_all_scales(self):
+        direction = np.array([1.0, -2.0, 0.5, 1.5], dtype=np.float32)
+        for exponent in (0, -6, -10, -23):
+            scale = np.float32(10.0**exponent)
+            g = (direction * scale,)
+            val = float(_gradient_alignment(g, (-direction * scale,)))
+            assert abs(val - (-1.0)) < 1e-4, f"cos(g,-g) = {val} at 1e{exponent}"
+
+    def test_perpendicular_gradients_cos_zero(self):
+        direction = np.array([1.0, -2.0, 0.5, 1.5], dtype=np.float32)
+        perpendicular = np.array([2.0, 1.0, -1.5, 0.5], dtype=np.float32)
+        for exponent in (-5, 0, 5):
+            c = np.float32(10.0**exponent)
+            val = float(_gradient_alignment((direction * c,), (perpendicular * c,)))
+            assert abs(val) < 1e-4, f"cos(a,b) = {val} at 1e{exponent}"
+
+    def test_zero_gradients_degenerate(self):
+        zero = (np.zeros(4, dtype=np.float32),)
+        val = float(_gradient_alignment(zero, zero))
+        assert val == 0.0 and not np.isnan(val)
+
+    def test_reference_implementation_matches_patch_shape(self):
+        # The patch must still expose the same static methods.
+        assert hasattr(UPGDLearner, "_tuple_norm")
+        assert hasattr(UPGDLearner, "_gradient_alignment")

--- a/tests/test_working_memory_cardinality_bounds.py
+++ b/tests/test_working_memory_cardinality_bounds.py
@@ -1,0 +1,83 @@
+"""Cardinality bounds for working-memory decay rates (#2220).
+
+Oversized decay-rate tuples (> 4096) must raise ValueError at config
+validation before per-rate iteration, and from_config must reject
+oversized or hostile list subclasses before element copy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.core.working_memory import (
+    WorkingMemoryConfig,
+    _MAX_WORKING_MEMORY_DECAY_RATES,
+    _validate_decay_rates,
+)
+
+
+class _HostileList(list):
+    calls = 0
+
+    def __len__(self) -> int:  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("hostile __len__ must not be called")
+
+    def __iter__(self):  # pragma: no cover
+        type(self).calls += 1
+        raise AssertionError("hostile __iter__ must not be called")
+
+
+def test_max_constant_is_4096() -> None:
+    assert _MAX_WORKING_MEMORY_DECAY_RATES == 4096
+
+
+def test_oversized_tuple_rejected() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"observation_decay_rates must contain at most 4096 decay rates",
+    ):
+        _validate_decay_rates(
+            "observation_decay_rates", tuple([0.5] * (4096 + 1))
+        )
+
+
+def test_boundary_accepted() -> None:
+    rates = _validate_decay_rates(
+        "observation_decay_rates", tuple([0.5] * 4096)
+    )
+    assert len(rates) == 4096
+
+
+def test_from_config_rejects_oversized_serialized_list() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"serialized reward_decay_rates must contain at most 4096 decay rates",
+    ):
+        WorkingMemoryConfig.from_config(
+            {
+                "type": "WorkingMemoryConfig",
+                "observation_decay_rates": [0.5, 0.9, 0.99],
+                "action_decay_rates": [0.5, 0.9],
+                "reward_decay_rates": [0.5] * (4096 + 1),
+                "observation_dim": 4,
+                "action_dim": 2,
+                "reward_dim": 1,
+            }
+        )
+
+
+def test_from_config_rejects_hostile_list_subclass() -> None:
+    hostile = _HostileList([0.5, 0.9])
+    with pytest.raises(ValueError, match="must be an actual list or tuple"):
+        WorkingMemoryConfig.from_config(
+            {
+                "type": "WorkingMemoryConfig",
+                "observation_decay_rates": hostile,
+                "action_decay_rates": [0.5, 0.9],
+                "reward_decay_rates": [0.5, 0.9],
+                "observation_dim": 4,
+                "action_dim": 2,
+                "reward_dim": 1,
+            }
+        )


### PR DESCRIPTION
## Summary
`targets()` normalizes observation targets by `safe_scale = max(observation_scale, 1e-6)`, but `_prediction_and_raw_diagnostics()` denormalized predictions by the raw `observation_scale`. Below `1e-6` a perfectly fitted learner reconstructed `observation_scale / max(observation_scale, 1e-6)` of its trained delta (e.g. `1e-9` scale reconstructed `1e-3` of the target). The reward leg was already paired on the raw config value with no floor; only the observation leg was unpaired.

## Fix
Decode by the same `safe_scale` used at encode:

```python
safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
decoded_next_observation = jnp.where(
    self._config.predict_delta,
    safe_obs + normalized_delta * safe_scale,
    normalized_delta * safe_scale,
)
```

## Verification
Numpy round-trip check (JAX not installed in the sandbox):

```text
scale=0.001: 固定后还原误差=0.00e+00 (旧版=0.00e+00)
scale=1e-07: 固定后还原误差=0.00e+00 (旧版=9.00e-01)
scale=1e-09: 固定后还原误差=0.00e+00 (旧版=9.99e-01)
```