### PR TITLE
fix(core): normalize observation targets by exact observation_scale (#2398)

### DIFF
--- a/alberta_framework/core/world_model.py
+++ b/alberta_framework/core/world_model.py
@@ -365,7 +365,9 @@ class ActionConditionedWorldModelConfig:
                 raise ValueError("observation_scale length must equal observation_dim")
             observation_scale = tuple(
                 _validated_config_float(
-                    f"observation_scale[{index}]", scale, positive=True
+                    f"observation_scale[{index}]",
+                    scale,
+                    lower=float(np.finfo(np.float32).tiny),
                 )
                 for index, scale in enumerate(observation_scale)
             )
@@ -806,11 +808,10 @@ class ActionConditionedWorldModel:
         reward_arr = _float32_operand("reward", reward, ())
         discount_arr = _float32_operand("discount", discount, ())
         obs_scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
-        safe_scale = jnp.maximum(obs_scale, jnp.asarray(1e-6, dtype=jnp.float32))
         normalized_delta = jnp.where(
             self._config.predict_delta,
-            (next_obs - obs) / safe_scale,
-            next_obs / safe_scale,
+            (next_obs - obs) / obs_scale,
+            next_obs / obs_scale,
         )
         reward_target = jnp.reshape(
             reward_arr / self._config.reward_scale,

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -464,7 +464,7 @@ class _FloatSpoof:
         ({"max_delta_scale": 1e100}, "max_delta_scale must remain finite once narrowed"),
         ({"reward_scale": 1e-100}, "reward_scale must remain positive once narrowed"),
         ({"max_delta_scale": 1e-100}, "max_delta_scale must remain positive once narrowed"),
-        ({"observation_scale": (1e-100, 1.0)}, "must remain positive once narrowed"),
+        ({"observation_scale": (1e-100, 1.0)}, r"must be >= 1\.1754943508222875e-38"),
         (
             {"utility_decay": 1.0 - 1e-10},
             r"utility_decay must remain in \[0.0, 1.0\) once narrowed",
@@ -955,3 +955,26 @@ def test_action_world_model_rolls_back_reduction_overflow() -> None:
     assert not bool(result.update_applied)
     assert float(result.observation_mse) == 0.0
     assert int(result.state.step_count) == 0
+
+
+def test_action_world_model_observation_scale_targets_paired_with_decode() -> None:
+    """Target normalization uses exact scale so decoded predictions match true delta."""
+    for scale in (1.0, 1e-3, 1e-6, 1e-7, 1e-9, 1e-12, 1e-20):
+        config = ActionConditionedWorldModelConfig(
+            observation_dim=1,
+            n_actions=2,
+            hidden_sizes=(),
+            step_size=0.05,
+            use_layer_norm=False,
+            predict_delta=True,
+            observation_scale=(scale,),
+        )
+        model = ActionConditionedWorldModel(config)
+        obs = jnp.asarray([1.0 * scale], dtype=jnp.float32)
+        next_obs = jnp.asarray([3.0 * scale], dtype=jnp.float32)
+        reward = jnp.asarray(0.0, dtype=jnp.float32)
+        discount = jnp.asarray(1.0, dtype=jnp.float32)
+
+        # Target normalized delta must be 2.0 exactly
+        targets = model.targets(obs, reward, discount, next_obs)
+        np.testing.assert_allclose(float(targets[0]), 2.0, rtol=1e-5)


### PR DESCRIPTION
Fixes #2398.

## Summary
In `alberta_framework/core/world_model.py`, `_targets` computed normalized observation deltas by dividing by `safe_scale = jnp.maximum(obs_scale, 1e-6)`, whereas `_prediction_and_raw_diagnostics` denormalized predictions by multiplying by the raw `obs_scale`. For configured `observation_scale` entries below `1e-6`, this asymmetry caused the world model to predict deltas shrunk by `obs_scale / 1e-6`.

## Proposed Changes
1. Updated `_targets` to divide by `obs_scale` directly, matching the decode operation in `_prediction_and_raw_diagnostics`.
2. Updated `ActionConditionedWorldModelConfig.__post_init__` to validate that `observation_scale >= np.finfo(np.float32).tiny`, ensuring every admitted scale is a normal float32 scalar with finite float32 reciprocal.
3. Added unit test in `tests/test_action_conditioned_world_model.py` verifying that target normalization pairs scale-invariantly across scales below `1e-6`.

## Test Plan
- `uv run pytest tests/test_action_conditioned_world_model.py` (69 passed)
- `uv run ruff check alberta_framework/core/world_model.py tests/test_action_conditioned_world_model.py` (clean)
- `uv run mypy alberta_framework/core/world_model.py` (clean)
