### PR TITLE
fix(core): preserve convex baseline centering in masked Hedge updates (#2409)

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -792,9 +792,7 @@ class FixedBudgetFeatureLearner:
             if value.shape != shape or value.dtype != jnp.int32:
                 raise ValueError(f"state.{name} must have shape {shape} and dtype int32")
         if observation.shape != (feature_dim,) or observation.dtype != jnp.float32:
-            raise ValueError(
-                f"observation must have shape {(feature_dim,)} and dtype float32"
-            )
+            raise ValueError(f"observation must have shape {(feature_dim,)} and dtype float32")
         if targets is not None and (
             targets.shape != (self._n_tasks,) or targets.dtype != jnp.float32
         ):
@@ -1036,8 +1034,16 @@ class FixedBudgetFeatureLearner:
         finite: Array,
     ) -> Array:
         """Exponentiated-gradient preference update for utility scores."""
-        finite_mass = jnp.maximum(jnp.sum(jnp.where(finite, allocation, 0.0)), 1e-12)
-        masked_allocation = jnp.where(finite, allocation / finite_mass, 0.0)
+        valid_mass = jnp.sum(jnp.where(finite, allocation, 0.0))
+        valid_count = jnp.maximum(jnp.sum(finite.astype(jnp.float32)), 1.0)
+        has_mass = jnp.logical_and(jnp.isfinite(valid_mass), valid_mass > 0.0)
+        masked_allocation = jnp.where(
+            finite,
+            jnp.where(
+                has_mass, allocation / jnp.where(has_mass, valid_mass, 1.0), 1.0 / valid_count
+            ),
+            0.0,
+        )
         baseline = jnp.sum(masked_allocation * jnp.where(finite, scores, 0.0))
         advantages = jnp.where(finite, scores - baseline, 0.0)
         advantages = jnp.clip(

--- a/alberta_framework/core/resource_manager.py
+++ b/alberta_framework/core/resource_manager.py
@@ -594,8 +594,14 @@ class LearnedResourceManager:
         adjusted = jnp.where(valid_actions, safe_losses + cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(valid_actions, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(valid_actions, weights / finite_weight_sum, 0.0)
+        valid_mass = jnp.sum(jnp.where(valid_actions, weights, 0.0))
+        valid_count = jnp.maximum(jnp.sum(valid_actions.astype(jnp.float32)), 1.0)
+        has_mass = jnp.logical_and(jnp.isfinite(valid_mass), valid_mass > 0.0)
+        masked_weights = jnp.where(
+            valid_actions,
+            jnp.where(has_mass, weights / jnp.where(has_mass, valid_mass, 1.0), 1.0 / valid_count),
+            0.0,
+        )
         baseline = jnp.sum(masked_weights * adjusted)
         advantages = jnp.where(valid_actions, baseline - adjusted, 0.0)
         advantages = jnp.clip(
@@ -1191,8 +1197,14 @@ class GeneratorMetaResourceManager:
         adjusted = jnp.where(finite, safe_rewards - cost_terms, 0.0)
 
         weights = self._weights_jit(state, context)
-        finite_weight_sum = jnp.maximum(jnp.sum(jnp.where(finite, weights, 0.0)), 1e-12)
-        masked_weights = jnp.where(finite, weights / finite_weight_sum, 0.0)
+        valid_mass = jnp.sum(jnp.where(finite, weights, 0.0))
+        valid_count = jnp.maximum(jnp.sum(finite.astype(jnp.float32)), 1.0)
+        has_mass = jnp.logical_and(jnp.isfinite(valid_mass), valid_mass > 0.0)
+        masked_weights = jnp.where(
+            finite,
+            jnp.where(has_mass, weights / jnp.where(has_mass, valid_mass, 1.0), 1.0 / valid_count),
+            0.0,
+        )
         baseline = jnp.sum(masked_weights * adjusted)
         selection_input_valid = jnp.asarray(True, dtype=jnp.bool_)
         if self._update_rule == "exp3":

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -859,3 +859,20 @@ def test_resource_manager_serialized_schemas_are_exact() -> None:
         invalid.update(mutation)
         with pytest.raises(ValueError, match=match):
             GeneratorMetaResourceManager.from_config(invalid)
+
+
+def test_learned_resource_manager_preserves_centering_with_tiny_surviving_mass() -> None:
+    """Surviving actions with total mass < 1e-12 should preserve exact centering."""
+    rm = LearnedResourceManager(n_actions=3, n_contexts=1, exploration=0.0)
+    state = rm.init()
+    # Put a large preference gap on action 0 so actions 1 and 2 have tiny remaining mass (< 1e-12)
+    state = state.replace(log_weights=jnp.array([[40.0, 0.0, 0.0]], dtype=jnp.float32))
+    # Action 0 is masked out by NaN loss; surviving actions 1 and 2 have losses 1.0 and 3.0
+    upd = rm.update(state, jnp.array([float("nan"), 1.0, 3.0], dtype=jnp.float32), 0)
+    assert bool(upd.update_applied)
+    # The baseline must be (1.0 + 3.0) / 2 = 2.0, giving advantages [0, +1.0, -1.0]
+    # In log_weights, new_context_logits should increase action 1 and decrease action 2
+    new_logits = upd.state.log_weights[0]
+    assert float(new_logits[1] - new_logits[2]) > 0.0
+    chex.assert_trees_all_close(upd.advantages[1], jnp.array(1.0, dtype=jnp.float32), atol=1e-5)
+    chex.assert_trees_all_close(upd.advantages[2], jnp.array(-1.0, dtype=jnp.float32), atol=1e-5)


### PR DESCRIPTION
Fixes #2409.

## Summary
In `LearnedResourceManager._update_jit`, `GeneratorMetaResourceManager._update_jit`, and `FixedBudgetFeatureLearner._resource_log_weight_update`, the masked baseline divided participating allocation by `jnp.maximum(jnp.sum(...), 1e-12)`. When surviving actions carried less total mass than `1e-12`, the divisor was replaced by the floor rather than the true mass, causing masked weights to no longer sum to 1.0 and pulling the baseline toward zero instead of forming a convex combination of surviving action scores/losses.

## Proposed Changes
1. Replaced the `1e-12` floor with exact division by `valid_mass` whenever `valid_mass > 0.0`.
2. Added fallback to uniform distribution `1.0 / valid_count` over valid actions when `valid_mass <= 0.0` or non-finite.
3. Added unit test in `tests/test_resource_manager.py` verifying that exact centering and relative preference direction are preserved when surviving actions carry sub-1e-12 mass.

## Test Plan
- `uv run pytest tests/test_resource_manager.py tests/test_feature_discovery.py` (215 passed)
- `uv run ruff check alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py tests/test_resource_manager.py` (clean)
- `uv run mypy alberta_framework/core/resource_manager.py alberta_framework/core/feature_discovery.py` (clean)
