### PR TITLE
Unnest get_final_performance's Raises: section from Returns:

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -665,7 +665,7 @@ def get_final_performance(
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
 
-        Raises:
+    Raises:
         ValueError: If ``window`` is not positive, a metric array has no
             time steps, any metric sample is non-finite, or ``window`` exceeds
             the shortest trace while trace lengths differ between methods.


### PR DESCRIPTION
Fixes #2439.

## The problem

In `get_final_performance`, the `Raises:` section is nested inside `Returns:` rather than being a sibling section:

```
    Args:                 <- indent 4
    Returns:              <- indent 4
        Dictionary mapping config name to ``(mean, sample_std)``. ...

        Raises:           <- indent 8, nested under Returns
        ValueError: If ``window`` is not positive, ...
```

Two things are wrong: the header is at indent 8 while every other section header in the docstring is at indent 4, and its body is at indent 8 too — the same level as its own header instead of nested under it. Google-style tooling reads the exception contract as part of the return-value description.

## Scope

Only occurrence in the package. An AST scan over every docstring in `alberta_framework/`, flagging any section header whose indent disagrees with the first section header in the same docstring, returns exactly one hit:

```
alberta_framework/utils/experiments.py:get_final_performance  'Raises:' at indent 8, expected 4
```

So this is an isolated typo, not a style debate.

## Scope of the change, stated plainly

Documentation-only — whitespace on two lines. No behavior changes and no numbers move. I'm not claiming more than that. The content itself is correct and worth surfacing properly, since it documents a genuinely non-obvious guard: `window=0` is refused because `arr[:, -0:]` is the full trace rather than the last step.

## Verification

- `tests/test_experiments*` / `*aggregat*` — 190 passed
- `ruff check .` — all checks passed
- `mypy alberta_framework/utils/experiments.py` — success, no issues
- Post-fix AST check confirms `Args:`, `Returns:`, `Raises:` all at indent 4
