### PR TITLE
fix(streams): score identical floor-level gauntlet savings as 1

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -1311,13 +1311,22 @@ def savings_ratio(
     Values > 1 mean the learner re-entered the recurring task closer to its
     old solution than it started at first exposure — the savings measure of
     memory.  A memoryless learner scores ~1; a learner whose representation
-    isolates tasks scores >> 1.  (Early-window MSE is used rather than
-    steps-to-criterion because it stays informative for learners whose
-    asymptotic error sits near the criterion threshold.)
+    isolates tasks scores >> 1.  Identical entry windows at or below the
+    ``1e-8`` numerical floor score ``1`` (same identity as
+    :func:`savings_ratio_steps`), not ``0``.  (Early-window MSE is used
+    rather than steps-to-criterion because it stays informative for learners
+    whose asymptotic error sits near the criterion threshold.)
     """
     first = early_window_mse(sq_errors, first_segment, segment_length, window)
     revisit = early_window_mse(sq_errors, revisit_segment, segment_length, window)
-    return first / jnp.maximum(revisit, 1e-8)
+    # The 1e-8 floor only prevents a zero-denominator blow-up. When both
+    # entry windows sit at or below that floor they are indistinguishable
+    # (oracle / noiseless / underflow), so the ratio is 1 — the same
+    # identity savings_ratio_steps already uses via max(steps, 1).
+    floor = jnp.asarray(1e-8, dtype=jnp.promote_types(first.dtype, jnp.float32))
+    both_at_floor = (first <= floor) & (revisit <= floor)
+    ratio = first / jnp.maximum(revisit, floor)
+    return jnp.where(both_at_floor, jnp.ones_like(ratio), ratio)
 
 
 def savings_ratio_steps(

--- a/tests/test_gauntlet_savings_identical_floor.py
+++ b/tests/test_gauntlet_savings_identical_floor.py
@@ -1,0 +1,59 @@
+"""savings_ratio must not report 0 when both entry windows sit at the floor."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+
+from alberta_framework.streams.gauntlet import (
+    GauntletConfig,
+    gauntlet_scorecard,
+    savings_ratio,
+    savings_ratio_steps,
+)
+
+
+def _nine_segment(values: float | np.ndarray, *, segment_length: int = 8, n_seeds: int = 2):
+    if np.ndim(values) == 0:
+        body = jnp.full((n_seeds, 9 * segment_length), float(values), dtype=jnp.float32)
+    else:
+        body = jnp.asarray(values, dtype=jnp.float32)
+    return body, segment_length
+
+
+def test_identical_zero_entry_windows_score_one_not_zero() -> None:
+    sq, length = _nine_segment(0.0)
+    ratio = np.asarray(savings_ratio(sq, 2, 4, length, window=4))
+    steps = np.asarray(savings_ratio_steps(sq, 2, 4, length, threshold=0.05))
+    np.testing.assert_allclose(ratio, [1.0, 1.0])
+    np.testing.assert_allclose(steps, [1.0, 1.0])
+
+
+def test_identical_underflow_entry_windows_score_one_not_floor_ratio() -> None:
+    sq, length = _nine_segment(1e-12)
+    ratio = np.asarray(savings_ratio(sq, 2, 4, length, window=4))
+    # Origin/main reported 1e-12 / 1e-8 = 1e-4.
+    np.testing.assert_allclose(ratio, [1.0, 1.0])
+
+
+def test_memoryless_identical_nonzero_windows_stay_one() -> None:
+    sq, length = _nine_segment(1.0)
+    ratio = np.asarray(savings_ratio(sq, 2, 4, length, window=4))
+    np.testing.assert_allclose(ratio, [1.0, 1.0])
+
+
+def test_perfect_first_worse_revisit_still_zero() -> None:
+    length = 8
+    sq = jnp.ones((2, 9 * length), dtype=jnp.float32)
+    sq = sq.at[..., 2 * length : 3 * length].set(0.0)
+    ratio = np.asarray(savings_ratio(sq, 2, 4, length, window=4))
+    np.testing.assert_allclose(ratio, [0.0, 0.0])
+
+
+def test_scorecard_zero_program_reports_identity_savings() -> None:
+    config = GauntletConfig(segment_length=200, relevant_dim=2, irrelevant_dim=0)
+    sq = jnp.zeros((2, 9 * config.segment_length), dtype=jnp.float32)
+    card = gauntlet_scorecard(sq, config)
+    np.testing.assert_allclose(np.asarray(card["savings_c"]), [1.0, 1.0])
+    np.testing.assert_allclose(np.asarray(card["savings_d"]), [1.0, 1.0])
+    np.testing.assert_allclose(np.asarray(card["savings_c_final"]), [1.0, 1.0])


### PR DESCRIPTION
## Outcome

Fix.

`savings_ratio` / `gauntlet_scorecard` (documented public gauntlet API in `alberta_framework.streams.gauntlet`) silently reported memory savings `0` when both entry windows were at or below the `1e-8` denominator floor — an oracle, noiseless, or underflow pair that is indistinguishable.

Supported path: `from alberta_framework.streams.gauntlet import savings_ratio, gauntlet_scorecard`. `GauntletConfig.noise_std = 0` is legal. The sibling `savings_ratio_steps` already uses `max(steps, 1)` so identical never-recovered (or zero) traces score `1`.

On live origin/main `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`:

```
sq = zeros((2, 9 * 200))
gauntlet_scorecard(sq, GauntletConfig(segment_length=200)).savings_c  ->  0.0
savings_ratio(zeros(...), 2, 4, 8, window=4)                         ->  0.0
savings_ratio(full(..., 1e-12), 2, 4, 8, window=4)                   ->  1e-4   # 1e-12 / 1e-8
savings_ratio_steps(zeros(...), 2, 4, 8, threshold=0.05)             ->  1.0
```

After the one-boundary fix the same zero and `1e-12` calls return `1.0`. Memoryless identical nonzero windows stay `1`. Perfect-first / worse-revisit stays `0`. All-finite ones traces stay bit-identical.

Load-bearing: reverting only the `savings_ratio` return to origin makes the three new tests fail `0.0` / `1e-4` vs `1.0`.

This is not a Kayvan skip-zero / exact-dict series, not a 10000-cap / walk-bound sibling of #2697, not a JEPA late-return glance-slice of #2696, not metrics.py FWT / tracking-error / recovery_lengths (#2694/#2695), and not the gauntlet EMA / steps-to-criterion NaN poison of #2698. No open ASI PR titles the same hole.

## Measurement gate

- Lane: documented gauntlet API `savings_ratio` / `gauntlet_scorecard`
- Metric: re-acquisition savings (`early_mse_first / early_mse_revisit`)
- Origin proof at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`: zero-program `savings_c = 0.0`; underflow pair `1e-4`
- Overlay at this head: identity `1.0` on both; memoryless ones stay `1.0`; perfect-first stays `0.0`
- Focused pytest `tests/test_gauntlet_savings_identical_floor.py` + `tests/test_gauntlet_scorecard_window.py`: 8 passed
- Related hostile / window tests: 20 passed
- `ruff check` on the two changed files: clean
- One production file: `alberta_framework/streams/gauntlet.py`

<!-- evidence-head:a482ad9a498367b521a88ef1723c62689945dd74 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - focused unit tests on the documented gauntlet API; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact; the measurement is savings `0.0` / `1e-4` vs `1.0` on the traces above
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - official `run-receipt.mjs start` failed before trace: `--client must be a concrete identifier`; this checkout origin is elizaOS/asi not SlopDotCash/asi; shared primary remotes were not mutated

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi"} -->
