### PR TITLE
fix(benchmarks): require exact dict/list in matched evaluation campaign JSON

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_evaluation_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_evaluation_campaign.py
@@ -57,7 +57,7 @@ class _ValidatedTransition:
 
 
 def _plain_json(value: Any) -> Any:
-    if isinstance(value, Mapping):
+    if type(value) is dict or type(value) is MappingProxyType:
         result: dict[str, Any] = {}
         for key, item in value.items():
             if type(key) is not str:
@@ -66,7 +66,7 @@ def _plain_json(value: Any) -> Any:
                 )
             result[key] = _plain_json(item)
         return result
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+    if type(value) is list:
         return [_plain_json(item) for item in value]
     if value is None or type(value) in {str, bool, int}:
         return value
@@ -374,7 +374,7 @@ def _decode_schedule(
                 "schedule is not valid UTF-8 JSON"
             ) from exc
         encoded = value
-    elif isinstance(value, Mapping):
+    elif type(value) is dict or type(value) is MappingProxyType:
         plain = _plain_json(value)
         if type(plain) is not dict:
             raise ForagerMatchedEvaluationCampaignError(

--- a/alberta_framework/benchmarks/forager_matched_evaluation_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_evaluation_campaign.py
@@ -18,7 +18,7 @@ import hashlib
 import json
 import math
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any, Final, cast
@@ -66,7 +66,7 @@ def _plain_json(value: Any) -> Any:
                 )
             result[key] = _plain_json(item)
         return result
-    if type(value) is list:
+    if type(value) is list or type(value) is tuple:
         return [_plain_json(item) for item in value]
     if value is None or type(value) in {str, bool, int}:
         return value

--- a/tests/test_eval_campaign_hostile.py
+++ b/tests/test_eval_campaign_hostile.py
@@ -82,6 +82,21 @@ def test_plain_json_rejects_mapping_and_sequence_subclasses() -> None:
         _plain_json(HostileList([1, 2]))
     assert HostileList.calls == 0
 
+    class HostileTuple(tuple):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileTuple.__iter__ must not run")
+
+    HostileTuple.calls = 0
+    with pytest.raises(
+        ForagerMatchedEvaluationCampaignError,
+        match="unsupported HostileTuple",
+    ):
+        _plain_json(HostileTuple((1, 2)))
+    assert HostileTuple.calls == 0
+
 
 def test_decode_schedule_rejects_mapping_subclass() -> None:
     from types import MappingProxyType

--- a/tests/test_eval_campaign_hostile.py
+++ b/tests/test_eval_campaign_hostile.py
@@ -44,3 +44,64 @@ def test_decode_schedule_rejects_hostile_dispatch() -> None:
     with pytest.raises(TypeError, match="mapping, bytes, or string"):
         _decode_schedule(hostile_s)  # type: ignore[arg-type]
     assert _HostileStr.calls == 0
+
+
+def test_plain_json_rejects_mapping_and_sequence_subclasses() -> None:
+    from alberta_framework.benchmarks.forager_matched_evaluation_campaign import (
+        ForagerMatchedEvaluationCampaignError,
+        _plain_json,
+    )
+
+    class HostileDict(dict):
+        calls = 0
+
+        def items(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.items must not run")
+
+    class HostileList(list):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileList.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(
+        ForagerMatchedEvaluationCampaignError,
+        match="unsupported HostileDict",
+    ):
+        _plain_json(HostileDict({"a": 1}))
+    assert HostileDict.calls == 0
+
+    HostileList.calls = 0
+    with pytest.raises(
+        ForagerMatchedEvaluationCampaignError,
+        match="unsupported HostileList",
+    ):
+        _plain_json(HostileList([1, 2]))
+    assert HostileList.calls == 0
+
+
+def test_decode_schedule_rejects_mapping_subclass() -> None:
+    from types import MappingProxyType
+
+    from alberta_framework.benchmarks.forager_matched_evaluation_campaign import (
+        _decode_schedule,
+    )
+
+    class HostileDict(dict):
+        calls = 0
+
+        def items(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.items must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(TypeError, match="mapping, bytes, or string"):
+        _decode_schedule(HostileDict({"schedule": 1}))  # type: ignore[arg-type]
+    assert HostileDict.calls == 0
+
+    decoded, raw = _decode_schedule(MappingProxyType({"schedule": 1}))
+    assert decoded == {"schedule": 1}
+    assert raw is None


### PR DESCRIPTION
## Summary
- Sealed evaluation campaign `_plain_json` / schedule decode accepted any `Mapping` or non-string `Sequence`, so hostile subclasses could enter canonicalization.
- Require exact `dict`/`MappingProxyType` and exact `list` containers.
- Add hostile regressions for subclass rejection.

## Test plan
- [x] `pytest tests/test_eval_campaign_hostile.py tests/test_forager_matched_evaluation_campaign.py -q`
- [x] `ruff check` on touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)