### PR TITLE
fix: require exact dict in evidence manifest acceptance/digest gates

### DIFF
--- a/alberta_framework/evaluation/evidence_manifest.py
+++ b/alberta_framework/evaluation/evidence_manifest.py
@@ -1212,11 +1212,11 @@ def _ftl_acceptance_passed(
     errors: list[str],
 ) -> bool | None:
     scientific = artifact.get("scientific_payload")
-    if not isinstance(scientific, Mapping):
+    if type(scientific) is not dict:
         errors.append(f"{location}.scientific_payload must be an object")
         return None
     acceptance = scientific.get("acceptance")
-    if not isinstance(acceptance, Mapping):
+    if type(acceptance) is not dict:
         errors.append(f"{location}.scientific_payload.acceptance must be an object")
         return None
     passed = acceptance.get("passed")
@@ -1236,10 +1236,10 @@ def _ftl_scientific_digest(
 ) -> str | None:
     scientific = artifact.get("scientific_payload")
     digest = artifact.get("scientific_digest")
-    if not isinstance(scientific, Mapping):
+    if type(scientific) is not dict:
         errors.append(f"{location}.scientific_payload must be an object")
         return None
-    if not isinstance(digest, Mapping):
+    if type(digest) is not dict:
         errors.append(f"{location}.scientific_digest must be an object")
         return None
     recorded = digest.get("sha256")
@@ -1346,9 +1346,7 @@ def _ftl_source_mismatch_errors(
     *,
     label: str,
 ) -> list[str]:
-    if not isinstance(artifact_source, Mapping) or not isinstance(
-        current_source, Mapping
-    ):
+    if type(artifact_source) is not dict or type(current_source) is not dict:
         return [f"{label} and validation source hashes must both be objects"]
     errors: list[str] = []
     for relative_path in sorted(set(artifact_source) | set(current_source)):
@@ -1369,11 +1367,11 @@ def _ia_acceptance_passed(
     errors: list[str],
 ) -> bool | None:
     content = artifact.get("content")
-    if not isinstance(content, Mapping):
+    if type(content) is not dict:
         errors.append(f"{location}.content must be an object")
         return None
     acceptance = content.get("acceptance")
-    if not isinstance(acceptance, Mapping):
+    if type(acceptance) is not dict:
         errors.append(f"{location}.content.acceptance must be an object")
         return None
     passed = acceptance.get("passed")
@@ -1391,10 +1389,10 @@ def _ia_content_digest(
 ) -> str | None:
     content = artifact.get("content")
     digest = artifact.get("content_digest")
-    if not isinstance(content, Mapping):
+    if type(content) is not dict:
         errors.append(f"{location}.content must be an object")
         return None
-    if not isinstance(digest, Mapping):
+    if type(digest) is not dict:
         errors.append(f"{location}.content_digest must be an object")
         return None
     recorded = digest.get("sha256")
@@ -1525,7 +1523,7 @@ def _ia_source_mismatch_errors(
     artifact_source: object,
     current_source: object,
 ) -> list[str]:
-    if not isinstance(artifact_source, Mapping) or not isinstance(current_source, Mapping):
+    if type(artifact_source) is not dict or type(current_source) is not dict:
         return ["current replay and validation source hashes must both be objects"]
     errors: list[str] = []
     for relative_path in sorted(set(artifact_source) | set(current_source)):

--- a/tests/test_evidence_manifest_acceptance_exact_json_hostile.py
+++ b/tests/test_evidence_manifest_acceptance_exact_json_hostile.py
@@ -1,0 +1,26 @@
+"""Hostile exact JSON gates for evidence-manifest acceptance/digest helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from alberta_framework.evaluation.evidence_manifest import _ftl_acceptance_passed
+
+pytestmark = pytest.mark.unit
+
+
+class HostileDict(dict):
+    calls = 0
+
+    def __iter__(self):  # type: ignore[override]
+        type(self).calls += 1
+        raise AssertionError("HostileDict.__iter__ must not run")
+
+
+def test_ftl_acceptance_passed_rejects_scientific_payload_subclass() -> None:
+    artifact: dict[str, object] = {"scientific_payload": HostileDict({"acceptance": {}})}
+    errors: list[str] = []
+    HostileDict.calls = 0
+    assert _ftl_acceptance_passed(artifact, location="artifact", errors=errors) is None
+    assert errors == ["artifact.scientific_payload must be an object"]
+    assert HostileDict.calls == 0


### PR DESCRIPTION
## Summary
- Require exact dict/list identity in JSON validation paths (reject hostile mapping/list subclasses before iteration).

## Test plan
- [x] Hostile subclass unit tests
- [x] ruff + targeted pytest

Made with Cursor. No Slop measured-run receipt (not an approved Codex or Claude Code client).

Made with [Cursor](https://cursor.com)