### PR TITLE
fix(core/intelligence_amplification): skip 0*inf when acceptance_ema_decay is zero

### DIFF
--- a/alberta_framework/core/intelligence_amplification.py
+++ b/alberta_framework/core/intelligence_amplification.py
@@ -905,6 +905,11 @@ def recommendation_protocol_state_is_valid(
     )
 
 
+def _skip_zero_scale(scale: Array, value: Array) -> Array:
+    """Skip ``0 * inf`` so a disabled decay does not poison the next EMA."""
+    return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
 def init_recommendation_protocol_state() -> RecommendationProtocolState:
     """Initialize recommendation feedback counters."""
     return RecommendationProtocolState(
@@ -977,12 +982,22 @@ def update_recommendation_protocol(
             raise TypeError("accept_recommendation must be a scalar boolean")
     accepted_f = accepted.astype(jnp.float32)
     decay = jnp.asarray(config.acceptance_ema_decay, dtype=jnp.float32)
-    source_state_valid = recommendation_protocol_state_is_valid(state)
     source_total_words, source_sum_available = _words_sum(
         state.accepted_words,
         state.rejected_words,
     )
     exact_partition_valid = source_sum_available & jnp.all(source_total_words == state.step_words)
+    counters_valid = (
+        _lifetime_counter_valid(state.accepted_words, state.accepted_count)
+        & _lifetime_counter_valid(state.rejected_words, state.rejected_count)
+        & _lifetime_counter_valid(state.step_words, state.step_count)
+    )
+    ema_valid = (
+        jnp.isfinite(state.acceptance_ema)
+        & (state.acceptance_ema >= 0.0)
+        & (state.acceptance_ema <= 1.0)
+    )
+    source_state_valid = counters_valid & exact_partition_valid & (ema_valid | (decay == 0.0))
     next_step_words, lifetime_capacity_available = _checked_lifetime_words_increment(
         state.step_words
     )
@@ -1008,7 +1023,8 @@ def update_recommendation_protocol(
             state.rejected_count,
             _saturating_int32_counter_increment(state.rejected_count),
         ),
-        acceptance_ema=decay * state.acceptance_ema + (1.0 - decay) * accepted_f,
+        acceptance_ema=_skip_zero_scale(decay, state.acceptance_ema)
+        + (1.0 - decay) * accepted_f,
         step_count=_saturating_int32_counter_increment(state.step_count),
         accepted_words=jnp.where(
             accepted,

--- a/tests/test_intelligence_amplification_horizon.py
+++ b/tests/test_intelligence_amplification_horizon.py
@@ -356,6 +356,26 @@ def test_all_ones_cerebellum_ia_and_protocol_are_terminal() -> None:
     chex.assert_trees_all_equal(protocol_result.state, protocol_terminal)
 
 
+def test_zero_acceptance_ema_decay_replaces_infinite_prior_without_nan() -> None:
+    """acceptance_ema_decay=0 times an infinite acceptance EMA is 0*inf = NaN."""
+    config = RecommendationProtocolConfig(acceptance_ema_decay=0.0)
+    state = init_recommendation_protocol_state().replace(
+        acceptance_ema=jnp.array(jnp.inf, dtype=jnp.float32)
+    )
+    result = update_recommendation_protocol(
+        config,
+        state,
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray(0, dtype=jnp.int32),
+        accept_recommendation=jnp.array(True),
+    )
+    chex.assert_tree_all_finite(result.state.acceptance_ema)
+    chex.assert_trees_all_close(
+        result.state.acceptance_ema,
+        jnp.array(1.0, dtype=jnp.float32),
+    )
+
+
 def test_protocol_exact_partition_crosses_int32_and_low_word_boundaries() -> None:
     config = RecommendationProtocolConfig(acceptance_ema_decay=0.5)
     saturated = _protocol_state(


### PR DESCRIPTION
## Summary
- Skip `0 * inf` when `acceptance_ema_decay=0` would poison recommendation acceptance EMA
- Keep counter/partition validation while permitting zero-decay recovery from a poisoned EMA

## Test plan
- [x] Targeted pytest for the regression added in this PR

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)