### PR TITLE
fix(scorecard): leave single-seed stderr undefined

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -984,8 +984,10 @@ def _sample_sd(values: Sequence[float]) -> float:
     return math.sqrt(math.fsum((value - average) ** 2 for value in values) / (len(values) - 1))
 
 
-def _stderr(values: Sequence[float]) -> float:
-    return _sample_sd(values) / math.sqrt(len(values)) if values else 0.0
+def _stderr(values: Sequence[float]) -> float | None:
+    if len(values) < 2:
+        return None
+    return _sample_sd(values) / math.sqrt(len(values))
 
 
 def _paired_lcb(values: Sequence[float]) -> float | None:

--- a/tests/test_reference_life_scorecard.py
+++ b/tests/test_reference_life_scorecard.py
@@ -378,6 +378,29 @@ def test_summary_retains_failures_and_reports_valid_baseline_failure() -> None:
     assert summary["status"] == "valid_baseline_failure"
 
 
+def test_partial_arm_summary_marks_single_seed_stderr_undefined() -> None:
+    records = _summary_records()
+    retained_seed = SEED_ROSTER[0]
+    for record in records:
+        if record["arm"] == "prototype" and record["seed"] != retained_seed:
+            record["status"] = "failed"
+            record["outcome"] = None
+            record["failure"] = {
+                "stage": "step",
+                "type": "RuntimeError",
+                "message": "synthetic shard failure",
+            }
+
+    summary = scorecard._summarize_validated_run_records(
+        build_development_plan(), records
+    )
+
+    prototype = summary["environments"]["switching_two_state"]["arms"]["prototype"]
+    assert prototype["completed_seed_count"] == 1
+    assert prototype["failed_seed_count"] == len(SEED_ROSTER) - 1
+    assert prototype["reward_sum_stderr"] is None
+
+
 @pytest.mark.skipif(
     not hasattr(os, "O_TMPFILE"),
     reason="write_new_json publishes through Linux O_TMPFILE and linkat(AT_EMPTY_PATH)",


### PR DESCRIPTION
## Defect

The supported reference-life scorecard aggregation path
`.github/workflows/reference-life-scorecard-dev.yml` → `summarize` CLI →
`summarize_shard_files()` → `_summarize_validated_run_records()` retains failed
shards, but it reported `reward_sum_stderr: 0.0` when an arm had exactly one completed
seed and eleven failed seeds.

That number is false: sample standard error is undefined at `n=1`. A retained partial
artifact therefore claimed zero uncertainty precisely when it had no between-seed
uncertainty estimate.

Base: `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`

## Before / after

Reproduction on the base commit, using the scorecard's retained-failure reducer:

```text
{'completed_seed_count': 1, 'failed_seed_count': 11, 'reward_sum_mean': 50.0, 'reward_sum_stderr': 0.0}
```

At the measured head `8c3de167a6bbe4d4035d733efe33a2c16603b868`:

```text
{'completed_seed_count': 1, 'failed_seed_count': 11, 'reward_sum_mean': 50.0, 'reward_sum_stderr': None}
```

Complete 12-seed scorecards and every selection gate are unchanged.

## Fix

`_stderr()` now returns `None` for fewer than two observations and computes the
ordinary sample standard error otherwise. The existing summary schema already uses
`null` when no seeds complete, so this corrects the same nullable descriptive field at
the adjacent `n=1` boundary without changing the plan, gates, workflow, or artifact
shape.

## Regression proof

The regression constructs the real retained-failure shape with one completed prototype
seed. With only the production fix reverted and the test kept:

```bash
.venv/bin/python -m pytest \
  tests/test_reference_life_scorecard.py::test_partial_arm_summary_marks_single_seed_stderr_undefined \
  -q -n 2
```

```text
E assert 0.0 is None
1 failed in 2.47s
```

After restoring the production fix:

```text
1 passed in 1.98s
```

## Verification

```bash
.venv/bin/python -m pytest tests/test_reference_life_scorecard.py -q -n 2
.venv/bin/python -m ruff check \
  alberta_framework/benchmarks/reference_life_scorecard.py \
  tests/test_reference_life_scorecard.py
.venv/bin/python -m mypy \
  alberta_framework/benchmarks/reference_life_scorecard.py
git diff --check HEAD^
```

```text
65 passed, 1 skipped
All checks passed!
Success: no issues found in 1 source file
```

Full-project mypy was also attempted and reached one unrelated pre-existing Darwin
typing failure at
`alberta_framework/evaluation/bounded_elastic_matched_runner.py:1111`:
`Module has no attribute "O_TMPFILE" [attr-defined]`.

This is a unit-level measurement-integrity fix. It produces no benchmark result, consumes
no development or evaluation seeds, changes no evidence status, and writes no
`outputs/` artifact.

<!-- evidence-head:8c3de167a6bbe4d4035d733efe33a2c16603b868 -->
<!-- evidence-row:logs -->
- [ ] logs: N/A - exact before/after and failing/passing outputs are inline above
<!-- evidence-row:domain-artifact -->
- [ ] domain-artifact: N/A - this unit fix produces no benchmark artifact
<!-- evidence-row:llm-trajectory -->
- [ ] llm-trajectory: N/A - private trace digest and upload identity are in the signed receipt

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [metric-boundary-fix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M13E3MBJXMWNEX6EG7AJS857","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-28T05:39:59.474Z","completed_at":"2026-08-28T05:55:39.839Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-28T05:40:00.102Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"9e137b746b31241b1ac40e5ae06de650b50ee1a069a5ac541e183c7267c572cd","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"12a302aa-e6ed-4576-aced-aeb610816321","object_id":"sha256:9e137b746b31241b1ac40e5ae06de650b50ee1a069a5ac541e183c7267c572cd","sha256":"9e137b746b31241b1ac40e5ae06de650b50ee1a069a5ac541e183c7267c572cd"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"0z9zBY9333iLbhLciD2fBVIH6BE0sDy2cr2VJz_I5EPp5TRLvLAJ5rAUNbm3hb8lvWuxiUw2syQWi5p83hjYCA"}} -->
