### PR TITLE
fix(core): bound n_dreams_per_step in PrototypeAgentConfig before arange scan

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -184,6 +184,7 @@ _PROTOTYPE_V2_REPLAY_MIGRATION_TAG = 0x50525632
 _PROTOTYPE_FEATURE_LIFECYCLE_KEY_TAG = 0x50464C43
 _UINT32_MAX = 2**32 - 1
 _INT32_MAX = 2**31 - 1
+_MAX_PROTOTYPE_DREAMS_PER_STEP = 10_000
 
 # ---------------------------------------------------------------------------
 # Standalone utility
@@ -725,7 +726,7 @@ class PrototypeAgentConfig:
                 "n_dreams_per_step",
                 self.n_dreams_per_step,
                 minimum=0,
-                maximum=_INT32_MAX,
+                maximum=_MAX_PROTOTYPE_DREAMS_PER_STEP,
             ),
         )
         # horde_hidden_sizes: hostile-safe per-element validation
@@ -1335,7 +1336,10 @@ class PrototypeAgentConfig:
             "buffer_capacity", data.pop("buffer_capacity", 200), minimum=1, maximum=_INT32_MAX
         )
         n_dreams_per_step = _require_int(
-            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=_INT32_MAX
+            "n_dreams_per_step",
+            data.pop("n_dreams_per_step", 0),
+            minimum=0,
+            maximum=_MAX_PROTOTYPE_DREAMS_PER_STEP,
         )
         dream_next_observation_mode = data.pop(
             "dream_next_observation_mode",

--- a/tests/test_prototype_agent_validation.py
+++ b/tests/test_prototype_agent_validation.py
@@ -303,3 +303,27 @@ def test_prototype_valid_construction() -> None:
     assert restored == cfg
     gru = GRUPerceptionConfig(observation_dim=4, hidden_dim=4)
     assert gru.augmented_dim() == 8
+
+def test_prototype_agent_rejects_oversized_n_dreams_per_step() -> None:
+    from alberta_framework.core.prototype_agent import (
+        _MAX_PROTOTYPE_DREAMS_PER_STEP,
+        PrototypeAgentConfig,
+    )
+
+    assert _MAX_PROTOTYPE_DREAMS_PER_STEP == 10_000
+
+    oak = _oak(obs_dim=2)
+    wm = _world_model(2)
+    with pytest.raises(ValueError, match="n_dreams_per_step"):
+        PrototypeAgentConfig(oak=oak, world_model=wm, n_dreams_per_step=10_001)
+
+    # Boundary case accepted:
+    cfg = PrototypeAgentConfig(oak=oak, world_model=wm, n_dreams_per_step=10_000)
+    assert cfg.n_dreams_per_step == 10_000
+
+    # Deserialization rejects oversized values:
+    serialized = cfg.to_config()
+    serialized["n_dreams_per_step"] = 10_001
+    with pytest.raises(ValueError, match="n_dreams_per_step"):
+        PrototypeAgentConfig.from_config(serialized)
+


### PR DESCRIPTION
Fixes #2441

## Summary
In `alberta_framework/core/prototype_agent.py`:
`PrototypeAgentConfig.n_dreams_per_step` was validated up to `_INT32_MAX` during initialization and deserialization (`from_config`), which then directly drives `jnp.arange(self._config.n_dreams_per_step)` feeding `jax.lax.scan(_dream_step, ...)`. Extreme integer values lead to multi-gigabyte buffer materializations and JAX compile hangs/OOMs.

## Proposed Changes
1. Defined `_MAX_PROTOTYPE_DREAMS_PER_STEP = 10_000`, matching peer scan budget limits in `core/dreaming.py` and `steps/step9.py`.
2. Enforced `maximum=_MAX_PROTOTYPE_DREAMS_PER_STEP` on `n_dreams_per_step` in `PrototypeAgentConfig.__post_init__` and `PrototypeAgentConfig.from_config`.
3. Extended `tests/test_prototype_agent_validation.py` to verify that values exceeding $10,000$ are rejected during construction and deserialization.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_prototype_agent_validation.py tests/test_prototype_agent.py` (126/126 passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/core/prototype_agent.py tests/test_prototype_agent_validation.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/core/prototype_agent.py` (clean).
