### PR TITLE
fix(nexting): promote computation dtype to floating in forward_view_returns (#2368)

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -155,8 +155,16 @@ def forward_view_returns(
     _require_leading_length(
         "cumulants", cumulants, ndim=1, maximum=_NEXTING_MAX_STEPS
     )
-    gamma_s = jnp.asarray(gamma, dtype=cumulants.dtype)
-    init = jnp.asarray(terminal_value, dtype=cumulants.dtype)
+    comp_dtype = jnp.result_type(
+        cumulants.dtype,
+        jnp.asarray(gamma).dtype,
+        jnp.asarray(terminal_value).dtype,
+    )
+    if not jnp.issubdtype(comp_dtype, jnp.floating):
+        comp_dtype = jnp.float32
+    c_arr = jnp.asarray(cumulants, dtype=comp_dtype)
+    gamma_s = jnp.asarray(gamma, dtype=comp_dtype)
+    init = jnp.asarray(terminal_value, dtype=comp_dtype)
 
     def step(carry: Array, c: Array) -> tuple[Array, Array]:
         # gamma=0 must not multiply an inf later return (0*inf).
@@ -164,7 +172,7 @@ def forward_view_returns(
         new_carry = c + bootstrap
         return new_carry, new_carry
 
-    _, returns_reversed = jax.lax.scan(step, init, cumulants[::-1])
+    _, returns_reversed = jax.lax.scan(step, init, c_arr[::-1])
     return returns_reversed[::-1]
 
 

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -617,3 +617,16 @@ class TestRunningRMSE:
         assert float(running[-1, 0]) < 0.01
         # Mid-series transition: some error
         assert float(running[19, 0]) > 0.5
+
+
+def test_forward_view_returns_promotes_integer_and_boolean_cumulants_to_float() -> None:
+    c_int = jnp.array([1, 0, 0, 0, 1], dtype=jnp.int32)
+    returns_int = forward_view_returns(c_int, 0.9)
+    expected = jnp.array([1.6561, 0.729, 0.81, 0.9, 1.0], dtype=jnp.float32)
+    np.testing.assert_allclose(np.asarray(returns_int), np.asarray(expected), rtol=1e-5)
+    assert jnp.issubdtype(returns_int.dtype, jnp.floating)
+
+    c_bool = jnp.array([True, False, False, False, True], dtype=jnp.bool_)
+    returns_bool = forward_view_returns(c_bool, 0.9)
+    np.testing.assert_allclose(np.asarray(returns_bool), np.asarray(expected), rtol=1e-5)
+    assert jnp.issubdtype(returns_bool.dtype, jnp.floating)


### PR DESCRIPTION
Fixes #2368.

## Summary
In `alberta_framework/utils/nexting.py`, `forward_view_returns` computed forward-view returns by casting `gamma` and `terminal_value` directly to `cumulants.dtype`. When callers supplied integer or boolean cumulant series, `gamma` was truncated to an integer (e.g. `0.9` -> `0`), causing the recurrence to degenerate to a raw cumulant echo and inverting evaluation verdicts.

## Proposed Changes
1. Updated `forward_view_returns` to promote the computation dtype across `(cumulants, gamma, terminal_value)`, defaulting to `float32` when non-floating.
2. Cast `cumulants`, `gamma`, and `terminal_value` to the promoted floating dtype prior to running `jax.lax.scan`.
3. Added unit tests in `tests/test_nexting.py` verifying that integer and boolean series produce mathematically correct float returns.

## Test Plan
- `uv run pytest tests/test_nexting.py` (90 passed)
- `uv run ruff check alberta_framework/utils/nexting.py tests/test_nexting.py` (clean)
- `uv run mypy alberta_framework/utils/nexting.py` (clean)
