### PR TITLE
Require exact dict/list containers in forager CLI JSON safe

### DIFF
--- a/alberta_framework/forager_cli.py
+++ b/alberta_framework/forager_cli.py
@@ -145,10 +145,14 @@ def _parse_named_config(value: str) -> tuple[str, str]:
 def _json_safe(value: Any) -> Any:
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return _json_safe(dataclasses.asdict(value))
-    if isinstance(value, Mapping):
+    if type(value) is dict:
         return {str(key): _json_safe(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
+    if type(value) is list or type(value) is tuple:
         return [_json_safe(item) for item in value]
+    if isinstance(value, Mapping):
+        raise TypeError("forager CLI payload must use exact dict containers")
+    if isinstance(value, (list, tuple)):
+        raise TypeError("forager CLI payload must use exact list containers")
     if isinstance(value, float) and not math.isfinite(value):
         raise ValueError("forager CLI payload is not finite JSON")
     if isinstance(value, Path):

--- a/tests/test_forager_cli_json_safe_hostile.py
+++ b/tests/test_forager_cli_json_safe_hostile.py
@@ -1,0 +1,41 @@
+"""Hostile container validation for forager CLI JSON serialization."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def items(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook executed")
+
+
+class _HostileList(list[object]):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile list hook executed")
+
+
+def test_json_safe_rejects_hostile_dict_before_items() -> None:
+    from alberta_framework.forager_cli import _json_safe
+
+    _HostileDict.calls = 0
+    with pytest.raises(TypeError, match="exact dict"):
+        _json_safe(_HostileDict({"a": 1}))
+    assert _HostileDict.calls == 0
+
+
+def test_json_safe_rejects_hostile_list_before_iteration() -> None:
+    from alberta_framework.forager_cli import _json_safe
+
+    _HostileList.calls = 0
+    with pytest.raises(TypeError, match="exact list"):
+        _json_safe(_HostileList([1]))
+    assert _HostileList.calls == 0


### PR DESCRIPTION
forager CLI JSON normalization accepted Mapping and Sequence subclasses, so hostile containers could run custom iteration during provenance serialization. Gate on exact dict/list/tuple and reject other container subclasses fail-closed.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)