### PR TITLE
fix(tests): suppress RuntimeWarning leak in _platform_longdouble_1e4000

### DIFF
--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from decimal import Decimal
 from fractions import Fraction
@@ -537,7 +538,8 @@ class _NonfiniteFloatThatConvertsFinite(float):
 
 def _platform_longdouble_1e4000() -> np.longdouble:
     """Parse the cross-platform boundary without leaking an expected warning."""
-    with np.errstate(over="ignore", invalid="ignore"):
+    with warnings.catch_warnings(), np.errstate(over="ignore", invalid="ignore"):
+        warnings.simplefilter("ignore", RuntimeWarning)
         return np.longdouble("1e4000")
 
 
@@ -1029,3 +1031,11 @@ def test_run_multi_seed_experiment_rejects_invalid_seed_sequences(
 def test_get_final_performance_rejects_non_builtin_positive_window(window: object) -> None:
     with pytest.raises(ValueError, match="window"):
         get_final_performance({"candidate": _two_seed_trace()}, window=window)  # type: ignore[arg-type]
+
+
+def test_platform_longdouble_1e4000_does_not_leak_warning() -> None:
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        val = _platform_longdouble_1e4000()
+        assert val is not None
+    assert len(captured) == 0


### PR DESCRIPTION
Fixes #2387

## Summary
`_platform_longdouble_1e4000` in `tests/test_experiments_validation.py` previously attempted to suppress overflow warnings during string-to-longdouble conversion using `np.errstate(over="ignore", invalid="ignore")`. However, Python's `warnings` system emits `RuntimeWarning: overflow encountered in conversion from string` separately, leaking the warning into collections and test runs on aarch64 platforms.

## Proposed Changes
1. Added `warnings.catch_warnings()` with `warnings.simplefilter("ignore", RuntimeWarning)` in `_platform_longdouble_1e4000`.
2. Added `test_platform_longdouble_1e4000_does_not_leak_warning` to verify that the helper executes completely silently.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_experiments_validation.py` (130/130 tests passed with 0 warnings).
