### PR TITLE
test(evaluation): gate Linux-only O_TMPFILE bounded elastic matched runner tests (#2251)

### DIFF
--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -16,6 +16,7 @@ from alberta_framework.benchmarks.upgd_ipmnist import IPMNISTConfig
 from alberta_framework.evaluation.bounded_elastic_ipmnist_nonpromoting import (
     registered_bounded_elastic_hyperparameters,
 )
+from tests._forager_matched_platform import HAS_O_TMPFILE, requires_o_tmpfile
 
 SMALL = IPMNISTConfig(n_tasks=1, task_length=5000, input_dim=2, hidden1=4, hidden2=2, n_classes=2)
 
@@ -291,6 +292,7 @@ def test_campaign_rejects_unregistered_outcome_decisions(
         )
 
 
+@requires_o_tmpfile
 def test_writer_is_create_only_and_retains_negative_outcomes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -314,6 +316,7 @@ def test_writer_is_create_only_and_retains_negative_outcomes(
     assert not destination.with_name(f".{destination.name}.reservation").exists()
 
 
+@requires_o_tmpfile
 def test_writer_strictly_rereads_before_link_and_retains_failed_attempt(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -340,6 +343,7 @@ def test_writer_strictly_rereads_before_link_and_retains_failed_attempt(
     assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
 
 
+@requires_o_tmpfile
 def test_writer_retains_reservation_after_reexecution_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -367,6 +371,7 @@ def test_writer_retains_reservation_after_reexecution_failure(
 
 
 @pytest.mark.parametrize("replace_linked_inode", [False, True])
+@requires_o_tmpfile
 def test_post_link_failure_rolls_back_only_the_exact_published_inode(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -407,6 +412,7 @@ def test_post_link_failure_rolls_back_only_the_exact_published_inode(
     assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
 
 
+@requires_o_tmpfile
 def test_link_success_followed_by_exception_rolls_back_exact_inode(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -434,6 +440,7 @@ def test_link_success_followed_by_exception_rolls_back_exact_inode(
     assert marker.read_bytes() == b"asi-bounded-elastic-consumed-without-result-v1\n"
 
 
+@requires_o_tmpfile
 def test_writer_rejects_replaced_visible_reservation_before_publication(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -464,6 +471,7 @@ def test_writer_rejects_replaced_visible_reservation_before_publication(
     marker.unlink()
 
 
+@requires_o_tmpfile
 def test_writer_parent_swap_does_not_publish_through_replacement(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -552,6 +560,7 @@ def test_standalone_paths_remain_disabled_after_flag_transition(
     assert not destination.parent.exists()
 
 
+@requires_o_tmpfile
 def test_transaction_reserves_before_dataset_load_or_runner(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -579,6 +588,7 @@ def test_transaction_reserves_before_dataset_load_or_runner(
     assert marker.read_bytes() == b"prior reservation"
 
 
+@requires_o_tmpfile
 def test_transaction_retains_owned_tombstone_after_first_dispatch_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -615,6 +625,7 @@ def test_transaction_retains_owned_tombstone_after_first_dispatch_failure(
     assert calls == 1
 
 
+@requires_o_tmpfile
 def test_transaction_publishes_only_after_strict_reexecution(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -841,3 +852,12 @@ def test_source_identity_detects_dependency_input_mutation(
         for path, digest in original.items()
         if path != dependency_input
     )
+
+
+@pytest.mark.skipif(HAS_O_TMPFILE, reason="tests Linux-only publication refusal off Linux")
+def test_reserve_output_refuses_without_linux_descriptor_support(tmp_path: Path) -> None:
+    destination = tmp_path / "report.json"
+    with pytest.raises(
+        OSError, match="immutable output publication requires Linux descriptor support"
+    ):
+        runner._reserve_output(destination, _capability=runner._TEST_EXECUTION_CAPABILITY)


### PR DESCRIPTION
Fixes #2251.

## Summary
`tests/test_bounded_elastic_matched_runner.py` exercised Linux-only immutable-publication primitives (`_reserve_output` via `O_TMPFILE`) without declaring the platform requirement via `tests._forager_matched_platform.requires_o_tmpfile`. Consequently, 11 tests failed on macOS with `OSError: immutable output publication requires Linux descriptor support`.

## Proposed Changes
1. Applied `@requires_o_tmpfile` to the 10 affected test functions in `tests/test_bounded_elastic_matched_runner.py`.
2. Added inverse test `test_reserve_output_refuses_without_linux_descriptor_support` asserting that `_reserve_output` fails closed with `OSError: immutable output publication requires Linux descriptor support` on non-Linux platforms.

## Test Plan
- `uv run pytest tests/test_bounded_elastic_matched_runner.py` (24 passed, 11 skipped gracefully on macOS)
- `uv run ruff check tests/test_bounded_elastic_matched_runner.py` (clean)
