### PR TITLE
fix(tests): silence RuntimeWarning in _platform_longdouble_1e4000 via catch_warnings

### DIFF
--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from decimal import Decimal
 from fractions import Fraction
@@ -537,7 +538,8 @@ class _NonfiniteFloatThatConvertsFinite(float):
 
 def _platform_longdouble_1e4000() -> np.longdouble:
     """Parse the cross-platform boundary without leaking an expected warning."""
-    with np.errstate(over="ignore", invalid="ignore"):
+    with warnings.catch_warnings(), np.errstate(over="ignore", invalid="ignore"):
+        warnings.simplefilter("ignore", RuntimeWarning)
         return np.longdouble("1e4000")
 
 
@@ -1029,3 +1031,11 @@ def test_run_multi_seed_experiment_rejects_invalid_seed_sequences(
 def test_get_final_performance_rejects_non_builtin_positive_window(window: object) -> None:
     with pytest.raises(ValueError, match="window"):
         get_final_performance({"candidate": _two_seed_trace()}, window=window)  # type: ignore[arg-type]
+
+def test_platform_longdouble_1e4000_emits_no_warnings() -> None:
+    """The helper must not leak RuntimeWarning on platforms where longdouble is float64."""
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        value = _platform_longdouble_1e4000()
+    assert len(recorded) == 0
+    assert isinstance(value, np.longdouble)


### PR DESCRIPTION
Fixes #2387

## Summary
In `tests/test_experiments_validation.py`:
`_platform_longdouble_1e4000` wrapped the parse in `np.errstate(over="ignore", invalid="ignore")`, but string conversion overflow in `np.longdouble("1e4000")` is dispatched through Python's `warnings` module, leaking `RuntimeWarning: overflow encountered in conversion from string` during test runs and collection on platforms where `longdouble` is `float64` (e.g. macOS arm64, aarch64 Linux).

## Proposed Changes
1. Wrapped the parse in `warnings.catch_warnings()` with `warnings.simplefilter("ignore", RuntimeWarning)`.
2. Added a test confirming `_platform_longdouble_1e4000` emits no warnings.

## Verification
- Passed `uv run pytest tests/test_experiments_validation.py` (130/130 passed with 0 warnings).
- Passed `uv run ruff check tests/test_experiments_validation.py`.
