### PR TITLE
fix(security): accept numpy integer action ids in coerce_security_action

### DIFF
--- a/alberta_framework/security.py
+++ b/alberta_framework/security.py
@@ -671,9 +671,13 @@ def coerce_security_action(action: object) -> SecurityAction:
         raise ValueError("security action must not be a boolean")
     if type(action) is SecurityAction:
         return action
-    if type(action) is int:
+    # Accept the same exact integer types as every other integer gate in this
+    # module. Gymnasium ``Discrete`` sampling and ``argmax`` over action values
+    # both hand callers a numpy integer, and ``to_security_gym_action`` already
+    # admits those types for ``risk_score``.
+    if any(type(action) is allowed for allowed in _ACTUAL_INT_TYPES):
         try:
-            return SecurityAction(action)
+            return SecurityAction(operator.index(cast(SupportsIndex, action)))
         except ValueError as exc:
             raise ValueError("unknown security action") from exc
     if type(action) is str:

--- a/tests/test_security_hostile_validation.py
+++ b/tests/test_security_hostile_validation.py
@@ -225,3 +225,52 @@ def test_numpy_risk_canonicalizes() -> None:
     assert res["risk_score"] == (5.5,)
     res2 = to_security_gym_action("pass", risk_score=np.int32(5))
     assert res2["risk_score"] == (5.0,)
+
+
+def test_coerce_admits_every_numpy_integer_action_id() -> None:
+    """Gymnasium and ``argmax`` hand callers numpy ids, so the gate must take them."""
+    families = (
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.longlong,
+        np.ulonglong,
+    )
+    for family in families:
+        coerced = coerce_security_action(family(3))  # type: ignore[arg-type]
+        assert coerced is SecurityAction(3)
+        assert type(coerced) is SecurityAction
+
+    # The documented producer of an action id is a discrete argmax/sample.
+    greedy = np.argmax(np.array([0.1, 0.4, 0.2, 0.9, 0.3, 0.0], dtype=np.float32))
+    assert coerce_security_action(greedy) is SecurityAction(3)  # type: ignore[arg-type]
+
+    # One call, one numpy type: ``risk_score`` already accepted it, so ``action``
+    # must too.
+    assert to_security_gym_action(np.int64(3), np.int64(3)) == {  # type: ignore[arg-type]
+        "action": 3,
+        "risk_score": (3.0,),
+    }
+
+
+def test_coerce_still_rejects_non_integer_lookalikes() -> None:
+    """Widening the integer families must not admit bools, reals, or arrays."""
+    for value in (
+        np.bool_(True),
+        np.float32(3.0),
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        np.int64(99),
+    ):
+        with pytest.raises(ValueError, match="security action"):
+            coerce_security_action(value)  # type: ignore[arg-type]
+
+    # An exact-type gate keeps hostile subclasses out without touching a hook.
+    with pytest.raises(ValueError, match="security action"):
+        coerce_security_action(_HostileInt(3))  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

`coerce_security_action` rejects every numpy integer action id with `ValueError: unknown security action`, while its own sibling gate in the same call accepts them.

### The defect

The integer branch is gated on `type(action) is int` (`alberta_framework/security.py:674` before this change). Every other integer gate in the module uses the `_ACTUAL_INT_TYPES` exact-type allowlist — `_require_int` at `security.py:200` — and `to_security_gym_action` gates `risk_score` on `_ALLOWED_REAL_TYPES`, which is a superset of it. So in a single documented call:

```python
to_security_gym_action(np.int64(3), np.int64(3))
# action=np.int64(3):     ValueError: unknown security action
# risk_score=np.int64(3): accepted, canonicalized to (3.0,)
```

One call, one numpy scalar type, opposite outcomes.

The module's own docstring for `to_security_gym_action` names the producer: *"``security-gym`` uses a Gymnasium ``Dict`` action space with a discrete ``action`` id"*. Both `Discrete.sample()` and `np.argmax` over action values return numpy integers, so the documented producer of an action id cannot pass the gate today.

Measured on the shipped code: all ten numpy integer families in `_ACTUAL_INT_TYPES` (`int8/16/32/64`, `uint8/16/32/64`, `longlong`, `ulonglong`) are rejected, as is `np.argmax(q_values)` directly.

### The fix

Gate the integer branch on `_ACTUAL_INT_TYPES` — the same exact-type allowlist `_require_int` uses — and convert with `operator.index(cast(SupportsIndex, action))`, exactly as that helper does:

```python
if any(type(action) is allowed for allowed in _ACTUAL_INT_TYPES):
    try:
        return SecurityAction(operator.index(cast(SupportsIndex, action)))
    except ValueError as exc:
        raise ValueError("unknown security action") from exc
```

The exact-type identity check keeps hostile `int` subclasses out without touching their `__index__` or `__repr__` hooks (the existing hostile-subclass test still passes), and bool remains refused by the earlier dedicated branch. `np.intc`/`np.uintc` are deliberately not added: they are absent from `_ACTUAL_INT_TYPES` upstream, and widening to them would collide with PR #2432's scope.

### Red → green

| check | shipped | patched |
| --- | --- | --- |
| numpy int families accepted by `coerce_security_action` | 0 / 10 | 10 / 10 |
| `np.argmax(q_values)` as action id | rejected | `SecurityAction(3)` |
| one-call parity `to_security_gym_action(np.int64(3), np.int64(3))` | raises | `{'action': 3, 'risk_score': (3.0,)}` |

Still rejected after the patch (negative controls): `bool`, `np.bool_`, `float`, `np.float32/64`, 0-d and 1-element arrays, `None`, out-of-range ids, and an `int` subclass with raising `__index__`/`__repr__` hooks — the subclass is refused without evaluating either hook.

### Tests

Two regression tests added in `tests/test_security_hostile_validation.py`:

- `test_coerce_admits_every_numpy_integer_action_id` — all ten families plus the two documented producers (`argmax`, one-call parity);
- `test_coerce_still_rejects_non_integer_lookalikes` — the negative-control matrix including the hostile subclass.

Red proof: stashing only `alberta_framework/security.py` (keeping the new tests) gives `1 failed, 20 passed`, failing at `security.py:688` with `ValueError: unknown security action`. Green: 21 passed in the host file; all six security test files together give **61 passed**. A repo-wide grep finds no other test exercising these symbols.

### Environment disclosure

- Verification ran under Python 3.12/miniconda with numpy 2.x on Windows; no mocks stood in for the module under test.
- `ruff check .`: clean on both touched files. `ruff format --check` reports pre-existing drift identical at HEAD; CI's lint job runs `ruff check` and `mypy`, not the formatter. `mypy` itself is not installed locally; the new lines reuse the already-type-checked `operator.index(cast(SupportsIndex, ...))` idiom from `_require_int`.
- Dedupe: the only open PR touching `security.py` is #2472, at non-overlapping hunks (~456, ~735 vs ~674).

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi
Attribution status: self-reported
— [fix]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0XBKXB50D624A7NJGVB8EPY","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-25T21:01:00.646Z","completed_at":"2026-08-25T21:08:51.756Z","skill_sha256":"c886ebaf39aaa1ae24938c800208205713d2c90099aabd3f8887e8e3b01049ed","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T21:01:09.207Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"86d52ab3791b3d015a711add7adaf631e4b85d519ca11f31ed17d0ce3b220250","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a9d2e320-9ae1-48b6-8ab6-6a3fdaaf8a3a","object_id":"sha256:86d52ab3791b3d015a711add7adaf631e4b85d519ca11f31ed17d0ce3b220250","sha256":"86d52ab3791b3d015a711add7adaf631e4b85d519ca11f31ed17d0ce3b220250"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA-7AlY49bu1bXEs0mH_mSq56SKv051kBjL8-958yQFks","device_key_id":"0a8cc2130f8821937839c2037d7b43cd4818cd7779cc45f64c80fd7d509113dd","device_signature":"6EW3EJIgfZ3z_74buzIO6Xsuege8PSJLC5mmBX8SxqhYv_oMb339F_cjOTV8rVamh5IPkYY1fu-_1Gx7t6WuBg"}} -->
