### PR TITLE
fix(pipeline): pass termination-aware discount to HordeActorCriticAgent in horde_ac control mode

### DIFF
--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -1573,10 +1573,15 @@ class AlbertaPipeline:
                 dtype=jnp.int32,
             )
             auxiliary_cumulants = horde_cumulants[aux_indices] if aux_indices.size else None
+            value_gamma = self._horde.horde_spec.gammas[value_index]
+            control_discount = jnp.where(
+                terminated == 0.0, value_gamma, jnp.zeros_like(value_gamma)
+            )
             ac_result = ac.update(
                 ac_state,
                 reward,
                 features,
+                discount=control_discount,
                 auxiliary_cumulants=auxiliary_cumulants,
             )
             new_control_state: SARSAState | HordeActorCriticState = ac_result.state

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1196,3 +1196,35 @@ def test_associative_pipeline_narrows_only_statically_safe_integer_dtypes() -> N
 
 # silence the import lint warnings used in the test runner
 _ = jax
+
+def test_pipeline_horde_ac_respects_terminated_flag() -> None:
+    config = AlbertaPipelineConfig(
+        features=Step2FeatureConfig.identity(observation_dim=3),
+        horde=Step3HordeConfig(
+            gammas=(0.9, 0.5),
+            lamdas=(0.0, 0.0),
+            hidden_sizes=(),
+            step_size=0.05,
+        ),
+        horde_ac=HordeActorCriticPipelineConfig(
+            n_actions=2,
+            value_head_index=0,
+            actor_lamda=0.8,
+        ),
+        control_mode="horde_ac",
+    )
+    pipeline = AlbertaPipeline(config)
+    state = pipeline.init(jr.key(0), jnp.asarray([0.2, -0.1, 0.4], dtype=jnp.float32))
+    obs = jnp.asarray([0.1, 0.3, -0.2], dtype=jnp.float32)
+    reward = jnp.asarray(0.5, dtype=jnp.float32)
+    cumulants = jnp.asarray([0.5, -0.2], dtype=jnp.float32)
+
+    res_cont = pipeline.update(state, obs, reward, jnp.asarray(0.0, dtype=jnp.float32), cumulants)
+    res_term = pipeline.update(state, obs, reward, jnp.asarray(1.0, dtype=jnp.float32), cumulants)
+
+    # In terminal step, value head target is reward alone (0.5), not bootstrapped (0.3454)
+    assert jnp.allclose(res_term.horde_td_targets[0], 0.5, atol=1e-5)
+    assert not jnp.allclose(res_cont.horde_td_targets[0], 0.5, atol=1e-5)
+    # In terminal step, actor traces are zeroed
+    assert jnp.allclose(res_term.state.control_state.actor_trace_weights, 0.0)
+


### PR DESCRIPTION
Fixes #2344

## Summary
In `alberta_framework/pipeline.py`:
When `control_mode == "horde_ac"`, `AlbertaPipeline.update` called `ac.update(...)` without forwarding the `terminated` argument (or passing `discount`). As a result, `HordeActorCriticAgent.update` defaulted to using the fixed value head demon gamma `self._critic.horde_spec.gammas[value_head_index]` on every step, causing the value head to bootstrap through episode terminations ($r + \gamma V(s')$ instead of $r$) and carrying the actor's eligibility trace across episode boundaries.

## Proposed Changes
1. Computed `control_discount = jnp.where(terminated == 0.0, value_gamma, jnp.zeros_like(value_gamma))`.
2. Passed `discount=control_discount` to `ac.update(...)` in the `horde_ac` control branch of `AlbertaPipeline.update`.
3. Added unit tests in `tests/test_pipeline.py` verifying that when `terminated == 1.0`, the value head target equals the reward alone and actor eligibility traces are reset.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_pipeline.py` (184/184 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/pipeline.py tests/test_pipeline.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/pipeline.py` (clean).
