### PR TITLE
fix(evaluation): validate L2-ER accuracy lattice

### DIFF
--- a/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py
@@ -227,6 +227,16 @@ def validate_l2er_development_result(payload: object) -> dict[str, object]:
     }
     if normalized_metrics["mean_online_accuracy"] > 1.0:
         raise ValueError("mean_online_accuracy must lie in [0,1]")
+    correct_count = normalized_metrics["mean_online_accuracy"] * observations
+    if not math.isclose(
+        correct_count,
+        round(correct_count),
+        rel_tol=0.0,
+        abs_tol=64.0 * math.ulp(correct_count),
+    ):
+        raise ValueError(
+            "mean_online_accuracy must lie on the integer correct-count lattice"
+        )
     if normalized_metrics["mean_plasticity"] > 1.0:
         raise ValueError("mean_plasticity must lie in [0,1]")
 

--- a/tests/test_l2er_ipmnist.py
+++ b/tests/test_l2er_ipmnist.py
@@ -325,6 +325,13 @@ def test_result_receipt_accounts_resources_and_is_permanently_nonpromoting() -> 
     with pytest.raises(ValueError, match="n_tasks"):
         validate_l2er_development_result(hostile_counter)
 
+    hostile_accuracy = deepcopy(payload)
+    hostile_metrics = hostile_accuracy["metrics"]
+    assert isinstance(hostile_metrics, dict)
+    hostile_metrics["mean_online_accuracy"] = 0.6001
+    with pytest.raises(ValueError, match="integer correct-count lattice"):
+        validate_l2er_development_result(hostile_accuracy)
+
     class HostileObject:
         def __iter__(self) -> object:
             raise AssertionError("hostile iteration must not run")
@@ -362,6 +369,28 @@ def test_matched_validator_requires_all_arms_and_axes() -> None:
     with pytest.raises(ValueError, match="exactly four"):
         validate_matched_l2er_development_results(HostileContainer())
     assert HostileMeta.calls == 0
+
+
+def test_result_validator_accepts_rounded_mean_on_integer_correct_count_lattice() -> None:
+    config = IPMNISTConfig(
+        n_tasks=3, task_length=100, input_dim=2, hidden1=2, hidden2=2, n_classes=2
+    )
+    result = ScreeningRunResult(
+        config_name="l2er_combined",
+        base_learner="upgd_w",
+        hyperparameters=dict(screening_spec("l2er_combined").hyperparameters),
+        seed=7,
+        config=config,
+        per_task_accuracy=np.asarray([0.33, 0.66, 1.0], dtype=np.float64),
+        per_task_loss=np.asarray([0.7, 0.6, 0.5], dtype=np.float64),
+        per_task_plasticity=np.asarray([0.1, 0.2, 0.3], dtype=np.float64),
+        wall_clock_seconds=1.5,
+    )
+    payload = l2er_development_result_payload(result, outcome="inconclusive")
+    metrics = payload["metrics"]
+    assert isinstance(metrics, dict)
+    assert metrics["mean_online_accuracy"] * 300 == pytest.approx(199.0)
+    validate_l2er_development_result(payload)
 
 
 def test_protocol_pins_sources_and_records_material_differences() -> None:


### PR DESCRIPTION
## Summary

This Fix-lane change makes the L2-ER development-result validator reject online
accuracies that cannot correspond to an integer number of correct predictions
across the receipt's recorded observations.

On exact `main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, a reconstructed
100-observation receipt with `mean_online_accuracy = 0.6001` passed validation,
despite representing 60.01 correct predictions. The validator checked only the
finite `[0, 1]` domain. The fix binds the mean to the integer correct-count
lattice with a rounding tolerance measured in ulps of the recovered count.

A positive regression retains a builder-produced mean representing 199 correct
predictions out of 300 observations.

## Scope and evidence

- Outcome: **Fix** — reproduced development-record measurement corruption.
- Metric: L2-ER `mean_online_accuracy`.
- Implementation head:
  `9eba186c595d8421b4ca6d46f44f7934afd4f47a`.
- Seeds and sample count: not applicable; this is deterministic validator
  coverage and no benchmark was run.
- Baseline/candidate means, spreads, and deltas: not applicable.
- Output artifacts: none.
- Changed source is not registered in the five-claim frozen evidence manifest.
- No arm, seed, threshold, development artifact, promotion state, or scientific
  claim changes.

Failing-test-first: the targeted regression failed on the exact base because no
`ValueError` was raised. Candidate verification:

- `.venv/bin/python -m pytest tests/test_l2er_ipmnist.py tests/test_l2er_matched_development.py -q`
  — 32 passed.
- `.venv/bin/python -m pytest tests/test_ipmnist_screening.py -q`
  — 340 passed.
- `.venv/bin/python -m ruff check .` — passed.
- strict mypy on
  `alberta_framework/evaluation/l2er_ipmnist_nonpromoting.py` — passed.
- `git diff --check` — passed.

Repository-wide mypy retained only the unchanged exact-base macOS stub error for
`os.O_TMPFILE` in
`alberta_framework/evaluation/bounded_elastic_matched_runner.py`; it is not
claimed green.

There was no deviation from the failing-test-first Fix plan. Independent
repository review and disposition remain open; this PR does not claim
acceptance, promotion, allocation, or payment.

<!-- evidence-head:9eba186c595d8421b4ca6d46f44f7934afd4f47a -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/attentionhead/asi/blob/cddb265b1b3b24e3f7a17fe96abd606f7561fefb/slop-evidence/l2er-accuracy-lattice-validation/verification.md
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/attentionhead/asi/blob/cddb265b1b3b24e3f7a17fe96abd606f7561fefb/slop-evidence/l2er-accuracy-lattice-validation/domain-note.md


Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-l2er-accuracy-lattice-validation]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0W4EJ6JN345JAH9NRQT3Z0K","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-25T09:36:30.931Z","completed_at":"2026-08-25T09:45:56.101Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T09:36:33.726Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"6ed3b8c3ff374b0e27ff441913fd44a850e3e8e08b9742a628b192a719c494b5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"79b1f7bd-233c-4c21-9593-21653675e4a6","object_id":"sha256:6ed3b8c3ff374b0e27ff441913fd44a850e3e8e08b9742a628b192a719c494b5","sha256":"6ed3b8c3ff374b0e27ff441913fd44a850e3e8e08b9742a628b192a719c494b5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"14U1NIhLn20glJxO8Pnz9VQGbv0q6nAmK4tqmfvH2-B3feB12cgrtLe85l404ZtmAQlCbvX3YsyPHzNS7KlqDA"}} -->
