### PR TITLE
fix(core): preserve valid probability simplex and uniform fallback in upgd_memory _normalize_simplex

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -675,7 +675,15 @@ def _active_mse(prediction: Array, target: Array) -> Array:
 
 def _normalize_simplex(prediction: Array) -> Array:
     clipped = jnp.maximum(prediction, 0.0)
-    return clipped / jnp.maximum(jnp.sum(clipped), 1e-12)
+    max_val = jnp.max(clipped)
+    _, exp_val = jnp.frexp(max_val)
+    scaled = jnp.ldexp(clipped, -exp_val)
+    scaled_total = jnp.sum(scaled)
+    positive = (max_val > 0.0) & (scaled_total > 0.0) & jnp.isfinite(scaled_total)
+    normalized = scaled / jnp.where(positive, scaled_total, 1.0)
+    n = jnp.maximum(prediction.shape[0], 1).astype(prediction.dtype)
+    uniform = jnp.full_like(clipped, 1.0 / n)
+    return jnp.where(positive, normalized, uniform)
 
 
 class UPGDMemoryLearner:

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -11,6 +11,7 @@ from alberta_framework.core.upgd_memory import (
     UPGDMemoryConfig,
     UPGDMemoryLearner,
     UPGDMemoryState,
+    _normalize_simplex,
     run_upgd_memory_arrays,
 )
 
@@ -564,3 +565,18 @@ def test_upgd_memory_preserves_legal_closed_endpoints() -> None:
     assert allocation_endpoint.target_allocation_rate == 1.0
     assert fixed_threshold.min_novelty_threshold == 0.5
     assert fixed_threshold.max_novelty_threshold == 0.5
+
+def test_normalize_simplex_preserves_valid_simplex_across_edge_cases() -> None:
+    cases = (
+        [0.0, 0.0, 0.0],
+        [-1.0, -2.0, -3.0],
+        [1e38, 1.0, 1.0],
+        [7.5e-13, 0.0, 0.0],
+        [1e-30, 0.0, 0.0],
+    )
+    for p in cases:
+        arr = jnp.asarray(p, dtype=jnp.float32)
+        res = _normalize_simplex(arr)
+        assert jnp.all(res >= 0.0)
+        assert jnp.allclose(jnp.sum(res), 1.0, atol=1e-5)
+


### PR DESCRIPTION
Fixes #2470

## Summary
In `alberta_framework/core/upgd_memory.py`:
`_normalize_simplex` returned a non-simplex in edge cases (all-zero vectors, negative entries, sums below $10^{-12}$, or large exponent entries), resulting in `sum(p) < 1.0` or `0.0`. When `previous_targets` (initialized to zeros) was blended via `target_trace_blend_scale * trace_pressure * trace_prediction`, up to 80% of prediction mass was silently destroyed.

## Proposed Changes
1. Rescaled clipped positive predictions by the maximum entry's exponent using `jnp.frexp` and `jnp.ldexp`.
2. Normalized by the positive scaled mass sum, and fell back to uniform distribution `1.0 / n` when total positive mass is non-positive or non-finite.
3. Added unit tests in `tests/test_upgd_memory.py` testing simplex validity (`sum == 1.0` and `p >= 0`) across edge cases.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_upgd_memory.py tests/test_upgd_memory_validation.py tests/test_upgd_memory_grad.py` (220/220 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/upgd_memory.py tests/test_upgd_memory.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/upgd_memory.py` (clean).
