### PR TITLE
fix(core): admit all numpy floating families in GVF terminal_reward

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -32,7 +32,7 @@ _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _INT32_MAX = 2**31 - 1
 _ACTUAL_REAL_SCALAR_TYPES = frozenset(
-    {float, np.float16, np.float32, np.float64, int}
+    {float, int, *(np.dtype(code).type for code in "efdg")}
 )
 
 _ACTUAL_INT_TYPES = frozenset(

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -431,6 +431,23 @@ class TestGVFSpecRemainingFields:
                 }
             )
 
+    @pytest.mark.parametrize(
+        "dtype_code",
+        ["e", "f", "d", "g"],
+    )
+    def test_terminal_reward_accepts_all_numpy_floating_families(self, dtype_code):
+        scalar_type = np.dtype(dtype_code).type
+        value = scalar_type(1.5)
+        spec = GVFSpec(
+            name="d0",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=0,
+            terminal_reward=value,
+        )
+        assert spec.terminal_reward == 1.5
+
     def test_terminal_reward_rejects_class_spoofed_float(self):
         class _SpoofedFloat:
             @property


### PR DESCRIPTION
Fixes #2283

`_ACTUAL_REAL_SCALAR_TYPES` in `alberta_framework/core/types.py` hand-enumerated `{float, np.float16, np.float32, np.float64, int}`, omitting `np.longdouble` (dtype code `g`), causing `GVFSpec.terminal_reward` to reject `np.longdouble` values even though sibling fields (`gamma`, `lamda`) and the underlying `validated_float32_scalar_with_ratio` helper accept all NumPy floating families.

### Changes
1. Updated `_ACTUAL_REAL_SCALAR_TYPES` to derive all floating types dynamically from dtype characters `frozenset({float, int, *(np.dtype(code).type for code in "efdg")})`, mirroring `_ACTUAL_INT_TYPES` and `_ACTUAL_FLOAT_TYPES`.
2. Added parametrized unit test in `tests/test_gvf_types.py` verifying that all NumPy floating families (`e`, `f`, `d`, `g` including `np.longdouble`) are accepted by `GVFSpec.terminal_reward`.

### Verification
- `pytest tests/test_gvf_types.py`: 84/84 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
