### PR TITLE
fix(utils): promote non-floating cumulant series to floating in forward-view returns (#2368)

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -155,8 +155,12 @@ def forward_view_returns(
     _require_leading_length(
         "cumulants", cumulants, ndim=1, maximum=_NEXTING_MAX_STEPS
     )
-    gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
-    init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
+    target_dtype = jnp.result_type(cumulants, gamma, terminal_value)
+    if not jnp.issubdtype(target_dtype, jnp.floating):
+        target_dtype = jnp.float32
+    cumulants_f = jnp.asarray(cumulants, dtype=target_dtype)
+    gamma_s = jnp.asarray(gamma, dtype=target_dtype)
+    init = jnp.asarray(terminal_value, dtype=target_dtype)
 
     def step(carry: Array, c: Array) -> tuple[Array, Array]:
         # gamma=0 must not multiply an inf later return (0*inf).
@@ -164,7 +168,7 @@ def forward_view_returns(
         new_carry = c + bootstrap
         return new_carry, new_carry
 
-    _, returns_reversed = jax.lax.scan(step, init, cumulants[::-1])
+    _, returns_reversed = jax.lax.scan(step, init, cumulants_f[::-1])
     return returns_reversed[::-1]
 
 

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -617,3 +617,17 @@ class TestRunningRMSE:
         assert float(running[-1, 0]) < 0.01
         # Mid-series transition: some error
         assert float(running[19, 0]) > 0.5
+
+
+def test_forward_view_returns_promotes_integer_and_boolean_cumulants() -> None:
+    c_int = jnp.array([1, 0, 0, 0, 1], dtype=jnp.int32)
+    c_float = c_int.astype(jnp.float32)
+    ret_int = forward_view_returns(c_int, 0.9)
+    ret_float = forward_view_returns(c_float, 0.9)
+    assert ret_int.dtype == jnp.float32
+    np.testing.assert_allclose(ret_int, ret_float, rtol=1e-5, atol=1e-5)
+
+    c_bool = jnp.array([True, False, False, False, True], dtype=jnp.bool_)
+    ret_bool = forward_view_returns(c_bool, 0.9)
+    assert ret_bool.dtype == jnp.float32
+    np.testing.assert_allclose(ret_bool, ret_float, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
Fixes #2368.

## Summary
In `forward_view_returns` (`alberta_framework/utils/nexting.py`), the discount `gamma` and `terminal_value` were cast into `cumulants.dtype`. When callers passed integer or boolean cumulant series (e.g. discrete rewards), `gamma=0.9` was truncated to `0`, collapsing recursive return accumulation to a raw cumulant echo.

## Proposed Changes
1. Promoted computation dtype across `(cumulants, gamma, terminal_value)` using `jnp.result_type`, falling back to `jnp.float32` if the result is non-floating.
2. Cast `cumulants`, `gamma_s`, and `init` to the promoted float dtype.
3. Added unit tests in `tests/test_nexting.py` verifying that int32 and boolean cumulants produce proper float32 forward-view returns matching float32 inputs.

## Test Plan
- `uv run pytest tests/test_nexting.py` (90 passed)
- `uv run ruff check alberta_framework/utils/nexting.py tests/test_nexting.py` (clean)
- `uv run mypy alberta_framework/utils/nexting.py` (clean)
