### PR TITLE
fix(core): enforce equal-width latent invariant in BoundedPolicyArchive constructor

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        first_latent_len: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if first_latent_len is None:
+                first_latent_len = len(entry.latent)
+            elif len(entry.latent) != first_latent_len:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -66,3 +66,37 @@ def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")
     assert POLICY_ARCHIVE_PROTOCOL["scientific_promotion_allowed"] is False
+
+
+def test_archive_constructor_rejects_mixed_widths() -> None:
+    e1 = _entry("a", (0.0,), 1.0)
+    e2 = _entry("b", (0.0, 1.0), 2.0)
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        BoundedPolicyArchive(byte_budget=4096, min_latent_distance=1.0, entries=(e1, e2))
+
+
+def test_archive_control_arms_accept_different_width_entry() -> None:
+    e1 = _entry("a", (0.0,), 1.0)
+    e2 = _entry("b", (0.0, 1.0), 2.0)
+    # fixed_snapshot returns self
+    fixed = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=1.0, mode="fixed_snapshot", entries=(e1,)
+    )
+    assert fixed.add(e2) is fixed
+
+    # one_model replaces with the new entry
+    one = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=1.0, mode="one_model", entries=(e1,)
+    )
+    updated = one.add(e2)
+    assert updated.entries == (e2,)
+
+
+def test_archive_diverse_arm_rejects_mismatched_width_candidate() -> None:
+    e1 = _entry("a", (0.0,), 1.0)
+    e2 = _entry("b", (0.0, 1.0), 2.0)
+    archive = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=1.0, mode="diverse_archive", entries=(e1,)
+    )
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        archive.add(e2)


### PR DESCRIPTION
Fixes #2322

## Summary
`BoundedPolicyArchive` declared an equal-width latent descriptor invariant in `add()`, but never checked it in `__post_init__`. This allowed constructing archives with mixed latent descriptor widths, leading NumPy distance calculations to broadcast mismatched dimensions into spurious `0.0` distances and silently discard valid candidates. Additionally, `add()` ran the width check on `one_model` and `fixed_snapshot` control arms that do not use latent descriptors.

## Proposed Changes
1. Enforced the archive-wide equal-width latent descriptor invariant in `BoundedPolicyArchive.__post_init__`.
2. Relocated the width check in `add()` into the diverse archive branch where pairwise latent distances are computed.
3. Added unit tests in `tests/test_policy_archive.py` validating constructor rejection of mixed widths, control arm acceptance of diverse descriptor dimensions, and candidate rejection on diverse archives.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_policy_archive.py` (9/9 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/policy_archive.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/policy_archive.py` (all checks passed).
