### PR TITLE
fix(core,streams): derive real scalar allowlists from dtype codes in swift_td and out_of_class (#2268)

### DIFF
--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -134,20 +134,10 @@ _DEFAULT_ETA_MIN = math.exp(-15.0)
 _SUPPORTED_CONFIG_REAL_TYPES: tuple[type[object], ...] = (
     int,
     float,
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.longlong,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.ulonglong,
-    np.float16,
-    np.float32,
-    np.float64,
-    np.longdouble,
+    *(
+        np.dtype(code).type
+        for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "e", "f", "d", "g")
+    ),
 )
 
 

--- a/alberta_framework/streams/out_of_class.py
+++ b/alberta_framework/streams/out_of_class.py
@@ -150,21 +150,9 @@ def _saturating_step_count(step_count: Array) -> Array:
     return jnp.minimum(jnp.maximum(step_count, 0), maximum - 1) + 1
 
 
-_SUPPORTED_NUMPY_REAL_SCALAR_TYPES: tuple[type[object], ...] = (
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.longlong,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.ulonglong,
-    np.float16,
-    np.float32,
-    np.float64,
-    np.longdouble,
+_SUPPORTED_NUMPY_REAL_SCALAR_TYPES: tuple[type[object], ...] = tuple(
+    np.dtype(code).type
+    for code in ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "e", "f", "d", "g")
 )
 
 

--- a/tests/test_out_of_class_streams.py
+++ b/tests/test_out_of_class_streams.py
@@ -68,9 +68,7 @@ def _scan_collect(stream, num_steps: int, key) -> tuple[jnp.ndarray, jnp.ndarray
         ts, new_state = stream.step(carry, idx)
         return new_state, (ts.observation, ts.target)
 
-    _, (observations, targets) = jax.lax.scan(
-        body, state, jnp.arange(num_steps)
-    )
+    _, (observations, targets) = jax.lax.scan(body, state, jnp.arange(num_steps))
     return observations, targets
 
 
@@ -83,9 +81,7 @@ class TestOutOfClassPolynomialStream:
     """Tests for the degree-3 polynomial out-of-class stream."""
 
     @pytest.mark.parametrize("active_count", [0, -1, True, 1.0, np.int64(1)])
-    def test_active_triple_count_requires_positive_builtin_int(
-        self, active_count: object
-    ) -> None:
+    def test_active_triple_count_requires_positive_builtin_int(self, active_count: object) -> None:
         with pytest.raises(ValueError, match="positive built-in integer"):
             OutOfClassPolynomialStream(
                 feature_dim=4,
@@ -477,8 +473,10 @@ class TestOutOfClassPolynomialStream:
             assert np.unique(row).size == triple_count
         threshold = jnp.sort(scores, axis=-1)[..., 1:2]
         legacy_mask = scores <= threshold
-        expected = dense_weights * legacy_mask.astype(jnp.float32) / jnp.sqrt(
-            jnp.sum(legacy_mask, axis=-1, keepdims=True)
+        expected = (
+            dense_weights
+            * legacy_mask.astype(jnp.float32)
+            / jnp.sqrt(jnp.sum(legacy_mask, axis=-1, keepdims=True))
         )
 
         np.testing.assert_array_equal(
@@ -517,24 +515,18 @@ class TestOutOfClassPolynomialStream:
             del key, kwargs
             return jnp.broadcast_to(jnp.asarray(scores, dtype=dtype), shape)
 
-        monkeypatch.setattr(
-            "alberta_framework.streams.out_of_class.jr.normal", fixed_normal
-        )
-        monkeypatch.setattr(
-            "alberta_framework.streams.out_of_class.jr.uniform", fixed_uniform
-        )
+        monkeypatch.setattr("alberta_framework.streams.out_of_class.jr.normal", fixed_normal)
+        monkeypatch.setattr("alberta_framework.streams.out_of_class.jr.uniform", fixed_uniform)
         init = jax.jit(stream.init) if compiled else stream.init
         state = init(jr.key(0))
 
         actual_mask = state.context_weights != 0.0
-        expected = jnp.broadcast_to(
-            jnp.asarray(expected_mask), state.context_weights.shape
-        )
+        expected = jnp.broadcast_to(jnp.asarray(expected_mask), state.context_weights.shape)
         chex.assert_trees_all_equal(actual_mask, expected)
 
-        observations, targets = jax.jit(
-            lambda key: _scan_collect(stream, num_steps=4, key=key)
-        )(jr.key(1))
+        observations, targets = jax.jit(lambda key: _scan_collect(stream, num_steps=4, key=key))(
+            jr.key(1)
+        )
         chex.assert_tree_all_finite((observations, targets))
 
     def test_step_shapes(self):
@@ -612,17 +604,13 @@ class TestOutOfClassPolynomialStream:
         def target_for_scale(s: jnp.ndarray) -> jnp.ndarray:
             xs = s * base_x  # (n_samples, feature_dim)
             triples = (
-                xs[:, state.triples_left]
-                * xs[:, state.triples_middle]
-                * xs[:, state.triples_right]
+                xs[:, state.triples_left] * xs[:, state.triples_middle] * xs[:, state.triples_right]
             )  # (n_samples, n_triples)
             ws = state.context_weights[0]  # (n_tasks, n_triples)
             return triples @ ws.T  # (n_samples, n_tasks)
 
         # Per-task variance at each scale, summed across tasks.
-        variances = jnp.array(
-            [jnp.var(target_for_scale(s)).item() for s in scales]
-        )
+        variances = jnp.array([jnp.var(target_for_scale(s)).item() for s in scales])
         # For a degree-3 polynomial, variance scales like s^6 (since each
         # output is a sum of triple products and var grows as the square
         # of the output magnitude scaling).  For a linear oracle it grows
@@ -711,9 +699,7 @@ class TestFrequencyMismatchStream:
         ("omega_min", "omega_max"),
         [(float("nan"), 3.0), (0.5, float("inf")), (float("inf"), float("inf"))],
     )
-    def test_frequency_bounds_must_be_finite(
-        self, omega_min: float, omega_max: float
-    ) -> None:
+    def test_frequency_bounds_must_be_finite(self, omega_min: float, omega_max: float) -> None:
         with pytest.raises(ValueError):
             FrequencyMismatchStream(omega_min=omega_min, omega_max=omega_max)
 
@@ -1078,9 +1064,7 @@ class TestCompositionalStream:
         stream = CompositionalStream(weight_scale=weight_scale)
 
         assert stream._weight_scale == weight_scale
-        assert math.copysign(1.0, stream._weight_scale) == math.copysign(
-            1.0, weight_scale
-        )
+        assert math.copysign(1.0, stream._weight_scale) == math.copysign(1.0, weight_scale)
         eager_state = stream.init(jr.key(94))
         eager_timestep, _ = stream.step(eager_state, jnp.array(0, dtype=jnp.int32))
         jit_state = jax.jit(stream.init)(jr.key(94))
@@ -1106,12 +1090,8 @@ class TestCompositionalStream:
         zero_stream = CompositionalStream(weight_scale=math.copysign(0.0, weight_scale))
 
         assert stream._weight_scale == 0.0
-        assert math.copysign(1.0, stream._weight_scale) == math.copysign(
-            1.0, weight_scale
-        )
-        chex.assert_trees_all_equal(
-            stream.init(jr.key(95)), zero_stream.init(jr.key(95))
-        )
+        assert math.copysign(1.0, stream._weight_scale) == math.copysign(1.0, weight_scale)
+        chex.assert_trees_all_equal(stream.init(jr.key(95)), zero_stream.init(jr.key(95)))
 
     @pytest.mark.parametrize("sign", [1, -1])
     @pytest.mark.parametrize(
@@ -1145,9 +1125,7 @@ class TestCompositionalStream:
         for seed in range(16):
             key = jr.key(seed)
             eager_state = stream.init(key)
-            eager_timestep, _ = stream.step(
-                eager_state, jnp.array(0, dtype=jnp.int32)
-            )
+            eager_timestep, _ = stream.step(eager_state, jnp.array(0, dtype=jnp.int32))
             jit_state = jit_init(key)
             jit_timestep, _ = jit_step(jit_state, jnp.array(0, dtype=jnp.int32))
             chex.assert_tree_all_finite(
@@ -1258,15 +1236,11 @@ class TestCompositionalStream:
             amplitude_scale=2.0,
             noise_std=0.0,
         )
-        observations, targets = _scan_collect(
-            stream, num_steps=800, key=jr.key(2)
-        )
+        observations, targets = _scan_collect(stream, num_steps=800, key=jr.key(2))
 
         # Solve y ~ Wx + b via stacking a bias column and lstsq.
         n = observations.shape[0]
-        x_bias = jnp.concatenate(
-            [observations, jnp.ones((n, 1), dtype=observations.dtype)], axis=1
-        )
+        x_bias = jnp.concatenate([observations, jnp.ones((n, 1), dtype=observations.dtype)], axis=1)
         # Use jnp.linalg.lstsq for a linear fit.  ``targets`` is (n, 1).
         sol, _, _, _ = jnp.linalg.lstsq(x_bias, targets, rcond=None)
         predictions = x_bias @ sol
@@ -1384,3 +1358,12 @@ def test_out_of_class_step_clocks_saturate(stream: object) -> None:
     )
     _, advanced = stream.step(state, jnp.asarray(0, dtype=jnp.int32))  # type: ignore[attr-defined]
     assert int(advanced.step_count) == 2**31 - 1
+
+
+@pytest.mark.parametrize(
+    "dtype_code", ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "e", "f", "d", "g")
+)
+def test_polynomial_stream_accepts_all_numpy_real_families_for_multiplier(dtype_code: str) -> None:
+    val = np.dtype(dtype_code).type(1)
+    s = OutOfClassPolynomialStream(feature_dim=4, noise_std=val)
+    assert s is not None

--- a/tests/test_swift_td.py
+++ b/tests/test_swift_td.py
@@ -69,19 +69,14 @@ class _RefSwiftTDNonSparse:
             self.delta_w[i] = delta * self.z[i] - self.z_delta[i] * self.v_delta
             self.w[i] += self.delta_w[i]
             self.beta[i] += (
-                self.meta_step_size
-                / np.exp(self.beta[i])
-                * (delta - self.v_delta)
-                * self.p[i]
+                self.meta_step_size / np.exp(self.beta[i]) * (delta - self.v_delta) * self.p[i]
             )
             if np.exp(self.beta[i]) > self.eta:
                 self.beta[i] = np.log(self.eta)
             if np.exp(self.beta[i]) < self.eta_min:
                 self.beta[i] = np.log(self.eta_min)
             self.h_old[i] = self.h[i]
-            self.h[i] = (
-                self.h_temp[i] + delta * self.z_bar[i] - self.z_delta[i] * self.v_delta
-            )
+            self.h[i] = self.h_temp[i] + delta * self.z_bar[i] - self.z_delta[i] * self.v_delta
             self.h_temp[i] = self.h[i]
             self.z_delta[i] = 0.0
             self.z[i] *= self.gamma * self.lam
@@ -134,9 +129,7 @@ class TestSwiftTDInit:
 
     def test_init_creates_correct_state(self):
         """Arrays get feature_dim + 1 entries (bias last), traces start at zero."""
-        optimizer = SwiftTD(
-            initial_step_size=0.01, meta_step_size=0.001, trace_decay=0.9, eta=0.1
-        )
+        optimizer = SwiftTD(initial_step_size=0.01, meta_step_size=0.001, trace_decay=0.9, eta=0.1)
         state = optimizer.init(feature_dim=10)
 
         chex.assert_shape(state.log_step_sizes, (11,))
@@ -272,9 +265,7 @@ class TestSwiftTDMatchesReference:
         for t in range(1, steps):
             obs = jnp.asarray(xs[t - 1], dtype=jnp.float32)
             nxt = jnp.asarray(xs[t], dtype=jnp.float32)
-            td_error = (
-                rewards[t] + gamma * (jnp.dot(w, nxt) + b) - (jnp.dot(w, obs) + b)
-            )
+            td_error = rewards[t] + gamma * (jnp.dot(w, nxt) + b) - (jnp.dot(w, obs) + b)
             upd = optimizer.update(state, td_error, obs, nxt, jnp.array(gamma))
             w = w + upd.weight_delta
             b = b + upd.bias_delta
@@ -378,9 +369,7 @@ class TestSwiftTDBehavior:
         )
         assert float(upd.metrics["decay_triggered"]) == 1.0
         expected = float(jnp.log(0.05) + jnp.log(0.99))  # phi_i^2 = 1 for all entries
-        chex.assert_trees_all_close(
-            upd.new_state.log_step_sizes, jnp.full(3, expected), atol=1e-6
-        )
+        chex.assert_trees_all_close(upd.new_state.log_step_sizes, jnp.full(3, expected), atol=1e-6)
 
         # tau = 0.02 * 3 = 0.06 < eta = 0.1 -> no decay, step-sizes unchanged.
         optimizer = SwiftTD(
@@ -403,9 +392,7 @@ class TestSwiftTDBehavior:
         obs = jnp.ones(3, dtype=jnp.float32)
 
         result = optimizer.update(state, jnp.array(1.0), obs, obs, jnp.array(0.0))
-        chex.assert_trees_all_close(
-            result.new_state.eligibility_traces, jnp.zeros(4), atol=1e-7
-        )
+        chex.assert_trees_all_close(result.new_state.eligibility_traces, jnp.zeros(4), atol=1e-7)
 
         result = optimizer.update(state, jnp.array(1.0), obs, obs, jnp.array(0.9))
         assert float(jnp.max(jnp.abs(result.new_state.eligibility_traces))) > 0.0
@@ -424,9 +411,7 @@ class TestSwiftTDBehavior:
         )
         assert bool(result.update_applied)
         assert bool(jnp.all(jnp.isfinite(result.weight_delta)))
-        chex.assert_trees_all_close(
-            result.new_state.eligibility_traces, jnp.zeros(3), atol=1e-7
-        )
+        chex.assert_trees_all_close(result.new_state.eligibility_traces, jnp.zeros(3), atol=1e-7)
 
     def test_zero_gamma_does_not_disguise_consumed_inf_trace_state(self) -> None:
         optimizer = SwiftTD(initial_step_size=0.01, trace_decay=0.0)
@@ -519,9 +504,7 @@ def _run_swift_seed(initial_step_size, key):
         (w, b, opt_state), s_state = carry
         ts, s_new = stream.step(s_state, idx)
         td_error = jnp.squeeze(ts.target) - (jnp.dot(w, ts.observation) + b)
-        upd = optimizer.update(
-            opt_state, td_error, ts.observation, ts.observation, jnp.array(0.0)
-        )
+        upd = optimizer.update(opt_state, td_error, ts.observation, ts.observation, jnp.array(0.0))
         new_carry = ((w + upd.weight_delta, b + upd.bias_delta, upd.new_state), s_new)
         return new_carry, td_error**2
 
@@ -560,8 +543,7 @@ class TestSwiftTDLearningQuality:
         swift_mean = float(jnp.mean(finals))
         best_fixed = _best_fixed_lms_mean()
         assert swift_mean < best_fixed, (
-            f"SwiftTD final MSE {swift_mean:.4f} should beat best fixed "
-            f"step-size {best_fixed:.4f}"
+            f"SwiftTD final MSE {swift_mean:.4f} should beat best fixed step-size {best_fixed:.4f}"
         )
         # Sanity: close to the stream's noise floor (0.1^2), far from divergence.
         assert swift_mean < 0.05
@@ -644,9 +626,7 @@ def test_swift_td_state_resource_endpoint_and_adjacent_are_allocation_free() -> 
         ("step_size_decay", 1e-100),
     ],
 )
-def test_swift_td_rejects_float32_overflow_and_underflow(
-    field: str, value: float
-) -> None:
+def test_swift_td_rejects_float32_overflow_and_underflow(field: str, value: float) -> None:
     with pytest.raises(ValueError, match=field):
         SwiftTD(**{field: value})
 
@@ -744,3 +724,12 @@ def test_swift_td_out_of_range_discount_rolls_back(gamma: float) -> None:
     chex.assert_trees_all_equal(result.bias_delta, jnp.zeros_like(result.bias_delta))
     for value in result.metrics.values():
         chex.assert_trees_all_equal(value, jnp.zeros_like(value))
+
+
+@pytest.mark.parametrize(
+    "dtype_code", ("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "e", "f", "d", "g")
+)
+def test_swift_td_accepts_all_numpy_real_families(dtype_code: str) -> None:
+    val = np.dtype(dtype_code).type(1)
+    opt = SwiftTD(eta=val)
+    assert opt._eta == 1.0  # noqa: SLF001


### PR DESCRIPTION
Fixes #2268.

## Summary
In `alberta_framework/core/swift_td.py` (`_SUPPORTED_CONFIG_REAL_TYPES`) and `alberta_framework/streams/out_of_class.py` (`_SUPPORTED_NUMPY_REAL_SCALAR_TYPES`), real scalar allowlists hand-enumerated fixed-width integer and float types. On platforms where C aliases are distinct scalar types (such as `np.intc` and `np.uintc`), passing those scalar types raised `ValueError`.

## Proposed Changes
1. Derived `_SUPPORTED_CONFIG_REAL_TYPES` in `swift_td.py` and `_SUPPORTED_NUMPY_REAL_SCALAR_TYPES` in `out_of_class.py` dynamically from dtype codes `("b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "e", "f", "d", "g")`.
2. Added parameterized unit tests in `tests/test_swift_td.py` and `tests/test_out_of_class_streams.py` verifying that configs and stream initializers accept values from all NumPy integer and floating scalar families.

## Test Plan
- `uv run pytest tests/test_swift_td.py tests/test_out_of_class_streams.py` (415 passed)
- `uv run ruff check alberta_framework/core/swift_td.py alberta_framework/streams/out_of_class.py tests/test_swift_td.py tests/test_out_of_class_streams.py` (clean)
- `uv run mypy alberta_framework/core/swift_td.py alberta_framework/streams/out_of_class.py` (clean)
