### PR TITLE
docs(utils): fix indentation of Raises section in get_final_performance docstring

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -665,7 +665,7 @@ def get_final_performance(
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
 
-        Raises:
+    Raises:
         ValueError: If ``window`` is not positive, a metric array has no
             time steps, any metric sample is non-finite, or ``window`` exceeds
             the shortest trace while trace lengths differ between methods.


### PR DESCRIPTION
Fixes #2439

## Summary
In `alberta_framework/utils/experiments.py`:
In the docstring of `get_final_performance`, the `Raises:` section header was indented at 8 spaces (nested under the `Returns:` section) instead of 4 spaces (as a top-level section sibling), preventing standard docstring tooling from recognizing the exception documentation.

## Proposed Changes
1. Fixed the indentation of `Raises:` from 8 spaces to 4 spaces.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_experiments_validation.py tests/test_experiments_hostile_validation.py` (141/141 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/utils/experiments.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/utils/experiments.py` (clean).
