### PR TITLE
fix(tests): gate test_forager_matched_final_analysis on Linux renameat2 support

### DIFF
--- a/tests/test_forager_matched_final_analysis.py
+++ b/tests/test_forager_matched_final_analysis.py
@@ -52,8 +52,9 @@ from alberta_framework.benchmarks import (
 from alberta_framework.benchmarks import forager_matched_statistics as statistics
 from tests import test_forager_matched_executor as executor_fixtures
 from tests import test_forager_matched_open_protocol as protocol_fixtures
+from tests._forager_matched_platform import requires_renameat2
 
-pytestmark = [pytest.mark.integration, pytest.mark.slow]
+pytestmark = [pytest.mark.integration, pytest.mark.slow, requires_renameat2]
 
 
 def _sha(label: str) -> str:


### PR DESCRIPTION
Fixes #2323

## Summary
In `tests/test_forager_matched_final_analysis.py`, all 33 tests exercise `create_forager_matched_seal_bundle` and `forager_matched_final_analysis` artifact publication, which deliberately require Linux `renameat2` support (via `_publish_verified_no_replace`). Because the test file lacked the `requires_renameat2` marker from `tests._forager_matched_platform`, running `pytest tests/test_forager_matched_final_analysis.py` was permanently red on non-Linux platforms (e.g. macOS).

## Proposed Changes
1. Imported `requires_renameat2` from `tests._forager_matched_platform` and added it to `pytestmark` in `tests/test_forager_matched_final_analysis.py`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_forager_matched_final_analysis.py` (33 skipped on macOS).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check tests/test_forager_matched_final_analysis.py` (all checks passed).
