### PR TITLE
fix: recurring feature artifact mapping exact dict/list gate

### DIFF
--- a/alberta_framework/evaluation/recurring_feature_artifact.py
+++ b/alberta_framework/evaluation/recurring_feature_artifact.py
@@ -895,7 +895,7 @@ def _mapping(
     errors: list[str],
 ) -> Mapping[str, object] | None:
     value = parent.get(key)
-    if not isinstance(value, Mapping):
+    if type(value) is not dict:
         errors.append(f"{location}.{key} must be an object")
         return None
     return value
@@ -940,7 +940,7 @@ def _extract_seed_metrics(
     summaries: object,
     errors: list[str],
 ) -> tuple[list[int], dict[str, list[dict[str, object]]]]:
-    if not isinstance(summaries, list) or not summaries:
+    if type(summaries) is not list or not summaries:
         errors.append("scientific_payload.seed_summaries must be a non-empty array")
         return [], {"retained": [], "no_retention": []}
     seeds: list[int] = []
@@ -950,7 +950,7 @@ def _extract_seed_metrics(
     }
     for index, raw_summary in enumerate(summaries):
         location = f"scientific_payload.seed_summaries[{index}]"
-        if not isinstance(raw_summary, Mapping):
+        if type(raw_summary) is not dict:
             errors.append(f"{location} must be an object")
             continue
         if set(raw_summary) != {"seed", "retained", "no_retention"}:

--- a/tests/test_recurring_feature_mapping_hostile.py
+++ b/tests/test_recurring_feature_mapping_hostile.py
@@ -1,0 +1,45 @@
+"""Hostile dict/list identity gate for recurring feature artifact mapping helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.recurring_feature_artifact import (
+    _extract_seed_metrics,
+    _mapping,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    def keys(self):  # type: ignore[no-untyped-def]
+        raise AssertionError("hostile mapping keys hook executed")
+
+
+class _HostileList(list[object]):
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        raise AssertionError("hostile sequence iteration hook executed")
+
+
+def test_mapping_rejects_hostile_dict_before_set_compare() -> None:
+    parent: dict[str, object] = {"nested": _HostileDict({"seed": 0})}
+    errors: list[str] = []
+    assert _mapping(parent, "nested", "parent", errors) is None
+    assert errors == ["parent.nested must be an object"]
+
+
+def test_extract_seed_metrics_rejects_hostile_list_before_iteration() -> None:
+    errors: list[str] = []
+    seeds, variants = _extract_seed_metrics(_HostileList([{"seed": 0}]), errors)
+    assert seeds == []
+    assert variants == {"retained": [], "no_retention": []}
+    assert errors == ["scientific_payload.seed_summaries must be a non-empty array"]
+
+
+def test_extract_seed_metrics_rejects_hostile_summary_before_set_compare() -> None:
+    errors: list[str] = []
+    seeds, variants = _extract_seed_metrics([_HostileDict({"seed": 0})], errors)
+    assert seeds == []
+    assert variants == {"retained": [], "no_retention": []}
+    assert any("must be an object" in error for error in errors)


### PR DESCRIPTION
## Summary
- Use exact dict/list identity in `_mapping` and `_extract_seed_metrics`
- Add hostile subclass regression tests

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_recurring_feature_mapping_hostile.py -q`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)