### PR TITLE
fix(core): reject future-utility shape broadcasts

### DIFF
--- a/alberta_framework/core/future_utility.py
+++ b/alberta_framework/core/future_utility.py
@@ -71,6 +71,30 @@ def _require_exact_mode(value: object) -> str:
     return value
 
 
+def _validate_estimator_axes(
+    errors: Array,
+    feature_values: Array,
+    active_mask: Array,
+    step_size_output: float | Array,
+    active_count: float | Array,
+) -> tuple[int, int]:
+    """Reject shape broadcasts before they can change retained estimator state."""
+    error_shape = jnp.shape(errors)
+    feature_shape = jnp.shape(feature_values)
+    mask_shape = jnp.shape(active_mask)
+    if len(error_shape) != 1:
+        raise ValueError("errors must be a rank-one task vector")
+    if len(feature_shape) != 1:
+        raise ValueError("feature_values must be a rank-one feature vector")
+    if mask_shape != error_shape:
+        raise ValueError("active_mask must match errors exactly")
+    if not jnp.issubdtype(jnp.asarray(active_mask).dtype, jnp.bool_):
+        raise ValueError("active_mask must have boolean dtype")
+    if jnp.shape(step_size_output) or jnp.shape(active_count):
+        raise ValueError("step_size_output and active_count must be scalars")
+    return error_shape[0], feature_shape[0]
+
+
 class FutureUtilityEstimate(NamedTuple):
     """One-step utility estimate with an explicit transaction verdict."""
 
@@ -148,6 +172,9 @@ def one_step_output_loss_reduction_with_diagnostics(
         Non-negative per-task/per-feature predicted loss reductions with
         inactive tasks masked to zero.
     """
+    _validate_estimator_axes(
+        errors, feature_values, active_mask, step_size_output, active_count
+    )
     step_size = jnp.asarray(step_size_output, dtype=jnp.float32)
     count = jnp.asarray(active_count, dtype=jnp.float32)
     delta_prediction = (
@@ -223,6 +250,17 @@ def contribution_trace_output_loss_reduction_with_diagnostics(
     Returns:
         ``(reductions, new_contribution_trace, new_feature_energy_trace)``.
     """
+    n_tasks, n_features = _validate_estimator_axes(
+        errors, feature_values, active_mask, step_size_output, active_count
+    )
+    if jnp.shape(contribution_trace) != (n_tasks, n_features):
+        raise ValueError(
+            "contribution_trace must have shape (n_tasks, n_features)"
+        )
+    if jnp.shape(feature_energy_trace) != (n_features,):
+        raise ValueError("feature_energy_trace must match feature_values")
+    if jnp.shape(trace_decay):
+        raise ValueError("trace_decay must be a scalar")
     decay = jnp.asarray(trace_decay, dtype=jnp.float32)
     step_size = jnp.asarray(step_size_output, dtype=jnp.float32)
     count = jnp.asarray(active_count, dtype=jnp.float32)
@@ -360,6 +398,17 @@ def trace_output_loss_reduction_with_diagnostics(
         new_feature_energy_trace)``.  ``reductions`` is non-negative and masked
         for inactive tasks.
     """
+    n_tasks, n_features = _validate_estimator_axes(
+        errors, feature_values, active_mask, step_size_output, active_count
+    )
+    if jnp.shape(error_trace) != (n_tasks,):
+        raise ValueError("error_trace must match errors exactly")
+    if jnp.shape(feature_trace) != (n_features,):
+        raise ValueError("feature_trace must match feature_values")
+    if jnp.shape(feature_energy_trace) != (n_features,):
+        raise ValueError("feature_energy_trace must match feature_values")
+    if jnp.shape(trace_decay):
+        raise ValueError("trace_decay must be a scalar")
     decay = jnp.asarray(trace_decay, dtype=jnp.float32)
     step_size = jnp.asarray(step_size_output, dtype=jnp.float32)
     count = jnp.asarray(active_count, dtype=jnp.float32)

--- a/tests/test_future_utility.py
+++ b/tests/test_future_utility.py
@@ -23,6 +23,46 @@ from alberta_framework.core.future_utility import (
 )
 
 
+def test_one_step_rejects_activity_mask_task_axis_broadcast() -> None:
+    with pytest.raises(ValueError, match="active_mask must match errors"):
+        one_step_output_loss_reduction_with_diagnostics(
+            errors=jnp.array([1.0, 2.0], dtype=jnp.float32),
+            feature_values=jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32),
+            active_mask=jnp.array([True]),
+            step_size_output=0.1,
+            active_count=2.0,
+        )
+
+
+def test_contribution_trace_rejects_task_axis_broadcast() -> None:
+    with pytest.raises(ValueError, match="contribution_trace must have shape"):
+        contribution_trace_output_loss_reduction_with_diagnostics(
+            errors=jnp.array([1.0, 2.0], dtype=jnp.float32),
+            feature_values=jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32),
+            active_mask=jnp.array([True, True]),
+            step_size_output=0.1,
+            active_count=2.0,
+            contribution_trace=jnp.zeros((1, 3), dtype=jnp.float32),
+            feature_energy_trace=jnp.zeros(3, dtype=jnp.float32),
+            trace_decay=0.9,
+        )
+
+
+def test_factored_trace_rejects_task_axis_broadcast() -> None:
+    with pytest.raises(ValueError, match="error_trace must match errors"):
+        trace_output_loss_reduction_with_diagnostics(
+            errors=jnp.array([1.0, 2.0], dtype=jnp.float32),
+            feature_values=jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32),
+            active_mask=jnp.array([True, True]),
+            step_size_output=0.1,
+            active_count=2.0,
+            error_trace=jnp.zeros(1, dtype=jnp.float32),
+            feature_trace=jnp.zeros(3, dtype=jnp.float32),
+            feature_energy_trace=jnp.zeros(3, dtype=jnp.float32),
+            trace_decay=0.9,
+        )
+
+
 def test_contribution_trace_matches_one_step_at_zero_decay() -> None:
     """Zero trace decay must recover the one-step LMS counterfactual exactly."""
     errors = jnp.array([2.0, 0.0], dtype=jnp.float32)


### PR DESCRIPTION
<!-- evidence-head:ee703368cd48911475b9ce305b619f37ec6a06ca -->

## What failed

The three causal future-utility estimators accepted a two-task residual vector together with a
one-task activity mask or retained trace. JAX broadcasting turned those incompatible axes into a
plausible `(2, 3)` result and every diagnostic returned `update_applied=True`.

The traced variants also silently resized retained state: a `(1, 3)` contribution trace became
`(2, 3)`, and a `(1,)` error trace became `(2,)`. That can change task ownership and feature
rankings instead of failing at the public estimator boundary.

## Fix

The shared estimator boundary now checks task, feature, mask, and scalar axes before numerical
work. The contribution and factored variants additionally require retained traces to match their
exact task/feature state shapes. A mismatch raises before any update or state replacement.

No estimator equation, hyperparameter, benchmark, seed, threshold, output artifact, or evidence
claim changes.

## Failing-test-first and verification

On exact base `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`:

```text
.venv/bin/python -m pytest tests/test_future_utility.py -q -k \
  'rejects_activity_mask_task_axis_broadcast or contribution_trace_rejects_task_axis_broadcast or factored_trace_rejects_task_axis_broadcast'
3 failed, 42 deselected
```

Each regression failed because the expected `ValueError` was not raised.

At head `ee703368cd48911475b9ce305b619f37ec6a06ca`:

- focused future-utility module: 45 passed
- focused plus feature-discovery and compositional-feature modules: 283 passed
- interaction-feature consumer panel: 84 passed
- repository-wide Ruff: passed
- changed-source strict mypy: passed
- `git diff --check`: passed
- repository-wide mypy retained the unchanged current-main macOS `os.O_TMPFILE` stub error at
  `alberta_framework/evaluation/bounded_elastic_matched_runner.py:1111`

<!-- evidence-row:logs -->
- [x] logs: https://raw.githubusercontent.com/attentionhead/asi/051438c6aa45bd6bb2d11452c85308dfc9b77a1a/contribution-evidence/future-utility-shape-validation/logs.txt
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://raw.githubusercontent.com/attentionhead/asi/051438c6aa45bd6bb2d11452c85308dfc9b77a1a/contribution-evidence/future-utility-shape-validation/domain-artifact.json

## Scope

The complete 309-open-PR file inventory found no source or test owner, and exact semantic issue
and pull-request searches found no matching work. Neither changed file appears in the frozen
five-claim evidence manifest.

Provider: openai
Model: gpt-5.6-sol
Client: codex

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [asi-future-utility-shape-validation]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0W2BDQFKRNX6RR50KMA0CBA","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-25T08:59:50.895Z","completed_at":"2026-08-25T09:08:25.171Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T08:59:54.574Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2c25bd0e033c822e0795a33102b2c86a8028ad44a588de6bf580eaa1629de9f1","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"36a4c2dd-6299-4839-9d86-7a9d9895d9f6","object_id":"sha256:2c25bd0e033c822e0795a33102b2c86a8028ad44a588de6bf580eaa1629de9f1","sha256":"2c25bd0e033c822e0795a33102b2c86a8028ad44a588de6bf580eaa1629de9f1"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"klddlJUHzAfEIc9H1bbhs3nyChP5y37llh2QgX3ZIon422FptanX--I1PzNgUoKEqZt-kWJvgo6VzhE8r7ZEAQ"}} -->
