### PR TITLE
fix(core): test narrowed float32 for underflow in cumulant_discovery preserve_nonzero (#2720)

### DIFF
--- a/alberta_framework/core/cumulant_discovery.py
+++ b/alberta_framework/core/cumulant_discovery.py
@@ -106,7 +106,8 @@ def _require_float32(
         upper_inclusive=upper_inclusive,
         positive=positive,
     )
-    if preserve_nonzero and numerator != 0 and stored == 0.0:
+    narrowed = float(np.float32(stored))
+    if preserve_nonzero and numerator != 0 and narrowed == 0.0:
         raise ValueError(f"{name} must remain nonzero once narrowed to float32")
     return stored
 

--- a/tests/test_cumulant_discovery.py
+++ b/tests/test_cumulant_discovery.py
@@ -473,3 +473,10 @@ def test_cumulant_discovery_hostile_observation_failure_is_normalized() -> None:
     state = discovery.init(jr.key(0))
     with pytest.raises(ValueError, match="readable float32 vector"):
         discovery.cumulants(state, HostileObservation())  # type: ignore[arg-type]
+
+
+def test_require_float32_rejects_builtin_float_underflow_with_preserve_nonzero() -> None:
+    from alberta_framework.core.cumulant_discovery import _require_float32
+
+    with pytest.raises(ValueError, match="must remain nonzero once narrowed to float32"):
+        _require_float32("gamma", 1e-50, lower=0.0, upper=1.0, preserve_nonzero=True)


### PR DESCRIPTION
Fixes #2720.

## Summary
`cumulant_discovery._require_float32(..., preserve_nonzero=True)` tested `stored == 0.0` to detect float32 underflow on non-zero inputs. However, for built-in Python `float`s, `validated_float32_scalar_with_ratio` returns the un-narrowed `float` (which has float64 dynamic range). Consequently, a float32-underflowing literal (e.g. `1e-50`) bypassed the `stored == 0.0` check and was accepted.

## Proposed Changes
1. Updated `_require_float32` in `alberta_framework/core/cumulant_discovery.py` to evaluate `narrowed = float(np.float32(stored))` before checking `narrowed == 0.0` under `preserve_nonzero`.
2. Added unit tests in `tests/test_cumulant_discovery.py` verifying that built-in float values underflowing in float32 are rejected with `ValueError`.

## Test Plan
- `uv run pytest tests/test_cumulant_discovery.py` (52 passed)
- `uv run ruff check alberta_framework/core/cumulant_discovery.py tests/test_cumulant_discovery.py` (clean)
- `uv run mypy alberta_framework/core/cumulant_discovery.py` (clean)
