### PR TITLE
fix(core): report a simplex when behavior-model floor mass is empty

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -225,11 +225,15 @@ def floor_and_renormalize_probabilities(
     if min_probability * n_actions >= 1.0:
         return jnp.ones_like(probs) / n_actions
     clipped = jnp.maximum(probs, 0.0)
-    normalizer = jnp.maximum(
-        jnp.sum(clipped, axis=-1, keepdims=True),
-        jnp.asarray(1e-12, dtype=jnp.float32),
-    )
-    normalized = clipped / normalizer
+    mass = jnp.sum(clipped, axis=-1, keepdims=True)
+    # A 1e-12 denominator floor on a zero (or nonpositive) mass scaled the
+    # zero vector by (1 - n*eps) and returned n*eps, not a simplex. Empty
+    # mass is the documented uniform fallback; positive mass divides by the
+    # actual sum so a tiny but nonzero vector still renormalizes to 1.
+    has_mass = mass > 0.0
+    safe_mass = jnp.where(has_mass, mass, jnp.ones_like(mass))
+    uniform = jnp.ones_like(clipped) / jnp.asarray(n_actions, dtype=jnp.float32)
+    normalized = jnp.where(has_mass, clipped / safe_mass, uniform)
     floor_mass = jnp.asarray(min_probability * n_actions, dtype=jnp.float32)
     return jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
 

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -389,6 +389,40 @@ def test_probability_simplex_and_helper_invariants() -> None:
     chex.assert_trees_all_close(logs, jnp.log(selected))
 
 
+def test_floor_and_renormalize_empty_mass_is_uniform_simplex() -> None:
+    """Empty mass must report a proper simplex, not n * min_probability.
+
+    ``floor_and_renormalize_probabilities`` is the documented public helper
+    for sampling or reporting. An all-zero or all-nonpositive vector used to
+    return ``min_probability`` on every action (sum ``n * eps``) because a
+    1e-12 denominator floor scaled the zero vector by ``(1 - n * eps)``.
+    """
+    empty = floor_and_renormalize_probabilities(
+        jnp.zeros(4, dtype=jnp.float32),
+        min_probability=1e-6,
+    )
+    negative = floor_and_renormalize_probabilities(
+        jnp.array([-1.0, -2.0, -0.5, 0.0], dtype=jnp.float32),
+        min_probability=1e-6,
+    )
+    tiny = floor_and_renormalize_probabilities(
+        jnp.array([1e-20, 0.0, 0.0, 0.0], dtype=jnp.float32),
+        min_probability=1e-6,
+    )
+    occupied = floor_and_renormalize_probabilities(
+        jnp.array([0.0, 0.2, 0.3, 0.5], dtype=jnp.float32),
+        min_probability=0.01,
+    )
+
+    uniform = jnp.full((4,), 0.25, dtype=jnp.float32)
+    chex.assert_trees_all_close(empty, uniform, atol=1e-6)
+    chex.assert_trees_all_close(negative, uniform, atol=1e-6)
+    chex.assert_trees_all_close(jnp.sum(tiny), 1.0, atol=1e-6)
+    assert float(jnp.min(tiny)) >= 1e-6 - 1e-7
+    chex.assert_trees_all_close(jnp.sum(occupied), 1.0, atol=1e-6)
+    assert float(jnp.min(occupied)) >= 0.01 - 1e-7
+
+
 @pytest.mark.parametrize(
     "action",
     [


### PR DESCRIPTION
## Outcome

Fix.

`floor_and_renormalize_probabilities` (documented public helper in `alberta_framework.core.behavior_model`) silently returned `n * min_probability` instead of a simplex when the clipped mass was empty. The helper is the sampling/reporting path: it must return a valid simplex whose entries are at least `min_probability`. Importance-ratio denominators use `selected_action_probabilities` and are unchanged.

Supported path: `floor_and_renormalize_probabilities(jnp.zeros(4, dtype=jnp.float32), min_probability=1e-6)`. All-zero (and all-nonpositive) vectors are the neutralized/failed probability shape this same module already publishes.

On live origin/main `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, that call returned `[1e-6, 1e-6, 1e-6, 1e-6]` (sum `4e-6`). A valid simplex is uniform `[0.25, 0.25, 0.25, 0.25]`. A 1e-12 denominator floor scaled the zero vector by `(1 - n * eps)` and never rebuilt unit mass.

After the one-boundary fix the same call returns `[0.25, 0.25, 0.25, 0.25]`. Occupied mass `[0.0, 0.2, 0.3, 0.5]` with `min_probability=0.01` is bit-identical (`sum 1.0`). Tiny positive mass `1e-20` now renormalizes to a simplex instead of summing to `~4e-6`.

Load-bearing: restoring the 1e-12 denominator floor makes `test_floor_and_renormalize_empty_mass_is_uniform_simplex` fail `4e-6` vs `1.0`.

This is not a Kayvan skip-zero / exact-dict series, not a 10000-cap / walk-bound sibling of #2697, not a JEPA late-return glance-slice of #2696, not metrics.py FWT / tracking-error (#2694/#2695), not a gauntlet EMA / savings floor (#2698/#2699), not the SIGReg unit-direction-below-eps hole (#2700), not the PrototypeMemoryLearner empty-class sentinel (#2701), not SparseInit fan_in wipe (#2702), not working-memory fast-trace innovation (#2704), and not leftover-tax (clocks / forager / IA / FTL / upgd / horde / dreaming / delight / export). Dedup searched occupancy (`scannedAt=2026-08-27T14:28:13.730Z`) plus open ASI titles; no open PR covers behavior-model empty-mass simplex.

## Measurement gate

- Lane: documented BehaviorModel helper (`alberta_framework.core.behavior_model`)
- Metric: `floor_and_renormalize_probabilities` sum and vector after all-zero input of length 4 at `min_probability=1e-6`
- Origin proof at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`: `[1e-6, 1e-6, 1e-6, 1e-6]` (sum `4e-6`)
- Overlay at this head: `[0.25, 0.25, 0.25, 0.25]` (sum `1.0`)
- Focused pytest `tests/test_behavior_model.py` `-n 2`: 65 passed
- `ruff check` on the two changed files: clean
- One production file: `alberta_framework/core/behavior_model.py`

<!-- evidence-head:b8568ab8f60089160d30e12ba14ed5ffaf6c435c -->
<!-- evidence-row:logs -->
- [x] logs: N/A - focused unit tests on the documented BehaviorModel helper; no benchmark shard was run
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - no `outputs/**` artifact; the measurement is simplex sum `4e-6` vs `1.0`
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - official `run-receipt.mjs start` failed in this Grok Bot.app session (`--client must be a concrete identifier`; later `--help` bind-failed with `The executable content could not be bound to this review`); this checkout origin is elizaOS/asi not SlopDotCash/asi; shared primary remotes were not mutated

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Grok Bot.app
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: Grok Bot.app
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [grok-bot-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Bot.app","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi"} -->
