### PR TITLE
fix(tests): declare Linux-only renameat2 publication in slow-lane files

### DIFF
--- a/tests/test_forager_matched_final_analysis.py
+++ b/tests/test_forager_matched_final_analysis.py
@@ -52,8 +52,9 @@ from alberta_framework.benchmarks import (
 from alberta_framework.benchmarks import forager_matched_statistics as statistics
 from tests import test_forager_matched_executor as executor_fixtures
 from tests import test_forager_matched_open_protocol as protocol_fixtures
+from tests._forager_matched_platform import requires_renameat2
 
-pytestmark = [pytest.mark.integration, pytest.mark.slow]
+pytestmark = [pytest.mark.integration, pytest.mark.slow, requires_renameat2]
 
 
 def _sha(label: str) -> str:

--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -34,6 +34,7 @@ from alberta_framework.reference_life_checkpoint import (
     save_reference_life_checkpoint,
 )
 from alberta_framework.streams.closed_loop import SwitchingTwoStateConfig
+from tests._forager_matched_platform import HAS_RENAMEAT2, requires_renameat2
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
@@ -199,6 +200,7 @@ def saved_case(
     return runner, state, barrier_state, checkpoint
 
 
+@requires_renameat2
 def test_quiescent_checkpoint_restores_exact_continuation(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
 ) -> None:
@@ -257,6 +259,7 @@ def _rehash_bundle(path: Path) -> None:
     (path / "COMMITTED").write_text(f"{bundle_id}\n", encoding="ascii")
 
 
+@requires_renameat2
 def test_restore_rejects_incomplete_tampered_unknown_and_symlink_bundles(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -343,6 +346,7 @@ def test_restore_rejects_incomplete_tampered_unknown_and_symlink_bundles(
         load_reference_life_checkpoint(symlinked)
 
 
+@requires_renameat2
 def test_restore_rejects_rehashed_duplicate_prototype_metadata_key(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -363,6 +367,7 @@ def test_restore_rejects_rehashed_duplicate_prototype_metadata_key(
         load_reference_life_checkpoint(duplicate)
 
 
+@requires_renameat2
 def test_publish_failure_and_existing_generation_leave_runner_unchanged(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -394,6 +399,7 @@ def test_publish_failure_and_existing_generation_leave_runner_unchanged(
     assert not tuple(parent.glob(".*.staging-*"))
 
 
+@requires_renameat2
 def test_post_commit_lock_cleanup_failure_returns_committed_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -428,6 +434,7 @@ def _bundle_bytes(path: Path) -> dict[str, bytes | None]:
     }
 
 
+@requires_renameat2
 @pytest.mark.parametrize("stale", [False, True], ids=["current", "stale"])
 def test_save_to_existing_generation_is_rejected_without_mutation(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
@@ -459,6 +466,7 @@ def test_save_to_existing_generation_is_rejected_without_mutation(
     assert restored_runner.current_state is restored_state
 
 
+@requires_renameat2
 def test_save_inside_existing_generation_is_rejected_without_mutation(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -480,6 +488,7 @@ def test_save_inside_existing_generation_is_rejected_without_mutation(
     assert restored_runner.current_state is restored_state
 
 
+@requires_renameat2
 def test_save_through_ancestor_symlink_into_generation_is_rejected(
     saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
     tmp_path: Path,
@@ -503,6 +512,21 @@ def test_save_through_ancestor_symlink_into_generation_is_rejected(
     assert restored_runner.current_state is restored_state
 
 
+@pytest.mark.skipif(HAS_RENAMEAT2, reason="Linux publishes the generation instead of refusing")
+def test_save_fails_closed_without_renameat2_and_publishes_nothing(tmp_path: Path) -> None:
+    """Off Linux the publisher refuses before any generation becomes visible."""
+
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+    assert state.phase is LifePhase.QUIESCENT
+    with pytest.raises(OSError, match="atomic no-replace rename requires Linux renameat2"):
+        save_reference_life_checkpoint(runner, state, tmp_path)
+
+    published = [entry for entry in tmp_path.iterdir() if not entry.name.startswith(".")]
+    assert published == []
+
+
+@requires_renameat2
 def test_checkpoint_filesystem_publication_stays_inside_runner_barrier(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_reference_life_riverswim_checkpoint.py
+++ b/tests/test_reference_life_riverswim_checkpoint.py
@@ -30,6 +30,7 @@ from alberta_framework.reference_life_checkpoint import (
     save_reference_life_checkpoint,
 )
 from alberta_framework.streams.closed_loop import RiverSwimConfig, RiverSwimMDP
+from tests._forager_matched_platform import requires_renameat2
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
@@ -189,6 +190,7 @@ def _rehash_bundle(path: Path) -> None:
     (path / "COMMITTED").write_text(f"{bundle_id}\n", encoding="ascii")
 
 
+@requires_renameat2
 def test_riverswim_quiescent_checkpoint_restores_exact_stochastic_continuation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Three slow-lane files drive Linux-only `renameat2` no-replace publication without declaring it, so they are permanently red on macOS.
- Apply `requires_renameat2` at module level in `test_forager_matched_final_analysis.py` and per-test in the two checkpoint files, matching the existing platform helper.
- Add an inverse test that the checkpoint publisher refuses off Linux and leaves no visible generation.
- Production publication is unchanged.

Fixes #2323