### PR TITLE
fix(core): normalize observation targets by exact observation_scale and bound config to normal float32

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -53,6 +53,7 @@ from alberta_framework.core.update_safety import (
 )
 
 _INT32_MAX = 2**31 - 1
+_FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -365,7 +366,7 @@ class ActionConditionedWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 _validated_config_float(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]", scale, lower=_FLOAT32_MIN_NORMAL
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -806,11 +807,10 @@ class ActionConditionedWorldModel:
         reward_arr = _float32_operand("reward", reward, ())
         discount_arr = _float32_operand("discount", discount, ())
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
             self._config.predict_delta,
-            (next_obs - obs) / safe_scale,
-            next_obs / safe_scale,
+            (next_obs - obs) / obs_scale,
+            next_obs / obs_scale,
         )
         reward_target = jnp.reshape(
             reward_arr / self._config.reward_scale,

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -464,7 +464,7 @@ class _FloatSpoof:
         ({"max_delta_scale": 1e100}, "max_delta_scale must remain finite once narrowed"),
         ({"reward_scale": 1e-100}, "reward_scale must remain positive once narrowed"),
         ({"max_delta_scale": 1e-100}, "max_delta_scale must remain positive once narrowed"),
-        ({"observation_scale": (1e-100, 1.0)}, "must remain positive once narrowed"),
+        ({"observation_scale": (1e-100, 1.0)}, r"observation_scale.*must be >= 1\.1754943508222875e-38"),
         (
             {"utility_decay": 1.0 - 1e-10},
             r"utility_decay must remain in \[0.0, 1.0\) once narrowed",
@@ -955,3 +955,30 @@ def test_action_world_model_rolls_back_reduction_overflow() -> None:
     assert not bool(result.update_applied)
     assert float(result.observation_mse) == 0.0
     assert int(result.state.step_count) == 0
+
+
+def test_world_model_observation_scale_targets_pairing() -> None:
+    # Verifies targets() normalizes by the exact observation_scale without 1e-6 floor
+    for scale in (1.0, 1e-6, 1e-9, 1e-20):
+        config = ActionConditionedWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            observation_scale=(scale,),
+            predict_delta=True,
+        )
+        model = ActionConditionedWorldModel(config)
+        obs = jnp.asarray([1.0 * scale], dtype=jnp.float32)
+        next_obs = jnp.asarray([3.0 * scale], dtype=jnp.float32)
+        target = model.targets(obs, 1.0, 0.9, next_obs)
+        # Normalized delta = (3.0 * scale - 1.0 * scale) / scale = 2.0
+        assert jnp.isclose(target[0], 2.0, atol=1e-4)
+
+
+def test_world_model_config_rejects_subnormal_scale() -> None:
+    subnormal = float(np.finfo(np.float32).smallest_subnormal)
+    with pytest.raises(ValueError, match="observation_scale"):
+        ActionConditionedWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            observation_scale=(subnormal,),
+        )


### PR DESCRIPTION
Fixes #2398

## Summary
`ActionConditionedWorldModel.targets()` normalized observation deltas using `safe_scale = jnp.maximum(obs_scale, 1e-6)` while `_prediction_and_raw_diagnostics` denormalized predictions using the raw `obs_scale`. Below `1e-6`, this mismatch caused the encode/decode composition to fail, under-predicting deltas by a factor of `obs_scale / 1e-6`.

## Proposed Changes
1. Removed the `1e-6` floor in `targets()` (`alberta_framework/core/world_model.py`) so observation targets are divided by the exact configured `observation_scale`.
2. Bounded `observation_scale` in `ActionConditionedWorldModelConfig` to positive normal float32 values (`lower=_FLOAT32_MIN_NORMAL`) to ensure finite float32 reciprocals and prevent subnormal zero-flush issues.
3. Added unit tests in `tests/test_action_conditioned_world_model.py` verifying that targets are accurately normalized and subnormal scales are rejected.

## Verification
- Ran pytest on world model test suites: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_world_model.py tests/test_action_conditioned_world_model.py` (92/92 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/world_model.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/world_model.py` (all checks passed).
