### PR TITLE
fix(pipeline): pass terminated discount to value head in horde_ac (#2344)

### DIFF
--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -1573,11 +1573,18 @@ class AlbertaPipeline:
                 dtype=jnp.int32,
             )
             auxiliary_cumulants = horde_cumulants[aux_indices] if aux_indices.size else None
+            value_gamma = self._horde.horde_spec.gammas[value_index]
+            control_discount = jnp.where(
+                terminated == 0.0,
+                value_gamma,
+                jnp.zeros_like(value_gamma),
+            )
             ac_result = ac.update(
                 ac_state,
                 reward,
                 features,
                 auxiliary_cumulants=auxiliary_cumulants,
+                discount=control_discount,
             )
             new_control_state: SARSAState | HordeActorCriticState = ac_result.state
             q_values_or_policy = ac_result.policy

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1196,3 +1196,37 @@ def test_associative_pipeline_narrows_only_statically_safe_integer_dtypes() -> N
 
 # silence the import lint warnings used in the test runner
 _ = jax
+
+
+def test_pipeline_horde_ac_passes_terminated_discount_to_value_head() -> None:
+    """Terminal step (terminated=1.0) must zero the value head discount and actor traces."""
+    cfg = AlbertaPipelineConfig(
+        features=Step2FeatureConfig.identity(observation_dim=3),
+        horde=Step3HordeConfig(
+            gammas=(0.9, 0.5),
+            lamdas=(0.0, 0.0),
+            hidden_sizes=(),
+            step_size=0.05,
+        ),
+        horde_ac=HordeActorCriticPipelineConfig(
+            n_actions=2,
+            value_head_index=0,
+            actor_step_size=0.05,
+            actor_lamda=0.8,
+        ),
+        control_mode="horde_ac",
+    )
+    pipeline = AlbertaPipeline(cfg)
+    state = pipeline.init(jr.key(0), jnp.asarray([0.2, -0.1, 0.4], dtype=jnp.float32))
+    obs = jnp.asarray([0.1, 0.3, -0.2], dtype=jnp.float32)
+    reward = jnp.asarray(0.5, dtype=jnp.float32)
+    cumulants = jnp.asarray([0.5, -0.2], dtype=jnp.float32)
+
+    # Terminated = 1.0 -> Value head target should be exactly reward (0.5), actor traces zeroed
+    res_term = pipeline.update(state, obs, reward, jnp.asarray(1.0, dtype=jnp.float32), cumulants)
+    np.testing.assert_allclose(float(res_term.horde_td_targets[0]), 0.5, rtol=1e-5)
+    np.testing.assert_allclose(
+        np.asarray(res_term.state.control_state.actor_trace_weights),
+        0.0,
+        atol=1e-6,
+    )


### PR DESCRIPTION
Fixes #2344.

## Summary
In `alberta_framework/pipeline.py`, `AlbertaPipeline.update` accepts a `terminated` argument (`0.0` or `1.0`). On the `control_mode="horde_ac"` path, `terminated` was not passed to `HordeActorCriticAgent.update`, causing the value head to bootstrap through episode terminations (`r + gamma * V(s')` instead of `r`) and allowing actor eligibility traces to survive across episode boundaries.

## Proposed Changes
1. Computed `control_discount = jnp.where(terminated == 0.0, value_gamma, jnp.zeros_like(value_gamma))` in `AlbertaPipeline.update` on the `horde_ac` branch and forwarded `discount=control_discount` to `ac.update()`.
2. Added unit test in `tests/test_pipeline.py` verifying that when `terminated=1.0`, the value head target is unbootstrapped reward (`0.5`) and actor traces are zeroed.

## Test Plan
- `uv run pytest tests/test_pipeline.py` (184 passed)
- `uv run ruff check alberta_framework/pipeline.py tests/test_pipeline.py` (clean)
- `uv run mypy alberta_framework/pipeline.py` (clean)
