### PR TITLE
fix(pipeline): pass terminal-aware discount to HordeActorCriticAgent.update (#2344)

### DIFF
--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -1573,10 +1573,18 @@ class AlbertaPipeline:
                 dtype=jnp.int32,
             )
             auxiliary_cumulants = horde_cumulants[aux_indices] if aux_indices.size else None
+            value_gamma = self._horde.horde_spec.gammas[value_index]
+            value_gamma_arr = jnp.asarray(value_gamma, dtype=jnp.float32)
+            control_discount = jnp.where(
+                terminated != 0.0,
+                jnp.zeros_like(value_gamma_arr),
+                value_gamma_arr,
+            )
             ac_result = ac.update(
                 ac_state,
                 reward,
                 features,
+                discount=control_discount,
                 auxiliary_cumulants=auxiliary_cumulants,
             )
             new_control_state: SARSAState | HordeActorCriticState = ac_result.state

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1196,3 +1196,20 @@ def test_associative_pipeline_narrows_only_statically_safe_integer_dtypes() -> N
 
 # silence the import lint warnings used in the test runner
 _ = jax
+
+
+def test_pipeline_horde_ac_honors_terminated_flag() -> None:
+    cfg = _small_horde_ac_config()
+    pipe = AlbertaPipeline(cfg)
+    state = pipe.init(jr.key(0), jnp.array([0.2, -0.1, 0.4], dtype=jnp.float32))
+    obs = jnp.array([0.1, 0.3, -0.2], dtype=jnp.float32)
+    reward = jnp.array(0.5, dtype=jnp.float32)
+    cumulants = jnp.array([0.5, -0.2], dtype=jnp.float32)
+
+    res_cont = pipe.update(state, obs, reward, jnp.array(0.0, dtype=jnp.float32), cumulants)
+    res_term = pipe.update(state, obs, reward, jnp.array(1.0, dtype=jnp.float32), cumulants)
+
+    # In terminal step, the value-head TD target must be reward alone (0.5)
+    np.testing.assert_allclose(float(res_term.horde_td_targets[0]), 0.5, atol=1e-5)
+    # Non-terminal bootstraps, so target differs from 0.5
+    assert not bool(jnp.isclose(res_cont.horde_td_targets[0], 0.5))


### PR DESCRIPTION
Fixes #2344.

## Summary
On the `control_mode="horde_ac"` path in `AlbertaPipeline.update`, `terminated` was validated but dropped when calling `HordeActorCriticAgent.update`. Consequently, at terminal episode transitions (`terminated == 1.0`), the value-head demon continued bootstrapping on the next state (`r + gamma * V(s')` instead of `r`), and the actor trace survived across the episode boundary.

## Proposed Changes
1. Computed `control_discount = jnp.where(terminated != 0.0, jnp.zeros_like(value_gamma_arr), value_gamma_arr)` in `AlbertaPipeline.update` on the `horde_ac` branch.
2. Passed `discount=control_discount` to `HordeActorCriticAgent.update`.
3. Added unit tests in `tests/test_pipeline.py` verifying that `terminated=1.0` zeroes value-head bootstrapping.

## Test Plan
- `uv run pytest tests/test_pipeline.py` (184 passed)
- `uv run ruff check alberta_framework/pipeline.py tests/test_pipeline.py` (clean)
- `uv run mypy alberta_framework/pipeline.py` (clean)
