### PR TITLE
fix(core): require exact dict/MappingProxyType for partner-fusion checkpoints

### DIFF
--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -29,8 +29,8 @@ import json
 import math
 import operator
 from collections.abc import Mapping
-from types import MappingProxyType
 from numbers import Real
+from types import MappingProxyType
 from typing import Any, SupportsIndex, cast
 
 import chex

--- a/alberta_framework/core/partner_policy_fusion.py
+++ b/alberta_framework/core/partner_policy_fusion.py
@@ -29,6 +29,7 @@ import json
 import math
 import operator
 from collections.abc import Mapping
+from types import MappingProxyType
 from numbers import Real
 from typing import Any, SupportsIndex, cast
 
@@ -1790,6 +1791,8 @@ class PartnerPolicyFusion:
     ) -> tuple[PartnerPolicyFusion, PartnerPolicyFusionState]:
         """Strictly restore an exact v1 construction and state."""
 
+        if type(checkpoint) is not dict and type(checkpoint) is not MappingProxyType:
+            raise ValueError("partner-fusion checkpoint must be an exact mapping")
         expected = {
             "schema",
             "mechanism_status",
@@ -1810,7 +1813,9 @@ class PartnerPolicyFusion:
             raise ValueError("partner-fusion checkpoint cannot claim promotion")
         construction = checkpoint.get("fusion")
         state_payload = checkpoint.get("state")
-        if not isinstance(construction, Mapping) or not isinstance(state_payload, Mapping):
+        if (type(construction) is not dict and type(construction) is not MappingProxyType) or (
+            type(state_payload) is not dict and type(state_payload) is not MappingProxyType
+        ):
             raise ValueError("checkpoint fusion and state fields must be mappings")
         if checkpoint.get("config_digest") != _payload_digest(construction):
             raise ValueError("partner-fusion checkpoint config digest mismatch")

--- a/tests/test_partner_policy_fusion.py
+++ b/tests/test_partner_policy_fusion.py
@@ -975,3 +975,34 @@ def test_maximum_fusion_config_keeps_derived_resources_in_int32_domain() -> None
     for value in budget.to_config().values():
         if type(value) is int:
             assert 0 <= value <= 2**31 - 1
+
+
+def test_from_checkpoint_payload_rejects_mapping_subclasses() -> None:
+    from types import MappingProxyType
+
+    fusion = _fusion()
+    armed = fusion.init()
+    payload = fusion.checkpoint_payload(armed)
+
+    class HostileDict(dict):
+        calls = 0
+
+        def get(self, *args, **kwargs):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.get must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(ValueError, match="exact mapping"):
+        PartnerPolicyFusion.from_checkpoint_payload(HostileDict(payload))
+    assert HostileDict.calls == 0
+
+    nested = dict(payload)
+    nested["fusion"] = HostileDict(payload["fusion"])
+    with pytest.raises(ValueError, match="must be mappings"):
+        PartnerPolicyFusion.from_checkpoint_payload(nested)
+
+    restored_fusion, restored_state = PartnerPolicyFusion.from_checkpoint_payload(
+        MappingProxyType(payload)
+    )
+    assert restored_fusion.to_config() == fusion.to_config()
+    assert restored_state is not None


### PR DESCRIPTION
## Summary
- Partner-fusion checkpoint restore accepted any `Mapping`, so dict subclasses could reach field access before rejection.
- Require exact `dict` or `MappingProxyType` for the checkpoint root and nested fusion/state objects.
- Add hostile regression coverage.

## Test plan
- [x] `pytest tests/test_partner_policy_fusion.py -q`
- [x] `ruff check` on touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)