### PR TITLE
Declare the Linux-only publication requirement in the bounded-elastic runner tests

### DIFF
--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -16,6 +16,7 @@ from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
 from alberta_framework.evaluation.bounded_elastic_ipmnist_nonpromoting import (
     registered_bounded_elastic_hyperparameters,
 )
+from tests._forager_matched_platform import requires_o_tmpfile
 
 SMALL = IPMNISTConfig(n_tasks=1, task_length=5000, input_dim=2, hidden1=4, hidden2=2, n_classes=2)
 
@@ -291,6 +292,7 @@ def test_campaign_rejects_unregistered_outcome_decisions(
         )
 
 
+@requires_o_tmpfile
 def test_writer_is_create_only_and_retains_negative_outcomes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -314,6 +316,7 @@ def test_writer_is_create_only_and_retains_negative_outcomes(
     assert not destination.with_name(f".{destination.name}.reservation").exists()
 
 
+@requires_o_tmpfile
 def test_writer_strictly_rereads_before_link_and_retains_failed_attempt(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -340,6 +343,7 @@ def test_writer_strictly_rereads_before_link_and_retains_failed_attempt(
     assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
 
 
+@requires_o_tmpfile
 def test_writer_retains_reservation_after_reexecution_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -367,6 +371,7 @@ def test_writer_retains_reservation_after_reexecution_failure(
 
 
 @pytest.mark.parametrize("replace_linked_inode", [False, True])
+@requires_o_tmpfile
 def test_post_link_failure_rolls_back_only_the_exact_published_inode(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -407,6 +412,7 @@ def test_post_link_failure_rolls_back_only_the_exact_published_inode(
     assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
 
 
+@requires_o_tmpfile
 def test_link_success_followed_by_exception_rolls_back_exact_inode(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -434,6 +440,7 @@ def test_link_success_followed_by_exception_rolls_back_exact_inode(
     assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
 
 
+@requires_o_tmpfile
 def test_writer_rejects_replaced_visible_reservation_before_publication(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -464,6 +471,7 @@ def test_writer_rejects_replaced_visible_reservation_before_publication(
     marker.unlink()
 
 
+@requires_o_tmpfile
 def test_writer_parent_swap_does_not_publish_through_replacement(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -552,6 +560,7 @@ def test_standalone_paths_remain_disabled_after_flag_transition(
     assert not destination.parent.exists()
 
 
+@requires_o_tmpfile
 def test_transaction_reserves_before_dataset_load_or_runner(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -579,6 +588,7 @@ def test_transaction_reserves_before_dataset_load_or_runner(
     assert marker.read_bytes() == b"prior reservation"
 
 
+@requires_o_tmpfile
 def test_transaction_retains_owned_tombstone_after_first_dispatch_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -615,6 +625,7 @@ def test_transaction_retains_owned_tombstone_after_first_dispatch_failure(
     assert calls == 1
 
 
+@requires_o_tmpfile
 def test_transaction_publishes_only_after_strict_reexecution(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Addresses #2251.

## The problem

`tests/test_bounded_elastic_matched_runner.py` exercises the immutable-publication path without declaring its requirement, so 11 of its 34 items are permanently red on macOS — invisible to CI, which runs `ubuntu-latest` only. The module fails closed by design:

```python
if not all(hasattr(os, name) for name in ("O_DIRECTORY", "O_NOFOLLOW", "O_TMPFILE")):
    raise OSError("immutable output publication requires Linux descriptor support")
```

Same class as #1981 and #2323.

## Fix

Gate the affected items with the existing `requires_o_tmpfile` predicate from `tests/_forager_matched_platform.py` — it reads the same `O_TMPFILE` availability the guard checks, so a gated test skips exactly when the library would refuse. Confirmed on this host that the two agree:

```
HAS_O_TMPFILE = False
all(hasattr(os, n) for n in (O_DIRECTORY, O_NOFOLLOW, O_TMPFILE)) = False
```

## The gated set was measured, not inferred

Making the guard's probe report no descriptor support reproduces the reported split **exactly**:

```
11 failed, 23 passed
```

The gate is applied to precisely those 10 `def`s (one, `test_post_link_failure_rolls_back_only_the_exact_published_inode`, is parametrized `[False]`/`[True]`, giving the 11th item).

## On Linux this is a strict no-op — and a caveat worth stating

This file **already fails 6 of its 34 items on clean `origin/main`** on Linux, for reasons unrelated to platform gating. I verified that by running the untouched file at `main`:

| | result |
|---|---|
| clean `main` | `6 failed, 28 passed` |
| with this change | `6 failed, 28 passed` |

Identical — the gate changes nothing where `O_TMPFILE` exists, which is the correct behavior. But it does mean this PR cannot be validated by a green Linux run, and those 6 pre-existing failures are outside its scope.

On arm64 Darwin, `HAS_O_TMPFILE` is `False` and the 11 items skip instead of failing — which is the point of the change.

## Verification

- `ruff check .` — all checks passed
- Failing-item count on Linux unchanged vs. `main` (verified by running the untouched file at `main`)
