### PR TITLE
fix(tests): silence RuntimeWarning in _platform_longdouble_1e4000 via warnings filter

### DIFF
--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from decimal import Decimal
 from fractions import Fraction
@@ -537,7 +538,8 @@ class _NonfiniteFloatThatConvertsFinite(float):
 
 def _platform_longdouble_1e4000() -> np.longdouble:
     """Parse the cross-platform boundary without leaking an expected warning."""
-    with np.errstate(over="ignore", invalid="ignore"):
+    with warnings.catch_warnings(), np.errstate(over="ignore", invalid="ignore"):
+        warnings.simplefilter("ignore", RuntimeWarning)
         return np.longdouble("1e4000")
 
 
@@ -1029,3 +1031,11 @@ def test_run_multi_seed_experiment_rejects_invalid_seed_sequences(
 def test_get_final_performance_rejects_non_builtin_positive_window(window: object) -> None:
     with pytest.raises(ValueError, match="window"):
         get_final_performance({"candidate": _two_seed_trace()}, window=window)  # type: ignore[arg-type]
+
+def test_platform_longdouble_1e4000_emits_no_warnings() -> None:
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        val = _platform_longdouble_1e4000()
+        assert val is not None
+    assert len(recorded) == 0
+


### PR DESCRIPTION
Fixes #2387

## Summary
In `tests/test_experiments_validation.py`, `_platform_longdouble_1e4000` scoped numpy's floating-point error state using `np.errstate(over="ignore", invalid="ignore")`. However, `np.longdouble("1e4000")` string conversion overflow emits a Python `RuntimeWarning` through the `warnings` module, leaking `RuntimeWarning: overflow encountered in conversion from string` into pytest test runs and test collection on aarch64 platforms.

## Proposed Changes
1. Added `warnings.catch_warnings()` with `warnings.simplefilter("ignore", RuntimeWarning)` inside `_platform_longdouble_1e4000`.
2. Added unit test `test_platform_longdouble_1e4000_emits_no_warnings` asserting zero warnings emitted.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_experiments_validation.py` (130/130 passed, 0 warnings).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check tests/test_experiments_validation.py` (clean).
