### PR TITLE
fix(behavior_model): floor_and_renormalize_probabilities returns a simplex on zero-mass input

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -231,7 +231,16 @@ def floor_and_renormalize_probabilities(
     )
     normalized = clipped / normalizer
     floor_mass = jnp.asarray(min_probability * n_actions, dtype=jnp.float32)
-    return jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
+    floored = jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
+    # `normalized` only sums to 1 when `clipped` carries nonzero mass that
+    # survives the float32 division without underflowing. Degenerate input
+    # (all-zero, or magnitudes whose ratio underflows) leaves `normalized`
+    # summing to less than 1, so `floored` silently sums to less than 1 too
+    # (as low as `n_actions * min_probability`) instead of being a simplex.
+    # Renormalizing by its own sum guarantees an exact simplex in every case:
+    # a no-op division by ~1 for well-behaved input, and a uniform
+    # distribution rather than a near-zero vector for degenerate input.
+    return floored / jnp.sum(floored, axis=-1, keepdims=True)
 
 
 def selected_action_probabilities(

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -389,6 +389,20 @@ def test_probability_simplex_and_helper_invariants() -> None:
     chex.assert_trees_all_close(logs, jnp.log(selected))
 
 
+def test_floor_and_renormalize_probabilities_degenerate_input_is_a_simplex() -> None:
+    # All-zero mass: `clipped` sums to 0, so pre-fix this silently returned
+    # `min_probability` in every slot (summing to n * min_probability, not 1)
+    # instead of failing or falling back to a proper distribution.
+    zero_mass = floor_and_renormalize_probabilities(
+        jnp.array([0.0, 0.0, 0.0], dtype=jnp.float32),
+        min_probability=1e-6,
+    )
+    chex.assert_trees_all_close(jnp.sum(zero_mass), 1.0, atol=1e-6)
+    chex.assert_trees_all_close(
+        zero_mass, jnp.full((3,), 1.0 / 3.0, dtype=jnp.float32), atol=1e-6
+    )
+
+
 @pytest.mark.parametrize(
     "action",
     [


### PR DESCRIPTION
For all-zero (or otherwise fully-clipped) input, `clipped` sums to 0, the denominator floors to `1e-12`, and `normalized` becomes all zeros. The affine floor step then returns `min_probability` in every slot, summing to `n_actions * min_probability` instead of `1.0`, despite the docstring's "valid simplex" guarantee.

Renormalizes the floored result by its own sum, which is always positive since every entry is at least `min_probability`. This is a no-op division by ~1 for well-behaved input, and produces the uniform distribution instead of a near-zero vector for degenerate input.

**Verification note:** I verified the zero-mass defect and the fix directly against the function's float32 arithmetic (NumPy, matching JAX's CPU float32 semantics for `max`/`sum`/`divide`) — jaxlib doesn't run natively on this machine. The linked issue's second reproduction case (a large-magnitude input `[1e38, 1, 1]` allegedly underflowing the same way) did **not** reproduce under this verification: that input already summed to `1.0` both before and after this change. This fix and its regression test are scoped to the zero-mass defect that does reproduce.

Fixes #2238