### PR TITLE
fix: revalidate nested JEPA transfer receipts

### DIFF
--- a/alberta_framework/benchmarks/jepa_transfer_feasibility.py
+++ b/alberta_framework/benchmarks/jepa_transfer_feasibility.py
@@ -254,10 +254,12 @@ class JEPATransferResult:
             raise ValueError("unsupported JEPA-transfer schema")
         if type(self.protocol) is not JEPATransferProtocol:
             raise ValueError("protocol must be exact")
+        object.__setattr__(self, "protocol", dataclasses.replace(self.protocol))
         if self.research_pins != PINNED_RESEARCH_ITEMS:
             raise ValueError("research pins differ from the independently audited roster")
         if type(self.identity) is not DevelopmentIdentity:
             raise ValueError("identity must be exact")
+        object.__setattr__(self, "identity", dataclasses.replace(self.identity))
         expected = tuple(
             (arm_id, seed) for seed in self.protocol.seeds for arm_id in FROZEN_ARM_IDS
         )
@@ -265,6 +267,18 @@ class JEPATransferResult:
             type(arm) is not TransferArmReceipt for arm in self.arms
         ):
             raise ValueError("arms must be exact receipts")
+        object.__setattr__(
+            self,
+            "arms",
+            tuple(
+                dataclasses.replace(
+                    arm,
+                    resources=dataclasses.replace(arm.resources),
+                    timing=dataclasses.replace(arm.timing),
+                )
+                for arm in self.arms
+            ),
+        )
         if tuple((arm.arm_id, arm.seed) for arm in self.arms) != expected:
             raise ValueError("arm/seed roster differs from the frozen order")
         for seed_index in range(len(self.protocol.seeds)):

--- a/tests/test_jepa_transfer_feasibility.py
+++ b/tests/test_jepa_transfer_feasibility.py
@@ -95,6 +95,35 @@ def test_result_rejects_promotion_parity_and_pin_drift(
         dataclasses.replace(result, **changes)
 
 
+@pytest.mark.parametrize(
+    ("path", "value", "message"),
+    [
+        (("arms", 0, "return_sum"), float("nan"), "finite float"),
+        (
+            ("arms", 0, "resources", "imported_pretraining_bytes"),
+            1,
+            "forbids imported",
+        ),
+        (("arms", 0, "timing", "clock"), "benchmark", "timing scope"),
+        (("identity", "workload_registry_sha256"), "0", "lowercase SHA-256"),
+    ],
+)
+def test_result_revalidates_nested_frozen_records(
+    result: lane.JEPATransferResult,
+    path: tuple[object, ...],
+    value: object,
+    message: str,
+) -> None:
+    corrupted = copy.deepcopy(result)
+    target: object = corrupted
+    for component in path[:-1]:
+        target = target[component] if type(component) is int else getattr(target, component)
+    object.__setattr__(target, path[-1], value)
+
+    with pytest.raises(ValueError, match=message):
+        dataclasses.replace(corrupted)
+
+
 def test_hostile_and_expanded_payloads_fail_closed(result: lane.JEPATransferResult) -> None:
     with pytest.raises(ValueError, match="exact dict"):
         lane.validate_jepa_transfer_payload(object())


### PR DESCRIPTION
## Summary

- revalidate every nested frozen JEPA transfer record at the outer result boundary
- store rebuilt protocol, identity, arm, resource, and timing records before matched-schedule checks
- add failing-test-first regressions for NaN returns, prohibited imported bytes, invalid timing scope, and malformed identity hashes

## Reproduction

Trusted `main` at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` accepted a reconstructed
`JEPATransferResult` after the first arm's `return_sum` was changed to NaN through
`object.__setattr__`. The same outer boundary accepted nonzero imported-pretraining bytes, a
timing receipt claiming benchmark scope, and a malformed development-identity digest.

The failing-test-first module reported 4 failures and 16 passes on that exact base. The candidate
reconstructs every nested record through its validating constructor before checking the frozen
roster and resource schedule.

## Validation

- `tests/test_jepa_transfer_feasibility.py`: 20 passed
- JEPA plus development-provenance and world-model qualification tests: 37 passed
- repository-wide Ruff: passed
- changed-source mypy: passed
- `git diff --check`: passed
- repository-wide mypy retains the unchanged macOS `os.O_TMPFILE` stub error in
  `bounded_elastic_matched_runner.py`; it is not claimed green

Open PR #2273 touches this source file only to add an external-catalog CLI path. It does not
change the native result classes or nested receipt validation. A complete 306-open-PR file
inventory and exact semantic searches found no owner for this defect.

This is a development-only measurement-integrity fix. It changes no arm, seed, threshold,
result, external qualification gate, or promotion policy.

<!-- evidence-head:f11a94308fb281620f46f59c1945da970a79a5fd -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/attentionhead/asi/blob/30809d5de0d7dfd891cc80ce4fa6e7a09e6542f6/.slop-evidence/jepa-transfer-arm-revalidation/verification.md
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/attentionhead/asi/blob/30809d5de0d7dfd891cc80ce4fa6e7a09e6542f6/.slop-evidence/jepa-transfer-arm-revalidation/domain-note.md

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-jepa-transfer-arm-revalidation]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0VTA5R4XJZTT6JQH4CMG52G","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-25T06:39:21.348Z","completed_at":"2026-08-25T06:47:21.793Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T06:39:24.495Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e65564168d1cc7f27807d276753f014f62c12087e3d85b7610ba11968bbc7be5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"8d89534e-08eb-419d-8fbd-7091b3852589","object_id":"sha256:e65564168d1cc7f27807d276753f014f62c12087e3d85b7610ba11968bbc7be5","sha256":"e65564168d1cc7f27807d276753f014f62c12087e3d85b7610ba11968bbc7be5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"BMqBMEuUC5G5wKkNIn9e0aTThQA3eiMnz2km40HieeJnYcHAFEl4v-Fmr_a1zcVdBUCYP1ywwsATjhG6rst1Cg"}} -->
