### PR TITLE
fix(metrics): use only the immediate pre-exposure row for FWT

### DIFF
--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -477,10 +477,6 @@ def compute_forward_transfer(
         # immediately before first exposure. An older finite probe is not a
         # substitute when that row is NaN (not evaluated) or divergent.
         immediate = matrix[int(first_row) - 1, task]
-        if np.isinf(immediate):
-            raise ValueError(
-                f"task {task} has an infinite evaluation immediately before first exposure"
-            )
         if not np.isfinite(immediate):
             continue
         transfer[task] = (

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -447,7 +447,10 @@ def compute_forward_transfer(
     on a task probed *before* it is ever trained on, minus a task-specific
     baseline (in GEM, the untrained-network performance).
 
-    Task 0, and any task without a finite pre-exposure probe, receives ``NaN``.
+    Task 0, and any task whose *immediate* pre-exposure checkpoint is not a
+    finite number, receives ``NaN``. Older finite probes are not backfilled
+    when that GEM checkpoint was not evaluated. An infinite immediate
+    pre-exposure is rejected rather than treated as a missing probe.
     The sign is normalized so positive values always mean beneficial transfer.
     """
 
@@ -468,13 +471,18 @@ def compute_forward_transfer(
     for task, first_row in enumerate(rows):
         if first_row == 0:
             continue
-        prior = matrix[:first_row, task]
-        finite_prior = prior[np.isfinite(prior)]
-        if finite_prior.size == 0:
+        # GEM FWT is R_{i-1, i} minus the task baseline: only the checkpoint
+        # immediately before first exposure. An older finite probe is not a
+        # substitute when that row is NaN (not evaluated) or divergent.
+        immediate = matrix[int(first_row) - 1, task]
+        if np.isinf(immediate):
+            raise ValueError(
+                f"task {task} has an infinite evaluation immediately before first exposure"
+            )
+        if not np.isfinite(immediate):
             continue
-        pre_exposure = finite_prior[-1]
         transfer[task] = (
-            pre_exposure - baseline[task] if higher_is_better else baseline[task] - pre_exposure
+            immediate - baseline[task] if higher_is_better else baseline[task] - immediate
         )
     return transfer
 

--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -449,8 +449,8 @@ def compute_forward_transfer(
     on a task probed *before* it is ever trained on, minus a task-specific
     baseline (in GEM, the untrained-network performance).
 
-    Task 0, and any task whose *immediate* pre-exposure checkpoint is not a
-    finite number, receives ``NaN``. Older finite probes are not backfilled
+    Tasks first exposed at row 0, and any task whose *immediate* pre-exposure
+    checkpoint is missing, receive ``NaN``. Older finite probes are not backfilled
     when that GEM checkpoint was not evaluated. An infinite immediate
     pre-exposure is rejected rather than treated as a missing probe.
     The sign is normalized so positive values always mean beneficial transfer.

--- a/tests/test_continual_metrics.py
+++ b/tests/test_continual_metrics.py
@@ -60,6 +60,59 @@ def test_accuracy_matrix_forgetting_and_backward_transfer() -> None:
     np.testing.assert_allclose(forward[1:], [0.05, -0.05])
 
 
+# Documented metric API: compute_forward_transfer must use the immediate
+# pre-exposure row (GEM R_{i-1,i}). A NaN there is not-evaluated, not a
+# license to backfill an older finite probe and emit a wrong FWT number.
+def test_forward_transfer_does_not_backfill_a_missing_immediate_pre_exposure() -> None:
+    performance = np.array(
+        [
+            [0.10, 0.99],
+            [0.20, np.nan],
+            [0.30, 0.40],
+        ]
+    )
+    forward = compute_forward_transfer(
+        performance,
+        first_exposure=[0, 2],
+        baseline_performance=[0.50, 0.50],
+    )
+    assert np.isnan(forward[0])
+    assert np.isnan(forward[1])
+
+
+def test_forward_transfer_uses_only_the_immediate_pre_exposure_row() -> None:
+    performance = np.array(
+        [
+            [0.10, 0.99],
+            [0.20, 0.60],
+            [0.30, 0.40],
+        ]
+    )
+    forward = compute_forward_transfer(
+        performance,
+        first_exposure=[0, 2],
+        baseline_performance=[0.50, 0.50],
+    )
+    assert np.isnan(forward[0])
+    assert forward[1] == pytest.approx(0.10)
+
+
+def test_forward_transfer_rejects_infinite_immediate_pre_exposure() -> None:
+    performance = np.array(
+        [
+            [0.10, 0.99],
+            [0.20, np.inf],
+            [0.30, 0.40],
+        ]
+    )
+    with pytest.raises(ValueError, match="infinite evaluation immediately before first exposure"):
+        compute_forward_transfer(
+            performance,
+            first_exposure=[0, 2],
+            baseline_performance=[0.50, 0.50],
+        )
+
+
 def test_loss_matrix_normalizes_metric_directions() -> None:
     losses = np.array(
         [

--- a/tests/test_continual_metrics.py
+++ b/tests/test_continual_metrics.py
@@ -105,7 +105,7 @@ def test_forward_transfer_rejects_infinite_immediate_pre_exposure() -> None:
             [0.30, 0.40],
         ]
     )
-    with pytest.raises(ValueError, match="infinite evaluation immediately before first exposure"):
+    with pytest.raises(ValueError, match="performance_matrix has an infinite evaluation"):
         compute_forward_transfer(
             performance,
             first_exposure=[0, 2],


### PR DESCRIPTION
## Outcome

Fix.

`compute_forward_transfer` (documented public metric API in `alberta_framework.utils.metrics`, re-exported from `alberta_framework.utils`) silently produced a wrong GEM forward-transfer number when the immediate pre-exposure checkpoint was NaN.

Supported path: `from alberta_framework.utils.metrics import compute_forward_transfer` on a checkpoint matrix whose `first_exposure[j]` is the first post-learning row. GEM FWT is `R_{i-1,i}` minus the task baseline — only that immediately preceding row.

On live origin/main `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, this matrix:

```
[[0.10, 0.99],
 [0.20,  nan],
 [0.30, 0.40]]
first_exposure = [0, 2]
baseline = [0.50, 0.50]
```

reported task-1 FWT `0.49` by walking back to the older 0.99 probe. The immediate GEM checkpoint (row 1) was not evaluated. After the one-boundary fix the same call returns `NaN`.

This is not a Kayvan skip-zero / exact-dict series, not a dumps-of-mapping / nest-preflight twin of #2157-#2177, and not leftover-tax (CanonicalUPGD / feature_discovery / clocks / forager / IA / FTL / upgd / horde / dreaming / delight / #1874). No open ASI PR titles the same hole.

## Measurement gate

- Lane: documented metric API `compute_forward_transfer`
- Metric: GEM forward transfer (`R_{i-1,i} - baseline`)
- Origin proof at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`: stale backfill `0.49`
- Overlay at this head: `NaN` (not evaluated), and `0.10` when the immediate row is the finite `0.60` probe
- Infinite immediate pre-exposure is rejected rather than treated as a missing probe
- Focused pytest `tests/test_continual_metrics.py`: 51 passed
- Related hostile metrics tests: 37 passed
- `ruff check` on the two changed files: clean
- One production file: `alberta_framework/utils/metrics.py`

<!-- evidence-head:5b37246bdf1431a5b54c7dde1fb319faf930db5d -->
<!-- evidence-row:logs -->
- [x] logs: N/A - focused unit tests on the documented metric API; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact; the measurement is the FWT number `0.49` vs `NaN` on the matrix above
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - official `run-receipt.mjs start` failed before trace: origin must be SlopDotCash/asi (this checkout origin is elizaOS/asi; shared primary remotes were not mutated)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@eb5702c87fef7e2b9c95b258b2bdfd9f449d9d0b:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: SlopDotCash/slopdotcash@eb5702c87fef7e2b9c95b258b2bdfd9f449d9d0b:skills/contribute-to-asi
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"SlopDotCash/slopdotcash@eb5702c87fef7e2b9c95b258b2bdfd9f449d9d0b:skills/contribute-to-asi"} -->
