### PR TITLE
Fix IPMNIST ceiling publication on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,7 @@ jobs:
             tests/test_step12_production.py::test_step12_narrows_original_real_directly_without_double_rounding \
             tests/test_actor_critic.py::test_actor_critic_update_is_jittable \
             tests/test_action_conditioned_world_model.py::test_action_conditioned_world_model_update_and_prediction_shapes \
+            tests/test_ipmnist_campaign_tools.py::test_ceiling_publication_refuses_to_replace_existing_bytes \
             -q \
             -o addopts="" \
             --strict-config \

--- a/alberta_framework/benchmarks/ipmnist_ceiling.py
+++ b/alberta_framework/benchmarks/ipmnist_ceiling.py
@@ -303,11 +303,13 @@ def _atomic_publish(path: Path, writer: Callable[[BinaryIO], None]) -> None:
             os.fsync(stream.fileno())
         os.link(temporary, path)
         published = True
-        directory_descriptor = os.open(path.parent, os.O_RDONLY)
-        try:
-            os.fsync(directory_descriptor)
-        finally:
-            os.close(directory_descriptor)
+        if os.name != "nt":
+            # Windows cannot open directory handles through os.open().
+            directory_descriptor = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_descriptor)
+            finally:
+                os.close(directory_descriptor)
     except BaseException:
         if published:
             path.unlink(missing_ok=True)

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -649,6 +649,9 @@ def test_atomic_publication_cleans_up_link_failure(
     assert list(tmp_path.iterdir()) == []
 
 
+@pytest.mark.skipif(
+    os.name == "nt", reason="Windows does not support directory fsync through os.open"
+)
 def test_atomic_publication_rolls_back_directory_sync_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Problem

`asi-ipmnist-ceiling` writes an artifact, fsyncs it, and atomically hard-links it
to the final no-replace path. It then opens the parent directory with
`os.open(..., os.O_RDONLY)` for a directory fsync.

Windows does not support opening a directory through `os.open`, so a successful
publication raises `PermissionError`. The rollback path then deletes the valid
destination. This affects stationary/carried/full NPZ output and batch-reference
JSON output after the expensive computation has completed.

The failure reproduces on current main
`c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` in
`test_ceiling_publication_refuses_to_replace_existing_bytes` at
`ipmnist_ceiling.py:306`. I found no overlapping open issue or pull request for
this publisher or failure mode.

## Change

- Keep the file fsync and atomic no-replace hard link on every platform.
- Keep the parent-directory fsync and fail-closed rollback on POSIX.
- Skip only the unsupported parent-directory `os.open`/fsync step on Windows.
- Mark the POSIX directory-sync fault-injection test as inapplicable on Windows.
- Add the real publication contract to the Windows/macOS portability CI panel.

No benchmark metric or scientific promotion is claimed by this operational
harness repair. No pinned output was changed.

## Exact-head evidence

Platform: Windows `10.0.26200.0`, Python `3.12.13`, JAX `0.11.0`.

<!-- evidence-head:5ad29b8d436798c36ad1cf5cd894d3a6e685a450 -->
<!-- evidence-row:logs -->
- [x] logs: [verification log](https://github.com/user-attachments/files/31454490/asi-windows-ceiling-publish-verification.log)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [fix evidence manifest](https://github.com/user-attachments/files/31454492/asi-windows-ceiling-publish-evidence.json)

Machine-readable test reports:

- [campaign-tools JUnit](https://github.com/user-attachments/files/31454494/campaign-5ad29b8d-junit.xml)
- [portability-panel JUnit](https://github.com/user-attachments/files/31454495/portability-5ad29b8d-junit.xml)

Commands and results at `5ad29b8d436798c36ad1cf5cd894d3a6e685a450`:

```text
python -B -m pytest -p no:cacheprovider --junitxml campaign-5ad29b8d-junit.xml tests/test_ipmnist_campaign_tools.py -q
81 passed, 1 skipped in 2.96s

python -B -m pytest -p no:cacheprovider --junitxml portability-5ad29b8d-junit.xml <complete portability CI node list> -q -o addopts='' --strict-config --strict-markers
8 passed in 2.95s

python -m ruff check alberta_framework/benchmarks/ipmnist_ceiling.py tests/test_ipmnist_campaign_tools.py
All checks passed!

python -m mypy alberta_framework/benchmarks/ipmnist_ceiling.py
Success: no issues found in 1 source file

git diff --check HEAD^ HEAD
passed
```

`alberta-evidence-status` remains `invalid` (exit 2): all five required
artifacts are present, but current persisted scientific claims already fail
their registered-source hashes. This PR changes none of the 25 registered
source paths and does not alter those artifacts.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [startrack3r-codex]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0YGTZWKGMEJHSC8WYW6KX14","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-26T07:51:29.939Z","completed_at":"2026-08-26T08:22:24.111Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-26T07:51:30.116Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f9a723a60a45c79cd397a12bf39779f1e4903b33bf79bfeae3fd1e6ca4691f08","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7be6448e-53fc-41fa-9882-de5e191ff78c","object_id":"sha256:f9a723a60a45c79cd397a12bf39779f1e4903b33bf79bfeae3fd1e6ca4691f08","sha256":"f9a723a60a45c79cd397a12bf39779f1e4903b33bf79bfeae3fd1e6ca4691f08"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAkrIdB7W0_AjiGUbTdv0oIfQQj8H9Fh2YRU3kFXkG_0E","device_key_id":"bd46738e133a242e351b905df4fce078504b9bc54453c9fc11dad3c08043ad92","device_signature":"iLQt1eitn3eeUiuyDf6-5mVbu4s2h28SQLLxrMbDjPBjTvnQtqY71434XcgdOF2gAzp1BoM6s38A3iB2qsRuAA"}} -->
