### PR TITLE
fix(utils): unnest Raises section in get_final_performance docstring

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -665,7 +665,7 @@ def get_final_performance(
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
 
-        Raises:
+    Raises:
         ValueError: If ``window`` is not positive, a metric array has no
             time steps, any metric sample is non-finite, or ``window`` exceeds
             the shortest trace while trace lengths differ between methods.


### PR DESCRIPTION
Fixes #2439

## Summary
In `alberta_framework/utils/experiments.py`, `get_final_performance` had its `Raises:` section header indented at 8 spaces (nested under the `Returns:` block) and its description body at 8 spaces as well. This prevented docstring parsers from parsing the exception contract as a top-level `Raises:` section.

## Proposed Changes
1. Unnested `Raises:` in `get_final_performance` docstring to 4-space indentation level, matching sibling sections (`Args:`, `Returns:`).

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_experiments*.py` (141/141 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/utils/experiments.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/utils/experiments.py` (clean).
