### PR TITLE
fix(optimizer-geometry): fail closed on all-subnormal float32 matrices in spectral_matrix_sign (#2391)

### DIFF
--- a/alberta_framework/evaluation/optimizer_geometry.py
+++ b/alberta_framework/evaluation/optimizer_geometry.py
@@ -173,7 +173,25 @@ def spectral_matrix_sign_transaction(matrix: Array, *, steps: int = 5) -> tuple[
         raise ValueError("matrix must be non-empty and steps a positive integer")
     norm = jnp.linalg.norm(value)
     valid = jnp.all(jnp.isfinite(value)) & jnp.isfinite(norm)
-    x = value / jnp.maximum(norm, jnp.asarray(1e-12, dtype=value.dtype))
+    max_val = jnp.max(jnp.abs(value))
+    _, exponent = jnp.frexp(max_val)
+    rescaled = jnp.ldexp(value, -exponent)
+    rescaled_norm = jnp.linalg.norm(rescaled)
+    if value.dtype == jnp.float32:
+        bits = jax.lax.bitcast_convert_type(value, jnp.uint32)
+        has_nonzero_bits = jnp.any((bits & 0x7FFFFFFF) != 0)
+    elif value.dtype == jnp.float64:
+        bits = jax.lax.bitcast_convert_type(value, jnp.uint64)
+        has_nonzero_bits = jnp.any((bits & 0x7FFFFFFFFFFFFFFF) != 0)
+    else:
+        has_nonzero_bits = jnp.any(value != 0.0)
+    valid = valid & jnp.logical_not(jnp.logical_and(has_nonzero_bits, rescaled_norm == 0.0))
+    positive = jnp.logical_and(jnp.isfinite(rescaled_norm), rescaled_norm > 0.0)
+    x = jnp.where(
+        positive,
+        rescaled / jnp.where(positive, rescaled_norm, jnp.ones_like(rescaled_norm)),
+        jnp.zeros_like(rescaled),
+    )
     if x.shape[0] > x.shape[1]:
         x = x.T
         transposed = True

--- a/tests/test_optimizer_geometry.py
+++ b/tests/test_optimizer_geometry.py
@@ -340,3 +340,13 @@ def test_geometry_runner_rejects_invalid_transactions(monkeypatch: pytest.Monkey
     )
     with pytest.raises(ValueError, match="transaction"):
         run_streaming_matrix_evaluation()
+
+
+def test_spectral_matrix_sign_fails_closed_on_all_subnormal_float32_matrix() -> None:
+    # A matrix of non-zero float32 subnormals whose float32 norm flushes to zero
+    m = np.array([[2.0, 1.0], [0.5, -1.0]], dtype=np.float32) * np.float32(1e-40)
+    subnormal_jax = jnp.asarray(m)
+    sign, valid = spectral_matrix_sign_transaction(subnormal_jax, steps=5)
+    # Must fail closed with valid=False rather than certifying an exact zero matrix as valid
+    assert not bool(valid)
+    np.testing.assert_array_equal(np.asarray(sign), np.zeros_like(m))


### PR DESCRIPTION
Fixes #2391.

## Summary
In `spectral_matrix_sign_transaction` (`alberta_framework/evaluation/optimizer_geometry.py`), passing a non-zero matrix of float32 subnormals caused reduction norms (`jnp.linalg.norm`) to flush to zero. Consequently, the transaction returned an exact zero matrix with `valid=True`, certifying a rank-0 result for a non-zero matrix.

## Proposed Changes
1. Added bitwise check detecting non-zero bits on float32/float64 inputs when reductions flush to zero, setting `valid=False` (fail-closed policy matching `test_geometry_float32_overflow_is_invalid_not_laundered`).
2. Added unit test in `tests/test_optimizer_geometry.py` verifying that an all-subnormal float32 matrix fails closed with `valid=False`.

## Test Plan
- `uv run pytest tests/test_optimizer_geometry.py` (29 passed)
- `uv run ruff check alberta_framework/evaluation/optimizer_geometry.py tests/test_optimizer_geometry.py` (clean)
- `uv run mypy alberta_framework/evaluation/optimizer_geometry.py` (clean)
