### PR TITLE
fix(core): divide by configured observation_scale without 1e-6 floor in world model targets

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -806,11 +806,10 @@ class ActionConditionedWorldModel:
         reward_arr = _float32_operand("reward", reward, ())
         discount_arr = _float32_operand("discount", discount, ())
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
             self._config.predict_delta,
-            (next_obs - obs) / safe_scale,
-            next_obs / safe_scale,
+            (next_obs - obs) / obs_scale,
+            next_obs / obs_scale,
         )
         reward_target = jnp.reshape(
             reward_arr / self._config.reward_scale,

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -955,3 +955,23 @@ def test_action_world_model_rolls_back_reduction_overflow() -> None:
     assert not bool(result.update_applied)
     assert float(result.observation_mse) == 0.0
     assert int(result.state.step_count) == 0
+
+def test_world_model_observation_scale_paired_normalization() -> None:
+    # Verify that prediction targets and decode scaling compose identically at small scales
+    for scale in (1.0, 1e-3, 1e-6, 1e-9, 1e-12, 1e-20):
+        config = ActionConditionedWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            hidden_sizes=(),
+            step_size=0.05,
+            use_layer_norm=False,
+            predict_delta=True,
+            observation_scale=(scale,),
+        )
+        model = ActionConditionedWorldModel(config)
+        obs = jnp.asarray([1.0 * scale], dtype=jnp.float32)
+        next_obs = jnp.asarray([3.0 * scale], dtype=jnp.float32)
+        targets = model.targets(obs, 0.0, 0.99, next_obs)
+        # Delta is (3.0 * scale - 1.0 * scale) / scale = 2.0
+        np.testing.assert_allclose(float(targets[0]), 2.0, atol=1e-5)
+


### PR DESCRIPTION
Fixes #2398

## Summary
In `alberta_framework/core/world_model.py`:
`_targets` divided observation vectors by `safe_scale = jnp.maximum(obs_scale, 1e-6)` whereas `_prediction_and_raw_diagnostics` multiplied the decoded predictions by the raw `obs_scale`. For any configured `observation_scale` below $10^{-6}$, the target normalization and prediction decoding differed by $\text{observation\_scale} / 10^{-6}$, causing the model to learn severely attenuated observation delta targets.

## Proposed Changes
1. Removed the `1e-6` floor in `ActionConditionedWorldModel.targets`, dividing delta and next observation targets directly by `obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)`.
2. Added unit tests in `tests/test_action_conditioned_world_model.py` verifying that target normalization and prediction scaling compose consistently across scales down to $10^{-20}$.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_action_conditioned_world_model.py tests/test_world_model.py` (91/91 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/world_model.py tests/test_action_conditioned_world_model.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/world_model.py` (clean).
