### PR TITLE
fix(core): normalize by exact observation_scale and bound config to normal float32

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -79,6 +79,7 @@ from alberta_framework.core.update_safety import (
 EVIDENCE_LEVEL = "L0"
 SCIENTIFIC_PROMOTION_ALLOWED = False
 _INT32_MAX = 2**31 - 1
+_FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -290,7 +291,7 @@ class LatentWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 validated_float32_scalar(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]", scale, lower=_FLOAT32_MIN_NORMAL
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -670,7 +671,7 @@ class LatentWorldModel:
         """Encode one observation with explicit (differentiable) encoder params."""
         obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._config.observation_dim,))
         scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
+        scaled = obs / scale
         return jnp.tanh(scaled @ encoder_matrix + encoder_bias)
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -749,3 +749,34 @@ def test_latent_world_model_init_rejects_nonfinite_encoder_draw() -> None:
 
     with pytest.raises(ValueError, match="encoder initialization"):
         model.init(jr.key(0))
+
+
+def test_latent_world_model_observation_scale_scale_free_encoding() -> None:
+    # Proportional observations across scales yield identical encodings
+    ref_latent = None
+    for scale in (1.0, 1e-6, 1e-9, 1e-20):
+        config = LatentWorldModelConfig(
+            observation_dim=2,
+            latent_dim=4,
+            n_actions=2,
+            observation_scale=(scale, scale),
+        )
+        model = LatentWorldModel(config)
+        state = model.init(jr.key(0))
+        obs = jnp.asarray([1.5 * scale, -0.75 * scale], dtype=jnp.float32)
+        latent = model.encode(state, obs)
+        if ref_latent is None:
+            ref_latent = latent
+        else:
+            assert jnp.allclose(latent, ref_latent, atol=1e-6)
+
+
+def test_latent_world_model_config_rejects_subnormal_scale() -> None:
+    # Rejects subnormal float32 scale
+    subnormal = float(np.finfo(np.float32).smallest_subnormal)
+    with pytest.raises(ValueError, match="observation_scale"):
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            observation_scale=(subnormal, 1.0),
+        )


### PR DESCRIPTION
Fixes #2411

## Summary
`LatentWorldModel._encode_with` normalized observations using `jnp.maximum(scale, 1e-6)`, which replaced declared scales below `1e-6` with `1e-6`, causing latent representations to shrink and triggering false-positive collapse gates.

## Proposed Changes
1. Removed `1e-6` floor in `_encode_with` (`alberta_framework/core/latent_world_model.py`) to divide by the exact configured `observation_scale`.
2. Bounded `observation_scale` validation in `LatentWorldModelConfig` to positive normal float32 values (`lower=_FLOAT32_MIN_NORMAL`) so every accepted scale has a finite float32 reciprocal.
3. Added unit tests in `tests/test_latent_world_model.py` asserting scale-free latent encoding across normal scales and rejection of subnormal values.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_latent_world_model.py` (58/58 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/latent_world_model.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/latent_world_model.py` (all checks passed).
