### PR TITLE
fix(scorecard): leave single-seed stderr undefined

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -984,8 +984,10 @@ def _sample_sd(values: Sequence[float]) -> float:
     return math.sqrt(math.fsum((value - average) ** 2 for value in values) / (len(values) - 1))
 
 
-def _stderr(values: Sequence[float]) -> float:
-    return _sample_sd(values) / math.sqrt(len(values)) if values else 0.0
+def _stderr(values: Sequence[float]) -> float | None:
+    if len(values) < 2:
+        return None
+    return _sample_sd(values) / math.sqrt(len(values))
 
 
 def _paired_lcb(values: Sequence[float]) -> float | None:

--- a/tests/test_reference_life_scorecard.py
+++ b/tests/test_reference_life_scorecard.py
@@ -378,6 +378,29 @@ def test_summary_retains_failures_and_reports_valid_baseline_failure() -> None:
     assert summary["status"] == "valid_baseline_failure"
 
 
+def test_partial_arm_summary_marks_single_seed_stderr_undefined() -> None:
+    records = _summary_records()
+    retained_seed = SEED_ROSTER[0]
+    for record in records:
+        if record["arm"] == "prototype" and record["seed"] != retained_seed:
+            record["status"] = "failed"
+            record["outcome"] = None
+            record["failure"] = {
+                "stage": "step",
+                "type": "RuntimeError",
+                "message": "synthetic shard failure",
+            }
+
+    summary = scorecard._summarize_validated_run_records(
+        build_development_plan(), records
+    )
+
+    prototype = summary["environments"]["switching_two_state"]["arms"]["prototype"]
+    assert prototype["completed_seed_count"] == 1
+    assert prototype["failed_seed_count"] == len(SEED_ROSTER) - 1
+    assert prototype["reward_sum_stderr"] is None
+
+
 @pytest.mark.skipif(
     not hasattr(os, "O_TMPFILE"),
     reason="write_new_json publishes through Linux O_TMPFILE and linkat(AT_EMPTY_PATH)",


### PR DESCRIPTION
## Summary
Ships leftover Antigravity work that was implemented locally but not opened as a PR.

## Evidence
- Rebased onto current origin/main before push.

N/A - leftover ship of already-implemented local commit; re-run focused tests in CI.