### PR TITLE
fix(benchmarks): derive rule-discovery verdicts

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery_summary.py
+++ b/alberta_framework/benchmarks/rule_discovery_summary.py
@@ -137,6 +137,19 @@ def build_rule_discovery_summary(
     ).encode()
     maintained = dict(legacy)
     maintained["schema"] = "asi.rule_discovery.real_screen.v2"
+    screen = maintained["screen_60_task"]
+    paired = maintained["paired_vs_champion_60_task"]
+    assert isinstance(screen, dict)
+    assert isinstance(paired, dict)
+    maintained["verdicts"] = {
+        (
+            f"{name}_verbatim" if name in {"disc_r1", "disc_r2", "disc_r3"} else name
+        ): (
+            f"screen mean {screen[name]['mean']:.5f}; paired vs champion "
+            f"{paired[name]['mean']:+.5f}; development screen only"
+        )
+        for name in DISCOVERY_ARMS
+    }
     maintained["legacy_compatibility"] = {
         "schema": legacy["schema"],
         "canonical_sha256": hashlib.sha256(legacy_canonical).hexdigest(),

--- a/tests/test_ipmnist_campaign_tools.py
+++ b/tests/test_ipmnist_campaign_tools.py
@@ -695,6 +695,22 @@ def test_rule_discovery_summary_uses_explicit_directories(tmp_path: Path) -> Non
     assert "ipmnist_provenance" in summary["provenance"]["sources"]
 
 
+def test_rule_discovery_summary_verdicts_follow_explicit_inputs(tmp_path: Path) -> None:
+    screen = tmp_path / "screen"
+    for name in SCREEN_ARMS:
+        accuracy = 0.95 if name == CHAMPION else 0.1
+        _shard(screen / f"{name}_seed0.json", seed=0, accuracy=accuracy)
+
+    summary = build_rule_discovery_summary(screen, tmp_path / "confirm", seeds=(0,))
+
+    assert summary["verdicts"]["disc_r1_verbatim"] == (
+        "screen mean 0.10000; paired vs champion -0.85000; development screen only"
+    )
+    assert summary["verdicts"]["disc_r1_pscale_norms"] == (
+        "screen mean 0.10000; paired vs champion -0.85000; development screen only"
+    )
+
+
 @pytest.mark.parametrize("seeds", [(), (0, 0), (True,), (-1,), (2**32,)])
 def test_rule_summary_rejects_noncanonical_or_duplicate_seeds_before_io(
     tmp_path: Path, seeds: object


### PR DESCRIPTION
## Defect

The supported `asi-rule-discovery-summary` path accepts explicit campaign directories and
seed rosters, computes their current arm means and paired deltas, but the maintained v2
payload copied verdict strings containing fixed numbers from the historical v1 campaign.
As a result, a real caller could publish a summary whose verdict contradicted the metrics in
the same JSON object. This branch is based on current `origin/main` at
`c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`.

Before, an explicit one-seed input with `disc_r1=0.10` and champion `=0.95` produced:

```text
computed disc_r1 mean: 0.1
reported disc_r1 verdict: below bar (0.78372); beats published UPGD-W control +0.006, no gate
computed paired delta: -0.85
reported paired verdict: discovered structure (surprise budget replaces utility gate) at champion constants beats the champion on the 60-task screen (+0.00173, 3/3 seeds) and ties-to-slightly-beats at 200 tasks (+0.00066 paired, 2/3 seeds; screening claims nothing by itself)
```

The maintained v2 boundary now derives each verdict from its already-computed screen mean and
paired comparison. The legacy v1 builder remains unchanged, preserving exact reconstruction
of the pinned historical payload. The same input now produces:

```text
computed disc_r1 mean: 0.1
reported disc_r1 verdict: screen mean 0.10000; paired vs champion -0.85000; development screen only
computed paired delta: -0.85
reported paired verdict: screen mean 0.10000; paired vs champion -0.85000; development screen only
```

## Regression proof

The new regression constructs explicit non-historical inputs and checks both a verbatim arm
and the previously positive-claim arm. With only the production change removed and the test
retained, it fails on the original stale number:

```text
E       AssertionError: assert 'below bar (0....006, no gate' == 'screen mean ...t screen only'
E         - screen mean 0.10000; paired vs champion -0.85000; development screen only
E         + below bar (0.78372); beats published UPGD-W control +0.006, no gate
```

Final verification in the exact-main prebuilt runtime, network-disabled and capped to two
CPUs:

```text
83 passed in 1.17s
All checks passed!
```

Commands covered `tests/test_ipmnist_campaign_tools.py` and Ruff on the changed source and
test. The environment image does not include pytest-xdist, so pytest ran serially under the
two-CPU container cap rather than accepting `-n 2`.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5
<!-- attribution-row:client -->
- Agent tooling: Codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi/SKILL.md
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:cae0ac9fc29c3e7a72bf23158a9691e62cb50639 -->

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi/SKILL.md
Attribution status: self-reported
— [contribute-to-asi]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi/SKILL.md"} -->
