### PR TITLE
fix(steps): preserve zero planning weights across overflow

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -956,14 +956,19 @@ def _apply_planning_importance_correction(
         DifferentialSARSAState,
         planned_state.replace(  # type: ignore[attr-defined]
             q_weights=old_state.q_weights
-            + rho * (planned_state.q_weights - old_state.q_weights),
-            q_bias=old_state.q_bias + rho * (planned_state.q_bias - old_state.q_bias),
+            + _skip_zero_scale(rho, planned_state.q_weights - old_state.q_weights),
+            q_bias=old_state.q_bias
+            + _skip_zero_scale(rho, planned_state.q_bias - old_state.q_bias),
             q_trace_weights=old_state.q_trace_weights
-            + rho * (planned_state.q_trace_weights - old_state.q_trace_weights),
+            + _skip_zero_scale(
+                rho, planned_state.q_trace_weights - old_state.q_trace_weights
+            ),
             q_trace_bias=old_state.q_trace_bias
-            + rho * (planned_state.q_trace_bias - old_state.q_trace_bias),
+            + _skip_zero_scale(rho, planned_state.q_trace_bias - old_state.q_trace_bias),
             average_reward=old_state.average_reward
-            + rho * (planned_state.average_reward - old_state.average_reward),
+            + _skip_zero_scale(
+                rho, planned_state.average_reward - old_state.average_reward
+            ),
         ),
     )
 

--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -841,16 +841,37 @@ def _select_planning_anchor(
     return anchor, index, jnp.where(memory_count > 0, score, 0.0)
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Return ``scale * value``, or exact zero when ``scale`` is zero.
+
+    A zero blend weight means the term is not applied at all, so it must
+    contribute zero even when ``value`` is non-finite.  Taking the raw
+    product first turns ``0 * inf`` into ``NaN``.
+    """
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _update_planning_utility(
     memory_utilities: Array,
     index: Array,
     td_signal: Array,
     step_size: float,
 ) -> Array:
-    """Update learned search-control utility for a planned transition."""
+    """Update learned search-control utility for a planned transition.
+
+    Both blend weights are skipped at exactly zero.  ``step_size`` is a
+    validated unit-interval real, so ``0.0`` (freeze the utility) and
+    ``1.0`` (replace it outright) are both admissible, while
+    ``td_signal`` comes from an unclamped imagined rollout and can be
+    non-finite.  Without the skip, the ignored term's ``0 * inf`` wrote
+    ``NaN`` into the stored utility, and a ``NaN`` utility poisons the
+    ``learned`` strategy's ranking for the rest of the run.
+    """
     alpha = jnp.asarray(step_size, dtype=jnp.float32)
     old_utility = memory_utilities[index]
-    new_utility = (1.0 - alpha) * old_utility + alpha * jnp.abs(td_signal)
+    retained = _skip_zero_scale(1.0 - alpha, old_utility)
+    applied = _skip_zero_scale(alpha, jnp.abs(td_signal))
+    new_utility = retained + applied
     return memory_utilities.at[index].set(new_utility)
 
 

--- a/tests/test_initializers_validation.py
+++ b/tests/test_initializers_validation.py
@@ -158,7 +158,7 @@ def test_sparse_init_accepts_valid_init_types() -> None:
 
 
 def test_sparse_init_preflight_without_allocation(monkeypatch: pytest.MonkeyPatch) -> None:
-    class AllocationReached(Exception):
+    class AllocationReachedError(Exception):
         pass
 
     requested_shapes: list[tuple[int, int]] = []
@@ -168,7 +168,7 @@ def test_sparse_init_preflight_without_allocation(monkeypatch: pytest.MonkeyPatc
     ) -> NoReturn:
         requested_shapes.append(shape)
         assert kwargs["dtype"] == jnp.float32
-        raise AllocationReached
+        raise AllocationReachedError
 
     # Test the byte boundary without constructing a roughly 2 GiB matrix and
     # its initialization intermediates. Real small-shape initialization stays
@@ -184,6 +184,6 @@ def test_sparse_init_preflight_without_allocation(monkeypatch: pytest.MonkeyPatc
     # The exact last representable element count passes validation and reaches
     # the allocator with the requested shape, while one more was rejected.
     last_fit_shape = (1, max_elements)
-    with pytest.raises(AllocationReached):
+    with pytest.raises(AllocationReachedError):
         sparse_init(key, last_fit_shape)
     assert requested_shapes == [last_fit_shape]

--- a/tests/test_initializers_validation.py
+++ b/tests/test_initializers_validation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import NoReturn
+
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -155,15 +157,33 @@ def test_sparse_init_accepts_valid_init_types() -> None:
     assert w_normal.shape == (4, 4)
 
 
-def test_sparse_init_preflight_without_allocation() -> None:
+def test_sparse_init_preflight_without_allocation(monkeypatch: pytest.MonkeyPatch) -> None:
+    class AllocationReached(Exception):
+        pass
+
+    requested_shapes: list[tuple[int, int]] = []
+
+    def stop_at_allocation(
+        key: object, shape: tuple[int, int], **kwargs: object
+    ) -> NoReturn:
+        requested_shapes.append(shape)
+        assert kwargs["dtype"] == jnp.float32
+        raise AllocationReached
+
+    # Test the byte boundary without constructing a roughly 2 GiB matrix and
+    # its initialization intermediates. Real small-shape initialization stays
+    # covered by the tests above; this test isolates the allocation preflight.
+    monkeypatch.setattr(jr, "uniform", stop_at_allocation)
     key = jr.key(0)
-    # Large dims that would overflow int32 bytes
-    with pytest.raises(ValueError, match="byte count"):
-        sparse_init(key, (_INT32_MAX, 2))
-    with pytest.raises(ValueError, match="byte count"):
-        sparse_init(key, (50000, 50000))
-    # Legal edge passes
-    legal = _INT32_MAX // 4
-    dim = int(legal**0.5)
-    weights = sparse_init(key, (dim, dim))
-    assert weights.shape == (dim, dim)
+    max_elements = _INT32_MAX // np.dtype(np.float32).itemsize
+    for invalid_shape in ((_INT32_MAX, 2), (50_000, 50_000), (1, max_elements + 1)):
+        with pytest.raises(ValueError, match="byte count"):
+            sparse_init(key, invalid_shape)
+    assert requested_shapes == []
+
+    # The exact last representable element count passes validation and reaches
+    # the allocator with the requested shape, while one more was rejected.
+    last_fit_shape = (1, max_elements)
+    with pytest.raises(AllocationReached):
+        sparse_init(key, last_fit_shape)
+    assert requested_shapes == [last_fit_shape]

--- a/tests/test_step7_planning_utility_zero_blend.py
+++ b/tests/test_step7_planning_utility_zero_blend.py
@@ -1,0 +1,48 @@
+"""Zero-blend regression for the Step 7 learned search-control utility."""
+
+import jax.numpy as jnp
+
+from alberta_framework.steps.step7 import _update_planning_utility
+
+
+def _utilities() -> tuple[jnp.ndarray, jnp.ndarray]:
+    return jnp.zeros(4, dtype=jnp.float32), jnp.array(1, dtype=jnp.int32)
+
+
+def test_zero_step_size_keeps_the_stored_utility_under_infinite_td() -> None:
+    utilities, index = _utilities()
+    utilities = utilities.at[index].set(jnp.float32(0.75))
+    td_signal = jnp.array(jnp.inf, dtype=jnp.float32)
+    alpha = jnp.float32(0.0)
+
+    # The raw applied term is the 0*inf that used to poison the utility.
+    assert not bool(jnp.isfinite(alpha * jnp.abs(td_signal)))
+
+    updated = _update_planning_utility(utilities, index, td_signal, 0.0)
+    assert bool(jnp.all(jnp.isfinite(updated)))
+    assert float(updated[index]) == 0.75
+
+
+def test_unit_step_size_replaces_an_infinite_stored_utility() -> None:
+    utilities, index = _utilities()
+    utilities = utilities.at[index].set(jnp.array(jnp.inf, dtype=jnp.float32))
+    td_signal = jnp.array(-2.0, dtype=jnp.float32)
+    retained_scale = jnp.float32(1.0) - jnp.float32(1.0)
+
+    # The raw retained term is the 0*inf that used to poison the utility.
+    assert not bool(jnp.isfinite(retained_scale * utilities[index]))
+
+    updated = _update_planning_utility(utilities, index, td_signal, 1.0)
+    assert bool(jnp.all(jnp.isfinite(updated)))
+    assert float(updated[index]) == 2.0
+
+
+def test_interior_step_size_still_blends_exactly() -> None:
+    utilities, index = _utilities()
+    utilities = utilities.at[index].set(jnp.float32(1.0))
+    td_signal = jnp.array(-3.0, dtype=jnp.float32)
+
+    updated = _update_planning_utility(utilities, index, td_signal, 0.25)
+    expected = jnp.float32(0.75) * jnp.float32(1.0) + jnp.float32(0.25) * jnp.float32(3.0)
+    assert float(updated[index]) == float(expected)
+    assert float(updated[0]) == 0.0

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -823,3 +823,39 @@ def test_step7_smoke_result_rejects_leftover_identities() -> None:
     assert '"seed": true' not in dumped
     assert '"finite": 1' not in dumped
     assert '"planning_acceptance_count": true' not in dumped
+
+
+def test_zero_importance_ratio_does_not_multiply_overflowing_planning_delta() -> None:
+    """Finite opposite endpoints can overflow their difference even when rho is zero."""
+    from alberta_framework.core.average_reward import (
+        DifferentialSARSAAgent,
+        DifferentialSARSAConfig,
+    )
+    from alberta_framework.steps.step7 import _apply_planning_importance_correction
+
+    agent = DifferentialSARSAAgent(DifferentialSARSAConfig(n_actions=2))
+    old = agent.init(3, jr.key(0))
+    maximum = jnp.finfo(jnp.float32).max
+    old = old.replace(q_weights=jnp.full_like(old.q_weights, -maximum))
+    planned = old.replace(  # type: ignore[attr-defined]
+        q_weights=jnp.full_like(old.q_weights, maximum),
+        q_bias=jnp.full_like(old.q_bias, maximum),
+        q_trace_weights=jnp.full_like(old.q_trace_weights, maximum),
+        q_trace_bias=jnp.full_like(old.q_trace_bias, maximum),
+        average_reward=jnp.asarray(maximum, dtype=jnp.float32),
+    )
+    raw = jnp.asarray(0.0, dtype=jnp.float32) * (
+        jnp.asarray(maximum, dtype=jnp.float32) - jnp.asarray(-maximum, dtype=jnp.float32)
+    )
+    assert not bool(jnp.isfinite(raw))
+
+    corrected = _apply_planning_importance_correction(
+        old, planned, jnp.asarray(0.0, dtype=jnp.float32)
+    )
+    chex.assert_trees_all_close(corrected.q_weights, old.q_weights)
+    chex.assert_trees_all_close(corrected.q_bias, old.q_bias)
+    chex.assert_trees_all_close(corrected.q_trace_weights, old.q_trace_weights)
+    chex.assert_trees_all_close(corrected.q_trace_bias, old.q_trace_bias)
+    chex.assert_trees_all_close(corrected.average_reward, old.average_reward)
+    chex.assert_tree_all_finite(corrected.q_weights)
+    chex.assert_tree_all_finite(corrected.average_reward)


### PR DESCRIPTION
Zero planning weights must preserve their inactive terms even when an ignored signal overflows. Step 7 previously wrote NaN when a utility EMA endpoint multiplied infinity by zero, or when zero importance correction multiplied the overflowing difference between two finite states.

Use one shared zero-scale helper for utility blending and importance correction. Nonzero terms retain their existing arithmetic. This incorporates the useful correction from #2559 and strengthens its regression to use finite opposite endpoints rather than an infinite planned state.

Validation: the finite-endpoint regression fails on the previous branch; all 142 Step 7 production, hostile-validation, and utility tests pass with the combined fix. Ruff and diff checks pass. No evidence promotion or pinned artifact changes.
