### PR TITLE
fix(core): enforce equal latent width in BoundedPolicyArchive constructor

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        expected_width: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if expected_width is None:
+                expected_width = len(entry.latent)
+            elif len(entry.latent) != expected_width:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -66,3 +66,26 @@ def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")
     assert POLICY_ARCHIVE_PROTOCOL["scientific_promotion_allowed"] is False
+
+def test_policy_archive_constructor_enforces_equal_width_invariant() -> None:
+    narrow = PolicyEntry(identity="a", policy_bytes=b"x", latent=(0.0,), score=0.0)
+    wide = PolicyEntry(identity="b", policy_bytes=b"y", latent=(3.0, 3.0), score=9.0)
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        BoundedPolicyArchive(byte_budget=4096, min_latent_distance=1.0, entries=(narrow, wide))
+
+
+def test_policy_archive_controls_accept_arbitrary_latent_width() -> None:
+    narrow = PolicyEntry(identity="a", policy_bytes=b"x", latent=(0.0,), score=0.0)
+    wide = PolicyEntry(identity="b", policy_bytes=b"y", latent=(3.0, 3.0), score=9.0)
+
+    fixed = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=1.0, mode="fixed_snapshot", entries=(narrow,)
+    )
+    assert fixed.add(wide) is fixed
+
+    one = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=1.0, mode="one_model", entries=(narrow,)
+    )
+    res_one = one.add(wide)
+    assert res_one.entries == (wide,)
+


### PR DESCRIPTION
Fixes #2322

## Summary
In `alberta_framework/core/policy_archive.py`:
`BoundedPolicyArchive` declared that all latent descriptors must have equal width, but `__post_init__` never enforced this invariant across `entries`. Consequently, directly constructing an archive with mixed-width descriptors resulted in numpy broadcasting mismatched shapes during distance calculation (`(3.0,) - (3.0, 3.0)` broadcasting to norm 0.0), silently discarding valid candidates. Furthermore, `add` ran the width check before checking mode controls (`one_model` and `fixed_snapshot`), rejecting descriptors that the control arms never read.

## Proposed Changes
1. Enforced the equal-width invariant in `BoundedPolicyArchive.__post_init__` across all populated `entries`.
2. Relocated the candidate width check in `add()` into the diverse archive distance-calculation branch so that single-policy controls (`fixed_snapshot` and `one_model`) are not spuriously aborted on descriptors they do not compute distances on.
3. Added unit tests in `tests/test_policy_archive.py` testing constructor rejection of mixed-width entries and control arm handling.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_policy_archive.py` (8/8 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/policy_archive.py tests/test_policy_archive.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/policy_archive.py` (clean).
