### PR TITLE
Require exact dict for matched seal JSON mappings

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_seal.py
+++ b/alberta_framework/benchmarks/forager_matched_seal.py
@@ -109,8 +109,8 @@ class ContentVerifiedSealBundle:
     def __post_init__(self) -> None:
         if not isinstance(self.output_root, Path):
             raise ForagerMatchedSealError("output_root must be a Path")
-        if not isinstance(self.manifest, Mapping):
-            raise ForagerMatchedSealError("manifest must be a Mapping")
+        if type(self.manifest) is not dict and type(self.manifest) is not MappingProxyType:
+            raise ForagerMatchedSealError("manifest must be an exact dict or MappingProxyType")
         if not isinstance(self.open_protocol, protocol.ForagerMatchedProtocol):
             raise ForagerMatchedSealError("open_protocol must be a ForagerMatchedProtocol")
         if not isinstance(self.open_score_evidence, evidence.MatchedScoreEvidence):
@@ -119,18 +119,33 @@ class ContentVerifiedSealBundle:
             raise ForagerMatchedSealError(
                 "open_verification_request must be a VerificationRequest"
             )
-        if not isinstance(self.recorded_bindings_cache, Mapping):
-            raise ForagerMatchedSealError("recorded_bindings_cache must be a Mapping")
+        if (
+            type(self.recorded_bindings_cache) is not dict
+            and type(self.recorded_bindings_cache) is not MappingProxyType
+        ):
+            raise ForagerMatchedSealError(
+                "recorded_bindings_cache must be an exact dict or MappingProxyType"
+            )
         if not isinstance(self.selection_result, protocol.ForagerMatchedSelectionResult):
             raise ForagerMatchedSealError(
                 "selection_result must be a ForagerMatchedSelectionResult"
             )
-        if not isinstance(self.selection_report, Mapping):
-            raise ForagerMatchedSealError("selection_report must be a Mapping")
+        if (
+            type(self.selection_report) is not dict
+            and type(self.selection_report) is not MappingProxyType
+        ):
+            raise ForagerMatchedSealError(
+                "selection_report must be an exact dict or MappingProxyType"
+            )
         if not isinstance(self.sealed_protocol, protocol.ForagerMatchedProtocol):
             raise ForagerMatchedSealError("sealed_protocol must be a ForagerMatchedProtocol")
-        if not isinstance(self.sealed_transition, Mapping):
-            raise ForagerMatchedSealError("sealed_transition must be a Mapping")
+        if (
+            type(self.sealed_transition) is not dict
+            and type(self.sealed_transition) is not MappingProxyType
+        ):
+            raise ForagerMatchedSealError(
+                "sealed_transition must be an exact dict or MappingProxyType"
+            )
         _require_sha256(self.sealed_transition_sha256, "sealed_transition_sha256")
 
 

--- a/tests/test_forager_matched_seal_hostile_validation.py
+++ b/tests/test_forager_matched_seal_hostile_validation.py
@@ -69,3 +69,31 @@ def test_open_directory_validation() -> None:
             descriptor=3,
             inode_identity=(1, True, 3),
         )
+
+
+def test_content_verified_seal_bundle_rejects_mapping_subclass_without_iter_hooks() -> None:
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(
+        ForagerMatchedSealError, match="manifest must be an exact dict or MappingProxyType"
+    ):
+        ContentVerifiedSealBundle(
+            output_root=Path("output/seal"),
+            manifest=HostileDict(),
+            open_protocol=None,  # type: ignore[arg-type]
+            open_score_evidence=None,  # type: ignore[arg-type]
+            open_verification_request=None,  # type: ignore[arg-type]
+            recorded_bindings_cache={},
+            selection_result=None,  # type: ignore[arg-type]
+            selection_report={},
+            sealed_protocol=None,  # type: ignore[arg-type]
+            sealed_transition={},
+            sealed_transition_sha256="a" * 64,
+        )
+    assert HostileDict.calls == 0


### PR DESCRIPTION
ContentVerifiedSealBundle accepted any Mapping for manifest and related JSON fields, so a dict subclass with a hostile __iter__ could run during later walks. Accept only exact dict or MappingProxyType.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).