### PR TITLE
fix(evaluation): make spectral_matrix_sign scale-free using power-of-two magnitude rescaling

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -173,7 +173,16 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
     valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    max_abs = jnp.max(jnp.abs(value))
+    _, exponent = jnp.frexp(max_abs)
+    rescaled = jnp.ldexp(value, -exponent)
+    rescaled_norm = jnp.linalg.norm(rescaled)
+    positive = (max_abs > 0.0) & (rescaled_norm > 0.0) & jnp.isfinite(rescaled_norm)
+    x = jnp.where(
+        positive,
+        rescaled / jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm)),
+        jnp.zeros_like(rescaled),
+    )
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,15 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+def test_spectral_matrix_sign_is_scale_free_for_tiny_matrices() -> None:
+    m = jnp.array([[2.0, 1.0], [0.5, -1.0]], dtype=jnp.float32)
+    expected_sign, expected_valid = spectral_matrix_sign_transaction(m)
+    assert bool(expected_valid)
+
+    for scale in (1e-13, 1e-15, 1e-20, 1e-25, 1e-35):
+        tiny = m * jnp.asarray(scale, dtype=jnp.float32)
+        sign, valid = spectral_matrix_sign_transaction(tiny)
+        assert bool(valid)
+        np.testing.assert_allclose(np.asarray(sign), np.asarray(expected_sign), atol=1e-5)
+


### PR DESCRIPTION
Fixes #2379

## Summary
In `alberta_framework/evaluation/optimizer_geometry.py`:
`spectral_matrix_sign_transaction` divided by `jnp.maximum(norm, 1e-12)`. When input matrices had Frobenius norm below $10^{-12}$, the divisor became the fixed floor rather than the actual norm, pushing singular values below the NS5 iteration's convergence interval and laundering small matrices into a numerically zero matrix sign with `valid=True`.

## Proposed Changes
1. Rescaled input matrices by their maximum absolute entry using exact power-of-two scaling (`jnp.frexp` and `jnp.ldexp`), keeping matrix entries in $[0.5, 1.0)$ prior to Frobenius norm computation.
2. Preserved exact zeros and verified validity via `positive = (max_abs > 0.0) & (rescaled_norm > 0.0) & jnp.isfinite(rescaled_norm)`.
3. Added unit tests in `tests/test_optimizer_geometry.py` verifying that small matrices ($10^{-13}$ down to $10^{-35}$) yield identical orthonormal matrix signs to unit-scale matrices.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (29/29 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (clean).
