### PR TITLE
fix(benchmarks): require exact dict/list JSON containers in forager matrix manifests

### DIFF
--- a/alberta_framework/benchmarks/forager_matrix.py
+++ b/alberta_framework/benchmarks/forager_matrix.py
@@ -847,10 +847,14 @@ def _validate_json_complexity(value: Any, *, description: str) -> None:
             raise ForagerMatrixManifestError(
                 f"{description} exceeds the JSON nesting limit"
             )
-        if isinstance(item, Mapping):
+        if type(item) is dict:
             pending.extend((child, depth + 1) for child in item.values())
-        elif isinstance(item, list):
+        elif type(item) is list:
             pending.extend((child, depth + 1) for child in item)
+        elif item is not None and type(item) not in (bool, int, float, str):
+            raise ForagerMatrixManifestError(
+                f"{description} contains a non-JSON value of type {type(item).__name__}"
+            )
 
 
 def _decode_strict_json(data: str, *, description: str) -> Any:
@@ -916,7 +920,7 @@ def _require_nonnegative_int(value: Any, path: str) -> int:
 
 
 def _require_seed_list(value: Any, path: str) -> tuple[int, ...]:
-    if not isinstance(value, list):
+    if type(value) is not list:
         raise ForagerMatrixManifestError(f"{path} must be a JSON array")
     if not value:
         raise ForagerMatrixManifestError(f"{path} must not be empty")
@@ -957,7 +961,7 @@ def _coerce_typed_value(value: Any, annotation: Any, path: str) -> Any:
             return _coerce_typed_value(value, non_none[0], path)
 
     if origin is tuple:
-        if not isinstance(value, list):
+        if type(value) is not list:
             raise ForagerMatrixManifestError(f"{path} must be a JSON array")
         element_type = arguments[0] if arguments else Any
         return tuple(

--- a/tests/test_forager_matrix_manifest_hostile_validation.py
+++ b/tests/test_forager_matrix_manifest_hostile_validation.py
@@ -192,3 +192,31 @@ def test_source_snapshot_rejects_hostile_archive_size_before_comparison() -> Non
             description="hostile snapshot",
         )
     assert _HostileString.calls == _ExplodingPattern.calls == 0
+
+
+def test_json_complexity_rejects_mapping_subclass_without_values_hooks() -> None:
+    class HostileDict(dict):
+        calls = 0
+
+        def values(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.values must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(matrix.ForagerMatrixManifestError, match="non-JSON value"):
+        matrix._validate_json_complexity(HostileDict({"a": 1}), description="manifest")
+    assert HostileDict.calls == 0
+
+
+def test_require_seed_list_rejects_list_subclass_without_iter_hooks() -> None:
+    class HostileList(list):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileList.__iter__ must not run")
+
+    HostileList.calls = 0
+    with pytest.raises(matrix.ForagerMatrixManifestError, match="must be a JSON array"):
+        matrix._require_seed_list(HostileList([1]), "seeds")
+    assert HostileList.calls == 0


### PR DESCRIPTION
## Problem

Forager matrix manifest validation walked decoded JSON with `isinstance(..., Mapping/list)` and accepted seed/tuple arrays via `isinstance(..., list)`.

A `dict` subclass with hostile `values()` therefore executed during complexity traversal, and a `list` subclass with hostile `__iter__` executed during seed-list validation.

## Fix

- `_validate_json_complexity`: walk only exact `dict`/`list`; reject other non-scalar types as non-JSON
- `_require_seed_list` and tuple coercion: require exact `list`

## Tests

Two hostile regressions in `tests/test_forager_matrix_manifest_hostile_validation.py`. Focused hostile suites green; `ruff` clean.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)