### PR TITLE
fix(core): preserve scale-free masked baseline centering in Hedge resource updates

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -197,6 +197,19 @@ class FeatureDiscoveryLearningResult:
     updates_applied: Bool[Array, " num_steps"]
 
 
+def _normalize_masked_allocation(weights: Array, mask: Array) -> Array:
+    masked = jnp.where(mask, jnp.maximum(weights, 0.0), 0.0)
+    max_val = jnp.max(masked)
+    _, exponent = jnp.frexp(max_val)
+    rescaled = jnp.ldexp(masked, -exponent)
+    total = jnp.sum(rescaled)
+    is_positive = (max_val > 0.0) & (total > 0.0) & jnp.isfinite(total)
+    mask_count = jnp.sum(mask.astype(jnp.float32))
+    safe_count = jnp.maximum(mask_count, 1.0)
+    uniform = jnp.where(mask, 1.0 / safe_count, 0.0)
+    return jnp.where(is_positive, rescaled / jnp.where(is_positive, total, 1.0), uniform)
+
+
 class FixedBudgetFeatureLearner:
     """One-hidden-layer feature bank with utility-based replacement.
 
@@ -792,9 +805,7 @@ class FixedBudgetFeatureLearner:
             if value.shape != shape or value.dtype != jnp.int32:
                 raise ValueError(f"state.{name} must have shape {shape} and dtype int32")
         if observation.shape != (feature_dim,) or observation.dtype != jnp.float32:
-            raise ValueError(
-                f"observation must have shape {(feature_dim,)} and dtype float32"
-            )
+            raise ValueError(f"observation must have shape {(feature_dim,)} and dtype float32")
         if targets is not None and (
             targets.shape != (self._n_tasks,) or targets.dtype != jnp.float32
         ):
@@ -1036,8 +1047,7 @@ class FixedBudgetFeatureLearner:
         finite: Array,
     ) -> Array:
         """Exponentiated-gradient preference update for utility scores."""
-        finite_mass = jnp.maximum(jnp.sum(jnp.where(finite, allocation, 0.0)), 1e-12)
-        masked_allocation = jnp.where(finite, allocation / finite_mass, 0.0)
+        masked_allocation = _normalize_masked_allocation(allocation, finite)
         baseline = jnp.sum(masked_allocation * jnp.where(finite, scores, 0.0))
         advantages = jnp.where(finite, scores - baseline, 0.0)
         advantages = jnp.clip(

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -50,9 +50,7 @@ from alberta_framework.core.update_safety import (
 )
 
 _INT32_MAX = 2**31 - 1
-_ACTUAL_INT_TYPES = frozenset(
-    {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
-)
+_ACTUAL_INT_TYPES = frozenset({int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")})
 _ACTUAL_REAL_TYPES = _ACTUAL_INT_TYPES | frozenset(
     {float, *(np.dtype(code).type for code in "efdg")}
 )
@@ -320,6 +318,19 @@ class LearnedResourceManagerUpdateResult:
     update_applied: Bool[Array, ""]
 
 
+def _normalize_masked_allocation(weights: Array, mask: Array) -> Array:
+    masked = jnp.where(mask, jnp.maximum(weights, 0.0), 0.0)
+    max_val = jnp.max(masked)
+    _, exponent = jnp.frexp(max_val)
+    rescaled = jnp.ldexp(masked, -exponent)
+    total = jnp.sum(rescaled)
+    is_positive = (max_val > 0.0) & (total > 0.0) & jnp.isfinite(total)
+    mask_count = jnp.sum(mask.astype(jnp.float32))
+    safe_count = jnp.maximum(mask_count, 1.0)
+    uniform = jnp.where(mask, 1.0 / safe_count, 0.0)
+    return jnp.where(is_positive, rescaled / jnp.where(is_positive, total, 1.0), uniform)
+
+
 class LearnedResourceManager:
     """Contextual Hedge manager over discrete resource policies.
 
@@ -502,9 +513,7 @@ class LearnedResourceManager:
         for name in ("log_weights", "loss_ema"):
             leaf = getattr(state, name)
             _require_array_metadata(f"state.{name}", leaf, shape, jnp.float32)
-        _require_array_metadata(
-            "state.action_counts", state.action_counts, shape, jnp.int32
-        )
+        _require_array_metadata("state.action_counts", state.action_counts, shape, jnp.int32)
         _require_array_metadata("state.step_count", state.step_count, (), jnp.int32)
 
     def weights(
@@ -559,9 +568,7 @@ class LearnedResourceManager:
         self._require_state_contract(state)
         _require_vector("losses", losses, self._n_actions, dtype=jnp.float32)
         if resource_costs is not None:
-            _require_vector(
-                "resource_costs", resource_costs, self._n_actions, dtype=jnp.float32
-            )
+            _require_vector("resource_costs", resource_costs, self._n_actions, dtype=jnp.float32)
         return cast(
             LearnedResourceManagerUpdateResult,
             self._update_jit(state, losses, context_id, resource_costs),
@@ -594,8 +601,7 @@ class LearnedResourceManager:
         adjusted = jnp.where(valid_actions, safe_losses + cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(valid_actions, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(valid_actions, weights / finite_weight_sum, 0.0)
+        masked_weights = _normalize_masked_allocation(weights, valid_actions)
         baseline = jnp.sum(masked_weights * adjusted)
         advantages = jnp.where(valid_actions, baseline - adjusted, 0.0)
         advantages = jnp.clip(
@@ -841,9 +847,7 @@ class GeneratorMetaResourceManager:
             for value in candidate_min_age_multipliers
         )
         imprint_scales = tuple(
-            _validated_float32(
-                "imprint_scales element", value, lower=0.0, preserve_nonzero=True
-            )
+            _validated_float32("imprint_scales element", value, lower=0.0, preserve_nonzero=True)
             for value in imprint_scales
         )
         if initial_preferences is not None:
@@ -975,12 +979,8 @@ class GeneratorMetaResourceManager:
                 op_ids=decoded_op_ids,
                 parent_modes=decoded_parent_modes,
                 replacement_multipliers=float_sequences["replacement_multipliers"],
-                promotion_margin_multipliers=float_sequences[
-                    "promotion_margin_multipliers"
-                ],
-                candidate_min_age_multipliers=float_sequences[
-                    "candidate_min_age_multipliers"
-                ],
+                promotion_margin_multipliers=float_sequences["promotion_margin_multipliers"],
+                candidate_min_age_multipliers=float_sequences["candidate_min_age_multipliers"],
                 imprint_scales=float_sequences["imprint_scales"],
                 initial_preferences=decoded_initial,
                 **config,
@@ -1012,9 +1012,7 @@ class GeneratorMetaResourceManager:
         for name in ("log_weights", "reward_ema"):
             leaf = getattr(state, name)
             _require_array_metadata(f"state.{name}", leaf, shape, jnp.float32)
-        _require_array_metadata(
-            "state.action_counts", state.action_counts, shape, jnp.int32
-        )
+        _require_array_metadata("state.action_counts", state.action_counts, shape, jnp.int32)
         _require_array_metadata("state.step_count", state.step_count, (), jnp.int32)
 
     def weights(
@@ -1141,9 +1139,7 @@ class GeneratorMetaResourceManager:
         if finite_mask is not None:
             _require_vector("finite_mask", finite_mask, self.n_policies, dtype=jnp.bool_)
         if resource_costs is not None:
-            _require_vector(
-                "resource_costs", resource_costs, self.n_policies, dtype=jnp.float32
-            )
+            _require_vector("resource_costs", resource_costs, self.n_policies, dtype=jnp.float32)
         return cast(
             GeneratorMetaResourceUpdateResult,
             self._update_jit(
@@ -1191,8 +1187,7 @@ class GeneratorMetaResourceManager:
         adjusted = jnp.where(finite, safe_rewards - cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(finite, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(finite, weights / finite_weight_sum, 0.0)
+        masked_weights = _normalize_masked_allocation(weights, finite)
         baseline = jnp.sum(masked_weights * adjusted)
         selection_input_valid = jnp.asarray(True, dtype=jnp.bool_)
         if self._update_rule == "exp3":

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -668,9 +668,7 @@ def _minimal_generator_manager(**overrides: object) -> GeneratorMetaResourceMana
         ("advantage_clip", True),
     ],
 )
-def test_learned_resource_manager_rejects_invalid_float32_config(
-    field: str, value: object
-) -> None:
+def test_learned_resource_manager_rejects_invalid_float32_config(field: str, value: object) -> None:
     with pytest.raises(ValueError, match=field):
         LearnedResourceManager(n_actions=2, **{field: value})  # type: ignore[arg-type]
 
@@ -686,10 +684,17 @@ def test_resource_manager_float32_config_is_canonical_and_json_safe() -> None:
         advantage_clip=np.float32(2.0),
     )
     config = manager.to_config()
-    assert all(type(config[name]) is float for name in (
-        "learning_rate", "discount", "exploration", "loss_decay", "cost_weight",
-        "advantage_clip",
-    ))
+    assert all(
+        type(config[name]) is float
+        for name in (
+            "learning_rate",
+            "discount",
+            "exploration",
+            "loss_decay",
+            "cost_weight",
+            "advantage_clip",
+        )
+    )
 
 
 def test_resource_manager_preflights_complete_state_before_allocation() -> None:
@@ -719,7 +724,7 @@ def test_generator_config_rejects_hostile_sequences_and_accepts_mapping_proxy() 
 
 @pytest.mark.parametrize("shape", [(), (1,), (1, 2), (2, 1), (3,)])
 def test_resource_manager_updates_reject_wrong_vector_shapes_under_jit(
-    shape: tuple[int, ...]
+    shape: tuple[int, ...],
 ) -> None:
     learned = LearnedResourceManager(n_actions=2)
     generator = _minimal_generator_manager()
@@ -859,3 +864,26 @@ def test_resource_manager_serialized_schemas_are_exact() -> None:
         invalid.update(mutation)
         with pytest.raises(ValueError, match=match):
             GeneratorMetaResourceManager.from_config(invalid)
+
+
+def test_resource_manager_masked_baseline_centers_at_extreme_preference_gap() -> None:
+    # 3 actions, 1 context, exploration=0.0
+    manager = LearnedResourceManager(
+        n_actions=3,
+        n_contexts=1,
+        exploration=0.0,
+        learning_rate=1.0,
+    )
+    state = manager.init()
+    # Action 0 has a 40-nat preference gap over actions 1 and 2
+    state = state.replace(log_weights=jnp.array([[40.0, 0.0, 0.0]], dtype=jnp.float32))
+
+    # Action 0 is masked out by NaN loss; actions 1 and 2 have losses 1.0 and 3.0
+    losses = jnp.array([np.nan, 1.0, 3.0], dtype=jnp.float32)
+    result = manager.update(state, losses, 0)
+    assert bool(result.update_applied)
+
+    # Baseline must be the convex combination of [1.0, 3.0] -> 2.0
+    # Centered advantages for actions 1 and 2 must be +1.0 and -1.0
+    assert np.isclose(float(result.advantages[1]), 1.0, atol=1e-4)
+    assert np.isclose(float(result.advantages[2]), -1.0, atol=1e-4)


### PR DESCRIPTION
Fixes #2409

## Summary
In `alberta_framework/core/resource_manager.py` and `alberta_framework/core/feature_discovery.py`:
Three Hedge-style preference updates (`LearnedResourceManager._update_jit`, `GeneratorMetaResourceManager._update_jit`, and `FixedBudgetFeatureLearner._resource_log_weight_update`) divided masked-in allocations by `jnp.maximum(jnp.sum(...), 1e-12)`. When active surviving entries carry less than $10^{-12}$ mass (e.g. at exploration 0.0 and large preference gaps), the divisor ceased being the actual mass sum, causing the baseline to collapse to zero rather than remaining a convex combination of participating entries.

## Proposed Changes
1. Added helper `_normalize_masked_allocation(weights, mask)` using power-of-two magnitude rescaling (`jnp.frexp`/`jnp.ldexp`) and fallback to uniform distribution across the active mask when mass is zero or underflows.
2. Replaced the floored division across all 3 update sites.
3. Added unit tests in `tests/test_resource_manager.py` verifying exact baseline centering and advantage computation at extreme preference gaps (40+ nats).

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_resource_manager.py tests/test_feature_discovery.py` (215/215 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py tests/test_resource_manager.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py` (clean).
