### PR TITLE
fix(benchmarks): replay Dreamer result metrics

### DIFF
--- a/alberta_framework/benchmarks/dreamer_continual_development.py
+++ b/alberta_framework/benchmarks/dreamer_continual_development.py
@@ -366,6 +366,23 @@ def validate_result(value: object) -> DevelopmentResult:
         )
         if receipt.persistent_bytes != expected_persistent:
             raise ValueError("persistent-byte receipt mismatch")
+        expected_arm = _run_arm(
+            value.seed,
+            value.steps_per_task,
+            value.replay_capacity,
+            value.imaginations_per_step,
+            arm.arm_id,
+        )
+        observed_arm = dataclasses.replace(
+            arm,
+            receipt=dataclasses.replace(arm.receipt, elapsed_ns=0),
+        )
+        expected_arm = dataclasses.replace(
+            expected_arm,
+            receipt=dataclasses.replace(expected_arm.receipt, elapsed_ns=0),
+        )
+        if observed_arm != expected_arm:
+            raise ValueError("deterministic replay mismatch")
     return value
 
 

--- a/tests/test_dreamer_continual_development.py
+++ b/tests/test_dreamer_continual_development.py
@@ -93,3 +93,23 @@ def test_validator_rejects_promotion_and_receipt_forgery() -> None:
     forged_identity = dataclasses.replace(result.identity, lane_source_sha256="0" * 64)
     with pytest.raises(ValueError, match="current source/runtime/registries"):
         validate_result(dataclasses.replace(result, identity=forged_identity))
+
+
+def test_validator_replays_reported_metrics() -> None:
+    result = run_development_lane(
+        seed=FROZEN_SEEDS[0],
+        steps_per_task=1,
+        replay_capacity=1,
+        imaginations_per_step=1,
+    )
+    first = result.arms[0]
+    forged_returns = dataclasses.replace(first, task_returns=(1_000_000.0,) * 3)
+    with pytest.raises(ValueError, match="deterministic replay"):
+        validate_result(dataclasses.replace(result, arms=(forged_returns, *result.arms[1:])))
+
+    forged_values = dataclasses.replace(
+        first,
+        final_action_values=(1_000_000.0, -1_000_000.0),
+    )
+    with pytest.raises(ValueError, match="deterministic replay"):
+        validate_result(dataclasses.replace(result, arms=(forged_values, *result.arms[1:])))


### PR DESCRIPTION
<!-- evidence-head:83a95c5ff9496ad208cbd95ef409ed9c39e34d7c -->

## What failed

`validate_result` accepted a Dreamer development record after the guarded-imagination arm's
task returns were replaced with `(1000000.0, 1000000.0, 1000000.0)`. It also accepted final
action values replaced with `(1000000.0, -1000000.0)`.

Those values are finite, so the nested type checks passed. They cannot come from the declared
one-step task schedule because the environment emits only `-1.0` or `1.0` rewards. The
validator checked resource formulas but did not bind the reported metrics to execution.

## Fix

The validator now replays every arm from the recorded seed, task length, replay capacity, and
imagination count. It compares the complete arm record after zeroing only `elapsed_ns`, which
the schema marks as telemetry-only.

This keeps the existing resource checks and adds an execution-derived check for task returns,
final action values, counters, and retained-byte accounting. No arm, metric, schedule, seed,
threshold, or promotion policy changes.

## Failing-test-first and verification

On exact base `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`:

```text
.venv/bin/python -m pytest tests/test_dreamer_continual_development.py -q -o addopts=''
1 failed, 8 passed
```

The new regression failed because forged task returns did not raise.

At head `83a95c5ff9496ad208cbd95ef409ed9c39e34d7c`:

- focused module: 9 passed
- focused plus dreaming, dreaming validation, action-conditioned world-model, and development
  provenance registry modules: 219 passed
- repository-wide Ruff: passed
- changed-source strict mypy: passed
- `git diff --check`: passed
- repository-wide mypy retained the unchanged current-main macOS `os.O_TMPFILE` stub error at
  `alberta_framework/evaluation/bounded_elastic_matched_runner.py:1111`

<!-- evidence-row:logs -->
- [x] logs: https://raw.githubusercontent.com/attentionhead/asi/a718fd8e99aad255f8ea8a54d95518e5cfef0527/.slop-evidence/dreamer-result-replay-validation/verification.md
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://raw.githubusercontent.com/attentionhead/asi/a718fd8e99aad255f8ea8a54d95518e5cfef0527/.slop-evidence/dreamer-result-replay-validation/domain-note.md

## Scope

This is a permanently nonpromoting development record. Neither changed file appears in the
frozen evidence manifest.

The complete 308-open-PR file inventory found no source owner. PR #2133 changes only the test
module's marker to `slow`. PR #2256 adds a separate external DreamerV3 qualification module.
Neither changes result validation.

Provider: openai
Model: gpt-5.6-sol
Client: codex

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-dreamer-result-replay-validation]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0W00QYPSP9FFN9YWFFV7CNA","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-25T08:19:03.767Z","completed_at":"2026-08-25T08:27:16.563Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T08:19:07.240Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"faa167e86fdfa1914d4ada29a7b28aac62d1967e2e446864019c05cc8eb7d8a4","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9f044178-7240-4260-93fc-c24c1ed18278","object_id":"sha256:faa167e86fdfa1914d4ada29a7b28aac62d1967e2e446864019c05cc8eb7d8a4","sha256":"faa167e86fdfa1914d4ada29a7b28aac62d1967e2e446864019c05cc8eb7d8a4"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"l69BfqUN7jpD2Gks33VUduyQJ05bjGbIMvaeoN2xrnoLaitcc3NGJWf-1x0oJI3we3stNJrPzr0OMsTKF_HbAA"}} -->
