### PR TITLE
fix(core): ensure _normalize_simplex in upgd_memory always returns a valid simplex

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -675,7 +675,13 @@ def _active_mse(prediction: Array, target: Array) -> Array:
 
 def _normalize_simplex(prediction: Array) -> Array:
     clipped = jnp.maximum(prediction, 0.0)
-    return clipped / jnp.maximum(jnp.sum(clipped), 1e-12)
+    max_val = jnp.max(clipped, axis=-1, keepdims=True)
+    _, exp = jnp.frexp(max_val)
+    rescaled = jnp.ldexp(clipped, -exp)
+    total = jnp.sum(rescaled, axis=-1, keepdims=True)
+    is_positive = (total > 0.0) & jnp.isfinite(total)
+    uniform = jnp.ones_like(prediction) / prediction.shape[-1]
+    return jnp.where(is_positive, rescaled / jnp.where(is_positive, total, 1.0), uniform)
 
 
 class UPGDMemoryLearner:

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -564,3 +564,23 @@ def test_upgd_memory_preserves_legal_closed_endpoints() -> None:
     assert allocation_endpoint.target_allocation_rate == 1.0
     assert fixed_threshold.min_novelty_threshold == 0.5
     assert fixed_threshold.max_novelty_threshold == 0.5
+
+
+def test_normalize_simplex_preserves_valid_distribution() -> None:
+    from alberta_framework.core.upgd_memory import _normalize_simplex
+
+    cases = [
+        [0.0, 0.0, 0.0],
+        [-1.0, -2.0, -3.0],
+        [1e38, 1.0, 1.0],
+        [7.5e-13, 0.0, 0.0],
+        [1e-30, 0.0, 0.0],
+        [0.2, 0.5, 0.3],
+    ]
+
+    for p in cases:
+        arr = jnp.asarray(p, dtype=jnp.float32)
+        norm = _normalize_simplex(arr)
+        assert jnp.all(norm >= 0.0)
+        assert jnp.all(jnp.isfinite(norm))
+        assert jnp.isclose(jnp.sum(norm), 1.0, atol=1e-5)


### PR DESCRIPTION
Fixes #2470

## Summary
`_normalize_simplex` in `alberta_framework/core/upgd_memory.py` returned non-simplex outputs (summing to 0.0 or < 1.0) for zero/negative inputs, positive inputs below the `1e-12` floor (e.g. `[7.5e-13, 0, 0]`), or inputs with large dynamic range. Because `UPGDLearner` initializes `previous_targets` to zeros, blending against this normalized vector silently lost up to 80% of distribution mass across updates.

## Proposed Changes
1. Used exact power-of-two rescaling (`jnp.frexp` and `jnp.ldexp`) on non-negative clipped predictions to prevent float32 underflow or overflow before computing sums.
2. Normalized by the true rescaled sum whenever positive and finite.
3. Added fallback to a uniform distribution over the class dimension when all inputs are non-positive or non-finite.
4. Added unit tests in `tests/test_upgd_memory.py` covering all edge cases (`[0,0,0]`, `[-1,-2,-3]`, `[1e38,1,1]`, `[7.5e-13,0,0]`, `[1e-30,0,0]`, etc.).

## Verification
- Ran pytest on upgd_memory test suites: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_upgd_memory.py tests/test_upgd_memory_grad.py tests/test_upgd_memory_validation.py` (220/220 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/upgd_memory.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/upgd_memory.py` (all checks passed).
