### PR TITLE
fix(benchmarks): require exact dict JSON objects in matched executor thaw

### DIFF
--- a/alberta_framework/benchmarks/forager_matched_executor.py
+++ b/alberta_framework/benchmarks/forager_matched_executor.py
@@ -336,7 +336,7 @@ class MatchedExecutionPlan:
         _validate_qualified_lock(frozen_protocol)
         object.__setattr__(self, "protocol", frozen_protocol)
         if not all(
-            isinstance(value, Mapping)
+            type(value) is dict
             for value in (
                 self.source_manifest,
                 self.executor_manifest,
@@ -409,10 +409,7 @@ class MatchedExecutionPlan:
         executor_digest = _canonical_sha256(executor_manifest)
         payload_source = payload.get("source_manifest")
         payload_executor = payload.get("executor_manifest")
-        if not isinstance(payload_source, Mapping) or not isinstance(
-            payload_executor,
-            Mapping,
-        ):
+        if type(payload_source) is not dict or type(payload_executor) is not dict:
             raise ForagerMatchedExecutorError(
                 "execution plan payload manifests must be objects"
             )
@@ -1270,12 +1267,16 @@ def _freeze(value: Any) -> Any:
 
 
 def _thaw(value: Any) -> Any:
-    if isinstance(value, Mapping):
+    if type(value) is dict:
         if any(type(key) is not str for key in value):
             raise ForagerMatchedExecutorError(
                 "canonical JSON object keys must be strings"
             )
         return {key: _thaw(item) for key, item in value.items()}
+    if isinstance(value, Mapping):
+        raise ForagerMatchedExecutorError(
+            "canonical JSON objects must be exact dict instances"
+        )
     if type(value) is tuple:
         return [_thaw(item) for item in value]
     return value
@@ -1672,7 +1673,7 @@ def _docker_mount_path(path: Path, label: str) -> str:
 
 
 def _decode_mapping(value: Mapping[str, Any] | bytes | str, label: str) -> dict[str, Any]:
-    if isinstance(value, Mapping):
+    if type(value) is dict:
         decoded = decode_strict_json(canonical_json_bytes(dict(value)))
     elif type(value) in (bytes, str):
         decoded = decode_strict_json(value)

--- a/tests/test_forager_matched_executor_hostile_validation.py
+++ b/tests/test_forager_matched_executor_hostile_validation.py
@@ -106,3 +106,19 @@ def test_seed_execution_artifacts_reject_bool_seed_and_score(
 ) -> None:
     with pytest.raises(ForagerMatchedExecutorError, match=field):
         _legal_seed_artifacts(**{field: value})
+
+def test_thaw_rejects_mapping_subclass_before_iteration() -> None:
+    from alberta_framework.benchmarks import forager_matched_executor as mod
+
+    class HostileDict(dict):
+        calls = 0
+
+        def items(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.items must not run")
+
+    HostileDict.calls = 0
+    with pytest.raises(mod.ForagerMatchedExecutorError, match="exact dict"):
+        mod._thaw(HostileDict({"a": 1}))
+    assert HostileDict.calls == 0
+


### PR DESCRIPTION
## Summary
- Matched executor JSON thaw/decode accepted `Mapping` subclasses.
- Require exact `dict` at object boundaries and reject mapping subclasses before iteration hooks run.

## Test plan
- [x] Hostile dict subclass rejected by `_thaw` without invoking `items`
- [ ] CI green

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)