### PR TITLE
fix(utils): fix Raises section indentation in get_final_performance docstring

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -665,7 +665,7 @@ def get_final_performance(
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
 
-        Raises:
+    Raises:
         ValueError: If ``window`` is not positive, a metric array has no
             time steps, any metric sample is non-finite, or ``window`` exceeds
             the shortest trace while trace lengths differ between methods.


### PR DESCRIPTION
Fixes #2439

## Summary
In `alberta_framework/utils/experiments.py`:
In `get_final_performance`, the `Raises:` section was indented by 8 spaces (nested inside the `Returns:` block) rather than at 4 spaces, preventing Google-style docstring tooling from recognizing it as a top-level section.

## Proposed Changes
1. Un-nested the `Raises:` section in `get_final_performance` so it aligns with `Args:` and `Returns:` at indent 4.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_experiments_validation.py` (129/129 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/utils/experiments.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/utils/experiments.py` (clean).
