### PR TITLE
fix(core): rank CBP units by bias-corrected utility (Dohare et al. 2024 Eq. 8)

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -483,29 +483,37 @@ def _select_replacement_index(
     utility: Array,
     age: Array,
     maturity_threshold: int,
+    decay_rate: float = 0.99,
 ) -> tuple[Array, Array]:
     """Pick the index of the lowest-utility mature unit, if any.
 
     A unit is "mature" iff ``age >= maturity_threshold``. Among mature
-    units we pick the one with the smallest utility. If no mature unit
-    exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
+    units we pick the one with the smallest bias-corrected utility
+    (Dohare et al. 2024, Eq. 8: ``u / (1 - eta ** age)``). If no mature
+    unit exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
     ``False``.
-
-    Implementation: replace the utility of immature or non-finite units
-    with ``+inf`` before taking ``argmin`` so they are never chosen.
 
     Args:
         utility: Per-unit utility array, shape ``(num_units,)``.
         age: Per-unit age array (same shape).
         maturity_threshold: Minimum age for eligibility.
+        decay_rate: EMA decay rate for warmup debiasing.
 
     Returns:
         Tuple ``(index, has_candidate)`` where ``index`` is the chosen
         unit (or ``-1``) and ``has_candidate`` is a boolean scalar.
     """
     mature = age >= jnp.asarray(maturity_threshold, dtype=age.dtype)
-    eligible = mature & jnp.isfinite(utility)
-    masked_utility = jnp.where(eligible, utility, jnp.inf)
+    decay = jnp.asarray(decay_rate, dtype=jnp.float32)
+    bias_correction = jnp.where(
+        decay == 0.0,
+        jnp.ones_like(utility),
+        1.0 - jnp.power(decay, age.astype(jnp.float32)),
+    )
+    bias_correction = jnp.maximum(bias_correction, 1e-12)
+    debiased_utility = utility / bias_correction
+    eligible = mature & jnp.isfinite(debiased_utility)
+    masked_utility = jnp.where(eligible, debiased_utility, jnp.inf)
     has_candidate = jnp.any(eligible)
     idx = jnp.argmin(masked_utility)
     selected = jnp.where(has_candidate, idx, jnp.int32(-1))
@@ -687,6 +695,7 @@ def replace_units_with_flags(
             new_cbp_state.utilities[layer_idx],
             new_cbp_state.ages[layer_idx],
             config.maturity_threshold,
+            decay_rate=config.decay_rate,
         )
         # Only replace if we both budgeted for it AND found a mature unit.
         gated = jnp.logical_and(do_replace, has_candidate)

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -988,3 +988,14 @@ class TestCBPWrapperConstructorIdentities:
         payload[field] = value
         with pytest.raises(ValueError, match="serialized"):
             CBPMultiHeadMLPLearner.from_config(payload)
+
+def test_select_replacement_index_uses_bias_corrected_utility() -> None:
+    # Unit 0: age 100, constant contribution 1.0 -> raw EMA ~ 0.634
+    # Unit 1: age 700, constant contribution 0.9 -> raw EMA ~ 0.899
+    # Debiased utilities are 1.0 and 0.9; unit 1 should be selected (0.9 < 1.0).
+    u = jnp.array([0.633967, 0.899209], dtype=jnp.float32)
+    a = jnp.array([100, 700], dtype=jnp.int32)
+    selected, has = _select_replacement_index(u, a, maturity_threshold=100, decay_rate=0.99)
+    assert bool(has)
+    assert int(selected) == 1
+


### PR DESCRIPTION
Fixes #2343

## Summary
In `alberta_framework/core/continual_backprop.py`:
`_select_replacement_index` ranked mature units by raw exponential moving average (EMA) utility `u[l, i, t]` rather than the bias-corrected EMA `u_hat[l, i, t] = u[l, i, t] / (1 - eta ** age)` specified in Dohare et al. (2024, *Nature*, Eq. 8). Because freshly reset units have young ages relative to older units, their raw EMA was attenuated by $(1 - \eta^{\text{age}})$, causing CBP to systematically target and re-replace freshly matured units instead of older, genuinely low-utility units.

## Proposed Changes
1. Added bias correction $\hat{u} = u / \max(1 - \eta^{\text{age}}, 10^{-12})$ to `_select_replacement_index` in `alberta_framework/core/continual_backprop.py`.
2. Forwarded `decay_rate=config.decay_rate` into `_select_replacement_index` in `replace_units_with_flags`.
3. Added unit tests in `tests/test_continual_backprop.py` verifying that a younger high-utility unit (age 100, contribution 1.0) is protected over an older low-utility unit (age 700, contribution 0.9).

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_continual_backprop.py tests/test_continual_backprop_validation.py` (130/130 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/continual_backprop.py tests/test_continual_backprop.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/continual_backprop.py` (clean).
