### PR TITLE
fix(evaluation): require exact dict/list JSON containers in FTL decision artifacts

### DIFF
--- a/alberta_framework/evaluation/ftl_decision_artifact.py
+++ b/alberta_framework/evaluation/ftl_decision_artifact.py
@@ -517,13 +517,13 @@ def _interval_metric(
     statistic: str,
 ) -> float | None:
     conditions = aggregate.get("conditions")
-    if not isinstance(conditions, Mapping):
+    if type(conditions) is not dict:
         return None
     condition_payload = conditions.get(condition)
-    if not isinstance(condition_payload, Mapping):
+    if type(condition_payload) is not dict:
         return None
     interval = condition_payload.get(field)
-    if not isinstance(interval, Mapping):
+    if type(interval) is not dict:
         return None
     return _finite_number(interval.get(statistic))
 
@@ -534,10 +534,10 @@ def _comparison_metric(
     statistic: str,
 ) -> float | None:
     comparison = comparisons.get(name)
-    if not isinstance(comparison, Mapping):
+    if type(comparison) is not dict:
         return None
     interval = comparison.get("interval")
-    if not isinstance(interval, Mapping):
+    if type(interval) is not dict:
         return None
     return _finite_number(interval.get(statistic))
 
@@ -912,7 +912,7 @@ def load_ftl_decision_artifact(path: Path) -> dict[str, object]:
         parse_float=_parse_finite_json_float,
         object_pairs_hook=_reject_duplicate_keys,
     )
-    if not isinstance(parsed, dict):
+    if type(parsed) is not dict:
         raise ValueError("evidence artifact must be a JSON object")
     return parsed
 
@@ -924,7 +924,7 @@ def _mapping(
     errors: list[str],
 ) -> Mapping[str, object] | None:
     value = parent.get(key)
-    if not isinstance(value, Mapping):
+    if type(value) is not dict:
         errors.append(f"{location}.{key} must be an object")
         return None
     return value
@@ -944,8 +944,8 @@ def _compare_structure(
 ) -> None:
     """Compare exact schemas and finite values after a JSON float round trip."""
 
-    if isinstance(expected, Mapping):
-        if not isinstance(actual, Mapping):
+    if type(expected) is dict:
+        if type(actual) is not dict:
             errors.append(f"{location} must be an object")
             return
         if set(actual) != set(expected):
@@ -958,8 +958,8 @@ def _compare_structure(
                 errors,
             )
         return
-    if isinstance(expected, list):
-        if not isinstance(actual, list):
+    if type(expected) is list:
+        if type(actual) is not list:
             errors.append(f"{location} must be an array")
             return
         if len(actual) != len(expected):
@@ -1001,7 +1001,7 @@ def _validate_source_provenance(
     """
 
     location = "scientific_payload.source_provenance"
-    if not isinstance(value, Mapping):
+    if type(value) is not dict:
         errors.append(f"{location} must be an object")
         return
     try:
@@ -1030,7 +1030,7 @@ def _validate_and_extract_seed_vectors(
     summaries: object,
     errors: list[str],
 ) -> dict[str, dict[str, NDArray[np.float64]]] | None:
-    if not isinstance(summaries, list):
+    if type(summaries) is not list:
         errors.append("scientific_payload.seed_summaries must be an array")
         return None
     if len(summaries) != len(_EXPECTED_EVIDENCE_SEEDS):
@@ -1043,7 +1043,7 @@ def _validate_and_extract_seed_vectors(
     }
     for index, summary in enumerate(summaries):
         location = f"scientific_payload.seed_summaries[{index}]"
-        if not isinstance(summary, Mapping):
+        if type(summary) is not dict:
             errors.append(f"{location} must be an object")
             continue
         if set(summary) != {"seed", "conditions"}:
@@ -1055,7 +1055,7 @@ def _validate_and_extract_seed_vectors(
             observed_seeds.append(seed)
 
         conditions = summary.get("conditions")
-        if not isinstance(conditions, Mapping):
+        if type(conditions) is not dict:
             errors.append(f"{location}.conditions must be an object")
             continue
         if set(conditions) != set(_EXPECTED_CONDITION_NAMES):
@@ -1063,7 +1063,7 @@ def _validate_and_extract_seed_vectors(
         for condition in _EXPECTED_CONDITION_NAMES:
             metric_payload = conditions.get(condition)
             metric_location = f"{location}.conditions.{condition}"
-            if not isinstance(metric_payload, Mapping):
+            if type(metric_payload) is not dict:
                 errors.append(f"{metric_location} must be an object")
                 continue
             if set(metric_payload) != set(_METRIC_FIELDS):
@@ -1181,14 +1181,14 @@ def _validate_operational(
         errors.append("operational_metadata.evaluation_wall_seconds must be non-negative")
 
     runtime = operational.get("runtime")
-    if not isinstance(runtime, Mapping):
+    if type(runtime) is not dict:
         errors.append("operational_metadata.runtime must be an object")
     else:
         if set(runtime) != {"python", "platform", "packages", "jax"}:
             errors.append("operational_metadata.runtime keys do not match the v1 schema")
         python_runtime = runtime.get("python")
         if (
-            not isinstance(python_runtime, Mapping)
+            type(python_runtime) is not dict
             or set(python_runtime) != {"implementation", "version"}
             or not all(
                 isinstance(python_runtime.get(key), str) and bool(python_runtime.get(key))
@@ -1198,7 +1198,7 @@ def _validate_operational(
             errors.append("operational_metadata.runtime.python is invalid")
         platform_runtime = runtime.get("platform")
         if (
-            not isinstance(platform_runtime, Mapping)
+            type(platform_runtime) is not dict
             or set(platform_runtime) != {"system", "release", "machine"}
             or not all(
                 isinstance(platform_runtime.get(key), str)
@@ -1208,7 +1208,7 @@ def _validate_operational(
             errors.append("operational_metadata.runtime.platform is invalid")
         packages = runtime.get("packages")
         if (
-            not isinstance(packages, Mapping)
+            type(packages) is not dict
             or set(packages) != {"alberta-framework", "jax", "jaxlib", "numpy"}
             or not all(
                 isinstance(packages.get(key), str) and bool(packages.get(key))
@@ -1217,7 +1217,7 @@ def _validate_operational(
         ):
             errors.append("operational_metadata.runtime.packages is invalid")
         jax_runtime = runtime.get("jax")
-        if not isinstance(jax_runtime, Mapping) or set(jax_runtime) != {
+        if type(jax_runtime) is not dict or set(jax_runtime) != {
             "default_backend",
             "devices",
         }:
@@ -1228,10 +1228,10 @@ def _validate_operational(
             if not isinstance(backend, str) or not backend:
                 errors.append("operational_metadata.runtime.jax.default_backend is invalid")
             if (
-                not isinstance(devices, list)
+                type(devices) is not list
                 or not devices
                 or not all(
-                    isinstance(device, Mapping)
+                    type(device) is dict
                     and set(device) == {"platform", "device_kind"}
                     and isinstance(device.get("platform"), str)
                     and bool(device.get("platform"))
@@ -1243,7 +1243,7 @@ def _validate_operational(
                 errors.append("operational_metadata.runtime.jax.devices is invalid")
 
     git_worktree = operational.get("git_worktree")
-    if not isinstance(git_worktree, Mapping):
+    if type(git_worktree) is not dict:
         errors.append("operational_metadata.git_worktree must be an object")
     else:
         if set(git_worktree) != {"head", "dirty"}:
@@ -1260,7 +1260,7 @@ def _validate_operational(
         provenance_head: object = None
         if scientific is not None:
             provenance = scientific.get("source_provenance")
-            if isinstance(provenance, Mapping):
+            if type(provenance) is dict:
                 provenance_head = provenance.get("git_head")
         if recorded_head != provenance_head:
             errors.append(

--- a/tests/test_ftl_decision_fidelity_hostile_validation.py
+++ b/tests/test_ftl_decision_fidelity_hostile_validation.py
@@ -313,3 +313,23 @@ def test_decision_probe_set_rejects_hostile_arrays_and_cross_field_drift() -> No
             true_rewards=np.zeros((2, 2, 1), dtype=np.float64),
             true_returns=np.ones((2, 2), dtype=np.float64),
         )
+
+
+def test_mapping_helper_rejects_dict_subclass_without_hooks() -> None:
+    """FTL artifact object gates require exact dict containers."""
+    from alberta_framework.evaluation.ftl_decision_artifact import _mapping
+
+    class HostileDict(dict):
+        calls = 0
+
+        def keys(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.keys must not run")
+
+    errors: list[str] = []
+    HostileDict.calls = 0
+    parent = {"scientific_payload": HostileDict({"a": 1})}
+    result = _mapping(parent, "scientific_payload", "artifact", errors)
+    assert result is None
+    assert errors == ["artifact.scientific_payload must be an object"]
+    assert HostileDict.calls == 0


### PR DESCRIPTION
## Problem

FTL decision artifact object gates used `isinstance(..., Mapping/list)`, so mapping subclasses could enter structural validation.

## Fix

Require exact `dict`/`list` identity in `_mapping` and related artifact validators.

## Tests

`tests/test_ftl_decision_fidelity_hostile_validation.py` — HostileDict rejected without hooks; artifact suites green; ruff clean.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).
