### PR TITLE
fix: evidence manifest required mapping hostile dict/list gate

### DIFF
--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -598,7 +598,7 @@ def _required_mapping(
     owner: str,
 ) -> Mapping[str, object]:
     candidate = value.get(key)
-    if not isinstance(candidate, Mapping) or not candidate:
+    if type(candidate) is not dict or not candidate:
         raise RuntimeError(f"{owner}.{key} must be a non-empty mapping")
     return candidate
 
@@ -612,7 +612,7 @@ def _required_string_tuple(
     for key in keys:
         candidate = value.get(key)
         if (
-            isinstance(candidate, list)
+            type(candidate) is list
             and candidate
             and all(type(item) is str and item for item in candidate)
         ):

--- a/tests/test_evidence_manifest_mapping_hostile.py
+++ b/tests/test_evidence_manifest_mapping_hostile.py
@@ -1,0 +1,34 @@
+"""Hostile dict/list identity gate for evidence manifest required helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.evidence_manifest import (
+    _required_mapping,
+    _required_string_tuple,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    def items(self):  # type: ignore[no-untyped-def]
+        raise AssertionError("hostile mapping iteration hook executed")
+
+
+class _HostileList(list[object]):
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        raise AssertionError("hostile sequence iteration hook executed")
+
+
+def test_required_mapping_rejects_hostile_dict_before_truthiness() -> None:
+    payload: dict[str, object] = {"seed_roles": _HostileDict({"development": [0]})}
+    with pytest.raises(RuntimeError, match="must be a non-empty mapping"):
+        _required_mapping(payload, "seed_roles", owner="test.protocol")
+
+
+def test_required_string_tuple_rejects_hostile_list_before_iteration() -> None:
+    payload: dict[str, object] = {"excluded_claims": _HostileList(["a", "b"])}
+    with pytest.raises(RuntimeError, match="must be a non-empty string array"):
+        _required_string_tuple(payload, ("excluded_claims",), owner="test.protocol")


### PR DESCRIPTION
## Summary
- Require exact `dict`/`list` identity in `_required_mapping` and `_required_string_tuple`
- Add hostile subclass regression tests

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_evidence_manifest_mapping_hostile.py -q`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)