### PR TITLE
fix(benchmarks): require exact dict JSON objects in forager RNG parity parse

### DIFF
--- a/alberta_framework/benchmarks/forager_rng_parity.py
+++ b/alberta_framework/benchmarks/forager_rng_parity.py
@@ -697,7 +697,7 @@ def _require_exact_keys(value: Mapping[str, Any], expected: set[str], path: str)
 
 
 def _require_object(value: Any, path: str) -> Mapping[str, Any]:
-    if not isinstance(value, Mapping) or any(type(key) is not str for key in value):
+    if type(value) is not dict or any(type(key) is not str for key in value):
         raise ForagerRngParityError(f"{path} must be a JSON object")
     return cast(Mapping[str, Any], value)
 

--- a/tests/test_forager_rng_hostile_validation.py
+++ b/tests/test_forager_rng_hostile_validation.py
@@ -92,3 +92,22 @@ def test_source_has_no_repr_leak() -> None:
 def test_valid_duplicate_passes() -> None:
     assert _duplicate_free_object([("a", 1), ("b", 2)]) == {"a": 1, "b": 2}
     assert _parse_json_float("1.23") == 1.23
+
+
+def test_require_object_rejects_dict_subclass_without_iter_hooks() -> None:
+    from alberta_framework.benchmarks.forager_rng_parity import (
+        ForagerRngParityError,
+        _require_object,
+    )
+
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(ForagerRngParityError, match="must be a JSON object"):
+        _require_object(HostileDict({"a": 1}), "path")
+    assert HostileDict.calls == 0


### PR DESCRIPTION
## Summary
Require exact `dict` instances when parsing JSON objects in forager RNG parity benchmark code.

## Test plan
- [ ] CI / relevant pytest for touched modules

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)