### PR TITLE
fix(cumulant-discovery): re-narrow to float32 before preserve_nonzero underflow check

### DIFF
--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -106,7 +106,7 @@ def _require_float32(
         upper_inclusive=upper_inclusive,
         positive=positive,
     )
-    if preserve_nonzero and numerator != 0 and stored == 0.0:
+    if preserve_nonzero and numerator != 0 and float(np.float32(stored)) == 0.0:
         raise ValueError(f"{name} must remain nonzero once narrowed to float32")
     return stored
 

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -14,6 +14,7 @@ import pytest
 from alberta_framework.core.cumulant_discovery import (
     CumulantDiscovery,
     CumulantDiscoveryState,
+    _require_float32,
 )
 
 # =============================================================================
@@ -473,3 +474,8 @@ def test_cumulant_discovery_hostile_observation_failure_is_normalized() -> None:
     state = discovery.init(jr.key(0))
     with pytest.raises(ValueError, match="readable float32 vector"):
         discovery.cumulants(state, HostileObservation())  # type: ignore[arg-type]
+
+def test_require_float32_preserve_nonzero_builtin_float_underflow() -> None:
+    # Underflows in float32 for built-in float
+    with pytest.raises(ValueError, match="must remain nonzero once narrowed to float32"):
+        _require_float32("gamma", 1e-50, lower=0.0, upper=1.0, preserve_nonzero=True)


### PR DESCRIPTION
Fixes #2720

## Summary
In `alberta_framework.core.cumulant_discovery`:
`_require_float32(..., preserve_nonzero=True)` tested `stored == 0.0` to detect float32 underflow. When callers pass built-in Python `float`s (e.g. `1e-50`), `validated_float32_scalar_with_ratio` stores the un-narrowed Python `float`, causing `stored == 0.0` to evaluate to `False` even when the value underflows to exact zero in float32.

## Proposed Changes
1. Re-narrowed `float(np.float32(stored)) == 0.0` when checking `preserve_nonzero` in `_require_float32`, matching the pattern in `option_value_duration.py`.
2. Added unit tests in `tests/test_cumulant_discovery.py` verifying that built-in `float` values that underflow in float32 are correctly rejected with `ValueError`.

## Verification
- Passed `uv run pytest tests/test_cumulant_discovery.py` (52/52 passed).
- Passed `uv run ruff check alberta_framework/core/cumulant_discovery.py tests/test_cumulant_discovery.py`.
- Passed `uv run mypy alberta_framework/core/cumulant_discovery.py`.
