### PR TITLE
fix(core): divide world model observation targets by declared scale (#2398)

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -365,7 +365,9 @@ class ActionConditionedWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 _validated_config_float(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]",
+                    scale,
+                    lower=float(np.finfo(np.float32).tiny),
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -806,11 +808,10 @@ class ActionConditionedWorldModel:
         reward_arr = _float32_operand("reward", reward, ())
         discount_arr = _float32_operand("discount", discount, ())
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
             self._config.predict_delta,
-            (next_obs - obs) / safe_scale,
-            next_obs / safe_scale,
+            (next_obs - obs) / obs_scale,
+            next_obs / obs_scale,
         )
         reward_target = jnp.reshape(
             reward_arr / self._config.reward_scale,

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import math
 import warnings
 from fractions import Fraction
 from types import MappingProxyType
@@ -464,7 +465,10 @@ class _FloatSpoof:
         ({"max_delta_scale": 1e100}, "max_delta_scale must remain finite once narrowed"),
         ({"reward_scale": 1e-100}, "reward_scale must remain positive once narrowed"),
         ({"max_delta_scale": 1e-100}, "max_delta_scale must remain positive once narrowed"),
-        ({"observation_scale": (1e-100, 1.0)}, "must remain positive once narrowed"),
+        (
+            {"observation_scale": (1e-100, 1.0)},
+            r"observation_scale\[0\] must be >= 1.1754943508222875e-38",
+        ),
         (
             {"utility_decay": 1.0 - 1e-10},
             r"utility_decay must remain in \[0.0, 1.0\) once narrowed",
@@ -955,3 +959,89 @@ def test_action_world_model_rolls_back_reduction_overflow() -> None:
     assert not bool(result.update_applied)
     assert float(result.observation_mse) == 0.0
     assert int(result.state.step_count) == 0
+
+
+@pytest.mark.parametrize(
+    "scale",
+    [1e-7, 1e-9, 1e-12, 1e-20, 1e-30, float(np.finfo(np.float32).tiny)],
+)
+def test_observation_scale_targets_divide_by_declared_scale_below_retired_floor(
+    scale: float,
+) -> None:
+    # 1. With predict_delta=True
+    config_delta = ActionConditionedWorldModelConfig(
+        observation_dim=1,
+        n_actions=2,
+        hidden_sizes=(),
+        predict_delta=True,
+        observation_scale=(scale,),
+    )
+    model_delta = ActionConditionedWorldModel(config_delta)
+    obs = jnp.asarray([1.0 * scale], dtype=jnp.float32)
+    next_obs = jnp.asarray([3.0 * scale], dtype=jnp.float32)
+    targets_delta = model_delta.targets(
+        obs,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(0.9, dtype=jnp.float32),
+        next_obs,
+    )
+    # Expected normalized delta is (3.0 * scale - 1.0 * scale) / scale = 2.0
+    assert math.isclose(float(targets_delta[0]), 2.0, rel_tol=1e-5)
+
+    # 2. With predict_delta=False
+    config_nodelta = ActionConditionedWorldModelConfig(
+        observation_dim=1,
+        n_actions=2,
+        hidden_sizes=(),
+        predict_delta=False,
+        observation_scale=(scale,),
+    )
+    model_nodelta = ActionConditionedWorldModel(config_nodelta)
+    targets_nodelta = model_nodelta.targets(
+        obs,
+        jnp.asarray(0.0, dtype=jnp.float32),
+        jnp.asarray(0.9, dtype=jnp.float32),
+        next_obs,
+    )
+    # Expected normalized observation target is (3.0 * scale) / scale = 3.0
+    assert math.isclose(float(targets_nodelta[0]), 3.0, rel_tol=1e-5)
+
+
+def test_observation_scale_rejects_below_smallest_normal_float32() -> None:
+    smallest_normal = float(np.finfo(np.float32).tiny)
+    subnormal = float(np.finfo(np.float32).smallest_subnormal)
+    assert subnormal < smallest_normal
+
+    for bad_scale in (subnormal, 1e-40, 1e-45, 0.0, -1.0):
+        with pytest.raises(
+            ValueError,
+            match=r"observation_scale\[0\] must (?:remain|be) >= 1.1754943508222875e-38",
+        ):
+            ActionConditionedWorldModelConfig(
+                observation_dim=1,
+                n_actions=2,
+                hidden_sizes=(),
+                observation_scale=(bad_scale,),
+            )
+
+
+def test_observation_scale_preserves_behavior_at_and_above_retired_floor() -> None:
+    for scale in (1e-6, 1e-3, 1.0, 2.0):
+        config = ActionConditionedWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=(),
+            predict_delta=True,
+            observation_scale=(scale, 2.0 * scale),
+        )
+        model = ActionConditionedWorldModel(config)
+        obs = jnp.asarray([1.0 * scale, 2.0 * scale], dtype=jnp.float32)
+        next_obs = jnp.asarray([3.0 * scale, 6.0 * scale], dtype=jnp.float32)
+        targets = model.targets(
+            obs,
+            jnp.asarray(0.0, dtype=jnp.float32),
+            jnp.asarray(0.9, dtype=jnp.float32),
+            next_obs,
+        )
+        assert math.isclose(float(targets[0]), 2.0, rel_tol=1e-5)
+        assert math.isclose(float(targets[1]), 2.0, rel_tol=1e-5)


### PR DESCRIPTION
Resolves #2398

### Root Cause
In `alberta_framework/core/world_model.py:809-815`, `ActionConditionedWorldModel.targets()` normalized observation targets with a `1e-6` floor:
```python
obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
normalized_delta = jnp.where(
    self._config.predict_delta,
    (next_obs - obs) / safe_scale,
    next_obs / safe_scale,
)
```
However, in `_prediction_and_raw_diagnostics()` (lines 835-845), the predicted delta was decoded by multiplying by the raw `obs_scale`:
```python
decoded_next_observation = jnp.where(
    self._config.predict_delta,
    safe_obs + normalized_delta * obs_scale,
    normalized_delta * obs_scale,
)
```
For `observation_scale` below `1e-6`, `targets()` normalized by `1e-6` while the model denormalized by `obs_scale`, breaking the round trip and causing the reconstructed deltas to be scaled down by `observation_scale / 1e-6`.

### Changes
1. Removed `safe_scale` in `ActionConditionedWorldModel.targets()`, directly dividing by `obs_scale` to match decode multiplication.
2. Updated config validation in `ActionConditionedWorldModelConfig` to require each `observation_scale[index]` to be `>= np.finfo(np.float32).tiny` (`1.1754943508222875e-38`, smallest normal float32), ensuring valid reciprocal without dividing by flushed subnormals.
3. Added unit tests in `tests/test_action_conditioned_world_model.py`:
   - Verification across scales below `1e-6` down to smallest normal float32 (`1e-7`, `1e-9`, `1e-12`, `1e-20`, `1e-30`, `1.17549435e-38`) for both `predict_delta=True` and `predict_delta=False`.
   - Validation that subnormal and negative scales are rejected with `ValueError`.
   - Verification that behavior at and above `1e-6` remains bit-for-bit unchanged.

### Verification
- `pytest tests/test_action_conditioned_world_model.py` (76 passed)
- `pytest tests/test_action_conditioned_world_model.py tests/test_world_model_ensemble.py tests/test_dreaming.py` (193 passed)
- `ruff check alberta_framework/core/world_model.py tests/test_action_conditioned_world_model.py` (clean)
- `mypy` (Success: no issues found in 224 source files)
- `git diff --check` (clean)

## Measured project receipt
Post-hoc / same-window receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M15SA4GY8ZYXG74WAYJJ9WKJ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-29T03:34:15.839Z","completed_at":"2026-08-29T03:34:28.209Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-29T03:34:16.423Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"65c4a1641b2f2843e915799ead77860c9cf3a0b8eaaab2b44c5ff8314173f06a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"cb1fecef-9b17-44aa-9f3f-2347b8fd459a","object_id":"sha256:65c4a1641b2f2843e915799ead77860c9cf3a0b8eaaab2b44c5ff8314173f06a","sha256":"65c4a1641b2f2843e915799ead77860c9cf3a0b8eaaab2b44c5ff8314173f06a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"U7Zwe5w47ltwikZAzAQYy-QyGnMvQ2dqRzJC8QTqGzzrSQF5jjTWPW1Ww_WdHeakvP800G9beF6GxXBabnOFBw"}} -->
