### PR TITLE
fix(adamo): cap dead Jacobian condition metric

### DIFF
--- a/alberta_framework/benchmarks/adamo_diagnostic.py
+++ b/alberta_framework/benchmarks/adamo_diagnostic.py
@@ -113,6 +113,9 @@ def _diagnostic(params: Mapping[str, Array], sentinel: Array) -> dict[str, float
     singular = np.asarray(jnp.linalg.svd(jacobian, compute_uv=False), dtype=np.float64)
     minimum = float(np.min(singular))
     maximum = float(np.max(singular))
+    condition_number = (
+        1e12 if minimum == 0.0 else min(maximum / minimum, 1e12)
+    )
     rms_deviation = float(np.sqrt(np.mean(np.square(singular - 1.0))))
     gram_penalty = 0.0
     for value in materialized.values():
@@ -124,7 +127,7 @@ def _diagnostic(params: Mapping[str, Array], sentinel: Array) -> dict[str, float
         "jacobian_min_singular_value": minimum,
         "jacobian_max_singular_value": maximum,
         "jacobian_mean_singular_value": float(np.mean(singular)),
-        "jacobian_condition_number_clipped_1e12": maximum / max(minimum, 1e-12),
+        "jacobian_condition_number_clipped_1e12": condition_number,
         "jacobian_rms_distance_from_one": rms_deviation,
         "weight_gram_penalty": gram_penalty,
     }

--- a/tests/test_adamo_diagnostic.py
+++ b/tests/test_adamo_diagnostic.py
@@ -64,6 +64,24 @@ def test_inert_reduction_includes_curves_params_state_and_jacobian(
         assert inert[key] == control[key]
 
 
+def test_dead_jacobian_reports_capped_ill_conditioning() -> None:
+    inputs = np.zeros((4, 4), dtype=np.float32)
+    labels = np.array([0, 1, 0, 1], dtype=np.int32)
+
+    dead = run_adamo_diagnostic(
+        inputs,
+        labels,
+        profile="contract-smoke",
+        seed=FROZEN_DEVELOPMENT_SEEDS[0],
+    )
+
+    for arm in dead["arms"]:
+        for diagnostic in arm["post_task_diagnostics"]:
+            assert diagnostic["jacobian_min_singular_value"] == 0.0
+            assert diagnostic["jacobian_max_singular_value"] == 0.0
+            assert diagnostic["jacobian_condition_number_clipped_1e12"] == 1e12
+
+
 @pytest.mark.parametrize(
     ("mutation", "message"),
     [


### PR DESCRIPTION
## Defect

The supported `asi-adamo-diagnostic` path reaches
`run_adamo_diagnostic(..., profile="contract-smoke")`, which records
`jacobian_condition_number_clipped_1e12` after every task. For a fully dead
ReLU network, the Jacobian has both minimum and maximum singular value `0.0`.
The reducer divided the maximum by `max(minimum, 1e-12)`, silently reporting
the condition number as `0.0`—apparently better than a well-conditioned
nonzero Jacobian—in the diagnostic intended to expose loss of plasticity.

This branch is based on current `origin/main` at
`c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`.

## Before / after

Reproduction through the public runner with a valid zero-input contract-smoke
dataset and frozen development seed `15600`:

```text
adamw_control min= [0.0, 0.0] max= [0.0, 0.0] condition= [0.0, 0.0]
adamo_inert min= [0.0, 0.0] max= [0.0, 0.0] condition= [0.0, 0.0]
adamo_l1e3 min= [0.0, 0.0] max= [0.0, 0.0] condition= [0.0, 0.0]
adam_iso_joint_l1e3 min= [0.0, 0.0] max= [0.0, 0.0] condition= [0.0, 0.0]
```

After the fix, the same path reports the declared cap for the singular
Jacobian:

```text
adamw_control min= [0.0, 0.0] max= [0.0, 0.0] condition= [1000000000000.0, 1000000000000.0]
adamo_inert min= [0.0, 0.0] max= [0.0, 0.0] condition= [1000000000000.0, 1000000000000.0]
adamo_l1e3 min= [0.0, 0.0] max= [0.0, 0.0] condition= [1000000000000.0, 1000000000000.0]
adam_iso_joint_l1e3 min= [0.0, 0.0] max= [0.0, 0.0] condition= [1000000000000.0, 1000000000000.0]
```

The fix is confined to the diagnostic reducer: zero singular minima map to
the `1e12` cap, and finite nonzero ratios are capped there as the field name
declares.

## Regression proof

The regression runs the same public runner on the dead-network dataset and
checks all four registered arms. With only the production change reverted and
the test retained, it fails on the original defect:

```text
E               assert 0.0 == 1000000000000.0
FAILED tests/test_adamo_diagnostic.py::test_dead_jacobian_reports_capped_ill_conditioning
1 failed in 3.71s
```

With the production fix restored:

```text
13 passed in 5.69s
```

Exact verification command at head
`273e75216d025319a5933a3dd39d6ec0624ba948`:

```bash
python -m pytest tests/test_adamo_diagnostic.py -q -o addopts="" -n 2
python -m ruff check alberta_framework/benchmarks/adamo_diagnostic.py tests/test_adamo_diagnostic.py
python -m mypy alberta_framework/benchmarks/adamo_diagnostic.py
```

Results: `13 passed`; Ruff passed; changed-module mypy passed. Full-project
mypy also ran and reached the pre-existing macOS-only
`bounded_elastic_matched_runner.py:1111: Module has no attribute "O_TMPFILE"`
error, outside this diff.

<!-- evidence-head:273e75216d025319a5933a3dd39d6ec0624ba948 -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [fix]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi"} -->
