### PR TITLE
fix(reference): finalize terminal segment reward metrics

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -687,6 +687,30 @@ class ReferenceLifeMetricsAdapter:
             latest_completed_segment_reward=latest,
         )
 
+    def complete_current_segment(
+        self,
+        state: ReferenceLifeMetricsState,
+    ) -> ReferenceLifeMetricsState:
+        """Record the current switching segment when the life ends on its boundary."""
+
+        if state.config_sha256 != self.config.config_sha256:
+            raise DecisionOwnershipError("metrics state config mismatch")
+        if self.config.mode != "switching_two_phase":
+            return state
+        phase = state.current_phase
+        first = state.first_completed_segment_reward
+        if first[phase] is None:
+            first = _replace_tuple_value(first, phase, state.current_segment_reward)
+        return dataclasses.replace(
+            state,
+            first_completed_segment_reward=first,
+            latest_completed_segment_reward=_replace_tuple_value(
+                state.latest_completed_segment_reward,
+                phase,
+                state.current_segment_reward,
+            ),
+        )
+
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class ReferenceEnvironmentStart:
@@ -2310,6 +2334,36 @@ class ReferenceLifeRunner:
         )
         return jr.fold_in(root, cursor)
 
+    def _observe_metrics(
+        self,
+        metrics: ReferenceLifeMetricsState,
+        *,
+        phase: int,
+        reward: float,
+        oracle_reward: float,
+        parameters_changed: bool,
+        next_accepted_events: int,
+    ) -> ReferenceLifeMetricsState:
+        observed = self._metrics_adapter.observe(
+            metrics,
+            phase=phase,
+            reward=reward,
+            oracle_reward=oracle_reward,
+            parameters_changed=parameters_changed,
+        )
+        if self._metrics_adapter.config.mode != "switching_two_phase":
+            return observed
+        phase_length = cast(
+            int,
+            self._environment_adapter.manifest.config["phase_length"],
+        )
+        if (
+            next_accepted_events == self.config.max_accepted_events
+            and observed.current_segment_events == phase_length
+        ):
+            return self._metrics_adapter.complete_current_segment(observed)
+        return observed
+
     def _validate_accepted_agent_update(
         self,
         update: ReferenceAgentUpdate,
@@ -3020,13 +3074,15 @@ class ReferenceLifeRunner:
                         ),
                     )
 
+            next_accepted_events = state.accepted_events + 1
             try:
-                metrics = self._metrics_adapter.observe(
+                metrics = self._observe_metrics(
                     state.metrics,
                     phase=execution.regime_id,
                     reward=transaction.reward,
                     oracle_reward=execution.oracle_reward,
                     parameters_changed=update.parameters_changed,
+                    next_accepted_events=next_accepted_events,
                 )
             except Exception as exc:
                 reason = f"metric update rejected retained outcome: {exc}"
@@ -3074,7 +3130,6 @@ class ReferenceLifeRunner:
                     transcript_sha256=transcript_sha256,
                     reason=f"post-execution transaction acceptance failed: {exc}",
                 )
-            next_accepted_events = state.accepted_events + 1
             phase = (
                 LifePhase.COMPLETED
                 if next_accepted_events == self.config.max_accepted_events
@@ -3222,13 +3277,15 @@ class ReferenceLifeRunner:
                     reason=f"accepted agent update failed recovery validation: {exc}",
                 )
 
+            next_accepted_events = state.accepted_events + 1
             try:
-                metrics = self._metrics_adapter.observe(
+                metrics = self._observe_metrics(
                     state.metrics,
                     phase=pending.regime_id,
                     reward=transaction.reward,
                     oracle_reward=pending.oracle_reward,
                     parameters_changed=update.parameters_changed,
+                    next_accepted_events=next_accepted_events,
                 )
             except (DecisionOwnershipError, RuntimeError, TypeError, ValueError) as exc:
                 reason = f"metric recovery rejected retained outcome: {exc}"
@@ -3243,7 +3300,6 @@ class ReferenceLifeRunner:
                 next_decision=update.next_decision,
                 parameters_changed=update.parameters_changed,
             )
-            next_accepted_events = state.accepted_events + 1
             phase = (
                 LifePhase.COMPLETED
                 if next_accepted_events == self.config.max_accepted_events

--- a/tests/test_reference_life.py
+++ b/tests/test_reference_life.py
@@ -484,6 +484,36 @@ def test_authoritative_life_crosses_phase_and_completes_at_horizon() -> None:
         runner.step(state)
 
 
+def test_completed_life_records_the_final_full_switching_segment() -> None:
+    agent_config = PrototypeAgentConfig(
+        oak=OaKConfig(
+            stomp=STOMPConfig(
+                subtask_specs=(),
+                observation_dim=2,
+                n_primitive_actions=2,
+                base_step_size=0.05,
+                epsilon_base=0.25,
+            )
+        )
+    )
+    runner = build_prototype_switching_life(
+        agent_config=agent_config,
+        environment_config=SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        lifecycle_id=_LIFECYCLE_ID,
+        seed=29,
+        max_accepted_events=6,
+    )
+
+    result = runner.run_to_completion(runner.init())
+    metrics = result.state.metrics
+
+    assert result.state.phase is LifePhase.COMPLETED
+    assert metrics.current_phase == PHASE_A
+    assert metrics.current_segment_events == 2
+    assert metrics.current_segment_reward == 0.0
+    assert metrics.latest_completed_segment_reward == (0.0, 2.0)
+
+
 def test_environment_rejects_bad_action_before_clipping_step(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Defect and supported path

`ReferenceLifeRunner.run_to_completion()` silently left the terminal switching segment out of `latest_completed_segment_reward` when the horizon ended exactly on a phase boundary. The supported production path is:

`ReferenceLifeRunner.run_to_completion()` → `_step_locked()` → `ReferenceLifeMetricsAdapter.observe()`.

With `SwitchingTwoStateConfig(phase_length=2)`, seed 29, and a six-event life, the final A segment earned `0.0 + 0.0`, but the completed state reported the preceding A segment's reward, `2.0`:

```text
event rewards/regimes: [(0, 1.0), (0, 1.0), (1, 1.0), (1, 1.0), (0, 0.0), (0, 0.0)]
phase: completed
current segment: 0 2 0.0
first completed: (2.0, 2.0)
latest completed: (2.0, 2.0)
```

After this fix, the same supported run reports the actual terminal segment:

```text
event rewards/regimes: [(0, 1.0), (0, 1.0), (1, 1.0), (1, 1.0), (0, 0.0), (0, 0.0)]
phase: completed
current segment: 0 2 0.0
first completed: (2.0, 2.0)
latest completed: (0.0, 2.0)
```

## Root cause and fix

Segment snapshots were updated only when a later event changed regimes. A life that stopped on the segment boundary had no later event, so its last completed segment remained invisible.

The fix adds one completion-aware metrics boundary used by both ordinary stepping and retained-outcome recovery. It finalizes only switching segments whose length equals the configured phase length at life completion. Partial terminal segments remain partial, stationary metrics remain unchanged, and checkpoint semantics are unaffected.

## Regression proof

The new end-to-end regression runs the public completion path and asserts the final tuple. With only the production change removed and the test retained, it failed on exactly the defect:

```text
>       assert metrics.latest_completed_segment_reward == (0.0, 2.0)
E       assert (2.0, 2.0) == (0.0, 2.0)
E         At index 0 diff: 2.0 != 0.0
1 failed in 3.62s
```

Restoring the production fix made the same test pass.

## Verification

Base: `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (`origin/main`)

Verified head: `ca04525826cb76c910722a90348dcfd4ea1062f1`

```text
.venv/bin/python -m pytest tests/test_reference_life.py -q -o addopts="" -n 2
44 passed in 10.73s

.venv/bin/python -m pytest tests/test_reference_life_riverswim.py -q -o addopts="" -n 2
7 passed in 4.17s

.venv/bin/python -m pytest tests/test_reference_life_scorecard.py -q -o addopts="" -n 2
64 passed, 1 skipped in 25.66s

.venv/bin/python -m ruff check alberta_framework/reference_life.py tests/test_reference_life.py
All checks passed!

.venv/bin/python -m mypy alberta_framework/reference_life.py
Success: no issues found in 1 source file
```

The full checkpoint module is Linux-only and fails on this macOS host at its existing `renameat2` requirement. Full-project mypy likewise reaches an untouched Linux `O_TMPFILE` reference. Neither blocker is in this diff.

This is a mechanism-level metric-correctness fix, not a benchmark improvement or scientific-promotion claim. The deterministic reproduction uses seed 29 (`n=1`); it consumes no frozen or evaluation seeds and writes no output artifact.

<!-- evidence-head:ca04525826cb76c910722a90348dcfd4ea1062f1 -->
<!-- evidence-row:logs -->
- [x] logs: exact before/after and regression output are reproduced inline above; the final-head suite is recorded by the factory proof ledger
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A — this runtime metric fix generates no benchmark or scientific artifact
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: private immutable trace digest and server object are bound by the signed receipt below; the privacy contract forbids publishing the trace body

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [metric-defect-fix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M130M842MJMNP00PH6JG0STP","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-28T01:44:23.938Z","completed_at":"2026-08-28T02:05:43.065Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-28T01:44:24.522Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4c68590deb507c059cf72057bfcbd6156dd80715d297a80781a5b7723e77416a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"72958b84-d4c9-4fd7-82b4-ee667311e13e","object_id":"sha256:4c68590deb507c059cf72057bfcbd6156dd80715d297a80781a5b7723e77416a","sha256":"4c68590deb507c059cf72057bfcbd6156dd80715d297a80781a5b7723e77416a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"QYIseb2z2SFJOE0CyR5t5HSACUeWzZ7ydcGnxXAzq08phvSgyyofMLct4bJ8nkBaf2lUji-VLklJ6g_60imzDg"}} -->
