### PR TITLE
fix(core): enforce equal latent width invariant in BoundedPolicyArchive (#2322)

### DIFF
--- a/alberta_framework/core/policy_archive.py
+++ b/alberta_framework/core/policy_archive.py
@@ -113,9 +113,14 @@ class BoundedPolicyArchive:
             raise ValueError("entries must be an exact tuple of PolicyEntry values")
         retained_bytes = 0
         identities: set[str] = set()
+        latent_width: int | None = None
         for entry in self.entries:
             if type(entry) is not PolicyEntry:
                 raise ValueError("entries must be an exact tuple of PolicyEntry values")
+            if latent_width is None:
+                latent_width = len(entry.latent)
+            elif len(entry.latent) != latent_width:
+                raise ValueError("all latent descriptors must have equal width")
             retained_bytes += entry.persistent_bytes
             if retained_bytes > self.byte_budget:
                 raise ValueError("entries exceed byte budget")
@@ -134,8 +139,6 @@ class BoundedPolicyArchive:
         if any(old.identity == entry.identity for old in self.entries):
             raise ValueError("entry identity already exists")
         candidates: tuple[PolicyEntry, ...]
-        if self.entries and len(entry.latent) != len(self.entries[0].latent):
-            raise ValueError("all latent descriptors must have equal width")
         if self.mode == "fixed_snapshot" and self.entries:
             return self
         if self.mode == "one_model":
@@ -143,6 +146,8 @@ class BoundedPolicyArchive:
         elif not self.entries:
             candidates = (entry,)
         else:
+            if len(entry.latent) != len(self.entries[0].latent):
+                raise ValueError("all latent descriptors must have equal width")
             distances = tuple(
                 float(np.linalg.norm(np.asarray(entry.latent) - np.asarray(old.latent)))
                 for old in self.entries

--- a/tests/test_policy_archive.py
+++ b/tests/test_policy_archive.py
@@ -66,3 +66,20 @@ def test_protocol_is_nonpromoting() -> None:
     assert POLICY_ARCHIVE_PROTOCOL["paper_revision"] == "arXiv:2604.15414v1"
     assert POLICY_ARCHIVE_PROTOCOL["controls"] == ("one_model", "fixed_snapshot")
     assert POLICY_ARCHIVE_PROTOCOL["scientific_promotion_allowed"] is False
+
+
+def test_archive_constructor_enforces_equal_latent_width() -> None:
+    narrow = _entry("a", (0.0,), 1.0)
+    wide = _entry("b", (1.0, 2.0), 2.0)
+    with pytest.raises(ValueError, match="all latent descriptors must have equal width"):
+        BoundedPolicyArchive(byte_budget=1024, min_latent_distance=1.0, entries=(narrow, wide))
+
+
+def test_control_modes_accept_varying_latent_widths_across_steps() -> None:
+    one = BoundedPolicyArchive(byte_budget=1024, min_latent_distance=0.0, mode="one_model")
+    one = one.add(_entry("a", (0.0,), 1.0)).add(_entry("b", (1.0, 2.0), 2.0))
+    assert [entry.identity for entry in one.entries] == ["b"]
+
+    fixed = BoundedPolicyArchive(byte_budget=1024, min_latent_distance=0.0, mode="fixed_snapshot")
+    fixed = fixed.add(_entry("a", (0.0,), 1.0)).add(_entry("b", (1.0, 2.0), 2.0))
+    assert [entry.identity for entry in fixed.entries] == ["a"]


### PR DESCRIPTION
Fixes #2322.

## Summary
In `alberta_framework/core/policy_archive.py`:
1. `BoundedPolicyArchive.__post_init__` did not enforce that all `PolicyEntry` elements in `entries` have equal `latent` length. Mismatched latent lengths caused NumPy broadcasting in `add()` to compute incorrect norm distances without error, silently dropping valid candidate policies.
2. `BoundedPolicyArchive.add` performed the `len(entry.latent) != len(self.entries[0].latent)` check before mode short-circuiting, rejecting entries with differing descriptor widths even on control arms (`one_model` and `fixed_snapshot`) that do not compute latent distances.

## Proposed Changes
1. Added equal latent descriptor width validation in `BoundedPolicyArchive.__post_init__`.
2. Moved the latent descriptor length check in `BoundedPolicyArchive.add` into the diverse archive branch that computes pairwise Euclidean distances.
3. Added unit tests in `tests/test_policy_archive.py`.

## Test Plan
- `uv run pytest tests/test_policy_archive.py` (8 passed)
- `uv run ruff check alberta_framework/core/policy_archive.py tests/test_policy_archive.py` (clean)
- `uv run mypy alberta_framework/core/policy_archive.py` (clean)
