### PR TITLE
fix(cumulant-discovery): skip zero-gamma 0*inf on V(s') bootstrap

### DIFF
--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -124,6 +124,12 @@ def _persistent_resources(raw_dim: int, n_candidates: int) -> dict[str, int]:
         "persistent_bytes": persistent_bytes,
     }
 
+
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Return 0 when ``scale`` is 0 so a 0*inf product cannot form."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 # =============================================================================
 # State
 # =============================================================================
@@ -397,7 +403,8 @@ class CumulantDiscovery:
         v = state.weights @ observation + state.biases  # (n,)
         v_next = state.weights @ next_observation + state.biases  # (n,)
 
-        td = cumulants + gamma * v_next - v  # (n,)
+        # Default gamma=0 still hits IEEE 0*inf when V(s') overflows.
+        td = cumulants + _skip_zero_scale(gamma, v_next) - v  # (n,)
 
         # Predictor update (per-candidate semi-gradient TD step)
         # weights_i += alpha * td_i * obs

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -133,6 +133,29 @@ class TestStep:
         chex.assert_tree_all_finite(recovered.utility)
         chex.assert_trees_all_close(recovered.ages, state.ages + 1)
 
+    def test_zero_gamma_does_not_multiply_overflow_v_next(self) -> None:
+        """Default gamma=0 times overflowed V(s') is 0*inf = NaN without a skip."""
+        d = CumulantDiscovery(
+            raw_dim=2, n_candidates=1, predictor_step_size=0.1, gamma=0.0
+        )
+        state = d.init(jr.key(0)).replace(  # type: ignore[attr-defined]
+            projections=jnp.array([[1.0, 0.0]], dtype=jnp.float32),
+            weights=jnp.array([[1.0e20, 0.0]], dtype=jnp.float32),
+            biases=jnp.zeros(1, dtype=jnp.float32),
+        )
+        obs = jnp.array([1.0, 0.0], dtype=jnp.float32)
+        next_obs = jnp.array([1.0e20, 0.0], dtype=jnp.float32)
+        v_next = state.weights @ next_obs + state.biases
+        assert bool(jnp.isinf(v_next[0]))
+        raw = jnp.asarray(0.0, dtype=jnp.float32) * v_next[0]
+        assert not bool(jnp.isfinite(raw))
+
+        updated = d.step(state, obs, next_obs)
+        assert not jnp.array_equal(updated.ages, state.ages)
+        chex.assert_tree_all_finite(updated.weights)
+        chex.assert_tree_all_finite(updated.biases)
+        chex.assert_tree_all_finite(updated.utility)
+
     def test_predictor_reduces_td_error(self) -> None:
         d = CumulantDiscovery(
             raw_dim=2, n_candidates=1, predictor_step_size=0.1, gamma=0.0


### PR DESCRIPTION
## Summary
- Cumulant TD used `gamma * V(s')` while the constructor default is `gamma=0.0`; overflowed `V(s')` still forms IEEE `0*inf` NaN and freezes the surprise step.
- Skip the zero-gamma bootstrap with `_skip_zero_scale` before the product.
- Regression: `test_zero_gamma_does_not_multiply_overflow_v_next`.

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_cumulant_discovery.py -q`
- [x] `.venv/bin/python -m ruff check alberta_framework/core/cumulant_discovery.py tests/test_cumulant_discovery.py`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)