### PR TITLE
fix(core): compute scale-free UPGD gradient alignment via power-of-two rescaling

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1996,13 +1996,44 @@ class UPGDLearner:
         current: tuple[Array, ...],
     ) -> Array:
         """Cosine alignment of two gradient tuples, zero for empty gradients."""
-        previous_norm = UPGDLearner._tuple_norm(previous)
-        current_norm = UPGDLearner._tuple_norm(current)
-        return jnp.where(
-            (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
-            jnp.array(0.0, dtype=jnp.float32),
+        max_prev = jnp.array(0.0, dtype=jnp.float32)
+        for p in previous:
+            max_prev = jnp.maximum(max_prev, jnp.max(jnp.abs(p)))
+        max_curr = jnp.array(0.0, dtype=jnp.float32)
+        for c in current:
+            max_curr = jnp.maximum(max_curr, jnp.max(jnp.abs(c)))
+
+        _, exp_prev = jnp.frexp(max_prev)
+        _, exp_curr = jnp.frexp(max_curr)
+
+        scaled_prev = tuple(jnp.ldexp(p, -exp_prev) for p in previous)
+        scaled_curr = tuple(jnp.ldexp(c, -exp_curr) for c in current)
+
+        sq_prev = jnp.array(0.0, dtype=jnp.float32)
+        for p_s in scaled_prev:
+            sq_prev = sq_prev + jnp.sum(jnp.square(p_s))
+        norm_prev = jnp.sqrt(sq_prev)
+
+        sq_curr = jnp.array(0.0, dtype=jnp.float32)
+        for c_s in scaled_curr:
+            sq_curr = sq_curr + jnp.sum(jnp.square(c_s))
+        norm_curr = jnp.sqrt(sq_curr)
+
+        dot = jnp.array(0.0, dtype=jnp.float32)
+        for p_s, c_s in zip(scaled_prev, scaled_curr):
+            dot = dot + jnp.sum(p_s * c_s)
+
+        cos = jnp.clip(dot / (norm_prev * norm_curr), -1.0, 1.0)
+        valid = (
+            (max_prev > 0.0)
+            & (max_curr > 0.0)
+            & jnp.isfinite(dot)
+            & jnp.isfinite(norm_prev)
+            & jnp.isfinite(norm_curr)
+            & (norm_prev > 0.0)
+            & (norm_curr > 0.0)
         )
+        return jnp.where(valid, cos, jnp.array(0.0, dtype=jnp.float32))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(self, state: UPGDState, observation: Array) -> Array:

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -2219,3 +2219,21 @@ class TestLoops:
         stream = RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.05)
         result = run_upgd_loop(learner, stream, num_steps=50, key=jr.key(0))
         chex.assert_shape(result.metrics, (50, 4))
+
+def test_upgd_gradient_alignment_is_scale_free() -> None:
+    for exponent in (20, 10, 0, -10, -20, -30):
+        scale = 10.0**exponent
+        g = (jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32) * scale,)
+        same_cos = UPGDLearner._gradient_alignment(g, g)
+        chex.assert_trees_all_close(same_cos, jnp.float32(1.0), atol=1e-5)
+
+        opp_cos = UPGDLearner._gradient_alignment(g, tuple(-x for x in g))
+        chex.assert_trees_all_close(opp_cos, jnp.float32(-1.0), atol=1e-5)
+
+    zeros = (jnp.zeros((3,), dtype=jnp.float32),)
+    g = (jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32),)
+    zero_align = UPGDLearner._gradient_alignment(zeros, g)
+    chex.assert_trees_all_close(zero_align, jnp.float32(0.0), atol=1e-5)
+    zero_align_rev = UPGDLearner._gradient_alignment(g, zeros)
+    chex.assert_trees_all_close(zero_align_rev, jnp.float32(0.0), atol=1e-5)
+


### PR DESCRIPTION
Fixes #2389

## Summary
In `alberta_framework/core/upgd.py`, `_gradient_alignment` gated cosine similarity on `_tuple_norm > 1e-6` with an unscaled sum of squares (`_tuple_norm`). For gradient elements below $10^{-6}$ (e.g. late in training or normalized loss scales), gradient alignment silently collapsed to `0.0`, disabling `gradient_alignment` meta-plasticity. Conversely, for gradients above $10^9$, raw squares overflowed float32 into `inf` and produced permanent `nan` multipliers.

## Proposed Changes
1. Rescaled gradient tuples by their maximum entry exponent using `jnp.frexp` and `jnp.ldexp` before accumulating squares and dot products.
2. Verified finiteness and non-zero scaled norm in `_gradient_alignment` rather than hard-coded magnitude floors.
3. Added unit tests in `tests/test_upgd.py` testing alignment across scales from $10^{-30}$ up to $10^{20}$, as well as zero-gradient edge cases.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_upgd.py` (89/89 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/upgd.py tests/test_upgd.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/upgd.py` (clean).
