### PR TITLE
fix(core): skip zero step size before scaling an overflowing option-duration TD error

### DIFF
--- a/alberta_framework/core/option_value_duration.py
+++ b/alberta_framework/core/option_value_duration.py
@@ -117,6 +117,14 @@ def _state_resources(n_options: int, feature_dim: int) -> dict[str, int]:
     }
 
 
+def _skip_zero_scale(scale: float, value: Array) -> Array:
+    """Keep finite multiplication exact while repairing zero-scaled poison."""
+    product = jnp.asarray(scale, dtype=jnp.float32) * value
+    if scale != 0.0:
+        return product
+    return jnp.where(jnp.isfinite(value), product, jnp.zeros_like(value))
+
+
 def _saturating_increment(value: Array) -> Array:
     """Increment an int32 counter without wrapping at its lifetime limit."""
     maximum = jnp.asarray(_INT32_MAX, dtype=jnp.int32)
@@ -500,15 +508,14 @@ class OptionValueDurationLearner:
         )
         td_targets = cumulants + bootstrap
         td_errors = td_targets - predictions
-        step_sizes = jnp.array(
-            [
-                self._config.reward_step_size,
-                self._config.duration_step_size,
-            ],
-            dtype=jnp.float32,
+        scaled_td_errors = jnp.stack(
+            (
+                _skip_zero_scale(self._config.reward_step_size, td_errors[0]),
+                _skip_zero_scale(self._config.duration_step_size, td_errors[1]),
+            )
         )
         proposed_option_weights = (
-            option_weights + step_sizes[:, None] * td_errors[:, None] * observation[None, :]
+            option_weights + scaled_td_errors[:, None] * observation[None, :]
         )
         source_valid = self._state_values_valid(state)
         next_needed = continuation_discount != 0.0

--- a/tests/test_option_value_duration.py
+++ b/tests/test_option_value_duration.py
@@ -754,3 +754,96 @@ def test_array_runner_accepts_jax_arrays_under_jit() -> None:
     )
     result = compiled(observations, option_indices, rewards, observations, discounts)
     chex.assert_tree_all_finite(result.predictions)
+
+
+def test_zero_step_size_head_commits_no_op_update_on_overflowing_td_error() -> None:
+    """A frozen head must not stall lifetime counters when the TD error overflows.
+
+    ``reward_step_size``/``duration_step_size`` accept ``0.0``, so a head can be
+    deliberately frozen. Scaling an overflowed float32 TD error by that zero
+    step size evaluates ``0 * inf`` and poisons the proposed weights, which used
+    to reject the whole transition even though every validated input was finite.
+    """
+    config = OptionValueDurationConfig(
+        reward_step_size=0.0,
+        duration_step_size=0.0,
+    )
+    learner = OptionValueDurationLearner(1, config)
+    weights = jnp.full((1, 2, 2), 3.0e38, dtype=jnp.float32)
+    state = learner.init(2).replace(weights=weights)  # type: ignore[attr-defined]
+    observation = jnp.array([1.0, 1.0], dtype=jnp.float32)
+    next_observation = jnp.array([0.0, 0.0], dtype=jnp.float32)
+
+    # Every validated input is finite; only the float32 dot product overflows.
+    assert bool(jnp.all(jnp.isfinite(state.weights)))
+    assert bool(jnp.all(jnp.isfinite(observation)))
+    assert not bool(jnp.all(jnp.isfinite(state.weights[0] @ observation)))
+    assert bool(jnp.isnan(jnp.float32(0.0) * jnp.float32(-jnp.inf)))
+
+    result = jax.jit(learner.update)(
+        state,
+        observation,
+        jnp.array(0, dtype=jnp.int32),
+        jnp.array(1.0, dtype=jnp.float32),
+        next_observation,
+        jnp.array(0.9, dtype=jnp.float32),
+    )
+
+    assert bool(jnp.all(result.head_updates_applied))
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 1
+    chex.assert_trees_all_equal(
+        result.state.option_update_counts,
+        jnp.array([1], dtype=jnp.int32),
+    )
+    chex.assert_trees_all_equal(result.state.weights, weights)
+    assert bool(jnp.all(jnp.isfinite(result.state.weights)))
+
+
+def test_nonzero_step_size_still_rejects_overflowing_td_error() -> None:
+    """A learning head keeps its fail-closed rejection of an infinite update."""
+    config = OptionValueDurationConfig(
+        reward_step_size=0.1,
+        duration_step_size=0.1,
+    )
+    learner = OptionValueDurationLearner(1, config)
+    weights = jnp.full((1, 2, 2), 3.0e38, dtype=jnp.float32)
+    state = learner.init(2).replace(weights=weights)  # type: ignore[attr-defined]
+
+    result = jax.jit(learner.update)(
+        state,
+        jnp.array([1.0, 1.0], dtype=jnp.float32),
+        jnp.array(0, dtype=jnp.int32),
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.0, 0.0], dtype=jnp.float32),
+        jnp.array(0.9, dtype=jnp.float32),
+    )
+
+    assert not bool(jnp.any(result.head_updates_applied))
+    assert not bool(result.update_applied)
+    assert int(result.state.step_count) == 0
+    chex.assert_trees_all_equal(result.state.weights, weights)
+
+
+def test_negative_zero_step_size_is_treated_as_frozen() -> None:
+    """``-0.0`` is a supported step size and must take the zero-scale path."""
+    config = OptionValueDurationConfig(
+        reward_step_size=-0.0,
+        duration_step_size=-0.0,
+    )
+    learner = OptionValueDurationLearner(1, config)
+    weights = jnp.full((1, 2, 2), 3.0e38, dtype=jnp.float32)
+    state = learner.init(2).replace(weights=weights)  # type: ignore[attr-defined]
+
+    result = jax.jit(learner.update)(
+        state,
+        jnp.array([1.0, 1.0], dtype=jnp.float32),
+        jnp.array(0, dtype=jnp.int32),
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.0, 0.0], dtype=jnp.float32),
+        jnp.array(0.9, dtype=jnp.float32),
+    )
+
+    assert bool(result.update_applied)
+    assert int(result.state.step_count) == 1
+    chex.assert_trees_all_equal(result.state.weights, weights)


### PR DESCRIPTION
## Problem

`OptionValueDurationConfig` validates both step sizes with `strictly_positive=False`, so `0.0` — and `-0.0`, which the existing suite covers explicitly — is a supported configuration for a deliberately frozen head.

`OptionValueDurationLearner.update` scaled the TD error by that step size *before* checking the proposed weights:

```python
step_sizes = jnp.array([reward_step_size, duration_step_size], dtype=jnp.float32)
proposed_option_weights = (
    option_weights + step_sizes[:, None] * td_errors[:, None] * observation[None, :]
)
```

`predictions = option_weights @ observation` can overflow float32 to `inf` from finite, validated weights and a finite observation. A frozen head then evaluates `0 * inf`, which is NaN, so `candidate_finite` rejects that head.

When every head is frozen this discards the entire transition: `step_count` and `option_update_counts` stop advancing and the reported `continuation_discount` is forced to `0.0`, even though the weights, observation, reward, and discount were all finite and passed validation. A frozen head performs a no-op update, so the transition is valid and the lifetime counters must advance.

Reproduced on `main` with `reward_step_size=0.0`, `duration_step_size=0.0`, weights `3.0e38`, observation `[1.0, 1.0]`:

```
weights all finite: True
observation finite: True
predictions: [inf inf]
head_updates_applied: [False False]
update_applied: False
step_count: 0            <- should be 1
option_update_counts: [0] <- should be [1]
continuation_discount: 0.0 <- should be 0.9
```

## Fix

Scale the TD error through the `_skip_zero_scale` convention already used in `core/feature_discovery.py` and `core/history_features.py`, so the zero-scaled product is repaired *before* it reaches the proposed weights.

The repair is confined to the zero-scale branch: a head with a nonzero step size returns exactly the same `scale * value` product as before, so its arithmetic is bit-identical and its fail-closed rejection of an infinite update is unchanged. Nothing masks NaN in committed state.

## Tests

Three regression tests in `tests/test_option_value_duration.py`:

- a frozen head commits its no-op update and advances the lifetime counters on an overflowing TD error, asserting first that every validated input is finite and that the raw `0 * inf` product is NaN
- a learning head still rejects an infinite update and leaves `step_count` at `0`
- `-0.0` takes the same frozen path

The first and third fail on unfixed source (`assert False == bool(result.update_applied)`) and pass with the fix.

`tests/test_option_value_duration.py` and `tests/test_option_value_duration_scan_steps.py`: 82 passed, including the pre-existing exact-analytic weight-update test. `ruff` and `mypy` clean.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)