### PR TITLE
fix(benchmarks): validate screening shard structure, arm attribution, and stage task counts in rule_discovery_summary

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery_summary.py
+++ b/alberta_framework/benchmarks/rule_discovery_summary.py
@@ -13,8 +13,9 @@ import numpy as np
 
 import alberta_framework.benchmarks.rule_discovery as rule_discovery_module
 from alberta_framework._seed_validation import require_jax_seed, require_unique_jax_seeds
-from alberta_framework._strict_json import load_strict_json_object
+from alberta_framework.benchmarks import ipmnist_screening
 from alberta_framework.benchmarks.ipmnist_provenance import analysis_provenance
+from alberta_framework.benchmarks.ipmnist_screening import load_shard
 from alberta_framework.benchmarks.rule_discovery import NONPROMOTING_POLICY
 
 SCREEN_ARMS = (
@@ -37,22 +38,37 @@ DISCOVERY_ARMS = (
 CHAMPION = "sigma0_shiftnorm_d099"
 
 
-def _arm(directory: Path, name: str, seeds: Sequence[int]) -> dict[str, Any]:
+def _arm(
+    directory: Path,
+    name: str,
+    seeds: Sequence[int],
+    *,
+    expected_n_tasks: int = 60,
+) -> dict[str, Any]:
     values = []
     for seed in seeds:
         path = directory / f"{name}_seed{seed}.json"
         if not path.exists():
             raise ValueError(f"{name} is missing seed {seed} in {directory}")
-        payload = load_strict_json_object(path)
+        payload = load_shard(path)
+        payload_arm = payload.get("config_name")
+        if payload_arm != name:
+            raise ValueError(
+                f"{path} config_name '{payload_arm}' does not match expected arm '{name}'"
+            )
+        payload_seed = require_jax_seed(payload.get("seed"), name=f"{path} seed")
+        if payload_seed != seed:
+            raise ValueError(f"{path} seed does not match requested seed {seed}")
         if (
             type(payload.get("per_task_accuracy")) is not list
             or not payload["per_task_accuracy"]
         ):
             raise ValueError(f"{path} lacks per_task_accuracy")
-        payload_seed = require_jax_seed(payload.get("seed"), name=f"{path} seed")
-        if payload_seed != seed:
-            raise ValueError(f"{path} seed does not match requested seed {seed}")
         accuracy = np.asarray(payload["per_task_accuracy"], dtype=np.float64)
+        if len(accuracy) != expected_n_tasks:
+            raise ValueError(
+                f"{path} per_task_accuracy has {len(accuracy)} tasks, expected {expected_n_tasks}"
+            )
         if (
             accuracy.ndim != 1
             or not bool(np.all(np.isfinite(accuracy)))
@@ -71,7 +87,10 @@ def build_legacy_rule_discovery_summary(
 ) -> dict[str, Any]:
     """Reconstruct the exact legacy v1 payload for compatibility checks."""
     seeds = require_unique_jax_seeds(seeds)
-    screen = {name: _arm(screen_dir, name, seeds) for name in SCREEN_ARMS}
+    screen = {
+        name: _arm(screen_dir, name, seeds, expected_n_tasks=60)
+        for name in SCREEN_ARMS
+    }
     confirm_names = ("disc_r1_pscale_norms", CHAMPION)
     present = [
         (confirm_dir / f"{name}_seed{seed}.json").exists()
@@ -81,7 +100,10 @@ def build_legacy_rule_discovery_summary(
     if any(present) and not all(present):
         raise ValueError("rule-discovery confirmation seeds are incomplete")
     full = (
-        {name: _arm(confirm_dir, name, seeds) for name in confirm_names}
+        {
+            name: _arm(confirm_dir, name, seeds, expected_n_tasks=200)
+            for name in confirm_names
+        }
         if all(present)
         else {}
     )
@@ -155,6 +177,7 @@ def build_rule_discovery_summary(
         sources={
             "rule_discovery": Path(rule_discovery_module.__file__),
             "rule_discovery_summary": Path(__file__),
+            "ipmnist_screening": Path(ipmnist_screening.__file__),
         },
         repository_root=Path(__file__).resolve().parents[2],
     )

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -47,12 +47,55 @@ class _StringSubclass(str):
     pass
 
 
-def _shard(path: Path, *, seed: int, accuracy: float) -> None:
+def _shard(
+    path: Path,
+    *,
+    seed: int,
+    accuracy: float,
+    config_name: str | None = None,
+    n_tasks: int | None = None,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps({"seed": seed, "per_task_accuracy": [accuracy, accuracy]}),
-        encoding="utf-8",
-    )
+    inferred_arm = path.stem.split("_seed")[0] if "_seed" in path.stem else "disc_r1"
+    arm = config_name if config_name is not None else inferred_arm
+    num_tasks = n_tasks if n_tasks is not None else (200 if "confirm" in str(path) else 60)
+    payload = {
+        "base_learner": "upgd_w",
+        "config": {
+            "hidden1": 300,
+            "hidden2": 150,
+            "input_dim": 784,
+            "n_classes": 10,
+            "n_tasks": num_tasks,
+            "task_length": 5000,
+        },
+        "config_name": arm,
+        "created_unix": 1785805898.8687427,
+        "environment": {
+            "jax": "0.11.0",
+            "numpy": "2.5.1",
+            "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.39",
+            "python": "3.12.3",
+        },
+        "evidence_policy": {
+            "development_only": True,
+            "evidence_class": "development_screening_diagnostic",
+            "scientific_promotion_allowed": False,
+        },
+        "hyperparameters": {
+            "step_size": 0.037,
+            "noise_std": 0.0,
+            "weight_decay": 0.0001,
+        },
+        "noise_mode": "step",
+        "per_task_accuracy": [accuracy] * num_tasks,
+        "per_task_loss": [1.0] * num_tasks,
+        "per_task_plasticity": [0.4] * num_tasks,
+        "schema": "alberta.ipmnist_screening.shard.v1",
+        "seed": seed,
+        "wall_clock_seconds": 10.0,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
 
 
 def _ceiling_run(
@@ -383,7 +426,7 @@ def test_ceiling_confirm_alignment_rejects_delta_above_frozen_tolerance(
     tmp_path: Path,
 ) -> None:
     confirm = tmp_path / "confirm"
-    _shard(confirm / "sigma0_ndecay099_seed0.json", seed=0, accuracy=0.8)
+    _shard(confirm / "sigma0_ndecay099_seed0.json", seed=0, accuracy=0.8, n_tasks=2)
     run = {"seed": 0, "per_task_accuracy": [0.8, 0.8 + 2 * CONFIRM_ALIGNMENT_ATOL]}
 
     with pytest.raises(ValueError, match="exceeds atol"):
@@ -713,7 +756,7 @@ def test_rule_summary_rejects_duplicate_json_object_keys(tmp_path: Path) -> None
     for name in SCREEN_ARMS[1:]:
         _shard(screen / f"{name}_seed0.json", seed=0, accuracy=0.8)
     (screen / f"{SCREEN_ARMS[0]}_seed0.json").write_text(
-        '{"seed":0,"per_task_accuracy":[0.1],"per_task_accuracy":[0.9]}',
+        '{"schema":"alberta.ipmnist_screening.shard.v1","config_name":"disc_r1","seed":0,"per_task_accuracy":[0.1],"per_task_accuracy":[0.9]}',
         encoding="utf-8",
     )
     with pytest.raises(ValueError, match="duplicate"):
@@ -727,9 +770,44 @@ def test_rule_summary_rejects_invalid_accuracy_payloads(
     screen = tmp_path / "screen"
     path = screen / f"{SCREEN_ARMS[0]}_seed0.json"
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps({"seed": 0, "per_task_accuracy": accuracy}), encoding="utf-8"
-    )
+    acc = accuracy if not accuracy or len(accuracy) == 60 else accuracy * 60
+    payload = {
+        "base_learner": "upgd_w",
+        "config": {
+            "hidden1": 300,
+            "hidden2": 150,
+            "input_dim": 784,
+            "n_classes": 10,
+            "n_tasks": 60,
+            "task_length": 5000,
+        },
+        "config_name": SCREEN_ARMS[0],
+        "created_unix": 1785805898.8687427,
+        "environment": {
+            "jax": "0.11.0",
+            "numpy": "2.5.1",
+            "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.39",
+            "python": "3.12.3",
+        },
+        "evidence_policy": {
+            "development_only": True,
+            "evidence_class": "development_screening_diagnostic",
+            "scientific_promotion_allowed": False,
+        },
+        "hyperparameters": {
+            "step_size": 0.037,
+            "noise_std": 0.0,
+            "weight_decay": 0.0001,
+        },
+        "noise_mode": "step",
+        "per_task_accuracy": acc,
+        "per_task_loss": [1.0] * 60,
+        "per_task_plasticity": [0.4] * 60,
+        "schema": "alberta.ipmnist_screening.shard.v1",
+        "seed": 0,
+        "wall_clock_seconds": 10.0,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
     with pytest.raises(ValueError):
         build_legacy_rule_discovery_summary(
             screen, tmp_path / "confirm", seeds=(0,)
@@ -771,3 +849,40 @@ def test_current_rule_discovery_legacy_payload_reconstructs_exactly() -> None:
     )
 
     assert actual == expected
+
+def test_rule_summary_rejects_misattributed_arm_name(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    for name in SCREEN_ARMS:
+        _shard(screen / f"{name}_seed0.json", seed=0, accuracy=0.8)
+    # Write a shard with filename disc_r1_seed0.json but config_name sigma0_shiftnorm_d099
+    _shard(
+        screen / f"{SCREEN_ARMS[0]}_seed0.json",
+        seed=0,
+        accuracy=0.8,
+        config_name=CHAMPION,
+    )
+    with pytest.raises(ValueError, match="does not match expected arm"):
+        build_legacy_rule_discovery_summary(screen, tmp_path / "confirm", seeds=(0,))
+
+
+def test_rule_summary_rejects_mismatched_stage_task_count(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    for name in SCREEN_ARMS:
+        _shard(screen / f"{name}_seed0.json", seed=0, accuracy=0.8)
+    # Put a 60-task shard in confirmation directory (which expects 200 tasks)
+    _shard(
+        confirm / f"{CHAMPION}_seed0.json",
+        seed=0,
+        accuracy=0.8,
+        n_tasks=60,
+    )
+    _shard(
+        confirm / "disc_r1_pscale_norms_seed0.json",
+        seed=0,
+        accuracy=0.8,
+        n_tasks=200,
+    )
+    with pytest.raises(ValueError, match="expected 200"):
+        build_legacy_rule_discovery_summary(screen, confirm, seeds=(0,))
+


### PR DESCRIPTION
Fixes #2134

## Summary
`alberta_framework.benchmarks.rule_discovery_summary._arm` was selecting shards solely by filename and validating only the seed and `per_task_accuracy` array without checking `config_name` or stage task count (60 tasks for screen vs 200 tasks for confirmation). This allowed misattributed or substituted shards to be accepted into summary aggregation and provenance.

## Proposed Changes
1. Used `ipmnist_screening.load_shard` to validate shard structure at the load boundary.
2. Added `payload.get("config_name") == name` validation in `_arm` to prevent arm misattribution.
3. Added `expected_n_tasks` validation (60 tasks for screen and 200 tasks for confirmation).
4. Bound `ipmnist_screening` into analysis provenance sources.
5. Added unit and regression tests in `tests/test_ipmnist_campaign_tools.py` covering arm misattribution and mismatched stage task counts.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_rule_discovery.py tests/test_rule_discovery_hostile_validation.py tests/test_ipmnist_campaign_tools.py` (177/177 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/benchmarks/rule_discovery_summary.py tests/test_ipmnist_campaign_tools.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/benchmarks/rule_discovery_summary.py` (clean).
