### PR TITLE
fix(latent-world-model): remove 1e-6 floor in encoder and restrict observation_scale to normal float32 range

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -290,7 +290,9 @@ class LatentWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 validated_float32_scalar(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]",
+                    scale,
+                    lower=float(np.finfo(np.float32).tiny),
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -670,7 +672,7 @@ class LatentWorldModel:
         """Encode one observation with explicit (differentiable) encoder params."""
         obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._config.observation_dim,))
         scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
+        scaled = obs / scale
         return jnp.tanh(scaled @ encoder_matrix + encoder_bias)
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -749,3 +749,39 @@ def test_latent_world_model_init_rejects_nonfinite_encoder_draw() -> None:
 
     with pytest.raises(ValueError, match="encoder initialization"):
         model.init(jr.key(0))
+
+def test_observation_scale_normal_preserves_scale_free_latents() -> None:
+    # Probing scales across normal float32 range down to 1e-20
+    for scale in (1.0, 1e-6, 1e-9, 1e-20):
+        config = LatentWorldModelConfig(
+            observation_dim=2,
+            latent_dim=4,
+            n_actions=2,
+            observation_scale=(scale, scale),
+        )
+        model = LatentWorldModel(config)
+        state = model.init(jr.key(0))
+        obs = jnp.asarray([1.5 * scale, -0.75 * scale], dtype=jnp.float32)
+        latent = model.encode(state, obs)
+        ref_config = LatentWorldModelConfig(
+            observation_dim=2,
+            latent_dim=4,
+            n_actions=2,
+            observation_scale=(1.0, 1.0),
+        )
+        ref_model = LatentWorldModel(ref_config)
+        ref_state = ref_model.init(jr.key(0))
+        ref_obs = jnp.asarray([1.5, -0.75], dtype=jnp.float32)
+        ref_latent = ref_model.encode(ref_state, ref_obs)
+        chex.assert_trees_all_close(latent, ref_latent, atol=1e-6)
+
+def test_observation_scale_rejects_subnormal_scales() -> None:
+    # Subnormal scales have no finite float32 reciprocal and must be rejected
+    smallest_subnormal = float(np.finfo(np.float32).smallest_subnormal)
+    with pytest.raises(ValueError, match="observation_scale"):
+        LatentWorldModelConfig(
+            observation_dim=1,
+            latent_dim=2,
+            n_actions=2,
+            observation_scale=(smallest_subnormal,),
+        )


### PR DESCRIPTION
Fixes #2411

## Summary
In `alberta_framework.core.latent_world_model`:
`LatentWorldModel._encode_with` normalized observations using `jnp.maximum(scale, 1e-6)`. When `observation_scale` was configured below `1e-6`, the encoder substituted `1e-6` instead of the accepted scale value, shrinking latents, artificially manufacturing `collapse_score` flags, and freezing encoder learning.

## Proposed Changes
1. Removed `jnp.maximum(scale, 1e-6)` from `_encode_with`, dividing directly by the configured `scale`.
2. Validated `observation_scale` to require positive normal `float32` values (`lower=float(np.finfo(np.float32).tiny)`), rejecting subnormals that lack finite float32 reciprocals at construction time.
3. Added unit tests in `tests/test_latent_world_model.py` verifying that normal scales yield scale-free latents and that subnormal scales are rejected.

## Verification
- Passed `uv run pytest tests/test_latent_world_model.py` (58/58 passed).
- Passed `uv run ruff check alberta_framework/core/latent_world_model.py tests/test_latent_world_model.py`.
- Passed `uv run mypy alberta_framework/core/latent_world_model.py`.
