### PR TITLE
fix(cora): remove task identity from evaluation ties

### DIFF
--- a/alberta_framework/benchmarks/cora_development.py
+++ b/alberta_framework/benchmarks/cora_development.py
@@ -232,7 +232,7 @@ def _evaluate(
             query_index = block * len(TASK_TARGETS) + task_id
             action = int(jr.randint(_rng_key(seed, 1, query_index), (), 0, 2))
         else:
-            action = _greedy(shared, (block + task_id) % 2)
+            action = _greedy(shared, (seed + block) % 2)
         returns.append(float(action == target))
     return tuple(returns)
 

--- a/tests/test_cora_development.py
+++ b/tests/test_cora_development.py
@@ -43,6 +43,15 @@ def test_end_to_end_slice_has_metrics_information_contract_and_exact_receipts() 
     assert task_control.candidate_eligible is False
 
 
+def test_candidate_evaluation_tie_break_does_not_receive_task_identity() -> None:
+    result = run_cora_development(
+        seed=FROZEN_SEEDS[0], steps_per_task=1, replay_capacity=2
+    )
+
+    for arm in result.arms[:2]:
+        assert arm.evaluation_matrix[0] in ((1.0, 0.0, 1.0), (0.0, 1.0, 0.0))
+
+
 def test_jit_and_eager_update_paths_match_except_timing() -> None:
     compiled = run_cora_development(seed=FROZEN_SEEDS[1], steps_per_task=1)
     with jax.disable_jit():


### PR DESCRIPTION
## Defect

The supported `run_cora_development` benchmark path declares that candidate agents do not receive task IDs, but `_evaluate` used the hidden evaluation `task_id` to break shared-Q action ties. On the frozen target sequence `(0, 1, 0)`, an untrained task-agnostic candidate therefore produced the impossible initial evaluation row `(1.0, 1.0, 1.0)`: the harness silently gave the policy a different target-matching action in each evaluation column.

This fixes the defect at the evaluation boundary. Shared-Q ties now use only the run seed and checkpoint block, so one task-agnostic policy has one action across every task evaluated at that checkpoint.

Base: `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`

## Before

Reproduced through `run_cora_development(seed=FROZEN_SEEDS[0], steps_per_task=1, replay_capacity=2)`:

```text
replay_q matrix= ((1.0, 1.0, 1.0), ...)
replay_off matrix= ((1.0, 1.0, 1.0), ...)
reported= 0.7142857142857143 0.0 -0.3333333333333333
```

The failing regression exposed the same impossible row:

```text
assert (1.0, 1.0, 1.0) in ((1.0, 0.0, 1.0), (0.0, 1.0, 0.0))
1 failed in 3.42s
```

## After

```text
replay_q initial= (1.0, 0.0, 1.0)
replay_off initial= (1.0, 0.0, 1.0)
reported= 0.6666666666666666 0.0 0.0
```

These remain permanently nonpromoting development diagnostics; the corrected numbers are not performance or scientific evidence.

## Regression proof

The regression calls the real benchmark runner and requires the initial shared-Q row to be one task-agnostic action pattern: `(1, 0, 1)` or `(0, 1, 0)`. I reverted only the production-line fix while retaining the test, and it failed on the exact hidden-task-identity defect:

```text
assert (1.0, 1.0, 1.0) in ((1.0, 0.0, 1.0), (0.0, 1.0, 0.0))
1 failed in 1.89s
```

After restoring the fix, the exact-head focused suite passed:

```text
17 passed in 3.72s
```

Command:

```text
$ASI_REVIEW_VENV/bin/python -m pytest tests/test_cora_development.py tests/test_cora_evaluation_matrix_hang.py -q -n 2 -o addopts=''
```

Static checks on the touched files also pass:

```text
ruff: All checks passed!
mypy alberta_framework/benchmarks/cora_development.py: Success: no issues found in 1 source file
git diff --check: clean
```

The repository-wide mypy run still encounters the pre-existing macOS-only `os.O_TMPFILE` attribute error in `bounded_elastic_matched_runner.py`; this change does not touch that module.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [runtime-metric-fix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M12S4NE2ERHN4X8HJ99X12NB","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-27T23:33:33.250Z","completed_at":"2026-08-27T23:50:29.883Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-27T23:33:33.823Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"caf176277527d092b56fa35638a18b037ea9760f02fb888f5a3847fd10543add","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3c751f84-5392-47b4-9eda-68b6818d2518","object_id":"sha256:caf176277527d092b56fa35638a18b037ea9760f02fb888f5a3847fd10543add","sha256":"caf176277527d092b56fa35638a18b037ea9760f02fb888f5a3847fd10543add"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA3qp2qlPvWwwKfIl5iPln7EUrHBcgqCX-87Cz0b_VVk0","device_key_id":"7fe9e8ddf85097400d555bf61a271e57f5b547ced7e28fe091fbbd54452478cb","device_signature":"uPet6uGut5NJ_vEyv0FYQxnMfo-hlXbpgCLWTfB3y-pP-sw0j3_esq8qQac-lneRA_JSJIuS6nEbLy90oGAjDg"}} -->
