### PR TITLE
fix(utils): include exact significance boundary

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -158,8 +158,8 @@ class SignificanceResult(_SignificanceResultTuple):
         checked_p = _require_result_probability("p_value", p_value, strict=False)
         checked_alpha = _require_result_probability("alpha", alpha, strict=True)
         checked_significant = _require_exact_bool("significant", significant)
-        if checked_significant is not (checked_p < checked_alpha):
-            raise ValueError("significant must exactly match p_value < alpha")
+        if checked_significant is not _is_significant(checked_p, checked_alpha):
+            raise ValueError("significant must exactly match p_value <= alpha")
         return tuple.__new__(
             cls,
             (
@@ -211,6 +211,12 @@ def _require_finite_values(values: NDArray[np.floating], *, name: str) -> None:
     """Reject NaN/inf samples so summaries cannot gold-plate a poisoned seed."""
     if not np.isfinite(values).all():
         raise ValueError(f"{name} must be finite")
+
+
+def _is_significant(p_value: float, alpha: float) -> bool:
+    """Return the inclusive rejection decision for a validated p-value."""
+
+    return p_value <= alpha
 
 
 def _require_sample_vector(values: object, *, name: str) -> NDArray[np.float64]:
@@ -509,7 +515,7 @@ def ttest_comparison(
         test_name=test_name,
         statistic=stat_val,
         p_value=p_val,
-        significant=p_val < alpha_value,
+        significant=_is_significant(p_val, alpha_value),
         alpha=alpha_value,
         effect_size=effect,
         method_a=method_a,
@@ -584,7 +590,7 @@ def mann_whitney_comparison(
         test_name="Mann-Whitney U",
         statistic=stat_val,
         p_value=p_val,
-        significant=p_val < alpha_value,
+        significant=_is_significant(p_val, alpha_value),
         alpha=alpha_value,
         effect_size=r,
         method_a=method_a,
@@ -663,7 +669,7 @@ def wilcoxon_comparison(
         test_name="Wilcoxon signed-rank",
         statistic=stat_val,
         p_value=p_val,
-        significant=p_val < alpha_value,
+        significant=_is_significant(p_val, alpha_value),
         alpha=alpha_value,
         effect_size=effect,
         method_a=method_a,
@@ -697,7 +703,7 @@ def bonferroni_correction(
     if n_tests == 0:
         return [], alpha_value
     corrected_alpha = alpha_value / n_tests
-    significant = [p < corrected_alpha for p in validated_p_values]
+    significant = [_is_significant(p, corrected_alpha) for p in validated_p_values]
     return significant, corrected_alpha
 
 
@@ -742,7 +748,7 @@ def _holm_decisions(
     for rank, raw_index in enumerate(sorted_indices):
         index = int(raw_index)
         rank_threshold = alpha / (n_tests - rank)
-        if stopped_threshold is None and p_values[index] < rank_threshold:
+        if stopped_threshold is None and _is_significant(p_values[index], rank_threshold):
             significant[index] = True
             thresholds[index] = rank_threshold
         else:

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -794,6 +794,24 @@ class TestOneSampleRejection:
 
 
 class TestCorrections:
+    def test_exact_decision_boundary_is_significant(self) -> None:
+        result = SignificanceResult(
+            test_name="boundary fixture",
+            statistic=1.0,
+            p_value=0.05,
+            significant=True,
+            alpha=0.05,
+            effect_size=0.0,
+            method_a="candidate",
+            method_b="control",
+        )
+        assert result.significant is True
+
+        bonferroni, corrected_alpha = bonferroni_correction([0.025, 1.0], alpha=0.05)
+        assert corrected_alpha == 0.025
+        assert bonferroni == [True, False]
+        assert holm_correction([0.025, 1.0], alpha=0.05) == [True, False]
+
     def test_bonferroni_empty_p_values(self) -> None:
         significant, corrected_alpha = bonferroni_correction([], alpha=0.05)
         assert significant == []


### PR DESCRIPTION
## Defect

The supported public path `alberta_framework.utils.statistics.{holm_correction,bonferroni_correction}` silently excluded an exact decision boundary because every statistics result used `p_value < alpha`. With `p_values=[0.025, 1.0]` and `alpha=0.05`, the first adjusted p-value is exactly 0.05, but both utilities reported `False`. `pairwise_comparisons` consumes the same correction path, and `SignificanceResult` also refused to represent the correct inclusive decision.

This disagreed with the repository's exact-rational Forager `holm_adjust`, whose existing boundary contract explicitly rejects when adjusted `p == alpha`.

Base: `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`  
Measured head: `49e2e22ada1f11c2cb90d0414fa39b031abde8de`

## Before / after

Reproduction before the edit (exit 1):

```text
utils.holm_correction: [False, False]
utils.bonferroni_correction: [False, False]
forager exact Holm boundary reject: True
Traceback (most recent call last):
  File "<stdin>", line 8, in <module>
AssertionError
```

The same supported call after the edit (exit 0):

```text
utils.holm_correction: [True, False]
utils.bonferroni_correction: [True, False]
forager exact Holm boundary reject: True
```

## Fix

One internal `_is_significant(p_value, alpha)` boundary now implements `p_value <= alpha`. Raw t-test, Mann-Whitney, and Wilcoxon results, `SignificanceResult`, Bonferroni, and Holm all use that same boundary so corrected decisions cannot disagree with the result record that carries them.

No benchmark protocol, seed, pinned artifact, threshold value, or scientific claim changes.

## Regression and mutation proof

The new regression covers `SignificanceResult`, Bonferroni, and Holm on exact boundaries. Before the production edit it failed with:

```text
ValueError: significant must exactly match p_value < alpha
1 failed in 1.29s
```

I then reverted only `alberta_framework/utils/statistics.py`, retained the test, and reran with `-n 2`; it failed on the same defect:

```text
ValueError: significant must exactly match p_value < alpha
1 failed in 1.22s
```

Restoring the production fix made the regression pass.

## Verification

- `python -m pytest tests/test_statistics_validation.py tests/test_statistics_hostile_validation.py -q -o addopts='' -n 2` — 252 passed, 2 existing scipy precision-loss warnings.
- The factory proof recorder repeated that suite at the measured head — 252 passed, 2 warnings.
- `python -m ruff check alberta_framework/utils/statistics.py tests/test_statistics_validation.py` — passed.
- `python -m mypy alberta_framework/utils/statistics.py` — passed.
- Repository-wide mypy still reports the unrelated existing macOS `os.O_TMPFILE` attribute error in `bounded_elastic_matched_runner.py:1111`.
- `git diff --check` — passed.

<!-- evidence-head:49e2e22ada1f11c2cb90d0414fa39b031abde8de -->
<!-- evidence-row:logs -->
- [x] logs: N/A — exact red/green outputs and exact-head test command are included above.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A — this is a deterministic public utility boundary fix; no benchmark artifact or seed was produced.
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: private trace `sha256:818195d4b8b8c1082a932f74cf0085f213491c5d68cb81688c8ceb6d8c779f2a` finalized through the signed receipt below.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [codex-metric-fix-20260828]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M134FRZ667K2B3BQJRZ1XWH5","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-28T02:51:51.654Z","completed_at":"2026-08-28T02:55:17.331Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-28T02:51:51.970Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"818195d4b8b8c1082a932f74cf0085f213491c5d68cb81688c8ceb6d8c779f2a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9784c802-e5e3-43a2-9eb7-d2fe90c24eb4","object_id":"sha256:818195d4b8b8c1082a932f74cf0085f213491c5d68cb81688c8ceb6d8c779f2a","sha256":"818195d4b8b8c1082a932f74cf0085f213491c5d68cb81688c8ceb6d8c779f2a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"EWHiCpd6QPEL7rKWvYTKKx-kkqMopAbBaPU5HSgTWmha9YTjy86FzRE0FpW5xWt3rilgVK5TwfHNHNsao5eXAg"}} -->
