### PR TITLE
fix(core): cap n_dreams_per_step at 10,000 to prevent scan hang/OOM

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -725,7 +725,7 @@ class PrototypeAgentConfig:
                 "n_dreams_per_step",
                 self.n_dreams_per_step,
                 minimum=0,
-                maximum=_INT32_MAX,
+                maximum=10_000,
             ),
         )
         # horde_hidden_sizes: hostile-safe per-element validation
@@ -1335,7 +1335,7 @@ class PrototypeAgentConfig:
             "buffer_capacity", data.pop("buffer_capacity", 200), minimum=1, maximum=_INT32_MAX
         )
         n_dreams_per_step = _require_int(
-            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=_INT32_MAX
+            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=10_000
         )
         dream_next_observation_mode = data.pop(
             "dream_next_observation_mode",

--- a/tests/test_prototype_agent_validation.py
+++ b/tests/test_prototype_agent_validation.py
@@ -303,3 +303,13 @@ def test_prototype_valid_construction() -> None:
     assert restored == cfg
     gru = GRUPerceptionConfig(observation_dim=4, hidden_dim=4)
     assert gru.augmented_dim() == 8
+
+def test_prototype_agent_config_caps_n_dreams_per_step() -> None:
+    oak = _oak()
+    with pytest.raises(ValueError, match="n_dreams_per_step"):
+        PrototypeAgentConfig(oak=oak, n_dreams_per_step=10_001)
+
+    payload = {"type": "PrototypeAgentConfig", "oak": oak.to_config(), "n_dreams_per_step": 10_001}
+    with pytest.raises(ValueError, match="n_dreams_per_step"):
+        PrototypeAgentConfig.from_config(payload)
+


### PR DESCRIPTION
Fixes #2441

## Summary
In `PrototypeAgentConfig` (`alberta_framework/core/prototype_agent.py`):
`n_dreams_per_step` was bounded only by `_INT32_MAX`. Because `n_dreams_per_step` drives a `jax.lax.scan` over `jnp.arange(self._config.n_dreams_per_step)` that executes an imagined world-model rollout and OaK update per step, large inputs (e.g. $> 10^5$) trigger severe process hangs and memory exhaustion.

## Proposed Changes
1. Capped `n_dreams_per_step` to a maximum of `10_000` steps in both `PrototypeAgentConfig.__post_init__` and `from_dict`, matching the `ScanBudget` precedent in `core.dreaming`.
2. Added unit tests in `tests/test_prototype_agent_validation.py` verifying that configurations and serialized payloads with `n_dreams_per_step > 10_000` are rejected with `ValueError`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_prototype_agent_validation.py` (24/24 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/prototype_agent.py tests/test_prototype_agent_validation.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/prototype_agent.py` (clean).
