### PR TITLE
fix(tests): suppress RuntimeWarning in _platform_longdouble_1e4000

### DIFF
--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from decimal import Decimal
 from fractions import Fraction
@@ -537,8 +538,10 @@ class _NonfiniteFloatThatConvertsFinite(float):
 
 def _platform_longdouble_1e4000() -> np.longdouble:
     """Parse the cross-platform boundary without leaking an expected warning."""
-    with np.errstate(over="ignore", invalid="ignore"):
-        return np.longdouble("1e4000")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        with np.errstate(over="ignore", invalid="ignore"):
+            return np.longdouble("1e4000")
 
 
 @pytest.mark.parametrize(
@@ -1029,3 +1032,9 @@ def test_run_multi_seed_experiment_rejects_invalid_seed_sequences(
 def test_get_final_performance_rejects_non_builtin_positive_window(window: object) -> None:
     with pytest.raises(ValueError, match="window"):
         get_final_performance({"candidate": _two_seed_trace()}, window=window)  # type: ignore[arg-type]
+
+def test_platform_longdouble_1e4000_suppresses_warning() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        _platform_longdouble_1e4000()
+


### PR DESCRIPTION
Fixes #2387

## Summary
In `tests/test_experiments_validation.py`:
`_platform_longdouble_1e4000` wrapped `np.longdouble("1e4000")` inside `np.errstate(over="ignore", invalid="ignore")`. However, string conversion overflow in numpy float parsing emits a standard Python `RuntimeWarning` through the `warnings` module, which `errstate` does not silence. This caused `RuntimeWarning: overflow encountered in conversion from string` to leak into test discovery/collection on platforms where `longdouble` is 64-bit (such as macOS arm64 / Linux aarch64).

## Proposed Changes
1. Wrapped `np.longdouble("1e4000")` inside `warnings.catch_warnings()` with `warnings.simplefilter("ignore", RuntimeWarning)`.
2. Added `test_platform_longdouble_1e4000_suppresses_warning()` asserting that calling the helper raises no warnings even under `warnings.simplefilter("error", RuntimeWarning)`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_experiments_validation.py` (130/130 passed, 0 warnings).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check tests/test_experiments_validation.py` (clean).
