### PR TITLE
fix(benchmarks): require exact dict for PreparedOciBuild build_spec

### DIFF
--- a/alberta_framework/benchmarks/official_foragax_oci.py
+++ b/alberta_framework/benchmarks/official_foragax_oci.py
@@ -198,7 +198,7 @@ class PreparedOciBuild:
     def __post_init__(self) -> None:
         if not isinstance(self.context, Path):
             raise OfficialForagaxOciError("context must be a Path")
-        if not isinstance(self.build_spec, Mapping):
+        if type(self.build_spec) is not dict:
             raise OfficialForagaxOciError("build_spec must be a mapping")
         _require_sha256(self.build_spec_sha256, label="build_spec_sha256")
         _require_sha256(self.dockerfile_sha256, label="dockerfile_sha256")

--- a/tests/test_official_foragax_oci_hostile_validation.py
+++ b/tests/test_official_foragax_oci_hostile_validation.py
@@ -77,3 +77,17 @@ def test_driver_launch_contract_rejects_invalid_inputs() -> None:
             cuda_wheel_library_paths=(),
             driver_user_library_paths=(),
         )
+
+
+def test_prepared_oci_build_rejects_build_spec_mapping_subclasses() -> None:
+    class HostileDict(dict[str, object]):
+        pass
+
+    with pytest.raises(OfficialForagaxOciError, match="build_spec must be a mapping"):
+        PreparedOciBuild(
+            context=Path("/context"),
+            build_spec=HostileDict(),  # type: ignore[arg-type]
+            build_spec_sha256="a" * 64,
+            dockerfile_sha256="b" * 64,
+            launcher_sha256="c" * 64,
+        )


### PR DESCRIPTION
## Summary
- Reject mapping subclasses for `PreparedOciBuild.build_spec` at the OCI boundary

## Test plan
- [x] Targeted pytest for the regression added in this PR

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)