### PR TITLE
fix(core): make floor_and_renormalize_probabilities scale-free with uniform fallback on zero mass

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -225,11 +225,13 @@ def floor_and_renormalize_probabilities(
     if min_probability * n_actions >= 1.0:
         return jnp.ones_like(probs) / n_actions
     clipped = jnp.maximum(probs, 0.0)
-    normalizer = jnp.maximum(
-        jnp.sum(clipped, axis=-1, keepdims=True),
-        jnp.asarray(1e-12, dtype=jnp.float32),
-    )
-    normalized = clipped / normalizer
+    max_val = jnp.max(clipped, axis=-1, keepdims=True)
+    _, exponent = jnp.frexp(max_val)
+    scaled = jnp.ldexp(clipped, -exponent)
+    total = jnp.sum(scaled, axis=-1, keepdims=True)
+    valid = (max_val > 0.0) & (total > 0.0) & jnp.isfinite(total)
+    uniform = jnp.full_like(clipped, 1.0 / n_actions)
+    normalized = jnp.where(valid, scaled / jnp.where(valid, total, 1.0), uniform)
     floor_mass = jnp.asarray(min_probability * n_actions, dtype=jnp.float32)
     return jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
 

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -868,3 +868,12 @@ class TestBehaviorModelSequenceCeiling:
         result = run_behavior_model_from_arrays(model, state, observations, actions)
         chex.assert_shape(result.probabilities, (12, 3))
         assert int(result.state.step_count) == 12
+
+def test_floor_and_renormalize_probabilities_returns_simplex_on_zero_and_extreme_mass() -> None:
+    from alberta_framework.core.behavior_model import floor_and_renormalize_probabilities
+
+    for probs in ([0.0, 0.0, 0.0], [1e38, 1.0, 1.0], [-1.0, -2.0, -3.0], [1e-30, 0.0, 0.0]):
+        out = floor_and_renormalize_probabilities(jnp.asarray(probs, dtype=jnp.float32))
+        np.testing.assert_allclose(float(jnp.sum(out)), 1.0, atol=1e-5)
+        assert np.all(np.asarray(out) >= 1e-6)
+


### PR DESCRIPTION
Fixes #2238

## Summary
In `alberta_framework/core/behavior_model.py`:
`floor_and_renormalize_probabilities` used a fixed $10^{-12}$ floor in `clipped / normalizer`. When inputs contained zero mass, all-negative values, or large entries ($10^{38}$) causing float32 division underflow, `normalized` was all zeros, resulting in a vector summing to $n \times \text{min\_probability}$ rather than $1.0$.

## Proposed Changes
1. Rescaled input positive probabilities by power-of-two magnitude normalization (`jnp.frexp` and `jnp.ldexp`).
2. Replaced the floored denominator with true sum normalization and fell back to uniform distribution `1.0 / n_actions` when no positive finite mass exists.
3. Added unit tests in `tests/test_behavior_model.py` verifying that zero, negative, and extreme inputs return a proper simplex summing to 1.0 with all entries $\ge \text{min\_probability}$.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_behavior_model.py` (80/80 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/behavior_model.py tests/test_behavior_model.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/behavior_model.py` (clean).
