### PR TITLE
fix(core): remove 1e-6 floor in ActionConditionedWorldModel observation targets

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -365,7 +365,9 @@ class ActionConditionedWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 _validated_config_float(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]",
+                    scale,
+                    positive=True,
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -806,11 +808,10 @@ class ActionConditionedWorldModel:
         reward_arr = _float32_operand("reward", reward, ())
         discount_arr = _float32_operand("discount", discount, ())
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
             self._config.predict_delta,
-            (next_obs - obs) / safe_scale,
-            next_obs / safe_scale,
+            (next_obs - obs) / obs_scale,
+            next_obs / obs_scale,
         )
         reward_target = jnp.reshape(
             reward_arr / self._config.reward_scale,

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -439,3 +439,25 @@ def test_world_model_config_rejects_hostile_float_subclass_without_hooks() -> No
     with pytest.raises(ValueError, match="finite real scalar"):
         WorldModelConfig(observation_dim=2, step_size=HostileFloat(0.1))
     assert not hook_ran
+
+def test_world_model_observation_scale_round_trip_below_1e6() -> None:
+    from alberta_framework.core.world_model import (
+        ActionConditionedWorldModel,
+        ActionConditionedWorldModelConfig,
+    )
+
+    for scale in (1.0, 1e-3, 1e-6, 1e-7, 1e-9, 1e-12, 1e-20, 1e-30):
+        config = ActionConditionedWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            hidden_sizes=(),
+            observation_scale=(scale,),
+            predict_delta=True,
+        )
+        model = ActionConditionedWorldModel(config)
+        obs = jnp.asarray([1.0 * scale], dtype=jnp.float32)
+        next_obs = jnp.asarray([3.0 * scale], dtype=jnp.float32)
+        target = model.targets(obs, jnp.array(0, dtype=jnp.int32), jnp.array(0.0), next_obs)
+        # Delta is 2.0 * scale, normalized delta target must be 2.0
+        chex.assert_trees_all_close(target[0], jnp.float32(2.0), atol=1e-5)
+


### PR DESCRIPTION
Fixes #2398

## Summary
In `alberta_framework/core/world_model.py`, `ActionConditionedWorldModel.targets()` normalized observation deltas by `jnp.maximum(obs_scale, 1e-6)` while `_prediction_and_raw_diagnostics` decoded normalized deltas by multiplying by the raw `obs_scale`. For configured `observation_scale` values below $10^{-6}$, this created an encode/decode asymmetry where fitted models reconstructed an observation change that was too small by the factor $\text{scale} / 10^{-6}$.

## Proposed Changes
1. Removed `jnp.maximum(obs_scale, 1e-6)` floor in `ActionConditionedWorldModel.targets()`, normalizing deltas by the exact configured `obs_scale` to match the decode step.
2. Added unit tests in `tests/test_world_model.py` across scales from $1.0$ down to $10^{-30}$.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_world_model.py tests/test_action_conditioned_world_model.py tests/test_world_model_update_working_set.py` (98/98 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/world_model.py tests/test_world_model.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/world_model.py` (clean).
