### PR TITLE
fix(benchmarks): admit all numpy integer families in gradual IPMNIST and causal map forager

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -59,15 +59,8 @@ CAUSAL_MAP_VARIANT_KIND = "alberta_causal_map"
 _CAUSAL_MAP_RNG_NAMESPACE = 0xCA05A14
 _CAUSAL_MAP_PRNG_IMPL = "threefry2x32"
 _CAUSAL_MAP_ENVIRONMENT_PRNG_IMPL = "threefry2x32"
-_EXACT_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
+_EXACT_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 _EXACT_INTEGER_TYPES = (int, *_EXACT_NUMPY_INTEGER_TYPES)
 _EXACT_REAL_TYPES = (

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -43,17 +43,8 @@ _MAX_RUN_STEPS = 1_000_000
 _PRNG_IMPLEMENTATION = "threefry2x32"
 _PAIR_RESULT_SCHEMA = "asi.ipmnist.gradual-input-pair.result.v1"
 _ADAMW_IDENTITY = tuple(sorted(ADAMW_PROTOCOL_HYPERPARAMETERS.items()))
-_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.longlong,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.ulonglong,
+_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 
 GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(

--- a/tests/test_causal_map_forager.py
+++ b/tests/test_causal_map_forager.py
@@ -2879,3 +2879,13 @@ def test_seed_batch_validation(monkeypatch: pytest.MonkeyPatch) -> None:
     unsafe = dataclasses.replace(benchmark, steps=np.iinfo(np.int32).max)
     with pytest.raises(ValueError, match="steps must be"):
         run_causal_map_forager_seeds(config, unsafe, (1,))
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"],
+)
+def test_causal_map_forager_accepts_all_numpy_integer_families(code: str) -> None:
+    t = np.dtype(code).type
+    cfg = CausalMapForagerConfig(initial_retry_delay=t(2))
+    assert cfg.initial_retry_delay == 2

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -315,3 +315,19 @@ def test_gradual_pair_preflights_parameter_allocation_before_initialization() ->
             config=config,
             transition_steps=1,
         )
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"],
+)
+def test_gradual_ipmnist_accepts_all_numpy_integer_families(code: str) -> None:
+    from alberta_framework.benchmarks.ipmnist_gradual import (
+        GradualTransitionConfig,
+        transition_alpha,
+    )
+
+    t = np.dtype(code).type
+    config = GradualTransitionConfig(mode="input_interpolation", transition_steps=t(10))
+    alpha = transition_alpha(t(1), config)
+    assert 0.0 <= alpha <= 1.0


### PR DESCRIPTION
Fixes #2295

`_NUMPY_INTEGER_TYPES` in `ipmnist_gradual.py` and `_EXACT_NUMPY_INTEGER_TYPES` in `causal_map_forager.py` used hand-enumerated fixed-width aliases that omitted platform-dependent C integer types (such as `np.intc` / `np.uintc`), causing valid NumPy integer scalar inputs to be rejected by integer validation gates across nine public surfaces.

### Changes
1. Derived `_NUMPY_INTEGER_TYPES` in `ipmnist_gradual.py` and `_EXACT_NUMPY_INTEGER_TYPES` in `causal_map_forager.py` directly from all 10 standard NumPy integer dtype characters: `tuple(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))`.
2. Added parametrized tests across all 10 integer dtype codes in `tests/test_ipmnist_gradual.py` and `tests/test_causal_map_forager.py`.

### Verification
- `pytest tests/test_ipmnist_gradual.py tests/test_causal_map_forager.py`: 185/185 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
