### PR TITLE
fix(tests): skip wheel-install smoke on platforms without Linux O_TMPFILE support

### DIFF
--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -240,6 +240,10 @@ def test_historical_cli_reports_provenance_and_validates_strict_pairing(
 
 
 @pytest.mark.package
+@pytest.mark.skipif(
+    not hasattr(os, "O_TMPFILE"),
+    reason="wheel-installed CLI provenance publication requires Linux O_TMPFILE support",
+)
 def test_wheel_and_sdist_are_complete_and_hard_link_safe(tmp_path: Path) -> None:
     uv = shutil.which("uv")
     if uv is None:


### PR DESCRIPTION
Fixes #2340

## Summary
In `tests/test_historical_forager_cli_package.py`:
`test_wheel_and_sdist_are_complete_and_hard_link_safe` runs `alberta-historical-forager provenance` from a wheel install. This subcommand calls `write_new_json`, which requires Linux `O_TMPFILE` support and fails closed on non-Linux platforms (such as macOS Darwin) where `os.O_TMPFILE` is not available.

## Proposed Changes
1. Added `@pytest.mark.skipif(not hasattr(os, "O_TMPFILE"), reason="...")` to `test_wheel_and_sdist_are_complete_and_hard_link_safe`, matching the declaration pattern in `tests/test_reference_life_scorecard.py`.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_historical_forager_cli_package.py` (3 passed, 1 skipped).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check tests/test_historical_forager_cli_package.py` (clean).
