### PR TITLE
fix(core): rank units by bias-corrected utility EMA in continual backprop (#2343)

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -483,13 +483,14 @@ def _select_replacement_index(
     utility: Array,
     age: Array,
     maturity_threshold: int,
+    decay_rate: float = 0.99,
 ) -> tuple[Array, Array]:
     """Pick the index of the lowest-utility mature unit, if any.
 
     A unit is "mature" iff ``age >= maturity_threshold``. Among mature
-    units we pick the one with the smallest utility. If no mature unit
-    exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
-    ``False``.
+    units we pick the one with the smallest bias-corrected utility
+    (Dohare et al. 2024, Eq. 8). If no mature unit exists, ``selected``
+    is ``-1`` (sentinel) and ``has_candidate`` is ``False``.
 
     Implementation: replace the utility of immature or non-finite units
     with ``+inf`` before taking ``argmin`` so they are never chosen.
@@ -498,6 +499,7 @@ def _select_replacement_index(
         utility: Per-unit utility array, shape ``(num_units,)``.
         age: Per-unit age array (same shape).
         maturity_threshold: Minimum age for eligibility.
+        decay_rate: Utility EMA decay rate for bias correction.
 
     Returns:
         Tuple ``(index, has_candidate)`` where ``index`` is the chosen
@@ -505,7 +507,13 @@ def _select_replacement_index(
     """
     mature = age >= jnp.asarray(maturity_threshold, dtype=age.dtype)
     eligible = mature & jnp.isfinite(utility)
-    masked_utility = jnp.where(eligible, utility, jnp.inf)
+    decay = jnp.asarray(decay_rate, dtype=jnp.float32)
+    # Bias correction (Eq. 8, Dohare et al. 2024):
+    # u_hat = u / (1 - eta ** age)
+    correction = 1.0 - jnp.power(decay, age.astype(jnp.float32))
+    correction = jnp.where(correction <= 0.0, 1.0, correction)
+    corrected_utility = utility / correction
+    masked_utility = jnp.where(eligible, corrected_utility, jnp.inf)
     has_candidate = jnp.any(eligible)
     idx = jnp.argmin(masked_utility)
     selected = jnp.where(has_candidate, idx, jnp.int32(-1))
@@ -687,6 +695,7 @@ def replace_units_with_flags(
             new_cbp_state.utilities[layer_idx],
             new_cbp_state.ages[layer_idx],
             config.maturity_threshold,
+            config.decay_rate,
         )
         # Only replace if we both budgeted for it AND found a mature unit.
         gated = jnp.logical_and(do_replace, has_candidate)

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -988,3 +988,19 @@ class TestCBPWrapperConstructorIdentities:
         payload[field] = value
         with pytest.raises(ValueError, match="serialized"):
             CBPMultiHeadMLPLearner.from_config(payload)
+
+
+def test_select_replacement_index_uses_bias_corrected_utility() -> None:
+    # Unit 0: constant contribution 1.0 for 100 steps -> raw EMA approx 0.634, age 100
+    # Unit 1: constant contribution 0.9 for 700 steps -> raw EMA approx 0.899, age 700
+    # Under raw EMA, unit 0 (0.634) < unit 1 (0.899) so unit 0 would be replaced.
+    # Under Eq. 8 bias-corrected EMA, unit 0 (1.0) > unit 1 (0.9), so unit 1 is replaced.
+    decay = 0.99
+    age0, age1 = 100, 700
+    u0 = 1.0 * (1.0 - decay**age0)
+    u1 = 0.9 * (1.0 - decay**age1)
+    utilities = jnp.array([u0, u1], dtype=jnp.float32)
+    ages = jnp.array([age0, age1], dtype=jnp.int32)
+    idx, has = _select_replacement_index(utilities, ages, 100, decay_rate=decay)
+    assert bool(has)
+    assert int(idx) == 1


### PR DESCRIPTION
Fixes #2343.

## Summary
`_select_replacement_index` in `alberta_framework/core/continual_backprop.py` ranked mature units by their raw utility EMA `utility`. As described in Dohare et al. (2024, Eq. 8), units of varying ages have warm-up bias (`u_hat = u / (1 - eta ** age)`). Without Eq. 8 bias correction, freshly matured units (e.g. at age 100 with default decay 0.99) read at ~0.634 of their true steady-state contribution and were repeatedly re-replaced ahead of older, strictly less useful units.

## Proposed Changes
1. Updated `_select_replacement_index` to compute per-unit bias correction factor `1.0 - decay_rate ** age` and rank mature units by bias-corrected utility `utility / correction`.
2. Passed `config.decay_rate` from `replace_units_with_flags` into `_select_replacement_index`.
3. Added unit tests in `tests/test_continual_backprop.py` verifying that units with higher steady-state contributions but younger ages are properly protected over older, lower-utility units.

## Test Plan
- `uv run pytest tests/test_continual_backprop.py` (96 passed)
- `uv run ruff check alberta_framework/core/continual_backprop.py tests/test_continual_backprop.py` (clean)
- `uv run mypy alberta_framework/core/continual_backprop.py` (clean)
