### PR TITLE
fix(core/oak): skip 0*inf when keyboard baseline_decay is zero

### DIFF
--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -1112,6 +1112,11 @@ def _keyboard_state_operand(
     return trusted
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled decay does not poison the next EMA."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def init_keyboard_chord_learner(
     config: KeyboardChordLearnerConfig,
 ) -> KeyboardChordLearnerState:
@@ -1163,10 +1168,16 @@ def update_keyboard_chord_learner(
         scaled_chord / scaled_chord_norm,
         jnp.zeros_like(chord),
     )
-    baseline = (
-        config.baseline_decay * state.reward_baseline + (1.0 - config.baseline_decay) * reward_arr
+    baseline_decay = jnp.asarray(config.baseline_decay, dtype=jnp.float32)
+    safe_prior_baseline = jnp.where(
+        jnp.isfinite(state.reward_baseline),
+        state.reward_baseline,
+        jnp.zeros_like(state.reward_baseline),
     )
-    advantage = reward_arr - state.reward_baseline
+    baseline = _skip_zero_scale(baseline_decay, state.reward_baseline) + (
+        1.0 - baseline_decay
+    ) * reward_arr
+    advantage = reward_arr - safe_prior_baseline
     proposed_vector = (
         state.chord_vector * (1.0 - config.step_size * config.l2_penalty)
         + config.step_size * advantage * chord_norm
@@ -1191,7 +1202,7 @@ def update_keyboard_chord_learner(
     # max-norm rescaling is nan/inf and the whole vector stays poisoned.
     source_valid = (
         jnp.all(jnp.isfinite(state.chord_vector))
-        & jnp.isfinite(state.reward_baseline)
+        & (jnp.isfinite(state.reward_baseline) | (baseline_decay == 0.0))
         & (state.step_count >= jnp.asarray(0, dtype=jnp.int32))
     )
     inputs_valid = jnp.all(jnp.isfinite(chord)) & jnp.isfinite(reward_arr)

--- a/tests/test_oak_prototype_fixes.py
+++ b/tests/test_oak_prototype_fixes.py
@@ -380,3 +380,28 @@ def test_oak_and_keyboard_close_schema_float32_and_resource_boundaries() -> None
     KeyboardChordLearnerConfig(n_options=last_legal_keyboard_options)
     with pytest.raises(ValueError, match="keyboard state bytes"):
         KeyboardChordLearnerConfig(n_options=last_legal_keyboard_options + 1)
+
+
+def test_zero_baseline_decay_does_not_multiply_inf_reward_baseline() -> None:
+    """baseline_decay=0 times an infinite reward baseline is 0*inf = NaN."""
+    from alberta_framework.core.oak import (
+        init_keyboard_chord_learner,
+        update_keyboard_chord_learner,
+    )
+
+    cfg = KeyboardChordLearnerConfig(
+        n_options=3,
+        step_size=0.1,
+        baseline_decay=0.0,
+        l2_penalty=0.0,
+        max_norm=10.0,
+    )
+    state = init_keyboard_chord_learner(cfg).replace(
+        reward_baseline=jnp.array(jnp.inf, dtype=jnp.float32)
+    )
+    selected = jnp.array([1.0, 0.0, 0.0], dtype=jnp.float32)
+    updated = update_keyboard_chord_learner(
+        cfg, state, selected, jnp.array(1.0, dtype=jnp.float32)
+    )
+    chex.assert_tree_all_finite(updated.reward_baseline)
+    chex.assert_trees_all_close(updated.reward_baseline, jnp.array(1.0, dtype=jnp.float32))


### PR DESCRIPTION
## Summary
- Skip `0 * inf` when `baseline_decay=0` would poison the keyboard reward baseline EMA
- Use a finite prior baseline for advantage when recovering from a poisoned tracker

## Test plan
- [x] Targeted pytest for the regression added in this PR

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)