### PR TITLE
fix(utils): derive significance marker tiers from result alpha (#2227)

### DIFF
--- a/alberta_framework/utils/export.py
+++ b/alberta_framework/utils/export.py
@@ -547,13 +547,22 @@ def _get_significance_marker(
         return ""
 
     p = result.p_value
-    if p < 0.001:
-        return r"$^{***}$"
-    elif p < 0.01:
-        return r"$^{**}$"
-    elif p < 0.05:
+    alpha = getattr(result, "alpha", 0.05)
+    if alpha == 0.05:
+        if p < 0.001:
+            return r"$^{***}$"
+        elif p < 0.01:
+            return r"$^{**}$"
+        elif p < 0.05:
+            return r"$^{*}$"
         return r"$^{*}$"
-    return ""
+    else:
+        if p < alpha / 100:
+            return r"$^{***}$"
+        elif p < alpha / 10:
+            return r"$^{**}$"
+        else:
+            return r"$^{*}$"
 
 
 def generate_markdown_table(
@@ -639,13 +648,22 @@ def _get_md_significance_marker(
         return ""
 
     p = result.p_value
-    if p < 0.001:
-        return " ***"
-    elif p < 0.01:
-        return " **"
-    elif p < 0.05:
+    alpha = getattr(result, "alpha", 0.05)
+    if alpha == 0.05:
+        if p < 0.001:
+            return " ***"
+        elif p < 0.01:
+            return " **"
+        elif p < 0.05:
+            return " *"
         return " *"
-    return ""
+    else:
+        if p < alpha / 100:
+            return " ***"
+        elif p < alpha / 10:
+            return " **"
+        else:
+            return " *"
 
 
 def generate_significance_table(

--- a/alberta_framework/utils/visualization.py
+++ b/alberta_framework/utils/visualization.py
@@ -669,10 +669,19 @@ def _get_significance_marker_for_plot(
         return ""
 
     p = result.p_value
-    if p < 0.001:
-        return "***"
-    elif p < 0.01:
-        return "**"
-    elif p < 0.05:
+    alpha = getattr(result, "alpha", 0.05)
+    if alpha == 0.05:
+        if p < 0.001:
+            return "***"
+        elif p < 0.01:
+            return "**"
+        elif p < 0.05:
+            return "*"
         return "*"
-    return ""
+    else:
+        if p < alpha / 100:
+            return "***"
+        elif p < alpha / 10:
+            return "**"
+        else:
+            return "*"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -581,3 +581,41 @@ def test_export_rejects_boolean_summary_statistics(
 
     with pytest.raises(ValueError, match="refusing to export boolean as numeric measurement"):
         generate_markdown_table(results)
+
+
+def test_significance_marker_derives_tiers_from_result_alpha() -> None:
+    from alberta_framework.utils.export import _get_md_significance_marker, _get_significance_marker
+    from alberta_framework.utils.statistics import SignificanceResult
+    from alberta_framework.utils.visualization import _get_significance_marker_for_plot
+
+    # Significant result with alpha=0.10, p=0.08
+    r_high_alpha = SignificanceResult(
+        test_name="wilcoxon",
+        statistic=1.0,
+        p_value=0.08,
+        significant=True,
+        alpha=0.10,
+        effect_size=0.5,
+        method_a="a",
+        method_b="b",
+    )
+    sig_map = {("b", "a"): r_high_alpha}
+    assert _get_md_significance_marker("b", "a", sig_map) == " *"
+    assert _get_significance_marker("b", "a", sig_map) == r"$^{*}$"
+    assert _get_significance_marker_for_plot("b", "a", sig_map) == "*"
+
+    # Significant result with Holm alpha=0.0025, p=0.002 -> p in [alpha/10, alpha] -> *
+    r_holm = SignificanceResult(
+        test_name="ttest",
+        statistic=5.0,
+        p_value=0.002,
+        significant=True,
+        alpha=0.0025,
+        effect_size=1.2,
+        method_a="a",
+        method_b="b",
+    )
+    sig_map_holm = {("b", "a"): r_holm}
+    assert _get_md_significance_marker("b", "a", sig_map_holm) == " *"
+    assert _get_significance_marker("b", "a", sig_map_holm) == r"$^{*}$"
+    assert _get_significance_marker_for_plot("b", "a", sig_map_holm) == "*"


### PR DESCRIPTION
Fixes #2227.

## Summary
In `alberta_framework/utils/export.py` (`_get_significance_marker`, `_get_md_significance_marker`) and `alberta_framework/utils/visualization.py` (`_get_significance_marker_for_plot`), significance stars were hardcoded to raw-p thresholds (`0.05 / 0.01 / 0.001`), ignoring each comparison's operative decision threshold `result.alpha`. Consequently, a corrected result declared significant by the statistics layer at `alpha > 0.05` was rendered with no marker, and stricter Holm-adjusted thresholds were misreported as uncorrected tiers.

## Proposed Changes
1. Updated `_get_significance_marker`, `_get_md_significance_marker`, and `_get_significance_marker_for_plot` to derive star tiers from `result.alpha` (`p < alpha/100` -> `***`, `p < alpha/10` -> `**`, `p <= alpha` -> `*`), while maintaining legacy bit-exact compatibility when `alpha == 0.05`.
2. Added unit tests in `tests/test_export.py`.

## Test Plan
- `uv run pytest tests/test_export.py` (123 passed)
- `uv run ruff check alberta_framework/utils/export.py alberta_framework/utils/visualization.py tests/test_export.py` (clean)
- `uv run mypy alberta_framework/utils/export.py alberta_framework/utils/visualization.py` (clean)
