### PR TITLE
fix(core): skip zero ObGD bound scale before scaling infinite traces

### DIFF
--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -52,6 +52,7 @@ from alberta_framework.core.horde import HordeUpdateResult
 from alberta_framework.core.initializers import sparse_init
 from alberta_framework.core.learners import (
     AnyOptimizer,
+    _skip_zero_scale,
     _update_from_gradient_with_diagnostics,
 )
 from alberta_framework.core.normalizers import Normalizer
@@ -796,7 +797,7 @@ class IndependentDemonHorde:
             )
             all_steps = list(bounded_steps)
             # Scale traces so future updates reflect the effective step
-            new_traces = [bound_scale * t for t in new_traces]
+            new_traces = [_skip_zero_scale(bound_scale, t) for t in new_traces]
 
         # 6. Apply: param += error * step
         new_weights: list[Array] = []

--- a/tests/test_independent_demon_horde.py
+++ b/tests/test_independent_demon_horde.py
@@ -765,3 +765,37 @@ def test_independent_horde_loop_preflights_shapes_and_output_budget() -> None:
     _require_loop_output_resources(119_304_647, 1)
     with pytest.raises(ValueError, match="learning-loop outputs"):
         _require_loop_output_resources(119_304_648, 1)
+
+class TestZeroBoundScaleTraceScaling:
+    def test_zero_obgd_scale_does_not_multiply_inf_traces(self) -> None:
+        """A collapsed ObGD scale must not form 0*inf on eligibility traces."""
+        spec = create_horde_spec(_make_all_gamma0_spec(1))
+        horde = IndependentDemonHorde(
+            horde_spec=spec,
+            hidden_sizes=(2,),
+            sparsity=0.0,
+            step_size=1e30,
+            bounder=ObGDBounding(kappa=2.0),
+        )
+        state = horde.init(2, jr.key(0))
+        ds = state.demon_states[0]
+        inf_traces = tuple(
+            jnp.full(shape, jnp.inf, dtype=jnp.float32)
+            for shape in (
+                (2, 2),
+                (2,),
+                (1, 2),
+                (1,),
+            )
+        )
+        ds = ds.replace(traces=inf_traces)
+        state = state.replace(demon_states=(ds,))
+        obs = jnp.ones(2, dtype=jnp.float32)
+        next_obs = jnp.ones(2, dtype=jnp.float32)
+        raw = jnp.float32(0.0) * inf_traces[0]
+        assert not bool(jnp.all(jnp.isfinite(raw)))
+
+        result = horde.update(state, obs, jnp.asarray([1.0], dtype=jnp.float32), next_obs)
+        for trace in result.state.demon_states[0].traces:  # type: ignore[attr-defined]
+            assert bool(jnp.all(jnp.isfinite(trace)))
+


### PR DESCRIPTION
## Summary
- Independent-demon ObGD bounding scales eligibility traces by `bound_scale`.
- When the scale collapses to zero, `0 * inf` traces became NaN and poisoned the demon update; skip the product via `_skip_zero_scale`.

## Test plan
- [x] Collapsed ObGD scale with infinite traces keeps finite trace tensors
- [ ] CI green

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)