### PR TITLE
Skip experiential-memory 0*inf utility decay

### DIFF
--- a/alberta_framework/core/experiential_memory.py
+++ b/alberta_framework/core/experiential_memory.py
@@ -490,6 +490,18 @@ def _validate_config(config: ExperientialMemoryConfig) -> None:
         "recency_scale",
         _validated_config_float("recency_scale", config.recency_scale, positive=True),
     )
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled utility decay does not poison eviction."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
+def _utilities_for_finite_guard(decay: float, utilities: Array) -> Array:
+    """Treat poisoned eviction utility as discarded when decay zeroes it."""
+    if decay != 0.0:
+        return utilities
+    return jnp.where(jnp.isfinite(utilities), utilities, jnp.zeros_like(utilities))
+
+
 def _saturating_increment(value: Array) -> Array:
     maximum_minus_one = jnp.asarray(_INT32_MAX - 1, dtype=jnp.int32)
     return jnp.minimum(value, maximum_minus_one) + jnp.asarray(1, dtype=jnp.int32)
@@ -701,6 +713,10 @@ class ExperientialMemory:
         """Return the global dynamic invariant for one structurally valid state."""
         entries = state.entries
         valid = entries.valid
+        utilities_for_check = _utilities_for_finite_guard(
+            self._config.utility_decay,
+            entries.utilities,
+        )
         all_float_payload_finite = (
             jnp.all(jnp.isfinite(entries.observations))
             & jnp.all(jnp.isfinite(entries.keys))
@@ -710,13 +726,13 @@ class ExperientialMemory:
             & jnp.all(jnp.isfinite(entries.uncertainties))
             & jnp.all(jnp.isfinite(entries.safety_costs))
             & jnp.all(jnp.isfinite(entries.reliabilities))
-            & jnp.all(jnp.isfinite(entries.utilities))
+            & jnp.all(jnp.isfinite(utilities_for_check))
         )
         scalar_ranges_valid = (
             jnp.all(entries.uncertainties >= 0.0)
             & jnp.all(entries.safety_costs >= 0.0)
             & jnp.all((entries.reliabilities >= 0.0) & (entries.reliabilities <= 1.0))
-            & jnp.all(entries.utilities >= 0.0)
+            & jnp.all(utilities_for_check >= 0.0)
             & jnp.all(entries.ages >= 0)
             & jnp.all(entries.recency_ages >= 0)
             & jnp.all(entries.retrieval_counts >= 0)
@@ -724,7 +740,7 @@ class ExperientialMemory:
         availability_honest = (
             jnp.all(entries.uncertainty_available | (entries.uncertainties == 0.0))
             & jnp.all(entries.safety_cost_available | (entries.safety_costs == 0.0))
-            & jnp.all(entries.utility_available | (entries.utilities == 0.0))
+            & jnp.all(entries.utility_available | (utilities_for_check == 0.0))
         )
         active_metadata_valid = jnp.all(
             (~valid)
@@ -935,6 +951,7 @@ class ExperientialMemory:
         """Compiled query after the public structural contract is established."""
         cfg = self._config
         entries = state.entries
+        utilities_for_check = _utilities_for_finite_guard(cfg.utility_decay, entries.utilities)
         query_key = jnp.asarray(key, dtype=jnp.float32)
         query_version = jnp.asarray(representation_version, dtype=jnp.int32)
         query_uncertainty_value = jnp.asarray(query_uncertainty, dtype=jnp.float32)
@@ -960,7 +977,7 @@ class ExperientialMemory:
             & jnp.isfinite(entries.uncertainties)
             & jnp.isfinite(entries.safety_costs)
             & jnp.isfinite(entries.reliabilities)
-            & jnp.isfinite(entries.utilities)
+            & jnp.isfinite(utilities_for_check)
         )
         sane_rows = (
             entries.valid
@@ -969,7 +986,7 @@ class ExperientialMemory:
             & (entries.safety_costs >= 0.0)
             & (entries.reliabilities >= 0.0)
             & (entries.reliabilities <= 1.0)
-            & (entries.utilities >= 0.0)
+            & (utilities_for_check >= 0.0)
             & (entries.representation_versions >= 0)
             & (entries.ages >= 0)
             & (entries.recency_ages >= 0)
@@ -1138,12 +1155,15 @@ class ExperientialMemory:
             _saturating_increment(entries.recency_ages),
             entries.recency_ages,
         )
-        utilities = jnp.where(
-            valid,
-            entries.utilities
-            * jnp.asarray(self._config.utility_decay, dtype=jnp.float32),
-            entries.utilities,
-        )
+        decay = jnp.asarray(self._config.utility_decay, dtype=jnp.float32)
+        if self._config.utility_decay == 0.0:
+            utilities = _skip_zero_scale(decay, entries.utilities)
+        else:
+            utilities = jnp.where(
+                valid,
+                _skip_zero_scale(decay, entries.utilities),
+                entries.utilities,
+            )
         return ExperientialMemoryState(
             entries=ExperientialMemoryEntries(
                 observations=entries.observations,

--- a/tests/test_experiential_memory.py
+++ b/tests/test_experiential_memory.py
@@ -796,6 +796,24 @@ def test_same_size_wrong_shapes_and_dtype_aliases_are_rejected_before_tracing() 
         )
 
 
+def test_zero_utility_decay_does_not_multiply_inf_utilities() -> None:
+    """utility_decay=0 drops leftover eviction utility; 0 * inf must not freeze."""
+    memory = ExperientialMemory(_config(utility_decay=0.0))
+    state = _write(memory, memory.init(), _entry(1, utility=2.0))
+    poisoned = state.replace(
+        entries=state.entries.replace(
+            utilities=jnp.full_like(state.entries.utilities, jnp.inf)
+        )
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    result = memory.write(poisoned, _entry(2, utility=0.5))
+    assert bool(result.wrote)
+    chex.assert_tree_all_finite(result.state.entries.utilities)
+    assert bool(jnp.all(result.state.entries.utilities >= 0.0))
+
+
 def test_dynamic_state_corruption_makes_query_abstain_and_mutations_exact_noops() -> None:
     memory = ExperientialMemory(_config())
     original = memory.init()


### PR DESCRIPTION
## Summary
- Experiential memory decays eviction utilities each step with a scale that may be 0. IEEE 0*inf is NaN and the finite-state guard freezes writes.
- Skip that product before aging slots. When decay is 0, treat already-infinite utilities as discarded in finite-state and query eligibility checks.

## Test plan
- [x] `test_zero_utility_decay_does_not_multiply_inf_utilities`
- [x] `tests/test_experiential_memory.py` (54 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)