### PR TITLE
fix(evaluation): reject non-finite activation-feature paired CI bounds

### DIFF
--- a/alberta_framework/evaluation/activation_feature_campaign.py
+++ b/alberta_framework/evaluation/activation_feature_campaign.py
@@ -1099,6 +1099,16 @@ def _paired_summary(
         margin = _T_CRITICAL_DF4_BONFERRONI_8 * standard_error
         lower = mean - margin
         upper = mean + margin
+        # Non-finite bounds must fail closed: IEEE comparisons involving NaN are
+        # always false, so ``lower > 0.0`` / ``upper < 0.0`` alone cannot reject
+        # ``nan``/``±inf`` and would otherwise report a false "inconclusive".
+        if not (
+            math.isfinite(mean)
+            and math.isfinite(lower)
+            and math.isfinite(upper)
+            and math.isfinite(standard_error)
+        ):
+            raise ValueError("paired confidence interval bounds must be finite")
         outcome = "supported" if lower > 0.0 else "rejected" if upper < 0.0 else "inconclusive"
         summaries.append(
             {

--- a/tests/test_activation_feature_campaign.py
+++ b/tests/test_activation_feature_campaign.py
@@ -774,3 +774,31 @@ def test_publication_rejects_zero_write_and_nonregular_reread_swap(
         monkeypatch.setattr(campaign, "_link_unnamed_file", link_then_swap)
         with pytest.raises(ValueError, match="regular file"):
             campaign._publish_reserved_json(target, cheap_plan)
+
+
+def test_paired_summary_rejects_nonfinite_interval_bounds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IEEE lower/upper comparisons are always false for NaN, so fail closed."""
+    import math
+
+    monkeypatch.setattr(
+        campaign,
+        "_COMPARISONS",
+        (("family", "candidate", "control"),),
+    )
+    seeds = (0, 1, 2, 3, 4)
+    by_identity: dict[tuple[int, str], dict[str, object]] = {}
+    for seed in seeds:
+        by_identity[(seed, "candidate")] = {
+            "result": {
+                "metrics": {
+                    "asi_whole_stream_mean_accuracy": math.nan if seed == 0 else 0.5
+                }
+            }
+        }
+        by_identity[(seed, "control")] = {
+            "result": {"metrics": {"asi_whole_stream_mean_accuracy": 0.4}}
+        }
+    with pytest.raises(ValueError, match="must be finite"):
+        campaign._paired_summary(by_identity, seeds)


### PR DESCRIPTION
## Summary
- Require finite mean/lower/upper/standard_error before classifying activation-feature paired CI outcomes.
- NaN bounds previously fell through to a false `inconclusive` because IEEE comparisons involving NaN are always false.

## Test plan
- [x] `pytest tests/test_activation_feature_campaign.py -q`
- [x] `ruff check` on touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)