### PR TITLE
fix(benchmarks): derive integer allowlists from numpy dtype codes

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -59,15 +59,8 @@ CAUSAL_MAP_VARIANT_KIND = "alberta_causal_map"
 _CAUSAL_MAP_RNG_NAMESPACE = 0xCA05A14
 _CAUSAL_MAP_PRNG_IMPL = "threefry2x32"
 _CAUSAL_MAP_ENVIRONMENT_PRNG_IMPL = "threefry2x32"
-_EXACT_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
+_EXACT_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 _EXACT_INTEGER_TYPES = (int, *_EXACT_NUMPY_INTEGER_TYPES)
 _EXACT_REAL_TYPES = (

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -43,17 +43,8 @@ _MAX_RUN_STEPS = 1_000_000
 _PRNG_IMPLEMENTATION = "threefry2x32"
 _PAIR_RESULT_SCHEMA = "asi.ipmnist.gradual-input-pair.result.v1"
 _ADAMW_IDENTITY = tuple(sorted(ADAMW_PROTOCOL_HYPERPARAMETERS.items()))
-_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.longlong,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.ulonglong,
+_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 
 GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(

--- a/tests/test_causal_map_forager.py
+++ b/tests/test_causal_map_forager.py
@@ -3086,3 +3086,14 @@ def test_deterministic_inv_cdf_coefficients_are_pinned() -> None:
         if isinstance(node, ast.Constant) and isinstance(node.value, float)
     )
     assert observed == _AS241_SOURCE_CONSTANTS
+
+@pytest.mark.parametrize(
+    "code",
+    ["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"],
+)
+def test_causal_map_forager_config_accepts_all_numpy_integer_types(code: str) -> None:
+    int_type = np.dtype(code).type
+    config = CausalMapForagerConfig(initial_retry_delay=int_type(1), visit_penalty=int_type(0))
+    assert config.initial_retry_delay == 1
+    assert config.visit_penalty == 0.0
+

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -315,3 +315,13 @@ def test_gradual_pair_preflights_parameter_allocation_before_initialization() ->
             config=config,
             transition_steps=1,
         )
+
+@pytest.mark.parametrize(
+    "code",
+    ["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"],
+)
+def test_gradual_transition_config_accepts_all_numpy_integer_types(code: str) -> None:
+    int_type = np.dtype(code).type
+    config = GradualTransitionConfig(mode="input_interpolation", transition_steps=int_type(50))
+    assert config.transition_steps == 50
+


### PR DESCRIPTION
Fixes #2295

## Summary
In `alberta_framework/benchmarks/ipmnist_gradual.py` and `alberta_framework/benchmarks/causal_map_forager.py`:
`_NUMPY_INTEGER_TYPES` and `_EXACT_NUMPY_INTEGER_TYPES` were hardcoded with fixed-width type names (`np.int8`, `np.int16`, `np.int32`, `np.int64`, etc.). Because numpy exposes 5 signed C integer types and only 4 fixed-width aliases, hardcoded names omit valid platform-specific integer types like `np.intc` and `np.uintc`, causing configurations to reject valid integer arguments with `ValueError`.

## Proposed Changes
1. Replaced hardcoded type lists in both modules with `tuple(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))`.
2. Added parameterized tests across all 10 integer type codes in `tests/test_ipmnist_gradual.py` and `tests/test_causal_map_forager.py`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_ipmnist_gradual.py` (30/30 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/benchmarks/ipmnist_gradual.py alberta_framework/benchmarks/causal_map_forager.py tests/test_ipmnist_gradual.py tests/test_causal_map_forager.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/benchmarks/ipmnist_gradual.py alberta_framework/benchmarks/causal_map_forager.py` (clean).
