### PR TITLE
fix(core): reject checkpoint dtype casts

### DIFF
--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -134,6 +134,42 @@ def _restore_empty_arrays(template: Any, restored: Any, manifest: object) -> Any
     )
 
 
+def _validate_restore_template(path: Path, template: Any) -> None:
+    """Reject shape or explicit array-dtype conversion before Orbax restore."""
+
+    saved_tree = ocp.StandardCheckpointHandler().metadata(path / "state").tree
+    saved_leaves = jax.tree.leaves(saved_tree)
+    template_leaves = jax.tree.leaves(template)
+    if len(saved_leaves) != len(template_leaves):
+        raise ValueError("checkpoint state leaf count does not match the restore template")
+
+    for index, (saved, expected) in enumerate(
+        zip(saved_leaves, template_leaves, strict=True)
+    ):
+        if hasattr(expected, "shape") and hasattr(expected, "dtype"):
+            if jnp.issubdtype(expected.dtype, jax.dtypes.prng_key):
+                key_data = jax.random.key_data(expected)
+                expected_shape = tuple(key_data.shape)
+                expected_dtype = str(key_data.dtype)
+            else:
+                expected_shape = tuple(expected.shape)
+                expected_dtype = str(expected.dtype)
+        else:
+            expected_array = np.asarray(expected)
+            expected_shape = expected_array.shape
+            expected_dtype = None
+        saved_shape = tuple(saved.shape)
+        saved_dtype = str(saved.dtype)
+        if saved_shape != expected_shape or (
+            expected_dtype is not None and saved_dtype != expected_dtype
+        ):
+            raise ValueError(
+                f"checkpoint state leaf {index} has shape {saved_shape} and dtype "
+                f"{saved_dtype}; restore template requires shape {expected_shape} and "
+                f"dtype {expected_dtype or 'its scalar type'}"
+            )
+
+
 def _copy_mapping(payload: object, *, name: str) -> dict[str, Any]:
     if not issubclass(type(payload), Mapping):
         raise ValueError(f"{name} must be a mapping")
@@ -257,6 +293,7 @@ def load_checkpoint(
 
     try:
         compatible_template = _orbax_compatible_tree(state_template)
+        _validate_restore_template(path, compatible_template)
         with ocp.Checkpointer(ocp.CompositeCheckpointHandler()) as ckptr:
             loaded = ckptr.restore(
                 str(path),

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -56,6 +56,15 @@ class TestSaveLoadRoundTrip:
         with pytest.raises(ValueError, match="does not match the restore template"):
             load_checkpoint(template, tmp_path / "empty_shape")
 
+    def test_template_dtype_cannot_silently_cast_saved_state(self, tmp_path):
+        saved = {"accepted_events": jnp.asarray(16_777_217, dtype=jnp.int32)}
+        template = {"accepted_events": jnp.asarray(0, dtype=jnp.float32)}
+
+        save_checkpoint(saved, tmp_path / "dtype_mismatch")
+
+        with pytest.raises(ValueError, match="dtype"):
+            load_checkpoint(template, tmp_path / "dtype_mismatch")
+
     def test_user_metadata_cannot_forge_empty_array_manifest(self, tmp_path):
         saved = {"x": jnp.array([42.0], dtype=jnp.float32)}
         template = {"x": jnp.empty((0,), dtype=jnp.float32)}


### PR DESCRIPTION
## Defect

The supported public path `from alberta_framework import save_checkpoint, load_checkpoint` reaches `core/checkpoints.py`; the model-replay and interaction-feature checkpoint wrappers use the same boundary. When a caller supplied a same-shape template with a different array dtype, Orbax `StandardRestore` silently cast the persisted value instead of rejecting the incompatible learner state. A saved `int32` event counter therefore changed numerically during a successful restore.

Base: `origin/main` at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`.

## Before / after

Reproduction before the fix:

```text
saved dtype/value: int32 16777217
template dtype: float32
restored dtype/value: float32 16777216.0
difference: -1.0
```

The same supported call after the fix:

```text
ValueError: State structure mismatch. Ensure the learner architecture matches the saved checkpoint. Original error: checkpoint state leaf 0 has shape () and dtype int32; restore template requires shape () and dtype float32
```

## Fix

At the single `load_checkpoint` boundary, read Orbax's stored pre-cast leaf metadata and compare explicit array shape and dtype with the restore template before `StandardRestore` can coerce data. Python scalar templates retain their existing compatibility, and typed JAX PRNG keys are compared using Orbax's persisted `uint32` key-data representation.

## Regression proof

The new regression failed before the production change:

```text
F [100%]
Failed: DID NOT RAISE ValueError
1 failed in 1.29s
```

I then reverted only the production validation, kept the test, and reproduced the exact defect:

```text
F [100%]
Failed: DID NOT RAISE ValueError
1 failed in 1.74s
```

Restoring the production fix without changing the test produced:

```text
1 passed in 1.75s
```

## Verification

- `pytest` checkpoint core plus typed-PRNG wrapper coverage with `-n 2`: `55 passed in 3.63s`
- checkpoint wrapper coverage with `-n 2`: `202 passed in 55.01s`
- checkpoint-dependent learner coverage with `-n 2`: `199 passed in 14.83s`
- Ruff: `All checks passed!`
- mypy: `Success: no issues found in 1 source file`
- `git diff --check`: passed
- The broader macOS run reached `3752 passed, 63 skipped`; its 29 observed failures were unrelated Linux-only publication tests requiring `O_TMPFILE` or `renameat2`.

<!-- evidence-head:57ec4eb481ab446b1b0092d96e2cefc673a9d9ff -->
<!-- evidence-row:logs -->
- [x] logs: N/A - exact before/after and test outputs are reproduced inline above
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - persistence boundary fix has no scientific result artifact
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - private content-addressed trace is joined by the signed receipt below

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [asi-metric-fix-20260828]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M12S0RDFJSGMFCZHN9SS4K69","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-27T23:31:25.231Z","completed_at":"2026-08-27T23:53:18.728Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-27T23:31:25.838Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b757ef4d868ae358a685648ba002c20f920af6755291057970fbf803014d15f7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"0bccbc90-5557-46ce-abfb-2c907e178072","object_id":"sha256:b757ef4d868ae358a685648ba002c20f920af6755291057970fbf803014d15f7","sha256":"b757ef4d868ae358a685648ba002c20f920af6755291057970fbf803014d15f7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"yXFbe4-EomqJFi5FoOCMy1nOX-qjpHNQkyk67oj5Opv0SBV_397904kp2PNqfjcNRGdD3emOZeKcnb78j9jTDg"}} -->
