### PR TITLE
fix(core): divide by true mass and fall back to uniform in _normalize_simplex (#2470)

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -675,7 +675,10 @@ def _active_mse(prediction: Array, target: Array) -> Array:
 
 def _normalize_simplex(prediction: Array) -> Array:
     clipped = jnp.maximum(prediction, 0.0)
-    return clipped / jnp.maximum(jnp.sum(clipped), 1e-12)
+    total = jnp.sum(clipped)
+    uniform = jnp.full_like(clipped, 1.0 / clipped.shape[0])
+    valid = jnp.logical_and(jnp.isfinite(total), total > 0.0)
+    return jnp.where(valid, clipped / jnp.where(valid, total, 1.0), uniform)
 
 
 class UPGDMemoryLearner:

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -11,6 +11,7 @@ from alberta_framework.core.upgd_memory import (
     UPGDMemoryConfig,
     UPGDMemoryLearner,
     UPGDMemoryState,
+    _normalize_simplex,
     run_upgd_memory_arrays,
 )
 
@@ -564,3 +565,18 @@ def test_upgd_memory_preserves_legal_closed_endpoints() -> None:
     assert allocation_endpoint.target_allocation_rate == 1.0
     assert fixed_threshold.min_novelty_threshold == 0.5
     assert fixed_threshold.max_novelty_threshold == 0.5
+
+
+@pytest.mark.parametrize(
+    "p",
+    [
+        [0.0, 0.0, 0.0],
+        [-1.0, -2.0, -3.0],
+        [7.5e-13, 0.0, 0.0],
+        [1e-30, 0.0, 0.0],
+    ],
+)
+def test_normalize_simplex_sums_to_one(p: list[float]) -> None:
+    pred = jnp.asarray(p, dtype=jnp.float32)
+    normalized = _normalize_simplex(pred)
+    chex.assert_trees_all_close(jnp.sum(normalized), jnp.array(1.0, dtype=jnp.float32), atol=1e-6)


### PR DESCRIPTION
Fixes #2470.

## Summary
In `alberta_framework/core/upgd_memory.py`, `_normalize_simplex` divided non-negative mass by `jnp.maximum(jnp.sum(clipped), 1e-12)`. When total mass was zero, negative, or positive below the `1e-12` floor (such as when `state.upgd_state.previous_targets` is all zeros at initialization), the returned array did not sum to 1.0 (reporting 0.0 or a shrunken mass).

## Proposed Changes
1. Updated `_normalize_simplex` to divide by the true finite positive sum `total`, and fall back to the uniform distribution `1.0 / clipped.shape[0]` when `total <= 0.0` or non-finite.
2. Added unit tests in `tests/test_upgd_memory.py` asserting that `_normalize_simplex` sums to 1.0 across zero vectors, negative vectors, and sub-1e-12 small positive vectors.

## Test Plan
- `uv run pytest tests/test_upgd_memory.py` (137 passed)
- `uv run ruff check alberta_framework/core/upgd_memory.py tests/test_upgd_memory.py` (clean)
- `uv run mypy alberta_framework/core/upgd_memory.py` (clean)
