### PR TITLE
fix(core): preserve convex combination and baseline centering in Hedge masked updates

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -1036,8 +1036,22 @@ class FixedBudgetFeatureLearner:
         finite: Array,
     ) -> Array:
         """Exponentiated-gradient preference update for utility scores."""
-        finite_mass = jnp.maximum(jnp.sum(jnp.where(finite, allocation, 0.0)), 1e-12)
-        masked_allocation = jnp.where(finite, allocation / finite_mass, 0.0)
+        masked_raw = jnp.where(finite, allocation, 0.0)
+        total_mass = jnp.sum(masked_raw)
+        n_valid = jnp.sum(finite.astype(jnp.float32))
+        uniform_fallback = jnp.where(
+            finite,
+            1.0 / jnp.maximum(n_valid, 1.0),
+            0.0,
+        )
+        safe_total = jnp.where(total_mass > 0.0, total_mass, 1.0)
+        normalized = masked_raw / safe_total
+        norm_sum = jnp.sum(normalized)
+        masked_allocation = jnp.where(
+            (total_mass > 0.0) & (norm_sum > 0.0),
+            normalized,
+            uniform_fallback,
+        )
         baseline = jnp.sum(masked_allocation * jnp.where(finite, scores, 0.0))
         advantages = jnp.where(finite, scores - baseline, 0.0)
         advantages = jnp.clip(

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -594,8 +594,22 @@ class LearnedResourceManager:
         adjusted = jnp.where(valid_actions, safe_losses + cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(valid_actions, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(valid_actions, weights / finite_weight_sum, 0.0)
+        masked_raw = jnp.where(valid_actions, weights, 0.0)
+        total_mass = jnp.sum(masked_raw)
+        n_valid = jnp.sum(valid_actions.astype(jnp.float32))
+        uniform_fallback = jnp.where(
+            valid_actions,
+            1.0 / jnp.maximum(n_valid, 1.0),
+            0.0,
+        )
+        safe_total = jnp.where(total_mass > 0.0, total_mass, 1.0)
+        normalized = masked_raw / safe_total
+        norm_sum = jnp.sum(normalized)
+        masked_weights = jnp.where(
+            (total_mass > 0.0) & (norm_sum > 0.0),
+            normalized,
+            uniform_fallback,
+        )
         baseline = jnp.sum(masked_weights * adjusted)
         advantages = jnp.where(valid_actions, baseline - adjusted, 0.0)
         advantages = jnp.clip(
@@ -1191,8 +1205,22 @@ class GeneratorMetaResourceManager:
         adjusted = jnp.where(finite, safe_rewards - cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(finite, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(finite, weights / finite_weight_sum, 0.0)
+        masked_raw = jnp.where(finite, weights, 0.0)
+        total_mass = jnp.sum(masked_raw)
+        n_valid = jnp.sum(finite.astype(jnp.float32))
+        uniform_fallback = jnp.where(
+            finite,
+            1.0 / jnp.maximum(n_valid, 1.0),
+            0.0,
+        )
+        safe_total = jnp.where(total_mass > 0.0, total_mass, 1.0)
+        normalized = masked_raw / safe_total
+        norm_sum = jnp.sum(normalized)
+        masked_weights = jnp.where(
+            (total_mass > 0.0) & (norm_sum > 0.0),
+            normalized,
+            uniform_fallback,
+        )
         baseline = jnp.sum(masked_weights * adjusted)
         selection_input_valid = jnp.asarray(True, dtype=jnp.bool_)
         if self._update_rule == "exp3":

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -859,3 +859,22 @@ def test_resource_manager_serialized_schemas_are_exact() -> None:
         invalid.update(mutation)
         with pytest.raises(ValueError, match=match):
             GeneratorMetaResourceManager.from_config(invalid)
+
+def test_learned_resource_manager_preserves_centering_under_large_leader_gaps() -> None:
+    for gap in (0.0, 20.0, 30.0, 40.0, 80.0, 200.0):
+        manager = LearnedResourceManager(n_actions=3, n_contexts=1, exploration=0.0)
+        state = manager.init()
+        # Set action 0 ahead by gap
+        new_log_weights = state.log_weights.at[0, 0].set(gap)
+        state = state.replace(log_weights=new_log_weights)
+
+        # Action 0 has NaN loss, survivors have losses 1.0 and 3.0
+        losses = jnp.array([float("nan"), 1.0, 3.0], dtype=jnp.float32)
+        result = manager.update(state, losses, 0)
+
+        # Baseline of 1.0 and 3.0 with equal allocation is 2.0
+        # Advantages must be +1.0 for action 1, -1.0 for action 2
+        adv = result.advantages
+        chex.assert_trees_all_close(adv[1], jnp.float32(1.0), atol=1e-4)
+        chex.assert_trees_all_close(adv[2], jnp.float32(-1.0), atol=1e-4)
+


### PR DESCRIPTION
Fixes #2409

## Summary
In `alberta_framework/core/resource_manager.py` and `alberta_framework/core/feature_discovery.py`, Hedge-style preference updates divided masked allocations by `jnp.maximum(finite_weight_sum, 1e-12)`. When masked-in entries carry less mass than $10^{-12}$ (e.g. after one action leads by $\ge 30$ nats), the divisor stopped being the true sum of mass, so `masked_weights` failed to sum to 1 and baseline centering collapsed to 0.

## Proposed Changes
1. Replaced the `1e-12` floor with exact positive sum normalization and uniform fallback over valid entries (`uniform_fallback = jnp.where(valid_actions, 1.0 / jnp.maximum(n_valid, 1.0), 0.0)`).
2. Applied across `LearnedResourceManager._update_jit`, `GeneratorMetaResourceManager._update_jit`, and `FixedBudgetFeatureLearner._resource_log_weight_update`.
3. Added unit tests in `tests/test_resource_manager.py` across leader gaps up to 200 nats.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_resource_manager.py tests/test_feature_discovery.py tests/test_feature_discovery_loop_steps.py` (227/227 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py tests/test_resource_manager.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py` (clean).
