### PR TITLE
fix(core): divide by exact observation_scale without 1e-6 floor in targets (#2398)

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -806,11 +806,10 @@ class ActionConditionedWorldModel:
         reward_arr = _float32_operand("reward", reward, ())
         discount_arr = _float32_operand("discount", discount, ())
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
             self._config.predict_delta,
-            (next_obs - obs) / safe_scale,
-            next_obs / safe_scale,
+            (next_obs - obs) / obs_scale,
+            next_obs / obs_scale,
         )
         reward_target = jnp.reshape(
             reward_arr / self._config.reward_scale,

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -955,3 +955,21 @@ def test_action_world_model_rolls_back_reduction_overflow() -> None:
     assert not bool(result.update_applied)
     assert float(result.observation_mse) == 0.0
     assert int(result.state.step_count) == 0
+
+
+
+def test_observation_scale_targets_paired_without_floor() -> None:
+    for scale in (1.0, 1e-3, 1e-6, 1e-9, 1e-20):
+        config = ActionConditionedWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            hidden_sizes=(),
+            observation_scale=(scale,),
+            predict_delta=True,
+        )
+        model = ActionConditionedWorldModel(config)
+        obs = jnp.asarray([1.0 * scale], dtype=jnp.float32)
+        next_obs = jnp.asarray([3.0 * scale], dtype=jnp.float32)
+        targets = model.targets(obs, 0.0, 0.0, next_obs)
+        # normalized delta target should be exact (3.0 - 1.0) / 1.0 = 2.0
+        np.testing.assert_allclose(float(targets[0]), 2.0, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
Fixes #2398.

## Summary
In `ActionConditionedWorldModel.targets` (`alberta_framework/core/world_model.py`), observation delta normalization divided by `jnp.maximum(obs_scale, 1e-6)` while `_prediction_and_raw_diagnostics` denormalized by the raw `obs_scale`. For configured `observation_scale` values below `1e-6`, this unpaired scaling caused fitted observation heads to predict deltas that were too small by `observation_scale / 1e-6`.

## Proposed Changes
- Removed the arbitrary `1e-6` floor in `ActionConditionedWorldModel.targets`, dividing directly by `obs_scale` to match the decode multiplier in `_prediction_and_raw_diagnostics`.
- Added unit tests in `tests/test_action_conditioned_world_model.py` verifying exact normalized delta targets across small scales (`1.0` down to `1e-20`).

## Test Plan
- `uv run pytest tests/test_action_conditioned_world_model.py` (69 passed)
- `uv run ruff check alberta_framework/core/world_model.py tests/test_action_conditioned_world_model.py` (clean)
- `uv run mypy alberta_framework/core/world_model.py` (clean)
