### PR TITLE
fix(benchmarks): bind V6 control reconstruction to frozen regime counts

### DIFF
--- a/alberta_framework/benchmarks/new_directions_v5_v6_audit.py
+++ b/alberta_framework/benchmarks/new_directions_v5_v6_audit.py
@@ -208,6 +208,15 @@ def reconstruct_v6_family_control(seed: object) -> dict[str, object]:
     distinct_by_family: dict[str, int] = {}
     for family in V6_FAMILIES:
         config = micro.MicroStreamConfig(family=family)
+        # Reconstruct only the frozen V6 control schedules. MicroStreamConfig still
+        # admits large ``n_regimes`` / ``recurrence_pool`` for other callers; binding
+        # the literal frozen sizes here keeps ``jnp.arange`` from tracing an
+        # unbounded regime axis during audit reconstruction.
+        if config.n_regimes != 100 or config.recurrence_pool != 5:
+            raise ValueError(
+                "V6 control reconstruction requires frozen n_regimes=100 and "
+                "recurrence_pool=5"
+            )
         *_, key_regime = micro._stream_keys(config, exact_seed)
         key_perm, _, _, key_pool, key_pool_schedule = jr.split(key_regime, 5)
         if family == "input_permutation":

--- a/tests/test_new_directions_v5_v6_audit.py
+++ b/tests/test_new_directions_v5_v6_audit.py
@@ -339,3 +339,19 @@ def test_maintained_audit_cli_is_packaged() -> None:
     assert project["project"]["scripts"]["asi-new-directions-audit"] == (
         "alberta_framework.benchmarks.new_directions_v5_v6_audit:main"
     )
+
+
+def test_v6_control_reconstruction_rejects_unfrozen_regime_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import alberta_framework.benchmarks.micro_continual as micro
+
+    class HostileConfig:
+        family = "input_permutation"
+        dim = 16
+        n_regimes = 200_000
+        recurrence_pool = 5
+
+    monkeypatch.setattr(micro, "MicroStreamConfig", lambda **_kwargs: HostileConfig())
+    with pytest.raises(ValueError, match="frozen n_regimes=100"):
+        reconstruct_v6_family_control(V6_SEEDS[0])


### PR DESCRIPTION
## Summary
- Require frozen `n_regimes=100` and `recurrence_pool=5` before V6 control `jnp.arange` reconstruction.
- Keeps the audit path fail-closed if MicroStreamConfig defaults drift away from the literal frozen schedule sizes.

## Test plan
- [x] `pytest tests/test_new_directions_v5_v6_audit.py::test_v6_control_reconstruction_rejects_unfrozen_regime_counts tests/test_new_directions_v5_v6_audit.py::test_v6_family_controls_reconstruct_all_exact_schedules -q`
- [x] `ruff check` on touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)