### PR TITLE
fix(cumulant_discovery): re-narrow before preserve_nonzero float32 underflow guard

### DIFF
--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -106,7 +106,7 @@ def _require_float32(
         upper_inclusive=upper_inclusive,
         positive=positive,
     )
-    if preserve_nonzero and numerator != 0 and stored == 0.0:
+    if preserve_nonzero and numerator != 0 and float(np.float32(stored)) == 0.0:
         raise ValueError(f"{name} must remain nonzero once narrowed to float32")
     return stored
 

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -14,6 +14,7 @@ import pytest
 from alberta_framework.core.cumulant_discovery import (
     CumulantDiscovery,
     CumulantDiscoveryState,
+    _require_float32,
 )
 
 # =============================================================================
@@ -375,6 +376,35 @@ def test_cumulant_discovery_rejects_exact_nonzero_float32_underflow(field: str) 
     tiny = np.nextafter(np.longdouble(0), np.longdouble(1))
     with pytest.raises(ValueError, match="remain nonzero"):
         CumulantDiscovery(raw_dim=4, **{field: tiny})
+
+
+def test_require_float32_preserve_nonzero_fires_for_builtin_float() -> None:
+    # np.float32(1e-50) underflows to exactly 0.0; the guard must reject it.
+    assert np.float32(1e-50) == 0.0
+    with pytest.raises(ValueError, match="remain nonzero"):
+        _require_float32("gamma", 1e-50, lower=0.0, upper=1.0, preserve_nonzero=True)
+
+
+def test_require_float32_preserve_nonzero_fires_for_numpy_float64() -> None:
+    with pytest.raises(ValueError, match="remain nonzero"):
+        _require_float32(
+            "gamma", np.float64(1e-50), lower=0.0, upper=1.0, preserve_nonzero=True
+        )
+
+
+def test_require_float32_preserve_nonzero_accepts_representable_small_value() -> None:
+    # 1e-30 remains nonzero in float32, so it must not be over-rejected.
+    assert np.float32(1e-30) != 0.0
+    assert _require_float32(
+        "gamma", 1e-30, lower=0.0, upper=1.0, preserve_nonzero=True
+    ) == pytest.approx(1e-30)
+
+
+def test_require_float32_preserve_nonzero_false_accepts_underflow() -> None:
+    # Without the guard, an underflowing value is accepted unchanged.
+    assert _require_float32(
+        "gamma", 1e-50, lower=0.0, upper=1.0, preserve_nonzero=False
+    ) == pytest.approx(1e-50)
 
 
 def test_cumulant_discovery_resource_formula_matches_state() -> None:


### PR DESCRIPTION
## What was broken

In `alberta_framework/core/cumulant_discovery.py`, the `_require_float32(..., preserve_nonzero=True)` guard is meant to reject a value that silently underflows to exactly `0.0` when narrowed to float32. The guard tested the **un-narrowed** `stored` value:

```python
if preserve_nonzero and numerator != 0 and stored == 0.0:
```

`validated_float32_scalar_with_ratio` returns the un-narrowed value for a built-in `float` (its last line is `stored = value if type(value) is float else narrowed`). The guarded parameters (`gamma`, `replacement_rate`, `predictor_step_size`) are annotated as built-in `float` and callers pass plain literals, so the underflow branch could never fire on the normal path.

### Measurement consequence

A configuration like `gamma=1e-50` (which becomes `np.float32(1e-50) == 0.0`) was **silently accepted** for built-in `float`, while the identical magnitude as `np.float64` was correctly rejected — same value, opposite outcome depending only on the Python type. This lets a cumulant-discovery discount / replacement-rate / step-size collapse to zero in the float32 compute path without any error, corrupting the demon dynamics it is supposed to guard.

## Fix

Re-narrow at the guard before the underflow test, mirroring the correct pattern already in `alberta_framework/core/option_value_duration.py`:

```python
if preserve_nonzero and numerator != 0 and float(np.float32(stored)) == 0.0:
    raise ValueError(f"{name} must remain nonzero once narrowed to float32")
```

Returned value is unchanged; only the guard's condition changes. `np` was already imported. `_float32_scalars.py` is untouched (changing `stored` there would affect every caller). One variable, one lane.

## Failing-then-passing reproduction

New regression tests in `tests/test_cumulant_discovery.py` (>=10 added lines) assert the built-in `float` path now raises, the `np.float64` path still raises, a representable small value (`1e-30`) is still accepted, and `preserve_nonzero=False` still accepts underflow.

**FAILING on unmodified source (fix reverted):**
```
### FAILING: new regression test on unmodified cumulant_discovery.py (fix reverted) ###
F...                                                                     [100%]
=================================== FAILURES ===================================
________ test_require_float32_preserve_nonzero_fires_for_builtin_float _________

    def test_require_float32_preserve_nonzero_fires_for_builtin_float() -> None:
        # np.float32(1e-50) underflows to exactly 0.0; the guard must reject it.
        assert np.float32(1e-50) == 0.0
>       with pytest.raises(ValueError, match="remain nonzero"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE ValueError

tests/test_cumulant_discovery.py:384: Failed
=========================== short test summary info ============================
FAILED tests/test_cumulant_discovery.py::test_require_float32_preserve_nonzero_fires_for_builtin_float
1 failed, 3 passed, 51 deselected in 1.15s
```

**PASSING after the one-line guard fix (full test file):**
```
### PASSING: full test file after fix ###
.......................................................                  [100%]
55 passed in 14.40s
```

## Verification commands and results

```
### ruff ###
All checks passed!
### mypy (repo CI scope: alberta_framework) ###
Success: no issues found in 224 source files
```

- `.venv/bin/python -m pytest tests/test_cumulant_discovery.py -q -o addopts=""` → `55 passed`
- `.venv/bin/python -m ruff check .` → `All checks passed!`
- `.venv/bin/python -m mypy` (repo CI scope, `files = ["alberta_framework"]`) → `Success: no issues found in 224 source files`

## What remains open

Nothing for this defect. The fix is scoped to the single guard condition plus its regression test. Other `preserve_nonzero` call sites already re-narrow correctly.

> Note: the immutable attachment-URL evidence uploader (`attach.mjs`) could not authenticate a session in this environment (GitHub verification interstitial), so the failing/passing/lint logs are pasted inline above rather than as minted attachment URLs. All outputs are reproducible via the exact commands listed.

Closes #2720

<!-- evidence-head:bf753d611ca5bb3b011409b7f1298b9d0ab99510 -->
<!-- evidence-row:logs -->
- [ ] logs: attachment-URL minting blocked (auth interstitial); logs inline above

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@eb5702c87fef7e2b9c95b258b2bdfd9f449d9d0b:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@eb5702c87fef7e2b9c95b258b2bdfd9f449d9d0b:skills/contribute-to-asi"} -->
