### PR TITLE
fix(core): cap working-memory decay rate cardinality and validate length

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -70,6 +70,7 @@ from alberta_framework.core.working_memory import (
 )
 
 _INT32_MAX = 2**31 - 1
+_MAX_FIXED_TRACE_DECAY_RATES = 1 << 12
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -119,6 +120,8 @@ def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
     rates = cast(tuple[object, ...], value)
+    if len(rates) > _MAX_FIXED_TRACE_DECAY_RATES:
+        raise ValueError(f"{name} must contain at most {_MAX_FIXED_TRACE_DECAY_RATES} decay rates")
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",
@@ -975,9 +978,7 @@ class FixedTraceStateBuilderConfig:
             + self.n_actions * len(self.action_decay_rates)
             + 2 * len(self.outcome_decay_rates)
         )
-        feature_dim = trace_scalars + (
-            self.observation_dim if self.include_raw_observation else 0
-        )
+        feature_dim = trace_scalars + (self.observation_dim if self.include_raw_observation else 0)
         state_scalars = trace_scalars + 4
         _require_derived_int32("feature_dim", feature_dim, minimum=1)
         _require_derived_int32("state_scalars", state_scalars)
@@ -1338,12 +1339,7 @@ class OnlineGatedStateBuilderConfig:
             self.observation_dim if self.include_raw_observation else 0
         )
         parameter_count = 2 * self.hidden_dim * (event_dim + 1)
-        state_scalars = (
-            parameter_count
-            + self.hidden_dim
-            + self.hidden_dim * parameter_count
-            + 3
-        )
+        state_scalars = parameter_count + self.hidden_dim + self.hidden_dim * parameter_count + 3
         _require_derived_int32("event_dim", event_dim, minimum=1)
         _require_derived_int32("feature_dim", feature_dim, minimum=1)
         _require_derived_int32("parameter_count", parameter_count, minimum=1)

--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -216,6 +216,7 @@ class WorkingMemoryArrayResult:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_WORKING_MEMORY_DECAY_RATES = 1 << 12
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
@@ -287,6 +288,10 @@ def _require_array(
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(rates) > _MAX_WORKING_MEMORY_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",
@@ -306,15 +311,9 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
     observation_decay_rates = _validate_decay_rates(
         "observation_decay_rates", config.observation_decay_rates
     )
-    action_decay_rates = _validate_decay_rates(
-        "action_decay_rates", config.action_decay_rates
-    )
-    reward_decay_rates = _validate_decay_rates(
-        "reward_decay_rates", config.reward_decay_rates
-    )
-    gate_threshold = validated_float32_scalar(
-        "gate_threshold", config.gate_threshold, lower=0.0
-    )
+    action_decay_rates = _validate_decay_rates("action_decay_rates", config.action_decay_rates)
+    reward_decay_rates = _validate_decay_rates("reward_decay_rates", config.reward_decay_rates)
+    gate_threshold = validated_float32_scalar("gate_threshold", config.gate_threshold, lower=0.0)
     gate_temperature = validated_float32_scalar(
         "gate_temperature", config.gate_temperature, lower=_FLOAT32_MIN_NORMAL
     )
@@ -361,11 +360,7 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
         raise ValueError("WorkingMemoryConfig state byte count must fit signed int32")
     if persistent_bytes > _UINT32_MAX:
         raise ValueError("working memory allocation exceeds uint32 byte accounting")
-    decay_scalars = (
-        len(observation_decay_rates)
-        + len(action_decay_rates)
-        + len(reward_decay_rates)
-    )
+    decay_scalars = len(observation_decay_rates) + len(action_decay_rates) + len(reward_decay_rates)
     signal_scalars = observation_dim + action_dim + reward_dim
     feature_work = total_state_scalars + feature_dim + 2 * signal_scalars
     update_work = (
@@ -378,12 +373,8 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
     )
     diagnostics_work = total_state_scalars + 3 * trace_scalars + 9
     _require_float32_resource("WorkingMemoryConfig features", vector_scalars=feature_dim)
-    _require_float32_resource(
-        "WorkingMemoryConfig feature operation", vector_scalars=feature_work
-    )
-    _require_float32_resource(
-        "WorkingMemoryConfig update operation", vector_scalars=update_work
-    )
+    _require_float32_resource("WorkingMemoryConfig feature operation", vector_scalars=feature_work)
+    _require_float32_resource("WorkingMemoryConfig update operation", vector_scalars=update_work)
     _require_float32_resource(
         "WorkingMemoryConfig diagnostics operation", vector_scalars=diagnostics_work
     )
@@ -634,9 +625,7 @@ class WorkingMemoryFeaturizer:
         rew = _empty_or_vector(reward, cfg.reward_dim)
         raw_outer_gate = jnp.asarray(external_gate, dtype=jnp.float32)
         if raw_outer_gate.shape != ():
-            raise ValueError(
-                f"external_gate must have scalar shape (); got {raw_outer_gate.shape}"
-            )
+            raise ValueError(f"external_gate must have scalar shape (); got {raw_outer_gate.shape}")
         inputs_valid = (
             jnp.all(jnp.isfinite(obs))
             & jnp.all(jnp.isfinite(act))
@@ -709,9 +698,7 @@ class WorkingMemoryFeaturizer:
                 reward_traces=jnp.zeros_like(state.reward_traces),
             )
         update_applied = (
-            inputs_valid
-            & self._state_is_valid(previous_checked)
-            & self._state_is_valid(candidate)
+            inputs_valid & self._state_is_valid(previous_checked) & self._state_is_valid(candidate)
         )
         return WorkingMemoryUpdateResult(
             state=select_transaction(update_applied, candidate, state),
@@ -818,9 +805,7 @@ def transform_working_memory_arrays(
     state_scalars = trace_scalars + 4
     signal_scalars = cfg.observation_dim + cfg.action_dim + cfg.reward_dim
     decay_scalars = (
-        len(cfg.observation_decay_rates)
-        + len(cfg.action_decay_rates)
-        + len(cfg.reward_decay_rates)
+        len(cfg.observation_decay_rates) + len(cfg.action_decay_rates) + len(cfg.reward_decay_rates)
     )
     per_step_work = (
         3 * state_scalars
@@ -832,8 +817,7 @@ def transform_working_memory_arrays(
     )
     _require_sequence_resource(
         "working memory transform aggregate",
-        float32_scalars=steps * (signal_scalars + cfg.feature_dim() + 1)
-        + per_step_work,
+        float32_scalars=steps * (signal_scalars + cfg.feature_dim() + 1) + per_step_work,
         bool_scalars=steps,
     )
     _require_array("observations", observations, shape=(steps, cfg.observation_dim))

--- a/tests/test_working_memory_validation.py
+++ b/tests/test_working_memory_validation.py
@@ -457,3 +457,18 @@ def test_working_transform_resource_preflight_precedes_jax_conversion() -> None:
             HostArray(1),  # type: ignore[arg-type]
             HostArray(1),  # type: ignore[arg-type]
         )
+
+
+def test_working_memory_rejects_oversized_decay_rates() -> None:
+    with pytest.raises(ValueError, match="decay rates"):
+        WorkingMemoryConfig(
+            observation_dim=1,
+            observation_decay_rates=(0.5,) * 4097,
+        )
+
+    # 4096 boundary is accepted
+    cfg = WorkingMemoryConfig(
+        observation_dim=1,
+        observation_decay_rates=(0.5,) * 4096,
+    )
+    assert len(cfg.observation_decay_rates) == 4096


### PR DESCRIPTION
Fixes #2220

In `alberta_framework/core/working_memory.py` and `alberta_framework/core/state_builder.py`, `WorkingMemoryConfig` and `FixedTraceStateBuilderConfig` validated decay rate sequences without an upper cardinality ceiling, walking unbounded sequences element-by-element during configuration validation.

### Changes
1. Defined `_MAX_WORKING_MEMORY_DECAY_RATES = 1 << 12` (4096) in `working_memory.py` and `_MAX_FIXED_TRACE_DECAY_RATES = 1 << 12` (4096) in `state_builder.py`.
2. Enforced maximum sequence length bounds ($\le 4096$) in `_validate_decay_rates` and `_require_decay_rates` before iterating over elements.
3. Added unit test `test_working_memory_rejects_oversized_decay_rates` in `tests/test_working_memory_validation.py` verifying rejection of oversized decay rate tuples ($> 4096$) and acceptance of the 4096 boundary.

### Verification
- `pytest tests/test_working_memory_validation.py tests/test_working_memory.py`: 155/155 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
