### PR TITLE
fix(core): skip zero mixer weights before 0*inf contribution products

### DIFF
--- a/alberta_framework/core/representation_gradient_mixer.py
+++ b/alberta_framework/core/representation_gradient_mixer.py
@@ -533,6 +533,12 @@ def _prepare_source(
     return _clip_l2(normalized, clip_norm)
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Keep finite multiplication exact while repairing zero-scaled poison."""
+
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def _safe_cosine(first: Array, second: Array) -> Array:
     """Return finite cosine similarity, with exact zero for either zero vector."""
 
@@ -653,8 +659,11 @@ def mix_representation_gradients(
     zeros = jnp.zeros((config.representation_dim,), dtype=jnp.float32)
     behavior_for_use = jnp.where(behavior_source_valid, prepared_behavior, zeros)
     world_for_use = jnp.where(world_source_valid, prepared_world, zeros)
-    behavior_contribution = behavior_effective_weight * behavior_for_use
-    world_contribution = world_effective_weight * world_for_use
+    # Mechanism-off is weight=0 exact zero contribution. ``weight * vector`` still
+    # evaluates ``0 * inf`` under JAX when a prepared source overflows, so skip
+    # the zero-scale product first.
+    behavior_contribution = _skip_zero_scale(behavior_effective_weight, behavior_for_use)
+    world_contribution = _skip_zero_scale(world_effective_weight, world_for_use)
     behavior_contribution_finite = jnp.all(jnp.isfinite(behavior_contribution))
     world_contribution_finite = jnp.all(jnp.isfinite(world_contribution))
     safe_behavior_contribution = jnp.where(

--- a/tests/test_representation_gradient_mixer.py
+++ b/tests/test_representation_gradient_mixer.py
@@ -344,6 +344,55 @@ def test_masked_or_zero_weight_invalid_source_is_recorded_without_poisoning_outp
         assert np.isinf(np.asarray(result.diagnostics.grounded_world_raw_norm)).all()
 
 
+def test_zero_weight_skips_infinite_prepared_contribution_product(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mechanism-off is weight=0 exact zero contribution.
+
+    ``weight * vector`` still evaluates ``0 * inf`` under JAX when a prepared
+    source overflows, so the product must be skipped before it can poison.
+    """
+    assert bool(jnp.isnan(jnp.float32(0.0) * jnp.float32(jnp.inf)))
+
+    def prepare(
+        value: jnp.ndarray,
+        *,
+        normalization: str,
+        epsilon: float,
+        clip_norm: float | None,
+    ) -> jnp.ndarray:
+        del normalization, epsilon, clip_norm
+        # Overflow only the inactive (zero-weight) behavior path.
+        if bool(jnp.all(value == jnp.asarray([1.0, -2.0], dtype=jnp.float32))):
+            return jnp.full_like(value, jnp.inf)
+        return value
+
+    monkeypatch.setattr(
+        "alberta_framework.core.representation_gradient_mixer._prepare_source",
+        prepare,
+    )
+    config = RepresentationGradientMixerConfig(
+        representation_dim=2,
+        mode="full",
+        behavior_weight=0.0,
+        grounded_world_weight=1.0,
+        behavior_normalization="none",
+        grounded_world_normalization="none",
+    )
+    behavior = jnp.asarray([1.0, -2.0], dtype=jnp.float32)
+    world = jnp.asarray([3.0, -4.0], dtype=jnp.float32)
+    result = mix_representation_gradients(config, behavior, world)
+    np.testing.assert_array_equal(result.gradient, world)
+    assert bool(result.valid)
+    assert bool(result.applied)
+    assert not bool(result.rejected)
+    assert not bool(result.diagnostics.behavior_active)
+    assert bool(result.diagnostics.grounded_world_active)
+    # Zero-scale skip keeps the inactive contribution exactly finite-zero;
+    # ``0 * inf`` would mark the contribution non-finite and report used_norm=inf.
+    np.testing.assert_allclose(result.diagnostics.behavior_used_norm, 0.0)
+
+
 def test_wrong_gradient_shape_or_dynamic_validity_predicate_fails_closed() -> None:
     config = RepresentationGradientMixerConfig(representation_dim=2)
     with pytest.raises(ValueError, match="shape"):


### PR DESCRIPTION
## Summary
- Skip zero behavior/world mixer weights before scaling prepared gradients.
- Prevents `0 * inf` from marking inactive contributions non-finite and reporting infinite used norms.

## Test plan
- [x] `pytest tests/test_representation_gradient_mixer.py -q`
- [x] `ruff check` on touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)