### PR TITLE
fix(core): fall back to uniform simplex in floor_and_renormalize_probabilities for zero/underflow mass

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -222,16 +222,16 @@ def floor_and_renormalize_probabilities(
     """
     probs = jnp.asarray(probabilities, dtype=jnp.float32)
     n_actions = probabilities.shape[-1]
+    uniform = jnp.ones_like(probs) / n_actions
     if min_probability * n_actions >= 1.0:
-        return jnp.ones_like(probs) / n_actions
+        return uniform
     clipped = jnp.maximum(probs, 0.0)
-    normalizer = jnp.maximum(
-        jnp.sum(clipped, axis=-1, keepdims=True),
-        jnp.asarray(1e-12, dtype=jnp.float32),
-    )
+    mass = jnp.sum(clipped, axis=-1, keepdims=True)
+    normalizer = jnp.where(mass > 0.0, mass, 1.0)
     normalized = clipped / normalizer
     floor_mass = jnp.asarray(min_probability * n_actions, dtype=jnp.float32)
-    return jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
+    floored = jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
+    return jnp.where(mass > 0.0, floored, uniform)
 
 
 def selected_action_probabilities(

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -868,3 +868,17 @@ class TestBehaviorModelSequenceCeiling:
         result = run_behavior_model_from_arrays(model, state, observations, actions)
         chex.assert_shape(result.probabilities, (12, 3))
         assert int(result.state.step_count) == 12
+
+
+def test_floor_and_renormalize_probabilities_degenerate_inputs() -> None:
+    # All zero mass falls back to uniform simplex
+    zero_probs = jnp.asarray([0.0, 0.0, 0.0], dtype=jnp.float32)
+    out_zero = floor_and_renormalize_probabilities(zero_probs)
+    assert jnp.allclose(out_zero, jnp.asarray([1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0], dtype=jnp.float32))
+    assert jnp.isclose(jnp.sum(out_zero), 1.0)
+
+    # Standard case satisfies simplex and min_probability
+    probs = jnp.asarray([1.0, 0.0, 0.0], dtype=jnp.float32)
+    out = floor_and_renormalize_probabilities(probs, min_probability=1e-3)
+    assert jnp.all(out >= 1e-3)
+    assert jnp.isclose(jnp.sum(out), 1.0)


### PR DESCRIPTION
Fixes #2238

## Summary
`floor_and_renormalize_probabilities` in `alberta_framework/core/behavior_model.py` returned a vector summing to `n * min_probability` (e.g. `3e-6`) instead of `1.0` when all clipped probability mass was zero or underflowed in float32.

## Proposed Changes
1. Added fallback to uniform simplex distribution (`jnp.ones_like(probs) / n_actions`) when clipped probability mass is `<= 0.0`.
2. Added unit tests in `tests/test_behavior_model.py` verifying that degenerate zero-mass inputs return a valid simplex summing to `1.0`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_behavior_model.py` (65/65 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/behavior_model.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/behavior_model.py` (all checks passed).
