### PR TITLE
Require exact dict for official ForagerX OCI build_spec

### DIFF
--- a/alberta_framework/benchmarks/official_foragax_oci.py
+++ b/alberta_framework/benchmarks/official_foragax_oci.py
@@ -198,8 +198,8 @@ class PreparedOciBuild:
     def __post_init__(self) -> None:
         if not isinstance(self.context, Path):
             raise OfficialForagaxOciError("context must be a Path")
-        if not isinstance(self.build_spec, Mapping):
-            raise OfficialForagaxOciError("build_spec must be a mapping")
+        if type(self.build_spec) is not dict:
+            raise OfficialForagaxOciError("build_spec must be an exact mapping")
         _require_sha256(self.build_spec_sha256, label="build_spec_sha256")
         _require_sha256(self.dockerfile_sha256, label="dockerfile_sha256")
         _require_sha256(self.launcher_sha256, label="launcher_sha256")

--- a/tests/test_official_foragax_oci_hostile_validation.py
+++ b/tests/test_official_foragax_oci_hostile_validation.py
@@ -87,14 +87,10 @@ class _HostileBuildSpec(dict[str, object]):
         raise AssertionError("hostile mapping hook executed")
 
 
-def test_build_context_rejects_hostile_build_spec_before_hooks() -> None:
-    from pathlib import Path
-
-    from alberta_framework.benchmarks.official_foragax_oci import BuildContext
-
+def test_prepared_oci_build_rejects_hostile_build_spec_before_hooks() -> None:
     _HostileBuildSpec.calls = 0
     with pytest.raises(OfficialForagaxOciError, match="exact mapping"):
-        BuildContext(
+        PreparedOciBuild(
             context=Path("/tmp"),
             build_spec=_HostileBuildSpec({"layers": []}),
             build_spec_sha256="a" * 64,

--- a/tests/test_official_foragax_oci_hostile_validation.py
+++ b/tests/test_official_foragax_oci_hostile_validation.py
@@ -34,7 +34,7 @@ def test_prepared_oci_build_rejects_invalid_inputs() -> None:
             launcher_sha256="c" * 64,
         )
 
-    with pytest.raises(OfficialForagaxOciError, match="build_spec must be a mapping"):
+    with pytest.raises(OfficialForagaxOciError, match="build_spec must be an exact mapping"):
         PreparedOciBuild(
             context=Path("/context"),
             build_spec=None,  # type: ignore[arg-type]
@@ -77,3 +77,28 @@ def test_driver_launch_contract_rejects_invalid_inputs() -> None:
             cuda_wheel_library_paths=(),
             driver_user_library_paths=(),
         )
+
+
+class _HostileBuildSpec(dict[str, object]):
+    calls = 0
+
+    def items(self):  # type: ignore[no-untyped-def, override]
+        type(self).calls += 1
+        raise AssertionError("hostile mapping hook executed")
+
+
+def test_build_context_rejects_hostile_build_spec_before_hooks() -> None:
+    from pathlib import Path
+
+    from alberta_framework.benchmarks.official_foragax_oci import BuildContext
+
+    _HostileBuildSpec.calls = 0
+    with pytest.raises(OfficialForagaxOciError, match="exact mapping"):
+        BuildContext(
+            context=Path("/tmp"),
+            build_spec=_HostileBuildSpec({"layers": []}),
+            build_spec_sha256="a" * 64,
+            dockerfile_sha256="b" * 64,
+            launcher_sha256="c" * 64,
+        )
+    assert _HostileBuildSpec.calls == 0


### PR DESCRIPTION
BuildContext accepted any Mapping for build_spec, so a hostile dict subclass could run during later canonical walks. Require an exact dict fail-closed.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)