### PR TITLE
fix(optimizer-geometry): use exact power-of-two rescaling in flad_noise_component_transaction (#2393)

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -203,12 +203,14 @@ def flad_noise_component_transaction(perturbation: Array, gradient: Array) -> tu
     direction = _trusted_array(gradient, name="gradient")
     if delta.shape != direction.shape or delta.ndim != 1 or delta.size < 1:
         raise ValueError("perturbation and gradient must be non-empty equal-width vectors")
-    squared_norm = jnp.vdot(direction, direction).real
-    numerator = jnp.vdot(direction, delta).real
-    active = squared_norm > 0.0
+    _, exponent = jnp.frexp(jnp.max(jnp.abs(direction)))
+    scaled = jnp.ldexp(direction, -exponent)
+    squared_norm = jnp.vdot(scaled, scaled).real
+    numerator = jnp.vdot(scaled, delta).real
+    active = (squared_norm > 0.0) & (jnp.max(jnp.abs(direction)) > 0.0)
     denominator = jnp.where(active, squared_norm, jnp.ones_like(squared_norm))
     coefficient = numerator / denominator
-    projection = direction * coefficient * active.astype(delta.dtype)
+    projection = scaled * coefficient * active.astype(delta.dtype)
     candidate = delta - projection
     valid = (
         jnp.all(jnp.isfinite(delta))

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,16 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+
+def test_flad_noise_component_underflow_scale_invariance() -> None:
+    delta = jnp.array([1.0, -2.0, 0.5, 3.0], dtype=jnp.float32)
+    grad = jnp.array([2.0, 1.0, -1.0, 0.5], dtype=jnp.float32)
+    ref_safe, ref_valid = flad_noise_component_transaction(delta, grad)
+    assert bool(ref_valid)
+
+    for scale in (1e-10, 1e-19, 1e-20, 1e-25, 1e-30):
+        scaled_grad = grad * jnp.asarray(scale, dtype=jnp.float32)
+        safe, valid = flad_noise_component_transaction(delta, scaled_grad)
+        assert bool(valid)
+        np.testing.assert_allclose(safe, ref_safe, atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
Fixes #2393.

## Summary
`flad_noise_component_transaction` in `alberta_framework/evaluation/optimizer_geometry.py` evaluated the projection denominator directly as `squared_norm = jnp.vdot(direction, direction).real`. When gradient entries had magnitudes around `1e-20` or below, the float32 sum of squares underflowed to zero, falsely treating well-conditioned non-zero gradients as zero and failing to remove the parallel component from the perturbation.

## Proposed Changes
1. Rescaled `direction` by an exact power-of-two using `frexp` and `ldexp` prior to computing inner products and projection in `flad_noise_component_transaction`.
2. Preserved the exact reduction to returning `delta` when the gradient is genuinely zero (`jnp.max(jnp.abs(direction)) == 0.0`).
3. Added unit tests in `tests/test_optimizer_geometry.py` asserting scale-invariance across small float32 scales (`1e-10` down to `1e-30`).

## Test Plan
- `uv run pytest tests/test_optimizer_geometry.py` (29 passed)
- `uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean)
- `uv run mypy alberta_framework/evaluation/optimizer_geometry.py` (clean)
