### PR TITLE
fix(core): fall back to uniform simplex in floor_and_renormalize_probabilities for zero or underflowing mass

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -222,16 +222,24 @@ def floor_and_renormalize_probabilities(
     """
     probs = jnp.asarray(probabilities, dtype=jnp.float32)
     n_actions = probabilities.shape[-1]
+    uniform = jnp.ones_like(probs) / n_actions
     if min_probability * n_actions >= 1.0:
-        return jnp.ones_like(probs) / n_actions
+        return uniform
     clipped = jnp.maximum(probs, 0.0)
+    total_mass = jnp.sum(clipped, axis=-1, keepdims=True)
     normalizer = jnp.maximum(
-        jnp.sum(clipped, axis=-1, keepdims=True),
+        total_mass,
         jnp.asarray(1e-12, dtype=jnp.float32),
     )
     normalized = clipped / normalizer
     floor_mass = jnp.asarray(min_probability * n_actions, dtype=jnp.float32)
-    return jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
+    result = jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
+    valid_mass = (
+        (total_mass > 1e-12)
+        & jnp.isfinite(total_mass)
+        & (jnp.abs(jnp.sum(normalized, axis=-1, keepdims=True) - 1.0) < 0.1)
+    )
+    return jnp.where(valid_mass, result, uniform)
 
 
 def selected_action_probabilities(

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -868,3 +868,11 @@ class TestBehaviorModelSequenceCeiling:
         result = run_behavior_model_from_arrays(model, state, observations, actions)
         chex.assert_shape(result.probabilities, (12, 3))
         assert int(result.state.step_count) == 12
+
+def test_floor_and_renormalize_probabilities_degenerate_inputs_return_simplex() -> None:
+    # Zero mass and float32 underflow degenerate cases must return valid simplex summing to 1.0
+    for probs in ([0.0, 0.0, 0.0], [1e38, 1.0, 1.0]):
+        out = floor_and_renormalize_probabilities(jnp.asarray(probs, jnp.float32))
+        chex.assert_trees_all_close(jnp.sum(out), 1.0, atol=1e-6)
+        chex.assert_trees_all_close(out, jnp.ones(3, dtype=jnp.float32) / 3.0, atol=1e-6)
+


### PR DESCRIPTION
Fixes #2238

## Summary
`floor_and_renormalize_probabilities` documents returning a valid simplex along the last axis summing to 1.0. For degenerate inputs with zero mass (e.g. `[0.0, 0.0, 0.0]`) or float32 intermediate underflow (e.g. `[1e38, 1.0, 1.0]` where reciprocal division produces zeros), `normalized` summed to `0.0`, returning `n * min_probability` (e.g. `3e-6`) instead of a valid simplex.

## Proposed Changes
1. Added fallback to uniform simplex along axes where mass is zero or underflowing.
2. Preserved exact affine output on all valid non-degenerate inputs.
3. Added unit and regression tests in `tests/test_behavior_model.py`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_behavior_model.py tests/test_behavior_model_resource_budget.py` (80/80 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/behavior_model.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/behavior_model.py` (clean).
