### PR TITLE
fix(core): include np.longdouble in _ACTUAL_REAL_SCALAR_TYPES (#2283)

### DIFF
--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -33,7 +33,7 @@ _FLOAT32_TINY = float(np.finfo(np.float32).tiny)
 _FLOAT32_HALF_MIN_SUBNORMAL_DENOMINATOR = 1 << 150
 _INT32_MAX = 2**31 - 1
 _ACTUAL_REAL_SCALAR_TYPES = frozenset(
-    {float, np.float16, np.float32, np.float64, int}
+    {float, int, *(np.dtype(code).type for code in "efdg")}
 )
 
 _ACTUAL_INT_TYPES = frozenset(

--- a/tests/test_gvf_types.py
+++ b/tests/test_gvf_types.py
@@ -632,3 +632,17 @@ class TestGVFSpecRemainingFields:
     def test_horde_spec_from_config_rejects_non_list_demons(self, invalid_demons):
         with pytest.raises(ValueError, match="HordeSpec demons must be an exact list"):
             HordeSpec.from_config({"demons": invalid_demons})
+
+
+@pytest.mark.parametrize("dtype_code", ["e", "f", "d", "g"])
+def test_gvf_spec_accepts_all_numpy_floating_types_for_terminal_reward(dtype_code: str) -> None:
+    val = np.dtype(dtype_code).type(1.5)
+    spec = GVFSpec(
+        name="d",
+        demon_type=DemonType.PREDICTION,
+        gamma=0.0,
+        lamda=0.0,
+        cumulant_index=0,
+        terminal_reward=val,
+    )
+    assert spec.terminal_reward == 1.5


### PR DESCRIPTION
Fixes #2283.

## Summary
In `alberta_framework/core/types.py`, `_ACTUAL_REAL_SCALAR_TYPES` enumerated `{float, np.float16, np.float32, np.float64, int}` and omitted `np.longdouble` (dtype code `g`). Consequently, `GVFSpec` rejected `terminal_reward=np.longdouble(1.5)` with `ValueError: terminal_reward must be a finite real number` even though sibling fields (`gamma`, `lamda`) and the downstream float32 scalar normalizer accept all NumPy floating scalar families.

## Proposed Changes
1. Defined `_ACTUAL_REAL_SCALAR_TYPES = frozenset({float, int, *(np.dtype(code).type for code in "efdg")})` in `alberta_framework/core/types.py`.
2. Added unit tests in `tests/test_gvf_types.py` verifying that `GVFSpec` accepts all NumPy float types (`float16`, `float32`, `float64`, `longdouble`) for `terminal_reward`.

## Test Plan
- `uv run pytest tests/test_gvf_types.py` (112 passed)
- `uv run ruff check alberta_framework/core/types.py tests/test_gvf_types.py` (clean)
- `uv run mypy alberta_framework/core/types.py` (clean)
