### PR TITLE
Pair the world-model observation decode with its encode scale

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -831,7 +831,15 @@ class ActionConditionedWorldModel:
         )
         raw_predictions = self._learner.predict(state.learner_state, inputs)
 
-        obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
+        # Pair the decode with the divisor ``targets`` actually used: it
+        # normalizes by ``max(observation_scale, 1e-6)``, so multiplying back by
+        # the raw value reconstructs only ``observation_scale / 1e-6`` of the
+        # delta once the configured scale drops below the floor. The reward leg
+        # below is already symmetric on the raw ``reward_scale``.
+        obs_scale = jnp.maximum(
+            jnp.asarray(self._observation_scale, dtype=jnp.float32),
+            jnp.asarray(1e-6, dtype=jnp.float32),
+        )
         normalized_delta = jnp.clip(
             raw_predictions[: self._config.observation_dim],
             -self._config.max_delta_scale,

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -6,6 +6,7 @@ import dataclasses
 import warnings
 from fractions import Fraction
 from types import MappingProxyType
+from typing import Any, cast
 
 import chex
 import jax
@@ -955,3 +956,64 @@ def test_action_world_model_rolls_back_reduction_overflow() -> None:
     assert not bool(result.update_applied)
     assert float(result.observation_mse) == 0.0
     assert int(result.state.step_count) == 0
+
+
+@pytest.mark.parametrize("scale", [1.0, 1e-3, 1e-6, 1e-7, 1e-8, 1e-10])
+def test_observation_encode_and_decode_use_the_same_scale(scale: float) -> None:
+    """A perfectly fitted observation head must reconstruct the delta it saw.
+
+    ``targets`` normalizes by ``max(observation_scale, 1e-6)`` while the decode
+    multiplied by the raw ``observation_scale``, so below the floor a converged
+    fit reconstructed only ``observation_scale / 1e-6`` of the true delta --
+    a tenth at ``1e-7``, a hundredth at ``1e-8``. The reward leg of the same
+    function is already symmetric on the raw ``reward_scale``.
+
+    This drives the real ``predict`` path rather than replaying the decode
+    arithmetic: the learner's raw output is forced to the normalized target, so
+    ``predict`` must hand back the original next observation.
+    """
+    config = ActionConditionedWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        observation_scale=(scale, scale),
+        predict_delta=True,
+    )
+    model = ActionConditionedWorldModel(config)
+    state = model.init(jr.key(0))
+
+    observation = jnp.zeros(2, dtype=jnp.float32)
+    next_observation = jnp.full(2, scale, dtype=jnp.float32)
+    action = jnp.asarray(0)
+
+    targets = model.targets(
+        observation,
+        action,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        next_observation,
+    )
+    normalized = np.asarray(targets[0] if isinstance(targets, tuple) else targets)
+
+    # A learner that has fitted these targets exactly returns them verbatim.
+    class _PerfectLearner:
+        def __init__(self, inner: object, values: np.ndarray) -> None:
+            self._inner = inner
+            self._values = jnp.asarray(values, dtype=jnp.float32)
+
+        def predict(self, _learner_state: object, _inputs: object) -> Any:
+            return self._values
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._inner, name)
+
+    model._learner = cast(  # type: ignore[assignment]
+        Any, _PerfectLearner(model._learner, normalized.ravel())
+    )
+
+    prediction = model.predict(state, observation, action)
+
+    chex.assert_trees_all_close(
+        prediction.next_observation,
+        next_observation,
+        rtol=1e-5,
+        atol=float(scale) * 1e-3,
+    )


### PR DESCRIPTION
Fixes #2398.

## The asymmetry

`targets()` normalizes observation targets by `max(observation_scale, 1e-6)`; `_prediction_and_raw_diagnostics()` — what both `predict()` and `update()` return — multiplied back by the raw `observation_scale`.

Above `1e-6` those agree. Below it a learner that has fitted its targets **perfectly** reconstructs only `observation_scale / 1e-6` of the delta it was trained on. Measured end-to-end through the real `predict()` path, forcing the learner's raw output to the normalized target:

| `observation_scale` | true delta | decoded (main) | ratio |
|---|---|---|---|
| 1e0 | 1.000e+00 | 1.000e+00 | 1.0000 |
| 1e-6 | 1.000e-06 | 1.000e-06 | 1.0000 |
| 1e-7 | 1.000e-07 | **1.000e-08** | **0.1000** |
| 1e-8 | 1.000e-08 | **1.000e-10** | **0.0100** |
| 1e-10 | 1.000e-10 | **1.000e-14** | **0.0001** |

Nothing reports the substitution, so the observation heads look converged while predicting a change too small by that factor.

## Which side is right

The reward leg of the same function is the in-file counter-example: `world_model.py:816` divides by the raw `reward_scale` and `:854` multiplies by it, symmetric, no floor. Only the observation leg was unpaired.

I floored the **decode** to match the encode rather than removing the encode's floor, because the floor is what protects the normalization from dividing by a near-zero configured scale. Pairing the decode preserves that protection and makes the round-trip exact.

## Test

Drives the real `predict()` path — the learner's raw output is forced to the normalized target, so `predict` must hand back the original next observation. It does not replay the decode arithmetic (my first draft did, which would have passed regardless of the fix).

Mutation-checked against `main`'s `world_model.py`: **exactly the three sub-floor scales fail** (`1e-7`, `1e-8`, `1e-10`) and the three at or above the floor pass in both directions — confirming no behavior change where the divisors already agreed.

## Verification

- `test_action_conditioned_world_model.py`, `test_model_replay_rehearsal.py`, `test_late_wave_transactions.py`, `test_dreaming.py` — **198 passed**
- `ruff check .` — all checks passed
- `mypy alberta_framework/core/world_model.py` — success, no issues
