### PR TITLE
test(package): gate wheel-install provenance smoke on requires_o_tmpfile (#2340)

### DIFF
--- a/tests/test_historical_forager_cli_package.py
+++ b/tests/test_historical_forager_cli_package.py
@@ -31,6 +31,7 @@ from alberta_framework.benchmarks.historical_forager_provenance import (
     HISTORICAL_FORAGER_FAMILY_ID,
     HISTORICAL_FORAGER_PROVENANCE_SHA256,
 )
+from tests._forager_matched_platform import requires_o_tmpfile
 
 pytestmark = pytest.mark.integration
 
@@ -239,6 +240,7 @@ def test_historical_cli_reports_provenance_and_validates_strict_pairing(
     assert "must be a real directory" in missing.stderr
 
 
+@requires_o_tmpfile
 @pytest.mark.package
 def test_wheel_and_sdist_are_complete_and_hard_link_safe(tmp_path: Path) -> None:
     uv = shutil.which("uv")


### PR DESCRIPTION
Fixes #2340.

## Summary
`test_wheel_and_sdist_are_complete_and_hard_link_safe` (`tests/test_historical_forager_cli_package.py`) exercises a wheel-install smoke test that invokes `alberta-historical-forager provenance`. This command writes provenance through `write_new_json`, which requires Linux `O_TMPFILE` support and fails closed with `OSError: immutable publication requires Linux O_TMPFILE support` on non-Linux platforms (such as macOS).

## Proposed Changes
1. Applied `@requires_o_tmpfile` from `tests._forager_matched_platform` to `test_wheel_and_sdist_are_complete_and_hard_link_safe`.

## Test Plan
- `uv run pytest tests/test_historical_forager_cli_package.py` (3 passed, 1 skipped gracefully on macOS)
- `uv run ruff check tests/test_historical_forager_cli_package.py` (clean)
