### PR TITLE
fix(benchmarks): suppress unpaired UPGD winner

### DIFF
--- a/alberta_framework/benchmarks/upgd_ipmnist.py
+++ b/alberta_framework/benchmarks/upgd_ipmnist.py
@@ -1254,7 +1254,11 @@ def build_comparison(summaries: dict[str, dict[str, Any]]) -> dict[str, Any]:
             "gap": round(gap, 6),
             "reproduction_gap_flagged": bool(abs(gap) > REPRODUCTION_GAP_THRESHOLD),
         }
-    if "upgd_w" in summaries and "adamw" in summaries:
+    if (
+        "upgd_w" in summaries
+        and "adamw" in summaries
+        and summaries["upgd_w"]["seeds"] == summaries["adamw"]["seeds"]
+    ):
         comparison["upgd_w_beats_adamw"] = bool(
             summaries["upgd_w"]["average_online_accuracy_mean"]
             > summaries["adamw"]["average_online_accuracy_mean"]

--- a/tests/test_upgd_ipmnist.py
+++ b/tests/test_upgd_ipmnist.py
@@ -1278,6 +1278,26 @@ class TestPartialMerge:
 
 
 class TestSummariesAndComparison:
+    def test_cross_learner_comparison_is_omitted_for_disjoint_seed_schedules(self):
+        comparison = build_comparison(
+            {
+                "upgd_w": {"average_online_accuracy_mean": 0.9, "seeds": [0]},
+                "adamw": {"average_online_accuracy_mean": 0.1, "seeds": [1]},
+            }
+        )
+
+        assert "upgd_w_beats_adamw" not in comparison
+
+    def test_cross_learner_comparison_is_retained_for_matching_seed_schedules(self):
+        comparison = build_comparison(
+            {
+                "upgd_w": {"average_online_accuracy_mean": 0.9, "seeds": [0, 1]},
+                "adamw": {"average_online_accuracy_mean": 0.1, "seeds": [0, 1]},
+            }
+        )
+
+        assert comparison["upgd_w_beats_adamw"] is True
+
     def test_summary_and_comparison_flag_logic(self):
         data_x, data_y = _synthetic_dataset(4, N_TRAIN, TINY.input_dim, TINY.n_classes)
         result = run_ipmnist(data_x, data_y, "upgd_w", seeds=(0, 1), config=TINY)


### PR DESCRIPTION
## Defect

The supported legacy development path

```text
python -m alberta_framework.benchmarks.upgd_ipmnist --merge-partials ...
```

accepted `upgd_w` and `adamw` shards with disjoint seed schedules. The artifact correctly recorded `all_learners_share_seed_ids: false`, but `build_comparison()` still published `upgd_w_beats_adamw` from the two unpaired means. An interrupted or interim merge could therefore silently report a confounded cross-learner winner.

This was reproduced from current `origin/main` at base SHA `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` using the real v2 merge CLI with UPGD-W seed 0 and AdamW seed 1:

```json
{
  "seed_ids": {"adamw": [1], "upgd_w": [0]},
  "all_learners_share_seed_ids": false,
  "upgd_w_beats_adamw": true
}
```

## Fix

The comparison boundary now emits `upgd_w_beats_adamw` only when both summaries carry exactly the same seed schedule. Per-learner paper-reference diagnostics remain available for interim or disjoint merges; only the invalid cross-learner verdict is omitted. Matched historical seed schedules retain their existing boolean.

The same CLI reproduction after the fix reports:

```json
{
  "seed_ids": {"adamw": [1], "upgd_w": [0]},
  "all_learners_share_seed_ids": false,
  "upgd_w_beats_adamw_present": false
}
```

No pinned or active `outputs/` artifact was modified. This remains a permanently nonpromoting development lane and makes no performance or scientific claim.

## Regression proof

With only the production condition reverted and the new test retained:

```text
AssertionError: assert 'upgd_w_beats_adamw' not in comparison
1 failed in 5.69s
```

Restoring the production fix makes the focused regression pass.

## Verification

Measured head: `8d501cf0fd3617bffd78b554a7e639ef2905a4b9`

```text
.venv/bin/python -m pytest tests/test_upgd_ipmnist.py tests/test_upgd_ipmnist_nonpromoting.py -q -o addopts="" -n 2
154 passed in 34.68s

.venv/bin/python -m ruff check alberta_framework/benchmarks/upgd_ipmnist.py tests/test_upgd_ipmnist.py
All checks passed!

.venv/bin/python -m mypy alberta_framework/benchmarks/upgd_ipmnist.py
Success: no issues found in 1 source file

git diff --check
exit 0
```

The repository-wide mypy invocation also reached one existing Darwin-only error at `alberta_framework/evaluation/bounded_elastic_matched_runner.py:1111` because `os.O_TMPFILE` is unavailable on this platform; it is outside this diff.

An independent read-only adversarial review approved the boundary, test sensitivity, strict-validator compatibility, and matched-artifact compatibility. Exact open-PR searches for `unpaired learner comparison`, `disjoint seeds winner`, `all_learners_share_seed_ids`, `upgd_w_beats_adamw`, and `UPGD IPMNIST paired seeds` found no pull request implementing this fix.

<!-- evidence-head:8d501cf0fd3617bffd78b554a7e639ef2905a4b9 -->
<!-- evidence-row:logs -->
- [x] logs: N/A — deterministic before/after and regression outputs are included above; no long benchmark run was needed.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A — temporary reproduction artifacts were development-only and were not published.
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: private trace finalized; its public SHA-256 and upload identity are bound in the signed receipt below.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [metric-fix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M13C11TYSZPX8RYQ2HZP5E9Z","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-28T05:03:37.823Z","completed_at":"2026-08-28T05:28:29.147Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-28T05:03:38.156Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"74babfa83806696e0c949099888ee0fbc4647b482c7e9bd0336dde1c3053e1e4","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"db8ea5c5-0dc7-45d9-8c3d-229487f2792c","object_id":"sha256:74babfa83806696e0c949099888ee0fbc4647b482c7e9bd0336dde1c3053e1e4","sha256":"74babfa83806696e0c949099888ee0fbc4647b482c7e9bd0336dde1c3053e1e4"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"bLD6PKZ01OVTXf3N54g-fl4d2CVTZmUfbw7-T5o0dq9ie8AYNBL3znNPrXP9uL-M9eiu07QuThYvCYNa0NISBQ"}} -->