### PR TITLE
fix(core): drop 1e-6 floor in latent encoder and validate normal float32 observation_scale (#2411)

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -288,9 +288,12 @@ class LatentWorldModelConfig:
                 raise ValueError("observation_scale must be an actual tuple or None")
             if len(observation_scale) != self.observation_dim:
                 raise ValueError("observation_scale length must equal observation_dim")
+            min_normal_float32 = float(np.finfo(np.float32).tiny)
             observation_scale = tuple(
                 validated_float32_scalar(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]",
+                    scale,
+                    lower=min_normal_float32,
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -670,7 +673,7 @@ class LatentWorldModel:
         """Encode one observation with explicit (differentiable) encoder params."""
         obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._config.observation_dim,))
         scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
+        scaled = obs / scale
         return jnp.tanh(scaled @ encoder_matrix + encoder_bias)
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -749,3 +749,31 @@ def test_latent_world_model_init_rejects_nonfinite_encoder_draw() -> None:
 
     with pytest.raises(ValueError, match="encoder initialization"):
         model.init(jr.key(0))
+
+def test_latent_world_model_observation_scale_below_1e6() -> None:
+    # Verify scale-free encoding across observation scales down to 1e-20
+    ref_scale = 1.0
+    cfg_ref = LatentWorldModelConfig(
+        observation_dim=2, latent_dim=4, n_actions=2, observation_scale=(ref_scale, ref_scale)
+    )
+    m_ref = LatentWorldModel(cfg_ref)
+    st_ref = m_ref.init(jr.key(0))
+    obs_ref = jnp.array([1.5, -0.75], dtype=jnp.float32)
+    latent_ref = m_ref.encode(st_ref, obs_ref)
+
+    for scale in (1e-6, 1e-9, 1e-15, 1e-20):
+        cfg = LatentWorldModelConfig(
+            observation_dim=2, latent_dim=4, n_actions=2, observation_scale=(scale, scale)
+        )
+        m = LatentWorldModel(cfg)
+        st = m.init(jr.key(0))
+        obs = jnp.array([1.5 * scale, -0.75 * scale], dtype=jnp.float32)
+        latent = m.encode(st, obs)
+        np.testing.assert_allclose(latent, latent_ref, atol=1e-5, rtol=1e-5)
+
+    # Subnormal float32 scale must be rejected at config validation
+    subnormal = float(np.finfo(np.float32).smallest_subnormal)
+    with pytest.raises(ValueError, match="observation_scale"):
+        LatentWorldModelConfig(
+            observation_dim=2, latent_dim=4, n_actions=2, observation_scale=(subnormal, subnormal)
+        )


### PR DESCRIPTION
Fixes #2411.

## Summary
`LatentWorldModel._encode_with` normalized observations by `jnp.maximum(scale, 1e-6)`. For configured `observation_scale` values below `1e-6`, the encoder divided by `1e-6` instead of the declared scale, shrinking latents, artificially triggering collapse diagnostics, and disabling encoder updates.

## Proposed Changes
1. Dropped the `1e-6` floor in `_encode_with` (`alberta_framework/core/latent_world_model.py`), dividing directly by `scale`.
2. Validated in `LatentWorldModelConfig.__post_init__` that each `observation_scale` entry is at least the smallest normal float32 (`np.finfo(np.float32).tiny`), preventing reciprocal overflow while admitting all normal float32 scales.
3. Added unit tests in `tests/test_latent_world_model.py` verifying that small scales (`1e-6` down to `1e-20`) produce identical scale-free latents, and that subnormal float32 scales are rejected at config validation.

## Test Plan
- `uv run pytest tests/test_latent_world_model.py` (57 passed)
- `uv run ruff check alberta_framework/core/latent_world_model.py tests/test_latent_world_model.py` (clean)
- `uv run mypy alberta_framework/core/latent_world_model.py` (clean)
