### PR TITLE
fix(core): ensure floor_and_renormalize_probabilities returns a valid simplex (#2238)

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -225,11 +225,20 @@ def floor_and_renormalize_probabilities(
     if min_probability * n_actions >= 1.0:
         return jnp.ones_like(probs) / n_actions
     clipped = jnp.maximum(probs, 0.0)
-    normalizer = jnp.maximum(
-        jnp.sum(clipped, axis=-1, keepdims=True),
-        jnp.asarray(1e-12, dtype=jnp.float32),
+    total_mass = jnp.sum(clipped, axis=-1, keepdims=True)
+    valid_mass = jnp.isfinite(total_mass) & (total_mass > 0.0)
+    normalized = jnp.where(
+        valid_mass,
+        clipped / jnp.where(valid_mass, total_mass, 1.0),
+        jnp.ones_like(clipped) / n_actions,
     )
-    normalized = clipped / normalizer
+    norm_sum = jnp.sum(normalized, axis=-1, keepdims=True)
+    valid_norm = jnp.isfinite(norm_sum) & (norm_sum > 0.0)
+    normalized = jnp.where(
+        valid_norm,
+        normalized / jnp.where(valid_norm, norm_sum, 1.0),
+        jnp.ones_like(clipped) / n_actions,
+    )
     floor_mass = jnp.asarray(min_probability * n_actions, dtype=jnp.float32)
     return jnp.asarray(min_probability, dtype=jnp.float32) + (1.0 - floor_mass) * normalized
 

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -868,3 +868,10 @@ class TestBehaviorModelSequenceCeiling:
         result = run_behavior_model_from_arrays(model, state, observations, actions)
         chex.assert_shape(result.probabilities, (12, 3))
         assert int(result.state.step_count) == 12
+
+
+def test_floor_and_renormalize_probabilities_returns_valid_simplex_on_degenerate_inputs() -> None:
+    for probs in ([0.0, 0.0, 0.0], [1e38, 1.0, 1.0], [-1.0, -2.0, -3.0]):
+        out = floor_and_renormalize_probabilities(jnp.asarray(probs, dtype=jnp.float32))
+        np.testing.assert_allclose(float(jnp.sum(out)), 1.0, atol=1e-6)
+        assert bool(jnp.all(out >= 1e-6))


### PR DESCRIPTION
Fixes #2238.

## Summary
In `alberta_framework/core/behavior_model.py`, `floor_and_renormalize_probabilities` computed normalized probabilities via `normalized = clipped / jnp.maximum(jnp.sum(clipped, axis=-1, keepdims=True), 1e-12)`. When inputs contained zero mass, negative values only, or underflowing ratios in float32, `normalized` summed to zero instead of 1.0, causing the affine combination to return `n_actions * min_probability` instead of a valid simplex summing to 1.0.

## Proposed Changes
1. Updated `floor_and_renormalize_probabilities` to divide by positive finite `total_mass` and fall back to uniform distribution `1.0 / n_actions` when total mass is zero, negative, non-finite, or when normalized ratios underflow.
2. Added unit test in `tests/test_behavior_model.py` verifying that degenerate inputs return a valid simplex summing to 1.0 with all entries `>= min_probability`.

## Test Plan
- `uv run pytest tests/test_behavior_model.py` (65 passed)
- `uv run ruff check alberta_framework/core/behavior_model.py tests/test_behavior_model.py` (clean)
- `uv run mypy alberta_framework/core/behavior_model.py` (clean)
