### PR TITLE
fix(core): reject oversized interaction-feature array scans before lax.scan

### DIFF
--- a/alberta_framework/core/interaction_features.py
+++ b/alberta_framework/core/interaction_features.py
@@ -35,6 +35,11 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, PRNGKeyArray, UInt
 
+from alberta_framework._scan_resources import (
+    ScanBudget,
+    require_jax_leading_length,
+    require_matching_jax_leading_length,
+)
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.checkpoints import (
     load_checkpoint,
@@ -53,6 +58,9 @@ _UINT32_MAX = 2**32 - 1
 # README / package-init public scan last-fit. Origin handed ``10**12`` to
 # ``jnp.arange`` with no reject — hang/OOM, not an INT32 leftover.
 _INTERACTION_FEATURE_LOOP_MAX_STEPS = 10_000
+_INTERACTION_FEATURE_LOOP_BUDGET = ScanBudget(
+    "interaction-feature learning-loop", _INTERACTION_FEATURE_LOOP_MAX_STEPS
+)
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -93,6 +101,37 @@ def _require_interaction_feature_loop_steps(name: str, value: object) -> int:
             f"{name} must be an integer in [1, {_INTERACTION_FEATURE_LOOP_MAX_STEPS}]"
         )
     return value
+
+
+def _require_interaction_feature_array_steps(observations: object, targets: object) -> int:
+    """Reject pre-collected scan lengths above the public last-fit before scan."""
+    if not isinstance(observations, jax.Array) or not isinstance(targets, jax.Array):
+        raise TypeError("observations and targets must be JAX arrays")
+    try:
+        num_steps = require_jax_leading_length(
+            "observations",
+            observations,
+            _INTERACTION_FEATURE_LOOP_BUDGET,
+            ranks=(2,),
+        )
+    except ValueError as error:
+        if (
+            observations.ndim == 2
+            and not 1 <= observations.shape[0] <= _INTERACTION_FEATURE_LOOP_MAX_STEPS
+        ):
+            raise ValueError(
+                "observations num_steps must be an integer in "
+                f"[1, {_INTERACTION_FEATURE_LOOP_MAX_STEPS}]"
+            ) from None
+        raise error
+    require_jax_leading_length(
+        "targets",
+        targets,
+        _INTERACTION_FEATURE_LOOP_BUDGET,
+        ranks=(2,),
+    )
+    require_matching_jax_leading_length("targets", targets, expected=num_steps)
+    return num_steps
 
 
 def _require_resource(name: str, *, scalars: int, nbytes: int) -> None:
@@ -3739,7 +3778,14 @@ def run_interaction_feature_arrays(
     observations: Array,
     targets: Array,
 ) -> InteractionFeatureLearningResult:
-    """Run an interaction-feature learner over pre-collected arrays."""
+    """Run an interaction-feature learner over pre-collected arrays.
+
+    Raises:
+        TypeError: If ``observations`` or ``targets`` is not a JAX array.
+        ValueError: If ``num_steps`` is not an exact integer in
+            ``[1, 10_000]``.
+    """
+    _require_interaction_feature_array_steps(observations, targets)
 
     def step_fn(
         carry: InteractionFeatureState,

--- a/tests/test_interaction_feature_loop_steps.py
+++ b/tests/test_interaction_feature_loop_steps.py
@@ -1,20 +1,25 @@
 """Protocol step ceilings for public interaction-feature scans.
 
 Origin handed ``10**12`` to ``jnp.arange`` with no reject — that is the
-hang/OOM class, not an INT32 leftover.
+hang/OOM class, not an INT32 leftover. The pre-collected array path
+``run_interaction_feature_arrays`` must reject the same ceiling before
+``jax.lax.scan``.
 """
 
 from __future__ import annotations
 
 from typing import Any, cast
 
+import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 import pytest
 
 from alberta_framework.core.interaction_features import (
     _INTERACTION_FEATURE_LOOP_MAX_STEPS,
+    _require_interaction_feature_array_steps,
     _require_interaction_feature_loop_steps,
+    run_interaction_feature_arrays,
     run_interaction_feature_loop,
 )
 
@@ -95,3 +100,58 @@ def test_rejects_numpy_and_subclass_step_counts_without_index_hooks() -> None:
         _require_interaction_feature_loop_steps("num_steps", np.int64(10))
     with pytest.raises(ValueError, match="num_steps must be an integer in"):
         _require_interaction_feature_loop_steps("num_steps", _HostileInt(10))
+
+
+class _HostileArrays:
+    calls = 0
+
+    @property
+    def ndim(self) -> Any:
+        type(self).calls += 1
+        raise AssertionError("ndim hook executed")
+
+    @property
+    def shape(self) -> Any:
+        type(self).calls += 1
+        raise AssertionError("shape hook executed")
+
+
+def _spy_scan(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    seen: list[object] = []
+
+    def spy(*args: object, **kwargs: object) -> Any:
+        seen.append((args, kwargs))
+        raise AssertionError(f"jax.lax.scan must not run: {args} {kwargs}")
+
+    monkeypatch.setattr("alberta_framework.core.interaction_features.jax.lax.scan", spy)
+    return seen
+
+
+def test_array_last_fit_length_is_accepted() -> None:
+    observations = jnp.zeros((_INTERACTION_FEATURE_LOOP_MAX_STEPS, 2), dtype=jnp.float32)
+    targets = jnp.zeros((_INTERACTION_FEATURE_LOOP_MAX_STEPS, 1), dtype=jnp.float32)
+    assert _require_interaction_feature_array_steps(observations, targets) == 10_000
+
+
+def test_array_first_overflow_rejected_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _spy_scan(monkeypatch)
+    observations = jnp.zeros((_INTERACTION_FEATURE_LOOP_MAX_STEPS + 1, 2), dtype=jnp.float32)
+    targets = jnp.zeros((_INTERACTION_FEATURE_LOOP_MAX_STEPS + 1, 1), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="observations num_steps must be an integer in"):
+        run_interaction_feature_arrays(
+            cast(Any, object()),
+            cast(Any, object()),
+            observations,
+            targets,
+        )
+    assert seen == []
+
+
+def test_array_gate_does_not_read_hostile_shape() -> None:
+    _HostileArrays.calls = 0
+    with pytest.raises(TypeError, match="observations and targets must be JAX arrays"):
+        _require_interaction_feature_array_steps(_HostileArrays(), _HostileArrays())
+    assert _HostileArrays.calls == 0
+


### PR DESCRIPTION
## Outcome

Fix.

`run_interaction_feature_arrays` is the supported public path from pre-collected JAX observation/target batches to an interaction-feature learning receipt. Its scan had no length gate. The same module's `run_interaction_feature_loop` already rejects above the documented 10_000-step ceiling, and the compositional sibling already rejects the matching arrays path. This lane did not.

Supported path: `run_interaction_feature_arrays(learner, state, observations, targets)` with JAX arrays of shape `(num_steps, feature_dim)` and `(num_steps, n_tasks)`. Existing suite callers use 2-step and 10-step batches (`tests/test_feature_discovery.py`). The public loop path documents `num_steps` in `[1, 10_000]`; the arrays path accepted any leading length and handed it to `jax.lax.scan`.

On live origin/main `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, `run_interaction_feature_arrays(..., jnp.zeros((10001, 2), dtype=jnp.float32), jnp.zeros((10001, 1), dtype=jnp.float32))` entered `jax.lax.scan` with length `10001`. After the one-boundary fix the same call raises `ValueError: observations num_steps must be an integer in [1, 10000]` before scan. Last-fit `10000` stays accepted. Hostile non-array objects still fail closed as `TypeError` without reading `.shape`.

This is not a Kayvan skip-zero / exact-dict series, not a dumps-of-mapping / nest-preflight twin of #2157-#2177, not leftover-tax (CanonicalUPGD / feature_discovery pair-cap / constructor pytree / clocks / forager / IA / FTL / upgd / horde / dreaming / delight / #1874), not JEPA late-return / phase-window glance-slice, and not the export common-final-window leftover. No open ASI PR titles this hole.

## Measurement gate

- Lane: documented interaction-feature discovery harness (`alberta_framework.core.interaction_features`)
- Metric: public arrays-path scan length rejected before `jax.lax.scan`
- Origin proof at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`: 10001-step JAX batch entered scan
- Overlay at this head: same call raises before scan; last-fit 10000 remains accepted
- Constructor / loop ceiling unchanged (`_INTERACTION_FEATURE_LOOP_MAX_STEPS = 10_000`)
- Focused pytest `tests/test_interaction_feature_loop_steps.py`: 15 passed
- Existing arrays-path callers `test_target_only_probe_runs_under_jit_and_scan` / `test_array_loop_shapes`: 3 passed
- `ruff check` on the two changed files: clean
- One production file: `alberta_framework/core/interaction_features.py`

<!-- evidence-head:b4c217e286a3c7c4975418304732c49f1a45dacd -->
<!-- evidence-row:logs -->
- [x] logs: N/A - focused unit tests on the public arrays path; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact; the measurement is scan-entered `10001` vs `ValueError` before scan
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - official `run-receipt.mjs start` failed before trace: Auto-review rejected the receipt CLI invocation ("The executable content could not be bound to this review. Run the resolved script directly or provide an explicit working directory."); origin must be SlopDotCash/asi (this checkout origin is elizaOS/asi; shared remotes were not mutated)

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi"} -->
