### PR TITLE
fix(core): derive _ACTUAL_REAL_SCALAR_TYPES from floating dtype codes including np.longdouble

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -33,7 +33,7 @@ _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _INT32_MAX = 2**31 - 1
 _ACTUAL_REAL_SCALAR_TYPES = frozenset(
-    {float, np.float16, np.float32, np.float64, int}
+    {float, int, *(np.dtype(code).type for code in "efdg")}
 )
 
 _ACTUAL_INT_TYPES = frozenset(

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -432,6 +432,19 @@ class TestGVFSpecRemainingFields:
                 }
             )
 
+
+    @pytest.mark.parametrize("scalar_type", [np.float16, np.float32, np.float64, np.longdouble])
+    def test_terminal_reward_accepts_all_numpy_floating_families(self, scalar_type):
+        spec = GVFSpec(
+            name="d0",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=0,
+            terminal_reward=scalar_type(1.5),
+        )
+        assert spec.terminal_reward == pytest.approx(1.5)
+
     def test_terminal_reward_rejects_class_spoofed_float(self):
         class _SpoofedFloat:
             @property


### PR DESCRIPTION
Fixes #2283

## Summary
`_ACTUAL_REAL_SCALAR_TYPES` in `alberta_framework/core/types.py` hand-enumerated `{float, np.float16, np.float32, np.float64, int}` and omitted `np.longdouble`. As a result, `GVFSpec.terminal_reward` rejected `np.longdouble` inputs that sibling fields (`gamma`, `lamda`) and the underlying `validated_float32_scalar_with_ratio` helper accept.

## Proposed Changes
1. Derived `_ACTUAL_REAL_SCALAR_TYPES` from dtype codes: `frozenset({float, int, *(np.dtype(code).type for code in "efdg")})`, matching `_ACTUAL_INT_TYPES` and `_ACTUAL_FLOAT_TYPES` in `_float32.py`.
2. Added unit tests in `tests/test_gvf_types.py` parametrizing all numpy floating families (`float16`, `float32`, `float64`, `longdouble`).

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_gvf_types.py tests/test_types_tracking_leftover_identities.py` (115/115 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/types.py tests/test_gvf_types.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/types.py` (clean).
