### PR TITLE
fix(bimu): bind zero-threshold label-query counts

### DIFF
--- a/alberta_framework/benchmarks/bimu.py
+++ b/alberta_framework/benchmarks/bimu.py
@@ -1127,6 +1127,8 @@ def validate_bimu_result(value: object) -> None:
         raise ValueError("optimizer updates exceed queried labels")
     if not 0 <= parsed_counters["label_queries"] <= expected_steps:
         raise ValueError("label-query count is impossible")
+    if config.query_threshold == 0.0 and parsed_counters["label_queries"] != expected_steps:
+        raise ValueError("zero query threshold must query every observation")
     expected_forwards = (
         expected_steps * config.query_samples
         + parsed_counters["label_queries"] * config.train_samples

--- a/tests/test_bimu.py
+++ b/tests/test_bimu.py
@@ -301,6 +301,17 @@ def test_receipt_derives_metrics_and_disclaims_unverifiable_digests() -> None:
     validate_bimu_result(reported_identity)
 
 
+def test_validator_binds_zero_threshold_to_all_label_queries() -> None:
+    payload = run_bimu_development(*_tiny_data(), config=_tiny_config(), seed=37)
+    forged = deepcopy(payload)
+    forged["counters"]["label_queries"] = 0
+    forged["counters"]["optimizer_updates"] = 0
+    forged["counters"]["model_forward_queries"] = 90
+
+    with pytest.raises(ValueError, match="zero query threshold"):
+        validate_bimu_result(forged)
+
+
 @pytest.mark.parametrize(
     ("path", "value"),
     [


### PR DESCRIPTION
## Summary

This Fix-lane change makes the BiMU development-result validator reject a label-query count
that is impossible under the receipt's bound zero query threshold.

On exact `main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, the tiny runner produced a
20-observation receipt with 20 label queries. A reconstructed receipt set `label_queries` and
`optimizer_updates` to zero and adjusted `model_forward_queries` to the validator's matching
formula value, 90. The validator accepted it even though `query_threshold=0.0` makes
`variation_ratio >= query_threshold` true for every observation.

The fix binds the zero-threshold query count to the complete observation horizon. It does not
equate optimizer updates with queries because the runner intentionally counts only nonzero-gradient
updates.

## Scope and evidence

- Outcome: **Fix** — reproduced development-receipt counter corruption.
- Lane and metric: BiMU development receipt; label-query and model-query resource accounting.
- Implementation head: `7ec698aae7cf32622b1a4f9e33c44736954f0b71`.
- Seeds and sample count: no benchmark campaign; the deterministic CI slice uses seed 37 and
  20 observations solely to exercise validation.
- Baseline/candidate means, spreads, and deltas: not applicable to this validator fix.
- Output artifacts: none.
- Neither changed file is registered in the five-claim frozen evidence manifest.
- No development seed, threshold, output artifact, promotion state, or scientific claim changes.

Failing-test-first: the targeted regression failed on the exact base with `DID NOT RAISE
ValueError`. Candidate verification:

- `.venv/bin/python -m pytest tests/test_bimu.py -q -k zero_threshold` — 1 passed,
  25 deselected.
- `.venv/bin/python -m pytest tests/test_bimu.py tests/test_bimu_matched_campaign.py tests/test_bimu_matched_nonpromoting.py -q`
  — 45 passed, 24 skipped.
- `.venv/bin/python -m ruff check .` — passed.
- `.venv/bin/python -m mypy alberta_framework/benchmarks/bimu.py` — passed.
- `git diff --check` — passed.

Repository-wide mypy retained only the unchanged exact-base macOS stub error for
`os.O_TMPFILE` in `alberta_framework/evaluation/bounded_elastic_matched_runner.py`; it is not
claimed green.

There was no deviation from the failing-test-first Fix plan. Independent repository review and
disposition remain open; this PR does not claim acceptance, promotion, allocation, or payment.

<!-- evidence-head:7ec698aae7cf32622b1a4f9e33c44736954f0b71 -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/attentionhead/asi/blob/b3706f3b8f80b55943593283f4a982f1c9c18f44/slop-evidence/bimu-query-count-validation/verification.md
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://github.com/attentionhead/asi/blob/b3706f3b8f80b55943593283f4a982f1c9c18f44/slop-evidence/bimu-query-count-validation/domain-note.md


Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [asi-bimu-counter-validation]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0XDYH9DD5N547E4EZC4HDR5","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-25T21:41:45.902Z","completed_at":"2026-08-25T21:48:30.155Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-25T21:41:49.174Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e972807eb5ef352ca713c302b3e203ddbd99264a26caa523d7e2756087de7577","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ebdafd14-7442-412e-b116-f8d7bf0819c6","object_id":"sha256:e972807eb5ef352ca713c302b3e203ddbd99264a26caa523d7e2756087de7577","sha256":"e972807eb5ef352ca713c302b3e203ddbd99264a26caa523d7e2756087de7577"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"KyFtAKlHDm2xmH7mq9Go1u4cxQanh1DkdgZjvRvN3uy5T7rxCvEeh7J4fXdEIJOcILNAxZUyXePlcVDwiDYbDA"}} -->
