### PR TITLE
fix(benchmarks): bind native suite headline accuracy

### DIFF
--- a/alberta_framework/benchmarks/native_supervised_suite.py
+++ b/alberta_framework/benchmarks/native_supervised_suite.py
@@ -491,6 +491,16 @@ def validate_result(value: object) -> SuiteResult:
     bytes_per_example = value.input_dim * 4 + 4
     for arm in value.arms:
         ArmResult.__post_init__(arm)
+        if len(arm.task_accuracies) != spec.n_tasks:
+            raise ValueError("accuracy record mismatch")
+        total_correct = 0
+        for accuracy in arm.task_accuracies:
+            correct = round(accuracy * value.examples_per_task)
+            if accuracy != correct / value.examples_per_task:
+                raise ValueError("accuracy record mismatch")
+            total_correct += correct
+        if arm.online_accuracy != total_correct / steps:
+            raise ValueError("accuracy record mismatch")
         if type(arm.receipt) is not ResourceReceipt:
             raise ValueError("receipt must be an exact ResourceReceipt")
         ResourceReceipt.__post_init__(arm.receipt)

--- a/tests/test_native_supervised_suite.py
+++ b/tests/test_native_supervised_suite.py
@@ -146,6 +146,26 @@ def test_validator_rejects_promotion_and_counter_forgery() -> None:
         validate_result(dataclasses.asdict(result))
 
 
+def test_validator_rejects_forged_headline_accuracy() -> None:
+    """The headline must reconstruct from the retained per-task accuracies."""
+    images, labels = _fixture(10, (4, 4))
+    result = run_native_suite(
+        "split_mnist", images, labels, seed=FROZEN_SEEDS[0], examples_per_task=2
+    )
+    original = result.arms[0]
+    forged_accuracy = 0.0 if original.online_accuracy != 0.0 else 1.0
+    forged = dataclasses.replace(
+        result,
+        arms=(
+            dataclasses.replace(original, online_accuracy=forged_accuracy),
+            *result.arms[1:],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="accuracy record mismatch"):
+        validate_result(forged)
+
+
 @pytest.mark.parametrize(
     ("seed", "count"), [(True, 1), (FROZEN_SEEDS[0], True), (0, 1), (FROZEN_SEEDS[0], 65)]
 )


### PR DESCRIPTION
## Defect

The supported `run_native_suite(...) -> validate_result(...)` path accepted a result whose headline `online_accuracy` contradicted its retained `task_accuracies`. A corrupted or forged headline therefore survived the canonical validator and could silently publish the wrong aggregate accuracy.

Based on current `origin/main` at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`.

Before (real suite result with only the headline replaced):

```text
retained_task_mean=0.100000
forged_online_accuracy=0.000000
validator=ACCEPTED
```

## Fix

At the single result-validation boundary, require one retained accuracy per task, require each accuracy to lie on the exact `correct / examples_per_task` count lattice, reconstruct the integer total correct count, and bind `online_accuracy` to `total_correct / steps`.

After, the same reproduction is rejected:

```text
retained_task_mean=0.100000
forged_online_accuracy=0.000000
validator=REJECTED (accuracy record mismatch)
```

## Regression proof

The regression test builds a genuine result through `run_native_suite`, changes only one arm's headline accuracy, and exercises `validate_result`.

With only the production validation block removed while retaining the test:

```text
FAILED tests/test_native_supervised_suite.py::test_validator_rejects_forged_headline_accuracy - Failed: DID NOT RAISE <class 'ValueError'>
1 failed in 1.07s
```

After restoring the production fix:

```text
...............                                                          [100%]
15 passed in 1.48s
All checks passed!
```

Validation covered the affected test module and Ruff on both changed files at commit `75c3ca48518993b99b88433528ecf15d23bf776e`. Pytest ran with one worker because xdist is unavailable in the installed runtime, remaining below the two-worker cap. The broader fast lane reached 1,159 passes before unrelated Docker bind-mount `O_TMPFILE` failures; `test_utils_smoke.py` also requires unavailable matplotlib, and mypy is unavailable in that runtime. No benchmark execution, evidence promotion, or output artifact changes are included.

<!-- evidence-head: 75c3ca48518993b99b88433528ecf15d23bf776e -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [metric-bugfix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M12H94YS1A522DDM55GDNXKB","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-27T21:16:11.609Z","completed_at":"2026-08-27T21:31:53.319Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-27T21:16:13.656Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"8784ffa07fa33b696f0c4aa18c056e96b49a7cc2d62fbb6c82a846a71c61b8c9","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"869ff00f-c10d-4ec7-9c01-69db95007e3d","object_id":"sha256:8784ffa07fa33b696f0c4aa18c056e96b49a7cc2d62fbb6c82a846a71c61b8c9","sha256":"8784ffa07fa33b696f0c4aa18c056e96b49a7cc2d62fbb6c82a846a71c61b8c9"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA3qp2qlPvWwwKfIl5iPln7EUrHBcgqCX-87Cz0b_VVk0","device_key_id":"7fe9e8ddf85097400d555bf61a271e57f5b547ced7e28fe091fbbd54452478cb","device_signature":"GP6bc1tH_DwHmoM-vg9aoms8cMuS6En2fJUVSr-hCc50TqNEEoqtgk0Dva0YKnf2QD7LolfclPe7UPWiAppvCA"}} -->
