### PR TITLE
fix(utils): promote nexting forward_view_returns computation to floating dtype

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -155,8 +155,13 @@ def forward_view_returns(
     _require_leading_length(
         "cumulants", cumulants, ndim=1, maximum=_NEXTING_MAX_STEPS
     )
-    gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
-    init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
+    calc_dtype = jnp.result_type(cumulants, gamma, terminal_value)
+    if not jnp.issubdtype(calc_dtype, jnp.floating):
+        calc_dtype = jnp.float32
+
+    c_series = jnp.asarray(cumulants, dtype=calc_dtype)
+    gamma_s = jnp.asarray(gamma, dtype=calc_dtype)
+    init = jnp.asarray(terminal_value, dtype=calc_dtype)
 
     def step(carry: Array, c: Array) -> tuple[Array, Array]:
         # gamma=0 must not multiply an inf later return (0*inf).
@@ -164,7 +169,7 @@ def forward_view_returns(
         new_carry = c + bootstrap
         return new_carry, new_carry
 
-    _, returns_reversed = jax.lax.scan(step, init, cumulants[::-1])
+    _, returns_reversed = jax.lax.scan(step, init, c_series[::-1])
     return returns_reversed[::-1]
 
 

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -21,6 +21,25 @@ from alberta_framework.utils.nexting import (
 
 
 class TestForwardViewReturns:
+
+    def test_integer_and_boolean_cumulants_promote_to_float_returns(self) -> None:
+        c_int = jnp.array([1, 0, 0, 0, 1], dtype=jnp.int32)
+        c_bool = jnp.array([True, False, False, False, True], dtype=jnp.bool_)
+        expected = jnp.array([1.6561, 0.729, 0.81, 0.9, 1.0], dtype=jnp.float32)
+
+        g_int = forward_view_returns(c_int, gamma=0.9)
+        g_bool = forward_view_returns(c_bool, gamma=0.9)
+
+        chex.assert_trees_all_close(g_int, expected, atol=1e-5)
+        chex.assert_trees_all_close(g_bool, expected, atol=1e-5)
+        assert jnp.issubdtype(g_int.dtype, jnp.floating)
+        assert jnp.issubdtype(g_bool.dtype, jnp.floating)
+
+        # Fractional terminal value with integer cumulants
+        g_init = forward_view_returns(c_int, gamma=0.9, terminal_value=7.6)
+        expected_init = jnp.array([6.143823, 5.715359, 6.3504, 7.056, 7.84], dtype=jnp.float32)
+        chex.assert_trees_all_close(g_init, expected_init, atol=1e-4)
+
     def test_gamma_zero_equals_next_cumulant(self) -> None:
         c = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0])
         g = forward_view_returns(c, gamma=0.0)


### PR DESCRIPTION
Fixes #2368

## Summary
In `alberta_framework/utils/nexting.py`, `forward_view_returns` previously cast `gamma` and `terminal_value` directly into `cumulants.dtype` (`gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)`). When cumulants were integer or boolean series, `gamma` was truncated to `0` (or `True`), causing the scan recursion to degenerate into raw cumulant echoes rather than exponential forward returns.

## Proposed Changes
1. Promoted computation dtype across `(cumulants, gamma, terminal_value)` using `jnp.result_type(...)`, falling back to `jnp.float32` when none of the inputs are floating.
2. Cast `c_series`, `gamma_s`, and `init` to `calc_dtype` prior to `jax.lax.scan`.
3. Added unit and regression tests in `tests/test_nexting.py` for integer, boolean, and fractional terminal values.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_nexting.py tests/test_nexting_series_length.py` (95/95 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/utils/nexting.py tests/test_nexting.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/utils/nexting.py` (clean).
