### PR TITLE
Skip world-model-ensemble 0*inf residual variance decay

### DIFF
--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -258,6 +258,23 @@ def _saturating_int32_sum(values: Array) -> Array:
     )
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled residual EMA does not poison the proxy."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
+def _residual_variances_for_finite_guard(
+    decay: float,
+    residual_variances: Array,
+    *,
+    floor: float,
+) -> Array:
+    """Treat residual-proxy history as discarded when decay zeroes it."""
+    if decay != 0.0:
+        return residual_variances
+    return jnp.full_like(residual_variances, floor)
+
+
 @dataclasses.dataclass(frozen=True)
 class WorldModelEnsembleConfig:
     """Static ensemble, bootstrap, and residual-proxy contract.
@@ -1208,7 +1225,17 @@ class WorldModelEnsemble:
             & jnp.where(step_count == 0, pristine_bounds, learned_bounds)
         )
 
-    def _state_valid(self, state: WorldModelEnsembleState) -> Array:
+    def _state_valid(
+        self,
+        state: WorldModelEnsembleState,
+        *,
+        residual_variances: Array | None = None,
+    ) -> Array:
+        checked_residuals = (
+            state.residual_variances
+            if residual_variances is None
+            else residual_variances
+        )
         member_valid = []
         member_counts_match = []
         for index, member_state in enumerate(state.member_states):
@@ -1245,9 +1272,9 @@ class WorldModelEnsemble:
             )
             & jnp.all(jnp.stack(member_valid))
             & jnp.all(jnp.stack(member_counts_match))
-            & jnp.all(jnp.isfinite(state.residual_variances))
-            & jnp.all(state.residual_variances >= self._config.residual_variance_floor)
-            & jnp.all(state.residual_variances <= signal_cfg.max_predicted_variance)
+            & jnp.all(jnp.isfinite(checked_residuals))
+            & jnp.all(checked_residuals >= self._config.residual_variance_floor)
+            & jnp.all(checked_residuals <= signal_cfg.max_predicted_variance)
             & self._signal_state_valid(signal_state)
             & signal_bounds_valid
             & (signal_state.step_count == state.event_count)
@@ -1548,7 +1575,12 @@ class WorldModelEnsemble:
             & jnp.all(jnp.isfinite(next_obs))
             & jnp.all(jnp.abs(next_obs) <= magnitude_bound)
         )
-        state_valid = self._state_valid(state)
+        checked_residuals = _residual_variances_for_finite_guard(
+            self._config.residual_variance_decay,
+            state.residual_variances,
+            floor=self._config.residual_variance_floor,
+        )
+        state_valid = self._state_valid(state, residual_variances=checked_residuals)
         capacity_available = (state.replay_event_count < _INT32_MAX) & jnp.all(
             state.member_update_counts + state.replay_member_update_counts < _INT32_MAX
         )
@@ -1720,7 +1752,12 @@ class WorldModelEnsemble:
             & jnp.all(jnp.isfinite(next_obs))
             & jnp.all(jnp.abs(next_obs) <= magnitude_bound)
         )
-        state_valid = self._state_valid(state)
+        checked_residuals = _residual_variances_for_finite_guard(
+            self._config.residual_variance_decay,
+            state.residual_variances,
+            floor=self._config.residual_variance_floor,
+        )
+        state_valid = self._state_valid(state, residual_variances=checked_residuals)
         capacity_available = (state.event_count < _INT32_MAX) & jnp.all(
             state.member_update_counts + state.replay_member_update_counts < _INT32_MAX
         )
@@ -1770,7 +1807,7 @@ class WorldModelEnsemble:
             candidate_signal_state, raw_signals = self._signals.observe(
                 state.signal_state,
                 prediction.member_raw_predictions,
-                state.residual_variances,
+                checked_residuals,
                 targets,
                 observed_loss,
             )
@@ -1782,7 +1819,8 @@ class WorldModelEnsemble:
                 state.event_count == 0,
                 jnp.maximum(squared_residuals, residual_floor),
                 jnp.maximum(
-                    decay * state.residual_variances + (1.0 - decay) * squared_residuals,
+                    _skip_zero_scale(decay, state.residual_variances)
+                    + (1.0 - decay) * squared_residuals,
                     residual_floor,
                 ),
             )

--- a/tests/test_world_model_ensemble.py
+++ b/tests/test_world_model_ensemble.py
@@ -582,6 +582,24 @@ def test_invalid_dynamic_input_is_an_exact_atomic_noop(
     _assert_tree_equal(result.state, state)
 
 
+def test_zero_residual_variance_decay_does_not_multiply_inf_variances() -> None:
+    """residual_variance_decay=0 replaces the proxy; 0 * inf must not freeze."""
+    config = dataclasses.replace(_config(), residual_variance_decay=0.0)
+    ensemble = WorldModelEnsemble(config)
+    state = ensemble.init(jr.key(29))
+    warmed = ensemble.update(state, *_event(0))
+    assert bool(warmed.diagnostics.applied)
+    poisoned = warmed.state.replace(
+        residual_variances=jnp.full_like(warmed.state.residual_variances, jnp.inf)
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    result = ensemble.update(poisoned, *_event(1))
+    assert bool(result.diagnostics.applied)
+    chex.assert_tree_all_finite(result.state.residual_variances)
+
+
 def test_corrupt_dynamic_state_is_an_exact_atomic_noop() -> None:
     ensemble = WorldModelEnsemble(_config())
     state = ensemble.init(jr.key(2))


### PR DESCRIPTION
## Summary
- WorldModelEnsemble decays residual variance proxies with a scale that may be 0. IEEE 0*inf is NaN and the transactional update freezes.
- Skip that product before writing the proxy. When decay is 0, treat already-infinite residual history as discarded for finite-state checks and learning-signal observation.

## Test plan
- [x] `test_zero_residual_variance_decay_does_not_multiply_inf_variances`
- [x] `tests/test_world_model_ensemble.py` (39 passed)
- [x] ruff on the touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)