### PR TITLE
Require exact dict/list JSON containers in matched evidence

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_evidence.py
+++ b/alberta_framework/benchmarks/forager_matched_evidence.py
@@ -209,10 +209,14 @@ def _validate_json_complexity(value: Any) -> None:
             raise ForagerMatchedEvidenceError("score evidence exceeds the JSON node bound")
         if depth > _MAX_JSON_DEPTH:
             raise ForagerMatchedEvidenceError("score evidence exceeds the JSON nesting bound")
-        if isinstance(current, dict):
+        if type(current) is dict:
             stack.extend((item, depth + 1) for item in current.values())
-        elif isinstance(current, list):
+        elif type(current) is list:
             stack.extend((item, depth + 1) for item in current)
+        elif current is not None and type(current) not in (bool, int, float, str):
+            raise ForagerMatchedEvidenceError(
+                f"score evidence contains a non-JSON value of type {type(current).__name__}"
+            )
 
 
 def decode_strict_json(raw: bytes | str) -> Any:
@@ -854,7 +858,7 @@ def _parse_matched_selection_report_structure(
                     "selection report contains invalid Unicode"
                 ) from exc
         canonical_input = True
-    elif isinstance(value, Mapping):
+    elif type(value) is dict or type(value) is MappingProxyType:
         try:
             thawed = cast(dict[str, Any], _thaw_json(value))
         except ForagerMatchedEvidenceError:
@@ -1182,7 +1186,7 @@ def parse_matched_score_evidence(
         decoded = decode_strict_json(cast(bytes | str, raw))
         input_bytes = raw if type(raw) is bytes else cast(str, raw).encode("utf-8")
         canonical_input = True
-    elif isinstance(value, Mapping):
+    elif type(value) is dict or type(value) is MappingProxyType:
         decoded = decode_strict_json(_canonical_json_bytes(dict(value)))
         canonical_input = False
         input_bytes = b""

--- a/tests/test_forager_matched_evidence.py
+++ b/tests/test_forager_matched_evidence.py
@@ -1300,3 +1300,33 @@ def test_expected_candidate_ids_fail_closed_on_malformed_values(
             authenticated_bindings=sealed_bindings,
             expected_candidate_ids=candidate_ids,
         )
+
+
+def test_parse_score_evidence_rejects_mapping_subclass_without_iter_hooks() -> None:
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(TypeError, match="score evidence must be a mapping, bytes, or str"):
+        evidence.parse_matched_score_evidence(HostileDict({"schema_version": "x"}))
+    assert HostileDict.calls == 0
+
+
+def test_validate_json_complexity_rejects_dict_subclass_without_iter_hooks() -> None:
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(
+        evidence.ForagerMatchedEvidenceError, match="non-JSON value"
+    ):
+        evidence._validate_json_complexity(HostileDict({"a": 1}))
+    assert HostileDict.calls == 0


### PR DESCRIPTION
Score-evidence complexity walks and in-memory parse paths used isinstance dict/Mapping, so a dict subclass with a hostile __iter__ ran during validation. Gate containers on exact dict/list (and MappingProxyType for frozen round-trips) and reject other non-JSON leaves fail-closed.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).