### PR TITLE
fix(core): skip zero-scale GTD correction products in the nonlinear shared Horde

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -1393,58 +1393,72 @@ class NonlinearSharedGTDHordeLearner:
             # (NaN cumulant) contribute nothing this step.
             masked_rho = jnp.where(effective_mask[i], clipped_rhos[i], 0.0)
             terminated_i = discounts[i] == 0.0
+            # A zero ratio means this demon contributes nothing to the shared
+            # trunk this step. Multiplying it through an overflowed
+            # ``secondary_dot`` or gradient would form 0*inf=NaN and, because
+            # the trunk steps are summed across demons, reject the whole
+            # update for every healthy demon too. Skip the product instead.
+            rho_discount = _skip_zero_scale(masked_rho, discounts[i])
             rho_dot = jnp.where(
                 terminated_i,
                 jnp.zeros_like(secondary_dot),
-                masked_rho * discounts[i] * secondary_dot,
+                _skip_zero_scale(rho_discount, secondary_dot),
             )
             correction_trunk_w = jnp.where(
                 terminated_i,
                 jnp.zeros_like(next_grad_trunk_w),
-                rho_dot * next_grad_trunk_w,
+                _skip_zero_scale(rho_dot, next_grad_trunk_w),
             )
             correction_trunk_b = jnp.where(
                 terminated_i,
                 jnp.zeros_like(next_grad_trunk_b),
-                rho_dot * next_grad_trunk_b,
+                _skip_zero_scale(rho_dot, next_grad_trunk_b),
             )
             correction_head_w = jnp.where(
                 terminated_i,
                 jnp.zeros_like(next_grad_head_w),
-                rho_dot * next_grad_head_w,
+                _skip_zero_scale(rho_dot, next_grad_head_w),
             )
             correction_head_b = jnp.where(
                 terminated_i,
                 jnp.zeros_like(next_grad_head_b),
-                rho_dot * next_grad_head_b,
+                _skip_zero_scale(rho_dot, next_grad_head_b),
             )
-            rho_delta = masked_rho * safe_td_errors[i]
+            rho_delta = _skip_zero_scale(masked_rho, safe_td_errors[i])
 
             trunk_w_step = trunk_w_step + primary_alpha * (
-                rho_delta * grad_trunk_w - correction_trunk_w
+                _skip_zero_scale(rho_delta, grad_trunk_w) - correction_trunk_w
             )
             trunk_b_step = trunk_b_step + primary_alpha * (
-                rho_delta * grad_trunk_b - correction_trunk_b
+                _skip_zero_scale(rho_delta, grad_trunk_b) - correction_trunk_b
             )
             head_w_step = head_w_step.at[i].add(
-                primary_alpha * (rho_delta * grad_head_w - correction_head_w)
+                primary_alpha * (_skip_zero_scale(rho_delta, grad_head_w) - correction_head_w)
             )
             head_b_step = head_b_step.at[i].add(
-                primary_alpha * (rho_delta * grad_head_b - correction_head_b)
+                primary_alpha * (_skip_zero_scale(rho_delta, grad_head_b) - correction_head_b)
             )
 
             masked_beta = jnp.where(effective_mask[i], secondary_beta, 0.0)
-            sec_trunk_w = state.secondary_trunk_w[i] + masked_beta * (
-                rho_delta * grad_trunk_w - secondary_dot * grad_trunk_w
+            sec_trunk_w = state.secondary_trunk_w[i] + _skip_zero_scale(
+                masked_beta,
+                _skip_zero_scale(rho_delta, grad_trunk_w)
+                - _skip_zero_scale(secondary_dot, grad_trunk_w),
             )
-            sec_trunk_b = state.secondary_trunk_b[i] + masked_beta * (
-                rho_delta * grad_trunk_b - secondary_dot * grad_trunk_b
+            sec_trunk_b = state.secondary_trunk_b[i] + _skip_zero_scale(
+                masked_beta,
+                _skip_zero_scale(rho_delta, grad_trunk_b)
+                - _skip_zero_scale(secondary_dot, grad_trunk_b),
             )
-            sec_head_w = state.secondary_head_w[i] + masked_beta * (
-                rho_delta * grad_head_w - secondary_dot * grad_head_w
+            sec_head_w = state.secondary_head_w[i] + _skip_zero_scale(
+                masked_beta,
+                _skip_zero_scale(rho_delta, grad_head_w)
+                - _skip_zero_scale(secondary_dot, grad_head_w),
             )
-            sec_head_b = state.secondary_head_b[i] + masked_beta * (
-                rho_delta * grad_head_b - secondary_dot * grad_head_b
+            sec_head_b = state.secondary_head_b[i] + _skip_zero_scale(
+                masked_beta,
+                _skip_zero_scale(rho_delta, grad_head_b)
+                - _skip_zero_scale(secondary_dot, grad_head_b),
             )
             new_secondary_trunk_w.append(sec_trunk_w)
             new_secondary_trunk_b.append(sec_trunk_b)

--- a/tests/test_off_policy_horde_zero_ratio.py
+++ b/tests/test_off_policy_horde_zero_ratio.py
@@ -1,0 +1,185 @@
+"""Zero-importance-ratio guards in the nonlinear shared-trunk GTD Horde.
+
+``update_with_ratios_and_discounts`` sums every demon's primary step into one
+shared trunk step. A demon whose masked ratio is exactly zero must therefore
+contribute *nothing*, even when the quantity it would have been multiplied by
+has overflowed to infinity. The unguarded ``0 * inf`` product forms NaN,
+which fails the whole-candidate finite check and rejects the update for every
+healthy demon in the Horde.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.off_policy_horde import NonlinearSharedGTDHordeLearner
+from alberta_framework.core.types import DemonType, GVFSpec, HordeSpec, create_horde_spec
+
+pytestmark = pytest.mark.unit
+
+_FLOAT32_NEAR_MAX = 3.0e38
+
+
+def _spec(gammas: tuple[float, ...]) -> HordeSpec:
+    demons = tuple(
+        GVFSpec(
+            name=f"demon_{i}",
+            demon_type=DemonType.PREDICTION,
+            gamma=gamma,
+            lamda=0.0,
+            cumulant_index=i,
+        )  # type: ignore[call-arg]
+        for i, gamma in enumerate(gammas)
+    )
+    return create_horde_spec(demons)
+
+
+def _learner() -> NonlinearSharedGTDHordeLearner:
+    return NonlinearSharedGTDHordeLearner(
+        _spec((0.8, 0.8)),
+        hidden_size=4,
+        primary_step_size=0.01,
+        secondary_step_size=0.01,
+        ratio_clip=10.0,
+    )
+
+
+def test_inactive_demon_overflowing_secondary_dot_does_not_reject_the_horde() -> None:
+    """An inactive demon's overflowed correction must not poison the trunk."""
+    learner = _learner()
+    state = learner.init(2, jax.random.key(5))
+    observation = jnp.array([2.0, 1.0], dtype=jnp.float32)
+    next_observation = jnp.array([-0.4, 1.0], dtype=jnp.float32)
+
+    # Finite-but-huge secondary weights for demon 0 only.
+    huge = jnp.full_like(state.secondary_trunk_w[0], _FLOAT32_NEAR_MAX)
+    state = state.replace(  # type: ignore[attr-defined]
+        secondary_trunk_w=state.secondary_trunk_w.at[0].set(huge),
+    )
+    assert bool(jnp.all(jnp.isfinite(state.secondary_trunk_w)))
+
+    # The raw product the implementation must not form: the masked ratio for an
+    # inactive demon is exactly zero and the secondary dot has overflowed.
+    hidden = jnp.tanh(state.trunk_w @ observation + state.trunk_b)
+    grad_hidden = state.head_w[0] * (1.0 - hidden**2)
+    grad_trunk_w = grad_hidden[:, None] * observation[None, :]
+    secondary_dot = jnp.vdot(huge, grad_trunk_w)
+    assert not bool(jnp.isfinite(secondary_dot))
+    assert not bool(jnp.isfinite(jnp.float32(0.0) * secondary_dot))
+
+    result = learner.update_with_ratios_and_discounts(
+        state,
+        observation,
+        jnp.array([jnp.nan, 1.0], dtype=jnp.float32),
+        next_observation,
+        jnp.array([1.0, 1.0], dtype=jnp.float32),
+        jnp.array([0.8, 0.8], dtype=jnp.float32),
+    )
+
+    assert bool(result.update_applied)
+    assert not bool(result.head_updates_applied[0])
+    assert bool(result.head_updates_applied[1])
+    assert bool(jnp.all(jnp.isfinite(result.state.trunk_w)))
+    assert bool(jnp.all(jnp.isfinite(result.state.head_w)))
+    # Demon 0 keeps its adopted secondary weights untouched.
+    np.testing.assert_array_equal(
+        np.asarray(result.state.secondary_trunk_w[0]),
+        np.asarray(huge),
+    )
+    assert bool(jnp.any(result.state.head_w[1] != state.head_w[1]))
+
+
+def test_inactive_demon_overflowing_gradient_does_not_reject_the_horde() -> None:
+    """An inactive demon's overflowed gradient must not poison the trunk."""
+    learner = _learner()
+    state = learner.init(2, jax.random.key(11))
+    observation = jnp.array([3.0, 1.0], dtype=jnp.float32)
+    next_observation = jnp.array([-0.4, 1.0], dtype=jnp.float32)
+
+    # Finite-but-huge output weights for demon 0 overflow its trunk gradient.
+    huge_head = jnp.full_like(state.head_w[0], _FLOAT32_NEAR_MAX)
+    state = state.replace(  # type: ignore[attr-defined]
+        head_w=state.head_w.at[0].set(huge_head),
+    )
+    assert bool(jnp.all(jnp.isfinite(state.head_w)))
+
+    hidden = jnp.tanh(state.trunk_w @ observation + state.trunk_b)
+    grad_trunk_w = (huge_head * (1.0 - hidden**2))[:, None] * observation[None, :]
+    assert not bool(jnp.all(jnp.isfinite(grad_trunk_w)))
+    assert not bool(jnp.all(jnp.isfinite(jnp.float32(0.0) * grad_trunk_w)))
+
+    result = learner.update_with_ratios_and_discounts(
+        state,
+        observation,
+        jnp.array([jnp.nan, 1.0], dtype=jnp.float32),
+        next_observation,
+        jnp.array([1.0, 1.0], dtype=jnp.float32),
+        jnp.array([0.8, 0.8], dtype=jnp.float32),
+    )
+
+    assert bool(result.update_applied)
+    assert not bool(result.head_updates_applied[0])
+    assert bool(result.head_updates_applied[1])
+    assert bool(jnp.all(jnp.isfinite(result.state.trunk_w)))
+    assert bool(jnp.all(jnp.isfinite(result.state.trunk_b)))
+    assert bool(jnp.all(jnp.isfinite(result.state.secondary_trunk_w)))
+    np.testing.assert_array_equal(
+        np.asarray(result.state.head_w[0]),
+        np.asarray(huge_head),
+    )
+
+
+def test_ordinary_gtd_step_still_matches_the_reference_algebra() -> None:
+    """Skipping zero-scale products must not perturb an ordinary update."""
+    gamma, alpha, beta, rho = 0.8, 0.01, 0.1, 1.5
+    learner = NonlinearSharedGTDHordeLearner(
+        _spec((gamma,)),
+        hidden_size=3,
+        primary_step_size=alpha,
+        secondary_step_size=beta,
+        ratio_clip=10.0,
+    )
+    state = learner.init(2, jax.random.key(3))
+
+    trunk_w = np.asarray(state.trunk_w, dtype=np.float64)
+    trunk_b = np.asarray(state.trunk_b, dtype=np.float64)
+    head_w = np.asarray(state.head_w[0], dtype=np.float64)
+    head_b = float(state.head_b[0])
+
+    observation = np.array([1.0, -0.5])
+    next_observation = np.array([-0.3, 1.0])
+    cumulant = 1.0
+
+    hidden = np.tanh(trunk_w @ observation + trunk_b)
+    next_hidden = np.tanh(trunk_w @ next_observation + trunk_b)
+    value = head_w @ hidden + head_b
+    next_value = head_w @ next_hidden + head_b
+    td_error = cumulant + gamma * next_value - value
+
+    grad_hidden = head_w * (1.0 - hidden**2)
+    grad_trunk_w = grad_hidden[:, None] * observation[None, :]
+    # Secondary weights start at zero, so the correction term vanishes.
+    expected_trunk_w = trunk_w + alpha * rho * td_error * grad_trunk_w
+    expected_secondary_head_w = beta * rho * td_error * hidden
+
+    result = learner.update_with_ratios_and_discounts(
+        state,
+        jnp.asarray(observation, dtype=jnp.float32),
+        jnp.array([cumulant], dtype=jnp.float32),
+        jnp.asarray(next_observation, dtype=jnp.float32),
+        jnp.array([rho], dtype=jnp.float32),
+        jnp.array([gamma], dtype=jnp.float32),
+    )
+
+    assert bool(result.update_applied)
+    np.testing.assert_allclose(
+        np.asarray(result.state.trunk_w), expected_trunk_w, atol=1e-6
+    )
+    np.testing.assert_allclose(
+        np.asarray(result.state.secondary_head_w[0]),
+        expected_secondary_head_w,
+        atol=1e-6,
+    )


### PR DESCRIPTION
## Problem

`NonlinearSharedGTDHordeLearner.update_with_ratios_and_discounts` accumulates every demon's primary step into one shared trunk step, so a single NaN anywhere in the per-demon arithmetic rejects the update for the entire Horde.

An inactive demon (NaN cumulant) has `masked_rho == 0` and contributes nothing by construction, but the implementation still evaluated the products:

```python
rho_dot = masked_rho * discounts[i] * secondary_dot
rho_delta = masked_rho * safe_td_errors[i]
... rho_delta * grad_trunk_w ...
```

When that demon's adopted secondary weights or output weights are large but finite (all still passing `_state_is_valid`), `secondary_dot` or `grad_trunk_w` overflows to inf and the zero ratio forms `0 * inf = NaN`. `_floating_tree_is_finite(proposed_state)` then rejects the step, so a healthy active demon in the same Horde silently stops learning.

Reproduced on `main`: with demon 0 inactive and `secondary_trunk_w[0] = 3e38`, `update_applied` is `False` and demon 1's parameters do not move, even though demon 1's own inputs, gradients, and target are ordinary finite values.

## Fix

Route the ratio-, discount-, and step-size-scaled products through the module's existing `_skip_zero_scale` helper, which returns exact zeros when the scale is `0.0` instead of forming the product. The same guard is applied to the beta-weighted secondary-weight update, where `masked_beta == 0` multiplied an infinite bracket.

`_skip_zero_scale(scale, value)` is bit-identical to `scale * value` for every nonzero scale, so ordinary updates are numerically unchanged. Nothing is NaN-masked: a genuinely non-finite active demon still fails `active_outputs_finite` and the update is still rejected.

## Tests

New `tests/test_off_policy_horde_zero_ratio.py`:

- an inactive demon whose `secondary_dot` overflows — asserts the raw `0 * secondary_dot` product is non-finite, then that the fixed path applies the update, leaves the healthy demon learning, keeps the trunk finite, and preserves the inactive demon's adopted secondary weights;
- the same for an inactive demon whose trunk gradient overflows;
- an ordinary finite GTD step still matches the hand-computed TDC reference algebra (guards against over-zeroing).

Both fail-closed tests fail on `main` and pass with the fix.

```
.venv/bin/python -m pytest tests/test_off_policy_horde.py tests/test_offpolicy_horde_rho.py tests/test_baird_horde.py tests/test_off_policy_horde_zero_ratio.py -q
44 passed
.venv/bin/python -m ruff check alberta_framework/core/off_policy_horde.py tests/test_off_policy_horde_zero_ratio.py
All checks passed!
.venv/bin/python -m mypy alberta_framework/core/off_policy_horde.py
Success: no issues found in 1 source file
```

## Scope

Development-only numeric hardening in one module. No promoted evidence, registered source, pinned `outputs/` artifact, or public signature is touched.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)