### PR TITLE
Require exact dict for scale-robust artifact mapping gates

### DIFF
--- a/alberta_framework/evaluation/scale_robust_feature_artifact.py
+++ b/alberta_framework/evaluation/scale_robust_feature_artifact.py
@@ -37,6 +37,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from types import MappingProxyType
 from typing import NoReturn
 
 import jax
@@ -1631,8 +1632,8 @@ def _mapping(
     location: str,
     errors: list[str],
 ) -> Mapping[str, object] | None:
-    if not isinstance(value, Mapping):
-        errors.append(f"{location} must be an object")
+    if type(value) is not dict and type(value) is not MappingProxyType:
+        errors.append(f"{location} must be an exact object")
         return None
     return value
 

--- a/tests/test_scale_robust_artifact_mapping_hostile.py
+++ b/tests/test_scale_robust_artifact_mapping_hostile.py
@@ -1,0 +1,26 @@
+"""Hostile dict gate for scale-robust artifact _mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.scale_robust_feature_artifact import _mapping
+
+pytestmark = pytest.mark.unit
+
+
+class HostileDict(dict):
+    calls = 0
+
+    def __getitem__(self, key: object):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileDict.__getitem__ must not run")
+
+
+def test_mapping_rejects_subclass_before_walk() -> None:
+    HostileDict.calls = 0
+    errors: list[str] = []
+    result = _mapping(HostileDict({"a": 1}), "probe", errors)
+    assert result is None
+    assert any("exact object" in err for err in errors)
+    assert HostileDict.calls == 0


### PR DESCRIPTION
Scale-robust artifact validation accepted any Mapping before walking nested records. Require exact dict or MappingProxyType.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)