### PR TITLE
fix(evaluation): revalidate recurring retention inputs

### DIFF
--- a/alberta_framework/evaluation/recurring_ipmnist_retention.py
+++ b/alberta_framework/evaluation/recurring_ipmnist_retention.py
@@ -876,6 +876,7 @@ def _validate_sentinel_snapshots(
     for index, (snapshot, requirement) in enumerate(zip(resolved, expected, strict=True)):
         if type(snapshot) is not SentinelProbeSnapshot:
             raise TypeError(f"sentinel_snapshots[{index}] must be SentinelProbeSnapshot")
+        SentinelProbeSnapshot.__post_init__(snapshot)
         if snapshot.ordering_key != requirement.ordering_key:
             raise ValueError("sentinel snapshots must appear once each in the exact required order")
         if snapshot.frozen_binding != requirement.frozen_binding:
@@ -1013,8 +1014,18 @@ def build_recurring_ipmnist_retention_report(
     """Validate one complete A/B/A trace and derive threshold-free metrics."""
     if type(protocol) is not RecurringIPMNISTProtocol:
         raise TypeError("protocol must be RecurringIPMNISTProtocol")
+    for phase in protocol.phases:
+        if type(phase) is not RecurringIPMNISTPhase:
+            raise TypeError("phases must contain RecurringIPMNISTPhase values")
+        RecurringIPMNISTPhase.__post_init__(phase)
+    for binding in protocol.sentinel_bindings:
+        if type(binding) is not SentinelProbeBinding:
+            raise TypeError("sentinel_bindings must contain SentinelProbeBinding values")
+        SentinelProbeBinding.__post_init__(binding)
+    RecurringIPMNISTProtocol.__post_init__(protocol)
     if type(trace) is not RecurringIPMNISTTrace:
         raise TypeError("trace must be RecurringIPMNISTTrace")
+    RecurringIPMNISTTrace.__post_init__(trace)
     if len(trace.pre_update_online_accuracy) != protocol.trace_length:
         raise ValueError(
             "the predict-before-update trace length must exactly match the A/B/A protocol"

--- a/tests/test_recurring_ipmnist_retention.py
+++ b/tests/test_recurring_ipmnist_retention.py
@@ -312,6 +312,43 @@ def test_report_is_explicitly_threshold_free_development_only_and_nonpromoting()
     assert payload["catastrophic_forgetting_absence_claimed"] is False
 
 
+def test_report_builder_revalidates_frozen_inputs() -> None:
+    protocol = _protocol()
+    trace = _trace(retaining=True)
+    snapshots = _snapshots(protocol, retaining=True)
+
+    object.__setattr__(
+        trace,
+        "pre_update_online_accuracy",
+        (0.5, *trace.pre_update_online_accuracy[1:]),
+    )
+    with pytest.raises(ValueError, match="binary"):
+        build_recurring_ipmnist_retention_report(
+            protocol=protocol,
+            trace=trace,
+            sentinel_snapshots=snapshots,
+        )
+
+    trace = _trace(retaining=True)
+    object.__setattr__(protocol.phases[0], "phase_index", False)
+    with pytest.raises(ValueError, match="phase_index must be a non-negative integer"):
+        build_recurring_ipmnist_retention_report(
+            protocol=protocol,
+            trace=trace,
+            sentinel_snapshots=snapshots,
+        )
+
+    protocol = _protocol()
+    snapshots = _snapshots(protocol, retaining=True)
+    object.__setattr__(snapshots[0], "correctness", (1, 1, 1, 1))
+    with pytest.raises(ValueError, match="canonical booleans"):
+        build_recurring_ipmnist_retention_report(
+            protocol=protocol,
+            trace=trace,
+            sentinel_snapshots=snapshots,
+        )
+
+
 @pytest.mark.parametrize("bad_accuracy", [-0.1, 0.5, 1.1, float("nan")])
 def test_trace_requires_binary_pre_update_outcomes(bad_accuracy: float) -> None:
     with pytest.raises(ValueError, match="binary"):


### PR DESCRIPTION
## Summary

`build_recurring_ipmnist_retention_report` trusted previously constructed
frozen inputs and derived metrics without rerunning their constructor
invariants. A trace mutated through Python's low-level `object.__setattr__`
could therefore replace a binary predict-before-update outcome with `0.5` and
still produce a plausible fractional-accuracy report.

This change revalidates every nested phase, sentinel binding, protocol, online
trace, and sentinel snapshot at the public report-builder boundary before any
metric derivation or hashing. Corrupted frozen inputs now fail with their
original field-specific validation errors.

## Reproduction and result

At baseline `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, the failing-test-first
fractional-accuracy regression failed because the builder did not raise. The
same trust gap admitted a boolean replacing a phase index and integers
replacing canonical sentinel-correctness booleans.

At candidate head `fad98ecdc320dcd74b168b73eb985e0978b0182e`:

```text
.venv/bin/python -m pytest tests/test_recurring_ipmnist_retention.py::test_report_builder_revalidates_frozen_inputs -q -o addopts=""
1 passed

.venv/bin/python -m pytest tests/test_recurring_ipmnist_retention.py tests/test_recurring_ipmnist_retention_hostile_validation.py -q -o addopts=""
21 passed

.venv/bin/python -m ruff check .
All checks passed!

.venv/bin/python -m mypy alberta_framework/evaluation/recurring_ipmnist_retention.py
Success: no issues found in 1 source file

git diff --check
exit 0
```

Repository-wide mypy retains the unchanged current-main macOS
`os.O_TMPFILE` stub error and is not claimed green.

This is a Fix-lane development measurement-integrity change. It changes no
benchmark arm, seed, threshold, output artifact, or promoted result. Exact
semantic searches found no open issue or PR for this invariant; open PRs
#2272 and #2275 touch this module only for the separate NumPy integer-alias
gate. Maintainer review and acceptance remain open.

Provider: `openai`

Model: `gpt-5.6-sol`

Client: `codex`

<!-- evidence-head:fad98ecdc320dcd74b168b73eb985e0978b0182e -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/attentionhead/asi/blob/95f66b4705b09f51ef3d94e79afd0fb54f2f8b7d/logs-recurring-retention-input-revalidation.txt
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/attentionhead/asi/blob/95f66b4705b09f51ef3d94e79afd0fb54f2f8b7d/evidence-recurring-retention-input-revalidation.md

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-recurring-retention-input-revalidation]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0VDCJ0K31TRBNVQPTXWMFCY","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-25T02:53:27.956Z","completed_at":"2026-08-25T02:58:59.448Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T02:53:30.882Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"1d3393256da7c9057965e2d22830f63a80bb5b1c8e9c4fd3fe0ed32eebd4a539","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"fb83da06-c850-4fac-b4d2-3476ccd83ad9","object_id":"sha256:1d3393256da7c9057965e2d22830f63a80bb5b1c8e9c4fd3fe0ed32eebd4a539","sha256":"1d3393256da7c9057965e2d22830f63a80bb5b1c8e9c4fd3fe0ed32eebd4a539"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"H-gQ86AMQVGyKJBSAGxhP2fq_PiHFCyczIIBP8jEytOPYIKtWqRWrzghEX23kGtkG_zPY7xagtGTWDJJYsMcBA"}} -->
