### PR TITLE
fix(noise-curvature): skip zero ema_decay 0*inf on curvature EMAs

### DIFF
--- a/alberta_framework/benchmarks/noise_curvature_ipmnist.py
+++ b/alberta_framework/benchmarks/noise_curvature_ipmnist.py
@@ -38,6 +38,11 @@ LAYER_PARAMETER_NAMES: Final[tuple[tuple[str, str], ...]] = (
     ("w2", "b2"),
     ("w3", "b3"),
 )
+
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a closed EMA decay does not poison curvature stats."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
 PARAMETER_NAMES: Final[frozenset[str]] = frozenset(
     name for layer in LAYER_PARAMETER_NAMES for name in layer
 )
@@ -454,11 +459,15 @@ def _controller_update(
     normalized_sharpness = jnp.stack(normalizing_steps) * sharpness
     controller_count = state.controller_count + jnp.asarray(1, dtype=jnp.int32)
     decay = jnp.asarray(config.ema_decay, dtype=jnp.float32)
-    mean_uncorrected = decay * state.curvature_mean + (1.0 - decay) * normalized_sharpness
+    mean_uncorrected = (
+        _skip_zero_scale(decay, state.curvature_mean) + (1.0 - decay) * normalized_sharpness
+    )
     correction = 1.0 - decay ** controller_count.astype(jnp.float32)
     mean = mean_uncorrected / correction
     deviations = jnp.square(normalized_sharpness - mean)
-    variance_uncorrected = decay * state.curvature_variance + (1.0 - decay) * deviations
+    variance_uncorrected = (
+        _skip_zero_scale(decay, state.curvature_variance) + (1.0 - decay) * deviations
+    )
     variance = variance_uncorrected / correction
     volatility = variance / (mean + config.volatility_epsilon)
 

--- a/tests/test_noise_curvature_ipmnist.py
+++ b/tests/test_noise_curvature_ipmnist.py
@@ -143,6 +143,35 @@ def test_fixed_scheduler_is_inert_and_cool_warm_decisions_are_causal() -> None:
     assert not bool(cooled) and bool(warmed)
 
 
+def test_zero_ema_decay_does_not_multiply_inf_curvature_stats() -> None:
+    """ema_decay=0 times poisoned curvature EMA history is 0*inf = NaN without a skip."""
+    params = _tiny_params()
+    config = NoiseCurvatureConfig(
+        mode="combined",
+        total_steps=2,
+        control_interval=2,
+        power_iterations=1,
+        ema_decay=0.0,
+    )
+    state = init_noise_curvature_state(params, config).replace(
+        curvature_mean=jnp.full((3,), jnp.inf, dtype=jnp.float32),
+        curvature_variance=jnp.full((3,), jnp.inf, dtype=jnp.float32),
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * state.curvature_mean
+    assert not bool(jnp.all(jnp.isfinite(raw)))
+
+    for index in range(2):
+        x = jnp.asarray([0.2, -0.1, 0.4, index * 0.1], dtype=jnp.float32)
+        y = jnp.asarray(index % 2, dtype=jnp.int32)
+        grads = jax.grad(lambda p: cross_entropy_loss(p, x, y)[0])(params)
+        params, state = noise_curvature_step(params, state, grads, x, y, cross_entropy_loss, config)
+
+    assert int(state.controller_count) == 1
+    assert int(state.diagnostic_failures) == 0
+    assert bool(jnp.all(jnp.isfinite(state.curvature_mean)))
+    assert bool(jnp.all(jnp.isfinite(state.curvature_variance)))
+
+
 def test_mechanism_off_matches_fixed_adamw_updates() -> None:
     params = _tiny_params()
     config = NoiseCurvatureConfig(mode="fixed", total_steps=2, control_interval=2)


### PR DESCRIPTION
## Summary
- Add `_skip_zero_scale` so `ema_decay=0` does not multiply poisoned `curvature_mean` / `curvature_variance` into NaN during controller updates.
- Regression test: poisoned infinite EMA history with `ema_decay=0` still applies a finite controller step without diagnostic failure.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).


Made with [Cursor](https://cursor.com)