### PR TITLE
Suppress the longdouble parse warning with catch_warnings

### DIFF
--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from decimal import Decimal
 from fractions import Fraction
@@ -536,8 +537,16 @@ class _NonfiniteFloatThatConvertsFinite(float):
 
 
 def _platform_longdouble_1e4000() -> np.longdouble:
-    """Parse the cross-platform boundary without leaking an expected warning."""
-    with np.errstate(over="ignore", invalid="ignore"):
+    """Parse the cross-platform boundary without leaking an expected warning.
+
+    Wherever ``longdouble`` is float64 (aarch64), the parse overflows and
+    numpy reports it through the ``warnings`` module, not through the
+    floating-point error state that ``np.errstate`` scopes.  Suppress it with
+    ``catch_warnings`` so the expected overflow does not leak into every
+    collection of this module.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
         return np.longdouble("1e4000")
 
 


### PR DESCRIPTION
Fixes #2387.

## The bug

`_platform_longdouble_1e4000` exists to parse the cross-platform overflow boundary "without leaking an expected warning" — its docstring's words. It wrapped the parse in `np.errstate(over="ignore", invalid="ignore")`, which is the wrong machinery: `errstate` scopes numpy's floating-point error state (`np.seterr`), while the overflow in a `longdouble` *string conversion* is reported through the Python `warnings` module. The `RuntimeWarning` leaked into every collection of this module wherever `longdouble` is float64.

## Fix

Use `warnings.catch_warnings()` + `simplefilter("ignore", RuntimeWarning)` — the mechanism that actually governs this warning.

## Measurement

Running each helper body verbatim on **arm64 Darwin** (`longdouble` 64-bit — the platform the helper was written for):

| helper body | value | leaked warnings |
|---|---|---|
| OLD (`np.errstate`) | `inf` | **1** |
| NEW (`catch_warnings`) | `inf` | **0** |

The leaked one is `RuntimeWarning: overflow encountered in conversion from string`. The parsed value is unchanged; only the suppression mechanism moves.

## A note on where this was verified

Worth stating plainly: the Linux container I used for the rest of the verification has **128-bit** `longdouble`, so `np.longdouble("1e4000")` never overflows there and the bug does not reproduce at all. The before/after above was therefore taken on the host (arm64 Darwin, `np.finfo(np.longdouble).bits == 64`). A run on x86-64 or any wide-`longdouble` platform will show 0 leaks both before and after — that is expected and is exactly why the issue specifies aarch64.

## Verification

- `tests/test_experiments_validation.py` — 129 passed
- `ruff check .` — all checks passed
