### PR TITLE
fix(core): keep SIGReg directions unit when the draw is below eps

### DIFF
--- a/alberta_framework/core/sigreg.py
+++ b/alberta_framework/core/sigreg.py
@@ -335,8 +335,20 @@ def sample_sigreg_directions(
         (cfg.n_projections, latent_dim),
         dtype=jnp.float32,
     )
+    # ``eps`` is a degeneracy floor, not a substitute denominator. Dividing a
+    # short Gaussian by ``eps`` silently returns a non-unit direction and
+    # changes the sliced SIGReg number. Renormalize after the floor so every
+    # returned row is a unit vector; exact-zero rows fall back to e_0.
+    eps = jnp.asarray(cfg.eps, dtype=jnp.float32)
     norms = jnp.linalg.norm(directions, axis=1, keepdims=True)
-    return directions / jnp.maximum(norms, jnp.asarray(cfg.eps, dtype=jnp.float32))
+    scaled = directions / jnp.maximum(norms, eps)
+    scaled_norms = jnp.linalg.norm(scaled, axis=1, keepdims=True)
+    # Second division uses the true scaled norm. Flooring it by ``eps``
+    # again would re-shorten any draw whose original norm is below ``eps``.
+    fallback = jnp.zeros_like(scaled).at[:, 0].set(1.0)
+    safe_scaled_norms = jnp.where(scaled_norms == 0.0, jnp.ones_like(scaled_norms), scaled_norms)
+    unit = scaled / safe_scaled_norms
+    return jnp.where(scaled_norms == 0.0, fallback, unit)
 
 
 def epps_pulley_gaussian_statistic(

--- a/tests/test_sigreg.py
+++ b/tests/test_sigreg.py
@@ -391,3 +391,35 @@ def test_sliced_sigreg_rejects_nonfinite_derived_projections() -> None:
     assert bool(jnp.isfinite(directions).all())
     with pytest.raises(ValueError, match="projected samples must be finite"):
         sliced_sigreg_loss(embeddings, directions)
+
+
+def test_sample_sigreg_directions_stay_unit_below_eps() -> None:
+    """A short Gaussian must still become a unit direction.
+
+    ``sample_sigreg_directions`` is the public sampler for sliced SIGReg.
+    The constructor accepts any positive ``eps`` floor. On origin/main a
+    one-dimensional draw whose abs-value is below that floor was divided
+    by ``eps`` and returned with norm ``|g|/eps < 1``. The sliced loss
+    then scored a collapsed projection instead of the true unit axis.
+    Frozen key 1 with ``eps=0.5`` is that supported path.
+    """
+    config = SIGRegConfig(n_projections=1, kernel_width=1.0, eps=0.5)
+    key = jr.key(1)
+    raw = jr.normal(key, (1, 1), dtype=jnp.float32)
+    assert float(jnp.abs(raw[0, 0])) < config.eps
+
+    directions = sample_sigreg_directions(key, latent_dim=1, config=config)
+    true_unit = raw / jnp.linalg.norm(raw, axis=1, keepdims=True)
+    chex.assert_trees_all_close(
+        jnp.linalg.norm(directions, axis=1),
+        jnp.ones((1,), dtype=jnp.float32),
+        atol=1.0e-5,
+    )
+    chex.assert_trees_all_close(jnp.abs(directions), jnp.abs(true_unit), atol=1.0e-5)
+
+    embeddings = jr.normal(jr.key(99), (64, 1), dtype=jnp.float32)
+    chex.assert_trees_all_close(
+        sliced_sigreg_loss(embeddings, directions, kernel_width=1.0),
+        sliced_sigreg_loss(embeddings, true_unit, kernel_width=1.0),
+        atol=1.0e-6,
+    )


### PR DESCRIPTION
## Outcome

Fix.

`sample_sigreg_directions` (documented public SIGReg sampler in `alberta_framework.core.sigreg`) silently returned a non-unit row when the Gaussian draw's norm was below `SIGRegConfig.eps`. The sliced Epps-Pulley number then scored a collapsed projection instead of the true unit axis.

Supported path: `sample_sigreg_directions(jr.key(1), latent_dim=1, config=SIGRegConfig(n_projections=1, kernel_width=1.0, eps=0.5))` then `sliced_sigreg_loss(embeddings, directions, kernel_width=1.0)`. The constructor accepts any positive `eps`; it does not require `||g|| >= eps`.

On live origin/main `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, frozen key `1` draws `g = -0.15443718`. `directions / max(||g||, 0.5)` returned norm `0.308874`. The same 64-sample N(0,1) batch then scored sliced SIGReg `0.113490` instead of the true-unit `0.003608`.

After the one-boundary fix the same call returns a unit row (sign of `g`) and sliced SIGReg `0.003608`. Default `eps=1e-8` / `latent_dim=5` key-0 unit-norm pin stays bit-identical. `eps` remains a degeneracy floor, not a substitute denominator.

Load-bearing: reverting only the sampler return to origin makes `test_sample_sigreg_directions_stay_unit_below_eps` fail `0.308874` vs `1.0`.

This is not a Kayvan skip-zero / exact-dict series, not a 10000-cap / walk-bound sibling of #2697, not a JEPA late-return glance-slice of #2696, not metrics.py FWT / tracking-error / recovery_lengths (#2694/#2695), not a gauntlet EMA / savings floor (#2698/#2699), and not leftover-tax (CanonicalUPGD / feature_discovery / clocks / forager / IA / FTL / upgd / horde / dreaming / delight / export common-final-window). Dedup searched open ASI PRs via `https://api.github.com/repos/elizaOS/asi/pulls?state=open&per_page=100` and `https://api.github.com/repos/elizaOS/asi/pulls?state=open&per_page=100&page=2`; no open title covers SIGReg direction unit-norm. Occupied Hedge PRs (#2568/#2526/#2513) touch `resource_manager.py` / `feature_discovery.py`, not `sigreg.py`.

## Measurement gate

- Lane: documented SIGReg sampler + sliced loss (`alberta_framework.core.sigreg`)
- Metric: `sliced_sigreg_loss` after `sample_sigreg_directions`
- Origin proof at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`: direction norm `0.308874`, loss `0.113490`
- Overlay at this head: direction norm `1.0`, loss `0.003608` (key `1`, `eps=0.5`, 64-sample N(0,1) batch from key `99`)
- Focused pytest `tests/test_sigreg.py` + `tests/test_sigreg_host_array_depth.py`: 53 passed
- `ruff check` on the two changed files: clean
- One production file: `alberta_framework/core/sigreg.py`

<!-- evidence-head:2b8daefc569bbff60667902c2eb8cb73c624615a -->
<!-- evidence-row:logs -->
- [x] logs: N/A - focused unit tests on the documented SIGReg sampler; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact; the measurement is direction norm `0.308874` / loss `0.113490` vs unit `1.0` / `0.003608`
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - official `run-receipt.mjs start` failed before trace: `--client must be a concrete identifier`; this checkout origin is elizaOS/asi not SlopDotCash/asi; shared primary remotes were not mutated

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi"} -->
