### PR TITLE
test(streams): gate longdouble-width tests on extended precision (#2324)

### DIFF
--- a/tests/test_pavlovian_stream.py
+++ b/tests/test_pavlovian_stream.py
@@ -485,6 +485,14 @@ def test_construct_canonicalizes_noise_std_to_float32() -> None:
     assert stream._noise_std == float(np.float32(0.1))  # noqa: SLF001
 
 
+_HAS_EXTENDED_LONGDOUBLE = np.finfo(np.longdouble).nmant > np.finfo(np.float64).nmant
+requires_extended_longdouble = pytest.mark.skipif(
+    not _HAS_EXTENDED_LONGDOUBLE,
+    reason="np.longdouble must have greater precision than float64",
+)
+
+
+@requires_extended_longdouble
 def test_construct_narrows_original_noise_real_once() -> None:
     midpoint_plus = (
         np.longdouble(1.0)
@@ -500,6 +508,7 @@ def test_construct_narrows_original_noise_real_once() -> None:
     assert stream._noise_std == float(np.float32(midpoint_plus))  # noqa: SLF001
 
 
+@requires_extended_longdouble
 def test_construct_rejects_negative_real_that_rounds_to_zero() -> None:
     below_zero = -np.nextafter(np.longdouble(0.0), np.longdouble(1.0))
     assert float(below_zero) == 0.0


### PR DESCRIPTION
Fixes #2324.

## Summary
`test_construct_narrows_original_noise_real_once` and `test_construct_rejects_negative_real_that_rounds_to_zero` in `tests/test_pavlovian_stream.py` verify the `noise_std` validator's double-rounding behavior using `np.longdouble` fixture values whose properties only exist where `np.longdouble` is wider than `float64`. On aarch64 (e.g., macOS ARM64), `np.longdouble` has 53 mantissa bits (same as `float64`), causing both tests to fail in their precondition assertions.

## Proposed Changes
1. Added `_HAS_EXTENDED_LONGDOUBLE = np.finfo(np.longdouble).nmant > np.finfo(np.float64).nmant` and `@requires_extended_longdouble` marker in `tests/test_pavlovian_stream.py`.
2. Applied `@requires_extended_longdouble` to `test_construct_narrows_original_noise_real_once` and `test_construct_rejects_negative_real_that_rounds_to_zero`.

## Test Plan
- `uv run pytest tests/test_pavlovian_stream.py` (100 passed, 2 skipped gracefully on aarch64 macOS)
- `uv run ruff check tests/test_pavlovian_stream.py` (clean)
