### PR TITLE
fix(streams): require exact dict for recurring two-agent checkpoint config

### DIFF
--- a/alberta_framework/streams/recurring_multiagent.py
+++ b/alberta_framework/streams/recurring_multiagent.py
@@ -948,7 +948,7 @@ def migrate_legacy_recurring_two_agent_state(
     world: RecurringTwoAgentWorld,
 ) -> RecurringTwoAgentState:
     """Migrate only an unsaturated pre-v2 environment lifetime."""
-    if isinstance(legacy_state, Mapping):
+    if type(legacy_state) is dict:
         fields = dict(legacy_state)
     elif dataclasses.is_dataclass(legacy_state) and not isinstance(legacy_state, type):
         fields = {
@@ -1022,7 +1022,7 @@ def load_recurring_two_agent_checkpoint(
     if schema != RECURRING_TWO_AGENT_CHECKPOINT_SCHEMA:
         raise ValueError("recurring two-agent checkpoint schema is unsupported")
     raw_config = metadata.get("world_config")
-    if not isinstance(raw_config, Mapping):
+    if type(raw_config) is not dict:
         raise ValueError("recurring two-agent checkpoint world_config is invalid")
     world = RecurringTwoAgentWorld.from_config(raw_config)
     template = world.init(jr.key(0))

--- a/tests/test_recurring_multiagent_hostile.py
+++ b/tests/test_recurring_multiagent_hostile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -162,3 +163,48 @@ def test_recurring_world_from_config_rejects_invalid_initial_positions() -> None
         RecurringTwoAgentWorld.from_config({**valid, "initial_positions": [-0.5]})
     with pytest.raises(ValueError, match="initial_positions must have length 2"):
         RecurringTwoAgentWorld.from_config({**valid, "initial_positions": [-0.5, 0.0, 0.5]})
+
+
+def test_checkpoint_loader_rejects_mapping_subclass_world_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from alberta_framework.streams import recurring_multiagent as mod
+
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    monkeypatch.setattr(
+        mod,
+        "load_checkpoint_metadata",
+        lambda _path: {
+            "schema": mod.RECURRING_TWO_AGENT_CHECKPOINT_SCHEMA,
+            "world_config": HostileDict({"type": "RecurringTwoAgentWorld"}),
+            "memory_accounting": {},
+            "zero_sized_array_leaf_indices": [],
+        },
+    )
+    with pytest.raises(ValueError, match="world_config is invalid"):
+        mod.load_recurring_two_agent_checkpoint(tmp_path / "unused.ckpt")
+    assert HostileDict.calls == 0
+
+
+def test_migrate_legacy_rejects_mapping_subclass_without_iter_hooks() -> None:
+    from alberta_framework.streams import recurring_multiagent as mod
+
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    world = RecurringTwoAgentWorld()
+    HostileDict.calls = 0
+    with pytest.raises(TypeError, match="mapping or dataclass"):
+        mod.migrate_legacy_recurring_two_agent_state(HostileDict(), world=world)
+    assert HostileDict.calls == 0


### PR DESCRIPTION
## Summary
- Require exact `dict` for recurring two-agent checkpoint `world_config` and legacy state migration mapping input.
- Aligns checkpoint load with `from_config`, which already rejects non-exact dictionaries.

## Test plan
- [x] `pytest tests/test_recurring_multiagent_hostile.py -q`
- [x] `ruff check` on touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)