### PR TITLE
fix(evaluation): enforce C-CHAIN coefficient delay

### DIFF
--- a/alberta_framework/evaluation/cchain_ipmnist_nonpromoting.py
+++ b/alberta_framework/evaluation/cchain_ipmnist_nonpromoting.py
@@ -317,6 +317,12 @@ def validate_cchain_development_result(payload: object) -> dict[str, object]:
         raise ValueError("mechanism-off coefficient must remain exactly one")
     if arm != "cchain_mechanism_off" and metrics["final_coefficient"] < 1.0:
         raise ValueError("adaptive C-CHAIN coefficient must remain at least one")
+    if (
+        arm != "cchain_mechanism_off"
+        and active_updates < COEFFICIENT_DELAY
+        and metrics["final_coefficient"] != 1.0
+    ):
+        raise ValueError("C-CHAIN coefficient cannot adapt before its delay")
 
     resource_object = _object(outer["resources"], _RESOURCE_KEYS, context="resources")
     integer_resources = {

--- a/tests/test_cchain_receipt_validation.py
+++ b/tests/test_cchain_receipt_validation.py
@@ -1,0 +1,52 @@
+"""Receipt-only regression tests for the C-CHAIN development lane."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.benchmarks.ipmnist_screening import (
+    cchain_development_result_payload,
+    run_screening_config,
+    screening_spec,
+)
+from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
+from alberta_framework.evaluation.cchain_ipmnist_nonpromoting import (
+    validate_cchain_development_result,
+)
+
+
+def test_receipt_rejects_coefficient_adaptation_before_delay() -> None:
+    config = IPMNISTConfig(
+        n_tasks=1,
+        task_length=4,
+        input_dim=4,
+        hidden1=3,
+        hidden2=2,
+        n_classes=2,
+    )
+    features = np.asarray(
+        [
+            [-1.0, -0.5, 0.5, 1.0],
+            [1.0, 0.5, -0.5, -1.0],
+            [-0.5, 1.0, -1.0, 0.5],
+            [0.5, -1.0, 1.0, -0.5],
+        ],
+        dtype=np.float32,
+    )
+    labels = np.asarray([0, 1, 0, 1], dtype=np.int32)
+    result = run_screening_config(
+        features,
+        labels,
+        screening_spec("cchain_full"),
+        0,
+        config,
+    )
+    receipt = cchain_development_result_payload(result, outcome="inconclusive")
+
+    assert receipt["metrics"]["diagnostic_updates"] == 2.0  # type: ignore[index]
+    assert receipt["metrics"]["final_coefficient"] == 1.0  # type: ignore[index]
+    receipt["metrics"]["final_coefficient"] = 2.0  # type: ignore[index]
+
+    with pytest.raises(ValueError, match="coefficient cannot adapt before its delay"):
+        validate_cchain_development_result(receipt)


### PR DESCRIPTION
## Summary

This Fix-lane change makes the C-CHAIN development-result validator reject a
coefficient change before the frozen diagnostic delay makes adaptation
possible.

On exact `main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, a registered
four-observation `cchain_full` receipt recorded two active diagnostics, below
the coefficient delay of ten, and the builder correctly emitted
`final_coefficient = 1.0`. Changing only that diagnostic to `2.0` still passed
the public validator. The fix derives the maximum possible window progress
from the receipt's existing observation count and requires the initial
coefficient until the delay is reachable.

## Scope and evidence

- Outcome: **Fix** — reproduced development-record measurement corruption.
- Metric: C-CHAIN `final_coefficient` diagnostic.
- Implementation head:
  `58242bd20b56aa4196331198300e9ba0b23db638`.
- Seeds and sample count: not applicable; this is deterministic validator
  coverage and no benchmark campaign was run.
- Baseline/candidate means, spreads, and deltas: not applicable.
- Output artifacts: none.
- Changed source is not registered in the five-claim frozen evidence manifest.
- No arm, seed, threshold, development artifact, promotion state, or scientific
  claim changes.

Failing-test-first: the targeted regression failed on the exact base because no
`ValueError` was raised. Candidate verification:

- `.venv/bin/python -m pytest tests/test_cchain_receipt_validation.py tests/test_cchain_ipmnist.py -q`
  — 17 passed.
- `.venv/bin/python -m pytest tests/test_ipmnist_screening.py tests/test_replay_frozen_ipmnist.py tests/test_noise_curvature_ipmnist.py tests/test_bounded_elastic_ipmnist.py -q`
  — 371 passed.
- `.venv/bin/python -m ruff check .` — passed.
- strict mypy on both changed files — passed.
- `git diff --check` — passed.

Repository-wide mypy retained only the unchanged exact-base macOS stub error for
`os.O_TMPFILE` in
`alberta_framework/evaluation/bounded_elastic_matched_runner.py`; it is not
claimed green.

There was no deviation from the failing-test-first Fix plan. Independent
repository review and disposition remain open; this PR does not claim
acceptance, promotion, allocation, or payment.

<!-- evidence-head:58242bd20b56aa4196331198300e9ba0b23db638 -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/attentionhead/asi/blob/5b4d7224a7d8f0988eb947211aab0fec2ec2e601/slop-evidence/cchain-coefficient-delay-validation/verification.md
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/attentionhead/asi/blob/5b4d7224a7d8f0988eb947211aab0fec2ec2e601/slop-evidence/cchain-coefficient-delay-validation/domain-note.md


Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [asi-cchain-coefficient-delay-validation]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0W71M9VMBEQQ61JYESGK4WR","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-25T10:21:52.828Z","completed_at":"2026-08-25T10:27:43.197Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T10:21:55.845Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"240b19b6b1861ea604b94c20d933541048f3b71f174e54f6a6504b521c488090","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"bfea7f75-50aa-404b-bcd4-cd5a54b2f303","object_id":"sha256:240b19b6b1861ea604b94c20d933541048f3b71f174e54f6a6504b521c488090","sha256":"240b19b6b1861ea604b94c20d933541048f3b71f174e54f6a6504b521c488090"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"FCSgZdUp81er8MQQy8AbsXxLyz-oElJCnJLCtIdwycCahEOjnSfs0WGStlFtye-tiwfvk1vugWXdPHfSCrpyDQ"}} -->
