### PR TITLE
fix(core): remove 1e-6 floor in LatentWorldModel encoder and validate minimum normal float32

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -151,9 +151,7 @@ def _latent_direct_state_scalars(
     n_heads = latent_dim + 2
     head_input = hidden_sizes[-1] if hidden_sizes else input_dim
     head_parameters = n_heads * (head_input + 1)
-    learner_direct_scalars = (
-        2 * (trunk_parameters + head_parameters) + sum(hidden_sizes) + 3
-    )
+    learner_direct_scalars = 2 * (trunk_parameters + head_parameters) + sum(hidden_sizes) + 3
     outer_state_scalars = observation_dim * latent_dim + 3 * latent_dim + 4
     return learner_direct_scalars + outer_state_scalars
 
@@ -206,9 +204,7 @@ def _preflight_latent_update_working_set(
         include_action_interactions=include_action_interactions,
     )
     if working_set_bytes > _INT32_MAX:
-        raise ValueError(
-            "latent world-model update working set byte count must fit signed int32"
-        )
+        raise ValueError("latent world-model update working set byte count must fit signed int32")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -288,10 +284,9 @@ class LatentWorldModelConfig:
                 raise ValueError("observation_scale must be an actual tuple or None")
             if len(observation_scale) != self.observation_dim:
                 raise ValueError("observation_scale length must equal observation_dim")
+            min_normal = float(np.finfo(np.float32).tiny)
             observation_scale = tuple(
-                validated_float32_scalar(
-                    f"observation_scale[{index}]", scale, positive=True
-                )
+                validated_float32_scalar(f"observation_scale[{index}]", scale, lower=min_normal)
                 for index, scale in enumerate(observation_scale)
             )
             object.__setattr__(self, "observation_scale", observation_scale)
@@ -320,9 +315,7 @@ class LatentWorldModelConfig:
                 validated_float32_scalar(name, getattr(self, name), **bounds),
             )
 
-        _require_int32_product(
-            "encoder_matrix_scalars", self.observation_dim, self.latent_dim
-        )
+        _require_int32_product("encoder_matrix_scalars", self.observation_dim, self.latent_dim)
         if self.latent_dim > _INT32_MAX - 2:
             raise ValueError("derived n_heads must fit in signed int32")
         n_heads = self.latent_dim + 2
@@ -337,9 +330,7 @@ class LatentWorldModelConfig:
                 raise ValueError("derived input_dim must fit in signed int32")
             input_dim += interactions
         layer_sizes = (input_dim, *self.hidden_sizes)
-        for index, (fan_in, fan_out) in enumerate(
-            zip(layer_sizes, layer_sizes[1:], strict=False)
-        ):
+        for index, (fan_in, fan_out) in enumerate(zip(layer_sizes, layer_sizes[1:], strict=False)):
             _require_int32_product(f"hidden_layer[{index}]_scalars", fan_in, fan_out)
         head_input = self.hidden_sizes[-1] if self.hidden_sizes else input_dim
         _require_int32_product("head_weight_scalars", n_heads, head_input)
@@ -644,10 +635,7 @@ class LatentWorldModel:
             if self._config.encoder_bias_scale > 0.0
             else jnp.zeros((latent_dim,), dtype=jnp.float32)
         )
-        if not bool(
-            jnp.all(jnp.isfinite(encoder_matrix))
-            & jnp.all(jnp.isfinite(encoder_bias))
-        ):
+        if not bool(jnp.all(jnp.isfinite(encoder_matrix)) & jnp.all(jnp.isfinite(encoder_bias))):
             raise ValueError("encoder initialization produced non-finite parameters")
         return LatentWorldModelState(
             encoder_matrix=encoder_matrix,
@@ -670,7 +658,7 @@ class LatentWorldModel:
         """Encode one observation with explicit (differentiable) encoder params."""
         obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._config.observation_dim,))
         scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
+        scaled = obs / scale
         return jnp.tanh(scaled @ encoder_matrix + encoder_bias)
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -126,6 +126,8 @@ def test_latent_default_discounts_do_not_inherit_the_reward_dtype() -> None:
     )
     chex.assert_trees_all_close(defaulted.discount_errors, explicit.discount_errors)
     chex.assert_trees_all_close(defaulted.discount_predictions, explicit.discount_predictions)
+
+
 class _FloatSpoof:
     @property
     def __class__(self) -> type[float]:  # type: ignore[override]
@@ -225,9 +227,7 @@ def test_latent_update_saturates_step_count_at_int32_max() -> None:
         hidden_sizes=(),
     )
     model = LatentWorldModel(config)
-    state = model.init(jr.key(0)).replace(
-        step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32)
-    )
+    state = model.init(jr.key(0)).replace(step_count=jnp.asarray(2**31 - 1, dtype=jnp.int32))
 
     result = model.update(
         state,
@@ -507,13 +507,9 @@ def test_trainable_encoder_collapse_gate_blocks_all_updates() -> None:
     # A fully gated trainable encoder leaves the whole trajectory bitwise
     # identical to the disabled path.
     chex.assert_trees_all_equal(gated_result.state, disabled_result.state)
-    chex.assert_trees_all_equal(
-        gated_result.latent_predictions, disabled_result.latent_predictions
-    )
+    chex.assert_trees_all_equal(gated_result.latent_predictions, disabled_result.latent_predictions)
     chex.assert_trees_all_equal(gated_result.surprises, disabled_result.surprises)
-    chex.assert_trees_all_equal(
-        gated_result.prediction_errors, disabled_result.prediction_errors
-    )
+    chex.assert_trees_all_equal(gated_result.prediction_errors, disabled_result.prediction_errors)
 
 
 @pytest.mark.unit
@@ -655,8 +651,9 @@ def test_latent_world_model_config_requires_exact_containers_and_schema() -> Non
     model_payload = LatentWorldModel(
         LatentWorldModelConfig(observation_dim=2, n_actions=2, hidden_sizes=())
     ).to_config()
-    assert LatentWorldModel.from_config(MappingProxyType(model_payload)).config.to_config() == (
-        model_payload["config"]
+    assert (
+        LatentWorldModel.from_config(MappingProxyType(model_payload)).config.to_config()
+        == (model_payload["config"])
     )
     malformed_model = dict(model_payload)
     malformed_model["task_id"] = 3
@@ -749,3 +746,52 @@ def test_latent_world_model_init_rejects_nonfinite_encoder_draw() -> None:
 
     with pytest.raises(ValueError, match="encoder initialization"):
         model.init(jr.key(0))
+
+
+def test_encode_is_scale_invariant_across_small_observation_scales() -> None:
+    import jax
+    import jax.numpy as jnp
+    import numpy as np
+
+    from alberta_framework.core.latent_world_model import LatentWorldModel, LatentWorldModelConfig
+
+    # Base reference at unit scale
+    cfg_base = LatentWorldModelConfig(
+        observation_dim=2,
+        latent_dim=4,
+        n_actions=2,
+        observation_scale=(1.0, 1.0),
+    )
+    model_base = LatentWorldModel(cfg_base)
+    state_base = model_base.init(jax.random.PRNGKey(0))
+    obs_base = jnp.asarray([1.5, -0.75], dtype=jnp.float32)
+    expected_latent = np.asarray(model_base.encode(state_base, obs_base))
+
+    for scale in (1e-6, 1e-9, 1e-20, 1e-35):
+        cfg = LatentWorldModelConfig(
+            observation_dim=2,
+            latent_dim=4,
+            n_actions=2,
+            observation_scale=(scale, scale),
+        )
+        model = LatentWorldModel(cfg)
+        state = model.init(jax.random.PRNGKey(0))
+        obs = jnp.asarray([1.5 * scale, -0.75 * scale], dtype=jnp.float32)
+        latent = np.asarray(model.encode(state, obs))
+        np.testing.assert_allclose(latent, expected_latent, rtol=1e-5, atol=1e-5)
+
+
+def test_latent_world_model_config_rejects_subnormal_observation_scale() -> None:
+    import numpy as np
+    import pytest
+
+    from alberta_framework.core.latent_world_model import LatentWorldModelConfig
+
+    subnormal = float(np.finfo(np.float32).smallest_subnormal)
+    with pytest.raises(ValueError, match="observation_scale"):
+        LatentWorldModelConfig(
+            observation_dim=1,
+            latent_dim=2,
+            n_actions=2,
+            observation_scale=(subnormal,),
+        )


### PR DESCRIPTION
Fixes #2411

## Summary
In `alberta_framework/core/latent_world_model.py`:
`_encode_with` divided observations by `jnp.maximum(scale, 1e-6)`. For any configured `observation_scale` below $10^{-6}$, the encoder normalized by $10^{-6}$ instead of the declared scale, artificially shrinking encoded latents and triggering false `collapse_score` flags that completely disabled trainable encoder updates.

## Proposed Changes
1. Removed the artificial $10^{-6}$ divisor floor in `_encode_with`, normalizing directly by `scale`.
2. Validated in `LatentWorldModelConfig.__post_init__` that each `observation_scale` element is at least `np.finfo(np.float32).tiny` ($1.17549435 \times 10^{-38}$), ensuring that every admitted float32 scale has a finite float32 reciprocal while rejecting subnormals at configuration time.
3. Added unit tests in `tests/test_latent_world_model.py` verifying scale-invariant encoding down to $10^{-35}$ and confirming rejection of subnormal scales at configuration.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_latent_world_model.py` (58/58 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/latent_world_model.py tests/test_latent_world_model.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/latent_world_model.py` (clean).
