### PR TITLE
fix(evaluation): fail closed on all-subnormal float32 matrix in spectral_matrix_sign_transaction

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -116,12 +116,7 @@ def orthogonal_correction_transaction(update: Array, protected_basis: Array) -> 
     """Return a finite orthogonal correction and caller-visible validity bit."""
     vector = _trusted_array(update, name="update")
     basis = _trusted_array(protected_basis, name="protected_basis")
-    if (
-        vector.ndim != 1
-        or vector.size < 1
-        or basis.ndim != 2
-        or basis.shape[1] != vector.shape[0]
-    ):
+    if vector.ndim != 1 or vector.size < 1 or basis.ndim != 2 or basis.shape[1] != vector.shape[0]:
         raise ValueError("update must be a non-empty vector and basis rows must match its width")
     coordinates = basis @ vector
     projection = basis.T @ coordinates
@@ -171,9 +166,18 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         or steps > 32
     ):
         raise ValueError("matrix must be non-empty and steps a positive integer")
-    norm = jnp.linalg.norm(value)
-    valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    raw_norm = jnp.linalg.norm(value)
+    max_val = jnp.max(jnp.abs(value))
+    _, exponent = jnp.frexp(max_val)
+    rescaled = jnp.ldexp(value, -exponent)
+    norm = jnp.linalg.norm(rescaled)
+    has_nonzero_bits = jnp.any(value.view(jnp.uint32) != 0)
+    is_positive = (max_val > 0.0) & (norm > 0.0) & jnp.isfinite(norm)
+    underflowed = has_nonzero_bits & (~is_positive)
+    valid = (
+        jnp.all(jnp.isfinite(value)) & jnp.isfinite(raw_norm) & jnp.isfinite(norm) & (~underflowed)
+    )
+    x = jnp.where(is_positive, rescaled / jnp.where(is_positive, norm, 1.0), jnp.zeros_like(value))
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True
@@ -244,11 +248,7 @@ def muon_ogd_dual_update_transaction(
         raise ValueError("dual must contain one multiplier per constraint")
     if type(dual_learning_rate) is not float or not math.isfinite(dual_learning_rate):
         raise ValueError("dual_learning_rate must be a finite float")
-    if (
-        dual_learning_rate < 0.0
-        or type(dual_steps) is not int
-        or not 1 <= dual_steps <= 32
-    ):
+    if dual_learning_rate < 0.0 or type(dual_steps) is not int or not 1 <= dual_steps <= 32:
         raise ValueError("dual learning rate must be non-negative and dual_steps bounded positive")
     valid = (
         jnp.all(jnp.isfinite(value))
@@ -271,9 +271,7 @@ def muon_ogd_dual_update_transaction(
         )
         multipliers = next_multipliers
     shifted = value + jnp.einsum("k,kij->ij", multipliers, protected)
-    update, sign_valid = spectral_matrix_sign_transaction(
-        shifted, steps=newton_schulz_steps
-    )
+    update, sign_valid = spectral_matrix_sign_transaction(shifted, steps=newton_schulz_steps)
     valid = valid & jnp.all(jnp.isfinite(shifted)) & sign_valid
     safe_update = jnp.where(valid, update, jnp.zeros_like(update))
     safe_dual = jnp.where(valid, multipliers, jnp.zeros_like(multipliers))
@@ -438,9 +436,7 @@ def _runtime_identity() -> dict[str, object]:
         "machine": _runtime_text("machine", platform.machine()),
         "packages": {
             "jax": _runtime_text("JAX version", jax.__version__),
-            "jaxlib": _runtime_text(
-                "jaxlib version", importlib.metadata.version("jaxlib")
-            ),
+            "jaxlib": _runtime_text("jaxlib version", importlib.metadata.version("jaxlib")),
             "numpy": _runtime_text("NumPy version", np.__version__),
         },
         "default_backend": _runtime_text("JAX backend", jax.default_backend()),
@@ -495,9 +491,7 @@ def _execute_frozen_stream(*, measure_timing: bool) -> dict[str, object]:
     constraints, basis = _protected_geometry(rows, columns)
     target_updates: list[Array] = []
     for matrix in stream:
-        target_update, target_valid = orthogonal_correction_transaction(
-            matrix.reshape(-1), basis
-        )
+        target_update, target_valid = orthogonal_correction_transaction(matrix.reshape(-1), basis)
         _require_valid(target_valid, name="target projection")
         target_updates.append(target_update.reshape((rows, columns)))
     target = jnp.sum(jnp.stack(target_updates), axis=0)
@@ -527,9 +521,7 @@ def _execute_frozen_stream(*, measure_timing: bool) -> dict[str, object]:
                 )
                 processed = flat_processed.reshape((rows, columns))
             elif arm == "fogo_projection":
-                flat_processed, valid = orthogonal_correction_transaction(
-                    matrix.reshape(-1), basis
-                )
+                flat_processed, valid = orthogonal_correction_transaction(matrix.reshape(-1), basis)
                 processed = flat_processed.reshape((rows, columns))
             elif arm == "flad_zero_gradient":
                 flat_processed, valid = flad_noise_component_transaction(
@@ -671,10 +663,7 @@ def _exact_equal(actual: object, expected: object) -> bool:
     if type(expected) is dict:
         actual_dict = cast(dict[object, object], actual)
         expected_dict = cast(dict[object, object], expected)
-        if (
-            len(actual_dict) > 32
-            or len(actual_dict) != len(expected_dict)
-        ):
+        if len(actual_dict) > 32 or len(actual_dict) != len(expected_dict):
             return False
         if not all(type(key) is str for key in actual_dict):
             return False
@@ -687,9 +676,13 @@ def _exact_equal(actual: object, expected: object) -> bool:
     if type(expected) is list:
         actual_list = cast(list[object], actual)
         expected_list = cast(list[object], expected)
-        return len(actual_list) <= 128 and len(actual_list) == len(expected_list) and all(
-            _exact_equal(left, right)
-            for left, right in zip(actual_list, expected_list, strict=True)
+        return (
+            len(actual_list) <= 128
+            and len(actual_list) == len(expected_list)
+            and all(
+                _exact_equal(left, right)
+                for left, right in zip(actual_list, expected_list, strict=True)
+            )
         )
     if type(expected) is str:
         actual_text = cast(str, actual)

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,13 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+def test_spectral_matrix_sign_fails_closed_on_all_subnormal_matrix() -> None:
+    # Subnormal float32 matrix
+    sub = np.array([[2.0, 1.0], [0.5, -1.0]], dtype=np.float32) * np.float32(1e-40)
+    matrix = jnp.asarray(sub)
+    safe, valid = spectral_matrix_sign_transaction(matrix)
+    assert not bool(valid)
+    with pytest.raises(ValueError, match="matrix sign must be finite"):
+        spectral_matrix_sign(matrix)
+


### PR DESCRIPTION
Fixes #2391

## Summary
In `alberta_framework/evaluation/optimizer_geometry.py`:
`spectral_matrix_sign_transaction` returned an exact zero matrix with `valid=True` for non-zero inputs whose float32 entries were all subnormal, because reductions flush float32 subnormals on the CPU backend and `jnp.isfinite(0.0)` is `True`. This caused callers to accept a rank-0 zero result as valid for rank-2 non-zero matrices.

## Proposed Changes
1. Detected subnormal float32 underflow bitwise (`has_nonzero_bits & (~is_positive)`) where bit patterns contain non-zero bits but reduction/norm flushes to 0.0.
2. Failed closed by reporting `valid=False` on underflowed subnormal matrices, preventing silent certification of degenerate zero answers.
3. Added unit tests in `tests/test_optimizer_geometry.py` testing subnormal float32 matrices with `spectral_matrix_sign_transaction` and `spectral_matrix_sign`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (29/29 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (clean).
