### PR TITLE
Require exact dict for Forager RNG parity JSON objects

### DIFF
--- a/alberta_framework/benchmarks/forager_rng_parity.py
+++ b/alberta_framework/benchmarks/forager_rng_parity.py
@@ -697,7 +697,9 @@ def _require_exact_keys(value: Mapping[str, Any], expected: set[str], path: str)
 
 
 def _require_object(value: Any, path: str) -> Mapping[str, Any]:
-    if not isinstance(value, Mapping) or any(type(key) is not str for key in value):
+    if type(value) is not dict and type(value) is not MappingProxyType:
+        raise ForagerRngParityError(f"{path} must be a JSON object")
+    if any(type(key) is not str for key in value):
         raise ForagerRngParityError(f"{path} must be a JSON object")
     return cast(Mapping[str, Any], value)
 

--- a/tests/test_forager_cli_json_safe_hostile.py
+++ b/tests/test_forager_cli_json_safe_hostile.py
@@ -1,0 +1,41 @@
+"""Hostile container validation for forager CLI JSON serialization."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def items(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook executed")
+
+
+class _HostileList(list[object]):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile list hook executed")
+
+
+def test_json_safe_rejects_hostile_dict_before_items() -> None:
+    from alberta_framework.forager_cli import _json_safe
+
+    _HostileDict.calls = 0
+    with pytest.raises(TypeError, match="exact dict"):
+        _json_safe(_HostileDict({"a": 1}))
+    assert _HostileDict.calls == 0
+
+
+def test_json_safe_rejects_hostile_list_before_iteration() -> None:
+    from alberta_framework.forager_cli import _json_safe
+
+    _HostileList.calls = 0
+    with pytest.raises(TypeError, match="exact list"):
+        _json_safe(_HostileList([1]))
+    assert _HostileList.calls == 0

--- a/tests/test_forager_rng_parity_hostile_validation.py
+++ b/tests/test_forager_rng_parity_hostile_validation.py
@@ -116,3 +116,21 @@ def test_environment_trace_digest_validation() -> None:
                 transitions=(_make_transition_digest(),),
                 trace_sha256=invalid_digest,  # type: ignore[arg-type]
             )
+
+
+class _HostileMappingDict(dict[str, object]):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook executed")
+
+
+def test_require_object_rejects_hostile_dict_before_key_walk() -> None:
+    from alberta_framework.benchmarks.forager_rng_parity import _require_object
+
+    hostile = _HostileMappingDict({"a": 1})
+    _HostileMappingDict.calls = 0
+    with pytest.raises(ForagerRngParityError, match="JSON object"):
+        _require_object(hostile, "probe")
+    assert _HostileMappingDict.calls == 0


### PR DESCRIPTION
RNG parity _require_object accepted any Mapping and iterated keys before rejecting hostile containers. Accept only exact dict or MappingProxyType fail-closed.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)