### PR TITLE
fix(utils): fix indentation of Raises section in get_final_performance docstring (#2439)

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -665,7 +665,7 @@ def get_final_performance(
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
 
-        Raises:
+    Raises:
         ValueError: If ``window`` is not positive, a metric array has no
             time steps, any metric sample is non-finite, or ``window`` exceeds
             the shortest trace while trace lengths differ between methods.


### PR DESCRIPTION
Fixes #2439.

## Summary
In `get_final_performance` (`alberta_framework/utils/experiments.py`), the `Raises:` section header was indented by 8 spaces (nested inside the `Returns:` section) instead of 4 spaces as a sibling section header.

## Proposed Changes
- Aligned `Raises:` section indentation to 4 spaces to match standard Google docstring conventions and other functions in `experiments.py`.

## Test Plan
- `uv run pytest tests/test_experiments_validation.py tests/test_experiments_hostile_validation.py` (141 passed)
- `uv run ruff check alberta_framework/utils/experiments.py` (clean)
- `uv run mypy alberta_framework/utils/experiments.py` (clean)
