### PR TITLE
Skip latent world-model 0*inf surprise and collapse EMA decay

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -131,6 +131,18 @@ def _saturating_int32_increment(value: Array) -> Array:
     return jnp.where(value < maximum, value + jnp.asarray(1, dtype=jnp.int32), maximum)
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled EMA decay does not poison diagnostics."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
+def _recover_nonfinite_at_zero_scale(scale: float, value: Array) -> Array:
+    """Repair only non-finite history that a zero scale is configured to forget."""
+    if scale != 0.0:
+        return value
+    return jnp.where(jnp.isfinite(value), value, jnp.zeros_like(value))
+
+
 def _latent_direct_state_scalars(
     *,
     observation_dim: int,
@@ -949,17 +961,39 @@ class LatentWorldModel:
 
         collapse_decay = jnp.asarray(self._config.collapse_decay, dtype=jnp.float32)
         surprise_decay = jnp.asarray(self._config.surprise_decay, dtype=jnp.float32)
+        checked_state = state
+        if self._config.collapse_decay == 0.0:
+            checked_state = dataclasses.replace(
+                checked_state,
+                latent_mean_ema=_recover_nonfinite_at_zero_scale(
+                    0.0, state.latent_mean_ema
+                ),
+                latent_var_ema=_recover_nonfinite_at_zero_scale(0.0, state.latent_var_ema),
+                collapse_score_ema=_recover_nonfinite_at_zero_scale(
+                    0.0, state.collapse_score_ema
+                ),
+            )
+        if self._config.surprise_decay == 0.0:
+            checked_state = dataclasses.replace(
+                checked_state,
+                surprise_ema=_recover_nonfinite_at_zero_scale(0.0, state.surprise_ema),
+                prediction_error_ema=_recover_nonfinite_at_zero_scale(
+                    0.0, state.prediction_error_ema
+                ),
+            )
         first = state.step_count == 0
         next_mean = jnp.where(
             first,
             target_next_latent,
-            collapse_decay * state.latent_mean_ema + (1.0 - collapse_decay) * target_next_latent,
+            _skip_zero_scale(collapse_decay, state.latent_mean_ema)
+            + (1.0 - collapse_decay) * target_next_latent,
         )
         centered = target_next_latent - next_mean
         next_var = jnp.where(
             first,
             centered**2,
-            collapse_decay * state.latent_var_ema + (1.0 - collapse_decay) * centered**2,
+            _skip_zero_scale(collapse_decay, state.latent_var_ema)
+            + (1.0 - collapse_decay) * centered**2,
         )
         latent_std = jnp.sqrt(jnp.maximum(next_var, jnp.asarray(1e-8, dtype=jnp.float32)))
         latent_std_mean = jnp.mean(latent_std)
@@ -971,17 +1005,20 @@ class LatentWorldModel:
         next_surprise_ema = jnp.where(
             first,
             surprise,
-            surprise_decay * state.surprise_ema + (1.0 - surprise_decay) * surprise,
+            _skip_zero_scale(surprise_decay, state.surprise_ema)
+            + (1.0 - surprise_decay) * surprise,
         )
         next_prediction_error_ema = jnp.where(
             first,
             prediction_error,
-            surprise_decay * state.prediction_error_ema + (1.0 - surprise_decay) * prediction_error,
+            _skip_zero_scale(surprise_decay, state.prediction_error_ema)
+            + (1.0 - surprise_decay) * prediction_error,
         )
         next_collapse_score_ema = jnp.where(
             first,
             collapse_score,
-            collapse_decay * state.collapse_score_ema + (1.0 - collapse_decay) * collapse_score,
+            _skip_zero_scale(collapse_decay, state.collapse_score_ema)
+            + (1.0 - collapse_decay) * collapse_score,
         )
 
         if self._config.encoder_learning:
@@ -1033,7 +1070,7 @@ class LatentWorldModel:
         update_applied = (
             inputs_valid
             & learner_result.update_applied
-            & floating_tree_is_finite(state)
+            & floating_tree_is_finite(checked_state)
             & floating_tree_is_finite(candidate_state)
             & diagnostics_finite
         )

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import math
 import warnings
 from types import MappingProxyType
@@ -97,6 +98,53 @@ def test_latent_world_model_update_and_prediction_shapes() -> None:
     chex.assert_shape(result.targets, (7,))
     chex.assert_tree_all_finite(result.surprise)
     chex.assert_tree_all_finite(result.latent_std_mean)
+
+
+def test_zero_surprise_decay_does_not_multiply_inf_diagnostic_emas() -> None:
+    """surprise_decay=0 replaces diagnostic EMAs; 0 * inf must not freeze updates."""
+    config = LatentWorldModelConfig(
+        observation_dim=2,
+        n_actions=2,
+        latent_dim=3,
+        hidden_sizes=(),
+        step_size=0.05,
+        sparsity=0.0,
+        surprise_decay=0.0,
+        collapse_decay=0.0,
+    )
+    model = LatentWorldModel(config)
+    state = model.init(jr.key(21))
+    warmed = model.update(
+        state,
+        jnp.array([0.1, -0.2], dtype=jnp.float32),
+        jnp.array(1, dtype=jnp.int32),
+        jnp.array(0.5, dtype=jnp.float32),
+        jnp.array(0.95, dtype=jnp.float32),
+        jnp.array([0.2, 0.1], dtype=jnp.float32),
+    )
+    assert bool(warmed.update_applied)
+    poisoned = dataclasses.replace(
+        warmed.state,
+        surprise_ema=jnp.full_like(warmed.state.surprise_ema, jnp.inf),
+        prediction_error_ema=jnp.full_like(warmed.state.prediction_error_ema, jnp.inf),
+        latent_mean_ema=jnp.full_like(warmed.state.latent_mean_ema, jnp.inf),
+        latent_var_ema=jnp.full_like(warmed.state.latent_var_ema, jnp.inf),
+        collapse_score_ema=jnp.full_like(warmed.state.collapse_score_ema, jnp.inf),
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    result = model.update(
+        poisoned,
+        jnp.array([0.0, 0.0], dtype=jnp.float32),
+        jnp.array(0, dtype=jnp.int32),
+        jnp.array(0.25, dtype=jnp.float32),
+        jnp.array(0.99, dtype=jnp.float32),
+        jnp.array([0.1, 0.0], dtype=jnp.float32),
+    )
+
+    assert bool(result.update_applied)
+    chex.assert_tree_all_finite(result.state)
 
 
 def test_latent_default_discounts_do_not_inherit_the_reward_dtype() -> None:


### PR DESCRIPTION
## Summary
- LatentWorldModel decays surprise and collapse diagnostics with scales that may be 0. IEEE 0*inf is NaN and the finite-state guard freezes updates.
- Skip those products before writing the EMAs. When a decay is 0, treat already-infinite tracker values as discarded in finite-state checks.

## Test plan
- [x] `test_zero_surprise_decay_does_not_multiply_inf_diagnostic_emas`
- [x] `tests/test_latent_world_model.py` (57 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)