### PR TITLE
fix(core): remove 1e-6 floor in world model targets to pair normalize and denormalize scales

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -365,7 +365,9 @@ class ActionConditionedWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 _validated_config_float(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]",
+                    scale,
+                    positive=True,
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -806,11 +808,10 @@ class ActionConditionedWorldModel:
         reward_arr = _float32_operand("reward", reward, ())
         discount_arr = _float32_operand("discount", discount, ())
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
             self._config.predict_delta,
-            (next_obs - obs) / safe_scale,
-            next_obs / safe_scale,
+            (next_obs - obs) / obs_scale,
+            next_obs / obs_scale,
         )
         reward_target = jnp.reshape(
             reward_arr / self._config.reward_scale,

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -955,3 +955,18 @@ def test_action_world_model_rolls_back_reduction_overflow() -> None:
     assert not bool(result.update_applied)
     assert float(result.observation_mse) == 0.0
     assert int(result.state.step_count) == 0
+
+def test_action_world_model_targets_are_scale_free_across_normal_range() -> None:
+    for scale in (1e-6, 1e-9, 1e-12, 1e-20, 1e-30):
+        config = ActionConditionedWorldModelConfig(
+            observation_dim=1, n_actions=2, hidden_sizes=(), observation_scale=(scale,)
+        )
+        model = ActionConditionedWorldModel(config)
+        obs = jnp.array([1.0 * scale], dtype=jnp.float32)
+        next_obs = jnp.array([3.0 * scale], dtype=jnp.float32)
+        target = model.targets(obs, jnp.array(0.0), jnp.array(1.0), next_obs)
+        np.testing.assert_allclose(float(target[0]), 2.0, rtol=1e-5)
+
+
+
+


### PR DESCRIPTION
Fixes #2398

## Summary
In `alberta_framework/core/world_model.py`:
`targets()` normalized delta targets with `safe_scale = jnp.maximum(obs_scale, 1e-6)`, whereas `_prediction_and_raw_diagnostics()` denormalized predictions using the raw `obs_scale`. For `observation_scale` below $10^{-6}$, the normalize and denormalize operations did not compose, causing observation heads to reconstruct only a fraction ($\text{scale} / 10^{-6}$) of the learned delta.

## Proposed Changes
1. Removed the unneeded `1e-6` floor in `targets()`, dividing directly by `obs_scale` (matching the decode step in `_prediction_and_raw_diagnostics()`).
2. Added unit tests in `tests/test_action_conditioned_world_model.py` verifying scale-invariance across normal float32 ranges ($10^{-6}, 10^{-9}, 10^{-12}, 10^{-20}, 10^{-30}$).

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_action_conditioned_world_model.py tests/test_world_model.py` (91/91 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/world_model.py tests/test_action_conditioned_world_model.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/world_model.py` (clean).
