### PR TITLE
fix(core): keep one SparseInit connection when rounding hits fan_in

### DIFF
--- a/alberta_framework/core/initializers.py
+++ b/alberta_framework/core/initializers.py
@@ -152,7 +152,14 @@ def sparse_init(
     if num_zeros <= 0:
         return weights
     if num_zeros >= fan_in:
-        return jnp.zeros_like(weights)
+        if sparsity_validated >= 1.0:
+            return jnp.zeros_like(weights)
+        # sparsity < 1 must keep one live incoming weight per row. The
+        # nearest-int count can equal fan_in (0.9 * 5 + 0.5 == 5.0) and
+        # the previous branch then returned an all-zero matrix.
+        num_zeros = fan_in - 1
+        if num_zeros <= 0:
+            return weights
 
     # Exact per-row sparsity without per-row random permutations.  `jr.permutation`
     # lowers to a shuffle kernel that can be very slow to compile in large suites.

--- a/tests/test_initializers.py
+++ b/tests/test_initializers.py
@@ -104,6 +104,24 @@ class TestSparseInit:
         chex.assert_shape(weights, (32, 16))
         assert jnp.all(weights == 0)
 
+    def test_default_sparsity_keeps_one_connection_when_rounding_hits_fan_in(self):
+        """Default sparsity=0.9 on fan_in=5 must not wipe every incoming weight.
+
+        ``int(0.9 * 5 + 0.5)`` is 5, and the ``num_zeros >= fan_in`` branch
+        used to return an all-zero matrix. The constructor accepts any
+        positive ``fan_in``; it does not require
+        ``round(sparsity * fan_in) < fan_in``. One live connection per row
+        remains when the requested sparsity is below 1.
+        """
+        weights = sparse_init(jr.key(0), (4, 5), sparsity=0.9)
+
+        assert not bool(jnp.all(weights == 0))
+        zeros_per_row = jnp.sum(weights == 0, axis=1)
+        chex.assert_trees_all_close(zeros_per_row, jnp.full((4,), 4))
+        assert float(jnp.mean(weights == 0)) == pytest.approx(0.8)
+        nonzero_per_row = jnp.sum(weights != 0, axis=1)
+        chex.assert_trees_all_close(nonzero_per_row, jnp.ones((4,), dtype=nonzero_per_row.dtype))
+
     @pytest.mark.parametrize(
         "invalid_shape",
         [


### PR DESCRIPTION
## Outcome

Fix.

`sparse_init` (documented public SparseInit helper in `alberta_framework.core.initializers`) silently returned an all-zero matrix when the nearest-int zero count reached `fan_in` while the requested sparsity was still below 1.

Supported path: `sparse_init(jr.key(0), (4, 5), sparsity=0.9)`. The constructor accepts any positive `fan_in` and any finite sparsity in `[0, 1]`; it does not require `round(sparsity * fan_in) < fan_in`. Default sparsity is `0.9`. `int(0.9 * 5 + 0.5)` is `5`.

On live origin/main `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, that call returned a `(4, 5)` zero matrix. Realized sparsity `1.0`. Nonzero weights per row `[0, 0, 0, 0]`.

After the one-boundary fix a requested sparsity below 1 keeps one live incoming weight per row. The same call returns realized sparsity `0.8` and nonzero-per-row `[1, 1, 1, 1]`. `sparsity=1.0` still returns all zeros (`test_one_sparsity`). Large-`fan_in` default pins stay exact: `fan_in=50` / `sparsity=0.8` still has 40 zeros per row; `fan_in=100` / `sparsity=0.9` still realizes `0.9`.

Load-bearing: reverting only the `num_zeros >= fan_in` branch to an unconditional all-zero return makes `test_default_sparsity_keeps_one_connection_when_rounding_hits_fan_in` fail `1.0` vs `0.8`.

This is not a Kayvan skip-zero / exact-dict series, not a 10000-cap / walk-bound sibling of #2697, not a JEPA late-return glance-slice of #2696, not metrics.py FWT / tracking-error / recovery_lengths (#2694/#2695), not a gauntlet EMA / savings floor (#2698/#2699), not the SIGReg unit-direction-below-eps hole (#2700), not the PrototypeMemoryLearner empty-class sentinel (#2701), and not leftover-tax (CanonicalUPGD / feature_discovery / clocks / forager / IA / FTL / upgd / horde / dreaming / delight / export common-final-window). Dedup searched open ASI PRs via `gh pr list --repo elizaOS/asi --state open --limit 200`; no open title covers SparseInit / `initializers.py` row wipe.

## Measurement gate

- Lane: documented SparseInit helper (`alberta_framework.core.initializers`)
- Metric: realized per-row sparsity after `sparse_init`
- Origin proof at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`: all-zero `(4, 5)`, realized sparsity `1.0`, nonzero-per-row `[0, 0, 0, 0]`
- Overlay at this head: realized sparsity `0.8`, nonzero-per-row `[1, 1, 1, 1]` (`jr.key(0)`, shape `(4, 5)`, `sparsity=0.9`)
- Focused pytest `tests/test_initializers.py` + `tests/test_initializers_validation.py`: 43 passed
- `ruff check` on the two changed files: clean
- One production file: `alberta_framework/core/initializers.py`

<!-- evidence-head:0e1d61ddf5f481e8c148dc34c3050d4fc045c085 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - focused unit tests on the documented SparseInit helper; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact; the measurement is realized sparsity `1.0` vs `0.8`
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - official `run-receipt.mjs start` failed before trace: `--client must be a concrete identifier`; this checkout origin is elizaOS/asi not SlopDotCash/asi; shared primary remotes were not mutated

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi"} -->
