### PR TITLE
fix(tests): skip longdouble precision-widening probes on platforms where longdouble is float64

### DIFF
--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -485,6 +485,10 @@ def test_construct_canonicalizes_noise_std_to_float32() -> None:
     assert stream._noise_std == float(np.float32(0.1))  # noqa: SLF001
 
 
+@pytest.mark.skipif(
+    np.finfo(np.longdouble).nmant <= np.finfo(np.float64).nmant,
+    reason="longdouble double-rounding probe requires longdouble mantissa to be wider than float64",
+)
 def test_construct_narrows_original_noise_real_once() -> None:
     midpoint_plus = (
         np.longdouble(1.0)
@@ -500,6 +504,10 @@ def test_construct_narrows_original_noise_real_once() -> None:
     assert stream._noise_std == float(np.float32(midpoint_plus))  # noqa: SLF001
 
 
+@pytest.mark.skipif(
+    np.finfo(np.longdouble).nmant <= np.finfo(np.float64).nmant,
+    reason="longdouble subnormal underflow probe requires longdouble to be wider than float64",
+)
 def test_construct_rejects_negative_real_that_rounds_to_zero() -> None:
     below_zero = -np.nextafter(np.longdouble(0.0), np.longdouble(1.0))
     assert float(below_zero) == 0.0


### PR DESCRIPTION
Fixes #2324

## Summary
In `tests/test_pavlovian_stream.py`, `test_construct_narrows_original_noise_real_once` and `test_construct_rejects_negative_real_that_rounds_to_zero` test double-rounding and subnormal underflow properties of `np.longdouble` which assume `long double` is strictly wider than IEEE 754 `float64`. On architectures where `np.longdouble` is 64-bit (such as aarch64 macOS), these precondition asserts failed before exercising library code.

## Proposed Changes
1. Added `@pytest.mark.skipif(np.finfo(np.longdouble).nmant <= np.finfo(np.float64).nmant, ...)` to both platform-width-dependent probes.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_pavlovian_stream.py` (100 passed, 2 skipped).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check tests/test_pavlovian_stream.py` (all checks passed).
