### PR TITLE
fix(benchmarks): admit all numpy integer families in gradual IPMNIST and causal map forager

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -59,15 +59,8 @@ CAUSAL_MAP_VARIANT_KIND = "alberta_causal_map"
 _CAUSAL_MAP_RNG_NAMESPACE = 0xCA05A14
 _CAUSAL_MAP_PRNG_IMPL = "threefry2x32"
 _CAUSAL_MAP_ENVIRONMENT_PRNG_IMPL = "threefry2x32"
-_EXACT_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
+_EXACT_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 _EXACT_INTEGER_TYPES = (int, *_EXACT_NUMPY_INTEGER_TYPES)
 _EXACT_REAL_TYPES = (

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -43,17 +43,8 @@ _MAX_RUN_STEPS = 1_000_000
 _PRNG_IMPLEMENTATION = "threefry2x32"
 _PAIR_RESULT_SCHEMA = "asi.ipmnist.gradual-input-pair.result.v1"
 _ADAMW_IDENTITY = tuple(sorted(ADAMW_PROTOCOL_HYPERPARAMETERS.items()))
-_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.longlong,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.ulonglong,
+_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 
 GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(

--- a/tests/test_causal_map_forager.py
+++ b/tests/test_causal_map_forager.py
@@ -3086,3 +3086,10 @@ def test_deterministic_inv_cdf_coefficients_are_pinned() -> None:
         if isinstance(node, ast.Constant) and isinstance(node.value, float)
     )
     assert observed == _AS241_SOURCE_CONSTANTS
+
+@pytest.mark.parametrize("code", ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))
+def test_causal_map_forager_admits_all_numpy_integer_families(code: str) -> None:
+    int_type = np.dtype(code).type
+    cfg = CausalMapForagerConfig(initial_retry_delay=int_type(1))
+    assert cfg.initial_retry_delay == 1
+

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -315,3 +315,10 @@ def test_gradual_pair_preflights_parameter_allocation_before_initialization() ->
             config=config,
             transition_steps=1,
         )
+
+@pytest.mark.parametrize("code", ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))
+def test_gradual_ipmnist_admits_all_numpy_integer_families(code: str) -> None:
+    int_type = np.dtype(code).type
+    cfg = GradualTransitionConfig(mode="input_interpolation", transition_steps=int_type(100))
+    assert cfg.transition_steps == 100
+


### PR DESCRIPTION
Fixes #2295

## Summary
In `alberta_framework/benchmarks/ipmnist_gradual.py` and `alberta_framework/benchmarks/causal_map_forager.py`:
Integer validation allowlists (`_NUMPY_INTEGER_TYPES` and `_EXACT_NUMPY_INTEGER_TYPES`) enumerated fixed-width type names (`np.int8`, `np.int16`, `np.int32`, `np.int64`, etc.) rather than deriving from all numpy integer character codes. Because numpy maps 5 C integer families (`bhilq`/`BHILQ`) to 4 fixed-width aliases depending on platform ABI, types such as `np.intc`/`np.uintc` or `np.longlong`/`np.ulonglong` were rejected with `ValueError` on integer and real parameter gates.

## Proposed Changes
1. Defined `_NUMPY_INTEGER_TYPES` and `_EXACT_NUMPY_INTEGER_TYPES` as `tuple(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))`.
2. Added unit tests across all 10 integer dtype codes in `tests/test_ipmnist_gradual.py` and `tests/test_causal_map_forager.py`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_ipmnist_gradual.py tests/test_causal_map_forager.py` (213/213 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/benchmarks/ipmnist_gradual.py alberta_framework/benchmarks/causal_map_forager.py tests/test_ipmnist_gradual.py tests/test_causal_map_forager.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/benchmarks/ipmnist_gradual.py alberta_framework/benchmarks/causal_map_forager.py` (clean).
