### PR TITLE
fix(core): divide latent observations by the declared observation_scale

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -79,6 +79,10 @@ from alberta_framework.core.update_safety import (
 EVIDENCE_LEVEL = "L0"
 SCIENTIFIC_PROMOTION_ALLOWED = False
 _INT32_MAX = 2**31 - 1
+# Smallest normal binary32 (float(np.finfo(np.float32).tiny)); every admitted
+# observation_scale must be at least this so its float32 reciprocal stays
+# finite when the encoder divides by the declared scale.
+_SMALLEST_NORMAL_FLOAT32 = 1.1754943508222875e-38
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -290,7 +294,9 @@ class LatentWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 validated_float32_scalar(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]",
+                    scale,
+                    lower=_SMALLEST_NORMAL_FLOAT32,
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -669,8 +675,11 @@ class LatentWorldModel:
     ) -> Float[Array, " latent_dim"]:
         """Encode one observation with explicit (differentiable) encoder params."""
         obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._config.observation_dim,))
+        # Divide by the declared per-dimension scale. The validator bounds every
+        # admitted scale at or above the smallest normal float32, so ``1/scale``
+        # stays finite; no ``max(scale, 1e-6)`` floor silently substitutes it.
         scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
+        scaled = obs / scale
         return jnp.tanh(scaled @ encoder_matrix + encoder_bias)
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -585,6 +585,78 @@ def test_trainable_encoder_config_validation_fails_closed(
         )
 
 
+def _encode_once(observation_scale: tuple[float, ...], observation: list[float]) -> Array:
+    """Encode one observation through a fresh model sharing a fixed init key.
+
+    The encoder matrix/bias init does not depend on ``observation_scale``, so
+    two models built with the same key differ only through the declared scale
+    the encoder divides by.
+    """
+    config = LatentWorldModelConfig(
+        observation_dim=len(observation_scale),
+        n_actions=2,
+        latent_dim=4,
+        hidden_sizes=(),
+        observation_scale=observation_scale,
+    )
+    model = LatentWorldModel(config)
+    state = model.init(jr.key(0))
+    return model.encode(state, jnp.asarray(observation, dtype=jnp.float32))
+
+
+@pytest.mark.unit
+def test_encoder_divides_by_declared_scale_below_the_retired_floor() -> None:
+    # Declared multiples of scale; the encoder must reduce obs/scale to these
+    # regardless of the scale magnitude (scale-free encoding).
+    multiples = [1.5, -0.75]
+    reference = _encode_once((1.0, 1.0), multiples)
+    # Scales spanning the previously corrupted [smallest-normal, 1e-6) range.
+    # (The exact smallest-normal boundary is excluded here only because
+    # obs = multiple * scale becomes subnormal for |multiple| < 1 and XLA
+    # flushes denormals to zero; the boundary's validation is checked below.)
+    for scale in (1e-9, 1e-20, 1e-30, 1e-37):
+        observation = [multiple * scale for multiple in multiples]
+        latent = _encode_once((scale, scale), observation)
+        # Before the fix, scales below the retired 1e-6 floor were divided by
+        # 1e-6 instead of their declared value, so obs/scale was corrupted and
+        # the latents diverged from the scale=1.0 reference row.
+        chex.assert_trees_all_close(latent, reference, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.unit
+def test_encoder_scale_at_or_above_retired_floor_is_unchanged() -> None:
+    # Scales at/above the retired 1e-6 floor kept their exact bits under the old
+    # ``max(scale, 1e-6)`` path; guard that behavior is preserved.
+    multiples = [2.0, -1.25]
+    reference = _encode_once((1.0, 1.0), multiples)
+    for scale in (1.0, 1e-3, 1e-6):
+        observation = [multiple * scale for multiple in multiples]
+        latent = _encode_once((scale, scale), observation)
+        chex.assert_trees_all_close(latent, reference, atol=1e-6, rtol=1e-6)
+
+
+@pytest.mark.unit
+def test_observation_scale_rejects_below_smallest_normal_float32() -> None:
+    smallest_normal = float(np.finfo(np.float32).tiny)
+    subnormal = float(np.finfo(np.float32).smallest_subnormal)
+    assert subnormal < smallest_normal
+    # A subnormal scale has no finite float32 reciprocal, so it must be refused
+    # at construction instead of being silently substituted by the old floor.
+    with pytest.raises(ValueError, match="observation_scale"):
+        LatentWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            observation_scale=(subnormal,),
+        )
+    # The smallest normal float32 is the boundary and must still validate.
+    boundary = LatentWorldModelConfig(
+        observation_dim=1,
+        n_actions=2,
+        observation_scale=(smallest_normal,),
+    )
+    assert boundary.observation_scale == (smallest_normal,)
+
+
 def test_latent_world_model_config_rejects_booleans_and_non_integers() -> None:
     with pytest.raises(ValueError, match="observation_dim"):
         LatentWorldModelConfig(observation_dim=True, n_actions=2)  # type: ignore[arg-type]


### PR DESCRIPTION
## What was broken

`LatentWorldModelConfig.observation_scale` is documented as the per-dimension scale the latent encoder divides observations by, and its validator admitted **any positive float32** via `validated_float32_scalar(..., positive=True)`. But `_encode_with` divided by a **floored** scale:

```python
scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
```

**Measurement consequence:** for every accepted `observation_scale` below `1e-6`, the encoder silently normalized by `1e-6` instead of the declared value. The declared normalization is silently replaced; `collapse_score` reports a floor-manufactured collapse; and with `encoder_collapse_gate_threshold` defaulting to `0.0` the trainable encoder can be pinned as a permanent no-op. At subnormal scales the validator still accepted (down to `1.4e-45`), `1/scale` overflows to `inf`, producing `nan` latents. The sibling `reward_scale` divides/multiplies by the raw configured value with no floor — the floored `observation_scale` was the outlier.

## The fix (one lane: `alberta_framework/core/latent_world_model.py`)

1. `_encode_with` now divides by the declared `scale` directly (floor removed).
2. The domain moved into the validator: `observation_scale` must be `>= 1.1754943508222875e-38` (the smallest **normal** float32, `float(np.finfo(np.float32).tiny)`) via the existing `validated_float32_scalar(..., lower=...)` keyword, so every admitted scale has a finite float32 reciprocal.

Net effect: scales in `[1.1754943508222875e-38, 1e-6)` are now divided by their declared value (previously corrupted); scales below the smallest normal float32 raise a clear construction-time `ValueError` instead of being silently substituted. Scales at/above the retired `1e-6` floor keep their exact bits (`max(scale, 1e-6) == scale` there), so existing passing configs are unaffected.

**Out of scope (deliberately untouched):** `alberta_framework/core/world_model.py` carries a related-but-different substitution (`max(obs_scale, 1e-6)`) with its own validator, `max_delta_scale` product check, and an existing test pinning its current error message. The reporter deferred it and a separate open PR addresses that side. Left alone.

## Failing-then-passing reproduction (reporter snippet)

Before the fix, a declared `observation_scale = 1e-9` with `obs = multiple * scale` gives latents ~1000x off the `scale=1.0` reference, and a subnormal scale is silently accepted. After the fix the latents are bit-identical to the reference and the subnormal scale is rejected at construction:

```
### Reporter reproduction — AFTER fix (git worktree, this branch)
$ .venv/bin/python repro_2411.py
ref   : [ 0.9099027 -0.8547688 -0.8266549 -0.6034254]
small : [ 0.9099027 -0.8547688 -0.8266549 -0.6034254]
max abs diff (should be ~0 after fix): 0.0
subnormal scale REJECTED: observation_scale[0] must be >= 1.1754943508222875e-38

### BEFORE fix (git stash of production change, tests kept)
Saved working directory and index state WIP on fix/latent-observation-scale-floor-2411: c9aba7b5 Merge pull request #2131 from SlopDotCash/agent/coom-runtime-identity-hardening
ref   : [ 0.9099027 -0.8547688 -0.8266549 -0.6034254]
small : [ 0.00152696 -0.00127359 -0.00117748 -0.00069852]
max abs diff (should be ~0 after fix): 0.90837574
subnormal scale ACCEPTED (bug)
Dropped refs/stash@{0} (d854d2a772f58ebb315b7eae76cb1204e13fa0f9)
```

New regression tests fail before the production change and pass after:

```
############################################################
# FAILING (production fix reverted, new tests present)
############################################################
Saved working directory and index state WIP on fix/latent-observation-scale-floor-2411: c9aba7b5 Merge pull request #2131 from SlopDotCash/agent/coom-runtime-identity-hardening
    def test_observation_scale_rejects_below_smallest_normal_float32() -> None:
        smallest_normal = float(np.finfo(np.float32).tiny)
        subnormal = float(np.finfo(np.float32).smallest_subnormal)
        assert subnormal < smallest_normal
        # A subnormal scale has no finite float32 reciprocal, so it must be refused
        # at construction instead of being silently substituted by the old floor.
>       with pytest.raises(ValueError, match="observation_scale"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE ValueError

tests/test_latent_world_model.py:645: Failed
=========================== short test summary info ============================
FAILED tests/test_latent_world_model.py::test_encoder_divides_by_declared_scale_below_the_retired_floor
FAILED tests/test_latent_world_model.py::test_observation_scale_rejects_below_smallest_normal_float32
2 failed, 1 passed, 56 deselected in 4.07s
Dropped refs/stash@{0} (06ec468240ab34611c974c671d17fa4cdeb37d23)

############################################################
# PASSING (fix applied)
############################################################
...                                                                      [100%]
3 passed, 56 deselected in 4.38s
```

## Verification (all commands + results)

```
$ pytest tests/test_latent_world_model.py tests/test_action_conditioned_latent.py tests/test_latent_world_model_update_working_set.py -q
........................................................................ [ 92%]
......                                                                   [100%]
78 passed in 149.88s (0:02:29)

$ ruff check alberta_framework/core/latent_world_model.py tests/test_latent_world_model.py
All checks passed!

$ mypy alberta_framework/core/latent_world_model.py
Success: no issues found in 1 source file
```

- `tests/test_latent_world_model.py`, `tests/test_action_conditioned_latent.py`, `tests/test_latent_world_model_update_working_set.py`: **78 passed**.
- `ruff check` (touched files): **All checks passed!**
- `mypy alberta_framework/core/latent_world_model.py`: **Success: no issues found**.

## What remains open

- The `world_model.py` `max(obs_scale, 1e-6)` substitution is intentionally not touched here (separate PR / reporter deferral).

## Evidence-attachment note (honest disclosure)

The immutable `user-attachments` upload path was **blocked** in this environment: the browser-login credential used by the attachment tool is rejected by GitHub ("Incorrect username or password"), so I could not mint `github.com/user-attachments/...` URLs. All evidence above is therefore embedded inline as verbatim command output. The measured head is recorded below.

Closes #2411

<!-- evidence-head:5cc3bbdfe86dd971cb32decc71a8c88cb4bc07d0 -->
<!-- evidence-row:logs -->
- [ ] logs: attachment-url minting blocked (browser credential rejected); logs inlined above

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@347ab09908138cf340ad2a5d03cc1f3f686a4f68:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@347ab09908138cf340ad2a5d03cc1f3f686a4f68:skills/contribute-to-asi"} -->
