### PR TITLE
fix(core): enforce equal latent width invariant in BoundedPolicyArchive constructor

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        expected_width: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if expected_width is None:
+                expected_width = len(entry.latent)
+            elif len(entry.latent) != expected_width:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -66,3 +66,24 @@ def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")
     assert POLICY_ARCHIVE_PROTOCOL["scientific_promotion_allowed"] is False
+
+def test_constructor_enforces_equal_latent_width_invariant() -> None:
+    narrow = _entry("a", (0.0,), 1.0)
+    wide = _entry("b", (1.0, 2.0), 2.0)
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        BoundedPolicyArchive(byte_budget=1024, min_latent_distance=1.0, entries=(narrow, wide))
+
+
+def test_single_policy_controls_accept_arbitrary_width_entries() -> None:
+    one = BoundedPolicyArchive(byte_budget=1024, min_latent_distance=0.0, mode="one_model")
+    one = one.add(_entry("a", (0.0,), 1.0))
+    # one_model does not read latent distance and replaces entry
+    one = one.add(_entry("b", (1.0, 2.0), 2.0))
+    assert [entry.identity for entry in one.entries] == ["b"]
+
+    fixed = BoundedPolicyArchive(byte_budget=1024, min_latent_distance=0.0, mode="fixed_snapshot")
+    fixed = fixed.add(_entry("a", (0.0,), 1.0))
+    # fixed_snapshot does not read latent distance and returns self
+    fixed = fixed.add(_entry("b", (1.0, 2.0), 2.0))
+    assert [entry.identity for entry in fixed.entries] == ["a"]
+


### PR DESCRIPTION
Fixes #2322

## Summary
In `alberta_framework/core/policy_archive.py`:
`BoundedPolicyArchive` did not validate that all initial `entries` have equal latent width in `__post_init__`, allowing mixed-width archives to be constructed. On subsequent `add()` calls, numpy broadcast mismatched widths (e.g. `(3.0,) - (3.0, 3.0)` yielding norm 0.0), silently discarding valid candidates. Furthermore, the check ran before mode dispatch, unnecessarily rejecting entries on `one_model` and `fixed_snapshot` control arms that never compute latent distances.

## Proposed Changes
1. Added equal latent descriptor width verification across `entries` in `BoundedPolicyArchive.__post_init__`.
2. Relocated the width compatibility check in `add()` to the distance calculation branch (`mode == "diverse_archive"`).
3. Added unit tests in `tests/test_policy_archive.py` testing constructor rejection of mixed widths and acceptance of arbitrary widths on single-policy controls.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_policy_archive.py` (8/8 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/policy_archive.py tests/test_policy_archive.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/policy_archive.py` (clean).
