### PR TITLE
fix: continual multiagent artifact mapping exact dict gate

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent_artifact.py
+++ b/alberta_framework/evaluation/continual_multiagent_artifact.py
@@ -429,7 +429,7 @@ def _validate_source_provenance(value: object, errors: list[str]) -> None:
     """Require exact hashes for every source that defines this evidence."""
 
     location = "content.source_provenance"
-    if not isinstance(value, Mapping):
+    if type(value) is not dict:
         errors.append(f"{location} must be an object")
         return
     try:
@@ -686,7 +686,7 @@ def _required_mapping(
     errors: list[str],
 ) -> Mapping[str, object] | None:
     value = parent.get(key)
-    if not isinstance(value, Mapping):
+    if type(value) is not dict:
         errors.append(f"{key} must be an object")
         return None
     return value

--- a/tests/test_continual_multiagent_mapping_hostile.py
+++ b/tests/test_continual_multiagent_mapping_hostile.py
@@ -1,0 +1,33 @@
+"""Hostile dict identity gate for continual multiagent required mapping helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.continual_multiagent_artifact import (
+    _required_mapping,
+    _validate_source_provenance,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    def keys(self):  # type: ignore[no-untyped-def]
+        raise AssertionError("hostile mapping keys hook executed")
+
+    def __bool__(self) -> bool:
+        raise AssertionError("hostile mapping truth hook executed")
+
+
+def test_required_mapping_rejects_hostile_dict_before_set_compare() -> None:
+    parent: dict[str, object] = {"content": _HostileDict({"thresholds": {}})}
+    errors: list[str] = []
+    assert _required_mapping(parent, "content", errors) is None
+    assert errors == ["content must be an object"]
+
+
+def test_validate_source_provenance_rejects_hostile_dict_before_set_compare() -> None:
+    errors: list[str] = []
+    _validate_source_provenance(_HostileDict({"repository_subtree": "x"}), errors)
+    assert errors == ["content.source_provenance must be an object"]


### PR DESCRIPTION
## Summary
- Use exact dict identity in `_required_mapping` and `_validate_source_provenance`
- Add hostile subclass regression tests

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_continual_multiagent_mapping_hostile.py -q`

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)