### PR TITLE
fix(forager): bind preflight image status to runtime identity

### DIFF
--- a/alberta_framework/benchmarks/forager_scientific_rerun_preflight.py
+++ b/alberta_framework/benchmarks/forager_scientific_rerun_preflight.py
@@ -152,8 +152,18 @@ class LocalImageInspection:
             type(self.runtime_executable) is not str or not self.runtime_executable
         ):
             raise ForagerScientificRerunPreflightError("invalid runtime executable")
+        if (self.status == "runtime_unavailable") != (self.runtime_executable is None):
+            raise ForagerScientificRerunPreflightError(
+                "runtime availability contradicts the executable identity"
+            )
         if self.observed_image_id is not None:
             _require_digest(self.observed_image_id, "observed image ID")
+        if self.status in {"runtime_unavailable", "image_absent"} and (
+            self.observed_image_id is not None
+        ):
+            raise ForagerScientificRerunPreflightError(
+                "unobserved image status cannot carry an image ID"
+            )
         if type(self.detail) is not str or not self.detail or len(self.detail) > 1_024:
             raise ForagerScientificRerunPreflightError("invalid local inspection detail")
         if (self.status == "exact_present") != (self.observed_image_id == REQUIRED_IMAGE_ID):

--- a/tests/test_forager_scientific_rerun_preflight.py
+++ b/tests/test_forager_scientific_rerun_preflight.py
@@ -134,6 +134,28 @@ def test_local_inspection_reports_absent_and_rejects_wrong_or_hostile_output(
         preflight.inspect_local_image(runner=lambda _command: object())  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize(
+    ("status", "runtime_executable", "observed_image_id"),
+    [
+        ("exact_present", None, preflight.REQUIRED_IMAGE_ID),
+        ("runtime_unavailable", "/usr/bin/docker", None),
+        ("image_absent", "/usr/bin/docker", "sha256:" + "1" * 64),
+    ],
+)
+def test_local_image_record_rejects_impossible_runtime_and_observation_states(
+    status: preflight.LocalStatus,
+    runtime_executable: str | None,
+    observed_image_id: str | None,
+) -> None:
+    with pytest.raises(preflight.ForagerScientificRerunPreflightError):
+        preflight.LocalImageInspection(
+            status=status,
+            runtime_executable=runtime_executable,
+            observed_image_id=observed_image_id,
+            detail="invalid cross-field state",
+        )
+
+
 def test_hostile_plan_and_report_mutations_fail_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- require a runtime executable for every status other than `runtime_unavailable`
- reject observed image IDs when inspection reports `runtime_unavailable` or `image_absent`
- add regressions for three impossible cross-field states

## Reproduction

At verified base `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, `LocalImageInspection(status="exact_present", runtime_executable=None, observed_image_id=REQUIRED_IMAGE_ID, ...)` validated. A reconstructed `PreflightReport` using it also validated with only three blockers, incorrectly omitting both local OCI-image blockers despite having no runtime executable.

The new parameterized regression failed all three cases before the fix.

## Verification

- `python -m pytest tests/test_forager_scientific_rerun_preflight.py tests/test_forager_rng_parity_qualification.py tests/test_forager_rng_parity.py -q` — 60 passed
- `python -m ruff check .` — passed
- strict mypy on the changed source — passed
- repository-wide mypy retains the unchanged macOS `os.O_TMPFILE` stub error
- `git diff --check` — passed

This changes only the offline, nonexecuting readiness validator and CI-cheap tests. It does not run Forager, alter a seed or threshold, change an output artifact, authorize a launch, or make a performance or scientific claim.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [asi-forager-preflight-runtime-closure]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0X528EKCTEA8NMWWYPTGTS2","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-25T19:06:30.739Z","completed_at":"2026-08-25T19:12:22.224Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T19:06:35.354Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"8829af29605c023daba2a04f3fe174c32e6e122b8fc10697519efca092a88076","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5664d491-8df3-42c7-85ca-f4048b3119bc","object_id":"sha256:8829af29605c023daba2a04f3fe174c32e6e122b8fc10697519efca092a88076","sha256":"8829af29605c023daba2a04f3fe174c32e6e122b8fc10697519efca092a88076"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"k6igHbW6PMwTSwW89FBUoIaQqiPrnRXH5trqf6IqYNNBY84ofPyvz67GsQ4Qu-1pJj1TBc7_8rs4-eBNgrCYCQ"}} -->