### PR TITLE
fix(core): compute exact log_softmax policy gradient in nonlinear horde actor-critic

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -688,7 +688,7 @@ class ActorCriticAgent:
         observation = self._observation(state, observation)
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
+        action = jr.categorical(sample_key, jnp.log(probs)).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -640,7 +640,7 @@ class QHordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
+        action = jr.categorical(sample_key, jnp.log(probs)).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -943,7 +943,7 @@ class HordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
+        action = jr.categorical(sample_key, jnp.log(probs)).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -1291,10 +1291,19 @@ def _nlhac_log_prob(
         trunk_weights, trunk_biases, obs, leaky_relu_slope, use_layer_norm
     )
     logits = head_w @ hidden + head_b
-    probs = jax.nn.softmax(logits / temperature)
-    n_actions = probs.shape[0]
-    mixed_probs = (1.0 - actor_epsilon) * probs + actor_epsilon / n_actions
-    return jnp.log(jnp.maximum(mixed_probs[action], 1e-8))
+    tempered_logits = logits / temperature
+    n_actions = tempered_logits.shape[0]
+    return cast(
+        Array,
+        jax.lax.cond(
+            actor_epsilon == 0.0,
+            lambda: jax.nn.log_softmax(tempered_logits)[action],
+            lambda: jnp.log(
+                (1.0 - actor_epsilon) * jax.nn.softmax(tempered_logits)[action]
+                + actor_epsilon / n_actions
+            ),
+        ),
+    )
 
 
 _nlhac_grad = jax.grad(_nlhac_log_prob, argnums=0)
@@ -1752,7 +1761,7 @@ class NonlinearHordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
+        action = jr.categorical(sample_key, jnp.log(probs)).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -2439,7 +2448,7 @@ class NonlinearQHordeActorCriticAgent:
         """Sample one action from the current softmax policy."""
         key, sample_key = jr.split(state.rng_key)
         probs = self.policy(state, observation)
-        action = jr.categorical(sample_key, jnp.log(jnp.maximum(probs, 1e-8))).astype(jnp.int32)
+        action = jr.categorical(sample_key, jnp.log(probs)).astype(jnp.int32)
         return action, key, probs
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_actor_critic.py
+++ b/tests/test_actor_critic.py
@@ -595,3 +595,15 @@ def test_actor_critic_state_contract_and_counter_saturation() -> None:
     )
     assert bool(result.update_applied)
     assert int(result.state.step_count) == 2**31 - 1
+
+
+def test_actor_critic_select_action_exact_distribution() -> None:
+    """select_action samples from exact log probabilities without artificial floor."""
+    agent = ActorCriticAgent(ActorCriticConfig(n_actions=2))
+    state = agent.init(2, jr.key(42))
+    weights = jnp.asarray([[100.0, 0.0], [-100.0, 0.0]], dtype=jnp.float32)
+    state = state.replace(actor_weights=weights)
+    obs = jnp.asarray([1.0, 0.0], dtype=jnp.float32)
+    action, _next_key, probs = agent.select_action(state, obs)
+    assert int(action) == 0
+    assert float(probs[0]) > 0.999

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -2019,3 +2019,37 @@ def test_all_horde_actor_critic_counters_saturate_and_rollback(
     assert applied.tolist() == [False, True]
     assert final_state.step_count.dtype == jnp.int32
     assert int(final_state.step_count) == 2**31 - 1
+
+
+def test_nlhac_log_prob_and_grad_prevents_gradient_vanishing_for_low_prob_actions() -> None:
+    """_nlhac_log_prob uses exact log_softmax so policy gradients do not vanish on rare actions."""
+    from alberta_framework.core.horde_actor_critic import _nlhac_grad, _nlhac_log_prob
+
+    trunk_w: tuple[jax.Array, ...] = ()
+    trunk_b: tuple[jax.Array, ...] = ()
+    head_w = jnp.asarray([[20.0, 0.0], [-10.0, 0.0]], dtype=jnp.float32)
+    head_b = jnp.asarray([0.0, 0.0], dtype=jnp.float32)
+    actor_params = (trunk_w, trunk_b, head_w, head_b)
+    obs = jnp.asarray([1.0, 0.0], dtype=jnp.float32)
+
+    # Action 1 has probability ~ exp(-30) << 1e-8
+    log_p = _nlhac_log_prob(actor_params, obs, 1, 0.0, False, 1.0, 0.0)
+    assert jnp.isfinite(log_p)
+    np.testing.assert_allclose(float(log_p), -30.0, rtol=1e-5)
+
+    # Gradients with respect to head_b and head_w should be non-zero and finite
+    grads = _nlhac_grad(actor_params, obs, 1, 0.0, False, 1.0, 0.0)
+    grad_trunk_w, grad_trunk_b, grad_head_w, grad_head_b = grads
+    assert jnp.all(jnp.isfinite(grad_head_b))
+    assert jnp.all(jnp.isfinite(grad_head_w))
+    np.testing.assert_allclose(
+        grad_head_b, jnp.asarray([-1.0, 1.0], dtype=jnp.float32), atol=1e-5
+    )
+    np.testing.assert_allclose(
+        grad_head_w[1], jnp.asarray([1.0, 0.0], dtype=jnp.float32), atol=1e-5
+    )
+
+    # Jitted grad
+    jitted_grad = jax.jit(_nlhac_grad, static_argnums=(3, 4, 5, 6))
+    j_grads = jitted_grad(actor_params, obs, 1, 0.0, False, 1.0, 0.0)
+    np.testing.assert_allclose(j_grads[3], jnp.asarray([-1.0, 1.0], dtype=jnp.float32), atol=1e-5)


### PR DESCRIPTION
## Summary

In `alberta_framework/core/horde_actor_critic.py:_nlhac_log_prob`, the previous implementation floored probabilities at `1e-8` (`jnp.log(jnp.maximum(mixed_probs[action], 1e-8))`) and took `probs = jax.nn.softmax(logits / temperature)`.
Because `_nlhac_grad = jax.grad(_nlhac_log_prob, argnums=0)` differentiates through `_nlhac_log_prob`:
1. When an action had low probability (`mixed_probs[action] <= 1e-8`), `jnp.maximum` produced a zero subgradient (`d(maximum)/dx = 0`), causing policy gradients for rare or unvisited actions to completely collapse to zero (`[0.0, 0.0]`). This resulted in dead gradients / policy freezing where the network could never update weights for an action once its probability dropped below 1e-8.
2. Direct `log(softmax(logits))` is subject to underflow/overflow precision loss in float32 arithmetic compared to numerically stable `log_softmax`.
3. In `select_action` across `ActorCriticAgent`, `QHordeActorCriticAgent`, `HordeActorCriticAgent`, `NonlinearHordeActorCriticAgent`, and `NonlinearQHordeActorCriticAgent`, `jr.categorical` was passed `jnp.log(jnp.maximum(probs, 1e-8))`, which distorted the categorical sampling distribution by assigning an artificial 1e-8 floor to zero-probability actions.

This PR:
- Updates `_nlhac_log_prob` to use `jax.lax.cond` to evaluate `jax.nn.log_softmax(tempered_logits)[action]` when `actor_epsilon == 0.0` (which has exact analytical derivative `e_a - softmax(logits)` that never vanishes) and exact `jnp.log(mixed_probs[action])` when `actor_epsilon > 0.0`.
- Removes the artificial `1e-8` floor in `select_action` across the 5 actor-critic classes, passing `jnp.log(probs)` cleanly to `jr.categorical`.
- Adds regression tests in `tests/test_horde_actor_critic.py` and `tests/test_actor_critic.py`.

## Verification
- `pytest tests/test_actor_critic.py tests/test_horde_actor_critic.py` (121 passed)
- `ruff check alberta_framework/core/actor_critic.py alberta_framework/core/horde_actor_critic.py tests/test_actor_critic.py tests/test_horde_actor_critic.py` (clean)
- `mypy alberta_framework/core/actor_critic.py alberta_framework/core/horde_actor_critic.py` (clean)
- `git diff --check` (clean)

## Measured project receipt
Post-hoc / same-window receipt. Client **agy** (Antigravity), provider **google**, model **gemini-3.7-flash-high**. Not Codex/Claude. Usage unavailable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: google / gemini-3.7-flash-high
Client / agent tooling: agy
Contribution skill revision: elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi
Attribution status: self-reported
— [rama0x1-agy]
<!-- slop-contribution-attribution:v1 {"provider":"google","model":"gemini-3.7-flash-high","client":"agy","skill_revision":"elizaOS/slopdotcash@792ba098a7590c293398446246a9d2bb3dd72f50:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M17S2ABDRPKWERDY7RA7D4CJ","project":"asi","repository":"elizaOS/asi","started_at":"2026-08-29T22:08:28.526Z","completed_at":"2026-08-29T22:08:51.598Z","skill_sha256":"b4515d9a8a823a1250f43125614cbce520f3ab93d1bd53be1f6e6ae0cda85408","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-08-29T22:08:28.732Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5706b77f6a2d4f87ecfa1a8c1136df32e92fccf4cd3761dc2bc73ceabb0acb81","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"071165df-2f6f-42c7-a7bb-f5b933e0e4ae","object_id":"sha256:5706b77f6a2d4f87ecfa1a8c1136df32e92fccf4cd3761dc2bc73ceabb0acb81","sha256":"5706b77f6a2d4f87ecfa1a8c1136df32e92fccf4cd3761dc2bc73ceabb0acb81"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA6HqMCNPWZ5tY9ak-obSbWC-rWwl3YKV-RrW2Ta0z9jQ","device_key_id":"98d203000b81f45652ae14c454d8c94cbecd263b9d30ff1c0856593d7f6353b2","device_signature":"4IBFBO-ZD0jDUNHZXvDHQzlg8axovEPDQ0uH4bTHukTr5gWRsNHT0N6T_5ErRndQbQhxndoovvzLyVazwCAoCQ"}} -->
