### PR TITLE
fix(forager): skip zero-gate 0*inf in recurrent GRU reservoir

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -1129,6 +1129,11 @@ def _init_forager_recurrent_state(
     )
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a closed GRU gate does not poison hidden state."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _augment_with_recurrent_features(
     features: Array,
     recurrent_state: ForagerRecurrentState,
@@ -1139,6 +1144,7 @@ def _augment_with_recurrent_features(
         return recurrent_state, features
 
     hidden = recurrent_state.hidden
+    safe_hidden = jnp.where(jnp.isfinite(hidden), hidden, jnp.zeros_like(hidden))
     input_terms = jnp.einsum(
         "ghi,i->gh",
         recurrent_state.input_kernel,
@@ -1146,21 +1152,21 @@ def _augment_with_recurrent_features(
     )
     update = jax.nn.sigmoid(
         input_terms[0]
-        + recurrent_state.recurrent_kernel[0] @ hidden
+        + recurrent_state.recurrent_kernel[0] @ safe_hidden
         + recurrent_state.bias[0]
     )
     reset = jax.nn.sigmoid(
         input_terms[1]
-        + recurrent_state.recurrent_kernel[1] @ hidden
+        + recurrent_state.recurrent_kernel[1] @ safe_hidden
         + recurrent_state.bias[1]
     )
     candidate = jnp.tanh(
         input_terms[2]
-        + recurrent_state.recurrent_kernel[2] @ (reset * hidden)
+        + recurrent_state.recurrent_kernel[2] @ _skip_zero_scale(reset, safe_hidden)
         + recurrent_state.bias[2]
     )
     next_hidden = jax.lax.stop_gradient(
-        (1.0 - update) * hidden + update * candidate
+        _skip_zero_scale(1.0 - update, hidden) + _skip_zero_scale(update, candidate)
     )
     next_state = recurrent_state._replace(hidden=next_hidden)
     return next_state, jnp.concatenate((features, next_hidden), axis=0)

--- a/tests/test_forager_recurrent.py
+++ b/tests/test_forager_recurrent.py
@@ -20,6 +20,7 @@ from alberta_framework.benchmarks.forager import (
     ForagerBenchmarkConfig,
     ForagerEnvConfig,
     ForagerFeatureConfig,
+    ForagerRecurrentState,
     _augment_with_recurrent_features,
     _init_forager_recurrent_state,
     _recurrent_key,
@@ -193,6 +194,31 @@ def test_zero_width_recurrence_is_an_exact_feature_noop() -> None:
     chex.assert_trees_all_equal(next_state, state)
     assert next_state.hidden.shape == (0,)
     assert next_state.input_kernel.shape == (3, 0, features.shape[0])
+
+
+def test_saturated_update_gate_does_not_multiply_inf_hidden() -> None:
+    """Saturated update/reset gates must not turn poisoned hidden state into NaN."""
+    config = AlbertaForagerConfig(recurrent_hidden_size=2)
+    hidden_size = 2
+    input_dim = 4
+    state = ForagerRecurrentState(
+        input_kernel=jnp.zeros((3, hidden_size, input_dim), dtype=jnp.float32),
+        recurrent_kernel=jnp.zeros((3, hidden_size, hidden_size), dtype=jnp.float32),
+        bias=jnp.stack(
+            (
+                jnp.full((hidden_size,), 90.0, dtype=jnp.float32),
+                jnp.full((hidden_size,), -90.0, dtype=jnp.float32),
+                jnp.asarray((0.25, -0.25), dtype=jnp.float32),
+            )
+        ),
+        hidden=jnp.full((hidden_size,), jnp.inf, dtype=jnp.float32),
+    )
+    features = jnp.zeros((input_dim,), dtype=jnp.float32)
+    next_state, augmented = _augment_with_recurrent_features(features, state, config)
+
+    assert np.all(np.isfinite(next_state.hidden))
+    np.testing.assert_allclose(next_state.hidden, jnp.tanh(state.bias[2]), rtol=1.0e-6, atol=1.0e-6)
+    assert np.all(np.isfinite(augmented))
 
 
 def test_recurrent_host_scan_and_chunk_boundaries_match(


### PR DESCRIPTION
## Summary
- Add `_skip_zero_scale` in Forager `_augment_with_recurrent_features` so saturated update/reset gates do not multiply poisoned hidden via `(1-update)*hidden` or `reset*hidden`.
- Sanitize non-finite hidden before gate logits so zero-weight recurrent matmuls do not produce `0*inf` NaNs in sigmoid inputs.
- Regression test: saturated gates with `hidden=inf` yield finite `tanh(candidate_bias)`.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).


Made with [Cursor](https://cursor.com)