### PR TITLE
fix(#2295): close LP64 gap in causal_map_forager int allowlist

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -60,14 +60,7 @@ _CAUSAL_MAP_RNG_NAMESPACE = 0xCA05A14
 _CAUSAL_MAP_PRNG_IMPL = "threefry2x32"
 _CAUSAL_MAP_ENVIRONMENT_PRNG_IMPL = "threefry2x32"
 _EXACT_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
+    *(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")),
 )
 _EXACT_INTEGER_TYPES = (int, *_EXACT_NUMPY_INTEGER_TYPES)
 _EXACT_REAL_TYPES = (

--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -355,6 +355,8 @@ def nexting_spec(
     feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
     raw_indices = _require_sequence("cumulant_indices", cumulant_indices)
     raw_gammas = _require_sequence("gammas", gammas)
+    if len(raw_indices) * len(raw_gammas) > _INT32_MAX:
+        raise ValueError("derived n_demons must be in the signed int32 domain")
     canonical_indices = tuple(
         _require_int32(f"cumulant_indices[{i}]", value, minimum=0)
         for i, value in enumerate(raw_indices)
@@ -365,7 +367,7 @@ def nexting_spec(
     )
     canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
     n_demons = len(canonical_indices) * len(canonical_gammas)
-    if n_demons < 1 or n_demons > _INT32_MAX:
+    if n_demons < 1:
         raise ValueError("derived n_demons must be in the signed int32 domain")
     _preflight_horde_resources(n_demons, feature_dim)
     _preflight_stacked_horde_update_working_set(n_demons, feature_dim)


### PR DESCRIPTION
Replace the hand-enumerated fixed-width tuple with the dtype-code derivation already used by normalizers.py/forager.py. This admits np.intc/np.uintc on LLP64 and np.longlong/np.ulonglong on LP64, closing the half-fix left by PR #2329.

Closes #2295