### PR TITLE
fix(pipeline): forward termination-aware discount in horde_ac update

### DIFF
--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -1573,11 +1573,18 @@ class AlbertaPipeline:
                 dtype=jnp.int32,
             )
             auxiliary_cumulants = horde_cumulants[aux_indices] if aux_indices.size else None
+            value_gamma = self._horde.horde_spec.gammas[value_index]
+            control_discount = jnp.where(
+                terminated == 0.0,
+                value_gamma,
+                jnp.zeros_like(value_gamma),
+            )
             ac_result = ac.update(
                 ac_state,
                 reward,
                 features,
                 auxiliary_cumulants=auxiliary_cumulants,
+                discount=control_discount,
             )
             new_control_state: SARSAState | HordeActorCriticState = ac_result.state
             q_values_or_policy = ac_result.policy

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1196,3 +1196,39 @@ def test_associative_pipeline_narrows_only_statically_safe_integer_dtypes() -> N
 
 # silence the import lint warnings used in the test runner
 _ = jax
+
+
+def test_pipeline_horde_ac_respects_terminated_flag() -> None:
+    from alberta_framework.core.horde_actor_critic import HordeActorCriticConfig
+
+    config = AlbertaPipelineConfig(
+        n_demons=2,
+        gammas=(0.9, 0.5),
+        lamdas=(0.1, 0.1),
+        cumulant_indices=(0, 1),
+        n_actions=2,
+        control_mode="horde_ac",
+        horde_actor_critic=HordeActorCriticConfig(
+            n_actions=2,
+            actor_learning_rate=0.01,
+            actor_lamda=0.8,
+            value_head_index=0,
+        ),
+    )
+    pipeline = make_alberta_pipeline(config)
+    state = pipeline.init(jr.key(0), jnp.asarray([0.2, -0.1], dtype=jnp.float32))
+    obs = jnp.asarray([0.1, 0.3], dtype=jnp.float32)
+    reward = jnp.asarray(0.5, dtype=jnp.float32)
+    cumulants = jnp.asarray([0.5, -0.2], dtype=jnp.float32)
+
+    res_terminal = pipeline.update(
+        state, obs, reward, jnp.asarray(1.0, dtype=jnp.float32), cumulants
+    )
+
+    # In terminal transition, value target must not bootstrap on next observation
+    assert float(res_terminal.horde_td_targets[0]) == pytest.approx(0.5, abs=1e-5)
+    # Actor eligibility trace must be reset to zero on terminal transition
+    chex.assert_trees_all_close(
+        res_terminal.state.control_state.actor_trace_weights,
+        jnp.zeros_like(res_terminal.state.control_state.actor_trace_weights),
+    )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1199,30 +1199,15 @@ _ = jax
 
 
 def test_pipeline_horde_ac_respects_terminated_flag() -> None:
-    from alberta_framework.core.horde_actor_critic import HordeActorCriticConfig
-
-    config = AlbertaPipelineConfig(
-        n_demons=2,
-        gammas=(0.9, 0.5),
-        lamdas=(0.1, 0.1),
-        cumulant_indices=(0, 1),
-        n_actions=2,
-        control_mode="horde_ac",
-        horde_actor_critic=HordeActorCriticConfig(
-            n_actions=2,
-            actor_learning_rate=0.01,
-            actor_lamda=0.8,
-            value_head_index=0,
-        ),
-    )
+    config = _small_horde_ac_config()
     pipeline = make_alberta_pipeline(config)
-    state = pipeline.init(jr.key(0), jnp.asarray([0.2, -0.1], dtype=jnp.float32))
-    obs = jnp.asarray([0.1, 0.3], dtype=jnp.float32)
+    context = jnp.asarray([0.1, 0.2, -0.3], dtype=jnp.float32)
+    state = pipeline.init(jr.key(0), context)
     reward = jnp.asarray(0.5, dtype=jnp.float32)
     cumulants = jnp.asarray([0.5, -0.2], dtype=jnp.float32)
 
     res_terminal = pipeline.update(
-        state, obs, reward, jnp.asarray(1.0, dtype=jnp.float32), cumulants
+        state, context, reward, jnp.asarray(1.0, dtype=jnp.float32), cumulants
     )
 
     # In terminal transition, value target must not bootstrap on next observation


### PR DESCRIPTION
Fixes #2344

In `alberta_framework/pipeline.py`, when `control_mode="horde_ac"`, `AlbertaPipeline.update` previously invoked `ac.update(ac_state, reward, features, auxiliary_cumulants=auxiliary_cumulants)` without passing a `discount`. This caused `HordeActorCriticAgent.update` to fall back to the static `value_head` gamma on every transition, failing to zero the value-head bootstrap (`r + gamma * V(s')` instead of `r`) and failing to reset the actor eligibility trace across terminal boundaries (`terminated == 1.0`).

### Changes
1. Computed `control_discount = jnp.where(terminated == 0.0, value_gamma, jnp.zeros_like(value_gamma))` in `AlbertaPipeline.update` for `control_mode="horde_ac"`, forwarding it via `discount=control_discount` to `ac.update`.
2. Added unit test `test_pipeline_horde_ac_respects_terminated_flag` in `tests/test_pipeline.py` verifying that terminal transitions (`terminated=1.0`) do not bootstrap the value-head TD target and reset the actor eligibility trace to zero.

### Verification
- `pytest tests/test_pipeline.py`: 184/184 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
