### PR TITLE
fix(core): derive _ACTUAL_INT_TYPES from dtype codes in stacked_horde and reward_model

### DIFF
--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -29,19 +29,7 @@ from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
+    {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
 )
 _ACTUAL_FLOAT_TYPES = frozenset(
     {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -142,19 +142,7 @@ _CONFIG_FIELDS = {
     "step_size",
 }
 _ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
+    {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
 )
 
 


### PR DESCRIPTION
Fixes #2268

## Summary
In `alberta_framework/core/stacked_horde.py` and `alberta_framework/core/reward_model.py`, `_ACTUAL_INT_TYPES` hand-enumerated fixed-width integer names instead of deriving from dtype codes `"bBhHiIlLqQpP"`. On platforms like Windows (LLP64) where C aliases (`np.intc`, `np.uintc`) are distinct type objects from fixed-width spellings, integer validation gates rejected valid numpy integer scalars.

## Proposed Changes
1. Updated `_ACTUAL_INT_TYPES` in `stacked_horde.py` and `reward_model.py` to derive dynamically from dtype codes `"bBhHiIlLqQpP"`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_stacked_horde.py tests/test_reward_model.py` (156/156 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/stacked_horde.py alberta_framework/core/reward_model.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/stacked_horde.py alberta_framework/core/reward_model.py` (all checks passed).
