### PR TITLE
fix(core): return valid simplex with uniform fallback in upgd_memory _normalize_simplex

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -675,7 +675,12 @@ def _active_mse(prediction: Array, target: Array) -> Array:
 
 def _normalize_simplex(prediction: Array) -> Array:
     clipped = jnp.maximum(prediction, 0.0)
-    return clipped / jnp.maximum(jnp.sum(clipped), 1e-12)
+    total = jnp.sum(clipped, axis=-1, keepdims=True)
+    uniform = jnp.ones_like(prediction) / prediction.shape[-1]
+    safe_total = jnp.where(total > 0.0, total, 1.0)
+    normalized = clipped / safe_total
+    norm_sum = jnp.sum(normalized, axis=-1, keepdims=True)
+    return jnp.where((total > 0.0) & (norm_sum > 0.0), normalized, uniform)
 
 
 class UPGDMemoryLearner:

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -564,3 +564,20 @@ def test_upgd_memory_preserves_legal_closed_endpoints() -> None:
     assert allocation_endpoint.target_allocation_rate == 1.0
     assert fixed_threshold.min_novelty_threshold == 0.5
     assert fixed_threshold.max_novelty_threshold == 0.5
+
+def test_normalize_simplex_guarantees_proper_simplex_distribution() -> None:
+    from alberta_framework.core.upgd_memory import _normalize_simplex
+
+    for p in (
+        [0.0, 0.0, 0.0],
+        [-1.0, -2.0, -3.0],
+        [1e38, 1.0, 1.0],
+        [7.5e-13, 0.0, 0.0],
+        [1e-30, 0.0, 0.0],
+        [0.2, 0.3, 0.5],
+    ):
+        arr = jnp.asarray(p, dtype=jnp.float32)
+        res = jax.jit(_normalize_simplex)(arr)
+        chex.assert_trees_all_close(jnp.sum(res), jnp.float32(1.0), atol=1e-5)
+        assert bool(jnp.all(res >= 0.0))
+


### PR DESCRIPTION
Fixes #2470

## Summary
In `alberta_framework/core/upgd_memory.py`, `_normalize_simplex` returned non-simplex distributions when given zero/negative inputs, values below `1e-12`, or extreme float32 ratios. When blended in `_blend_predictions`, this silently shrank prediction mass down to $1 - \text{trace\_gate}$ rather than mixing valid probability distributions.

## Proposed Changes
1. Normalized by the exact positive sum rather than a fixed `1e-12` floor.
2. Added uniform simplex fallback `jnp.ones_like(prediction) / prediction.shape[-1]` when total mass is non-positive or normalizer sum underflows to zero.
3. Added unit tests in `tests/test_upgd_memory.py` covering zero inputs, negative inputs, extreme ratios, and sub-`1e-12` masses.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_upgd_memory.py tests/test_upgd_memory_validation.py tests/test_upgd_memory_grad.py` (220/220 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/upgd_memory.py tests/test_upgd_memory.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/upgd_memory.py` (clean).
