### PR TITLE
fix(core): make upgd_memory._normalize_simplex scale-free and preserve unit mass

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -675,7 +675,15 @@ def _active_mse(prediction: Array, target: Array) -> Array:
 
 def _normalize_simplex(prediction: Array) -> Array:
     clipped = jnp.maximum(prediction, 0.0)
-    return clipped / jnp.maximum(jnp.sum(clipped), 1e-12)
+    max_val = jnp.max(clipped)
+    _, exponent = jnp.frexp(max_val)
+    rescaled = jnp.ldexp(clipped, -exponent)
+    total = jnp.sum(rescaled)
+    is_positive = (max_val > 0.0) & (total > 0.0) & jnp.isfinite(total)
+    n = clipped.shape[-1] if clipped.ndim > 0 else 1
+    uniform = jnp.full_like(clipped, 1.0 / n)
+    normalized = jnp.where(is_positive, rescaled / jnp.where(is_positive, total, 1.0), uniform)
+    return normalized
 
 
 class UPGDMemoryLearner:

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -11,6 +11,7 @@ from alberta_framework.core.upgd_memory import (
     UPGDMemoryConfig,
     UPGDMemoryLearner,
     UPGDMemoryState,
+    _normalize_simplex,
     run_upgd_memory_arrays,
 )
 
@@ -564,3 +565,21 @@ def test_upgd_memory_preserves_legal_closed_endpoints() -> None:
     assert allocation_endpoint.target_allocation_rate == 1.0
     assert fixed_threshold.min_novelty_threshold == 0.5
     assert fixed_threshold.max_novelty_threshold == 0.5
+
+@pytest.mark.parametrize(
+    "p",
+    [
+        [0.0, 0.0, 0.0],
+        [-1.0, -2.0, -3.0],
+        [1e38, 1.0, 1.0],
+        [7.5e-13, 0.0, 0.0],
+        [1e-30, 0.0, 0.0],
+        [1.0, 2.0, 3.0],
+    ],
+)
+def test_normalize_simplex_preserves_unit_mass(p: list[float]) -> None:
+    arr = jnp.asarray(p, dtype=jnp.float32)
+    norm = _normalize_simplex(arr)
+    assert bool(jnp.all(norm >= 0.0))
+    assert bool(jnp.isclose(jnp.sum(norm), 1.0, atol=1e-5))
+


### PR DESCRIPTION
Fixes #2470

## Summary
In `alberta_framework/core/upgd_memory.py`:
`_normalize_simplex` computed `clipped / jnp.maximum(jnp.sum(clipped), 1e-12)`. When input mass was zero or below the `1e-12` floor (or when large values caused float32 overflow), the division yielded sum $< 1.0$ or zero mass, silently eroding probability distribution mass during downstream target-trace blending.

## Proposed Changes
1. Rescaled vectors using power-of-two magnitude normalization (`jnp.frexp`/`jnp.ldexp`) before computing total sum.
2. Normalized by the exact rescaled sum when positive, and fell back to uniform `1.0 / n` distribution when total mass is zero.
3. Added tests in `tests/test_upgd_memory.py` asserting unit simplex normalization across edge cases (all zeros, negative, sub-floor, large magnitude, standard).

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_upgd_memory.py tests/test_upgd_memory_validation.py tests/test_upgd_memory_grad.py` (225/225 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/upgd_memory.py tests/test_upgd_memory.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/upgd_memory.py` (clean).
