### PR TITLE
fix(core): bound PrototypeAgentConfig n_dreams_per_step before lax.scan

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -184,6 +184,7 @@ _PROTOTYPE_V2_REPLAY_MIGRATION_TAG = 0x50525632
 _PROTOTYPE_FEATURE_LIFECYCLE_KEY_TAG = 0x50464C43
 _UINT32_MAX = 2**32 - 1
 _INT32_MAX = 2**31 - 1
+_MAX_N_DREAMS_PER_STEP = 10_000
 
 # ---------------------------------------------------------------------------
 # Standalone utility
@@ -725,7 +726,7 @@ class PrototypeAgentConfig:
                 "n_dreams_per_step",
                 self.n_dreams_per_step,
                 minimum=0,
-                maximum=_INT32_MAX,
+                maximum=_MAX_N_DREAMS_PER_STEP,
             ),
         )
         # horde_hidden_sizes: hostile-safe per-element validation
@@ -1335,7 +1336,10 @@ class PrototypeAgentConfig:
             "buffer_capacity", data.pop("buffer_capacity", 200), minimum=1, maximum=_INT32_MAX
         )
         n_dreams_per_step = _require_int(
-            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=_INT32_MAX
+            "n_dreams_per_step",
+            data.pop("n_dreams_per_step", 0),
+            minimum=0,
+            maximum=_MAX_N_DREAMS_PER_STEP,
         )
         dream_next_observation_mode = data.pop(
             "dream_next_observation_mode",

--- a/tests/test_prototype_agent_validation.py
+++ b/tests/test_prototype_agent_validation.py
@@ -303,3 +303,20 @@ def test_prototype_valid_construction() -> None:
     assert restored == cfg
     gru = GRUPerceptionConfig(observation_dim=4, hidden_dim=4)
     assert gru.augmented_dim() == 8
+
+
+def test_prototype_agent_config_n_dreams_per_step_bounds() -> None:
+    wm = _world_model(4)
+    # Accepts 0 to 10_000
+    cfg = _cfg(oak=_oak(obs_dim=4), world_model=wm, n_dreams_per_step=10_000)
+    assert cfg.n_dreams_per_step == 10_000
+
+    # Rejects > 10_000
+    with pytest.raises(ValueError, match="n_dreams_per_step must be <= 10000"):
+        _cfg(oak=_oak(obs_dim=4), world_model=wm, n_dreams_per_step=10_001)
+
+    # Rejects deserialization with > 10_000
+    payload = cfg.to_config()
+    payload["n_dreams_per_step"] = 10_001
+    with pytest.raises(ValueError, match="n_dreams_per_step must be <= 10000"):
+        PrototypeAgentConfig.from_config(payload)


### PR DESCRIPTION
Fixes #2441

## Summary
`PrototypeAgentConfig.n_dreams_per_step` was validated against `_INT32_MAX`, which can drive `jnp.arange(...)` inside `lax.scan` to hang or exhaust system memory long before executing dreams.

## Proposed Changes
1. Capped `n_dreams_per_step` to `_MAX_N_DREAMS_PER_STEP = 10_000` in both `PrototypeAgentConfig.__post_init__` and `PrototypeAgentConfig.from_config`.
2. Added unit tests in `tests/test_prototype_agent_validation.py` verifying bounds enforcement for `n_dreams_per_step`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_prototype_agent_validation.py` (24/24 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/prototype_agent.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/prototype_agent.py` (all checks passed).
