### PR TITLE
Require exact dict for legacy multi-head migration

### DIFF
--- a/alberta_framework/core/multi_head_learner.py
+++ b/alberta_framework/core/multi_head_learner.py
@@ -20,7 +20,7 @@ import functools
 import math
 import operator
 import time
-from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any, SupportsIndex, cast
 
 import chex
@@ -1494,14 +1494,16 @@ def measure_multi_head_mlp_state_nbytes(state: MultiHeadMLPState) -> int:
 def _host_field_mapping(legacy_state: Any) -> dict[str, Any]:
     """Return a shallow host mapping for an old state dataclass."""
 
-    if isinstance(legacy_state, Mapping):
+    if type(legacy_state) is dict:
+        return dict(legacy_state)
+    if type(legacy_state) is MappingProxyType:
         return dict(legacy_state)
     if dataclasses.is_dataclass(legacy_state) and not isinstance(legacy_state, type):
         return {
             field.name: getattr(legacy_state, field.name)
             for field in dataclasses.fields(legacy_state)
         }
-    raise TypeError("legacy MultiHeadMLP state must be a mapping or dataclass")
+    raise TypeError("legacy MultiHeadMLP state must be an exact dict or dataclass")
 
 
 def _legacy_normalizer_type(legacy_state: Any) -> str:

--- a/tests/test_multi_head_legacy_mapping_hostile.py
+++ b/tests/test_multi_head_legacy_mapping_hostile.py
@@ -1,0 +1,25 @@
+"""Hostile mapping validation for legacy multi-head migration."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def items(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook executed")
+
+
+def test_migrate_legacy_rejects_hostile_dict_before_field_manifest() -> None:
+    from alberta_framework.core.multi_head_learner import migrate_legacy_multi_head_mlp_state
+
+    payload = _HostileDict({"head_params": ()})
+    _HostileDict.calls = 0
+    with pytest.raises(TypeError, match="exact dict"):
+        migrate_legacy_multi_head_mlp_state(payload)
+    assert _HostileDict.calls == 0


### PR DESCRIPTION
Legacy MultiHeadMLP migration copied any Mapping via dict(), so a hostile dict subclass could run hooks before the field manifest failed closed. Accept only exact dict or MappingProxyType.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)