### PR TITLE
fix(benchmarks): require exact dict for qualification bundle mappings

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_qualification.py
+++ b/alberta_framework/benchmarks/forager_matched_qualification.py
@@ -438,14 +438,11 @@ class MatchedCurrentQualificationBundle:
     manifest_sha256: str
 
     def __post_init__(self) -> None:
-        if not isinstance(self.candidate_qualifications, Mapping) or not isinstance(
-            self.candidate_assets,
-            Mapping,
-        ):
+        if type(self.candidate_qualifications) is not dict or type(self.candidate_assets) is not dict:
             raise ForagerMatchedQualificationError(
                 "qualification bundle candidate mappings are invalid"
             )
-        if not isinstance(self.manifest, Mapping):
+        if type(self.manifest) is not dict:
             raise ForagerMatchedQualificationError(
                 "qualification bundle manifest must be a mapping"
             )

--- a/tests/test_forager_matched_qualification_hostile_validation.py
+++ b/tests/test_forager_matched_qualification_hostile_validation.py
@@ -91,3 +91,43 @@ def test_probe_invocation_rejects_nonhex_sha256(field: str) -> None:
     inv = _make_probe_invocation()
     with pytest.raises(ForagerMatchedQualificationError, match=f"{field} must be"):
         replace(inv, **{field: "z" * 64})
+
+
+def test_matched_current_qualification_bundle_rejects_mapping_subclasses() -> None:
+    from alberta_framework.benchmarks.forager_matched_qualification import (
+        MatchedCurrentQualificationBundle,
+    )
+
+    class HostileDict(dict[str, object]):
+        pass
+
+    base_kwargs = {
+        "output_root": Path("/out"),
+        "cpu_qualification_root": Path("/cpu"),
+        "rng_parity_qualification_root": Path("/rng"),
+        "runtime_qualification": {},
+        "manifest_bytes": b"{}",
+        "manifest_sha256": "a" * 64,
+    }
+
+    with pytest.raises(
+        ForagerMatchedQualificationError,
+        match="candidate mappings are invalid",
+    ):
+        MatchedCurrentQualificationBundle(
+            **base_kwargs,
+            candidate_qualifications=HostileDict({"cand": {}}),
+            candidate_assets={"cand": {}},
+            manifest={"schema_version": "unused"},
+        )
+
+    with pytest.raises(
+        ForagerMatchedQualificationError,
+        match="manifest must be a mapping",
+    ):
+        MatchedCurrentQualificationBundle(
+            **base_kwargs,
+            candidate_qualifications={"cand": {}},
+            candidate_assets={"cand": {}},
+            manifest=HostileDict({"schema_version": "unused"}),
+        )


### PR DESCRIPTION
## Summary
- Require exact dict containers for matched-current qualification bundle manifest and candidate mappings

## Test plan
- [x] Targeted pytest for the regression added in this PR

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)