### PR TITLE
fix(utils/experiments): unnest Raises section in get_final_performance docstring

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -665,7 +665,7 @@ def get_final_performance(
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
 
-        Raises:
+    Raises:
         ValueError: If ``window`` is not positive, a metric array has no
             time steps, any metric sample is non-finite, or ``window`` exceeds
             the shortest trace while trace lengths differ between methods.


### PR DESCRIPTION
Fixes #2439

## Summary
In `alberta_framework.utils.experiments`:
In `get_final_performance`, the `Raises:` section header was indented at 8 spaces (nested within the `Returns:` block) rather than at 4 spaces as a sibling section header.

## Proposed Changes
1. Un-nested the `Raises:` section header in `get_final_performance`'s Google-style docstring to align with the standard 4-space section indentation.

## Verification
- Passed `uv run pytest tests/test_experiments_validation.py` (129/129 passed).
- Passed `uv run ruff check alberta_framework/utils/experiments.py`.
- Passed `uv run mypy alberta_framework/utils/experiments.py`.
