### PR TITLE
fix(core): bound feature-discovery array scans

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -35,7 +35,12 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, PRNGKeyArray
 
-from alberta_framework._scan_resources import ScanBudget, require_scan_steps
+from alberta_framework._scan_resources import (
+    ScanBudget,
+    require_jax_leading_length,
+    require_matching_jax_leading_length,
+    require_scan_steps,
+)
 from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 from alberta_framework.core.future_utility import (
     bias_correct_future_utility,
@@ -90,6 +95,40 @@ def _require_int32(name: str, value: object, *, minimum: int) -> int:
 def _require_feature_discovery_loop_steps(name: str, value: object) -> int:
     """Reject scan lengths above the public last-fit before ``jnp.arange``."""
     return require_scan_steps(name, value, _FEATURE_DISCOVERY_LOOP_BUDGET)
+
+
+def _require_feature_discovery_array_steps(
+    observations: object,
+    targets: object,
+) -> int:
+    """Reject pre-collected scan lengths above the public last-fit before scan."""
+    if not isinstance(observations, jax.Array) or not isinstance(targets, jax.Array):
+        raise TypeError("observations and targets must be JAX arrays")
+    try:
+        num_steps = require_jax_leading_length(
+            "observations",
+            observations,
+            _FEATURE_DISCOVERY_LOOP_BUDGET,
+            ranks=(2,),
+        )
+    except ValueError as error:
+        if (
+            observations.ndim == 2
+            and not 1 <= observations.shape[0] <= _FEATURE_DISCOVERY_LOOP_MAX_STEPS
+        ):
+            raise ValueError(
+                "observations num_steps must be an integer in "
+                f"[1, {_FEATURE_DISCOVERY_LOOP_MAX_STEPS}]"
+            ) from None
+        raise error
+    require_jax_leading_length(
+        "targets",
+        targets,
+        _FEATURE_DISCOVERY_LOOP_BUDGET,
+        ranks=(2,),
+    )
+    require_matching_jax_leading_length("targets", targets, expected=num_steps)
+    return num_steps
 
 
 def _saturating_int32_increment(value: Array) -> Array:
@@ -1961,7 +2000,14 @@ def run_feature_discovery_arrays(
     observations: Array,
     targets: Array,
 ) -> FeatureDiscoveryLearningResult:
-    """Run a feature-discovery learner over pre-collected stream arrays."""
+    """Run a feature-discovery learner over pre-collected stream arrays.
+
+    Raises:
+        TypeError: If ``observations`` or ``targets`` is not a JAX array.
+        ValueError: If the arrays are not rank two, do not share a leading
+            length, or contain a step count outside ``[1, 10_000]``.
+    """
+    _require_feature_discovery_array_steps(observations, targets)
 
     def step_fn(
         carry: FeatureDiscoveryState,

--- a/tests/test_feature_discovery_loop_steps.py
+++ b/tests/test_feature_discovery_loop_steps.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 
 from typing import Any
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from alberta_framework.core.feature_discovery import (
     _FEATURE_DISCOVERY_LOOP_MAX_STEPS,
+    _require_feature_discovery_array_steps,
     _require_feature_discovery_loop_steps,
+    run_feature_discovery_arrays,
     run_feature_discovery_loop,
 )
 
@@ -104,3 +107,83 @@ def test_rejects_numpy_and_subclass_step_counts_without_index_hooks() -> None:
         _require_feature_discovery_loop_steps("num_steps", np.int64(10))
     with pytest.raises(ValueError, match="num_steps must be an integer in"):
         _require_feature_discovery_loop_steps("num_steps", _HostileInt(10))
+
+
+class _HostileArrays:
+    calls = 0
+
+    @property
+    def ndim(self) -> Any:
+        type(self).calls += 1
+        raise AssertionError("ndim hook executed")
+
+    @property
+    def shape(self) -> Any:
+        type(self).calls += 1
+        raise AssertionError("shape hook executed")
+
+
+def _spy_scan(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    seen: list[object] = []
+
+    def spy(*args: object, **kwargs: object) -> Any:
+        seen.append((args, kwargs))
+        raise AssertionError(f"jax.lax.scan must not run: {args} {kwargs}")
+
+    monkeypatch.setattr("alberta_framework.core.feature_discovery.jax.lax.scan", spy)
+    return seen
+
+
+def test_array_last_fit_length_is_accepted() -> None:
+    observations = jnp.zeros(
+        (_FEATURE_DISCOVERY_LOOP_MAX_STEPS, 2),
+        dtype=jnp.float32,
+    )
+    targets = jnp.zeros(
+        (_FEATURE_DISCOVERY_LOOP_MAX_STEPS, 1),
+        dtype=jnp.float32,
+    )
+    assert _require_feature_discovery_array_steps(observations, targets) == 10_000
+
+
+def test_array_first_overflow_rejected_before_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _spy_scan(monkeypatch)
+    observations = jnp.zeros(
+        (_FEATURE_DISCOVERY_LOOP_MAX_STEPS + 1, 2),
+        dtype=jnp.float32,
+    )
+    targets = jnp.zeros(
+        (_FEATURE_DISCOVERY_LOOP_MAX_STEPS + 1, 1),
+        dtype=jnp.float32,
+    )
+    with pytest.raises(ValueError, match="observations num_steps must be an integer in"):
+        run_feature_discovery_arrays(  # type: ignore[arg-type]
+            object(),
+            object(),
+            observations,
+            targets,
+        )
+    assert seen == []
+
+
+def test_array_gate_rejects_rank_and_length_mismatch() -> None:
+    observations = jnp.zeros((3, 2), dtype=jnp.float32)
+    with pytest.raises(ValueError, match="targets must have rank"):
+        _require_feature_discovery_array_steps(
+            observations,
+            jnp.zeros((3,), dtype=jnp.float32),
+        )
+    with pytest.raises(ValueError, match="primary sequence length"):
+        _require_feature_discovery_array_steps(
+            observations,
+            jnp.zeros((2, 1), dtype=jnp.float32),
+        )
+
+
+def test_array_gate_does_not_read_hostile_shape() -> None:
+    _HostileArrays.calls = 0
+    with pytest.raises(TypeError, match="observations and targets must be JAX arrays"):
+        _require_feature_discovery_array_steps(_HostileArrays(), _HostileArrays())
+    assert _HostileArrays.calls == 0


### PR DESCRIPTION
## Summary

Bound the public `run_feature_discovery_arrays` consumer to the same explicit 10,000-step resource budget already enforced by `run_feature_discovery_loop`.

The trusted-main runner accepted a valid 10,001-step pair and handed it directly to `jax.lax.scan`. The candidate now performs a host-side preflight that:

- requires real rank-two JAX arrays;
- binds both inputs to one matching leading length;
- accepts the documented 10,000-step last fit; and
- rejects the first overflow before tracing or scanning, without invoking hostile non-JAX metadata hooks.

## Reproduction and result

Lane: deterministic trusted-main bug reproduction and unit contract verification. This is not a benchmark or scientific-evidence lane; seeds, tuning/evaluation splits, means, and spreads are not applicable.

Base `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`:

```text
DEFECT_REPRODUCED scan_received_steps=10001 allowed_max=10000
RuntimeError oversized scan reached jax.lax.scan
```

Candidate `c3593dec33f39fe647fc786a68eb8eb596550331`:

```text
LAST_FIT_ACCEPTED steps=10000
FIRST_OVERFLOW_REJECTED error=observations num_steps must be an integer in [1, 10000]
SCAN_CALLS count=0
```

<!-- evidence-head:c3593dec33f39fe647fc786a68eb8eb596550331 -->
<!-- evidence-row:logs -->
- [x] logs: https://gist.githubusercontent.com/batmanscode/7e68a822b08f9df49b291db5a05d4381/raw/862458b4ea5c44379e8fbc1ed5e7995cfbb3f66c/asi-feature-discovery-array-scan-evidence.json
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: https://gist.githubusercontent.com/batmanscode/7e68a822b08f9df49b291db5a05d4381/raw/862458b4ea5c44379e8fbc1ed5e7995cfbb3f66c/asi-feature-discovery-array-scan-evidence.json

The structured artifact is bound to the candidate SHA and records baseline/candidate behavior, boundary measurements, runtime versions, and verification outcomes. SHA-256: `3c27f4a30c6e3388d7f172e958b3d833204160c0f1104d5420e467bb1096d542`.

## Verification

- `JAX_PLATFORMS=cpu .venv/bin/python -m pytest -q tests/test_feature_discovery_loop_steps.py tests/test_feature_discovery.py -k 'feature_discovery or array or loop_steps' --maxfail=1` — `164 passed in 74.73s`
- `.venv/bin/python -m ruff check .` — passed
- `.venv/bin/python -m mypy` — passed, 224 source files
- `.venv/bin/alberta-evidence-status` — existing registered artifacts remain invalid against current upstream source hashes; no pinned artifact was modified or promotion claimed
- Broader fast-lane probe — `407 passed, 2 skipped` before an unrelated existing associative-memory test hit this cloud kernel's reproducible XNNPACK `/proc/cpuinfo` initialization failure; the failing test does not import or exercise the changed runner

No open issue or pull request covered this array consumer when the work began. The live review epoch and current-main workflow gate were clear. The patch does not alter update semantics inside the accepted budget, touch pinned outputs, or make benchmark, performance, safety, or scientific-promotion claims. Independent maintainer review and hosted GitHub CI remain the acceptance gates.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@f784f8b0c64731c1aa2cc1e60e2247cf41f4e29d:skills/contribute-to-asi
Attribution status: self-reported
— [codex-asi-epoch2-fix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@f784f8b0c64731c1aa2cc1e60e2247cf41f4e29d:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M12T13EET6KJ0D5T3VZQCTTP","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-27T23:49:05.102Z","completed_at":"2026-08-28T00:29:37.055Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-27T23:50:44.642Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2d820f8209eff50964564d7e2d38f528ff38cd5fdcc5f7a400e0cd53c55484e2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b8a69b5c-51ad-47b4-a038-a8a26d6c8aa7","object_id":"sha256:2d820f8209eff50964564d7e2d38f528ff38cd5fdcc5f7a400e0cd53c55484e2","sha256":"2d820f8209eff50964564d7e2d38f528ff38cd5fdcc5f7a400e0cd53c55484e2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAS0W7RkWnRdow4VQR-NX9hvCJ8PG7-GQ20LIgFz9HAQE","device_key_id":"7b90dca810bb781db75e51e9696be360cf83238ef20df86d536c1b8fcdf1ff2d","device_signature":"MqFs7SLg5XcuB282LQneerLZawpejH2oDnUGFK5f_IGV5NKPASbMvNFcNJ-AR7nFNZvHB_WWydk3pOT1EXFoDQ"}} -->
