### PR TITLE
fix(core): preserve rare actor policy sampling

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -688,7 +688,11 @@ class ActorCriticAgent:
         observation = self._observation(state, observation)
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
+        action = jr.categorical(
+            sample_key,
+            jnp.log(probs),
+            mode="high",
+        ).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -899,7 +899,8 @@ class AverageRewardHordeActorCriticAgent:
         behavior = self.behavior_policy(state, observation)
         action = jr.categorical(
             sample_key,
-            jnp.log(jnp.maximum(behavior, 1e-8)),
+            jnp.log(behavior),
+            mode="high",
         ).astype(jnp.int32)
         target_probability = target[action]
         behavior_probability = behavior[action]
@@ -975,7 +976,7 @@ class AverageRewardHordeActorCriticAgent:
         actor_score_scale = (
             (1.0 - self._config.epsilon)
             * old_sample.target_probability
-            / jnp.maximum(old_sample.behavior_probability, 1e-8)
+            / old_sample.behavior_probability
         )
         score = (
             actor_score_scale * (action_mask - old_sample.target_policy) / self._config.temperature

--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -640,7 +640,11 @@ class QHordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
+        action = jr.categorical(
+            sample_key,
+            jnp.log(probs),
+            mode="high",
+        ).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -943,7 +947,11 @@ class HordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
+        action = jr.categorical(
+            sample_key,
+            jnp.log(probs),
+            mode="high",
+        ).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -1291,10 +1299,16 @@ def _nlhac_log_prob(
         trunk_weights, trunk_biases, obs, leaky_relu_slope, use_layer_norm
     )
     logits = head_w @ hidden + head_b
-    probs = jax.nn.softmax(logits / temperature)
-    n_actions = probs.shape[0]
-    mixed_probs = (1.0 - actor_epsilon) * probs + actor_epsilon / n_actions
-    return jnp.log(jnp.maximum(mixed_probs[action], 1e-8))
+    # Keep the score in log space so finite extreme logits retain finite gradients.
+    log_probs = jax.nn.log_softmax(logits / temperature)
+    epsilon = jnp.asarray(actor_epsilon, dtype=log_probs.dtype)
+    uniform_log_prob = jnp.log(epsilon) - jnp.log(
+        jnp.asarray(log_probs.shape[0], dtype=log_probs.dtype)
+    )
+    return jnp.logaddexp(
+        jnp.log1p(-epsilon) + log_probs[action],
+        uniform_log_prob,
+    )
 
 
 _nlhac_grad = jax.grad(_nlhac_log_prob, argnums=0)
@@ -1752,7 +1766,11 @@ class NonlinearHordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
+        action = jr.categorical(
+            sample_key,
+            jnp.log(probs),
+            mode="high",
+        ).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -2439,7 +2457,11 @@ class NonlinearQHordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
+        action = jr.categorical(
+            sample_key,
+            jnp.log(probs),
+            mode="high",
+        ).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -2070,7 +2070,11 @@ class RecurrentTraceActorCriticAgent:
         tempered_logits = logits / self._config.temperature
         probabilities = jax.nn.softmax(tempered_logits)
         key, sample_key = jr.split(state.rng_key)
-        action = jr.categorical(sample_key, tempered_logits).astype(jnp.int32)
+        action = jr.categorical(
+            sample_key,
+            tempered_logits,
+            mode="high",
+        ).astype(jnp.int32)
         return action, key, probabilities
 
     def _advance_actor(

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -54,6 +54,37 @@ def test_actor_critic_init_predict_and_start_shapes() -> None:
     assert int(next_state.last_action) in range(3)
 
 
+def test_actor_critic_sampling_preserves_reported_rare_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+    state = agent.init(feature_dim=1, key=jr.key(15)).replace(  # type: ignore[attr-defined]
+        actor_weights=jnp.zeros((2, 1), dtype=jnp.float32),
+        actor_bias=jnp.asarray((0.0, -20.0), dtype=jnp.float32),
+    )
+    observation = jnp.zeros((1,), dtype=jnp.float32)
+    observed_logits: list[jax.Array] = []
+    observed_modes: list[object] = []
+
+    def fake_categorical(
+        _key: jax.Array,
+        logits: jax.Array,
+        **kwargs: object,
+    ) -> jax.Array:
+        observed_logits.append(logits)
+        observed_modes.append(kwargs.get("mode"))
+        return jnp.asarray(0, dtype=jnp.int32)
+
+    monkeypatch.setattr(jr, "categorical", fake_categorical)
+    with jax.disable_jit():
+        action, _next_key, policy = agent.select_action(state, observation)
+
+    assert int(action) == 0
+    assert observed_modes == ["high"]
+    chex.assert_trees_all_close(observed_logits[0], jnp.log(policy))
+    assert float(policy[1]) < 1e-8
+
+
 def test_actor_critic_update_changes_actor_and_critic() -> None:
     config = ActorCriticConfig(
         n_actions=2,

--- a/tests/test_average_reward.py
+++ b/tests/test_average_reward.py
@@ -474,6 +474,54 @@ def test_average_reward_actor_critic_behavior_policy_is_exact_epsilon_mixture() 
     )
 
 
+def test_average_reward_actor_sampling_preserves_reported_rare_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = AverageRewardHordeActorCriticAgent(
+        AverageRewardHordeActorCriticConfig(
+            n_actions=2,
+            hidden_sizes=(4,),
+            epsilon=0.0,
+        )
+    )
+    state = agent.init(2, jr.key(101)).replace(
+        actor_weights=jnp.zeros((2, 4), dtype=jnp.float32),
+        actor_bias=jnp.asarray((0.0, -20.0), dtype=jnp.float32),
+    )
+    observation = jnp.zeros((2,), dtype=jnp.float32)
+    observed_logits: list[jax.Array] = []
+    observed_modes: list[object] = []
+
+    def fake_categorical(
+        _key: jax.Array,
+        logits: jax.Array,
+        **kwargs: object,
+    ) -> jax.Array:
+        observed_logits.append(logits)
+        observed_modes.append(kwargs.get("mode"))
+        return jnp.asarray(1, dtype=jnp.int32)
+
+    monkeypatch.setattr(jr, "categorical", fake_categorical)
+    with jax.disable_jit():
+        started, action = agent.start(state, observation)
+        result = agent.update(
+            started,
+            jnp.asarray(1.0, dtype=jnp.float32),
+            observation,
+        )
+    sample = started.last_policy_sample
+
+    assert int(action) == 1
+    assert observed_modes == ["high", "high"]
+    chex.assert_trees_all_close(
+        observed_logits[0],
+        jnp.log(sample.behavior_policy),
+    )
+    assert float(sample.behavior_policy[1]) < 1e-8
+    assert bool(result.update_applied)
+    assert float(result.actor_score_scale) == pytest.approx(1.0)
+
+
 @pytest.mark.parametrize("epsilon", [0.0, 0.3, 1.0])
 def test_average_reward_actor_critic_score_matches_mixture_derivative(
     epsilon: float,

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -776,12 +776,111 @@ def _make_nlhac_agent(
     return NonlinearHordeActorCriticAgent(cfg, critic)
 
 
+def _make_nlqhac_agent() -> NonlinearQHordeActorCriticAgent:
+    demons = [
+        GVFSpec(  # type: ignore[call-arg]
+            name=f"q_{action}",
+            demon_type=DemonType.CONTROL,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=-1,
+        )
+        for action in range(N_ACTIONS)
+    ]
+    critic = HordeLearner(
+        create_horde_spec(demons),
+        hidden_sizes=(16,),
+        step_size=0.03,
+    )
+    return NonlinearQHordeActorCriticAgent(
+        NonlinearQHordeActorCriticConfig(
+            n_actions=N_ACTIONS,
+            hidden_sizes=(16,),
+            actor_td_error_clip=1.0,
+            actor_gradient_clip_norm=1.0,
+        ),
+        critic,
+        actor_optimizer=Autostep(initial_step_size=0.01),
+    )
+
+
 def _init_nlhac(
     agent: NonlinearHordeActorCriticAgent,
 ) -> NonlinearHordeActorCriticState:
     state = agent.init(feature_dim=OBS_DIM, key=jr.key(0))
     state, _, _ = agent.start(state, jnp.zeros(OBS_DIM))
     return state
+
+
+def test_all_horde_actor_samplers_preserve_reported_rare_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cases: list[tuple[Any, int]] = [
+        (_make_agent(), 2),
+        (_make_qhorde_agent(), 2),
+        (_make_nlhac_agent(), OBS_DIM),
+        (_make_nlqhac_agent(), OBS_DIM),
+    ]
+    observed_logits: list[jax.Array] = []
+    observed_modes: list[object] = []
+
+    def fake_categorical(
+        _key: jax.Array,
+        logits: jax.Array,
+        **kwargs: object,
+    ) -> jax.Array:
+        observed_logits.append(logits)
+        observed_modes.append(kwargs.get("mode"))
+        return jnp.asarray(0, dtype=jnp.int32)
+
+    monkeypatch.setattr(jr, "categorical", fake_categorical)
+    for agent, feature_dim in cases:
+        state = agent.init(feature_dim=feature_dim, key=jr.key(feature_dim))
+        rare_logit = jnp.log(jnp.asarray(5e-9, dtype=jnp.float32)) * agent.config.temperature
+        if hasattr(state, "actor_bias"):
+            rare_bias = jnp.full_like(state.actor_bias, rare_logit).at[0].set(0.0)
+            state = state.replace(
+                actor_weights=jnp.zeros_like(state.actor_weights),
+                actor_bias=rare_bias,
+            )
+        else:
+            rare_bias = jnp.full_like(state.actor_head_b, rare_logit).at[0].set(0.0)
+            state = state.replace(
+                actor_head_w=jnp.zeros_like(state.actor_head_w),
+                actor_head_b=rare_bias,
+            )
+        observation = jnp.zeros((feature_dim,), dtype=jnp.float32)
+        with jax.disable_jit():
+            action, _next_key, policy = agent.select_action(state, observation)
+
+        assert int(action) == 0
+        assert float(policy[1]) < 1e-8
+        chex.assert_trees_all_close(observed_logits[-1], jnp.log(policy))
+
+    assert observed_modes == ["high"] * len(cases)
+
+
+@pytest.mark.parametrize("rare_bias", [-10.0, -100.0])
+def test_nonlinear_horde_actor_learns_from_a_rare_policy_action(
+    rare_bias: float,
+) -> None:
+    agent = _make_nlhac_agent(hidden_sizes=())
+    state = agent.init(feature_dim=OBS_DIM, key=jr.key(81)).replace(
+        actor_head_w=jnp.zeros((N_ACTIONS, OBS_DIM), dtype=jnp.float32),
+        actor_head_b=jnp.asarray((0.0, rare_bias, rare_bias), dtype=jnp.float32),
+        last_observation=jnp.zeros((OBS_DIM,), dtype=jnp.float32),
+        last_action=jnp.asarray(1, dtype=jnp.int32),
+    )
+
+    assert float(agent.policy(state, state.last_observation)[1]) < 1e-8
+    result = agent.update(
+        state,
+        reward=jnp.asarray(1.0, dtype=jnp.float32),
+        observation=jnp.zeros((OBS_DIM,), dtype=jnp.float32),
+    )
+
+    assert bool(result.update_applied)
+    assert not jnp.array_equal(result.state.actor_head_b, state.actor_head_b)
 
 
 def test_nonlinear_horde_zero_discount_neutralizes_inf_next_value() -> None:
@@ -1406,32 +1505,7 @@ class TestNonlinearHordeActorCriticExport:
 
 class TestNonlinearQHordeActorCritic:
     def _agent(self) -> NonlinearQHordeActorCriticAgent:
-        demons = [
-            GVFSpec(  # type: ignore[call-arg]
-                name=f"q_{action}",
-                demon_type=DemonType.CONTROL,
-                gamma=0.0,
-                lamda=0.0,
-                cumulant_index=-1,
-            )
-            for action in range(N_ACTIONS)
-        ]
-        critic = HordeLearner(
-            create_horde_spec(demons),
-            hidden_sizes=(16,),
-            step_size=0.03,
-        )
-        cfg = NonlinearQHordeActorCriticConfig(
-            n_actions=N_ACTIONS,
-            hidden_sizes=(16,),
-            actor_td_error_clip=1.0,
-            actor_gradient_clip_norm=1.0,
-        )
-        return NonlinearQHordeActorCriticAgent(
-            cfg,
-            critic,
-            actor_optimizer=Autostep(initial_step_size=0.01),
-        )
+        return _make_nlqhac_agent()
 
     def test_actor_optimizer_must_support_mlp(self) -> None:
         demons = [

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -1161,7 +1161,9 @@ def test_counters_and_welford_moments_saturate_without_wrap_eager_or_jit() -> No
         _assert_tree_finite(result)
 
 
-def test_action_sampling_uses_tempered_logits_directly() -> None:
+def test_action_sampling_uses_high_dynamic_range_tempered_logits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     config = _small_config(temperature=0.37)
     agent = RecurrentTraceActorCriticAgent(config)
     state = agent.init(feature_dim=2, key=jr.key(33))
@@ -1176,13 +1178,28 @@ def test_action_sampling_uses_tempered_logits_directly() -> None:
     )
     sampling_key = jr.key(34)
     state = state.replace(actor_params=actor_params, rng_key=sampling_key)
-    action, next_key, probabilities = agent.select_action(state)
+    original_categorical = jr.categorical
+    observed_modes: list[object] = []
+
+    def recording_categorical(
+        key: jax.Array,
+        sampling_logits: jax.Array,
+        **kwargs: object,
+    ) -> jax.Array:
+        observed_modes.append(kwargs.get("mode"))
+        return original_categorical(key, sampling_logits, **kwargs)
+
+    monkeypatch.setattr(jr, "categorical", recording_categorical)
+    with jax.disable_jit():
+        action, next_key, probabilities = agent.select_action(state)
     expected_key, sample_key = jr.split(sampling_key)
-    expected_action = jr.categorical(
+    expected_action = original_categorical(
         sample_key,
         logits / config.temperature,
+        mode="high",
     ).astype(jnp.int32)
 
+    assert observed_modes == ["high"]
     assert jnp.array_equal(action, expected_action)
     assert jnp.array_equal(jr.key_data(next_key), jr.key_data(expected_key))
     assert jnp.allclose(


### PR DESCRIPTION
## Summary

- sample from the policy vectors returned by all seven actor-critic categorical samplers instead of adding an unreported `1e-8` floor
- opt those samplers into JAX `mode="high"`, extending documented float32 Gumbel precision from roughly `1e-7` to `1e-14`
- preserve rare-action learning in average-reward and nonlinear Horde actors, including a stable log-domain epsilon-mixture score for extreme finite logits

## Why

JAX 0.11.0 defaults categorical sampling to low dynamic range. For rare actor probabilities, that can bias the action draw. Six samplers also passed `log(max(policy, 1e-8))`, so the actual categorical distribution differed from the policy returned to runners and diagnostics.

This is an operational L0 correctness change only. It does not claim scientific improvement or promote any persisted result.

## Verification

Exact base: `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`  
Exact head: `312680764d53e4e0374005cc37efe18322f1c6e4`

- focused regressions: **6 passed**
- full changed actor/Horde/average-reward test files: **236 passed, 2 deselected**
- full changed recurrent test file: **129 passed, 2 deselected**
- Ruff on all changed source and tests: **passed**
- mypy on all four changed source files: **passed**
- `git diff --check`: **passed**

The four deselected NumPy alias tests fail unchanged on the exact base commit; their base JUnit comparison is included with the evidence. They overlap existing integer-type work in #2272 and #2275.

`alberta-evidence-status` remains `invalid` (exit 2, 0/5 supported) on both base and head. `average_reward.py` is a registered source, so the source drift is disclosed. No pinned output was touched and no scientific promotion is claimed.

## Compatibility

- high mode approximately doubles categorical sampling cost at these seven call sites
- fixed seeds produce different action sequences, including for ordinary policies
- high mode extends the documented precision range; it is not exact at every representable probability
- average-reward diagnostic log-probability fields keep their existing finite `1e-8` lower bound; sampling and actor scoring are the corrected contracts here
- non-actor categorical selectors are intentionally out of scope

## Overlap review

No exact issue or PR overlap was found. #2357 changes which Horde policy array runners report, but does not touch categorical sampling or these score paths.

## Evidence

<!-- evidence-head:312680764d53e4e0374005cc37efe18322f1c6e4 -->
<!-- evidence-row:logs -->
- [x] logs: [verification narrative](https://github.com/user-attachments/files/31456078/asi-actor-policy-sampling-verification.txt)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [machine-readable evidence manifest](https://github.com/user-attachments/files/31456080/asi-actor-policy-sampling-evidence.json)
- [focused regression JUnit](https://github.com/user-attachments/files/31456082/focused-31268076-junit-public.xml)
- [actor/Horde/average-reward JUnit](https://github.com/user-attachments/files/31456083/actor-horde-average-31268076-junit-public.xml)
- [recurrent actor JUnit](https://github.com/user-attachments/files/31456086/recurrent-31268076-junit-public.xml)
- [exact-base NumPy alias comparison JUnit](https://github.com/user-attachments/files/31456088/baseline-c9aba7b5-integer-aliases-junit-public.xml)

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi
Attribution status: self-reported
— [startrack3r-codex]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M0YJV8F1YH4MGXNZ7QG9GY1Q","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-26T08:26:35.873Z","completed_at":"2026-08-26T09:12:49.307Z","skill_sha256":"2cbfa4213c446ee00c2a66dfdc8892eb5c13899af90a395c82a70e660a7d4ded","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-26T08:26:36.055Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5e8022908c018f101b41f59ef0ade032e4a8efce6b5c33a377fd0f25ecddd1c6","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c04ab660-f35c-4792-ae1a-4125c5bc283a","object_id":"sha256:5e8022908c018f101b41f59ef0ade032e4a8efce6b5c33a377fd0f25ecddd1c6","sha256":"5e8022908c018f101b41f59ef0ade032e4a8efce6b5c33a377fd0f25ecddd1c6"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAkrIdB7W0_AjiGUbTdv0oIfQQj8H9Fh2YRU3kFXkG_0E","device_key_id":"bd46738e133a242e351b905df4fce078504b9bc54453c9fc11dad3c08043ad92","device_signature":"kk09-RQ-zGReJUI0iziCsPlUnjM2iqZRejo5wYHeqSe4Qwtnsp2MN81m_XYpeL4VlT3mSyi3UQJo0kDvYcVdDQ"}} -->
