### PR TITLE
fix(core): bound stacked-horde demon count and preflight sequence length in deserializer

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -132,6 +132,7 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_STACKED_HORDE_DEMONS = 1 << 12
 _CONFIG_FIELDS = {
     "type",
     "n_demons",
@@ -176,7 +177,10 @@ def _require_sequence(name: str, value: object) -> tuple[object, ...]:
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
     if type(value) not in (list, tuple):
         raise ValueError(f"{name} must be an actual list or tuple")
-    return tuple(cast(list[object] | tuple[object, ...], value))
+    seq = cast(list[object] | tuple[object, ...], value)
+    if len(seq) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(f"{name} must contain at most {_MAX_STACKED_HORDE_DEMONS} items")
+    return tuple(seq)
 
 
 def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
@@ -257,7 +261,9 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        n_demons = _require_int32(
+            "n_demons", self.n_demons, minimum=1, maximum=_MAX_STACKED_HORDE_DEMONS
+        )
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
         raw_sequences = {
@@ -355,6 +361,10 @@ def nexting_spec(
     feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
     raw_indices = _require_sequence("cumulant_indices", cumulant_indices)
     raw_gammas = _require_sequence("gammas", gammas)
+    if len(raw_indices) * len(raw_gammas) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"nexting demon count must be <= {_MAX_STACKED_HORDE_DEMONS}"
+        )
     canonical_indices = tuple(
         _require_int32(f"cumulant_indices[{i}]", value, minimum=0)
         for i, value in enumerate(raw_indices)

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -939,3 +939,39 @@ def test_stacked_horde_public_state_shape_rejected_before_dot() -> None:
     state = horde.init().replace(weights=jnp.zeros((1, 3), dtype=jnp.float32))
     with pytest.raises(ValueError, match="weights"):
         horde.predict(state, jnp.ones(2, dtype=jnp.float32))
+
+
+def test_stacked_horde_demon_count_cardinality_bounds() -> None:
+    # 4096 is accepted
+    cfg = StackedHordeConfig(
+        n_demons=4096,
+        feature_dim=2,
+        gammas=(0.9,) * 4096,
+        lamdas=(0.1,) * 4096,
+        cumulant_indices=(0,) * 4096,
+    )
+    assert cfg.n_demons == 4096
+
+    # 4097 is rejected
+    with pytest.raises(ValueError, match="n_demons must be an integer in \\[1, 4096\\]"):
+        StackedHordeConfig(
+            n_demons=4097,
+            feature_dim=2,
+            gammas=(0.9,) * 4097,
+            lamdas=(0.1,) * 4097,
+            cumulant_indices=(0,) * 4097,
+        )
+
+    # from_config rejects oversized sequences
+    payload = cfg.to_config()
+    payload["gammas"] = [0.9] * 4097
+    with pytest.raises(ValueError, match="must contain at most 4096 items"):
+        StackedHordeConfig.from_config(payload)
+
+    # nexting_spec rejects oversized product
+    with pytest.raises(ValueError, match="nexting demon count must be <= 4096"):
+        nexting_spec(
+            feature_dim=2,
+            cumulant_indices=tuple(range(100)),
+            gammas=(0.1,) * 50,
+        )


### PR DESCRIPTION
Fixes #2225

## Summary
`StackedHordeConfig` allowed `n_demons` up to `_INT32_MAX` (2,147,483,647), and `_decode_sequence` deserialized lists and tuples of any size without a cardinality ceiling check.

## Proposed Changes
1. Added `_MAX_STACKED_HORDE_DEMONS = 1 << 12` (4096) in `stacked_horde.py`.
2. Validated `n_demons <= _MAX_STACKED_HORDE_DEMONS` in `StackedHordeConfig.__post_init__`.
3. Preflighted sequence length in `_decode_sequence`.
4. Preflighted total demon product count in `nexting_spec`.
5. Added unit tests in `tests/test_stacked_horde.py` verifying cardinality bounds.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_stacked_horde.py` (95/95 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/stacked_horde.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/stacked_horde.py` (all checks passed).
