### PR TITLE
fix(step7): skip a zero priority-propagation scale over an infinite TD

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -877,18 +877,28 @@ def _propagate_predecessor_priorities(
     td_error: Array,
     propagation_scale: float,
 ) -> Array:
-    """Propagate backup priority to predecessor transitions in the queue."""
+    """Propagate backup priority to predecessor transitions in the queue.
+
+    ``propagation_scale`` is a validated non-negative real, so ``0.0``
+    (propagation disabled) is admissible, while ``td_error`` comes from an
+    unclamped imagined rollout and can be non-finite.  The scale is skipped
+    at exactly zero: the raw ``0 * inf`` produced ``NaN``, and because
+    ``jnp.maximum`` propagates ``NaN`` that wrote ``NaN`` over every live
+    queue priority — so disabling propagation destroyed the queue instead
+    of leaving it alone.
+    """
     memory_size = memory_priorities.shape[0]
     valid = jnp.arange(memory_size, dtype=jnp.int32) < memory_count
     predecessor_distance = jnp.mean(
         (memory_next_observations - anchor_observation[None, :]) ** 2,
         axis=1,
     )
-    propagated = (
-        jnp.asarray(propagation_scale, dtype=jnp.float32)
-        * jnp.abs(td_error)
-        / (1.0 + predecessor_distance)
-    )
+    scale = jnp.asarray(propagation_scale, dtype=jnp.float32)
+    magnitude = jnp.abs(td_error)
+    # Keep the original (scale * |td|) / (1 + d) association so a non-zero
+    # scale stays bit-exact; only the zero-scale lane is short-circuited.
+    scaled = jnp.where(scale == 0.0, jnp.zeros_like(magnitude), scale * magnitude)
+    propagated = scaled / (1.0 + predecessor_distance)
     return jnp.where(valid, jnp.maximum(memory_priorities, propagated), memory_priorities)
 
 

--- a/tests/test_step7_priority_propagation_zero_scale.py
+++ b/tests/test_step7_priority_propagation_zero_scale.py
@@ -1,0 +1,53 @@
+"""Zero-scale regression for Step 7 predecessor priority propagation."""
+
+import jax.numpy as jnp
+
+from alberta_framework.steps.step7 import _propagate_predecessor_priorities
+
+
+def _queue() -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    next_observations = jnp.zeros((3, 2), dtype=jnp.float32)
+    priorities = jnp.array([0.5, 0.25, 0.125], dtype=jnp.float32)
+    count = jnp.array(3, dtype=jnp.int32)
+    anchor = jnp.zeros((2,), dtype=jnp.float32)
+    return next_observations, priorities, count, anchor
+
+
+def test_disabled_propagation_leaves_the_queue_intact_under_infinite_td() -> None:
+    next_observations, priorities, count, anchor = _queue()
+    td_error = jnp.array(jnp.inf, dtype=jnp.float32)
+    scale = jnp.float32(0.0)
+
+    # The raw scale*|td| product is the 0*inf that used to poison the queue,
+    # and jnp.maximum propagates the resulting NaN over every live priority.
+    raw = scale * jnp.abs(td_error)
+    assert not bool(jnp.isfinite(raw))
+    assert not bool(jnp.isfinite(jnp.maximum(priorities[0], raw)))
+
+    updated = _propagate_predecessor_priorities(
+        next_observations, priorities, count, anchor, td_error, 0.0
+    )
+    assert bool(jnp.all(jnp.isfinite(updated)))
+    assert [float(value) for value in updated] == [0.5, 0.25, 0.125]
+
+
+def test_enabled_propagation_still_raises_priorities() -> None:
+    next_observations, priorities, count, anchor = _queue()
+    td_error = jnp.array(-4.0, dtype=jnp.float32)
+
+    updated = _propagate_predecessor_priorities(
+        next_observations, priorities, count, anchor, td_error, 0.5
+    )
+    # distance is 0, so propagated = 0.5 * 4.0 / 1.0 = 2.0 everywhere.
+    assert [float(value) for value in updated] == [2.0, 2.0, 2.0]
+
+
+def test_entries_beyond_memory_count_are_untouched() -> None:
+    next_observations, priorities, _, anchor = _queue()
+    count = jnp.array(1, dtype=jnp.int32)
+    td_error = jnp.array(-4.0, dtype=jnp.float32)
+
+    updated = _propagate_predecessor_priorities(
+        next_observations, priorities, count, anchor, td_error, 0.5
+    )
+    assert [float(value) for value in updated] == [2.0, 0.25, 0.125]


### PR DESCRIPTION
## Problem

`_propagate_predecessor_priorities` in `alberta_framework/steps/step7.py` formed the propagated priority as a raw product:

```python
propagated = (
    jnp.asarray(propagation_scale, dtype=jnp.float32)
    * jnp.abs(td_error)
    / (1.0 + predecessor_distance)
)
return jnp.where(valid, jnp.maximum(memory_priorities, propagated), memory_priorities)
```

`planning_priority_propagation` is validated with `_require_nonnegative_real`, so `0.0` is admissible — and it is the setting that means *propagation disabled*. `td_error` is `rollout_td_signal`, produced by an imagined rollout of a learned world model and value function with no clamp on the path into this function, so it can reach `inf`.

The disabled path therefore evaluated `0 * inf` and produced `NaN`. Because `jnp.maximum` propagates `NaN`, that `NaN` was then written over **every live queue priority** — not just one slot. So asking Step 7 to leave the prioritized queue alone was the one configuration that destroyed it, and `_pop_prioritized_planning_anchor`'s `argmax` stays poisoned for the rest of the run.

Reproduced on `main` with a 3-entry queue at priorities `[0.5, 0.5, 0.5]`, `td_error = inf`, `propagation_scale = 0.0`:

```
propagation=0.0 -> [nan nan nan]
```

## Fix

Skip the scale at exactly zero, before the product:

```python
scale = jnp.asarray(propagation_scale, dtype=jnp.float32)
magnitude = jnp.abs(td_error)
scaled = jnp.where(scale == 0.0, jnp.zeros_like(magnitude), scale * magnitude)
propagated = scaled / (1.0 + predecessor_distance)
```

Fail-closed and minimal:

- The original `(scale * |td|) / (1 + d)` association is preserved, so non-zero scales are bit-exact — the guard is inserted without reassociating the float arithmetic.
- No NaN-to-zero masking of real values; only the exactly-zero-scale lane is short-circuited. A non-finite `td_error` under a *non-zero* scale still propagates.
- Public signature unchanged; no config, schema, or `outputs/` change.

## Tests

New `tests/test_step7_priority_propagation_zero_scale.py` asserts that the raw `scale * |td_error|` product is non-finite and that `jnp.maximum` propagates it, that the fixed path leaves every priority finite and unchanged when propagation is disabled, that an enabled scale still raises priorities to the expected exact value, and that entries beyond `memory_count` stay untouched.

```
tests/test_step7_priority_propagation_zero_scale.py  3 passed
tests/test_step7_production.py
tests/test_step7_hostile_validation.py               138 passed
ruff check                                           All checks passed!
```

This is a numeric fail-closed fix only. It creates no evidence, does not touch `outputs/`, and does not promote any claim.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)