### PR TITLE
test(experiments): silence RuntimeWarning in _platform_longdouble_1e4000 (#2387)

### DIFF
--- a/tests/test_experiments_validation.py
+++ b/tests/test_experiments_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from decimal import Decimal
 from fractions import Fraction
@@ -537,8 +538,10 @@ class _NonfiniteFloatThatConvertsFinite(float):
 
 def _platform_longdouble_1e4000() -> np.longdouble:
     """Parse the cross-platform boundary without leaking an expected warning."""
-    with np.errstate(over="ignore", invalid="ignore"):
-        return np.longdouble("1e4000")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        with np.errstate(over="ignore", invalid="ignore"):
+            return np.longdouble("1e4000")
 
 
 @pytest.mark.parametrize(
@@ -1029,3 +1032,10 @@ def test_run_multi_seed_experiment_rejects_invalid_seed_sequences(
 def test_get_final_performance_rejects_non_builtin_positive_window(window: object) -> None:
     with pytest.raises(ValueError, match="window"):
         get_final_performance({"candidate": _two_seed_trace()}, window=window)  # type: ignore[arg-type]
+
+
+def test_platform_longdouble_1e4000_emits_no_warnings() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        val = _platform_longdouble_1e4000()
+        assert val is not None


### PR DESCRIPTION
Fixes #2387.

## Summary
`_platform_longdouble_1e4000` in `tests/test_experiments_validation.py` wrapped `np.longdouble("1e4000")` inside `np.errstate(...)`. However, numpy reports string conversion overflow through the Python `warnings` module (`RuntimeWarning`) rather than numpy's floating-point error state (`np.seterr`), causing a warning to leak on platforms where `np.longdouble` has 64-bit precision (such as arm64 macOS).

## Proposed Changes
1. Wrapped the string parse in `warnings.catch_warnings()` with `warnings.simplefilter("ignore", RuntimeWarning)` inside `_platform_longdouble_1e4000`.
2. Added unit test `test_platform_longdouble_1e4000_emits_no_warnings` asserting that the helper executes with zero warnings under `warnings.simplefilter("error")`.

## Test Plan
- `uv run pytest tests/test_experiments_validation.py` (130 passed, 0 warnings)
- `uv run ruff check tests/test_experiments_validation.py` (clean)
