### PR TITLE
fix: evidence manifest artifact digest exact dict gate

### DIFF
--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -870,7 +870,7 @@ def _artifact_digest(artifact: Mapping[str, object]) -> str | None:
 
     for key in ("scientific_digest", "content_digest"):
         record = artifact.get(key)
-        if not isinstance(record, Mapping):
+        if type(record) is not dict:
             continue
         value = record.get("sha256")
         if (

--- a/tests/test_evidence_manifest_artifact_digest_hostile.py
+++ b/tests/test_evidence_manifest_artifact_digest_hostile.py
@@ -1,0 +1,24 @@
+"""Hostile dict identity gate for evidence manifest artifact digest lookup."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.evidence_manifest import _artifact_digest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    def get(self, key: str, default: object = None) -> object:  # type: ignore[override]
+        if key == "sha256":
+            return "a" * 64
+        return super().get(key, default)
+
+    def __bool__(self) -> bool:
+        raise AssertionError("hostile mapping truth hook executed")
+
+
+def test_artifact_digest_rejects_hostile_digest_record_before_truthiness() -> None:
+    artifact: dict[str, object] = {"content_digest": _HostileDict()}
+    assert _artifact_digest(artifact) is None


### PR DESCRIPTION
## Summary
- Use `type(record) is dict` in `_artifact_digest` instead of `isinstance(..., Mapping)`
- Add hostile subclass regression test

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_evidence_manifest_artifact_digest_hostile.py -q`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)