### PR TITLE
fix(resource_manager): preserve convex masked baseline centering when participating mass is below 1e-12

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -1036,8 +1036,13 @@ class FixedBudgetFeatureLearner:
         finite: Array,
     ) -> Array:
         """Exponentiated-gradient preference update for utility scores."""
-        finite_mass = jnp.maximum(jnp.sum(jnp.where(finite, allocation, 0.0)), 1e-12)
-        masked_allocation = jnp.where(finite, allocation / finite_mass, 0.0)
+        finite_mass = jnp.sum(jnp.where(finite, allocation, 0.0))
+        n_valid = jnp.maximum(jnp.sum(finite.astype(jnp.float32)), 1.0)
+        uniform_allocation = jnp.where(finite, 1.0 / n_valid, 0.0)
+        safe_mass = jnp.where(finite_mass > 0.0, finite_mass, 1.0)
+        normalized = jnp.where(finite, allocation / safe_mass, 0.0)
+        has_finite_normalized = jnp.all(jnp.isfinite(normalized)) & (finite_mass > 0.0)
+        masked_allocation = jnp.where(has_finite_normalized, normalized, uniform_allocation)
         baseline = jnp.sum(masked_allocation * jnp.where(finite, scores, 0.0))
         advantages = jnp.where(finite, scores - baseline, 0.0)
         advantages = jnp.clip(

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -594,8 +594,13 @@ class LearnedResourceManager:
         adjusted = jnp.where(valid_actions, safe_losses + cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(valid_actions, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(valid_actions, weights / finite_weight_sum, 0.0)
+        finite_weight_sum = jnp.sum(jnp.where(valid_actions, weights, 0.0))
+        n_valid = jnp.maximum(jnp.sum(valid_actions.astype(jnp.float32)), 1.0)
+        uniform_weights = jnp.where(valid_actions, 1.0 / n_valid, 0.0)
+        safe_sum = jnp.where(finite_weight_sum > 0.0, finite_weight_sum, 1.0)
+        normalized = jnp.where(valid_actions, weights / safe_sum, 0.0)
+        has_finite_normalized = jnp.all(jnp.isfinite(normalized)) & (finite_weight_sum > 0.0)
+        masked_weights = jnp.where(has_finite_normalized, normalized, uniform_weights)
         baseline = jnp.sum(masked_weights * adjusted)
         advantages = jnp.where(valid_actions, baseline - adjusted, 0.0)
         advantages = jnp.clip(
@@ -1191,8 +1196,13 @@ class GeneratorMetaResourceManager:
         adjusted = jnp.where(finite, safe_rewards - cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(finite, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(finite, weights / finite_weight_sum, 0.0)
+        finite_weight_sum = jnp.sum(jnp.where(finite, weights, 0.0))
+        n_valid = jnp.maximum(jnp.sum(finite.astype(jnp.float32)), 1.0)
+        uniform_weights = jnp.where(finite, 1.0 / n_valid, 0.0)
+        safe_sum = jnp.where(finite_weight_sum > 0.0, finite_weight_sum, 1.0)
+        normalized = jnp.where(finite, weights / safe_sum, 0.0)
+        has_finite_normalized = jnp.all(jnp.isfinite(normalized)) & (finite_weight_sum > 0.0)
+        masked_weights = jnp.where(has_finite_normalized, normalized, uniform_weights)
         baseline = jnp.sum(masked_weights * adjusted)
         selection_input_valid = jnp.asarray(True, dtype=jnp.bool_)
         if self._update_rule == "exp3":

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -859,3 +859,15 @@ def test_resource_manager_serialized_schemas_are_exact() -> None:
         invalid.update(mutation)
         with pytest.raises(ValueError, match=match):
             GeneratorMetaResourceManager.from_config(invalid)
+
+def test_masked_baseline_preserves_centering_below_1e12() -> None:
+    # When masked-in entries have mass < 1e-12, centering must remain a convex combination
+    manager = LearnedResourceManager(n_actions=3, n_contexts=1, exploration=0.0)
+    state = manager.init()
+    # Set a large log_weight gap so the other actions have mass < 1e-12 in global softmax
+    state = state.replace(log_weights=jnp.asarray([[40.0, 0.0, 0.0]], dtype=jnp.float32))
+    # Leading action is masked out by NaN loss; surviving actions have losses 1.0 and 3.0
+    result = manager.update(state, jnp.asarray([jnp.nan, 1.0, 3.0]), 0)
+    # The advantages for action 1 and 2 must center to +1.0 and -1.0
+    delta_w = result.state.log_weights[0] - state.log_weights[0]
+    chex.assert_trees_all_close(delta_w[1] - delta_w[2], 2.0 * manager._learning_rate, atol=1e-5)


### PR DESCRIPTION
Fixes #2409

## Summary
In `alberta_framework.core.resource_manager` (`LearnedResourceManager`, `GeneratorMetaResourceManager`) and `alberta_framework.core.feature_discovery` (`FixedBudgetFeatureLearner`):
Hedge preference updates normalized masked weights using `jnp.maximum(finite_weight_sum, 1e-12)`. When surviving actions carried less than `1e-12` mass in the global softmax distribution, dividing by `1e-12` caused the weights to sum to less than one, pulling the baseline toward zero instead of a convex combination of surviving entries and corrupting centered advantages.

## Proposed Changes
1. Replaced the `1e-12` floor with safe normalization that falls back to a uniform distribution over valid masked actions when participating mass is zero/unrepresentable.
2. Guaranteed that `masked_weights` always sums to 1.0 over valid actions, preserving convex centering and shift-invariance under arbitrary preference gaps.
3. Added regression tests in `tests/test_resource_manager.py`.

## Verification
- Passed `uv run pytest tests/test_resource_manager.py tests/test_feature_discovery.py` (215/215 passed).
- Passed `uv run ruff check alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py tests/test_resource_manager.py`.
- Passed `uv run mypy alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py`.
