### PR TITLE
fix(evaluation): keep multiagent probes on policy actions

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent.py
+++ b/alberta_framework/evaluation/continual_multiagent.py
@@ -857,10 +857,8 @@ def _probe_policy(
     """Read-only deterministic rollout from a fixed evaluator-owned state."""
 
     state = _probe_state(world, context=context, phase_steps=config.phase_steps)
-    action_preferences = (
-        controller.action_values[:, context, 1] - controller.action_values[:, context, 0]
-    )
-    actions = np.sign(action_preferences).astype(np.float32)
+    action_indices = np.argmax(controller.action_values[:, context, :], axis=1)
+    actions = (2 * action_indices - 1).astype(np.float32)
     rewards = np.empty((config.probe_horizon,), dtype=np.float64)
     for step_index in range(config.probe_horizon):
         transition, state = step_world(state, jnp.asarray(actions))

--- a/tests/test_continual_multiagent_probe_policy.py
+++ b/tests/test_continual_multiagent_probe_policy.py
@@ -1,0 +1,50 @@
+"""Unit coverage for continual-multiagent evaluator policy probes."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from alberta_framework.evaluation.continual_multiagent import (
+    ContinualMultiAgentConfig,
+    _initial_controller,
+    _probe_policy,
+)
+from alberta_framework.streams.recurring_multiagent import RecurringTwoAgentWorld
+
+pytestmark = pytest.mark.unit
+
+
+def test_tied_probe_values_select_a_supported_controller_action() -> None:
+    config = ContinualMultiAgentConfig(
+        phase_steps=2,
+        nuisance_dim=0,
+        probe_horizon=1,
+        probe_tail_steps=1,
+        recovery_window=1,
+    )
+    world = RecurringTwoAgentWorld(
+        context_length=config.phase_steps,
+        nuisance_dim=config.nuisance_dim,
+        damping=0.0,
+        acceleration=0.25,
+        max_speed=0.25,
+    )
+    observed_actions: list[np.ndarray] = []
+
+    def recording_step(state, actions):  # type: ignore[no-untyped-def]
+        observed_actions.append(np.asarray(actions))
+        return world.step(state, actions)
+
+    _probe_policy(
+        world,
+        recording_step,
+        _initial_controller(seed=30),
+        context=0,
+        config=config,
+    )
+
+    np.testing.assert_array_equal(
+        np.stack(observed_actions),
+        -np.ones((config.probe_horizon, 2), dtype=np.float32),
+    )


### PR DESCRIPTION
## Defect

The supported `run_continual_multiagent_benchmark` path reaches `_run_condition`,
then phase-end `_probe_policy`, whose actions feed the `performance_matrix` and
the summary, aggregate, and artifact metrics.

For tied controller values, the probe used `sign(Q1 - Q0)` and emitted `0`.
That action is impossible for this controller: its two action indices are mapped
to exactly `{-1, +1}` everywhere else. Ties occur in the public path because the
initial controller is all zero, frozen arms retain ties, and unvisited contexts
remain tied. The result was a silent evaluation of a third, nonexistent action
and wrong benchmark numbers.

Base: current `origin/main` at
`c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`.

## Fix

At the evaluator boundary, select the legal action index with the same
deterministic argmax semantics used by the controller, then apply the canonical
`2 * index - 1` mapping. This is one production-boundary change; no call sites
or unrelated modules are patched.

## Before / after

The real `RecurringTwoAgentWorld` probe with the tied initial controller failed
before the change:

```text
probe_score=0.5
probe_actions=[0.0]
supported_controller_actions=[1.0, -1.0]
Traceback (most recent call last):
  File "<stdin>", line 34, in <module>
AssertionError: probe emitted unsupported controller actions [0.0]
```

After the change, the same reproduction stays within the supported action set:

```text
probe_score=1.0
probe_actions=[-1.0]
supported_controller_actions=[1.0, -1.0]
```

This is numerically material. For seed 30, the frozen arm's performance matrix
changed from three rows of `[0.5, 0.5]` to three rows of `[1.0, 0.0]`; the old
matrix measured a behavior the controller cannot execute.

## Regression proof

The focused unit test records the actions passed by `_probe_policy` to the real
world step boundary. With only the production change reverted and the test kept,
it failed on this exact defect:

```text
ACTUAL: array([[0., 0.]], dtype=float32)
DESIRED: array([[-1., -1.]], dtype=float32)
1 failed
```

Restoring the production fix made the test pass.

## Verification

- `pytest -n 2` across the continual-multiagent test family: `253 passed, 2 skipped`
- focused scientific benchmark primitives: `32 passed`
- changed-file Ruff: all checks passed
- changed-file strict mypy: no issues in 2 source files
- `git diff --check`: passed

Full-project mypy reaches an unrelated existing Darwin-only error:
`bounded_elastic_matched_runner.py:1111: Module has no attribute O_TMPFILE`.

Exact open-PR searches for `probe_policy`, `continual_multiagent tie action`,
and `multiagent zero action` found no PR applying this idea. The only nearby
result, #2399, reconstructs validator aggregates and does not change probe action
semantics.

## Evidence and provenance

`continual_multiagent.py` is a registered evidence source. The pinned historical
artifact was not changed or replayed, and this PR makes no promotion claim. Its
current-source invalid status remains the expected fail-closed behavior until a
proper frozen protocol is rerun.

<!-- evidence-head:c58e6f108a7cd77df40a3980475181b6d8b63529 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - verbatim reproduction and regression outputs are included above.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - this evaluator bug fix does not create a promotable artifact; pinned evidence remains untouched.
<!-- evidence-row:llm-trajectory -->
- [x] llm-trajectory: N/A - the permanently retained private trace is bound by the signed receipt below and is not public by contract.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi
Attribution status: self-reported
— [metric-boundary-fix]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M13FYN44CCVB47X87W7V92MY","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-08-28T06:12:13.572Z","completed_at":"2026-08-28T06:33:25.944Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-28T06:12:13.921Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"65b89965185df2253cb2405ba0fd0541c265dcf4a9eea8220c2ad5a43d4f653c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a87d4bb7-6639-49ab-b01e-dd80403d4419","object_id":"sha256:65b89965185df2253cb2405ba0fd0541c265dcf4a9eea8220c2ad5a43d4f653c","sha256":"65b89965185df2253cb2405ba0fd0541c265dcf4a9eea8220c2ad5a43d4f653c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"vao5EQcLtoNQdjFHK9ciuRnRNM6AN-QIhzgxK87YCXK08TMBu1IcidNwxHuX0lKc0UmT18t3yV6BHkSnvnblAA"}} -->