### PR TITLE
fix(evaluation): reject non-finite interval bounds in measurement validation

### DIFF
--- a/alberta_framework/evaluation/_measurement_validation.py
+++ b/alberta_framework/evaluation/_measurement_validation.py
@@ -43,8 +43,16 @@ def nonnegative_finite_real(name: str, value: object) -> float:
 def validate_interval_bounds(
     *, lower: float, upper: float, confidence_level: float
 ) -> None:
-    """Validate ordering and the open-unit confidence domain."""
+    """Validate ordering and the open-unit confidence domain.
 
+    Non-finite bounds must fail closed: IEEE comparisons involving NaN are
+    always false, so ``lower > upper`` alone cannot reject ``nan``/``±inf``.
+    """
+
+    if not (
+        math.isfinite(lower) and math.isfinite(upper) and math.isfinite(confidence_level)
+    ):
+        raise ValueError("interval bounds and confidence_level must be finite")
     if lower > upper:
         raise ValueError("lower must not exceed upper")
     if not 0.0 < confidence_level < 1.0:

--- a/tests/test_measurement_validation_interval_bounds.py
+++ b/tests/test_measurement_validation_interval_bounds.py
@@ -1,0 +1,41 @@
+"""Fail-closed interval bound checks for shared measurement validation."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from alberta_framework.evaluation._measurement_validation import validate_interval_bounds
+
+
+def test_validate_interval_bounds_accepts_finite_ordered_interval() -> None:
+    validate_interval_bounds(lower=0.1, upper=0.9, confidence_level=0.95)
+
+
+@pytest.mark.parametrize(
+    ("lower", "upper"),
+    [
+        (math.nan, 1.0),
+        (0.0, math.nan),
+        (math.inf, math.inf),
+        (-math.inf, 0.0),
+        (math.nan, math.nan),
+    ],
+)
+def test_validate_interval_bounds_rejects_nonfinite_bounds(
+    lower: float, upper: float
+) -> None:
+    """IEEE ``lower > upper`` is always false for NaN, so finiteness must be gated."""
+    with pytest.raises(ValueError, match="must be finite"):
+        validate_interval_bounds(lower=lower, upper=upper, confidence_level=0.95)
+
+
+def test_validate_interval_bounds_rejects_nonfinite_confidence() -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        validate_interval_bounds(lower=0.0, upper=1.0, confidence_level=math.nan)
+
+
+def test_validate_interval_bounds_still_rejects_inverted_finite_bounds() -> None:
+    with pytest.raises(ValueError, match="lower must not exceed upper"):
+        validate_interval_bounds(lower=0.9, upper=0.1, confidence_level=0.95)


### PR DESCRIPTION
## Problem

`validate_interval_bounds` only checked:

```python
if lower > upper: raise ...
if not 0.0 < confidence_level < 1.0: raise ...
```

IEEE comparisons involving NaN are always false, so `lower=nan` / `upper=nan` / `±inf` bounds were accepted as ordered intervals. Callers in continual IA, multiagent acceptance, and FTL fidelity then recorded non-finite Wilson-style intervals as structurally valid.

## Fix

Require `math.isfinite` on `lower`, `upper`, and `confidence_level` before the ordering and open-unit checks.

## Tests

`tests/test_measurement_validation_interval_bounds.py` — 6 cases fail on unfixed source and pass with the fix; ordered finite intervals and inverted finite bounds keep their prior behavior.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)