### PR TITLE
fix(tests): catch RuntimeWarning in _platform_longdouble_1e4000 helper

### DIFF
--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from decimal import Decimal
 from fractions import Fraction
@@ -537,7 +538,8 @@ class _NonfiniteFloatThatConvertsFinite(float):
 
 def _platform_longdouble_1e4000() -> np.longdouble:
     """Parse the cross-platform boundary without leaking an expected warning."""
-    with np.errstate(over="ignore", invalid="ignore"):
+    with warnings.catch_warnings(), np.errstate(over="ignore", invalid="ignore"):
+        warnings.simplefilter("ignore", RuntimeWarning)
         return np.longdouble("1e4000")
 
 
@@ -1029,3 +1031,9 @@ def test_run_multi_seed_experiment_rejects_invalid_seed_sequences(
 def test_get_final_performance_rejects_non_builtin_positive_window(window: object) -> None:
     with pytest.raises(ValueError, match="window"):
         get_final_performance({"candidate": _two_seed_trace()}, window=window)  # type: ignore[arg-type]
+
+def test_platform_longdouble_helper_does_not_leak_runtime_warning() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        _platform_longdouble_1e4000()
+


### PR DESCRIPTION
Fixes #2387

## Summary
In `tests/test_experiments_validation.py`:
`_platform_longdouble_1e4000` wrapped the parsing of `"1e4000"` in `np.errstate(over="ignore", invalid="ignore")`. However, floating-point string conversion overflow in numpy is emitted via Python's `warnings` subsystem (`RuntimeWarning: overflow encountered in conversion from string`), which `np.errstate` does not suppress. This leaked a warning on platforms where `np.longdouble` is 64-bit (e.g. aarch64 / macOS).

## Proposed Changes
1. Wrapped `np.longdouble("1e4000")` inside `warnings.catch_warnings()` with `warnings.simplefilter("ignore", RuntimeWarning)`.
2. Added unit test `test_platform_longdouble_helper_does_not_leak_runtime_warning` verifying no `RuntimeWarning` is leaked under `warnings.simplefilter("error", RuntimeWarning)`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_experiments_validation.py` (130/130 passed, 0 warnings).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check tests/test_experiments_validation.py` (clean).
