### PR TITLE
fix: reference life scorecard reward sum exact dict gate

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -1031,7 +1031,7 @@ def _admit_aggregate_records(
 
 def _reward_sum(record: Mapping[str, Any]) -> float:
     outcome = record.get("outcome")
-    if not isinstance(outcome, Mapping):
+    if type(outcome) is not dict:
         raise ValueError("completed run record lacks an outcome")
     value = outcome.get("reward_sum")
     if type(value) is not int and type(value) is not float:
@@ -1058,7 +1058,7 @@ def _summarize_validated_run_records(
     }
     indexed: dict[tuple[str, str, int], Mapping[str, Any]] = {}
     for record in records:
-        if not isinstance(record, Mapping):
+        if type(record) is not dict:
             raise ValueError("every run record must be an object")
         identity = _record_identity(record)
         if identity in indexed:
@@ -1098,9 +1098,9 @@ def _summarize_validated_run_records(
                 }
             )
         outcome = record.get("outcome")
-        if isinstance(outcome, Mapping):
+        if type(outcome) is dict:
             check = outcome.get("parameter_change_check")
-            if isinstance(check, Mapping) and check.get("passed") is not True:
+            if type(check) is dict and check.get("passed") is not True:
                 parameter_failures.append(
                     {
                         "environment_kind": identity[0],

--- a/tests/test_scorecard_reward_sum_hostile.py
+++ b/tests/test_scorecard_reward_sum_hostile.py
@@ -1,0 +1,40 @@
+"""Hostile dict identity gate for scorecard reward aggregation helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks import reference_life_scorecard as scorecard
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    def get(self, key: str, default: object = None) -> object:  # type: ignore[override]
+        if key == "reward_sum":
+            return 1.0
+        return super().get(key, default)
+
+    def __bool__(self) -> bool:
+        raise AssertionError("hostile mapping truth hook executed")
+
+
+def test_reward_sum_rejects_hostile_outcome_before_get() -> None:
+    record: dict[str, object] = {"outcome": _HostileDict({"reward_sum": 1.0})}
+    with pytest.raises(ValueError, match="lacks an outcome"):
+        scorecard._reward_sum(record)
+
+
+def test_summarize_rejects_hostile_record_before_identity() -> None:
+    plan = scorecard.build_development_plan()
+    hostile_record = _HostileDict(
+        {
+            "environment_kind": "switching_two_state",
+            "arm": "prototype",
+            "seed": 0,
+            "status": "completed",
+            "outcome": {"reward_sum": 0.0},
+        }
+    )
+    with pytest.raises(ValueError, match="every run record must be an object"):
+        scorecard._summarize_validated_run_records(plan, [hostile_record])


### PR DESCRIPTION
## Summary
- Use exact dict identity in `_reward_sum` and `_summarize_validated_run_records`
- Add hostile subclass regression tests

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_scorecard_reward_sum_hostile.py -q`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)