### PR TITLE
fix(optimizer-geometry): use exact power-of-two rescaling in flad_noise_component_transaction

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -203,12 +203,14 @@ def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tu
     direction = _trusted_array(gradient, name="gradient")
     if delta.shape != direction.shape or delta.ndim != 1 or delta.size < 1:
         raise ValueError("perturbation and gradient must be non-empty equal-width vectors")
-    squared_norm = jnp.vdot(direction, direction).real
-    numerator = jnp.vdot(direction, delta).real
+    _, exponent = jnp.frexp(jnp.max(jnp.abs(direction)))
+    scaled = jnp.ldexp(direction, -exponent)
+    squared_norm = jnp.vdot(scaled, scaled).real
+    numerator = jnp.vdot(scaled, delta).real
     active = squared_norm > 0.0
     denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
     coefficient = numerator / denominator
-    projection = direction * coefficient * active.astype(delta.dtype)
+    projection = scaled * coefficient * active.astype(delta.dtype)
     candidate = delta - projection
     valid = (
         jnp.all(jnp.isfinite(delta))

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,27 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+
+def test_flad_noise_component_underflow_scales() -> None:
+    delta = jnp.array([1.0, -2.0, 0.5, 3.0], dtype=jnp.float32)
+    grad = jnp.array([2.0, 1.0, -1.0, 0.5], dtype=jnp.float32)
+
+    # Reference projection in float64
+    d64 = np.asarray(delta, dtype=np.float64)
+    g64 = np.asarray(grad, dtype=np.float64)
+    expected = d64 - g64 * (float(g64 @ d64) / float(g64 @ g64))
+
+    for scale in (1.0, 1e-10, 1e-20, 1e-25, 1e-30):
+        scaled_grad = grad * jnp.asarray(scale, dtype=jnp.float32)
+        safe, valid = flad_noise_component_transaction(delta, scaled_grad)
+        assert bool(valid)
+        assert jnp.allclose(safe, jnp.asarray(expected, dtype=jnp.float32), atol=1e-5)
+
+
+def test_flad_noise_component_zero_gradient() -> None:
+    delta = jnp.array([1.0, -2.0, 0.5, 3.0], dtype=jnp.float32)
+    zero_grad = jnp.zeros_like(delta)
+    safe, valid = flad_noise_component_transaction(delta, zero_grad)
+    assert bool(valid)
+    assert jnp.all(safe == delta)


### PR DESCRIPTION
Fixes #2393

## Summary
In `flad_noise_component_transaction` (`alberta_framework/evaluation/optimizer_geometry.py`), the squared norm `squared_norm = jnp.vdot(direction, direction).real` underflowed to zero in float32 for well-conditioned gradient directions with entries at or below `1e-20`. When `squared_norm == 0.0`, the projection was skipped, failing to remove the gradient component from the perturbation while reporting `valid=True`.

## Proposed Changes
1. Used exact power-of-two rescaling (`jnp.frexp` and `jnp.ldexp`) on `direction` before computing inner products and projection.
2. Formed the projection from the rescaled direction, maintaining scale invariance across 30+ orders of magnitude.
3. Preserved exact `delta` return when `direction` is genuinely zero.
4. Added unit tests in `tests/test_optimizer_geometry.py` validating underflow scales down to `1e-30` and zero-gradient reductions.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (30/30 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (all checks passed).
