### PR TITLE
fix(ipmnist-screening): skip zero utility/Lion/RMS 0*inf EMA decays

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -496,7 +496,7 @@ def _sorted_flat_noise(
 
 
 def _skip_zero_scale(scale: Array | float, value: Array) -> Array:
-    """Skip ``0 * inf`` so a closed utility decay does not poison EMA state."""
+    """Skip ``0 * inf`` so a closed EMA/momentum decay does not poison state."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
 
 
@@ -4027,8 +4027,10 @@ def _make_muon_gate_learner(
             keep = 1.0 - gate[name]
             g = grads[name]
             if params[name].ndim == 2:
-                momentum = mu * state.momentum[name] + g
-                direction = _newton_schulz_orthogonalize(g + mu * momentum, ns_steps)
+                momentum = _skip_zero_scale(mu, state.momentum[name]) + g
+                direction = _newton_schulz_orthogonalize(
+                    g + _skip_zero_scale(mu, momentum), ns_steps
+                )
                 m_dim, n_dim = params[name].shape
                 scale = math.sqrt(max(m_dim, n_dim) / min(m_dim, n_dim))
                 new_params[name] = params[name] * param_decay - step_size * (
@@ -4106,11 +4108,15 @@ def _make_lion_gate_learner(
         new_momentum: dict[str, Array] = {}
         for name in params:
             g = grads[name]
-            interpolated = beta1 * state.momentum[name] + (1.0 - beta1) * g
+            interpolated = _skip_zero_scale(beta1, state.momentum[name]) + (
+                1.0 - beta1
+            ) * g
             new_params[name] = params[name] * param_decay - step_size * (
                 (1.0 - gate[name]) * jnp.sign(interpolated)
             )
-            new_momentum[name] = beta2 * state.momentum[name] + (1.0 - beta2) * g
+            new_momentum[name] = _skip_zero_scale(beta2, state.momentum[name]) + (
+                1.0 - beta2
+            ) * g
         metrics = _step_metrics(new_params, x_norm, y, loss, logits)
         return new_params, LionGateState(  # type: ignore[call-arg]
             utility=utility, step=count, momentum=new_momentum, norm=new_norm
@@ -5470,7 +5476,7 @@ def _make_norm_rmsprop_gate_learner(
         new_v: dict[str, Array] = {}
         for name in params:
             g = grads[name]
-            v = rho * state.v[name] + (1.0 - rho) * g * g
+            v = _skip_zero_scale(rho, state.v[name]) + (1.0 - rho) * g * g
             direction = g / (jnp.sqrt(v) + rms_epsilon)
             new_params[name] = params[name] * param_decay - step_size * (
                 direction * (1.0 - gate[name])
@@ -5588,10 +5594,10 @@ def _make_norm_apollo_gate_learner(
             g = grads[name]
             if params[name].ndim == 2:
                 stat = jnp.mean(g * g, axis=0)
-                v = rho * state.vchan[name] + (1.0 - rho) * stat
+                v = _skip_zero_scale(rho, state.vchan[name]) + (1.0 - rho) * stat
                 denom = jnp.sqrt(v)[None, :] + apollo_epsilon
             else:
-                v = rho * state.vchan[name] + (1.0 - rho) * (g * g)
+                v = _skip_zero_scale(rho, state.vchan[name]) + (1.0 - rho) * (g * g)
                 denom = jnp.sqrt(v) + apollo_epsilon
             new_params[name] = params[name] * param_decay - step_size * (
                 (g / denom) * (1.0 - gate[name])
@@ -5667,7 +5673,9 @@ def _make_sgd_momentum_gate_learner(
         new_params: dict[str, Array] = {}
         new_momentum: dict[str, Array] = {}
         for name in params:
-            momentum = mu * state.momentum[name] + (1.0 - mu) * grads[name]
+            momentum = _skip_zero_scale(mu, state.momentum[name]) + (
+                1.0 - mu
+            ) * grads[name]
             m_hat = momentum / correction
             new_params[name] = params[name] * param_decay - step_size * (
                 m_hat * (1.0 - gate[name])

--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -495,6 +495,11 @@ def _sorted_flat_noise(
     }
 
 
+def _skip_zero_scale(scale: Array | float, value: Array) -> Array:
+    """Skip ``0 * inf`` so a closed utility decay does not poison EMA state."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _upgd_utility_and_gate(
     params: dict[str, Array],
     grads: dict[str, Array],
@@ -505,7 +510,8 @@ def _upgd_utility_and_gate(
     """UPGD utility EMA update + global-max sigmoid gate (lean-step equations)."""
     beta = utility_decay
     new_utility = {
-        name: beta * utility[name] + (1.0 - beta) * (-grads[name] * params[name])
+        name: _skip_zero_scale(beta, utility[name])
+        + (1.0 - beta) * (-grads[name] * params[name])
         for name in params
     }
     global_max = jnp.max(jnp.stack([jnp.max(new_utility[name]) for name in sorted(params)]))
@@ -2151,7 +2157,7 @@ def _make_upgd_ema_norm_ext_learner(
         noise = _sorted_flat_noise(key, params, noise_std)
         count = state.step + jnp.array(1, dtype=jnp.int32)
         utility = {
-            name: utility_decay * state.utility[name]
+            name: _skip_zero_scale(utility_decay, state.utility[name])
             + (1.0 - utility_decay) * (-grads[name] * params[name])
             for name in params
         }
@@ -2355,7 +2361,7 @@ def _make_adaptive_norm_sigma0_learner(
         )
         count = state.step + jnp.array(1, dtype=jnp.int32)
         utility = {
-            name: utility_decay * state.utility[name]
+            name: _skip_zero_scale(utility_decay, state.utility[name])
             + (1.0 - utility_decay) * (-grads[name] * params[name])
             for name in params
         }
@@ -2769,7 +2775,7 @@ def _make_discovered_rule_learner(
                 1.0 - shifted[:, None].astype(jnp.float32)
             )
         utility = {
-            name: utility_decay * prev_utility[name]
+            name: _skip_zero_scale(utility_decay, prev_utility[name])
             + (1.0 - utility_decay) * (-grads[name] * params[name])
             for name in params
         }
@@ -3066,7 +3072,8 @@ def upgd_w_localgate_update(
     decay = 1.0 - step_size * hp["weight_decay"]
     count = state.step + jnp.array(1, dtype=jnp.int32)
     utility = {
-        name: beta * state.utility[name] + (1.0 - beta) * (-grads[name] * params[name])
+        name: _skip_zero_scale(beta, state.utility[name])
+        + (1.0 - beta) * (-grads[name] * params[name])
         for name in params
     }
     bias_correction = 1.0 - jnp.power(
@@ -4741,7 +4748,7 @@ def _make_rls_head_learner(
         over ``names``; other tensors pass through with untouched utility."""
         new_utility = dict(utility)
         for name in names:
-            new_utility[name] = utility_decay * utility[name] + (
+            new_utility[name] = _skip_zero_scale(utility_decay, utility[name]) + (
                 1.0 - utility_decay
             ) * (-grads[name] * params[name])
         bias_correction = 1.0 - jnp.power(
@@ -6178,7 +6185,8 @@ def _make_sigma0_gated_l2init_learner(
         decay_factor = 1.0 - step_size * hp["weight_decay"]
         count = state.step + jnp.array(1, dtype=jnp.int32)
         utility = {
-            name: beta * state.utility[name] + (1.0 - beta) * (-grads[name] * params[name])
+            name: _skip_zero_scale(beta, state.utility[name])
+            + (1.0 - beta) * (-grads[name] * params[name])
             for name in params
         }
         global_max = jnp.max(
@@ -6269,9 +6277,9 @@ def _make_cpr_ipmnist_learner(
         for name in params:
             magnitude = jnp.abs(grads[name])
             score = magnitude / (jnp.mean(magnitude) + norm_epsilon)
-            utility[name] = (
-                utility_decay * state.utility[name] + (1.0 - utility_decay) * score
-            )
+            utility[name] = _skip_zero_scale(utility_decay, state.utility[name]) + (
+                1.0 - utility_decay
+            ) * score
         sgd_params = {
             name: params[name] - step_size * grads[name] for name in params
         }

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -109,6 +109,34 @@ SMALL = IPMNISTConfig(
 )
 
 
+def test_zero_utility_decay_does_not_multiply_inf_utility() -> None:
+    """utility_decay=0 times poisoned utility EMA is 0*inf = NaN without a skip."""
+    params = {
+        "w": jnp.asarray([[1.0, -0.5], [0.25, 0.5]], dtype=jnp.float32),
+        "b": jnp.asarray([0.1, -0.2], dtype=jnp.float32),
+    }
+    poisoned = {name: jnp.full_like(value, jnp.inf) for name, value in params.items()}
+    grads = {name: jnp.ones_like(value) for name, value in params.items()}
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+
+    new_utility, gate = _upgd_utility_and_gate(
+        params,
+        grads,
+        poisoned,
+        jnp.asarray(3, dtype=jnp.int32),
+        0.0,
+    )
+    for name in params:
+        assert bool(jnp.all(jnp.isfinite(new_utility[name])))
+        assert bool(jnp.all(jnp.isfinite(gate[name])))
+        np.testing.assert_allclose(
+            np.asarray(new_utility[name]),
+            np.asarray(-grads[name] * params[name]),
+            atol=1e-6,
+        )
+
+
 def _test_source_provenance(
     *, source_sha256: str = "3" * 64,
 ) -> dict[str, object]:

--- a/tests/test_ipmnist_screening.py
+++ b/tests/test_ipmnist_screening.py
@@ -136,6 +136,60 @@ def test_zero_utility_decay_does_not_multiply_inf_utility() -> None:
             atol=1e-6,
         )
 
+def test_zero_lion_beta_does_not_multiply_inf_momentum() -> None:
+    """lion_beta1/beta2=0 times poisoned momentum is 0*inf = NaN without a skip."""
+    from alberta_framework.benchmarks.ipmnist_screening import (
+        LionGateState,
+        _init_input_norm_state,
+    )
+
+    params = init_mlp_params(jr.key(0), SMALL)
+    hp = dict(screening_spec("lion_gate").hyperparameters)
+    hp["lion_beta1"] = 0.0
+    hp["lion_beta2"] = 0.0
+    _, step_fn = _make_lion_gate_learner(hp)
+    state = LionGateState(  # type: ignore[call-arg]
+        utility={name: jnp.zeros_like(value) for name, value in params.items()},
+        step=jnp.asarray(2, dtype=jnp.int32),
+        momentum={name: jnp.full_like(value, jnp.inf) for name, value in params.items()},
+        norm=_init_input_norm_state(params),
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+    x = jr.normal(jr.key(1), (SMALL.input_dim,))
+    y = jnp.asarray(0, dtype=jnp.int32)
+    new_params, new_state, _ = step_fn(params, state, x, y, jr.key(2))
+    for name in params:
+        assert bool(jnp.all(jnp.isfinite(new_state.momentum[name])))
+        assert bool(jnp.all(jnp.isfinite(new_params[name])))
+
+
+def test_zero_rms_rho_does_not_multiply_inf_second_moment() -> None:
+    """rms_rho=0 times poisoned second-moment EMA is 0*inf = NaN without a skip."""
+    from alberta_framework.benchmarks.ipmnist_screening import (
+        NormRMSGateState,
+        _init_input_norm_state,
+    )
+
+    params = init_mlp_params(jr.key(0), SMALL)
+    hp = dict(screening_spec("norm_rmsprop_gate").hyperparameters)
+    hp["rms_rho"] = 0.0
+    _, step_fn = _make_norm_rmsprop_gate_learner(hp)
+    state = NormRMSGateState(  # type: ignore[call-arg]
+        utility={name: jnp.zeros_like(value) for name, value in params.items()},
+        step=jnp.asarray(2, dtype=jnp.int32),
+        v={name: jnp.full_like(value, jnp.inf) for name, value in params.items()},
+        norm=_init_input_norm_state(params),
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * jnp.asarray(jnp.inf, dtype=jnp.float32)
+    assert not bool(jnp.isfinite(raw))
+    x = jr.normal(jr.key(1), (SMALL.input_dim,))
+    y = jnp.asarray(0, dtype=jnp.int32)
+    new_params, new_state, _ = step_fn(params, state, x, y, jr.key(2))
+    for name in params:
+        assert bool(jnp.all(jnp.isfinite(new_state.v[name])))
+        assert bool(jnp.all(jnp.isfinite(new_params[name])))
+
 
 def _test_source_provenance(
     *, source_sha256: str = "3" * 64,


### PR DESCRIPTION
## Summary
- Skip `utility_decay * utility` when `utility_decay == 0` so leftover `inf` EMA history cannot produce `0*inf` NaNs in IPMNIST screening UPGD utility updates and gates.
- Skip the same class of hole for Lion `beta1`/`beta2`, RMSprop/Apollo `rho`, Muon heavy-ball `mu`, and SGD momentum `mu`.
- Covers the shared `_upgd_utility_and_gate` helper plus remaining inline utility-EMA sites.
- Adds regressions for zero utility decay, zero Lion betas, and zero RMSprop rho with poisoned `inf` state.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_ipmnist_screening.py::test_zero_utility_decay_does_not_multiply_inf_utility tests/test_ipmnist_screening.py::test_zero_lion_beta_does_not_multiply_inf_momentum tests/test_ipmnist_screening.py::test_zero_rms_rho_does_not_multiply_inf_second_moment -q`
- [x] `.venv/bin/python -m pytest tests/test_ipmnist_screening.py::TestOptimizerFloorHybrids tests/test_ipmnist_screening.py::TestLocalGateNorm -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/benchmarks/ipmnist_screening.py tests/test_ipmnist_screening.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).