### PR TITLE
Require exact dict/list JSON containers in foragax open screen

### DIFF
--- a/alberta_framework/benchmarks/foragax_open_screen.py
+++ b/alberta_framework/benchmarks/foragax_open_screen.py
@@ -319,7 +319,7 @@ def _load_json_bytes(raw: bytes, label: str) -> dict[str, Any]:
         raise
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ScreenError(f"{label} is not valid duplicate-free UTF-8 JSON") from error
-    if not isinstance(value, dict):
+    if type(value) is not dict:
         raise ScreenError(f"{label} must contain a JSON object")
     return cast(dict[str, Any], value)
 
@@ -1072,7 +1072,7 @@ def _inspect_image(docker: str, image_id: str) -> dict[str, Any]:
         raise
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ScreenError("docker image inspect returned invalid JSON") from error
-    if not isinstance(value, list) or len(value) != 1 or not isinstance(value[0], dict):
+    if type(value) is not list or len(value) != 1 or type(value[0]) is not dict:
         raise ScreenError("docker image inspect must resolve exactly one image")
     inspection = cast(dict[str, Any], value[0])
     if inspection.get("Id") != image_id:
@@ -1276,7 +1276,7 @@ def _run_preflight(protocol: FrozenProtocol, docker: str) -> tuple[dict[str, Any
         raise ScreenError("OCI preflight source identity mismatch")
     probe_configs = _require_list(probe.get("configurations"), "preflight.configurations")
     if len(probe_configs) != len(protocol.configurations) or any(
-        not isinstance(item, dict) for item in probe_configs
+        type(item) is not dict for item in probe_configs
     ):
         raise ScreenError("OCI preflight configuration inventory is malformed")
     if [cast(dict[str, Any], item).get("path") for item in probe_configs] != [
@@ -1293,7 +1293,7 @@ def _run_preflight(protocol: FrozenProtocol, docker: str) -> tuple[dict[str, Any
             or item.get("stored_seeds") != list(protocol.seeds)
             or item.get("effective_seeds") != list(protocol.seeds)
             or type(item.get("result_root")) is not str
-            or not isinstance(item.get("metadata_contract"), dict)
+            or type(item.get("metadata_contract")) is not dict
         ):
             raise ScreenError(f"OCI preflight configuration binding drift: {config.path}")
     entrypoints = list(dict.fromkeys(config.entrypoint for config in protocol.configurations))
@@ -2588,7 +2588,7 @@ def _parse_scorer_capture(
         raise ScreenError("pinned-image scorer result contract drift")
     records = _require_list(payload.get("records"), "pinned-image scorer records")
     if len(records) != len(protocol.seeds) or any(
-        not isinstance(record, dict) for record in records
+        type(record) is not dict for record in records
     ):
         raise ScreenError("pinned-image scorer record inventory drift")
     return payload

--- a/tests/test_foragax_open_screen_hostile_validation.py
+++ b/tests/test_foragax_open_screen_hostile_validation.py
@@ -88,3 +88,26 @@ def test_frozen_configuration_rejects_string_subclass_before_len_hook() -> None:
             stdout="not bytes",  # type: ignore[arg-type]
             stderr=b"",
         )
+
+
+def test_require_dict_rejects_mapping_subclass_without_iter_hooks() -> None:
+    from alberta_framework.benchmarks import foragax_open_screen as screen
+
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(screen.ScreenError, match="must be an object"):
+        screen._require_dict(HostileDict({"a": 1}), "fixture")
+    assert HostileDict.calls == 0
+
+
+def test_load_json_bytes_rejects_non_object_root() -> None:
+    from alberta_framework.benchmarks import foragax_open_screen as screen
+
+    with pytest.raises(screen.ScreenError, match="must contain a JSON object"):
+        screen._load_json_bytes(b"[]", "fixture")


### PR DESCRIPTION
JSON load and OCI preflight binding checks used isinstance(dict/list), so a hostile container subclass could pass the gate and run custom hooks later. Require exact dict/list types fail-closed.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).