### PR TITLE
fix(benchmarks): score JEPA late return on the last complete phase

### DIFF
--- a/alberta_framework/benchmarks/jepa_transfer_feasibility.py
+++ b/alberta_framework/benchmarks/jepa_transfer_feasibility.py
@@ -523,6 +523,19 @@ def _deployment_state(
     )
 
 
+def _late_phase_return_sum(rewards: Sequence[float], phase_length: int) -> float:
+    """Sum rewards over the last complete SwitchingTwoState payoff phase.
+
+    The environment switches every ``phase_length`` steps.  ``rewards[-phase_length:]``
+    is that last complete phase only when ``len(rewards)`` is a multiple of
+    ``phase_length``.  Otherwise the trailing window straddles two phases and
+    silently reports a mixed-phase number on a supported protocol (``steps``
+    need only cover one A/B recurrence, not land on a phase boundary).
+    """
+    completed = (len(rewards) // phase_length) * phase_length
+    return float(sum(rewards[completed - phase_length : completed]))
+
+
 def _run_model_arm(protocol: JEPATransferProtocol, seed: int, arm_id: str) -> TransferArmReceipt:
     pretrained = None
     replay_bytes = pretraining_ns = encoder_updates = 0
@@ -593,7 +606,7 @@ def _run_model_arm(protocol: JEPATransferProtocol, seed: int, arm_id: str) -> Tr
         arm_id=arm_id,
         seed=seed,
         return_sum=float(sum(rewards)),
-        late_return_sum=float(sum(rewards[-protocol.phase_length :])),
+        late_return_sum=_late_phase_return_sum(rewards, protocol.phase_length),
         mean_prediction_loss=float(np.mean(np.asarray(losses, dtype=np.float64))),
         action_sha256=_sha(actions),
         reward_sha256=_sha(rewards, floats=True),
@@ -669,7 +682,7 @@ def _run_control(protocol: JEPATransferProtocol, seed: int, *, sarsa: bool) -> T
         arm_id="sarsa_control" if sarsa else "mechanism_off",
         seed=seed,
         return_sum=float(sum(rewards)),
-        late_return_sum=float(sum(rewards[-protocol.phase_length :])),
+        late_return_sum=_late_phase_return_sum(rewards, protocol.phase_length),
         mean_prediction_loss=None,
         action_sha256=_sha(actions),
         reward_sha256=_sha(rewards, floats=True),

--- a/tests/test_jepa_transfer_feasibility.py
+++ b/tests/test_jepa_transfer_feasibility.py
@@ -167,3 +167,35 @@ def test_result_research_pins_are_deeply_immutable(result: lane.JEPATransferResu
 def test_protocol_rejects_hostile_or_unmatched_axes(changes: dict[str, object]) -> None:
     with pytest.raises(ValueError):
         lane.JEPATransferProtocol(**changes)  # type: ignore[arg-type]
+
+
+def test_late_return_uses_last_complete_phase_not_trailing_window() -> None:
+    """Supported unaligned protocol must not mix two payoff phases.
+
+    ``JEPATransferProtocol`` accepts ``steps=10, phase_length=4`` (covers one
+    A/B recurrence). Frozen seed 1577003 then yields a trailing 4-step window
+    that straddles phase B and the next phase A, so ``rewards[-phase_length:]``
+    silently reports 0.0 while the last complete phase sums to 1.0.
+    """
+    protocol = lane.JEPATransferProtocol(
+        steps=10,
+        phase_length=4,
+        pretraining_steps=4,
+        warmup_steps=2,
+        exploration_period=2,
+    )
+    seed = 1_577_003
+    receipt = lane._run_control(protocol, seed, sarsa=False)
+    assert receipt.late_return_sum == 1.0
+    assert receipt.return_sum == 3.0
+    # The buggy trailing slice is 0.0 on this supported seed.
+    assert receipt.late_return_sum != 0.0
+
+
+def test_late_phase_return_sum_keeps_aligned_windows() -> None:
+    aligned = (0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0)
+    assert lane._late_phase_return_sum(aligned, 4) == 1.0
+    unaligned = aligned + (0.0, 0.0)
+    assert lane._late_phase_return_sum(unaligned, 4) == 1.0
+    assert sum(unaligned[-4:]) == 0.0
+


### PR DESCRIPTION
## Outcome

Fix.

`JEPATransferProtocol` (public constructor and CLI `--steps` / `--phase-length`) silently produced a mixed-phase late-return number when `steps` covered one SwitchingTwoState A/B recurrence without landing on a phase boundary.

Supported path: `JEPATransferProtocol(steps=10, phase_length=4, pretraining_steps=4, warmup_steps=2, exploration_period=2)` and the matching CLI `--steps 10 --phase-length 4 --pretraining-steps 4 --warmup-steps 2 --exploration-period 2`. The constructor requires `steps >= 2 * phase_length`, not `steps % phase_length == 0`. TeLAPA already rejects incomplete phases; this lane did not.

On live origin/main `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, frozen development seed `1577003` through `_run_control(..., sarsa=False)` (the `mechanism_off` arm) yields rewards `[0, 1, 0, 1, 1, 0, 0, 0, 0, 0]` on phases `[0, 0, 0, 0, 1, 1, 1, 1, 0, 0]`. `late_return_sum=float(sum(rewards[-phase_length:]))` reported `0.0` from the trailing window (steps 6–9, phases B then A). The last complete phase (steps 4–7) sums to `1.0`. After the one-boundary fix the same call returns `1.0`. Default 256/32 stays aligned and unchanged.

This is not a Kayvan skip-zero / exact-dict series, not a dumps-of-mapping / nest-preflight twin of #2157-#2177, not leftover-tax (CanonicalUPGD / feature_discovery / clocks / forager / IA / FTL / upgd / horde / dreaming / delight / #1874), and not the export common-final-window leftover. Open #2483 revalidates nested JEPA receipts; it does not change late-return windowing. No open ASI PR titles this hole.

## Measurement gate

- Lane: documented JEPA transfer feasibility harness (`alberta_framework.benchmarks.jepa_transfer_feasibility`)
- Metric: `TransferArmReceipt.late_return_sum` (last complete SwitchingTwoState payoff phase)
- Origin proof at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`: mixed-phase trailing window `0.0`
- Overlay at this head: last complete phase `1.0` (seed `1577003`, `mechanism_off`); aligned 8/4 windows stay `1.0`
- Constructor still accepts unaligned `steps=10, phase_length=4` (supported path not shrunk)
- Focused pytest `tests/test_jepa_transfer_feasibility.py`: 18 passed
- `ruff check` on the two changed files: clean
- One production file: `alberta_framework/benchmarks/jepa_transfer_feasibility.py`

<!-- evidence-head:333f7faa249abedd7466b69eaac5f7a67af03fdd -->
<!-- evidence-row:logs -->
- [x] logs: N/A - focused unit tests on the public protocol and control arm; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact; the measurement is the late-return number `0.0` vs `1.0` on seed `1577003` above
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - official `run-receipt.mjs start` failed before trace: origin must be SlopDotCash/asi (this checkout origin is elizaOS/asi; shared primary remotes were not mutated)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@eb5702c87fef7e2b9c95b258b2bdfd9f449d9d0b:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: SlopDotCash/slopdotcash@eb5702c87fef7e2b9c95b258b2bdfd9f449d9d0b:skills/contribute-to-asi
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"SlopDotCash/slopdotcash@eb5702c87fef7e2b9c95b258b2bdfd9f449d9d0b:skills/contribute-to-asi"} -->
