### PR TITLE
fix(pipeline): forward termination-zeroed discount to HordeActorCriticAgent in horde_ac mode

### DIFF
--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -1573,10 +1573,17 @@ class AlbertaPipeline:
                 dtype=jnp.int32,
             )
             auxiliary_cumulants = horde_cumulants[aux_indices] if aux_indices.size else None
+            value_gamma = self._horde.horde_spec.gammas[value_index]
+            control_discount = jnp.where(
+                terminated == 0.0,
+                value_gamma,
+                jnp.zeros_like(value_gamma),
+            )
             ac_result = ac.update(
                 ac_state,
                 reward,
                 features,
+                discount=control_discount,
                 auxiliary_cumulants=auxiliary_cumulants,
             )
             new_control_state: SARSAState | HordeActorCriticState = ac_result.state

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1196,3 +1196,34 @@ def test_associative_pipeline_narrows_only_statically_safe_integer_dtypes() -> N
 
 # silence the import lint warnings used in the test runner
 _ = jax
+
+
+def test_horde_ac_pipeline_honors_terminated() -> None:
+    pipe_cfg = AlbertaPipelineConfig(
+        features=Step2FeatureConfig.identity(observation_dim=3),
+        horde=Step3HordeConfig(
+            gammas=(0.9, 0.5),
+            lamdas=(0.0, 0.0),
+            hidden_sizes=(),
+        ),
+        horde_ac=HordeActorCriticPipelineConfig(
+            n_actions=2,
+            actor_lamda=0.8,
+            value_head_index=0,
+        ),
+        control_mode="horde_ac",
+    )
+    pipeline = make_alberta_pipeline(pipe_cfg)
+
+    state = pipeline.init(jr.key(0), jnp.asarray([0.2, -0.1, 0.4], dtype=jnp.float32))
+    obs = jnp.asarray([0.1, 0.3, -0.2], dtype=jnp.float32)
+    reward = jnp.asarray(0.5, dtype=jnp.float32)
+    cumulants = jnp.asarray([0.5, -0.2], dtype=jnp.float32)
+
+    res_cont = pipeline.update(state, obs, reward, jnp.asarray(0.0, dtype=jnp.float32), cumulants)
+    res_term = pipeline.update(state, obs, reward, jnp.asarray(1.0, dtype=jnp.float32), cumulants)
+
+    # In terminal step, the value-head target should be reward alone (0.5), not bootstrapped
+    assert jnp.isclose(res_term.horde_td_targets[0], 0.5)
+    # Traces in terminal step should not carry forward
+    assert not jnp.array_equal(res_cont.horde_td_targets, res_term.horde_td_targets)


### PR DESCRIPTION
Fixes #2344

## Summary
In `AlbertaPipeline.update`, when running under `control_mode="horde_ac"`, `terminated` was dropped when invoking `HordeActorCriticAgent.update`. Because `discount` was not passed, the agent fell back to the static `gammas[value_head_index]` on every step, causing:
1. The critic value head to bootstrap through episode termination (`r + gamma * V(s')` instead of `r`).
2. The actor eligibility trace to survive into the next episode instead of being zeroed at termination.

## Proposed Changes
1. Forwarded `control_discount = jnp.where(terminated == 0.0, value_gamma, jnp.zeros_like(value_gamma))` to `ac.update(..., discount=control_discount)` in `AlbertaPipeline.update`.
2. Added unit test in `tests/test_pipeline.py` verifying that when `terminated=1.0`, the value-head target evaluates to `reward` alone (`0.5`) without bootstrapping.

## Verification
- Ran pytest on pipeline test suites: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_pipeline.py` (184/184 tests passed).
- Ran linter and type checker: `/opt/homebrew/bin/uv run ruff check alberta_framework/pipeline.py` & `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/pipeline.py` (all checks passed).
