### PR TITLE
test(slow): gate Linux-only renameat2 checkpoint and seal publication tests (#2323)

### DIFF
--- a/tests/test_forager_matched_final_analysis.py
+++ b/tests/test_forager_matched_final_analysis.py
@@ -52,8 +52,9 @@ from alberta_framework.benchmarks import (
 from alberta_framework.benchmarks import forager_matched_statistics as statistics
 from tests import test_forager_matched_executor as executor_fixtures
 from tests import test_forager_matched_open_protocol as protocol_fixtures
+from tests._forager_matched_platform import requires_renameat2
 
-pytestmark = [pytest.mark.integration, pytest.mark.slow]
+pytestmark = [pytest.mark.integration, pytest.mark.slow, requires_renameat2]
 
 
 def _sha(label: str) -> str:

--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -34,6 +34,7 @@ from alberta_framework.reference_life_checkpoint import (
     save_reference_life_checkpoint,
 )
 from alberta_framework.streams.closed_loop import SwitchingTwoStateConfig
+from tests._forager_matched_platform import HAS_RENAMEAT2, requires_renameat2
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
@@ -188,6 +189,8 @@ def _assert_typed_exact(left: object, right: object, *, path: str = "state") -> 
 def saved_case(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path]:
+    if not HAS_RENAMEAT2:
+        pytest.skip("atomic no-replace rename requires Linux renameat2")
     runner = _runner()
     state, _ = _advance(runner, runner.init(), 2)
     assert state.phase is LifePhase.QUIESCENT
@@ -394,6 +397,7 @@ def test_publish_failure_and_existing_generation_leave_runner_unchanged(
     assert not tuple(parent.glob(".*.staging-*"))
 
 
+@requires_renameat2
 def test_post_commit_lock_cleanup_failure_returns_committed_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -503,6 +507,7 @@ def test_save_through_ancestor_symlink_into_generation_is_rejected(
     assert restored_runner.current_state is restored_state
 
 
+@requires_renameat2
 def test_checkpoint_filesystem_publication_stays_inside_runner_barrier(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -573,3 +578,12 @@ def test_checkpoint_filesystem_publication_stays_inside_runner_barrier(
     restored_runner, restored_state = load_reference_life_checkpoint(checkpoint)
     _assert_semantic_state_exact(restored_state, barrier)
     assert restored_runner.current_state is restored_state
+
+
+@pytest.mark.skipif(HAS_RENAMEAT2, reason="tests Linux-only publication refusal off Linux")
+def test_save_reference_life_checkpoint_refuses_off_linux(tmp_path: Path) -> None:
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+    with pytest.raises(OSError, match="atomic no-replace rename requires Linux renameat2"):
+        save_reference_life_checkpoint(runner, state, tmp_path)
+    assert not any(p.name.startswith("generation-") for p in tmp_path.iterdir())

--- a/tests/test_reference_life_riverswim_checkpoint.py
+++ b/tests/test_reference_life_riverswim_checkpoint.py
@@ -30,6 +30,7 @@ from alberta_framework.reference_life_checkpoint import (
     save_reference_life_checkpoint,
 )
 from alberta_framework.streams.closed_loop import RiverSwimConfig, RiverSwimMDP
+from tests._forager_matched_platform import requires_renameat2
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
@@ -189,6 +190,7 @@ def _rehash_bundle(path: Path) -> None:
     (path / "COMMITTED").write_text(f"{bundle_id}\n", encoding="ascii")
 
 
+@requires_renameat2
 def test_riverswim_quiescent_checkpoint_restores_exact_stochastic_continuation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Fixes #2323.

## Summary
In slow-lane test files (`tests/test_forager_matched_final_analysis.py`, `tests/test_reference_life_checkpoint.py`, and `tests/test_reference_life_riverswim_checkpoint.py`), tests exercised Linux-only atomic directory publication primitives (`seal.create_forager_matched_seal_bundle` and `save_reference_life_checkpoint`) without declaring their platform requirements via `tests._forager_matched_platform.requires_renameat2`. Consequently, 44 tests failed on macOS with `ForagerMatchedSealError: renameat2 is required for seal publication` or `OSError: atomic no-replace rename requires Linux renameat2`.

## Proposed Changes
1. Applied `requires_renameat2` marker to `tests/test_forager_matched_final_analysis.py` (module-level `pytestmark`), `saved_case` fixture and standalone saving tests in `tests/test_reference_life_checkpoint.py`, and `test_riverswim_quiescent_checkpoint_restores_exact_stochastic_continuation` in `tests/test_reference_life_riverswim_checkpoint.py`.
2. Added test `test_save_reference_life_checkpoint_refuses_off_linux` in `tests/test_reference_life_checkpoint.py` asserting that `save_reference_life_checkpoint` fails closed on non-Linux platforms without publishing generation directories.

## Test Plan
- `uv run pytest tests/test_forager_matched_final_analysis.py tests/test_reference_life_checkpoint.py tests/test_reference_life_riverswim_checkpoint.py` (5 passed, 44 skipped gracefully on macOS)
- `uv run ruff check tests/test_forager_matched_final_analysis.py tests/test_reference_life_checkpoint.py tests/test_reference_life_riverswim_checkpoint.py` (clean)
