### PR TITLE
Fail open when noise-curvature safe_bound is NaN

### DIFF
--- a/alberta_framework/benchmarks/plasticity_comparators.py
+++ b/alberta_framework/benchmarks/plasticity_comparators.py
@@ -672,7 +672,11 @@ def noise_curvature_step_size(
     """One bounded per-layer cooling/warming decision from paper Algorithm 1."""
     base = _finite_scalar("base_step_size", base_step_size)
     effective = _finite_scalar("effective_step_size", effective_step_size)
-    if type(safe_bound) not in (int, float) or math.isnan(safe_bound) or safe_bound < 0:
+    if type(safe_bound) not in (int, float):
+        raise ValueError("safe_bound must be an exact scalar")
+    if math.isnan(safe_bound):
+        return base
+    if safe_bound < 0:
         raise ValueError("safe_bound must be an exact nonnegative scalar")
     bound = float(safe_bound)
     rate = _probability("adjustment", adjustment, include_one=False)

--- a/tests/test_plasticity_comparators.py
+++ b/tests/test_plasticity_comparators.py
@@ -321,3 +321,13 @@ def test_jitted_pure_kernel_matches_eager_without_partial_state() -> None:
     assert all(bool(jnp.all(jnp.isnan(value))) for value in updated)
     with pytest.raises(ValueError, match="Threefry"):
         interval_dropout(jnp.ones(1), jnp.asarray([0, 0], dtype=jnp.uint32), relu_probability=1)
+
+
+def test_noise_curvature_fail_open_on_nan_safe_bound() -> None:
+    result = noise_curvature_step_size(
+        0.2,
+        effective_step_size=0.5,
+        safe_bound=float("nan"),
+        early_training=False,
+    )
+    assert result == pytest.approx(0.2)


### PR DESCRIPTION
Paper Algorithm 1 cooling used a NaN safe_bound as a hard error even though a missing bound should leave the step size unchanged. Treat NaN safe_bound as unbounded and return the base step size fail-open.

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)