### PR TITLE
fix(core): rank units by bias-corrected utility in Continual Backprop

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -483,29 +483,36 @@ def _select_replacement_index(
     utility: Array,
     age: Array,
     maturity_threshold: int,
+    decay_rate: float = 0.99,
 ) -> tuple[Array, Array]:
     """Pick the index of the lowest-utility mature unit, if any.
 
     A unit is "mature" iff ``age >= maturity_threshold``. Among mature
-    units we pick the one with the smallest utility. If no mature unit
-    exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
+    units we pick the one with the smallest bias-corrected utility (Dohare et al. 2024, Eq. 8).
+    If no mature unit exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
     ``False``.
 
-    Implementation: replace the utility of immature or non-finite units
-    with ``+inf`` before taking ``argmin`` so they are never chosen.
+    Implementation: debias utility with ``1 - decay_rate ** age``, and replace the utility
+    of immature or non-finite units with ``+inf`` before taking ``argmin`` so they are never chosen.
 
     Args:
         utility: Per-unit utility array, shape ``(num_units,)``.
         age: Per-unit age array (same shape).
         maturity_threshold: Minimum age for eligibility.
+        decay_rate: Utility EMA decay rate for debiasing.
 
     Returns:
         Tuple ``(index, has_candidate)`` where ``index`` is the chosen
         unit (or ``-1``) and ``has_candidate`` is a boolean scalar.
     """
+    decay = jnp.asarray(decay_rate, dtype=jnp.float32)
+    bias_correction = 1.0 - jnp.power(decay, age.astype(jnp.float32))
+    bias_correction = jnp.where(bias_correction > 0.0, bias_correction, 1.0)
+    corrected_utility = utility / bias_correction
+
     mature = age >= jnp.asarray(maturity_threshold, dtype=age.dtype)
-    eligible = mature & jnp.isfinite(utility)
-    masked_utility = jnp.where(eligible, utility, jnp.inf)
+    eligible = mature & jnp.isfinite(corrected_utility)
+    masked_utility = jnp.where(eligible, corrected_utility, jnp.inf)
     has_candidate = jnp.any(eligible)
     idx = jnp.argmin(masked_utility)
     selected = jnp.where(has_candidate, idx, jnp.int32(-1))
@@ -687,6 +694,7 @@ def replace_units_with_flags(
             new_cbp_state.utilities[layer_idx],
             new_cbp_state.ages[layer_idx],
             config.maturity_threshold,
+            config.decay_rate,
         )
         # Only replace if we both budgeted for it AND found a mature unit.
         gated = jnp.logical_and(do_replace, has_candidate)

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -988,3 +988,14 @@ class TestCBPWrapperConstructorIdentities:
         payload[field] = value
         with pytest.raises(ValueError, match="serialized"):
             CBPMultiHeadMLPLearner.from_config(payload)
+
+def test_select_replacement_index_uses_bias_corrected_utility() -> None:
+    # Scenario A: Unit 0 has utility EMA 0.633967 at age 100 (true utility 1.0)
+    # Unit 1 has utility EMA 0.899209 at age 700 (true utility 0.9)
+    # Raw EMA ranks unit 0 lower, but bias-corrected Eq. 8 ranks unit 1 lower
+    utilities = jnp.array([0.633967, 0.899209], dtype=jnp.float32)
+    ages = jnp.array([100, 700], dtype=jnp.int32)
+    idx, has = _select_replacement_index(utilities, ages, maturity_threshold=100, decay_rate=0.99)
+    assert bool(has)
+    assert int(idx) == 1
+


### PR DESCRIPTION
Fixes #2343

## Summary
In `alberta_framework/core/continual_backprop.py`:
`_select_replacement_index` ranked mature units by raw utility EMA rather than the paper's per-unit age debiased utility (Dohare et al. 2024, Eq. 8: $\hat{u} = u / (1 - \eta^a)$). Because reset units restart their EMA at 0 upon replacement, units that just reach the maturity threshold ($a = 100$) read at $1 - 0.99^{100} \approx 0.634$ of their true utility, causing newly matured units to be systematically re-targeted for replacement over weaker older units.

## Proposed Changes
1. Added bias correction `corrected_utility = utility / jnp.where(bias_correction > 0.0, bias_correction, 1.0)` using `bias_correction = 1.0 - jnp.power(decay, age)` in `_select_replacement_index`.
2. Passed `config.decay_rate` from `replace_units_with_flags`.
3. Added unit test in `tests/test_continual_backprop.py` verifying replacement of old weak units over young strong units.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_continual_backprop.py tests/test_continual_backprop_validation.py` (130/130 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/continual_backprop.py tests/test_continual_backprop.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/continual_backprop.py` (clean).
