### PR TITLE
fix(core): enforce equal latent descriptor width in BoundedPolicyArchive constructor

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        expected_width: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if expected_width is None:
+                expected_width = len(entry.latent)
+            elif len(entry.latent) != expected_width:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -66,3 +66,30 @@ def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")
     assert POLICY_ARCHIVE_PROTOCOL["scientific_promotion_allowed"] is False
+
+
+def test_archive_constructor_enforces_equal_latent_width() -> None:
+    narrow = _entry("a", (0.0,), 1.0)
+    wide = _entry("b", (1.0, 2.0), 2.0)
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        BoundedPolicyArchive(byte_budget=100, min_latent_distance=1.0, entries=(narrow, wide))
+
+
+def test_control_modes_allow_different_entry_widths_on_add() -> None:
+    one = BoundedPolicyArchive(byte_budget=100, min_latent_distance=0.0, mode="one_model")
+    one = one.add(_entry("a", (0.0,), 1.0))
+    one = one.add(_entry("b", (1.0, 2.0), 2.0))
+    assert [e.identity for e in one.entries] == ["b"]
+
+    fixed = BoundedPolicyArchive(byte_budget=100, min_latent_distance=0.0, mode="fixed_snapshot")
+    fixed = fixed.add(_entry("a", (0.0,), 1.0))
+    fixed = fixed.add(_entry("b", (1.0, 2.0), 2.0))
+    assert [e.identity for e in fixed.entries] == ["a"]
+
+
+def test_diverse_archive_add_rejects_mismatched_latent_width() -> None:
+    archive = BoundedPolicyArchive(byte_budget=100, min_latent_distance=1.0).add(
+        _entry("a", (0.0,), 1.0)
+    )
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        archive.add(_entry("b", (1.0, 2.0), 2.0))


### PR DESCRIPTION
Fixes #2322

`BoundedPolicyArchive` previously only checked that candidate entries matched `self.entries[0].latent` length in `add()`, never verifying equal descriptor width across entries in `__post_init__`. As a result, constructing an archive with mixed-width descriptors resulted in NumPy broadcasting mismatched dimensions during distance computation (e.g. `(3.0,) - (3.0, 3.0)` returning `[0.0, 0.0]`), silently discarding valid candidates without error. Additionally, running the width guard before mode dispatch caused control arms (`one_model` and `fixed_snapshot`) to raise errors on latent width even though they never read `latent`.

### Changes
1. Added validation in `BoundedPolicyArchive.__post_init__` enforcing that all `self.entries` have identical `latent` descriptor lengths (`all latent descriptors must have equal width`).
2. Moved the `add()` candidate width check into the `diverse_archive` branch that actually computes latent distances, allowing control modes (`one_model`, `fixed_snapshot`) to accept new entries without checking unused latent widths.
3. Added unit tests in `tests/test_policy_archive.py`:
   - Validating constructor rejection of mixed-width entries.
   - Validating that `one_model` and `fixed_snapshot` control modes accept entries regardless of latent width.
   - Validating that `diverse_archive.add()` rejects mismatched candidate widths.

### Verification
- `pytest tests/test_policy_archive.py`: 9/9 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
