### PR TITLE
fix(reference): require exact list/dict in agent nested tuple and manifest config

### DIFF
--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -360,7 +360,7 @@ def _cast_representable(
 
 
 def _nested_tuple(value: Any) -> Any:
-    if isinstance(value, list):
+    if type(value) is list:
         return tuple(_nested_tuple(item) for item in value)
     return value
 
@@ -733,7 +733,7 @@ class AgentManifest:
         if not isinstance(self.capabilities, AgentCapabilities):
             raise ValueError("capabilities must be AgentCapabilities")
         config = _load_manifest_config_json(self._config_json)
-        if not isinstance(config, dict):
+        if type(config) is not dict:
             raise ValueError("manifest config must be a JSON object")
         if _canonical_json_bytes(config).decode("utf-8") != self._config_json:
             raise ValueError("manifest config must use canonical JSON encoding")
@@ -789,7 +789,7 @@ class AgentManifest:
     @property
     def config(self) -> dict[str, Any]:
         config = _load_manifest_config_json(self._config_json)
-        assert isinstance(config, dict)
+        assert type(config) is dict
         return config
 
     def make_decision(

--- a/tests/test_reference_agent_hostile_validation.py
+++ b/tests/test_reference_agent_hostile_validation.py
@@ -93,3 +93,19 @@ def test_valid_array_value() -> None:
         semantic_id="a.b", dtype="float32", shape=(), payload=b"\x00\x00\x80\x3f"
     )
     assert v.dtype == "float32"
+
+
+def test_nested_tuple_rejects_list_subclass_without_iter_hooks() -> None:
+    from alberta_framework.reference_agent import _nested_tuple
+
+    class HostileList(list):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileList.__iter__ must not run")
+
+    hostile = HostileList([1])
+    HostileList.calls = 0
+    assert _nested_tuple(hostile) is hostile
+    assert HostileList.calls == 0


### PR DESCRIPTION
## Summary
Require exact `list`/`dict` when validating nested tuples and manifest config in reference agent code.

## Test plan
- [ ] CI / relevant pytest for touched modules

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)