### PR TITLE
fix(optimizer_geometry): rescale gradient in flad_noise_component_transaction to prevent squared norm underflow

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -203,12 +203,15 @@ def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tu
     direction = _trusted_array(gradient, name="gradient")
     if delta.shape != direction.shape or delta.ndim != 1 or delta.size < 1:
         raise ValueError("perturbation and gradient must be non-empty equal-width vectors")
-    squared_norm = jnp.vdot(direction, direction).real
-    numerator = jnp.vdot(direction, delta).real
+    max_mag = jnp.max(jnp.abs(direction))
+    _, exponent = jnp.frexp(max_mag)
+    scaled_direction = jnp.where(max_mag > 0.0, jnp.ldexp(direction, -exponent), direction)
+    squared_norm = jnp.vdot(scaled_direction, scaled_direction).real
+    numerator = jnp.vdot(scaled_direction, delta).real
     active = squared_norm > 0.0
     denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
     coefficient = numerator / denominator
-    projection = direction * coefficient * active.astype(delta.dtype)
+    projection = scaled_direction * coefficient * active.astype(delta.dtype)
     candidate = delta - projection
     valid = (
         jnp.all(jnp.isfinite(delta))

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -2,6 +2,7 @@ import copy
 import json
 from pathlib import Path
 
+import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -340,3 +341,15 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+def test_flad_noise_component_underflow_rescaling() -> None:
+    # Projection must remain accurate across small gradient scales down to 1e-30
+    delta = jnp.asarray([1.0, -2.0, 0.5, 3.0], dtype=jnp.float32)
+    grad = jnp.asarray([2.0, 1.0, -1.0, 0.5], dtype=jnp.float32)
+    ref_safe, ref_valid = flad_noise_component_transaction(delta, grad)
+
+    for scale in (1e-10, 1e-20, 1e-25, 1e-30):
+        scaled_grad = grad * jnp.asarray(scale, dtype=jnp.float32)
+        safe, valid = flad_noise_component_transaction(delta, scaled_grad)
+        assert bool(valid)
+        chex.assert_trees_all_close(safe, ref_safe, atol=1e-6)


### PR DESCRIPTION
Fixes #2393

## Summary
In `alberta_framework.evaluation.optimizer_geometry`:
`flad_noise_component_transaction` computed `squared_norm = jnp.vdot(direction, direction).real` directly. When the gradient had small float32 entries (at or below `1e-20`), the squared norm underflowed to zero, erroneously triggering the zero-gradient fallback and returning `perturbation` untouched instead of subtracting the gradient projection.

## Proposed Changes
1. Scaled `direction` by its maximum magnitude's power of two using `jnp.frexp` and `jnp.ldexp` prior to calculating the projection.
2. Maintained scale invariance and exact zero-gradient reduction while preserving numerical accuracy across 30+ decades of gradient magnitudes (down to `1e-30`).
3. Added unit tests in `tests/test_optimizer_geometry.py`.

## Verification
- Passed `uv run pytest tests/test_optimizer_geometry.py` (29/29 passed).
- Passed `uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py`.
- Passed `uv run mypy alberta_framework/evaluation/optimizer_geometry.py`.
