### PR TITLE
fix(core): return valid simplex with uniform fallback for degenerate mass in _normalize_simplex (#2470)

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -675,7 +675,17 @@ def _active_mse(prediction: Array, target: Array) -> Array:
 
 def _normalize_simplex(prediction: Array) -> Array:
     clipped = jnp.maximum(prediction, 0.0)
-    return clipped / jnp.maximum(jnp.sum(clipped), 1e-12)
+    mass = jnp.sum(clipped, axis=-1, keepdims=True)
+    n = prediction.shape[-1]
+    uniform = jnp.ones_like(prediction) / n
+    normalizer = jnp.maximum(mass, jnp.asarray(1e-38, dtype=prediction.dtype))
+    normalized = clipped / normalizer
+    valid_mass = (
+        (mass > 0.0)
+        & jnp.all(jnp.isfinite(normalized), axis=-1, keepdims=True)
+        & (jnp.sum(normalized, axis=-1, keepdims=True) > 0.0)
+    )
+    return jnp.where(valid_mass, normalized, uniform)
 
 
 class UPGDMemoryLearner:

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -564,3 +564,20 @@ def test_upgd_memory_preserves_legal_closed_endpoints() -> None:
     assert allocation_endpoint.target_allocation_rate == 1.0
     assert fixed_threshold.min_novelty_threshold == 0.5
     assert fixed_threshold.max_novelty_threshold == 0.5
+
+
+
+def test_normalize_simplex_degenerate_mass_returns_valid_simplex() -> None:
+    from alberta_framework.core.upgd_memory import _normalize_simplex
+
+    cases = (
+        [0.0, 0.0, 0.0],
+        [-1.0, -2.0, -3.0],
+        [1e38, 1.0, 1.0],
+        [7.5e-13, 0.0, 0.0],
+        [1e-30, 0.0, 0.0],
+    )
+    for p in cases:
+        out = _normalize_simplex(jnp.asarray(p, jnp.float32))
+        assert bool(jnp.isclose(jnp.sum(out), 1.0, atol=1e-5))
+        assert bool(jnp.all(out >= 0.0))


### PR DESCRIPTION
Fixes #2470.

## Summary
`_normalize_simplex` in `alberta_framework/core/upgd_memory.py` divided clipped values by `jnp.maximum(jnp.sum(clipped), 1e-12)`. When input predictions had zero/negative mass, positive total below `1e-12`, or an underflowing float32 ratio, the returned vector summed to zero or fractional mass (e.g. `0.75`), which silently scaled down downstream prediction blending in `UPGDMemoryLearner`.

## Proposed Changes
1. Updated `_normalize_simplex` to divide by actual mass without arbitrary floor and fall back to the uniform simplex `jnp.ones_like(prediction) / n` whenever mass is non-positive or underflowing.
2. Added unit tests in `tests/test_upgd_memory.py` verifying proper simplex properties across degenerate, sub-floor, and underflowing input predictions.

## Test Plan
- `uv run pytest tests/test_upgd_memory.py` (134 passed)
- `uv run ruff check alberta_framework/core/upgd_memory.py tests/test_upgd_memory.py` (clean)
- `uv run mypy alberta_framework/core/upgd_memory.py` (clean)
