### PR TITLE
fix(evaluation): make flad_noise_component_transaction scale-free via power-of-two rescaling

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -203,12 +203,15 @@ def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tu
     direction = _trusted_array(gradient, name="gradient")
     if delta.shape != direction.shape or delta.ndim != 1 or delta.size < 1:
         raise ValueError("perturbation and gradient must be non-empty equal-width vectors")
-    squared_norm = jnp.vdot(direction, direction).real
-    numerator = jnp.vdot(direction, delta).real
-    active = squared_norm > 0.0
+    max_val = jnp.max(jnp.abs(direction))
+    _, exponent = jnp.frexp(max_val)
+    scaled = jnp.ldexp(direction, -exponent)
+    squared_norm = jnp.vdot(scaled, scaled).real
+    numerator = jnp.vdot(scaled, delta).real
+    active = (max_val > 0.0) & (squared_norm > 0.0) & jnp.isfinite(squared_norm)
     denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
     coefficient = numerator / denominator
-    projection = direction * coefficient * active.astype(delta.dtype)
+    projection = scaled * coefficient * active.astype(delta.dtype)
     candidate = delta - projection
     valid = (
         jnp.all(jnp.isfinite(delta))

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,21 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+def test_flad_noise_component_scale_free_across_extreme_magnitudes() -> None:
+    delta = np.array([1.0, -2.0, 0.5, 3.0], dtype=np.float32)
+    grad = np.array([2.0, 1.0, -1.0, 0.5], dtype=np.float32)
+
+    def reference(d_arr: np.ndarray, g_arr: np.ndarray) -> np.ndarray:
+        d = np.asarray(d_arr, dtype=np.float64)
+        g = np.asarray(g_arr, dtype=np.float64)
+        denom = float(g @ g)
+        return d if denom == 0.0 else d - g * (float(g @ d) / denom)
+
+    ref = reference(delta, grad)
+    for scale in (1.0, 1e-10, 1e-20, 1e-30, 1e20, 1e30):
+        scaled_g = jnp.asarray(grad * np.float32(scale))
+        safe, valid = jax.jit(flad_noise_component_transaction)(jnp.asarray(delta), scaled_g)
+        assert bool(valid)
+        np.testing.assert_allclose(np.asarray(safe), ref, rtol=1e-5)
+


### PR DESCRIPTION
Fixes #2393

## Summary
In `alberta_framework/evaluation/optimizer_geometry.py`:
`flad_noise_component_transaction` accumulated squared gradient norms `squared_norm = jnp.vdot(direction, direction).real` in unscaled float32. When gradient magnitudes dropped below $\approx 10^{-19}$, squared norms underflowed to zero (`active = False`), causing the function to silently return the input perturbation unchanged with `valid=True`, omitting the projection component along the gradient.

## Proposed Changes
1. Rescaled gradient vectors by power-of-two magnitude normalization using `jnp.frexp` and `jnp.ldexp`.
2. Computed `squared_norm`, `numerator`, and projection in the rescaled domain.
3. Added unit tests in `tests/test_optimizer_geometry.py` testing mathematical equivalence against float64 reference across extreme scales from $10^{-30}$ to $10^{30}$.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (29/29 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (clean).
