### PR TITLE
Require exact dict for recurring multiagent migrate/checkpoint

### DIFF
--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -948,7 +948,7 @@ def migrate_legacy_recurring_two_agent_state(
     world: RecurringTwoAgentWorld,
 ) -> RecurringTwoAgentState:
     """Migrate only an unsaturated pre-v2 environment lifetime."""
-    if isinstance(legacy_state, Mapping):
+    if type(legacy_state) is dict:
         fields = dict(legacy_state)
     elif dataclasses.is_dataclass(legacy_state) and not isinstance(legacy_state, type):
         fields = {
@@ -1022,7 +1022,7 @@ def load_recurring_two_agent_checkpoint(
     if schema != RECURRING_TWO_AGENT_CHECKPOINT_SCHEMA:
         raise ValueError("recurring two-agent checkpoint schema is unsupported")
     raw_config = metadata.get("world_config")
-    if not isinstance(raw_config, Mapping):
+    if type(raw_config) is not dict:
         raise ValueError("recurring two-agent checkpoint world_config is invalid")
     world = RecurringTwoAgentWorld.from_config(raw_config)
     template = world.init(jr.key(0))

--- a/tests/test_recurring_multiagent_hostile.py
+++ b/tests/test_recurring_multiagent_hostile.py
@@ -4,7 +4,10 @@ from typing import Any
 
 import pytest
 
-from alberta_framework.streams.recurring_multiagent import RecurringTwoAgentWorld
+from alberta_framework.streams.recurring_multiagent import (
+    RecurringTwoAgentWorld,
+    migrate_legacy_recurring_two_agent_state,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -162,3 +165,28 @@ def test_recurring_world_from_config_rejects_invalid_initial_positions() -> None
         RecurringTwoAgentWorld.from_config({**valid, "initial_positions": [-0.5]})
     with pytest.raises(ValueError, match="initial_positions must have length 2"):
         RecurringTwoAgentWorld.from_config({**valid, "initial_positions": [-0.5, 0.0, 0.5]})
+
+
+def test_migrate_legacy_state_rejects_mapping_subclass_without_iter_hooks() -> None:
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(TypeError, match="must be a mapping or dataclass"):
+        migrate_legacy_recurring_two_agent_state(
+            HostileDict(
+                {
+                    "key": None,
+                    "positions": None,
+                    "velocities": None,
+                    "nuisance": None,
+                    "step_count": None,
+                }
+            ),
+            world=RecurringTwoAgentWorld(),
+        )
+    assert HostileDict.calls == 0


### PR DESCRIPTION
## Summary
- Dict subclasses can override iteration during legacy migrate and checkpoint `world_config` handling.
- Accept only an exact `dict` (or the expected dataclass) and fail closed on hostile mapping subclasses.

## Test plan
- [ ] CI green on the branch
- [ ] Hostile subclass fixtures rejected at migrate/checkpoint boundaries

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)