### PR TITLE
fix(steps): bound Step 7 planning and Step 9 dreaming loop lengths (#2214)

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -161,6 +161,8 @@ class Step7DynaConfig:
 
 
 _INT32_MAX = 2**31 - 1
+_STEP7_PLANNING_MAX_STEPS = 10_000
+_STEP7_ROLLOUT_MAX_DEPTH = 10_000
 _STEP7_CONFIG_FIELDS = frozenset(
     {
         "control",
@@ -279,13 +281,13 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
         "planning_steps",
         config.planning_steps,
         minimum=0,
-        maximum=_INT32_MAX,
+        maximum=_STEP7_PLANNING_MAX_STEPS,
     )
     planning_rollout_depth = _require_int(
         "planning_rollout_depth",
         config.planning_rollout_depth,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_STEP7_ROLLOUT_MAX_DEPTH,
     )
     planning_warmup_steps = _require_int(
         "planning_warmup_steps",

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -71,6 +71,9 @@ from alberta_framework.steps.step6 import (
 )
 
 _INT32_MAX = 2**31 - 1
+_STEP9_PLANNING_MAX_BUDGET = 10_000
+_STEP9_DREAM_MAX_ROLLOUT_HORIZON = 10_000
+_STEP9_DREAM_MAX_CANDIDATE_COUNT = 10_000
 _MAX_CONFIG_SEQUENCE_LENGTH = 4_096
 _MAX_DREAM_WORK_PER_REAL_STEP = 4_096
 # Matches the established ceiling for other scan-driven array-loop runners
@@ -426,20 +429,23 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         config.behavior_model_step_size,
     )
     planning_budget = _require_int(
-        "planning_budget", config.planning_budget, minimum=0, maximum=_INT32_MAX
+        "planning_budget",
+        config.planning_budget,
+        minimum=0,
+        maximum=_STEP9_PLANNING_MAX_BUDGET,
     )
     dream_rollout_horizon = _require_int(
         "dream_rollout_horizon",
         config.dream_rollout_horizon,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_STEP9_DREAM_MAX_ROLLOUT_HORIZON,
     )
     # Candidate selection publishes selected indices as signed int32 values.
     dream_candidate_count = _require_int(
         "dream_candidate_count",
         config.dream_candidate_count,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_STEP9_DREAM_MAX_CANDIDATE_COUNT,
     )
     dream_surprise_weight = _require_real(
         "dream_surprise_weight",

--- a/tests/test_step7_hostile_validation.py
+++ b/tests/test_step7_hostile_validation.py
@@ -293,3 +293,11 @@ def test_smoke_preflights_all_live_arrays_before_allocation(
     monkeypatch.setattr(jr, "normal", unexpected_allocation)
     with pytest.raises(ValueError, match="smoke resources"):
         run_step7_smoke(steps=50_000_000)
+
+
+def test_step7_rejects_oversized_planning_and_rollout_steps() -> None:
+    kwargs = _valid_config_kwargs()
+    with pytest.raises(ValueError, match="planning_steps"):
+        Step7DynaConfig(**{**kwargs, "planning_steps": 10_001})
+    with pytest.raises(ValueError, match="planning_rollout_depth"):
+        Step7DynaConfig(**{**kwargs, "planning_rollout_depth": 10_001})

--- a/tests/test_step9_hostile_validation.py
+++ b/tests/test_step9_hostile_validation.py
@@ -409,3 +409,12 @@ def test_run_step9_scan_accepts_a_small_in_bounds_sequence() -> None:
     cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(4)
     result = run_step9_scan(cfg, agent, model, buffer, state, rewards, next_observations)
     assert result.real_td_errors.shape == (4,)
+
+
+def test_step9_rejects_oversized_loop_budgets() -> None:
+    with pytest.raises(ValueError, match="planning_budget"):
+        Step9DreamingConfig(observation_dim=2, n_actions=2, planning_budget=10_001)
+    with pytest.raises(ValueError, match="dream_rollout_horizon"):
+        Step9DreamingConfig(observation_dim=2, n_actions=2, dream_rollout_horizon=10_001)
+    with pytest.raises(ValueError, match="dream_candidate_count"):
+        Step9DreamingConfig(observation_dim=2, n_actions=2, dream_candidate_count=10_001)


### PR DESCRIPTION
Fixes #2214.

## Summary
`Step7DynaConfig` and `Step9DreamingConfig` accepted inner planning/dreaming loop lengths (`planning_steps`, `planning_rollout_depth`, `planning_budget`, `dream_rollout_horizon`, `dream_candidate_count`) up to `_INT32_MAX` before passing them to `jnp.arange(...)` driving `lax.scan` and `vmap`.

## Proposed Changes
1. Defined named `10_000` ceilings for planning, rollout, and candidate steps in `alberta_framework/steps/step7.py` and `alberta_framework/steps/step9.py`.
2. Validated `planning_steps` and `planning_rollout_depth` against `_STEP7_PLANNING_MAX_STEPS` / `_STEP7_ROLLOUT_MAX_DEPTH`.
3. Validated `planning_budget`, `dream_rollout_horizon`, and `dream_candidate_count` against `_STEP9_PLANNING_MAX_BUDGET`, `_STEP9_DREAM_MAX_ROLLOUT_HORIZON`, and `_STEP9_DREAM_MAX_CANDIDATE_COUNT`.
4. Added unit tests in `tests/test_step7_hostile_validation.py` and `tests/test_step9_hostile_validation.py`.

## Test Plan
- `uv run pytest tests/test_step7_hostile_validation.py tests/test_step9_hostile_validation.py` (46 passed)
- `uv run ruff check alberta_framework/steps/step7.py alberta_framework/steps/step9.py tests/test_step7_hostile_validation.py tests/test_step9_hostile_validation.py` (clean)
- `uv run mypy alberta_framework/steps/step7.py alberta_framework/steps/step9.py` (clean)
