### PR TITLE
fix(core): cap working-memory decay rate cardinality before per-element iteration

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -124,8 +124,23 @@ class WorkingMemoryConfig:
             if key in payload:
                 value = payload[key]
                 if type(value) is list:
+                    if len(value) > _MAX_WORKING_MEMORY_CONFIGURATION_ITEMS:
+                        raise ValueError(
+
+                                f"{key} must contain at most "
+                                f"{_MAX_WORKING_MEMORY_CONFIGURATION_ITEMS} decay rates"
+
+                        )
                     payload[key] = tuple(value)
-                elif type(value) is not tuple:
+                elif type(value) is tuple:
+                    if len(value) > _MAX_WORKING_MEMORY_CONFIGURATION_ITEMS:
+                        raise ValueError(
+
+                                f"{key} must contain at most "
+                                f"{_MAX_WORKING_MEMORY_CONFIGURATION_ITEMS} decay rates"
+
+                        )
+                else:
                     raise ValueError(f"{key} must be an actual list or tuple")
                 if any(type(item) is not float for item in payload[key]):
                     raise ValueError(f"serialized {key} values must be JSON numbers")
@@ -216,6 +231,7 @@ class WorkingMemoryArrayResult:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_WORKING_MEMORY_CONFIGURATION_ITEMS = 1 << 12
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
@@ -287,6 +303,10 @@ def _require_array(
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(rates) > _MAX_WORKING_MEMORY_CONFIGURATION_ITEMS:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_WORKING_MEMORY_CONFIGURATION_ITEMS} decay rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",

--- a/tests/test_working_memory_validation.py
+++ b/tests/test_working_memory_validation.py
@@ -457,3 +457,31 @@ def test_working_transform_resource_preflight_precedes_jax_conversion() -> None:
             HostArray(1),  # type: ignore[arg-type]
             HostArray(1),  # type: ignore[arg-type]
         )
+
+
+def test_working_memory_decay_rates_cardinality_bounds() -> None:
+    # 4096 is accepted
+    rates_4096 = (0.5,) * 4096
+    cfg = WorkingMemoryConfig(
+        observation_dim=2,
+        action_dim=1,
+        reward_dim=1,
+        observation_decay_rates=rates_4096,
+    )
+    assert len(cfg.observation_decay_rates) == 4096
+
+    # 4097 is rejected before per-element validation
+    rates_4097 = (0.5,) * 4097
+    with pytest.raises(ValueError, match="at most 4096 decay rates"):
+        WorkingMemoryConfig(
+            observation_dim=2,
+            action_dim=1,
+            reward_dim=1,
+            observation_decay_rates=rates_4097,
+        )
+
+    # Deserialization rejects > 4096 items
+    payload = cfg.to_config()
+    payload["observation_decay_rates"] = [0.5] * 4097
+    with pytest.raises(ValueError, match="at most 4096 decay rates"):
+        WorkingMemoryConfig.from_config(payload)


### PR DESCRIPTION
Fixes #2220

## Summary
In `alberta_framework/core/working_memory.py`, `_validate_decay_rates` and `WorkingMemoryConfig.from_config` iterated across decay rate sequences without a preflight cardinality check (`_MAX_WORKING_MEMORY_CONFIGURATION_ITEMS = 4096`), allowing unbounded sequence iterations.

## Proposed Changes
1. Added `_MAX_WORKING_MEMORY_CONFIGURATION_ITEMS = 1 << 12` (4096) in `working_memory.py`.
2. Checked sequence length in `_validate_decay_rates` before per-element `validated_float32_scalar` validation.
3. Preflighted decay rate sequence length in `WorkingMemoryConfig.from_config`.
4. Added unit tests in `tests/test_working_memory_validation.py` verifying cardinality bounds enforcement.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_working_memory_validation.py tests/test_working_memory.py` (155/155 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/working_memory.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/working_memory.py` (all checks passed).
