### PR TITLE
fix: require exact dict/list in recurring-feature artifact validation

### DIFF
--- a/alberta_framework/evaluation/recurring_feature_artifact.py
+++ b/alberta_framework/evaluation/recurring_feature_artifact.py
@@ -883,7 +883,7 @@ def load_recurring_feature_artifact(path: Path) -> dict[str, object]:
         parse_float=_parse_finite_json_float,
         object_pairs_hook=_reject_duplicate_keys,
     )
-    if not isinstance(parsed, dict):
+    if type(parsed) is not dict:
         raise ValueError("evidence artifact must be a JSON object")
     return parsed
 
@@ -895,7 +895,7 @@ def _mapping(
     errors: list[str],
 ) -> Mapping[str, object] | None:
     value = parent.get(key)
-    if not isinstance(value, Mapping):
+    if type(value) is not dict:
         errors.append(f"{location}.{key} must be an object")
         return None
     return value
@@ -996,12 +996,12 @@ def _nmse_values(
 
 
 def _pair_set(value: object) -> set[tuple[int, int]] | None:
-    if not isinstance(value, list):
+    if type(value) is not list:
         return None
     pairs: set[tuple[int, int]] = set()
     for pair in value:
         if (
-            not isinstance(pair, list)
+            type(pair) is not list
             or len(pair) != 2
             or any(isinstance(item, bool) or not isinstance(item, int) for item in pair)
         ):

--- a/tests/test_recurring_feature_exact_json_hostile.py
+++ b/tests/test_recurring_feature_exact_json_hostile.py
@@ -1,0 +1,40 @@
+"""Hostile exact JSON gates for recurring-feature artifact validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.recurring_feature_artifact import _mapping, _pair_set
+
+pytestmark = pytest.mark.unit
+
+
+class HostileDict(dict):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileDict.__iter__ must not run")
+
+
+class HostileList(list):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileList.__iter__ must not run")
+
+
+def test_mapping_rejects_dict_subclass_without_iter_hooks() -> None:
+    parent: dict[str, object] = {"child": HostileDict({"a": 1})}
+    errors: list[str] = []
+    HostileDict.calls = 0
+    assert _mapping(parent, "child", "root", errors) is None
+    assert errors == ["root.child must be an object"]
+    assert HostileDict.calls == 0
+
+
+def test_pair_set_rejects_list_subclass_without_iter_hooks() -> None:
+    HostileList.calls = 0
+    assert _pair_set(HostileList([[0, 1]])) is None
+    assert HostileList.calls == 0


### PR DESCRIPTION
## Summary
- Require exact dict/list identity in recurring-feature artifact load and validation helpers.

## Test plan
- [x] Hostile subclass unit tests
- [x] ruff + targeted pytest

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)