### PR TITLE
fix(core): rank replacement candidates by bias-corrected utility in CBP (#2343)

### DIFF
--- a/alberta_framework/core/continual_backprop.py
+++ b/alberta_framework/core/continual_backprop.py
@@ -483,21 +483,20 @@ def _select_replacement_index(
     utility: Array,
     age: Array,
     maturity_threshold: int,
+    decay_rate: float = 0.0,
 ) -> tuple[Array, Array]:
-    """Pick the index of the lowest-utility mature unit, if any.
+    """Pick the index of the lowest bias-corrected utility mature unit, if any.
 
     A unit is "mature" iff ``age >= maturity_threshold``. Among mature
-    units we pick the one with the smallest utility. If no mature unit
-    exists, ``selected`` is ``-1`` (sentinel) and ``has_candidate`` is
-    ``False``.
-
-    Implementation: replace the utility of immature or non-finite units
-    with ``+inf`` before taking ``argmin`` so they are never chosen.
+    units we pick the one with the smallest bias-corrected utility (Dohare
+    et al. 2024, Eq. 8). If no mature unit exists, ``selected`` is ``-1``
+    (sentinel) and ``has_candidate`` is ``False``.
 
     Args:
         utility: Per-unit utility array, shape ``(num_units,)``.
         age: Per-unit age array (same shape).
         maturity_threshold: Minimum age for eligibility.
+        decay_rate: Utility EMA decay rate for debiasing.
 
     Returns:
         Tuple ``(index, has_candidate)`` where ``index`` is the chosen
@@ -505,7 +504,10 @@ def _select_replacement_index(
     """
     mature = age >= jnp.asarray(maturity_threshold, dtype=age.dtype)
     eligible = mature & jnp.isfinite(utility)
-    masked_utility = jnp.where(eligible, utility, jnp.inf)
+    decay = jnp.asarray(decay_rate, dtype=utility.dtype)
+    bias_correction = 1.0 - jnp.power(decay, age.astype(utility.dtype))
+    bias_corrected_utility = utility / jnp.maximum(bias_correction, 1e-12)
+    masked_utility = jnp.where(eligible, bias_corrected_utility, jnp.inf)
     has_candidate = jnp.any(eligible)
     idx = jnp.argmin(masked_utility)
     selected = jnp.where(has_candidate, idx, jnp.int32(-1))
@@ -687,6 +689,7 @@ def replace_units_with_flags(
             new_cbp_state.utilities[layer_idx],
             new_cbp_state.ages[layer_idx],
             config.maturity_threshold,
+            config.decay_rate,
         )
         # Only replace if we both budgeted for it AND found a mature unit.
         gated = jnp.logical_and(do_replace, has_candidate)

--- a/tests/test_continual_backprop.py
+++ b/tests/test_continual_backprop.py
@@ -37,9 +37,7 @@ class TestInitCbpStateShapes:
     """init_cbp_state should produce zero utility/age arrays matching the trunk."""
 
     def test_init_cbp_state_shapes(self):
-        learner = MultiHeadMLPLearner(
-            n_heads=3, hidden_sizes=(32, 16), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=3, hidden_sizes=(32, 16), sparsity=0.0)
         mlp_state = learner.init(feature_dim=8, key=jr.key(0))
         cbp_state = init_cbp_state(mlp_state, (32, 16), key=jr.key(1))
 
@@ -57,18 +55,14 @@ class TestInitCbpStateShapes:
             assert int(jnp.sum(a)) == 0
 
     def test_init_cbp_state_linear_baseline(self):
-        learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(), sparsity=0.0)
         mlp_state = learner.init(feature_dim=5, key=jr.key(0))
         cbp_state = init_cbp_state(mlp_state, (), key=jr.key(1))
         assert len(cbp_state.utilities) == 0
         assert len(cbp_state.ages) == 0
 
     def test_init_cbp_state_mismatch_raises(self):
-        learner = MultiHeadMLPLearner(
-            n_heads=2, hidden_sizes=(8,), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=2, hidden_sizes=(8,), sparsity=0.0)
         mlp_state = learner.init(feature_dim=4, key=jr.key(0))
         try:
             init_cbp_state(mlp_state, (8, 4), key=jr.key(1))
@@ -284,9 +278,7 @@ class TestReplacement:
 
     def test_replacement_re_initializes_low_utility_unit(self):
         """Force a replacement and verify the unit's incoming weights changed."""
-        learner = MultiHeadMLPLearner(
-            n_heads=1, hidden_sizes=(4,), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(4,), sparsity=0.0)
         mlp_state = learner.init(feature_dim=3, key=jr.key(42))
         cbp_state = init_cbp_state(mlp_state, (4,), key=jr.key(7))
 
@@ -331,14 +323,10 @@ class TestReplacement:
         )
         # Outgoing column 2 in the head weight matrix should be zero.
         head_w = new_mlp_state.head_params.weights[0]
-        chex.assert_trees_all_close(
-            head_w[:, 2], jnp.zeros_like(head_w[:, 2])
-        )
+        chex.assert_trees_all_close(head_w[:, 2], jnp.zeros_like(head_w[:, 2]))
 
     def test_age_resets_on_replacement(self):
-        learner = MultiHeadMLPLearner(
-            n_heads=1, hidden_sizes=(4,), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(4,), sparsity=0.0)
         mlp_state = learner.init(feature_dim=3, key=jr.key(42))
         cbp_state = init_cbp_state(mlp_state, (4,), key=jr.key(7))
 
@@ -355,9 +343,7 @@ class TestReplacement:
             maturity_threshold=100,
             enabled=True,
         )
-        _, new_cbp = maybe_replace_units(
-            mlp_state, cbp_state, config, sparsity=0.0
-        )
+        _, new_cbp = maybe_replace_units(mlp_state, cbp_state, config, sparsity=0.0)
         # Unit 2 had lowest utility, so its age should be reset to 0.
         assert int(new_cbp.ages[0][2]) == 0
         # Other units retain their age.
@@ -369,9 +355,7 @@ class TestReplacement:
 
     def test_maturity_threshold_protects_young_units(self):
         """No unit above maturity_threshold => no replacement happens."""
-        learner = MultiHeadMLPLearner(
-            n_heads=1, hidden_sizes=(4,), sparsity=0.0
-        )
+        learner = MultiHeadMLPLearner(n_heads=1, hidden_sizes=(4,), sparsity=0.0)
         mlp_state = learner.init(feature_dim=3, key=jr.key(42))
         cbp_state = init_cbp_state(mlp_state, (4,), key=jr.key(7))
 
@@ -391,9 +375,7 @@ class TestReplacement:
             enabled=True,
         )
 
-        new_mlp_state, new_cbp = maybe_replace_units(
-            mlp_state, cbp_state, config, sparsity=0.0
-        )
+        new_mlp_state, new_cbp = maybe_replace_units(mlp_state, cbp_state, config, sparsity=0.0)
         # All weights must be unchanged.
         chex.assert_trees_all_close(
             mlp_state.trunk_params.weights[0],
@@ -401,10 +383,7 @@ class TestReplacement:
         )
         # Ages and utilities must be unchanged.
         chex.assert_trees_all_close(cbp_state.ages[0], new_cbp.ages[0])
-        chex.assert_trees_all_close(
-            cbp_state.utilities[0], new_cbp.utilities[0]
-        )
-
+        chex.assert_trees_all_close(cbp_state.utilities[0], new_cbp.utilities[0])
 
     def _replacement_trace(
         self, *, n_units: int, rate: float, maturity: int, steps: int
@@ -443,7 +422,6 @@ class TestReplacement:
         )
         assert sum(replaced) == 20
         assert final_accumulator <= 1.0
-
 
     def test_wrapper_replacements_made_is_the_gated_decision(self):
         """replacements_made must not be re-inferred from the old rate * hidden_size formula."""
@@ -532,9 +510,7 @@ class TestDisabledReturnsUnchanged:
             plain_result = plain_learner.update(plain_running, obs, tgt)
 
             # Predictions and trunk weights should match exactly.
-            chex.assert_trees_all_close(
-                cbp_result.predictions, plain_result.predictions, atol=1e-6
-            )
+            chex.assert_trees_all_close(cbp_result.predictions, plain_result.predictions, atol=1e-6)
             chex.assert_trees_all_close(
                 cbp_result.state.mlp_state.trunk_params.weights[0],
                 plain_result.state.trunk_params.weights[0],
@@ -575,9 +551,7 @@ class TestJitCompatibility:
 
         jit_out = step(cbp_state, acts, grads)
 
-        chex.assert_trees_all_close(
-            eager_out.utilities[0], jit_out.utilities[0]
-        )
+        chex.assert_trees_all_close(eager_out.utilities[0], jit_out.utilities[0])
         chex.assert_trees_all_close(eager_out.ages[0], jit_out.ages[0])
 
     def test_full_update_jit_compatible(self):
@@ -988,3 +962,20 @@ class TestCBPWrapperConstructorIdentities:
         payload[field] = value
         with pytest.raises(ValueError, match="serialized"):
             CBPMultiHeadMLPLearner.from_config(payload)
+
+
+def test_select_replacement_index_uses_bias_corrected_utility() -> None:
+    """Young unit with high steady-state utility should not be replaced over old weak unit."""
+    # Unit 0: constant 1.0 contribution for 100 steps -> raw EMA ~0.634, corrected = 1.0
+    # Unit 1: constant 0.9 contribution for 700 steps -> raw EMA ~0.900, corrected = 0.9
+    utility = jnp.array([0.633967, 0.899209], dtype=jnp.float32)
+    age = jnp.array([100, 700], dtype=jnp.int32)
+    selected, has_candidate = _select_replacement_index(
+        utility=utility,
+        age=age,
+        maturity_threshold=100,
+        decay_rate=0.99,
+    )
+    assert bool(has_candidate)
+    # Unit 1 is the weaker unit (0.9 < 1.0), so unit 1 should be selected for replacement
+    assert int(selected) == 1


### PR DESCRIPTION
Fixes #2343.

## Summary
In `alberta_framework/core/continual_backprop.py`, `_select_replacement_index` ranked mature units directly by their raw utility EMA (`utilities[layer_idx]`). Because units reset their age and utility EMA upon replacement, a unit that has just crossed the `maturity_threshold` suffers warm-up bias (reading at `1 - decay_rate ** maturity_threshold` of its steady-state utility, e.g. ~0.634 at defaults `decay_rate=0.99`, `maturity_threshold=100`), causing CBP to systematically target freshly matured units over older, lower-performing units.

## Proposed Changes
1. Updated `_select_replacement_index` to compute the per-unit bias-corrected utility `utility / (1.0 - decay_rate ** age)` matching Dohare et al. (2024, Eq. 8) and the reference GnT/CBP implementation.
2. Passed `config.decay_rate` from `replace_units_with_flags` into `_select_replacement_index`.
3. Added unit test in `tests/test_continual_backprop.py` verifying that a younger unit with higher steady-state utility is protected from replacement in favor of an older, lower-utility unit.

## Test Plan
- `uv run pytest tests/test_continual_backprop.py` (96 passed)
- `uv run ruff check alberta_framework/core/continual_backprop.py tests/test_continual_backprop.py` (clean)
- `uv run mypy alberta_framework/core/continual_backprop.py` (clean)
