### PR TITLE
fix(utils): use Cohen's d_z for paired t-test and Wilcoxon effect size

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -428,6 +428,50 @@ def cohens_d(
     return float((mean_a - mean_b) / pooled_std)
 
 
+def _paired_cohens_d(
+    values_a: NDArray[np.float64] | list[float],
+    values_b: NDArray[np.float64] | list[float],
+) -> float:
+    """Compute paired Cohen's d_z effect size.
+
+    Args:
+        values_a: Values for first group
+        values_b: Values for second group
+
+    Returns:
+        Cohen's d_z (positive means a > b). Pairs with zero variance in their
+        differences have a signed-infinite standardized difference.
+
+    Raises:
+        ValueError: If samples differ in length, are empty, or hold fewer than
+            2 pairs.
+    """
+    a = _require_sample_vector(values_a, name="values_a")
+    b = _require_sample_vector(values_b, name="values_b")
+    _require_finite_values(a, name="values_a")
+    _require_finite_values(b, name="values_b")
+
+    if len(a) != len(b):
+        raise ValueError(
+            f"paired cohens_d requires equal-length samples (got {len(a)} and {len(b)})"
+        )
+    if len(a) < 2:
+        raise ValueError(
+            f"paired cohens_d requires at least 2 pairs (got {len(a)})"
+        )
+
+    diff = a - b
+    mean_diff = np.mean(diff)
+    std_diff = np.std(diff, ddof=1)
+
+    if std_diff == 0:
+        if mean_diff == 0:
+            return 0.0
+        return float(np.copysign(np.inf, mean_diff))
+
+    return float(mean_diff / std_diff)
+
+
 def ttest_comparison(
     values_a: NDArray[np.float64] | list[float],
     values_b: NDArray[np.float64] | list[float],
@@ -503,7 +547,10 @@ def ttest_comparison(
     except ImportError:
         raise ImportError("scipy is required for t-test. Install with: pip install scipy")
 
-    effect = cohens_d(a, b)
+    if paired:
+        effect = _paired_cohens_d(a, b)
+    else:
+        effect = cohens_d(a, b)
 
     return SignificanceResult(
         test_name=test_name,
@@ -657,7 +704,7 @@ def wilcoxon_comparison(
     except ImportError:
         raise ImportError("scipy is required for Wilcoxon test. Install with: pip install scipy")
 
-    effect = cohens_d(a, b)
+    effect = _paired_cohens_d(a, b)
 
     return SignificanceResult(
         test_name="Wilcoxon signed-rank",

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -575,6 +575,24 @@ def _paired_replication_rates(
 
 
 class TestPairedTests:
+
+    def test_paired_ttest_and_wilcoxon_use_dz_effect_size(self) -> None:
+        # Paired samples with large shared between-seed variance but consistent shift
+        a = [101.0, 202.0, 303.0, 404.0]
+        b = [100.0, 200.0, 300.0, 400.0]
+        diff = np.array(a) - np.array(b)
+        expected_dz = float(np.mean(diff) / np.std(diff, ddof=1))
+
+        res_ttest = ttest_comparison(a, b, paired=True)
+        assert res_ttest.effect_size == pytest.approx(expected_dz)
+
+        res_wilcoxon = wilcoxon_comparison(a, b)
+        assert res_wilcoxon.effect_size == pytest.approx(expected_dz)
+
+        # Unpaired t-test continues to use pooled Cohen's d
+        res_unpaired = ttest_comparison(a, b, paired=False)
+        assert res_unpaired.effect_size != pytest.approx(expected_dz)
+
     def test_paired_ttest_null_and_power(self) -> None:
         """Null rejection ~alpha (measured 0.0575), power ~1.0 (measured 1.000)."""
         null_rate, power = _paired_replication_rates(
@@ -668,7 +686,7 @@ class TestIdenticalWilcoxonRejection:
         assert result.test_name == "Wilcoxon signed-rank"
         assert result.statistic == pytest.approx(0.0)
         assert result.p_value < 1.0
-        assert result.effect_size == cohens_d([1.0, 2.0, 3.0], [0.5, 1.5, 2.5])
+        assert np.isposinf(result.effect_size)
 
 
 class TestOneSampleRejection:


### PR DESCRIPTION
Fixes #2154

## Summary
`ttest_comparison(..., paired=True)` and `wilcoxon_comparison(...)` were reporting `effect_size` computed via `cohens_d(a, b)` (the pooled independent-groups formula). In paired designs, shared between-seed variance is controlled for by the test statistic, and using the independent pooled variance swamped the denominator, deflating effect sizes by orders of magnitude for consistent within-pair shifts.

## Proposed Changes
1. Added `_paired_cohens_d` to compute Cohen's $d_z = \text{mean}(a - b) / \text{std}(a - b, \text{ddof}=1)$.
2. Updated `ttest_comparison(..., paired=True)` and `wilcoxon_comparison(...)` to report paired Cohen's $d_z$.
3. Added unit tests in `tests/test_statistics_validation.py` verifying $d_z$ calculation on paired samples.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_statistics_validation.py tests/test_statistics_hostile_validation.py tests/test_forager_matched_statistics.py` (304/304 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/utils/statistics.py tests/test_statistics_validation.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/utils/statistics.py` (clean).
