### PR TITLE
fix(types): admit np.longdouble in _ACTUAL_REAL_SCALAR_TYPES

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -33,7 +33,7 @@ _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _INT32_MAX = 2**31 - 1
 _ACTUAL_REAL_SCALAR_TYPES = frozenset(
-    {float, np.float16, np.float32, np.float64, int}
+    {float, int, *(np.dtype(code).type for code in "efdg")}
 )
 
 _ACTUAL_INT_TYPES = frozenset(

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -632,3 +632,11 @@ class TestGVFSpecRemainingFields:
     def test_horde_spec_from_config_rejects_non_list_demons(self, invalid_demons):
         with pytest.raises(ValueError, match="HordeSpec demons must be an exact list"):
             HordeSpec.from_config({"demons": invalid_demons})
+
+def test_gvf_spec_terminal_reward_accepts_all_numpy_float_families() -> None:
+    base = dict(name="d", demon_type=DemonType.PREDICTION, gamma=0.0, lamda=0.0, cumulant_index=0)
+    for code in ("e", "f", "d", "g"):
+        dtype_type = np.dtype(code).type
+        val = dtype_type(1.5)
+        spec = GVFSpec(**base, terminal_reward=val)
+        assert spec.terminal_reward == 1.5


### PR DESCRIPTION
Fixes #2283

## Summary
In `alberta_framework.core.types`:
`_ACTUAL_REAL_SCALAR_TYPES` hand-enumerated `{float, np.float16, np.float32, np.float64, int}` and omitted `np.longdouble` (dtype code `g`). As a result, `GVFSpec.terminal_reward` rejected `np.longdouble` scalars even though sibling fields (`gamma`, `lamda`) and the underlying `validated_float32_scalar_with_ratio` helper accept all NumPy floating families.

## Proposed Changes
1. Defined `_ACTUAL_REAL_SCALAR_TYPES` using dtype codes `"efdg"`, matching `_ACTUAL_INT_TYPES` and `_ACTUAL_FLOAT_TYPES` in `_float32.py`.
2. Added unit tests in `tests/test_gvf_types.py` verifying that all NumPy float types (`float16`, `float32`, `float64`, `longdouble`) are accepted for `GVFSpec.terminal_reward`.

## Verification
- Passed `uv run pytest tests/test_gvf_types.py` (109/109 passed).
- Passed `uv run ruff check alberta_framework/core/types.py tests/test_gvf_types.py`.
- Passed `uv run mypy alberta_framework/core/types.py`.
