### PR TITLE
fix(core): admit all numpy integer dtype families in reward_model and stacked_horde

### DIFF
--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -28,24 +28,8 @@ from jaxtyping import Bool, Float
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 _INT32_MAX = 2**31 - 1
-_ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
-)
-_ACTUAL_FLOAT_TYPES = frozenset(
-    {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
-)
+_ACTUAL_INT_TYPES = frozenset({int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")})
+_ACTUAL_FLOAT_TYPES = frozenset({float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))})
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -75,16 +59,13 @@ def _preflight_update_working_set(feature_dim: int) -> None:
     # an execution backend can sometimes donate/alias it.
     update_scalars = 4 * feature_dim * feature_dim + 7 * feature_dim + 8
     if 4 * update_scalars > _INT32_MAX:
-        raise ValueError(
-            "reward-model update working set byte count must fit signed int32"
-        )
+        raise ValueError("reward-model update working set byte count must fit signed int32")
 
 
 def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
     actual_type = type(value)
     if not any(
-        actual_type is allowed_type
-        for allowed_type in (*_ACTUAL_INT_TYPES, *_ACTUAL_FLOAT_TYPES)
+        actual_type is allowed_type for allowed_type in (*_ACTUAL_INT_TYPES, *_ACTUAL_FLOAT_TYPES)
     ):
         raise ValueError(f"{name} must be a finite real scalar")
     return validated_float32_scalar(name, value, **bounds)
@@ -336,6 +317,7 @@ class RLSRewardModel:
             gain=jnp.where(update_applied, gain, jnp.zeros_like(gain)),
             update_applied=update_applied,
         )
+
 
 __all__ = [
     "RLSRewardModel",

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -141,21 +141,7 @@ _CONFIG_FIELDS = {
     "cumulant_indices",
     "step_size",
 }
-_ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
-)
+_ACTUAL_INT_TYPES = frozenset({int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")})
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:
@@ -233,24 +219,18 @@ class StackedHordeConfig:
         raw_sequences = {
             "gammas": _require_sequence("gammas", self.gammas),
             "lamdas": _require_sequence("lamdas", self.lamdas),
-            "cumulant_indices": _require_sequence(
-                "cumulant_indices", self.cumulant_indices
-            ),
+            "cumulant_indices": _require_sequence("cumulant_indices", self.cumulant_indices),
         }
         for name, seq in raw_sequences.items():
             if len(seq) != n_demons:
                 raise ValueError(f"{name} must have length n_demons={n_demons}")
 
         gammas = tuple(
-            validated_float32_scalar(
-                f"gammas[{i}]", value, lower=0.0, upper=1.0
-            )
+            validated_float32_scalar(f"gammas[{i}]", value, lower=0.0, upper=1.0)
             for i, value in enumerate(raw_sequences["gammas"])
         )
         lamdas = tuple(
-            validated_float32_scalar(
-                f"lamdas[{i}]", value, lower=0.0, upper=1.0
-            )
+            validated_float32_scalar(f"lamdas[{i}]", value, lower=0.0, upper=1.0)
             for i, value in enumerate(raw_sequences["lamdas"])
         )
 


### PR DESCRIPTION
Fixes #2268

In `alberta_framework/core/reward_model.py` and `alberta_framework/core/stacked_horde.py`, `_ACTUAL_INT_TYPES` was previously hand-enumerated using fixed-width numpy types (`np.int8`, `np.int16`, `np.int32`, `np.int64`, etc.). On platforms where C-alias integers like `np.intc` or `np.uintc` are distinct type objects from `np.int32`/`np.uint32` (e.g. 64-bit Windows LLP64), valid integer inputs passed into configuration constructors and integer validators were rejected with `ValueError`.

### Changes
1. Replaced hand-enumerated integer types in `reward_model.py` and `stacked_horde.py` with dynamic dtype-code derivation: `frozenset({int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")})`, matching peer modules (`types.py`, `horde.py`, `actor_critic.py`, `resource_manager.py`).
2. Validated against parameterized integer tests across all numpy integer families (`bhilqBHILQpP`).

### Verification
- `pytest tests/test_stacked_horde.py tests/test_reward_model.py`: 156/156 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
