### PR TITLE
fix(core): preserve baseline centering in Hedge updates when masked-in mass underflows

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -105,6 +105,17 @@ def validated_float32_scalar(name: str, value: object, **domain: Any) -> float:
     return stored
 
 
+def _masked_normalized_weights(weights: Array, mask: Array) -> Array:
+    """Normalize weights over the active mask, falling back to uniform over the mask."""
+    active_weights = jnp.where(mask, weights, 0.0)
+    mass = jnp.sum(active_weights)
+    count = jnp.maximum(jnp.sum(mask.astype(jnp.float32)), 1.0)
+    uniform = jnp.where(mask, 1.0 / count, 0.0)
+    normalized = active_weights / jnp.maximum(mass, jnp.asarray(1e-12, dtype=jnp.float32))
+    valid_mass = (mass > 1e-12) & jnp.isfinite(mass) & (jnp.abs(jnp.sum(normalized) - 1.0) < 0.1)
+    return jnp.where(valid_mass, normalized, uniform)
+
+
 def _skip_zero_scale(scale: float, value: Array) -> Array:
     """Keep finite multiplication exact while repairing zero-scaled poison."""
     product = scale * value
@@ -1036,8 +1047,7 @@ class FixedBudgetFeatureLearner:
         finite: Array,
     ) -> Array:
         """Exponentiated-gradient preference update for utility scores."""
-        finite_mass = jnp.maximum(jnp.sum(jnp.where(finite, allocation, 0.0)), 1e-12)
-        masked_allocation = jnp.where(finite, allocation / finite_mass, 0.0)
+        masked_allocation = _masked_normalized_weights(allocation, finite)
         baseline = jnp.sum(masked_allocation * jnp.where(finite, scores, 0.0))
         advantages = jnp.where(finite, scores - baseline, 0.0)
         advantages = jnp.clip(

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -165,6 +165,17 @@ def _require_vector(name: str, value: object, length: int, *, dtype: Any) -> Arr
     return cast(Array, value)
 
 
+def _masked_normalized_weights(weights: Array, mask: Array) -> Array:
+    """Normalize weights over the active mask, falling back to uniform over the mask."""
+    active_weights = jnp.where(mask, weights, 0.0)
+    mass = jnp.sum(active_weights)
+    count = jnp.maximum(jnp.sum(mask.astype(jnp.float32)), 1.0)
+    uniform = jnp.where(mask, 1.0 / count, 0.0)
+    normalized = active_weights / jnp.maximum(mass, jnp.asarray(1e-12, dtype=jnp.float32))
+    valid_mass = (mass > 1e-12) & jnp.isfinite(mass) & (jnp.abs(jnp.sum(normalized) - 1.0) < 0.1)
+    return jnp.where(valid_mass, normalized, uniform)
+
+
 def _skip_zero_scale(scale: float, value: Array) -> Array:
     """Keep finite multiplication exact while repairing zero-scaled poison."""
     product = scale * value
@@ -594,8 +605,7 @@ class LearnedResourceManager:
         adjusted = jnp.where(valid_actions, safe_losses + cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(valid_actions, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(valid_actions, weights / finite_weight_sum, 0.0)
+        masked_weights = _masked_normalized_weights(weights, valid_actions)
         baseline = jnp.sum(masked_weights * adjusted)
         advantages = jnp.where(valid_actions, baseline - adjusted, 0.0)
         advantages = jnp.clip(
@@ -1191,8 +1201,7 @@ class GeneratorMetaResourceManager:
         adjusted = jnp.where(finite, safe_rewards - cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(finite, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(finite, weights / finite_weight_sum, 0.0)
+        masked_weights = _masked_normalized_weights(weights, finite)
         baseline = jnp.sum(masked_weights * adjusted)
         selection_input_valid = jnp.asarray(True, dtype=jnp.bool_)
         if self._update_rule == "exp3":

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -668,9 +668,7 @@ def _minimal_generator_manager(**overrides: object) -> GeneratorMetaResourceMana
         ("advantage_clip", True),
     ],
 )
-def test_learned_resource_manager_rejects_invalid_float32_config(
-    field: str, value: object
-) -> None:
+def test_learned_resource_manager_rejects_invalid_float32_config(field: str, value: object) -> None:
     with pytest.raises(ValueError, match=field):
         LearnedResourceManager(n_actions=2, **{field: value})  # type: ignore[arg-type]
 
@@ -686,10 +684,17 @@ def test_resource_manager_float32_config_is_canonical_and_json_safe() -> None:
         advantage_clip=np.float32(2.0),
     )
     config = manager.to_config()
-    assert all(type(config[name]) is float for name in (
-        "learning_rate", "discount", "exploration", "loss_decay", "cost_weight",
-        "advantage_clip",
-    ))
+    assert all(
+        type(config[name]) is float
+        for name in (
+            "learning_rate",
+            "discount",
+            "exploration",
+            "loss_decay",
+            "cost_weight",
+            "advantage_clip",
+        )
+    )
 
 
 def test_resource_manager_preflights_complete_state_before_allocation() -> None:
@@ -719,7 +724,7 @@ def test_generator_config_rejects_hostile_sequences_and_accepts_mapping_proxy() 
 
 @pytest.mark.parametrize("shape", [(), (1,), (1, 2), (2, 1), (3,)])
 def test_resource_manager_updates_reject_wrong_vector_shapes_under_jit(
-    shape: tuple[int, ...]
+    shape: tuple[int, ...],
 ) -> None:
     learned = LearnedResourceManager(n_actions=2)
     generator = _minimal_generator_manager()
@@ -859,3 +864,19 @@ def test_resource_manager_serialized_schemas_are_exact() -> None:
         invalid.update(mutation)
         with pytest.raises(ValueError, match=match):
             GeneratorMetaResourceManager.from_config(invalid)
+
+
+def test_learned_resource_manager_preserves_centering_under_extreme_gap() -> None:
+    # Extreme preference gap where leading action is masked out with NaN
+    manager = LearnedResourceManager(n_actions=3, n_contexts=1, exploration=0.0, learning_rate=1.0)
+    base_state = manager.init()
+    for gap in [0.0, 30.0, 60.0, 200.0]:
+        state = base_state.replace(log_weights=jnp.array([[gap, 0.0, 0.0]], dtype=jnp.float32))
+        res = manager.update(
+            state, jnp.array([float("nan"), 1.0, 3.0], dtype=jnp.float32), context_id=0
+        )
+        # Surviving actions (indices 1 and 2) have losses 1.0 and 3.0 -> advantages are +1 and -1
+        adv1 = float(res.advantages[1])
+        adv2 = float(res.advantages[2])
+        assert adv1 == pytest.approx(1.0, abs=1e-5)
+        assert adv2 == pytest.approx(-1.0, abs=1e-5)


### PR DESCRIPTION
Fixes #2409

## Summary
In Hedge-style preference updates (`LearnedResourceManager`, `GeneratorMetaResourceManager`, and `FixedBudgetFeatureLearner`), centering baselines were computed by dividing masked weights by `jnp.maximum(jnp.sum(jnp.where(mask, weights, 0.0)), 1e-12)`. When masked-in weights carry less mass than `1e-12` (e.g. after a large preference gap where the leader is masked out by a NaN), the divisor clamped to `1e-12`, causing `masked_weights` to sum to $< 1.0$ (or $0.0$) and pulling the baseline towards $0$ rather than the participating actions, thus silently losing centering.

## Proposed Changes
1. Added `_masked_normalized_weights` to normalize active weights over the valid mask and fall back to uniform distribution over the mask when valid mass underflows or is zero.
2. Applied `_masked_normalized_weights` across `LearnedResourceManager._update_jit`, `GeneratorMetaResourceManager._update_jit`, and `FixedBudgetFeatureLearner._resource_log_weight_update`.
3. Added unit and regression test in `tests/test_resource_manager.py`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_resource_manager.py tests/test_feature_discovery_loop_steps.py` (79/79 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py tests/test_resource_manager.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py` (clean).
