### PR TITLE
fix(step7): skip zero importance-ratio 0*inf on planning deltas

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -924,6 +924,11 @@ def _maybe_accept_planning_state(
     )
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a closed importance ratio does not poison planning."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _apply_planning_importance_correction(
     old_state: DifferentialSARSAState,
     planned_state: DifferentialSARSAState,
@@ -935,14 +940,19 @@ def _apply_planning_importance_correction(
         DifferentialSARSAState,
         planned_state.replace(  # type: ignore[attr-defined]
             q_weights=old_state.q_weights
-            + rho * (planned_state.q_weights - old_state.q_weights),
-            q_bias=old_state.q_bias + rho * (planned_state.q_bias - old_state.q_bias),
+            + _skip_zero_scale(rho, planned_state.q_weights - old_state.q_weights),
+            q_bias=old_state.q_bias
+            + _skip_zero_scale(rho, planned_state.q_bias - old_state.q_bias),
             q_trace_weights=old_state.q_trace_weights
-            + rho * (planned_state.q_trace_weights - old_state.q_trace_weights),
+            + _skip_zero_scale(
+                rho, planned_state.q_trace_weights - old_state.q_trace_weights
+            ),
             q_trace_bias=old_state.q_trace_bias
-            + rho * (planned_state.q_trace_bias - old_state.q_trace_bias),
+            + _skip_zero_scale(rho, planned_state.q_trace_bias - old_state.q_trace_bias),
             average_reward=old_state.average_reward
-            + rho * (planned_state.average_reward - old_state.average_reward),
+            + _skip_zero_scale(
+                rho, planned_state.average_reward - old_state.average_reward
+            ),
         ),
     )
 

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -823,3 +823,37 @@ def test_step7_smoke_result_rejects_leftover_identities() -> None:
     assert '"seed": true' not in dumped
     assert '"finite": 1' not in dumped
     assert '"planning_acceptance_count": true' not in dumped
+
+
+def test_zero_importance_ratio_does_not_multiply_inf_planning_delta() -> None:
+    """rho=0 times an infinite imagined delta is 0*inf = NaN without a skip."""
+    from alberta_framework.core.average_reward import (
+        DifferentialSARSAAgent,
+        DifferentialSARSAConfig,
+    )
+    from alberta_framework.steps.step7 import _apply_planning_importance_correction
+
+    agent = DifferentialSARSAAgent(DifferentialSARSAConfig(n_actions=2))
+    old = agent.init(3, jr.key(0))
+    planned = old.replace(  # type: ignore[attr-defined]
+        q_weights=jnp.full_like(old.q_weights, jnp.inf),
+        q_bias=jnp.full_like(old.q_bias, jnp.inf),
+        q_trace_weights=jnp.full_like(old.q_trace_weights, jnp.inf),
+        q_trace_bias=jnp.full_like(old.q_trace_bias, jnp.inf),
+        average_reward=jnp.asarray(jnp.inf, dtype=jnp.float32),
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * (
+        jnp.asarray(jnp.inf, dtype=jnp.float32) - jnp.asarray(0.0, dtype=jnp.float32)
+    )
+    assert not bool(jnp.isfinite(raw))
+
+    corrected = _apply_planning_importance_correction(
+        old, planned, jnp.asarray(0.0, dtype=jnp.float32)
+    )
+    chex.assert_trees_all_close(corrected.q_weights, old.q_weights)
+    chex.assert_trees_all_close(corrected.q_bias, old.q_bias)
+    chex.assert_trees_all_close(corrected.q_trace_weights, old.q_trace_weights)
+    chex.assert_trees_all_close(corrected.q_trace_bias, old.q_trace_bias)
+    chex.assert_trees_all_close(corrected.average_reward, old.average_reward)
+    chex.assert_tree_all_finite(corrected.q_weights)
+    chex.assert_tree_all_finite(corrected.average_reward)


### PR DESCRIPTION
## Summary
- Skip `rho * (planned - old)` when the planning importance ratio is exactly 0 so leftover `inf` imagined SARSA deltas cannot produce `0*inf` NaNs.
- Applies to Q weights/bias, traces, and average-reward corrections in `_apply_planning_importance_correction`.
- Adds a regression that proves `rho=0` with poisoned infinite planned deltas keeps the finite outer state.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_step7_production.py::test_zero_importance_ratio_does_not_multiply_inf_planning_delta -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/steps/step7.py tests/test_step7_production.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)