### PR TITLE
fix(eval): rescale matrix by max magnitude in spectral_matrix_sign_transaction

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -173,7 +173,16 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
     valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    max_mag = jnp.max(jnp.abs(value))
+    _, exponent = jnp.frexp(max_mag)
+    rescaled = jnp.ldexp(value, -exponent)
+    rescaled_norm = jnp.linalg.norm(rescaled)
+    positive = (rescaled_norm > 0.0) & (max_mag > 0.0)
+    x = jnp.where(
+        positive,
+        rescaled / jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm)),
+        jnp.zeros_like(rescaled),
+    )
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,14 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+def test_spectral_matrix_sign_underflow_scale_preserves_orthogonal_sign() -> None:
+    m = jnp.array([[2.0, 1.0], [0.5, -1.0]], dtype=jnp.float32)
+    expected_sign, _ = jax.jit(spectral_matrix_sign_transaction)(m)
+
+    for scale in (1e-13, 1e-15, 1e-20, 1e-25):
+        tiny = m * jnp.asarray(scale, dtype=jnp.float32)
+        safe, valid = jax.jit(spectral_matrix_sign_transaction)(tiny)
+        assert bool(valid)
+        np.testing.assert_allclose(safe, expected_sign, rtol=1e-5, atol=1e-6)
+


### PR DESCRIPTION
Fixes #2379

## Summary
In `spectral_matrix_sign_transaction` (`alberta_framework/evaluation/optimizer_geometry.py`), dividing by `jnp.maximum(norm, 1e-12)` caused any matrix whose Frobenius norm fell below `1e-12` (or whose sum of squares underflowed to zero near `1e-20`) to divide by the constant floor rather than its norm. This caused the NS5 recurrence to be evaluated on sub-convergent singular values $\ll 1$, returning a near-zero matrix with `valid=True` instead of an orthogonal matrix sign.

## Proposed Changes
1. Rescaled `value` by its maximum magnitude via `jnp.frexp` and `jnp.ldexp` before computing the norm, making initial normalization exact and immune to underflow across extreme scales down to $10^{-25}$.
2. Preserved exact reduction to zero for genuinely zero matrices where `max_mag == 0.0`.
3. Added regression tests in `tests/test_optimizer_geometry.py` across input scales from $10^{-13}$ to $10^{-25}$.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (29/29 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (clean).
