### PR TITLE
fix(evaluation): make spectral_matrix_sign scale-free via power-of-two frexp rescaling

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -173,7 +173,16 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
     valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    max_val = jnp.max(jnp.abs(value))
+    _, exponent = jnp.frexp(max_val)
+    rescaled = jnp.ldexp(value, -exponent)
+    rescaled_norm = jnp.linalg.norm(rescaled)
+    positive = (max_val > 0.0) & (rescaled_norm > 0.0) & jnp.isfinite(rescaled_norm)
+    x = jnp.where(
+        positive,
+        rescaled / jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm)),
+        jnp.zeros_like(rescaled),
+    )
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,14 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+def test_spectral_matrix_sign_scale_free_across_small_magnitudes() -> None:
+    m = jnp.array([[2.0, 1.0], [0.5, -1.0]], dtype=jnp.float32)
+    ref, ref_valid = jax.jit(spectral_matrix_sign_transaction)(m)
+    assert bool(ref_valid)
+    for scale in (1e-13, 1e-15, 1e-20, 1e-25, 1e-30):
+        tiny = m * jnp.asarray(scale, dtype=jnp.float32)
+        safe, valid = jax.jit(spectral_matrix_sign_transaction)(tiny)
+        assert bool(valid)
+        np.testing.assert_allclose(np.asarray(safe), np.asarray(ref), atol=1e-5)
+


### PR DESCRIPTION
Fixes #2379

## Summary
In `alberta_framework/evaluation/optimizer_geometry.py`:
`spectral_matrix_sign_transaction` divided matrices by `jnp.maximum(norm, 1e-12)`. When a matrix norm fell below $10^{-12}$ (or entries dropped below $10^{-20}$ where sum-of-squares underflowed to 0.0), the divisor defaulted to $10^{-12}$ instead of the true Frobenius norm. As a result, singular values were placed far below the NS5 convergence interval, causing the recurrence to return a numerically zero matrix with `valid=True` rather than orthogonalizing the matrix.

## Proposed Changes
1. Rescaled input matrices by power-of-two magnitude normalization using `jnp.frexp` and `jnp.ldexp`.
2. Normalized the rescaled matrix by its rescaled Frobenius norm, preserving exact zero on genuinely zero inputs while eliminating the $10^{-12}$ floor bug.
3. Added unit tests in `tests/test_optimizer_geometry.py` verifying numerical equivalence of matrix signs across small input scales from $10^{-13}$ down to $10^{-30}$.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (29/29 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (clean).
