### PR TITLE
Cap n_dreams_per_step before it drives an arange scan

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -184,6 +184,12 @@ _PROTOTYPE_V2_REPLAY_MIGRATION_TAG = 0x50525632
 _PROTOTYPE_FEATURE_LIFECYCLE_KEY_TAG = 0x50464C43
 _UINT32_MAX = 2**32 - 1
 _INT32_MAX = 2**31 - 1
+# ``_dream_step`` scans ``jnp.arange(n_dreams_per_step)`` and materializes one
+# float32 td-error per imagined transition, so an INT32-legal value hangs or
+# exhausts memory long before it runs. Match the dream-rollout ceiling already
+# fixed in ``core.dreaming`` (``_DREAM_ROLLOUT_BUDGET``); the public last-fit in
+# tests is 4 dreams per step.
+_MAX_N_DREAMS_PER_STEP = 10_000
 
 # ---------------------------------------------------------------------------
 # Standalone utility
@@ -725,7 +731,7 @@ class PrototypeAgentConfig:
                 "n_dreams_per_step",
                 self.n_dreams_per_step,
                 minimum=0,
-                maximum=_INT32_MAX,
+                maximum=_MAX_N_DREAMS_PER_STEP,
             ),
         )
         # horde_hidden_sizes: hostile-safe per-element validation
@@ -1335,7 +1341,10 @@ class PrototypeAgentConfig:
             "buffer_capacity", data.pop("buffer_capacity", 200), minimum=1, maximum=_INT32_MAX
         )
         n_dreams_per_step = _require_int(
-            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=_INT32_MAX
+            "n_dreams_per_step",
+            data.pop("n_dreams_per_step", 0),
+            minimum=0,
+            maximum=_MAX_N_DREAMS_PER_STEP,
         )
         dream_next_observation_mode = data.pop(
             "dream_next_observation_mode",

--- a/tests/test_prototype_agent_validation.py
+++ b/tests/test_prototype_agent_validation.py
@@ -12,6 +12,7 @@ import pytest
 from alberta_framework.core.oak import OaKConfig
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
 from alberta_framework.core.prototype_agent import (
+    _MAX_N_DREAMS_PER_STEP,
     GRUPerceptionConfig,
     PrototypeAgent,
     PrototypeAgentConfig,
@@ -303,3 +304,30 @@ def test_prototype_valid_construction() -> None:
     assert restored == cfg
     gru = GRUPerceptionConfig(observation_dim=4, hidden_dim=4)
     assert gru.augmented_dim() == 8
+
+
+def test_n_dreams_per_step_is_capped_before_it_drives_a_scan() -> None:
+    """An INT32-legal dream count hangs the agent instead of being rejected.
+
+    ``PrototypeAgent._dream`` scans ``jnp.arange(n_dreams_per_step)`` and
+    materializes one float32 td-error per imagined transition, so a value near
+    ``_INT32_MAX`` costs an 8.6 GB output before any dream executes. The
+    config must fail closed at construction, matching the dream-rollout
+    ceiling already enforced in ``core.dreaming``.
+    """
+    # Match the cap's own message: a bare "n_dreams_per_step" would also be
+    # satisfied by the unrelated "requires the legacy world_model" guard.
+    expected = f"n_dreams_per_step must be <= {_MAX_N_DREAMS_PER_STEP}"
+    for oversized in (_INT32_MAX, _MAX_N_DREAMS_PER_STEP + 1):
+        with pytest.raises(ValueError) as excinfo:
+            _cfg(n_dreams_per_step=oversized, world_model=_world_model(4))
+        assert str(excinfo.value) == expected
+
+    # The ceiling itself, and the counts the suite actually exercises, stay legal.
+    # ``n_dreams_per_step > 0`` additionally requires the legacy world model.
+    dreaming = _cfg(
+        n_dreams_per_step=_MAX_N_DREAMS_PER_STEP,
+        world_model=_world_model(4),
+    )
+    assert dreaming.n_dreams_per_step == _MAX_N_DREAMS_PER_STEP
+    assert _cfg(n_dreams_per_step=4, world_model=_world_model(4)).n_dreams_per_step == 4


### PR DESCRIPTION
Fixes #2441.

## Summary

`n_dreams_per_step` was validated only against `_INT32_MAX`, then handed to `jnp.arange` inside the `lax.scan` in `_dream` (`prototype_agent.py:5537`), which materializes one float32 td-error per imagined transition. Same class as the merged #2128 and #2124.

Cap at **10,000**, matching `_DREAM_ROLLOUT_BUDGET` — the ceiling `core.dreaming` already set for the sibling rollout horizon after this exact hang:

```python
# Public last-fit in tests is rollout_horizon=5. Origin handed large
# horizons to jnp.arange with no last-fit reject -- hang/OOM, not INT32 leftover.
_DREAM_ROLLOUT_BUDGET = ScanBudget("dream rollout", maximum_steps=10_000)
```

The public last-fit in the suite is 4 dreams per step, so this leaves three orders of magnitude of headroom.

## Evidence

The config accepted the extreme value:

```python
>>> _require_int("n_dreams_per_step", 2**31 - 1, minimum=0, maximum=_INT32_MAX)
2147483647
```

At that count `dream_td_errors` alone is 8.6 GB. Measured cost of a **bare** scan of this shape (no-op body — the real `_dream_step` runs a world-model rollout plus an OaK update per iteration):

| n | wall time | output |
|---|---|---|
| 1,000 | 0.074s | 0.0 MB |
| 200,000 | 24.178s | 0.8 MB |
| 2,000,000 | did not finish (timeout) | — |

The practical hang arrives around 10^5–10^6, roughly four orders of magnitude below the accepted ceiling.

## Both sites

The dataclass `__post_init__` **and** the `from_dict` deserialization path — a cap on only the first would be bypassed by loading a config from disk.

## On the test

Worth flagging, because my first version was wrong. I originally asserted `pytest.raises(ValueError, match="n_dreams_per_step")` — and it **passed with the cap reverted**. The unrelated `n_dreams_per_step > 0 requires the legacy world_model` guard also raises a `ValueError` naming that field, so the substring match was satisfied for the wrong reason.

The test now passes a world model (so that guard cannot fire) and asserts the cap's exact message. Re-verified by mutation: reverting `maximum=_MAX_N_DREAMS_PER_STEP` to `maximum=_INT32_MAX` makes it fail, restoring it makes it pass.

## Verification

- `tests/test_prototype_agent_validation.py` + `test_prototype_agent.py` + `test_dreaming.py` — 205 passed
- `ruff check .` — all checks passed
- `mypy alberta_framework/core/prototype_agent.py` — success, no issues
