### PR TITLE
Require exact dict for legacy normalizer migration

### DIFF
--- a/alberta_framework/core/normalizers.py
+++ b/alberta_framework/core/normalizers.py
@@ -23,8 +23,8 @@ import dataclasses
 import math
 import operator
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
 from numbers import Real
+from types import MappingProxyType
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -986,14 +986,16 @@ def measure_normalizer_state_nbytes(state: AnyNormalizerState) -> int:
 def _legacy_state_mapping(legacy_state: Any) -> dict[str, Any]:
     """Return a shallow field mapping for one host-side legacy dataclass."""
 
-    if isinstance(legacy_state, Mapping):
+    if type(legacy_state) is dict:
+        return dict(legacy_state)
+    if type(legacy_state) is MappingProxyType:
         return dict(legacy_state)
     if dataclasses.is_dataclass(legacy_state) and not isinstance(legacy_state, type):
         return {
             field.name: getattr(legacy_state, field.name)
             for field in dataclasses.fields(legacy_state)
         }
-    raise TypeError("legacy normalizer state must be a mapping or dataclass instance")
+    raise TypeError("legacy normalizer state must be an exact dict or dataclass instance")
 
 
 def migrate_legacy_normalizer_state(

--- a/tests/test_normalizers_legacy_mapping_hostile.py
+++ b/tests/test_normalizers_legacy_mapping_hostile.py
@@ -1,0 +1,32 @@
+"""Hostile mapping validation for legacy normalizer migration."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def items(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook executed")
+
+
+def test_migrate_legacy_rejects_hostile_dict_before_field_manifest() -> None:
+    from alberta_framework.core.normalizers import migrate_legacy_normalizer_state
+
+    payload = _HostileDict(
+        {
+            "decay": 0.1,
+            "mean": [0.0],
+            "var": [1.0],
+            "sample_count": 1.0,
+        }
+    )
+    _HostileDict.calls = 0
+    with pytest.raises(TypeError, match="exact dict"):
+        migrate_legacy_normalizer_state(payload, normalizer_type="EMANormalizer")
+    assert _HostileDict.calls == 0


### PR DESCRIPTION
Legacy normalizer migration copied any Mapping via dict(), so a hostile dict subclass could run custom iteration during field manifest checks. Accept only exact dict or MappingProxyType before walking legacy fields.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)