### PR TITLE
Declare the Linux-only publisher requirement in the checkpoint tests

### DIFF
--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -55,7 +55,6 @@ def test_switching_metric_schedule_is_constant_time_at_counter_horizon() -> None
         _switching_metric_schedule(1, 0)
 
 
-@requires_renameat2
 def test_checkpoint_validator_rejects_generation_and_zero_event_metric_forgery() -> None:
     runner = _runner()
     state, _ = _advance(runner, runner.init(), 2)

--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -34,6 +34,7 @@ from alberta_framework.reference_life_checkpoint import (
     save_reference_life_checkpoint,
 )
 from alberta_framework.streams.closed_loop import SwitchingTwoStateConfig
+from tests._forager_matched_platform import requires_renameat2
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
@@ -54,6 +55,7 @@ def test_switching_metric_schedule_is_constant_time_at_counter_horizon() -> None
         _switching_metric_schedule(1, 0)
 
 
+@requires_renameat2
 def test_checkpoint_validator_rejects_generation_and_zero_event_metric_forgery() -> None:
     runner = _runner()
     state, _ = _advance(runner, runner.init(), 2)
@@ -199,6 +201,7 @@ def saved_case(
     return runner, state, barrier_state, checkpoint
 
 
+@requires_renameat2
 def test_quiescent_checkpoint_restores_exact_continuation(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
 ) -> None:
@@ -257,6 +260,7 @@ def _rehash_bundle(path: Path) -> None:
     (path / "COMMITTED").write_text(f"{bundle_id}\n", encoding="ascii")
 
 
+@requires_renameat2
 def test_restore_rejects_incomplete_tampered_unknown_and_symlink_bundles(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -343,6 +347,7 @@ def test_restore_rejects_incomplete_tampered_unknown_and_symlink_bundles(
         load_reference_life_checkpoint(symlinked)
 
 
+@requires_renameat2
 def test_restore_rejects_rehashed_duplicate_prototype_metadata_key(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -363,6 +368,7 @@ def test_restore_rejects_rehashed_duplicate_prototype_metadata_key(
         load_reference_life_checkpoint(duplicate)
 
 
+@requires_renameat2
 def test_publish_failure_and_existing_generation_leave_runner_unchanged(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -394,6 +400,7 @@ def test_publish_failure_and_existing_generation_leave_runner_unchanged(
     assert not tuple(parent.glob(".*.staging-*"))
 
 
+@requires_renameat2
 def test_post_commit_lock_cleanup_failure_returns_committed_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -429,6 +436,7 @@ def _bundle_bytes(path: Path) -> dict[str, bytes | None]:
 
 
 @pytest.mark.parametrize("stale", [False, True], ids=["current", "stale"])
+@requires_renameat2
 def test_save_to_existing_generation_is_rejected_without_mutation(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -459,6 +467,7 @@ def test_save_to_existing_generation_is_rejected_without_mutation(
     assert restored_runner.current_state is restored_state
 
 
+@requires_renameat2
 def test_save_inside_existing_generation_is_rejected_without_mutation(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -480,6 +489,7 @@ def test_save_inside_existing_generation_is_rejected_without_mutation(
     assert restored_runner.current_state is restored_state
 
 
+@requires_renameat2
 def test_save_through_ancestor_symlink_into_generation_is_rejected(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -503,6 +513,7 @@ def test_save_through_ancestor_symlink_into_generation_is_rejected(
     assert restored_runner.current_state is restored_state
 
 
+@requires_renameat2
 def test_checkpoint_filesystem_publication_stays_inside_runner_barrier(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_reference_life_riverswim_checkpoint.py
+++ b/tests/test_reference_life_riverswim_checkpoint.py
@@ -30,6 +30,7 @@ from alberta_framework.reference_life_checkpoint import (
     save_reference_life_checkpoint,
 )
 from alberta_framework.streams.closed_loop import RiverSwimConfig, RiverSwimMDP
+from tests._forager_matched_platform import requires_renameat2
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
@@ -189,6 +190,7 @@ def _rehash_bundle(path: Path) -> None:
     (path / "COMMITTED").write_text(f"{bundle_id}\n", encoding="ascii")
 
 
+@requires_renameat2
 def test_riverswim_quiescent_checkpoint_restores_exact_stochastic_continuation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Addresses part of #2323 — the two `reference_life` checkpoint files. See "Scope" below for why the third file is not included.

## The problem

Both files drive `save_reference_life_checkpoint`, whose `_rename_noreplace` refuses off Linux:

```python
if sys.platform != "linux":
    raise OSError(errno.ENOTSUP, "atomic no-replace rename requires Linux renameat2")
```

Neither declared that requirement, so the items are permanently red on macOS and invisible to CI — the slow lane runs `ubuntu-latest` only.

## Fix

Gate them with the existing `requires_renameat2` predicate from `tests/_forager_matched_platform.py`, already used by six sibling files. Its docstring states the contract: each predicate "runs the same probe as the guard it stands in for, so a gated test skips exactly when the library would refuse."

## Which items need the gate — measured, not inferred

Reading call sites gave me 7 `def`s. That was wrong: forcing `_rename_noreplace` to raise `ENOTSUP` in the container reproduces the reported **10-of-12** split exactly —

```
2 failed, 2 passed, 8 errors
```

— and the two survivors are precisely the two that never reach the publisher (`test_switching_metric_schedule_is_constant_time_at_counter_horizon`, `test_checkpoint_validator_rejects_generation_and_zero_event_metric_forgery`). Three items reach it through a shared fixture and source inspection missed them. The gate is applied to the empirically-failing set.

## Verified both ways

| platform | `HAS_RENAMEAT2` | result |
|---|---|---|
| Linux container | True | **all 15 items run and pass** |
| arm64 Darwin (host) | False | gated items **skip** instead of failing |

The second row is the point of the change; the first confirms nothing is skipped where the library actually works.

## Scope

The issue also names `tests/test_forager_matched_final_analysis.py` (33 items). I have left it out: **30 of its 33 items already fail on clean `origin/main` on Linux**, for reasons unrelated to platform gating — I verified this by running the untouched file at `main` (`30 failed, 3 passed`, identical set). Gating it would not produce a verifiable green result here, and bundling an unverifiable change with two verifiable ones seemed worse than saying so. Happy to follow up separately once that file's Linux failures are understood.

## Verification

- `tests/test_reference_life_checkpoint.py` + `tests/test_reference_life_riverswim_checkpoint.py` — 15 passed
- `ruff check .` — all checks passed
