### PR TITLE
fix(evaluation): rescale batch gradient squared-norm mean by a power of two

### DIFF
--- a/alberta_framework/evaluation/optimization_readiness.py
+++ b/alberta_framework/evaluation/optimization_readiness.py
@@ -214,6 +214,25 @@ def _squared_norm(value: NDArray[np.float64], *, name: str) -> float:
     return result
 
 
+def _mean_squared_norm(values: NDArray[np.float64], *, name: str) -> float:
+    """Average finite squared norms without an overflowing intermediate sum.
+
+    A direct ``np.mean`` accumulates the sum before dividing, so a batch of
+    large-but-finite row norms reaches infinity even though their mean is
+    representable.  Rescaling by a power of two is exact, keeps every summand in
+    ``[0, 1]``, and therefore preserves the mean's magnitude domain.
+    """
+    maximum = float(np.max(values))
+    if maximum == 0.0:
+        return 0.0
+    _, exponent = math.frexp(maximum)
+    scaled = float(np.mean(np.ldexp(values, -exponent)))
+    result = math.ldexp(scaled, exponent)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must fit in a finite float64")
+    return result
+
+
 def estimate_optimization_readiness(
     *,
     loss: float,
@@ -258,7 +277,9 @@ def estimate_optimization_readiness(
         [_squared_norm(row, name="batch gradient") for row in gradients],
         dtype=np.float64,
     )
-    expected_squared_norm = float(np.mean(row_squared_norms))
+    expected_squared_norm = _mean_squared_norm(
+        row_squared_norms, name="expected batch gradient squared norm"
+    )
     strength = gradient_squared_norm / resolved_loss if resolved_loss > 0.0 else 0.0
     reliability = (
         gradient_squared_norm / expected_squared_norm if expected_squared_norm > 0.0 else 0.0
@@ -269,7 +290,13 @@ def estimate_optimization_readiness(
         readiness = strength * reliability
     else:
         readiness = 0.0
-    outputs = (strength, reliability, readiness)
+    outputs = (
+        gradient_squared_norm,
+        expected_squared_norm,
+        strength,
+        reliability,
+        readiness,
+    )
     if not all(math.isfinite(value) for value in outputs):
         raise ValueError("optimization-readiness outputs must be finite")
     return OptimizationReadiness(

--- a/tests/test_optimization_readiness.py
+++ b/tests/test_optimization_readiness.py
@@ -151,6 +151,33 @@ def test_readiness_rejects_nonrepresentable_squared_norms() -> None:
         )
 
 
+def test_batch_gradient_mean_survives_large_but_representable_row_norms() -> None:
+    """A representable batch mean must not be fabricated from an overflowed sum.
+
+    Summing 128 rows whose individual squared norms are near the float64 ceiling
+    overflows, and dividing infinity by the batch count keeps it infinite.  The
+    reliability ratio then silently collapses to ``0.0`` while every gated
+    output stays finite, so the receipt reports zero readiness for a real
+    gradient.
+    """
+    row_norm = 6.5e153
+    batch_gradients = np.tile(np.full(4, row_norm), (128, 1))
+    with np.errstate(over="ignore"):
+        unscaled_mean = float(np.mean(np.square(batch_gradients).sum(axis=1)))
+    assert not np.isfinite(unscaled_mean)
+
+    readiness = estimate_optimization_readiness(
+        loss=1.0,
+        full_validation_gradient=np.ones(4),
+        batch_gradients=batch_gradients,
+    )
+    expected = 4.0 * row_norm * row_norm
+    assert np.isfinite(readiness.expected_batch_gradient_squared_norm)
+    assert readiness.expected_batch_gradient_squared_norm == pytest.approx(expected, rel=1e-12)
+    assert readiness.gradient_reliability > 0.0
+    assert readiness.optimization_readiness > 0.0
+
+
 def test_energy_rank_is_scale_stable() -> None:
     assert energy_rank(np.diag([9e307, 1e307]), threshold=0.99) == 2
 


### PR DESCRIPTION
## Problem

`estimate_optimization_readiness` in `alberta_framework/evaluation/optimization_readiness.py` averaged the per-row squared norms with a plain `np.mean`:

```python
row_squared_norms = np.asarray([_squared_norm(row, name="batch gradient") for row in gradients])
expected_squared_norm = float(np.mean(row_squared_norms))
```

`_squared_norm` already guarantees every row norm is finite, but `np.mean` accumulates the sum *before* dividing. A batch of 128 rows whose individual squared norms sit near the float64 ceiling overflows that intermediate sum, so `expected_squared_norm` becomes `inf` even though the true mean is comfortably representable (about `1.69e308`).

The consequences are silently wrong rather than loud:

- `reliability = gradient_squared_norm / inf` collapses to exactly `0.0`
- `readiness = strength * 0.0` collapses to exactly `0.0`
- the finiteness gate only covered `(strength, reliability, readiness)`, so it passed
- the returned `OptimizationReadiness` carried `expected_batch_gradient_squared_norm == inf`
- `validate_development_result` only requires `optimization_readiness` and `gradient_norm` to be `_strict_finite_float`, and both are `0.0`, so the downstream receipt validator accepts the fabricated zeros too

On `origin/main`:

```
expected_batch_gradient_squared_norm = inf
gradient_reliability = 0.0
optimization_readiness = 0.0
```

A real gradient is reported as having zero optimization readiness, indistinguishable from a genuinely dead one.

## Fix

Average after an exact power-of-two rescale (`math.frexp` / `np.ldexp`), which keeps every summand in `[0, 1]` so the intermediate sum cannot overflow, then scale the result back. Because the mean of finite values never exceeds their maximum, a representable mean now always survives; the residual `math.isfinite` check keeps the helper fail-closed.

The finiteness gate is also extended to cover `gradient_squared_norm` and `expected_squared_norm`, so no non-finite accounting field can reach the record.

After the fix the same input yields `expected_batch_gradient_squared_norm = 1.69e308` and a real nonzero reliability, and the ordinary small-magnitude case is unchanged.

## Test

`tests/test_optimization_readiness.py::test_batch_gradient_mean_survives_large_but_representable_row_norms` asserts that the naive mean of the same rows is non-finite, then asserts the estimator returns a finite mean matching `4 * row_norm**2` with strictly positive reliability and readiness. It fails on `origin/main` and passes here.

```
$ .venv/bin/python -m pytest tests/test_optimization_readiness.py -q
37 passed

$ .venv/bin/python -m ruff check alberta_framework/evaluation/optimization_readiness.py tests/test_optimization_readiness.py
All checks passed!

$ .venv/bin/python -m mypy alberta_framework/evaluation/optimization_readiness.py
Success: no issues found in 1 source file
```

No registered evidence source is touched, no threshold is retuned, and nothing under `outputs/` is modified.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)