### PR TITLE
fix: require exact dict/list in reference-life scorecard walks

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -818,11 +818,11 @@ def _iter_array_leaves(value: Any) -> Any:
         for field in dataclasses.fields(value):
             yield from _iter_array_leaves(getattr(value, field.name))
         return
-    if isinstance(value, Mapping):
+    if type(value) is dict:
         for item in value.values():
             yield from _iter_array_leaves(item)
         return
-    if isinstance(value, (tuple, list)):
+    if type(value) is tuple or type(value) is list:
         for item in value:
             yield from _iter_array_leaves(item)
 
@@ -1632,7 +1632,7 @@ def _load_json_strict_with_metadata(
     finally:
         if descriptor is not None:
             os.close(descriptor)
-    if not isinstance(payload, dict):
+    if type(payload) is not dict:
         raise ValueError(f"{path}: top-level JSON value must be an object")
     _validate_json_value(payload)
     return payload, final_metadata

--- a/tests/test_reference_life_scorecard_exact_json_hostile.py
+++ b/tests/test_reference_life_scorecard_exact_json_hostile.py
@@ -1,0 +1,43 @@
+"""Hostile exact JSON gates for reference-life scorecard array walks."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.benchmarks.reference_life_scorecard import _iter_array_leaves
+
+pytestmark = pytest.mark.unit
+
+
+class HostileDict(dict):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileDict.__iter__ must not run")
+
+    def values(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileDict.values must not run")
+
+
+class HostileList(list):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileList.__iter__ must not run")
+
+
+def test_iter_array_leaves_rejects_dict_subclass_without_iter_hooks() -> None:
+    HostileDict.calls = 0
+    with pytest.raises(StopIteration):
+        next(_iter_array_leaves(HostileDict({"a": 1})))
+    assert HostileDict.calls == 0
+
+
+def test_iter_array_leaves_rejects_list_subclass_without_iter_hooks() -> None:
+    HostileList.calls = 0
+    with pytest.raises(StopIteration):
+        next(_iter_array_leaves(HostileList([1])))
+    assert HostileList.calls == 0


### PR DESCRIPTION
## Summary
- Require exact dict/list identity in `_iter_array_leaves` and strict JSON load paths so hostile mapping/list subclasses cannot trigger `__iter__` during resource accounting.

## Test plan
- [x] Hostile subclass unit tests
- [x] ruff + targeted pytest

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)