### PR TITLE
fix(benchmarks): derive numpy integer allowlists from dtype codes (#2295)

### DIFF
--- a/alberta_framework/benchmarks/causal_map_forager.py
+++ b/alberta_framework/benchmarks/causal_map_forager.py
@@ -59,15 +59,8 @@ CAUSAL_MAP_VARIANT_KIND = "alberta_causal_map"
 _CAUSAL_MAP_RNG_NAMESPACE = 0xCA05A14
 _CAUSAL_MAP_PRNG_IMPL = "threefry2x32"
 _CAUSAL_MAP_ENVIRONMENT_PRNG_IMPL = "threefry2x32"
-_EXACT_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
+_EXACT_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 _EXACT_INTEGER_TYPES = (int, *_EXACT_NUMPY_INTEGER_TYPES)
 _EXACT_REAL_TYPES = (

--- a/alberta_framework/benchmarks/ipmnist_gradual.py
+++ b/alberta_framework/benchmarks/ipmnist_gradual.py
@@ -43,17 +43,8 @@ _MAX_RUN_STEPS = 1_000_000
 _PRNG_IMPLEMENTATION = "threefry2x32"
 _PAIR_RESULT_SCHEMA = "asi.ipmnist.gradual-input-pair.result.v1"
 _ADAMW_IDENTITY = tuple(sorted(ADAMW_PROTOCOL_HYPERPARAMETERS.items()))
-_NUMPY_INTEGER_TYPES = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.longlong,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.ulonglong,
+_NUMPY_INTEGER_TYPES = tuple(
+    np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q")
 )
 
 GRADUAL_IPMNIST_PROTOCOL = MappingProxyType(

--- a/tests/test_causal_map_forager.py
+++ b/tests/test_causal_map_forager.py
@@ -3086,3 +3086,10 @@ def test_deterministic_inv_cdf_coefficients_are_pinned() -> None:
         if isinstance(node, ast.Constant) and isinstance(node.value, float)
     )
     assert observed == _AS241_SOURCE_CONSTANTS
+
+
+@pytest.mark.parametrize("dtype_code", ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))
+def test_causal_map_forager_config_accepts_all_numpy_integer_families(dtype_code: str) -> None:
+    val = np.dtype(dtype_code).type(1)
+    cfg = CausalMapForagerConfig(initial_retry_delay=val)
+    assert cfg.initial_retry_delay == 1

--- a/tests/test_ipmnist_gradual.py
+++ b/tests/test_ipmnist_gradual.py
@@ -315,3 +315,10 @@ def test_gradual_pair_preflights_parameter_allocation_before_initialization() ->
             config=config,
             transition_steps=1,
         )
+
+
+@pytest.mark.parametrize("dtype_code", ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))
+def test_gradual_transition_config_accepts_all_numpy_integer_families(dtype_code: str) -> None:
+    val = np.dtype(dtype_code).type(10)
+    cfg = GradualTransitionConfig(mode="input_interpolation", transition_steps=val)
+    assert cfg.transition_steps == 10


### PR DESCRIPTION
Fixes #2295.

## Summary
In `benchmarks/ipmnist_gradual.py` (`_NUMPY_INTEGER_TYPES`) and `benchmarks/causal_map_forager.py` (`_EXACT_NUMPY_INTEGER_TYPES`), integer allowlists were hand-enumerated using fixed-width scalar names. Because NumPy exposes 5 signed and 5 unsigned C integer scalar families across platforms (`b`, `B`, `h`, `H`, `i`, `I`, `l`, `L`, `q`, `Q`), fixed-width names omitted C-alias types (`np.intc`, `np.uintc`, `np.longlong`, `np.ulonglong` depending on ABI).

## Proposed Changes
1. Derived `_NUMPY_INTEGER_TYPES` in `ipmnist_gradual.py` and `_EXACT_NUMPY_INTEGER_TYPES` in `causal_map_forager.py` dynamically via `tuple(np.dtype(code).type for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q"))`.
2. Added parameterized unit tests in `tests/test_ipmnist_gradual.py` and `tests/test_causal_map_forager.py` asserting that configs accept values across all 10 NumPy integer families.

## Test Plan
- `uv run pytest tests/test_ipmnist_gradual.py tests/test_causal_map_forager.py` (203 passed)
- `uv run ruff check alberta_framework/benchmarks/ipmnist_gradual.py alberta_framework/benchmarks/causal_map_forager.py tests/test_ipmnist_gradual.py tests/test_causal_map_forager.py` (clean)
- `uv run mypy alberta_framework/benchmarks/ipmnist_gradual.py alberta_framework/benchmarks/causal_map_forager.py` (clean)
