### PR TITLE
fix(core): remove 1e-6 floor in latent encoder observation scaling

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -290,7 +290,9 @@ class LatentWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 validated_float32_scalar(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]",
+                    scale,
+                    lower=float(np.finfo(np.float32).tiny),
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -670,7 +672,7 @@ class LatentWorldModel:
         """Encode one observation with explicit (differentiable) encoder params."""
         obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._config.observation_dim,))
         scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
+        scaled = obs / scale
         return jnp.tanh(scaled @ encoder_matrix + encoder_bias)
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -749,3 +749,39 @@ def test_latent_world_model_init_rejects_nonfinite_encoder_draw() -> None:
 
     with pytest.raises(ValueError, match="encoder initialization"):
         model.init(jr.key(0))
+
+def test_latent_world_model_observation_scale_is_scale_free() -> None:
+    for scale in (1.0, 1e-6, 1e-9, 1e-20):
+        config = LatentWorldModelConfig(
+            observation_dim=2,
+            latent_dim=4,
+            n_actions=2,
+            observation_scale=(scale, scale),
+        )
+        model = LatentWorldModel(config)
+        state = model.init(jr.key(0))
+        obs = jnp.asarray([1.5 * scale, -0.75 * scale], dtype=jnp.float32)
+        latent = np.asarray(model.encode(state, obs))
+        ref_config = LatentWorldModelConfig(
+            observation_dim=2,
+            latent_dim=4,
+            n_actions=2,
+            observation_scale=(1.0, 1.0),
+        )
+        ref_model = LatentWorldModel(ref_config)
+        ref_state = ref_model.init(jr.key(0))
+        ref_obs = jnp.asarray([1.5, -0.75], dtype=jnp.float32)
+        ref_latent = np.asarray(ref_model.encode(ref_state, ref_obs))
+        np.testing.assert_allclose(latent, ref_latent, atol=1e-5)
+
+
+def test_latent_world_model_rejects_subnormal_observation_scale() -> None:
+    subnormal = float(np.finfo(np.float32).smallest_subnormal)
+    with pytest.raises(ValueError, match="observation_scale"):
+        LatentWorldModelConfig(
+            observation_dim=1,
+            latent_dim=2,
+            n_actions=2,
+            observation_scale=(subnormal,),
+        )
+


### PR DESCRIPTION
Fixes #2411

## Summary
In `alberta_framework/core/latent_world_model.py`:
`_encode_with` divided observation vectors by `jnp.maximum(scale, 1e-6)`. For any configured `observation_scale` below $10^{-6}$, the encoder normalized by $10^{-6}$ instead of the declared scale. This caused extreme latent shrinkage, false `collapse_score` detections, and disabled the trainable encoder.

## Proposed Changes
1. Removed the `1e-6` floor in `_encode_with`, dividing observations directly by `self._observation_scale`.
2. Validated `observation_scale` in `LatentWorldModelConfig.__post_init__` with `lower=float(np.finfo(np.float32).tiny)` so that every admitted scale has a finite float32 reciprocal.
3. Added unit tests in `tests/test_latent_world_model.py` verifying that normalized encoding is scale-free across scales ($1.0$, $10^{-6}$, $10^{-9}$, $10^{-20}$) and that subnormal scales are rejected with `ValueError`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_latent_world_model.py tests/test_latent_world_model_update_working_set.py` (64/64 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/latent_world_model.py tests/test_latent_world_model.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/latent_world_model.py` (clean).
