### PR TITLE
fix(core): preserve convex combination and baseline centering in Hedge masked updates

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -1036,8 +1036,15 @@ class FixedBudgetFeatureLearner:
         finite: Array,
     ) -> Array:
         """Exponentiated-gradient preference update for utility scores."""
-        finite_mass = jnp.maximum(jnp.sum(jnp.where(finite, allocation, 0.0)), 1e-12)
-        masked_allocation = jnp.where(finite, allocation / finite_mass, 0.0)
+        masked_raw = jnp.where(finite, allocation, 0.0)
+        mass = jnp.sum(masked_raw)
+        valid_count = jnp.maximum(jnp.sum(finite), 1)
+        uniform_fallback = jnp.where(finite, 1.0 / valid_count, 0.0)
+        masked_allocation = jnp.where(
+            mass > 0.0,
+            masked_raw / jnp.where(mass > 0.0, mass, 1.0),
+            uniform_fallback,
+        )
         baseline = jnp.sum(masked_allocation * jnp.where(finite, scores, 0.0))
         advantages = jnp.where(finite, scores - baseline, 0.0)
         advantages = jnp.clip(

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -594,8 +594,15 @@ class LearnedResourceManager:
         adjusted = jnp.where(valid_actions, safe_losses + cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(valid_actions, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(valid_actions, weights / finite_weight_sum, 0.0)
+        masked_raw = jnp.where(valid_actions, weights, 0.0)
+        mass = jnp.sum(masked_raw)
+        valid_count = jnp.maximum(jnp.sum(valid_actions), 1)
+        uniform_fallback = jnp.where(valid_actions, 1.0 / valid_count, 0.0)
+        masked_weights = jnp.where(
+            mass > 0.0,
+            masked_raw / jnp.where(mass > 0.0, mass, 1.0),
+            uniform_fallback,
+        )
         baseline = jnp.sum(masked_weights * adjusted)
         advantages = jnp.where(valid_actions, baseline - adjusted, 0.0)
         advantages = jnp.clip(
@@ -1191,8 +1198,15 @@ class GeneratorMetaResourceManager:
         adjusted = jnp.where(finite, safe_rewards - cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(finite, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(finite, weights / finite_weight_sum, 0.0)
+        masked_raw = jnp.where(finite, weights, 0.0)
+        mass = jnp.sum(masked_raw)
+        valid_count = jnp.maximum(jnp.sum(finite), 1)
+        uniform_fallback = jnp.where(finite, 1.0 / valid_count, 0.0)
+        masked_weights = jnp.where(
+            mass > 0.0,
+            masked_raw / jnp.where(mass > 0.0, mass, 1.0),
+            uniform_fallback,
+        )
         baseline = jnp.sum(masked_weights * adjusted)
         selection_input_valid = jnp.asarray(True, dtype=jnp.bool_)
         if self._update_rule == "exp3":

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -859,3 +859,18 @@ def test_resource_manager_serialized_schemas_are_exact() -> None:
         invalid.update(mutation)
         with pytest.raises(ValueError, match=match):
             GeneratorMetaResourceManager.from_config(invalid)
+
+
+def test_resource_manager_masked_baseline_centering_below_floor() -> None:
+    # Action 0 has large log_weight (concentrated mass).
+    # Update passes nan for action 0, leaving action 1 (loss 1.0) and action 2 (loss 3.0).
+    manager = LearnedResourceManager(n_actions=3, n_contexts=1, exploration=0.0)
+    state = manager.init().replace(log_weights=jnp.asarray([[40.0, 0.0, 0.0]], dtype=jnp.float32))
+    losses = jnp.asarray([float("nan"), 1.0, 3.0], dtype=jnp.float32)
+    result = manager.update(state, losses, context_id=0)
+    assert bool(result.update_applied)
+    # Baseline of {1.0, 3.0} is 2.0 (uniform over remaining valid actions).
+    # Centered advantages are (2.0 - 1.0) = +1.0 and (2.0 - 3.0) = -1.0.
+    adv = result.advantages
+    assert jnp.isclose(adv[1], 1.0, atol=1e-5)
+    assert jnp.isclose(adv[2], -1.0, atol=1e-5)


### PR DESCRIPTION
Fixes #2409

## Summary
In `LearnedResourceManager`, `GeneratorMetaResourceManager`, and `FixedBudgetFeatureLearner`, Hedge preference updates used `finite_weight_sum = jnp.maximum(jnp.sum(...), 1e-12)` to normalize masked weights. When participating entries carried less mass than `1e-12` (e.g. when the dominant action was masked out by NaN/non-finite loss), `masked_weights` failed to sum to 1.0, collapsing the centering baseline to 0.0 and losing uniform shift invariance.

## Proposed Changes
1. Replaced the floored denominator with an exact convex combination over participating entries, falling back to a uniform allocation over valid entries when participating mass is zero or underflowed (`mass <= 0.0`).
2. Applied this fix across all three Hedge update sites in `alberta_framework/core/resource_manager.py` and `alberta_framework/core/feature_discovery.py`.
3. Added a unit test in `tests/test_resource_manager.py` verifying that masking out the dominant action with NaN maintains proper baseline centering and advantage computation.

## Verification
- Ran pytest on affected test suites: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_resource_manager.py tests/test_feature_discovery.py` (215/215 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py` (all checks passed).
