### PR TITLE
test(pavlovian): gate longdouble double-rounding and subnormal probes on platform width (#2324)

### DIFF
--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -485,6 +485,15 @@ def test_construct_canonicalizes_noise_std_to_float32() -> None:
     assert stream._noise_std == float(np.float32(0.1))  # noqa: SLF001
 
 
+_LONGDOUBLE_IS_WIDER_THAN_FLOAT64 = np.finfo(np.longdouble).nmant > np.finfo(np.float64).nmant
+
+@pytest.mark.skipif(
+    not _LONGDOUBLE_IS_WIDER_THAN_FLOAT64,
+    reason=(
+        "np.longdouble must have wider mantissa than float64 "
+        "to construct midpoint-plus float32 probe"
+    ),
+)
 def test_construct_narrows_original_noise_real_once() -> None:
     midpoint_plus = (
         np.longdouble(1.0)
@@ -500,6 +509,13 @@ def test_construct_narrows_original_noise_real_once() -> None:
     assert stream._noise_std == float(np.float32(midpoint_plus))  # noqa: SLF001
 
 
+@pytest.mark.skipif(
+    not _LONGDOUBLE_IS_WIDER_THAN_FLOAT64,
+    reason=(
+        "np.longdouble must have wider mantissa than float64 "
+        "for subnormal underflow to float64 zero"
+    ),
+)
 def test_construct_rejects_negative_real_that_rounds_to_zero() -> None:
     below_zero = -np.nextafter(np.longdouble(0.0), np.longdouble(1.0))
     assert float(below_zero) == 0.0


### PR DESCRIPTION
Fixes #2324.

## Summary
In `tests/test_pavlovian_stream.py`, `test_construct_narrows_original_noise_real_once` and `test_construct_rejects_negative_real_that_rounds_to_zero` constructed probes using `np.longdouble` assuming that `longdouble` has a wider mantissa than `float64`. On platforms where `np.longdouble` has 53-bit precision (same as `float64`, e.g. arm64 macOS), the precondition assertions failed.

## Proposed Changes
1. Defined `_LONGDOUBLE_IS_WIDER_THAN_FLOAT64 = np.finfo(np.longdouble).nmant > np.finfo(np.float64).nmant`.
2. Gated both tests with `@pytest.mark.skipif(not _LONGDOUBLE_IS_WIDER_THAN_FLOAT64, ...)` to skip gracefully on platforms where `np.longdouble` is not wider than `float64`.

## Test Plan
- `uv run pytest tests/test_pavlovian_stream.py` (100 passed, 2 skipped on arm64 macOS)
- `uv run ruff check tests/test_pavlovian_stream.py` (clean)
