### PR TITLE
Require exact dict for lifetime gauntlet legacy migration

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -53,6 +53,7 @@ import math
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, cast
 
 import chex
@@ -979,7 +980,9 @@ def migrate_legacy_lifetime_gauntlet_state(
     stream: LifetimeGauntletStream,
 ) -> LifetimeState:
     """Migrate only an exact unsaturated pre-v2 lifetime clock."""
-    if isinstance(legacy_state, Mapping):
+    if type(legacy_state) is dict:
+        fields = dict(legacy_state)
+    elif type(legacy_state) is MappingProxyType:
         fields = dict(legacy_state)
     elif dataclasses.is_dataclass(legacy_state) and not isinstance(legacy_state, type):
         fields = {
@@ -987,7 +990,7 @@ def migrate_legacy_lifetime_gauntlet_state(
             for field in dataclasses.fields(legacy_state)
         }
     else:
-        raise TypeError("legacy lifetime-gauntlet state must be a mapping or dataclass")
+        raise TypeError("legacy lifetime-gauntlet state must be an exact dict or dataclass")
     expected = {"key", "step_count", "w_fresh", "w_c", "w_d"}
     if set(fields) != expected:
         raise ValueError("legacy lifetime-gauntlet state fields are invalid")
@@ -1047,7 +1050,7 @@ def load_lifetime_gauntlet_checkpoint(
     if schema != LIFETIME_GAUNTLET_CHECKPOINT_SCHEMA:
         raise ValueError("lifetime-gauntlet checkpoint schema is unsupported")
     raw_config = metadata.get("stream_config")
-    if not isinstance(raw_config, Mapping):
+    if type(raw_config) is not dict and type(raw_config) is not MappingProxyType:
         raise ValueError("lifetime-gauntlet checkpoint stream_config is invalid")
     stream = LifetimeGauntletStream.from_config(raw_config)
     restored, restored_metadata = load_checkpoint(stream.init(jr.key(0)), path)

--- a/tests/test_forager_matched_qualification_mapping_hostile.py
+++ b/tests/test_forager_matched_qualification_mapping_hostile.py
@@ -1,0 +1,39 @@
+"""Hostile mapping validation for matched qualification bundles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_qualification import (
+    ForagerMatchedQualificationError,
+    MatchedCurrentQualificationBundle,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def items(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook executed")
+
+
+def test_bundle_rejects_hostile_candidate_qualifications_before_hooks() -> None:
+    _HostileDict.calls = 0
+    with pytest.raises(ForagerMatchedQualificationError, match="candidate mappings"):
+        MatchedCurrentQualificationBundle(
+            output_root=Path("/tmp/out"),
+            cpu_qualification_root=Path("/tmp/cpu"),
+            rng_parity_qualification_root=Path("/tmp/rng"),
+            runtime_qualification=object(),
+            candidate_qualifications=_HostileDict(),
+            candidate_assets={},
+            manifest={"schema": "test"},
+            manifest_bytes=b'{"schema":"test"}',
+            manifest_sha256="a" * 64,
+        )
+    assert _HostileDict.calls == 0

--- a/tests/test_gauntlet_legacy_mapping_hostile.py
+++ b/tests/test_gauntlet_legacy_mapping_hostile.py
@@ -1,0 +1,33 @@
+"""Hostile mapping validation for lifetime gauntlet legacy migration."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def items(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook executed")
+
+
+def test_migrate_legacy_rejects_hostile_dict_before_field_manifest() -> None:
+    from alberta_framework.streams.gauntlet import migrate_legacy_lifetime_gauntlet_state
+
+    payload = _HostileDict(
+        {
+            "key": None,
+            "step_count": None,
+            "w_fresh": None,
+            "w_c": None,
+            "w_d": None,
+        }
+    )
+    _HostileDict.calls = 0
+    with pytest.raises(TypeError, match="exact dict"):
+        migrate_legacy_lifetime_gauntlet_state(payload, stream=object())  # type: ignore[arg-type]
+    assert _HostileDict.calls == 0


### PR DESCRIPTION
Lifetime gauntlet legacy migration and checkpoint stream_config accepted Mapping subclasses, so hostile dict iteration could run during manifest walks. Accept only exact dict or MappingProxyType.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)