### PR TITLE
fix(optimizer-geometry): fail closed in spectral_matrix_sign_transaction when subnormal matrix norm underflows

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -172,7 +172,19 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
     ):
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
-    valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
+    uint_type = {
+        jnp.dtype("float32"): jnp.uint32,
+        jnp.dtype("float64"): jnp.uint64,
+        jnp.dtype("float16"): jnp.uint16,
+        jnp.dtype("bfloat16"): jnp.uint16,
+    }.get(value.dtype, jnp.uint32)
+    mask_int = (1 << (value.dtype.itemsize * 8 - 1)) - 1
+    mask = jnp.asarray(mask_int, dtype=uint_type)
+    has_nonzero_bits = jnp.any(
+        jax.lax.bitwise_and(jax.lax.bitcast_convert_type(value, uint_type), mask) != uint_type(0)
+    )
+    underflowed_nonzero = (norm == 0.0) & has_nonzero_bits
+    valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm) & ~underflowed_nonzero
     x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
     if x.shape[0] > x.shape[1]:
         x = x.T

--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -173,11 +173,11 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
     uint_type = {
-        jnp.dtype("float32"): jnp.uint32,
-        jnp.dtype("float64"): jnp.uint64,
-        jnp.dtype("float16"): jnp.uint16,
-        jnp.dtype("bfloat16"): jnp.uint16,
-    }.get(value.dtype, jnp.uint32)
+        1: jnp.uint8,
+        2: jnp.uint16,
+        4: jnp.uint32,
+        8: jnp.uint64,
+    }.get(value.dtype.itemsize, jnp.uint32)
     mask_int = (1 << (value.dtype.itemsize * 8 - 1)) - 1
     mask = jnp.asarray(mask_int, dtype=uint_type)
     has_nonzero_bits = jnp.any(

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -350,8 +350,22 @@ def test_spectral_matrix_sign_subnormal_fails_closed() -> None:
     assert not bool(valid)
     assert bool(jnp.all(safe == 0.0))
 
-    # Exact zero matrix remains valid
+    # Exact zero and signed zero matrices remain valid
     zeros_f32 = jnp.zeros((2, 2), dtype=jnp.float32)
     safe_zero, valid_zero = spectral_matrix_sign_transaction(zeros_f32)
     assert bool(valid_zero)
     assert bool(jnp.all(safe_zero == 0.0))
+
+    signed_zeros_f32 = jnp.array([[-0.0, -0.0], [-0.0, -0.0]], dtype=jnp.float32)
+    safe_neg_zero, valid_neg_zero = spectral_matrix_sign_transaction(signed_zeros_f32)
+    assert bool(valid_neg_zero)
+    assert bool(jnp.all(safe_neg_zero == 0.0))
+
+    # Float8 unit matrices evaluate eagerly and under JIT
+    for dt_name in ("float8_e4m3fn", "float8_e5m2"):
+        dt = getattr(jnp, dt_name)
+        eye_f8 = jnp.eye(2, dtype=dt)
+        safe_f8, valid_f8 = spectral_matrix_sign_transaction(eye_f8)
+        assert bool(valid_f8)
+        jit_safe_f8, jit_valid_f8 = jax.jit(spectral_matrix_sign_transaction)(eye_f8)
+        assert bool(jit_valid_f8)

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,18 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+
+def test_spectral_matrix_sign_subnormal_fails_closed() -> None:
+    # All entries subnormal in float32
+    base = np.array([[2.0, 1.0], [0.5, -1.0]], dtype=np.float64) * 2.938736e-39
+    subnormal_f32 = jnp.asarray(base, dtype=jnp.float32)
+    safe, valid = spectral_matrix_sign_transaction(subnormal_f32)
+    assert not bool(valid)
+    assert bool(jnp.all(safe == 0.0))
+
+    # Exact zero matrix remains valid
+    zeros_f32 = jnp.zeros((2, 2), dtype=jnp.float32)
+    safe_zero, valid_zero = spectral_matrix_sign_transaction(zeros_f32)
+    assert bool(valid_zero)
+    assert bool(jnp.all(safe_zero == 0.0))


### PR DESCRIPTION
Fixes #2391

## Summary
`spectral_matrix_sign_transaction` in `alberta_framework/evaluation/optimizer_geometry.py` returned an exact zero matrix with `valid=True` for non-zero inputs whose float32 entries were all subnormal. Because reductions flush float32 subnormals on the backend, `jnp.linalg.norm(value)` evaluated to `0.0`, laundering a rank-0 answer with `valid=True` for a non-zero input.

## Proposed Changes
1. Added bitwise check on float representations (`float32`, `float64`, `float16`, `bfloat16`) to detect non-zero magnitude entries when `norm == 0.0`.
2. Marked transaction invalid (`valid=False`) and returned zero matrix safely when a non-zero matrix's norm underflows to zero, properly failing closed.
3. Preserved `valid=True` for the exact all-zero matrix.
4. Added unit tests in `tests/test_optimizer_geometry.py` verifying that all-subnormal float32 matrices fail closed with `valid=False` while exact zero matrices remain valid.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (29/29 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (all checks passed).
