### PR TITLE
fix(core): cap working-memory decay rate cardinality and reject oversized serialized sequences (#2220)

### DIFF
--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -127,6 +127,10 @@ class WorkingMemoryConfig:
                     payload[key] = tuple(value)
                 elif type(value) is not tuple:
                     raise ValueError(f"{key} must be an actual list or tuple")
+                if len(payload[key]) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                    raise ValueError(
+                        f"{key} must contain at most {_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+                    )
                 if any(type(item) is not float for item in payload[key]):
                     raise ValueError(f"serialized {key} values must be JSON numbers")
         for key in ("observation_dim", "action_dim", "reward_dim"):
@@ -284,9 +288,16 @@ def _require_array(
         raise TypeError(f"{name} has an invalid dtype")
 
 
+_MAX_WORKING_MEMORY_CONFIGURATION_ITEMS = 1 << 12
+_MAX_WORKING_MEMORY_DECAY_RATES = _MAX_WORKING_MEMORY_CONFIGURATION_ITEMS
+
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(rates) > _MAX_WORKING_MEMORY_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -756,3 +756,19 @@ def test_zero_decay_does_not_multiply_inf_traces() -> None:
     )
     assert bool(result.update_applied)
     chex.assert_trees_all_close(result.state.observation_traces, obs[None, :])
+
+
+def test_working_memory_rejects_oversized_decay_rates() -> None:
+    with pytest.raises(ValueError, match="decay rates"):
+        WorkingMemoryConfig(
+            observation_dim=2,
+            observation_decay_rates=(0.5,) * 4097,
+        )
+
+
+def test_working_memory_from_config_rejects_oversized_decay_rates() -> None:
+    cfg = WorkingMemoryConfig(observation_dim=2)
+    payload = cfg.to_config()
+    payload["observation_decay_rates"] = [0.5] * 4097
+    with pytest.raises(ValueError, match="decay rates"):
+        WorkingMemoryConfig.from_config(payload)


### PR DESCRIPTION
Fixes #2220.

## Summary
In `WorkingMemoryConfig` (`alberta_framework/core/working_memory.py`), multi-timescale decay rate tuples lacked an upper cardinality bound before iterating across elements in `_validate_decay_rates` and `WorkingMemoryConfig.from_config`.

## Proposed Changes
1. Defined `_MAX_WORKING_MEMORY_DECAY_RATES = 4096` in `alberta_framework/core/working_memory.py`.
2. Validated `len(rates) <= _MAX_WORKING_MEMORY_DECAY_RATES` in `_validate_decay_rates` before per-item loop.
3. Validated sequence length in `WorkingMemoryConfig.from_config` before per-item type checking.
4. Added unit tests in `tests/test_working_memory.py` testing cardinality bounds on `WorkingMemoryConfig` and `from_config`.

## Test Plan
- `uv run pytest tests/test_working_memory.py` (102 passed)
- `uv run ruff check alberta_framework/core/working_memory.py tests/test_working_memory.py` (clean)
- `uv run mypy alberta_framework/core/working_memory.py` (clean)
