### PR TITLE
fix: revalidate low-cost comparator results

### DIFF
--- a/alberta_framework/benchmarks/low_cost_controls_ipmnist.py
+++ b/alberta_framework/benchmarks/low_cost_controls_ipmnist.py
@@ -15,7 +15,7 @@ import dataclasses
 import math
 import time
 from collections.abc import Mapping
-from typing import Literal
+from typing import Literal, cast
 
 import jax
 import jax.numpy as jnp
@@ -102,6 +102,20 @@ def _exact_int(value: object, name: str, low: int, high: int) -> int:
     if type(value) is not int or isinstance(value, bool) or not low <= value <= high:
         raise ValueError(f"{name} must be an exact int within [{low}, {high}]")
     return value
+
+
+def _digest(value: object, name: str) -> str:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256")
+    return value
+
+
+def _mechanism_enabled(arm_id: str) -> bool:
+    return not arm_id.endswith("_off") and arm_id != "sgd_current_control"
 
 
 def _init_params(key: Array, width: int, preactivation_width: int) -> dict[str, Array]:
@@ -268,19 +282,41 @@ class LowCostArmResult:
     elapsed_ns: int
 
     def __post_init__(self) -> None:
-        if self.arm_id not in ARM_IDS:
+        if type(self.arm_id) is not str or self.arm_id not in ARM_IDS:
             raise ValueError(f"unknown arm: {self.arm_id}")
+        if (
+            type(self.mechanism_enabled) is not bool
+            or self.mechanism_enabled != _mechanism_enabled(self.arm_id)
+        ):
+            raise ValueError("mechanism flag differs from the frozen arm roster")
         _exact_int(self.preactivation_width, "preactivation_width", 1, 4096)
         _exact_int(self.persistent_bytes, "persistent_bytes", 1, 2**63 - 1)
         _exact_int(self.parameter_updates, "parameter_updates", 1, 2**63 - 1)
         _exact_int(self.model_queries, "model_queries", 1, 2**63 - 1)
         _exact_int(self.elapsed_ns, "elapsed_ns", 0, 2**63 - 1)
-        for name in ("task_accuracy", "task_loss", "dead_unit_fraction", "effective_rank"):
-            series = getattr(self, name)
-            if type(series) is not tuple or not series:
-                raise ValueError(f"{name} must be a non-empty tuple")
-            if any(type(v) is not float or not math.isfinite(v) for v in series):
-                raise ValueError(f"{name} must hold finite exact floats")
+        curves = (
+            self.task_accuracy,
+            self.task_loss,
+            self.dead_unit_fraction,
+            self.effective_rank,
+        )
+        if any(type(curve) is not tuple or not curve for curve in curves):
+            raise ValueError("diagnostic curves must be non-empty exact tuples")
+        if len({len(curve) for curve in curves}) != 1:
+            raise ValueError("diagnostic curves must have equal lengths")
+        if any(
+            type(value) is not float or not math.isfinite(value)
+            for curve in curves
+            for value in curve
+        ):
+            raise ValueError("diagnostic curves must hold finite exact floats")
+        if any(
+            not 0.0 <= value <= 1.0
+            for value in self.task_accuracy + self.dead_unit_fraction
+        ):
+            raise ValueError("probability curves must lie in [0, 1]")
+        if any(value < 0.0 for value in self.task_loss + self.effective_rank):
+            raise ValueError("loss and rank curves must be nonnegative")
 
 
 def _run_arm(
@@ -336,7 +372,7 @@ def _run_arm(
 
     return LowCostArmResult(
         arm_id=arm_id,
-        mechanism_enabled=not arm_id.endswith("_off") and arm_id != "sgd_current_control",
+        mechanism_enabled=_mechanism_enabled(arm_id),
         preactivation_width=preactivation_width,
         task_accuracy=tuple(accuracies),
         task_loss=tuple(losses),
@@ -360,17 +396,38 @@ class LowCostResult:
     development_only: bool = True
 
     def __post_init__(self) -> None:
-        if self.schema != SCHEMA:
+        if type(self.schema) is not str or self.schema != SCHEMA:
             raise ValueError("schema drift")
-        if self.profile_id not in PROFILES:
+        if type(self.profile_id) is not str or self.profile_id not in PROFILES:
             raise ValueError("unknown profile")
-        if type(self.arms) is not tuple or len(self.arms) != len(ARM_IDS):
+        if type(self.seed) is not int or self.seed not in FROZEN_SEEDS:
+            raise ValueError("seed must be an exact frozen development seed")
+        _digest(self.dataset_sha256, "dataset identity")
+        if type(self.catalog) is not LowCostCatalogEntry:
+            raise ValueError("catalog must be an exact LowCostCatalogEntry")
+        if (
+            type(self.arms) is not tuple
+            or len(self.arms) != len(ARM_IDS)
+            or any(type(arm) is not LowCostArmResult for arm in self.arms)
+        ):
             raise ValueError("every declared arm must be reported")
         if tuple(arm.arm_id for arm in self.arms) != ARM_IDS:
             raise ValueError("arm order must match the declared arm list")
-        if self.development_only is not True:
+        if type(self.development_only) is not bool or self.development_only is not True:
             raise ValueError("result must remain permanently nonpromoting")
         self.catalog.validate()
+        profile = PROFILES[self.profile_id]
+        expected_updates = profile.n_tasks * profile.examples_per_task
+        for arm in self.arms:
+            LowCostArmResult.__post_init__(arm)
+            if len(arm.task_accuracy) != profile.n_tasks:
+                raise ValueError("diagnostic curves must bind every frozen task")
+            if arm.preactivation_width != _preactivation_width(
+                cast(ArmID, arm.arm_id), profile.hidden_width
+            ):
+                raise ValueError("preactivation width differs from the frozen arm geometry")
+            if arm.parameter_updates != expected_updates:
+                raise ValueError("parameter updates differ from the frozen schedule")
 
 
 def run_comparator(

--- a/tests/test_low_cost_controls_ipmnist.py
+++ b/tests/test_low_cost_controls_ipmnist.py
@@ -1,11 +1,16 @@
 """Contract tests for the issue #1566 low-cost activation comparator lane."""
 
+import dataclasses
+import math
+
 import numpy as np
 import pytest
 
 from alberta_framework.benchmarks.low_cost_controls_ipmnist import (
     ARM_IDS,
+    FROZEN_SEEDS,
     SCHEMA,
+    LowCostArmResult,
     LowCostCatalogEntry,
     LowCostResult,
     _preactivation_width,
@@ -134,6 +139,82 @@ class TestResultContract:
                 catalog=LowCostCatalogEntry(),
                 arms=tuple(reversed(result.arms)),
             )
+
+    def test_reconstructed_result_revalidates_nested_arms(self) -> None:
+        images, labels = _fixture()
+        result = run_comparator(images, labels)
+        object.__setattr__(
+            result.arms[0],
+            "task_accuracy",
+            (math.nan, *result.arms[0].task_accuracy[1:]),
+        )
+
+        with pytest.raises(ValueError, match="diagnostic curves"):
+            dataclasses.replace(result)
+
+    @pytest.mark.parametrize(
+        ("changes", "message"),
+        [
+            ({"seed": True}, "frozen development seed"),
+            ({"seed": FROZEN_SEEDS[0] - 1}, "frozen development seed"),
+            ({"dataset_sha256": "not-a-digest"}, "dataset identity"),
+        ],
+    )
+    def test_result_rejects_malformed_schedule_identity(
+        self, changes: dict[str, object], message: str
+    ) -> None:
+        images, labels = _fixture()
+        result = run_comparator(images, labels)
+
+        with pytest.raises(ValueError, match=message):
+            dataclasses.replace(result, **changes)
+
+    def test_arm_binds_mechanism_flag_to_roster(self) -> None:
+        with pytest.raises(ValueError, match="mechanism flag"):
+            LowCostArmResult(
+                arm_id="sgd_current_control",
+                mechanism_enabled=True,
+                preactivation_width=8,
+                task_accuracy=(0.5,),
+                task_loss=(1.0,),
+                dead_unit_fraction=(0.0,),
+                effective_rank=(1.0,),
+                persistent_bytes=1,
+                parameter_updates=1,
+                model_queries=1,
+                elapsed_ns=0,
+            )
+
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        [
+            ("task_accuracy", (1.1,), "probability curves"),
+            ("dead_unit_fraction", (-0.1,), "probability curves"),
+            ("task_loss", (-0.1,), "nonnegative"),
+            ("effective_rank", (-0.1,), "nonnegative"),
+            ("task_loss", (1.0, 2.0), "equal lengths"),
+        ],
+    )
+    def test_arm_curves_are_bounded_and_equal_length(
+        self, field: str, value: tuple[float, ...], message: str
+    ) -> None:
+        fields = {
+            "arm_id": "sgd_current_control",
+            "mechanism_enabled": False,
+            "preactivation_width": 8,
+            "task_accuracy": (0.5,),
+            "task_loss": (1.0,),
+            "dead_unit_fraction": (0.0,),
+            "effective_rank": (1.0,),
+            "persistent_bytes": 1,
+            "parameter_updates": 1,
+            "model_queries": 1,
+            "elapsed_ns": 0,
+        }
+        fields[field] = value
+
+        with pytest.raises(ValueError, match=message):
+            LowCostArmResult(**fields)
 
     def test_unknown_profile_is_refused(self) -> None:
         images, labels = _fixture()


### PR DESCRIPTION
## Summary

- revalidate every nested low-cost IPMNIST arm at the outer result boundary
- bind the frozen seed, dataset digest, arm flags, geometry, curve lengths, and update schedule
- reject non-finite, out-of-range, negative, or mismatched diagnostic curves

## Reproduction

Trusted `main` at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` accepted a reconstructed
`LowCostResult` after the first frozen arm's task accuracy was changed to NaN through
`object.__setattr__`. The same boundary accepted a built-in boolean seed, a seed outside the
frozen schedule, and a malformed dataset digest. The nested arm constructor also accepted a
roster-inconsistent mechanism flag, out-of-range accuracy/dead-unit values, negative loss/rank
values, and unequal curve lengths.

The failing-test-first selection reported 10 failures and 16 deselected tests on that exact
base. The candidate validates the exact result identity and re-runs each nested arm validator
before accepting the frozen roster.

## Validation

- `tests/test_low_cost_controls_ipmnist.py`: 26 passed
- low-cost, parity, plasticity-comparator, plasticity-diagnostic, and NaP modules: 87 passed
- repository-wide Ruff: passed
- changed-source mypy: passed
- `git diff --check`: passed
- repository-wide mypy retains the unchanged macOS `os.O_TMPFILE` stub error in
  `bounded_elastic_matched_runner.py`; it is not claimed green

A complete 307-open-PR file inventory found PR #2246 in the same source and test files. Its exact
head only corrects post-task diagnostic query billing in `_run_arm`; this candidate deliberately
does not change that query formula. Exact semantic searches found no open owner for result-record
revalidation. Neither changed file appears in the frozen evidence manifest.

This is a permanently nonpromoting development measurement-integrity fix. It changes no arm,
seed schedule, threshold, stored result, query-accounting formula, or promotion policy.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported

<!-- evidence-head:51a62e12fd461f5c54f80c78f38bbfd5d711d396 -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/attentionhead/asi/blob/99c5c5d2d679d6aea8f3468ae8b8fb63249ad290/.slop-evidence/low-cost-result-revalidation/verification.md
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/attentionhead/asi/blob/99c5c5d2d679d6aea8f3468ae8b8fb63249ad290/.slop-evidence/low-cost-result-revalidation/domain-note.md

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-low-cost-result-revalidation]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0VWFB8DC1Q09RATZ72AH2TE","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-25T07:17:07.981Z","completed_at":"2026-08-25T07:25:15.948Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T07:17:12.260Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"7d65c0ce53296221d09d5d29c0a12a8ef9d04aa811cb4a0b3f8547a55e8b5751","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ffd1ef00-6119-4871-90f4-043e9f61a392","object_id":"sha256:7d65c0ce53296221d09d5d29c0a12a8ef9d04aa811cb4a0b3f8547a55e8b5751","sha256":"7d65c0ce53296221d09d5d29c0a12a8ef9d04aa811cb4a0b3f8547a55e8b5751"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"xczr36_iYqdt8OkfbjwhmcmxGhrfh0aSS4zBj-Cu_x0q9fWChfRFSzAICvzsGxCKHs4TGplb9FQJz3j8LnuDBQ"}} -->
