### PR TITLE
fix: evidence manifest FTL chain mapping exact dict gate

### DIFF
--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -1197,7 +1197,7 @@ def _chain_mapping(
     expected_keys: set[str],
     errors: list[str],
 ) -> Mapping[str, object] | None:
-    if not isinstance(value, Mapping):
+    if type(value) is not dict:
         errors.append(f"{location} must be an object")
         return None
     if set(value) != expected_keys:
@@ -1212,11 +1212,11 @@ def _ftl_acceptance_passed(
     errors: list[str],
 ) -> bool | None:
     scientific = artifact.get("scientific_payload")
-    if not isinstance(scientific, Mapping):
+    if type(scientific) is not dict:
         errors.append(f"{location}.scientific_payload must be an object")
         return None
     acceptance = scientific.get("acceptance")
-    if not isinstance(acceptance, Mapping):
+    if type(acceptance) is not dict:
         errors.append(f"{location}.scientific_payload.acceptance must be an object")
         return None
     passed = acceptance.get("passed")
@@ -1236,10 +1236,10 @@ def _ftl_scientific_digest(
 ) -> str | None:
     scientific = artifact.get("scientific_payload")
     digest = artifact.get("scientific_digest")
-    if not isinstance(scientific, Mapping):
+    if type(scientific) is not dict:
         errors.append(f"{location}.scientific_payload must be an object")
         return None
-    if not isinstance(digest, Mapping):
+    if type(digest) is not dict:
         errors.append(f"{location}.scientific_digest must be an object")
         return None
     recorded = digest.get("sha256")

--- a/tests/test_evidence_manifest_chain_mapping_hostile.py
+++ b/tests/test_evidence_manifest_chain_mapping_hostile.py
@@ -1,0 +1,52 @@
+"""Hostile dict identity gate for evidence manifest FTL chain helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.evidence_manifest import (
+    _chain_mapping,
+    _ftl_acceptance_passed,
+    _ftl_scientific_digest,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    def keys(self):  # type: ignore[no-untyped-def]
+        raise AssertionError("hostile mapping keys hook executed")
+
+    def __bool__(self) -> bool:
+        raise AssertionError("hostile mapping truth hook executed")
+
+
+def test_chain_mapping_rejects_hostile_dict_before_set_compare() -> None:
+    errors: list[str] = []
+    assert (
+        _chain_mapping(
+            _HostileDict({"a": 1}),
+            location="artifact",
+            expected_keys={"a"},
+            errors=errors,
+        )
+        is None
+    )
+    assert errors == ["artifact must be an object"]
+
+
+def test_ftl_acceptance_rejects_hostile_scientific_before_set_compare() -> None:
+    errors: list[str] = []
+    artifact: dict[str, object] = {"scientific_payload": _HostileDict({"acceptance": {}})}
+    assert _ftl_acceptance_passed(artifact, location="artifact", errors=errors) is None
+    assert errors == ["artifact.scientific_payload must be an object"]
+
+
+def test_ftl_scientific_digest_rejects_hostile_digest_before_set_compare() -> None:
+    errors: list[str] = []
+    artifact: dict[str, object] = {
+        "scientific_payload": {},
+        "scientific_digest": _HostileDict({"sha256": "a" * 64}),
+    }
+    assert _ftl_scientific_digest(artifact, location="artifact", errors=errors) is None
+    assert errors == ["artifact.scientific_digest must be an object"]


### PR DESCRIPTION
## Summary
- Use exact dict identity in `_chain_mapping`, `_ftl_acceptance_passed`, and `_ftl_scientific_digest`
- Add hostile subclass regression tests

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_evidence_manifest_chain_mapping_hostile.py -q`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)