### PR TITLE
fix(utils): correct Raises section indentation in get_final_performance docstring

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -665,7 +665,7 @@ def get_final_performance(
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
 
-        Raises:
+    Raises:
         ValueError: If ``window`` is not positive, a metric array has no
             time steps, any metric sample is non-finite, or ``window`` exceeds
             the shortest trace while trace lengths differ between methods.


### PR DESCRIPTION
Fixes #2439

## Summary
In `alberta_framework/utils/experiments.py`, the `Raises:` section of `get_final_performance` was indented at 8 spaces inside the `Returns:` block instead of being a sibling section at indent 4. As a result, Google-style docstring tooling treated the exception specification as part of the return value description.

## Proposed Changes
1. Adjusted `Raises:` in `get_final_performance` to indent 4 so it is parsed as a top-level section header.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_experiments_validation.py tests/test_experiments_hostile_validation.py` (141/141 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/utils/experiments.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/utils/experiments.py` (all checks passed).
