### PR TITLE
fix(optimizer-geometry): use exact power-of-two rescaling in spectral_matrix_sign

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -173,7 +173,15 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
     valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    _, exponent = jnp.frexp(jnp.max(jnp.abs(value)))
+    rescaled = jnp.ldexp(value, -exponent)
+    rescaled_norm = jnp.linalg.norm(rescaled)
+    positive = rescaled_norm > 0
+    x = jnp.where(
+        positive,
+        rescaled / jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm)),
+        jnp.zeros_like(rescaled),
+    )
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,23 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+
+def test_spectral_matrix_sign_small_magnitude_matrices() -> None:
+    m = jnp.array([[2.0, 1.0], [0.5, -1.0]], dtype=jnp.float32)
+    ref_sign = spectral_matrix_sign(m)
+    assert jnp.isclose(jnp.linalg.norm(ref_sign), jnp.sqrt(2.0), atol=1e-4)
+
+    for scale in (1e-13, 1e-15, 1e-20, 1e-25):
+        tiny = m * jnp.asarray(scale, dtype=jnp.float32)
+        sign, valid = spectral_matrix_sign_transaction(tiny)
+        assert bool(valid)
+        assert jnp.allclose(sign, ref_sign, atol=1e-4)
+        assert jnp.isclose(jnp.linalg.norm(sign), jnp.sqrt(2.0), atol=1e-4)
+
+
+def test_spectral_matrix_sign_exact_zero_matrix() -> None:
+    zero_mat = jnp.zeros((2, 2), dtype=jnp.float32)
+    sign, valid = spectral_matrix_sign_transaction(zero_mat)
+    assert bool(valid)
+    assert jnp.all(sign == 0.0)


### PR DESCRIPTION
Fixes #2379

## Summary
`spectral_matrix_sign_transaction` in `alberta_framework/evaluation/optimizer_geometry.py` divided matrices by `jnp.maximum(norm, 1e-12)`. When a matrix had Frobenius norm below `1e-12` (common for small gradients or float32 sum-of-squares underflow), the divisor became `1e-12` instead of the matrix norm, collapsing the matrix sign toward zero while reporting `valid=True`.

## Proposed Changes
1. Used exact power-of-two rescaling via `jnp.frexp` and `jnp.ldexp` before computing the Frobenius norm in `spectral_matrix_sign_transaction`.
2. Computed the normalized matrix safely without magnitude floors, preserving scale-free orthogonalization across both large and tiny matrix magnitudes while keeping exact zeros for zero matrices.
3. Added unit tests in `tests/test_optimizer_geometry.py` testing small matrices across scales down to `1e-25` and asserting exact zero preservation.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (30/30 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (all checks passed).
