### PR TITLE
fix(tests): collapse the shadowed duplicate _SpoofedFloat in the forager suite

### DIFF
--- a/tests/test_forager_benchmark.py
+++ b/tests/test_forager_benchmark.py
@@ -237,6 +237,12 @@ class _SpoofedFloat:
     def __float__(self) -> float:
         return 0.5
 
+    def __le__(self, other: float) -> bool:
+        return 0.5 <= other
+
+    def __lt__(self, other: float) -> bool:
+        return 0.5 < other
+
 
 def test_benchmark_config_rejects_class_spoofed_ewm_decay() -> None:
     with pytest.raises(ValueError, match="ewm_decay"):
@@ -838,23 +844,6 @@ def test_official_npz_import_rejects_nonfinite_ewm_decay(tmp_path: Path) -> None
             OfficialForagaxRunSpec(agent="DQN", seed=0, path=path),
             ewm_decay=math.nan,
         )
-
-
-class _SpoofedFloat:
-    """Mimics ``float`` via ``__class__`` to defeat ``isinstance`` checks."""
-
-    @property
-    def __class__(self) -> type:  # type: ignore[override]
-        return float
-
-    def __float__(self) -> float:
-        return 0.5
-
-    def __le__(self, other: float) -> bool:
-        return 0.5 <= other
-
-    def __lt__(self, other: float) -> bool:
-        return 0.5 < other
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`tests/test_forager_benchmark.py` defines `_SpoofedFloat` twice, at lines 230 and 843.

The two are not identical. The later definition additionally implements the comparison hooks, so the spoof survives the config's range checks:

```python
    def __le__(self, other: float) -> bool:
        return 0.5 <= other

    def __lt__(self, other: float) -> bool:
        return 0.5 < other
```

The later definition shadows the earlier one at import time, so both call sites — `test_benchmark_config_rejects_class_spoofed_ewm_decay` at line 243 and the `ewm_decay` parametrize case at line 864 — bind the stronger class.

That leaves the first definition unreachable dead code sitting directly above the test that appears to use it. A reader at that call site sees a weaker spoof than the one actually exercised, which is exactly the kind of mismatch that makes a hostile-input test suite hard to trust.

## Fix

Keep a single `_SpoofedFloat`, including the comparison hooks, defined before its first use, and delete the shadowed duplicate.

This is behaviour-preserving: the surviving class is byte-for-byte the one both call sites already resolved to at runtime.

## Tests

`tests/test_forager_benchmark.py`: 103 passed, 3 skipped. `ruff` clean. Verified by AST that exactly one `_SpoofedFloat` definition remains.

No source module is touched, so Forager run provenance is unaffected.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)