### PR TITLE
fix(tests): stop a duplicate _HostileInt from shadowing the __index__ and __class__ traps

### DIFF
--- a/tests/test_feature_discovery_hostile_validation.py
+++ b/tests/test_feature_discovery_hostile_validation.py
@@ -40,35 +40,36 @@ class _HostileInt(int):
     @property
     def __class__(self) -> type[int]:  # pragma: no cover
         type(self).calls += 1
-        raise AssertionError("class hook")
+        raise AssertionError("HostileInt.__class__ must not be called")
 
     def __int__(self) -> int:  # pragma: no cover
         type(self).calls += 1
-        raise AssertionError("int hook")
+        raise AssertionError("HostileInt.__int__ must not be called")
 
     def __index__(self) -> int:  # pragma: no cover
         type(self).calls += 1
-        raise AssertionError("index hook")
-
-    def __repr__(self) -> str:  # pragma: no cover
-        type(self).calls += 1
-        raise AssertionError("repr hook")
-
-    def __float__(self) -> float:  # type: ignore[override]
-        type(self).calls += 1
-        raise AssertionError("HostileFloat hook must not leak via !r")
-
-
-class _HostileInt(int):
-    calls = 0
-
-    def __int__(self) -> int:
-        type(self).calls += 1
-        raise AssertionError("HostileInt.__int__ must not be called")
+        raise AssertionError("HostileInt.__index__ must not be called")
 
     def __repr__(self) -> str:  # pragma: no cover
         type(self).calls += 1
         raise AssertionError("HostileInt.__repr__ must not be called")
+
+
+def test_hostile_int_traps_every_documented_coercion_hook() -> None:
+    """Guard against a second definition shadowing the stronger traps.
+
+    A duplicate ``_HostileInt`` used to shadow this class while trapping only
+    ``__int__`` and ``__repr__``, so the ``__class__`` and ``__index__`` traps
+    never ran -- and ``__index__`` is precisely the hook the house integer
+    gates reach for.
+    """
+    for hook in ("__class__", "__int__", "__index__", "__repr__"):
+        assert hook in vars(_HostileInt), hook
+
+    _HostileInt.calls = 0
+    with pytest.raises(AssertionError, match=r"HostileInt\.__int__"):
+        int(_HostileInt(4))
+    assert _HostileInt.calls == 1
 
 
 def test_rejects_string_subclass_for_feature_dim() -> None:


### PR DESCRIPTION
## Problem

`tests/test_feature_discovery_hostile_validation.py` defines `_HostileInt` **twice**, at lines 37 and 62.

The first definition traps four coercion hooks:

```python
class _HostileInt(int):
    @property
    def __class__(self) -> type[int]: ...   # raises
    def __int__(self) -> int: ...           # raises
    def __index__(self) -> int: ...         # raises
    def __repr__(self) -> str: ...          # raises
```

The second definition traps only `__int__` and `__repr__`, and silently shadows the first. Every test that references `_HostileInt` — `test_rejects_bool_and_hostile_int_for_feature_dim` and the 11-case `test_every_integer_field_rejects_subclass_without_hooks` — binds the weaker class.

So the `__class__` and `__index__` traps never ran, in a module whose entire purpose is hostile validation. `__index__` is the significant loss: it is precisely the hook the house integer gates reach for via `operator.index`, so the strongest adversarial case was silently not covered.

The first definition also carried a stray `__float__` raising `"HostileFloat hook must not leak via !r"`, a copy-paste artifact from the neighbouring `_HostileFloat` class.

## Fix

Merge the two into a single `_HostileInt` that traps `__class__`, `__int__`, `__index__`, and `__repr__`, with messages consistently namespaced to `HostileInt`. Drop the misplaced `__float__`.

This strengthens coverage without weakening any assertion: the sink gates reject the subclass on its exact type before reaching any hook, so `assert _HostileInt.calls == 0` still holds everywhere.

## Tests

Added `test_hostile_int_traps_every_documented_coercion_hook`, which asserts all four hooks are present in `vars(_HostileInt)` so a future duplicate cannot silently disable them again, and confirms the `__int__` trap actually fires.

The guard deliberately exercises `int()` rather than `operator.index()`, because CPython takes a fast path for `int` subclasses and does not dispatch to an overridden `__index__` — asserting otherwise would encode a false claim.

`tests/test_feature_discovery_hostile_validation.py`: 38 passed. `ruff` clean.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)