### PR TITLE
fix(core): renormalize masked baselines instead of flooring the divisor

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -47,6 +47,7 @@ from alberta_framework.core.future_utility import (
 )
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
+    masked_convex_weights,
     neutralize_array,
     select_transaction,
 )
@@ -1036,8 +1037,7 @@ class FixedBudgetFeatureLearner:
         finite: Array,
     ) -> Array:
         """Exponentiated-gradient preference update for utility scores."""
-        finite_mass = jnp.maximum(jnp.sum(jnp.where(finite, allocation, 0.0)), 1e-12)
-        masked_allocation = jnp.where(finite, allocation / finite_mass, 0.0)
+        masked_allocation = masked_convex_weights(finite, allocation)
         baseline = jnp.sum(masked_allocation * jnp.where(finite, scores, 0.0))
         advantages = jnp.where(finite, scores - baseline, 0.0)
         advantages = jnp.clip(

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -44,6 +44,7 @@ from jaxtyping import Bool, Float, Int
 from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 from alberta_framework.core.update_safety import (
     floating_tree_is_finite,
+    masked_convex_weights,
     neutralize_array,
     safe_discrete_action,
     select_transaction,
@@ -340,6 +341,12 @@ class LearnedResourceManager:
     Positive advantage means action ``i`` beat the current allocation.  Centering
     by the allocation baseline keeps the preferences numerically stable and
     makes uniform shifts in all losses irrelevant.
+
+    ``weights`` in the advantage above is the emitted allocation renormalized to
+    sum to one over the actions with a finite loss, so the baseline stays a
+    convex combination of exactly the losses that took part.  Both properties
+    above depend on that: an allocation summing to less than one would pull the
+    baseline toward zero and leave the advantage tracking the raw loss.
     """
 
     def __init__(
@@ -594,8 +601,7 @@ class LearnedResourceManager:
         adjusted = jnp.where(valid_actions, safe_losses + cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(valid_actions, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(valid_actions, weights / finite_weight_sum, 0.0)
+        masked_weights = masked_convex_weights(valid_actions, weights)
         baseline = jnp.sum(masked_weights * adjusted)
         advantages = jnp.where(valid_actions, baseline - adjusted, 0.0)
         advantages = jnp.clip(
@@ -1191,8 +1197,7 @@ class GeneratorMetaResourceManager:
         adjusted = jnp.where(finite, safe_rewards - cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(finite, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(finite, weights / finite_weight_sum, 0.0)
+        masked_weights = masked_convex_weights(finite, weights)
         baseline = jnp.sum(masked_weights * adjusted)
         selection_input_valid = jnp.asarray(True, dtype=jnp.bool_)
         if self._update_rule == "exp3":

--- a/alberta_framework/core/update_safety.py
+++ b/alberta_framework/core/update_safety.py
@@ -199,6 +199,39 @@ def neutralize_metrics(
     return {name: neutralize_array(applied, value) for name, value in metrics.items()}
 
 
+def masked_convex_weights(mask: Bool[Array, " n"], weights: Array) -> Array:
+    """Renormalize non-negative ``weights`` to sum to one over ``mask``.
+
+    A baseline built from the result is a convex combination of the masked-in
+    values, so it is bounded by them and a uniform shift in all of them moves it
+    by exactly that shift.  Flooring the divisor instead promises neither: once
+    the masked-in entries carry less mass than the floor, the row sums to less
+    than one and the baseline is pulled toward zero rather than toward the values
+    that took part, which turns a centered advantage into the raw value.
+
+    Masked-in entries whose total is not a normal float of ``weights.dtype`` fall
+    back to a uniform allocation.  Every arithmetic operand below the smallest
+    normal is returned as an exact zero by the accelerator backends this runs on,
+    so their relative sizes cannot be recovered here and uniform is the only
+    convex answer left.  A non-finite total is passed through so the caller's
+    finiteness gate still sees it.
+    """
+
+    participating = jnp.where(mask, weights, jnp.zeros_like(weights))
+    mass = jnp.sum(participating)
+    smallest_normal = jnp.asarray(np.finfo(cast(Any, weights.dtype)).tiny, dtype=mass.dtype)
+    usable = mass >= smallest_normal
+    counted = jnp.sum(mask.astype(weights.dtype))
+    uniform = jnp.where(mask, jnp.ones_like(weights), jnp.zeros_like(weights)) / jnp.maximum(
+        counted, jnp.ones_like(counted)
+    )
+    return jnp.where(
+        usable | ~jnp.isfinite(mass),
+        participating / jnp.where(usable, mass, jnp.ones_like(mass)),
+        uniform,
+    )
+
+
 def zero_if_collapsed_infinity(
     product: Array,
     infinite_input: Array,

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -23,6 +23,10 @@ from alberta_framework.core.compositional_features import (
     CompositionalFeatureLearner,
     run_compositional_arrays,
 )
+from alberta_framework.core.resource_manager import (
+    GeneratorMetaResourceManagerState,
+    LearnedResourceManagerState,
+)
 
 
 class TestLearnedResourceManager:
@@ -315,6 +319,121 @@ class TestLearnedResourceManager:
         )
         assert math.isinf(bound)
 
+    # The manager renormalizes its allocation over the actions whose loss was
+    # finite.  Once a learned preference puts that subset far enough below the
+    # leader the subset's own mass underflows, and the tests below pin that the
+    # baseline stays the mean of the losses that took part.
+    _MASKED_BASELINE_GAPS = [0.0, 10.0, 28.0, 30.0, 40.0, 60.0, 80.0, 88.0, 110.0, 200.0]
+
+    @staticmethod
+    def _seeded_state(
+        manager: LearnedResourceManager,
+        gap: float,
+    ) -> LearnedResourceManagerState:
+        """Return a state whose first action leads the others by ``gap`` nats."""
+        fresh = manager.init()
+        return LearnedResourceManagerState(  # type: ignore[call-arg]
+            log_weights=jnp.asarray([[gap, 0.0, 0.0]], dtype=jnp.float32),
+            loss_ema=fresh.loss_ema,
+            action_counts=fresh.action_counts,
+            step_count=fresh.step_count,
+        )
+
+    @classmethod
+    def _masked_update(
+        cls,
+        gap: float,
+        shift: float = 0.0,
+    ) -> tuple[NDArray[np.float32], NDArray[np.float32], bool]:
+        """Update with the leading action's loss masked out by ``NaN``."""
+        manager = LearnedResourceManager(n_actions=3, n_contexts=1, exploration=0.0)
+        state = cls._seeded_state(manager, gap)
+        losses = jnp.asarray([jnp.nan, 1.0 + shift, 3.0 + shift], dtype=jnp.float32)
+        result = manager.update(state, losses, 0)
+        return (
+            np.asarray(result.advantages, dtype=np.float32),
+            np.asarray(result.state.log_weights, dtype=np.float32).ravel(),
+            bool(result.update_applied),
+        )
+
+    @pytest.mark.parametrize("gap", _MASKED_BASELINE_GAPS)
+    def test_masked_baseline_centers_on_the_losses_that_took_part(self, gap: float) -> None:
+        advantages, _, applied = self._masked_update(gap)
+        assert applied
+        # The two participating losses are 1.0 and 3.0 with equal allocation, so
+        # the baseline is 2.0 and the advantages are its distance to each.
+        np.testing.assert_allclose(advantages[1], 1.0, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(advantages[2], -1.0, rtol=0.0, atol=1e-6)
+        assert advantages[0] == 0.0
+
+    @pytest.mark.parametrize("shift", [0.0, 1.0, 10.0, 100.0, 1000.0])
+    @pytest.mark.parametrize("gap", _MASKED_BASELINE_GAPS)
+    def test_masked_advantages_ignore_a_uniform_shift_in_all_losses(
+        self,
+        gap: float,
+        shift: float,
+    ) -> None:
+        baseline_advantages, _, _ = self._masked_update(gap)
+        shifted_advantages, _, _ = self._masked_update(gap, shift)
+        np.testing.assert_allclose(
+            shifted_advantages,
+            baseline_advantages,
+            rtol=0.0,
+            atol=1e-4,
+        )
+
+    @pytest.mark.parametrize("gap", _MASKED_BASELINE_GAPS)
+    def test_masked_advantages_stay_inside_the_participating_loss_spread(
+        self,
+        gap: float,
+    ) -> None:
+        advantages, _, _ = self._masked_update(gap)
+        assert np.abs(advantages).max() <= 2.0
+
+    @pytest.mark.parametrize(
+        ("gap", "advantage_words", "log_weight_words"),
+        [
+            pytest.param(
+                0.0,
+                ("0x00000000", "0x3f800000", "0xbf800000"),
+                ("0x00000000", "0x3f800000", "0xbf800000"),
+                id="gap-0",
+            ),
+            pytest.param(
+                10.0,
+                ("0x00000000", "0x3f800000", "0xbf800000"),
+                ("0x40d44444", "0xc0144444", "0xc08a2222"),
+                id="gap-10",
+            ),
+            pytest.param(
+                20.0,
+                ("0x00000000", "0x3f800000", "0xbf800000"),
+                ("0x41544444", "0xc0b44444", "0xc0f44444"),
+                id="gap-20",
+            ),
+            pytest.param(
+                28.0,
+                ("0x00000000", "0x3f800000", "0xbf800000"),
+                ("0x41949630", "0xc1049630", "0xc1249630"),
+                id="gap-28",
+            ),
+        ],
+    )
+    def test_masked_update_is_bit_for_bit_unchanged_where_the_mass_was_representable(
+        self,
+        gap: float,
+        advantage_words: tuple[str, ...],
+        log_weight_words: tuple[str, ...],
+    ) -> None:
+        """Pin the words recorded from the floored formulation above its floor."""
+        advantages, log_weights, _ = self._masked_update(gap)
+
+        def words(values: NDArray[np.float32]) -> tuple[str, ...]:
+            return tuple(f"0x{word:08x}" for word in values.view(np.uint32))
+
+        assert words(advantages) == advantage_words
+        assert words(log_weights) == log_weight_words
+
 
 class TestGeneratorMetaResourceManager:
     """Behavioral checks for generator-internal meta-resource policies."""
@@ -581,6 +700,77 @@ class TestGeneratorMetaResourceManager:
 
         assert jnp.all(jnp.isfinite(result.metrics))
         assert jnp.all(jnp.isfinite(result.state.generator_resource_state.log_weights))
+
+    _MASKED_BASELINE_GAPS = [0.0, 28.0, 30.0, 40.0, 80.0, 110.0]
+
+    @staticmethod
+    def _three_policy_manager(*, exploration: float) -> GeneratorMetaResourceManager:
+        return GeneratorMetaResourceManager(
+            policy_names=("safe", "residual", "product"),
+            op_ids=(1, 3, 5),
+            parent_modes=(0, 3, 1),
+            replacement_multipliers=(0.5, 2.0, 1.0),
+            promotion_margin_multipliers=(1.25, 0.75, 1.0),
+            candidate_min_age_multipliers=(1.5, 0.5, 1.0),
+            imprint_scales=(0.0, 1.0, 0.5),
+            n_contexts=1,
+            exploration=exploration,
+        )
+
+    @classmethod
+    def _masked_update(
+        cls,
+        gap: float,
+        shift: float = 0.0,
+        *,
+        exploration: float = 0.0,
+    ) -> tuple[NDArray[np.float32], bool]:
+        """Update with the leading policy's reward masked out by ``NaN``."""
+        manager = cls._three_policy_manager(exploration=exploration)
+        fresh = manager.init()
+        state = GeneratorMetaResourceManagerState(  # type: ignore[call-arg]
+            log_weights=jnp.asarray([[gap, 0.0, 0.0]], dtype=jnp.float32),
+            reward_ema=fresh.reward_ema,
+            action_counts=fresh.action_counts,
+            step_count=fresh.step_count,
+        )
+        rewards = jnp.asarray([jnp.nan, 1.0 + shift, 3.0 + shift], dtype=jnp.float32)
+        result = manager.update(state, rewards, 0)
+        return (
+            np.asarray(result.advantages, dtype=np.float32),
+            bool(result.update_applied),
+        )
+
+    @pytest.mark.parametrize("gap", _MASKED_BASELINE_GAPS)
+    def test_masked_baseline_centers_on_the_rewards_that_took_part(self, gap: float) -> None:
+        advantages, applied = self._masked_update(gap)
+        assert applied
+        # Rewards 1.0 and 3.0 share the remaining allocation equally, so the
+        # baseline is 2.0 and the centered rewards are its distance to each.
+        np.testing.assert_allclose(advantages[1], -1.0, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(advantages[2], 1.0, rtol=0.0, atol=1e-6)
+
+    @pytest.mark.parametrize("shift", [0.0, 100.0, 1000.0])
+    @pytest.mark.parametrize("gap", _MASKED_BASELINE_GAPS)
+    def test_masked_advantages_ignore_a_uniform_shift_in_all_rewards(
+        self,
+        gap: float,
+        shift: float,
+    ) -> None:
+        unshifted, _ = self._masked_update(gap)
+        shifted, _ = self._masked_update(gap, shift)
+        np.testing.assert_allclose(shifted, unshifted, rtol=0.0, atol=1e-4)
+
+    @pytest.mark.parametrize("gap", _MASKED_BASELINE_GAPS)
+    def test_default_exploration_floor_keeps_the_masked_mass_representable(
+        self,
+        gap: float,
+    ) -> None:
+        """The class default already protects this path; pin that it still does."""
+        advantages, applied = self._masked_update(gap, exploration=0.01)
+        assert applied
+        np.testing.assert_allclose(advantages[1], -1.0, rtol=0.0, atol=1e-6)
+        np.testing.assert_allclose(advantages[2], 1.0, rtol=0.0, atol=1e-6)
 
 
 def test_learned_resource_manager_integer_validation() -> None:

--- a/tests/test_update_safety.py
+++ b/tests/test_update_safety.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from jax import Array
 
-from alberta_framework.core.update_safety import safe_discrete_action
+from alberta_framework.core.update_safety import masked_convex_weights, safe_discrete_action
 
 
 def test_legal_action_in_domain_is_valid() -> None:
@@ -81,3 +83,108 @@ def test_numpy_int_n_actions_remains_legal() -> None:
 def test_n_actions_must_fit_the_int32_action_sink(n_actions: object) -> None:
     with pytest.raises(ValueError, match=r"n_actions.*\[0, 2147483647\]"):
         safe_discrete_action(0, n_actions)  # type: ignore[arg-type]
+
+
+_SMALLEST_NORMAL_FLOAT32 = float(np.finfo(np.float32).tiny)
+# A softmax over these logit gaps puts the two trailing entries far enough below
+# the leader to walk the masked mass from ordinary down through the old 1e-12
+# floor to an exact zero.
+_MASS_DECAY_GAPS = [0.0, 10.0, 28.0, 30.0, 40.0, 60.0, 80.0, 87.0, 88.0, 110.0, 200.0]
+
+
+def _trailing_pair_allocation(gap: float) -> tuple[Array, Array]:
+    """Return ``(mask, weights)`` for a softmax whose leader is ``gap`` nats ahead."""
+
+    weights = jax.nn.softmax(jnp.asarray([gap, 0.0, 0.0], dtype=jnp.float32))
+    return jnp.asarray([False, True, True]), weights
+
+
+@pytest.mark.parametrize("gap", _MASS_DECAY_GAPS)
+def test_masked_convex_weights_sum_to_one_over_the_mask(gap: float) -> None:
+    mask, weights = _trailing_pair_allocation(gap)
+    row = masked_convex_weights(mask, weights)
+    np.testing.assert_allclose(float(jnp.sum(row)), 1.0, rtol=0.0, atol=6e-8)
+
+
+@pytest.mark.parametrize("gap", _MASS_DECAY_GAPS)
+def test_masked_convex_weights_zero_the_masked_out_entries(gap: float) -> None:
+    mask, weights = _trailing_pair_allocation(gap)
+    row = np.asarray(masked_convex_weights(mask, weights))
+    assert row[0] == 0.0
+
+
+@pytest.mark.parametrize("gap", _MASS_DECAY_GAPS)
+def test_masked_convex_weights_bound_the_baseline_by_the_values_averaged(gap: float) -> None:
+    mask, weights = _trailing_pair_allocation(gap)
+    row = masked_convex_weights(mask, weights)
+    values = jnp.asarray([0.0, 1.0, 3.0], dtype=jnp.float32)
+    baseline = float(jnp.sum(row * values))
+    assert 1.0 - 6e-8 <= baseline <= 3.0 + 6e-8
+
+
+@pytest.mark.parametrize("shift", [0.0, 1.0, 10.0, 100.0, 1000.0])
+@pytest.mark.parametrize("gap", _MASS_DECAY_GAPS)
+def test_masked_convex_weights_make_a_uniform_shift_move_the_baseline_by_that_shift(
+    gap: float, shift: float
+) -> None:
+    mask, weights = _trailing_pair_allocation(gap)
+    row = masked_convex_weights(mask, weights)
+    values = jnp.asarray([0.0, 1.0, 3.0], dtype=jnp.float32)
+    baseline = float(jnp.sum(row * values))
+    shifted = float(jnp.sum(row * (values + shift)))
+    np.testing.assert_allclose(shifted - baseline, shift, rtol=0.0, atol=1e-4)
+
+
+def test_masked_convex_weights_match_the_plain_quotient_for_a_normal_mass() -> None:
+    mask, weights = _trailing_pair_allocation(40.0)
+    row = np.asarray(masked_convex_weights(mask, weights))
+    reference = np.asarray(jnp.where(mask, weights, 0.0)) / float(
+        jnp.sum(jnp.where(mask, weights, 0.0))
+    )
+    np.testing.assert_array_equal(row, reference)
+
+
+def test_masked_convex_weights_fall_back_to_uniform_when_the_mass_underflows() -> None:
+    mask = jnp.asarray([True, False, True, True])
+    weights = jnp.zeros(4, dtype=jnp.float32)
+    row = np.asarray(masked_convex_weights(mask, weights))
+    third = 1.0 / 3.0
+    np.testing.assert_array_equal(row, np.asarray([third, 0.0, third, third], dtype=np.float32))
+
+
+def test_masked_convex_weights_fall_back_to_uniform_for_a_subnormal_mass() -> None:
+    mask = jnp.asarray([True, True, False])
+    weights = jnp.asarray([_SMALLEST_NORMAL_FLOAT32 / 4.0, 0.0, 1.0], dtype=jnp.float32)
+    row = np.asarray(masked_convex_weights(mask, weights))
+    np.testing.assert_array_equal(row, np.asarray([0.5, 0.5, 0.0], dtype=np.float32))
+
+
+def test_masked_convex_weights_return_zeros_for_an_empty_mask() -> None:
+    mask = jnp.zeros(3, dtype=jnp.bool_)
+    weights = jnp.asarray([0.2, 0.3, 0.5], dtype=jnp.float32)
+    row = np.asarray(masked_convex_weights(mask, weights))
+    np.testing.assert_array_equal(row, np.zeros(3, dtype=np.float32))
+
+
+def test_masked_convex_weights_pass_a_non_finite_allocation_through() -> None:
+    mask = jnp.asarray([True, True])
+    weights = jnp.asarray([jnp.nan, jnp.nan], dtype=jnp.float32)
+    row = np.asarray(masked_convex_weights(mask, weights))
+    assert not np.isfinite(row).any()
+
+
+@pytest.mark.parametrize("gap", _MASS_DECAY_GAPS)
+def test_masked_convex_weights_stay_finite_and_non_negative(gap: float) -> None:
+    mask, weights = _trailing_pair_allocation(gap)
+    row = np.asarray(masked_convex_weights(mask, weights))
+    assert np.isfinite(row).all()
+    assert (row >= 0.0).all()
+
+
+@pytest.mark.parametrize("gap", _MASS_DECAY_GAPS)
+def test_masked_convex_weights_agree_under_jit(gap: float) -> None:
+    mask, weights = _trailing_pair_allocation(gap)
+    eager = np.asarray(masked_convex_weights(mask, weights))
+    compiled = np.asarray(jax.jit(masked_convex_weights)(mask, weights))
+    np.testing.assert_array_equal(eager, compiled)
+


### PR DESCRIPTION
Fixes #2409.

## Problem

Three Hedge-style preference updates centered their advantages against a baseline built
from a **floored** masked mass:

```python
finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(mask, weights, 0.0)), 1e-12)
masked_weights = jnp.where(mask, weights / finite_weight_sum, 0.0)
baseline = jnp.sum(masked_weights * adjusted)
```

- `alberta_framework/core/resource_manager.py:597` — `LearnedResourceManager._update_jit`
- `alberta_framework/core/resource_manager.py:1194` — `GeneratorMetaResourceManager._update_jit`
- `alberta_framework/core/feature_discovery.py:1039` — `FixedBudgetFeatureLearner._resource_log_weight_update`

Once the masked-in entries carry less mass than `1e-12`, the divisor stops being the
mass, so `masked_weights` no longer sums to one. The baseline is then pulled toward zero
instead of toward the values that took part, and `advantage_i` degenerates into the raw
value with a sign flip. `update_applied` stays `True`, so the update is committed to
state with nothing to indicate that centering was lost.

`LearnedResourceManager`'s own class docstring is the contract this breaks:

> `advantage_i = dot(weights, adjusted_losses) - adjusted_losses_i`
>
> Centering by the allocation baseline keeps the preferences numerically stable and
> makes uniform shifts in all losses irrelevant.

Both clauses require `weights` to sum to one over the participating actions.

## Reproduction

`LearnedResourceManager(n_actions=3, n_contexts=1, exploration=0.0)`, one context,
`log_weights = [[gap, 0.0, 0.0]]`, `update(state, [nan, 1.0, 3.0], 0)`. The leading
action is masked out by its `nan`, so the survivors have adjusted losses `1.0` and `3.0`;
a convex baseline over those is `2.0` and centering must give `+1.0 / -1.0`.

| leader gap | masked mass | class | `applied` | before `adv[1]` | before `adv[2]` | after `adv[1]` | after `adv[2]` |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 0.0 | 6.66667e-01 | normal | 1 | 1.00000e+00 | -1.00000e+00 | 1.00000e+00 | -1.00000e+00 |
| 5.0 | 1.32967e-02 | normal | 1 | 1.00000e+00 | -1.00000e+00 | 1.00000e+00 | -1.00000e+00 |
| 10.0 | 9.07916e-05 | normal | 1 | 1.00000e+00 | -1.00000e+00 | 1.00000e+00 | -1.00000e+00 |
| 20.0 | 4.12231e-09 | normal | 1 | 1.00000e+00 | -1.00000e+00 | 1.00000e+00 | -1.00000e+00 |
| 27.0 | 3.75906e-12 | normal | 1 | 1.00000e+00 | -1.00000e+00 | 1.00000e+00 | -1.00000e+00 |
| 28.0 | 1.38288e-12 | normal | 1 | 1.00000e+00 | -1.00000e+00 | 1.00000e+00 | -1.00000e+00 |
| **30.0** | 1.87152e-13 | normal | 1 | **-6.25695e-01** | **-2.62569e+00** | 1.00000e+00 | -1.00000e+00 |
| **40.0** | 8.49671e-18 | normal | 1 | **-9.99983e-01** | **-2.99998e+00** | 1.00000e+00 | -1.00000e+00 |
| **60.0** | 1.75130e-26 | normal | 1 | **-1.00000e+00** | **-3.00000e+00** | 1.00000e+00 | -1.00000e+00 |
| **80.0** | 3.60970e-35 | normal | 1 | **-1.00000e+00** | **-3.00000e+00** | 1.00000e+00 | -1.00000e+00 |
| **90.0** | 0.00000e+00 | zero | 1 | **-1.00000e+00** | **-3.00000e+00** | 1.00000e+00 | -1.00000e+00 |
| **200.0** | 0.00000e+00 | zero | 1 | **-1.00000e+00** | **-3.00000e+00** | 1.00000e+00 | -1.00000e+00 |

The transition sits exactly on the floor: `1.38e-12 > 1e-12` still centers,
`1.87e-13 < 1e-12` does not. Past it the baseline collapses to `0` and
`advantage_i -> -adjusted_loss_i`.

Uniform shifts, which the docstring says are irrelevant, are absorbed by
`advantage_clip=10.0` into a total loss of ordering — `advantages[1], advantages[2]`:

| leader gap | shift 0 | shift 1 | shift 10 | shift 100 | after (any shift) |
| --- | --- | --- | --- | --- | --- |
| 0.0 | 1.0000, -1.0000 | 1.0000, -1.0000 | 1.0000, -1.0000 | 1.0000, -1.0000 | 1.0000, -1.0000 |
| 28.0 | 1.0000, -1.0000 | 1.0000, -1.0000 | 1.0000, -1.0000 | 1.0000, -1.0000 | 1.0000, -1.0000 |
| 30.0 | -0.6257, -2.6257 | -1.4385, -3.4385 | -8.7542, **-10.0000** | **-10.0000, -10.0000** | 1.0000, -1.0000 |
| 40.0 | -1.0000, -3.0000 | -2.0000, -4.0000 | **-10.0000, -10.0000** | **-10.0000, -10.0000** | 1.0000, -1.0000 |
| 110.0 | -1.0000, -3.0000 | -2.0000, -4.0000 | **-10.0000, -10.0000** | **-10.0000, -10.0000** | 1.0000, -1.0000 |

At gap 40 with every loss shifted by 10, the manager can no longer distinguish the
loss-1 action from the loss-3 action.

`GeneratorMetaResourceManager` at `exploration=0.0` reproduces identically with the sign
inverted (it maximizes): gap 40 gives `+0.999983 / +2.99998` where `-1 / +1` is required,
and shift 100 saturates both to `+10.0`. After the change it is `-1.0 / +1.0` at every
gap and shift.

## Reachability

`LearnedResourceManager` **defaults** to `exploration=0.0`, so nothing holds its
allocation off the floor. A Hedge run concentrating on one action — the algorithm working
as intended — walks into this range on its own; a 30-nat gap after `learning_rate=1.0`
steps is unremarkable.

`GeneratorMetaResourceManager` (`exploration=0.01`) and `FixedBudgetFeatureLearner`
(`resource_exploration=0.01`) are protected **by the exploration floor, not by this
code** — it holds any non-empty valid subset at `>= exploration / n`, measured
`6.66667e-03` at every gap with correct advantages. That protection disappears at
`exploration=0.0`, an accepted value and the one the repository's own tests use.

In `feature_discovery.py`, the call at line 1788 passes a real `generator_finite` mask
and is exposed; line 1823 passes an all-true mask, where the mass is `1.0` and the floor
never binds.

## The fix

One shared helper in `alberta_framework/core/update_safety.py`, the existing home for
fail-closed numerical update primitives — both consumers already import from it, so no
new dependency edge appears:

```python
participating = jnp.where(mask, weights, jnp.zeros_like(weights))
mass = jnp.sum(participating)
smallest_normal = jnp.asarray(np.finfo(cast(Any, weights.dtype)).tiny, dtype=mass.dtype)
usable = mass >= smallest_normal
...
return jnp.where(
    usable | ~jnp.isfinite(mass),
    participating / jnp.where(usable, mass, jnp.ones_like(mass)),
    uniform,
)
```

Three decisions:

1. **Divide by the raw mass over the normal-float32 domain.** Where the floor never
   bound, `max(mass, 1e-12) == mass` and `where(usable, mass, 1.0) == mass` — the same
   op on the same inputs, so those rows are bit-for-bit unchanged. Every row the floor
   did reach becomes a true convex combination.
2. **Fall back to a uniform allocation below the smallest normal** (`1.17549435e-38`).
   The backend has already returned exact zeros for operands down there, so no relative
   size survives to recover, and uniform is the only convex answer left. The old floor
   sat 26 orders of magnitude *above* that point, discarding a very large range of
   perfectly representable masses.
3. **Pass a non-finite mass through unchanged.** Both callers already have a finiteness
   gate that neutralizes the update; swallowing the `nan` here would hide the condition
   from it.

Rejected:

- **Lower the floor to the smallest normal.** Still a floor, so the row still sums to
  less than one across the range it covers; it moves the boundary rather than removing
  the defect.
- **Accumulate the mass in float64.** `x64` is disabled in this project; enabling it
  globally to fix one divisor is far larger than the defect warrants.
- **Fall back to the unmasked row.** That readmits the masked-out entries into a
  baseline defined over the participating ones only.

Two implementation notes: `np.finfo` is used rather than `jnp.finfo` because `mypy`
strict rejects the latter as an untyped call; and the `LearnedResourceManager` class
docstring now states that the advantage weights are renormalized over the finite-loss
actions, since it previously specified the advantage without naming the step the defect
broke.

## Verification

Two backend facts shaped the assertions, both measured here (`jax 0.11.0`, CPU, `x64`
off):

- Summing float32 subnormals flushes them, so the masked mass jumps from a normal
  `3.29e-38` at gap 87 straight to exactly `0.0` at gap 88 — a subnormal total is
  unreachable through the accumulation the callers use. The subnormal branch is still
  covered directly at the helper's own boundary.
- CPU division is not correctly rounded: with `mass` exactly `2w`, `w / mass` returns
  `0x3effffff` (`0.49999997`), not `0.5`. Repaired rows are therefore asserted with
  tolerances (`atol` 6e-8 on the row sum, 1e-6 / 1e-4 on advantages); exact bit
  assertions are reserved for the rows the change provably does not touch.

**Bit identity where the floor was inactive.** Advantage and `log_weights` words are
identical between the pristine and changed trees at gaps 0, 5, 10, 20, 27 and 28,
compared as raw `uint32` views. Four of those are pinned in
`test_masked_update_is_bit_for_bit_unchanged_where_the_mass_was_representable`:

| gap | advantages | `log_weights` |
| --- | --- | --- |
| 0 | `0x00000000 0x3f800000 0xbf800000` | `0x00000000 0x3f800000 0xbf800000` |
| 10 | `0x00000000 0x3f800000 0xbf800000` | `0x40d44444 0xc0144444 0xc08a2222` |
| 20 | `0x00000000 0x3f800000 0xbf800000` | `0x41544444 0xc0b44444 0xc0f44444` |
| 28 | `0x00000000 0x3f800000 0xbf800000` | `0x41949630 0xc1049630 0xc1249630` |

**Fail-first,** the new tests run against pristine `c9aba7b5` in a separate checkout:

```
pytest tests/test_resource_manager.py   ->  54 failed, 116 passed
pytest tests/test_update_safety.py      ->  collection error: cannot import
                                            masked_convex_weights
```

The 54 failures are 5 distinct tests: `LearnedResourceManager` centering (7 gaps),
uniform-shift invariance (28 cases) and loss-spread bounds (7 gaps);
`GeneratorMetaResourceManager` centering (4 gaps) and uniform-shift invariance (8 cases).
Two new tests pass on pristine *by design* — the recorded-bit-pattern test, whose golden
words were taken from that tree, and the default-exploration-floor test, which asserts
the configuration the floor protects.

**Gates on the change:**

```
ruff check .                                                     All checks passed!
mypy                                            108 errors (unchanged from baseline)
pytest tests/test_resource_manager.py tests/test_update_safety.py  303 passed
pytest the four feature-discovery suites + the pytree-depth suite  206 passed, 2 failed
pytest the six compositional-feature suites                        115 passed
```

The two failures are `test_update_safety_tree_depth.py::test_last_fit_list_nesting_still_walks`
and `::test_last_fit_tuple_and_dict_nests_still_walk`, both a Python recursion limit in
the harness. They reproduce identically on a pristine `c9aba7b5` checkout (`2 failed,
7 passed`) and are unrelated to this change.

**Tests added:** 18 tests, 219 parametrized cases.

- `tests/test_update_safety.py` — 11 unit tests, 115 cases, over the helper directly:
  the row sums to one over the mask; masked-out entries are zero; the baseline is bounded
  by the values averaged; a uniform shift moves the baseline by exactly that shift; the
  plain quotient is matched with exact array equality for a normal mass; an underflowed
  mass falls back to uniform; a subnormal mass falls back to uniform; an empty mask
  returns zeros; a non-finite allocation passes through; the row stays finite and
  non-negative; eager and `jit` agree bit-for-bit.
- `tests/test_resource_manager.py` — 7 behavioural tests, 104 cases, through the public
  `update` API of both managers, including the bit-identity pins above and the
  exploration-floor protection.

Worst advantage error across all repaired rows for uniform shifts up to 1000 is `6.1e-5`.

## Boundaries not crossed

Other `jnp.maximum(jnp.sum(...), ...)` occurrences are a different pattern and are
correct, so they are untouched: count guards of the form `max(sum(mask), 1.0)`, where a
zero count also means a zero numerator, and unmasked softmax denominators
(`associative_memory.py:540`/`548`, `prototype_memory.py:308`), where the numerator is
part of the sum. A `grep` over every occurrence confirms no floored *masked*
renormalization remains.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [fix]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0SQQCRTDN6XG6653J9MN54Y","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T11:15:39.930Z","completed_at":"2026-08-24T17:40:52.803Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T11:15:40.445Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c1dcda834e6bea703e9cb10bda68a7b7905e2f1a859e8b9c97735ff2a2d03727","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"8f4119d4-02ee-4f81-9b1c-69b2f0d36bf0","object_id":"sha256:c1dcda834e6bea703e9cb10bda68a7b7905e2f1a859e8b9c97735ff2a2d03727","sha256":"c1dcda834e6bea703e9cb10bda68a7b7905e2f1a859e8b9c97735ff2a2d03727"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"Fw91Q-WUrqvNLhynSw2tY73KBl4eGmBMcIJu0TzpzvcpUi5feY26gYppBNU72HHLDAAEFXrjtv3-DmkYuANSCQ"}} -->