### PR TITLE
fix(core): cap working-memory decay rate cardinality (#2220)

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -69,6 +69,7 @@ from alberta_framework.core.working_memory import (
     WorkingMemoryState,
 )
 
+_MAX_FIXED_TRACE_DECAY_RATES = 1 << 12  # 4096
 _INT32_MAX = 2**31 - 1
 _ACTUAL_INT_TYPES = frozenset(
     {
@@ -119,6 +120,10 @@ def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
     rates = cast(tuple[object, ...], value)
+    if len(rates) > _MAX_FIXED_TRACE_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_FIXED_TRACE_DECAY_RATES} decay rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",
@@ -1036,12 +1041,17 @@ class FixedTraceStateBuilderConfig:
         obs_decays = data["observation_decay_rates"]
         act_decays = data["action_decay_rates"]
         out_decays = data["outcome_decay_rates"]
-        if (
-            not isinstance(obs_decays, (list, tuple))
-            or not isinstance(act_decays, (list, tuple))
-            or not isinstance(out_decays, (list, tuple))
+        for field_name, val in (
+            ("observation_decay_rates", obs_decays),
+            ("action_decay_rates", act_decays),
+            ("outcome_decay_rates", out_decays),
         ):
-            raise ValueError("decay rates must be lists or tuples")
+            if type(val) not in (list, tuple):
+                raise ValueError("decay rates must be lists or tuples")
+            if len(val) > _MAX_FIXED_TRACE_DECAY_RATES:
+                raise ValueError(
+                    f"{field_name} must not exceed {_MAX_FIXED_TRACE_DECAY_RATES} items"
+                )
         return cls(
             observation_dim=data["observation_dim"],
             n_actions=data["n_actions"],

--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -124,8 +124,17 @@ class WorkingMemoryConfig:
             if key in payload:
                 value = payload[key]
                 if type(value) is list:
+                    if len(value) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                        raise ValueError(
+                            f"{key} must not exceed {_MAX_WORKING_MEMORY_DECAY_RATES} items"
+                        )
                     payload[key] = tuple(value)
-                elif type(value) is not tuple:
+                elif type(value) is tuple:
+                    if len(value) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                        raise ValueError(
+                            f"{key} must not exceed {_MAX_WORKING_MEMORY_DECAY_RATES} items"
+                        )
+                else:
                     raise ValueError(f"{key} must be an actual list or tuple")
                 if any(type(item) is not float for item in payload[key]):
                     raise ValueError(f"serialized {key} values must be JSON numbers")
@@ -215,6 +224,7 @@ class WorkingMemoryArrayResult:
         yield self.features
 
 
+_MAX_WORKING_MEMORY_DECAY_RATES = 1 << 12  # 4096
 _INT32_MAX = 2**31 - 1
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
@@ -287,6 +297,10 @@ def _require_array(
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    if len(rates) > _MAX_WORKING_MEMORY_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_WORKING_MEMORY_DECAY_RATES} decay rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",

--- a/tests/test_working_memory.py
+++ b/tests/test_working_memory.py
@@ -756,3 +756,31 @@ def test_zero_decay_does_not_multiply_inf_traces() -> None:
     )
     assert bool(result.update_applied)
     chex.assert_trees_all_close(result.state.observation_traces, obs[None, :])
+
+
+def test_working_memory_cardinality_bounds() -> None:
+    from alberta_framework.core.working_memory import _MAX_WORKING_MEMORY_DECAY_RATES
+
+    assert _MAX_WORKING_MEMORY_DECAY_RATES == 4096
+
+    # Rejection of decay rates > 4096
+    with pytest.raises(ValueError, match="must contain at most 4096 decay rates"):
+        WorkingMemoryConfig(
+            observation_dim=1,
+            observation_decay_rates=(0.5,) * 4097,
+        )
+
+    # Acceptance of boundary case 4096
+    cfg = WorkingMemoryConfig(
+        observation_dim=1,
+        observation_decay_rates=(0.5,) * 4096,
+        action_decay_rates=(),
+        reward_decay_rates=(),
+    )
+    assert len(cfg.observation_decay_rates) == 4096
+
+    # from_config rejects oversized sequences (> 4096)
+    cfg_dict = cfg.to_config()
+    cfg_dict["observation_decay_rates"] = [0.5] * 4097
+    with pytest.raises(ValueError, match="must not exceed 4096 items"):
+        WorkingMemoryConfig.from_config(cfg_dict)


### PR DESCRIPTION
Fixes #2220.

## Summary
In `alberta_framework/core/working_memory.py` and `alberta_framework/core/state_builder.py`, decay rate sequences were iterated through per-element validation and deserialization without first checking an upper cardinality limit (`_MAX_WORKING_MEMORY_DECAY_RATES = 4096`), unlike peer modules.

## Proposed Changes
1. Added `_MAX_WORKING_MEMORY_DECAY_RATES = 4096` in `working_memory.py` and enforced cardinality bounds in `_validate_decay_rates` and `WorkingMemoryConfig.from_config`.
2. Added `_MAX_FIXED_TRACE_DECAY_RATES = 4096` in `state_builder.py` and enforced cardinality bounds in `_require_decay_rates` and `FixedTraceStateBuilderConfig.from_config`.
3. Added unit tests in `tests/test_working_memory.py`.

## Test Plan
- `uv run pytest tests/test_working_memory.py tests/test_state_builder.py` (181 passed)
- `uv run ruff check alberta_framework/core/working_memory.py alberta_framework/core/state_builder.py tests/test_working_memory.py` (clean)
- `uv run mypy alberta_framework/core/working_memory.py alberta_framework/core/state_builder.py` (clean)
