### PR TITLE
fix(prototype_agent): cap n_dreams_per_step at 10_000 to prevent scan hang and OOM

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -184,6 +184,7 @@ _PROTOTYPE_V2_REPLAY_MIGRATION_TAG = 0x50525632
 _PROTOTYPE_FEATURE_LIFECYCLE_KEY_TAG = 0x50464C43
 _UINT32_MAX = 2**32 - 1
 _INT32_MAX = 2**31 - 1
+_MAX_DREAMS_PER_STEP = 10_000
 
 # ---------------------------------------------------------------------------
 # Standalone utility
@@ -725,7 +726,7 @@ class PrototypeAgentConfig:
                 "n_dreams_per_step",
                 self.n_dreams_per_step,
                 minimum=0,
-                maximum=_INT32_MAX,
+                maximum=_MAX_DREAMS_PER_STEP,
             ),
         )
         # horde_hidden_sizes: hostile-safe per-element validation
@@ -1335,7 +1336,10 @@ class PrototypeAgentConfig:
             "buffer_capacity", data.pop("buffer_capacity", 200), minimum=1, maximum=_INT32_MAX
         )
         n_dreams_per_step = _require_int(
-            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=_INT32_MAX
+            "n_dreams_per_step",
+            data.pop("n_dreams_per_step", 0),
+            minimum=0,
+            maximum=_MAX_DREAMS_PER_STEP,
         )
         dream_next_observation_mode = data.pop(
             "dream_next_observation_mode",

--- a/tests/test_prototype_agent_validation.py
+++ b/tests/test_prototype_agent_validation.py
@@ -303,3 +303,20 @@ def test_prototype_valid_construction() -> None:
     assert restored == cfg
     gru = GRUPerceptionConfig(observation_dim=4, hidden_dim=4)
     assert gru.augmented_dim() == 8
+
+def test_prototype_agent_config_caps_n_dreams_per_step() -> None:
+    from alberta_framework.core.prototype_agent import _MAX_DREAMS_PER_STEP
+
+    # Accepts up to _MAX_DREAMS_PER_STEP when world_model is present
+    cfg = _cfg(
+        world_model=ActionConditionedWorldModelConfig(observation_dim=4, n_actions=2),
+        n_dreams_per_step=_MAX_DREAMS_PER_STEP,
+    )
+    assert cfg.n_dreams_per_step == _MAX_DREAMS_PER_STEP
+
+    # Rejects values above _MAX_DREAMS_PER_STEP
+    with pytest.raises(ValueError, match="n_dreams_per_step"):
+        _cfg(
+            world_model=ActionConditionedWorldModelConfig(observation_dim=4, n_actions=2),
+            n_dreams_per_step=_MAX_DREAMS_PER_STEP + 1,
+        )


### PR DESCRIPTION
Fixes #2441

## Summary
In `alberta_framework.core.prototype_agent`:
`PrototypeAgentConfig.n_dreams_per_step` was bounded only by `_INT32_MAX`. When set to a large value within that range, `jax.lax.scan` over `jnp.arange(self._config.n_dreams_per_step)` causes hangs or out-of-memory errors before execution starts.

## Proposed Changes
1. Capped `n_dreams_per_step` at `10_000` (matching `_DREAM_ROLLOUT_BUDGET.maximum_steps` in `core.dreaming`) across both `__post_init__` and `from_dict`.
2. Added unit tests in `tests/test_prototype_agent_validation.py` verifying that values up to `10_000` are accepted and values exceeding `10_000` are rejected with `ValueError`.

## Verification
- Passed `uv run pytest tests/test_prototype_agent_validation.py` (24/24 passed).
- Passed `uv run ruff check alberta_framework/core/prototype_agent.py tests/test_prototype_agent_validation.py`.
- Passed `uv run mypy alberta_framework/core/prototype_agent.py`.
