### PR TITLE
fix(evaluation): make flad_noise_component_transaction scale-free via power-of-two rescaling

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -203,12 +203,15 @@ def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tu
     direction = _trusted_array(gradient, name="gradient")
     if delta.shape != direction.shape or delta.ndim != 1 or delta.size < 1:
         raise ValueError("perturbation and gradient must be non-empty equal-width vectors")
-    squared_norm = jnp.vdot(direction, direction).real
-    numerator = jnp.vdot(direction, delta).real
-    active = squared_norm > 0.0
+    max_abs = jnp.max(jnp.abs(direction))
+    _, exponent = jnp.frexp(max_abs)
+    scaled = jnp.ldexp(direction, -exponent)
+    squared_norm = jnp.vdot(scaled, scaled).real
+    numerator = jnp.vdot(scaled, delta).real
+    active = (max_abs > 0.0) & (squared_norm > 0.0)
     denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
     coefficient = numerator / denominator
-    projection = direction * coefficient * active.astype(delta.dtype)
+    projection = scaled * coefficient * active.astype(delta.dtype)
     candidate = delta - projection
     valid = (
         jnp.all(jnp.isfinite(delta))

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -2,6 +2,7 @@ import copy
 import json
 from pathlib import Path
 
+import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -340,3 +341,28 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+def test_flad_noise_component_is_scale_free_across_gradient_scales() -> None:
+    delta = np.array([1.0, -2.0, 0.5, 3.0], dtype=np.float32)
+    grad = np.array([2.0, 1.0, -1.0, 0.5], dtype=np.float32)
+
+    def reference(d_arr: np.ndarray, g_arr: np.ndarray) -> np.ndarray:
+        d = np.asarray(d_arr, dtype=np.float64)
+        g = np.asarray(g_arr, dtype=np.float64)
+        denom = float(g @ g)
+        return d if denom == 0.0 else d - g * (float(g @ d) / denom)
+
+    for scale in (1e30, 1e20, 1.0, 1e-10, 1e-19, 1e-20, 1e-25, 1e-30):
+        g = jnp.asarray(grad * np.float32(scale))
+        safe, valid = jax.jit(flad_noise_component_transaction)(jnp.asarray(delta), g)
+        assert bool(valid)
+        ref = reference(delta, grad * np.float32(scale))
+        chex.assert_trees_all_close(safe, jnp.asarray(ref, dtype=jnp.float32), atol=1e-5)
+
+    # Exact zero gradient returns delta
+    safe_zero, valid_zero = jax.jit(flad_noise_component_transaction)(
+        jnp.asarray(delta), jnp.zeros_like(jnp.asarray(grad))
+    )
+    assert bool(valid_zero)
+    chex.assert_trees_all_close(safe_zero, jnp.asarray(delta), atol=1e-7)
+


### PR DESCRIPTION
Fixes #2393

## Summary
In `alberta_framework/evaluation/optimizer_geometry.py`:
`flad_noise_component_transaction` computes the orthogonal component to gradient directions. When gradient squared norms underflow in float32 ($\le 10^{-20}$), `squared_norm > 0.0` evaluated to `False`, dropping the entire projection component and returning the unprojected perturbation. Conversely, squared norms overflowed for gradients $\ge 10^{20}$, returning `valid=False`.

## Proposed Changes
1. Rescaled gradient vectors by maximum entry exponent using `jnp.frexp` and `jnp.ldexp` prior to calculating inner products and projection coefficients.
2. Maintained exact zero-gradient reduction (`active = (max_abs > 0.0) & (squared_norm > 0.0)`).
3. Added unit tests in `tests/test_optimizer_geometry.py` verifying precision across gradient scales from $10^{-30}$ to $10^{30}$ and exact zero-gradient preservation.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (29/29 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (clean).
