### PR TITLE
fix(benchmarks): freeze micro-continual SGD when step_size is zero under infinite grads

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -824,12 +824,32 @@ class MicroArmSpec:
         )
 
 
+def _sgd_raw_param_update(
+    params: dict[str, Array],
+    grads: dict[str, Array],
+    *,
+    step_size: float,
+    weight_decay: float,
+) -> dict[str, Array]:
+    """Apply plain SGD with decoupled decay, skipping a frozen step size.
+
+    ``step_size=0`` is a supported freeze. Scaling infinite grads by that zero
+    step size evaluates ``0 * inf`` and would poison finite parameters.
+    """
+    decay = 1.0 - step_size * weight_decay
+    if step_size == 0.0:
+        return {name: params[name] for name in params}
+    return {
+        name: params[name] * decay - step_size * grads[name] for name in params
+    }
+
+
 def _make_sgd_raw_learner(
     hp: Mapping[str, float],
 ) -> tuple[LearnerInitFn, ScreeningStepFn]:
     """Plain SGD (optionally with decoupled decay) on raw inputs."""
     step_size = hp["step_size"]
-    decay = 1.0 - step_size * hp["weight_decay"]
+    weight_decay = hp["weight_decay"]
 
     def init_fn(params: dict[str, Array]) -> Array:
         del params
@@ -839,10 +859,12 @@ def _make_sgd_raw_learner(
         params: dict[str, Array], state: Array, grads: dict[str, Array], key: Array
     ) -> tuple[dict[str, Array], Array]:
         del key  # deterministic
-        new_params = {
-            name: params[name] * decay - step_size * grads[name] for name in params
-        }
-        return new_params, state
+        return (
+            _sgd_raw_param_update(
+                params, grads, step_size=step_size, weight_decay=weight_decay
+            ),
+            state,
+        )
 
     return _wrap_grad_learner(init_fn, step_fn)
 

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -2096,3 +2096,33 @@ def test_micro_run_result_rejects_numeric_subclasses_without_conversion_hooks() 
         _legal_micro_run_result(overall_accuracy=HostileFloat(0.5))
     with pytest.raises(ValueError, match="wall_clock_seconds"):
         _legal_micro_run_result(wall_clock_seconds=HostileFloat(1.0))
+
+
+def test_sgd_raw_zero_step_size_preserves_params_under_infinite_grads() -> None:
+    """Frozen SGD must not poison params when grads overflow to inf.
+
+    Hyperparameter freeze accepts ``step_size=0.0``. The update used to
+    evaluate ``params - 0 * grads``, which is ``0 * inf = NaN`` and destroys
+    finite parameters on a no-op step.
+    """
+    params = {"w": jnp.array([1.0, -2.0], dtype=jnp.float32)}
+    grads = {"w": jnp.array([jnp.inf, 3.0], dtype=jnp.float32)}
+    assert bool(jnp.isnan(jnp.float32(0.0) * jnp.float32(jnp.inf)))
+
+    updated = micro_continual._sgd_raw_param_update(
+        params, grads, step_size=0.0, weight_decay=0.01
+    )
+    chex.assert_trees_all_equal(updated, params)
+    assert bool(jnp.all(jnp.isfinite(updated["w"])))
+
+
+def test_sgd_raw_nonzero_step_size_still_applies_to_finite_grads() -> None:
+    params = {"w": jnp.array([1.0, -2.0], dtype=jnp.float32)}
+    grads = {"w": jnp.array([0.5, -1.0], dtype=jnp.float32)}
+    updated = micro_continual._sgd_raw_param_update(
+        params, grads, step_size=0.1, weight_decay=0.0
+    )
+    chex.assert_trees_all_close(
+        updated["w"],
+        params["w"] - 0.1 * grads["w"],
+    )


### PR DESCRIPTION
## Problem

`_freeze_micro_hyperparameters` accepts any finite `step_size`, including `0.0`. The SGD raw arm updated with:

```python
decay = 1.0 - step_size * weight_decay
params[name] * decay - step_size * grads[name]
```

When `step_size=0`, `decay` is exactly `1.0`, but `0 * inf` grads still evaluate to NaN and poison finite parameters on a freeze step.

## Fix

Extract `_sgd_raw_param_update` and return the input params unchanged when `step_size == 0.0`, before any grad scaling.

## Tests

- `test_sgd_raw_zero_step_size_preserves_params_under_infinite_grads`
- `test_sgd_raw_nonzero_step_size_still_applies_to_finite_grads`

Focused suite green; `ruff` clean.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)