### PR TITLE
fix(rule_discovery): reject semantic shard substitution in _arm

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery_summary.py
+++ b/alberta_framework/benchmarks/rule_discovery_summary.py
@@ -13,8 +13,8 @@ import numpy as np
 
 import alberta_framework.benchmarks.rule_discovery as rule_discovery_module
 from alberta_framework._seed_validation import require_jax_seed, require_unique_jax_seeds
-from alberta_framework._strict_json import load_strict_json_object
 from alberta_framework.benchmarks.ipmnist_provenance import analysis_provenance
+from alberta_framework.benchmarks.ipmnist_screening import load_shard
 from alberta_framework.benchmarks.rule_discovery import NONPROMOTING_POLICY
 
 SCREEN_ARMS = (
@@ -37,13 +37,38 @@ DISCOVERY_ARMS = (
 CHAMPION = "sigma0_shiftnorm_d099"
 
 
-def _arm(directory: Path, name: str, seeds: Sequence[int]) -> dict[str, Any]:
+def _require_stage_geometry(payload: dict[str, Any], expected_arm: str,
+                            expected_n_tasks: int, path: Path) -> None:
+    """Require the load_shard-validated payload to match its expected slot.
+
+    ``load_shard`` already validates the shard's internal consistency
+    (schema, config_name against the registry, curves, seed, environment).
+    This adds the rule-discovery-specific binding: the registered arm must
+    be the one this builder reads the file under, and the stage geometry
+    must match (60 tasks for screen, 200 for confirmation, length 5,000),
+    so semantic substitution is rejected before aggregation or provenance.
+    """
+    if payload["config_name"] != expected_arm:
+        raise ValueError(
+            f"{path}: config_name {payload['config_name']!r} does not match "
+            f"expected arm {expected_arm!r}"
+        )
+    n_tasks = payload["config"]["n_tasks"]
+    if n_tasks != expected_n_tasks:
+        raise ValueError(f"{path}: n_tasks must be {expected_n_tasks}, got {n_tasks!r}")
+    if payload["config"]["task_length"] != 5000:
+        raise ValueError(f"{path}: task_length must be 5000")
+
+
+def _arm(directory: Path, name: str, seeds: Sequence[int],
+         expected_n_tasks: int) -> dict[str, Any]:
     values = []
     for seed in seeds:
         path = directory / f"{name}_seed{seed}.json"
         if not path.exists():
             raise ValueError(f"{name} is missing seed {seed} in {directory}")
-        payload = load_strict_json_object(path)
+        payload = load_shard(path)
+        _require_stage_geometry(payload, name, expected_n_tasks, path)
         if (
             type(payload.get("per_task_accuracy")) is not list
             or not payload["per_task_accuracy"]
@@ -71,7 +96,8 @@ def build_legacy_rule_discovery_summary(
 ) -> dict[str, Any]:
     """Reconstruct the exact legacy v1 payload for compatibility checks."""
     seeds = require_unique_jax_seeds(seeds)
-    screen = {name: _arm(screen_dir, name, seeds) for name in SCREEN_ARMS}
+    screen = {name: _arm(screen_dir, name, seeds, expected_n_tasks=60)
+              for name in SCREEN_ARMS}
     confirm_names = ("disc_r1_pscale_norms", CHAMPION)
     present = [
         (confirm_dir / f"{name}_seed{seed}.json").exists()
@@ -81,7 +107,8 @@ def build_legacy_rule_discovery_summary(
     if any(present) and not all(present):
         raise ValueError("rule-discovery confirmation seeds are incomplete")
     full = (
-        {name: _arm(confirm_dir, name, seeds) for name in confirm_names}
+        {name: _arm(confirm_dir, name, seeds, expected_n_tasks=200)
+         for name in confirm_names}
         if all(present)
         else {}
     )

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -425,7 +425,7 @@ def test_ceiling_confirm_alignment_rejects_delta_above_frozen_tolerance(
     tmp_path: Path,
 ) -> None:
     confirm = tmp_path / "confirm"
-    _shard(confirm / "sigma0_ndecay099_seed0.json", seed=0, accuracy=0.8)
+    _shard(confirm / "sigma0_ndecay099_seed0.json", seed=0, accuracy=0.8, n_tasks=2)
     run = {"seed": 0, "per_task_accuracy": [0.8, 0.8 + 2 * CONFIRM_ALIGNMENT_ATOL]}
 
     with pytest.raises(ValueError, match="exceeds atol"):

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -47,12 +47,54 @@ class _StringSubclass(str):
     pass
 
 
-def _shard(path: Path, *, seed: int, accuracy: float) -> None:
+def _shard(path: Path, *, seed: int, accuracy: float,
+            config_name: str = "disc_r1", n_tasks: int | None = None) -> None:
+    """Write a valid legacy v1 shard that survives ``_validate_shard_payload``.
+
+    The filename-derived config_name and n_tasks are inferred from the path so
+    rule-discovery and campaign-tools fixtures keep working after #2134 adds
+    payload-level arm / stage validation. Override config_name and n_tasks only
+    when constructing deliberate substitution probes.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps({"seed": seed, "per_task_accuracy": [accuracy, accuracy]}),
-        encoding="utf-8",
-    )
+    # Derive config_name + n_tasks from the expected filename / directory so the
+    # payload matches the arm and stage the builder will read it under.
+    stem = path.stem
+    if stem.endswith(f"_seed{seed}"):
+        inferred_name = stem[: -len(f"_seed{seed}")]
+    else:
+        inferred_name = config_name
+    # Infer stage from the parent directory name: "confirm" -> 200 tasks,
+    # everything else (e.g. "screen") -> 60 tasks.
+    if n_tasks is None:
+        parent_name = path.parent.name.lower()
+        n_tasks = 200 if parent_name == "confirm" else 60
+    payload = {
+        "schema": "alberta.ipmnist_screening.shard.v1",
+        "config_name": inferred_name,
+        "base_learner": "upgd_w",
+        "seed": seed,
+        "hyperparameters": {},
+        "per_task_accuracy": [accuracy] * n_tasks,
+        "per_task_loss": [0.5] * n_tasks,
+        "per_task_plasticity": [0.3] * n_tasks,
+        "wall_clock_seconds": 1.0,
+        "config": {
+            "input_dim": 784,
+            "hidden1": 300,
+            "hidden2": 150,
+            "n_classes": 10,
+            "n_tasks": n_tasks,
+            "task_length": 5000,
+        },
+        "environment": {
+            "jax": "0.11.0",
+            "numpy": "2.5.1",
+            "python": "3.12.3",
+            "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.39",
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
 
 
 def _ceiling_run(

--- a/tests/test_rule_discovery_substitution.py
+++ b/tests/test_rule_discovery_substitution.py
@@ -1,0 +1,158 @@
+"""Regression tests for #2134: rule-discovery summary rejects semantic substitution.
+
+Both cases reproduce the exact scenarios from the issue:
+
+1. Arm substitution — a shard whose config_name is sigma0_shiftnorm_d099
+   placed under the disc_r1 filename is accepted and misattributed.
+2. Stage substitution — 60-task screen shards placed under confirm filenames
+   are published as 200-task confirmation measurements.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.ipmnist_screening import IPMNISTConfig
+from alberta_framework.benchmarks.rule_discovery_summary import (
+    SCREEN_ARMS,
+    DISCOVERY_ARMS,
+    CHAMPION,
+    build_legacy_rule_discovery_summary,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _legacy_shard(path: Path, *, config_name: str, seed: int, n_tasks: int,
+                  mean_accuracy: float, base_learner: str = "upgd_w") -> None:
+    """Write a valid legacy v1 shard (schema, config, curves, environment).
+
+    The shard passes load_shard validation but may be semantically misplaced
+    (wrong config_name for the expected arm, or wrong n_tasks for the stage).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    accuracy = [mean_accuracy] * n_tasks
+    payload = {
+        "schema": "alberta.ipmnist_screening.shard.v1",
+        "config_name": config_name,
+        "base_learner": base_learner,
+        "seed": seed,
+        "hyperparameters": {},
+        "per_task_accuracy": accuracy,
+        "per_task_loss": [0.5] * n_tasks,
+        "per_task_plasticity": [0.3] * n_tasks,
+        "wall_clock_seconds": 1.0,
+        "config": {
+            "input_dim": 784,
+            "hidden1": 300,
+            "hidden2": 150,
+            "n_classes": 10,
+            "n_tasks": n_tasks,
+            "task_length": 5000,
+        },
+        "environment": {
+            "jax": "0.11.0",
+            "numpy": "2.5.1",
+            "python": "3.12.3",
+            "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.39",
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_arm_substitution_rejects_misattributed_shard(tmp_path: Path) -> None:
+    """A sigma0_shiftnorm_d099 shard placed under disc_r1's filename is rejected.
+
+    Exact repro from the issue: copy the sigma0_shiftnorm_d099 seed-0 shard
+    to disc_r1_seed0.json, build the summary, and observe that the sigma0
+    payload is accepted under disc_r1 with mean 0.8635.
+    """
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    screen.mkdir(parents=True)
+    confirm.mkdir(parents=True)
+    # Place sigma0's real payload under disc_r1's expected filename.
+    _legacy_shard(
+        screen / "disc_r1_seed0.json",
+        config_name="sigma0_shiftnorm_d099",
+        seed=0,
+        n_tasks=60,
+        mean_accuracy=0.8635,
+    )
+    # Also write the other required screen arms + confirm shards so the
+    # builder gets past existence checks for the other arms.
+    for name in SCREEN_ARMS:
+        if name == "disc_r1":
+            continue
+        _legacy_shard(screen / f"{name}_seed0.json", config_name=name,
+                      seed=0, n_tasks=60, mean_accuracy=0.79)
+    _legacy_shard(confirm / "disc_r1_pscale_norms_seed0.json",
+                  config_name="disc_r1_pscale_norms", seed=0, n_tasks=200,
+                  mean_accuracy=0.8)
+    _legacy_shard(confirm / f"{CHAMPION}_seed0.json", config_name=CHAMPION,
+                  seed=0, n_tasks=200, mean_accuracy=0.8)
+    with pytest.raises(ValueError, match="config_name"):
+        build_legacy_rule_discovery_summary(screen, confirm, seeds=(0,))
+
+
+@pytest.mark.parametrize("name", SCREEN_ARMS)
+def test_arm_substitution_rejects_every_misattributed_arm(
+    tmp_path: Path, name: str
+) -> None:
+    """Any shard whose config_name != expected arm is rejected for that arm."""
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    screen.mkdir(parents=True)
+    confirm.mkdir(parents=True)
+    other = "sigma0_shiftnorm_d099" if name != "sigma0_shiftnorm_d099" else "disc_r1"
+    _legacy_shard(
+        screen / f"{name}_seed0.json",
+        config_name=other,
+        seed=0,
+        n_tasks=60,
+        mean_accuracy=0.8,
+    )
+    for n in SCREEN_ARMS:
+        if n == name:
+            continue
+        _legacy_shard(screen / f"{n}_seed0.json", config_name=n,
+                      seed=0, n_tasks=60, mean_accuracy=0.79)
+    _legacy_shard(confirm / "disc_r1_pscale_norms_seed0.json",
+                  config_name="disc_r1_pscale_norms", seed=0, n_tasks=200,
+                  mean_accuracy=0.8)
+    _legacy_shard(confirm / f"{CHAMPION}_seed0.json", config_name=CHAMPION,
+                  seed=0, n_tasks=200, mean_accuracy=0.8)
+    with pytest.raises(ValueError, match="config_name"):
+        build_legacy_rule_discovery_summary(screen, confirm, seeds=(0,))
+
+
+def test_stage_substitution_rejects_screen_as_confirmation(tmp_path: Path) -> None:
+    """60-task screen shards placed under confirm filenames are rejected.
+
+    Exact repro from the issue: copy genuine 60-task v1 screen shards for
+    disc_r1_pscale_norms and sigma0_shiftnorm_d099 into the confirmation
+    directory; the maintained summary publishes both as confirm_200_task.
+    """
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    screen.mkdir(parents=True)
+    confirm.mkdir(parents=True)
+    # Legitimate 60-task screen shards for all 8 screen arms.
+    for name in SCREEN_ARMS:
+        _legacy_shard(screen / f"{name}_seed0.json", config_name=name,
+                      seed=0, n_tasks=60, mean_accuracy=0.79)
+    # Misplaced: 60-task shards under confirmation filenames.
+    for name in ("disc_r1_pscale_norms", CHAMPION):
+        _legacy_shard(
+            confirm / f"{name}_seed0.json",
+            config_name=name,
+            seed=0,
+            n_tasks=60,
+            mean_accuracy=0.8,
+        )
+    with pytest.raises(ValueError, match="n_tasks"):
+        build_legacy_rule_discovery_summary(screen, confirm, seeds=(0,))


### PR DESCRIPTION
## Summary

Route every rule-discovery shard through the existing `ipmnist_screening.load_shard` boundary (as the issue requests), then require the load_shard-validated payload to match the slot it is read under:

- `config_name` equal to the expected arm (rejects renamed-shard misattribution)
- 60 tasks for the screen stage, 200 for confirmation (rejects screen-as-confirmation substitution)
- `task_length == 5000`

`load_shard` already validates schema, registry membership of `config_name`, curves, seed, and environment; `_require_stage_geometry` adds only the rule-discovery-specific arm/stage binding. Semantic substitution is now rejected before aggregation or provenance publication.

## Changes

- `alberta_framework/benchmarks/rule_discovery_summary.py`: `_arm` loads via `load_shard(path)`; new `_require_stage_geometry`; call sites pass `expected_n_tasks=60` / `=200`.
- `tests/test_rule_discovery_substitution.py`: regression-first coverage — the issue's exact repro (sigma0 shard under disc_r1 filename), all-8-arm parametrized substitution, and stage substitution.
- `tests/test_ipmnist_campaign_tools.py`: `_shard` fixture upgraded to emit valid legacy shards (config_name inferred from filename, n_tasks from parent dir) so existing tests keep passing.

## Validation

- `pytest tests/test_rule_discovery_substitution.py -q`: **10 passed**
- `pytest tests/test_ipmnist_campaign_tools.py -q`: **79 passed** (3 pre-existing Windows temp-permission flakes fail identically on clean main — verified via stash)
- Exact reconstruction of the historical v1 payload preserved: `test_current_rule_discovery_legacy_payload_reconstructs_exactly` passes against real campaign outputs.

Closes #2134