### PR TITLE
fix(benchmarks): require exact dict or MappingProxyType in matched seal bundles

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_seal.py
+++ b/alberta_framework/benchmarks/forager_matched_seal.py
@@ -84,6 +84,11 @@ class PublishedSealUncertainError(ForagerMatchedSealError):
         super().__init__(f"seal published at {destination}, but {detail}")
 
 
+def _is_exact_json_object(value: object) -> bool:
+    """True for exact dict or MappingProxyType JSON object containers."""
+    return type(value) is dict or type(value) is MappingProxyType
+
+
 @dataclass(frozen=True, slots=True)
 class ContentVerifiedSealBundle:
     """A deterministically replayed seal whose external trust is unchecked.
@@ -109,7 +114,7 @@ class ContentVerifiedSealBundle:
     def __post_init__(self) -> None:
         if not isinstance(self.output_root, Path):
             raise ForagerMatchedSealError("output_root must be a Path")
-        if not isinstance(self.manifest, Mapping):
+        if not _is_exact_json_object(self.manifest):
             raise ForagerMatchedSealError("manifest must be a Mapping")
         if not isinstance(self.open_protocol, protocol.ForagerMatchedProtocol):
             raise ForagerMatchedSealError("open_protocol must be a ForagerMatchedProtocol")
@@ -119,17 +124,17 @@ class ContentVerifiedSealBundle:
             raise ForagerMatchedSealError(
                 "open_verification_request must be a VerificationRequest"
             )
-        if not isinstance(self.recorded_bindings_cache, Mapping):
+        if not _is_exact_json_object(self.recorded_bindings_cache):
             raise ForagerMatchedSealError("recorded_bindings_cache must be a Mapping")
         if not isinstance(self.selection_result, protocol.ForagerMatchedSelectionResult):
             raise ForagerMatchedSealError(
                 "selection_result must be a ForagerMatchedSelectionResult"
             )
-        if not isinstance(self.selection_report, Mapping):
+        if not _is_exact_json_object(self.selection_report):
             raise ForagerMatchedSealError("selection_report must be a Mapping")
         if not isinstance(self.sealed_protocol, protocol.ForagerMatchedProtocol):
             raise ForagerMatchedSealError("sealed_protocol must be a ForagerMatchedProtocol")
-        if not isinstance(self.sealed_transition, Mapping):
+        if not _is_exact_json_object(self.sealed_transition):
             raise ForagerMatchedSealError("sealed_transition must be a Mapping")
         _require_sha256(self.sealed_transition_sha256, "sealed_transition_sha256")
 

--- a/tests/test_forager_matched_seal_hostile_validation.py
+++ b/tests/test_forager_matched_seal_hostile_validation.py
@@ -69,3 +69,48 @@ def test_open_directory_validation() -> None:
             descriptor=3,
             inode_identity=(1, True, 3),
         )
+
+
+def test_seal_bundle_rejects_manifest_subclass_before_other_fields() -> None:
+    """Manifest identity requires exact dict or MappingProxyType."""
+    from types import MappingProxyType
+
+    class HostileDict(dict):
+        calls = 0
+
+        def keys(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.keys must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(ForagerMatchedSealError, match="manifest must be a Mapping"):
+        ContentVerifiedSealBundle(
+            output_root=Path("."),
+            manifest=HostileDict({}),
+            open_protocol=None,  # type: ignore[arg-type]
+            open_score_evidence=None,  # type: ignore[arg-type]
+            open_verification_request=None,  # type: ignore[arg-type]
+            recorded_bindings_cache={},
+            selection_result=None,  # type: ignore[arg-type]
+            selection_report={},
+            sealed_protocol=None,  # type: ignore[arg-type]
+            sealed_transition={},
+            sealed_transition_sha256="a" * 64,
+        )
+    assert HostileDict.calls == 0
+
+    # MappingProxyType remains an intentional round-trip container.
+    with pytest.raises(ForagerMatchedSealError, match="open_protocol must be"):
+        ContentVerifiedSealBundle(
+            output_root=Path("."),
+            manifest=MappingProxyType({}),
+            open_protocol=None,  # type: ignore[arg-type]
+            open_score_evidence=None,  # type: ignore[arg-type]
+            open_verification_request=None,  # type: ignore[arg-type]
+            recorded_bindings_cache=MappingProxyType({}),
+            selection_result=None,  # type: ignore[arg-type]
+            selection_report=MappingProxyType({}),
+            sealed_protocol=None,  # type: ignore[arg-type]
+            sealed_transition=MappingProxyType({}),
+            sealed_transition_sha256="a" * 64,
+        )


### PR DESCRIPTION
## Problem

Matched seal bundle JSON fields accepted arbitrary `Mapping` subclasses.

## Fix

Allow only exact `dict` or `MappingProxyType` so intentional freezes still round-trip while hostile mappings are rejected before other field hooks.

## Tests

`tests/test_forager_matched_seal_hostile_validation.py` — HostileDict rejected on manifest; MappingProxyType still reaches later gates; ruff clean.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).
