### PR TITLE
fix(core): normalize actor TD error by the true EMA instead of a 1e-3 floor

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -1834,7 +1834,15 @@ class NonlinearHordeActorCriticAgent:
             actor_td_error_normalizer = _skip_zero_scale(decay, actor_td_error_normalizer) + (
                 1.0 - decay
             ) * jnp.abs(actor_td_error)
-            actor_td_error = actor_td_error / jnp.maximum(actor_td_error_normalizer, 1e-3)
+            # Divide by the EMA itself. Because the EMA always contains the
+            # (1 - decay) * |td| term, |td / EMA| <= 1 / (1 - decay), so no
+            # stability floor is needed; a fixed positive floor would silently
+            # substitute its own scale whenever the recent magnitude drops
+            # below it and distort the normalized magnitude there.
+            normalizer_denominator = jnp.where(
+                actor_td_error_normalizer > 0.0, actor_td_error_normalizer, 1.0
+            )
+            actor_td_error = actor_td_error / normalizer_denominator
 
         # Policy gradient via jax.grad through the full MLP forward pass
         actor_params = (

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -1093,6 +1093,55 @@ class TestNonlinearHordeActorCriticUpdate:
         assert bool(result.update_applied)
         chex.assert_tree_all_finite(result.state.actor_td_error_normalizer)
 
+    def test_small_td_error_warmup_normalizes_by_true_ema(self) -> None:
+        """Sub-1e-3 warmup errors divide by the true EMA, not a fixed floor."""
+        # With decay=0.9 the first update sets EMA = 0.1 * |td|, so the
+        # normalized actor signal is ~10 whatever the TD scale. Identical
+        # initial states mean the only difference between the two runs below
+        # is the reward, so the actor movement must match. The former 1e-3
+        # denominator floor substituted its own scale whenever |td| fell
+        # below it, weakening the small-error update by orders of magnitude.
+        critic = HordeLearner(
+            create_horde_spec(
+                [
+                    GVFSpec(  # type: ignore[call-arg]
+                        name="v",
+                        demon_type=DemonType.PREDICTION,
+                        gamma=0.99,
+                        lamda=0.0,
+                        cumulant_index=0,
+                    )
+                ]
+            ),
+            hidden_sizes=(8,),
+            step_size=0.03,
+        )
+        cfg = NonlinearHordeActorCriticConfig(
+            n_actions=N_ACTIONS,
+            hidden_sizes=(8,),
+            actor_td_error_normalizer_decay=0.9,
+        )
+
+        def _first_update(reward: float):
+            agent = NonlinearHordeActorCriticAgent(cfg, critic)
+            state = agent.init(OBS_DIM, jr.key(7))
+            obs = jr.normal(jr.key(8), (OBS_DIM,))
+            state, _, _ = agent.start(state, obs)
+            before = state.actor_head_w.copy()
+            result = agent.update(state, jnp.array(reward, dtype=jnp.float32), obs)
+            return result, result.state.actor_head_w - before
+
+        small_result, small_delta = _first_update(1e-4)
+        large_result, large_delta = _first_update(1e-2)
+
+        # First update sets the stored EMA to 0.1 * |raw td| (exposed verbatim).
+        assert float(small_result.state.actor_td_error_normalizer) == pytest.approx(
+            0.1 * abs(float(small_result.td_error)), rel=1e-5
+        )
+
+        # Both normalized signals are ~10, so the actor must move equally.
+        chex.assert_trees_all_close(small_delta, large_delta, rtol=1e-4, atol=0.0)
+
     def test_policy_sums_to_one(self) -> None:
         agent = _make_nlhac_agent()
         state = _init_nlhac(agent)


### PR DESCRIPTION
## Summary

The nonlinear horde actor-critic divides its TD error by `max(recent-magnitude EMA, 1e-3)`. The fixed 1e-3 floor does not protect anything numerically — it silently substitutes its own scale whenever the recent absolute TD magnitude drops below it, which is exactly the warmup regime the normalizer exists to handle. This PR replaces the floor with a pure zero-guard so the documented contract ("normalizing the actor-only TD error by its recent absolute magnitude") holds at every magnitude.

Sibling precedent for this defect class: #2409 (Autostep min-denominator) and #2411 (`observation_scale` floored at 1e-6).

## The math

Let `E` be the stored normalizer EMA and `d` the decay, with config validation guaranteeing `d ∈ [0, 1)`:

```
E ← _skip_zero_scale(d, E) + (1 − d)·|td|          (update rule)
td_normalized = td / max(E, 1e-3)                  (current code)
```

After any committed update the `(1 − d)·|td|` term makes `E > 0`, so `|td / E| ≤ 1 / (1 − d)` — finite by configuration alone. When `E = 0` no update has ever committed and `|td| = 0` as well (the only path to a zero EMA is a zero first error), so division is degenerate regardless. **A positive fixed floor therefore never prevents a non-finite quotient.** Its sole observable effect: whenever `E < 1e-3`, the normalized signal becomes `td / 1e-3` instead of `td / E`.

That distortion is not marginal in warmup. With `d = 0.9`, the very first committed update stores `E = 0.1·|td|`. A raw TD error of ~1e-4 should normalize to ~10 (its true recent-magnitude scale); with the floor it normalizes to ~0.1. During exactly the low-magnitude steps the EMA exists to handle, the actor's learning signal is weakened by two orders of magnitude relative to its own recent scale.

## The fix

```python
normalizer_denominator = jnp.where(
    actor_td_error_normalizer > 0.0, actor_td_error_normalizer, 1.0
)
actor_td_error = actor_td_error / normalizer_denominator
```

The zero branch is unreachable except through the degenerate zero-first-error path; dividing by 1 there keeps the step a no-op without inventing a scale. The QHorde variant does not consume this normalizer (it uses `expected_advantage`/Autostep-scaled paths), so it is untouched.

## Measured red/green

Identical seeds and initial states, two first updates differing only in reward scale (1e-4 vs 1e-2). Actor head-weight movement ratio (small-reward / large-reward):

| | ratio |
| --- | --- |
| unpatched (floor active in sub-1e-3 regime) | 0.008112 |
| patched (true-EMA normalization) | 1.000000 |

Scale invariance of the normalized update is restored.

## Regression test

`tests/test_horde_actor_critic.py::TestNonlinearHordeActorCriticUpdate::test_small_td_error_warmup_normalizes_by_true_ema` — identical seeded agents take their first updates with rewards 1e-4 and 1e-2; the test asserts the stored EMA equals `0.1 × observed raw TD error` and that both runs produce matching actor weight deltas under `chex.assert_trees_all_close`. It is designed differentially because `result.td_error` exposes the raw error while normalization affects only the internal actor signal, and raw TD ≠ reward due to critic dynamics.

## Test environment disclosure

Run on Windows (no WSL/container available on this host):

- Targeted run over the seven explicitly named horde-related test files: **286 passed, 2 failed**.
- Both failures are pre-existing environmental numpy integer canonicalization cases (`tests/test_stacked_horde.py::test_stacked_horde_config_canonicalizes_every_numpy_integer_family[intc]` / `[uintc]`) — verified failing identically on an unmodified baseline checkout before any change.
- Full-suite collection fails on this host because unrelated modules import `fcntl` (Unix-only), independent of this change; explicit-file invocation was used instead.

Measured with claude-code / anthropic / claude-opus-5.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [fix]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0TNK08RBABWF3MZFT99W7PG","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-24T19:57:33.336Z","completed_at":"2026-08-25T19:27:02.695Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-24T19:57:43.803Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"18df6573ab869d9d1755d10f6b45009434221d7eecb6a47a221be9047badd566","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"0f40ee17-c9f5-42e4-a801-c601ffd38d67","object_id":"sha256:18df6573ab869d9d1755d10f6b45009434221d7eecb6a47a221be9047badd566","sha256":"18df6573ab869d9d1755d10f6b45009434221d7eecb6a47a221be9047badd566"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"m-hTneE7-_n2o1uQkj70Op3wNHioGL33phIm5ehxOj5GhvOk5A5t_C2bmexTiq0WBvipFWtKR0QsW6ZJ5qdRBw"}} -->
