### PR TITLE
fix: preserve_nonzero float32 underflow guard was dead for built-in floats (#2720)

### DIFF
--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -106,7 +106,11 @@ def _require_float32(
         upper_inclusive=upper_inclusive,
         positive=positive,
     )
-    if preserve_nonzero and numerator != 0 and stored == 0.0:
+    # Re-narrow before testing: validated_float32_scalar_with_ratio returns a
+    # built-in float UN-narrowed, so testing ``stored`` directly makes this
+    # guard dead for the annotated input type (issue #2720).  The re-narrowing
+    # matches option_value_duration's underflow guard.
+    if preserve_nonzero and numerator != 0 and float(np.float32(stored)) == 0.0:
         raise ValueError(f"{name} must remain nonzero once narrowed to float32")
     return stored
 

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -473,3 +473,36 @@ def test_cumulant_discovery_hostile_observation_failure_is_normalized() -> None:
     state = discovery.init(jr.key(0))
     with pytest.raises(ValueError, match="readable float32 vector"):
         discovery.cumulants(state, HostileObservation())  # type: ignore[arg-type]
+
+
+# =============================================================================
+# Issue #2720 — preserve_nonzero must reject float32 underflow for ALL
+# supported input types, including built-in float
+# =============================================================================
+
+
+class TestPreserveNonzeroNarrowing:
+    def test_builtin_float_underflow_rejected(self) -> None:
+        # 1e-50 is nonzero in float64 but exactly 0.0 in float32; the guard
+        # exists to reject precisely this, independent of the Python type.
+        with pytest.raises(ValueError, match="gamma"):
+            CumulantDiscovery(raw_dim=4, gamma=1e-50)
+        with pytest.raises(ValueError, match="replacement_rate"):
+            CumulantDiscovery(raw_dim=4, replacement_rate=1e-50)
+
+    def test_numpy_float_underflow_rejected(self) -> None:
+        with pytest.raises(ValueError, match="gamma"):
+            CumulantDiscovery(raw_dim=4, gamma=np.float64(1e-50))
+
+    def test_type_value_parity(self) -> None:
+        # The same value must produce the same verdict for float and
+        # np.float64 across the boundary region.
+        for value in (1e-50, 1e-45, 0.25):
+            outcomes = []
+            for cast_value in (value, np.float64(value)):
+                try:
+                    CumulantDiscovery(raw_dim=4, gamma=cast_value)
+                    outcomes.append("accepted")
+                except ValueError:
+                    outcomes.append("rejected")
+            assert outcomes[0] == outcomes[1], (value, outcomes)


### PR DESCRIPTION
Fixes #2720.

`validated_float32_scalar_with_ratio` returns a built-in `float` un-narrowed, so `cumulant_discovery`'s `preserve_nonzero` guard tested the float64 value — dead for the annotated input type. Same value, opposite outcome, decided by Python type:

```python
_require_float32("gamma", 1e-50, preserve_nonzero=True)             # ACCEPTED (bug)
_require_float32("gamma", np.float64(1e-50), preserve_nonzero=True) # REJECTED
```

**Failing-test-first**: `TestPreserveNonzeroNarrowing` (3 tests) pins rejection for both input types and type/value parity across the boundary region; 2 of 3 failed before the fix, exactly along the bug's fault line.

**Fix**: re-narrow at the guard — `float(np.float32(stored)) == 0.0` — the pattern `option_value_duration.py:98-99` already uses correctly. The narrower of the two possible fixes: `_float32_scalars.py:189` itself is untouched (changing it would alter `stored` for every caller), so accepted inputs return exactly what they did before; only the reject set grows, to precisely the values whose float32 narrowing is zero.

Verified: 54/54 in `test_cumulant_discovery.py`, 125/125 in the adjacent consumer suites, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)