### PR TITLE
Require exact dict for Forager RNG parity JSON objects

### DIFF
--- a/alberta_framework/benchmarks/forager_rng_parity.py
+++ b/alberta_framework/benchmarks/forager_rng_parity.py
@@ -697,8 +697,13 @@ def _require_exact_keys(value: Mapping[str, Any], expected: set[str], path: str)
 
 
 def _require_object(value: Any, path: str) -> Mapping[str, Any]:
-    if not isinstance(value, Mapping) or any(type(key) is not str for key in value):
-        raise ForagerRngParityError(f"{path} must be a JSON object")
+    if (
+        type(value) is not dict
+        and type(value) is not MappingProxyType
+    ) or any(type(key) is not str for key in value):
+        raise ForagerRngParityError(
+            f"{path} must be an exact dict or MappingProxyType JSON object"
+        )
     return cast(Mapping[str, Any], value)
 
 

--- a/tests/test_forager_rng_parity_hostile_validation.py
+++ b/tests/test_forager_rng_parity_hostile_validation.py
@@ -116,3 +116,25 @@ def test_environment_trace_digest_validation() -> None:
                 transitions=(_make_transition_digest(),),
                 trace_sha256=invalid_digest,  # type: ignore[arg-type]
             )
+
+
+def test_require_object_rejects_mapping_subclass_before_iter() -> None:
+    from alberta_framework.benchmarks.forager_rng_parity import (
+        ForagerRngParityError,
+        _require_object,
+    )
+
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(
+        ForagerRngParityError,
+        match="exact dict or MappingProxyType",
+    ):
+        _require_object(HostileDict({"a": 1}), "probe")
+    assert HostileDict.calls == 0


### PR DESCRIPTION
_require_object accepted any Mapping, so a dict subclass with a hostile __iter__ could run during later JSON walks. Accept only exact dict or MappingProxyType.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)