### PR TITLE
fix(optimizer-geometry): use exact power-of-two rescaling in spectral_matrix_sign_transaction (#2379)

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -173,7 +173,16 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
     valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    max_val = jnp.max(jnp.abs(value))
+    _, exponent = jnp.frexp(max_val)
+    rescaled = jnp.ldexp(value, -exponent)
+    rescaled_norm = jnp.linalg.norm(rescaled)
+    positive = jnp.logical_and(jnp.isfinite(rescaled_norm), rescaled_norm > 0.0)
+    x = jnp.where(
+        positive,
+        rescaled / jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm)),
+        jnp.zeros_like(rescaled),
+    )
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,14 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+
+@pytest.mark.parametrize("scale", [1.0, 1e-13, 1e-15, 1e-20, 1e-25])
+def test_spectral_matrix_sign_is_scale_invariant_for_small_matrices(scale: float) -> None:
+    m = jnp.array([[2.0, 1.0], [0.5, -1.0]], dtype=jnp.float32)
+    tiny = m * jnp.asarray(scale, dtype=jnp.float32)
+    sign, valid = spectral_matrix_sign_transaction(tiny, steps=5)
+    assert bool(valid)
+    expected_norm = float(jnp.linalg.norm(spectral_matrix_sign(m, steps=5)))
+    actual_norm = float(jnp.linalg.norm(sign))
+    assert abs(actual_norm - expected_norm) < 1e-3


### PR DESCRIPTION
Fixes #2379.

## Summary
In `spectral_matrix_sign_transaction` (`alberta_framework/evaluation/optimizer_geometry.py`), normalization divided by `jnp.maximum(norm, 1e-12)`. When a matrix's Frobenius norm fell below `1e-12` (or entries were near `1e-20` where standard float32 squared sums underflow), the divisor became the `1e-12` floor instead of the matrix's norm. This caused the NS5 recurrence to run far below its convergence interval, returning a numerically zero matrix with `valid=True`.

## Proposed Changes
1. Used exact power-of-two rescaling (`jnp.frexp` and `jnp.ldexp`) before computing the Frobenius norm in `spectral_matrix_sign_transaction`.
2. Normalized the rescaled matrix whenever `rescaled_norm > 0.0`, preserving scale-invariance across the entire float32 dynamic range while preserving exact zero on zero matrices.
3. Added unit tests in `tests/test_optimizer_geometry.py` verifying that `spectral_matrix_sign_transaction` produces scale-invariant unit-scale orthogonal signs across inputs scaled down to `1e-25`.

## Test Plan
- `uv run pytest tests/test_optimizer_geometry.py` (33 passed)
- `uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean)
- `uv run mypy alberta_framework/evaluation/optimizer_geometry.py` (clean)
