### PR TITLE
Require exact dict for matched qualification bundle maps

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_qualification.py
+++ b/alberta_framework/benchmarks/forager_matched_qualification.py
@@ -438,16 +438,22 @@ class MatchedCurrentQualificationBundle:
     manifest_sha256: str
 
     def __post_init__(self) -> None:
-        if not isinstance(self.candidate_qualifications, Mapping) or not isinstance(
-            self.candidate_assets,
-            Mapping,
+        if (
+            type(self.candidate_qualifications) is not dict
+            and type(self.candidate_qualifications) is not MappingProxyType
+        ) or (
+            type(self.candidate_assets) is not dict
+            and type(self.candidate_assets) is not MappingProxyType
         ):
             raise ForagerMatchedQualificationError(
                 "qualification bundle candidate mappings are invalid"
             )
-        if not isinstance(self.manifest, Mapping):
+        if (
+            type(self.manifest) is not dict
+            and type(self.manifest) is not MappingProxyType
+        ):
             raise ForagerMatchedQualificationError(
-                "qualification bundle manifest must be a mapping"
+                "qualification bundle manifest must be an exact dict or MappingProxyType"
             )
         if (
             type(self.manifest_bytes) is not bytes

--- a/tests/test_forager_matched_qualification_hostile_validation.py
+++ b/tests/test_forager_matched_qualification_hostile_validation.py
@@ -91,3 +91,34 @@ def test_probe_invocation_rejects_nonhex_sha256(field: str) -> None:
     inv = _make_probe_invocation()
     with pytest.raises(ForagerMatchedQualificationError, match=f"{field} must be"):
         replace(inv, **{field: "z" * 64})
+
+
+def test_qualification_bundle_rejects_mapping_subclass_without_iter_hooks() -> None:
+    from alberta_framework.benchmarks.forager_matched_qualification import (
+        MatchedCurrentQualificationBundle,
+    )
+
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(
+        ForagerMatchedQualificationError,
+        match="manifest must be an exact dict or MappingProxyType",
+    ):
+        MatchedCurrentQualificationBundle(
+            output_root=Path("out"),
+            cpu_qualification_root=Path("cpu"),
+            rng_parity_qualification_root=Path("rng"),
+            runtime_qualification=None,
+            candidate_qualifications={},
+            candidate_assets={},
+            manifest=HostileDict(),
+            manifest_bytes=b"{}",
+            manifest_sha256="a" * 64,
+        )
+    assert HostileDict.calls == 0


### PR DESCRIPTION
MatchedCurrentQualificationBundle accepted any Mapping for manifest and candidate maps, so a dict subclass with a hostile __iter__ could run during later plain-JSON walks. Accept only exact dict or MappingProxyType.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)