### PR TITLE
Require exact dict after reference-life canonical JSON round-trip

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -147,8 +147,8 @@ def _canonical_json(value: Mapping[str, Any]) -> str:
     except (TypeError, ValueError) as exc:
         raise ValueError("reference-life configuration must be canonical finite JSON") from exc
     decoded = json.loads(encoded)
-    if not isinstance(decoded, dict):
-        raise ValueError("reference-life configuration must be a JSON object")
+    if type(decoded) is not dict:
+        raise ValueError("reference-life configuration must be an exact JSON object")
     return encoded
 
 

--- a/tests/test_reference_life_hostile_canonical_json.py
+++ b/tests/test_reference_life_hostile_canonical_json.py
@@ -1,0 +1,24 @@
+"""Hostile dict gate for reference-life canonical JSON digest."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.reference_life import _canonical_json
+
+pytestmark = pytest.mark.unit
+
+
+class HostileDict(dict):
+    pass
+
+
+def test_canonical_json_rejects_non_exact_dict_after_loads(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"a": 1}
+
+    def hostile_loads(_text: str) -> object:
+        return HostileDict(payload)
+
+    monkeypatch.setattr("alberta_framework.reference_life.json.loads", hostile_loads)
+    with pytest.raises(ValueError, match="exact JSON object"):
+        _canonical_json(payload)


### PR DESCRIPTION
_canonical_json accepted any Mapping subclass from json.loads before digesting configuration. Require exact dict after round-trip.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)