### PR TITLE
fix(core): bound stacked-horde demon count and reject oversized sequences in deserializer (#2225)

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -62,6 +62,7 @@ __all__ = [
     "nexting_spec",
 ]
 
+_MAX_STACKED_HORDE_DEMONS = 1 << 12  # 4096
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _STEP_SIZE_ERROR = "step_size must be positive"
 _NUMPY_STEP_SIZE_TYPES = tuple(
@@ -176,7 +177,10 @@ def _require_sequence(name: str, value: object) -> tuple[object, ...]:
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
     if type(value) not in (list, tuple):
         raise ValueError(f"{name} must be an actual list or tuple")
-    return tuple(cast(list[object] | tuple[object, ...], value))
+    raw_list = cast(list[object] | tuple[object, ...], value)
+    if len(raw_list) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(f"{name} must not exceed {_MAX_STACKED_HORDE_DEMONS} items")
+    return tuple(raw_list)
 
 
 def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
@@ -257,7 +261,9 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        n_demons = _require_int32(
+            "n_demons", self.n_demons, minimum=1, maximum=_MAX_STACKED_HORDE_DEMONS
+        )
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
         raw_sequences = {
@@ -365,8 +371,10 @@ def nexting_spec(
     )
     canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
     n_demons = len(canonical_indices) * len(canonical_gammas)
-    if n_demons < 1 or n_demons > _INT32_MAX:
-        raise ValueError("derived n_demons must be in the signed int32 domain")
+    if n_demons < 1 or n_demons > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"derived n_demons must be in [1, {_MAX_STACKED_HORDE_DEMONS}]"
+        )
     _preflight_horde_resources(n_demons, feature_dim)
     _preflight_stacked_horde_update_working_set(n_demons, feature_dim)
     idxs: list[int] = []

--- a/tests/test_stacked_horde.py
+++ b/tests/test_stacked_horde.py
@@ -939,3 +939,43 @@ def test_stacked_horde_public_state_shape_rejected_before_dot() -> None:
     state = horde.init().replace(weights=jnp.zeros((1, 3), dtype=jnp.float32))
     with pytest.raises(ValueError, match="weights"):
         horde.predict(state, jnp.ones(2, dtype=jnp.float32))
+
+
+def test_stacked_horde_cardinality_bounds() -> None:
+    from alberta_framework.core.stacked_horde import _MAX_STACKED_HORDE_DEMONS, nexting_spec
+
+    assert _MAX_STACKED_HORDE_DEMONS == 4096
+
+    # Rejection of n_demons > 4096
+    with pytest.raises(ValueError, match="must be an integer in"):
+        StackedHordeConfig(
+            n_demons=4097,
+            feature_dim=2,
+            gammas=(0.9,) * 4097,
+            lamdas=(0.5,) * 4097,
+            cumulant_indices=(0,) * 4097,
+        )
+
+    # Acceptance of boundary case 4096
+    cfg = StackedHordeConfig(
+        n_demons=4096,
+        feature_dim=2,
+        gammas=(0.9,) * 4096,
+        lamdas=(0.5,) * 4096,
+        cumulant_indices=(0,) * 4096,
+    )
+    assert cfg.n_demons == 4096
+
+    # from_config rejects oversized sequences (> 4096)
+    cfg_dict = cfg.to_config()
+    cfg_dict["gammas"] = [0.9] * 4097
+    with pytest.raises(ValueError, match="must not exceed 4096 items"):
+        StackedHordeConfig.from_config(cfg_dict)
+
+    # nexting_spec rejects oversized products (> 4096)
+    with pytest.raises(ValueError, match="derived n_demons must be in"):
+        nexting_spec(
+            feature_dim=2,
+            cumulant_indices=tuple(range(100)),
+            gammas=tuple(np.linspace(0.0, 0.99, 50)),
+        )


### PR DESCRIPTION
Fixes #2225.

## Summary
In `alberta_framework/core/stacked_horde.py`, `StackedHordeConfig` admitted demon counts up to signed int32 maximum (`2,147,483,647`) without capping cardinality against peer module conventions (`_MAX_HORDE_DEMONS = 4096`). Oversized demon counts could allocate large validation sequences and memory buffers before resource preflights ran. Furthermore, `_decode_sequence` did not reject sequences exceeding the maximum demon count, and `nexting_spec` did not preflight product cardinality before allocating demon index grids.

## Proposed Changes
1. Defined `_MAX_STACKED_HORDE_DEMONS = 1 << 12` (4096) in `stacked_horde.py`.
2. Validated `n_demons` with `maximum=_MAX_STACKED_HORDE_DEMONS` in `StackedHordeConfig.__post_init__`.
3. Added sequence length ceiling in `_decode_sequence` rejecting lists/tuples exceeding `_MAX_STACKED_HORDE_DEMONS`.
4. Preflighted product demon cardinality in `nexting_spec`.
5. Added unit tests in `tests/test_stacked_horde.py`.

## Test Plan
- `uv run pytest tests/test_stacked_horde.py` (95 passed)
- `uv run ruff check alberta_framework/core/stacked_horde.py tests/test_stacked_horde.py` (clean)
- `uv run mypy alberta_framework/core/stacked_horde.py` (clean)
