### PR TITLE
fix(scorecard): validate partial metric windows against shard totals

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -2447,6 +2447,7 @@ def _validate_partial_outcome(
         if set(windows) != {"initial_a", "first_b", "return_a"}:
             raise ValueError(f"{path}.windows does not match the A/B/A contract")
         window = protocol["post_switch_window"]
+        window_reward_sums = [0.0, 0.0]
         for name, start, phase in (
             ("initial_a", 0, 0),
             ("first_b", phase_length, 1),
@@ -2459,7 +2460,7 @@ def _validate_partial_outcome(
                     raise ValueError(f"{path}.windows.{name} must be empty")
             else:
                 rewards = [float(item) for row in payoffs[phase] for item in row]
-                _validate_metric_window(
+                window_reward_sums[phase] += _validate_metric_window(
                     value,
                     event_count=expected_count,
                     oracle_reward=oracle_rewards[phase],
@@ -2468,6 +2469,13 @@ def _validate_partial_outcome(
                     reward_values=rewards,
                     path=f"{path}.windows.{name}",
                 )
+        if any(
+            window_sum > phase_sum + 1e-9
+            for window_sum, phase_sum in zip(
+                window_reward_sums, phase_reward_values, strict=True
+            )
+        ):
+            raise ValueError(f"{path}.windows exceed their switching-phase rewards")
         if partial["high_end_visit_count"] is not None or partial[
             "high_end_visit_rate"
         ] is not None:
@@ -2493,6 +2501,7 @@ def _validate_partial_outcome(
             raise ValueError(f"{path}.phase_reward_sums violates RiverSwim rewards")
         if set(windows) != {"early", "late"}:
             raise ValueError(f"{path}.windows does not match the RiverSwim contract")
+        window_reward_sum = 0.0
         for name, start, stop in (
             ("early", 0, protocol["early_window"]),
             ("late", horizon - protocol["late_window"], horizon),
@@ -2503,7 +2512,7 @@ def _validate_partial_outcome(
                 if value is not None:
                     raise ValueError(f"{path}.windows.{name} must be empty")
             else:
-                _validate_metric_window(
+                window_reward_sum += _validate_metric_window(
                     value,
                     event_count=expected_count,
                     oracle_reward=oracle_rewards[0],
@@ -2512,6 +2521,8 @@ def _validate_partial_outcome(
                     reward_values=river_rewards,
                     path=f"{path}.windows.{name}",
                 )
+        if window_reward_sum > phase_reward_values[0] + 1e-9:
+            raise ValueError(f"{path}.windows exceed the stationary reward sum")
         visits = partial["high_end_visit_count"]
         if type(visits) is not int or not 0 <= visits <= accepted:
             raise ValueError(f"{path}.high_end_visit_count is invalid")

--- a/tests/test_reference_life_scorecard.py
+++ b/tests/test_reference_life_scorecard.py
@@ -694,6 +694,75 @@ def test_completed_shard_rejects_impossible_reward_lattice_total() -> None:
         scorecard.validate_scorecard_run_record(record)
 
 
+@pytest.mark.parametrize("environment", ENVIRONMENT_ROSTER)
+def test_failed_shard_rejects_window_reward_exceeding_partial_total(
+    environment: str,
+) -> None:
+    plan = build_development_plan()
+    spec = next(
+        item
+        for item in scorecard.iter_run_specs(plan)
+        if item.environment_kind == environment
+        and item.arm == "random"
+        and item.seed == SEED_ROSTER[0]
+    )
+    record = _completed_record(plan, spec)
+    horizon = plan.protocol(environment)["horizon"]
+    oracle_reward = record["outcome"]["oracle_reward_sum"] / horizon
+    window = {
+        "event_count": 1,
+        "reward_sum": 1.0,
+        "mean_reward": 1.0,
+        "mean_oracle_regret": oracle_reward - 1.0,
+    }
+    if environment == "switching_two_state":
+        windows = {"initial_a": window, "first_b": None, "return_a": None}
+        high_end_visit_count = None
+        high_end_visit_rate = None
+    else:
+        windows = {"early": window, "late": None}
+        high_end_visit_count = 0
+        high_end_visit_rate = 0.0
+    record.update(
+        {
+            "status": "failed",
+            "failure": {
+                "stage": "step",
+                "type": "RuntimeError",
+                "message": "synthetic post-step failure",
+                "accepted_events": 1,
+            },
+            "outcome": None,
+            "partial_outcome": {
+                "summary_mode": "streaming_o1_no_retained_events",
+                "configured_horizon": horizon,
+                "accepted_events": 1,
+                "reward_sum": 0.0,
+                "mean_reward": 0.0,
+                "oracle_reward_sum": oracle_reward,
+                "regret_sum": oracle_reward,
+                "parameter_change_events": 0,
+                "phase_event_counts": [1, 0],
+                "phase_reward_sums": [0.0, 0.0],
+                "windows": windows,
+                "high_end_visit_count": high_end_visit_count,
+                "high_end_visit_rate": high_end_visit_rate,
+            },
+        }
+    )
+    record["telemetry"].update(
+        {
+            "warmed_step_seconds_total": 0.0,
+            "warmed_step_count": 0,
+            "warmed_step_seconds_mean": None,
+        }
+    )
+    _redigest(record)
+
+    with pytest.raises(ValueError, match="windows exceed"):
+        scorecard.validate_scorecard_run_record(record)
+
+
 def test_completed_shard_rejects_self_asserted_zero_resource_payload() -> None:
     plan = build_development_plan()
     spec = scorecard.iter_run_specs(plan)[0]


### PR DESCRIPTION
## Summary

Failed reference-life shards could report a metric-window reward larger than their recorded
phase and total reward. The validator checked each value against the reward lattice but never
checked that the nested window belonged to the enclosing summary.

This change accumulates validated window rewards and rejects that contradiction for both
`switching_two_state` and `riverswim`.

## Reproduction and result

At parent `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, the new two-environment regression test failed
twice because the validator accepted a failed shard with total reward `0.0` and window reward
`1.0`.

At `4370bb0e8c0050839c8e66b4586a1c80be97c433`:

```text
.venv/bin/python -m pytest tests/test_reference_life_scorecard.py -q -o addopts=""
66 passed, 1 skipped

.venv/bin/python -m ruff check .
All checks passed!

git diff --check origin/main...HEAD
exit 0
```

Full-tree mypy retains the current-main macOS stub error for `os.O_TMPFILE` in the untouched
`bounded_elastic_matched_runner.py`. A broad fast-lane sample reached 1,697 passes and 34 skips;
its 11 failures were the known Linux-only publication tests tracked by #2251.

This is a validator-integrity fix, not a performance comparison. It uses no tuning or evaluation
seeds, writes no benchmark output, and makes no promotion claim. `alberta-evidence-status`
retains the expected source-drift exit 2 and was not weakened.

Provider: `openai`

Model: `gpt-5.6-sol`

Client: `codex`

<!-- evidence-head:4370bb0e8c0050839c8e66b4586a1c80be97c433 -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/attentionhead/asi/blob/ec6bed97a7ebedff922cbbe428308d4ce348d23c/logs-partial-window-containment.txt
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/attentionhead/asi/blob/ec6bed97a7ebedff922cbbe428308d4ce348d23c/evidence-partial-window-containment.md

Compute receipt: 3250473 project-attributed tokens (bounded; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-watch]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0SWKVY1N8K1C99CHN9R84F7","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T12:41:07.265Z","completed_at":"2026-08-24T18:41:08.550Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T12:41:09.358Z"},"usage":{"source":"ccusage-session-v20","confidence":"bounded","input_tokens":208455,"output_tokens":23778,"cache_creation_tokens":0,"cache_read_tokens":3018240,"total_tokens":3250473,"cost_micro_usd":"2516676","session_count":3},"trajectory_sha256":"a47932370697cdd1f78cccbb8317cae0388ae5e2bca6c34ec7d66e476f3c3f18","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"385b2b74-8438-4275-881b-4b1410b88190","object_id":"sha256:a47932370697cdd1f78cccbb8317cae0388ae5e2bca6c34ec7d66e476f3c3f18","sha256":"a47932370697cdd1f78cccbb8317cae0388ae5e2bca6c34ec7d66e476f3c3f18"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"12sCxVlv-ZpxAqHyD_s7L2oZ5Uo3dSgbQGm9ocPX1pBARlAmbhq_TRz9jnKIk_1--_e-5tKKn7eE9cQSyV8ZBw"}} -->
