### PR TITLE
Make UPGD gradient alignment scale-free

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1991,16 +1991,49 @@ class UPGDLearner:
         return jnp.sqrt(total + 1e-12)
 
     @staticmethod
+    def _tuple_peak(xs: tuple[Array, ...]) -> Array:
+        """Largest absolute entry over a static tuple of arrays."""
+        peak = jnp.array(0.0, dtype=jnp.float32)
+        for x in xs:
+            peak = jnp.maximum(peak, jnp.max(jnp.abs(x), initial=0.0))
+        return peak
+
+    @staticmethod
     def _gradient_alignment(
         previous: tuple[Array, ...],
         current: tuple[Array, ...],
     ) -> Array:
-        """Cosine alignment of two gradient tuples, zero for empty gradients."""
-        previous_norm = UPGDLearner._tuple_norm(previous)
-        current_norm = UPGDLearner._tuple_norm(current)
+        """Cosine alignment of two gradient tuples, zero for empty gradients.
+
+        A cosine is scale-free by definition -- ``cos(c*a, c*b) == cos(a, b)``
+        for every ``c > 0`` -- so each tuple is divided by its largest absolute
+        entry before the dot product and norms are taken.  Comparing the raw
+        magnitudes against fixed absolute constants instead made the result a
+        function of the input scale: two identical gradients reported ``0.875``
+        at element scale ``1e-6`` and exactly ``0.0`` at ``1e-10``, because
+        ``sqrt(total + 1e-12)`` floored the norm at ``1e-6`` and the gate then
+        inspected the floor rather than the gradient.  Rescaling also keeps the
+        float32 accumulator off its overflow, which previously returned ``nan``
+        for finite gradients around ``1e20``.
+
+        A tuple whose entries are all exactly zero has no direction; it keeps
+        the documented zero.
+        """
+        previous_peak = UPGDLearner._tuple_peak(previous)
+        current_peak = UPGDLearner._tuple_peak(current)
+        has_direction = (previous_peak > 0.0) & (current_peak > 0.0)
+        safe_previous_peak = jnp.where(previous_peak > 0.0, previous_peak, 1.0)
+        safe_current_peak = jnp.where(current_peak > 0.0, current_peak, 1.0)
+        scaled_previous = tuple(x / safe_previous_peak for x in previous)
+        scaled_current = tuple(y / safe_current_peak for y in current)
+        previous_norm = UPGDLearner._tuple_norm(scaled_previous)
+        current_norm = UPGDLearner._tuple_norm(scaled_current)
+        cosine = UPGDLearner._tuple_dot(scaled_previous, scaled_current) / (
+            previous_norm * current_norm
+        )
         return jnp.where(
-            (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
+            has_direction,
+            jnp.clip(cosine, -1.0, 1.0),
             jnp.array(0.0, dtype=jnp.float32),
         )
 

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -2219,3 +2219,46 @@ class TestLoops:
         stream = RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.05)
         result = run_upgd_loop(learner, stream, num_steps=50, key=jr.key(0))
         chex.assert_shape(result.metrics, (50, 4))
+
+
+@pytest.mark.parametrize("scale", [1e-20, 1e-12, 1e-10, 1e-6, 1e-3, 1.0, 1e10, 1e20, 1e30])
+def test_gradient_alignment_is_scale_free(scale: float) -> None:
+    """A cosine must satisfy ``cos(c*a, c*b) == cos(a, b)`` for every ``c > 0``.
+
+    Fixed absolute constants made the result a function of the input scale:
+    ``sqrt(total + 1e-12)`` floored the reported norm at ``1e-6``, so the
+    ``> 1e-6`` gate inspected the floor rather than the gradient. Two identical
+    gradients reported ``0.875`` at element scale ``1e-6`` and exactly ``0.0``
+    at ``1e-10``, and the float32 accumulator returned ``nan`` around ``1e20``
+    for gradients that were themselves finite.
+    """
+    gradient = (jnp.asarray([1.0, 2.0, 3.0], dtype=jnp.float32) * scale,)
+    negated = tuple(-x for x in gradient)
+
+    assert float(UPGDLearner._gradient_alignment(gradient, gradient)) == pytest.approx(
+        1.0, abs=1e-4
+    )
+    assert float(UPGDLearner._gradient_alignment(gradient, negated)) == pytest.approx(
+        -1.0, abs=1e-4
+    )
+
+
+def test_gradient_alignment_keeps_zero_for_directionless_gradients() -> None:
+    """An all-zero tuple has no direction and keeps the documented zero."""
+    zero = (jnp.zeros(3, dtype=jnp.float32),)
+    nonzero = (jnp.asarray([1.0, 2.0, 3.0], dtype=jnp.float32),)
+
+    assert float(UPGDLearner._gradient_alignment(zero, zero)) == 0.0
+    assert float(UPGDLearner._gradient_alignment(zero, nonzero)) == 0.0
+
+
+def test_gradient_alignment_reports_ordinary_geometry() -> None:
+    """Rescaling must not disturb the angles themselves."""
+    unit_x = (jnp.asarray([1.0, 0.0], dtype=jnp.float32),)
+    unit_y = (jnp.asarray([0.0, 1.0], dtype=jnp.float32),)
+    diagonal = (jnp.asarray([1.0, 1.0], dtype=jnp.float32),)
+
+    assert float(UPGDLearner._gradient_alignment(unit_x, unit_y)) == pytest.approx(0.0, abs=1e-6)
+    assert float(UPGDLearner._gradient_alignment(unit_x, diagonal)) == pytest.approx(
+        0.5**0.5, abs=1e-6
+    )


### PR DESCRIPTION
Fixes #2389.

## The defect

`_gradient_alignment` is a cosine, so by definition `cos(c*a, c*b) == cos(a, b)` for every `c > 0`. Three fixed absolute constants broke that: `+ 1e-12` inside `_tuple_norm`'s `sqrt` floors the reported norm at exactly `1e-6`, the `> 1e-6` gate then inspects that floor instead of the gradient, and a further `+ 1e-12` sits in the denominator.

Two **identical** gradient tuples, where the true cosine is exactly `1.0`:

| element scale | `main` | this PR |
|---|---|---|
| 1e0 | 1.000000 | 1.000000 |
| 1e-5 | 0.998573 | 1.000000 |
| 1e-6 | **0.875000** | 1.000000 |
| 1e-8 | **0.000700** | 1.000000 |
| 1e-10 | **0.000000** | 1.000000 |
| 1e-12 | **0.000000** | 1.000000 |
| 1e20 | **nan** | 1.000000 |

The `nan` is reached with gradients that are themselves finite — the float32 accumulator overflows.

## Fix

Divide each tuple by its largest absolute entry before the dot product and norms. That is exact for a cosine, and it keeps the accumulator off both the underflow that produced the zeros and the overflow that produced the `nan`.

An all-zero tuple genuinely has no direction, so it keeps the documented zero — that case is now keyed on the peak magnitude being zero rather than on a magnitude constant.

## Verification

Correct at every scale from `1e-20` to `1e30`: `cos(g, g) == 1.0` and `cos(g, -g) == -1.0`.

Ordinary geometry is undisturbed — orthogonal gradients report `0.0`, a 45° pair reports `0.7071067`.

The added tests are mutation-checked, not merely green: against `main`'s `upgd.py` **6 of the 11 fail**; with the fix all 11 pass.

- `tests/test_upgd.py` and all `*upgd*` suites — **840 passed**
- `ruff check .` — all checks passed
- `mypy alberta_framework/core/upgd.py` — success, no issues

The two pre-existing gradient-alignment tests (`test_gradient_alignment_can_learn_kappa_multiplier`, `test_gradient_alignment_meta_plasticity_changes_head_scales`) are behavioral rather than pins on these constants, and both still pass.
