### PR TITLE
fix(evaluation): make spectral_matrix_sign scale-free via power-of-two rescaling

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -116,12 +116,7 @@ def orthogonal_correction_transaction(update: Array, protected_basis: Array) -> 
     """Return a finite orthogonal correction and caller-visible validity bit."""
     vector = _trusted_array(update, name="update")
     basis = _trusted_array(protected_basis, name="protected_basis")
-    if (
-        vector.ndim != 1
-        or vector.size < 1
-        or basis.ndim != 2
-        or basis.shape[1] != vector.shape[0]
-    ):
+    if vector.ndim != 1 or vector.size < 1 or basis.ndim != 2 or basis.shape[1] != vector.shape[0]:
         raise ValueError("update must be a non-empty vector and basis rows must match its width")
     coordinates = basis @ vector
     projection = basis.T @ coordinates
@@ -172,8 +167,17 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
     ):
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
-    valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    max_abs = jnp.max(jnp.abs(value))
+    _, exponent = jnp.frexp(max_abs)
+    rescaled = jnp.ldexp(value, -exponent)
+    rescaled_norm = jnp.linalg.norm(rescaled)
+    positive = rescaled_norm > 0
+    x = jnp.where(
+        positive,
+        rescaled / jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm)),
+        jnp.zeros_like(rescaled),
+    )
+    valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm) & jnp.isfinite(rescaled_norm)
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True
@@ -244,11 +248,7 @@ def muon_ogd_dual_update_transaction(
         raise ValueError("dual must contain one multiplier per constraint")
     if type(dual_learning_rate) is not float or not math.isfinite(dual_learning_rate):
         raise ValueError("dual_learning_rate must be a finite float")
-    if (
-        dual_learning_rate < 0.0
-        or type(dual_steps) is not int
-        or not 1 <= dual_steps <= 32
-    ):
+    if dual_learning_rate < 0.0 or type(dual_steps) is not int or not 1 <= dual_steps <= 32:
         raise ValueError("dual learning rate must be non-negative and dual_steps bounded positive")
     valid = (
         jnp.all(jnp.isfinite(value))
@@ -271,9 +271,7 @@ def muon_ogd_dual_update_transaction(
         )
         multipliers = next_multipliers
     shifted = value + jnp.einsum("k,kij->ij", multipliers, protected)
-    update, sign_valid = spectral_matrix_sign_transaction(
-        shifted, steps=newton_schulz_steps
-    )
+    update, sign_valid = spectral_matrix_sign_transaction(shifted, steps=newton_schulz_steps)
     valid = valid & jnp.all(jnp.isfinite(shifted)) & sign_valid
     safe_update = jnp.where(valid, update, jnp.zeros_like(update))
     safe_dual = jnp.where(valid, multipliers, jnp.zeros_like(multipliers))
@@ -438,9 +436,7 @@ def _runtime_identity() -> dict[str, object]:
         "machine": _runtime_text("machine", platform.machine()),
         "packages": {
             "jax": _runtime_text("JAX version", jax.__version__),
-            "jaxlib": _runtime_text(
-                "jaxlib version", importlib.metadata.version("jaxlib")
-            ),
+            "jaxlib": _runtime_text("jaxlib version", importlib.metadata.version("jaxlib")),
             "numpy": _runtime_text("NumPy version", np.__version__),
         },
         "default_backend": _runtime_text("JAX backend", jax.default_backend()),
@@ -495,9 +491,7 @@ def _execute_frozen_stream(*, measure_timing: bool) -> dict[str, object]:
     constraints, basis = _protected_geometry(rows, columns)
     target_updates: list[Array] = []
     for matrix in stream:
-        target_update, target_valid = orthogonal_correction_transaction(
-            matrix.reshape(-1), basis
-        )
+        target_update, target_valid = orthogonal_correction_transaction(matrix.reshape(-1), basis)
         _require_valid(target_valid, name="target projection")
         target_updates.append(target_update.reshape((rows, columns)))
     target = jnp.sum(jnp.stack(target_updates), axis=0)
@@ -527,9 +521,7 @@ def _execute_frozen_stream(*, measure_timing: bool) -> dict[str, object]:
                 )
                 processed = flat_processed.reshape((rows, columns))
             elif arm == "fogo_projection":
-                flat_processed, valid = orthogonal_correction_transaction(
-                    matrix.reshape(-1), basis
-                )
+                flat_processed, valid = orthogonal_correction_transaction(matrix.reshape(-1), basis)
                 processed = flat_processed.reshape((rows, columns))
             elif arm == "flad_zero_gradient":
                 flat_processed, valid = flad_noise_component_transaction(
@@ -671,10 +663,7 @@ def _exact_equal(actual: object, expected: object) -> bool:
     if type(expected) is dict:
         actual_dict = cast(dict[object, object], actual)
         expected_dict = cast(dict[object, object], expected)
-        if (
-            len(actual_dict) > 32
-            or len(actual_dict) != len(expected_dict)
-        ):
+        if len(actual_dict) > 32 or len(actual_dict) != len(expected_dict):
             return False
         if not all(type(key) is str for key in actual_dict):
             return False
@@ -687,9 +676,13 @@ def _exact_equal(actual: object, expected: object) -> bool:
     if type(expected) is list:
         actual_list = cast(list[object], actual)
         expected_list = cast(list[object], expected)
-        return len(actual_list) <= 128 and len(actual_list) == len(expected_list) and all(
-            _exact_equal(left, right)
-            for left, right in zip(actual_list, expected_list, strict=True)
+        return (
+            len(actual_list) <= 128
+            and len(actual_list) == len(expected_list)
+            and all(
+                _exact_equal(left, right)
+                for left, right in zip(actual_list, expected_list, strict=True)
+            )
         )
     if type(expected) is str:
         actual_text = cast(str, actual)

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -283,9 +283,7 @@ def test_geometry_primitives_are_outer_jit_safe() -> None:
     np.testing.assert_allclose(corrected, [0.0, 2.0])
     invalid = jax.jit(flad_noise_component)(jnp.array([jnp.nan]), jnp.ones(1))
     assert bool(jnp.all(jnp.isnan(invalid)))
-    safe, valid = jax.jit(flad_noise_component_transaction)(
-        jnp.array([jnp.nan]), jnp.ones(1)
-    )
+    safe, valid = jax.jit(flad_noise_component_transaction)(jnp.array([jnp.nan]), jnp.ones(1))
     np.testing.assert_array_equal(safe, jnp.zeros(1))
     assert not bool(valid)
 
@@ -340,3 +338,15 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+
+def test_spectral_matrix_sign_scale_freedom() -> None:
+    m = jnp.array([[2.0, 1.0], [0.5, -1.0]], dtype=jnp.float32)
+    ref_sign, ref_valid = jax.jit(spectral_matrix_sign_transaction)(m)
+    assert bool(ref_valid)
+
+    for scale in (1e-13, 1e-15, 1e-20, 1e-25):
+        tiny = m * jnp.asarray(scale, dtype=jnp.float32)
+        sign, valid = jax.jit(spectral_matrix_sign_transaction)(tiny)
+        assert bool(valid)
+        np.testing.assert_allclose(np.asarray(sign), np.asarray(ref_sign), rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
Fixes #2379

`spectral_matrix_sign` previously normalized inputs using a fixed `1e-12` Frobenius magnitude floor: `x = value / max(norm, 1e-12)`. When `norm < 1e-12`, the NS5 cubic recurrence $f(X) = \frac{3}{2}X - \frac{1}{2}X X^T X$ was applied to singular values far below its convergence interval, laundering small matrices into numerically zero matrix signs while returning `valid=True`.

### Changes
1. Replaced the `1e-12` magnitude floor with exact power-of-two exponent rescaling:
   ```python
   max_abs = jnp.max(jnp.abs(value))
   _, exponent = jnp.frexp(max_abs)
   rescaled = jnp.ldexp(value, -exponent)
   rescaled_norm = jnp.linalg.norm(rescaled)
   ```
   This centers input entries in $[0.5, 1.0)$, placing all singular values within the NS5 convergence basin and making the orthogonalization scale-free from $1.0$ down to $10^{-25}$.
2. Added unit test `test_spectral_matrix_sign_scale_freedom` in `tests/test_optimizer_geometry.py` verifying that small matrices ($10^{-13}$ to $10^{-25}$) return the exact orthogonal polar factor matching unit scale.

### Verification
- `pytest tests/test_optimizer_geometry.py`: 29/29 tests passed.
- `ruff check`: All checks passed.
- `mypy`: Clean.
