### PR TITLE
fix(benchmarks): require exact dict/list JSON containers in matched protocol parse

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_protocol.py
@@ -1086,7 +1086,7 @@ def _validate_json_complexity(value: Any) -> None:
             raise ForagerMatchedProtocolError("protocol exceeds the JSON node limit")
         if depth > _MAX_JSON_NESTING:
             raise ForagerMatchedProtocolError("protocol exceeds the JSON nesting limit")
-        if isinstance(item, Mapping):
+        if type(item) is dict:
             for key in item:
                 if type(key) is not str:
                     raise ForagerMatchedProtocolError("JSON object keys must be strings")
@@ -1097,7 +1097,7 @@ def _validate_json_complexity(value: Any) -> None:
                         "JSON object keys must contain valid Unicode"
                     ) from exc
             pending.extend((child, depth + 1) for child in item.values())
-        elif isinstance(item, list):
+        elif type(item) is list:
             pending.extend((child, depth + 1) for child in item)
         elif type(item) is str:
             try:
@@ -1106,7 +1106,7 @@ def _validate_json_complexity(value: Any) -> None:
                 raise ForagerMatchedProtocolError(
                     "JSON strings must contain valid Unicode"
                 ) from exc
-        elif isinstance(item, float):
+        elif type(item) is float:
             if not math.isfinite(item):
                 raise ForagerMatchedProtocolError("non-finite JSON numbers are forbidden")
         elif item is not None and type(item) not in (bool, int, float, str, dict, list):
@@ -1147,7 +1147,7 @@ def decode_strict_json(data: bytes | str) -> Any:
 
 
 def _require_object(value: Any, path: str) -> Mapping[str, Any]:
-    if not isinstance(value, Mapping):
+    if type(value) is not dict:
         raise ForagerMatchedProtocolError(f"{path} must be a JSON object")
     if any(type(key) is not str for key in value):
         raise ForagerMatchedProtocolError(f"{path} keys must be strings")
@@ -1155,7 +1155,7 @@ def _require_object(value: Any, path: str) -> Mapping[str, Any]:
 
 
 def _require_array(value: Any, path: str) -> list[Any]:
-    if not isinstance(value, list):
+    if type(value) is not list:
         raise ForagerMatchedProtocolError(f"{path} must be a JSON array")
     return value
 

--- a/tests/test_forager_matched_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_protocol_hostile_validation.py
@@ -211,3 +211,35 @@ def test_selection_result_parser_rejects_subclass_without_conversion() -> None:
     with pytest.raises(ForagerMatchedProtocolError):
         parse_forager_matched_selection_result(hostile)
     assert _HostileSelectionResult.calls == 0
+
+
+def test_parse_rejects_mapping_subclass_without_iter_hooks() -> None:
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(
+        ForagerMatchedProtocolError, match="non-JSON value|must be a JSON object"
+    ):
+        parse_forager_matched_protocol(HostileDict({"schema_version": "x"}))
+    assert HostileDict.calls == 0
+
+
+def test_require_array_rejects_list_subclass_without_iter_hooks() -> None:
+    from alberta_framework.benchmarks.forager_matched_protocol import _require_array
+
+    class HostileList(list):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileList.__iter__ must not run")
+
+    HostileList.calls = 0
+    with pytest.raises(ForagerMatchedProtocolError, match="must be a JSON array"):
+        _require_array(HostileList([1]), "path")
+    assert HostileList.calls == 0


### PR DESCRIPTION
## Problem

`parse_forager_matched_protocol` accepts in-memory values, not only decoded JSON text. Validation walked containers with `isinstance(..., Mapping)` / `isinstance(..., list)` and accepted `isinstance(..., float)` for finiteness.

A `dict` subclass with a hostile `__iter__` therefore entered the Mapping branch and fired during key enumeration instead of being rejected as a non-JSON value:

```
parse_forager_matched_protocol(HostileDict(...))
-> AssertionError: HostileDict.__iter__
```

## Fix

Gate `_validate_json_complexity`, `_require_object`, and `_require_array` on exact `dict` / `list` / `float` types (house JSON-builtin identity), matching the existing exact-type checks for strings and the final non-JSON reject list.

## Tests

Two hostile regressions in `tests/test_forager_matched_protocol_hostile_validation.py`. Protocol suites: 79 passed. `ruff` clean.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)