### PR TITLE
fix(nexting): promote computation dtype for integer and boolean cumulants

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -155,8 +155,12 @@ def forward_view_returns(
     _require_leading_length(
         "cumulants", cumulants, ndim=1, maximum=_NEXTING_MAX_STEPS
     )
-    gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
-    init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
+    comp_dtype = jnp.result_type(cumulants, gamma, terminal_value)
+    if not jnp.issubdtype(comp_dtype, jnp.floating):
+        comp_dtype = jnp.float32
+    c_arr = jnp.asarray(cumulants, dtype=comp_dtype)
+    gamma_s = jnp.asarray(gamma, dtype=comp_dtype)
+    init = jnp.asarray(terminal_value, dtype=comp_dtype)
 
     def step(carry: Array, c: Array) -> tuple[Array, Array]:
         # gamma=0 must not multiply an inf later return (0*inf).
@@ -164,7 +168,7 @@ def forward_view_returns(
         new_carry = c + bootstrap
         return new_carry, new_carry
 
-    _, returns_reversed = jax.lax.scan(step, init, cumulants[::-1])
+    _, returns_reversed = jax.lax.scan(step, init, c_arr[::-1])
     return returns_reversed[::-1]
 
 

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -617,3 +617,27 @@ class TestRunningRMSE:
         assert float(running[-1, 0]) < 0.01
         # Mid-series transition: some error
         assert float(running[19, 0]) > 0.5
+
+def test_forward_view_returns_promotes_integer_and_boolean_cumulants() -> None:
+    from alberta_framework.utils.nexting import (
+        forward_view_returns,
+        multi_horizon_returns,
+    )
+
+    c_int = jnp.array([1, 0, 0, 0, 1], dtype=jnp.int32)
+    res_int = forward_view_returns(c_int, 0.9)
+    assert jnp.issubdtype(res_int.dtype, jnp.floating)
+    expected = np.array([1.6561, 0.729, 0.81, 0.9, 1.0], dtype=np.float32)
+    np.testing.assert_allclose(np.asarray(res_int), expected, rtol=1e-5)
+
+    c_bool = jnp.array([True, False, False, False, True], dtype=bool)
+    res_bool = forward_view_returns(c_bool, 0.9)
+    assert jnp.issubdtype(res_bool.dtype, jnp.floating)
+    np.testing.assert_allclose(np.asarray(res_bool), expected, rtol=1e-5)
+
+    # Multi-horizon returns with int32 cumulants
+    horizons = jnp.array([0.0, 0.5, 0.9], dtype=jnp.float32)
+    res_multi = multi_horizon_returns(c_int, horizons)
+    assert res_multi.shape == (5, 3)
+    assert jnp.issubdtype(res_multi.dtype, jnp.floating)
+


### PR DESCRIPTION
Fixes #2368

## Summary
In `alberta_framework/utils/nexting.py`:
`forward_view_returns` cast `gamma` and `terminal_value` directly into `cumulants.dtype` (`gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)`). When an integer or boolean cumulant series was provided, fractional discounts (e.g. $\gamma = 0.9$) were silently truncated to integer 0, causing forward-view return calculations to collapse to a raw cumulant echo.

## Proposed Changes
1. Promoted the computation dtype across `(cumulants, gamma, terminal_value)` with fallback to `jnp.float32` if non-floating (`comp_dtype = jnp.result_type(cumulants, gamma, terminal_value)`).
2. Cast `cumulants`, `gamma`, and `terminal_value` to `comp_dtype` before `lax.scan`.
3. Added unit tests in `tests/test_nexting.py` verifying accurate forward-view returns for integer and boolean series across single and multi-horizon return calculations.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_nexting.py tests/test_nexting_series_length.py` (95/95 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/utils/nexting.py tests/test_nexting.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/utils/nexting.py` (clean).
