### PR TITLE
Skip online-gated state-builder 0*inf when unit gate is open

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -443,6 +443,11 @@ def _divide_by_positive_scale(values: Array, scale: Array) -> Array:
     return jnp.where(scale > 0.0, scaled, 0.0)
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a closed unit gate does not poison sensitivity."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _scale_safe_clip_by_l2_norm(
     values: Array,
     clip: Array,
@@ -1715,7 +1720,16 @@ class OnlineGatedStateBuilder:
 
         gate_weights, gate_bias, _, _ = self._unpack_parameters(state.parameters)
         gate = jax.nn.sigmoid(gate_weights @ safe_event + gate_bias)
-        new_sensitivity = direct_sensitivity + ((1.0 - gate)[:, None] * state.parameter_sensitivity)
+        forget_scale = (1.0 - gate)[:, None]
+        checked_sensitivity = jnp.where(
+            forget_scale == 0.0,
+            jnp.zeros_like(state.parameter_sensitivity),
+            state.parameter_sensitivity,
+        )
+        new_sensitivity = direct_sensitivity + _skip_zero_scale(
+            forget_scale,
+            state.parameter_sensitivity,
+        )
         candidate_state = OnlineGatedStateBuilderState(
             parameters=state.parameters,
             hidden=new_hidden,
@@ -1725,7 +1739,12 @@ class OnlineGatedStateBuilder:
             last_gradient_norm=state.last_gradient_norm,
         )
         update_applied = (
-            event_valid & self._state_is_valid(state) & self._state_is_valid(candidate_state)
+            event_valid
+            & self._state_is_valid(
+                state,
+                parameter_sensitivity=checked_sensitivity,
+            )
+            & self._state_is_valid(candidate_state)
         )
         next_state = select_transaction(update_applied, candidate_state, state)
         representation = self.encode(next_state, raw_observation)
@@ -1826,11 +1845,20 @@ class OnlineGatedStateBuilder:
         )
 
     @staticmethod
-    def _state_is_valid(state: OnlineGatedStateBuilderState) -> Array:
+    def _state_is_valid(
+        state: OnlineGatedStateBuilderState,
+        *,
+        parameter_sensitivity: Array | None = None,
+    ) -> Array:
+        sensitivity = (
+            state.parameter_sensitivity
+            if parameter_sensitivity is None
+            else parameter_sensitivity
+        )
         return (
             jnp.all(jnp.isfinite(state.parameters))
             & jnp.all(jnp.isfinite(state.hidden))
-            & jnp.all(jnp.isfinite(state.parameter_sensitivity))
+            & jnp.all(jnp.isfinite(sensitivity))
             & jnp.isfinite(state.last_gradient_norm)
             & (state.last_gradient_norm >= 0.0)
             & (state.step_count >= 0)

--- a/tests/test_state_builder.py
+++ b/tests/test_state_builder.py
@@ -185,6 +185,45 @@ def test_fixed_trace_episode_reset_clears_memory_but_preserves_event_count() -> 
     assert bool(jnp.any(restarted_state.observation_traces != 0.0))
 
 
+def test_online_gated_unit_gate_one_does_not_multiply_inf_sensitivity() -> None:
+    """A fully open gate forgets old sensitivity; 0 * inf must not freeze updates."""
+    builder = OnlineGatedStateBuilder(
+        OnlineGatedStateBuilderConfig(
+            observation_dim=2,
+            hidden_dim=2,
+        )
+    )
+    state = builder.init(jr.key(11))
+    cfg = builder.config
+    matrix_size = cfg.hidden_dim * cfg.event_dim()
+    saturated_gate_parameters = (
+        state.parameters.at[:matrix_size]
+        .set(0.0)
+        .at[matrix_size : matrix_size + cfg.hidden_dim]
+        .set(90.0)
+    )
+    state = state.replace(parameters=saturated_gate_parameters)
+    state, _ = builder.start(state, jnp.asarray([1.0, 0.0]))
+    poisoned = state.replace(
+        parameter_sensitivity=jnp.full_like(state.parameter_sensitivity, jnp.inf)
+    )
+    gate = jnp.ones((builder.config.hidden_dim,), dtype=jnp.float32)
+    forget_scale = (1.0 - gate)[:, None]
+    raw = forget_scale * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.all(jnp.isfinite(raw)))
+
+    next_state, reported = builder.update(
+        poisoned,
+        jnp.asarray([0.0, 1.0]),
+        0,
+        0.0,
+        1.0,
+    )
+
+    chex.assert_tree_all_finite(next_state)
+    assert bool(jnp.all(jnp.isfinite(reported)))
+
+
 def test_online_gated_builder_updates_recurrent_parameters_from_delayed_gradient() -> None:
     builder = OnlineGatedStateBuilder(
         OnlineGatedStateBuilderConfig(


### PR DESCRIPTION
## Summary
- OnlineGatedStateBuilder carries RTRL sensitivity with a `(1 - gate)` forget scale. When a unit gate is fully open, IEEE 0*inf is NaN and the finite-state guard freezes recurrence.
- Skip that product before writing sensitivity. When the forget scale is 0, treat already-infinite carried sensitivity as discarded in the source finite-state check.

## Test plan
- [x] `test_online_gated_unit_gate_one_does_not_multiply_inf_sensitivity`
- [x] `tests/test_state_builder.py` (81 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)