### PR TITLE
fix(evaluation): make flad_noise_component scale-free using power-of-two gradient rescaling

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -203,12 +203,15 @@ def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tu
     direction = _trusted_array(gradient, name="gradient")
     if delta.shape != direction.shape or delta.ndim != 1 or delta.size < 1:
         raise ValueError("perturbation and gradient must be non-empty equal-width vectors")
-    squared_norm = jnp.vdot(direction, direction).real
-    numerator = jnp.vdot(direction, delta).real
-    active = squared_norm > 0.0
+    max_abs = jnp.max(jnp.abs(direction))
+    _, exponent = jnp.frexp(max_abs)
+    scaled = jnp.ldexp(direction, -exponent)
+    squared_norm = jnp.vdot(scaled, scaled).real
+    numerator = jnp.vdot(scaled, delta).real
+    active = (max_abs > 0.0) & (squared_norm > 0.0) & jnp.isfinite(squared_norm)
     denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
     coefficient = numerator / denominator
-    projection = direction * coefficient * active.astype(delta.dtype)
+    projection = scaled * coefficient * active.astype(delta.dtype)
     candidate = delta - projection
     valid = (
         jnp.all(jnp.isfinite(delta))

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,19 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+def test_flad_noise_component_removes_projection_at_underflowing_gradient_scales() -> None:
+    delta = jnp.array([1.0, -2.0, 0.5, 3.0], dtype=jnp.float32)
+    grad = jnp.array([2.0, 1.0, -1.0, 0.5], dtype=jnp.float32)
+
+    # Base reference
+    expected_safe, expected_valid = flad_noise_component_transaction(delta, grad)
+    assert bool(expected_valid)
+
+    # Across extreme underflow scales
+    for scale in (1e-10, 1e-19, 1e-20, 1e-25, 1e-30, 1e20, 1e30):
+        scaled_grad = grad * jnp.asarray(scale, dtype=jnp.float32)
+        safe, valid = flad_noise_component_transaction(delta, scaled_grad)
+        assert bool(valid)
+        np.testing.assert_allclose(np.asarray(safe), np.asarray(expected_safe), atol=1e-5)
+


### PR DESCRIPTION
Fixes #2393

## Summary
In `alberta_framework/evaluation/optimizer_geometry.py`:
`flad_noise_component_transaction` formed `active = squared_norm > 0.0`. When gradient entries fell below $10^{-20}$ in float32, the gradient's squared norm underflowed to 0.0, causing the projection removal to be skipped and returning the perturbation unaltered with `valid=True`.

## Proposed Changes
1. Rescaled the gradient direction by its maximum absolute entry using exact power-of-two scaling (`jnp.frexp` and `jnp.ldexp`), keeping entries in $[0.5, 1.0)$ prior to computing `squared_norm` and the projection coefficient.
2. Built projection along `scaled`, ensuring projection removal is invariant to gradient scale across all float32 exponent ranges ($10^{-30}$ to $10^{30}$).
3. Added unit tests in `tests/test_optimizer_geometry.py` verifying that projection removal is accurate at underflowing and overflowing gradient scales.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (29/29 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (clean).
