### PR TITLE
fix(forager): require exact dict/list containers in CLI JSON safe walk

### DIFF
--- a/alberta_framework/forager_cli.py
+++ b/alberta_framework/forager_cli.py
@@ -145,9 +145,9 @@ def _parse_named_config(value: str) -> tuple[str, str]:
 def _json_safe(value: Any) -> Any:
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return _json_safe(dataclasses.asdict(value))
-    if isinstance(value, Mapping):
+    if type(value) is dict:
         return {str(key): _json_safe(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
+    if type(value) is list or type(value) is tuple:
         return [_json_safe(item) for item in value]
     if isinstance(value, float) and not math.isfinite(value):
         raise ValueError("forager CLI payload is not finite JSON")

--- a/tests/test_forager_cli.py
+++ b/tests/test_forager_cli.py
@@ -155,3 +155,33 @@ def test_main_passes_explicit_final_window_to_config() -> None:
     assert "_explicit_int_or_default(" in source
     assert "args.final_window, protocol.final_window_steps" in source
     assert "args.final_window or protocol.final_window_steps" not in source
+
+
+def test_json_safe_rejects_non_exact_mapping_without_items_hooks() -> None:
+    class HostileDict(dict):
+        calls = 0
+
+        def items(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.items must not run")
+
+    hostile = HostileDict({"a": 1})
+    HostileDict.calls = 0
+    result = forager_cli._json_safe(hostile)
+    assert result is hostile
+    assert HostileDict.calls == 0
+
+
+def test_json_safe_rejects_non_exact_list_without_iter_hooks() -> None:
+    class HostileList(list):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileList.__iter__ must not run")
+
+    hostile = HostileList([1])
+    HostileList.calls = 0
+    result = forager_cli._json_safe(hostile)
+    assert result is hostile
+    assert HostileList.calls == 0


### PR DESCRIPTION
## Summary
Use `type(x) is dict` / `type(x) is list` in the forager CLI JSON safe-walk path for strict container typing.

## Test plan
- [ ] CI / relevant pytest for touched modules

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)