### PR TITLE
fix(core): enforce equal latent width invariant in BoundedPolicyArchive constructor (#2322)

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        first_latent_len: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if first_latent_len is None:
+                first_latent_len = len(entry.latent)
+            elif len(entry.latent) != first_latent_len:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -66,3 +66,28 @@ def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")
     assert POLICY_ARCHIVE_PROTOCOL["scientific_promotion_allowed"] is False
+
+
+def test_bounded_policy_archive_enforces_equal_latent_width_in_constructor() -> None:
+    e1 = PolicyEntry(identity="a", policy_bytes=b"x", latent=(0.0,), score=0.0)
+    e2 = PolicyEntry(identity="b", policy_bytes=b"y", latent=(3.0, 3.0), score=9.0)
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        BoundedPolicyArchive(byte_budget=4096, min_latent_distance=1.0, entries=(e1, e2))
+
+
+def test_control_modes_accept_arbitrary_latent_width_entries() -> None:
+    e1 = PolicyEntry(identity="a", policy_bytes=b"x", latent=(0.0,), score=0.0)
+    e2 = PolicyEntry(identity="b", policy_bytes=b"y", latent=(3.0, 3.0), score=9.0)
+
+    # fixed_snapshot returns self without checking latent width
+    archive_fixed = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=1.0, mode="fixed_snapshot", entries=(e1,)
+    )
+    assert archive_fixed.add(e2) is archive_fixed
+
+    # one_model replaces entry without checking latent width against previous
+    archive_one = BoundedPolicyArchive(
+        byte_budget=4096, min_latent_distance=1.0, mode="one_model", entries=(e1,)
+    )
+    next_one = archive_one.add(e2)
+    assert next_one.entries == (e2,)


### PR DESCRIPTION
Fixes #2322.

## Summary
`BoundedPolicyArchive` declared an archive-wide equal latent width invariant ("all latent descriptors must have equal width") but never enforced it in `__post_init__`. When directly constructed with mixed-width entries, numpy distance calculations broadcast across mismatched latent dimensions, producing fabricated zero distances that silently discarded valid diverse policies. Additionally, `add()` checked latent width before evaluating control modes (`one_model` and `fixed_snapshot`), rejecting descriptors those control arms never read.

## Proposed Changes
1. Enforced the equal latent width invariant across `self.entries` in `BoundedPolicyArchive.__post_init__`.
2. Moved the latent width check in `BoundedPolicyArchive.add` inside the `diverse_archive` branch where distances are actually computed, allowing single-policy control modes to operate without unwarranted descriptor shape constraints.
3. Added unit tests in `tests/test_policy_archive.py` asserting constructor validation of latent widths and verifying control arm semantics.

## Test Plan
- `uv run pytest tests/test_policy_archive.py` (8 passed)
- `uv run ruff check alberta_framework/core/policy_archive.py tests/test_policy_archive.py` (clean)
- `uv run mypy alberta_framework/core/policy_archive.py` (clean)
