### PR TITLE
fix(core): cap working-memory decay rate cardinality and reject oversized serialized sequences before iteration

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -70,6 +70,7 @@ from alberta_framework.core.working_memory import (
 )
 
 _INT32_MAX = 2**31 - 1
+_MAX_FIXED_TRACE_DECAY_RATES = 1 << 12
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -118,6 +119,8 @@ def _require_int32(name: str, value: object, *, minimum: int) -> int:
 def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(value) > _MAX_FIXED_TRACE_DECAY_RATES:
+        raise ValueError(f"{name} must contain at most {_MAX_FIXED_TRACE_DECAY_RATES} decay rates")
     rates = cast(tuple[object, ...], value)
     return tuple(
         validated_float32_scalar(
@@ -1001,9 +1004,7 @@ class FixedTraceStateBuilderConfig:
             + self.n_actions * len(self.action_decay_rates)
             + 2 * len(self.outcome_decay_rates)
         )
-        feature_dim = trace_scalars + (
-            self.observation_dim if self.include_raw_observation else 0
-        )
+        feature_dim = trace_scalars + (self.observation_dim if self.include_raw_observation else 0)
         state_scalars = trace_scalars + 4
         _require_derived_int32("feature_dim", feature_dim, minimum=1)
         _require_derived_int32("state_scalars", state_scalars)
@@ -1033,15 +1034,17 @@ class FixedTraceStateBuilderConfig:
             raise ValueError(
                 "FixedTraceStateBuilderConfig payload type must be 'FixedTraceStateBuilder'"
             )
+        for name in ("observation_decay_rates", "action_decay_rates", "outcome_decay_rates"):
+            val = data[name]
+            if type(val) is not list and type(val) is not tuple:
+                raise ValueError(f"{name} must be an actual list or tuple")
+            if len(val) > _MAX_FIXED_TRACE_DECAY_RATES:
+                raise ValueError(
+                    f"{name} must contain at most {_MAX_FIXED_TRACE_DECAY_RATES} elements"
+                )
         obs_decays = data["observation_decay_rates"]
         act_decays = data["action_decay_rates"]
         out_decays = data["outcome_decay_rates"]
-        if (
-            not isinstance(obs_decays, (list, tuple))
-            or not isinstance(act_decays, (list, tuple))
-            or not isinstance(out_decays, (list, tuple))
-        ):
-            raise ValueError("decay rates must be lists or tuples")
         return cls(
             observation_dim=data["observation_dim"],
             n_actions=data["n_actions"],
@@ -1355,9 +1358,7 @@ def _online_gated_update_working_set_bytes(
     event_dim = observation_dim + n_actions + 2
     feature_dim = hidden_dim + (observation_dim if include_raw_observation else 0)
     parameter_count = 2 * hidden_dim * (event_dim + 1)
-    persist_scalars = (
-        parameter_count + hidden_dim + hidden_dim * parameter_count + 3
-    )
+    persist_scalars = parameter_count + hidden_dim + hidden_dim * parameter_count + 3
     update_scalars = (
         3 * persist_scalars
         + 2 * hidden_dim * parameter_count
@@ -1385,9 +1386,7 @@ def _preflight_online_gated_update_working_set(
         include_raw_observation=include_raw_observation,
     )
     if working_set_bytes > _INT32_MAX:
-        raise ValueError(
-            "online-gated update working set byte count must fit signed int32"
-        )
+        raise ValueError("online-gated update working set byte count must fit signed int32")
 
 
 @dataclass(frozen=True)
@@ -1448,12 +1447,7 @@ class OnlineGatedStateBuilderConfig:
             self.observation_dim if self.include_raw_observation else 0
         )
         parameter_count = 2 * self.hidden_dim * (event_dim + 1)
-        state_scalars = (
-            parameter_count
-            + self.hidden_dim
-            + self.hidden_dim * parameter_count
-            + 3
-        )
+        state_scalars = parameter_count + self.hidden_dim + self.hidden_dim * parameter_count + 3
         _require_derived_int32("event_dim", event_dim, minimum=1)
         _require_derived_int32("feature_dim", feature_dim, minimum=1)
         _require_derived_int32("parameter_count", parameter_count, minimum=1)

--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -123,10 +123,13 @@ class WorkingMemoryConfig:
         ):
             if key in payload:
                 value = payload[key]
-                if type(value) is list:
-                    payload[key] = tuple(value)
-                elif type(value) is not tuple:
+                if type(value) is not list and type(value) is not tuple:
                     raise ValueError(f"{key} must be an actual list or tuple")
+                if len(value) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                    raise ValueError(
+                        f"{key} must contain at most {_MAX_WORKING_MEMORY_DECAY_RATES} elements"
+                    )
+                payload[key] = tuple(value)
                 if any(type(item) is not float for item in payload[key]):
                     raise ValueError(f"serialized {key} values must be JSON numbers")
         for key in ("observation_dim", "action_dim", "reward_dim"):
@@ -216,6 +219,7 @@ class WorkingMemoryArrayResult:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_WORKING_MEMORY_DECAY_RATES = 1 << 12
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
@@ -287,6 +291,10 @@ def _require_array(
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(rates) > _MAX_WORKING_MEMORY_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",
@@ -306,15 +314,9 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
     observation_decay_rates = _validate_decay_rates(
         "observation_decay_rates", config.observation_decay_rates
     )
-    action_decay_rates = _validate_decay_rates(
-        "action_decay_rates", config.action_decay_rates
-    )
-    reward_decay_rates = _validate_decay_rates(
-        "reward_decay_rates", config.reward_decay_rates
-    )
-    gate_threshold = validated_float32_scalar(
-        "gate_threshold", config.gate_threshold, lower=0.0
-    )
+    action_decay_rates = _validate_decay_rates("action_decay_rates", config.action_decay_rates)
+    reward_decay_rates = _validate_decay_rates("reward_decay_rates", config.reward_decay_rates)
+    gate_threshold = validated_float32_scalar("gate_threshold", config.gate_threshold, lower=0.0)
     gate_temperature = validated_float32_scalar(
         "gate_temperature", config.gate_temperature, lower=_FLOAT32_MIN_NORMAL
     )
@@ -361,11 +363,7 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
         raise ValueError("WorkingMemoryConfig state byte count must fit signed int32")
     if persistent_bytes > _UINT32_MAX:
         raise ValueError("working memory allocation exceeds uint32 byte accounting")
-    decay_scalars = (
-        len(observation_decay_rates)
-        + len(action_decay_rates)
-        + len(reward_decay_rates)
-    )
+    decay_scalars = len(observation_decay_rates) + len(action_decay_rates) + len(reward_decay_rates)
     signal_scalars = observation_dim + action_dim + reward_dim
     feature_work = total_state_scalars + feature_dim + 2 * signal_scalars
     update_work = (
@@ -378,12 +376,8 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
     )
     diagnostics_work = total_state_scalars + 3 * trace_scalars + 9
     _require_float32_resource("WorkingMemoryConfig features", vector_scalars=feature_dim)
-    _require_float32_resource(
-        "WorkingMemoryConfig feature operation", vector_scalars=feature_work
-    )
-    _require_float32_resource(
-        "WorkingMemoryConfig update operation", vector_scalars=update_work
-    )
+    _require_float32_resource("WorkingMemoryConfig feature operation", vector_scalars=feature_work)
+    _require_float32_resource("WorkingMemoryConfig update operation", vector_scalars=update_work)
     _require_float32_resource(
         "WorkingMemoryConfig diagnostics operation", vector_scalars=diagnostics_work
     )
@@ -634,9 +628,7 @@ class WorkingMemoryFeaturizer:
         rew = _empty_or_vector(reward, cfg.reward_dim)
         raw_outer_gate = jnp.asarray(external_gate, dtype=jnp.float32)
         if raw_outer_gate.shape != ():
-            raise ValueError(
-                f"external_gate must have scalar shape (); got {raw_outer_gate.shape}"
-            )
+            raise ValueError(f"external_gate must have scalar shape (); got {raw_outer_gate.shape}")
         inputs_valid = (
             jnp.all(jnp.isfinite(obs))
             & jnp.all(jnp.isfinite(act))
@@ -709,9 +701,7 @@ class WorkingMemoryFeaturizer:
                 reward_traces=jnp.zeros_like(state.reward_traces),
             )
         update_applied = (
-            inputs_valid
-            & self._state_is_valid(previous_checked)
-            & self._state_is_valid(candidate)
+            inputs_valid & self._state_is_valid(previous_checked) & self._state_is_valid(candidate)
         )
         return WorkingMemoryUpdateResult(
             state=select_transaction(update_applied, candidate, state),
@@ -860,9 +850,7 @@ def transform_working_memory_arrays(
     state_scalars = trace_scalars + 4
     signal_scalars = cfg.observation_dim + cfg.action_dim + cfg.reward_dim
     decay_scalars = (
-        len(cfg.observation_decay_rates)
-        + len(cfg.action_decay_rates)
-        + len(cfg.reward_decay_rates)
+        len(cfg.observation_decay_rates) + len(cfg.action_decay_rates) + len(cfg.reward_decay_rates)
     )
     per_step_work = (
         3 * state_scalars
@@ -874,8 +862,7 @@ def transform_working_memory_arrays(
     )
     _require_sequence_resource(
         "working memory transform aggregate",
-        float32_scalars=steps * (signal_scalars + cfg.feature_dim() + 1)
-        + per_step_work,
+        float32_scalars=steps * (signal_scalars + cfg.feature_dim() + 1) + per_step_work,
         bool_scalars=steps,
     )
     _require_array("observations", observations, shape=(steps, cfg.observation_dim))

--- a/tests/test_state_builder.py
+++ b/tests/test_state_builder.py
@@ -1448,3 +1448,28 @@ def test_online_builder_init_returns_a_valid_state_at_normal_scale() -> None:
     state = builder.init(jr.key(0))
 
     assert bool(builder.state_valid(state))
+
+
+def test_state_builder_rejects_oversized_decay_rates() -> None:
+    from alberta_framework.core.state_builder import (
+        _MAX_FIXED_TRACE_DECAY_RATES,
+        FixedTraceStateBuilderConfig,
+    )
+
+    assert _MAX_FIXED_TRACE_DECAY_RATES == 4096
+
+    with pytest.raises(ValueError, match="observation_decay_rates"):
+        FixedTraceStateBuilderConfig(
+            observation_dim=2,
+            n_actions=2,
+            observation_decay_rates=(0.5,) * 4097,
+        )
+
+
+def test_state_builder_from_config_rejects_oversized_decay_rates() -> None:
+    from alberta_framework.core.state_builder import FixedTraceStateBuilderConfig
+
+    cfg_dict = FixedTraceStateBuilderConfig(observation_dim=2, n_actions=2).to_config()
+    cfg_dict["observation_decay_rates"] = [0.5] * 4097
+    with pytest.raises(ValueError, match="must contain at most 4096 elements"):
+        FixedTraceStateBuilderConfig.from_config(cfg_dict)

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -80,9 +80,7 @@ def test_working_memory_config_from_config_accepts_exact_lists_or_tuples() -> No
         "action_decay_rates": tuple(base["action_decay_rates"]),
         "reward_decay_rates": tuple(base["reward_decay_rates"]),
     }
-    assert WorkingMemoryConfig.from_config(tuple_payload) == WorkingMemoryConfig.from_config(
-        base
-    )
+    assert WorkingMemoryConfig.from_config(tuple_payload) == WorkingMemoryConfig.from_config(base)
 
 
 def test_working_memory_trace_decay_and_feature_causality() -> None:
@@ -670,11 +668,14 @@ def test_zero_width_vectors_and_batches_preserve_exact_shapes() -> None:
     chex.assert_shape(result.features, (3, memory.feature_dim()))
 
 
-@pytest.mark.parametrize("field", [
-    "observation_decay_rates",
-    "action_decay_rates",
-    "reward_decay_rates",
-])
+@pytest.mark.parametrize(
+    "field",
+    [
+        "observation_decay_rates",
+        "action_decay_rates",
+        "reward_decay_rates",
+    ],
+)
 @pytest.mark.parametrize(
     "rates",
     [
@@ -699,17 +700,13 @@ def test_decay_rates_must_be_finite_and_in_unit_half_open_interval(
 @pytest.mark.parametrize("temperature", [float("nan"), float("inf"), float("-inf"), 0.0, -1.0])
 def test_gate_temperature_must_be_finite_and_positive(temperature: float) -> None:
     with pytest.raises(ValueError, match="gate_temperature"):
-        WorkingMemoryFeaturizer(
-            _minimal_config(gated_update=True, gate_temperature=temperature)
-        )
+        WorkingMemoryFeaturizer(_minimal_config(gated_update=True, gate_temperature=temperature))
 
 
 @pytest.mark.parametrize("threshold", [float("nan"), float("inf"), float("-inf"), -1.0])
 def test_gate_threshold_must_be_finite_and_nonnegative(threshold: float) -> None:
     with pytest.raises(ValueError, match="gate_threshold"):
-        WorkingMemoryFeaturizer(
-            _minimal_config(gated_update=True, gate_threshold=threshold)
-        )
+        WorkingMemoryFeaturizer(_minimal_config(gated_update=True, gate_threshold=threshold))
 
 
 def test_legal_finite_decay_endpoints_still_construct_and_update() -> None:
@@ -756,3 +753,27 @@ def test_zero_decay_does_not_multiply_inf_traces() -> None:
     )
     assert bool(result.update_applied)
     chex.assert_trees_all_close(result.state.observation_traces, obs[None, :])
+
+
+def test_working_memory_rejects_oversized_decay_rates() -> None:
+    from alberta_framework.core.working_memory import (
+        _MAX_WORKING_MEMORY_DECAY_RATES,
+        WorkingMemoryConfig,
+    )
+
+    assert _MAX_WORKING_MEMORY_DECAY_RATES == 4096
+
+    with pytest.raises(ValueError, match="observation_decay_rates"):
+        WorkingMemoryConfig(
+            observation_dim=2,
+            observation_decay_rates=(0.5,) * 4097,
+        )
+
+
+def test_working_memory_from_config_rejects_oversized_decay_rates() -> None:
+    from alberta_framework.core.working_memory import WorkingMemoryConfig
+
+    cfg_dict = WorkingMemoryConfig(observation_dim=2).to_config()
+    cfg_dict["observation_decay_rates"] = [0.5] * 4097
+    with pytest.raises(ValueError, match="must contain at most 4096 elements"):
+        WorkingMemoryConfig.from_config(cfg_dict)


### PR DESCRIPTION
Fixes #2220

## Summary
In `alberta_framework/core/working_memory.py` and `alberta_framework/core/state_builder.py`:
`WorkingMemoryConfig` and `FixedTraceStateBuilderConfig` accepted arbitrarily large decay rate tuples without an upper cardinality ceiling, causing unbounded iteration in Python before aggregate resource validation is reached. Deserialization in `from_config` also lacked sequence length preflight checks.

## Proposed Changes
1. Added `_MAX_WORKING_MEMORY_DECAY_RATES = 1 << 12` (4096) in `working_memory.py` and `_MAX_FIXED_TRACE_DECAY_RATES = 1 << 12` (4096) in `state_builder.py`.
2. Validated `len(rates) <= _MAX_WORKING_MEMORY_DECAY_RATES` in `_validate_decay_rates` and `WorkingMemoryConfig.from_config`.
3. Validated `len(value) <= _MAX_FIXED_TRACE_DECAY_RATES` in `_require_decay_rates` and `FixedTraceStateBuilderConfig.from_config`.
4. Added unit tests in `tests/test_working_memory.py` and `tests/test_state_builder.py` verifying that oversized decay rate sequences ($> 4096$) are rejected during construction and deserialization.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_working_memory.py tests/test_state_builder.py` (184/184 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/working_memory.py alberta_framework/core/state_builder.py tests/test_working_memory.py tests/test_state_builder.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/working_memory.py alberta_framework/core/state_builder.py` (clean).
