### PR TITLE
fix(benchmarks): derive integer allowlists from numpy dtype codes to cover all integer families

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -59,15 +59,8 @@ CAUSAL_MAP_VARIANT_KIND = "alberta_causal_map"
 _CAUSAL_MAP_RNG_NAMESPACE = 0xCA05A14
 _CAUSAL_MAP_PRNG_IMPL = "threefry2x32"
 _CAUSAL_MAP_ENVIRONMENT_PRNG_IMPL = "threefry2x32"
-_EXACT_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
+_EXACT_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 _EXACT_INTEGER_TYPES = (int, *_EXACT_NUMPY_INTEGER_TYPES)
 _EXACT_REAL_TYPES = (
@@ -87,16 +80,16 @@ def _require_exact_str(name: object, value: object) -> str:
     if type(value) is not str:
         raise ValueError(f"{name} must be an exact string")
     return value
+
+
 _INT32_MAX = int(np.iinfo(np.int32).max)
 _CAUSAL_MAP_CHUNK_BUDGET = ScanBudget("causal-map JAX chunk", 10_000)
 _MAX_CAUSAL_MAP_CELLS = 4_096
-_MAX_SAFE_FLOAT32_INT32 = float(
-    np.nextafter(np.float32(_INT32_MAX), np.float32(-np.inf))
-)
+_MAX_SAFE_FLOAT32_INT32 = float(np.nextafter(np.float32(_INT32_MAX), np.float32(-np.inf)))
 _FLOAT32_SCORE_HEADROOM = float(np.finfo(np.float32).max) / 8.0
 _DIRECTION_STEPS = (
-    (0, 1),   # action 0: +y
-    (1, 0),   # action 1: +x
+    (0, 1),  # action 0: +y
+    (1, 0),  # action 1: +x
     (0, -1),  # action 2: -y
     (-1, 0),  # action 3: -x
 )
@@ -109,9 +102,7 @@ _DIRECTIONS = jnp.asarray(
 def causal_map_rng_contract() -> dict[str, Any]:
     """Describe the causal-map agent's seed-isolated PRNG root."""
     return {
-        "root": (
-            "jax.random.fold_in(jax.random.key(seed, impl=prng_impl), namespace)"
-        ),
+        "root": ("jax.random.fold_in(jax.random.key(seed, impl=prng_impl), namespace)"),
         "namespace": _CAUSAL_MAP_RNG_NAMESPACE,
         "prng_impl": _CAUSAL_MAP_PRNG_IMPL,
         "jax_threefry_partitionable": _threefry_partitionable_mode(),
@@ -185,11 +176,7 @@ def _deterministic_inv_cdf(p: float) -> float:
                     (
                         (
                             (
-                                (
-                                    2.5090809287301226727e3 * r
-                                    + 3.3430575583588128105e4
-                                )
-                                * r
+                                (2.5090809287301226727e3 * r + 3.3430575583588128105e4) * r
                                 + 6.7265770927008700853e4
                             )
                             * r
@@ -212,26 +199,21 @@ def _deterministic_inv_cdf(p: float) -> float:
                 (
                     (
                         (
-                            (
-                                (5.2264952788528545610e3 * r + 2.8729085735721942674e4)
-                                * r
-                                + 3.9307895800092710610e4
-                            )
-                            * r
-                            + 2.1213794301586595867e4
+                            (5.2264952788528545610e3 * r + 2.8729085735721942674e4) * r
+                            + 3.9307895800092710610e4
                         )
                         * r
-                        + 5.3941960214247511077e3
+                        + 2.1213794301586595867e4
                     )
                     * r
-                    + 6.8718700749205790830e2
+                    + 5.3941960214247511077e3
                 )
                 * r
-                + 4.2313330701600911252e1
+                + 6.8718700749205790830e2
             )
             * r
-            + 1.0
-        )
+            + 4.2313330701600911252e1
+        ) * r + 1.0
         return num / den
     r = p if q <= 0.0 else 1.0 - p
     r = math.sqrt(-math.log(r))
@@ -242,57 +224,41 @@ def _deterministic_inv_cdf(p: float) -> float:
                 (
                     (
                         (
-                            (
-                                (
-                                    7.74545014278341407640e-4 * r
-                                    + 2.27238449892691845833e-2
-                                )
-                                * r
-                                + 2.41780725177450611770e-1
-                            )
-                            * r
-                            + 1.27045825245236838258e0
+                            (7.74545014278341407640e-4 * r + 2.27238449892691845833e-2) * r
+                            + 2.41780725177450611770e-1
                         )
                         * r
-                        + 3.64784832476320460504e0
+                        + 1.27045825245236838258e0
                     )
                     * r
-                    + 5.76949722146069140550e0
+                    + 3.64784832476320460504e0
                 )
                 * r
-                + 4.63033784615654529590e0
+                + 5.76949722146069140550e0
             )
             * r
-            + 1.42343711074968357734e0
-        )
+            + 4.63033784615654529590e0
+        ) * r + 1.42343711074968357734e0
         den = (
             (
                 (
                     (
                         (
-                            (
-                                (
-                                    1.05075007164441684324e-9 * r
-                                    + 5.47593808499534494600e-4
-                                )
-                                * r
-                                + 1.51986665636164571966e-2
-                            )
-                            * r
-                            + 1.48103976427480074590e-1
+                            (1.05075007164441684324e-9 * r + 5.47593808499534494600e-4) * r
+                            + 1.51986665636164571966e-2
                         )
                         * r
-                        + 6.89767334985100004550e-1
+                        + 1.48103976427480074590e-1
                     )
                     * r
-                    + 1.67638483018380384940e0
+                    + 6.89767334985100004550e-1
                 )
                 * r
-                + 2.05319162663775882187e0
+                + 1.67638483018380384940e0
             )
             * r
-            + 1.0
-        )
+            + 2.05319162663775882187e0
+        ) * r + 1.0
     else:
         r = r - 5.0
         num = (
@@ -300,57 +266,41 @@ def _deterministic_inv_cdf(p: float) -> float:
                 (
                     (
                         (
-                            (
-                                (
-                                    2.01033439929228813265e-7 * r
-                                    + 2.71155556874348757815e-5
-                                )
-                                * r
-                                + 1.24266094738807843860e-3
-                            )
-                            * r
-                            + 2.65321895265761230930e-2
+                            (2.01033439929228813265e-7 * r + 2.71155556874348757815e-5) * r
+                            + 1.24266094738807843860e-3
                         )
                         * r
-                        + 2.96560571828504891230e-1
+                        + 2.65321895265761230930e-2
                     )
                     * r
-                    + 1.78482653991729133580e0
+                    + 2.96560571828504891230e-1
                 )
                 * r
-                + 5.46378491116411436990e0
+                + 1.78482653991729133580e0
             )
             * r
-            + 6.65790464350110377720e0
-        )
+            + 5.46378491116411436990e0
+        ) * r + 6.65790464350110377720e0
         den = (
             (
                 (
                     (
                         (
-                            (
-                                (
-                                    2.04426310338993978564e-15 * r
-                                    + 1.42151175831644588870e-7
-                                )
-                                * r
-                                + 1.84631831751005468180e-5
-                            )
-                            * r
-                            + 7.86869131145613259100e-4
+                            (2.04426310338993978564e-15 * r + 1.42151175831644588870e-7) * r
+                            + 1.84631831751005468180e-5
                         )
                         * r
-                        + 1.48753612908506148525e-2
+                        + 7.86869131145613259100e-4
                     )
                     * r
-                    + 1.36929880922735805310e-1
+                    + 1.48753612908506148525e-2
                 )
                 * r
-                + 5.99832206555887937690e-1
+                + 1.36929880922735805310e-1
             )
             * r
-            + 1.0
-        )
+            + 5.99832206555887937690e-1
+        ) * r + 1.0
     x = num / den
     if q < 0.0:
         x = -x
@@ -409,8 +359,7 @@ class CausalMapForagerConfig:
             type(self.world_shape) is not tuple
             or len(self.world_shape) != 2
             or any(
-                type(value) is not int or value < 1
-                or value > _INT32_MAX
+                type(value) is not int or value < 1 or value > _INT32_MAX
                 for value in self.world_shape
             )
             or math.prod(self.world_shape) > _MAX_CAUSAL_MAP_CELLS
@@ -455,9 +404,7 @@ class CausalMapForagerConfig:
                 raise ValueError(f"{name} must be finite and positive")
             object.__setattr__(self, name, float(value))
         if np.float32(self.respawn_safety_factor) < np.float32(1.0):
-            raise ValueError(
-                "respawn_safety_factor must be at least 1.0 after float32 conversion"
-            )
+            raise ValueError("respawn_safety_factor must be at least 1.0 after float32 conversion")
         nonnegative_float = (
             "reverse_action_penalty",
             "visit_penalty",
@@ -496,11 +443,7 @@ class CausalMapForagerConfig:
         )
         for name in positive_int:
             value = getattr(self, name)
-            if (
-                type(value) not in _EXACT_INTEGER_TYPES
-                or value < 1
-                or value > _INT32_MAX
-            ):
+            if type(value) not in _EXACT_INTEGER_TYPES or value < 1 or value > _INT32_MAX:
                 raise ValueError(f"{name} must be a positive integer")
             object.__setattr__(self, name, int(value))
         if (
@@ -519,9 +462,7 @@ class CausalMapForagerConfig:
             or self.maximum_exact_interval_width < 0
             or self.maximum_exact_interval_width > _INT32_MAX
         ):
-            raise ValueError(
-                "maximum_exact_interval_width must be a non-negative integer"
-            )
+            raise ValueError("maximum_exact_interval_width must be a non-negative integer")
         object.__setattr__(
             self,
             "maximum_exact_interval_width",
@@ -535,9 +476,7 @@ class CausalMapForagerConfig:
         if self.maximum_retry_delay < self.initial_retry_delay:
             raise ValueError("maximum_retry_delay must be at least initial_retry_delay")
         if self.maximum_respawn_delay < self.minimum_respawn_delay:
-            raise ValueError(
-                "maximum_respawn_delay must be at least minimum_respawn_delay"
-            )
+            raise ValueError("maximum_respawn_delay must be at least minimum_respawn_delay")
         if (
             type(self.respawn_safety_quantile) not in _EXACT_REAL_TYPES
             or not math.isfinite(self.respawn_safety_quantile)
@@ -552,10 +491,9 @@ class CausalMapForagerConfig:
         )
         if not _finite_float32(self.respawn_quantile_z):
             raise ValueError("respawn_safety_quantile produces a non-finite float32 z")
-        if (
-            not 0.0 < self.one_hot_tolerance < 0.5
-            or not np.float32(self.one_hot_tolerance) < np.float32(0.5)
-        ):
+        if not 0.0 < self.one_hot_tolerance < 0.5 or not np.float32(
+            self.one_hot_tolerance
+        ) < np.float32(0.5):
             raise ValueError("one_hot_tolerance must lie strictly between 0 and 0.5")
         # Every configurable term below is combined in float32 inside the JAX
         # planner.  Individual float32 representability is insufficient: for
@@ -578,15 +516,9 @@ class CausalMapForagerConfig:
                 + self.reverse_action_penalty
                 + self.tie_break_scale
             ),
-            "exploration": (
-                _INT32_MAX
-                + self.reverse_action_penalty
-                + self.tie_break_scale
-            ),
+            "exploration": (_INT32_MAX + self.reverse_action_penalty + self.tie_break_scale),
             "respawn": (
-                self.respawn_safety_factor
-                * (1.0 + abs(self.respawn_quantile_z))
-                * _INT32_MAX
+                self.respawn_safety_factor * (1.0 + abs(self.respawn_quantile_z)) * _INT32_MAX
             ),
         }
         invalid_bounds = [
@@ -625,8 +557,7 @@ class CausalMapForagerConfig:
             for name, value in data.items()
         }
         data["world_shape"] = [
-            value.item() if isinstance(value, np.generic) else value
-            for value in self.world_shape
+            value.item() if isinstance(value, np.generic) else value for value in self.world_shape
         ]
         data["respawn_quantile_z"] = self.respawn_quantile_z
         return data
@@ -661,9 +592,7 @@ class CausalMapForagerConfig:
                 abs_tol=1e-15,
             )
         ):
-            raise ValueError(
-                "respawn_quantile_z does not match respawn_safety_quantile"
-            )
+            raise ValueError("respawn_quantile_z does not match respawn_safety_quantile")
         return config
 
     def fingerprint(self) -> str:
@@ -755,10 +684,7 @@ _STATE_BOOLEAN_FIELDS = frozenset(
     }
 )
 _STATE_FLOAT_FIELDS = frozenset(CausalMapForagerState._fields) - (
-    _STATE_INTEGER_FIELDS
-    | _STATE_UINT32_FIELDS
-    | _STATE_BOOLEAN_FIELDS
-    | {"rng_key"}
+    _STATE_INTEGER_FIELDS | _STATE_UINT32_FIELDS | _STATE_BOOLEAN_FIELDS | {"rng_key"}
 )
 _STATE_SERIALIZED_DTYPES = {
     name: (
@@ -767,8 +693,7 @@ _STATE_SERIALIZED_DTYPES = {
         else (
             "uint32"
             if name in _STATE_UINT32_FIELDS
-            else
-            "int32"
+            else "int32"
             if name in _STATE_INTEGER_FIELDS
             else "bool"
             if name in _STATE_BOOLEAN_FIELDS
@@ -789,9 +714,7 @@ def _image(observation: Any) -> Array:
     try:
         raw_image = jnp.asarray(image)
     except (OverflowError, TypeError, ValueError) as exc:
-        raise ValueError(
-            "causal-map observation must have a real numeric dtype"
-        ) from exc
+        raise ValueError("causal-map observation must have a real numeric dtype") from exc
     if not (
         jnp.issubdtype(raw_image.dtype, jnp.integer)
         or jnp.issubdtype(raw_image.dtype, jnp.floating)
@@ -814,21 +737,16 @@ def _validated_seed(seed: int | Array) -> Array:
             or host_seed.dtype.kind not in ("i", "u")
             or not 0 <= int(host_seed) <= np.iinfo(np.uint32).max
         ):
-            raise ValueError(
-                "causal-map seed must be one non-bool uint32-compatible integer"
-            )
+            raise ValueError("causal-map seed must be one non-bool uint32-compatible integer")
         return jnp.asarray(int(host_seed), dtype=jnp.uint32)
 
     raw_seed = jnp.asarray(seed)
     if raw_seed.ndim != 0 or not jnp.issubdtype(raw_seed.dtype, jnp.integer):
-        raise ValueError(
-            "causal-map seed must be one non-bool uint32-compatible integer"
-        )
+        raise ValueError("causal-map seed must be one non-bool uint32-compatible integer")
     valid_range = raw_seed >= 0
     if raw_seed.dtype.itemsize > np.dtype(np.uint32).itemsize:
         valid_range = valid_range & (
-            raw_seed
-            <= jnp.asarray(np.iinfo(np.uint32).max, dtype=raw_seed.dtype)
+            raw_seed <= jnp.asarray(np.iinfo(np.uint32).max, dtype=raw_seed.dtype)
         )
     checked_seed = _runtime_require(
         valid_range,
@@ -848,12 +766,7 @@ def _validate_observation_host(
     aperture_h, aperture_w, channels = image.shape
     if channels < 1:
         raise ValueError("causal-map Forager requires at least one object/color channel")
-    if (
-        aperture_h < 3
-        or aperture_w < 3
-        or aperture_h % 2 == 0
-        or aperture_w % 2 == 0
-    ):
+    if aperture_h < 3 or aperture_w < 3 or aperture_h % 2 == 0 or aperture_w % 2 == 0:
         raise ValueError(
             "causal-map Forager requires an odd aperture of at least 3; "
             "aperture 1 cannot causally identify a collected destination channel"
@@ -868,9 +781,7 @@ def _validate_observation_host(
     channel_sums = np.sum(image, axis=-1)
     if np.any(channel_sums > 1.0 + tolerance):
         raise ValueError("causal-map planner requires one-hot color/object channels")
-    near_binary = np.isclose(image, 0.0, atol=tolerance) | np.isclose(
-        image, 1.0, atol=tolerance
-    )
+    near_binary = np.isclose(image, 0.0, atol=tolerance) | np.isclose(image, 1.0, atol=tolerance)
     if not bool(np.all(near_binary)):
         raise ValueError("causal-map planner requires binary one-hot observations")
     return aperture_h, aperture_w, channels
@@ -886,12 +797,7 @@ def _validate_static_observation_shape(
     aperture_h, aperture_w, channels = image.shape
     if channels < 1:
         raise ValueError("causal-map Forager requires at least one object/color channel")
-    if (
-        aperture_h < 3
-        or aperture_w < 3
-        or aperture_h % 2 == 0
-        or aperture_w % 2 == 0
-    ):
+    if aperture_h < 3 or aperture_w < 3 or aperture_h % 2 == 0 or aperture_w % 2 == 0:
         raise ValueError(
             "causal-map Forager requires an odd aperture of at least 3; "
             "aperture 1 cannot causally identify a collected destination channel"
@@ -944,16 +850,13 @@ def _validated_observation_image(
     tolerance = jnp.asarray(config.one_hot_tolerance, dtype=jnp.float32)
     finite = jnp.all(jnp.isfinite(image))
     in_range = jnp.all((image >= -tolerance) & (image <= 1.0 + tolerance))
-    binary = jnp.all(
-        (jnp.abs(image) <= tolerance) | (jnp.abs(image - 1.0) <= tolerance)
-    )
+    binary = jnp.all((jnp.abs(image) <= tolerance) | (jnp.abs(image - 1.0) <= tolerance))
     one_hot = jnp.all(jnp.sum(image, axis=-1) <= 1.0 + tolerance)
     return _runtime_require(
         finite & in_range & binary & one_hot,
         image,
         message=(
-            "causal-map observation must be finite, [0, 1]-bounded, binary, "
-            "and one-hot per pixel"
+            "causal-map observation must be finite, [0, 1]-bounded, binary, and one-hot per pixel"
         ),
     )
 
@@ -1074,9 +977,7 @@ def _retry_delay(
     config: CausalMapForagerConfig,
 ) -> Array:
     """Return a positive, saturating exponential retry delay."""
-    maximum_safe_exponent = (
-        _INT32_MAX // config.initial_retry_delay
-    ).bit_length() - 1
+    maximum_safe_exponent = (_INT32_MAX // config.initial_retry_delay).bit_length() - 1
     safe_exponent = jnp.minimum(
         jnp.asarray(retry_count, dtype=jnp.int32),
         jnp.asarray(maximum_safe_exponent, dtype=jnp.int32),
@@ -1124,8 +1025,7 @@ def _estimated_respawn_delay(
     denominator = jnp.maximum(exact_count - 1, 1)
     exact_variance = jnp.where(
         exact_count > 1,
-        state.respawn_exact_m2[safe_channel]
-        / denominator.astype(jnp.float32),
+        state.respawn_exact_m2[safe_channel] / denominator.astype(jnp.float32),
         0.0,
     )
     exact_quantile = state.respawn_exact_mean[safe_channel] + jnp.asarray(
@@ -1134,9 +1034,7 @@ def _estimated_respawn_delay(
     ) * jnp.sqrt(jnp.maximum(exact_variance, 0.0))
     identified_upper = _saturating_add_int32(
         state.respawn_interval_upper_floor[safe_channel],
-        (state.respawn_interval_upper_remainder[safe_channel] > 0).astype(
-            jnp.int32
-        ),
+        (state.respawn_interval_upper_remainder[safe_channel] > 0).astype(jnp.int32),
     )
     conservative_upper = jnp.maximum(
         identified_upper.astype(jnp.float32),
@@ -1147,8 +1045,7 @@ def _estimated_respawn_delay(
         ),
     )
     estimate = jnp.ceil(
-        jnp.asarray(config.respawn_safety_factor, dtype=jnp.float32)
-        * conservative_upper
+        jnp.asarray(config.respawn_safety_factor, dtype=jnp.float32) * conservative_upper
     )
     # Do not cast a float32 value above its largest int32-safe representation:
     # the mathematical int32 maximum rounds upward in float32 and can wrap
@@ -1196,8 +1093,7 @@ def _rational_mean_float32(
     """Evaluate a quotient/remainder mean under one explicit float32 contract."""
     denominator = jnp.maximum(jnp.asarray(count, dtype=jnp.int32), 1)
     return jnp.asarray(floor, dtype=jnp.float32) + (
-        jnp.asarray(remainder, dtype=jnp.float32)
-        / denominator.astype(jnp.float32)
+        jnp.asarray(remainder, dtype=jnp.float32) / denominator.astype(jnp.float32)
     )
 
 
@@ -1212,13 +1108,9 @@ def _add_exact_mean_sample(
     # floor((r + x - q) / (n + 1)).  Split positive and negative cases so no
     # signed intermediate can overflow; r+x fits exactly in uint32.
     floor_minus_sample = floor - sample
-    nonnegative = (sample >= floor) | (
-        (sample < floor) & (remainder >= floor_minus_sample)
-    )
+    nonnegative = (sample >= floor) | ((sample < floor) & (remainder >= floor_minus_sample))
     positive_numerator = (
-        remainder.astype(jnp.uint32)
-        + sample.astype(jnp.uint32)
-        - floor.astype(jnp.uint32)
+        remainder.astype(jnp.uint32) + sample.astype(jnp.uint32) - floor.astype(jnp.uint32)
     )
     unsigned_count = next_count.astype(jnp.uint32)
     positive_adjustment = (positive_numerator // unsigned_count).astype(jnp.int32)
@@ -1296,12 +1188,7 @@ def _merge_channel_interval_bounds(
         channel, lower_bound, upper_bound, enabled = sample_data
         safe_channel = jnp.clip(channel, 0, channel_count - 1)
         old_count = current_count[safe_channel]
-        accepted = (
-            enabled
-            & (channel >= 0)
-            & (channel < channel_count)
-            & (old_count < _INT32_MAX)
-        )
+        accepted = enabled & (channel >= 0) & (channel < channel_count) & (old_count < _INT32_MAX)
         next_count = old_count + accepted.astype(jnp.int32)
         next_lower_floor, next_lower_remainder = _add_exact_mean_sample(
             current_lower_floor[safe_channel],
@@ -1406,12 +1293,7 @@ def _merge_exact_channel_samples(
         channel, sample, enabled = sample_data
         safe_channel = jnp.clip(channel, 0, channel_count - 1)
         old_count = current_count[safe_channel]
-        accepted = (
-            enabled
-            & (channel >= 0)
-            & (channel < channel_count)
-            & (old_count < _INT32_MAX)
-        )
+        accepted = enabled & (channel >= 0) & (channel < channel_count) & (old_count < _INT32_MAX)
         next_count = old_count + accepted.astype(jnp.int32)
         denominator = jnp.maximum(next_count, 1)
         next_floor, next_remainder = _add_exact_mean_sample(
@@ -1435,9 +1317,7 @@ def _merge_exact_channel_samples(
             denominator,
         )
         center_delta = provisional_mean - canonical_mean
-        centered_m2 = provisional_m2 + (
-            denominator_float * jnp.square(center_delta)
-        )
+        centered_m2 = provisional_m2 + (denominator_float * jnp.square(center_delta))
         return (
             (
                 current_count.at[safe_channel].set(next_count),
@@ -1501,11 +1381,7 @@ def _integrate_observation(
     old_ready = state.cell_ready_step[ys, xs]
     old_retry = state.cell_retry_count[ys, xs]
     old_last_absent = state.cell_last_absent_step[ys, xs]
-    reappeared = (
-        flat_active
-        & (old_collection >= 0)
-        & (old_collection < state.step_count)
-    )
+    reappeared = flat_active & (old_collection >= 0) & (old_collection < state.step_count)
     upper_elapsed = state.step_count - old_collection
     lower_elapsed = jnp.maximum(
         old_last_absent + 1 - old_collection,
@@ -1513,8 +1389,7 @@ def _integrate_observation(
     ).astype(jnp.int32)
     interval_width = upper_elapsed - lower_elapsed
     exact_reappearance = reappeared & (
-        interval_width
-        <= jnp.asarray(config.maximum_exact_interval_width, dtype=jnp.int32)
+        interval_width <= jnp.asarray(config.maximum_exact_interval_width, dtype=jnp.int32)
     )
     sample_channels = jnp.where(old_channel >= 0, old_channel, flat_channels)
 
@@ -1556,10 +1431,7 @@ def _integrate_observation(
     )
 
     visible_retry_miss = (
-        ~flat_active
-        & (old_collection >= 0)
-        & (old_ready >= 0)
-        & (state.step_count >= old_ready)
+        ~flat_active & (old_collection >= 0) & (old_ready >= 0) & (state.step_count >= old_ready)
     )
     next_retry = _increment_retry_count(old_retry, config)
     retry_delay = _retry_delay(next_retry, config)
@@ -1592,25 +1464,29 @@ def _integrate_observation(
     )
     learned_count = jnp.sum(reappeared, dtype=jnp.int32)
     visible_retry_count = jnp.sum(visible_retry_miss, dtype=jnp.int32)
-    return state._replace(
-        cell_channel=cell_channel,
-        cell_active=cell_active,
-        cell_collection_step=collection_step,
-        cell_ready_step=ready_step,
-        cell_retry_count=retry_count,
-        cell_last_seen_step=last_seen,
-        cell_last_absent_step=last_absent,
-        respawn_interval_count=respawn_interval_count,
-        respawn_interval_lower_floor=respawn_interval_lower_floor,
-        respawn_interval_lower_remainder=respawn_interval_lower_remainder,
-        respawn_interval_upper_floor=respawn_interval_upper_floor,
-        respawn_interval_upper_remainder=respawn_interval_upper_remainder,
-        respawn_exact_count=respawn_exact_count,
-        respawn_exact_floor=respawn_exact_floor,
-        respawn_exact_remainder=respawn_exact_remainder,
-        respawn_exact_mean=respawn_exact_mean,
-        respawn_exact_m2=respawn_exact_m2,
-    ), learned_count, visible_retry_count
+    return (
+        state._replace(
+            cell_channel=cell_channel,
+            cell_active=cell_active,
+            cell_collection_step=collection_step,
+            cell_ready_step=ready_step,
+            cell_retry_count=retry_count,
+            cell_last_seen_step=last_seen,
+            cell_last_absent_step=last_absent,
+            respawn_interval_count=respawn_interval_count,
+            respawn_interval_lower_floor=respawn_interval_lower_floor,
+            respawn_interval_lower_remainder=respawn_interval_lower_remainder,
+            respawn_interval_upper_floor=respawn_interval_upper_floor,
+            respawn_interval_upper_remainder=respawn_interval_upper_remainder,
+            respawn_exact_count=respawn_exact_count,
+            respawn_exact_floor=respawn_exact_floor,
+            respawn_exact_remainder=respawn_exact_remainder,
+            respawn_exact_mean=respawn_exact_mean,
+            respawn_exact_m2=respawn_exact_m2,
+        ),
+        learned_count,
+        visible_retry_count,
+    )
 
 
 def _channel_values(
@@ -1655,10 +1531,7 @@ def _cost_aware_route_grid(
     base = jnp.asarray(cell_count + 1, dtype=jnp.int32)
     infinity = jnp.asarray((cell_count + 1) * (cell_count + 2), dtype=jnp.int32)
     source_x, source_y = source[0], source[1]
-    entry_cost = (
-        negative_cells.astype(jnp.int32) * base
-        + jnp.asarray(1, dtype=jnp.int32)
-    )
+    entry_cost = negative_cells.astype(jnp.int32) * base + jnp.asarray(1, dtype=jnp.int32)
     encoded = jnp.full(config.world_shape, infinity, dtype=jnp.int32)
     encoded = encoded.at[source_y, source_x].set(0)
 
@@ -1764,9 +1637,7 @@ def _choose_action(
         ),
         maximum_entry_penalty,
     )
-    route_negative_cost = (
-        route_negative_entries.astype(jnp.float32) * negative_entry_penalty
-    )
+    route_negative_cost = route_negative_entries.astype(jnp.float32) * negative_entry_penalty
     target_noise = jr.uniform(
         target_key,
         state.cell_channel.shape,
@@ -1872,15 +1743,13 @@ def _choose_action(
             jnp.asarray(path_infinity, dtype=jnp.int32),
         )
     )
-    pursuit_allowed = (
-        (target_distances_int < path_infinity)
-        & (target_negative_entries == minimum_route_negative_entries)
+    pursuit_allowed = (target_distances_int < path_infinity) & (
+        target_negative_entries == minimum_route_negative_entries
     )
     neighbor_visits = state.visit_count[neighbor_y, neighbor_x].astype(jnp.float32)
     reverse_action = jnp.mod(state.last_action + 2, 4)
     reverse_cost = (
-        (state.last_action >= 0)
-        & (jnp.arange(4, dtype=jnp.int32) == reverse_action)
+        (state.last_action >= 0) & (jnp.arange(4, dtype=jnp.int32) == reverse_action)
     ).astype(jnp.float32) * jnp.asarray(
         config.reverse_action_penalty,
         dtype=jnp.float32,
@@ -1891,16 +1760,11 @@ def _choose_action(
     )
     pursuit_cost = (
         target_distances
-        + jnp.asarray(config.visit_penalty, dtype=jnp.float32)
-        * jnp.log1p(neighbor_visits)
+        + jnp.asarray(config.visit_penalty, dtype=jnp.float32) * jnp.log1p(neighbor_visits)
         + reverse_cost
         + action_noise
     )
-    exploration_cost = (
-        neighbor_visits
-        + reverse_cost
-        + action_noise
-    )
+    exploration_cost = neighbor_visits + reverse_cost + action_noise
     pursuing = has_target & route_available
     costs = jnp.where(pursuing, pursuit_cost, exploration_cost)
     selected_allowed = jnp.where(pursuing, pursuit_allowed, allowed)
@@ -1916,9 +1780,9 @@ def _choose_action(
         jnp.arange(4, dtype=jnp.float32),
         jnp.inf,
     )
-    action = jnp.argmin(
-        jnp.where(has_finite_action, finite_costs, fallback_costs)
-    ).astype(jnp.int32)
+    action = jnp.argmin(jnp.where(has_finite_action, finite_costs, fallback_costs)).astype(
+        jnp.int32
+    )
 
     destination = neighbor_positions[action]
     destination_y, destination_x = destination[1], destination[0]
@@ -1977,16 +1841,12 @@ def causal_map_step(
     )
     image = _validated_observation_image(observation, config)
     if image.shape[-1] != state.reward_sum.shape[0]:
-        raise ValueError(
-            "causal-map observation channel count changed during the continuing run"
-        )
+        raise ValueError("causal-map observation channel count changed during the continuing run")
     mode_checked_step_count = _runtime_require(
         state.jax_threefry_partitionable
         == jnp.asarray(_threefry_partitionable_mode(), dtype=jnp.bool_),
         state.step_count,
-        message=(
-            "causal-map state jax_threefry_partitionable mode does not match runtime"
-        ),
+        message=("causal-map state jax_threefry_partitionable mode does not match runtime"),
     )
     checked_step_count = _require_unsaturated_step_count(mode_checked_step_count)
     position = jnp.mod(
@@ -2001,9 +1861,7 @@ def causal_map_step(
         state.visit_count[position[1], position[0]],
         jnp.asarray(1, dtype=jnp.int32),
     )
-    visit_count = state.visit_count.at[position[1], position[0]].set(
-        next_visit_count
-    )
+    visit_count = state.visit_count.at[position[1], position[0]].set(next_visit_count)
     state = state._replace(
         step_count=step_count,
         position=position,
@@ -2012,14 +1870,10 @@ def causal_map_step(
 
     valid_channel = state.last_target_channel >= 0
     observed_reward = (
-        valid_channel
-        & jnp.isfinite(reward)
-        & (jnp.abs(reward) > config.reward_observation_epsilon)
+        valid_channel & jnp.isfinite(reward) & (jnp.abs(reward) > config.reward_observation_epsilon)
     )
     safe_channel = jnp.maximum(state.last_target_channel, 0)
-    reward_sum = state.reward_sum.at[safe_channel].add(
-        jnp.where(observed_reward, reward, 0.0)
-    )
+    reward_sum = state.reward_sum.at[safe_channel].add(jnp.where(observed_reward, reward, 0.0))
     reward_sum = _runtime_require(
         jnp.all(jnp.isfinite(reward_sum)),
         reward_sum,
@@ -2029,9 +1883,7 @@ def causal_map_step(
         state.reward_count[safe_channel],
         observed_reward.astype(jnp.int32),
     )
-    reward_count = state.reward_count.at[safe_channel].set(
-        next_reward_count
-    )
+    reward_count = state.reward_count.at[safe_channel].set(next_reward_count)
 
     # A reward collected from a cell that was still pending proves that the
     # previous object reappeared before it was immediately collected again.
@@ -2186,8 +2038,7 @@ def validate_causal_map_state(
             host_impl = _require_exact_str("impl", impl)
             if host_impl != _CAUSAL_MAP_PRNG_IMPL:
                 raise ValueError(
-                    "rng_key must use the causal-map PRNG implementation "
-                    f"'{_CAUSAL_MAP_PRNG_IMPL}'"
+                    f"rng_key must use the causal-map PRNG implementation '{_CAUSAL_MAP_PRNG_IMPL}'"
                 )
             if array.shape != (2,) or array.dtype != np.dtype(np.uint32):
                 raise ValueError("rng_key must contain exactly two uint32 words")
@@ -2203,9 +2054,7 @@ def validate_causal_map_state(
                 else np.float32
             )
             if array.dtype != expected_dtype:
-                raise ValueError(
-                    f"{name} must have dtype {expected_dtype}, found {array.dtype}"
-                )
+                raise ValueError(f"{name} must have dtype {expected_dtype}, found {array.dtype}")
         arrays[name] = array
 
     scalar_fields = (
@@ -2253,8 +2102,7 @@ def validate_causal_map_state(
     if channel_count < 1:
         raise ValueError("state must contain at least one observation channel")
     if observation_channels is not None and (
-        type(observation_channels) not in _EXACT_INTEGER_TYPES
-        or observation_channels < 1
+        type(observation_channels) not in _EXACT_INTEGER_TYPES or observation_channels < 1
     ):
         raise ValueError("observation_channels must be a positive integer")
     if observation_channels is not None and channel_count != int(observation_channels):
@@ -2276,9 +2124,7 @@ def validate_causal_map_state(
     if not 0 <= initial_seed <= np.iinfo(np.uint32).max:
         raise ValueError("initial_seed must be uint32-compatible")
     if bool(arrays["jax_threefry_partitionable"]) != _threefry_partitionable_mode():
-        raise ValueError(
-            "state jax_threefry_partitionable mode does not match runtime"
-        )
+        raise ValueError("state jax_threefry_partitionable mode does not match runtime")
     last_action = int(arrays["last_action"])
     if last_action not in (-1, 0, 1, 2, 3):
         raise ValueError("last_action must be -1 or one of the four public actions")
@@ -2318,9 +2164,7 @@ def validate_causal_map_state(
             raise ValueError(f"{name} exceeds the causal map/step bound")
         if int(np.sum(arrays[name], dtype=np.int64)) > maximum_reappearances:
             raise ValueError(f"total {name} exceeds the causal map/step bound")
-    if np.any(
-        arrays["respawn_exact_count"] > arrays["respawn_interval_count"]
-    ):
+    if np.any(arrays["respawn_exact_count"] > arrays["respawn_interval_count"]):
         raise ValueError("exact respawn counts cannot exceed all reappearance counts")
     if np.any(arrays["visit_count"] > min(step_count + 1, _INT32_MAX)):
         raise ValueError("visit_count cannot exceed the number of visited states")
@@ -2379,8 +2223,7 @@ def validate_causal_map_state(
     expected_cell_active = last_seen > last_absent
     if not np.array_equal(arrays["cell_active"], expected_cell_active):
         raise ValueError(
-            "cell_active must exactly match whether the last observation "
-            "followed the last absence"
+            "cell_active must exactly match whether the last observation followed the last absence"
         )
     if np.any(has_collection & (last_absent < collection)):
         raise ValueError("collected cells must be observed absent at collection time")
@@ -2396,9 +2239,7 @@ def validate_causal_map_state(
         accounted_collections,
         arrays["reward_count"].astype(np.int64),
     ):
-        raise ValueError(
-            "reward counts must equal reappearances plus pending collections"
-        )
+        raise ValueError("reward counts must equal reappearances plus pending collections")
 
     if last_action >= 0:
         direction_x, direction_y = _DIRECTION_STEPS[last_action]
@@ -2410,31 +2251,21 @@ def validate_causal_map_state(
             dtype=np.int32,
         )
         if not np.array_equal(arrays["last_target_position"], expected_target):
-            raise ValueError(
-                "last_target_position must be the destination of last_action"
-            )
+            raise ValueError("last_target_position must be the destination of last_action")
         target_x, target_y = (int(value) for value in expected_target)
         expected_channel = int(channels[target_y, target_x])
         if last_target_channel != expected_channel:
-            raise ValueError(
-                "last_target_channel must match the destination map cell"
-            )
+            raise ValueError("last_target_channel must match the destination map cell")
         predicted_ready = bool(
             collection[target_y, target_x] >= 0
             and ready[target_y, target_x] >= 0
             and step_count >= ready[target_y, target_x]
         )
         expected_active = bool(
-            expected_channel >= 0
-            and (
-                arrays["cell_active"][target_y, target_x]
-                or predicted_ready
-            )
+            expected_channel >= 0 and (arrays["cell_active"][target_y, target_x] or predicted_ready)
         )
         if bool(arrays["last_target_expected_active"]) != expected_active:
-            raise ValueError(
-                "last_target_expected_active does not match destination state"
-            )
+            raise ValueError("last_target_expected_active does not match destination state")
     elif (
         last_target_channel != -1
         or bool(arrays["last_target_expected_active"])
@@ -2463,23 +2294,15 @@ def validate_causal_map_state(
     if any(np.any(interval_empty & (arrays[name] != 0)) for name in interval_fields):
         raise ValueError("zero-count respawn interval bounds must be zero")
     interval_populated = ~interval_empty
-    if np.any(
-        interval_populated & (arrays["respawn_interval_lower_floor"] < 1)
-    ):
+    if np.any(interval_populated & (arrays["respawn_interval_lower_floor"] < 1)):
         raise ValueError("respawn interval lower floors must be at least one step")
     if np.any(
         interval_populated
         & (
             (arrays["respawn_interval_lower_remainder"] < 0)
             | (arrays["respawn_interval_upper_remainder"] < 0)
-            | (
-                arrays["respawn_interval_lower_remainder"]
-                >= arrays["respawn_interval_count"]
-            )
-            | (
-                arrays["respawn_interval_upper_remainder"]
-                >= arrays["respawn_interval_count"]
-            )
+            | (arrays["respawn_interval_lower_remainder"] >= arrays["respawn_interval_count"])
+            | (arrays["respawn_interval_upper_remainder"] >= arrays["respawn_interval_count"])
         )
     ):
         raise ValueError("respawn interval remainders must lie in [0, count)")
@@ -2512,10 +2335,7 @@ def validate_causal_map_state(
         )
     ):
         raise ValueError("zero-count exact respawn statistics must be zero")
-    if np.any(
-        (arrays["respawn_exact_count"] <= 1)
-        & (arrays["respawn_exact_m2"] != 0.0)
-    ):
+    if np.any((arrays["respawn_exact_count"] <= 1) & (arrays["respawn_exact_m2"] != 0.0)):
         raise ValueError("exact respawn M2 must be zero with at most one sample")
     exact_populated = ~exact_empty
     exact_floor = arrays["respawn_exact_floor"]
@@ -2523,10 +2343,7 @@ def validate_causal_map_state(
     exact_count = arrays["respawn_exact_count"]
     if np.any(exact_populated & (exact_floor < 1)):
         raise ValueError("populated exact respawn floors must be at least one step")
-    if np.any(
-        exact_populated
-        & ((exact_remainder < 0) | (exact_remainder >= exact_count))
-    ):
+    if np.any(exact_populated & ((exact_remainder < 0) | (exact_remainder >= exact_count))):
         raise ValueError("exact respawn remainders must lie in [0, count)")
     if np.any(
         exact_populated
@@ -2543,38 +2360,21 @@ def validate_causal_map_state(
         exact_fraction,
         dtype=np.float32,
     )
-    if np.any(
-        canonical_exact_mean.view(np.uint32)
-        != arrays["respawn_exact_mean"].view(np.uint32)
-    ):
+    if np.any(canonical_exact_mean.view(np.uint32) != arrays["respawn_exact_mean"].view(np.uint32)):
         raise ValueError(
             "exact respawn mean must match its rational sample sum under the "
             "schema float32 contract"
         )
 
-    exact_population = (
-        arrays["respawn_exact_count"] == arrays["respawn_interval_count"]
-    )
+    exact_population = arrays["respawn_exact_count"] == arrays["respawn_interval_count"]
     if np.any(
-        exact_population
-        & (
-            (lower_floor != upper_floor)
-            | (lower_remainder != upper_remainder)
-        )
+        exact_population & ((lower_floor != upper_floor) | (lower_remainder != upper_remainder))
     ):
-        raise ValueError(
-            "all-exact respawn intervals must have identical rational endpoints"
-        )
+        raise ValueError("all-exact respawn intervals must have identical rational endpoints")
     if np.any(
-        exact_population
-        & (
-            (lower_floor != exact_floor)
-            | (lower_remainder != exact_remainder)
-        )
+        exact_population & ((lower_floor != exact_floor) | (lower_remainder != exact_remainder))
     ):
-        raise ValueError(
-            "all-exact respawn interval and exact-sample rational means must match"
-        )
+        raise ValueError("all-exact respawn interval and exact-sample rational means must match")
 
 
 def causal_map_state_to_dict(
@@ -2593,9 +2393,7 @@ def causal_map_state_to_dict(
     return {
         "schema": CAUSAL_MAP_STATE_SCHEMA,
         "prng_impl": _prng_impl_name(state.rng_key),
-        "jax_threefry_partitionable": bool(
-            np.asarray(state.jax_threefry_partitionable)
-        ),
+        "jax_threefry_partitionable": bool(np.asarray(state.jax_threefry_partitionable)),
         "config": config.to_dict(),
         "config_sha256": config.fingerprint(),
         "dtypes": dict(_STATE_SERIALIZED_DTYPES),
@@ -2611,15 +2409,14 @@ def _raw_json_array(
     kind: str,
 ) -> None:
     """Validate a JSON field without relying on coercive NumPy conversion."""
+
     def require_json_shape(value: Any, dimensions: tuple[int, ...]) -> None:
         if not dimensions:
             if isinstance(value, (list, tuple, Mapping)):
                 raise ValueError(f"serialized {name} must contain JSON scalars")
             return
         if type(value) is not list or len(value) != dimensions[0]:
-            raise ValueError(
-                f"serialized {name} must use JSON arrays with shape {shape}"
-            )
+            raise ValueError(f"serialized {name} must use JSON arrays with shape {shape}")
         for child in value:
             require_json_shape(child, dimensions[1:])
 
@@ -2633,10 +2430,7 @@ def _raw_json_array(
 
     for value in array.reshape(-1):
         if kind == "int32":
-            valid = (
-                type(value) is int
-                and np.iinfo(np.int32).min <= value <= np.iinfo(np.int32).max
-            )
+            valid = type(value) is int and np.iinfo(np.int32).min <= value <= np.iinfo(np.int32).max
         elif kind == "uint32-key-data":
             valid = type(value) is int and 0 <= value <= np.iinfo(np.uint32).max
         elif kind == "uint32":
@@ -2646,17 +2440,12 @@ def _raw_json_array(
         elif kind == "float32":
             valid = type(value) is float and math.isfinite(value)
             if valid:
-                valid = (
-                    abs(value) <= np.finfo(np.float32).max
-                    and float(np.float32(value)) == value
-                )
+                valid = abs(value) <= np.finfo(np.float32).max and float(np.float32(value)) == value
         else:  # pragma: no cover - internal schema table is closed
             host_kind = _require_exact_str("kind", kind)
             raise RuntimeError(f"unknown serialized state kind '{host_kind}'")
         if not valid:
-            raise ValueError(
-                f"serialized {name} contains a value incompatible with {kind}"
-            )
+            raise ValueError(f"serialized {name} contains a value incompatible with {kind}")
 
 
 def _require_raw_json_value(value: Any, *, path: str) -> None:
@@ -2706,13 +2495,9 @@ def causal_map_state_from_dict(
         raise ValueError("serialized state PRNG implementation does not match")
     checkpoint_partitionable = payload.get("jax_threefry_partitionable")
     if type(checkpoint_partitionable) is not bool:
-        raise ValueError(
-            "serialized state jax_threefry_partitionable mode must be boolean"
-        )
+        raise ValueError("serialized state jax_threefry_partitionable mode must be boolean")
     if checkpoint_partitionable != _threefry_partitionable_mode():
-        raise ValueError(
-            "serialized state jax_threefry_partitionable mode does not match runtime"
-        )
+        raise ValueError("serialized state jax_threefry_partitionable mode does not match runtime")
     declared_config_value = payload.get("config")
     _require_raw_json_value(
         declared_config_value,
@@ -2744,24 +2529,17 @@ def causal_map_state_from_dict(
     declared_config_sha256 = hashlib.sha256(declared_config.encode()).hexdigest()
     raw_config_sha256 = payload.get("config_sha256")
     declared_hash_matches = (
-        type(raw_config_sha256) is str
-        and raw_config_sha256 == declared_config_sha256
+        type(raw_config_sha256) is str and raw_config_sha256 == declared_config_sha256
     )
     current_config_matches = (
-        declared_config == expected_config
-        and declared_config_sha256 == config.fingerprint()
+        declared_config == expected_config and declared_config_sha256 == config.fingerprint()
     )
     # State v5 predates the scheduling option but its state tuple is unchanged.
     # A field-absent checkpoint therefore remains resumable only under the
     # explicit legacy decision-time policy.  Never silently resume it under the
     # new arrival-aware default, which would change continuation behavior.
-    legacy_config_matches = (
-        not config.arrival_aware_readiness
-        and declared_config == legacy_config
-    )
-    if not declared_hash_matches or not (
-        current_config_matches or legacy_config_matches
-    ):
+    legacy_config_matches = not config.arrival_aware_readiness and declared_config == legacy_config
+    if not declared_hash_matches or not (current_config_matches or legacy_config_matches):
         raise ValueError("serialized state embeds a different configuration")
     raw_dtypes = payload.get("dtypes")
     if not isinstance(raw_dtypes, Mapping) or dict(raw_dtypes) != _STATE_SERIALIZED_DTYPES:
@@ -2818,13 +2596,9 @@ def causal_map_state_from_dict(
             shape=shape,
             kind=_STATE_SERIALIZED_DTYPES[name],
         )
-    if (
-        raw_fields["jax_threefry_partitionable"]
-        is not checkpoint_partitionable
-    ):
+    if raw_fields["jax_threefry_partitionable"] is not checkpoint_partitionable:
         raise ValueError(
-            "serialized state-bound and top-level jax_threefry_partitionable "
-            "modes do not match"
+            "serialized state-bound and top-level jax_threefry_partitionable modes do not match"
         )
 
     values: dict[str, Array] = {}
@@ -2923,9 +2697,7 @@ class CausalMapForagerAgent:
             raise ValueError("reward must be one finite float32 scalar")
         _, _, channels = _validate_observation_host(observation, self.config)
         if channels != self._state.reward_sum.shape[0]:
-            raise ValueError(
-                "observation channel count changed during the continuing run"
-            )
+            raise ValueError("observation channel count changed during the continuing run")
         self._state, action, _ = causal_map_step(
             self._state,
             jnp.asarray(reward_value, dtype=jnp.float32),
@@ -2955,9 +2727,7 @@ class CausalMapForagerAgent:
             "config": self.config.to_dict(),
             "config_sha256": self.config.fingerprint(),
             "status_claim": "candidate; no SOTA claim without matched-seed evidence",
-            "update_semantics": (
-                "one causal map/reward/schedule update per transition; no replay"
-            ),
+            "update_semantics": ("one causal map/reward/schedule update per transition; no replay"),
             "world_model": {
                 "kind": "relative_toroidal_cognitive_map",
                 "origin": "arbitrary initial agent location",
@@ -3059,10 +2829,7 @@ def causal_map_variant_spec(
         "jax_threefry_partitionable": _threefry_partitionable_mode(),
         "config": config.to_dict(),
         "config_sha256": config.fingerprint(),
-        "implementation": (
-            "alberta_framework.benchmarks.causal_map_forager:"
-            "CausalMapForagerAgent"
-        ),
+        "implementation": ("alberta_framework.benchmarks.causal_map_forager:CausalMapForagerAgent"),
     }
 
 
@@ -3076,18 +2843,14 @@ def _validate_benchmark_contract(
         or benchmark_config.steps < 1
         or benchmark_config.steps >= _INT32_MAX
     ):
-        raise ValueError(
-            "causal-map benchmark steps must be a positive int below int32 maximum"
-        )
+        raise ValueError("causal-map benchmark steps must be a positive int below int32 maximum")
     require_scan_steps(
         "causal-map jax_chunk_size",
         benchmark_config.jax_chunk_size,
         _CAUSAL_MAP_CHUNK_BUDGET,
     )
     if env.preset != "field_of_view" or env.resolved_env_id != "ForagaxTwoBiomeLarge-v1":
-        raise ValueError(
-            "causal-map variant is defined only for stationary Forager field_of_view"
-        )
+        raise ValueError("causal-map variant is defined only for stationary Forager field_of_view")
     if env.require_exact_version is not True:
         raise ValueError("causal-map benchmark requires the exact pinned Foragax build")
     if env.resolved_observation_type != "color":
@@ -3113,9 +2876,7 @@ def _validate_benchmark_contract(
         raise ValueError("aperture cannot exceed the configured world")
     maximum_batch_observations = env.aperture_size * env.aperture_size
     if benchmark_config.steps * maximum_batch_observations >= _INT32_MAX:
-        raise ValueError(
-            "causal-map horizon and aperture can overflow int32 reappearance counts"
-        )
+        raise ValueError("causal-map horizon and aperture can overflow int32 reappearance counts")
 
 
 class _LaneMetrics:
@@ -3124,9 +2885,7 @@ class _LaneMetrics:
     def __init__(self, config: ForagerBenchmarkConfig) -> None:
         self.config = config
         self.target_steps = [1]
-        self.target_steps.extend(
-            range(config.record_every, config.steps + 1, config.record_every)
-        )
+        self.target_steps.extend(range(config.record_every, config.steps + 1, config.record_every))
         if self.target_steps[-1] != config.steps:
             self.target_steps.append(config.steps)
         self.target_steps = sorted(set(self.target_steps))
@@ -3166,10 +2925,7 @@ class _LaneMetrics:
             decay=FORAGER_FOV_EMA_DECAY,
             filter_state=self.fov_filter_state,
         )
-        fov_mask = (
-            np.arange(completed, completed + active) % FORAGER_FOV_EMA_SUBSAMPLE
-            == 0
-        )
+        fov_mask = np.arange(completed, completed + active) % FORAGER_FOV_EMA_SUBSAMPLE == 0
         self.fov_samples.extend(float(value) for value in fov[fov_mask])
         self.final_ewm = float(ewm[-1])
         self.all_finite = self.all_finite and bool(np.all(finite))
@@ -3195,13 +2951,9 @@ class _LaneMetrics:
             start = max(0, end - self.config.final_window)
             self.curve_steps.append(step_number)
             self.curve_ewm.append(float(ewm[local_count - 1]))
-            self.curve_window.append(
-                float((prefix[end] - prefix[start]) / (end - start))
-            )
+            self.curve_window.append(float((prefix[end] - prefix[start]) / (end - start)))
             self.target_index += 1
-        self.reward_tail = combined[
-            -min(self.config.final_window, combined.size) :
-        ]
+        self.reward_tail = combined[-min(self.config.final_window, combined.size) :]
 
 
 def _make_scan_chunk(
@@ -3314,8 +3066,7 @@ def _require_host_threefry_mode(expected: bool) -> None:
     """Reject host-side runtime drift from a trajectory's state-bound mode."""
     if _threefry_partitionable_mode() != expected:
         raise RuntimeError(
-            "causal-map runner jax_threefry_partitionable mode drifted "
-            "before trace finalization"
+            "causal-map runner jax_threefry_partitionable mode drifted before trace finalization"
         )
 
 
@@ -3401,8 +3152,7 @@ def _build_causal_map_result(
                 math.sqrt(
                     max(
                         0.0,
-                        lane_respawn_exact_m2[index]
-                        / (lane_respawn_exact_count[index] - 1),
+                        lane_respawn_exact_m2[index] / (lane_respawn_exact_count[index] - 1),
                     )
                 )
             )
@@ -3414,9 +3164,7 @@ def _build_causal_map_result(
     lane_cell_channel = np.asarray(lane_state.cell_channel, dtype=np.int32)
     negative_channel_mask = np.asarray(
         [
-            channel_count > 0
-            and mean is not None
-            and mean < agent_config.negative_reward_threshold
+            channel_count > 0 and mean is not None and mean < agent_config.negative_reward_threshold
             for channel_count, mean in zip(
                 lane_reward_count,
                 learned_reward_means,
@@ -3426,16 +3174,12 @@ def _build_causal_map_result(
         dtype=np.bool_,
     )
     known_mask = lane_cell_channel >= 0
-    known_negative_mask = known_mask & negative_channel_mask[
-        np.maximum(lane_cell_channel, 0)
-    ]
+    known_negative_mask = known_mask & negative_channel_mask[np.maximum(lane_cell_channel, 0)]
     metadata["final_causal_diagnostics"] = {
         "reward_count_by_observed_channel": lane_reward_count.tolist(),
         "reward_sum_by_observed_channel": lane_reward_sum.tolist(),
         "reward_mean_by_observed_channel": learned_reward_means,
-        "respawn_interval_count_by_observed_channel": (
-            lane_respawn_interval_count.tolist()
-        ),
+        "respawn_interval_count_by_observed_channel": (lane_respawn_interval_count.tolist()),
         "respawn_interval_lower_floor_by_observed_channel": (
             lane_respawn_interval_lower_floor.tolist()
         ),
@@ -3456,15 +3200,9 @@ def _build_causal_map_result(
         ),
         "exact_respawn_count_by_observed_channel": lane_respawn_exact_count.tolist(),
         "exact_respawn_floor_by_observed_channel": lane_respawn_exact_floor.tolist(),
-        "exact_respawn_remainder_by_observed_channel": (
-            lane_respawn_exact_remainder.tolist()
-        ),
-        "exact_respawn_delay_mean_by_observed_channel": (
-            lane_respawn_exact_mean.tolist()
-        ),
-        "exact_respawn_delay_sample_std_by_observed_channel": (
-            learned_respawn_exact_std
-        ),
+        "exact_respawn_remainder_by_observed_channel": (lane_respawn_exact_remainder.tolist()),
+        "exact_respawn_delay_mean_by_observed_channel": (lane_respawn_exact_mean.tolist()),
+        "exact_respawn_delay_sample_std_by_observed_channel": (learned_respawn_exact_std),
         "known_fixed_cells": int(np.sum(known_mask)),
         "known_learned_negative_cells": int(np.sum(known_negative_mask)),
         "map_cells": int(agent_config.height * agent_config.width),
@@ -3592,13 +3330,10 @@ def _run_causal_map_lanes(
             jax.block_until_ready(outputs)  # type: ignore[no-untyped-call]
             raw_rewards = _host_metric_array(rewards_device[:, :active])
             raw_regrets = _host_metric_array(regrets_device[:, :active])
-            if (
-                raw_rewards.dtype != np.dtype(np.float32)
-                or raw_regrets.dtype != np.dtype(np.float32)
+            if raw_rewards.dtype != np.dtype(np.float32) or raw_regrets.dtype != np.dtype(
+                np.float32
             ):
-                raise TypeError(
-                    "Foragax evaluator outputs must retain exact float32 dtype"
-                )
+                raise TypeError("Foragax evaluator outputs must retain exact float32 dtype")
             rewards = raw_rewards.astype(np.float64)
             regrets = raw_regrets.astype(np.float64)
             done = _host_metric_array(done_device[:, :active], dtype=np.bool_)
@@ -3633,9 +3368,7 @@ def _run_causal_map_lanes(
             if jnp.issubdtype(leaf.dtype, jnp.inexact)
         )
         if not state_finite or not all(item.all_finite for item in metrics):
-            raise FloatingPointError(
-                "causal-map Alberta variant produced non-finite values"
-            )
+            raise FloatingPointError("causal-map Alberta variant produced non-finite values")
         validated_lane_states: list[CausalMapForagerState] = []
         for lane in range(len(seeds)):
             lane_state = jax.device_get(
@@ -3652,13 +3385,10 @@ def _run_causal_map_lanes(
                 )
             validated_lane_states.append(lane_state)
         bound_partitionable_modes = {
-            bool(np.asarray(state.jax_threefry_partitionable))
-            for state in validated_lane_states
+            bool(np.asarray(state.jax_threefry_partitionable)) for state in validated_lane_states
         }
         if len(bound_partitionable_modes) != 1:
-            raise ValueError(
-                "causal-map lanes disagree on jax_threefry_partitionable mode"
-            )
+            raise ValueError("causal-map lanes disagree on jax_threefry_partitionable mode")
         bound_partitionable_mode = bound_partitionable_modes.pop()
     except BaseException:
         _abort_reward_trace_sinks(trace_sinks)
@@ -3666,12 +3396,8 @@ def _run_causal_map_lanes(
     try:
         base_metadata_by_lane: list[Mapping[str, Any]] = []
         for seed in seeds:
-            base_metadata = dict(
-                CausalMapForagerAgent(agent_config, seed=seed).metadata()
-            )
-            base_metadata["jax_threefry_partitionable"] = (
-                bound_partitionable_mode
-            )
+            base_metadata = dict(CausalMapForagerAgent(agent_config, seed=seed).metadata())
+            base_metadata["jax_threefry_partitionable"] = bound_partitionable_mode
             base_metadata_by_lane.append(base_metadata)
         # This is the final fallible runtime-mode check before trace sealing.
         # Result construction below uses only the captured state-bound mode.
@@ -3689,9 +3415,7 @@ def _run_causal_map_lanes(
                 lane_metrics=lane_metrics,
                 lane_state=lane_state,
                 base_metadata=base_metadata_by_lane[lane],
-                trace_metadata=(
-                    trace_metadata[lane] if trace_metadata else None
-                ),
+                trace_metadata=(trace_metadata[lane] if trace_metadata else None),
                 overall_duration=overall_duration,
                 overall_started=overall_started,
                 compile_started=compile_started,
@@ -3748,10 +3472,7 @@ def run_causal_map_forager_seeds(
     raw_seeds = tuple(seeds)
     if not raw_seeds:
         raise ValueError("seeds must be non-empty")
-    if any(
-        type(seed) not in _EXACT_INTEGER_TYPES
-        for seed in raw_seeds
-    ):
+    if any(type(seed) not in _EXACT_INTEGER_TYPES for seed in raw_seeds):
         raise ValueError("seeds must be uint32-compatible integers without coercion")
     ordered = tuple(int(seed) for seed in raw_seeds)
     if len(set(ordered)) != len(ordered):

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -43,17 +43,8 @@ _MAX_RUN_STEPS = 1_000_000
 _PRNG_IMPLEMENTATION = "threefry2x32"
 _PAIR_RESULT_SCHEMA = "asi.ipmnist.gradual-input-pair.result.v1"
 _ADAMW_IDENTITY = tuple(sorted(ADAMW_PROTOCOL_HYPERPARAMETERS.items()))
-_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.longlong,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.ulonglong,
+_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 
 GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(
@@ -281,9 +272,7 @@ class GradualInputPairResult:
                 or type(item[1]) is not float
                 or item != expected_identity_item
             ):
-                raise ValueError(
-                    "learner_hyperparameters must identify the frozen AdamW control"
-                )
+                raise ValueError("learner_hyperparameters must identify the frozen AdamW control")
         if (
             type(self.prng_implementation) is not str
             or self.prng_implementation != _PRNG_IMPLEMENTATION
@@ -324,9 +313,7 @@ class GradualInputPairResult:
             snapshots["correct_counts"] > config.task_length
         ):
             raise ValueError("correct_counts must be valid per-task integer numerators")
-        if not np.all(np.isfinite(snapshots["loss_sums"])) or np.any(
-            snapshots["loss_sums"] < 0.0
-        ):
+        if not np.all(np.isfinite(snapshots["loss_sums"])) or np.any(snapshots["loss_sums"] < 0.0):
             raise ValueError("loss_sums must be finite and nonnegative")
         expected_persistent_bytes = (
             config.parameter_count * 16

--- a/tests/test_causal_map_forager.py
+++ b/tests/test_causal_map_forager.py
@@ -237,9 +237,7 @@ def test_config_rejects_finite_terms_whose_combined_scores_can_overflow(
 
 
 def test_config_rejects_respawn_factor_below_float32_one() -> None:
-    below_one = float(
-        np.nextafter(np.float32(1.0), np.float32(0.0), dtype=np.float32)
-    )
+    below_one = float(np.nextafter(np.float32(1.0), np.float32(0.0), dtype=np.float32))
     with pytest.raises(ValueError, match="at least 1.0 after float32 conversion"):
         CausalMapForagerConfig(respawn_safety_factor=below_one)
 
@@ -278,28 +276,21 @@ def test_config_round_trip_fingerprint_and_variant_spec() -> None:
     assert spec["kind"] == CAUSAL_MAP_VARIANT_KIND
     assert spec["privileged"] is False
     assert spec["prng_impl"] == "threefry2x32"
-    assert spec["jax_threefry_partitionable"] is bool(
-        jax.config.jax_threefry_partitionable
-    )
+    assert spec["jax_threefry_partitionable"] is bool(jax.config.jax_threefry_partitionable)
     rng_contract = causal_map_rng_contract()
     assert rng_contract["prng_impl"] == "threefry2x32"
-    assert rng_contract["jax_threefry_partitionable"] is bool(
-        jax.config.jax_threefry_partitionable
-    )
+    assert rng_contract["jax_threefry_partitionable"] is bool(jax.config.jax_threefry_partitionable)
     assert "impl=prng_impl" in rng_contract["root"]
     assert spec["config_sha256"] == config.fingerprint()
     assert config.to_dict()["arrival_aware_readiness"] is True
     assert spec["config"]["arrival_aware_readiness"] is True
     assert (
-        CausalMapForagerConfig(arrival_aware_readiness=False).fingerprint()
-        != config.fingerprint()
+        CausalMapForagerConfig(arrival_aware_readiness=False).fingerprint() != config.fingerprint()
     )
     with pytest.raises(ValueError, match="unknown"):
         CausalMapForagerConfig.from_dict({**config.to_dict(), "object_delay": 300})
     with pytest.raises(ValueError, match="respawn_quantile_z"):
-        CausalMapForagerConfig.from_dict(
-            {**config.to_dict(), "respawn_quantile_z": 999.0}
-        )
+        CausalMapForagerConfig.from_dict({**config.to_dict(), "respawn_quantile_z": 999.0})
     with pytest.raises(ValueError, match="mapping"):
         CausalMapForagerConfig.from_dict([])  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="CausalMapForagerConfig"):
@@ -328,9 +319,7 @@ def test_metadata_declares_arrival_and_exploration_scheduler_semantics() -> None
         dataclasses.replace(config, arrival_aware_readiness=False)
     ).metadata()["world_model"]
     assert decision_world_model["arrival_aware_readiness"] is False
-    assert decision_world_model["arrival_readiness_semantics"] == (
-        "ready_step <= step_count"
-    )
+    assert decision_world_model["arrival_readiness_semantics"] == ("ready_step <= step_count")
 
 
 def test_start_infers_aperture_channels_and_builds_relative_map() -> None:
@@ -378,9 +367,7 @@ def test_pure_start_and_step_reject_invalid_observation_values_eager_and_jit() -
         valid.at[0, 0, :].set(1.0),
     )
     compiled_start = jax.jit(lambda image: causal_map_start(image, config, 0))
-    compiled_step = jax.jit(
-        lambda current, image: causal_map_step(current, 0.0, image, config)
-    )
+    compiled_step = jax.jit(lambda current, image: causal_map_step(current, 0.0, image, config))
     for image in invalid:
         with pytest.raises(Exception, match="observation must be finite"):
             jax.block_until_ready(  # type: ignore[no-untyped-call]
@@ -405,26 +392,22 @@ def test_host_and_pure_paths_reject_complex_observations_before_cast(
     complex_value: complex,
 ) -> None:
     config = CausalMapForagerConfig()
-    complex_observation = jnp.zeros((3, 3, 2), dtype=jnp.complex64).at[0, 0, 0].set(
-        complex_value
-    )
+    complex_observation = jnp.zeros((3, 3, 2), dtype=jnp.complex64).at[0, 0, 0].set(complex_value)
     with pytest.raises(ValueError, match="real numeric dtype"):
         CausalMapForagerAgent(config).start(complex_observation)
     with pytest.raises(ValueError, match="real numeric dtype"):
         causal_map_start(complex_observation, config, 0)
     with pytest.raises(ValueError, match="real numeric dtype"):
-        jax.jit(lambda image: causal_map_start(image, config, 0))(
-            complex_observation
-        )
+        jax.jit(lambda image: causal_map_start(image, config, 0))(complex_observation)
 
     valid = _observation(aperture=3, channels=2)
     state, _ = causal_map_start(valid, config, 0)
     with pytest.raises(ValueError, match="real numeric dtype"):
         causal_map_step(state, 0.0, complex_observation, config)
     with pytest.raises(ValueError, match="real numeric dtype"):
-        jax.jit(
-            lambda current, image: causal_map_step(current, 0.0, image, config)
-        )(state, complex_observation)
+        jax.jit(lambda current, image: causal_map_step(current, 0.0, image, config))(
+            state, complex_observation
+        )
 
 
 @pytest.mark.parametrize(
@@ -443,9 +426,7 @@ def test_pure_start_rejects_invalid_seed_eager_and_jit(seed: Any) -> None:
         jax.block_until_ready(  # type: ignore[no-untyped-call]
             causal_map_start(observation, config, seed)
         )
-    compiled = jax.jit(
-        lambda value: causal_map_start(observation, config, value)
-    )
+    compiled = jax.jit(lambda value: causal_map_start(observation, config, value))
     with pytest.raises(Exception, match="seed must be (?:one non-bool )?uint32-compatible"):
         jax.block_until_ready(compiled(seed))  # type: ignore[no-untyped-call]
 
@@ -455,9 +436,7 @@ def test_pure_start_accepts_full_uint32_seed_range_eager_and_jit() -> None:
     observation = _observation(aperture=3, channels=2)
     seed = jnp.asarray(np.iinfo(np.uint32).max, dtype=jnp.uint32)
     eager_state, _ = causal_map_start(observation, config, seed)
-    compiled_state, _ = jax.jit(
-        lambda value: causal_map_start(observation, config, value)
-    )(seed)
+    compiled_state, _ = jax.jit(lambda value: causal_map_start(observation, config, value))(seed)
     assert int(eager_state.initial_seed) == np.iinfo(np.uint32).max
     chex.assert_trees_all_equal(eager_state, compiled_state)
 
@@ -476,9 +455,7 @@ def test_pure_step_rejects_channel_count_change_and_invalid_reward_eager_and_jit
     with pytest.raises(ValueError, match="channel count changed"):
         causal_map_step(state, 0.0, changed_channels, config)
     with pytest.raises(ValueError, match="channel count changed"):
-        jax.jit(lambda image: causal_map_step(state, 0.0, image, config))(
-            changed_channels
-        )
+        jax.jit(lambda image: causal_map_step(state, 0.0, image, config))(changed_channels)
 
     compiled = jax.jit(
         lambda current, reward: causal_map_step(
@@ -531,9 +508,7 @@ def test_reward_accumulation_overflow_is_rejected_eager_and_jit() -> None:
         jax.block_until_ready(  # type: ignore[no-untyped-call]
             causal_map_step(state, maximum, observation, config)
         )
-    compiled = jax.jit(
-        lambda current: causal_map_step(current, maximum, observation, config)
-    )
+    compiled = jax.jit(lambda current: causal_map_step(current, maximum, observation, config))
     with pytest.raises(Exception, match="reward accumulation must remain finite"):
         jax.block_until_ready(compiled(state))  # type: ignore[no-untyped-call]
 
@@ -590,9 +565,7 @@ def test_nonfinite_candidate_scores_fail_closed_to_finite_target(
         0,
     )
     state = state._replace(
-        reward_sum=(
-            state.reward_sum.at[1].set(corrupt_value).at[2].set(1.0)
-        ),
+        reward_sum=(state.reward_sum.at[1].set(corrupt_value).at[2].set(1.0)),
         reward_count=state.reward_count.at[1].set(1).at[2].set(1),
     )
     planned, action = _choose_action(state, config)
@@ -659,9 +632,7 @@ def _host_cost_aware_route_grid(
                 int(distances[neighbor_y, neighbor_x]),
             )
             if candidate < incumbent:
-                risks[neighbor_y, neighbor_x], distances[neighbor_y, neighbor_x] = (
-                    candidate
-                )
+                risks[neighbor_y, neighbor_x], distances[neighbor_y, neighbor_x] = candidate
                 heapq.heappush(
                     queue,
                     (candidate[0], candidate[1], neighbor_x, neighbor_y),
@@ -698,9 +669,7 @@ def test_cost_aware_route_grid_matches_lexicographic_dijkstra_under_jit_vmap(
                 expected_distances.append(expected_distance)
 
     actual_risks, actual_distances = jax.jit(
-        jax.vmap(
-            lambda source, mask: _cost_aware_route_grid(source, mask, config)
-        )
+        jax.vmap(lambda source, mask: _cost_aware_route_grid(source, mask, config))
     )(
         jnp.asarray(sources, dtype=jnp.int32),
         jnp.asarray(np.stack(masks), dtype=jnp.bool_),
@@ -802,12 +771,7 @@ def _negative_crossing_state(
         cell_last_seen_step=jnp.zeros(config.world_shape, dtype=jnp.int32),
         cell_last_absent_step=last_absent,
         reward_sum=(
-            state.reward_sum.at[0]
-            .set(-1.0)
-            .at[1]
-            .set(remote_reward)
-            .at[2]
-            .set(local_reward)
+            state.reward_sum.at[0].set(-1.0).at[1].set(remote_reward).at[2].set(local_reward)
         ),
         reward_count=jnp.ones((3,), dtype=jnp.int32),
     )
@@ -888,14 +852,10 @@ def _readiness_routing_state(
     active_x = config.width - 1
     return state._replace(
         step_count=jnp.asarray(step_count, dtype=jnp.int32),
-        cell_channel=(
-            state.cell_channel.at[0, pending_x].set(1).at[0, active_x].set(2)
-        ),
+        cell_channel=(state.cell_channel.at[0, pending_x].set(1).at[0, active_x].set(2)),
         cell_active=state.cell_active.at[0, active_x].set(True),
         cell_collection_step=state.cell_collection_step.at[0, pending_x].set(1),
-        cell_ready_step=(
-            state.cell_ready_step.at[0, pending_x].set(pending_ready_step)
-        ),
+        cell_ready_step=(state.cell_ready_step.at[0, pending_x].set(pending_ready_step)),
         # Every cell has genuinely been observed, so exploration_probability
         # cannot mask which exploitation target passed the readiness gate.
         cell_last_seen_step=jnp.full(
@@ -1012,9 +972,7 @@ def test_exploration_probability_never_redirects_after_reachable_map_is_observed
         reward_count=state.reward_count.at[1].set(1),
     )
     eager_state, eager_action = _choose_action(state, config)
-    compiled_state, compiled_action = jax.jit(
-        lambda value: _choose_action(value, config)
-    )(state)
+    compiled_state, compiled_action = jax.jit(lambda value: _choose_action(value, config))(state)
     assert int(eager_action) == 1
     assert int(compiled_action) == 1
     chex.assert_trees_all_equal(eager_state, compiled_state)
@@ -1263,15 +1221,15 @@ def test_reappearance_interval_updates_channel_schedule_without_type_prior() -> 
 def test_censored_interval_estimator_preserves_online_identification_bounds() -> None:
     count, lower_floor, lower_remainder, upper_floor, upper_remainder = (
         _merge_channel_interval_bounds(
-        jnp.zeros((2,), dtype=jnp.int32),
-        jnp.zeros((2,), dtype=jnp.int32),
-        jnp.zeros((2,), dtype=jnp.int32),
-        jnp.zeros((2,), dtype=jnp.int32),
-        jnp.zeros((2,), dtype=jnp.int32),
-        jnp.asarray((1, 1), dtype=jnp.int32),
-        jnp.asarray((2, 101), dtype=jnp.int32),
-        jnp.asarray((300, 300), dtype=jnp.int32),
-        jnp.asarray((True, True)),
+            jnp.zeros((2,), dtype=jnp.int32),
+            jnp.zeros((2,), dtype=jnp.int32),
+            jnp.zeros((2,), dtype=jnp.int32),
+            jnp.zeros((2,), dtype=jnp.int32),
+            jnp.zeros((2,), dtype=jnp.int32),
+            jnp.asarray((1, 1), dtype=jnp.int32),
+            jnp.asarray((2, 101), dtype=jnp.int32),
+            jnp.asarray((300, 300), dtype=jnp.int32),
+            jnp.asarray((True, True)),
         )
     )
     assert int(count[1]) == 2
@@ -1337,9 +1295,9 @@ def test_exact_rational_interval_bound_is_outward_after_65_537_samples() -> None
         respawn_interval_upper_remainder=upper_remainder,
     )
     assert int(_estimated_respawn_delay(state, jnp.asarray(0), config)) == 301
-    compiled_delay = jax.jit(
-        lambda value: _estimated_respawn_delay(value, jnp.asarray(0), config)
-    )(state)
+    compiled_delay = jax.jit(lambda value: _estimated_respawn_delay(value, jnp.asarray(0), config))(
+        state
+    )
     assert int(compiled_delay) == 301
 
 
@@ -1381,12 +1339,8 @@ def test_immediate_recollection_captures_reappearance_before_pending_overwrite()
         cell_channel=state.cell_channel.at[1, 0].set(1),
         cell_collection_step=state.cell_collection_step.at[1, 0].set(1),
         cell_ready_step=state.cell_ready_step.at[1, 0].set(5),
-        cell_last_seen_step=(
-            state.cell_last_seen_step.at[0, 0].set(10).at[1, 0].set(10)
-        ),
-        cell_last_absent_step=(
-            state.cell_last_absent_step.at[0, 0].set(10).at[1, 0].set(10)
-        ),
+        cell_last_seen_step=(state.cell_last_seen_step.at[0, 0].set(10).at[1, 0].set(10)),
+        cell_last_absent_step=(state.cell_last_absent_step.at[0, 0].set(10).at[1, 0].set(10)),
         visit_count=state.visit_count.at[0, 0].set(11),
         reward_sum=state.reward_sum.at[1].set(1.0),
         reward_count=state.reward_count.at[1].set(1),
@@ -1446,9 +1400,7 @@ def test_respawn_delay_clips_before_unsafe_float32_to_int32_conversion() -> None
     state = state._replace(
         respawn_interval_count=state.respawn_interval_count.at[0].set(1),
         respawn_interval_lower_floor=state.respawn_interval_lower_floor.at[0].set(1),
-        respawn_interval_upper_floor=(
-            state.respawn_interval_upper_floor.at[0].set(1_500_000_000)
-        ),
+        respawn_interval_upper_floor=(state.respawn_interval_upper_floor.at[0].set(1_500_000_000)),
     )
     assert int(_estimated_respawn_delay(state, jnp.asarray(0), config)) == maximum
 
@@ -1467,7 +1419,7 @@ def test_exact_respawn_safety_statistics_can_only_raise_interval_schedule() -> N
     assert int(_estimated_respawn_delay(state, jnp.asarray(1), config)) == 20
     state = state._replace(
         respawn_exact_floor=state.respawn_exact_floor.at[1].set(30),
-        respawn_exact_mean=state.respawn_exact_mean.at[1].set(30.0)
+        respawn_exact_mean=state.respawn_exact_mean.at[1].set(30.0),
     )
     assert int(_estimated_respawn_delay(state, jnp.asarray(1), config)) == 30
 
@@ -1479,9 +1431,7 @@ def test_state_serialization_round_trip_and_validation() -> None:
     assert payload["schema"] == CAUSAL_MAP_STATE_SCHEMA
     assert payload["schema"].endswith(".v5")
     assert payload["prng_impl"] == "threefry2x32"
-    assert payload["jax_threefry_partitionable"] is bool(
-        jax.config.jax_threefry_partitionable
-    )
+    assert payload["jax_threefry_partitionable"] is bool(jax.config.jax_threefry_partitionable)
     assert payload["fields"]["initial_seed"] == 19
     restored = causal_map_state_from_dict(payload, config)
     chex.assert_trees_all_equal(state, restored)
@@ -1585,8 +1535,7 @@ def test_checkpoint_rejects_cross_mode_threefry_partitionable_restore() -> None:
             causal_map_state_from_dict(payload, config)
         assert causal_map_rng_contract()["jax_threefry_partitionable"] is not recorded
         assert (
-            CausalMapForagerAgent(config).metadata()["jax_threefry_partitionable"]
-            is not recorded
+            CausalMapForagerAgent(config).metadata()["jax_threefry_partitionable"] is not recorded
         )
 
 
@@ -1612,9 +1561,7 @@ def test_state_bound_threefry_mode_rejects_midrun_drift_eager_and_jit() -> None:
             jax.block_until_ready(  # type: ignore[no-untyped-call]
                 causal_map_step(state, 0.0, observation, config)
             )
-        compiled = jax.jit(
-            lambda current: causal_map_step(current, 0.0, observation, config)
-        )
+        compiled = jax.jit(lambda current: causal_map_step(current, 0.0, observation, config))
         with pytest.raises(Exception, match="mode does not match runtime"):
             jax.block_until_ready(compiled(state))  # type: ignore[no-untyped-call]
 
@@ -1623,9 +1570,7 @@ def test_checkpoint_cross_checks_state_bound_and_top_level_threefry_modes() -> N
     config = CausalMapForagerConfig()
     state, _ = causal_map_start(_observation(), config, 23)
     payload = causal_map_state_to_dict(state, config)
-    payload["fields"]["jax_threefry_partitionable"] = not payload[
-        "jax_threefry_partitionable"
-    ]
+    payload["fields"]["jax_threefry_partitionable"] = not payload["jax_threefry_partitionable"]
     with pytest.raises(ValueError, match="state-bound and top-level"):
         causal_map_state_from_dict(payload, config)
 
@@ -1754,13 +1699,9 @@ def test_state_validation_rejects_dtype_and_cross_field_corruption() -> None:
         reward_count=advanced.reward_count.at[0].set(2),
         respawn_interval_count=advanced.respawn_interval_count.at[0].set(2),
         respawn_interval_lower_floor=advanced.respawn_interval_lower_floor.at[0].set(1),
-        respawn_interval_lower_remainder=(
-            advanced.respawn_interval_lower_remainder.at[0].set(1)
-        ),
+        respawn_interval_lower_remainder=(advanced.respawn_interval_lower_remainder.at[0].set(1)),
         respawn_interval_upper_floor=advanced.respawn_interval_upper_floor.at[0].set(2),
-        respawn_interval_upper_remainder=(
-            advanced.respawn_interval_upper_remainder.at[0].set(0)
-        ),
+        respawn_interval_upper_remainder=(advanced.respawn_interval_upper_remainder.at[0].set(0)),
         respawn_exact_count=advanced.respawn_exact_count.at[0].set(2),
         respawn_exact_floor=advanced.respawn_exact_floor.at[0].set(1),
         respawn_exact_mean=advanced.respawn_exact_mean.at[0].set(1.0),
@@ -1773,13 +1714,9 @@ def test_state_validation_rejects_dtype_and_cross_field_corruption() -> None:
         reward_count=advanced.reward_count.at[0].set(2),
         respawn_interval_count=advanced.respawn_interval_count.at[0].set(2),
         respawn_interval_lower_floor=advanced.respawn_interval_lower_floor.at[0].set(1),
-        respawn_interval_lower_remainder=(
-            advanced.respawn_interval_lower_remainder.at[0].set(1)
-        ),
+        respawn_interval_lower_remainder=(advanced.respawn_interval_lower_remainder.at[0].set(1)),
         respawn_interval_upper_floor=advanced.respawn_interval_upper_floor.at[0].set(1),
-        respawn_interval_upper_remainder=(
-            advanced.respawn_interval_upper_remainder.at[0].set(1)
-        ),
+        respawn_interval_upper_remainder=(advanced.respawn_interval_upper_remainder.at[0].set(1)),
         respawn_exact_count=advanced.respawn_exact_count.at[0].set(2),
         respawn_exact_floor=advanced.respawn_exact_floor.at[0].set(1),
         respawn_exact_mean=advanced.respawn_exact_mean.at[0].set(1.0),
@@ -1792,20 +1729,14 @@ def test_state_validation_rejects_dtype_and_cross_field_corruption() -> None:
         reward_count=advanced.reward_count.at[0].set(2),
         respawn_interval_count=advanced.respawn_interval_count.at[0].set(2),
         respawn_interval_lower_floor=advanced.respawn_interval_lower_floor.at[0].set(1),
-        respawn_interval_lower_remainder=(
-            advanced.respawn_interval_lower_remainder.at[0].set(1)
-        ),
+        respawn_interval_lower_remainder=(advanced.respawn_interval_lower_remainder.at[0].set(1)),
         respawn_interval_upper_floor=advanced.respawn_interval_upper_floor.at[0].set(1),
-        respawn_interval_upper_remainder=(
-            advanced.respawn_interval_upper_remainder.at[0].set(1)
-        ),
+        respawn_interval_upper_remainder=(advanced.respawn_interval_upper_remainder.at[0].set(1)),
         respawn_exact_count=advanced.respawn_exact_count.at[0].set(2),
         respawn_exact_floor=advanced.respawn_exact_floor.at[0].set(1),
         respawn_exact_remainder=advanced.respawn_exact_remainder.at[0].set(1),
         respawn_exact_mean=advanced.respawn_exact_mean.at[0].set(1.5),
-        respawn_exact_m2=(
-            advanced.respawn_exact_m2.at[0].set(-np.finfo(np.float32).tiny)
-        ),
+        respawn_exact_m2=(advanced.respawn_exact_m2.at[0].set(-np.finfo(np.float32).tiny)),
     )
     with pytest.raises(ValueError, match="non-negative"):
         validate_causal_map_state(negative_m2, config)
@@ -1867,15 +1798,9 @@ def test_state_validation_binds_selected_action_target_and_causal_counts() -> No
     )
     validate_causal_map_state(collected, config)
     unaccounted_reappearance = collected._replace(
-        respawn_interval_count=(
-            collected.respawn_interval_count.at[1].set(1)
-        ),
-        respawn_interval_lower_floor=(
-            collected.respawn_interval_lower_floor.at[1].set(1)
-        ),
-        respawn_interval_upper_floor=(
-            collected.respawn_interval_upper_floor.at[1].set(1)
-        ),
+        respawn_interval_count=(collected.respawn_interval_count.at[1].set(1)),
+        respawn_interval_lower_floor=(collected.respawn_interval_lower_floor.at[1].set(1)),
+        respawn_interval_upper_floor=(collected.respawn_interval_upper_floor.at[1].set(1)),
     )
     with pytest.raises(ValueError, match="reappearances plus pending"):
         validate_causal_map_state(unaccounted_reappearance, config)
@@ -2049,18 +1974,10 @@ def test_exact_81_reappearance_production_path_validates_and_continues() -> None
         last_target_position=jnp.asarray((7, 8), dtype=jnp.int32),
         last_target_expected_active=jnp.asarray(True),
         cell_channel=state.cell_channel.at[visible_slice].set(0),
-        cell_collection_step=(
-            state.cell_collection_step.at[visible_slice].set(collection_steps)
-        ),
-        cell_ready_step=(
-            state.cell_ready_step.at[visible_slice].set(collection_steps + 1)
-        ),
-        cell_last_seen_step=(
-            state.cell_last_seen_step.at[visible_slice].set(step_count - 1)
-        ),
-        cell_last_absent_step=(
-            state.cell_last_absent_step.at[visible_slice].set(step_count - 1)
-        ),
+        cell_collection_step=(state.cell_collection_step.at[visible_slice].set(collection_steps)),
+        cell_ready_step=(state.cell_ready_step.at[visible_slice].set(collection_steps + 1)),
+        cell_last_seen_step=(state.cell_last_seen_step.at[visible_slice].set(step_count - 1)),
+        cell_last_absent_step=(state.cell_last_absent_step.at[visible_slice].set(step_count - 1)),
         visit_count=state.visit_count.at[7, 7].set(step_count + 1),
         reward_sum=state.reward_sum.at[0].set(81.0),
         reward_count=state.reward_count.at[0].set(81),
@@ -2212,9 +2129,7 @@ def test_agent_metadata_is_explicitly_nonprivileged_and_context_independent() ->
     assert metadata["privileged"] is False
     assert metadata["state_schema"] == CAUSAL_MAP_STATE_SCHEMA
     assert metadata["prng_impl"] == "threefry2x32"
-    assert metadata["jax_threefry_partitionable"] is bool(
-        jax.config.jax_threefry_partitionable
-    )
+    assert metadata["jax_threefry_partitionable"] is bool(jax.config.jax_threefry_partitionable)
     assert "identification interval" in metadata["world_model"]["respawn_model"]
     assert "maximum delay ceiling" in metadata["world_model"]["respawn_model"]
     assert metadata["world_model"]["maximum_map_cells"] == 4096
@@ -2303,9 +2218,7 @@ def test_scan_host_chunk_and_batch_parity(
         (7, 3),
         mode="vmap",
     )
-    signatures_by_seed = {
-        result.seed: _result_signature(result) for result in batch_vmap
-    }
+    signatures_by_seed = {result.seed: _result_signature(result) for result in batch_vmap}
     for result in reordered:
         assert _result_signature(result) == signatures_by_seed[result.seed]
     assert _result_signature(batch_vmap[0]) == _result_signature(scan_a)
@@ -2500,9 +2413,7 @@ def test_runner_binds_final_state_to_requested_horizon_and_lane_before_finalizat
             next_carry, outputs = scan(carry, active_steps)
             env_state, env_key, agent_state, action = next_carry
             if field == "step_count":
-                agent_state = agent_state._replace(
-                    step_count=jnp.asarray(0, dtype=jnp.int32)
-                )
+                agent_state = agent_state._replace(step_count=jnp.asarray(0, dtype=jnp.int32))
             else:
                 agent_state = agent_state._replace(
                     initial_seed=agent_state.initial_seed + jnp.asarray(1, jnp.uint32)
@@ -2848,12 +2759,8 @@ def test_installed_foragax_batch_modes_and_seed_order_are_invariant() -> None:
         mode="vmap",
     )
     expected = {result.seed: _result_signature(result) for result in batched}
-    assert {
-        result.seed: _result_signature(result) for result in strict
-    } == expected
-    assert {
-        result.seed: _result_signature(result) for result in reordered
-    } == expected
+    assert {result.seed: _result_signature(result) for result in strict} == expected
+    assert {result.seed: _result_signature(result) for result in reordered} == expected
 
 
 def test_seed_batch_validation(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3086,3 +2993,14 @@ def test_deterministic_inv_cdf_coefficients_are_pinned() -> None:
         if isinstance(node, ast.Constant) and isinstance(node.value, float)
     )
     assert observed == _AS241_SOURCE_CONSTANTS
+
+
+@pytest.mark.parametrize(
+    "scalar_type",
+    [np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")],
+)
+def test_causal_map_forager_accepts_all_numpy_integer_scalar_types(scalar_type: type) -> None:
+    from alberta_framework.benchmarks.causal_map_forager import CausalMapForagerConfig
+
+    config = CausalMapForagerConfig(initial_retry_delay=scalar_type(1))
+    assert config.initial_retry_delay == 1

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -213,9 +213,7 @@ def test_gradual_input_pair_runs_one_matched_real_learner_schedule() -> None:
 def test_gradual_pair_rng_is_independent_of_global_default() -> None:
     data_x = np.arange(16, dtype=np.float32).reshape(4, 4)
     data_y = np.asarray([0, 1, 0, 1], dtype=np.int32)
-    config = IPMNISTConfig(
-        n_tasks=2, task_length=4, input_dim=4, hidden1=2, hidden2=2, n_classes=2
-    )
+    config = IPMNISTConfig(n_tasks=2, task_length=4, input_dim=4, hidden1=2, hidden2=2, n_classes=2)
 
     with jax.default_prng_impl("threefry2x32"):
         first = run_gradual_input_pair(
@@ -315,3 +313,14 @@ def test_gradual_pair_preflights_parameter_allocation_before_initialization() ->
             config=config,
             transition_steps=1,
         )
+
+
+@pytest.mark.parametrize(
+    "scalar_type",
+    [np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")],
+)
+def test_gradual_ipmnist_accepts_all_numpy_integer_scalar_types(scalar_type: type) -> None:
+    from alberta_framework.benchmarks.ipmnist_gradual import GradualTransitionConfig
+
+    config = GradualTransitionConfig(mode="input_interpolation", transition_steps=scalar_type(100))
+    assert config.transition_steps == 100


### PR DESCRIPTION
Fixes #2295

## Summary
In `alberta_framework/benchmarks/ipmnist_gradual.py` and `alberta_framework/benchmarks/causal_map_forager.py`:
`_NUMPY_INTEGER_TYPES` and `_EXACT_NUMPY_INTEGER_TYPES` were hardcoded with fixed-width type names (e.g. `np.int8, np.int16, np.int32, np.int64`). Because NumPy exposes 5 signed and 5 unsigned C integer scalar families while providing only 4 fixed-width names per signedness, platforms where `np.intc` / `np.uintc` or `np.longlong` / `np.ulonglong` are distinct scalar families inappropriately rejected valid numpy integer scalar instances.

## Proposed Changes
1. Derived `_NUMPY_INTEGER_TYPES` and `_EXACT_NUMPY_INTEGER_TYPES` dynamically from complete dtype character codes:
   `tuple(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))`.
2. Added parametrized tests in `tests/test_ipmnist_gradual.py` and `tests/test_causal_map_forager.py` validating that all 10 numpy integer scalar types are accepted.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_ipmnist_gradual.py tests/test_causal_map_forager.py` (199 passed, 4 skipped).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/benchmarks/ipmnist_gradual.py alberta_framework/benchmarks/causal_map_forager.py tests/test_ipmnist_gradual.py tests/test_causal_map_forager.py` (clean).
