### PR TITLE
fix(core): enforce equal latent width invariant in BoundedPolicyArchive constructor and add

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        first_latent_len: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if first_latent_len is None:
+                first_latent_len = len(entry.latent)
+            elif len(entry.latent) != first_latent_len:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -66,3 +66,26 @@ def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")
     assert POLICY_ARCHIVE_PROTOCOL["scientific_promotion_allowed"] is False
+
+def test_constructor_enforces_equal_latent_width_invariant() -> None:
+    narrow = _entry("a", (0.0,), 1.0)
+    wide = _entry("b", (1.0, 2.0), 2.0)
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        BoundedPolicyArchive(byte_budget=4096, min_latent_distance=1.0, entries=(narrow, wide))
+
+
+def test_control_modes_accept_candidate_with_different_latent_width() -> None:
+    # fixed_snapshot retains existing entry without comparing latent widths
+    fixed = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=0.0, mode="fixed_snapshot"
+    ).add(_entry("a", (0.0,), 1.0))
+    successor_fixed = fixed.add(_entry("b", (1.0, 2.0), 2.0))
+    assert [e.identity for e in successor_fixed.entries] == ["a"]
+
+    # one_model replaces with the candidate without comparing latent widths
+    one = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=0.0, mode="one_model"
+    ).add(_entry("a", (0.0,), 1.0))
+    successor_one = one.add(_entry("b", (1.0, 2.0), 2.0))
+    assert [e.identity for e in successor_one.entries] == ["b"]
+


### PR DESCRIPTION
Fixes #2322

## Summary
In `alberta_framework/core/policy_archive.py`:
`BoundedPolicyArchive` did not validate that all initial entries in `self.entries` have equal latent width in `__post_init__`. If mixed-width entries were passed, numpy array subtraction `np.asarray(entry.latent) - np.asarray(old.latent)` broadcasted mismatched dimensions (e.g. `(3.0,) - (3.0, 3.0) -> [0.0, 0.0]`), creating an artificial distance 0.0 and silently discarding valid candidate policies. Additionally, `add()` executed the latent width check before mode dispatches, inappropriately rejecting candidates on control arms (`one_model` and `fixed_snapshot`) that never read latent vectors.

## Proposed Changes
1. Added equal latent descriptor width validation to `BoundedPolicyArchive.__post_init__` across all entries in `self.entries`.
2. Relocated the latent width check in `add()` inside the `diverse_archive` distance branch where `self.entries` descriptors are actually read.
3. Added unit tests in `tests/test_policy_archive.py` asserting constructor rejection of mixed-width initial entries and verifying that control arms accept candidates without comparing latent widths.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_policy_archive.py` (8/8 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/policy_archive.py tests/test_policy_archive.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/policy_archive.py` (clean).
