### PR TITLE
fix: require exact dict/list in scale-robust artifact validation

### DIFF
--- a/alberta_framework/evaluation/scale_robust_feature_artifact.py
+++ b/alberta_framework/evaluation/scale_robust_feature_artifact.py
@@ -1593,7 +1593,7 @@ def load_evidence_artifact(path: Path) -> dict[str, object]:
         parse_float=_parse_finite_json_float,
         object_pairs_hook=_object_without_duplicates,
     )
-    if not isinstance(loaded, dict):
+    if type(loaded) is not dict:
         raise ValueError("artifact root must be an object")
     return loaded
 
@@ -1631,19 +1631,19 @@ def _mapping(
     location: str,
     errors: list[str],
 ) -> Mapping[str, object] | None:
-    if not isinstance(value, Mapping):
+    if type(value) is not dict:
         errors.append(f"{location} must be an object")
         return None
     return value
 
 
 def _parsed_pairs(value: object) -> tuple[tuple[int, int], ...] | None:
-    if not isinstance(value, list):
+    if type(value) is not list:
         return None
     pairs: list[tuple[int, int]] = []
     for pair in value:
         if (
-            not isinstance(pair, list)
+            type(pair) is not list
             or len(pair) != 2
             or _strict_int(pair[0]) is None
             or _strict_int(pair[1]) is None

--- a/tests/test_scale_robust_exact_json_hostile.py
+++ b/tests/test_scale_robust_exact_json_hostile.py
@@ -1,0 +1,55 @@
+"""Hostile exact JSON gates for scale-robust artifact validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.scale_robust_feature_artifact import (
+    _mapping,
+    _parsed_pairs,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class HostileDict(dict):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileDict.__iter__ must not run")
+
+
+class HostileList(list):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileList.__iter__ must not run")
+
+
+def test_mapping_rejects_dict_subclass_without_iter_hooks() -> None:
+    errors: list[str] = []
+    HostileDict.calls = 0
+    assert _mapping(HostileDict({"a": 1}), "root", errors) is None
+    assert errors == ["root must be an object"]
+    assert HostileDict.calls == 0
+
+
+def test_parsed_pairs_rejects_list_subclass_without_iter_hooks() -> None:
+    HostileList.calls = 0
+    assert _parsed_pairs(HostileList([[0, 1]])) is None
+    assert HostileList.calls == 0
+
+
+def test_parsed_pairs_rejects_pair_list_subclass_without_iter_hooks() -> None:
+    class HostilePairList(list):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostilePairList.__iter__ must not run")
+
+    HostilePairList.calls = 0
+    assert _parsed_pairs([HostilePairList([0, 1])]) is None
+    assert HostilePairList.calls == 0


### PR DESCRIPTION
## Summary
- Enforce exact `dict`/`list` checks in scale-robust evidence artifact validation.

## Test plan
- [ ] Scale-robust evidence / validation tests

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).