### PR TITLE
fix(core): normalize by exact observation_scale in LatentWorldModel (#2411)

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -290,7 +290,9 @@ class LatentWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 validated_float32_scalar(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]",
+                    scale,
+                    lower=float(np.finfo(np.float32).tiny),
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -670,7 +672,7 @@ class LatentWorldModel:
         """Encode one observation with explicit (differentiable) encoder params."""
         obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._config.observation_dim,))
         scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        scaled = obs / jnp.maximum(scale, jnp.asarray(1e-6, dtype=jnp.float32))
+        scaled = obs / scale
         return jnp.tanh(scaled @ encoder_matrix + encoder_bias)
 
     @functools.partial(jax.jit, static_argnums=(0,))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -749,3 +749,33 @@ def test_latent_world_model_init_rejects_nonfinite_encoder_draw() -> None:
 
     with pytest.raises(ValueError, match="encoder initialization"):
         model.init(jr.key(0))
+
+
+def test_latent_world_model_observation_scale_normalizes_without_floor() -> None:
+    """Observation scale below 1e-6 normalizes by exact configured scale."""
+    key = jr.key(42)
+    latents = []
+    for scale in (1.0, 1e-6, 1e-9, 1e-20):
+        config = LatentWorldModelConfig(
+            observation_dim=2,
+            latent_dim=4,
+            n_actions=2,
+            observation_scale=(scale, scale),
+        )
+        model = LatentWorldModel(config)
+        state = model.init(key)
+        obs = jnp.asarray([1.5 * scale, -0.75 * scale], dtype=jnp.float32)
+        latents.append(np.asarray(model.encode(state, obs)))
+
+    for i in range(1, len(latents)):
+        np.testing.assert_allclose(latents[i], latents[0], atol=1e-6)
+
+    # Subnormal scale whose float32 reciprocal overflows to inf must be rejected
+    subnormal = float(np.finfo(np.float32).smallest_subnormal)
+    with pytest.raises(ValueError, match="observation_scale"):
+        LatentWorldModelConfig(
+            observation_dim=1,
+            latent_dim=2,
+            n_actions=2,
+            observation_scale=(subnormal,),
+        )


### PR DESCRIPTION
Fixes #2411.

## Summary
In `alberta_framework/core/latent_world_model.py`, `_encode_with` normalized observations by `jnp.maximum(scale, 1e-6)`. For configured `observation_scale` values below `1e-6`, observations were normalized by `1e-6` instead of the declared scale, compressing the latent space and causing false collapse detections on small-scale observations.

## Proposed Changes
1. Removed the `1e-6` floor in `LatentWorldModel._encode_with` so observations are scaled by the exact declared `observation_scale`.
2. Updated `LatentWorldModelConfig.__post_init__` to validate that `observation_scale >= np.finfo(np.float32).tiny` (ensuring every admitted scale is a normal float32 scalar with finite float32 reciprocal).
3. Added unit test in `tests/test_latent_world_model.py` verifying that scales below `1e-6` normalize scale-invariantly, and subnormal scales are rejected at config validation.

## Test Plan
- `uv run pytest tests/test_latent_world_model.py` (57 passed)
- `uv run ruff check alberta_framework/core/latent_world_model.py tests/test_latent_world_model.py` (clean)
- `uv run mypy alberta_framework/core/latent_world_model.py` (clean)
