### PR TITLE
Require exact list or tuple for reference-life hidden_sizes

### DIFF
--- a/alberta_framework/reference_life_controls.py
+++ b/alberta_framework/reference_life_controls.py
@@ -189,8 +189,8 @@ def _canonical_hidden_sizes(
     observation_dim: int,
     n_actions: int,
 ) -> tuple[int, ...]:
-    if not isinstance(value, (tuple, list)):
-        raise ValueError("hidden_sizes must be a bounded tuple or list")
+    if type(value) is not tuple and type(value) is not list:
+        raise ValueError("hidden_sizes must be an exact tuple or list")
     if len(value) > _MAX_HIDDEN_LAYERS:
         raise ValueError(f"hidden_sizes must contain at most {_MAX_HIDDEN_LAYERS} layers")
     hidden_sizes = tuple(value)

--- a/tests/test_reference_life_controls.py
+++ b/tests/test_reference_life_controls.py
@@ -1069,3 +1069,23 @@ def test_learning_controls_reject_increasing_epsilon_schedules(factory: object) 
             epsilon_start=0.1,
             epsilon_end=0.2,
         )
+
+
+def test_hidden_sizes_rejects_list_subclass_before_len() -> None:
+    from alberta_framework.reference_life_controls import _canonical_hidden_sizes
+
+    class HostileList(list):
+        calls = 0
+
+        def __len__(self) -> int:  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileList.__len__ must not run")
+
+    HostileList.calls = 0
+    with pytest.raises(ValueError, match="exact tuple or list"):
+        _canonical_hidden_sizes(
+            HostileList([32]),
+            observation_dim=2,
+            n_actions=2,
+        )
+    assert HostileList.calls == 0


### PR DESCRIPTION
_canonical_hidden_sizes used isinstance(value, (tuple, list)), allowing subclasses to run container hooks during validation. Require exact list or tuple.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)