### PR TITLE
fix(benchmarks): skip zero AdaLin alpha before 0*inf poisons base activation

### DIFF
--- a/alberta_framework/benchmarks/adalin.py
+++ b/alberta_framework/benchmarks/adalin.py
@@ -73,6 +73,11 @@ def _trusted_float_array(value: object, *, name: str) -> Array:
     return array
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Keep finite multiplication exact while repairing zero-scaled poison."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _adalin_transaction(
     x: Array, alpha: Array, *, activation: Array, derivative: Array
 ) -> tuple[Array, Array]:
@@ -83,9 +88,15 @@ def _adalin_transaction(
     if math.prod(output_shape) > _MAX_ARRAY_ELEMENTS:
         raise ValueError("broadcast output exceeds the 1000000-element limit")
     gate = jax.lax.stop_gradient(jnp.cos(0.5 * jnp.pi * jnp.abs(derivative)))
-    candidate = activation + alpha * x * gate
+    # Mechanism-off is alpha=0 exact base activation. ``alpha * x * gate`` still
+    # evaluates ``0 * inf`` under JAX, so skip the zero-scale product first.
+    correction = _skip_zero_scale(alpha, x * gate)
+    candidate = activation + correction
+    x_required_finite = jnp.where(alpha == 0.0, True, jnp.isfinite(x))
     valid = (
-        jnp.all(jnp.isfinite(x)) & jnp.all(jnp.isfinite(alpha)) & jnp.all(jnp.isfinite(candidate))
+        jnp.all(x_required_finite)
+        & jnp.all(jnp.isfinite(alpha))
+        & jnp.all(jnp.isfinite(candidate))
     )
     safe = jnp.where(valid, candidate, jnp.zeros_like(candidate))
     return safe, valid

--- a/tests/test_adalin.py
+++ b/tests/test_adalin.py
@@ -19,6 +19,7 @@ from alberta_framework.benchmarks.adalin import (
     adalin_sgd_step,
     adalin_sgd_step_transaction,
     adalin_tanh,
+    adalin_tanh_transaction,
     initialize_adalin_state,
     make_pmnist_schedule,
     run_adalin_development,
@@ -56,6 +57,38 @@ def test_adalin_is_outer_jit_safe() -> None:
     safe, valid = jax.jit(adalin_relu_transaction)(jnp.array([jnp.nan]), jnp.array([0.2]))
     np.testing.assert_array_equal(safe, jnp.zeros(1))
     assert not bool(valid)
+
+
+def test_zero_alpha_returns_exact_base_activation_on_infinite_x() -> None:
+    """Protocol mechanism-off is alpha=0 exact base activation.
+
+    ``alpha * x * gate`` still evaluates ``0 * inf`` under JAX, which used to
+    poison the candidate and reject the transaction even when the base
+    activation was finite (tanh saturates; ReLU of -inf is 0).
+    """
+    x = jnp.array([jnp.inf, -jnp.inf, 0.5], dtype=jnp.float32)
+    alpha = jnp.zeros_like(x)
+    assert bool(jnp.isnan(jnp.float32(0.0) * jnp.float32(jnp.inf)))
+
+    safe, valid = jax.jit(adalin_tanh_transaction)(x, alpha)
+    assert bool(valid)
+    np.testing.assert_allclose(safe, jnp.tanh(x))
+
+    relu_x = jnp.array([-jnp.inf, 2.0], dtype=jnp.float32)
+    relu_safe, relu_valid = jax.jit(adalin_relu_transaction)(
+        relu_x, jnp.zeros_like(relu_x)
+    )
+    assert bool(relu_valid)
+    np.testing.assert_array_equal(relu_safe, jax.nn.relu(relu_x))
+
+
+def test_nonzero_alpha_still_rejects_infinite_x() -> None:
+    """A learning AdaLin coefficient keeps fail-closed rejection of infinite x."""
+    x = jnp.array([jnp.inf], dtype=jnp.float32)
+    alpha = jnp.array([0.25], dtype=jnp.float32)
+    safe, valid = jax.jit(adalin_tanh_transaction)(x, alpha)
+    assert not bool(valid)
+    np.testing.assert_array_equal(safe, jnp.zeros(1))
 
 
 def test_adalin_preflights_cross_broadcast_and_hostile_array() -> None:


### PR DESCRIPTION
## Problem

`ADALIN_PROTOCOL` declares mechanism-off as `alpha_zero_exact_base_activation`. `_adalin_transaction` still evaluated:

```python
candidate = activation + alpha * x * gate
valid = jnp.all(jnp.isfinite(x)) & ... & jnp.all(jnp.isfinite(candidate))
```

Under JAX, `alpha * x * gate` still evaluates both sides of a `where`, so `alpha=0` with infinite `x` computes `0 * inf = NaN`, poisons `candidate`, and rejects the transaction — even when the base activation is finite (`tanh(±inf)` saturates; `relu(-inf)` is `0`). That breaks the declared mechanism-off reduction.

Reproduced on `main`:

```
adalin_tanh_transaction(+inf, alpha=0) -> (0.0, valid=False)  # should be (1.0, True)
```

## Fix

Skip the zero-scale product before it reaches the candidate (`_skip_zero_scale`), and only require finite `x` on coordinates where `alpha != 0`. Nonzero alpha keeps fail-closed rejection of infinite `x`. Finite arithmetic stays bit-identical for nonzero alpha.

## Tests

- `test_zero_alpha_returns_exact_base_activation_on_infinite_x` — fails on unfixed source, passes with the fix
- `test_nonzero_alpha_still_rejects_infinite_x` — fail-closed preserved

`tests/test_adalin.py`: 21 passed. `ruff` clean.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)