### PR TITLE
fix(core): rank units by bias-corrected utility EMA in CBP replacement selection

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -483,13 +483,14 @@ def _select_replacement_index(
     utility: Array,
     age: Array,
     maturity_threshold: int,
+    decay_rate: float = 0.99,
 ) -> tuple[Array, Array]:
     """Pick the index of the lowest-utility mature unit, if any.
 
     A unit is "mature" iff ``age >= maturity_threshold``. Among mature
-    units we pick the one with the smallest utility. If no mature unit
-    exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
-    ``False``.
+    units we pick the one with the smallest bias-corrected utility (Dohare
+    et al. 2024, Eq. 8). If no mature unit exists, ``selected`` is ``-1``
+    (sentinel) and ``has_candidate`` is ``False``.
 
     Implementation: replace the utility of immature or non-finite units
     with ``+inf`` before taking ``argmin`` so they are never chosen.
@@ -498,6 +499,7 @@ def _select_replacement_index(
         utility: Per-unit utility array, shape ``(num_units,)``.
         age: Per-unit age array (same shape).
         maturity_threshold: Minimum age for eligibility.
+        decay_rate: Utility EMA decay factor.
 
     Returns:
         Tuple ``(index, has_candidate)`` where ``index`` is the chosen
@@ -505,7 +507,10 @@ def _select_replacement_index(
     """
     mature = age >= jnp.asarray(maturity_threshold, dtype=age.dtype)
     eligible = mature & jnp.isfinite(utility)
-    masked_utility = jnp.where(eligible, utility, jnp.inf)
+    decay = jnp.asarray(decay_rate, dtype=jnp.float32)
+    bias_correction = jnp.maximum(1.0 - jnp.power(decay, age.astype(jnp.float32)), 1e-12)
+    debiased_utility = utility / bias_correction
+    masked_utility = jnp.where(eligible, debiased_utility, jnp.inf)
     has_candidate = jnp.any(eligible)
     idx = jnp.argmin(masked_utility)
     selected = jnp.where(has_candidate, idx, jnp.int32(-1))
@@ -687,6 +692,7 @@ def replace_units_with_flags(
             new_cbp_state.utilities[layer_idx],
             new_cbp_state.ages[layer_idx],
             config.maturity_threshold,
+            config.decay_rate,
         )
         # Only replace if we both budgeted for it AND found a mature unit.
         gated = jnp.logical_and(do_replace, has_candidate)

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -988,3 +988,17 @@ class TestCBPWrapperConstructorIdentities:
         payload[field] = value
         with pytest.raises(ValueError, match="serialized"):
             CBPMultiHeadMLPLearner.from_config(payload)
+
+
+def test_select_replacement_index_uses_bias_corrected_utility() -> None:
+    from alberta_framework.core.continual_backprop import _select_replacement_index
+
+    # Unit 0: age 100, raw EMA = 0.634 (steady-state 1.0)
+    # Unit 1: age 700, raw EMA = 0.899 (steady-state 0.9)
+    # Bias-corrected utilities: unit 0 = 1.0, unit 1 = 0.9
+    # Unit 1 should be selected for replacement (index 1).
+    utilities = jnp.array([0.633967, 0.899209], dtype=jnp.float32)
+    ages = jnp.array([100, 700], dtype=jnp.int32)
+    idx, has_candidate = _select_replacement_index(utilities, ages, maturity_threshold=100, decay_rate=0.99)
+    assert bool(has_candidate)
+    assert int(idx) == 1


### PR DESCRIPTION
Fixes #2343

## Summary
`_select_replacement_index` in `alberta_framework/core/continual_backprop.py` ranked mature units by their raw utility EMA rather than the paper's per-unit bias-corrected utility (Dohare et al. 2024, Eq. 8: $\hat{u} = u / (1 - \eta^a)$). Because replaced units have their age and utility reset to 0, freshly matured units (age $\approx m$) read at only a fraction of their steady-state utility ($1 - 0.99^{100} \approx 0.634$) and were systematically re-selected for replacement over older, lower-utility units.

## Proposed Changes
1. Added bias correction ($\hat{u} = u / \max(1 - \text{decay}^{\text{age}}, 10^{-12})$) to `_select_replacement_index` in `alberta_framework/core/continual_backprop.py`.
2. Passed `config.decay_rate` into `_select_replacement_index` in `replace_units_with_flags`.
3. Added a unit test in `tests/test_continual_backprop.py` verifying that young units with high true utility are not selected over older units with lower true utility.

## Verification
- Ran pytest on CBP test suites: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_continual_backprop.py tests/test_continual_backprop_validation.py` (130/130 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/continual_backprop.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/continual_backprop.py` (all checks passed).
