### PR TITLE
fix(nexting): promote computation dtype for integer and boolean cumulants to floating point

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -155,8 +155,15 @@ def forward_view_returns(
     _require_leading_length(
         "cumulants", cumulants, ndim=1, maximum=_NEXTING_MAX_STEPS
     )
-    gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
-    init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
+    promoted = jnp.result_type(
+        cumulants.dtype,
+        jnp.asarray(gamma).dtype,
+        jnp.asarray(terminal_value).dtype,
+    )
+    compute_dtype = promoted if jnp.issubdtype(promoted, jnp.floating) else jnp.float32
+    cumulants_cast = jnp.asarray(cumulants, dtype=compute_dtype)
+    gamma_s = jnp.asarray(gamma, dtype=compute_dtype)
+    init = jnp.asarray(terminal_value, dtype=compute_dtype)
 
     def step(carry: Array, c: Array) -> tuple[Array, Array]:
         # gamma=0 must not multiply an inf later return (0*inf).
@@ -164,7 +171,7 @@ def forward_view_returns(
         new_carry = c + bootstrap
         return new_carry, new_carry
 
-    _, returns_reversed = jax.lax.scan(step, init, cumulants[::-1])
+    _, returns_reversed = jax.lax.scan(step, init, cumulants_cast[::-1])
     return returns_reversed[::-1]
 
 

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -617,3 +617,17 @@ class TestRunningRMSE:
         assert float(running[-1, 0]) < 0.01
         # Mid-series transition: some error
         assert float(running[19, 0]) > 0.5
+
+def test_forward_view_returns_promotes_integer_and_boolean_cumulants() -> None:
+    c_int = jnp.array([1, 0, 0, 0, 1], dtype=jnp.int32)
+    c_float = c_int.astype(jnp.float32)
+    c_bool = jnp.array([True, False, False, False, True], dtype=jnp.bool_)
+
+    ret_float = forward_view_returns(c_float, 0.9)
+    ret_int = forward_view_returns(c_int, 0.9)
+    ret_bool = forward_view_returns(c_bool, 0.9)
+
+    chex.assert_trees_all_close(ret_int, ret_float)
+    chex.assert_trees_all_close(ret_bool, ret_float)
+    assert jnp.issubdtype(ret_int.dtype, jnp.floating)
+    assert jnp.issubdtype(ret_bool.dtype, jnp.floating)


### PR DESCRIPTION
Fixes #2368

## Summary
In `alberta_framework.utils.nexting`:
`forward_view_returns` cast discount `gamma` and `terminal_value` directly into `cumulants.dtype`. When callers provided integer or boolean cumulant arrays (e.g. event counts, flags, or binary rewards), non-integer discounts were truncated to zero, causing the return recursion to degenerate into raw cumulant echoes.

## Proposed Changes
1. Promoted computation dtype across `(cumulants.dtype, gamma.dtype, terminal_value.dtype)` and defaulted to `float32` if non-floating.
2. Cast `cumulants`, `gamma`, and `terminal_value` to `compute_dtype` prior to running `jax.lax.scan`.
3. Added unit tests in `tests/test_nexting.py`.

## Verification
- Passed `uv run pytest tests/test_nexting.py tests/test_nexting_series_length.py` (95/95 passed).
- Passed `uv run ruff check alberta_framework/utils/nexting.py tests/test_nexting.py`.
- Passed `uv run mypy alberta_framework/utils/nexting.py`.
