### PR TITLE
fix(core): enforce equal latent width invariant in BoundedPolicyArchive constructor

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        expected_latent_width: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if expected_latent_width is None:
+                expected_latent_width = len(entry.latent)
+            elif len(entry.latent) != expected_latent_width:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -66,3 +66,26 @@ def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")
     assert POLICY_ARCHIVE_PROTOCOL["scientific_promotion_allowed"] is False
+
+
+def test_constructor_enforces_equal_latent_width_invariant() -> None:
+    e1 = _entry("a", (1.0,), 1.0)
+    e2 = _entry("b", (2.0, 3.0), 2.0)
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        BoundedPolicyArchive(byte_budget=1024, min_latent_distance=0.5, entries=(e1, e2))
+
+
+def test_control_modes_accept_entries_without_latent_width_restriction() -> None:
+    e1 = _entry("a", (1.0,), 1.0)
+    e2 = _entry("b", (2.0, 3.0), 2.0)
+    one = BoundedPolicyArchive(
+        byte_budget=1024, min_latent_distance=0.0, mode="one_model", entries=(e1,)
+    )
+    res_one = one.add(e2)
+    assert [entry.identity for entry in res_one.entries] == ["b"]
+
+    fixed = BoundedPolicyArchive(
+        byte_budget=1024, min_latent_distance=0.0, mode="fixed_snapshot", entries=(e1,)
+    )
+    res_fixed = fixed.add(e2)
+    assert [entry.identity for entry in res_fixed.entries] == ["a"]


### PR DESCRIPTION
Fixes #2322

## Summary
`BoundedPolicyArchive` declared an archive-wide equal-width invariant for latent descriptors (`"all latent descriptors must have equal width"`), but `__post_init__` never enforced it across `self.entries`. Furthermore, `add()` checked descriptor width before checking `self.mode`, erroneously rejecting candidates on single-policy control modes (`one_model`, `fixed_snapshot`) that do not read or compute latent distances.

## Proposed Changes
1. Enforced the equal-width invariant in `BoundedPolicyArchive.__post_init__` across all entries in `self.entries`.
2. Relocated the `add()` candidate width check into the diverse archive branch that actually performs pairwise latent distance computations.
3. Added regression tests in `tests/test_policy_archive.py` covering constructor validation and control mode operations.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_policy_archive.py` (8/8 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/policy_archive.py tests/test_policy_archive.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/policy_archive.py` (clean).
