### PR TITLE
fix(benchmarks): require exact dict or MappingProxyType in matched campaign bundles

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_campaign.py
@@ -180,6 +180,11 @@ class CampaignStatus:
         }
 
 
+def _is_exact_json_object(value: object) -> bool:
+    """True for exact dict or MappingProxyType JSON object containers."""
+    return type(value) is dict or type(value) is MappingProxyType
+
+
 @dataclass(frozen=True, slots=True)
 class CompletedCampaignBundle:
     """Exact completed content closure, without any authentication or promotion claim.
@@ -226,9 +231,9 @@ class CompletedCampaignBundle:
             raise ForagerMatchedCampaignError(
                 "active_seeds must be a tuple of non-negative ints"
             )
-        if not isinstance(self.schedule, Mapping):
+        if not _is_exact_json_object(self.schedule):
             raise ForagerMatchedCampaignError("schedule must be a Mapping")
-        if not isinstance(self.seed_artifacts, Mapping):
+        if not _is_exact_json_object(self.seed_artifacts):
             raise ForagerMatchedCampaignError("seed_artifacts must be a Mapping")
         if not isinstance(
             self.execution_receipt_index, executor.MatchedExecutionReceiptIndex
@@ -242,9 +247,9 @@ class CompletedCampaignBundle:
             raise ForagerMatchedCampaignError(
                 "verification_request must be a VerificationRequest"
             )
-        if not isinstance(self.completion_summary, Mapping):
+        if not _is_exact_json_object(self.completion_summary):
             raise ForagerMatchedCampaignError("completion_summary must be a Mapping")
-        if not isinstance(self.final_file_sha256, Mapping):
+        if not _is_exact_json_object(self.final_file_sha256):
             raise ForagerMatchedCampaignError("final_file_sha256 must be a Mapping")
 
 
@@ -2096,7 +2101,7 @@ def _validate_completion_summary_common(
     request: executor.VerificationRequest,
     summary: Mapping[str, Any],
 ) -> None:
-    if not isinstance(summary, Mapping):
+    if not _is_exact_json_object(summary):
         raise ForagerMatchedCampaignError("completion summary builder returned a non-mapping")
     required: dict[str, Any] = {
         "classification": "content_only_unendorsed_nonpromoting",

--- a/tests/test_forager_matched_campaign_hostile_validation.py
+++ b/tests/test_forager_matched_campaign_hostile_validation.py
@@ -11,6 +11,7 @@ from alberta_framework.benchmarks.forager_matched_campaign import (
     CompletedCampaignBundle,
     ForagerMatchedCampaignError,
     _CellScan,
+    _validate_completion_summary_common,
 )
 from alberta_framework.benchmarks.forager_matched_executor import SeedExecutionArtifacts
 
@@ -197,3 +198,29 @@ def test_cell_scan_rejects_bool_attempt_and_byte_identities(
 def test_cell_scan_rejects_incoherent_state(overrides: dict[str, object], message: str) -> None:
     with pytest.raises(ForagerMatchedCampaignError, match=message):
         _legal_cell_scan(**overrides)
+
+
+
+def test_completion_summary_rejects_mapping_subclass_without_hooks() -> None:
+    """Completion summary identity requires exact dict or MappingProxyType."""
+
+    class HostileDict(dict):
+        calls = 0
+
+        def keys(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.keys must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(
+        ForagerMatchedCampaignError,
+        match="completion summary builder returned a non-mapping",
+    ):
+        _validate_completion_summary_common(
+            None,  # type: ignore[arg-type]
+            None,  # type: ignore[arg-type]
+            None,  # type: ignore[arg-type]
+            None,  # type: ignore[arg-type]
+            HostileDict({}),
+        )
+    assert HostileDict.calls == 0


### PR DESCRIPTION
## Problem

Completed matched-campaign JSON fields and completion-summary validation accepted arbitrary `Mapping` subclasses.

## Fix

Allow only exact `dict` or `MappingProxyType` at those identity gates.

## Tests

`tests/test_forager_matched_campaign_hostile_validation.py` — HostileDict rejected by completion-summary validation without hooks; suite green; ruff clean.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).
