### PR TITLE
fix(streams): skip zero feature scales in ScaledStreamWrapper

### DIFF
--- a/alberta_framework/streams/synthetic.py
+++ b/alberta_framework/streams/synthetic.py
@@ -167,6 +167,16 @@ def _require_finite_float32(name: str, value: object) -> float:
     return narrowed
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Return ``scale * value``, or exact zero where ``scale`` is zero.
+
+    A zero scale removes the term entirely, so it must contribute zero even
+    when ``value`` is non-finite.  Forming the raw product first turns
+    ``0 * inf`` into ``NaN``.
+    """
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 @chex.dataclass(frozen=True)
 class RandomWalkState:
     """State for RandomWalkStream.
@@ -932,6 +942,9 @@ class ScaledStreamWrapper:
             inner_stream: Stream to wrap (must implement ScanStream protocol)
             feature_scales: Array of scale factors, one per feature. Must have
                 shape (feature_dim,) matching the inner stream's feature_dim.
+                Values must be finite; a scale of exactly ``0.0`` suppresses
+                its channel and yields ``0.0`` regardless of what the wrapped
+                stream emitted there, including a non-finite feature.
 
         Raises:
             ValueError: If feature_scales length doesn't match inner stream's feature_dim
@@ -989,7 +1002,14 @@ class ScaledStreamWrapper:
         """
         timestep, new_inner_state = self._inner_stream.step(state.inner_state, idx)
 
-        scaled_observation = timestep.observation * self._feature_scales
+        # A zero scale suppresses the channel, so it must contribute exact
+        # zero even when the wrapped stream emits a non-finite feature.  The
+        # raw product turned that 0*inf into a NaN in a channel the caller
+        # asked to remove, and one NaN feature destroys every learner weight
+        # through the dot product.
+        scaled_observation = _skip_zero_scale(
+            self._feature_scales, timestep.observation
+        )
 
         scaled_timestep = TimeStep(
             observation=scaled_observation,

--- a/tests/test_scaled_stream_wrapper_zero_scale.py
+++ b/tests/test_scaled_stream_wrapper_zero_scale.py
@@ -1,0 +1,49 @@
+"""Zero-scale regression for ``ScaledStreamWrapper``."""
+
+from typing import Any
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from alberta_framework.core.types import TimeStep
+from alberta_framework.streams.synthetic import ScaledStreamWrapper
+
+
+class _NonFiniteChannelStream:
+    """Minimal ScanStream whose middle channel diverges to +inf."""
+
+    feature_dim = 3
+
+    def init(self, key: Any) -> tuple[()]:
+        del key
+        return ()
+
+    def step(self, state: tuple[()], idx: Any) -> tuple[TimeStep, tuple[()]]:
+        del idx
+        observation = jnp.array([1.0, jnp.inf, 3.0], dtype=jnp.float32)
+        target = jnp.array([0.0], dtype=jnp.float32)
+        return TimeStep(observation=observation, target=target), state
+
+
+def test_zero_scale_suppresses_a_non_finite_inner_channel() -> None:
+    scales = jnp.array([1.0, 0.0, 2.0], dtype=jnp.float32)
+    wrapper = ScaledStreamWrapper(_NonFiniteChannelStream(), scales)
+    inner_observation, _ = _NonFiniteChannelStream().step((), jnp.array(0))
+
+    # The raw scale*value product is the 0*inf that used to leak a NaN.
+    raw = inner_observation.observation * scales
+    assert not bool(jnp.isfinite(raw[1]))
+
+    timestep, _ = wrapper.step(wrapper.init(jr.key(0)), jnp.array(0))
+    assert bool(jnp.all(jnp.isfinite(timestep.observation)))
+    assert float(timestep.observation[1]) == 0.0
+    # Non-zero scales are untouched.
+    assert float(timestep.observation[0]) == 1.0
+    assert float(timestep.observation[2]) == 6.0
+
+
+def test_non_finite_feature_scales_are_still_rejected() -> None:
+    scales = jnp.array([1.0, jnp.inf, 2.0], dtype=jnp.float32)
+    with pytest.raises(ValueError, match="finite"):
+        ScaledStreamWrapper(_NonFiniteChannelStream(), scales)


### PR DESCRIPTION
## Problem

`ScaledStreamWrapper.step` in `alberta_framework/streams/synthetic.py` scaled the wrapped stream's observation with a raw product:

```python
scaled_observation = timestep.observation * self._feature_scales
```

The constructor validates that every scale is finite, but it deliberately admits `0.0` — that is the natural way to tell the wrapper to suppress a channel. Meanwhile the wrapped stream is an arbitrary caller-supplied `ScanStream[Any]`; the wrapper never constrains the inner observation, so a channel can carry `inf`.

The result is that the *suppressed* channel evaluated `0 * inf` and emitted `NaN` — in exactly the feature the caller asked to remove. That is worse than the original `inf`: a single `NaN` feature destroys every learner weight through the dot product, whereas a zeroed channel is inert by construction.

Reproduced on `main` with a 3-channel inner stream whose middle channel is `+inf` and scales `[1.0, 0.0, 2.0]`:

```
suppressed channel obs: [ 1. nan  6.]
```

## Fix

Skip the product where the scale is exactly zero:

```python
def _skip_zero_scale(scale: Array, value: Array) -> Array:
    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
```

Fail-closed and minimal:

- No NaN-to-zero masking of real values — only the exactly-zero-scale lane is short-circuited. A non-finite feature under a *non-zero* scale still propagates, as it should.
- Non-zero scales take the same `scale * value` path and keep their previous bit-exact result.
- Non-finite `feature_scales` are still rejected at construction (covered by a test).
- Public signature unchanged; no config, schema, or `outputs/` change.

The `feature_scales` docstring now records the zero-scale contract.

## Tests

New `tests/test_scaled_stream_wrapper_zero_scale.py` asserts that the raw `observation * scales` product is non-finite in the suppressed channel, that the fixed wrapper stays finite and yields exactly `0.0` there, that the neighbouring non-zero scales are still applied exactly, and that non-finite scales remain a construction-time rejection.

```
tests/test_scaled_stream_wrapper_zero_scale.py     2 passed
pytest tests -k "synthetic or scaled or stream"    864 passed, 2 skipped
ruff check                                         All checks passed!
```

This is a numeric fail-closed fix only. It creates no evidence, does not touch `outputs/`, and does not promote any claim.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)