### PR TITLE
fix(streams): score identical floor-level savings as 1 in lifetime_scorecard

### DIFF
--- a/alberta_framework/streams/gauntlet.py
+++ b/alberta_framework/streams/gauntlet.py
@@ -1102,13 +1102,21 @@ def lifetime_scorecard(
     fresh_early = jnp.mean(per_cycle[..., :, 0, :window], axis=-1)
     recur_c_early = jnp.mean(per_cycle[..., :, 1, :window], axis=-1)
     recur_d_early = jnp.mean(per_cycle[..., :, 3, :window], axis=-1)
-    eps = 1e-8
+    floor = jnp.asarray(1e-8, dtype=jnp.promote_types(sq_errors.dtype, jnp.float32))
+    both_at_floor_c = (recur_c_early[..., :1] <= floor) & (recur_c_early[..., 1:] <= floor)
+    raw_savings_c = recur_c_early[..., :1] / jnp.maximum(recur_c_early[..., 1:], floor)
+    savings_c = jnp.where(both_at_floor_c, jnp.ones_like(raw_savings_c), raw_savings_c)
+
+    both_at_floor_d = (recur_d_early[..., :1] <= floor) & (recur_d_early[..., 1:] <= floor)
+    raw_savings_d = recur_d_early[..., :1] / jnp.maximum(recur_d_early[..., 1:], floor)
+    savings_d = jnp.where(both_at_floor_d, jnp.ones_like(raw_savings_d), raw_savings_d)
+
     return {
         "fresh_early": fresh_early,
         "recur_c_early": recur_c_early,
         "recur_d_early": recur_d_early,
-        "savings_c": recur_c_early[..., :1] / jnp.maximum(recur_c_early[..., 1:], eps),
-        "savings_d": recur_d_early[..., :1] / jnp.maximum(recur_d_early[..., 1:], eps),
+        "savings_c": savings_c,
+        "savings_d": savings_d,
         "nan_steps": jnp.sum(~jnp.isfinite(sq_errors), axis=-1),
     }
 

--- a/tests/test_gauntlet_scorecard_window.py
+++ b/tests/test_gauntlet_scorecard_window.py
@@ -80,3 +80,50 @@ def test_segment_slice_rejects_boolean_and_negative_indices() -> None:
         segment_slice(errors, segment=True, segment_length=50)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="segment_length"):
         segment_slice(errors, segment=0, segment_length=False)  # type: ignore[arg-type]
+
+
+def test_lifetime_scorecard_identical_floor_and_underflow_windows_score_one() -> None:
+    import numpy as np
+
+    config = GauntletConfig(segment_length=50)
+    # 2 seeds, 3 cycles of (4 subsegments * 50) = 600 steps
+    n_cycles = 3
+    total_steps = n_cycles * 4 * config.segment_length
+
+    # 1. Identical zeros (oracle / noiseless) must report 1.0 savings across cycles, not 0.0
+    zeros = jnp.zeros((2, total_steps), dtype=jnp.float32)
+    card_zeros = lifetime_scorecard(zeros, config, n_cycles=n_cycles, window=20)
+    np.testing.assert_allclose(np.asarray(card_zeros["savings_c"]), np.ones((2, n_cycles - 1)))
+    np.testing.assert_allclose(np.asarray(card_zeros["savings_d"]), np.ones((2, n_cycles - 1)))
+
+    # 2. Identical sub-floor underflow (1e-12) must report 1.0, not 1e-12 / 1e-8 = 1e-4
+    underflow = jnp.full((2, total_steps), 1e-12, dtype=jnp.float32)
+    card_underflow = lifetime_scorecard(underflow, config, n_cycles=n_cycles, window=20)
+    np.testing.assert_allclose(np.asarray(card_underflow["savings_c"]), np.ones((2, n_cycles - 1)))
+    np.testing.assert_allclose(np.asarray(card_underflow["savings_d"]), np.ones((2, n_cycles - 1)))
+
+    # 3. Memoryless identical non-zero (1.0) traces remain 1.0
+    ones = jnp.ones((2, total_steps), dtype=jnp.float32)
+    card_ones = lifetime_scorecard(ones, config, n_cycles=n_cycles, window=20)
+    np.testing.assert_allclose(np.asarray(card_ones["savings_c"]), np.ones((2, n_cycles - 1)))
+    np.testing.assert_allclose(np.asarray(card_ones["savings_d"]), np.ones((2, n_cycles - 1)))
+
+    # 4. Perfect first exposure (0.0) with degraded revisit (1.0) correctly scores 0.0
+    degraded = jnp.ones((2, total_steps), dtype=jnp.float32)
+    # Cycle 0 subsegment 1 (task C) and subsegment 3 (task D) have zero error
+    degraded = degraded.at[:, : 4 * config.segment_length].set(0.0)
+    # Revisit in cycles 1 and 2 has error 1.0
+    card_degraded = lifetime_scorecard(degraded, config, n_cycles=n_cycles, window=20)
+    np.testing.assert_allclose(np.asarray(card_degraded["savings_c"]), np.zeros((2, n_cycles - 1)))
+    np.testing.assert_allclose(np.asarray(card_degraded["savings_d"]), np.zeros((2, n_cycles - 1)))
+
+    # 5. Genuine improvement (1.0 first exposure, 0.1 revisit) scores expected ratio (10.0)
+    improved = jnp.full((2, total_steps), 0.1, dtype=jnp.float32)
+    improved = improved.at[:, : 4 * config.segment_length].set(1.0)
+    card_improved = lifetime_scorecard(improved, config, n_cycles=n_cycles, window=20)
+    np.testing.assert_allclose(
+        np.asarray(card_improved["savings_c"]), np.full((2, n_cycles - 1), 10.0), rtol=1e-5
+    )
+    np.testing.assert_allclose(
+        np.asarray(card_improved["savings_d"]), np.full((2, n_cycles - 1), 10.0), rtol=1e-5
+    )


### PR DESCRIPTION
## Outcome

Fix (measurement trust).

`lifetime_scorecard` in `alberta_framework.streams.gauntlet` previously computed memory savings ratios across cycles as:
`savings_c = recur_c_early[..., :1] / jnp.maximum(recur_c_early[..., 1:], 1e-8)`
`savings_d = recur_d_early[..., :1] / jnp.maximum(recur_d_early[..., 1:], 1e-8)`

When both the baseline exposure error (`recur_*_early[..., :1]`) and subsequent cycle revisit errors (`recur_*_early[..., 1:]`) sit at or below the `1e-8` floor (such as in an oracle learner, noiseless stream with `noise_std=0.0`, or underflowing squared errors like `1e-12`):
- `0.0 / 1e-8` evaluated to `0.0` (falsely reporting complete catastrophic forgetting for an optimal zero-error learner).
- `1e-12 / 1e-8` evaluated to `1e-4` (falsely reporting 0.01% retention).

## Fix

When both initial and revisit entry errors sit at or below the `1e-8` floor, they are indistinguishable (oracle / noiseless / underflow) and score `1.0` (matching the identity behavior of `savings_ratio` and `savings_ratio_steps`).

- Non-floor ratios, degraded revisits (scoring 0.0), and improvements (> 1.0) remain exact.
- Added comprehensive unit tests in `tests/test_gauntlet_scorecard_window.py` verifying identical zeros, underflows (1e-12), memoryless ones (1.0), degraded revisits (0.0), and genuine improvements (10.0).

## Verification

- `pytest tests/test_gauntlet_scorecard_window.py` (4 passed)
- `pytest tests/test_gauntlet*.py` (43 passed)
- `ruff check alberta_framework/streams/gauntlet.py tests/test_gauntlet_scorecard_window.py` (clean)
- `mypy alberta_framework/streams/gauntlet.py` (clean)
- `git diff --check` (clean)