### PR TITLE
fix(core): derive _ACTUAL_REAL_SCALAR_TYPES from floating dtype codes to include np.longdouble

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -33,7 +33,7 @@ _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _INT32_MAX = 2**31 - 1
 _ACTUAL_REAL_SCALAR_TYPES = frozenset(
-    {float, np.float16, np.float32, np.float64, int}
+    {float, int, *(np.dtype(code).type for code in "efdg")}
 )
 
 _ACTUAL_INT_TYPES = frozenset(

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -632,3 +632,19 @@ class TestGVFSpecRemainingFields:
     def test_horde_spec_from_config_rejects_non_list_demons(self, invalid_demons):
         with pytest.raises(ValueError, match="HordeSpec demons must be an exact list"):
             HordeSpec.from_config({"demons": invalid_demons})
+
+@pytest.mark.parametrize(
+    "scalar_type",
+    [np.dtype(code).type for code in "efdg"],
+)
+def test_gvf_spec_accepts_all_numpy_floating_types_for_terminal_reward(scalar_type: type) -> None:
+    spec = GVFSpec(
+        name="d",
+        demon_type=DemonType.PREDICTION,
+        gamma=0.0,
+        lamda=0.0,
+        cumulant_index=0,
+        terminal_reward=scalar_type(1.5),
+    )
+    assert spec.terminal_reward == 1.5
+


### PR DESCRIPTION
Fixes #2283

## Summary
In `alberta_framework/core/types.py`:
`_ACTUAL_REAL_SCALAR_TYPES` hand-enumerated `{float, np.float16, np.float32, np.float64, int}` and omitted `np.longdouble`. As a result, `GVFSpec.terminal_reward` rejected `np.longdouble` inputs that sibling fields (`gamma` and `lamda`) and the underlying `validated_float32_scalar_with_ratio` helper accept.

## Proposed Changes
1. Derived `_ACTUAL_REAL_SCALAR_TYPES` from dtype character codes (`frozenset({float, int, *(np.dtype(code).type for code in "efdg")})`), matching `_ACTUAL_INT_TYPES` in `types.py` and `_ACTUAL_FLOAT_TYPES` in `_float32.py`.
2. Added parametrized tests in `tests/test_gvf_types.py` validating that `GVFSpec(terminal_reward=...)` accepts all four numpy floating scalar families (`float16`, `float32`, `float64`, `longdouble`).

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_gvf_types.py` (112/112 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/types.py tests/test_gvf_types.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/types.py` (clean).
