### PR TITLE
Require exact dict for matched qualification bounded process env

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_qualification.py
+++ b/alberta_framework/benchmarks/forager_matched_qualification.py
@@ -3033,8 +3033,13 @@ def _run_bounded_process(
         raise ValueError("bounded process output limits must be nonnegative integers")
     materialized_environment: dict[str, str] | None = None
     if environment is not None:
-        if not isinstance(environment, Mapping):
-            raise TypeError("bounded process environment must be a mapping")
+        if (
+            type(environment) is not dict
+            and type(environment) is not MappingProxyType
+        ):
+            raise TypeError(
+                "bounded process environment must be an exact dict or MappingProxyType"
+            )
         materialized_environment = {}
         for env_key, value in environment.items():
             if (

--- a/tests/test_forager_qual_timeout_hostile.py
+++ b/tests/test_forager_qual_timeout_hostile.py
@@ -69,3 +69,24 @@ def test_benign_timeout_passes() -> None:
         assert "finite and positive" not in str(error)
     except Exception:
         pass
+
+
+class _HostileEnvDict(dict):
+    calls = 0
+
+    def items(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("hostile env items")
+
+
+def test_environment_rejects_mapping_subclass_before_items() -> None:
+    _HostileEnvDict.calls = 0
+    with pytest.raises(TypeError, match="exact dict or MappingProxyType"):
+        _run_bounded_process(
+            ["echo", "hi"],
+            timeout=1,
+            maximum_stdout_bytes=100,
+            maximum_stderr_bytes=100,
+            environment=_HostileEnvDict({"A": "b"}),  # type: ignore[arg-type]
+        )
+    assert _HostileEnvDict.calls == 0


### PR DESCRIPTION
_run_bounded_process accepted any Mapping for child environment variables before iterating keys. Require exact dict or MappingProxyType.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)