### PR TITLE
fix(core): derive _ACTUAL_INT_TYPES from dtype codes in stacked_horde and reward_model

### DIFF
--- a/alberta_framework/core/reward_model.py
+++ b/alberta_framework/core/reward_model.py
@@ -28,21 +28,7 @@ from jaxtyping import Bool, Float
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 
 _INT32_MAX = 2**31 - 1
-_ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
-)
+_ACTUAL_INT_TYPES = frozenset({int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")})
 _ACTUAL_FLOAT_TYPES = frozenset(
     {float, *(np.dtype(code).type for code in ("e", "f", "d", "g"))}
 )

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -141,21 +141,7 @@ _CONFIG_FIELDS = {
     "cumulant_indices",
     "step_size",
 }
-_ACTUAL_INT_TYPES = frozenset(
-    {
-        int,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.longlong,
-        np.ulonglong,
-    }
-)
+_ACTUAL_INT_TYPES = frozenset({int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")})
 
 
 def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _INT32_MAX) -> int:


### PR DESCRIPTION
Fixes #2268

## Summary
In `alberta_framework/core/stacked_horde.py` and `alberta_framework/core/reward_model.py`:
`_ACTUAL_INT_TYPES` hand-enumerated fixed-width numpy integer names, which rejects distinct C alias integer types (`np.intc`, `np.uintc`) on platforms where C aliases do not alias to fixed-width types (such as LLP64 platforms like 64-bit Windows).

## Proposed Changes
1. Derived `_ACTUAL_INT_TYPES` from dtype character codes (`frozenset({int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")})`) in `stacked_horde.py` and `reward_model.py`, matching the portable pattern used across the codebase.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_stacked_horde.py tests/test_reward_model.py` (156/156 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/stacked_horde.py alberta_framework/core/reward_model.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/stacked_horde.py alberta_framework/core/reward_model.py` (clean).
