### PR TITLE
fix(utils/metrics): clarify compute_forward_transfer NaN condition in docstring

### DIFF
--- a/alberta_framework/utils/metrics.py
+++ b/alberta_framework/utils/metrics.py
@@ -447,8 +447,9 @@ def compute_forward_transfer(
     on a task probed *before* it is ever trained on, minus a task-specific
     baseline (in GEM, the untrained-network performance).
 
-    Task 0, and any task without a finite pre-exposure probe, receives ``NaN``.
-    The sign is normalized so positive values always mean beneficial transfer.
+    Any task whose first exposure is row 0, and any task without a finite
+    pre-exposure probe, receives ``NaN``. The sign is normalized so positive
+    values always mean beneficial transfer.
     """
 
     higher_is_better = _require_exact_bool("higher_is_better", higher_is_better)


### PR DESCRIPTION
Fixes #2437

## Summary
In `alberta_framework.utils.metrics`:
`compute_forward_transfer`'s docstring claimed that "Task 0, and any task without a finite pre-exposure probe, receives `NaN`." However, the GEM forward-transfer implementation skips tasks based on their `first_exposure` row (`first_row == 0`), which corresponds to task 0 only under the identity ordering.

## Proposed Changes
1. Updated `compute_forward_transfer`'s docstring to accurately state that any task whose first exposure occurs at row 0 (or lacks a finite pre-exposure probe) receives `NaN`.

## Verification
- Passed `uv run pytest tests/test_continual_metrics.py` (48/48 passed).
- Passed `uv run ruff check alberta_framework/utils/metrics.py`.
- Passed `uv run mypy alberta_framework/utils/metrics.py`.
