### PR TITLE
fix(steps): bound Step 7 planning and Step 9 dreaming loop lengths before jnp.arange/lax.scan

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -161,6 +161,8 @@ class Step7DynaConfig:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_PLANNING_STEPS = 10_000
+_MAX_PLANNING_ROLLOUT_DEPTH = 10_000
 _STEP7_CONFIG_FIELDS = frozenset(
     {
         "control",
@@ -258,7 +260,7 @@ def _require_int(
             raise ValueError(f"{name} must be non-negative")
         raise ValueError(f"{name} must be >= {minimum}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{name} must be at most int32 max")
+        raise ValueError(f"{name} must be <= {maximum}")
     return number
 
 
@@ -279,13 +281,13 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
         "planning_steps",
         config.planning_steps,
         minimum=0,
-        maximum=_INT32_MAX,
+        maximum=_MAX_PLANNING_STEPS,
     )
     planning_rollout_depth = _require_int(
         "planning_rollout_depth",
         config.planning_rollout_depth,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_MAX_PLANNING_ROLLOUT_DEPTH,
     )
     planning_warmup_steps = _require_int(
         "planning_warmup_steps",

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -71,6 +71,7 @@ from alberta_framework.steps.step6 import (
 )
 
 _INT32_MAX = 2**31 - 1
+_MAX_DREAM_STEPS = 10_000
 _MAX_CONFIG_SEQUENCE_LENGTH = 4_096
 _MAX_DREAM_WORK_PER_REAL_STEP = 4_096
 # Matches the established ceiling for other scan-driven array-loop runners
@@ -426,20 +427,20 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         config.behavior_model_step_size,
     )
     planning_budget = _require_int(
-        "planning_budget", config.planning_budget, minimum=0, maximum=_INT32_MAX
+        "planning_budget", config.planning_budget, minimum=0, maximum=_MAX_DREAM_STEPS
     )
     dream_rollout_horizon = _require_int(
         "dream_rollout_horizon",
         config.dream_rollout_horizon,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_MAX_DREAM_STEPS,
     )
     # Candidate selection publishes selected indices as signed int32 values.
     dream_candidate_count = _require_int(
         "dream_candidate_count",
         config.dream_candidate_count,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_MAX_DREAM_STEPS,
     )
     dream_surprise_weight = _require_real(
         "dream_surprise_weight",

--- a/tests/test_step7_hostile_validation.py
+++ b/tests/test_step7_hostile_validation.py
@@ -293,3 +293,16 @@ def test_smoke_preflights_all_live_arrays_before_allocation(
     monkeypatch.setattr(jr, "normal", unexpected_allocation)
     with pytest.raises(ValueError, match="smoke resources"):
         run_step7_smoke(steps=50_000_000)
+
+
+def test_step7_planning_bounds() -> None:
+    # 10_000 is accepted
+    cfg = Step7DynaConfig(planning_steps=10_000, planning_rollout_depth=10_000)
+    assert cfg.planning_steps == 10_000
+    assert cfg.planning_rollout_depth == 10_000
+
+    # > 10_000 is rejected
+    with pytest.raises(ValueError, match="planning_steps must be <= 10000"):
+        Step7DynaConfig(planning_steps=10_001)
+    with pytest.raises(ValueError, match="planning_rollout_depth must be <= 10000"):
+        Step7DynaConfig(planning_rollout_depth=10_001)

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -673,9 +673,9 @@ def test_step7_dyna_preserves_float32_boundaries() -> None:
 
 
 def test_step7_dyna_rejects_derived_work_and_memory_resources() -> None:
-    with pytest.raises(ValueError, match="derived planning evaluations"):
+    with pytest.raises(ValueError, match="planning_steps must be <= 10000"):
         Step7DynaConfig(planning_steps=2**30, planning_rollout_depth=2)
-    with pytest.raises(ValueError, match="planning output bytes"):
+    with pytest.raises(ValueError, match="planning_steps must be <= 10000"):
         Step7DynaConfig(planning_steps=2**26, planning_rollout_depth=1)
     with pytest.raises(ValueError, match="planning-memory bytes"):
         Step7DynaConfig(planning_memory_size=2**28)

--- a/tests/test_step9_hostile_validation.py
+++ b/tests/test_step9_hostile_validation.py
@@ -409,3 +409,23 @@ def test_run_step9_scan_accepts_a_small_in_bounds_sequence() -> None:
     cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(4)
     result = run_step9_scan(cfg, agent, model, buffer, state, rewards, next_observations)
     assert result.real_td_errors.shape == (4,)
+
+
+def test_step9_dreaming_bounds() -> None:
+    # 10_000 is accepted when total dream work is within aggregate limit
+    cfg = Step9DreamingConfig(
+        planning_budget=0,
+        dream_rollout_horizon=10_000,
+        dream_candidate_count=10_000,
+    )
+    assert cfg.planning_budget == 0
+    assert cfg.dream_rollout_horizon == 10_000
+    assert cfg.dream_candidate_count == 10_000
+
+    # > 10_000 is rejected
+    with pytest.raises(ValueError, match="planning_budget must be <= 10000"):
+        Step9DreamingConfig(planning_budget=10_001)
+    with pytest.raises(ValueError, match="dream_rollout_horizon must be <= 10000"):
+        Step9DreamingConfig(dream_rollout_horizon=10_001)
+    with pytest.raises(ValueError, match="dream_candidate_count must be <= 10000"):
+        Step9DreamingConfig(dream_candidate_count=10_001)


### PR DESCRIPTION
Fixes #2214

## Summary
In `alberta_framework/steps/step7.py` and `alberta_framework/steps/step9.py`, planning and dreaming loop lengths were validated up to `_INT32_MAX`, which can cause `jnp.arange(...)` feeding `lax.scan` and `jax.vmap` to trigger multi-gigabyte memory allocations or hangs before executing.

## Proposed Changes
1. Added ceiling bounds (10,000) for `planning_steps` and `planning_rollout_depth` in `Step7DynaConfig`.
2. Added ceiling bounds (10,000) for `planning_budget`, `dream_rollout_horizon`, and `dream_candidate_count` in `Step9DreamingConfig`.
3. Added unit tests in `tests/test_step7_hostile_validation.py` and `tests/test_step9_hostile_validation.py` asserting bounds enforcement.

## Verification
- Ran pytest on hostile validation suites: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_step7_hostile_validation.py tests/test_step9_hostile_validation.py` (46/46 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/steps/step7.py alberta_framework/steps/step9.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/steps/step7.py alberta_framework/steps/step9.py` (all checks passed).
