### PR TITLE
fix(core): make UPGD gradient alignment scale-free using power-of-two rescaling

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1941,11 +1941,13 @@ class UPGDLearner:
         return total
 
     @staticmethod
-    def _rescaled_tuple_norm(xs: tuple[Array, ...]) -> tuple[Array, tuple[Array, ...], Array]:
+    def _rescaled_tuple_norm(xs: tuple[Array, ...]) -> tuple[Array, Array, tuple[Array, ...], Array]:
         """Compute exact power-of-two rescaled tuple, unscaled norm, and rescaled norm."""
         max_abs = jnp.array(0.0, dtype=jnp.float32)
+        is_finite = jnp.array(True, dtype=jnp.bool_)
         for x in xs:
             if x.size > 0:
+                is_finite = is_finite & jnp.all(jnp.isfinite(x))
                 max_abs = jnp.maximum(max_abs, jnp.max(jnp.abs(x)))
         _, exponent = jnp.frexp(max_abs)
         rescaled = tuple(jnp.ldexp(x, -exponent) for x in xs)
@@ -1954,12 +1956,12 @@ class UPGDLearner:
             rescaled_sum_sq = rescaled_sum_sq + jnp.sum(jnp.square(rx))
         rescaled_norm = jnp.sqrt(rescaled_sum_sq)
         norm = jnp.ldexp(rescaled_norm, exponent)
-        return norm, rescaled, rescaled_norm
+        return is_finite, norm, rescaled, rescaled_norm
 
     @staticmethod
     def _tuple_norm(xs: tuple[Array, ...]) -> Array:
         """L2 norm over a static tuple of arrays, robust to underflow/overflow."""
-        norm, _, _ = UPGDLearner._rescaled_tuple_norm(xs)
+        _, norm, _, _ = UPGDLearner._rescaled_tuple_norm(xs)
         return norm
 
     @staticmethod
@@ -1968,14 +1970,16 @@ class UPGDLearner:
         current: tuple[Array, ...],
     ) -> Array:
         """Cosine alignment of two gradient tuples, zero for empty/nonfinite gradients."""
-        prev_norm, prev_rescaled, prev_rn = UPGDLearner._rescaled_tuple_norm(previous)
-        curr_norm, curr_rescaled, curr_rn = UPGDLearner._rescaled_tuple_norm(current)
+        prev_finite, _, prev_rescaled, prev_rn = UPGDLearner._rescaled_tuple_norm(previous)
+        curr_finite, _, curr_rescaled, curr_rn = UPGDLearner._rescaled_tuple_norm(current)
         dot = jnp.array(0.0, dtype=jnp.float32)
         for rx, ry in zip(prev_rescaled, curr_rescaled):
             dot = dot + jnp.sum(rx * ry)
         valid = (
-            jnp.isfinite(prev_norm)
-            & jnp.isfinite(curr_norm)
+            prev_finite
+            & curr_finite
+            & jnp.isfinite(prev_rn)
+            & jnp.isfinite(curr_rn)
             & (prev_rn > 0.0)
             & (curr_rn > 0.0)
         )

--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1941,26 +1941,47 @@ class UPGDLearner:
         return total
 
     @staticmethod
-    def _tuple_norm(xs: tuple[Array, ...]) -> Array:
-        """L2 norm over a static tuple of arrays."""
-        total = jnp.array(0.0, dtype=jnp.float32)
+    def _rescaled_tuple_norm(xs: tuple[Array, ...]) -> tuple[Array, tuple[Array, ...], Array]:
+        """Compute exact power-of-two rescaled tuple, unscaled norm, and rescaled norm."""
+        max_abs = jnp.array(0.0, dtype=jnp.float32)
         for x in xs:
-            total = total + jnp.sum(jnp.square(x))
-        return jnp.sqrt(total + 1e-12)
+            if x.size > 0:
+                max_abs = jnp.maximum(max_abs, jnp.max(jnp.abs(x)))
+        _, exponent = jnp.frexp(max_abs)
+        rescaled = tuple(jnp.ldexp(x, -exponent) for x in xs)
+        rescaled_sum_sq = jnp.array(0.0, dtype=jnp.float32)
+        for rx in rescaled:
+            rescaled_sum_sq = rescaled_sum_sq + jnp.sum(jnp.square(rx))
+        rescaled_norm = jnp.sqrt(rescaled_sum_sq)
+        norm = jnp.ldexp(rescaled_norm, exponent)
+        return norm, rescaled, rescaled_norm
+
+    @staticmethod
+    def _tuple_norm(xs: tuple[Array, ...]) -> Array:
+        """L2 norm over a static tuple of arrays, robust to underflow/overflow."""
+        norm, _, _ = UPGDLearner._rescaled_tuple_norm(xs)
+        return norm
 
     @staticmethod
     def _gradient_alignment(
         previous: tuple[Array, ...],
         current: tuple[Array, ...],
     ) -> Array:
-        """Cosine alignment of two gradient tuples, zero for empty gradients."""
-        previous_norm = UPGDLearner._tuple_norm(previous)
-        current_norm = UPGDLearner._tuple_norm(current)
-        return jnp.where(
-            (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
-            jnp.array(0.0, dtype=jnp.float32),
+        """Cosine alignment of two gradient tuples, zero for empty/nonfinite gradients."""
+        prev_norm, prev_rescaled, prev_rn = UPGDLearner._rescaled_tuple_norm(previous)
+        curr_norm, curr_rescaled, curr_rn = UPGDLearner._rescaled_tuple_norm(current)
+        dot = jnp.array(0.0, dtype=jnp.float32)
+        for rx, ry in zip(prev_rescaled, curr_rescaled):
+            dot = dot + jnp.sum(rx * ry)
+        valid = (
+            jnp.isfinite(prev_norm)
+            & jnp.isfinite(curr_norm)
+            & (prev_rn > 0.0)
+            & (curr_rn > 0.0)
         )
+        safe_denom = jnp.where(valid, prev_rn * curr_rn, jnp.ones_like(prev_rn))
+        cosine = jnp.where(valid, dot / safe_denom, jnp.zeros_like(dot))
+        return jnp.where(jnp.isfinite(cosine), cosine, jnp.zeros_like(cosine))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(self, state: UPGDState, observation: Array) -> Array:

--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1991,18 +1991,43 @@ class UPGDLearner:
         return jnp.sqrt(total + 1e-12)
 
     @staticmethod
+    def _tuple_max_abs(xs: tuple[Array, ...]) -> Array:
+        """Maximum absolute value across a static tuple of arrays."""
+        if not xs:
+            return jnp.array(0.0, dtype=jnp.float32)
+        max_val = jnp.max(jnp.abs(xs[0]))
+        for x in xs[1:]:
+            max_val = jnp.maximum(max_val, jnp.max(jnp.abs(x)))
+        return max_val
+
+    @staticmethod
     def _gradient_alignment(
         previous: tuple[Array, ...],
         current: tuple[Array, ...],
     ) -> Array:
-        """Cosine alignment of two gradient tuples, zero for empty gradients."""
-        previous_norm = UPGDLearner._tuple_norm(previous)
-        current_norm = UPGDLearner._tuple_norm(current)
-        return jnp.where(
-            (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
-            jnp.array(0.0, dtype=jnp.float32),
+        """Cosine alignment of two gradient tuples, zero for empty or non-finite gradients."""
+        if not previous or not current:
+            return jnp.array(0.0, dtype=jnp.float32)
+        prev_max = UPGDLearner._tuple_max_abs(previous)
+        curr_max = UPGDLearner._tuple_max_abs(current)
+        _, prev_exp = jnp.frexp(prev_max)
+        _, curr_exp = jnp.frexp(curr_max)
+        prev_scaled = tuple(jnp.ldexp(x, -prev_exp) for x in previous)
+        curr_scaled = tuple(jnp.ldexp(y, -curr_exp) for y in current)
+        prev_norm_sq = sum(jnp.sum(jnp.square(x)) for x in prev_scaled)
+        curr_norm_sq = sum(jnp.sum(jnp.square(y)) for y in curr_scaled)
+        dot_scaled = sum(jnp.sum(x * y) for x, y in zip(prev_scaled, curr_scaled))
+        denom = jnp.sqrt(prev_norm_sq * curr_norm_sq)
+        cos = jnp.clip(dot_scaled / jnp.where(denom > 0.0, denom, 1.0), -1.0, 1.0)
+        valid = (
+            (prev_max > 0.0)
+            & (curr_max > 0.0)
+            & jnp.isfinite(prev_max)
+            & jnp.isfinite(curr_max)
+            & (denom > 0.0)
+            & jnp.isfinite(cos)
         )
+        return jnp.where(valid, cos, jnp.array(0.0, dtype=jnp.float32))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(self, state: UPGDState, observation: Array) -> Array:

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -2219,3 +2219,27 @@ class TestLoops:
         stream = RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.05)
         result = run_upgd_loop(learner, stream, num_steps=50, key=jr.key(0))
         chex.assert_shape(result.metrics, (50, 4))
+
+
+class TestGradientAlignmentScaleFreedom:
+    """Gradient alignment must be scale-free across extreme float32 ranges."""
+
+    @pytest.mark.parametrize("scale", [1e-30, 1e-20, 1e-10, 1.0, 1e10, 1e20, 1e30])
+    def test_gradient_alignment_is_scale_free(self, scale: float) -> None:
+        g = (jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32) * scale,)
+        g_opp = (jnp.array([-1.0, 0.5, -0.25], dtype=jnp.float32) * scale,)
+
+        align_same = UPGDLearner._gradient_alignment(g, g)
+        chex.assert_trees_all_close(align_same, jnp.asarray(1.0, dtype=jnp.float32), atol=1e-5)
+
+        align_opp = UPGDLearner._gradient_alignment(g, g_opp)
+        chex.assert_trees_all_close(align_opp, jnp.asarray(-1.0, dtype=jnp.float32), atol=1e-5)
+
+    def test_gradient_alignment_handles_zero_and_nonfinite(self) -> None:
+        g_zero = (jnp.zeros(3, dtype=jnp.float32),)
+        g_norm = (jnp.ones(3, dtype=jnp.float32),)
+        g_nan = (jnp.array([float("nan"), 1.0, 2.0], dtype=jnp.float32),)
+
+        assert float(UPGDLearner._gradient_alignment(g_zero, g_norm)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(g_norm, g_zero)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(g_nan, g_norm)) == 0.0

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -2219,3 +2219,27 @@ class TestLoops:
         stream = RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.05)
         result = run_upgd_loop(learner, stream, num_steps=50, key=jr.key(0))
         chex.assert_shape(result.metrics, (50, 4))
+
+
+def test_upgd_gradient_alignment_scale_free() -> None:
+    # Scale-free gradient alignment across 20 orders of magnitude
+    t1 = (jnp.array([1.0, -2.0, 3.0], dtype=jnp.float32),)
+    for scale in (1e-10, 1e-5, 1.0, 1e5, 1e10):
+        scaled_t1 = (t1[0] * jnp.asarray(scale, dtype=jnp.float32),)
+        # Identical
+        align_pos = UPGDLearner._gradient_alignment(scaled_t1, scaled_t1)
+        assert jnp.isclose(align_pos, 1.0, atol=1e-5)
+        # Reversed
+        scaled_t1_neg = (-scaled_t1[0],)
+        align_neg = UPGDLearner._gradient_alignment(scaled_t1, scaled_t1_neg)
+        assert jnp.isclose(align_neg, -1.0, atol=1e-5)
+
+
+def test_upgd_gradient_alignment_empty_or_nonfinite() -> None:
+    zero_t = (jnp.zeros(3, dtype=jnp.float32),)
+    norm_t = (jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32),)
+    nan_t = (jnp.array([1.0, float("nan"), 3.0], dtype=jnp.float32),)
+
+    assert jnp.isclose(UPGDLearner._gradient_alignment(zero_t, norm_t), 0.0)
+    assert jnp.isclose(UPGDLearner._gradient_alignment(norm_t, zero_t), 0.0)
+    assert jnp.isclose(UPGDLearner._gradient_alignment(nan_t, norm_t), 0.0)

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -2235,6 +2235,17 @@ class TestGradientAlignmentScaleFreedom:
         align_opp = UPGDLearner._gradient_alignment(g, g_opp)
         chex.assert_trees_all_close(align_opp, jnp.asarray(-1.0, dtype=jnp.float32), atol=1e-5)
 
+    def test_gradient_alignment_finite_near_limit_components(self) -> None:
+        """Components near the float32 max retain exact cosine alignment."""
+        v = (jnp.array([3.0e38, -1.5e38, 7.5e37], dtype=jnp.float32),)
+        neg_v = (jnp.array([-3.0e38, 1.5e38, -7.5e37], dtype=jnp.float32),)
+
+        align_same = UPGDLearner._gradient_alignment(v, v)
+        chex.assert_trees_all_close(align_same, jnp.asarray(1.0, dtype=jnp.float32), atol=1e-5)
+
+        align_opp = UPGDLearner._gradient_alignment(v, neg_v)
+        chex.assert_trees_all_close(align_opp, jnp.asarray(-1.0, dtype=jnp.float32), atol=1e-5)
+
     def test_gradient_alignment_handles_zero_and_nonfinite(self) -> None:
         g_zero = (jnp.zeros(3, dtype=jnp.float32),)
         g_norm = (jnp.ones(3, dtype=jnp.float32),)


### PR DESCRIPTION
Fixes #2389

## Summary
In `UPGDLearner._gradient_alignment` (`alberta_framework/core/upgd.py`), gradient tuples were checked against hardcoded floors `(previous_norm > 1e-6) & (current_norm > 1e-6)`. At small gradient magnitudes (< 1e-6 per element or float32 sum-of-squares underflow), identical gradients reported cosine 0.0 (rendering gradient-alignment meta-plasticity a no-op). At large magnitudes (> 1e9), float32 squaring overflowed into `NaN`.

## Proposed Changes
1. Used exact power-of-two rescaling (`jnp.frexp` and `jnp.ldexp`) on gradient tuples before computing norms and inner products.
2. Formed the cosine similarity from the rescaled tuples, guaranteeing scale-free alignment invariant to gradient magnitude across 20+ orders of magnitude.
3. Added unit tests in `tests/test_upgd.py` verifying exact +1.0 and -1.0 alignment across scales from `1e-10` to `1e+10` and proper 0.0 handling on zero/non-finite gradients.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_upgd.py` (90/90 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/upgd.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/upgd.py` (all checks passed).
