### PR TITLE
fix(core): include np.longdouble in _ACTUAL_REAL_SCALAR_TYPES

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -33,7 +33,7 @@ _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _INT32_MAX = 2**31 - 1
 _ACTUAL_REAL_SCALAR_TYPES = frozenset(
-    {float, np.float16, np.float32, np.float64, int}
+    {float, int, *(np.dtype(code).type for code in "efdg")}
 )
 
 _ACTUAL_INT_TYPES = frozenset(

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -632,3 +632,16 @@ class TestGVFSpecRemainingFields:
     def test_horde_spec_from_config_rejects_non_list_demons(self, invalid_demons):
         with pytest.raises(ValueError, match="HordeSpec demons must be an exact list"):
             HordeSpec.from_config({"demons": invalid_demons})
+
+
+def test_gvf_spec_terminal_reward_accepts_longdouble() -> None:
+    base = dict(
+        name="d_ld",
+        demon_type=DemonType.PREDICTION,
+        gamma=0.0,
+        lamda=0.0,
+        cumulant_index=0,
+    )
+    spec = GVFSpec(**base, terminal_reward=np.longdouble(1.5))
+    assert spec.terminal_reward == pytest.approx(1.5)
+    assert isinstance(spec.terminal_reward, float)


### PR DESCRIPTION
Fixes #2283

## Summary
In `alberta_framework/core/types.py`, `_ACTUAL_REAL_SCALAR_TYPES` hand-enumerated `float16`, `float32`, `float64`, and `int`, but omitted `np.longdouble` (dtype code `g`). Consequently, `GVFSpec.terminal_reward` rejected `np.longdouble` scalars that its sibling fields (`gamma`, `lamda`) and the underlying float32 conversion helpers accept.

## Proposed Changes
1. Defined `_ACTUAL_REAL_SCALAR_TYPES` using dtype codes `"efdg"`, matching `_ACTUAL_INT_TYPES` and `_float32.py`.
2. Added unit tests in `tests/test_gvf_types.py` verifying that `GVFSpec.terminal_reward` accepts `np.longdouble`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_gvf_types.py` (109/109 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/types.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/types.py` (all checks passed).
