### PR TITLE
fix(recurrent-latent): skip zero-gate 0*inf in member GRU predict

### DIFF
--- a/alberta_framework/core/recurrent_latent_world_model_ensemble.py
+++ b/alberta_framework/core/recurrent_latent_world_model_ensemble.py
@@ -227,6 +227,11 @@ def _saturating_increment(value: Array, maximum: int) -> Array:
     return jnp.minimum(jnp.maximum(value, 0), bound - 1) + 1
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a closed GRU gate does not poison hidden state."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _static_signature(tree: Any) -> tuple[Any, tuple[tuple[tuple[int, ...], Any], ...]]:
     leaves, structure = jax.tree_util.tree_flatten(tree)
     return structure, tuple((jnp.asarray(leaf).shape, jnp.asarray(leaf).dtype) for leaf in leaves)
@@ -1112,16 +1117,22 @@ class RecurrentLatentWorldModelEnsemble:
         cfg = self._config
         action_one_hot = jax.nn.one_hot(action, cfg.n_actions, dtype=jnp.float32)
         recurrent_input = jnp.concatenate((observation, action_one_hot), axis=0)
-        gate_input = jnp.concatenate((recurrent_input, hidden), axis=0)
+        safe_hidden = jnp.where(jnp.isfinite(hidden), hidden, jnp.zeros_like(hidden))
+        gate_input = jnp.concatenate((recurrent_input, safe_hidden), axis=0)
         reset_and_update = jax.nn.sigmoid(
             parameters.gate_kernel @ gate_input + parameters.gate_bias
         )
         reset_gate, update_gate = jnp.split(reset_and_update, 2, axis=0)
-        candidate_input = jnp.concatenate((recurrent_input, reset_gate * hidden), axis=0)
+        candidate_input = jnp.concatenate(
+            (recurrent_input, _skip_zero_scale(reset_gate, safe_hidden)),
+            axis=0,
+        )
         candidate = jnp.tanh(
             parameters.candidate_kernel @ candidate_input + parameters.candidate_bias
         )
-        next_hidden = (1.0 - update_gate) * hidden + update_gate * candidate
+        next_hidden = _skip_zero_scale(1.0 - update_gate, hidden) + _skip_zero_scale(
+            update_gate, candidate
+        )
 
         mean_logits = parameters.mean_kernel @ next_hidden + parameters.mean_bias
         variance_logits = parameters.variance_kernel @ next_hidden + parameters.variance_bias

--- a/tests/test_recurrent_latent_world_model_ensemble.py
+++ b/tests/test_recurrent_latent_world_model_ensemble.py
@@ -21,6 +21,7 @@ from alberta_framework.core.recurrent_latent_world_model_ensemble import (
     EVIDENCE_LEVEL,
     SCIENTIFIC_PROMOTION_ALLOWED,
     RecurrentLatentDecisionCache,
+    RecurrentLatentMemberParameters,
     RecurrentLatentTransitionRecord,
     RecurrentLatentWorldModelEnsemble,
     RecurrentLatentWorldModelEnsembleConfig,
@@ -307,6 +308,38 @@ def test_start_and_decide_are_read_only_predict_before_update_caches() -> None:
     assert not bool(prediction.availability.epistemic)
     assert not bool(prediction.availability.aleatoric)
     assert float(prediction.aleatoric_uncertainty) > 0.0
+
+
+def test_member_predict_saturated_update_gate_does_not_multiply_inf_hidden() -> None:
+    """Saturated update/reset gates must not turn poisoned hidden state into NaN."""
+    model = RecurrentLatentWorldModelEnsemble(_config(latent_dim=2))
+    cfg = model.config
+    latent = cfg.latent_dim
+    joined = cfg.recurrent_input_dim + latent
+    target = cfg.target_dim
+    params = RecurrentLatentMemberParameters(
+        gate_kernel=jnp.zeros((2 * latent, joined), dtype=jnp.float32),
+        gate_bias=jnp.concatenate(
+            (
+                jnp.full((latent,), -90.0, dtype=jnp.float32),
+                jnp.full((latent,), 90.0, dtype=jnp.float32),
+            )
+        ),
+        candidate_kernel=jnp.zeros((latent, joined), dtype=jnp.float32),
+        candidate_bias=jnp.asarray((0.25, -0.25), dtype=jnp.float32),
+        mean_kernel=jnp.zeros((target, latent), dtype=jnp.float32),
+        mean_bias=jnp.zeros((target,), dtype=jnp.float32),
+        variance_kernel=jnp.zeros((target, latent), dtype=jnp.float32),
+        variance_bias=jnp.full((target,), cfg.initial_variance_bias_magnitude, dtype=jnp.float32),
+    )
+    hidden = jnp.full((latent,), jnp.inf, dtype=jnp.float32)
+    observation = jnp.zeros((cfg.observation_dim,), dtype=jnp.float32)
+    action = jnp.asarray(0, dtype=jnp.int32)
+
+    next_hidden, _, _, _ = model._member_predict(params, hidden, observation, action)
+
+    assert jnp.all(jnp.isfinite(next_hidden))
+    np.testing.assert_allclose(next_hidden, jnp.tanh(params.candidate_bias), rtol=1.0e-6, atol=1.0e-6)
 
 
 def test_nonboundary_update_commits_one_recurrent_advance_and_masked_nll_updates() -> None:


### PR DESCRIPTION
## Summary
- Add `_skip_zero_scale` in recurrent latent ensemble `_member_predict` so saturated update/reset gates do not multiply poisoned hidden via `(1-update_gate)*hidden` or `reset_gate*hidden`.
- Sanitize non-finite hidden before gate logits so zero-weight matmuls do not produce `0*inf` NaNs in sigmoid inputs.
- Regression test: saturated gates with `hidden=inf` yield finite `tanh(candidate_bias)`.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).


Made with [Cursor](https://cursor.com)