### PR TITLE
fix(core): bound stacked-horde demon count and reject oversized sequences

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -132,6 +132,7 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_STACKED_HORDE_DEMONS = 1 << 12
 _CONFIG_FIELDS = {
     "type",
     "n_demons",
@@ -170,13 +171,19 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 def _require_sequence(name: str, value: object) -> tuple[object, ...]:
     if type(value) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
-    return cast(tuple[object, ...], value)
+    seq = cast(tuple[object, ...], value)
+    if len(seq) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(f"{name} length must not exceed {_MAX_STACKED_HORDE_DEMONS}")
+    return seq
 
 
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
     if type(value) not in (list, tuple):
         raise ValueError(f"{name} must be an actual list or tuple")
-    return tuple(cast(list[object] | tuple[object, ...], value))
+    seq = cast(list[object] | tuple[object, ...], value)
+    if len(seq) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(f"{name} length must not exceed {_MAX_STACKED_HORDE_DEMONS}")
+    return tuple(seq)
 
 
 def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
@@ -227,30 +234,26 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        n_demons = _require_int32(
+            "n_demons", self.n_demons, minimum=1, maximum=_MAX_STACKED_HORDE_DEMONS
+        )
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
         raw_sequences = {
             "gammas": _require_sequence("gammas", self.gammas),
             "lamdas": _require_sequence("lamdas", self.lamdas),
-            "cumulant_indices": _require_sequence(
-                "cumulant_indices", self.cumulant_indices
-            ),
+            "cumulant_indices": _require_sequence("cumulant_indices", self.cumulant_indices),
         }
         for name, seq in raw_sequences.items():
             if len(seq) != n_demons:
                 raise ValueError(f"{name} must have length n_demons={n_demons}")
 
         gammas = tuple(
-            validated_float32_scalar(
-                f"gammas[{i}]", value, lower=0.0, upper=1.0
-            )
+            validated_float32_scalar(f"gammas[{i}]", value, lower=0.0, upper=1.0)
             for i, value in enumerate(raw_sequences["gammas"])
         )
         lamdas = tuple(
-            validated_float32_scalar(
-                f"lamdas[{i}]", value, lower=0.0, upper=1.0
-            )
+            validated_float32_scalar(f"lamdas[{i}]", value, lower=0.0, upper=1.0)
             for i, value in enumerate(raw_sequences["lamdas"])
         )
 
@@ -334,8 +337,8 @@ def nexting_spec(
     )
     canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
     n_demons = len(canonical_indices) * len(canonical_gammas)
-    if n_demons < 1 or n_demons > _INT32_MAX:
-        raise ValueError("derived n_demons must be in the signed int32 domain")
+    if n_demons < 1 or n_demons > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(f"derived n_demons must be in [1, {_MAX_STACKED_HORDE_DEMONS}]")
     _preflight_horde_resources(n_demons, feature_dim)
     idxs: list[int] = []
     gs: list[float] = []

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -938,3 +938,33 @@ def test_stacked_horde_public_state_shape_rejected_before_dot() -> None:
     state = horde.init().replace(weights=jnp.zeros((1, 3), dtype=jnp.float32))
     with pytest.raises(ValueError, match="weights"):
         horde.predict(state, jnp.ones(2, dtype=jnp.float32))
+
+
+def test_stacked_horde_rejects_oversized_demon_count() -> None:
+    with pytest.raises(ValueError, match="n_demons"):
+        StackedHordeConfig(
+            n_demons=4097,
+            feature_dim=2,
+            gammas=(0.9,) * 4097,
+            lamdas=(0.1,) * 4097,
+            cumulant_indices=(0,) * 4097,
+        )
+
+    # 4096 boundary is accepted
+    cfg = StackedHordeConfig(
+        n_demons=4096,
+        feature_dim=2,
+        gammas=(0.9,) * 4096,
+        lamdas=(0.1,) * 4096,
+        cumulant_indices=(0,) * 4096,
+    )
+    assert cfg.n_demons == 4096
+
+
+def test_stacked_horde_nexting_spec_rejects_oversized_demons() -> None:
+    with pytest.raises(ValueError, match="derived n_demons"):
+        nexting_spec(
+            feature_dim=2,
+            cumulant_indices=tuple(range(100)),
+            gammas=tuple(0.9 for _ in range(50)),
+        )


### PR DESCRIPTION
Fixes #2225

`StackedHordeConfig` previously validated `n_demons` against `_INT32_MAX` (2,147,483,647) without an explicit cardinality bound, allowing unbounded element allocations in `_require_sequence`, `_decode_sequence`, and `nexting_spec` during deserialization and configuration construction.

### Changes
1. Defined `_MAX_STACKED_HORDE_DEMONS = 1 << 12` (4096) matching horde and buffer cardinality bounds in peer modules.
2. Enforced `maximum=_MAX_STACKED_HORDE_DEMONS` on `n_demons` during `StackedHordeConfig.__post_init__`.
3. Preflighted maximum sequence lengths ($\le 4096$) in `_require_sequence` and `_decode_sequence`.
4. Enforced $n\_demons \le 4096$ in `nexting_spec` before combinatorial tuple construction.
5. Added unit tests in `tests/test_stacked_horde.py` verifying rejection of oversized configurations and acceptance of the 4096 boundary.

### Verification
- `pytest tests/test_stacked_horde.py`: 96/96 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
