### PR TITLE
fix(forager): bind custom policy metadata in summaries

### DIFF
--- a/alberta_framework/benchmarks/forager.py
+++ b/alberta_framework/benchmarks/forager.py
@@ -3987,39 +3987,23 @@ def summarize_forager_runs(
     def method_signature(run: ForagerRunResult) -> str:
         metadata = run.agent_metadata
         stable_metadata = {
-            "config": metadata.get("config"),
-            "result_source": metadata.get("result_source"),
-            "source_repository": metadata.get("source_repository"),
-            "source_commit": metadata.get("source_commit"),
-            "config_path": metadata.get("config_path"),
-            "attestation_state": metadata.get("attestation_state"),
-            "official_foragax_evidence": metadata.get(
-                "official_foragax_evidence"
-            ),
-            "protocol_attested": metadata.get("protocol_attested"),
-            "runtime_profile_id": metadata.get("runtime_profile_id"),
-            "environment_runtime_profile_sha256": metadata.get(
-                "environment_runtime_profile_sha256"
-            ),
-            "environment_rng_schedule": metadata.get(
-                "environment_rng_schedule"
-            ),
-            "environment_rng_schedule_sha256": metadata.get(
-                "environment_rng_schedule_sha256"
-            ),
-            "paper_search_oracle": metadata.get("paper_search_oracle"),
-            "random_backend": metadata.get("random_backend"),
-            "runner_kind": (
+            key: value
+            for key, value in metadata.items()
+            if key
+            not in {"seed", "name", "privileged", "runner", "raw_metric_trace"}
+        }
+        stable_metadata["runner"] = {
+            "kind": (
                 metadata.get("runner", {}).get("kind")
                 if isinstance(metadata.get("runner"), Mapping)
                 else None
             ),
-            "runner_batch_mode": (
+            "batch_mode": (
                 metadata.get("runner", {}).get("batch_mode")
                 if isinstance(metadata.get("runner"), Mapping)
                 else None
             ),
-            "runner_rounding_contract": (
+            "rounding_contract": (
                 metadata.get("runner", {}).get("rounding_contract")
                 if isinstance(metadata.get("runner"), Mapping)
                 else None

--- a/tests/test_forager_benchmark.py
+++ b/tests/test_forager_benchmark.py
@@ -1129,6 +1129,18 @@ def test_summary_and_paired_comparison_fail_closed() -> None:
         summarize_forager_runs(
             [candidate[0], _result("alberta_horde_ac", 1, 2.0, config_id="different")]
         )
+    different_custom_metadata = [
+        dataclasses.replace(
+            candidate[0],
+            agent_metadata={"learning_rate": 0.01},
+        ),
+        dataclasses.replace(
+            candidate[1],
+            agent_metadata={"learning_rate": 0.99},
+        ),
+    ]
+    with pytest.raises(ValueError, match="configuration"):
+        summarize_forager_runs(different_custom_metadata)
     incompatible_metric = _result("alberta_horde_ac", 1, 2.0, ewm_decay=0.5)
     with pytest.raises(ValueError, match="metric contract"):
         summarize_forager_runs([candidate[0], incompatible_metric])


### PR DESCRIPTION
## Defect

The supported custom-policy path `compare_forager_agents` → `run_forager` →
`summarize_forager_runs` preserved arbitrary JSON-compatible policy metadata, but the
summarizer compared only a small hard-coded allowlist. Two seeds using different custom-policy
hyperparameters were therefore presented as replications of one method and silently produced a
wrong aggregate number.

Before, two runs with `learning_rate` values `0.01` and `0.99` were accepted:

```text
input learning_rates: [0.01, 0.99]
accepted seeds: (0, 1)
reported mean: 0.5
```

After the fix, the same supported input is rejected at the aggregation boundary:

```text
rejected=runs must share one method configuration and provenance
```

## Fix

`summarize_forager_runs` now binds all custom method metadata into its canonical method
signature. It normalizes only per-run identity, raw trace data, and timing telemetry while
retaining the existing stable runner identity fields. The change is confined to the one boundary
that decides whether runs may be aggregated.

Base: `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (`origin/main`).

## Regression proof

The new regression first failed on the original implementation:

```text
E Failed: DID NOT RAISE ValueError
1 failed in 2.99s
```

After applying the production fix it passed. I then reverted only the production change while
keeping the test, and it failed on exactly the same missing rejection:

```text
E Failed: DID NOT RAISE ValueError
1 failed in 2.81s
```

Restoring the fix produced:

```text
1 passed in 2.72s
```

## Verification

```text
.venv/bin/python -m pytest tests/test_forager_benchmark.py -q -o addopts= -n 2
103 passed, 3 skipped in 13.87s

.venv/bin/python -m ruff check alberta_framework/benchmarks/forager.py tests/test_forager_benchmark.py
All checks passed!

.venv/bin/python -m mypy alberta_framework/benchmarks/forager.py
Success: no issues found in 1 source file
```

<!-- evidence-head:86a350f26e2dedc6530e15880d2b078d83e408be -->
<!-- evidence-row:logs -->
- [x] logs: verbatim before/after, mutation proof, and exact-head test output are included above
<!-- evidence-row:domain-artifact -->
- [ ] domain-artifact: N/A - this fixes aggregation validation and produces no scientific artifact
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: finalized private trace is bound in the signed receipt below

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [codex-fix-metric-boundary-20260828]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M13AKW3AA6YXBS1NTSHT9Q9Z","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-28T04:38:57.386Z","completed_at":"2026-08-28T04:54:43.645Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-28T04:38:58.289Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"bc30862d5b4824cb0c9eaea7be451c9206566cf4002894ab56be64a0551eff6b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"f7ee4ea2-54eb-4ae9-ace4-c7305f838562","object_id":"sha256:bc30862d5b4824cb0c9eaea7be451c9206566cf4002894ab56be64a0551eff6b","sha256":"bc30862d5b4824cb0c9eaea7be451c9206566cf4002894ab56be64a0551eff6b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"DSsIXt4z5aGihXLn_FxP3fe23c0umHv3W9aQmDYc03jh-X9NMefXF9VQP3UF_ca4ehTX2FjCoTcR4tHJpW9PBg"}} -->
