### PR TITLE
fix(core): require exact dict or MappingProxyType for dreaming config payloads

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -22,8 +22,8 @@ from __future__ import annotations
 import dataclasses
 import functools
 import operator
-from collections.abc import Mapping
 from fractions import Fraction
+from types import MappingProxyType
 from typing import Any, Literal, Protocol, SupportsIndex, cast
 
 import chex
@@ -132,7 +132,7 @@ def _require_float32_resource(
 
 
 def _copy_mapping(payload: object, *, name: str) -> dict[str, object]:
-    if not isinstance(payload, Mapping):
+    if type(payload) is not dict and type(payload) is not MappingProxyType:
         raise ValueError(f"{name} payload must be a mapping")
     try:
         data = dict(payload)
@@ -434,7 +434,7 @@ class GuardedDreamer:
         if set(data) != {"config"}:
             raise ValueError("GuardedDreamer payload has unknown fields")
         raw = data["config"]
-        if not isinstance(raw, Mapping):
+        if type(raw) is not dict and type(raw) is not MappingProxyType:
             raise ValueError("GuardedDreamer config must be a mapping")
         return cls(DreamingConfig.from_config(raw))
 

--- a/tests/test_dreaming_validation.py
+++ b/tests/test_dreaming_validation.py
@@ -295,9 +295,9 @@ def test_dreaming_mapping_loaders_preserve_markers_and_exact_keys() -> None:
     bad = {StringSubclass("type"): "DreamingConfig", "warmup_steps": 1}
     with pytest.raises(ValueError, match="exact strings"):
         DreamingConfig.from_config(bad)  # type: ignore[arg-type]
-    # Hostile mapping should be rejected
+    # Hostile mapping should be rejected without running container hooks.
     hostile = _HostileMapping({"type": "DreamingConfig", "warmup_steps": 1})
-    with pytest.raises(ValueError, match="payload could not be read"):
+    with pytest.raises(ValueError, match="must be a mapping|payload could not be read"):
         DreamingConfig.from_config(hostile)  # type: ignore[arg-type]
 
     # DreamSelectionConfig


### PR DESCRIPTION
## Problem

Dreaming config loaders used `isinstance(payload, Mapping)`. A `dict` subclass with hostile `__iter__`/`keys`/`items` was accepted into `_copy_mapping`, which then executed those hooks (surfaced only as a generic \"payload could not be read\").

`MappingProxyType` round-trips are intentional and covered by existing tests, so the gate must keep that exact type.

## Fix

Require `type(payload) is dict` or `type(payload) is MappingProxyType` in `_copy_mapping` and the nested `GuardedDreamer` config check. Hostile subclasses are rejected before container hooks run.

## Tests

Updated the hostile-mapping expectation in `tests/test_dreaming_validation.py`. `tests/test_dreaming_validation.py` + `tests/test_dreaming.py`: 132 passed. `ruff` clean.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)