### PR TITLE
Require exact dict for forager CLI JSON-safe mapping walk

### DIFF
--- a/alberta_framework/forager_cli.py
+++ b/alberta_framework/forager_cli.py
@@ -28,6 +28,7 @@ import tempfile
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, cast
 
 import jax
@@ -145,7 +146,7 @@ def _parse_named_config(value: str) -> tuple[str, str]:
 def _json_safe(value: Any) -> Any:
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return _json_safe(dataclasses.asdict(value))
-    if isinstance(value, Mapping):
+    if type(value) is dict or type(value) is MappingProxyType:
         return {str(key): _json_safe(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
         return [_json_safe(item) for item in value]

--- a/tests/test_forager_cli_hostile_json_safe.py
+++ b/tests/test_forager_cli_hostile_json_safe.py
@@ -1,0 +1,29 @@
+"""Hostile dict gate for forager CLI _json_safe before item walk."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.forager_cli import _json_safe
+
+pytestmark = pytest.mark.unit
+
+
+class HostileDict(dict):
+    calls = 0
+
+    def items(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileDict.items must not run")
+
+
+def test_json_safe_rejects_mapping_subclass_before_items() -> None:
+    HostileDict.calls = 0
+    hostile = HostileDict({"a": 1})
+    result = _json_safe(hostile)
+    assert HostileDict.calls == 0
+    assert result is hostile
+
+
+def test_json_safe_accepts_plain_dict() -> None:
+    assert _json_safe({"a": 1}) == {"a": 1}


### PR DESCRIPTION
_json_safe treated any Mapping as a JSON object and iterated items, so hostile dict subclasses could run during provenance serialization. Accept only exact dict or MappingProxyType.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)