### PR TITLE
fix(statistics): reject non-matrix time series

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -337,9 +337,16 @@ def compute_timeseries_statistics(
         Tuple of (mean, ci_lower, ci_upper) arrays of shape (n_steps,)
 
     Raises:
-        ValueError: If metric_array has no seed rows, any sample is
-            non-finite, or ``confidence_level`` is not strictly between 0 and 1.
+        ValueError: If metric_array is not a two-dimensional seed-by-step
+            matrix, has no seed rows, contains a non-finite sample, or
+            ``confidence_level`` is not strictly between 0 and 1.
     """
+    if metric_array.ndim != 2:
+        raise ValueError(
+            "metric_array must be a two-dimensional matrix "
+            "(one row per seed, one column per step), got shape "
+            f"{metric_array.shape}"
+        )
     n_seeds = metric_array.shape[0]
     if n_seeds == 0:
         raise ValueError("metric_array must contain at least one seed row")

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -363,6 +363,18 @@ class TestProbabilityContracts:
 
 
 class TestTimeseriesStatistics:
+    @pytest.mark.parametrize("shape", [(), (3,), (2, 3, 1)])
+    def test_non_matrix_input_rejected(self, shape: tuple[int, ...]) -> None:
+        metric_array = np.ones(shape, dtype=np.float64)
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"^metric_array must be a two-dimensional matrix "
+                r"\(one row per seed, one column per step\), got shape "
+            ),
+        ):
+            compute_timeseries_statistics(metric_array)
+
     def test_matches_per_column_compute_statistics(self) -> None:
         """Vectorised timeseries CI agrees with per-step scalar CI."""
         rng = np.random.default_rng(2)


### PR DESCRIPTION
## Summary

`compute_timeseries_statistics` documents a two-dimensional
`(n_seeds, n_steps)` input and one-dimensional `(n_steps,)` outputs, but its
runtime boundary accepted other ranks. A rank-one trace was interpreted as
multiple seeds and collapsed to scalar statistics; rank-three input returned
rank-two statistics; scalar input crashed with an internal `IndexError`.

This change rejects every non-matrix input with a shape-bearing `ValueError`
before seed counting or numerical work. Valid two-dimensional behavior is
unchanged.

## Reproduction and result

At baseline `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, the failing-test-first
regression produced three failures:

- shape `()` raised `IndexError: tuple index out of range`;
- shape `(3,)` did not raise and returned scalar statistics;
- shape `(2, 3, 1)` did not raise and returned `(3, 1)` arrays.

At `62ce4ee7f78d704e4e2adc05682b89a2d638afdf`:

```text
.venv/bin/python -m pytest tests/test_statistics_validation.py tests/test_utils_smoke.py tests/test_experiments_validation.py -q -o addopts=''
401 passed, 3 pre-existing warnings

.venv/bin/python -m pytest tests/test_visualization_grid_cap.py tests/test_continual_metrics.py -q -o addopts=''
54 passed

.venv/bin/ruff check .
All checks passed!

.venv/bin/python -m mypy alberta_framework/utils/statistics.py
Success: no issues found in 1 source file

git diff --check origin/main...HEAD
exit 0
```

Full-tree mypy retains current `main`'s macOS `os.O_TMPFILE` typing error in
the unchanged `bounded_elastic_matched_runner.py`; it is not claimed green.

This is the Fix lane for a measurement-validator defect, not a benchmark
comparison. It has no metric delta, tuning/evaluation seeds, benchmark output,
or pre-registration. Closed issue #29 explicitly left non-2D validation as a
separate contract; searches found no open issue or PR covering it. Maintainer
review and acceptance remain open.

Provider: `openai`

Model: `gpt-5.6-sol`

Client: `codex`

<!-- evidence-head:62ce4ee7f78d704e4e2adc05682b89a2d638afdf -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/attentionhead/asi/blob/20e99547edc87f5c4e7eedf10e9a09830fa5f4a3/logs-timeseries-statistics-rank.txt
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/attentionhead/asi/blob/20e99547edc87f5c4e7eedf10e9a09830fa5f4a3/evidence-timeseries-statistics-rank.md

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [fix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0TNX2H53D4CEKYXBHQ8APE0","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T20:03:03.333Z","completed_at":"2026-08-24T20:08:36.125Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T20:03:04.230Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"14504c397973a3a39c04ac2a9bd7d554dbaf6400bc3aafc587d78a84f3b1e046","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"119191ff-d04e-4764-9332-d2eb10ef39e6","object_id":"sha256:14504c397973a3a39c04ac2a9bd7d554dbaf6400bc3aafc587d78a84f3b1e046","sha256":"14504c397973a3a39c04ac2a9bd7d554dbaf6400bc3aafc587d78a84f3b1e046"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"NINt2GYPF2QY3nfnrlt_gqN98UTyk3GLrxiwmItTfwTgfS8CWoSTLcRqXZbZpEkt3LI1gKrT1huwvi5FfurKCg"}} -->
