### PR TITLE
fix(benchmarks): require exact dict/list in official hyperparameter JSON walk

### DIFF
--- a/alberta_framework/benchmarks/official_foragax.py
+++ b/alberta_framework/benchmarks/official_foragax.py
@@ -5100,7 +5100,7 @@ def _validated_resolved_hyperparameters(
     forbidden_host_paths: Sequence[Path] = (),
 ) -> dict[str, Any]:
     value = probe.get("resolved_hyperparameters")
-    if not isinstance(value, dict):
+    if type(value) is not dict:
         raise OfficialForagaxValidationError(
             "official ExperimentModel did not return resolved hyperparameters"
         )
@@ -5116,7 +5116,10 @@ def _validated_resolved_hyperparameters(
         raise OfficialForagaxValidationError(
             "official resolved hyperparameters are not canonical JSON"
         ) from exc
-    assert isinstance(normalized, dict)
+    if type(normalized) is not dict:
+        raise OfficialForagaxValidationError(
+            "official resolved hyperparameters are not a JSON object"
+        )
     expected_hash = probe.get("resolved_hyperparameters_sha256")
     actual_hash = hashlib.sha256(encoded.encode()).hexdigest()
     if expected_hash != actual_hash:
@@ -5131,14 +5134,14 @@ def _validated_resolved_hyperparameters(
     )
 
     def validate_strings(item: Any) -> None:
-        if isinstance(item, dict):
+        if type(item) is dict:
             for key, nested in item.items():
                 if type(key) is not str:
                     raise OfficialForagaxValidationError(
                         "official resolved hyperparameter keys must be strings"
                     )
                 validate_strings(nested)
-        elif isinstance(item, list):
+        elif type(item) is list:
             for nested in item:
                 validate_strings(nested)
         elif type(item) is str:

--- a/tests/test_official_foragax_resolved_hyperparameters_exact.py
+++ b/tests/test_official_foragax_resolved_hyperparameters_exact.py
@@ -1,0 +1,44 @@
+"""Exact dict/list gates for official resolved-hyperparameter validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from alberta_framework.benchmarks import official_foragax as mod
+
+
+def _probe(payload: dict[str, object]) -> dict[str, object]:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return {
+        "resolved_hyperparameters": payload,
+        "resolved_hyperparameters_sha256": hashlib.sha256(encoded.encode()).hexdigest(),
+    }
+
+
+def test_resolved_hyperparameters_accept_exact_dict_tree() -> None:
+    probe = _probe({"alpha": 0.1, "nested": {"path": "relative/ok"}})
+    assert mod._validated_resolved_hyperparameters(probe)["alpha"] == 0.1
+
+
+def test_resolved_hyperparameters_reject_mapping_subclass_without_hooks() -> None:
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(
+        mod.OfficialForagaxValidationError, match="resolved hyperparameters"
+    ):
+        mod._validated_resolved_hyperparameters(
+            {
+                "resolved_hyperparameters": HostileDict({"alpha": 0.1}),
+                "resolved_hyperparameters_sha256": "0" * 64,
+            }
+        )
+    assert HostileDict.calls == 0


### PR DESCRIPTION
## Summary
- Require exact `dict`/`list` containers when validating official resolved hyperparameters.
- Prevents dict-subclass hooks from running during canonicalization and host-path string walking.

## Test plan
- [x] `pytest tests/test_official_foragax_resolved_hyperparameters_exact.py -q`
- [x] `ruff check` on touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)