### PR TITLE
fix(utils): derive significance markers from stored result alpha

### DIFF
--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -532,11 +532,20 @@ def _get_significance_marker(
         return ""
 
     p = result.p_value
-    if p < 0.001:
+    alpha = result.alpha
+    if alpha == 0.05:
+        if p < 0.001:
+            return r"$^{***}$"
+        elif p < 0.01:
+            return r"$^{**}$"
+        elif p < 0.05:
+            return r"$^{*}$"
+        return ""
+    if p < alpha / 100.0:
         return r"$^{***}$"
-    elif p < 0.01:
+    elif p < alpha / 10.0:
         return r"$^{**}$"
-    elif p < 0.05:
+    elif p <= alpha:
         return r"$^{*}$"
     return ""
 
@@ -624,11 +633,20 @@ def _get_md_significance_marker(
         return ""
 
     p = result.p_value
-    if p < 0.001:
+    alpha = result.alpha
+    if alpha == 0.05:
+        if p < 0.001:
+            return " ***"
+        elif p < 0.01:
+            return " **"
+        elif p < 0.05:
+            return " *"
+        return ""
+    if p < alpha / 100.0:
         return " ***"
-    elif p < 0.01:
+    elif p < alpha / 10.0:
         return " **"
-    elif p < 0.05:
+    elif p <= alpha:
         return " *"
     return ""
 

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -627,10 +627,19 @@ def _get_significance_marker_for_plot(
         return ""
 
     p = result.p_value
-    if p < 0.001:
+    alpha = result.alpha
+    if alpha == 0.05:
+        if p < 0.001:
+            return "***"
+        elif p < 0.01:
+            return "**"
+        elif p < 0.05:
+            return "*"
+        return ""
+    if p < alpha / 100.0:
         return "***"
-    elif p < 0.01:
+    elif p < alpha / 10.0:
         return "**"
-    elif p < 0.05:
+    elif p <= alpha:
         return "*"
     return ""

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -538,3 +538,24 @@ def test_export_rejects_boolean_summary_statistics(
 
     with pytest.raises(ValueError, match="refusing to export boolean as numeric measurement"):
         generate_markdown_table(results)
+
+
+def test_significance_marker_uses_stored_alpha_threshold() -> None:
+    from alberta_framework.utils.export import _get_md_significance_marker, _get_significance_marker
+    from alberta_framework.utils.statistics import SignificanceResult
+
+    r1 = SignificanceResult(
+        test_name="wilcoxon", statistic=1.0, p_value=0.08,
+        significant=True, alpha=0.10, effect_size=0.5,
+        method_a="a", method_b="b",
+    )
+    assert _get_md_significance_marker("b", "a", {("b", "a"): r1}) == " *"
+    assert _get_significance_marker("b", "a", {("b", "a"): r1}) == r"$^{*}$"
+
+    r2 = SignificanceResult(
+        test_name="ttest", statistic=5.0, p_value=0.002,
+        significant=True, alpha=0.0025, effect_size=1.2,
+        method_a="a", method_b="b",
+    )
+    assert _get_md_significance_marker("b", "a", {("b", "a"): r2}) == " *"
+    assert _get_significance_marker("b", "a", {("b", "a"): r2}) == r"$^{*}$"


### PR DESCRIPTION
Fixes #2227

In `alberta_framework/utils/export.py` and `alberta_framework/utils/visualization.py`, `_get_significance_marker`, `_get_md_significance_marker`, and `_get_significance_marker_for_plot` derived significance stars from hard-coded raw p-value tiers ($0.05 / 0.01 / 0.001$), ignoring each `SignificanceResult.alpha` threshold. This caused statistically significant results under corrected alphas (such as Holm/Bonferroni tests with $\alpha > 0.05$) to render with no markers, while misrepresenting strict step-down tiers.

### Changes
1. Updated `_get_significance_marker`, `_get_md_significance_marker`, and `_get_significance_marker_for_plot` to scale significance tiers relative to each result's operative decision threshold `result.alpha` ($p \le \alpha \rightarrow *$, $p < \alpha/10 \rightarrow **$, $p < \alpha/100 \rightarrow ***$) while preserving legacy byte-identical formatting on default $\alpha = 0.05$ runs.
2. Added unit tests in `tests/test_export.py` verifying that significant results with corrected alphas render valid significance markers consistent with their own thresholds.

### Verification
- `pytest tests/test_export.py`: 118/118 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
