### PR TITLE
fix(core): remove 1e-6 floor in world model targets to pair with decode scale (#2398)

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -363,9 +363,12 @@ class ActionConditionedWorldModelConfig:
                 raise ValueError("observation_scale must be an actual tuple or None")
             if len(observation_scale) != observation_dim:
                 raise ValueError("observation_scale length must equal observation_dim")
+            min_normal_float32 = float(np.finfo(np.float32).tiny)
             observation_scale = tuple(
                 _validated_config_float(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]",
+                    scale,
+                    lower=min_normal_float32,
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -806,11 +809,10 @@ class ActionConditionedWorldModel:
         reward_arr = _float32_operand("reward", reward, ())
         discount_arr = _float32_operand("discount", discount, ())
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
             self._config.predict_delta,
-            (next_obs - obs) / safe_scale,
-            next_obs / safe_scale,
+            (next_obs - obs) / obs_scale,
+            next_obs / obs_scale,
         )
         reward_target = jnp.reshape(
             reward_arr / self._config.reward_scale,

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -464,7 +464,7 @@ class _FloatSpoof:
         ({"max_delta_scale": 1e100}, "max_delta_scale must remain finite once narrowed"),
         ({"reward_scale": 1e-100}, "reward_scale must remain positive once narrowed"),
         ({"max_delta_scale": 1e-100}, "max_delta_scale must remain positive once narrowed"),
-        ({"observation_scale": (1e-100, 1.0)}, "must remain positive once narrowed"),
+        ({"observation_scale": (1e-100, 1.0)}, r"observation_scale\[0\] must be"),
         (
             {"utility_decay": 1.0 - 1e-10},
             r"utility_decay must remain in \[0.0, 1.0\) once narrowed",
@@ -955,3 +955,28 @@ def test_action_world_model_rolls_back_reduction_overflow() -> None:
     assert not bool(result.update_applied)
     assert float(result.observation_mse) == 0.0
     assert int(result.state.step_count) == 0
+
+
+def test_world_model_observation_scale_below_1e6_round_trip() -> None:
+    for scale in (1e-6, 1e-9, 1e-15, 1e-20, 1e-30):
+        cfg = ActionConditionedWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            hidden_sizes=(),
+            observation_scale=(scale,),
+            predict_delta=True,
+        )
+        wm = ActionConditionedWorldModel(cfg)
+        obs = jnp.array([1.0 * scale], dtype=jnp.float32)
+        next_obs = jnp.array([3.0 * scale], dtype=jnp.float32)
+        targets = wm.targets(obs, 0.0, 0.0, next_obs)
+        # Normalized delta target should be exactly 2.0
+        np.testing.assert_allclose(float(targets[0]), 2.0, atol=1e-5, rtol=1e-5)
+
+    subnormal = float(np.finfo(np.float32).smallest_subnormal)
+    with pytest.raises(ValueError, match="observation_scale"):
+        ActionConditionedWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            observation_scale=(subnormal,),
+        )


### PR DESCRIPTION
Fixes #2398.

## Summary
`ActionConditionedWorldModel.targets` normalized observation changes by `jnp.maximum(obs_scale, 1e-6)`, whereas `_prediction_and_raw_diagnostics` decoded normalized delta predictions by multiplying by the raw `obs_scale`. For configured `observation_scale` values below `1e-6`, this broke normalize/denormalize composition, causing observation delta predictions to be attenuated by `scale / 1e-6`.

## Proposed Changes
1. Removed the `1e-6` floor in `ActionConditionedWorldModel.targets` (`alberta_framework/core/world_model.py`), dividing directly by `obs_scale`.
2. Validated in `ActionConditionedWorldModelConfig.__post_init__` that each `observation_scale` entry is at least the smallest normal float32 (`np.finfo(np.float32).tiny`), preventing reciprocal overflow.
3. Added unit tests in `tests/test_action_conditioned_world_model.py` verifying round-trip target calculations across small scales (`1e-6` down to `1e-30`) and rejecting subnormal scales at config validation.

## Test Plan
- `uv run pytest tests/test_action_conditioned_world_model.py` (69 passed)
- `uv run ruff check alberta_framework/core/world_model.py tests/test_action_conditioned_world_model.py` (clean)
- `uv run mypy alberta_framework/core/world_model.py` (clean)
