### PR TITLE
fix(core): score working-memory innovations against the fastest trace

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -51,7 +51,7 @@ class WorkingMemoryConfig:
         include_current_action: Include the current action vector in output.
         include_current_reward: Include the current reward vector in output.
         include_traces: Include all trace banks in output.
-        include_innovations: Include current-minus-fast-trace innovations.
+        include_innovations: Include current minus the fastest trace (lowest decay, first on ties).
         gated_update: If true, trace updates are scaled by a surprise gate.
         gate_threshold: Surprise level where gated updates start opening.
         gate_temperature: Positive softness for the surprise gate.
@@ -389,6 +389,12 @@ def _validate_config(config: WorkingMemoryConfig) -> None:
     )
 
 
+
+def _fastest_trace_index(rates: tuple[float, ...]) -> int:
+    """Return the fastest EMA row: lowest decay, first listed on ties."""
+    return min(range(len(rates)), key=lambda index: (rates[index], index))
+
+
 def _empty_or_vector(value: Array, dim: int) -> Array:
     _require_array("vector", value, shape=(dim,))
     return jnp.asarray(value)
@@ -552,10 +558,16 @@ class WorkingMemoryFeaturizer:
         """Return a zero reward vector with the configured dimension."""
         return jnp.zeros((self._config.reward_dim,), dtype=jnp.float32)
 
-    def _surprise_gate(self, traces: Array, value: Array, threshold: Array) -> Array:
+    def _surprise_gate(
+        self,
+        traces: Array,
+        value: Array,
+        threshold: Array,
+        fast_index: int,
+    ) -> Array:
         if (not self._config.gated_update) or traces.shape[0] == 0 or value.size == 0:
             return jnp.asarray(1.0, dtype=jnp.float32)
-        surprise = _root_mean_square(value - traces[0])
+        surprise = _root_mean_square(value - traces[fast_index])
         temperature = jnp.asarray(self._config.gate_temperature, dtype=jnp.float32)
         return jax.nn.sigmoid((surprise - threshold) / temperature)
 
@@ -610,11 +622,22 @@ class WorkingMemoryFeaturizer:
             )
         if cfg.include_innovations:
             if len(cfg.observation_decay_rates) > 0:
-                blocks.append(obs - state.observation_traces[0])
+                blocks.append(
+                    obs
+                    - state.observation_traces[
+                        _fastest_trace_index(cfg.observation_decay_rates)
+                    ]
+                )
             if len(cfg.action_decay_rates) > 0:
-                blocks.append(act - state.action_traces[0])
+                blocks.append(
+                    act
+                    - state.action_traces[_fastest_trace_index(cfg.action_decay_rates)]
+                )
             if len(cfg.reward_decay_rates) > 0:
-                blocks.append(rew - state.reward_traces[0])
+                blocks.append(
+                    rew
+                    - state.reward_traces[_fastest_trace_index(cfg.reward_decay_rates)]
+                )
         return jnp.concatenate(blocks, axis=0)
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -657,16 +680,21 @@ class WorkingMemoryFeaturizer:
             state.observation_traces,
             safe_obs,
             threshold,
+            _fastest_trace_index(cfg.observation_decay_rates)
+            if cfg.observation_decay_rates
+            else 0,
         )
         action_gate = outer_gate * self._surprise_gate(
             state.action_traces,
             safe_act,
             threshold,
+            _fastest_trace_index(cfg.action_decay_rates) if cfg.action_decay_rates else 0,
         )
         reward_gate = outer_gate * self._surprise_gate(
             state.reward_traces,
             safe_rew,
             threshold,
+            _fastest_trace_index(cfg.reward_decay_rates) if cfg.reward_decay_rates else 0,
         )
 
         candidate = WorkingMemoryState(

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -117,6 +117,49 @@ def test_working_memory_trace_decay_and_feature_causality() -> None:
     chex.assert_trees_all_close(state2.observation_traces[0], jnp.asarray([0.5]))
 
 
+
+
+def test_innovation_uses_fastest_decay_not_first_listed_rate() -> None:
+    """``include_innovations`` subtracts the fastest trace, not ``traces[0]``.
+
+    Decay rates are an unordered supported tuple. The constructor accepts
+    ``(0.99, 0.0)``: 0.99 is a long-horizon EMA and 0.0 is a full replace.
+    After one write of 4.0 the slow row is 0.04 and the fast row is 4.0, so
+    the documented current-minus-fast-trace innovation is 0. Using the first
+    listed row silently returns 3.96 instead.
+    """
+    config = WorkingMemoryConfig(
+        observation_dim=1,
+        action_dim=0,
+        reward_dim=0,
+        observation_decay_rates=(0.99, 0.0),
+        action_decay_rates=(),
+        reward_decay_rates=(),
+        include_current_observation=False,
+        include_current_action=False,
+        include_current_reward=False,
+        include_traces=True,
+        include_innovations=True,
+    )
+    memory = WorkingMemoryFeaturizer(config)
+    observation = jnp.asarray([4.0])
+    state = memory.update(
+        memory.init(),
+        observation,
+        memory.zero_action(),
+        memory.zero_reward(),
+    )
+    features = memory.features(
+        state,
+        observation,
+        memory.zero_action(),
+        memory.zero_reward(),
+    )
+    chex.assert_trees_all_close(state.observation_traces[0], jnp.asarray([0.04]), atol=1e-6)
+    chex.assert_trees_all_close(state.observation_traces[1], jnp.asarray([4.0]))
+    chex.assert_trees_all_close(features, jnp.asarray([0.04, 4.0, 0.0]), atol=1e-6)
+
+
 def test_working_memory_reset_semantics() -> None:
     memory = WorkingMemoryFeaturizer(
         WorkingMemoryConfig(observation_dim=2, action_dim=1, reward_dim=1)


### PR DESCRIPTION
## Outcome

Fix.

`WorkingMemoryFeaturizer.features` (documented public helper in `alberta_framework.core.working_memory`) silently scored `include_innovations` against `traces[0]` instead of the fastest EMA. The constructor accepts any decay tuple in `[0, 1)` and does not require the fastest (lowest) rate to be listed first. The config contract calls this block current-minus-fast-trace.

Supported path: `WorkingMemoryConfig(observation_dim=1, action_dim=0, reward_dim=0, observation_decay_rates=(0.99, 0.0), action_decay_rates=(), reward_decay_rates=(), include_current_observation=False, include_current_action=False, include_current_reward=False, include_traces=True, include_innovations=True)`, then one `update`/`features` cycle on observation `4.0`. `0.99` is a long-horizon EMA; `0.0` is a documented full replace.

On live origin/main `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, that path stored traces `[0.04, 4.0]` and returned features `[0.04, 4.0, 3.96]`. The documented fast-trace innovation is `4.0 - 4.0 = 0.0`. The implementation returned the slow residual `3.96`.

After the one-boundary fix the same call returns `[0.04, 4.0, 0.0]`. Default increasing rates `(0.5, 0.9, 0.99)` still use row 0 (already fastest). Equal fastest rates keep the first listed row.

Load-bearing: reverting only the observation innovation to `traces[0]` makes `test_innovation_uses_fastest_decay_not_first_listed_rate` fail `3.96` vs `0.0`.

This is not a Kayvan skip-zero / exact-dict series, not a 10000-cap / walk-bound sibling of #2697, not a JEPA late-return glance-slice of #2696, not metrics.py FWT / tracking-error (#2694/#2695), not a gauntlet EMA / savings floor (#2698/#2699), not the SIGReg unit-direction-below-eps hole (#2700), not the PrototypeMemoryLearner empty-class sentinel (#2701), not SparseInit fan_in wipe (#2702), and not leftover-tax (clocks / forager / IA / FTL / upgd / horde / dreaming / delight / export). Dedup searched occupancy (`scannedAt=2026-08-27T14:03:31.213Z`) plus open ASI titles; no open PR covers working-memory fast-trace innovation.

## Measurement gate

- Lane: documented WorkingMemory helper (`alberta_framework.core.working_memory`)
- Metric: `include_innovations` feature value after one write of `4.0` on rates `(0.99, 0.0)`
- Origin proof at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`: features `[0.04, 4.0, 3.96]`
- Overlay at this head: features `[0.04, 4.0, 0.0]`
- Focused pytest `tests/test_working_memory.py` + `tests/test_working_memory_validation.py` `-n 2`: 155 passed
- `ruff check` on the two changed files: clean
- One production file: `alberta_framework/core/working_memory.py`

<!-- evidence-head:3cdaa6021a7fe0dd2176acba10f3b2822af69cbd -->
<!-- evidence-row:logs -->
- [x] logs: N/A - focused unit tests on the documented WorkingMemory helper; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact; the measurement is innovation `3.96` vs `0.0`
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - official `run-receipt.mjs start` could not be bound/executed in this Grok Bot.app session (`The executable content could not be bound to this review`); this checkout origin is elizaOS/asi not SlopDotCash/asi; shared primary remotes were not mutated

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi"} -->
