### PR TITLE
fix(benchmarks): derive numpy integer types from dtype codes in ipmnist_gradual and causal_map_forager

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -59,15 +59,8 @@ CAUSAL_MAP_VARIANT_KIND = "alberta_causal_map"
 _CAUSAL_MAP_RNG_NAMESPACE = 0xCA05A14
 _CAUSAL_MAP_PRNG_IMPL = "threefry2x32"
 _CAUSAL_MAP_ENVIRONMENT_PRNG_IMPL = "threefry2x32"
-_EXACT_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
+_EXACT_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 _EXACT_INTEGER_TYPES = (int, *_EXACT_NUMPY_INTEGER_TYPES)
 _EXACT_REAL_TYPES = (

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -43,17 +43,8 @@ _MAX_RUN_STEPS = 1_000_000
 _PRNG_IMPLEMENTATION = "threefry2x32"
 _PAIR_RESULT_SCHEMA = "asi.ipmnist.gradual-input-pair.result.v1"
 _ADAMW_IDENTITY = tuple(sorted(ADAMW_PROTOCOL_HYPERPARAMETERS.items()))
-_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.longlong,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.ulonglong,
+_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 
 GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(

--- a/tests/test_causal_map_forager.py
+++ b/tests/test_causal_map_forager.py
@@ -3086,3 +3086,10 @@ def test_deterministic_inv_cdf_coefficients_are_pinned() -> None:
         if isinstance(node, ast.Constant) and isinstance(node.value, float)
     )
     assert observed == _AS241_SOURCE_CONSTANTS
+
+def test_causal_map_forager_config_accepts_all_numpy_integer_families() -> None:
+    from alberta_framework.benchmarks.causal_map_forager import CausalMapForagerConfig
+    for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"):
+        dtype_type = np.dtype(code).type
+        cfg = CausalMapForagerConfig(initial_retry_delay=dtype_type(1))
+        assert cfg.initial_retry_delay == 1

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -315,3 +315,10 @@ def test_gradual_pair_preflights_parameter_allocation_before_initialization() ->
             config=config,
             transition_steps=1,
         )
+
+def test_gradual_ipmnist_accepts_all_numpy_integer_families() -> None:
+    from alberta_framework.benchmarks.ipmnist_gradual import GradualTransitionConfig
+    for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"):
+        dtype_type = np.dtype(code).type
+        cfg = GradualTransitionConfig(mode="input_interpolation", transition_steps=dtype_type(10))
+        assert cfg.transition_steps == 10


### PR DESCRIPTION
Fixes #2295

## Summary
In `alberta_framework.benchmarks.ipmnist_gradual` and `alberta_framework.benchmarks.causal_map_forager`:
`_NUMPY_INTEGER_TYPES` and `_EXACT_NUMPY_INTEGER_TYPES` hand-enumerated fixed-width scalar type names, omitting C integer scalar type aliases (`intc`/`uintc` or `longlong`/`ulonglong` depending on platform ABI).

## Proposed Changes
1. Derived `_NUMPY_INTEGER_TYPES` and `_EXACT_NUMPY_INTEGER_TYPES` dynamically from dtype codes `("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")`.
2. Added unit tests in `tests/test_ipmnist_gradual.py` and `tests/test_causal_map_forager.py` verifying acceptance of all 10 NumPy integer families.

## Verification
- Passed `uv run pytest tests/test_ipmnist_gradual.py tests/test_causal_map_forager.py` (181/181 passed, 4 skipped).
- Passed `uv run ruff check alberta_framework/benchmarks/ipmnist_gradual.py alberta_framework/benchmarks/causal_map_forager.py tests/test_ipmnist_gradual.py tests/test_causal_map_forager.py`.
- Passed `uv run mypy alberta_framework/benchmarks/ipmnist_gradual.py alberta_framework/benchmarks/causal_map_forager.py`.
