### PR TITLE
fix(core): bound n_dreams_per_step in prototype agent config and deserializer (#2441)

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -184,6 +184,7 @@ _PROTOTYPE_V2_REPLAY_MIGRATION_TAG = 0x50525632
 _PROTOTYPE_FEATURE_LIFECYCLE_KEY_TAG = 0x50464C43
 _UINT32_MAX = 2**32 - 1
 _INT32_MAX = 2**31 - 1
+_MAX_DREAMS_PER_STEP = 10_000
 
 # ---------------------------------------------------------------------------
 # Standalone utility
@@ -725,7 +726,7 @@ class PrototypeAgentConfig:
                 "n_dreams_per_step",
                 self.n_dreams_per_step,
                 minimum=0,
-                maximum=_INT32_MAX,
+                maximum=_MAX_DREAMS_PER_STEP,
             ),
         )
         # horde_hidden_sizes: hostile-safe per-element validation
@@ -1335,7 +1336,10 @@ class PrototypeAgentConfig:
             "buffer_capacity", data.pop("buffer_capacity", 200), minimum=1, maximum=_INT32_MAX
         )
         n_dreams_per_step = _require_int(
-            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=_INT32_MAX
+            "n_dreams_per_step",
+            data.pop("n_dreams_per_step", 0),
+            minimum=0,
+            maximum=_MAX_DREAMS_PER_STEP,
         )
         dream_next_observation_mode = data.pop(
             "dream_next_observation_mode",

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -1357,3 +1357,15 @@ class TestAutoCurate:
             state = result.state
         # Fires at step_count 0, 5, 10 → exactly 3
         assert curations == 3
+
+
+
+def test_prototype_agent_config_rejects_oversized_dreams_per_step() -> None:
+    with pytest.raises(ValueError, match="n_dreams_per_step"):
+        PrototypeAgentConfig(oak=_oak_cfg(), n_dreams_per_step=10_001)
+
+    cfg = PrototypeAgentConfig(oak=_oak_cfg())
+    payload = cfg.to_config()
+    payload["n_dreams_per_step"] = 10_001
+    with pytest.raises(ValueError, match="n_dreams_per_step"):
+        PrototypeAgentConfig.from_config(payload)


### PR DESCRIPTION
Fixes #2441.

## Summary
`PrototypeAgentConfig.n_dreams_per_step` was validated only against `_INT32_MAX` in `__post_init__` and `from_config` before driving `jnp.arange(...)` inside a `lax.scan` that materializes float32 TD errors per imagined transition, risking severe compilation hangs and OOMs on hostile or oversized values.

## Proposed Changes
1. Defined `_MAX_DREAMS_PER_STEP = 10_000` in `alberta_framework/core/prototype_agent.py`.
2. Validated `n_dreams_per_step` against `_MAX_DREAMS_PER_STEP` in `PrototypeAgentConfig.__post_init__` and `PrototypeAgentConfig.from_config`.
3. Added unit tests in `tests/test_prototype_agent.py` asserting that values exceeding 10,000 are rejected at configuration and deserialization time.

## Test Plan
- `uv run pytest tests/test_prototype_agent.py` (103 passed)
- `uv run ruff check alberta_framework/core/prototype_agent.py tests/test_prototype_agent.py` (clean)
- `uv run mypy alberta_framework/core/prototype_agent.py` (clean)
