### PR TITLE
fix: require exact dict/list in reference life JSON paths

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -147,7 +147,7 @@ def _canonical_json(value: Mapping[str, Any]) -> str:
     except (TypeError, ValueError) as exc:
         raise ValueError("reference-life configuration must be canonical finite JSON") from exc
     decoded = json.loads(encoded)
-    if not isinstance(decoded, dict):
+    if type(decoded) is not dict:
         raise ValueError("reference-life configuration must be a JSON object")
     return encoded
 
@@ -307,7 +307,7 @@ class ReferenceEnvironmentManifest:
     @property
     def config(self) -> dict[str, Any]:
         value = json.loads(self._config_json)
-        assert isinstance(value, dict)
+        assert type(value) is dict
         return value
 
     def _manifest_payload(self) -> dict[str, Any]:
@@ -1552,7 +1552,7 @@ class ReferenceLifeConfig:
     @property
     def config(self) -> dict[str, Any]:
         value = json.loads(self._config_json)
-        assert isinstance(value, dict)
+        assert type(value) is dict
         return value
 
 

--- a/alberta_framework/reference_life_controls.py
+++ b/alberta_framework/reference_life_controls.py
@@ -189,7 +189,7 @@ def _canonical_hidden_sizes(
     observation_dim: int,
     n_actions: int,
 ) -> tuple[int, ...]:
-    if not isinstance(value, (tuple, list)):
+    if type(value) is not tuple and type(value) is not list:
         raise ValueError("hidden_sizes must be a bounded tuple or list")
     if len(value) > _MAX_HIDDEN_LAYERS:
         raise ValueError(f"hidden_sizes must contain at most {_MAX_HIDDEN_LAYERS} layers")
@@ -743,7 +743,7 @@ class AnalyticOracleReferenceConfig:
         except (TypeError, json.JSONDecodeError) as exc:
             raise ValueError("oracle environment config must be canonical JSON") from exc
         if (
-            not isinstance(decoded, dict)
+            type(decoded) is not dict
             or _canonical_json(decoded) != self.environment_config_json
         ):
             raise ValueError("oracle environment config must use canonical JSON")
@@ -846,7 +846,7 @@ class AnalyticOracleReferenceConfig:
     @property
     def environment_config(self) -> dict[str, Any]:
         decoded = json.loads(self.environment_config_json)
-        assert isinstance(decoded, dict)
+        assert type(decoded) is dict
         return decoded
 
     @property

--- a/tests/test_reference_life_controls.py
+++ b/tests/test_reference_life_controls.py
@@ -1069,3 +1069,19 @@ def test_learning_controls_reject_increasing_epsilon_schedules(factory: object) 
             epsilon_start=0.1,
             epsilon_end=0.2,
         )
+
+
+def test_canonical_hidden_sizes_rejects_list_subclass_without_iter_hooks() -> None:
+    from alberta_framework.reference_life_controls import _canonical_hidden_sizes
+
+    class HostileList(list):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileList.__iter__ must not run")
+
+    HostileList.calls = 0
+    with pytest.raises(ValueError, match="hidden_sizes must be a bounded tuple or list"):
+        _canonical_hidden_sizes(HostileList([32, 32]), observation_dim=4, n_actions=2)
+    assert HostileList.calls == 0


### PR DESCRIPTION
## Summary
Tighten reference-life JSON parsing so nested paths require exact `dict`/`list` containers instead of accepting arbitrary mapping/sequence types.

## Test plan
- [ ] CI / relevant pytest for touched modules

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)