### PR TITLE
docs(utils): unnest Raises: section in get_final_performance docstring (#2439)

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -665,7 +665,7 @@ def get_final_performance(
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
 
-        Raises:
+    Raises:
         ValueError: If ``window`` is not positive, a metric array has no
             time steps, any metric sample is non-finite, or ``window`` exceeds
             the shortest trace while trace lengths differ between methods.

--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -1029,3 +1029,18 @@ def test_run_multi_seed_experiment_rejects_invalid_seed_sequences(
 def test_get_final_performance_rejects_non_builtin_positive_window(window: object) -> None:
     with pytest.raises(ValueError, match="window"):
         get_final_performance({"candidate": _two_seed_trace()}, window=window)  # type: ignore[arg-type]
+
+
+def test_get_final_performance_docstring_section_structure() -> None:
+    doc = get_final_performance.__doc__
+    assert doc is not None
+    lines = doc.split("\n")
+    sections = [
+        (line.strip(), len(line) - len(line.lstrip()))
+        for line in lines
+        if line.strip() in ("Args:", "Returns:", "Raises:")
+    ]
+    assert sections == [("Args:", 0), ("Returns:", 0), ("Raises:", 0)]
+    raises_idx = lines.index("Raises:")
+    value_error_line = lines[raises_idx + 1]
+    assert value_error_line.startswith("    ValueError:")


### PR DESCRIPTION
## Summary
Fixes #2439.

In `alberta_framework/utils/experiments.py:get_final_performance`, the `Raises:` section header was indented at 8 spaces (nested inside the `Returns:` block) and its body was also indented at 8 spaces.

This PR un-nests `Raises:` to sit at 4 spaces as a sibling to `Args:` and `Returns:`, and indents its body at 8 spaces according to Google-style docstring standards.

## Changes
- `alberta_framework/utils/experiments.py`: Correct indentation of `Raises:` section header in `get_final_performance`.
- `tests/test_experiments_validation.py`: Add `test_get_final_performance_docstring_section_structure` to verify that `Args:`, `Returns:`, and `Raises:` are recognized as sibling sections with properly indented exception descriptions.

## Verification
- `pytest tests/test_experiments_validation.py` (130 passed)
- `pytest tests/test_experiments*.py` (142 passed)
- `ruff check alberta_framework/utils/experiments.py tests/test_experiments_validation.py` (clean)
- `ruff check .` (clean)
- `mypy alberta_framework/utils/experiments.py` (clean)
- `mypy` (224 source files checked, clean)
- `git diff --check` (clean)

## Measured project receipt
Post-hoc / same-window receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M15TFERYA7P0XDQNZG93HR0N","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-29T03:54:38.750Z","completed_at":"2026-08-29T03:55:21.911Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-29T03:54:39.492Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"97177fcd0e74283a381ad5d7437237b1ce7a665e49bbb4bf242ab8f3549b0cb5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"fa5341ef-64bc-4d43-8dc3-7b087fa1d586","object_id":"sha256:97177fcd0e74283a381ad5d7437237b1ce7a665e49bbb4bf242ab8f3549b0cb5","sha256":"97177fcd0e74283a381ad5d7437237b1ce7a665e49bbb4bf242ab8f3549b0cb5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"k6LILcpiZ-d1VFMN0Y7ByQSeAd-TTG1q5q3vWqP4TEqiYas8nnoWh90Ana8qRd1LxHM1HAtE1tiOk4RY46CrCw"}} -->
