### PR TITLE
fix(utils): preserve report metric direction

### DIFF
--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -723,6 +723,7 @@ def save_experiment_report(
     experiment_name: str,
     significance_results: dict[tuple[str, str], "SignificanceResult"] | None = None,
     metric: str = "squared_error",
+    lower_is_better: bool = True,
 ) -> dict[str, Path]:
     """Save a complete experiment report with all artifacts.
 
@@ -732,6 +733,7 @@ def save_experiment_report(
         experiment_name: Name for the experiment (used in filenames)
         significance_results: Optional pairwise significance test results
         metric: Primary metric to report
+        lower_is_better: Whether lower primary metric values are better
 
     Returns:
         Dictionary mapping artifact type to file path
@@ -740,6 +742,7 @@ def save_experiment_report(
     output_dir = _require_path(output_dir, name="output_dir")
     experiment_name = _require_filename_component(experiment_name)
     _require_exact_str("metric", metric)
+    lower_is_better = _require_exact_bool("lower_is_better", lower_is_better)
     if significance_results is not None:
         _preflight_significance_results(significance_results)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -764,6 +767,7 @@ def save_experiment_report(
         metric=metric,
         caption=f"{experiment_name} Results",
         label=f"tab:{experiment_name}",
+        lower_is_better=lower_is_better,
     )
     _write_text_atomically(latex_path, latex_content)
     artifacts["latex_table"] = latex_path
@@ -774,6 +778,7 @@ def save_experiment_report(
         results,
         significance_results=significance_results,
         metric=metric,
+        lower_is_better=lower_is_better,
     )
     _write_text_atomically(md_path, md_content)
     artifacts["markdown_table"] = md_path

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -451,6 +451,33 @@ def test_report_preflight_rejects_before_output_directory_mutation(
     assert list(existing.iterdir()) == [sentinel]
 
 
+def test_report_preserves_higher_is_better_table_direction(tmp_path: Path) -> None:
+    weak = _constant_result("weak", 0.2)
+    strong = _constant_result("strong", 0.9)
+    results = {
+        name: result._replace(
+            metric_arrays={"accuracy": result.metric_arrays[_METRIC]},
+            summary={"accuracy": result.summary[_METRIC]},
+        )
+        for name, result in (("weak", weak), ("strong", strong))
+    }
+
+    artifacts = save_experiment_report(
+        results,
+        tmp_path,
+        "accuracy_comparison",
+        metric="accuracy",
+        lower_is_better=False,
+    )
+
+    assert "| weak | 0.2000 ± 0.0000 |" in artifacts["markdown_table"].read_text()
+    assert "| strong | **0.9000** ± 0.0000 |" in artifacts["markdown_table"].read_text()
+    assert r"weak & 0.2000 $\pm$ 0.0000" in artifacts["latex_table"].read_text()
+    assert r"strong & \textbf{0.9000} $\pm$ 0.0000" in artifacts[
+        "latex_table"
+    ].read_text()
+
+
 @pytest.mark.parametrize("mode", ["summary_csv", "timeseries_csv", "json"])
 def test_shared_preflight_accepts_uint32_seed_boundaries(mode: str, tmp_path: Path) -> None:
     result = _timeseries_result()._replace(seeds=[0, (1 << 32) - 1])


### PR DESCRIPTION
`save_experiment_report` accepts an arbitrary primary metric, but the supported report path did not expose or forward the table renderers' metric direction. A caller saving an accuracy or reward report therefore silently marked the lowest-scoring method as best in both generated tables.

Supported path: `run_multi_seed_experiment`/`AggregatedResults` -> `save_experiment_report(..., metric="accuracy")` -> generated Markdown and LaTeX result tables.

Base: `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (`origin/main`).

Before:

```text
| Method | Error (mean ± std) | Seeds |
|--------|-------------------------|-------|
| weak | **0.2000** ± 0.0000 | 1 |
| strong | 0.9000 ± 0.0000 | 1 |
```

The report wrapper now accepts an exact `lower_is_better` boolean, validates it before filesystem mutation, and forwards it to the existing Markdown and LaTeX renderers at the single report-generation boundary.

After `lower_is_better=False`:

```text
| Method | Error (mean ± std) | Seeds |
|--------|-------------------------|-------|
| weak | 0.2000 ± 0.0000 | 1 |
| strong | **0.9000** ± 0.0000 | 1 |
```

Regression proof:

- Added one end-to-end report test that reads both saved table artifacts.
- Before the production change: `TypeError: save_experiment_report() got an unexpected keyword argument 'lower_is_better'` (`1 failed, 122 deselected`).
- With the fix: `1 passed, 122 deselected`.
- Mutation proof: removed only the production change while retaining the test; it failed on that same missing direction argument, then passed after restoring the fix.

Verification:

- `python -m pytest tests/test_export.py -q` -> `123 passed in 0.53s` (serial; one worker).
- `python -m ruff check alberta_framework/utils/export.py tests/test_export.py` -> `All checks passed!`.
- The supplied runtime lacks pytest-xdist, so the suite ran serially within the requested two-worker cap. A broader collection attempt was blocked by the supplied image's missing `matplotlib` dependency in `tests/test_utils_smoke.py`; dependencies were not reinstalled.

Evidence scope:

| Evidence class | Claim |
|---|---|
| Unit/runtime regression | The saved report preserves a caller-selected higher-is-better direction in both table formats. |
| Scientific/performance evidence | None; this changes report selection rendering only. |

AI provider/model: openai/gpt-5.6-sol

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [defect-fix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M128QDGB0P343YYR0NB1CPPC","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-27T18:46:41.931Z","completed_at":"2026-08-27T19:19:03.368Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-27T18:46:42.748Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"781e28c42c1c3ac17273dc6a90bf81afdff02fcc53c47ff024681da839085c61","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"83036d89-691e-46d7-b99a-ef0fdc600250","object_id":"sha256:781e28c42c1c3ac17273dc6a90bf81afdff02fcc53c47ff024681da839085c61","sha256":"781e28c42c1c3ac17273dc6a90bf81afdff02fcc53c47ff024681da839085c61"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA3qp2qlPvWwwKfIl5iPln7EUrHBcgqCX-87Cz0b_VVk0","device_key_id":"7fe9e8ddf85097400d555bf61a271e57f5b547ced7e28fe091fbbd54452478cb","device_signature":"MOtWYHysx30lA-MN5iXnPJ0EqDZt9EQpzwSworBBPEVeCQb6YImjuFZa36O9U_h-Am5F_XjnWHrvBuEVhCv3CQ"}} -->
