### PR TITLE
Correct compute_forward_transfer's documented skip condition

### DIFF
--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -447,7 +447,14 @@ def compute_forward_transfer(
     on a task probed *before* it is ever trained on, minus a task-specific
     baseline (in GEM, the untrained-network performance).
 
-    Task 0, and any task without a finite pre-exposure probe, receives ``NaN``.
+    A task whose ``first_exposure`` row is 0 has no pre-exposure checkpoint and
+    receives ``NaN``, as does any task without a finite pre-exposure probe.
+    That is a property of the ``first_exposure`` row, not of the task index: in
+    the conventional ordering where task 0 is trained first it is task 0 that
+    is skipped, but a task ordered later is scored whenever an earlier
+    checkpoint probed it, and task 0 is scored if it was first trained after
+    row 0.
+
     The sign is normalized so positive values always mean beneficial transfer.
     """
 

--- a/tests/test_continual_metrics.py
+++ b/tests/test_continual_metrics.py
@@ -403,3 +403,25 @@ def test_continual_learning_summary_rejects_leftover_identities() -> None:
     )
     assert '"final_performance": 0.8' in dumped
     assert '"final_performance": true' not in dumped
+
+
+def test_forward_transfer_is_keyed_on_first_exposure_row_not_task_index() -> None:
+    """FWT skips a task with no pre-exposure checkpoint, whatever its index.
+
+    The GEM measure is "performance on a task probed *before* it is ever
+    trained on", so the skip condition is a ``first_exposure`` row of 0 rather
+    than a task index of 0. Task 0 is the skipped one only under the
+    conventional ordering where it is trained first.
+    """
+    matrix = np.array(
+        [[0.5, 0.6, 0.7], [0.9, 0.9, 0.9], [0.95, 0.95, 0.95]],
+        dtype=np.float64,
+    )
+    baseline = np.array([0.1, 0.1, 0.1], dtype=np.float64)
+
+    # Task 0 is trained *second*, so row 0 is a genuine pre-exposure probe.
+    forward = compute_forward_transfer(matrix, [1, 0, 0], baseline)
+
+    assert forward[0] == pytest.approx(0.4)
+    assert np.isnan(forward[1])
+    assert np.isnan(forward[2])


### PR DESCRIPTION
Fixes #2437.

## The mismatch

`compute_forward_transfer`'s docstring promised:

> Task 0, and any task without a finite pre-exposure probe, receives `NaN`.

The code skips on the `first_exposure` **row**:

```python
for task, first_row in enumerate(rows):
    if first_row == 0:
        continue
```

Those coincide only when task 0 happens to be trained first. `first_exposure` is caller-supplied and only bounds-checked in `_first_exposure_rows`, so nothing ties task index 0 to row 0:

```python
matrix = np.array([[0.5, 0.6, 0.7], [0.9, 0.9, 0.9], [0.95, 0.95, 0.95]])
compute_forward_transfer(matrix, [1, 0, 0], np.array([0.1, 0.1, 0.1]))
# -> [0.4 nan nan]      task 0 is scored, not NaN
```

## Why the docstring is the wrong side

The measure cited is GEM's FWT — "performance on a task probed *before* it is ever trained on". Whether that probe exists is determined by the `first_exposure` row, not the task index.

Changing the code to match the docstring would actively break the metric: it would discard a legitimate pre-exposure measurement for task 0 under any non-identity ordering, while still reporting nothing for a later task that genuinely had no pre-exposure checkpoint. So this PR corrects the documented contract instead.

## Scope, stated plainly

**Documentation-only — no computed value changes.** I'm not claiming a numerical fix. The value is that the stated contract misdescribes the metric precisely for non-identity task orderings, which is the case where a reader would go looking.

## Test

The added test pins the row-based semantics. I mutation-checked it rather than trusting that it passes: implementing the docstring's task-index reading (`if task == 0`) makes FWT return `[nan nan nan]`, and the test's `forward[0] == approx(0.4)` assertion fails. It exercises the real code path, not a restatement of the output.

## Verification

- `tests/test_continual_metrics.py` + `tests/test_metrics_hostile_validation.py` — 67 passed
- `ruff check .` — all checks passed
- `mypy alberta_framework/utils/metrics.py` — success, no issues
