### PR TITLE
fix(optimizer-geometry): use exact power-of-two rescaling for spectral matrix sign normalization (#2379)

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -173,7 +173,15 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
     valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    _, exponent = jnp.frexp(jnp.max(jnp.abs(value)))
+    rescaled = jnp.ldexp(value, -exponent)
+    rescaled_norm = jnp.linalg.norm(rescaled)
+    positive = rescaled_norm > 0
+    x = jnp.where(
+        positive,
+        rescaled / jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm)),
+        jnp.zeros_like(rescaled),
+    )
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,12 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+
+def test_spectral_matrix_sign_scale_invariance_underflow() -> None:
+    m = jnp.array([[2.0, 1.0], [0.5, -1.0]], dtype=jnp.float32)
+    ref_sign = spectral_matrix_sign(m)
+    for scale in (1e-13, 1e-15, 1e-20, 1e-25):
+        tiny = m * jnp.asarray(scale, dtype=jnp.float32)
+        scaled_sign = spectral_matrix_sign(tiny)
+        np.testing.assert_allclose(scaled_sign, ref_sign, atol=1e-4, rtol=1e-4)


### PR DESCRIPTION
Fixes #2379.

## Summary
`spectral_matrix_sign_transaction` in `alberta_framework/evaluation/optimizer_geometry.py` divided matrices by `jnp.maximum(norm, 1e-12)`. When input matrices had Frobenius norms below `1e-12` or had elements underflowing in direct sum-of-squares (e.g. scales below `1e-13`), the `1e-12` floor caused the initial normalized matrix to have singular values far below the NS5 convergence interval, returning near-zero matrices with `valid=True`.

## Proposed Changes
1. Used exact power-of-two rescaling (`frexp` / `ldexp`) before computing the Frobenius norm in `spectral_matrix_sign_transaction`.
2. Preserved exact zero matrices using boolean masking without an arbitrary magnitude floor.
3. Added regression tests in `tests/test_optimizer_geometry.py` verifying scale-invariance across small float32 scales (`1e-13` down to `1e-25`).

## Test Plan
- `uv run pytest tests/test_optimizer_geometry.py` (29 passed)
- `uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean)
- `uv run mypy alberta_framework/evaluation/optimizer_geometry.py` (clean)
