### PR TITLE
fix(benchmarks): validate shard arm name and stage task count in rule_discovery_summary

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery_summary.py
+++ b/alberta_framework/benchmarks/rule_discovery_summary.py
@@ -37,18 +37,30 @@ DISCOVERY_ARMS = (
 CHAMPION = "sigma0_shiftnorm_d099"
 
 
-def _arm(directory: Path, name: str, seeds: Sequence[int]) -> dict[str, Any]:
+def _arm(
+    directory: Path,
+    name: str,
+    seeds: Sequence[int],
+    *,
+    expected_tasks: int | None = None,
+) -> dict[str, Any]:
     values = []
     for seed in seeds:
         path = directory / f"{name}_seed{seed}.json"
         if not path.exists():
             raise ValueError(f"{name} is missing seed {seed} in {directory}")
         payload = load_strict_json_object(path)
-        if (
-            type(payload.get("per_task_accuracy")) is not list
-            or not payload["per_task_accuracy"]
-        ):
+        if "config_name" in payload and payload["config_name"] != name:
+            raise ValueError(
+                f"{path} config_name '{payload['config_name']}' "
+                f"does not match expected arm '{name}'"
+            )
+        if type(payload.get("per_task_accuracy")) is not list or not payload["per_task_accuracy"]:
             raise ValueError(f"{path} lacks per_task_accuracy")
+        if expected_tasks is not None and len(payload["per_task_accuracy"]) != expected_tasks:
+            raise ValueError(
+                f"{path} has {len(payload['per_task_accuracy'])} tasks, expected {expected_tasks}"
+            )
         payload_seed = require_jax_seed(payload.get("seed"), name=f"{path} seed")
         if payload_seed != seed:
             raise ValueError(f"{path} seed does not match requested seed {seed}")
@@ -71,7 +83,7 @@ def build_legacy_rule_discovery_summary(
 ) -> dict[str, Any]:
     """Reconstruct the exact legacy v1 payload for compatibility checks."""
     seeds = require_unique_jax_seeds(seeds)
-    screen = {name: _arm(screen_dir, name, seeds) for name in SCREEN_ARMS}
+    screen = {name: _arm(screen_dir, name, seeds, expected_tasks=60) for name in SCREEN_ARMS}
     confirm_names = ("disc_r1_pscale_norms", CHAMPION)
     present = [
         (confirm_dir / f"{name}_seed{seed}.json").exists()
@@ -81,7 +93,7 @@ def build_legacy_rule_discovery_summary(
     if any(present) and not all(present):
         raise ValueError("rule-discovery confirmation seeds are incomplete")
     full = (
-        {name: _arm(confirm_dir, name, seeds) for name in confirm_names}
+        {name: _arm(confirm_dir, name, seeds, expected_tasks=200) for name in confirm_names}
         if all(present)
         else {}
     )
@@ -129,9 +141,7 @@ def build_rule_discovery_summary(
 ) -> dict[str, Any]:
     """Build the maintained v2 summary with explicit legacy compatibility."""
     seeds = require_unique_jax_seeds(seeds)
-    legacy = build_legacy_rule_discovery_summary(
-        screen_dir, confirm_dir, seeds=seeds
-    )
+    legacy = build_legacy_rule_discovery_summary(screen_dir, confirm_dir, seeds=seeds)
     legacy_canonical = json.dumps(
         legacy, sort_keys=True, separators=(",", ":"), allow_nan=False
     ).encode()
@@ -172,9 +182,7 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Emit a nonpromoting summary to stdout without modifying artifacts."""
     args = _parser().parse_args(argv)
-    result = build_rule_discovery_summary(
-        args.screen_dir, args.confirm_dir, seeds=args.seeds
-    )
+    result = build_rule_discovery_summary(args.screen_dir, args.confirm_dir, seeds=args.seeds)
     print(json.dumps(result, indent=2, sort_keys=True, allow_nan=False))
     return 0
 

--- a/tests/test_rule_discovery_summary.py
+++ b/tests/test_rule_discovery_summary.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.rule_discovery_summary import (
+    CHAMPION,
+    SCREEN_ARMS,
+    build_rule_discovery_summary,
+)
+
+
+def _write_shard(path: Path, arm: str, seed: int, n_tasks: int) -> None:
+    payload = {
+        "config_name": arm,
+        "seed": seed,
+        "per_task_accuracy": [0.85] * n_tasks,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_rule_discovery_summary_validates_arm_name_and_task_count(tmp_path: Path) -> None:
+    screen_dir = tmp_path / "screen"
+    confirm_dir = tmp_path / "confirm"
+    screen_dir.mkdir()
+    confirm_dir.mkdir()
+
+    # Populate valid screen directory (60 tasks)
+    for name in SCREEN_ARMS:
+        _write_shard(screen_dir / f"{name}_seed0.json", name, 0, 60)
+
+    # Populate valid confirm directory (200 tasks)
+    for name in ("disc_r1_pscale_norms", CHAMPION):
+        _write_shard(confirm_dir / f"{name}_seed0.json", name, 0, 200)
+
+    res = build_rule_discovery_summary(screen_dir, confirm_dir, seeds=(0,))
+    assert res["schema"] == "asi.rule_discovery.real_screen.v2"
+    assert "disc_r1" in res["screen_60_task"]
+
+    # Reject mismatched arm name
+    bad_shard = screen_dir / "disc_r1_seed0.json"
+    _write_shard(bad_shard, "sigma0_shiftnorm_d099", 0, 60)
+    with pytest.raises(ValueError, match="does not match expected arm"):
+        build_rule_discovery_summary(screen_dir, confirm_dir, seeds=(0,))
+
+    # Fix arm name but use wrong task count (e.g. 200 tasks in screen)
+    _write_shard(bad_shard, "disc_r1", 0, 200)
+    with pytest.raises(ValueError, match="tasks, expected 60"):
+        build_rule_discovery_summary(screen_dir, confirm_dir, seeds=(0,))
+
+    # Fix screen shard, then test wrong task count in confirm (e.g. 60 tasks in confirm)
+    _write_shard(bad_shard, "disc_r1", 0, 60)
+    bad_confirm = confirm_dir / "disc_r1_pscale_norms_seed0.json"
+    _write_shard(bad_confirm, "disc_r1_pscale_norms", 0, 60)
+    with pytest.raises(ValueError, match="tasks, expected 200"):
+        build_rule_discovery_summary(screen_dir, confirm_dir, seeds=(0,))


### PR DESCRIPTION
Fixes #2134

## Summary
In `alberta_framework/benchmarks/rule_discovery_summary.py`:
`_arm` loaded shards by target filename pattern (`{name}_seed{seed}.json`) but only checked the seed and `per_task_accuracy` array values. It did not verify that the payload `config_name` matched the expected arm name, nor did it verify the required task count (60 tasks for screening, 200 tasks for confirmation), allowing misattributed or mis-staged shards to be silently accepted.

## Proposed Changes
1. Added validation in `_arm` that `payload["config_name"] == name` when present.
2. Added `expected_tasks` validation in `_arm` to enforce exactly 60 tasks in `screen_60_task` and 200 tasks in `confirm_200_task`.
3. Created test suite in `tests/test_rule_discovery_summary.py` verifying detection and rejection of mismatched arm names and stage task counts.

## Verification
- Ran pytest: `/opt/homebrew/bin/uv run pytest -o pythonpath=. tests/test_rule_discovery_summary.py` (passed).
- Ran ruff: `/opt/homebrew/bin/uv run ruff check alberta_framework/benchmarks/rule_discovery_summary.py tests/test_rule_discovery_summary.py` (clean).
- Ran mypy: `/opt/homebrew/bin/uv run mypy --follow-imports=silent alberta_framework/benchmarks/rule_discovery_summary.py` (clean).
