### PR TITLE
fix(core): bound stacked-horde demon count and reject oversized sequences in deserializer (#2225)

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -132,6 +132,7 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_STACKED_HORDE_DEMONS = 4096
 _CONFIG_FIELDS = {
     "type",
     "n_demons",
@@ -176,7 +177,10 @@ def _require_sequence(name: str, value: object) -> tuple[object, ...]:
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
     if type(value) not in (list, tuple):
         raise ValueError(f"{name} must be an actual list or tuple")
-    return tuple(cast(list[object] | tuple[object, ...], value))
+    seq = cast(list[object] | tuple[object, ...], value)
+    if len(seq) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(f"{name} sequence length exceeds {_MAX_STACKED_HORDE_DEMONS}")
+    return tuple(seq)
 
 
 def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
@@ -257,7 +261,9 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        n_demons = _require_int32(
+            "n_demons", self.n_demons, minimum=1, maximum=_MAX_STACKED_HORDE_DEMONS
+        )
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
         raw_sequences = {
@@ -355,6 +361,8 @@ def nexting_spec(
     feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
     raw_indices = _require_sequence("cumulant_indices", cumulant_indices)
     raw_gammas = _require_sequence("gammas", gammas)
+    if len(raw_indices) * len(raw_gammas) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(f"nexting demon count exceeds {_MAX_STACKED_HORDE_DEMONS}")
     canonical_indices = tuple(
         _require_int32(f"cumulant_indices[{i}]", value, minimum=0)
         for i, value in enumerate(raw_indices)

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -939,3 +939,23 @@ def test_stacked_horde_public_state_shape_rejected_before_dot() -> None:
     state = horde.init().replace(weights=jnp.zeros((1, 3), dtype=jnp.float32))
     with pytest.raises(ValueError, match="weights"):
         horde.predict(state, jnp.ones(2, dtype=jnp.float32))
+
+
+def test_stacked_horde_rejects_oversized_demon_count() -> None:
+    with pytest.raises(ValueError, match="n_demons"):
+        StackedHordeConfig(
+            n_demons=4097,
+            feature_dim=2,
+            gammas=(0.9,) * 4097,
+            lamdas=(0.7,) * 4097,
+            cumulant_indices=(0,) * 4097,
+        )
+
+
+def test_nexting_spec_rejects_oversized_demon_product() -> None:
+    with pytest.raises(ValueError, match="nexting demon count exceeds"):
+        nexting_spec(
+            feature_dim=2,
+            cumulant_indices=tuple(range(100)),
+            gammas=(0.1,) * 50,
+        )


### PR DESCRIPTION
Fixes #2225.

## Summary
In `StackedHordeConfig` (`alberta_framework/core/stacked_horde.py`), `n_demons` allowed values up to `_INT32_MAX` (2,147,483,647) without an upper cardinality ceiling, allowing oversized sequences to walk millions of elements before aggregate preflight. Similarly, `_decode_sequence` and `nexting_spec` lacked cardinality bounds before allocating and building demon grids.

## Proposed Changes
1. Defined `_MAX_STACKED_HORDE_DEMONS = 4096` in `alberta_framework/core/stacked_horde.py`.
2. Bounded `n_demons` in `StackedHordeConfig.__post_init__` with `maximum=_MAX_STACKED_HORDE_DEMONS`.
3. In `_decode_sequence`, rejected sequences exceeding `_MAX_STACKED_HORDE_DEMONS`.
4. In `nexting_spec`, validated `len(raw_indices) * len(raw_gammas) <= _MAX_STACKED_HORDE_DEMONS` before building the demon grid.
5. Added unit tests in `tests/test_stacked_horde.py` testing cardinality bounds on `StackedHordeConfig` and `nexting_spec`.

## Test Plan
- `uv run pytest tests/test_stacked_horde.py` (96 passed)
- `uv run ruff check alberta_framework/core/stacked_horde.py tests/test_stacked_horde.py` (clean)
- `uv run mypy alberta_framework/core/stacked_horde.py` (clean)
