### PR TITLE
fix: require exact dict for open-protocol candidate qualifications

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_open_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_open_protocol.py
@@ -1368,7 +1368,7 @@ def build_forager_matched_open_protocol(
     iteration order is ignored; protocol order comes only from frozen constants.
     """
     _validate_runtime(runtime)
-    if not isinstance(candidate_qualifications, Mapping):
+    if type(candidate_qualifications) is not dict:
         raise ForagerMatchedOpenProtocolBuildError(
             "candidate_qualifications must be a mapping"
         )

--- a/alberta_framework/benchmarks/forager_matched_open_protocol.py
+++ b/alberta_framework/benchmarks/forager_matched_open_protocol.py
@@ -1368,9 +1368,11 @@ def build_forager_matched_open_protocol(
     iteration order is ignored; protocol order comes only from frozen constants.
     """
     _validate_runtime(runtime)
-    if type(candidate_qualifications) is not dict:
+    if type(candidate_qualifications) is not dict and not isinstance(
+        candidate_qualifications, MappingProxyType
+    ):
         raise ForagerMatchedOpenProtocolBuildError(
-            "candidate_qualifications must be a mapping"
+            "candidate_qualifications must be an exact dict or mapping proxy"
         )
     actual_ids = set(candidate_qualifications)
     expected_ids = set(MATCHED_CURRENT_CANDIDATE_IDS)

--- a/tests/test_forager_matched_open_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_open_protocol_hostile_validation.py
@@ -91,7 +91,7 @@ def test_build_rejects_hostile_candidate_qualifications_mapping_subclass() -> No
     HostileDict.calls = 0
     with pytest.raises(
         ForagerMatchedOpenProtocolBuildError,
-        match="candidate_qualifications must be a mapping",
+        match="candidate_qualifications must be an exact dict or mapping proxy",
     ):
         build_forager_matched_open_protocol(
             runtime=_runtime(),
@@ -196,3 +196,19 @@ def test_candidate_spec_rejects_cross_field_and_provenance_drift(
 ) -> None:
     with pytest.raises(ForagerMatchedOpenProtocolBuildError):
         replace(_legal_spec(), **updates)
+
+def test_build_accepts_mapping_proxy_type() -> None:
+    from types import MappingProxyType
+
+    from alberta_framework.benchmarks.forager_matched_open_protocol import (
+        build_forager_matched_open_protocol,
+    )
+    from tests.test_forager_matched_open_protocol import _qualifications, _runtime
+
+    runtime = _runtime()
+    quals = _qualifications()
+    protocol = build_forager_matched_open_protocol(
+        runtime=runtime,
+        candidate_qualifications=MappingProxyType(dict(quals)),
+    )
+    assert protocol.stage == "open_tuning"

--- a/tests/test_forager_matched_open_protocol_hostile_validation.py
+++ b/tests/test_forager_matched_open_protocol_hostile_validation.py
@@ -75,6 +75,31 @@ def test_runtime_qualification_rejects_invalid_inputs() -> None:
         )
 
 
+def test_build_rejects_hostile_candidate_qualifications_mapping_subclass() -> None:
+    from alberta_framework.benchmarks.forager_matched_open_protocol import (
+        build_forager_matched_open_protocol,
+    )
+    from tests.test_forager_matched_open_protocol import _qualifications, _runtime
+
+    class HostileDict(dict):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.__iter__ must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(
+        ForagerMatchedOpenProtocolBuildError,
+        match="candidate_qualifications must be a mapping",
+    ):
+        build_forager_matched_open_protocol(
+            runtime=_runtime(),
+            candidate_qualifications=HostileDict(_qualifications()),
+        )
+    assert HostileDict.calls == 0
+
+
 def test_runtime_qualification_rejects_digest_subclass_without_dispatch() -> None:
     hostile = _HostileString(_digest(b"image"))
     _HostileString.calls = 0


### PR DESCRIPTION
## Summary
- Require exact dict identity for `candidate_qualifications` before set-based panel validation.

## Test plan
- [x] Hostile subclass unit test
- [x] ruff + targeted pytest

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)