### PR TITLE
fix(upgd_memory): ensure _normalize_simplex returns valid probability distribution

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -675,7 +675,13 @@ def _active_mse(prediction: Array, target: Array) -> Array:
 
 def _normalize_simplex(prediction: Array) -> Array:
     clipped = jnp.maximum(prediction, 0.0)
-    return clipped / jnp.maximum(jnp.sum(clipped), 1e-12)
+    total = jnp.sum(clipped)
+    n = jnp.maximum(clipped.shape[0], 1)
+    uniform = jnp.full_like(clipped, 1.0 / n)
+    safe_total = jnp.where(total > 0.0, total, 1.0)
+    normalized = clipped / safe_total
+    is_valid = (total > 0.0) & jnp.all(jnp.isfinite(normalized)) & (jnp.sum(normalized) > 0.0)
+    return jnp.where(is_valid, normalized, uniform)
 
 
 class UPGDMemoryLearner:

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -564,3 +564,19 @@ def test_upgd_memory_preserves_legal_closed_endpoints() -> None:
     assert allocation_endpoint.target_allocation_rate == 1.0
     assert fixed_threshold.min_novelty_threshold == 0.5
     assert fixed_threshold.max_novelty_threshold == 0.5
+
+def test_normalize_simplex_guarantees_unit_sum_across_edge_cases() -> None:
+    from alberta_framework.core.upgd_memory import _normalize_simplex
+
+    for case in (
+        [0.0, 0.0, 0.0],
+        [-1.0, -2.0, -3.0],
+        [1e38, 1.0, 1.0],
+        [7.5e-13, 0.0, 0.0],
+        [1e-30, 0.0, 0.0],
+        [1.0, 2.0, 3.0],
+    ):
+        arr = jnp.asarray(case, dtype=jnp.float32)
+        norm = _normalize_simplex(arr)
+        chex.assert_trees_all_close(jnp.sum(norm), 1.0, atol=1e-6)
+        assert bool(jnp.all(norm >= 0.0))


### PR DESCRIPTION
Fixes #2470

## Summary
In `alberta_framework.core.upgd_memory`:
`_normalize_simplex` returned a non-simplex (summing to zero or `< 1.0`) when input vectors were all-zero, negative, subnormal, or underflowed below the `1e-12` floor. When blended with `previous_targets` in `UPGDMemoryLearner`, this caused mass loss and distorted predictions without reporting any error.

## Proposed Changes
1. Normalized by the true unfloored sum (`jnp.sum(clipped)`).
2. Added robust fallback to a uniform distribution whenever total mass is non-positive or underflows.
3. Added unit tests in `tests/test_upgd_memory.py` covering edge-case inputs.

## Verification
- Passed `uv run pytest tests/test_upgd_memory.py tests/test_upgd_memory_grad.py tests/test_upgd_memory_validation.py` (220/220 passed).
- Passed `uv run ruff check alberta_framework/core/upgd_memory.py tests/test_upgd_memory.py`.
- Passed `uv run mypy alberta_framework/core/upgd_memory.py`.
