### PR TITLE
fix(streams): skip missing gauntlet probes in the recovery EMA

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -1224,13 +1224,24 @@ def run_gauntlet_batched(
 
 
 def ema_smooth(values: Array, halflife: float = 50.0) -> Array:
-    """Exponential-moving-average smoothing along the last axis."""
+    """Exponential-moving-average smoothing along the last axis.
+
+    Non-finite probes are treated as not evaluated: they do not enter the
+    carry, and the corresponding output is ``NaN``.  The next finite
+    observation continues from the last finite carry (or starts the EMA
+    if no finite value has been seen yet).  All-finite traces keep the
+    historical bit-identical recurrence.
+    """
     decay = 0.5 ** (1.0 / halflife)
     time_major = jnp.moveaxis(values, -1, 0)
 
     def step(carry: Array, v: Array) -> tuple[Array, Array]:
-        new = decay * carry + (1.0 - decay) * v
-        return new, new
+        finite_v = jnp.isfinite(v)
+        finite_c = jnp.isfinite(carry)
+        updated = decay * carry + (1.0 - decay) * v
+        new_carry = jnp.where(finite_v, jnp.where(finite_c, updated, v), carry)
+        out = jnp.where(finite_v, new_carry, jnp.full_like(v, jnp.nan))
+        return new_carry, out
 
     _, smoothed = jax.lax.scan(step, values[..., 0], time_major)
     return jnp.moveaxis(smoothed, 0, -1)
@@ -1238,6 +1249,10 @@ def ema_smooth(values: Array, halflife: float = 50.0) -> Array:
 
 def steps_to_criterion(sq_segment: Array, threshold: float) -> Array:
     """First step whose EMA-smoothed squared error is <= *threshold*.
+
+    Non-finite probes are not evaluated (see :func:`ema_smooth`): a later
+    finite recovery still reports its first-below-threshold step instead of
+    the segment-length "never recovered" cap.
 
     Args:
         sq_segment: Squared errors within one segment, shape ``(seg_len,)`` or

--- a/tests/test_gauntlet_recovery_missing_probes.py
+++ b/tests/test_gauntlet_recovery_missing_probes.py
@@ -1,0 +1,60 @@
+"""Recovery clocks must not treat one missing probe as never recovered."""
+
+import jax.numpy as jnp
+
+from alberta_framework.streams.gauntlet import (
+    GauntletConfig,
+    ema_smooth,
+    gauntlet_scorecard,
+    steps_to_criterion,
+)
+
+
+def _recovery_trace(*, poison: bool) -> jnp.ndarray:
+    # 20 high, one probe, then a long quiet tail — enough for the default
+    # half-life-50 EMA to cross a 0.05 criterion after the quiet stretch.
+    mid = jnp.nan if poison else 1.0
+    return jnp.concatenate(
+        [jnp.ones(20), jnp.asarray([mid]), jnp.zeros(400)]
+    ).astype(jnp.float32)
+
+
+def test_ema_smooth_all_finite_stays_bit_identical_to_recurrence() -> None:
+    values = jnp.arange(24, dtype=jnp.float32).reshape(2, 3, 4)
+    decay = 0.5 ** (1.0 / 1.0)
+    expected = jnp.empty_like(values)
+    carry = values[..., 0]
+    for t in range(values.shape[-1]):
+        carry = decay * carry + (1.0 - decay) * values[..., t]
+        expected = expected.at[..., t].set(carry)
+    actual = ema_smooth(values, halflife=1.0)
+    assert jnp.array_equal(actual, expected)
+
+
+def test_steps_to_criterion_recovers_after_a_mid_segment_nan() -> None:
+    """A single NaN must not cap recovery at the segment length."""
+    clean = _recovery_trace(poison=False)
+    poison = _recovery_trace(poison=True)
+    threshold = 0.05
+    clean_steps = int(steps_to_criterion(clean, threshold))
+    poison_steps = int(steps_to_criterion(poison, threshold))
+    assert clean_steps < clean.shape[0]
+    assert poison_steps < poison.shape[0]
+    # Skipping one missing probe shifts the first-below index by at most one
+    # step versus the all-finite twin.
+    assert abs(poison_steps - clean_steps) <= 1
+
+
+def test_gauntlet_scorecard_recovery_survives_one_missing_probe() -> None:
+    """Public scorecard path: nan_steps counts the hole, recovery still fires."""
+    length = 421
+    config = GauntletConfig(segment_length=length)
+    poison = _recovery_trace(poison=True)
+    sq_errors = jnp.ones((1, 9 * length), dtype=jnp.float32)
+    # Segment 2 is the first task-C exposure (recovery_steps_c).
+    start = 2 * length
+    sq_errors = sq_errors.at[0, start : start + length].set(poison)
+    card = gauntlet_scorecard(sq_errors, config)
+    rec_c = int(card["recovery_steps_c"][0])
+    assert int(card["nan_steps"][0]) == 1
+    assert rec_c < length


### PR DESCRIPTION
## Outcome

Fix.

`steps_to_criterion` / `gauntlet_scorecard` (documented public gauntlet API in `alberta_framework.streams.gauntlet`) silently reported the segment-length "never recovered" cap after a later finite recovery, because one mid-segment NaN poisoned the rest of the causal EMA.

Supported path: `from alberta_framework.streams.gauntlet import steps_to_criterion, gauntlet_scorecard`. NaN in squared-error traces is first-class: the same scorecard documents `nan_steps` (P6) on the same array.

On live origin/main `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, this 421-step segment (`decay = 0.5**(1/50)`):

```
[1.0] * 20 + [1.0] + [0.0] * 400   -> steps_to_criterion(..., 0.05) = 237
[1.0] * 20 + [nan] + [0.0] * 400   -> steps_to_criterion(..., 0.05) = 421  (cap = len)
```

The poison trace has 20 finite EMA values and last EMA `nan`. After the one-boundary fix, the same poison call returns `237` (last EMA ~0.0039). `gauntlet_scorecard` on the documented nine-segment program (`segment_length=421`, poison in segment 2) reports `recovery_steps_c=303` and `nan_steps=1` instead of the never-recovered cap `421`.

All-finite traces stay bit-identical (`test_ema_smooth_preserves_leading_batch_axes`). Load-bearing: reverting only `ema_smooth` to origin makes both new tests fail `421 < 421`.

This is not a Kayvan skip-zero / exact-dict series, not a 10000-cap / walk-bound sibling of #2697, not a JEPA late-return glance-slice of #2696, not metrics.py FWT / tracking-error (#2694/#2695), and not leftover-tax (CanonicalUPGD / feature_discovery / clocks / forager / IA / FTL / upgd / horde / dreaming / delight / #1874 / #2157-#2177). No open ASI PR titles the same hole.

## Measurement gate

- Lane: documented gauntlet API `steps_to_criterion` / `gauntlet_scorecard`
- Metric: steps-to-criterion / `recovery_steps_c` after a missing probe
- Origin proof at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`: poison `421` (never recovered)
- Overlay at this head: poison `237` (recovers with the all-finite twin)
- Focused pytest `tests/test_gauntlet_recovery_missing_probes.py` + existing EMA / scorecard-window tests: 7 passed
- `ruff check` on the two changed files: clean
- One production file: `alberta_framework/streams/gauntlet.py`

<!-- evidence-head:a628f22c261cac1af386c1bce434a5f18b8b6380 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - focused unit tests on the documented gauntlet API; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact; the measurement is steps-to-criterion `421` vs `237` on the traces above
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - official `run-receipt.mjs start` failed before trace: `--client must be a concrete identifier`; this checkout origin is elizaOS/asi not SlopDotCash/asi; shared primary remotes were not mutated

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-asi
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-asi"} -->
