### PR TITLE
fix(nexting): promote cumulants, gamma, and terminal_value to float in forward_view_returns

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -155,8 +155,15 @@ def forward_view_returns(
     _require_leading_length(
         "cumulants", cumulants, ndim=1, maximum=_NEXTING_MAX_STEPS
     )
-    gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
-    init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
+    dtype = jnp.promote_types(
+        jnp.promote_types(cumulants.dtype, jnp.asarray(gamma).dtype),
+        jnp.asarray(terminal_value).dtype,
+    )
+    if not jnp.issubdtype(dtype, jnp.floating):
+        dtype = jnp.float32
+    cumulants_f = jnp.asarray(cumulants, dtype=dtype)
+    gamma_s = jnp.asarray(gamma, dtype=dtype)
+    init = jnp.asarray(terminal_value, dtype=dtype)
 
     def step(carry: Array, c: Array) -> tuple[Array, Array]:
         # gamma=0 must not multiply an inf later return (0*inf).
@@ -164,7 +171,7 @@ def forward_view_returns(
         new_carry = c + bootstrap
         return new_carry, new_carry
 
-    _, returns_reversed = jax.lax.scan(step, init, cumulants[::-1])
+    _, returns_reversed = jax.lax.scan(step, init, cumulants_f[::-1])
     return returns_reversed[::-1]
 
 

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -617,3 +617,18 @@ class TestRunningRMSE:
         assert float(running[-1, 0]) < 0.01
         # Mid-series transition: some error
         assert float(running[19, 0]) > 0.5
+
+
+def test_forward_view_returns_int_and_bool_cumulants() -> None:
+    # int32 cumulants with gamma=0.9
+    c_int = jnp.array([1, 0, 0, 0, 1], dtype=jnp.int32)
+    returns_int = forward_view_returns(c_int, 0.9)
+    expected_int = jnp.array([1.6561, 0.729, 0.81, 0.9, 1.0], dtype=jnp.float32)
+    assert jnp.issubdtype(returns_int.dtype, jnp.floating)
+    assert jnp.allclose(returns_int, expected_int, atol=1e-4)
+
+    # bool cumulants
+    c_bool = jnp.array([True, False, False, False, True], dtype=jnp.bool_)
+    returns_bool = forward_view_returns(c_bool, 0.9)
+    assert jnp.issubdtype(returns_bool.dtype, jnp.floating)
+    assert jnp.allclose(returns_bool, expected_int, atol=1e-4)


### PR DESCRIPTION
Fixes #2368

## Summary
`forward_view_returns` in `alberta_framework/utils/nexting.py` cast `gamma` and `terminal_value` into `cumulants.dtype`. When callers provided integer or boolean cumulant series, non-integer discounts (e.g. `gamma=0.9`) silently truncated to `0` (or `True`), converting forward-view return calculation into a degenerate raw cumulant echo or all-True boolean array.

## Proposed Changes
1. Promoted the computation dtype across `cumulants`, `gamma`, and `terminal_value` to a floating dtype (defaulting to `float32` if non-floating).
2. Cast `cumulants`, `gamma_s`, and `init` to the promoted floating dtype before the `lax.scan` recursion.
3. Added unit tests in `tests/test_nexting.py` verifying that `int32` and `bool` cumulant arrays produce mathematically correct float returns.

## Verification
- Ran pytest on nexting test suites: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_nexting.py tests/test_nexting_series_length.py` (95/95 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/utils/nexting.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/utils/nexting.py` (all checks passed).
