### PR TITLE
fix(streams): bound Gymnasium learn_from_trajectory scan length before lax.scan

### DIFF
--- a/alberta_framework/streams/gymnasium.py
+++ b/alberta_framework/streams/gymnasium.py
@@ -44,6 +44,14 @@ if TYPE_CHECKING:
 
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
+# ``learn_from_trajectory`` hands caller-supplied step arrays straight to
+# ``jax.lax.scan`` with no bound tighter than ``_INT32_MAX``. Bounding only
+# by ``_INT32_MAX`` still lets a caller force JAX to trace/compile a scan of
+# up to ~2 billion steps (resource preflight only catches wide rows, not
+# long-but-narrow ones), hanging the process well before any step executes.
+# Matches the ceiling convention for sibling scan-driven array loops
+# (``streams.feature_discovery``, ``core.sarsa``, ``core.horde``).
+_GYMNASIUM_TRAJECTORY_MAX_STEPS = 10_000
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -499,6 +507,11 @@ def learn_from_trajectory(
         metrics have shape (num_steps, 3) with columns
         [squared_error, error, mean_step_size]; a learner constructed with
         a normalizer emits a fourth column, normalizer_mean_var.
+
+    Raises:
+        ValueError: If ``num_steps`` is outside
+            ``[1, _GYMNASIUM_TRAJECTORY_MAX_STEPS]`` or the arrays are otherwise
+            malformed for a scan.
     """
     if type(learner) is not LinearLearner and not isinstance(learner, LinearLearner):
         raise TypeError("learner must be an instance of LinearLearner")
@@ -528,8 +541,11 @@ def learn_from_trajectory(
         raise ValueError("observations must be a 2D array of shape (num_steps, feature_dim)")
     if tgt_ndim not in (1, 2):
         raise ValueError("targets must be a 1D or 2D array")
-    if not 1 <= num_steps <= _INT32_MAX:
-        raise ValueError("observations sequence length must be an integer in [1, 2147483647]")
+    if not 1 <= num_steps <= _GYMNASIUM_TRAJECTORY_MAX_STEPS:
+        raise ValueError(
+            "observations sequence length must be an integer in "
+            f"[1, {_GYMNASIUM_TRAJECTORY_MAX_STEPS}]"
+        )
     if target_steps != num_steps:
         raise ValueError("targets sequence length must match observations sequence length")
     if feature_dim is None or not 1 <= feature_dim <= _INT32_MAX:

--- a/tests/test_step3_gymnasium_prototype_scan_bounds.py
+++ b/tests/test_step3_gymnasium_prototype_scan_bounds.py
@@ -26,6 +26,7 @@ from alberta_framework.steps.step3 import (
     run_step3_scan,
 )
 from alberta_framework.streams.gymnasium import (
+    _GYMNASIUM_TRAJECTORY_MAX_STEPS,
     learn_from_trajectory,
     learn_from_trajectory_normalized,
 )
@@ -250,6 +251,53 @@ class TestGymnasiumTrajectoryScanValidation:
         final_state, metrics = learn_from_trajectory(learner, obs, targets)
         assert isinstance(final_state, LearnerState)
         assert metrics.shape == (8, 3)
+
+    def test_documented_trajectory_scan_ceiling(self) -> None:
+        assert _GYMNASIUM_TRAJECTORY_MAX_STEPS == 10_000
+
+    def test_rejects_overflow_sequence_length_before_scan(
+        self, learner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[int] = []
+
+        def spy(fn, init, xs, **kwargs):  # type: ignore[no-untyped-def]
+            first = xs[0] if isinstance(xs, tuple) else xs
+            seen.append(int(first.shape[0]))
+            raise AssertionError(f"jax.lax.scan must not run: T={first.shape[0]}")
+
+        monkeypatch.setattr(
+            "alberta_framework.streams.gymnasium.jax.lax.scan", spy
+        )
+        obs = jnp.zeros((_GYMNASIUM_TRAJECTORY_MAX_STEPS + 1, 3), dtype=jnp.float32)
+        targets = jnp.zeros((_GYMNASIUM_TRAJECTORY_MAX_STEPS + 1, 1), dtype=jnp.float32)
+        with pytest.raises(
+            ValueError,
+            match=r"observations sequence length must be an integer in \[1, 10000\]",
+        ):
+            learn_from_trajectory(learner, obs, targets)
+        assert seen == []
+
+    def test_rejects_origin_hang_class_sized_sequence_before_scan(
+        self, learner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[int] = []
+
+        def spy(fn, init, xs, **kwargs):  # type: ignore[no-untyped-def]
+            first = xs[0] if isinstance(xs, tuple) else xs
+            seen.append(int(first.shape[0]))
+            raise AssertionError(f"jax.lax.scan must not run: T={first.shape[0]}")
+
+        monkeypatch.setattr(
+            "alberta_framework.streams.gymnasium.jax.lax.scan", spy
+        )
+        obs = jnp.zeros((200_000, 1), dtype=jnp.float32)
+        targets = jnp.zeros((200_000, 1), dtype=jnp.float32)
+        with pytest.raises(
+            ValueError,
+            match=r"observations sequence length must be an integer in \[1, 10000\]",
+        ):
+            learn_from_trajectory(learner, obs, targets)
+        assert seen == []
 
     def test_learn_from_trajectory_normalized_alias(self, learner) -> None:
         obs = jnp.ones((8, 3), dtype=jnp.float32)


### PR DESCRIPTION
## Problem

`learn_from_trajectory` accepted any leading axis up to signed int32 and handed it straight to `jax.lax.scan`. Resource preflight only catches wide rows, so a long-but-narrow array (for example `T=200_000`, `feature_dim=1`) still forces JAX to trace/compile a huge scan and hang the process before any step runs — the same hang class already closed for `streams.feature_discovery`, `core.sarsa`, and `core.horde`.

## Fix

Introduce `_GYMNASIUM_TRAJECTORY_MAX_STEPS = 10_000` and reject overflow lengths before `lax.scan`.

## Tests

- Document the ceiling.
- Reject first overflow (`10001`) and hang-class (`200_000`) lengths with a scan spy asserting `lax.scan` never runs.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)