### PR TITLE
fix(benchmarks): require exact dict/MappingProxyType in matched campaign records

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_campaign.py
@@ -45,6 +45,10 @@ from alberta_framework.benchmarks import forager_matched_qualification as qualif
 from alberta_framework.benchmarks.forager_matched_evidence import MatchedScoreEvidence
 from alberta_framework.benchmarks.forager_matched_protocol import ForagerMatchedProtocol
 
+
+def _is_exact_mapping(value: object) -> bool:
+    return type(value) is dict or type(value) is MappingProxyType
+
 MATCHED_OPEN_CAMPAIGN_SCHEMA_VERSION: Final = (
     "alberta.forager_matched_open_tuning_campaign.v2"
 )
@@ -226,9 +230,9 @@ class CompletedCampaignBundle:
             raise ForagerMatchedCampaignError(
                 "active_seeds must be a tuple of non-negative ints"
             )
-        if not isinstance(self.schedule, Mapping):
+        if not _is_exact_mapping(self.schedule):
             raise ForagerMatchedCampaignError("schedule must be a Mapping")
-        if not isinstance(self.seed_artifacts, Mapping):
+        if not _is_exact_mapping(self.seed_artifacts):
             raise ForagerMatchedCampaignError("seed_artifacts must be a Mapping")
         if not isinstance(
             self.execution_receipt_index, executor.MatchedExecutionReceiptIndex
@@ -242,9 +246,9 @@ class CompletedCampaignBundle:
             raise ForagerMatchedCampaignError(
                 "verification_request must be a VerificationRequest"
             )
-        if not isinstance(self.completion_summary, Mapping):
+        if not _is_exact_mapping(self.completion_summary):
             raise ForagerMatchedCampaignError("completion_summary must be a Mapping")
-        if not isinstance(self.final_file_sha256, Mapping):
+        if not _is_exact_mapping(self.final_file_sha256):
             raise ForagerMatchedCampaignError("final_file_sha256 must be a Mapping")
 
 
@@ -2096,7 +2100,7 @@ def _validate_completion_summary_common(
     request: executor.VerificationRequest,
     summary: Mapping[str, Any],
 ) -> None:
-    if not isinstance(summary, Mapping):
+    if not _is_exact_mapping(summary):
         raise ForagerMatchedCampaignError("completion summary builder returned a non-mapping")
     required: dict[str, Any] = {
         "classification": "content_only_unendorsed_nonpromoting",

--- a/tests/test_forager_matched_campaign_hostile_validation.py
+++ b/tests/test_forager_matched_campaign_hostile_validation.py
@@ -197,3 +197,34 @@ def test_cell_scan_rejects_bool_attempt_and_byte_identities(
 def test_cell_scan_rejects_incoherent_state(overrides: dict[str, object], message: str) -> None:
     with pytest.raises(ForagerMatchedCampaignError, match=message):
         _legal_cell_scan(**overrides)
+
+
+def test_completion_summary_gate_rejects_mapping_subclass() -> None:
+    from types import MappingProxyType
+
+    from alberta_framework.benchmarks.forager_matched_campaign import (
+        _is_exact_mapping,
+        _validate_completion_summary_common,
+    )
+
+    class HostileDict(dict):
+        calls = 0
+
+        def keys(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.keys must not run")
+
+    assert _is_exact_mapping({}) is True
+    assert _is_exact_mapping(MappingProxyType({})) is True
+    assert _is_exact_mapping(HostileDict()) is False
+
+    HostileDict.calls = 0
+    with pytest.raises(ForagerMatchedCampaignError, match="non-mapping"):
+        _validate_completion_summary_common(
+            None,  # type: ignore[arg-type]
+            None,  # type: ignore[arg-type]
+            None,  # type: ignore[arg-type]
+            None,  # type: ignore[arg-type]
+            HostileDict({"status": "x"}),
+        )
+    assert HostileDict.calls == 0


### PR DESCRIPTION
## Summary
- Completed matched-campaign records accepted any `Mapping` for schedule, seed artifacts, completion summary, and final digests.
- Require exact `dict` or `MappingProxyType` (frozen JSON) at those gates and in completion-summary validation.
- Add hostile regression coverage.

## Test plan
- [x] `pytest tests/test_forager_matched_campaign_hostile_validation.py tests/test_forager_matched_campaign.py -q`
- [x] `ruff check` on touched files

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)