### PR TITLE
fix(core): make UPGD gradient alignment scale-free via power-of-two frexp rescaling

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1983,26 +1983,52 @@ class UPGDLearner:
         return total
 
     @staticmethod
+    def _scale_free_unit_tuple(xs: tuple[Array, ...]) -> tuple[tuple[Array, ...], Array]:
+        """Normalize a static tuple of arrays to unit L2 norm in a scale-free manner."""
+        max_val = jnp.array(0.0, dtype=jnp.float32)
+        all_finite = jnp.array(True, dtype=jnp.bool_)
+        for x in xs:
+            max_val = jnp.maximum(max_val, jnp.max(jnp.abs(x)))
+            all_finite = all_finite & jnp.all(jnp.isfinite(x))
+        _, exp = jnp.frexp(max_val)
+        scaled_xs = tuple(jnp.ldexp(x, -exp) for x in xs)
+        sq_sum = jnp.array(0.0, dtype=jnp.float32)
+        for sx in scaled_xs:
+            sq_sum = sq_sum + jnp.sum(jnp.square(sx))
+        norm = jnp.sqrt(sq_sum)
+        valid = (
+            (max_val > 0.0)
+            & (sq_sum > 0.0)
+            & jnp.isfinite(sq_sum)
+            & jnp.isfinite(norm)
+            & (norm > 0.0)
+            & all_finite
+        )
+        unit_xs = tuple(
+            jnp.where(valid, sx / jnp.where(valid, norm, 1.0), 0.0)
+            for sx in scaled_xs
+        )
+        return unit_xs, valid
+
+    @staticmethod
     def _tuple_norm(xs: tuple[Array, ...]) -> Array:
         """L2 norm over a static tuple of arrays."""
         total = jnp.array(0.0, dtype=jnp.float32)
         for x in xs:
             total = total + jnp.sum(jnp.square(x))
-        return jnp.sqrt(total + 1e-12)
+        return jnp.sqrt(total)
 
     @staticmethod
     def _gradient_alignment(
         previous: tuple[Array, ...],
         current: tuple[Array, ...],
     ) -> Array:
-        """Cosine alignment of two gradient tuples, zero for empty gradients."""
-        previous_norm = UPGDLearner._tuple_norm(previous)
-        current_norm = UPGDLearner._tuple_norm(current)
-        return jnp.where(
-            (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
-            jnp.array(0.0, dtype=jnp.float32),
-        )
+        """Cosine alignment of two gradient tuples, zero for empty or non-finite gradients."""
+        unit_prev, valid_prev = UPGDLearner._scale_free_unit_tuple(previous)
+        unit_curr, valid_curr = UPGDLearner._scale_free_unit_tuple(current)
+        dot = UPGDLearner._tuple_dot(unit_prev, unit_curr)
+        valid = valid_prev & valid_curr & jnp.isfinite(dot)
+        return jnp.where(valid, jnp.clip(dot, -1.0, 1.0), 0.0)
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(self, state: UPGDState, observation: Array) -> Array:

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -2219,3 +2219,26 @@ class TestLoops:
         stream = RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.05)
         result = run_upgd_loop(learner, stream, num_steps=50, key=jr.key(0))
         chex.assert_shape(result.metrics, (50, 4))
+
+def test_upgd_gradient_alignment_is_scale_free_across_magnitudes() -> None:
+    for exponent in (10, 8, 6, 4, 0, -4, -6, -8, -10):
+        scale = 10.0**exponent
+        learner = UPGDLearner(
+            n_heads=1,
+            hidden_sizes=(),
+            sparsity=0.0,
+            step_size=0.0,
+            perturbation_sigma=0.0,
+            meta_plasticity_mode="gradient_alignment",
+            meta_plasticity_step_size=0.5,
+            meta_plasticity_min_multiplier=0.1,
+            meta_plasticity_max_multiplier=10.0,
+        )
+        state = learner.init(feature_dim=3, key=jr.key(16))
+        obs = jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32) * scale
+        target = jnp.array([1.0], dtype=jnp.float32) * scale
+        state = learner.update(state, obs, target).state
+        state = learner.update(state, obs, target).state
+        assert jnp.allclose(state.meta_head_weight_log_scale, 0.5, atol=1e-4)
+        assert jnp.allclose(state.meta_head_bias_log_scale, 0.5, atol=1e-4)
+


### PR DESCRIPTION
Fixes #2389

## Summary
In `alberta_framework/core/upgd.py`:
`_gradient_alignment` used fixed absolute thresholds `previous_norm > 1e-6` and `current_norm > 1e-6` along with unscaled sum-of-squares norm calculations.
As a result:
- At small gradient scales (below $10^{-6}$), gradient alignment silently collapsed to `0.0` regardless of cosine similarity, making `meta_plasticity_mode="gradient_alignment"` an invisible no-op.
- At large gradient scales (above $10^9$), squared norms overflowed float32, producing permanent `NaN` in `meta_head_weight_log_scale`.

## Proposed Changes
1. Added `_scale_free_unit_tuple` which normalizes static gradient tuples by power-of-two magnitude rescaling (`jnp.frexp` and `jnp.ldexp`).
2. Computed cosine similarity directly as the inner product of scale-free normalized unit tuples, clipped to `[-1.0, 1.0]`.
3. Added unit tests in `tests/test_upgd.py` verifying exact alignment across input scales from $10^{-10}$ to $10^{10}$.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_upgd.py` (89/89 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/upgd.py tests/test_upgd.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/upgd.py` (clean).
