### PR TITLE
fix(core): rank units by bias-corrected utility in Continual Backprop

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -483,13 +483,14 @@ def _select_replacement_index(
     utility: Array,
     age: Array,
     maturity_threshold: int,
+    decay_rate: float = 0.99,
 ) -> tuple[Array, Array]:
     """Pick the index of the lowest-utility mature unit, if any.
 
     A unit is "mature" iff ``age >= maturity_threshold``. Among mature
-    units we pick the one with the smallest utility. If no mature unit
-    exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
-    ``False``.
+    units we pick the one with the smallest bias-corrected utility
+    (Dohare et al., 2024, Eq. 8). If no mature unit exists, ``selected``
+    is ``-1`` (sentinel) and ``has_candidate`` is ``False``.
 
     Implementation: replace the utility of immature or non-finite units
     with ``+inf`` before taking ``argmin`` so they are never chosen.
@@ -498,14 +499,20 @@ def _select_replacement_index(
         utility: Per-unit utility array, shape ``(num_units,)``.
         age: Per-unit age array (same shape).
         maturity_threshold: Minimum age for eligibility.
+        decay_rate: EMA decay rate used for debiasing.
 
     Returns:
         Tuple ``(index, has_candidate)`` where ``index`` is the chosen
         unit (or ``-1``) and ``has_candidate`` is a boolean scalar.
     """
+    decay = jnp.asarray(decay_rate, dtype=jnp.float32)
+    bias_correction = 1.0 - jnp.power(decay, age.astype(jnp.float32))
+    safe_bias_correction = jnp.maximum(bias_correction, jnp.asarray(1e-12, dtype=jnp.float32))
+    bias_corrected_utility = utility / safe_bias_correction
+
     mature = age >= jnp.asarray(maturity_threshold, dtype=age.dtype)
-    eligible = mature & jnp.isfinite(utility)
-    masked_utility = jnp.where(eligible, utility, jnp.inf)
+    eligible = mature & jnp.isfinite(bias_corrected_utility)
+    masked_utility = jnp.where(eligible, bias_corrected_utility, jnp.inf)
     has_candidate = jnp.any(eligible)
     idx = jnp.argmin(masked_utility)
     selected = jnp.where(has_candidate, idx, jnp.int32(-1))
@@ -687,6 +694,7 @@ def replace_units_with_flags(
             new_cbp_state.utilities[layer_idx],
             new_cbp_state.ages[layer_idx],
             config.maturity_threshold,
+            decay_rate=config.decay_rate,
         )
         # Only replace if we both budgeted for it AND found a mature unit.
         gated = jnp.logical_and(do_replace, has_candidate)

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -244,6 +244,17 @@ class TestUtilityUpdate:
         expected = jnp.abs(activations[0] * grads[0])
         chex.assert_trees_all_close(new.utilities[0], expected)
 
+    def test_select_replacement_index_uses_bias_corrected_utility(self) -> None:
+        u0_raw = float(1.0 - 0.99**100)
+        u1_raw = float(0.9 * (1.0 - 0.99**700))
+        utilities = jnp.array([u0_raw, u1_raw], dtype=jnp.float32)
+        ages = jnp.array([100, 700], dtype=jnp.int32)
+        idx, has = _select_replacement_index(
+            utilities, ages, maturity_threshold=100, decay_rate=0.99
+        )
+        assert bool(has)
+        assert int(idx) == 1
+
 
 class TestWrapperUtilityGradients:
     """The CBP wrapper should track utility in every hidden layer."""


### PR DESCRIPTION
Fixes #2343

`_select_replacement_index` in `alberta_framework/core/continual_backprop.py` previously ranked mature units using the raw EMA utility instead of the per-unit bias-corrected utility $\hat{u} = u / (1 - \eta^a)$ specified by Dohare et al. (2024, Eq. 8). Because freshly mature units have small ages ($a \approx m$), their raw EMA utility is heavily attenuated by warm-up bias ($1 - 0.99^{100} \approx 0.634$), causing CBP to systematically target and replace the youngest eligible units repeatedly.

### Changes
1. Updated `_select_replacement_index` to compute per-unit bias correction $1 - \text{decay}^{\text{age}}$ and rank eligible mature units by bias-corrected utility $u / (1 - \text{decay}^{\text{age}})$.
2. Forwarded `decay_rate=config.decay_rate` from `replace_units_with_flags` into `_select_replacement_index`.
3. Added unit test `test_select_replacement_index_uses_bias_corrected_utility` in `tests/test_continual_backprop.py` verifying that young mature units with higher true contributions are protected from replacement over older units with lower true utility.

### Verification
- `pytest tests/test_continual_backprop.py`: 96/96 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
