### PR TITLE
fix(core): make UPGD gradient alignment scale-free via power-of-two rescaling

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1983,26 +1983,49 @@ class UPGDLearner:
         return total
 
     @staticmethod
+    def _rescale_tuple(xs: tuple[Array, ...]) -> tuple[tuple[Array, ...], Array, Array]:
+        """Rescale array tuple by power of two of maximum absolute value."""
+        max_val = jnp.array(0.0, dtype=jnp.float32)
+        for x in xs:
+            max_val = jnp.maximum(max_val, jnp.max(jnp.abs(x)))
+        _, exp_val = jnp.frexp(max_val)
+        scaled_xs = tuple(jnp.ldexp(x, -exp_val) for x in xs)
+        norm_sq = jnp.array(0.0, dtype=jnp.float32)
+        for sx in scaled_xs:
+            norm_sq = norm_sq + jnp.sum(jnp.square(sx))
+        norm = jnp.sqrt(norm_sq)
+        return scaled_xs, norm, max_val
+
+    @staticmethod
     def _tuple_norm(xs: tuple[Array, ...]) -> Array:
         """L2 norm over a static tuple of arrays."""
-        total = jnp.array(0.0, dtype=jnp.float32)
-        for x in xs:
-            total = total + jnp.sum(jnp.square(x))
-        return jnp.sqrt(total + 1e-12)
+        _, norm, max_val = UPGDLearner._rescale_tuple(xs)
+        _, exp_val = jnp.frexp(max_val)
+        return jnp.ldexp(norm, exp_val)
 
     @staticmethod
     def _gradient_alignment(
         previous: tuple[Array, ...],
         current: tuple[Array, ...],
     ) -> Array:
-        """Cosine alignment of two gradient tuples, zero for empty gradients."""
-        previous_norm = UPGDLearner._tuple_norm(previous)
-        current_norm = UPGDLearner._tuple_norm(current)
-        return jnp.where(
-            (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
-            jnp.array(0.0, dtype=jnp.float32),
+        """Cosine alignment of two gradient tuples, zero for empty or non-finite gradients."""
+        scaled_prev, norm_prev, max_prev = UPGDLearner._rescale_tuple(previous)
+        scaled_curr, norm_curr, max_curr = UPGDLearner._rescale_tuple(current)
+
+        dot_val = UPGDLearner._tuple_dot(scaled_prev, scaled_curr)
+        denom = norm_prev * norm_curr
+        cos_val = dot_val / jnp.maximum(denom, 1e-30)
+
+        valid = (
+            jnp.isfinite(max_prev)
+            & jnp.isfinite(max_curr)
+            & (max_prev > 0.0)
+            & (max_curr > 0.0)
+            & (norm_prev > 0.0)
+            & (norm_curr > 0.0)
+            & jnp.isfinite(cos_val)
         )
+        return jnp.where(valid, jnp.clip(cos_val, -1.0, 1.0), jnp.array(0.0, dtype=jnp.float32))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(self, state: UPGDState, observation: Array) -> Array:

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -2219,3 +2219,26 @@ class TestLoops:
         stream = RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.05)
         result = run_upgd_loop(learner, stream, num_steps=50, key=jr.key(0))
         chex.assert_shape(result.metrics, (50, 4))
+
+    def test_gradient_alignment_is_scale_free(self):
+        for exponent in (10, 8, 4, 0, -4, -8, -10):
+            scale = 10.0**exponent
+            learner = UPGDLearner(
+                n_heads=1,
+                hidden_sizes=(),
+                sparsity=0.0,
+                step_size=0.0,
+                perturbation_sigma=0.0,
+                meta_plasticity_mode="gradient_alignment",
+                meta_plasticity_step_size=0.5,
+                meta_plasticity_min_multiplier=0.1,
+                meta_plasticity_max_multiplier=10.0,
+            )
+            state = learner.init(feature_dim=3, key=jr.key(16))
+            obs = jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32) * scale
+            target = jnp.array([1.0], dtype=jnp.float32) * scale
+            state = learner.update(state, obs, target).state
+            state = learner.update(state, obs, target).state
+            assert jnp.allclose(state.meta_head_weight_log_scale, 0.5, atol=1e-5)
+            assert jnp.allclose(state.meta_head_bias_log_scale, 0.5, atol=1e-5)
+


### PR DESCRIPTION
Fixes #2389

## Summary
In `alberta_framework/core/upgd.py`:
`UPGDLearner._gradient_alignment` computed cosine similarity using fixed magnitude gates (`previous_norm > 1e-6`, `current_norm > 1e-6`) and raw square accumulations.
- For gradients below $10^{-6}$ per element (e.g. late training, small learning rates, or wide layers), the hard-coded floor suppressed true non-zero alignments to `0.0`. Below $10^{-20}$, float32 sums of squares underflowed to 0.
- For gradients above $10^9$ per element, the unscaled sum of squares overflowed float32, introducing persistent `NaN` into meta-plasticity multipliers.

## Proposed Changes
1. Added `_rescale_tuple` using `jnp.frexp` and `jnp.ldexp` to scale gradient tuples by the maximum entry's exponent before accumulating norms and dot products.
2. Formulated `_gradient_alignment` to compute cosine on rescaled tuples and check validity dynamically (`jnp.isfinite` and positive norms) rather than comparing against a fixed magnitude floor.
3. Added unit tests in `tests/test_upgd.py` verifying exact scale invariance from $10^{-10}$ to $10^{10}$.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_upgd.py` (89/89 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/upgd.py tests/test_upgd.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/upgd.py` (clean).
