### PR TITLE
fix(benchmarks): require exact dict for bounded process environment

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_qualification.py
+++ b/alberta_framework/benchmarks/forager_matched_qualification.py
@@ -3033,7 +3033,7 @@ def _run_bounded_process(
         raise ValueError("bounded process output limits must be nonnegative integers")
     materialized_environment: dict[str, str] | None = None
     if environment is not None:
-        if not isinstance(environment, Mapping):
+        if type(environment) is not dict:
             raise TypeError("bounded process environment must be a mapping")
         materialized_environment = {}
         for env_key, value in environment.items():

--- a/tests/test_forager_matched_qualification.py
+++ b/tests/test_forager_matched_qualification.py
@@ -80,6 +80,20 @@ def test_canonical_json_rejects_hostile_container_subclasses_without_hooks() -> 
             qualification._plain_json(value)  # noqa: SLF001
 
 
+def test_bounded_process_rejects_environment_mapping_subclasses() -> None:
+    class HostileDict(dict[str, str]):
+        pass
+
+    with pytest.raises(TypeError, match="environment must be a mapping"):
+        qualification._run_bounded_process(  # noqa: SLF001
+            ("true",),
+            timeout=1.0,
+            maximum_stdout_bytes=1024,
+            maximum_stderr_bytes=1024,
+            environment=HostileDict({"SAFE": "1"}),
+        )
+
+
 def test_replace_integer_literals_keeps_finite_configuration_copy() -> None:
     raw = b'{"total_steps": 1}'
     transform = SimpleNamespace(


### PR DESCRIPTION
## Summary
- Reject mapping subclasses before iterating bounded subprocess environments in matched qualification

## Test plan
- [x] Targeted pytest for the regression added in this PR

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)