### PR TITLE
fix(core/oak): skip 0*inf when utility_ema_decay is zero

### DIFF
--- a/alberta_framework/core/oak.py
+++ b/alberta_framework/core/oak.py
@@ -538,8 +538,9 @@ def _oak_outer_state_validity(
             config.observation_dim,
         )
     )
-    values_finite = jnp.all(jnp.isfinite(state.cumulative_pseudo_rewards)) & jnp.all(
-        jnp.isfinite(state.utility_ema)
+    values_finite = jnp.all(jnp.isfinite(state.cumulative_pseudo_rewards)) & (
+        jnp.all(jnp.isfinite(state.utility_ema))
+        | (config.utility_ema_decay == 0.0)
     )
     counter_ceiling = jnp.where(
         state.step_count < jnp.int32(2_147_483_647),
@@ -1112,6 +1113,11 @@ def _keyboard_state_operand(
     return trusted
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled decay does not poison the next EMA."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def init_keyboard_chord_learner(
     config: KeyboardChordLearnerConfig,
 ) -> KeyboardChordLearnerState:
@@ -1531,7 +1537,8 @@ class OaKAgent:
         decay = jnp.asarray(cfg.utility_ema_decay, dtype=jnp.float32)
         new_utility_ema = jnp.where(
             prior_option_mask & prior_active,
-            decay * source_state.utility_ema + (1.0 - decay) * stomp_result.pseudo_reward,
+            _skip_zero_scale(decay, source_state.utility_ema)
+            + (1.0 - decay) * stomp_result.pseudo_reward,
             source_state.utility_ema,
         )
 

--- a/tests/test_oak_transition_accounting.py
+++ b/tests/test_oak_transition_accounting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import chex
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -176,4 +177,42 @@ def test_terminal_pseudo_reward_credits_prior_option_and_counts_restart(
     np.testing.assert_array_equal(
         np.asarray(after.execution_counts),
         expected_counts,
+    )
+
+
+def test_zero_utility_ema_decay_replaces_infinite_prior_without_nan() -> None:
+    """utility_ema_decay=0 must skip 0*inf on a poisoned utility EMA."""
+    config = OaKConfig(
+        utility_ema_decay=0.0,
+        stomp=STOMPConfig(
+            subtask_specs=(
+                SubtaskSpec(
+                    feature_index=0,
+                    threshold=1.0e6,
+                    pseudo_reward_scale=PSEUDO_REWARD,
+                    max_option_steps=1,
+                ),
+            ),
+            observation_dim=2,
+            n_primitive_actions=N_PRIMITIVE,
+            base_step_size=0.05,
+            epsilon_base=0.0,
+            epsilon_option=0.0,
+        ),
+    )
+    agent = OaKAgent(config)
+    state = agent.start(agent.init(jr.key(0)), OBS)
+    state = state.replace(utility_ema=jnp.array([jnp.inf], dtype=jnp.float32))
+    stomp_state = state.stomp_state.replace(
+        executing_option=jnp.array(0, dtype=jnp.int32),
+        option_steps=jnp.array(0, dtype=jnp.int32),
+    )
+    state = state.replace(stomp_state=stomp_state)
+
+    after = agent.update(state, jnp.array(0.0, dtype=jnp.float32), OBS)
+
+    chex.assert_tree_all_finite(after.utility_ema)
+    chex.assert_trees_all_close(
+        after.utility_ema,
+        jnp.array([PSEUDO_REWARD], dtype=jnp.float32),
     )


### PR DESCRIPTION
## Summary
- Skip `0 * inf` when `utility_ema_decay=0` would poison per-option utility EMA updates
- Allow outer-state recovery when the prior utility tracker was non-finite but decay is zero

## Test plan
- [x] Targeted pytest for the regression added in this PR

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)