### PR TITLE
fix(tests): gate test_forager_matched_final_analysis on Linux renameat2 support

### DIFF
--- a/tests/test_forager_matched_final_analysis.py
+++ b/tests/test_forager_matched_final_analysis.py
@@ -52,8 +52,9 @@ from alberta_framework.benchmarks import (
 from alberta_framework.benchmarks import forager_matched_statistics as statistics
 from tests import test_forager_matched_executor as executor_fixtures
 from tests import test_forager_matched_open_protocol as protocol_fixtures
+from tests._forager_matched_platform import requires_renameat2
 
-pytestmark = [pytest.mark.integration, pytest.mark.slow]
+pytestmark = [pytest.mark.integration, pytest.mark.slow, requires_renameat2]
 
 
 def _sha(label: str) -> str:


### PR DESCRIPTION
Fixes #2323

## Summary
In `tests/test_forager_matched_final_analysis.py`:
The test fixtures build synthetic campaign bundles via `_publish_verified_no_replace`, which requires Linux `renameat2` and fails closed with `ForagerMatchedSealError: renameat2 is required for seal publication` on platforms without `renameat2` (such as macOS Darwin).

## Proposed Changes
1. Added `requires_renameat2` from `tests._forager_matched_platform` to `pytestmark` in `tests/test_forager_matched_final_analysis.py`, aligning it with the other matched-campaign integration test suites.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_forager_matched_final_analysis.py` (33/33 skipped off Linux).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check tests/test_forager_matched_final_analysis.py` (clean).
