### PR TITLE
fix(utils): unnest Raises section in get_final_performance docstring

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -665,7 +665,7 @@ def get_final_performance(
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
 
-        Raises:
+    Raises:
         ValueError: If ``window`` is not positive, a metric array has no
             time steps, any metric sample is non-finite, or ``window`` exceeds
             the shortest trace while trace lengths differ between methods.


### PR DESCRIPTION
Fixes #2439

## Summary
In `alberta_framework/utils/experiments.py`:
In `get_final_performance`, the `Raises:` section header was indented by 8 spaces, nesting it inside the `Returns:` description instead of being a sibling section. This prevented Google-style docstring parsers and documentation generators from identifying the exception specification.

## Proposed Changes
1. Unnested the `Raises:` header to 4 spaces indentation matching the other docstring section headers.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_experiments_validation.py tests/test_experiments_hostile_validation.py` (141/141 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/utils/experiments.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/utils/experiments.py` (clean).
