### PR TITLE
fix(eval): rescale gradient direction by max magnitude in flad_noise_component_transaction

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -203,16 +203,20 @@ def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tu
     direction = _trusted_array(gradient, name="gradient")
     if delta.shape != direction.shape or delta.ndim != 1 or delta.size < 1:
         raise ValueError("perturbation and gradient must be non-empty equal-width vectors")
-    squared_norm = jnp.vdot(direction, direction).real
-    numerator = jnp.vdot(direction, delta).real
-    active = squared_norm > 0.0
+    max_mag = jnp.max(jnp.abs(direction))
+    _, exponent = jnp.frexp(max_mag)
+    scaled_direction = jnp.ldexp(direction, -exponent)
+    squared_norm = jnp.vdot(scaled_direction, scaled_direction).real
+    numerator = jnp.vdot(scaled_direction, delta).real
+    active = (squared_norm > 0.0) & (max_mag > 0.0)
     denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
     coefficient = numerator / denominator
-    projection = direction * coefficient * active.astype(delta.dtype)
+    projection = scaled_direction * coefficient * active.astype(delta.dtype)
     candidate = delta - projection
     valid = (
         jnp.all(jnp.isfinite(delta))
         & jnp.all(jnp.isfinite(direction))
+        & jnp.isfinite(max_mag)
         & jnp.isfinite(squared_norm)
         & jnp.isfinite(numerator)
         & jnp.isfinite(coefficient)

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -358,3 +358,17 @@ def test_flad_noise_component_underflow_scale_preserves_projection() -> None:
         expected = ref(np.array(delta), np.array(scaled_grad))
         np.testing.assert_allclose(safe, expected, rtol=1e-5, atol=1e-6)
 
+def test_flad_noise_component_zero_gradient_returns_delta_exactly() -> None:
+    delta = jnp.array([1.0, -2.0, 0.5, 3.0], dtype=jnp.float32)
+    zero_grad = jnp.zeros_like(delta)
+    safe, valid = jax.jit(flad_noise_component_transaction)(delta, zero_grad)
+    assert bool(valid)
+    assert np.array_equal(np.asarray(safe), np.asarray(delta))
+
+
+def test_flad_noise_component_nonfinite_inputs_invalid() -> None:
+    delta = jnp.array([1.0, -2.0, 0.5, 3.0], dtype=jnp.float32)
+    nan_grad = jnp.array([1.0, np.nan, 0.5, 3.0], dtype=jnp.float32)
+    safe, valid = jax.jit(flad_noise_component_transaction)(delta, nan_grad)
+    assert not bool(valid)
+

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,21 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+def test_flad_noise_component_underflow_scale_preserves_projection() -> None:
+    delta = jnp.array([1.0, -2.0, 0.5, 3.0], dtype=jnp.float32)
+    grad = jnp.array([2.0, 1.0, -1.0, 0.5], dtype=jnp.float32)
+
+    def ref(d_arr: np.ndarray, g_arr: np.ndarray) -> np.ndarray:
+        d = np.asarray(d_arr, dtype=np.float64)
+        g = np.asarray(g_arr, dtype=np.float64)
+        denom = float(g @ g)
+        return d if denom == 0.0 else d - g * (float(g @ d) / denom)
+
+    for scale in (1.0, 1e-10, 1e-20, 1e-25, 1e-30, 1e20, 1e30):
+        scaled_grad = grad * np.float32(scale)
+        safe, valid = jax.jit(flad_noise_component_transaction)(delta, scaled_grad)
+        assert bool(valid)
+        expected = ref(np.array(delta), np.array(scaled_grad))
+        np.testing.assert_allclose(safe, expected, rtol=1e-5, atol=1e-6)
+


### PR DESCRIPTION
Fixes #2393

## Summary
In `flad_noise_component_transaction` (`alberta_framework/evaluation/optimizer_geometry.py`), computing `squared_norm = jnp.vdot(direction, direction).real` directly on unscaled float32 gradients caused the squared norm to underflow to `0.0` when gradient magnitudes dropped to $\le 10^{-20}$ (or overflow to `inf` when magnitudes exceeded $\approx 1.8 \times 10^{19}$). When `squared_norm` underflows to zero, `active = squared_norm > 0.0` evaluated to `False`, falsely triggering the mechanism-off zero-gradient branch and dropping the entire gradient-aligned projection component.

## Proposed Changes
1. Rescaled `direction` by its maximum magnitude exponent via `jnp.frexp` and `jnp.ldexp` before forming inner products, making the projection computation scale-invariant across over 60 orders of magnitude.
2. Preserved exact reduction to `delta` on genuinely zero gradients where `max_mag == 0.0`.
3. Added unit and regression tests in `tests/test_optimizer_geometry.py` verifying precision across scales from $10^{-30}$ to $10^{30}$.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (29/29 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (clean).
