### PR TITLE
fix(prototype): skip zero-gate 0*inf in GRU perception update

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -479,6 +479,11 @@ def _glorot_uniform(key: Array, shape: tuple[int, int]) -> Array:
     return jr.uniform(key, shape, dtype=jnp.float32, minval=-limit, maxval=limit)
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a closed GRU gate does not poison hidden state."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _init_gru_state(cfg: GRUPerceptionConfig, key: Array) -> GRUPerceptionState:
     """Glorot-uniform weight init + zero hidden state."""
     keys = jr.split(key, 6)
@@ -507,10 +512,11 @@ def _gru_step(
     ``[obs, new_hidden]`` as the augmented observation.
     """
     h = gru.hidden
-    z = jax.nn.sigmoid(gru.W_z @ obs + gru.U_z @ h + gru.b_z)
-    r = jax.nn.sigmoid(gru.W_r @ obs + gru.U_r @ h + gru.b_r)
-    h_tilde = jnp.tanh(gru.W_h @ obs + gru.U_h @ (r * h) + gru.b_h)
-    new_h = (1.0 - z) * h + z * h_tilde
+    safe_h = jnp.where(jnp.isfinite(h), h, jnp.zeros_like(h))
+    z = jax.nn.sigmoid(gru.W_z @ obs + gru.U_z @ safe_h + gru.b_z)
+    r = jax.nn.sigmoid(gru.W_r @ obs + gru.U_r @ safe_h + gru.b_r)
+    h_tilde = jnp.tanh(gru.W_h @ obs + gru.U_h @ _skip_zero_scale(r, safe_h) + gru.b_h)
+    new_h = _skip_zero_scale(1.0 - z, h) + _skip_zero_scale(z, h_tilde)
     new_gru = cast(GRUPerceptionState, gru.replace(hidden=new_h))
     return new_gru, jnp.concatenate([obs, new_h], axis=0)
 

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -1239,6 +1239,36 @@ class TestGRUPerceptionStateInit:
 
 
 class TestGRUPerceptionUpdate:
+    def test_unit_update_gate_one_does_not_multiply_inf_hidden(self) -> None:
+        """A fully open update gate must forget poisoned hidden state without NaN."""
+        from alberta_framework.core.prototype_agent import (
+            GRUPerceptionConfig,
+            _gru_step,
+            _init_gru_state,
+        )
+
+        gru = _init_gru_state(GRUPerceptionConfig(observation_dim=2, hidden_dim=2), jr.key(0))
+        gru = gru.replace(
+            hidden=jnp.full((2,), jnp.inf, dtype=jnp.float32),
+            W_z=jnp.zeros_like(gru.W_z),
+            U_z=jnp.zeros_like(gru.U_z),
+            b_z=jnp.full((2,), 90.0, dtype=jnp.float32),
+            W_r=jnp.zeros_like(gru.W_r),
+            U_r=jnp.zeros_like(gru.U_r),
+            b_r=jnp.full((2,), -90.0, dtype=jnp.float32),
+            W_h=jnp.zeros_like(gru.W_h),
+            U_h=jnp.zeros_like(gru.U_h),
+            b_h=jnp.asarray([0.25, -0.25], dtype=jnp.float32),
+        )
+        raw = (1.0 - jnp.ones((2,), dtype=jnp.float32)) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+        assert not bool(jnp.all(jnp.isfinite(raw)))
+
+        new_gru, augmented = _gru_step(gru, jnp.zeros((2,), dtype=jnp.float32))
+
+        chex.assert_tree_all_finite(new_gru)
+        chex.assert_tree_all_finite(augmented)
+        chex.assert_trees_all_close(new_gru.hidden, jnp.tanh(gru.b_h))
+
     def test_hidden_updates_after_start(self) -> None:
         agent = PrototypeAgent(_gru_config())
         state0 = agent.init(jr.key(0))


### PR DESCRIPTION
## Summary
- Add `_skip_zero_scale` in Prototype GRU `_gru_step` so saturated update/reset gates do not multiply poisoned hidden states via `(1-z)*h` or `r*h`.
- Sanitize non-finite hidden before gate logits so zero-weight matmuls do not produce `0*inf` NaNs in sigmoid inputs.
- Regression test: unit gate saturated with `hidden=inf` yields finite `tanh(b_h)` candidate state.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).


Made with [Cursor](https://cursor.com)