### PR TITLE
fix(core): make UPGD gradient alignment scale-free across underflow and overflow (#2389)

### DIFF
--- a/alberta_framework/core/upgd.py
+++ b/alberta_framework/core/upgd.py
@@ -1985,10 +1985,20 @@ class UPGDLearner:
     @staticmethod
     def _tuple_norm(xs: tuple[Array, ...]) -> Array:
         """L2 norm over a static tuple of arrays."""
+        max_abs = jnp.array(0.0, dtype=jnp.float32)
+        for x in xs:
+            max_abs = jnp.maximum(max_abs, jnp.max(jnp.abs(x)))
+        _, exponent = jnp.frexp(max_abs)
         total = jnp.array(0.0, dtype=jnp.float32)
         for x in xs:
-            total = total + jnp.sum(jnp.square(x))
-        return jnp.sqrt(total + 1e-12)
+            scaled_x = jnp.ldexp(x, -exponent)
+            total = total + jnp.sum(jnp.square(scaled_x))
+        scaled_norm = jnp.sqrt(total)
+        return jnp.where(
+            max_abs > 0.0,
+            jnp.ldexp(scaled_norm, exponent),
+            jnp.array(0.0, dtype=jnp.float32),
+        )
 
     @staticmethod
     def _gradient_alignment(
@@ -1996,13 +2006,31 @@ class UPGDLearner:
         current: tuple[Array, ...],
     ) -> Array:
         """Cosine alignment of two gradient tuples, zero for empty gradients."""
-        previous_norm = UPGDLearner._tuple_norm(previous)
-        current_norm = UPGDLearner._tuple_norm(current)
-        return jnp.where(
-            (previous_norm > 1e-6) & (current_norm > 1e-6),
-            UPGDLearner._tuple_dot(previous, current) / (previous_norm * current_norm + 1e-12),
-            jnp.array(0.0, dtype=jnp.float32),
-        )
+        prev_max = jnp.array(0.0, dtype=jnp.float32)
+        curr_max = jnp.array(0.0, dtype=jnp.float32)
+        for p, c in zip(previous, current):
+            prev_max = jnp.maximum(prev_max, jnp.max(jnp.abs(p)))
+            curr_max = jnp.maximum(curr_max, jnp.max(jnp.abs(c)))
+        _, p_exp = jnp.frexp(prev_max)
+        _, c_exp = jnp.frexp(curr_max)
+
+        dot = jnp.array(0.0, dtype=jnp.float32)
+        p_sq = jnp.array(0.0, dtype=jnp.float32)
+        c_sq = jnp.array(0.0, dtype=jnp.float32)
+        for p, c in zip(previous, current):
+            p_scaled = jnp.ldexp(p, -p_exp)
+            c_scaled = jnp.ldexp(c, -c_exp)
+            dot = dot + jnp.sum(p_scaled * c_scaled)
+            p_sq = p_sq + jnp.sum(jnp.square(p_scaled))
+            c_sq = c_sq + jnp.sum(jnp.square(c_scaled))
+
+        p_norm = jnp.sqrt(p_sq)
+        c_norm = jnp.sqrt(c_sq)
+        active = (prev_max > 0.0) & (curr_max > 0.0) & (p_norm > 0.0) & (c_norm > 0.0)
+        denom = jnp.where(active, p_norm * c_norm, jnp.ones_like(p_norm))
+        cos = dot / denom
+        valid = active & jnp.isfinite(cos)
+        return jnp.where(valid, jnp.clip(cos, -1.0, 1.0), jnp.array(0.0, dtype=jnp.float32))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(self, state: UPGDState, observation: Array) -> Array:

--- a/tests/test_upgd.py
+++ b/tests/test_upgd.py
@@ -2219,3 +2219,20 @@ class TestLoops:
         stream = RandomWalkStream(feature_dim=4, drift_rate=0.0, noise_std=0.05)
         result = run_upgd_loop(learner, stream, num_steps=50, key=jr.key(0))
         chex.assert_shape(result.metrics, (50, 4))
+
+
+def test_gradient_alignment_scale_invariance_underflow_overflow() -> None:
+    g1 = (
+        jnp.array([1.0, -2.0, 3.0], dtype=jnp.float32),
+        jnp.array([[0.5, -1.0]], dtype=jnp.float32),
+    )
+    for exponent in (10, 8, 4, 0, -4, -8, -10, -20):
+        scale = jnp.asarray(10.0**exponent, dtype=jnp.float32)
+        scaled_g1 = tuple(x * scale for x in g1)
+        # Identical gradients should have alignment +1.0
+        align = UPGDLearner._gradient_alignment(scaled_g1, scaled_g1)
+        assert bool(jnp.isclose(align, 1.0, atol=1e-5))
+        # Opposing gradients should have alignment -1.0
+        neg_g1 = tuple(-x for x in scaled_g1)
+        opp_align = UPGDLearner._gradient_alignment(scaled_g1, neg_g1)
+        assert bool(jnp.isclose(opp_align, -1.0, atol=1e-5))


### PR DESCRIPTION
Fixes #2389.

## Summary
In `UPGDLearner`, `_tuple_norm` and `_gradient_alignment` used unscaled sums of squares and hardcoded `1e-6` / `1e-12` floors. For gradient norms below `1e-6` (or elements underflowing in float32 squared norms below `1e-20`), the alignment collapsed to `0.0`, disabling meta-plasticity updates. For large gradients (above `1e+10`), unscaled sums of squares overflowed to `nan`.

## Proposed Changes
1. Used exact power-of-two rescaling (`frexp` and `ldexp`) in `_tuple_norm` and `_gradient_alignment` to make vector norms and cosine calculations scale-free across float32 dynamic range.
2. Preserved the exact reduction to returning `0.0` for all-zero or non-finite gradient inputs.
3. Added unit tests in `tests/test_upgd.py` verifying that identical and opposing gradient tuples consistently produce alignments of `+1.0` and `-1.0` across scales from `1e-20` up to `1e+10`.

## Test Plan
- `uv run pytest tests/test_upgd.py` (89 passed)
- `uv run ruff check alberta_framework/core/upgd.py tests/test_upgd.py` (clean)
- `uv run mypy alberta_framework/core/upgd.py` (clean)
