### PR TITLE
fix(gauntlet): skip zero context-gate 0*inf on feature products

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -79,6 +79,12 @@ _GAUNTLET_LOOP_MAX_STEPS = NUM_SEGMENTS * 3000
 _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
 
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a closed context gate does not poison features."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 LIFETIME_GAUNTLET_CONFIG_SCHEMA = "alberta.lifetime-gauntlet-config.v2"
 LIFETIME_GAUNTLET_STATE_SCHEMA = "alberta.lifetime-gauntlet-state.v2"
 LIFETIME_GAUNTLET_CHECKPOINT_SCHEMA = "alberta.lifetime-gauntlet-checkpoint.v2"
@@ -530,7 +536,14 @@ class ContextGatedFeatures:
         x = timestep.observation[:d]
         ctx = timestep.observation[d:]
         base_gate = 1.0 - ctx[0] - ctx[1] if self._exclusive else 1.0
-        gated = jnp.concatenate([base_gate * x, ctx, ctx[0] * x, ctx[1] * x])
+        gated = jnp.concatenate(
+            [
+                _skip_zero_scale(base_gate, x),
+                ctx,
+                _skip_zero_scale(ctx[0], x),
+                _skip_zero_scale(ctx[1], x),
+            ]
+        )
         return TimeStep(observation=gated, target=timestep.target), new_state
 
 

--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -80,7 +80,7 @@ _INT32_MAX = 2**31 - 1
 _UINT32_MAX = 2**32 - 1
 
 
-def _skip_zero_scale(scale: Array, value: Array) -> Array:
+def _skip_zero_scale(scale: Array | float, value: Array) -> Array:
     """Skip ``0 * inf`` so a closed context gate does not poison features."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
 

--- a/tests/test_gauntlet_zero_gate_inf.py
+++ b/tests/test_gauntlet_zero_gate_inf.py
@@ -1,0 +1,51 @@
+"""Regression: closed context gates must not turn poisoned x into NaN."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+import pytest
+
+from alberta_framework.core.types import TimeStep
+from alberta_framework.streams.gauntlet import ContextGatedFeatures, GauntletConfig
+
+pytestmark = pytest.mark.unit
+
+
+class _PoisonedInner:
+    """Stub stream that returns a fixed observation."""
+
+    def __init__(self, observation: Any) -> None:
+        self.config = GauntletConfig(
+            relevant_dim=2,
+            irrelevant_dim=0,
+            segment_length=1,
+            noise_std=0.0,
+            context_noise_std=0.0,
+        )
+        self._observation = observation
+
+    def step(self, state: Any, idx: Any) -> tuple[TimeStep, Any]:
+        del idx
+        target = jnp.zeros((1,), dtype=jnp.float32)
+        return TimeStep(observation=self._observation, target=target), state
+
+
+def test_closed_context_gates_do_not_multiply_inf_features() -> None:
+    """Exact-zero gates times poisoned x is 0*inf = NaN without a skip."""
+    # ctx=(1,0) => exclusive base_gate=0 and ctx[1]=0; ctx[0]=1 keeps one open block.
+    observation = jnp.asarray([jnp.inf, -jnp.inf, 1.0, 0.0], dtype=jnp.float32)
+    raw_closed = jnp.asarray(0.0, dtype=jnp.float32) * observation[:2]
+    assert bool(jnp.any(~jnp.isfinite(raw_closed)))
+
+    wrapper = ContextGatedFeatures(_PoisonedInner(observation), exclusive=True)
+    timestep, _ = wrapper.step(None, jnp.asarray(0, dtype=jnp.int32))
+    gated = timestep.observation
+
+    assert gated.shape == (2 + 2 + 2 + 2,)
+    assert not bool(jnp.any(jnp.isnan(gated)))
+    np_gated = jnp.asarray(gated)
+    assert bool(jnp.all(np_gated[:2] == 0.0))
+    assert bool(jnp.all(np_gated[4:6] == observation[:2]))
+    assert bool(jnp.all(np_gated[6:] == 0.0))


### PR DESCRIPTION
## Summary
- Add `_skip_zero_scale` in `ContextGatedFeatures` so exact-zero `base_gate` / `ctx[i]` do not multiply poisoned `x` into NaN.
- Open gates still pass through non-finite `x` (no NaN-to-zero masking).
- Regression test: exclusive gates with `ctx=(1,0)` and infinite `x` yield no NaNs and zero closed blocks.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).


Made with [Cursor](https://cursor.com)