### PR TITLE
fix(evaluation): make flad_noise_component_transaction scale-free via power-of-two rescaling

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -203,12 +203,15 @@ def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tu
     direction = _trusted_array(gradient, name="gradient")
     if delta.shape != direction.shape or delta.ndim != 1 or delta.size < 1:
         raise ValueError("perturbation and gradient must be non-empty equal-width vectors")
-    squared_norm = jnp.vdot(direction, direction).real
-    numerator = jnp.vdot(direction, delta).real
+    max_abs = jnp.max(jnp.abs(direction))
+    _, exponent = jnp.frexp(max_abs)
+    scaled = jnp.ldexp(direction, -exponent)
+    squared_norm = jnp.vdot(scaled, scaled).real
+    numerator = jnp.vdot(scaled, delta).real
     active = squared_norm > 0.0
     denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
     coefficient = numerator / denominator
-    projection = direction * coefficient * active.astype(delta.dtype)
+    projection = scaled * coefficient * active.astype(delta.dtype)
     candidate = delta - projection
     valid = (
         jnp.all(jnp.isfinite(delta))

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,26 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+
+def test_flad_noise_component_scale_freedom() -> None:
+    delta = np.array([1.0, -2.0, 0.5, 3.0], dtype=np.float32)
+    grad = np.array([2.0, 1.0, -1.0, 0.5], dtype=np.float32)
+
+    # Reference projection in float64
+    d_f64 = np.asarray(delta, dtype=np.float64)
+    g_f64 = np.asarray(grad, dtype=np.float64)
+    ref = d_f64 - g_f64 * (float(g_f64 @ d_f64) / float(g_f64 @ g_f64))
+
+    for scale in (1.0, 1e-10, 1e-20, 1e-30):
+        scaled_grad = jnp.asarray(grad * np.float32(scale))
+        safe, valid = jax.jit(flad_noise_component_transaction)(jnp.asarray(delta), scaled_grad)
+        assert bool(valid)
+        np.testing.assert_allclose(np.asarray(safe, dtype=np.float64), ref, rtol=1e-5, atol=1e-5)
+
+    # Zero gradient returns delta bit-identically
+    safe_zero, valid_zero = jax.jit(flad_noise_component_transaction)(
+        jnp.asarray(delta), jnp.zeros_like(scaled_grad)
+    )
+    assert bool(valid_zero)
+    np.testing.assert_array_equal(safe_zero, jnp.asarray(delta))


### PR DESCRIPTION
Fixes #2393

In `flad_noise_component_transaction`, the gradient projection denominator $g^T g$ previously underflowed to float32 zero when gradient entries fell below $\sim 10^{-20}$. This caused `active = (squared_norm > 0.0)` to evaluate to `False`, mistakenly treating non-zero gradients as zero and returning the unprojected perturbation $\delta$ unchanged with `valid=True`.

### Changes
1. Rescaled `direction` by exact power-of-two shifts (`jnp.frexp` and `jnp.ldexp`) before computing norms, inner products, and projection vectors. Because orthogonal projection onto $\text{span}(g)$ is scale-invariant, this reformulation preserves exact mantissa bits while preventing underflow/overflow across dynamic ranges from $10^{-30}$ to $10^{30}$.
2. Preserved exact reduction to $\delta$ when `gradient` is genuinely zero.
3. Added unit test `test_flad_noise_component_scale_freedom` in `tests/test_optimizer_geometry.py` verifying accurate gradient component removal from $1.0$ down to $10^{-30}$ against float64 reference arithmetic.

### Verification
- `pytest tests/test_optimizer_geometry.py`: 29/29 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
