### PR TITLE
fix(core): bound independent-demon Horde scan length before lax.scan

### DIFF
--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -76,6 +76,11 @@ from alberta_framework.core.update_safety import (
 
 
 _INT32_MAX = 2**31 - 1
+# Matches the documented learning-loop step ceiling used by sibling Horde and
+# SARSA scan drivers. Origin handed caller-supplied trajectories to
+# ``jax.lax.scan`` with no bound tighter than ``_INT32_MAX``, which still lets a
+# narrow-but-long sequence force JAX to trace/compile up to ~2 billion steps.
+_INDEPENDENT_HORDE_SEQUENCE_MAX_STEPS = 10_000
 _ACTUAL_INT_TYPES = frozenset(
     {int, *(np.dtype(code).type for code in "bBhHiIlLqQpP")}
 )
@@ -201,7 +206,12 @@ def _require_learning_arrays(
     if len(obs_shape) != 2 or obs_shape[0] < 1 or obs_shape[1] < 1:
         raise ValueError("observations must have shape (num_steps, feature_dim)")
     num_steps, feature_dim = obs_shape
-    if not 1 <= num_steps <= _INT32_MAX or not 1 <= feature_dim <= _INT32_MAX:
+    if not 1 <= num_steps <= _INDEPENDENT_HORDE_SEQUENCE_MAX_STEPS:
+        raise ValueError(
+            "observations sequence length must be an integer in "
+            f"[1, {_INDEPENDENT_HORDE_SEQUENCE_MAX_STEPS}]"
+        )
+    if not 1 <= feature_dim <= _INT32_MAX:
         raise ValueError("observations must contain between 1 and signed-int32 dimensions")
 
     obs = _trusted_array("observations", observations, shape=obs_shape, dtype=jnp.float32)

--- a/tests/test_independent_demon_horde.py
+++ b/tests/test_independent_demon_horde.py
@@ -765,3 +765,42 @@ def test_independent_horde_loop_preflights_shapes_and_output_budget() -> None:
     _require_loop_output_resources(119_304_647, 1)
     with pytest.raises(ValueError, match="learning-loop outputs"):
         _require_loop_output_resources(119_304_648, 1)
+
+
+def test_independent_horde_documented_sequence_scan_ceiling() -> None:
+    from alberta_framework.core.independent_demon_horde import (
+        _INDEPENDENT_HORDE_SEQUENCE_MAX_STEPS,
+    )
+
+    assert _INDEPENDENT_HORDE_SEQUENCE_MAX_STEPS == 10_000
+
+
+def test_independent_horde_rejects_overflow_sequence_length_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from alberta_framework.core import independent_demon_horde as mod
+
+    seen: list[int] = []
+
+    def spy(fn, init, xs, **kwargs):  # type: ignore[no-untyped-def]
+        first = xs[0] if isinstance(xs, tuple) else xs
+        seen.append(int(first.shape[0]))
+        raise AssertionError(f"jax.lax.scan must not run: T={first.shape[0]}")
+
+    monkeypatch.setattr(mod.jax.lax, "scan", spy)
+    spec = create_horde_spec(_make_all_gamma0_spec(1))
+    horde = IndependentDemonHorde(horde_spec=spec, hidden_sizes=())
+    state = horde.init(1, jr.key(0))
+    steps = mod._INDEPENDENT_HORDE_SEQUENCE_MAX_STEPS + 1
+    with pytest.raises(
+        ValueError,
+        match=r"observations sequence length must be an integer in \[1, 10000\]",
+    ):
+        run_independent_horde_learning_loop(
+            horde,
+            state,
+            jnp.zeros((steps, 1), dtype=jnp.float32),
+            jnp.zeros((steps, 1), dtype=jnp.float32),
+            jnp.zeros((steps, 1), dtype=jnp.float32),
+        )
+    assert seen == []


### PR DESCRIPTION
## Summary
- Cap independent-demon Horde learning-loop trajectories at the shared 10_000-step scan ceiling before `jax.lax.scan`.
- Origin only checked signed-int32, which still allowed narrow-but-long sequences to hang compilation.

## Test plan
- [x] `pytest tests/test_independent_demon_horde.py -q`
- [x] `ruff check` on touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)