### PR TITLE
Fix causal running RMSE window attribution

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -298,15 +298,10 @@ def _sliding_sum(values: Array, window_size: int) -> Array:
     return prefix[window_size:] - prefix[:-window_size]
 
 
-def _pad_running_window(values: Array, window_size: int) -> Array:
-    pad = jnp.broadcast_to(values[0], (window_size - 1, values.shape[1]))
-    return jnp.concatenate([pad, values], axis=0)
-
-
 def _scaled_running_rmse_terms(
     errors: Array, window_size: int
 ) -> tuple[Array, Array, Array]:
-    """Return one global power-of-two scale and stable sliding RMS terms."""
+    """Return one power-of-two scale and stable sliding RMS terms."""
     scale = jnp.max(jnp.abs(errors), axis=0)
     _, exponent = jnp.frexp(scale)
     scaled_errors = jnp.ldexp(errors, -exponent)
@@ -319,7 +314,7 @@ def _scaled_running_rmse_terms(
 def _finite_running_rmse(errors: Array, window_size: int) -> Array:
     """Compute a finite sliding RMSE with a scale-free derivative."""
     exponent, _, scaled_running = _scaled_running_rmse_terms(errors, window_size)
-    return _pad_running_window(jnp.ldexp(scaled_running, exponent), window_size)
+    return jnp.ldexp(scaled_running, exponent)
 
 
 @_finite_running_rmse.defjvp
@@ -332,19 +327,14 @@ def _finite_running_rmse_jvp(
     exponent, scaled_errors, scaled_running = _scaled_running_rmse_terms(
         errors, window_size
     )
-    running = _pad_running_window(
-        jnp.ldexp(scaled_running, exponent), window_size
-    )
+    running = jnp.ldexp(scaled_running, exponent)
     safe_scaled_running = jnp.where(
         scaled_running > 0.0,
         scaled_running,
         jnp.ones_like(scaled_running),
     )
     numerator = _sliding_sum(scaled_errors * errors_dot, window_size) / window_size
-    running_dot = _pad_running_window(
-        numerator / safe_scaled_running,
-        window_size,
-    )
+    running_dot = numerator / safe_scaled_running
     return running, running_dot
 
 
@@ -421,7 +411,7 @@ def per_horizon_running_rmse(
 
     Returns:
         Array of shape ``(T, H)``. The first ``window_size - 1`` rows are
-        equal to ``running_rmse[window_size - 1]``.
+        ``NaN`` because a complete causal trailing window does not exist yet.
 
     Raises:
         ValueError: If the arrays do not have identical nonempty ``(T, H)``
@@ -437,11 +427,41 @@ def per_horizon_running_rmse(
             f"(got window_size={window_size}, n_steps={n_steps})"
         )
     errors = predictions - forward_returns
-    finite_columns = jnp.all(jnp.isfinite(errors), axis=0)
-    safe_errors = jnp.where(finite_columns[None, :], errors, jnp.zeros_like(errors))
-    stable_running = _finite_running_rmse(safe_errors, window_size)
-    nonfinite = jnp.broadcast_to(
-        jnp.max(jnp.abs(errors), axis=0),
-        stable_running.shape,
+    finite_errors = jnp.isfinite(errors)
+    safe_errors = jnp.where(finite_errors, errors, jnp.zeros_like(errors))
+    stable_windows = _finite_running_rmse(safe_errors, window_size)
+    finite_counts = _sliding_sum(finite_errors.astype(jnp.int32), window_size)
+    finite_windows = finite_counts == window_size
+    nan_counts = _sliding_sum(jnp.isnan(errors).astype(jnp.int32), window_size)
+    inf_counts = _sliding_sum(jnp.isinf(errors).astype(jnp.int32), window_size)
+    nan_diagnostic = jnp.broadcast_to(
+        jnp.sum(jnp.where(jnp.isnan(errors), errors, jnp.zeros_like(errors)), axis=0),
+        stable_windows.shape,
     )
-    return jnp.where(finite_columns[None, :], stable_running, nonfinite)
+    inf_diagnostic = jnp.broadcast_to(
+        jnp.max(
+            jnp.where(jnp.isinf(errors), jnp.abs(errors), jnp.zeros_like(errors)),
+            axis=0,
+        ),
+        stable_windows.shape,
+    )
+    nonfinite_windows = jnp.where(
+        nan_counts > 0,
+        nan_diagnostic,
+        jnp.where(
+            inf_counts > 0,
+            inf_diagnostic,
+            jnp.zeros_like(stable_windows),
+        ),
+    )
+    complete_windows = jnp.where(
+        finite_windows,
+        stable_windows,
+        nonfinite_windows,
+    )
+    warmup = jnp.full(
+        (window_size - 1, errors.shape[1]),
+        jnp.nan,
+        dtype=complete_windows.dtype,
+    )
+    return jnp.concatenate([warmup, complete_windows], axis=0)

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -406,6 +406,30 @@ class TestRMSE:
 
 
 class TestRunningRMSE:
+    def test_warmup_rows_do_not_use_future_errors(self) -> None:
+        predictions = jnp.asarray([[1.0], [3.0], [5.0]], dtype=jnp.float32)
+        returns = jnp.zeros_like(predictions)
+
+        running = per_horizon_running_rmse(predictions, returns, window_size=2)
+
+        expected = np.asarray(
+            [[np.nan], [np.sqrt(5.0)], [np.sqrt(17.0)]], dtype=np.float32
+        )
+        np.testing.assert_allclose(np.asarray(running), expected, rtol=1e-6)
+
+    @pytest.mark.parametrize("nonfinite", [jnp.nan, jnp.inf])
+    def test_future_nonfinite_does_not_poison_earlier_complete_window(
+        self, nonfinite: float
+    ) -> None:
+        predictions = jnp.asarray([[1.0], [3.0], [nonfinite]], dtype=jnp.float32)
+        returns = jnp.zeros_like(predictions)
+
+        running = per_horizon_running_rmse(predictions, returns, window_size=2)
+
+        assert bool(jnp.isnan(running[0, 0]))
+        assert float(running[1, 0]) == pytest.approx(np.sqrt(5.0))
+        assert not bool(jnp.isfinite(running[2, 0]))
+
     def test_large_finite_errors_do_not_overflow(self) -> None:
         predictions = jnp.asarray([[2.0e20], [2.0e20]], dtype=jnp.float32)
         returns = jnp.zeros_like(predictions)
@@ -413,10 +437,11 @@ class TestRunningRMSE:
         with jax.debug_infs(True):
             running = per_horizon_running_rmse(predictions, returns, window_size=2)
 
-        assert bool(jnp.all(jnp.isfinite(running)))
+        assert bool(jnp.isnan(running[0, 0]))
+        assert bool(jnp.isfinite(running[1, 0]))
         np.testing.assert_allclose(
-            np.asarray(running),
-            np.full((2, 1), 2.0e20, dtype=np.float32),
+            np.asarray(running[1:]),
+            np.full((1, 1), 2.0e20, dtype=np.float32),
         )
 
     @pytest.mark.parametrize("magnitude", [2.0e20, 1.0e38, 3.0e38])
@@ -440,7 +465,8 @@ class TestRunningRMSE:
 
         chex.assert_trees_all_close(eager, expected, rtol=5e-6, atol=0.0)
         chex.assert_trees_all_close(compiled, expected, rtol=5e-6, atol=0.0)
-        chex.assert_trees_all_close(tangent, jnp.ones_like(tangent), rtol=5e-6, atol=0.0)
+        expected_tangent = jnp.asarray([[0.0], [1.0]], dtype=jnp.float32)
+        chex.assert_trees_all_close(tangent, expected_tangent, rtol=5e-6, atol=0.0)
 
     def test_zero_running_rmse_uses_zero_eager_jit_and_jvp_gradient_convention(
         self,
@@ -476,8 +502,8 @@ class TestRunningRMSE:
         preds = jnp.zeros((t, h))
         truths = jnp.ones((t, h)) * 2.0
         running = per_horizon_running_rmse(preds, truths, window_size=5)
-        # All windows should contain the same constant error
-        np.testing.assert_allclose(np.asarray(running), 2.0, atol=1e-6)
+        assert bool(jnp.all(jnp.isnan(running[:4])))
+        np.testing.assert_allclose(np.asarray(running[4:]), 2.0, atol=1e-6)
 
     @pytest.mark.parametrize(
         "window_size",
@@ -550,7 +576,10 @@ class TestRunningRMSE:
         )
         expected_by_window = {
             1: np.array([[1.0, 2.0], [1.0, 2.0], [5.0, 10.0]], dtype=np.float32),
-            3: np.tile(np.array([[3.0, 6.0]], dtype=np.float32), (3, 1)),
+            3: np.array(
+                [[np.nan, np.nan], [np.nan, np.nan], [3.0, 6.0]],
+                dtype=np.float32,
+            ),
         }
 
         for window_size, expected in expected_by_window.items():
@@ -578,7 +607,8 @@ class TestRunningRMSE:
         running = per_horizon_running_rmse(predictions, returns, window_size=2)
 
         assert bool(jnp.all(jnp.isnan(running[:, 0])))
-        assert bool(jnp.all(jnp.isinf(running[:, 1])))
+        assert bool(jnp.isnan(running[0, 1]))
+        assert bool(jnp.isinf(running[1, 1]))
 
     def test_dynamic_jit_window_is_named_and_default_call_recovers(self) -> None:
         predictions = jnp.tile(jnp.array([[3.0, -4.0]], dtype=jnp.float32), (100, 1))
@@ -589,7 +619,8 @@ class TestRunningRMSE:
             compiled(predictions, returns, window_size=1)
 
         recovered = compiled(predictions, returns)
-        expected = np.tile(np.array([[3.0, 4.0]], dtype=np.float32), (100, 1))
+        expected = np.full((100, 2), np.nan, dtype=np.float32)
+        expected[-1] = np.array([3.0, 4.0], dtype=np.float32)
         np.testing.assert_array_equal(np.asarray(recovered), expected)
 
     def test_jit_rejects_broadcasting_at_the_shape_boundary(self) -> None:


### PR DESCRIPTION
DEFECT: The supported public path `from alberta_framework.utils.nexting import per_horizon_running_rmse` silently backdated the first complete trailing-window RMSE into the incomplete prefix. For a two-step window, step 0 therefore incorporated step 1's error. The same boundary reduced finiteness over an entire horizon column, so a later NaN or Inf also poisoned earlier valid windows.

This fixes the metric once at `per_horizon_running_rmse`: incomplete causal rows are unavailable (`NaN`), complete windows retain the existing stable sliding computation, and non-finite diagnostics are scoped to the windows that contain them. The implementation retains O(T * H) intermediate storage.

Base: `origin/main` at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`.

Before

```text
observed:
[[2.236068 ]
 [2.236068 ]
 [4.1231055]]
step_0_uses_future_step_1: True
```

After

```text
observed:
[[      nan]
 [2.236068 ]
 [4.1231055]]
step_0_is_unavailable: True
```

Regression proof

I reverted only `alberta_framework/utils/nexting.py`, kept the new tests, and ran the three focused cases with `pytest -n 2`. All three failed on the defect: the warmup was `2.236068` instead of `NaN`, and future NaN/Inf values corrupted an earlier complete window. Restoring the production fix made the full nexting module pass:

```text
bringing up nodes...
bringing up nodes...

........................................................................ [ 78%]
....................                                                     [100%]
92 passed in 6.46s
```

Additional verification:

- `ruff check .`: passed
- targeted strict mypy on `alberta_framework/utils/nexting.py`: passed
- maximum supported `(10000, 16)` shape smoke: passed, with 99 unavailable warmup rows and final mean RMSE 1.0
- full pytest reached `4292 passed, 76 skipped`; its 41 failures were unrelated existing macOS/Linux-only `O_TMPFILE`/`renameat2` cases in bounded-elastic and Forager paths
- full mypy reached the same existing macOS `os.O_TMPFILE` attribute error in `bounded_elastic_matched_runner.py`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [qualified-metric-defect]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M12BV36ZB5J2NZX5YC5559D0","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-27T19:41:08.191Z","completed_at":"2026-08-27T20:02:31.209Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-27T19:41:08.967Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c3f3e5cd1aa61060ac0b02a8f4fcd7ef2588899aa1048c6095e0914d6e2d7fe7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"720852f4-2294-4b21-a73b-896f64e049d7","object_id":"sha256:c3f3e5cd1aa61060ac0b02a8f4fcd7ef2588899aa1048c6095e0914d6e2d7fe7","sha256":"c3f3e5cd1aa61060ac0b02a8f4fcd7ef2588899aa1048c6095e0914d6e2d7fe7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA3qp2qlPvWwwKfIl5iPln7EUrHBcgqCX-87Cz0b_VVk0","device_key_id":"7fe9e8ddf85097400d555bf61a271e57f5b547ced7e28fe091fbbd54452478cb","device_signature":"RVQtMTOeM8XjE5O3GdmTVizqkesTmSDcJ7gz2WRSblrClLM5SIfRjTsREwjME7CB9z-m-sBhULTL7VeX8IjMAQ"}} -->
