### PR TITLE
Reject non-exact plan config before hashing in UPGD label EMNIST

### DIFF
--- a/alberta_framework/benchmarks/upgd_label_emnist.py
+++ b/alberta_framework/benchmarks/upgd_label_emnist.py
@@ -98,6 +98,7 @@ import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, fields
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Literal, cast
 
 import chex
@@ -1088,7 +1089,7 @@ def _strict_json_object(path: Path) -> dict[str, Any]:
         parse_constant=reject_constant,
         parse_float=parse_float,
     )
-    if not isinstance(payload, dict):
+    if type(payload) is not dict:
         raise ValueError(f"{path}: payload must be one JSON object")
     return payload
 
@@ -1105,7 +1106,7 @@ def _validated_float_hyperparameters(
     ``type(...) is float`` (rejecting bool, the int subclass, and every other
     alias) plus finiteness, before any comparison.
     """
-    if not isinstance(value, dict):
+    if type(value) is not dict:
         raise ValueError(f"{context}: {learner} hyperparameters must be an object")
     invalid = sorted(
         str(name)
@@ -1128,15 +1129,15 @@ def load_plan(path: Path) -> dict[str, Any]:
     if payload.get("evidence_policy") != NONPROMOTING_POLICY:
         raise ValueError(f"{path}: evidence policy must remain permanently nonpromoting")
     body = payload.get("plan")
-    if not isinstance(body, dict):
+    if type(body) is not dict:
         raise ValueError(f"{path}: plan body must be an object")
+    raw_config = body.get("config")
+    if type(raw_config) is not dict and type(raw_config) is not MappingProxyType:
+        raise ValueError(f"{path}: plan config must be an object")
     if payload.get("plan_sha256") != canonical_json_sha256(body):
         raise ValueError(f"{path}: plan_sha256 does not match the plan body")
     if body.get("benchmark") != BENCHMARK:
         raise ValueError(f"{path}: plan benchmark is not {BENCHMARK}")
-    raw_config = body.get("config")
-    if not isinstance(raw_config, Mapping):
-        raise ValueError(f"{path}: plan config must be an object")
     config_payload = dict(raw_config)
     n_steps = config_payload.pop("n_steps", None)
     _require_exact_config_fields(config_payload, context=f"{path}: config")
@@ -1158,7 +1159,7 @@ def load_plan(path: Path) -> dict[str, Any]:
                 f"{path}: {learner} hyperparameters must list the complete arm"
             )
     raw_seeds = body.get("seed_ids")
-    if not isinstance(raw_seeds, list):
+    if type(raw_seeds) is not list:
         raise ValueError(f"{path}: plan seed_ids must be a list")
     seeds = require_unique_jax_seeds(raw_seeds, name=f"{path}: plan seed_ids")
     if seeds != tuple(sorted(seeds)):
@@ -1233,7 +1234,7 @@ def _validated_partial(path: Path, plan: dict[str, Any]) -> dict[str, Any]:
         "per_task_plasticity": (0.0, 1.0),
     }.items():
         values = payload.get(field)
-        if not isinstance(values, list) or len(values) != n_tasks:
+        if type(values) is not list or len(values) != n_tasks:
             raise ValueError(f"{path}: {field} must be a list of {n_tasks} numbers")
         array = np.asarray(values, dtype=np.float64)
         if not np.all(np.isfinite(array)) or not np.all(array >= lower):

--- a/tests/test_upgd_label_hostile_validation.py
+++ b/tests/test_upgd_label_hostile_validation.py
@@ -132,3 +132,42 @@ def test_duplicate_key_sanitized() -> None:
 def test_source_has_no_repr_leak() -> None:
     text = pathlib.Path("alberta_framework/benchmarks/upgd_label_emnist.py").read_text()
     assert "!r" not in text
+
+
+
+def test_load_plan_rejects_mapping_subclass_config_without_iter_hooks(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from alberta_framework.benchmarks import upgd_label_emnist as label
+
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text("{}", encoding="utf-8")
+
+    def _fake_strict(_path: pathlib.Path) -> dict:
+        return {
+            "schema": label.PLAN_SCHEMA,
+            "schema_version": 1,
+            "evidence_policy": label.NONPROMOTING_POLICY,
+            "plan_sha256": "0" * 64,
+            "plan": {
+                "benchmark": label.BENCHMARK,
+                "config": HostileDict({"n_tasks": 1}),
+                "learner_ids": ["adamw"],
+                "hyperparameters": {},
+                "seed_ids": [0],
+                "planned_shard_count": 1,
+            },
+        }
+
+    monkeypatch.setattr(label, "_strict_json_object", _fake_strict)
+    HostileDict.calls = 0
+    with pytest.raises(ValueError, match="plan config must be an object"):
+        label.load_plan(plan_path)
+    assert HostileDict.calls == 0


### PR DESCRIPTION
load_plan hashed the plan body before checking config container identity, so a dict subclass config could run hostile iteration during canonical_json_sha256. Require exact dict/MappingProxyType first, and gate task-series lists on exact list type.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)