### PR TITLE
Require exact list for reference agent nested tuple coercion

### DIFF
--- a/alberta_framework/reference_agent.py
+++ b/alberta_framework/reference_agent.py
@@ -360,7 +360,7 @@ def _cast_representable(
 
 
 def _nested_tuple(value: Any) -> Any:
-    if isinstance(value, list):
+    if type(value) is list:
         return tuple(_nested_tuple(item) for item in value)
     return value
 

--- a/tests/test_reference_agent_hostile_validation.py
+++ b/tests/test_reference_agent_hostile_validation.py
@@ -93,3 +93,25 @@ def test_valid_array_value() -> None:
         semantic_id="a.b", dtype="float32", shape=(), payload=b"\x00\x00\x80\x3f"
     )
     assert v.dtype == "float32"
+
+
+def test_nested_tuple_skips_list_subclass_before_iter() -> None:
+    from alberta_framework.reference_agent import _nested_tuple
+
+    class HostileList(list):
+        calls = 0
+
+        def __iter__(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileList.__iter__ must not run")
+
+    HostileList.calls = 0
+    hostile = HostileList([1])
+    assert _nested_tuple(hostile) is hostile
+    assert HostileList.calls == 0
+
+
+def test_nested_tuple_accepts_exact_list() -> None:
+    from alberta_framework.reference_agent import _nested_tuple
+
+    assert _nested_tuple([1, [2, 3]]) == (1, (2, 3))


### PR DESCRIPTION
_nested_tuple used isinstance(value, list), so list subclasses with hostile __iter__ could run during array freezing. Require exact list.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)