### PR TITLE
fix(plasticity): skip zero AdamO beta 0*inf on moment history

### DIFF
--- a/alberta_framework/benchmarks/plasticity_comparators.py
+++ b/alberta_framework/benchmarks/plasticity_comparators.py
@@ -176,6 +176,11 @@ def _probability(name: str, value: object, *, include_one: bool = True) -> float
     return scalar
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a closed Adam beta does not poison moment state."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _array(name: str, value: object) -> Array:
     actual_type = type(value)
     if actual_type is not np.ndarray and not issubclass(actual_type, (Array, core.Tracer)):
@@ -372,8 +377,12 @@ def adamo_update(
         or second_moment.shape != weights.shape
     ):
         raise ValueError("AdamO weights, gradients, and moments must be matching matrices")
-    moment = beta1 * first_moment + (1.0 - beta1) * gradient
-    variance = beta2 * second_moment + (1.0 - beta2) * jnp.square(gradient)
+    moment = _skip_zero_scale(jnp.asarray(beta1, dtype=weights.dtype), first_moment) + (
+        1.0 - beta1
+    ) * gradient
+    variance = _skip_zero_scale(jnp.asarray(beta2, dtype=weights.dtype), second_moment) + (
+        1.0 - beta2
+    ) * jnp.square(gradient)
     corrected_moment = moment / (1.0 - beta1**step)
     corrected_variance = variance / (1.0 - beta2**step)
     task_delta = learning_rate * corrected_moment / (jnp.sqrt(corrected_variance) + epsilon)

--- a/tests/test_plasticity_comparators.py
+++ b/tests/test_plasticity_comparators.py
@@ -73,6 +73,40 @@ def test_adamo_moments_exclude_isometry_and_off_matches_adam() -> None:
     assert float(isometry_penalty(jnp.eye(2))) == 0
 
 
+def test_adamo_zero_beta_does_not_multiply_inf_moments() -> None:
+    """beta=0 times poisoned moment history is 0*inf = NaN without a skip."""
+    weights = jnp.asarray([[1.0, 0.0], [0.0, 1.0]], dtype=jnp.float32)
+    gradient = jnp.ones_like(weights)
+    poisoned = jnp.full_like(weights, jnp.inf)
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * poisoned
+    assert not bool(jnp.all(jnp.isfinite(raw)))
+
+    def update(
+        w: jax.Array,
+        g: jax.Array,
+        first: jax.Array,
+        second: jax.Array,
+    ) -> tuple[jax.Array, jax.Array, jax.Array]:
+        return adamo_update(
+            w,
+            g,
+            first,
+            second,
+            step=1,
+            learning_rate=0.01,
+            isometry_strength=0.0,
+            beta1=0.0,
+            beta2=0.0,
+        )
+
+    candidate, moment, variance = jax.jit(update)(weights, gradient, poisoned, poisoned)
+    assert bool(jnp.all(jnp.isfinite(candidate)))
+    assert bool(jnp.all(jnp.isfinite(moment)))
+    assert bool(jnp.all(jnp.isfinite(variance)))
+    assert jnp.allclose(moment, gradient)
+    assert jnp.allclose(variance, jnp.square(gradient))
+
+
 def test_intentional_update_equations_and_trace_reduction() -> None:
     gradient = jnp.asarray([3.0, 4.0])
     assert np.isclose(float(intentional_td_step_size(gradient, intended_fraction=0.5)), 0.02)


### PR DESCRIPTION
## Summary
- Add `_skip_zero_scale` in AdamO moment updates so `beta1=0` / `beta2=0` do not multiply poisoned moment history into NaN.
- Host eager validation still rejects non-finite moments; the hole is under JIT where that check is skipped.
- Regression test: jitted AdamO with zero betas and infinite prior moments yields finite task moments equal to the current gradient signals.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).


Made with [Cursor](https://cursor.com)