### PR TITLE
fix(steps): bound Step 7 planning and Step 9 dreaming loop lengths before jnp.arange/lax.scan

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -103,9 +103,7 @@ class Step7DynaConfig:
     fixed number of model-generated one-step backups, gated by model warmup.
     """
 
-    control: Step6DifferentialSARSAConfig = field(
-        default_factory=Step6DifferentialSARSAConfig
-    )
+    control: Step6DifferentialSARSAConfig = field(default_factory=Step6DifferentialSARSAConfig)
     world_model: Step8WorldModelConfig = field(default_factory=Step8WorldModelConfig)
     planning_steps: int = 1
     planning_rollout_depth: int = 1
@@ -161,6 +159,8 @@ class Step7DynaConfig:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_STEP7_PLANNING_STEPS = 10_000
+_MAX_STEP7_PLANNING_ROLLOUT_DEPTH = 10_000
 _STEP7_CONFIG_FIELDS = frozenset(
     {
         "control",
@@ -279,13 +279,13 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
         "planning_steps",
         config.planning_steps,
         minimum=0,
-        maximum=_INT32_MAX,
+        maximum=_MAX_STEP7_PLANNING_STEPS,
     )
     planning_rollout_depth = _require_int(
         "planning_rollout_depth",
         config.planning_rollout_depth,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_MAX_STEP7_PLANNING_ROLLOUT_DEPTH,
     )
     planning_warmup_steps = _require_int(
         "planning_warmup_steps",
@@ -344,9 +344,7 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
     ):
         raise ValueError("derived Step 7 planning output bytes must fit signed int32")
     memory_scalars = (
-        2 * planning_memory_size * config.world_model.observation_dim
-        + 4 * planning_memory_size
-        + 3
+        2 * planning_memory_size * config.world_model.observation_dim + 4 * planning_memory_size + 3
     )
     if memory_scalars > _INT32_MAX or 4 * memory_scalars > _INT32_MAX:
         raise ValueError("derived Step 7 planning-memory bytes must fit signed int32")
@@ -496,12 +494,8 @@ class Step7SmokeResult:
         payload["real_td_errors_shape"] = list(self.real_td_errors_shape)
         payload["planning_td_errors_shape"] = list(self.planning_td_errors_shape)
         payload["planning_priorities_shape"] = list(self.planning_priorities_shape)
-        payload["planning_anchor_indices_shape"] = list(
-            self.planning_anchor_indices_shape
-        )
-        payload["planning_importance_ratios_shape"] = list(
-            self.planning_importance_ratios_shape
-        )
+        payload["planning_anchor_indices_shape"] = list(self.planning_anchor_indices_shape)
+        payload["planning_importance_ratios_shape"] = list(self.planning_importance_ratios_shape)
         payload["actions_shape"] = list(self.actions_shape)
         return payload
 
@@ -627,9 +621,7 @@ def init_step7_state(
         raise TypeError("agent must be an actual DifferentialSARSAAgent")
     if type(model) is not OneStepWorldModel:
         raise TypeError("model must be an actual OneStepWorldModel")
-    memory_size = _require_int(
-        "memory_size", memory_size, minimum=1, maximum=_INT32_MAX - 1
-    )
+    memory_size = _require_int("memory_size", memory_size, minimum=1, maximum=_INT32_MAX - 1)
     feature_dim = model.config.observation_dim
     if model.config.n_actions != agent.config.n_actions:
         raise ValueError("model and agent action counts must match")
@@ -726,11 +718,7 @@ def _score_planning_actions(
             jnp.mean((prediction.next_observation - anchor_observation) ** 2)
         )
         reward_priority = jnp.abs(prediction.reward)
-        return (
-            reward_priority
-            if strategy == "reward"
-            else reward_priority + transition_magnitude
-        )
+        return reward_priority if strategy == "reward" else reward_priority + transition_magnitude
 
     priorities = jax.vmap(predict_action)(actions)
     selected = jnp.argmax(priorities).astype(jnp.int32)
@@ -749,9 +737,7 @@ def _store_real_transition(
     index = state.memory_position
     memory_size = state.memory_actions.shape[0]
     observations = state.memory_observations.at[index].set(
-        jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (state.memory_observations.shape[1],)
-        )
+        jnp.asarray(observation, dtype=jnp.float32).reshape((state.memory_observations.shape[1],))
     )
     actions = state.memory_actions.at[index].set(action.astype(jnp.int32))
     rewards = state.memory_rewards.at[index].set(jnp.asarray(reward, dtype=jnp.float32))
@@ -760,12 +746,8 @@ def _store_real_transition(
             (state.memory_next_observations.shape[1],)
         )
     )
-    priorities = state.memory_priorities.at[index].set(
-        jnp.asarray(priority, dtype=jnp.float32)
-    )
-    utilities = state.memory_utilities.at[index].set(
-        jnp.asarray(priority, dtype=jnp.float32)
-    )
+    priorities = state.memory_priorities.at[index].set(jnp.asarray(priority, dtype=jnp.float32))
+    utilities = state.memory_utilities.at[index].set(jnp.asarray(priority, dtype=jnp.float32))
     count = jnp.minimum(state.memory_count + 1, memory_size)
     position = (state.memory_position + 1) % memory_size
     return (
@@ -934,8 +916,7 @@ def _apply_planning_importance_correction(
     return cast(
         DifferentialSARSAState,
         planned_state.replace(  # type: ignore[attr-defined]
-            q_weights=old_state.q_weights
-            + rho * (planned_state.q_weights - old_state.q_weights),
+            q_weights=old_state.q_weights + rho * (planned_state.q_weights - old_state.q_weights),
             q_bias=old_state.q_bias + rho * (planned_state.q_bias - old_state.q_bias),
             q_trace_weights=old_state.q_trace_weights
             + rho * (planned_state.q_trace_weights - old_state.q_trace_weights),
@@ -1064,9 +1045,7 @@ def step7_update(
             model,
             model_state,
             anchor_observation,
-            config.planning_strategy
-            if config.planning_strategy != "random"
-            else "surprise",
+            config.planning_strategy if config.planning_strategy != "random" else "surprise",
             config.control.n_actions,
         )
         action = jnp.where(
@@ -1097,13 +1076,12 @@ def step7_update(
             anchor_priority,
             anchor_priority + priority,
         )
+
         def rollout_step(
             rollout_carry: tuple[DifferentialSARSAState, Array, Array, Array],
             _: Array,
         ) -> tuple[tuple[DifferentialSARSAState, Array, Array, Array], tuple[Array, Array]]:
-            rollout_state, rollout_observation, rollout_action, rollout_key = (
-                rollout_carry
-            )
+            rollout_state, rollout_observation, rollout_action, rollout_key = rollout_carry
             prediction = model.predict(
                 model_state,
                 rollout_observation,
@@ -1310,20 +1288,23 @@ def run_step7_scan(
             result.planning_accepted,
         )
 
-    final_state, (
-        real_td_errors,
-        average_rewards,
-        actions,
-        model_reward_errors,
-        model_next_observation_errors,
-        model_updates_applied,
-        planning_td_errors,
-        planning_priorities,
-        planning_anchor_indices,
-        planning_behavior_probs,
-        planning_target_probs,
-        planning_importance_ratios,
-        planning_accepted,
+    (
+        final_state,
+        (
+            real_td_errors,
+            average_rewards,
+            actions,
+            model_reward_errors,
+            model_next_observation_errors,
+            model_updates_applied,
+            planning_td_errors,
+            planning_priorities,
+            planning_anchor_indices,
+            planning_behavior_probs,
+            planning_target_probs,
+            planning_importance_ratios,
+            planning_accepted,
+        ),
     ) = jax.lax.scan(scan_step, state, (rewards, next_observations))
     return Step7DynaArrayResult(
         state=final_state,
@@ -1364,9 +1345,7 @@ def run_step7_smoke(
     real_output_bytes = steps * (17 + 4 * observation_dim)
     planning_output_bytes = steps * cfg.planning_steps * 25
     memory_scalars = (
-        2 * cfg.planning_memory_size * observation_dim
-        + 4 * cfg.planning_memory_size
-        + 3
+        2 * cfg.planning_memory_size * observation_dim + 4 * cfg.planning_memory_size + 3
     )
     memory_bytes = 4 * memory_scalars
     total_bytes = input_bytes + real_output_bytes + planning_output_bytes + memory_bytes
@@ -1416,9 +1395,7 @@ def run_step7_smoke(
         seed=seed,
         real_td_errors_shape=tuple(int(dim) for dim in result.real_td_errors.shape),
         planning_td_errors_shape=tuple(int(dim) for dim in result.planning_td_errors.shape),
-        planning_priorities_shape=tuple(
-            int(dim) for dim in result.planning_priorities.shape
-        ),
+        planning_priorities_shape=tuple(int(dim) for dim in result.planning_priorities.shape),
         planning_anchor_indices_shape=tuple(
             int(dim) for dim in result.planning_anchor_indices.shape
         ),

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -71,6 +71,9 @@ from alberta_framework.steps.step6 import (
 )
 
 _INT32_MAX = 2**31 - 1
+_MAX_STEP9_PLANNING_BUDGET = 10_000
+_MAX_STEP9_DREAM_ROLLOUT_HORIZON = 10_000
+_MAX_STEP9_DREAM_CANDIDATE_COUNT = 10_000
 _MAX_CONFIG_SEQUENCE_LENGTH = 4_096
 _MAX_DREAM_WORK_PER_REAL_STEP = 4_096
 # Matches the established ceiling for other scan-driven array-loop runners
@@ -150,9 +153,7 @@ class Step9DreamingConfig:
             move it. Set True only when dream TD errors should update rbar.
     """
 
-    control: Step6DifferentialSARSAConfig = field(
-        default_factory=Step6DifferentialSARSAConfig
-    )
+    control: Step6DifferentialSARSAConfig = field(default_factory=Step6DifferentialSARSAConfig)
     observation_dim: int = 4
     n_actions: int = 2
     model_hidden_sizes: tuple[int, ...] = (64,)
@@ -197,9 +198,7 @@ class Step9DreamingConfig:
             name="control payload",
             fields=frozenset(Step6DifferentialSARSAConfig.__dataclass_fields__),
         )
-        data["control"] = Step6DifferentialSARSAConfig.from_dict(
-            control_raw
-        )
+        data["control"] = Step6DifferentialSARSAConfig.from_dict(control_raw)
         hs = data["model_hidden_sizes"]
         if type(hs) is not list:
             raise ValueError("model_hidden_sizes payload must be an exact list")
@@ -310,9 +309,7 @@ def _require_exact_payload(
 
 def _require_sequence_length(name: str, count: int) -> None:
     if count > _MAX_CONFIG_SEQUENCE_LENGTH:
-        raise ValueError(
-            f"{name} must contain at most {_MAX_CONFIG_SEQUENCE_LENGTH} values"
-        )
+        raise ValueError(f"{name} must contain at most {_MAX_CONFIG_SEQUENCE_LENGTH} values")
 
 
 def _checked_product(name: str, *factors: int) -> int:
@@ -358,12 +355,8 @@ def _preflight_step9_resources(config: Step9DreamingConfig) -> None:
 
 def _preflight_step9_smoke_resources(config: Step9DreamingConfig, steps: int) -> None:
     rows = _checked_sum("Step 9 observation row count", steps, 1)
-    observations = _checked_product(
-        "Step 9 observation count", rows, config.observation_dim
-    )
-    dream_outputs = _checked_product(
-        "Step 9 dream output count", steps, config.planning_budget
-    )
+    observations = _checked_product("Step 9 observation count", rows, config.observation_dim)
+    dream_outputs = _checked_product("Step 9 dream output count", steps, config.planning_budget)
     _checked_sum(
         "Step 9 smoke array bytes",
         _checked_product("Step 9 observation bytes", 4, observations),
@@ -380,13 +373,10 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
     observation_dim = _require_int(
         "observation_dim", config.observation_dim, minimum=1, maximum=_INT32_MAX
     )
-    n_actions = _require_int(
-        "n_actions", config.n_actions, minimum=1, maximum=_INT32_MAX
-    )
+    n_actions = _require_int("n_actions", config.n_actions, minimum=1, maximum=_INT32_MAX)
     if config.control.n_actions != n_actions:
         raise ValueError(
-            f"control.n_actions ({config.control.n_actions}) must equal "
-            f"n_actions ({n_actions})"
+            f"control.n_actions ({config.control.n_actions}) must equal n_actions ({n_actions})"
         )
     if type(config.model_hidden_sizes) is not tuple:
         raise ValueError("model_hidden_sizes must be a tuple of integers")
@@ -426,20 +416,20 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         config.behavior_model_step_size,
     )
     planning_budget = _require_int(
-        "planning_budget", config.planning_budget, minimum=0, maximum=_INT32_MAX
+        "planning_budget", config.planning_budget, minimum=0, maximum=_MAX_STEP9_PLANNING_BUDGET
     )
     dream_rollout_horizon = _require_int(
         "dream_rollout_horizon",
         config.dream_rollout_horizon,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_MAX_STEP9_DREAM_ROLLOUT_HORIZON,
     )
     # Candidate selection publishes selected indices as signed int32 values.
     dream_candidate_count = _require_int(
         "dream_candidate_count",
         config.dream_candidate_count,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_MAX_STEP9_DREAM_CANDIDATE_COUNT,
     )
     dream_surprise_weight = _require_real(
         "dream_surprise_weight",
@@ -718,9 +708,8 @@ def step9_update(
     buffer_state = buffer.add(state.buffer_state, next_observation)
 
     warmup_ready = model_state.step_count >= config.dreaming_warmup_steps
-    error_ok = (
-        model_state.model_error_ema
-        <= jnp.asarray(config.dreaming_max_model_error, dtype=jnp.float32)
+    error_ok = model_state.model_error_ema <= jnp.asarray(
+        config.dreaming_max_model_error, dtype=jnp.float32
     )
     dream_gate = warmup_ready & error_ok
 
@@ -729,8 +718,8 @@ def step9_update(
         _: Array,
     ) -> tuple[tuple[DifferentialSARSAState, BehaviorModelState], tuple[Array, Array]]:
         ctrl_state, behavior_state = carry
-        next_master_key, candidate_key, behavior_rollout_key, control_rollout_key = (
-            jr.split(ctrl_state.rng_key, 4)
+        next_master_key, candidate_key, behavior_rollout_key, control_rollout_key = jr.split(
+            ctrl_state.rng_key, 4
         )
         candidate_keys = jr.split(candidate_key, config.dream_candidate_count)
 
@@ -739,17 +728,13 @@ def step9_update(
             del index
             anchor_key, sample_key = jr.split(cand_key)
             anchor_obs, _ = buffer.sample(buffer_state, anchor_key)
-            behavior_for_sample = behavior_state.replace(
-                rng_key=sample_key
-            )
+            behavior_for_sample = behavior_state.replace(rng_key=sample_key)
             behavior_sample = behavior_model.sample_action(
                 behavior_for_sample,
                 anchor_obs,
             )
             prediction = model.predict(model_state, anchor_obs, behavior_sample.action)
-            transition_magnitude = jnp.mean(
-                (prediction.next_observation - anchor_obs) ** 2
-            )
+            transition_magnitude = jnp.mean((prediction.next_observation - anchor_obs) ** 2)
             surprise = transition_magnitude + jnp.abs(prediction.reward)
             utility = jnp.abs(prediction.reward)
             return (
@@ -797,12 +782,8 @@ def step9_update(
         selected_index = selection.selected_indices[0]
         anchor_obs = candidate_anchors[selected_index]
         action = candidate_actions[selected_index]
-        initial_control_state = ctrl_state.replace(
-            rng_key=control_rollout_key
-        )
-        initial_behavior_state = behavior_state.replace(
-            rng_key=behavior_rollout_key
-        )
+        initial_control_state = ctrl_state.replace(rng_key=control_rollout_key)
+        initial_behavior_state = behavior_state.replace(rng_key=behavior_rollout_key)
 
         def rollout_step(
             rollout_carry: tuple[
@@ -816,9 +797,7 @@ def step9_update(
             tuple[DifferentialSARSAState, BehaviorModelState, Array, Array],
             tuple[Array, Array, Array],
         ]:
-            rollout_ctrl, rollout_behavior, rollout_obs, rollout_action = (
-                rollout_carry
-            )
+            rollout_ctrl, rollout_behavior, rollout_obs, rollout_action = rollout_carry
             prediction = model.predict(model_state, rollout_obs, rollout_action)
             temp_state = rollout_ctrl.replace(
                 last_observation=rollout_obs,
@@ -836,9 +815,7 @@ def step9_update(
                 # Planning backups improve value estimates only: restore the
                 # pre-dream reward-rate estimate so imagined rewards can never
                 # move rbar (see Step9DreamingConfig docstring).
-                dream_state = dream_state.replace(
-                    average_reward=rollout_ctrl.average_reward
-                )
+                dream_state = dream_state.replace(average_reward=rollout_ctrl.average_reward)
             next_behavior = behavior_model.sample_action(
                 rollout_behavior,
                 prediction.next_observation,
@@ -863,9 +840,7 @@ def step9_update(
             jnp.arange(config.dream_rollout_horizon, dtype=jnp.int32),
         )
         rollout_td_signal = jnp.sum(rollout_td_errors)
-        finite = jnp.all(jnp.isfinite(rollout_td_errors)) & jnp.all(
-            jnp.isfinite(rollout_discounts)
-        )
+        finite = jnp.all(jnp.isfinite(rollout_td_errors)) & jnp.all(jnp.isfinite(rollout_discounts))
         selected_discount = candidate_discounts[selected_index]
         selected_accepted = selection.accepted[selected_index]
         accepted = (
@@ -985,9 +960,7 @@ def run_step9_scan(
     except (AttributeError, IndexError, TypeError, ValueError) as error:
         raise TypeError("rewards must expose trusted shape metadata") from error
     if not 1 <= steps <= _STEP9_SEQUENCE_MAX_STEPS:
-        raise ValueError(
-            f"rewards length must be an integer in [1, {_STEP9_SEQUENCE_MAX_STEPS}]"
-        )
+        raise ValueError(f"rewards length must be an integer in [1, {_STEP9_SEQUENCE_MAX_STEPS}]")
     rewards = _require_step9_trusted_array("rewards", rewards, shape=(steps,), dtype=jnp.float32)
     next_observations = _require_step9_trusted_array(
         "next_observations",
@@ -1012,14 +985,17 @@ def run_step9_scan(
             result.dream_accepted,
         )
 
-    final_state, (
-        real_td_errors,
-        average_rewards,
-        actions,
-        model_prediction_errors,
-        model_updates_applied,
-        dream_td_errors,
-        dream_accepted,
+    (
+        final_state,
+        (
+            real_td_errors,
+            average_rewards,
+            actions,
+            model_prediction_errors,
+            model_updates_applied,
+            dream_td_errors,
+            dream_accepted,
+        ),
     ) = jax.lax.scan(scan_step, state, (rewards, next_observations))
     return Step9ArrayResult(
         state=final_state,

--- a/tests/test_step7_hostile_validation.py
+++ b/tests/test_step7_hostile_validation.py
@@ -136,7 +136,9 @@ def test_rejects_hostile_int_metaclass_without_hooks() -> None:
 def test_rejects_hostile_float_without_hook_and_repr_leak() -> None:
     _HostileFloat.calls = 0
     with pytest.raises(ValueError, match="must be") as exc:
-        Step7DynaConfig(**{**_valid_config_kwargs(), "planning_utility_step_size": _HostileFloat(0.1)})  # type: ignore[arg-type]  # noqa: E501
+        Step7DynaConfig(
+            **{**_valid_config_kwargs(), "planning_utility_step_size": _HostileFloat(0.1)}
+        )  # type: ignore[arg-type]  # noqa: E501
     assert _HostileFloat.calls == 0
     assert "HostileFloat" not in str(exc.value)
     assert "!r" not in str(exc.value)
@@ -293,3 +295,19 @@ def test_smoke_preflights_all_live_arrays_before_allocation(
     monkeypatch.setattr(jr, "normal", unexpected_allocation)
     with pytest.raises(ValueError, match="smoke resources"):
         run_step7_smoke(steps=50_000_000)
+
+
+def test_step7_rejects_oversized_planning_steps_and_rollout_depth() -> None:
+    control, world = _control_world()
+    with pytest.raises(ValueError, match="planning_steps"):
+        Step7DynaConfig(control=control, world_model=world, planning_steps=10_001)
+
+    with pytest.raises(ValueError, match="planning_rollout_depth"):
+        Step7DynaConfig(control=control, world_model=world, planning_rollout_depth=10_001)
+
+    # Boundary cases accepted:
+    cfg_max = Step7DynaConfig(
+        control=control, world_model=world, planning_steps=10_000, planning_rollout_depth=10_000
+    )
+    assert cfg_max.planning_steps == 10_000
+    assert cfg_max.planning_rollout_depth == 10_000

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -131,7 +131,10 @@ def _init(cfg: Step7DynaConfig | None = None) -> tuple[object, object, Step7Dyna
     agent, model = make_step7_components(cfg)
     obs0 = jnp.zeros(OBS_DIM)
     state = init_step7_state(
-        agent, model, key=jr.key(0), initial_observation=obs0,
+        agent,
+        model,
+        key=jr.key(0),
+        initial_observation=obs0,
         memory_size=cfg.planning_memory_size,
     )
     return agent, model, state
@@ -586,9 +589,7 @@ class TestScorePlanningActions:
         state = model.init(jr.key(7))
         obs = jr.normal(jr.key(8), (OBS_DIM,), dtype=jnp.float32)
         next_obs = jr.normal(jr.key(9), (OBS_DIM,), dtype=jnp.float32)
-        result = model.update(
-            state, obs, jnp.array(1, dtype=jnp.int32), jnp.array(0.7), next_obs
-        )
+        result = model.update(state, obs, jnp.array(1, dtype=jnp.int32), jnp.array(0.7), next_obs)
         return result.state
 
     def test_reward_strategy_score_is_selected_abs_reward(self) -> None:
@@ -597,17 +598,11 @@ class TestScorePlanningActions:
         model_state = self._trained_model_state(model)
         anchor = jr.normal(jr.key(10), (OBS_DIM,), dtype=jnp.float32)
 
-        selected, score = _score_planning_actions(
-            model, model_state, anchor, "reward", N_ACTIONS
-        )
+        selected, score = _score_planning_actions(model, model_state, anchor, "reward", N_ACTIONS)
 
         rewards = jnp.array(
             [
-                jnp.abs(
-                    model.predict(
-                        model_state, anchor, jnp.array(a, dtype=jnp.int32)
-                    ).reward
-                )
+                jnp.abs(model.predict(model_state, anchor, jnp.array(a, dtype=jnp.int32)).reward)
                 for a in range(N_ACTIONS)
             ]
         )
@@ -620,13 +615,9 @@ class TestScorePlanningActions:
         model_state = self._trained_model_state(model)
         anchor = jr.normal(jr.key(11), (OBS_DIM,), dtype=jnp.float32)
 
-        selected, score = _score_planning_actions(
-            model, model_state, anchor, "surprise", N_ACTIONS
-        )
+        selected, score = _score_planning_actions(model, model_state, anchor, "surprise", N_ACTIONS)
 
-        prediction = model.predict(
-            model_state, anchor, jnp.asarray(selected, dtype=jnp.int32)
-        )
+        prediction = model.predict(model_state, anchor, jnp.asarray(selected, dtype=jnp.int32))
         expected = jnp.abs(prediction.reward) + jnp.sqrt(
             jnp.mean((prediction.next_observation - anchor) ** 2)
         )
@@ -673,9 +664,9 @@ def test_step7_dyna_preserves_float32_boundaries() -> None:
 
 
 def test_step7_dyna_rejects_derived_work_and_memory_resources() -> None:
-    with pytest.raises(ValueError, match="derived planning evaluations"):
+    with pytest.raises(ValueError, match="planning_steps|derived planning evaluations"):
         Step7DynaConfig(planning_steps=2**30, planning_rollout_depth=2)
-    with pytest.raises(ValueError, match="planning output bytes"):
+    with pytest.raises(ValueError, match="planning_steps|planning output bytes"):
         Step7DynaConfig(planning_steps=2**26, planning_rollout_depth=1)
     with pytest.raises(ValueError, match="planning-memory bytes"):
         Step7DynaConfig(planning_memory_size=2**28)
@@ -764,8 +755,7 @@ def test_step7_dyna_json_roundtrip() -> None:
     assert restored.planning_strategy == config.planning_strategy
     assert restored.planning_importance_ratio_clip == config.planning_importance_ratio_clip
     assert (
-        restored.planning_apply_importance_correction
-        == config.planning_apply_importance_correction
+        restored.planning_apply_importance_correction == config.planning_apply_importance_correction
     )
     assert restored.planning_priority_propagation == config.planning_priority_propagation
     assert restored.planning_utility_step_size == config.planning_utility_step_size

--- a/tests/test_step9_hostile_validation.py
+++ b/tests/test_step9_hostile_validation.py
@@ -333,9 +333,7 @@ def test_run_step9_scan_rejects_origin_hang_class_before_scan(
     """A far larger sequence length -- the actual hang class -- is also
     rejected before ``jax.lax.scan`` is ever called."""
     seen = _spy_scan(monkeypatch)
-    cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(
-        200_000
-    )
+    cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(200_000)
     with pytest.raises(ValueError, match="rewards length must be an integer in"):
         run_step9_scan(cfg, agent, model, buffer, state, rewards, next_observations)
     assert seen == []
@@ -358,9 +356,7 @@ def test_run_step9_scan_rejects_non_config_type_before_scan(
     seen = _spy_scan(monkeypatch)
     _cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(5)
     with pytest.raises(TypeError, match="actual Step9DreamingConfig"):
-        run_step9_scan(
-            cast(Any, object()), agent, model, buffer, state, rewards, next_observations
-        )
+        run_step9_scan(cast(Any, object()), agent, model, buffer, state, rewards, next_observations)
     assert seen == []
 
 
@@ -409,3 +405,22 @@ def test_run_step9_scan_accepts_a_small_in_bounds_sequence() -> None:
     cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(4)
     result = run_step9_scan(cfg, agent, model, buffer, state, rewards, next_observations)
     assert result.real_td_errors.shape == (4,)
+
+
+def test_step9_rejects_oversized_planning_budget_rollout_and_candidate_count() -> None:
+    with pytest.raises(ValueError, match="planning_budget"):
+        Step9DreamingConfig(planning_budget=10_001)
+
+    with pytest.raises(ValueError, match="dream_rollout_horizon"):
+        Step9DreamingConfig(dream_rollout_horizon=10_001)
+
+    with pytest.raises(ValueError, match="dream_candidate_count"):
+        Step9DreamingConfig(dream_candidate_count=10_001)
+
+    # Boundary cases accepted:
+    cfg_max = Step9DreamingConfig(
+        planning_budget=0, dream_rollout_horizon=10_000, dream_candidate_count=10_000
+    )
+    assert cfg_max.planning_budget == 0
+    assert cfg_max.dream_rollout_horizon == 10_000
+    assert cfg_max.dream_candidate_count == 10_000


### PR DESCRIPTION
Fixes #2214

## Summary
In `alberta_framework/steps/step7.py` and `alberta_framework/steps/step9.py`:
Config validators permitted `planning_steps`, `planning_rollout_depth`, `planning_budget`, `dream_rollout_horizon`, and `dream_candidate_count` up to `_INT32_MAX` before driving `jnp.arange` and `lax.scan` / `vmap`, leading to memory exhaustion or hangs during JAX trace time for hostile or oversized configs.

## Proposed Changes
1. Capped `planning_steps` and `planning_rollout_depth` to $10,000$ in `alberta_framework/steps/step7.py`.
2. Capped `planning_budget`, `dream_rollout_horizon`, and `dream_candidate_count` to $10,000$ in `alberta_framework/steps/step9.py`.
3. Extended `tests/test_step7_hostile_validation.py` and `tests/test_step9_hostile_validation.py` to verify rejection of values exceeding the ceiling.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_step7_hostile_validation.py tests/test_step7_production.py tests/test_step9_hostile_validation.py tests/test_step9_production.py` (348/348 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/steps/step7.py alberta_framework/steps/step9.py tests/test_step7_hostile_validation.py tests/test_step7_production.py tests/test_step9_hostile_validation.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/steps/step7.py alberta_framework/steps/step9.py` (clean).
