### PR TITLE
fix(core): cap n_dreams_per_step before jnp.arange scan hang (#2441)

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -261,6 +261,13 @@ def feature_to_subtask_specs(
 
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 4_294_967_295
+# Public last-fit in tests is n_dreams_per_step=4. The value drives jnp.arange
+# inside a jax.lax.scan that materializes one float32 td-error per imagined
+# transition, so an INT32-legal ceiling hangs/OOMs long before any dream runs.
+# Cap at the sibling dream-rollout ScanBudget ceiling (core.dreaming's
+# _DREAM_ROLLOUT_BUDGET.maximum_steps == 10_000); the same defect class as #2128
+# and #2124. This leaves three orders of magnitude of headroom over the last-fit.
+_N_DREAMS_PER_STEP_MAX = 10_000
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
         int,
         np.int8,
@@ -725,7 +732,7 @@ class PrototypeAgentConfig:
                 "n_dreams_per_step",
                 self.n_dreams_per_step,
                 minimum=0,
-                maximum=_INT32_MAX,
+                maximum=_N_DREAMS_PER_STEP_MAX,
             ),
         )
         # horde_hidden_sizes: hostile-safe per-element validation
@@ -1335,7 +1342,10 @@ class PrototypeAgentConfig:
             "buffer_capacity", data.pop("buffer_capacity", 200), minimum=1, maximum=_INT32_MAX
         )
         n_dreams_per_step = _require_int(
-            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=_INT32_MAX
+            "n_dreams_per_step",
+            data.pop("n_dreams_per_step", 0),
+            minimum=0,
+            maximum=_N_DREAMS_PER_STEP_MAX,
         )
         dream_next_observation_mode = data.pop(
             "dream_next_observation_mode",

--- a/tests/test_prototype_agent_validation.py
+++ b/tests/test_prototype_agent_validation.py
@@ -9,6 +9,7 @@ from typing import Any
 import numpy as np
 import pytest
 
+from alberta_framework.core.dreaming import DreamingConfig
 from alberta_framework.core.oak import OaKConfig
 from alberta_framework.core.options import STOMPConfig, SubtaskSpec
 from alberta_framework.core.prototype_agent import (
@@ -21,6 +22,7 @@ from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
 from alberta_framework.core.world_model import ActionConditionedWorldModelConfig
 
 _INT32_MAX = 2**31 - 1
+_N_DREAMS_PER_STEP_MAX = 10_000
 
 
 class _HostileInt(int):
@@ -303,3 +305,39 @@ def test_prototype_valid_construction() -> None:
     assert restored == cfg
     gru = GRUPerceptionConfig(observation_dim=4, hidden_dim=4)
     assert gru.augmented_dim() == 8
+
+
+def _dreaming_cfg(n_dreams: int) -> dict[str, Any]:
+    # A world_model and permissive dreaming schedule are required before a
+    # positive n_dreams_per_step is accepted at all.
+    return {
+        "oak": _oak(obs_dim=4, n_prim=2),
+        "world_model": _world_model(observation_dim=4),
+        "dreaming": DreamingConfig(warmup_steps=1, max_model_error_ema=1e6),
+        "buffer_capacity": 20,
+        "n_dreams_per_step": n_dreams,
+    }
+
+
+def test_prototype_n_dreams_per_step_accepts_within_scan_budget() -> None:
+    # The public last-fit is 4; the boundary ceiling is 10_000 (mirrors the
+    # sibling dream-rollout ScanBudget ceiling in core.dreaming).
+    for accepted in (4, _N_DREAMS_PER_STEP_MAX):
+        cfg = _cfg(**_dreaming_cfg(accepted))
+        assert cfg.n_dreams_per_step == accepted
+        # The deserialization entry point must also accept the boundary value.
+        restored = PrototypeAgentConfig.from_config(cfg.to_config())
+        assert restored.n_dreams_per_step == accepted
+
+
+@pytest.mark.parametrize("rejected", [_N_DREAMS_PER_STEP_MAX + 1, _INT32_MAX])
+def test_prototype_n_dreams_per_step_caps_before_scan_hang(rejected: int) -> None:
+    # An INT32-legal value drives jnp.arange inside jax.lax.scan and hangs/OOMs
+    # long before any dream runs (issue #2441). Both validation sites must reject
+    # it with the field-naming _require_int error, so deserialization cannot
+    # bypass the guard.
+    with pytest.raises(ValueError, match="n_dreams_per_step must be <="):
+        _cfg(**_dreaming_cfg(rejected))
+    accepted_payload = _cfg(**_dreaming_cfg(4)).to_config()
+    with pytest.raises(ValueError, match="n_dreams_per_step must be <="):
+        PrototypeAgentConfig.from_config({**accepted_payload, "n_dreams_per_step": rejected})


### PR DESCRIPTION
## What was broken and its measurement consequence

`PrototypeAgentConfig.n_dreams_per_step` was validated only against
`_INT32_MAX` at **both** validation sites — the dataclass `__post_init__`
and the `from_config` deserialization path — and the accepted value then
drives `jnp.arange(self._config.n_dreams_per_step)` inside a
`jax.lax.scan` (`prototype_agent.py`, the `_dream_step` scan) that
materializes one float32 td-error per imagined transition.

An INT32‑legal value such as `2**31 - 1` is accepted, then the scan output
alone is ~8.6 GB of float32; the process hangs or OOMs (the practical hang
arrives around 10^5–10^6, roughly four orders of magnitude below the accepted
INT32 ceiling) **before any dream executes**. Any harness or deserialized
config carrying an oversized value silently corrupts/blocks measurement instead
of failing fast. This is the same defect class as the already-fixed #2128 and
#2124.

## Fix (one variable, one lane)

Cap `n_dreams_per_step` at **10,000** via a named module constant
`_N_DREAMS_PER_STEP_MAX = 10_000`, mirroring the sibling dream-rollout ceiling
`_DREAM_ROLLOUT_BUDGET = ScanBudget("dream rollout", maximum_steps=10_000)` in
`core.dreaming`. The cap is applied at **both** validation sites so the guard
cannot be bypassed by deserialization. `minimum=0` is unchanged. The public
last-fit of 4 and the boundary value 10,000 still pass; 10,001 and `2**31-1`
are rejected with the existing `_require_int` error style
(`ValueError: n_dreams_per_step must be <= 10000`).

Files changed (2):
- `alberta_framework/core/prototype_agent.py` — constant + both caps
- `tests/test_prototype_agent_validation.py` — regression tests (+38 lines)

No benchmark/GPU run is involved (CPU-only ARM). No frozen lifecycle, consumed
seed, validator, threshold, or pinned `outputs/` artifact is touched.

## Failing-then-passing reproduction

**BEFORE (unmodified source) — the extreme value is accepted at both sites:**
```
$ .venv/bin/python  # on origin/main source
__post_init__ ACCEPTED n_dreams_per_step=2147483647  (defect: drives jnp.arange in scan -> hang/OOM)
from_config   ACCEPTED n_dreams_per_step=2147483647  (defect: deserialization bypass)
```

**AFTER (this PR) — rejected at both sites, boundary still accepted:**
```
__post_init__ REJECTED 10001:      n_dreams_per_step must be <= 10000
__post_init__ REJECTED 2147483647: n_dreams_per_step must be <= 10000
from_config   REJECTED 10001:      n_dreams_per_step must be <= 10000
from_config   REJECTED 2147483647: n_dreams_per_step must be <= 10000
boundary 10000 accepted: 10000
```

## Exact verification commands and results

```
$ .venv/bin/python -m pytest tests/test_prototype_agent_validation.py -q -o addopts=""
..........................                                               [100%]
26 passed in 1.76s

$ .venv/bin/python -m ruff check alberta_framework/core/prototype_agent.py tests/test_prototype_agent_validation.py
All checks passed!

$ .venv/bin/python -m mypy alberta_framework/core/prototype_agent.py
Success: no issues found in 1 source file

$ .venv/bin/python -m mypy            # repo-configured target: files=["alberta_framework"]
Success: no issues found in 224 source files
```

## What remains open

- The scan consumer itself is unchanged; this PR bounds the *input contract*
  before allocation, matching the #2128/#2124 precedent. A separately-owned
  `ScanBudget`/`require_scan_steps` guard at the arange site could later
  centralize the cap, but is out of scope for this bounded fix.

## Evidence tooling note (transparency)

The fork's immutable `user-attachments` minting tool
(`attach.mjs upload`) could not authenticate in this environment: the stored
`agent-cortex` credential is a token that works for `gh`/`git push` but
GitHub's **web** login flow rejects it ("Incorrect username or password"), so
no browser session can be established to mint attachment URLs. The full
verification logs are therefore pasted inline above, bound to the head SHA
below. All commands were run in the worktree with the project venv.

<!-- evidence-head:9c9f1ff645efe350f34faa0d1fd491e3c03b5014 -->
<!-- evidence-row:logs -->
- [x] logs: pasted inline above (attachment minting unavailable — see "Evidence tooling note")

Closes #2441

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@347ab09908138cf340ad2a5d03cc1f3f686a4f68:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@347ab09908138cf340ad2a5d03cc1f3f686a4f68:skills/contribute-to-asi"} -->
