### PR TITLE
fix(nexting): promote computation to float dtype in forward_view_returns

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -122,8 +122,17 @@ def forward_view_returns(
     """
     gamma = _require_host_discount("gamma", gamma, ndim=0)
     terminal_value = _require_host_finite_real("terminal_value", terminal_value)
-    gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
-    init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
+    computation_dtype = jnp.result_type(
+        cumulants.dtype,
+        jnp.asarray(gamma).dtype,
+        jnp.asarray(terminal_value).dtype,
+    )
+    if not jnp.issubdtype(computation_dtype, jnp.floating):
+        computation_dtype = jnp.float32
+
+    cumulants_f = jnp.asarray(cumulants, dtype=computation_dtype)
+    gamma_s = jnp.asarray(gamma, dtype=computation_dtype)
+    init = jnp.asarray(terminal_value, dtype=computation_dtype)
 
     def step(carry: Array, c: Array) -> tuple[Array, Array]:
         # gamma=0 must not multiply an inf later return (0*inf).
@@ -131,7 +140,7 @@ def forward_view_returns(
         new_carry = c + bootstrap
         return new_carry, new_carry
 
-    _, returns_reversed = jax.lax.scan(step, init, cumulants[::-1])
+    _, returns_reversed = jax.lax.scan(step, init, cumulants_f[::-1])
     return returns_reversed[::-1]
 
 

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -64,6 +64,22 @@ class TestForwardViewReturns:
         g = forward_view_returns(c, gamma=1.0, terminal_value=10.0)
         chex.assert_trees_all_close(g, jnp.array([11.0, 11.0, 11.0]))
 
+    def test_integer_and_boolean_cumulants_promote_to_float_returns(self) -> None:
+        c_int = jnp.array([1, 0, 0, 0, 1], dtype=jnp.int32)
+        g_int = forward_view_returns(c_int, gamma=0.9)
+        expected = jnp.array([1.6561, 0.729, 0.81, 0.9, 1.0], dtype=jnp.float32)
+        chex.assert_trees_all_close(g_int, expected, atol=1e-5)
+        assert jnp.issubdtype(g_int.dtype, jnp.floating)
+
+        c_bool = jnp.array([True, False, False, False, True], dtype=jnp.bool_)
+        g_bool = forward_view_returns(c_bool, gamma=0.9)
+        chex.assert_trees_all_close(g_bool, expected, atol=1e-5)
+        assert jnp.issubdtype(g_bool.dtype, jnp.floating)
+
+        g_term = forward_view_returns(c_int, gamma=0.5, terminal_value=7.6)
+        expected_term = jnp.array([1.3, 0.6, 1.2, 2.4, 4.8], dtype=jnp.float32)
+        chex.assert_trees_all_close(g_term, expected_term, atol=1e-5)
+
     @pytest.mark.parametrize("gamma", [True, False, float("nan"), float("inf"), -0.1, 1.1])
     def test_gamma_rejects_boolean_and_non_discount_host_values(self, gamma: object) -> None:
         """True used to compile as undiscounted gamma=1.0; False as gamma=0.0."""


### PR DESCRIPTION
Fixes #2368

`forward_view_returns` in `alberta_framework/utils/nexting.py` previously cast `gamma` and `terminal_value` directly into `cumulants.dtype`. When callers passed integer or boolean cumulant series, this silently truncated fractional `gamma` discounts (e.g. `0.9 -> 0`) and fractional terminal values, degenerating forward-view return calculations into raw cumulant echoes.

### Changes
1. Promoted computation dtype across `(cumulants.dtype, gamma, terminal_value)` with a fallback to `float32` if non-floating.
2. Cast `cumulants`, `gamma`, and `terminal_value` to the promoted floating dtype during scan execution.
3. Added unit test `test_integer_and_boolean_cumulants_promote_to_float_returns` in `tests/test_nexting.py` verifying that `int32` and `bool` cumulants with fractional discounts compute correct decaying forward-view returns and preserve fractional terminal values.

### Verification
- `pytest tests/test_nexting.py`: 90/90 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
