### PR TITLE
fix(core): remove 1e-6 floor in LatentWorldModel observation_scale encoding

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -290,7 +290,9 @@ class LatentWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 validated_float32_scalar(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]",
+                    scale,
+                    lower=float(np.finfo(np.float32).tiny),
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -670,7 +672,7 @@ class LatentWorldModel:
         """Encode one observation with explicit (differentiable) encoder params."""
         obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._config.observation_dim,))
         scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
+        scaled = obs / scale
         return jnp.tanh(scaled @ encoder_matrix + encoder_bias)
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -749,3 +749,32 @@ def test_latent_world_model_init_rejects_nonfinite_encoder_draw() -> None:
 
     with pytest.raises(ValueError, match="encoder initialization"):
         model.init(jr.key(0))
+
+def test_latent_world_model_observation_scale_is_scale_free_across_normal_range() -> None:
+
+    ref_latents = None
+    for scale in (1.0, 1e-6, 1e-9, 1e-20):
+        config = LatentWorldModelConfig(
+            observation_dim=2,
+            latent_dim=4,
+            n_actions=2,
+            observation_scale=(scale, scale),
+        )
+        model = LatentWorldModel(config)
+        state = model.init(jr.key(0))
+        obs = jnp.asarray([1.5 * scale, -0.75 * scale], dtype=jnp.float32)
+        latent = model.encode(state, obs)
+        if ref_latents is None:
+            ref_latents = latent
+        else:
+            chex.assert_trees_all_close(latent, ref_latents, atol=1e-6)
+
+    # Subnormals below float32 tiny are rejected at validation time
+    with pytest.raises(ValueError, match="observation_scale"):
+        LatentWorldModelConfig(
+            observation_dim=1,
+            latent_dim=2,
+            n_actions=2,
+            observation_scale=(float(np.finfo(np.float32).smallest_subnormal),),
+        )
+


### PR DESCRIPTION
Fixes #2411

## Summary
In `alberta_framework/core/latent_world_model.py`, `_encode_with` divided observations by `jnp.maximum(scale, 1e-6)` instead of the configured `observation_scale`. For scales below $10^{-6}$, this silently substituted $10^{-6}$, shrinking latents, tripping spurious `collapse_score` warnings, and blocking encoder learning.

## Proposed Changes
1. Removed `jnp.maximum(scale, 1e-6)` floor in `_encode_with`, dividing by the exact configured `scale`.
2. Bounded `observation_scale` validation in `LatentWorldModelConfig.__post_init__` at `np.finfo(np.float32).tiny` ($1.17549435 \times 10^{-38}$), ensuring every admitted scale has a finite float32 reciprocal.
3. Added unit tests in `tests/test_latent_world_model.py` verifying scale-free encoding across normal ranges ($1.0$ down to $10^{-20}$) and subnormal rejection.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_latent_world_model.py tests/test_latent_world_model_update_working_set.py` (63/63 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/latent_world_model.py tests/test_latent_world_model.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/latent_world_model.py` (clean).
