### PR TITLE
fix(core): keep occupied prototype classes ahead of empty ones

### DIFF
--- a/alberta_framework/core/prototype_memory.py
+++ b/alberta_framework/core/prototype_memory.py
@@ -423,7 +423,7 @@ class PrototypeMemoryLearner:
         slot_logits = jnp.where(state.counts > 0.0, slot_logits, -jnp.inf)
         logits = jnp.max(slot_logits, axis=1)
         any_active = jnp.any(state.counts > 0.0, axis=1)
-        logits = jnp.where(any_active, logits, -1e9)
+        # Inactive classes keep -inf; only an all-empty bank becomes zeros.
         logits = jnp.where(jnp.any(any_active), logits, jnp.zeros_like(logits))
         inputs_valid = self._state_is_valid(state) & jnp.all(jnp.isfinite(x))
         return jnp.where(inputs_valid, logits, jnp.full_like(logits, jnp.nan))

--- a/tests/test_prototype_memory.py
+++ b/tests/test_prototype_memory.py
@@ -82,6 +82,41 @@ def test_empty_memory_predicts_uniformly() -> None:
     chex.assert_trees_all_close(prediction, jnp.full((4,), 0.25, dtype=jnp.float32))
 
 
+def test_occupied_class_keeps_mass_when_distance_is_below_empty_sentinel() -> None:
+    """An occupied class worse than -1e9 must not lose to an empty class.
+
+    ``class_logits`` used to replace empty-class max-slots with ``-1e9``.
+    A legal ``bandwidth=1e-8`` and a finite observation of ``5`` then scored
+    the occupied prototype at ``-2.5e9`` and the empty class at ``-1e9``, so
+    ``predict`` returned ``[0, 1]`` for a class that was never observed.
+    """
+    learner = PrototypeMemoryLearner(
+        PrototypeMemoryConfig(
+            feature_dim=1,
+            n_classes=2,
+            slots_per_class=1,
+            bandwidth=1e-8,
+        )
+    )
+    state = learner.init().replace(
+        means=learner.init().means.at[0, 0, 0].set(0.0),
+        counts=learner.init().counts.at[0, 0].set(1),
+    )
+    observation = jnp.asarray([5.0], dtype=jnp.float32)
+
+    logits = learner.class_logits(state, observation)
+    prediction = learner.predict(state, observation)
+
+    assert float(logits[0]) == pytest.approx(-2.5e9)
+    assert not bool(jnp.isfinite(logits[1]))
+    assert float(logits[1]) < 0.0
+    chex.assert_trees_all_close(
+        prediction,
+        jnp.asarray([1.0, 0.0], dtype=jnp.float32),
+    )
+    assert int(jnp.argmax(prediction)) == 0
+
+
 def test_repeated_update_moves_prediction_to_target_class() -> None:
     """A repeated class example should become confidently classified."""
     learner = PrototypeMemoryLearner(


### PR DESCRIPTION
## Outcome

Fix.

`PrototypeMemoryLearner.class_logits` / `predict` (documented public prototype-memory API in `alberta_framework.core.prototype_memory`) silently assigned all softmax mass to an empty class when an occupied prototype's mean-squared distance over `bandwidth` fell below the empty-class `-1e9` sentinel.

Supported path: `PrototypeMemoryConfig(n_classes=2, feature_dim=1, slots_per_class=1, bandwidth=1e-8)` then `predict` after occupying only class 0 at `0` and scoring observation `5`. The constructor accepts any positive finite `bandwidth`; it does not require `-||x-μ||² / bandwidth >= -1e9`. Finite observations are a documented predict path.

On live origin/main `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, that call returned logits `[-2.5e9, -1e9]` and probabilities `[0, 1]`. The never-observed class scored `1.0`.

After the one-boundary fix empty classes keep `-inf`. The same call returns logits `[-2.5e9, -inf]` and probabilities `[1, 0]`. The all-empty bank still predicts uniform (`test_empty_memory_predicts_uniformly`). Nearby occupied-class predictions at default bandwidth stay bit-identical.

Load-bearing: reverting only the empty-class logit to `-1e9` makes `test_occupied_class_keeps_mass_when_distance_is_below_empty_sentinel` fail `[0, 1]` vs `[1, 0]`.

This is not a Kayvan skip-zero / exact-dict series, not a 10000-cap / walk-bound sibling of #2697, not a JEPA late-return glance-slice of #2696, not metrics.py FWT / tracking-error / recovery_lengths (#2694/#2695), not a gauntlet EMA / savings floor (#2698/#2699), not the SIGReg unit-direction-below-eps hole (#2700), and not leftover-tax (CanonicalUPGD / feature_discovery / clocks / forager / IA / FTL / upgd / horde / dreaming / delight / export common-final-window). Dedup searched open ASI PRs via `https://api.github.com/repos/elizaOS/asi/pulls?state=open&per_page=100`; no open title covers prototype-memory empty-class sentinels.

## Measurement gate

- Lane: documented prototype-memory predictor (`alberta_framework.core.prototype_memory`)
- Metric: `predict` / `class_logits` class mass after a one-class occupancy
- Origin proof at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`: logits `[-2.5e9, -1e9]`, probabilities `[0.0, 1.0]`
- Overlay at this head: logits `[-2.5e9, -inf]`, probabilities `[1.0, 0.0]` (`bandwidth=1e-8`, occupied prototype `0`, observation `5`)
- Focused pytest `tests/test_prototype_memory.py` + `tests/test_prototype_memory_validation.py`: 154 passed
- `ruff check` on the two changed files: clean
- One production file: `alberta_framework/core/prototype_memory.py`

<!-- evidence-head:9649d84408195014a4aa0e1231c5581ba8923b74 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - focused unit tests on the documented prototype-memory predictor; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact; the measurement is empty-class mass `1.0` vs occupied mass `1.0`
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - official `run-receipt.mjs start` failed before trace: `--client must be a concrete identifier`; this checkout origin is elizaOS/asi not SlopDotCash/asi; shared primary remotes were not mutated

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi"} -->
