### PR TITLE
fix(benchmarks): require exact dict for matched container scorer JSON

### DIFF
--- a/alberta_framework/benchmarks/_forager_matched_container.py
+++ b/alberta_framework/benchmarks/_forager_matched_container.py
@@ -811,7 +811,7 @@ def _strict_json(raw: bytes) -> dict[str, Any]:
         raise
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ContainerError("scorer did not return strict UTF-8 JSON") from exc
-    if not isinstance(value, dict):
+    if type(value) is not dict:
         raise ContainerError("scorer result must be a JSON object")
     return value
 

--- a/tests/test_matched_container_hostile_validation.py
+++ b/tests/test_matched_container_hostile_validation.py
@@ -75,3 +75,24 @@ def test_valid_json_passes() -> None:
     raw = b'{"a": 1, "b": 2}'
     data = _strict_json(raw)
     assert data == {"a": 1, "b": 2}
+
+def test_strict_json_rejects_dict_subclass_after_load(monkeypatch: pytest.MonkeyPatch) -> None:
+    from alberta_framework.benchmarks import _forager_matched_container as mod
+
+    class HostileDict(dict):
+        calls = 0
+
+        def keys(self):  # type: ignore[override]
+            type(self).calls += 1
+            raise AssertionError("HostileDict.keys must not run")
+
+    HostileDict.calls = 0
+
+    def fake_loads(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return HostileDict({"schema": "x"})
+
+    monkeypatch.setattr(mod.json, "loads", fake_loads)
+    with pytest.raises(mod.ContainerError, match="must be a JSON object"):
+        mod._strict_json(b"{}")
+    assert HostileDict.calls == 0
+


### PR DESCRIPTION
## Summary
- Matched container scorer JSON gate used `isinstance(..., dict)`.
- Require `type(value) is dict` so hostile mapping subclasses fail closed.

## Test plan
- [x] Hostile dict subclass rejected after mocked `json.loads`
- [ ] CI green

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)