### PR TITLE
fix(tests): silence RuntimeWarning in _platform_longdouble_1e4000

### DIFF
--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from decimal import Decimal
 from fractions import Fraction
@@ -537,7 +538,8 @@ class _NonfiniteFloatThatConvertsFinite(float):
 
 def _platform_longdouble_1e4000() -> np.longdouble:
     """Parse the cross-platform boundary without leaking an expected warning."""
-    with np.errstate(over="ignore", invalid="ignore"):
+    with warnings.catch_warnings(), np.errstate(over="ignore", invalid="ignore"):
+        warnings.simplefilter("ignore", RuntimeWarning)
         return np.longdouble("1e4000")
 
 
@@ -1029,3 +1031,12 @@ def test_run_multi_seed_experiment_rejects_invalid_seed_sequences(
 def test_get_final_performance_rejects_non_builtin_positive_window(window: object) -> None:
     with pytest.raises(ValueError, match="window"):
         get_final_performance({"candidate": _two_seed_trace()}, window=window)  # type: ignore[arg-type]
+
+
+def test_platform_longdouble_1e4000_emits_no_warnings() -> None:
+    """_platform_longdouble_1e4000 must not leak conversion warnings."""
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        val = _platform_longdouble_1e4000()
+        assert val is not None
+    assert len(recorded) == 0


### PR DESCRIPTION
Fixes #2387

`_platform_longdouble_1e4000` (`tests/test_experiments_validation.py`) wrapped `np.longdouble("1e4000")` with `np.errstate(...)`, which only intercepts floating-point errors (`np.seterr`) but does not suppress `RuntimeWarning: overflow encountered in conversion from string` emitted through Python's `warnings` subsystem during string-to-float conversion on platforms where `np.longdouble` is 64-bit (such as aarch64 / arm64 Darwin / Linux).

### Changes
1. Added `with warnings.catch_warnings(): warnings.simplefilter("ignore", RuntimeWarning)` alongside `np.errstate` in `_platform_longdouble_1e4000`.
2. Added unit test `test_platform_longdouble_1e4000_emits_no_warnings` asserting zero warnings are emitted during execution.

### Verification
- `pytest tests/test_experiments_validation.py`: 130/130 tests passed without warning leak.
- `ruff check`: All checks passed.
- `mypy`: Clean.
