### PR TITLE
fix(evaluation): make spectral_matrix_sign scale-free via power-of-two rescaling

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -173,7 +173,15 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
     valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    _, exponent = jnp.frexp(jnp.max(jnp.abs(value)))
+    rescaled = jnp.ldexp(value, -exponent)
+    rescaled_norm = jnp.linalg.norm(rescaled)
+    positive = rescaled_norm > 0
+    x = jnp.where(
+        positive,
+        rescaled / jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm)),
+        jnp.zeros_like(rescaled),
+    )
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,13 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+def test_spectral_matrix_sign_is_scale_free_for_small_matrices() -> None:
+    m = jnp.array([[2.0, 1.0], [0.5, -1.0]], dtype=jnp.float32)
+    expected_norm = float(jnp.linalg.norm(spectral_matrix_sign(m)))
+    for scale in (1e-13, 1e-15, 1e-20, 1e-25):
+        tiny = m * jnp.asarray(scale, dtype=jnp.float32)
+        safe, valid = spectral_matrix_sign_transaction(tiny)
+        assert bool(valid)
+        assert jnp.allclose(jnp.linalg.norm(safe), expected_norm, atol=1e-5)
+


### PR DESCRIPTION
Fixes #2379

## Summary
In `alberta_framework/evaluation/optimizer_geometry.py`:
`spectral_matrix_sign_transaction` divided by a hard-coded `1e-12` magnitude floor (`jnp.maximum(norm, 1e-12)`). For input matrices with Frobenius norm below $10^{-12}$, the initial matrix was normalized against $10^{-12}$ rather than its own norm ($\|x\|_F \ll 1$), leaving singular values far below the NS5 iteration's convergence domain and returning a numerically zero matrix with `valid=True`.

## Proposed Changes
1. Applied power-of-two exponent normalization via `jnp.frexp` and `jnp.ldexp` to rescale the matrix prior to computing the Frobenius norm in `spectral_matrix_sign_transaction`.
2. Normalized by `rescaled_norm` when positive, preserving exact zeroes without laundering small matrices.
3. Added unit tests in `tests/test_optimizer_geometry.py` testing scale invariance across matrix magnitudes from $10^{-13}$ down to $10^{-25}$.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (29/29 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (clean).
