### PR TITLE
fix(streams): preserve RiverSwim stationary reward ratios

### DIFF
--- a/alberta_framework/streams/closed_loop.py
+++ b/alberta_framework/streams/closed_loop.py
@@ -37,6 +37,7 @@ The state and config records are immutable chex dataclasses.
 from __future__ import annotations
 
 import itertools
+import math
 import operator
 from fractions import Fraction
 from numbers import Real
@@ -233,7 +234,28 @@ def _stationary_average_reward(
         The long-run average reward ``d @ step_rewards``.
     """
     n = transition.shape[0]
-    constraints = np.vstack([transition.T - np.eye(n), np.ones((1, n))])
+    kernel = np.asarray(transition, dtype=np.float64)
+    row_totals = np.array([math.fsum(row) for row in kernel], dtype=np.float64)
+    kernel = kernel / row_totals[:, None]
+
+    # Build the equivalent continuous-time generator from the categorical
+    # kernel's off-diagonal mass.  Forming ``P - I`` would subtract nearly
+    # equal float32 diagonal values and can overwhelm very small transition
+    # probabilities with rounding error.  The categorical sampler normalizes
+    # each stored row, so use those normalized off-diagonal weights directly
+    # and derive the diagonal from their sum.
+    generator = kernel.copy()
+    np.fill_diagonal(generator, 0.0)
+    np.fill_diagonal(
+        generator,
+        [-math.fsum(row) for row in generator],
+    )
+
+    balance = generator.T
+    equation_scales = np.max(np.abs(balance), axis=1)
+    nonzero_equations = equation_scales > 0.0
+    balance[nonzero_equations] /= equation_scales[nonzero_equations, None]
+    constraints = np.vstack([balance, np.ones((1, n))])
     targets = np.zeros(n + 1)
     targets[-1] = 1.0
     distribution, *_ = np.linalg.lstsq(constraints, targets, rcond=None)

--- a/tests/test_closed_loop_env.py
+++ b/tests/test_closed_loop_env.py
@@ -510,6 +510,28 @@ class TestRiverSwim:
         assert uniform < optimal
         assert always_left < optimal
 
+    def test_stationary_gain_preserves_tiny_categorical_transition_ratios(self):
+        """Stationary mass follows the row-normalized categorical kernel."""
+        env = RiverSwimMDP(
+            RiverSwimConfig(
+                n_states=2,
+                p_right_up=1.0e-7,
+                p_right_down=2.0e-7,
+                reward_left=0.0,
+                reward_right=1.0,
+            )
+        )
+        kernel = env.transition_tensor[RIGHT_ACTION].astype(np.float64)
+        up = kernel[0, 1] / kernel[0].sum()
+        down = kernel[1, 0] / kernel[1].sum()
+        expected_top_state_mass = up / (up + down)
+
+        assert env.policy_average_reward([RIGHT_ACTION, RIGHT_ACTION]) == pytest.approx(
+            expected_top_state_mass,
+            rel=1.0e-12,
+            abs=1.0e-12,
+        )
+
     def test_policy_gain_matches_scan_simulation(self):
         """A long scan rollout of always-right attains its analytic gain."""
         env = RiverSwimMDP(RiverSwimConfig(n_states=4))


### PR DESCRIPTION
## Defect

`RiverSwimMDP.policy_average_reward()` silently misreported the long-run reward for supported slow-mixing kernels. This public path also supplies `optimal_average_reward()` and `uniform_random_average_reward()`, so the same numerical error corrupted RiverSwim benchmark baselines and the reference-life scorecard oracle.

The solver formed `P.T - I` from a float32 transition tensor. When off-diagonal probabilities were small, subtracting a nearly-one diagonal erased balance information before NumPy's least-squares rank decision.

Base: `origin/main` at `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`.

## Before and after

Supported reproduction: `RiverSwimConfig(n_states=2, p_right_up=1e-7, p_right_down=2e-7, reward_left=0, reward_right=1)` with an always-right policy.

Before:

```text
stored kernel row 0 = [0.9999998807907104, 1.0000000116860974e-07]
stored kernel row 1 = [2.0000000233721948e-07, 0.9999998211860657]
expected always-right average reward = 0.333333342310079
reported always-right average reward = 0.367051452471610
absolute error = 0.033718110161531
```

After:

```text
expected always-right average reward = 0.333333342310079
reported always-right average reward = 0.333333342310079
absolute error = 0.000000000000000
```

## Fix

At the single stationary-solver boundary, the patch normalizes the stored categorical weights in float64, constructs the equivalent flow generator directly from off-diagonal mass, scales nonzero balance equations, and retains the normalization constraint. This avoids the destructive diagonal subtraction without changing callers or policy enumeration.

## Regression proof

The focused test derives the exact two-state stationary ratio from the stored, row-normalized categorical weights. With only the production change reverted and the new test retained, it failed on the original defect:

```text
E       assert 0.36705145247160986 == 0.3333333423100792 ± 1.0e-12
E         Obtained: 0.36705145247160986
E         Expected: 0.3333333423100792 ± 1.0e-12
1 failed in 1.46s
```

After restoring the fix:

```text
185 passed, 1 skipped in 31.27s
All checks passed!
Success: no issues found in 1 source file
```

Commands used pytest with `-n 2` across `test_closed_loop_env.py`, `test_reference_life_riverswim.py`, and `test_reference_life_scorecard.py`, plus Ruff, mypy on the changed source, and `git diff --check`. Independent adversarial review approved the numerical construction and regression sensitivity.

`closed_loop.py` is registered by the historical continual-IA evidence chain. This source correction intentionally leaves every pinned artifact untouched; the registry's fail-closed source-drift response remains intact until that frozen protocol is independently rerun.

<!-- evidence-head:1e72e9407fc8a6604ee5177d6fbda3bac0459e69 -->
<!-- evidence-row:logs -->
- [x] logs: reproduced before/after and exact-head test output are included above; N/A attachment because this deterministic unit-scale proof has no external log artifact.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A — this fixes an analytic benchmark metric and does not create or modify scientific evidence artifacts.
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: private trace finalized as `sha256:cf079109d8e2e109a260066beee5ca5f4e67bed0e4986fc8056aa9a3e9819f8f`; the signed receipt below carries the immutable server join.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [metric-integrity-fix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1358AA8513JP63B5N5GRV7Y","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-28T03:05:15.848Z","completed_at":"2026-08-28T03:26:27.319Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-28T03:05:16.754Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"cf079109d8e2e109a260066beee5ca5f4e67bed0e4986fc8056aa9a3e9819f8f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c42c3d86-a951-481f-97f5-7a0b0ac3de89","object_id":"sha256:cf079109d8e2e109a260066beee5ca5f4e67bed0e4986fc8056aa9a3e9819f8f","sha256":"cf079109d8e2e109a260066beee5ca5f4e67bed0e4986fc8056aa9a3e9819f8f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"-kmaRwP8lZxdNF6zhyNkaZVxMw7FbdRnA7w3p0Lpn_dNZUsASziSAM3pcred7wng9ofrZwtX4TvApK5CtFTiAg"}} -->
