### PR TITLE
Gate the pavlovian double-rounding probes on longdouble width

### DIFF
--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -485,6 +485,20 @@ def test_construct_canonicalizes_noise_std_to_float32() -> None:
     assert stream._noise_std == float(np.float32(0.1))  # noqa: SLF001
 
 
+_LONGDOUBLE_IS_WIDER_THAN_FLOAT64 = np.finfo(np.longdouble).nmant > np.finfo(np.float64).nmant
+_NEEDS_WIDE_LONGDOUBLE = pytest.mark.skipif(
+    not _LONGDOUBLE_IS_WIDER_THAN_FLOAT64,
+    reason=(
+        "needs a C long double wider than float64; where numpy aliases "
+        "longdouble to float64 (aarch64 macOS, Windows) the fixture value "
+        "loses the very bits that make it a double-rounding probe. The "
+        "Fraction-parametrized cases below cover the same narrowing "
+        "semantics on every platform."
+    ),
+)
+
+
+@_NEEDS_WIDE_LONGDOUBLE
 def test_construct_narrows_original_noise_real_once() -> None:
     midpoint_plus = (
         np.longdouble(1.0)
@@ -500,6 +514,7 @@ def test_construct_narrows_original_noise_real_once() -> None:
     assert stream._noise_std == float(np.float32(midpoint_plus))  # noqa: SLF001
 
 
+@_NEEDS_WIDE_LONGDOUBLE
 def test_construct_rejects_negative_real_that_rounds_to_zero() -> None:
     below_zero = -np.nextafter(np.longdouble(0.0), np.longdouble(1.0))
     assert float(below_zero) == 0.0


### PR DESCRIPTION
Fixes #2324.

## The problem

Two `noise_std` validator tests build `np.longdouble` fixture values whose defining property only exists where C `long double` is wider than `float64`. Where numpy aliases `longdouble` to `float64` — aarch64 macOS, Windows — the fixture loses the very bits that make it a probe, and both tests fail **in their own precondition asserts**, before the library is exercised.

Measured on arm64 Darwin (`np.finfo(np.longdouble).nmant == 52`):

```
=== precondition 1: np.float32(mp) != np.float32(float(mp)) ===
  FAILS: both sides are np.float32(1.0)

=== precondition 2: float(below_zero) == 0.0 ===
  FAILS: float(below_zero) = -5e-324, not 0.0
```

Same class as #1979.

## Fix

Skip both where `longdouble` is not wider than `float64`, keyed on **mantissa width** (`np.finfo(np.longdouble).nmant > np.finfo(np.float64).nmant`) rather than a platform name — the property the fixtures actually depend on.

## No coverage is lost

The `Fraction`-parametrized cases immediately below these two already cover the same narrowing semantics — including the `1 + 2⁻²⁴ ± 2⁻⁶⁰` midpoint cases — using exact rationals instead of a platform-width assumption. Those run everywhere and are untouched.

## Verified both ways

| platform | `nmant` | before | after |
|---|---|---|---|
| container (128-bit longdouble) | 112 | pass | **still run and pass** |
| host arm64 Darwin | 52 | **fail (precondition)** | **skip** |

The point of the second row is that these become skips rather than silent deletions, and the first row confirms the probes still execute on the platforms where they are meaningful.

## Verification

- `tests/test_pavlovian_stream.py` — 102 passed (container)
- `ruff check .` — all checks passed
