### PR TITLE
Require exact dict/list in matched evaluation campaign JSON

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_evaluation_campaign.py
+++ b/alberta_framework/benchmarks/forager_matched_evaluation_campaign.py
@@ -18,7 +18,7 @@ import hashlib
 import json
 import math
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any, Final, cast
@@ -57,7 +57,7 @@ class _ValidatedTransition:
 
 
 def _plain_json(value: Any) -> Any:
-    if isinstance(value, Mapping):
+    if type(value) is dict or type(value) is MappingProxyType:
         result: dict[str, Any] = {}
         for key, item in value.items():
             if type(key) is not str:
@@ -66,7 +66,7 @@ def _plain_json(value: Any) -> Any:
                 )
             result[key] = _plain_json(item)
         return result
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+    if type(value) is list or type(value) is tuple:
         return [_plain_json(item) for item in value]
     if value is None or type(value) in {str, bool, int}:
         return value
@@ -374,7 +374,7 @@ def _decode_schedule(
                 "schedule is not valid UTF-8 JSON"
             ) from exc
         encoded = value
-    elif isinstance(value, Mapping):
+    elif type(value) is dict or type(value) is MappingProxyType:
         plain = _plain_json(value)
         if type(plain) is not dict:
             raise ForagerMatchedEvaluationCampaignError(

--- a/tests/test_forager_matched_evaluation_campaign.py
+++ b/tests/test_forager_matched_evaluation_campaign.py
@@ -273,3 +273,34 @@ def test_builder_rejects_wrong_stage_and_wrong_typed_transition(
         match="selection_result_sha256",
     ):
         evaluation.build_sealed_transition_descriptor(sealed, wrong_result)
+
+
+def test_plain_json_rejects_mapping_subclass_without_iter_hooks() -> None:
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(
+        evaluation.ForagerMatchedEvaluationCampaignError,
+        match="unsupported HostileDict",
+    ):
+        evaluation._plain_json(HostileDict({"a": 1}))
+    assert HostileDict.calls == 0
+
+
+def test_decode_schedule_rejects_mapping_subclass_without_iter_hooks() -> None:
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(TypeError, match="schedule must be a mapping, bytes, or string"):
+        evaluation._decode_schedule(HostileDict({"schema_version": "x"}))
+    assert HostileDict.calls == 0


### PR DESCRIPTION
_plain_json and schedule decode walked isinstance Mapping/Sequence, so a dict subclass with a hostile __iter__ ran during canonicalization. Accept only exact dict/list (plus MappingProxyType/tuple for frozen trees).

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).