### PR TITLE
fix(ipmnist): reject oversized slope windows

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -11519,6 +11519,8 @@ def merge_shards(
             f"seed sets differ across configs: {seed_sets}; "
             "merge_shards ranks configs on paired seeds only"
         )
+    if slope_window > shards[0]["config"]["n_tasks"]:
+        raise ValueError("slope_window cannot exceed n_tasks")
 
     entries: list[dict[str, Any]] = []
     for name, per_seed in sorted(by_config.items()):

--- a/tests/test_ipmnist_screening_provenance.py
+++ b/tests/test_ipmnist_screening_provenance.py
@@ -684,6 +684,18 @@ def test_merge_rejects_invalid_slope_window(
         )
 
 
+def test_merge_rejects_slope_window_larger_than_task_trace(tmp_path: Path) -> None:
+    path = tmp_path / "shard.json"
+    path.write_text(json.dumps(_payload()), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="slope_window cannot exceed n_tasks"):
+        screening.merge_shards(
+            [path],
+            control_name="upgd_w_control",
+            slope_window=SMALL.n_tasks + 1,
+        )
+
+
 def test_proxy_validation_refuses_mixed_or_mismatched_v2_provenance(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Defect

The documented `alberta_framework.benchmarks.ipmnist_screening merge` path accepted a `slope_window` larger than the validated task trace. NumPy silently shortened `per_task_accuracy[-window:]`, so a valid two-task shard merged with the CLI default published a numeric two-task slope while the artifact claimed `slope_window: 15`.

Base: `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (`origin/main` at branch creation and immediately before commit).

Before, using a consistently trimmed copy of the checked-in legacy `colnorm_gate_seed0.json` shard through the supported merge CLI:

```text
2026-08-27 13:52:13,448 INFO merged 1 shards -> /repro/summary-before.json
{'requested_slope_window': 15, 'actual_task_count': 2, 'published_late_window_slope': 0.0116}
```

The source module executed for this reproduction had SHA-256 `a3705873327fda5feb89b1409c9d6cf7898fcba8a7242864fde663140d006d18`, byte-identical to the module at the base commit.

## Fix

`merge_shards` now rejects `slope_window > n_tasks` after existing shard identity, mode, and seed-set validation, immediately before metric computation. This is one guard at the aggregation boundary; no call sites or evidence artifacts changed.

After, the same CLI invocation exits before publishing a summary:

```text
ValueError: slope_window cannot exceed n_tasks
```

## Regression proof

The new regression test fails on the unfixed production code:

```text
FAILED tests/test_ipmnist_screening_provenance.py::test_merge_rejects_slope_window_larger_than_task_trace
E       Failed: DID NOT RAISE ValueError
1 failed in 1.45s
```

I produced that result by removing only the two-line production guard while retaining the test, then restored the guard. With the fix restored:

```text
1 passed in 1.39s
```

## Verification

Head tested: `afe40080d02fc847be6cd9e220078fe36bc470c1`.

```text
tests/test_ipmnist_screening.py
340 passed in 96.47s

tests/test_ipmnist_screening_provenance.py
41 passed, 12 deselected in 1.88s
```

The exact-head 340-test run was recorded by the required proof runner in a network-disabled container capped at two CPUs. The 12 deselected provenance fixtures require `git`, which the prebuilt dependency image does not contain; the attempted full-file run produced those 12 environment-only failures and 41 passes. `pytest -n 2` was attempted first, but pytest-xdist is not installed, so subsequent tests ran serially under the two-CPU cap. Ruff and mypy were also absent from the checkout and both prebuilt ASI images; no dependencies were installed. `git diff --check` passed.

This is a deterministic harness/metric-integrity fix. It consumes no benchmark seeds, changes no benchmark result, writes no repository output artifact, and makes no promoting claim.

<!-- evidence-head:afe40080d02fc847be6cd9e220078fe36bc470c1 -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [runtime-defect]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M11QJ96SQ8SW7FCYZYHP6XY7","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-27T13:46:47.897Z","completed_at":"2026-08-27T14:08:54.285Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-27T13:46:49.062Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"58f775d14fdc386b87816121156f29da792fdd7235be23556d4184553b5db4c0","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3d4340f5-6ee2-4ce6-8d29-44ac0cf9cc49","object_id":"sha256:58f775d14fdc386b87816121156f29da792fdd7235be23556d4184553b5db4c0","sha256":"58f775d14fdc386b87816121156f29da792fdd7235be23556d4184553b5db4c0"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA3qp2qlPvWwwKfIl5iPln7EUrHBcgqCX-87Cz0b_VVk0","device_key_id":"7fe9e8ddf85097400d555bf61a271e57f5b547ced7e28fe091fbbd54452478cb","device_signature":"MZu6cQ5RJY1bo6ur429QaSqOyi1BL88TXCU5NLu-VpPgLoTXANV1UHoo3khB7-oS5Z06_VagOmYCBdUF1PwACA"}} -->
