### PR TITLE
fix(core): rank CBP mature units by bias-corrected utility in replacement selection

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -483,21 +483,21 @@ def _select_replacement_index(
     utility: Array,
     age: Array,
     maturity_threshold: int,
+    decay_rate: float = 0.99,
 ) -> tuple[Array, Array]:
     """Pick the index of the lowest-utility mature unit, if any.
 
     A unit is "mature" iff ``age >= maturity_threshold``. Among mature
-    units we pick the one with the smallest utility. If no mature unit
-    exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
-    ``False``.
-
-    Implementation: replace the utility of immature or non-finite units
-    with ``+inf`` before taking ``argmin`` so they are never chosen.
+    units we pick the one with the smallest bias-corrected utility
+    (Dohare et al. 2024, Eq. 8: ``u_hat = u / (1 - decay ** age)``).
+    If no mature unit exists, ``selected`` is ``-1`` (sentinel) and
+    ``has_candidate`` is ``False``.
 
     Args:
         utility: Per-unit utility array, shape ``(num_units,)``.
         age: Per-unit age array (same shape).
         maturity_threshold: Minimum age for eligibility.
+        decay_rate: Utility EMA decay factor for bias correction.
 
     Returns:
         Tuple ``(index, has_candidate)`` where ``index`` is the chosen
@@ -505,7 +505,14 @@ def _select_replacement_index(
     """
     mature = age >= jnp.asarray(maturity_threshold, dtype=age.dtype)
     eligible = mature & jnp.isfinite(utility)
-    masked_utility = jnp.where(eligible, utility, jnp.inf)
+    decay = jnp.asarray(decay_rate, dtype=jnp.float32)
+    bias_correction = 1.0 - jnp.power(decay, age.astype(jnp.float32))
+    corrected_utility = jnp.where(
+        bias_correction > 0.0,
+        utility / jnp.where(bias_correction > 0.0, bias_correction, 1.0),
+        utility,
+    )
+    masked_utility = jnp.where(eligible, corrected_utility, jnp.inf)
     has_candidate = jnp.any(eligible)
     idx = jnp.argmin(masked_utility)
     selected = jnp.where(has_candidate, idx, jnp.int32(-1))
@@ -687,6 +694,7 @@ def replace_units_with_flags(
             new_cbp_state.utilities[layer_idx],
             new_cbp_state.ages[layer_idx],
             config.maturity_threshold,
+            config.decay_rate,
         )
         # Only replace if we both budgeted for it AND found a mature unit.
         gated = jnp.logical_and(do_replace, has_candidate)

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -988,3 +988,24 @@ class TestCBPWrapperConstructorIdentities:
         payload[field] = value
         with pytest.raises(ValueError, match="serialized"):
             CBPMultiHeadMLPLearner.from_config(payload)
+
+def test_cbp_selects_replacement_using_bias_corrected_utility() -> None:
+    # Young-strong vs old-weak:
+    # Unit 0: constant contribution 1.0 for 100 steps -> age=100
+    # Unit 1: constant contribution 0.9 for 700 steps -> age=700
+    # decay_rate = 0.99, maturity_threshold = 100
+    decay_rate = 0.99
+    age = jnp.array([100, 700], dtype=jnp.int32)
+    # Raw EMA values
+    raw_u0 = 1.0 * (1.0 - decay_rate**100)  # ~0.634
+    raw_u1 = 0.9 * (1.0 - decay_rate**700)  # ~0.899
+    utilities = jnp.array([raw_u0, raw_u1], dtype=jnp.float32)
+
+    # With bias-correction, unit 0 has u_hat=1.0 and unit 1 has u_hat=0.9
+    # Unit 1 (the less useful unit) must be selected for replacement
+    idx, has_candidate = _select_replacement_index(
+        utilities, age, maturity_threshold=100, decay_rate=decay_rate
+    )
+    assert bool(has_candidate)
+    assert int(idx) == 1
+


### PR DESCRIPTION
Fixes #2343

## Summary
In `alberta_framework/core/continual_backprop.py`:
`_select_replacement_index` ranked mature units by raw utility EMA rather than the bias-corrected utility defined in Eq. 8 of Dohare et al. (2024) ($\hat{u}_{l,i,t} = u_{l,i,t} / (1 - \eta^{a_{l,i,t}})$). Because replaced units reset their age and utility to 0, freshly matured units with short lifespans read at systematically lower raw EMA fractions ($\approx 1 - \eta^m \approx 0.634$ at $m=100, \eta=0.99$) compared to long-lived units ($\approx 1.0$), causing CBP to repeatedly target recently reset units.

## Proposed Changes
1. Updated `_select_replacement_index` to compute the per-unit bias correction $1 - \eta^{\text{age}}$ and rank eligible candidates by bias-corrected utility $\hat{u}$.
2. Forwarded `config.decay_rate` from `replace_units_with_flags`.
3. Added unit tests in `tests/test_continual_backprop.py` verifying that younger units with higher true contributions are preserved over older units with lower steady-state contributions.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_continual_backprop.py` (96/96 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/continual_backprop.py tests/test_continual_backprop.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/continual_backprop.py` (clean).
