### PR TITLE
fix(upgd): make gradient alignment scale-invariant using power-of-two rescaling

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1983,26 +1983,41 @@ class UPGDLearner:
         return total
 
     @staticmethod
-    def _tuple_norm(xs: tuple[Array, ...]) -> Array:
-        """L2 norm over a static tuple of arrays."""
-        total = jnp.array(0.0, dtype=jnp.float32)
+    def _tuple_normalized(xs: tuple[Array, ...]) -> tuple[tuple[Array, ...], Array]:
+        """Normalize a static tuple of arrays with power-of-two rescaling for scale invariance."""
+        if not xs:
+            return xs, jnp.asarray(False, dtype=jnp.bool_)
+        max_mag = jnp.array(0.0, dtype=jnp.float32)
         for x in xs:
+            max_mag = jnp.maximum(max_mag, jnp.max(jnp.abs(x)))
+        _, exponent = jnp.frexp(max_mag)
+        scaled_xs = tuple(
+            jnp.where(max_mag > 0.0, jnp.ldexp(x, -exponent), x)
+            for x in xs
+        )
+        total = jnp.array(0.0, dtype=jnp.float32)
+        for x in scaled_xs:
             total = total + jnp.sum(jnp.square(x))
-        return jnp.sqrt(total + 1e-12)
+        norm = jnp.sqrt(total)
+        is_valid = (norm > 0.0) & jnp.isfinite(norm)
+        safe_norm = jnp.where(is_valid, norm, 1.0)
+        unit_xs = tuple(
+            jnp.where(is_valid, x / safe_norm, jnp.zeros_like(x))
+            for x in scaled_xs
+        )
+        return unit_xs, is_valid
 
     @staticmethod
     def _gradient_alignment(
         previous: tuple[Array, ...],
         current: tuple[Array, ...],
     ) -> Array:
-        """Cosine alignment of two gradient tuples, zero for empty gradients."""
-        previous_norm = UPGDLearner._tuple_norm(previous)
-        current_norm = UPGDLearner._tuple_norm(current)
-        return jnp.where(
-            (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
-            jnp.array(0.0, dtype=jnp.float32),
-        )
+        """Cosine alignment of two gradient tuples, zero for empty/zero/nonfinite gradients."""
+        prev_unit, prev_valid = UPGDLearner._tuple_normalized(previous)
+        curr_unit, curr_valid = UPGDLearner._tuple_normalized(current)
+        dot = UPGDLearner._tuple_dot(prev_unit, curr_unit)
+        is_valid = prev_valid & curr_valid & jnp.isfinite(dot)
+        return jnp.where(is_valid, jnp.clip(dot, -1.0, 1.0), jnp.array(0.0, dtype=jnp.float32))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(self, state: UPGDState, observation: Array) -> Array:

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -21,6 +21,7 @@ so noise effects are unmistakable) and ``sparsity=0.5`` round-trips.
 """
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
@@ -2219,3 +2220,20 @@ class TestLoops:
         stream = RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.05)
         result = run_upgd_loop(learner, stream, num_steps=50, key=jr.key(0))
         chex.assert_shape(result.metrics, (50, 4))
+
+def test_upgd_gradient_alignment_is_scale_invariant() -> None:
+    g_base = (
+        jnp.array([1.0, -2.0, 0.5], dtype=jnp.float32),
+        jnp.array([0.25], dtype=jnp.float32),
+    )
+
+    for scale in (1e10, 1e5, 1.0, 1e-5, 1e-10, 1e-20, 1e-30):
+        g = tuple(x * jnp.float32(scale) for x in g_base)
+        align_pos = jax.jit(UPGDLearner._gradient_alignment)(g, g)
+        align_neg = jax.jit(UPGDLearner._gradient_alignment)(g, tuple(-x for x in g))
+        chex.assert_trees_all_close(align_pos, 1.0, atol=1e-5)
+        chex.assert_trees_all_close(align_neg, -1.0, atol=1e-5)
+
+    zero_g = tuple(jnp.zeros_like(x) for x in g_base)
+    align_zero = jax.jit(UPGDLearner._gradient_alignment)(zero_g, g_base)
+    chex.assert_trees_all_close(align_zero, 0.0, atol=1e-5)


### PR DESCRIPTION
Fixes #2389

## Summary
In `alberta_framework.core.upgd`:
`UPGDLearner._gradient_alignment` used hard-coded `1e-6` thresholding and a `1e-12` floor when computing the cosine similarity of gradient tuples. When gradient norms were small (below `1e-6`), alignment collapsed to zero; when gradient magnitudes were large (above `1e9`), squaring caused float32 overflow and generated `nan` values that corrupted meta-plasticity state.

## Proposed Changes
1. Replaced unscaled norm and dot calculation with power-of-two exponent normalization (`jnp.frexp`/`jnp.ldexp`).
2. Calculated cosine similarity on unit-normalized tuples, making gradient alignment scale-invariant across all float32 orders of magnitude (from `1e-30` to `1e10`).
3. Added unit tests in `tests/test_upgd.py`.

## Verification
- Passed `uv run pytest tests/test_upgd.py` (89/89 passed).
- Passed `uv run ruff check alberta_framework/core/upgd.py tests/test_upgd.py`.
- Passed `uv run mypy alberta_framework/core/upgd.py`.
