### PR TITLE
Require exact dict for evidence manifest chain mapping gates

### DIFF
--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -40,7 +40,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from types import FunctionType
+from types import FunctionType, MappingProxyType
 from typing import Literal, NoReturn, Protocol, cast
 
 from alberta_framework.evaluation.continual_ia import (
@@ -1197,8 +1197,8 @@ def _chain_mapping(
     expected_keys: set[str],
     errors: list[str],
 ) -> Mapping[str, object] | None:
-    if not isinstance(value, Mapping):
-        errors.append(f"{location} must be an object")
+    if type(value) is not dict and type(value) is not MappingProxyType:
+        errors.append(f"{location} must be an exact object")
         return None
     if set(value) != expected_keys:
         errors.append(f"{location} keys do not match the frozen chain schema")

--- a/tests/test_evidence_manifest_chain_mapping_hostile.py
+++ b/tests/test_evidence_manifest_chain_mapping_hostile.py
@@ -1,0 +1,31 @@
+"""Hostile dict gate for evidence manifest _chain_mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.evidence_manifest import _chain_mapping
+
+pytestmark = pytest.mark.unit
+
+
+class HostileDict(dict):
+    calls = 0
+
+    def keys(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileDict.keys must not run")
+
+
+def test_chain_mapping_rejects_subclass_before_key_compare() -> None:
+    HostileDict.calls = 0
+    errors: list[str] = []
+    result = _chain_mapping(
+        HostileDict({"a": 1}),
+        location="chain",
+        expected_keys={"a"},
+        errors=errors,
+    )
+    assert result is None
+    assert any("exact object" in err for err in errors)
+    assert HostileDict.calls == 0


### PR DESCRIPTION
_chain_mapping accepted any Mapping before key-set comparison, so hostile dict subclasses could run during chain validation. Require exact dict or MappingProxyType.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)