### PR TITLE
fix: require exact dict in evidence manifest mapping gates

### DIFF
--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -598,7 +598,7 @@ def _required_mapping(
     owner: str,
 ) -> Mapping[str, object]:
     candidate = value.get(key)
-    if not isinstance(candidate, Mapping) or not candidate:
+    if type(candidate) is not dict or not candidate:
         raise RuntimeError(f"{owner}.{key} must be a non-empty mapping")
     return candidate
 
@@ -940,7 +940,7 @@ def _load_strict_json_object(path: Path) -> dict[str, object]:
         parse_float=_parse_finite_json_float,
         object_pairs_hook=_reject_duplicate_json_keys,
     )
-    if not isinstance(parsed, dict):
+    if type(parsed) is not dict:
         raise ValueError(f"{path} must contain a JSON object")
     return parsed
 

--- a/tests/test_evidence_manifest_exact_json_hostile.py
+++ b/tests/test_evidence_manifest_exact_json_hostile.py
@@ -1,0 +1,25 @@
+"""Hostile exact JSON gates for evidence manifest mapping helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.evidence_manifest import _required_mapping
+
+pytestmark = pytest.mark.unit
+
+
+class HostileDict(dict):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileDict.__iter__ must not run")
+
+
+def test_required_mapping_rejects_dict_subclass_without_iter_hooks() -> None:
+    owner: dict[str, object] = {"nested": HostileDict({"a": 1})}
+    HostileDict.calls = 0
+    with pytest.raises(RuntimeError, match="owner.nested must be a non-empty mapping"):
+        _required_mapping(owner, "nested", owner="owner")
+    assert HostileDict.calls == 0


### PR DESCRIPTION
## Summary
- Require exact `dict` instances at evidence manifest mapping gate checks.

## Test plan
- [ ] Evidence manifest unit tests and `alberta-evidence-status`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)