### PR TITLE
fix(core): cap PrototypeAgentConfig n_dreams_per_step at 10000

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -184,6 +184,7 @@ _PROTOTYPE_V2_REPLAY_MIGRATION_TAG = 0x50525632
 _PROTOTYPE_FEATURE_LIFECYCLE_KEY_TAG = 0x50464C43
 _UINT32_MAX = 2**32 - 1
 _INT32_MAX = 2**31 - 1
+_MAX_DREAMS_PER_STEP = 10_000
 
 # ---------------------------------------------------------------------------
 # Standalone utility
@@ -725,7 +726,7 @@ class PrototypeAgentConfig:
                 "n_dreams_per_step",
                 self.n_dreams_per_step,
                 minimum=0,
-                maximum=_INT32_MAX,
+                maximum=_MAX_DREAMS_PER_STEP,
             ),
         )
         # horde_hidden_sizes: hostile-safe per-element validation
@@ -1335,7 +1336,10 @@ class PrototypeAgentConfig:
             "buffer_capacity", data.pop("buffer_capacity", 200), minimum=1, maximum=_INT32_MAX
         )
         n_dreams_per_step = _require_int(
-            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=_INT32_MAX
+            "n_dreams_per_step",
+            data.pop("n_dreams_per_step", 0),
+            minimum=0,
+            maximum=_MAX_DREAMS_PER_STEP,
         )
         dream_next_observation_mode = data.pop(
             "dream_next_observation_mode",

--- a/tests/test_prototype_agent_validation.py
+++ b/tests/test_prototype_agent_validation.py
@@ -303,3 +303,20 @@ def test_prototype_valid_construction() -> None:
     assert restored == cfg
     gru = GRUPerceptionConfig(observation_dim=4, hidden_dim=4)
     assert gru.augmented_dim() == 8
+
+
+def test_prototype_agent_config_caps_n_dreams_per_step() -> None:
+    with pytest.raises(ValueError, match="n_dreams_per_step"):
+        _cfg(n_dreams_per_step=10_001)
+
+    with pytest.raises(ValueError, match="n_dreams_per_step"):
+        _cfg(n_dreams_per_step=2**31 - 1)
+
+    with pytest.raises(ValueError, match="n_dreams_per_step"):
+        PrototypeAgent.from_config(
+            {
+                "type": "PrototypeAgentConfig",
+                "oak": _oak(obs_dim=4).to_config(),
+                "n_dreams_per_step": 10_001,
+            }
+        )


### PR DESCRIPTION
Fixes #2441

## Summary
In `alberta_framework/core/prototype_agent.py`, `PrototypeAgentConfig.n_dreams_per_step` was validated against `_INT32_MAX` before driving `jnp.arange(self._config.n_dreams_per_step)` inside `jax.lax.scan` (`_run_dreams`), leading to potential memory exhaustion or CPU hangs on large values.

## Proposed Changes
1. Defined `_MAX_DREAMS_PER_STEP = 10_000` matching sibling dreaming scan budgets in `core.dreaming`.
2. Validated `n_dreams_per_step` against `_MAX_DREAMS_PER_STEP` in `PrototypeAgentConfig.__post_init__` and `PrototypeAgent.from_config`.
3. Added unit tests in `tests/test_prototype_agent_validation.py`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_prototype_agent_validation.py` (24/24 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/prototype_agent.py tests/test_prototype_agent_validation.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/prototype_agent.py` (clean).
