### PR TITLE
fix(utils): promote integer and boolean cumulants to floating dtype in forward-view returns

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -155,8 +155,12 @@ def forward_view_returns(
     _require_leading_length(
         "cumulants", cumulants, ndim=1, maximum=_NEXTING_MAX_STEPS
     )
-    gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
-    init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
+    compute_dtype = jnp.result_type(cumulants, gamma, terminal_value)
+    if not jnp.issubdtype(compute_dtype, jnp.floating):
+        compute_dtype = jnp.float32
+    cumulants_f = jnp.asarray(cumulants, dtype=compute_dtype)
+    gamma_s = jnp.asarray(gamma, dtype=compute_dtype)
+    init = jnp.asarray(terminal_value, dtype=compute_dtype)
 
     def step(carry: Array, c: Array) -> tuple[Array, Array]:
         # gamma=0 must not multiply an inf later return (0*inf).
@@ -164,7 +168,7 @@ def forward_view_returns(
         new_carry = c + bootstrap
         return new_carry, new_carry
 
-    _, returns_reversed = jax.lax.scan(step, init, cumulants[::-1])
+    _, returns_reversed = jax.lax.scan(step, init, cumulants_f[::-1])
     return returns_reversed[::-1]
 
 

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -617,3 +617,12 @@ class TestRunningRMSE:
         assert float(running[-1, 0]) < 0.01
         # Mid-series transition: some error
         assert float(running[19, 0]) > 0.5
+
+    def test_integer_cumulants_produce_correct_float_returns(self) -> None:
+        c_int = jnp.array([1, 0, 0, 0, 1], dtype=jnp.int32)
+        c_float = c_int.astype(jnp.float32)
+        expected = forward_view_returns(c_float, 0.9)
+        actual = forward_view_returns(c_int, 0.9)
+        assert jnp.issubdtype(actual.dtype, jnp.floating)
+        np.testing.assert_allclose(actual, expected, rtol=1e-5)
+


### PR DESCRIPTION
Fixes #2368

## Summary
In `alberta_framework/utils/nexting.py`:
`forward_view_returns` cast discount `gamma` and `terminal_value` directly into `cumulants.dtype` (`gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)`). When non-floating cumulant series (e.g. integer event indicators or boolean signals) were provided, fractional discount factors $\gamma \in (0, 1)$ were truncated to 0, degenerating the scan into a raw cumulant echo and collapsing multi-horizon predictions in `multi_horizon_returns`.

## Proposed Changes
1. Computed `compute_dtype = jnp.result_type(cumulants, gamma, terminal_value)`.
2. Ensured `compute_dtype` is a floating type (falling back to `jnp.float32` for purely integer or boolean inputs).
3. Cast `cumulants`, `gamma`, and `terminal_value` to `compute_dtype` before scanning.
4. Added unit test in `tests/test_nexting.py` verifying accurate float return calculations on int32 cumulant series.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_nexting.py tests/test_nexting_series_length.py` (95/95 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/utils/nexting.py tests/test_nexting.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/utils/nexting.py` (clean).
