### PR TITLE
fix(ipmnist): require all seeds for confirmation

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_campaign_tools.py
+++ b/alberta_framework/benchmarks/ipmnist_campaign_tools.py
@@ -154,18 +154,22 @@ def build_frontier(
                 f"{sorted(screen)} != {sorted(screen_base)}"
             )
         paired_seeds = sorted(screen)
+        screen_deltas = [
+            screen[seed] - screen_base[seed] for seed in paired_seeds
+        ]
+        screen_paired_delta = statistics.mean(screen_deltas)
         row: dict[str, Any] = {
             "config_name": arm,
             "n_screen_seeds": len(paired_seeds),
             "screen_mean": statistics.mean(screen[seed] for seed in paired_seeds),
-            "screen_paired_delta_vs_base": statistics.mean(
-                screen[seed] - screen_base[seed] for seed in paired_seeds
-            ),
-            "screen_per_seed_delta": [
-                round(screen[seed] - screen_base[seed], 6) for seed in paired_seeds
-            ],
+            "screen_paired_delta_vs_base": screen_paired_delta,
+            "screen_per_seed_delta": [round(delta, 6) for delta in screen_deltas],
         }
-        row["confirmation_candidate"] = row["screen_paired_delta_vs_base"] > threshold
+        row["confirmation_candidate"] = (
+            len(paired_seeds) >= 2
+            and all(delta > 0.0 for delta in screen_deltas)
+            and screen_paired_delta > threshold
+        )
         if confirm:
             if confirm.keys() != confirm_base.keys():
                 raise ValueError(

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -299,6 +299,28 @@ def test_frontier_requires_and_uses_exact_paired_seed_sets(tmp_path: Path) -> No
     } == {"pyproject.toml", "uv.lock"}
 
 
+def test_frontier_requires_every_paired_seed_to_improve(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    confirm = tmp_path / "confirm"
+    for seed, accuracy in enumerate((0.79, 0.81, 0.81)):
+        _shard(screen / f"base_seed{seed}.json", seed=seed, accuracy=0.80)
+        _shard(screen / f"candidate_seed{seed}.json", seed=seed, accuracy=accuracy)
+
+    frontier = build_frontier(
+        screen,
+        confirm,
+        base="base",
+        arms=["candidate"],
+        threshold=0.002,
+        created_unix=0.0,
+    )
+    row = frontier["results"][0]
+
+    assert row["screen_per_seed_delta"] == pytest.approx([-0.01, 0.01, 0.01])
+    assert row["screen_paired_delta_vs_base"] > 0.002
+    assert row["confirmation_candidate"] is False
+
+
 def test_frontier_rejects_mismatched_confirm_seed_sets(tmp_path: Path) -> None:
     screen = tmp_path / "screen"
     confirm = tmp_path / "confirm"


### PR DESCRIPTION
`asi-ipmnist-campaign frontier` silently marked an arm as a confirmation candidate when its paired mean cleared the threshold even though one paired seed regressed. The supported path is the README-listed console script (`asi-ipmnist-campaign frontier` → `main()` → `build_frontier()`), and the wrong `true` can authorize the campaign's expensive 200-task confirmation wave.

Base: `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (current `origin/main`)

## Before / after

Reproduced through the public CLI with a base accuracy of `0.80` on seeds 0–2 and candidate accuracies `[0.79, 0.81, 0.81]`, using threshold `0.002`.

Before:

```json
{
  "screen_per_seed_delta": [-0.01, 0.01, 0.01],
  "screen_paired_delta_vs_base": 0.003333333333333336,
  "confirmation_candidate": true
}
```

After:

```json
{
  "screen_per_seed_delta": [-0.01, 0.01, 0.01],
  "screen_paired_delta_vs_base": 0.003333333333333336,
  "confirmation_candidate": false
}
```

## Fix

Compute the exact paired deltas once at the frontier aggregation boundary and mirror the canonical `ipmnist_screening.merge_shards()` compute-spending gate: require at least two paired seeds, every paired delta positive, and the paired mean above the configured threshold. This is one boundary fix; no call sites or unrelated metric modules change.

Open-PR searches for `ipmnist campaign frontier`, `mixed-sign confirmation`, `frontier losing seed`, and `all-positive confirmation` found no matching open implementation.

## Regression proof

The new regression uses the mixed-sign deltas above. With only the production hunk reverted and the test retained, it failed on exactly the defect:

```text
>       assert row["confirmation_candidate"] is False
E       assert True is False
1 failed in 2.73s
```

Restoring the production fix made the targeted test pass. The existing checked-in `frontier_results.json` reconstruction also remains unchanged because its sole confirmation candidate improves on every paired seed.

## Verification

```text
python -m pytest tests/test_ipmnist_campaign_tools.py tests/test_ipmnist_screening.py -q -o addopts= -n 2
423 passed in 44.79s

python -m ruff check alberta_framework/benchmarks/ipmnist_campaign_tools.py tests/test_ipmnist_campaign_tools.py
All checks passed!

python -m mypy alberta_framework/benchmarks/ipmnist_campaign_tools.py
Success: no issues found in 1 source file
```

The factory proof ledger recorded the 423-test run at head `5507a3614d53c16d9aead3e33e0cdee3b14e750f`.

<!-- evidence-head:5507a3614d53c16d9aead3e33e0cdee3b14e750f -->
<!-- evidence-row:logs -->
- [x] logs: N/A - deterministic before/after CLI and exact-head test output are reproduced inline above
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - this corrects a nonpromoting compute gate and does not produce a scientific evidence artifact
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - the minimized trajectory is private by protocol and is bound by the terminal device-signed receipt

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [codex-metric-fix-20260828]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M12XGAF293YECKV4MW10GBKE","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-28T00:49:49.538Z","completed_at":"2026-08-28T01:08:25.186Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-28T00:49:50.436Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a973c6ef5d5cc8e9797586256e53b88bf1d2b45701819a25e2bc37a145636df1","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"d07f1280-4511-4715-912b-4ee3207ab528","object_id":"sha256:a973c6ef5d5cc8e9797586256e53b88bf1d2b45701819a25e2bc37a145636df1","sha256":"a973c6ef5d5cc8e9797586256e53b88bf1d2b45701819a25e2bc37a145636df1"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"lNcc1CtiYiyBsWSK3QFgezU8r0R6p6CZ3r1xyW2K1rl1ODMu8THPlg7mLJcD9b8LUh12cmGhJAdaKN8yXAfxBA"}} -->
