### PR TITLE
Require exact dict for matched qualification bundle mappings

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_qualification.py
+++ b/alberta_framework/benchmarks/forager_matched_qualification.py
@@ -438,16 +438,19 @@ class MatchedCurrentQualificationBundle:
     manifest_sha256: str
 
     def __post_init__(self) -> None:
-        if not isinstance(self.candidate_qualifications, Mapping) or not isinstance(
-            self.candidate_assets,
-            Mapping,
+        if (
+            type(self.candidate_qualifications) is not dict
+            and type(self.candidate_qualifications) is not MappingProxyType
+        ) or (
+            type(self.candidate_assets) is not dict
+            and type(self.candidate_assets) is not MappingProxyType
         ):
             raise ForagerMatchedQualificationError(
                 "qualification bundle candidate mappings are invalid"
             )
-        if not isinstance(self.manifest, Mapping):
+        if type(self.manifest) is not dict and type(self.manifest) is not MappingProxyType:
             raise ForagerMatchedQualificationError(
-                "qualification bundle manifest must be a mapping"
+                "qualification bundle manifest must be an exact mapping"
             )
         if (
             type(self.manifest_bytes) is not bytes

--- a/tests/test_forager_matched_qualification_mapping_hostile.py
+++ b/tests/test_forager_matched_qualification_mapping_hostile.py
@@ -1,0 +1,39 @@
+"""Hostile mapping validation for matched qualification bundles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from alberta_framework.benchmarks.forager_matched_qualification import (
+    ForagerMatchedQualificationError,
+    MatchedCurrentQualificationBundle,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _HostileDict(dict[str, object]):
+    calls = 0
+
+    def items(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook executed")
+
+
+def test_bundle_rejects_hostile_candidate_qualifications_before_hooks() -> None:
+    _HostileDict.calls = 0
+    with pytest.raises(ForagerMatchedQualificationError, match="candidate mappings"):
+        MatchedCurrentQualificationBundle(
+            output_root=Path("/tmp/out"),
+            cpu_qualification_root=Path("/tmp/cpu"),
+            rng_parity_qualification_root=Path("/tmp/rng"),
+            runtime_qualification=object(),
+            candidate_qualifications=_HostileDict(),
+            candidate_assets={},
+            manifest={"schema": "test"},
+            manifest_bytes=b'{"schema":"test"}',
+            manifest_sha256="a" * 64,
+        )
+    assert _HostileDict.calls == 0


### PR DESCRIPTION
Qualification bundle construction accepted any Mapping for candidate tables and manifest, so hostile dict subclasses could run hooks before canonicalization. Accept only exact dict or MappingProxyType.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)