### PR TITLE
fix(core): encode with the declared observation_scale instead of a 1e-6 floor

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -79,6 +79,10 @@ from alberta_framework.core.update_safety import (
 EVIDENCE_LEVEL = "L0"
 SCIENTIFIC_PROMOTION_ALLOWED = False
 _INT32_MAX = 2**31 - 1
+# The encoder divides observations by ``observation_scale``, so the reciprocal of every
+# admitted scale has to be a finite float32.  That holds for the normal range and fails
+# for every subnormal, where ``1 / scale`` overflows and the quotient is nan or inf.
+_SMALLEST_NORMAL_FLOAT32 = float(np.finfo(np.float32).tiny)
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -222,6 +226,11 @@ class LatentWorldModelConfig:
     ``max_encoder_update`` and skipped whenever the fresh ``collapse_score``
     exceeds ``encoder_collapse_gate_threshold`` (the anti-collapse diagnostic
     acting as a gate) or any gradient/candidate value is non-finite.
+
+    ``observation_scale`` is the per-dimension divisor the encoder applies, so
+    every entry must be a normal float32: a subnormal scale has no finite
+    reciprocal and the quotient it asks for is nan or inf.  Every admitted
+    entry is applied exactly as declared.
     """
 
     observation_dim: int
@@ -290,7 +299,7 @@ class LatentWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 validated_float32_scalar(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]", scale, lower=_SMALLEST_NORMAL_FLOAT32
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -667,10 +676,17 @@ class LatentWorldModel:
         encoder_bias: Array,
         observation: Array,
     ) -> Float[Array, " latent_dim"]:
-        """Encode one observation with explicit (differentiable) encoder params."""
+        """Encode one observation with explicit (differentiable) encoder params.
+
+        Divides by the configured ``observation_scale`` itself.  The config admits
+        only scales whose reciprocal is a finite float32, so no floor is needed
+        here, and substituting one would normalize by a number the caller never
+        declared: the latents would shrink by the ratio between the two, which
+        ``collapse_score`` then reports as degenerate input.
+        """
         obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._config.observation_dim,))
         scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
+        scaled = obs / scale
         return jnp.tanh(scaled @ encoder_matrix + encoder_bias)
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -24,6 +24,7 @@ from alberta_framework.core.latent_world_model import (
     SCIENTIFIC_PROMOTION_ALLOWED,
     LatentWorldModel,
     LatentWorldModelConfig,
+    LatentWorldModelState,
     run_latent_world_model_learning_loop,
 )
 
@@ -749,3 +750,209 @@ def test_latent_world_model_init_rejects_nonfinite_encoder_draw() -> None:
 
     with pytest.raises(ValueError, match="encoder initialization"):
         model.init(jr.key(0))
+
+
+_SMALLEST_NORMAL_FLOAT32 = float(np.finfo(np.float32).tiny)
+
+# Two observations expressed as normalized coordinates: the encoder divides by the
+# declared scale, so a scale-free encoder returns one latent for all of these.
+_DECLARED_COORDINATES = (1.5, -0.75)
+
+# Latent words at scales the retired ``max(scale, 1e-6)`` floor never altered, recorded
+# from the revision that still floored.  The repair must leave these rows alone.
+_UNFLOORED_GOLDEN_LATENTS = (
+    (1.0, (0x3F68EF62, 0xBF5AD221, 0xBF539FA8, 0xBF1A7A16)),
+    (1e-1, (0x3F68EF62, 0xBF5AD221, 0xBF539FA8, 0xBF1A7A16)),
+    (1e-3, (0x3F68EF63, 0xBF5AD221, 0xBF539FA5, 0xBF1A7A16)),
+    (1e-5, (0x3F68EF62, 0xBF5AD221, 0xBF539FA8, 0xBF1A7A16)),
+    (1e-6, (0x3F68EF62, 0xBF5AD221, 0xBF539FA8, 0xBF1A7A16)),
+)
+
+# Scales the floor silently replaced.  All are normal float32 values, so each one has a
+# finite reciprocal and the encoder can apply it exactly as declared.
+_FLOORED_SCALES = (1e-7, 1e-9, 1e-12, 1e-20, 1e-30, 1e-37)
+
+
+def _scale_probe(scale: float) -> tuple[LatentWorldModel, LatentWorldModelState]:
+    config = LatentWorldModelConfig(
+        observation_dim=2,
+        latent_dim=4,
+        n_actions=2,
+        hidden_sizes=(),
+        observation_scale=(scale, scale),
+    )
+    model = LatentWorldModel(config)
+    return model, model.init(jr.key(0))
+
+
+def _encode_declared_coordinates(
+    scale: float, coordinates: tuple[float, float] = _DECLARED_COORDINATES
+) -> np.ndarray:
+    """Encode the observation sitting at ``coordinates`` in declared-scale units."""
+    model, state = _scale_probe(scale)
+    observation = jnp.asarray([value * scale for value in coordinates], dtype=jnp.float32)
+    return np.asarray(model.encode(state, observation))
+
+
+@pytest.mark.parametrize(
+    "scale",
+    [
+        1e-38,
+        _SMALLEST_NORMAL_FLOAT32 / 2.0,
+        1e-40,
+        float(np.finfo(np.float32).smallest_subnormal),
+        0.0,
+        -1.0,
+    ],
+)
+def test_observation_scale_rejects_scales_without_a_finite_reciprocal(scale: float) -> None:
+    """A subnormal divisor asks for a quotient float32 cannot hold, so reject it up front."""
+    with pytest.raises(ValueError, match=r"observation_scale\[0\] must be >= 1\.17549435"):
+        LatentWorldModelConfig(
+            observation_dim=2,
+            latent_dim=4,
+            n_actions=2,
+            observation_scale=(scale, 1.0),
+        )
+
+
+def test_observation_scale_admits_the_smallest_normal_float32() -> None:
+    config = LatentWorldModelConfig(
+        observation_dim=1,
+        latent_dim=2,
+        n_actions=2,
+        observation_scale=(_SMALLEST_NORMAL_FLOAT32,),
+    )
+
+    assert config.observation_scale == (_SMALLEST_NORMAL_FLOAT32,)
+    assert all(type(value) is float for value in config.observation_scale)
+    assert math.isfinite(1.0 / config.observation_scale[0])
+
+
+@pytest.mark.parametrize("scale", _FLOORED_SCALES)
+def test_config_round_trip_preserves_a_scale_below_the_retired_floor(scale: float) -> None:
+    config = LatentWorldModelConfig(
+        observation_dim=2,
+        latent_dim=4,
+        n_actions=2,
+        observation_scale=(scale, 1.0),
+    )
+
+    restored = LatentWorldModelConfig.from_config(config.to_config())
+
+    assert restored.observation_scale == config.observation_scale
+
+
+@pytest.mark.parametrize(("scale", "expected_words"), _UNFLOORED_GOLDEN_LATENTS)
+def test_encode_is_bit_for_bit_unchanged_where_the_floor_never_applied(
+    scale: float, expected_words: tuple[int, ...]
+) -> None:
+    """At and above the retired floor ``max(scale, 1e-6)`` was the scale, so nothing moves."""
+    latent = _encode_declared_coordinates(scale)
+
+    words = tuple(int(word) for word in latent.view(np.uint32))
+    assert words == expected_words
+
+
+@pytest.mark.parametrize("scale", _FLOORED_SCALES)
+def test_encode_applies_the_declared_observation_scale(scale: float) -> None:
+    """One declared coordinate encodes to one latent, whatever scale declares that unit."""
+    reference = _encode_declared_coordinates(1.0)
+
+    latent = _encode_declared_coordinates(scale)
+
+    chex.assert_tree_all_finite(latent)
+    np.testing.assert_allclose(latent, reference, rtol=0.0, atol=1e-6)
+
+
+@pytest.mark.parametrize("scale", (1.0, 1e-6, *_FLOORED_SCALES, _SMALLEST_NORMAL_FLOAT32))
+@pytest.mark.parametrize("coordinate", (1.0, 8.0, 1e2, 1e4, 1e6))
+def test_encode_recovers_whole_normalized_coordinates_at_every_admitted_scale(
+    scale: float, coordinate: float
+) -> None:
+    """Whole coordinates are exactly representable, so they survive the division intact."""
+    reference = _encode_declared_coordinates(1.0, (coordinate, -coordinate))
+
+    latent = _encode_declared_coordinates(scale, (coordinate, -coordinate))
+
+    chex.assert_tree_all_finite(latent)
+    np.testing.assert_allclose(latent, reference, rtol=0.0, atol=1e-6)
+
+
+@pytest.mark.parametrize("scale", _FLOORED_SCALES)
+def test_latent_separation_matches_the_scale_that_declared_it(scale: float) -> None:
+    """Observations one declared unit apart stay one declared unit apart in latent space."""
+    expected = np.max(
+        np.abs(
+            _encode_declared_coordinates(1.0, (2.0, 2.0))
+            - _encode_declared_coordinates(1.0, (1.0, 1.0))
+        )
+    )
+
+    separation = np.max(
+        np.abs(
+            _encode_declared_coordinates(scale, (2.0, 2.0))
+            - _encode_declared_coordinates(scale, (1.0, 1.0))
+        )
+    )
+
+    assert separation == pytest.approx(float(expected), abs=1e-6)
+
+
+def _run_declared_scale_transitions(
+    scale: float, *, encoder_learning: bool, steps: int = 40
+) -> tuple[float, float, float, float]:
+    """Drive ``steps`` transitions whose observations are standard normal in declared units.
+
+    Returns the final collapse score, the final mean latent spread, the largest encoder
+    matrix movement, and the configured minimum latent spread.
+    """
+    config = LatentWorldModelConfig(
+        observation_dim=3,
+        latent_dim=6,
+        n_actions=2,
+        observation_scale=(scale,) * 3,
+        encoder_learning=encoder_learning,
+    )
+    model = LatentWorldModel(config)
+    state = model.init(jr.key(0))
+    before = np.asarray(state.encoder_matrix).copy()
+    key = jr.key(7)
+    collapse_score = 0.0
+    latent_spread = 0.0
+    for step in range(steps):
+        key, observation_key, next_key = jr.split(key, 3)
+        observation = jr.normal(observation_key, (3,), dtype=jnp.float32) * scale
+        next_observation = jr.normal(next_key, (3,), dtype=jnp.float32) * scale
+        result = model.update(state, observation, step % 2, 0.5, 0.99, next_observation)
+        state = result.state
+        collapse_score = float(result.collapse_score)
+        latent_spread = float(result.latent_std_mean)
+    movement = float(np.max(np.abs(np.asarray(state.encoder_matrix) - before)))
+    return collapse_score, latent_spread, movement, config.min_latent_std
+
+
+@pytest.mark.parametrize("scale", _FLOORED_SCALES)
+def test_update_reports_no_collapse_at_declared_scales_below_the_retired_floor(
+    scale: float,
+) -> None:
+    """A well-conditioned stream is well-conditioned at any scale that declares its unit."""
+    collapse_score, latent_spread, _, min_latent_std = _run_declared_scale_transitions(
+        scale, encoder_learning=False
+    )
+
+    assert collapse_score == 0.0
+    assert latent_spread >= min_latent_std
+
+
+@pytest.mark.parametrize("scale", _FLOORED_SCALES)
+def test_trainable_encoder_still_learns_at_declared_scales_below_the_retired_floor(
+    scale: float,
+) -> None:
+    """The anti-collapse gate blocks every encoder step while collapse is manufactured."""
+    collapse_score, _, movement, _ = _run_declared_scale_transitions(
+        scale, encoder_learning=True
+    )
+
+    assert collapse_score == 0.0
+    assert movement > 0.0


### PR DESCRIPTION
Fixes #2411.

## What was wrong

`LatentWorldModelConfig` documents `observation_scale` as the per-dimension scale the
encoder divides by, and its validator accepted any value that stayed positive once
narrowed to `float32`. The encoder divided by something else:

```python
scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
```

Every accepted scale below `1e-6` was normalized by `1e-6` instead of the declared value.
Nothing reported the substitution.

The sibling `reward_scale` in the same class is the counter-example: line 752 divides by the
raw configured value and line 781 multiplies by it, with no floor on either side. The
floored `observation_scale` was the outlier, not the convention. There is also no decode
path in this module (`def decode`, `def reconstruct`, `decoder` all match nothing), so
nothing downstream cancelled the substitution.

## Why it mattered

Observations drawn from one standard normal and multiplied by `observation_scale` are
identically well-conditioned in declared units, so every row below should read the same.
Forty transitions through `LatentWorldModel.update`, `observation_dim=3`, `latent_dim=6`,
`min_latent_std=0.05`, `encoder_collapse_gate_threshold=0.0`:

| `observation_scale` | mean latent std | `collapse_score` | encoder moved | max abs encoder delta |
| --- | --- | --- | --- | --- |
| `1.0` | 6.054746e-01 | 0.0000 | True | 4.293072e-02 |
| `1e-3` | 6.054746e-01 | 0.0000 | True | 4.293072e-02 |
| `1e-6` | 6.054746e-01 | 0.0000 | True | 4.293072e-02 |
| `1e-7` | 1.020295e-01 | 0.1667 | **False** | 0.000000e+00 |
| `1e-9` | 1.036086e-03 | **1.0000** | **False** | 0.000000e+00 |
| `1e-12` | 1.036088e-06 | **1.0000** | **False** | 0.000000e+00 |
| `1e-20` | 1.036088e-14 | **1.0000** | **False** | 0.000000e+00 |

Three consequences, in order:

1. **The declared normalization was replaced.** At `1e-9` an observation the config places
   at `2.0` normalized units reached the encoder as `2e-3`.
2. **`collapse_score` reported the shrink the floor manufactured.** The module docstring
   describes it as flagging "degenerate inputs or encoders". The input was neither.
3. **The trainable encoder was a permanent no-op.** `encoder_collapse_gate_threshold`
   defaults to `0.0`, so that score blocked every encoder step. Across 40 accepted
   transitions at `1e-9` and below, `state.encoder_matrix` never changed by a byte.

Latent separation for two observations one declared unit apart, `observation_dim=2`,
`latent_dim=3`:

| `observation_scale` | max abs latent separation |
| --- | --- |
| `1e-6` | 1.367620e-01 |
| `1e-7` | 1.211860e-01 |
| `1e-9` | 1.256927e-03 |
| `1e-12` | 1.256932e-06 |
| `1e-20` | 1.256932e-14 |
| `1e-30` | 1.256932e-24 |
| `1e-38` | 2.513863e-32 |
| `1.4e-45` | **0.000000e+00** |

In the linear region of `tanh` each decade of declared scale cost one decade of
separation, which is the substituted divisor showing through. At the smallest subnormal —
a scale the validator accepted — two distinct observations became the identical latent.

## What the fix is

Divide by the declared scale, and admit only scales the encoder can actually apply:

```python
observation_scale = tuple(
    validated_float32_scalar(
        f"observation_scale[{index}]", scale, lower=_SMALLEST_NORMAL_FLOAT32
    )
    for index, scale in enumerate(observation_scale)
)
...
scaled = obs / scale
```

The bound is not arbitrary. `1 / scale` is what the division has to reach:

| `observation_scale` | `1 / scale` (float32) | `obs / scale` for `obs = 2 * scale` |
| --- | --- | --- |
| `1.17549435e-38` (smallest normal) | 8.507059e+37 | 2.0 |
| `5.87747175e-39` (half that) | `inf` | `inf` |
| `1e-40` | `inf` | `nan` |
| `1.40129846e-45` (smallest subnormal) | `inf` | `nan` |

So the floor was protecting against a range the validator should never have admitted, and
it paid for that protection with the entire normal range below `1e-6`. The change is
strictly better at both ends: correct for `1.175e-38 <= scale < 1e-6`, which the floor
corrupted, and an actionable construction-time error instead of a silent substitution
below it.

`lower=` rather than `positive=True` is deliberate: the shared validator describes a
positive domain as `positive` and ignores `lower` in that mode, so the message would not
have named the bound it enforces. A positive lower bound still rejects zero and negatives.

## Bit-level evidence

`encode` at declared coordinates `+1.5` and `-0.75`, `observation_dim=2`, `latent_dim=4`,
`jr.key(0)`. A scale-free encoder returns one latent at every scale.

Before, on `c9aba7b5`:

```
scale 1.000e+00  latent 0x3f68ef62 0xbf5ad221 0xbf539fa8 0xbf1a7a16
scale 1.000e-06  latent 0x3f68ef62 0xbf5ad221 0xbf539fa8 0xbf1a7a16
scale 1.000e-07  latent 0x3e1b2816 0xbe01b728 0xbdf00a0c 0xbd8ed2f0
scale 1.000e-09  latent 0x3ac82432 0xbaa6eeb5 0xba9a5598 0xba371ca6
scale 1.000e-12  latent 0x35ccf1e7 0xb5aaf05e 0xb59e09d9 0xb53b81b3
scale 1.000e-20  latent 0x28898946 0xa8656e2b 0xa8541d9a 0xa7fbaaca
scale 1.000e-30  latent 0x17ec4912 0x97c51445 0x97b634b8 0x97582e31
scale 1.000e-37  latent 0x0c4635ea 0x8c25526f 0x8c18d86e 0x8bb55865
```

After:

```
scale 1.000e+00  latent 0x3f68ef62 0xbf5ad221 0xbf539fa8 0xbf1a7a16
scale 1.000e-06  latent 0x3f68ef62 0xbf5ad221 0xbf539fa8 0xbf1a7a16
scale 1.000e-07  latent 0x3f68ef62 0xbf5ad221 0xbf539fa8 0xbf1a7a16
scale 1.000e-09  latent 0x3f68ef62 0xbf5ad221 0xbf539fa8 0xbf1a7a16
scale 1.000e-12  latent 0x3f68ef62 0xbf5ad221 0xbf539fa8 0xbf1a7a16
scale 1.000e-20  latent 0x3f68ef62 0xbf5ad221 0xbf539fa8 0xbf1a7a16
scale 1.000e-30  latent 0x3f68ef62 0xbf5ad221 0xbf539fa8 0xbf1a7a16
scale 1.000e-37  latent 0x3f68ef62 0xbf5ad221 0xbf539fa8 0xbf1a7a16
```

Four of twelve probed scales matched the scale-one reference before; ten of twelve match
now. **Scales at or above the retired floor are bit-for-bit identical in both trees**,
compared as raw `uint32` views — `max(scale, 1e-6)` was already the scale there, so the
change cannot touch them, and the recorded-bit test pins that.

The same repair shows in the diagnostics. Every scale from `1.0` to `1e-20` now reports
mean latent std `6.054746e-01`, `collapse_score 0.0000`, encoder moved `True`, max abs
delta `4.293072e-02` — identical to the well-scaled case.

## Two backend facts behind the tolerances

- **The CPU backend division is not correctly rounded.** An observation at `1.5` declared
  units at scale `1e-3` differs from the reference row by one unit in the last place in two
  of four lanes (`0x3f68ef63` versus `0x3f68ef62`). The recorded-bit test therefore stores
  the words measured at each scale rather than asserting equality with the reference row,
  and the scale-invariance tests use `atol=1e-6`.
- **XLA flushes a subnormal numerator on this backend.** An observation at `1e-3` declared
  units at the smallest normal scale divides to exactly `0.0`, where `float64` returns
  `1.000047e-03`. Sub-unit structure is unavailable at the very bottom of the normal range
  whatever the divisor is, so the tests assert finiteness there and keep tight assertions to
  scales where the observations themselves stay normal.

Observations placed at normalized coordinates from `1e-3` to `1e38`, at scales from `1.0`
down to the smallest normal, all keep a finite quotient, and coordinates `1`, `8`, `1e2`,
`1e4` and `1e6` come back exactly. A finite reciprocal is what makes that hold.

## Rejected alternatives

- **Lower the floor to the smallest normal.** Still a substitution on the range it covers.
  It moves the boundary instead of removing the defect.
- **Clamp or rescale the observation instead of the divisor.** That edits the caller's data
  to protect an arithmetic choice, and the declared quantity is the divisor.
- **Keep the permissive validator and special-case subnormals inside `encode`.** Keeps a
  silent branch on the hot path and still normalizes by a number the caller never declared.
- **Repair `world_model.py` in the same change.** It carries the same substitution with an
  added round-trip asymmetry — `targets` divides by `jnp.maximum(obs_scale, 1e-6)` while
  `_prediction_and_raw_diagnostics` multiplies by the raw `obs_scale`, so below `1e-6` the
  normalize/denormalize pair does not compose. That config validates `observation_scale`
  differently and an existing test pins its current error message, so it needs its own
  change. Disclosed in #2411 rather than bundled here.

## Tests

One file, 8 test functions, **87 parametrized cases**, counted from the collected node ids:

- a subnormal, zero or negative scale is rejected and the message names the bound
- the smallest normal `float32` is admitted and stored exactly
- a scale below the retired floor survives the config round trip
- `encode` is bit-for-bit unchanged where the floor never applied
- `encode` applies the declared scale below the retired floor
- whole normalized coordinates are recovered at every admitted scale
- latent separation matches the scale that declared it
- `update` reports no collapse at small declared scales
- the trainable encoder still moves at small declared scales

### Fail-first

Run against a separate pristine checkout at `c9aba7b5`: **62 failed, 25 passed** of the 87
new cases.

```
62 failed, 25 passed, 56 deselected in 24.72s
```

The failures group as: the config admits every subnormal scale and reports a different
domain for zero and negatives (6), `encode` does not apply the declared scale below `1e-6`
(6), whole normalized coordinates are not recovered (32), latent separation does not match
the scale that declared it (6), `update` reports collapse on a well-conditioned stream (6),
and the trainable encoder never moves (6).

The 25 that pass on the pristine tree pass **by design**: the five recorded-bit rows at and
above the retired floor (that is the no-regression anchor and must hold in both trees), the
six serialization round-trip cases (serialization never consulted the floor), the
smallest-normal admission case (the permissive validator accepted everything positive), and
thirteen whole-coordinate rows where `tanh` saturates both trees to the same words and
hides the substitution.

The comparison tree was restored to a clean checkout afterwards.

## Verification

| Gate | Result |
| --- | --- |
| `ruff check .` | passed |
| `mypy` | 108 errors, unchanged from the `c9aba7b5` baseline |
| `pytest tests/test_latent_world_model.py` | 143 passed in 49.06s |
| `pytest` the seven suites constructing the latent or action-conditioned configs | 257 passed in 172.07s |
| `pytest` the two remaining suites importing the latent world model | 19 passed in 38.73s |

Consumer sweep: 11 files reference `LatentWorldModelConfig`. The only `observation_scale`
literal below `1e-6` anywhere in the repository belongs to the action-conditioned config in
`world_model.py`, a different class this change does not touch, so no existing caller or
test meets the new lower bound.

Environment: JAX 0.11.0, CPU backend, `jax_enable_x64` off.

## Boundaries not crossed

- No evidence artifact, hash pin or validation threshold was touched.
- No test was weakened or skipped to obtain a green run.
- The pre-existing `mypy` error count is unchanged rather than suppressed.
- `ruff format` is not a repository gate and was not run as one.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
â€” [fix]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0TE6QAJPJGQ9RYTHT940G3Y","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T17:48:30.930Z","completed_at":"2026-08-24T19:28:34.262Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T17:48:32.332Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0a1c11876783712eb561c5f09393253ff48036ae1b01982840a44acec0fa20ba","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"931c858e-ded3-4399-b90e-95094d43cf9a","object_id":"sha256:0a1c11876783712eb561c5f09393253ff48036ae1b01982840a44acec0fa20ba","sha256":"0a1c11876783712eb561c5f09393253ff48036ae1b01982840a44acec0fa20ba"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"3voDUckyQ8fIImpgH7Zky1_6dPUXxScCa73djAY7LTrVQpxk1pWFEXpD7coVAIvBdtDosVLOOk5bEoCBeS2rCQ"}} -->
