### PR TITLE
fix(core): make UPGD gradient alignment scale-free via power-of-two rescaling (#2389)

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1983,24 +1983,65 @@ class UPGDLearner:
         return total
 
     @staticmethod
+    def _unit_tuple(xs: tuple[Array, ...]) -> tuple[tuple[Array, ...], Array]:
+        """Normalize a static tuple of arrays to unit L2 norm via power-of-two rescaling."""
+        if not xs:
+            return (), jnp.array(False)
+        peak = functools.reduce(
+            jnp.maximum,
+            (jnp.max(jnp.abs(x)) if x.size > 0 else jnp.array(0.0, dtype=jnp.float32) for x in xs),
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        is_valid_peak = jnp.isfinite(peak) & (peak > 0.0)
+        _, exponent = jnp.frexp(peak)
+        safe_exp = jnp.where(is_valid_peak, exponent, jnp.int32(0))
+        xs_scaled = tuple(jnp.ldexp(x, -safe_exp) for x in xs)
+        scaled_sum_sq = functools.reduce(
+            operator.add,
+            (jnp.sum(jnp.square(xr)) for xr in xs_scaled),
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        scaled_norm = jnp.sqrt(scaled_sum_sq)
+        is_valid = is_valid_peak & jnp.isfinite(scaled_norm) & (scaled_norm > 0.0)
+        safe_norm = jnp.where(is_valid, scaled_norm, jnp.float32(1.0))
+        unit_xs = tuple(jnp.where(is_valid, xr / safe_norm, jnp.zeros_like(xr)) for xr in xs_scaled)
+        return unit_xs, is_valid
+
+    @staticmethod
     def _tuple_norm(xs: tuple[Array, ...]) -> Array:
-        """L2 norm over a static tuple of arrays."""
-        total = jnp.array(0.0, dtype=jnp.float32)
-        for x in xs:
-            total = total + jnp.sum(jnp.square(x))
-        return jnp.sqrt(total + 1e-12)
+        """L2 norm over a static tuple of arrays with power-of-two rescaling."""
+        if not xs:
+            return jnp.array(0.0, dtype=jnp.float32)
+        peak = functools.reduce(
+            jnp.maximum,
+            (jnp.max(jnp.abs(x)) if x.size > 0 else jnp.array(0.0, dtype=jnp.float32) for x in xs),
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        is_valid_peak = jnp.isfinite(peak) & (peak > 0.0)
+        _, exponent = jnp.frexp(peak)
+        safe_exp = jnp.where(is_valid_peak, exponent, jnp.int32(0))
+        scaled_sum_sq = functools.reduce(
+            operator.add,
+            (jnp.sum(jnp.square(jnp.ldexp(x, -safe_exp))) for x in xs),
+            jnp.array(0.0, dtype=jnp.float32),
+        )
+        scaled_norm = jnp.sqrt(scaled_sum_sq)
+        is_valid = is_valid_peak & jnp.isfinite(scaled_norm) & (scaled_norm > 0.0)
+        raw_norm = jnp.ldexp(scaled_norm, safe_exp)
+        return jnp.where(is_valid, raw_norm, jnp.array(0.0, dtype=jnp.float32))
 
     @staticmethod
     def _gradient_alignment(
         previous: tuple[Array, ...],
         current: tuple[Array, ...],
     ) -> Array:
-        """Cosine alignment of two gradient tuples, zero for empty gradients."""
-        previous_norm = UPGDLearner._tuple_norm(previous)
-        current_norm = UPGDLearner._tuple_norm(current)
+        """Cosine alignment of two gradient tuples, zero for empty or non-finite gradients."""
+        unit_prev, valid_prev = UPGDLearner._unit_tuple(previous)
+        unit_curr, valid_curr = UPGDLearner._unit_tuple(current)
+        dot = UPGDLearner._tuple_dot(unit_prev, unit_curr)
         return jnp.where(
-            (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
+            valid_prev & valid_curr,
+            jnp.clip(dot, -1.0, 1.0),
             jnp.array(0.0, dtype=jnp.float32),
         )
 

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -23,7 +23,9 @@ so noise effects are unmistakable) and ``sparsity=0.5`` round-trips.
 import chex
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
+from jax import Array
 
 from alberta_framework.core.optimizers import AdaptiveObGDBounding, ObGDBounding
 from alberta_framework.core.upgd import (
@@ -2219,3 +2221,91 @@ class TestLoops:
         stream = RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.05)
         result = run_upgd_loop(learner, stream, num_steps=50, key=jr.key(0))
         chex.assert_shape(result.metrics, (50, 4))
+
+
+class TestGradientAlignmentScaleInvariance:
+    """Tests that gradient alignment and tuple norms are invariant to magnitude and scale-free."""
+
+    def test_tuple_norm_scale_free(self):
+        v = (jnp.array([3.0, 4.0], dtype=jnp.float32), jnp.array([12.0], dtype=jnp.float32))
+        expected_base = 13.0  # sqrt(9 + 16 + 144) = sqrt(169) = 13.0
+        for exp in (-30, -20, -10, -5, 0, 5, 10, 20, 30):
+            scale = 10.0**exp
+            scaled_v = tuple(x * scale for x in v)
+            norm = UPGDLearner._tuple_norm(scaled_v)
+            np.testing.assert_allclose(float(norm), expected_base * scale, rtol=1e-5)
+
+        # Empty and zero cases
+        assert float(UPGDLearner._tuple_norm(())) == 0.0
+        assert float(UPGDLearner._tuple_norm((jnp.zeros((3,), dtype=jnp.float32),))) == 0.0
+
+    def test_gradient_alignment_scale_invariance(self):
+        t1 = (jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32), jnp.array([2.0], dtype=jnp.float32))
+        for exp in (-30, -20, -10, -5, -4, -2, 0, 2, 4, 5, 10, 20, 30):
+            scale = 10.0**exp
+            scaled1 = tuple(x * scale for x in t1)
+            scaled2 = tuple(x * scale for x in t1)
+            neg_scaled = tuple(-x * scale for x in t1)
+
+            cos_same = float(UPGDLearner._gradient_alignment(scaled1, scaled2))
+            cos_neg = float(UPGDLearner._gradient_alignment(scaled1, neg_scaled))
+
+            np.testing.assert_allclose(cos_same, 1.0, atol=1e-6)
+            np.testing.assert_allclose(cos_neg, -1.0, atol=1e-6)
+
+    def test_gradient_alignment_orthogonal_and_zero(self):
+        t1 = (jnp.array([1.0, 0.0], dtype=jnp.float32),)
+        t2 = (jnp.array([0.0, 1.0], dtype=jnp.float32),)
+        zero = (jnp.zeros(2, dtype=jnp.float32),)
+        empty: tuple[Array, ...] = ()
+
+        assert float(UPGDLearner._gradient_alignment(t1, t2)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(t1, zero)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(zero, t1)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(zero, zero)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(empty, t1)) == 0.0
+
+    def test_gradient_alignment_nonfinite_inputs(self):
+        t_valid = (jnp.array([1.0, 2.0], dtype=jnp.float32),)
+        t_nan = (jnp.array([1.0, jnp.nan], dtype=jnp.float32),)
+        t_inf = (jnp.array([jnp.inf, 2.0], dtype=jnp.float32),)
+
+        assert float(UPGDLearner._gradient_alignment(t_valid, t_nan)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(t_nan, t_valid)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(t_valid, t_inf)) == 0.0
+        assert float(UPGDLearner._gradient_alignment(t_inf, t_valid)) == 0.0
+
+    def test_upgd_meta_plasticity_scale_invariance_end_to_end(self):
+        for exp in (10, 6, 2, 0, -2, -6, -10):
+            scale = 10.0**exp
+            learner = UPGDLearner(
+                n_heads=1,
+                hidden_sizes=(),
+                sparsity=0.0,
+                step_size=0.0,
+                perturbation_sigma=0.0,
+                meta_plasticity_mode="gradient_alignment",
+                meta_plasticity_step_size=0.5,
+                meta_plasticity_min_multiplier=0.1,
+                meta_plasticity_max_multiplier=10.0,
+            )
+            state = learner.init(feature_dim=3, key=jr.key(16))
+            obs = jnp.array([1.0, -0.5, 0.25], dtype=jnp.float32) * scale
+            target1 = jnp.array([1.0], dtype=jnp.float32) * scale
+
+            # Step 1: seeds previous gradients (scales stay at 0.0)
+            state = learner.update(state, obs, target1).state
+            assert float(state.meta_head_weight_log_scale) == 0.0
+            assert float(state.meta_head_bias_log_scale) == 0.0
+
+            # Step 2: identical gradients -> alignment is 1.0 -> log scale increases by 0.5
+            state_same = learner.update(state, obs, target1).state
+            np.testing.assert_allclose(float(state_same.meta_head_weight_log_scale), 0.5, atol=1e-5)
+            np.testing.assert_allclose(float(state_same.meta_head_bias_log_scale), 0.5, atol=1e-5)
+
+            # Step 2 alt: reversed target -> alignment is -1.0 -> log scale decreases by 0.5
+            pred = learner.predict(state, obs)
+            target_rev = 2.0 * pred - target1
+            state_rev = learner.update(state, obs, target_rev).state
+            np.testing.assert_allclose(float(state_rev.meta_head_weight_log_scale), -0.5, atol=1e-5)
+            np.testing.assert_allclose(float(state_rev.meta_head_bias_log_scale), -0.5, atol=1e-5)


### PR DESCRIPTION
Resolves #2389

### Root Cause
In `alberta_framework/core/upgd.py:1985-2005`, `UPGDLearner._tuple_norm` and `_gradient_alignment` relied on fixed absolute constants (`1e-12` inside `_tuple_norm` norm square root, `> 1e-6` magnitude gate, and `+ 1e-12` in the cosine denominator):
```python
@staticmethod
def _tuple_norm(xs: tuple[Array, ...]) -> Array:
    total = jnp.array(0.0, dtype=jnp.float32)
    for x in xs:
        total = total + jnp.sum(jnp.square(x))
    return jnp.sqrt(total + 1e-12)

@staticmethod
def _gradient_alignment(
    previous: tuple[Array, ...],
    current: tuple[Array, ...],
) -> Array:
    previous_norm = UPGDLearner._tuple_norm(previous)
    current_norm = UPGDLearner._tuple_norm(current)
    return jnp.where(
        (previous_norm > 1e-6) & (current_norm > 1e-6),
        UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
        jnp.array(0.0, dtype=jnp.float32),
    )
```
This caused two severe failure modes for a scale-free geometric quantity (cosine):
1. For small gradient scales (`<= 1e-6`), `_tuple_norm` saturated at `1e-6`, failing the `> 1e-6` gate and silently reporting `0.0` (making gradient alignment meta-plasticity an expensive no-op for small learning rates or normalized tasks). Furthermore, for element scale `~ 1e-20`, squaring in float32 underflowed to exact zero before the sum.
2. For large gradient scales (`>= 1e10`), squaring element magnitudes `> 1.8e19` overflowed float32, producing `nan` in the state that permanently poisoned learning.

### Solution
1. Replaced `_tuple_norm` and `_gradient_alignment` with scale-free power-of-two rescaling (`_unit_tuple` helper using `jnp.frexp` and `jnp.ldexp`).
2. Finding the peak magnitude exponent shifts each tensor lossless into `[0.5, 1.0)`, eliminating both squaring underflow and float32 overflow across the entire representable float32 dynamic range (`1e-30` to `1e30`).
3. Safely guards against non-finite (NaN / Inf) and zero gradients, returning `0.0` cleanly.
4. Added test suite `TestGradientAlignmentScaleInvariance` in `tests/test_upgd.py` covering:
   - Scale-free tuple norm from `1e-30` to `1e30`.
   - Scale-free gradient alignment for identical (`+1.0`), negated (`-1.0`), orthogonal (`0.0`), all-zero, and non-finite inputs.
   - End-to-end `UPGDLearner` meta-plasticity updates across scales from `1e-10` to `1e10` for identical and reversed gradient steps.

### Verification
- `pytest tests/test_upgd.py` (93 passed)
- `pytest tests/test_upgd.py tests/test_canonical_upgd.py tests/test_upgd_memory.py` (295 passed)
- `ruff check alberta_framework/core/upgd.py tests/test_upgd.py` (clean)
- `mypy` (Success: no issues found in 224 source files)
- `git diff --check` (clean)

## Measured project receipt
Post-hoc / same-window receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M15SR48X1Z7GG3GPYVSG5SX9","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-29T03:41:54.333Z","completed_at":"2026-08-29T03:42:30.928Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-29T03:41:54.895Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"81bb98568815fa6e3d8fd9d6ad3991857517fcf74cfcf825499f077b53442c9f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5f35fcea-c3d8-4d6f-8b1d-233eb206e7c4","object_id":"sha256:81bb98568815fa6e3d8fd9d6ad3991857517fcf74cfcf825499f077b53442c9f","sha256":"81bb98568815fa6e3d8fd9d6ad3991857517fcf74cfcf825499f077b53442c9f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"LOgy8JNY4gw5hxIdA7-KYxh-YIU5bb7dR_1ZOYzOWDKu-IiZmNjnPUf6aclYFnl9VYVoJDqQ3n_72ySSNwXNDA"}} -->
