### PR TITLE
docs(experiments): fix indentation of Raises section in get_final_performance (#2439)

### DIFF
--- a/alberta_framework/utils/experiments.py
+++ b/alberta_framework/utils/experiments.py
@@ -665,7 +665,7 @@ def get_final_performance(
         Dictionary mapping config name to ``(mean, sample_std)``. A one-seed
         aggregate reports zero spread.
 
-        Raises:
+    Raises:
         ValueError: If ``window`` is not positive, a metric array has no
             time steps, any metric sample is non-finite, or ``window`` exceeds
             the shortest trace while trace lengths differ between methods.


### PR DESCRIPTION
Fixes #2439.

## Summary
In `get_final_performance` (`alberta_framework/utils/experiments.py`), the `Raises:` section header was indented at 8 spaces, nesting it inside the `Returns:` section rather than being formatted as a top-level docstring section.

## Proposed Changes
1. Adjusted `Raises:` header indentation from 8 spaces to 4 spaces in `get_final_performance` docstring.

## Test Plan
- `uv run pytest tests/test_experiments_validation.py` (129 passed)
- `uv run ruff check alberta_framework/utils/experiments.py` (clean)
- `uv run mypy alberta_framework/utils/experiments.py` (clean)
