### PR TITLE
fix(world_model): divide targets by configured observation_scale instead of floored scale

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -806,11 +806,10 @@ class ActionConditionedWorldModel:
         reward_arr = _float32_operand("reward", reward, ())
         discount_arr = _float32_operand("discount", discount, ())
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
             self._config.predict_delta,
-            (next_obs - obs) / safe_scale,
-            next_obs / safe_scale,
+            (next_obs - obs) / obs_scale,
+            next_obs / obs_scale,
         )
         reward_target = jnp.reshape(
             reward_arr / self._config.reward_scale,

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -955,3 +955,20 @@ def test_action_world_model_rolls_back_reduction_overflow() -> None:
     assert not bool(result.update_applied)
     assert float(result.observation_mse) == 0.0
     assert int(result.state.step_count) == 0
+
+def test_observation_scale_targets_round_trip_exact_below_1e6() -> None:
+    # A transition scaled to match observation_scale must reconstruct delta accurately
+    for scale in (1e-6, 1e-7, 1e-9, 1e-12, 1e-20, 1e-30):
+        config = ActionConditionedWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            hidden_sizes=(),
+            predict_delta=True,
+            observation_scale=(scale,),
+        )
+        model = ActionConditionedWorldModel(config)
+        obs = jnp.asarray([1.0 * scale], dtype=jnp.float32)
+        next_obs = jnp.asarray([3.0 * scale], dtype=jnp.float32)
+        targets = model.targets(obs, 0.0, 1.0, next_obs)
+        # Target normalized delta is (3.0 - 1.0) = 2.0
+        chex.assert_trees_all_close(targets[0], 2.0, atol=1e-5)


### PR DESCRIPTION
Fixes #2398

## Summary
In `alberta_framework.core.world_model`:
`ActionConditionedWorldModel.targets` normalized observation targets by dividing by `jnp.maximum(obs_scale, 1e-6)`. However, `_prediction_and_raw_diagnostics` (which decodes predictions for `predict()` and `update()`) multiplied normalized deltas by the raw configured `obs_scale`. For `observation_scale < 1e-6`, the targets and decoded predictions were scaled asymmetrically, reconstructing deltas that were too small by `observation_scale / 1e-6`.

## Proposed Changes
1. Removed `safe_scale = jnp.maximum(obs_scale, 1e-6)` in `targets()`, dividing directly by `obs_scale` to match the decode multiplier in `_prediction_and_raw_diagnostics`.
2. Added unit tests in `tests/test_action_conditioned_world_model.py` verifying exact round-trip target reconstruction across scales below `1e-6`.

## Verification
- Passed `uv run pytest tests/test_action_conditioned_world_model.py` (69/69 passed).
- Passed `uv run ruff check alberta_framework/core/world_model.py tests/test_action_conditioned_world_model.py`.
- Passed `uv run mypy alberta_framework/core/world_model.py`.
