### PR TITLE
fix(core): enforce equal-width latent invariant in BoundedPolicyArchive constructor (#2322)

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        expected_width: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if expected_width is None:
+                expected_width = len(entry.latent)
+            elif len(entry.latent) != expected_width:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -66,3 +66,31 @@ def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")
     assert POLICY_ARCHIVE_PROTOCOL["scientific_promotion_allowed"] is False
+
+
+def test_constructor_enforces_equal_latent_width_invariant() -> None:
+    narrow = _entry("a", (0.0,), 1.0)
+    wide = _entry("b", (1.0, 2.0), 2.0)
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        BoundedPolicyArchive(
+            byte_budget=4096,
+            min_latent_distance=1.0,
+            entries=(narrow, wide),
+        )
+
+
+def test_control_modes_accept_varying_latent_widths_on_add() -> None:
+    first = _entry("a", (0.0,), 1.0)
+    wider = _entry("b", (1.0, 2.0), 2.0)
+
+    # one_model replaces the single model regardless of latent width
+    one = BoundedPolicyArchive(byte_budget=4096, min_latent_distance=0.0, mode="one_model")
+    one = one.add(first).add(wider)
+    assert [e.identity for e in one.entries] == ["b"]
+    assert len(one.entries[0].latent) == 2
+
+    # fixed_snapshot retains original snapshot regardless of candidate latent width
+    fixed = BoundedPolicyArchive(byte_budget=4096, min_latent_distance=0.0, mode="fixed_snapshot")
+    fixed = fixed.add(first).add(wider)
+    assert [e.identity for e in fixed.entries] == ["a"]
+    assert len(fixed.entries[0].latent) == 1


### PR DESCRIPTION
Fixes #2322.

## Summary
`BoundedPolicyArchive` declared an archive-wide equal-width invariant on latent descriptors, but only checked `len(entry.latent) != len(self.entries[0].latent)` during `add()`. When direct instances of `BoundedPolicyArchive` were constructed with mixed-width entries, numpy broadcasting in Euclidean distance subtraction `(entry.latent - old.latent)` generated fabricated norm `0.0` values, silently dropping valid candidate policies. Furthermore, checking width before mode branching caused control arms (`fixed_snapshot` and `one_model`) to reject candidates on a field they never inspect.

## Proposed Changes
1. Enforced the equal-width invariant in `BoundedPolicyArchive.__post_init__` across all initial entries.
2. Relocated the width check in `add()` into the diverse archive candidate branch after control mode dispatch.
3. Added unit tests in `tests/test_policy_archive.py` verifying constructor invariant validation and control mode handling across varied descriptor widths.

## Test Plan
- `uv run pytest tests/test_policy_archive.py` (8 passed)
- `uv run ruff check alberta_framework/core/policy_archive.py tests/test_policy_archive.py` (clean)
- `uv run mypy alberta_framework/core/policy_archive.py` (clean)
