### PR TITLE
fix(security): revalidate rollout records

### DIFF
--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -456,6 +456,18 @@ class SecurityRolloutStep:
         _require_rfc_json_mapping(payload, name="security rollout step")
         return payload
 
+    def _revalidated_copy(self) -> SecurityRolloutStep:
+        """Reconstruct the record before a public validator trusts its fields."""
+        return SecurityRolloutStep(
+            state=self.state,
+            action=self.action,
+            reward=self.reward,
+            next_state=self.next_state,
+            terminated=self.terminated,
+            truncated=self.truncated,
+            policy_metadata=self.policy_metadata,
+        )
+
     @classmethod
     def from_dict(cls, data: object) -> SecurityRolloutStep:
         """Reconstruct a rollout step from ``to_dict`` output."""
@@ -735,10 +747,17 @@ def validate_security_rollout(
     schema: SecurityFeatureSchema,
 ) -> None:
     """Validate that rollout transitions satisfy the active-defense contract."""
+    if type(steps) is not list and type(steps) is not tuple:
+        raise ValueError("security rollout steps must be an exact list or tuple")
+    if type(schema) is not SecurityFeatureSchema:
+        raise ValueError("schema must be an exact SecurityFeatureSchema")
     for idx, step in enumerate(steps):
+        if type(step) is not SecurityRolloutStep:
+            raise ValueError(f"invalid rollout step {idx}: wrong record type")
         try:
-            schema.validate_observation(step.state)
-            schema.validate_observation(step.next_state)
+            validated = step._revalidated_copy()
+            schema.validate_observation(validated.state)
+            schema.validate_observation(validated.next_state)
         except ValueError as exc:
             raise ValueError(f"invalid rollout step {idx}: {exc}") from exc
 

--- a/tests/test_security_rollout_leftover_identities.py
+++ b/tests/test_security_rollout_leftover_identities.py
@@ -8,9 +8,11 @@ import pytest
 
 from alberta_framework.security import (
     SecurityAction,
+    SecurityFeatureSchema,
     SecurityRolloutStep,
     ThroughputMeasurement,
     to_security_gym_action,
+    validate_security_rollout,
 )
 
 
@@ -82,3 +84,26 @@ def test_real_type_gates_do_not_hash_hostile_runtime_classes() -> None:
         ThroughputMeasurement(n_events=hostile, elapsed_s=1.0)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="elapsed_s"):
         ThroughputMeasurement(n_events=1, elapsed_s=hostile)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("reward", float("nan")),
+        ("action", 0),
+        ("terminated", 0),
+        ("state", [0.0, 1.0]),
+    ],
+)
+def test_validate_security_rollout_revalidates_mutated_records(
+    field: str,
+    value: object,
+) -> None:
+    step = _legal_step()
+    object.__setattr__(step, field, value)
+
+    with pytest.raises(ValueError, match="invalid rollout step 0"):
+        validate_security_rollout(
+            [step],
+            SecurityFeatureSchema(names=("first", "second")),
+        )


### PR DESCRIPTION
## Summary

`validate_security_rollout` trusted previously constructed frozen records and
rechecked only the lengths of `state` and `next_state`. A record mutated through
Python's low-level `object.__setattr__` could therefore pass validation with a
NaN reward, a built-in integer action or termination flag, or a list replacing
the canonical state tuple.

This change requires exact rollout and schema types, reconstructs every step
through `SecurityRolloutStep`'s constructor, and then checks feature widths.
Corrupted fields now fail with an indexed validation error.

## Reproduction and result

At baseline `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, a valid record whose
reward was replaced with `float("nan")` was accepted by
`validate_security_rollout`. The same gap accepted mutations of `action`,
`terminated`, and `state`.

The four failing-test-first regressions failed on baseline. At candidate head
`84359ed6deae2de787096b96581885dad533a51d`:

```text
.venv/bin/python -m pytest tests/test_security_rollout_leftover_identities.py -q -o addopts=""
6 passed

.venv/bin/python -m pytest tests/test_security*.py -q -o addopts=""
63 passed

.venv/bin/python -m ruff check .
All checks passed!

.venv/bin/python -m mypy alberta_framework/security.py
Success: no issues found in 1 source file

git diff --check
exit 0
```

This is a Fix-lane measurement-integrity change. It changes no benchmark arm,
seed, threshold, output artifact, or promoted result. Live searches found no
open issue or pull request covering this validator defect. Maintainer review
and acceptance remain open.

Provider: `openai`

Model: `gpt-5.6-sol`

Client: `codex`

<!-- evidence-head:84359ed6deae2de787096b96581885dad533a51d -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/attentionhead/asi/blob/8f073b86ccbd302804708966ffae84f2410d2307/logs-security-rollout-revalidation.txt
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/attentionhead/asi/blob/8f073b86ccbd302804708966ffae84f2410d2307/evidence-security-rollout-revalidation.md

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-security-rollout-revalidation]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0V7RYCT63QEWAT5VMCEC054","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-25T01:15:22.395Z","completed_at":"2026-08-25T01:23:03.079Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T01:15:25.367Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e7c30baf1c71bdc9e87d514e66447beae38dc1d02fc6d85ae0fe0ffd604e7554","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b891ada2-f755-4524-9f8f-490bde41e183","object_id":"sha256:e7c30baf1c71bdc9e87d514e66447beae38dc1d02fc6d85ae0fe0ffd604e7554","sha256":"e7c30baf1c71bdc9e87d514e66447beae38dc1d02fc6d85ae0fe0ffd604e7554"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"xlSnN_O6HCeLqCyXJy_QzVRwc5aKPK5dQjNNEFHvbovCschVF16kTq2hEXjrkfVEJM10jTO9E0CQl2QVeQELCA"}} -->
