### PR TITLE
fix(steps): bound Step 7 planning and Step 9 dreaming loop lengths before lax.scan

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -160,6 +160,8 @@ class Step7DynaConfig:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_PLANNING_STEPS = 10_000
+_MAX_PLANNING_ROLLOUT_DEPTH = 10_000
 _STEP7_CONFIG_FIELDS = frozenset(
     {
         "control",
@@ -278,13 +280,13 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
         "planning_steps",
         config.planning_steps,
         minimum=0,
-        maximum=_INT32_MAX,
+        maximum=_MAX_PLANNING_STEPS,
     )
     planning_rollout_depth = _require_int(
         "planning_rollout_depth",
         config.planning_rollout_depth,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_MAX_PLANNING_ROLLOUT_DEPTH,
     )
     planning_warmup_steps = _require_int(
         "planning_warmup_steps",

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -71,6 +71,9 @@ from alberta_framework.steps.step6 import (
 
 _INT32_MAX = 2**31 - 1
 _MAX_CONFIG_SEQUENCE_LENGTH = 4_096
+_MAX_PLANNING_BUDGET = 10_000
+_MAX_DREAM_ROLLOUT_HORIZON = 10_000
+_MAX_DREAM_CANDIDATE_COUNT = 10_000
 _MAX_DREAM_WORK_PER_REAL_STEP = 4_096
 _ACTUAL_INT_TYPES = frozenset(
     {
@@ -414,20 +417,23 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         config.behavior_model_step_size,
     )
     planning_budget = _require_int(
-        "planning_budget", config.planning_budget, minimum=0, maximum=_INT32_MAX
+        "planning_budget",
+        config.planning_budget,
+        minimum=0,
+        maximum=_MAX_PLANNING_BUDGET,
     )
     dream_rollout_horizon = _require_int(
         "dream_rollout_horizon",
         config.dream_rollout_horizon,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_MAX_DREAM_ROLLOUT_HORIZON,
     )
     # Candidate selection publishes selected indices as signed int32 values.
     dream_candidate_count = _require_int(
         "dream_candidate_count",
         config.dream_candidate_count,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_MAX_DREAM_CANDIDATE_COUNT,
     )
     dream_surprise_weight = _require_real(
         "dream_surprise_weight",

--- a/tests/test_step7_hostile_validation.py
+++ b/tests/test_step7_hostile_validation.py
@@ -293,3 +293,14 @@ def test_smoke_preflights_all_live_arrays_before_allocation(
     monkeypatch.setattr(jr, "normal", unexpected_allocation)
     with pytest.raises(ValueError, match="smoke resources"):
         run_step7_smoke(steps=50_000_000)
+
+
+def test_step7_config_rejects_oversized_planning_and_rollout_steps() -> None:
+    with pytest.raises(ValueError, match="planning_steps"):
+        Step7DynaConfig(planning_steps=10_001)
+    with pytest.raises(ValueError, match="planning_rollout_depth"):
+        Step7DynaConfig(planning_rollout_depth=10_001)
+
+    cfg = Step7DynaConfig(planning_steps=10_000, planning_rollout_depth=10_000)
+    assert cfg.planning_steps == 10_000
+    assert cfg.planning_rollout_depth == 10_000

--- a/tests/test_step9_hostile_validation.py
+++ b/tests/test_step9_hostile_validation.py
@@ -244,3 +244,21 @@ def test_runtime_entry_points_require_exact_config_without_truthiness_hooks() ->
 def test_smoke_preflights_complete_output_shape_before_allocation() -> None:
     with pytest.raises(ValueError, match="observation row count"):
         run_step9_smoke(steps=2**31 - 1)
+
+
+def test_step9_config_rejects_oversized_dream_parameters() -> None:
+    with pytest.raises(ValueError, match="planning_budget"):
+        Step9DreamingConfig(planning_budget=10_001)
+    with pytest.raises(ValueError, match="dream_rollout_horizon"):
+        Step9DreamingConfig(dream_rollout_horizon=10_001)
+    with pytest.raises(ValueError, match="dream_candidate_count"):
+        Step9DreamingConfig(dream_candidate_count=10_001)
+
+    cfg = Step9DreamingConfig(
+        planning_budget=0,
+        dream_rollout_horizon=10_000,
+        dream_candidate_count=10_000,
+    )
+    assert cfg.planning_budget == 0
+    assert cfg.dream_rollout_horizon == 10_000
+    assert cfg.dream_candidate_count == 10_000


### PR DESCRIPTION
Fixes #2214

In `alberta_framework/steps/step7.py` and `alberta_framework/steps/step9.py`, inner planning and dreaming loop lengths (`planning_steps`, `planning_rollout_depth`, `planning_budget`, `dream_rollout_horizon`, `dream_candidate_count`) were validated only against `_INT32_MAX`. Extremely large or hostile config values passed initial validation and caused unbounded multi-gigabyte `jnp.arange(...)` allocations and compiled scan timeouts at JAX trace time.

### Changes
1. Defined explicit `10_000` ceilings on `planning_steps` and `planning_rollout_depth` in `step7.py`.
2. Defined explicit `10_000` ceilings on `planning_budget`, `dream_rollout_horizon`, and `dream_candidate_count` in `step9.py`.
3. Added unit tests in `tests/test_step7_hostile_validation.py` and `tests/test_step9_hostile_validation.py` verifying that oversized loop parameters ($> 10,000$) fail closed immediately during configuration validation.

### Verification
- `pytest tests/test_step7_hostile_validation.py tests/test_step9_hostile_validation.py tests/test_step7_production.py tests/test_step9_production.py`: 40/40 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
