### PR TITLE
fix(micro): require every paired gate seed to improve

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1588,6 +1588,7 @@ def transfer_validation(
         "gate_small_positive",
         bool(
             gate_delta.mean() > 0.0
+            and np.all(gate_delta > 0.0)
             and gate_delta.mean() <= conditioning_delta.mean() / 2.0
         ),
         "full protocol: gate +0.011, an order below conditioning +0.061",

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -1723,6 +1723,25 @@ class TestTransferValidation:
         assert checks["gate_small_positive"]["passed"] is False
         assert report["transfer_valid"] is False
 
+    def test_gate_requires_every_paired_seed_to_improve(self):
+        ladder = _synthetic_ladder(seeds=(0, 1, 2))
+        ladder["gated_norm"] = {
+            0: np.full(8, 0.830),
+            1: np.full(8, 0.870),
+            2: np.full(8, 0.870),
+        }
+
+        report = transfer_validation(ladder)
+        checks = {check["name"]: check for check in report["checks"]}
+        gate = checks["gate_small_positive"]
+
+        assert gate["values"]["per_seed_gate_delta"] == pytest.approx(
+            [-0.010, 0.029, 0.028]
+        )
+        assert gate["values"]["all_seeds_positive"] is False
+        assert gate["passed"] is False
+        assert report["transfer_valid"] is False
+
     def test_nondecaying_adam_fails(self):
         ladder = _synthetic_ladder()
         ladder["adamw"] = {seed: np.linspace(0.70, 0.75, 8) for seed in (0, 1)}


### PR DESCRIPTION
## Defect

The supported `python -m alberta_framework.benchmarks.micro_continual ladder` path merges campaign shards through `transfer_validation_from_shards()` into `transfer_validation()`. Its `gate_small_positive` check exposed an `all_seeds_positive` field but accepted a positive mean even when one paired seed regressed. That let the CLI write `transfer_valid: true` and exit 0 for a ladder that violated its stated all-seed gate.

Base: `origin/main` at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`.

## Before / after

Before, the supported validator accepted a mixed paired result:

```text
{"all_seeds_positive": false, "gate_passed": true, "per_seed_gate_delta": [-0.01, 0.03, 0.03], "transfer_valid": true}
```

After requiring every paired gate delta to be positive at the validator boundary:

```text
{"all_seeds_positive": false, "gate_passed": false, "per_seed_gate_delta": [-0.01, 0.03, 0.03], "transfer_valid": false}
```

The existing three-seed campaign shards still validate through a copied output directory without modifying immutable artifacts:

```text
transfer_valid=True (primary checks: {'conditioning_dominates': True, 'gate_small_positive': True, 'adam_decays': True, 'adam_below_upgd_raw': True, 'naive_bayes_placement': True, 'champion_top': True})
```

## Regression proof

The new regression was red before the fix:

```text
>       assert gate["passed"] is False
E       assert True is False
1 failed in 1.08s
```

With the fix:

```text
1 passed in 1.15s
```

I then reverted only the production predicate, kept the test unchanged, and reproduced the same assertion failure (`1 failed in 1.08s`) before restoring the fix.

Focused verification at head `26b503eab510ba672a6541c05abadb207a1ff103` (one pytest worker in a Docker sandbox capped at two CPUs):

```text
11 passed in 8.11s
All checks passed!
```

The broader module run reached `223 passed`; its five remaining tests could not start because the available pinned runtime image lacks optional `scikit-learn`. Those are the separate legacy digits lane and do not exercise this validator.

No issue is linked; this is a directly reproduced supported-path validator defect. Open-PR searches for `gate_small_positive`, `micro_continual transfer_valid`, and all-seed transfer gating found no matching fix.

<!-- evidence-head:26b503eab510ba672a6541c05abadb207a1ff103 -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [runtime-metric-fix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1355MPCJ7GZJKH7V7RPX5E8","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-28T03:03:48.173Z","completed_at":"2026-08-28T03:21:44.413Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-28T03:03:48.835Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"782e3baad9449df2552cc5e67bf7b55d1c6a72370b8500d67463508a7bed4796","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"29f67e7e-b927-49ed-a9a6-8a0bcc10c520","object_id":"sha256:782e3baad9449df2552cc5e67bf7b55d1c6a72370b8500d67463508a7bed4796","sha256":"782e3baad9449df2552cc5e67bf7b55d1c6a72370b8500d67463508a7bed4796"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA3qp2qlPvWwwKfIl5iPln7EUrHBcgqCX-87Cz0b_VVk0","device_key_id":"7fe9e8ddf85097400d555bf61a271e57f5b547ced7e28fe091fbbd54452478cb","device_signature":"XWepwvyg0Yw62N9m_kVUqNBkl8V5agK79FpaQaivMgWbw3LsMwN6i0T94VKl2dP9DHbCQGRWYSEGRxzhIKW0AQ"}} -->
