### PR TITLE
fix(core): ensure valid simplex distribution in floor_and_renormalize_probabilities

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -152,11 +152,17 @@ def floor_and_renormalize_probabilities(
     if min_probability * n_actions >= 1.0:
         return jnp.ones_like(probs) / n_actions
     clipped = jnp.maximum(probs, 0.0)
-    normalizer = jnp.maximum(
-        jnp.sum(clipped, axis=-1, keepdims=True),
-        jnp.asarray(1e-12, dtype=jnp.float32),
+    raw_sum = jnp.sum(clipped, axis=-1, keepdims=True)
+    has_positive_mass = raw_sum > 0.0
+    safe_sum = jnp.where(has_positive_mass, raw_sum, jnp.ones_like(raw_sum))
+    candidate = clipped / safe_sum
+    norm_sum = jnp.sum(candidate, axis=-1, keepdims=True)
+    valid_norm = has_positive_mass & (norm_sum > 0.0) & jnp.isfinite(norm_sum)
+    normalized = jnp.where(
+        valid_norm,
+        candidate / jnp.where(valid_norm, norm_sum, jnp.ones_like(norm_sum)),
+        jnp.ones_like(clipped) / n_actions,
     )
-    normalized = clipped / normalizer
     floor_mass = jnp.asarray(min_probability * n_actions, dtype=jnp.float32)
     return jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
 

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -674,3 +674,16 @@ def test_action_ids_still_accept_trusted_hosts_and_tracers() -> None:
         jnp.asarray(3, dtype=jnp.int32)
     )
     chex.assert_tree_all_finite(traced)
+
+
+def test_floor_and_renormalize_probabilities_degenerate_inputs_return_valid_simplex() -> None:
+    for degenerate in [
+        [0.0, 0.0, 0.0],
+        [-1.0, -2.0, -3.0],
+        [1e-38, 1e-38, 1e-38],
+        [1e38, 1.0, 1.0],
+    ]:
+        probs = jnp.array(degenerate, dtype=jnp.float32)
+        res = floor_and_renormalize_probabilities(probs, min_probability=1e-6)
+        chex.assert_trees_all_close(jnp.sum(res), 1.0, atol=1e-6)
+        assert float(jnp.min(res)) >= 1e-6 - 1e-7


### PR DESCRIPTION
Fixes #2238

`floor_and_renormalize_probabilities` in `alberta_framework/core/behavior_model.py` previously floored its normalizer with `jnp.maximum(sum(clipped), 1e-12)`. When all clipped entries were zero (zero mass) or when float32 precision underflowed the normalizer ratios, `normalized` became all zeros, causing the affine combination to return a degenerate vector summing to `n * min_probability` (e.g. `3e-6`) rather than the documented proper simplex distribution summing to `1.0`.

### Changes
1. Updated `floor_and_renormalize_probabilities` to verify positive finite normalizer mass and fallback safely to a uniform distribution over actions when the clipped mass cannot yield a usable normalizer.
2. Added unit tests in `tests/test_behavior_model.py` verifying that all degenerate cases (zero vectors, negative vectors, subnormal/extreme float inputs) return a valid simplex summing to `1.0` and bounded by `min_probability`.

### Verification
- `pytest tests/test_behavior_model.py`: 50/50 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
