### PR TITLE
fix(benchmarks): reject non-finite L2ER paired confidence bounds

### DIFF
--- a/alberta_framework/benchmarks/l2er_matched_development.py
+++ b/alberta_framework/benchmarks/l2er_matched_development.py
@@ -420,6 +420,11 @@ def _outcome(deltas: tuple[float, ...]) -> tuple[float, float, float, str]:
     stderr = float(values.std(ddof=1) / math.sqrt(len(values)))
     lower = mean - _T95_DF2 * stderr
     upper = mean + _T95_DF2 * stderr
+    # Non-finite bounds must fail closed: IEEE comparisons involving NaN are
+    # always false, so ``lower > 0.0`` / ``upper <= 0.0`` alone cannot reject
+    # ``nan``/``±inf`` and would otherwise report a false "inconclusive".
+    if not (math.isfinite(mean) and math.isfinite(lower) and math.isfinite(upper)):
+        raise ValueError("paired confidence interval bounds must be finite")
     outcome = "supported" if lower > 0.0 else "rejected" if upper <= 0.0 else "inconclusive"
     return mean, lower, upper, outcome
 

--- a/tests/test_l2er_matched_development.py
+++ b/tests/test_l2er_matched_development.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
+import math
 import os
 from copy import deepcopy
 from pathlib import Path
@@ -239,6 +240,20 @@ def test_three_seed_interval_uses_student_t_not_normal_critical_value() -> None:
     assert critical == 4.302652729749464
     assert isinstance(critical, float)
     assert critical.hex() == "0x1.135ea98e146bbp+2"
+
+
+@pytest.mark.parametrize(
+    "deltas",
+    [
+        (math.nan, 0.0, 0.0),
+        (math.inf, math.inf, math.inf),
+        (-math.inf, 0.0, 0.0),
+    ],
+)
+def test_outcome_rejects_nonfinite_interval_bounds(deltas: tuple[float, float, float]) -> None:
+    """IEEE lower/upper comparisons are always false for NaN, so fail closed."""
+    with pytest.raises(ValueError, match="must be finite"):
+        matched._outcome(deltas)
 
 
 @pytest.mark.parametrize("version", ("v1",))


### PR DESCRIPTION
## Summary
- Require finite mean/lower/upper before classifying L2ER paired CI outcomes.
- NaN bounds previously fell through to a false `inconclusive` because IEEE comparisons involving NaN are always false.

## Test plan
- [x] `pytest tests/test_l2er_matched_development.py -q`
- [x] `ruff check` on touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)