### PR TITLE
fix(evaluation): fail closed on all-subnormal float32 matrix in spectral_matrix_sign_transaction

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -116,12 +116,7 @@ def orthogonal_correction_transaction(update: Array, protected_basis: Array) -> 
     """Return a finite orthogonal correction and caller-visible validity bit."""
     vector = _trusted_array(update, name="update")
     basis = _trusted_array(protected_basis, name="protected_basis")
-    if (
-        vector.ndim != 1
-        or vector.size < 1
-        or basis.ndim != 2
-        or basis.shape[1] != vector.shape[0]
-    ):
+    if vector.ndim != 1 or vector.size < 1 or basis.ndim != 2 or basis.shape[1] != vector.shape[0]:
         raise ValueError("update must be a non-empty vector and basis rows must match its width")
     coordinates = basis @ vector
     projection = basis.T @ coordinates
@@ -171,9 +166,21 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         or steps > 32
     ):
         raise ValueError("matrix must be non-empty and steps a positive integer")
-    norm = jnp.linalg.norm(value)
+    max_abs = jnp.max(jnp.abs(value))
+    _, exponent = jnp.frexp(max_abs)
+    scaled = jnp.ldexp(value, -exponent)
+    rescaled_norm = jnp.linalg.norm(scaled)
+    positive = (max_abs > 0.0) & (rescaled_norm > 0.0) & jnp.isfinite(rescaled_norm)
+    norm = jnp.ldexp(rescaled_norm, exponent)
     valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    if value.dtype == jnp.float32:
+        raw_bits = jax.lax.bitcast_convert_type(value, jnp.uint32)
+        nonzero_bits = jnp.any(
+            jax.lax.bitwise_and(raw_bits, jnp.uint32(0x7FFFFFFF)) != jnp.uint32(0)
+        )
+        valid = valid & (~(nonzero_bits & (~positive)))
+    divisor = jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm))
+    x = jnp.where(positive, scaled / divisor, jnp.zeros_like(value))
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True
@@ -244,11 +251,7 @@ def muon_ogd_dual_update_transaction(
         raise ValueError("dual must contain one multiplier per constraint")
     if type(dual_learning_rate) is not float or not math.isfinite(dual_learning_rate):
         raise ValueError("dual_learning_rate must be a finite float")
-    if (
-        dual_learning_rate < 0.0
-        or type(dual_steps) is not int
-        or not 1 <= dual_steps <= 32
-    ):
+    if dual_learning_rate < 0.0 or type(dual_steps) is not int or not 1 <= dual_steps <= 32:
         raise ValueError("dual learning rate must be non-negative and dual_steps bounded positive")
     valid = (
         jnp.all(jnp.isfinite(value))
@@ -271,9 +274,7 @@ def muon_ogd_dual_update_transaction(
         )
         multipliers = next_multipliers
     shifted = value + jnp.einsum("k,kij->ij", multipliers, protected)
-    update, sign_valid = spectral_matrix_sign_transaction(
-        shifted, steps=newton_schulz_steps
-    )
+    update, sign_valid = spectral_matrix_sign_transaction(shifted, steps=newton_schulz_steps)
     valid = valid & jnp.all(jnp.isfinite(shifted)) & sign_valid
     safe_update = jnp.where(valid, update, jnp.zeros_like(update))
     safe_dual = jnp.where(valid, multipliers, jnp.zeros_like(multipliers))
@@ -438,9 +439,7 @@ def _runtime_identity() -> dict[str, object]:
         "machine": _runtime_text("machine", platform.machine()),
         "packages": {
             "jax": _runtime_text("JAX version", jax.__version__),
-            "jaxlib": _runtime_text(
-                "jaxlib version", importlib.metadata.version("jaxlib")
-            ),
+            "jaxlib": _runtime_text("jaxlib version", importlib.metadata.version("jaxlib")),
             "numpy": _runtime_text("NumPy version", np.__version__),
         },
         "default_backend": _runtime_text("JAX backend", jax.default_backend()),
@@ -495,9 +494,7 @@ def _execute_frozen_stream(*, measure_timing: bool) -> dict[str, object]:
     constraints, basis = _protected_geometry(rows, columns)
     target_updates: list[Array] = []
     for matrix in stream:
-        target_update, target_valid = orthogonal_correction_transaction(
-            matrix.reshape(-1), basis
-        )
+        target_update, target_valid = orthogonal_correction_transaction(matrix.reshape(-1), basis)
         _require_valid(target_valid, name="target projection")
         target_updates.append(target_update.reshape((rows, columns)))
     target = jnp.sum(jnp.stack(target_updates), axis=0)
@@ -527,9 +524,7 @@ def _execute_frozen_stream(*, measure_timing: bool) -> dict[str, object]:
                 )
                 processed = flat_processed.reshape((rows, columns))
             elif arm == "fogo_projection":
-                flat_processed, valid = orthogonal_correction_transaction(
-                    matrix.reshape(-1), basis
-                )
+                flat_processed, valid = orthogonal_correction_transaction(matrix.reshape(-1), basis)
                 processed = flat_processed.reshape((rows, columns))
             elif arm == "flad_zero_gradient":
                 flat_processed, valid = flad_noise_component_transaction(
@@ -671,10 +666,7 @@ def _exact_equal(actual: object, expected: object) -> bool:
     if type(expected) is dict:
         actual_dict = cast(dict[object, object], actual)
         expected_dict = cast(dict[object, object], expected)
-        if (
-            len(actual_dict) > 32
-            or len(actual_dict) != len(expected_dict)
-        ):
+        if len(actual_dict) > 32 or len(actual_dict) != len(expected_dict):
             return False
         if not all(type(key) is str for key in actual_dict):
             return False
@@ -687,9 +679,13 @@ def _exact_equal(actual: object, expected: object) -> bool:
     if type(expected) is list:
         actual_list = cast(list[object], actual)
         expected_list = cast(list[object], expected)
-        return len(actual_list) <= 128 and len(actual_list) == len(expected_list) and all(
-            _exact_equal(left, right)
-            for left, right in zip(actual_list, expected_list, strict=True)
+        return (
+            len(actual_list) <= 128
+            and len(actual_list) == len(expected_list)
+            and all(
+                _exact_equal(left, right)
+                for left, right in zip(actual_list, expected_list, strict=True)
+            )
         )
     if type(expected) is str:
         actual_text = cast(str, actual)

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -283,9 +283,7 @@ def test_geometry_primitives_are_outer_jit_safe() -> None:
     np.testing.assert_allclose(corrected, [0.0, 2.0])
     invalid = jax.jit(flad_noise_component)(jnp.array([jnp.nan]), jnp.ones(1))
     assert bool(jnp.all(jnp.isnan(invalid)))
-    safe, valid = jax.jit(flad_noise_component_transaction)(
-        jnp.array([jnp.nan]), jnp.ones(1)
-    )
+    safe, valid = jax.jit(flad_noise_component_transaction)(jnp.array([jnp.nan]), jnp.ones(1))
     np.testing.assert_array_equal(safe, jnp.zeros(1))
     assert not bool(valid)
 
@@ -340,3 +338,20 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+
+def test_spectral_matrix_sign_fails_closed_on_all_subnormal_matrix() -> None:
+    subnormal_val = float(np.finfo(np.float32).smallest_subnormal)
+    sub_mat = jnp.asarray(
+        [[subnormal_val, subnormal_val], [subnormal_val, subnormal_val]], dtype=jnp.float32
+    )
+    safe, valid = spectral_matrix_sign_transaction(sub_mat)
+    assert not bool(valid)
+    assert np.all(np.asarray(safe) == 0.0)
+
+
+def test_spectral_matrix_sign_preserves_exact_zero_matrix() -> None:
+    zero_mat = jnp.zeros((2, 2), dtype=jnp.float32)
+    safe, valid = spectral_matrix_sign_transaction(zero_mat)
+    assert bool(valid)
+    assert np.all(np.asarray(safe) == 0.0)


### PR DESCRIPTION
Fixes #2391

## Summary
In `alberta_framework/evaluation/optimizer_geometry.py`:
`spectral_matrix_sign_transaction` returned an exact zero matrix with `valid=True` for non-zero inputs whose float32 entries were all subnormal (because reductions in float32 flush subnormals to zero while `jnp.isfinite(0.0)` is `True`).

## Proposed Changes
1. Added bitwise nonzero check `raw_bits = jax.lax.bitcast_convert_type(value, jnp.uint32)` for float32 operands to detect inputs with non-zero magnitude bits that flushed to zero in floating-point operations.
2. Formed `valid = valid & (~(nonzero_bits & (~positive)))` to fail closed (`valid=False`, safe zero output) rather than certifying a rank-0 zero matrix as a valid matrix sign.
3. Preserved `valid=True` and exact zero output for genuinely bitwise-zero matrices.
4. Added unit tests in `tests/test_optimizer_geometry.py` testing fail-closed behavior on all-subnormal float32 matrices and exact preservation of zero matrices.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_optimizer_geometry.py` (30/30 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/evaluation/optimizer_geometry.py` (clean).
