### PR TITLE
fix(steps): bound Step 7 planning and Step 9 dreaming loop lengths (#2214)

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -59,6 +59,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._scan_resources import ScanBudget
 from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.average_reward import (
     DifferentialSARSAAgent,
@@ -161,6 +162,8 @@ class Step7DynaConfig:
 
 
 _INT32_MAX = 2**31 - 1
+_STEP7_PLANNING_BUDGET = ScanBudget("Step 7 planning", maximum_steps=10_000)
+_STEP7_ROLLOUT_BUDGET = ScanBudget("Step 7 planning rollout", maximum_steps=10_000)
 _STEP7_CONFIG_FIELDS = frozenset(
     {
         "control",
@@ -258,7 +261,9 @@ def _require_int(
             raise ValueError(f"{name} must be non-negative")
         raise ValueError(f"{name} must be >= {minimum}")
     if maximum is not None and number > maximum:
-        raise ValueError(f"{name} must be at most int32 max")
+        if maximum == _INT32_MAX:
+            raise ValueError(f"{name} must be at most int32 max")
+        raise ValueError(f"{name} must be <= {maximum}")
     return number
 
 
@@ -279,13 +284,13 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
         "planning_steps",
         config.planning_steps,
         minimum=0,
-        maximum=_INT32_MAX,
+        maximum=_STEP7_PLANNING_BUDGET.maximum_steps,
     )
     planning_rollout_depth = _require_int(
         "planning_rollout_depth",
         config.planning_rollout_depth,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_STEP7_ROLLOUT_BUDGET.maximum_steps,
     )
     planning_warmup_steps = _require_int(
         "planning_warmup_steps",

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -36,6 +36,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._scan_resources import ScanBudget
 from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.average_reward import (
     DifferentialSARSAAgent,
@@ -71,6 +72,9 @@ from alberta_framework.steps.step6 import (
 )
 
 _INT32_MAX = 2**31 - 1
+_STEP9_PLANNING_BUDGET = ScanBudget("Step 9 dream planning", maximum_steps=10_000)
+_STEP9_ROLLOUT_BUDGET = ScanBudget("Step 9 dream rollout", maximum_steps=10_000)
+_STEP9_CANDIDATE_BUDGET = ScanBudget("Step 9 dream candidate", maximum_steps=10_000)
 _MAX_CONFIG_SEQUENCE_LENGTH = 4_096
 _MAX_DREAM_WORK_PER_REAL_STEP = 4_096
 # Matches the established ceiling for other scan-driven array-loop runners
@@ -426,20 +430,23 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         config.behavior_model_step_size,
     )
     planning_budget = _require_int(
-        "planning_budget", config.planning_budget, minimum=0, maximum=_INT32_MAX
+        "planning_budget",
+        config.planning_budget,
+        minimum=0,
+        maximum=_STEP9_PLANNING_BUDGET.maximum_steps,
     )
     dream_rollout_horizon = _require_int(
         "dream_rollout_horizon",
         config.dream_rollout_horizon,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_STEP9_ROLLOUT_BUDGET.maximum_steps,
     )
     # Candidate selection publishes selected indices as signed int32 values.
     dream_candidate_count = _require_int(
         "dream_candidate_count",
         config.dream_candidate_count,
         minimum=1,
-        maximum=_INT32_MAX,
+        maximum=_STEP9_CANDIDATE_BUDGET.maximum_steps,
     )
     dream_surprise_weight = _require_real(
         "dream_surprise_weight",

--- a/tests/test_step7_hostile_validation.py
+++ b/tests/test_step7_hostile_validation.py
@@ -293,3 +293,18 @@ def test_smoke_preflights_all_live_arrays_before_allocation(
     monkeypatch.setattr(jr, "normal", unexpected_allocation)
     with pytest.raises(ValueError, match="smoke resources"):
         run_step7_smoke(steps=50_000_000)
+
+
+def test_step7_planning_and_rollout_depth_scan_budget_bounds() -> None:
+    from alberta_framework.steps.step7 import Step7DynaConfig
+
+    with pytest.raises(ValueError, match=r"planning_steps must be <= 10000"):
+        Step7DynaConfig(planning_steps=10_001)
+
+    with pytest.raises(ValueError, match=r"planning_rollout_depth must be <= 10000"):
+        Step7DynaConfig(planning_rollout_depth=10_001)
+
+    # Acceptance of boundary values
+    cfg = Step7DynaConfig(planning_steps=10_000, planning_rollout_depth=10_000)
+    assert cfg.planning_steps == 10_000
+    assert cfg.planning_rollout_depth == 10_000

--- a/tests/test_step9_hostile_validation.py
+++ b/tests/test_step9_hostile_validation.py
@@ -409,3 +409,23 @@ def test_run_step9_scan_accepts_a_small_in_bounds_sequence() -> None:
     cfg, agent, model, buffer, state, rewards, next_observations = _step9_scan_components(4)
     result = run_step9_scan(cfg, agent, model, buffer, state, rewards, next_observations)
     assert result.real_td_errors.shape == (4,)
+
+
+def test_step9_dreaming_scan_budget_bounds() -> None:
+    from alberta_framework.steps.step9 import Step9DreamingConfig
+
+    with pytest.raises(ValueError, match=r"planning_budget must be <= 10000"):
+        Step9DreamingConfig(planning_budget=10_001)
+
+    with pytest.raises(ValueError, match=r"dream_rollout_horizon must be <= 10000"):
+        Step9DreamingConfig(dream_rollout_horizon=10_001)
+
+    with pytest.raises(ValueError, match=r"dream_candidate_count must be <= 10000"):
+        Step9DreamingConfig(dream_candidate_count=10_001)
+
+    # Acceptance of boundary values (when planning_budget=0, dream work is 0 <= 4096)
+    cfg1 = Step9DreamingConfig(planning_budget=0, dream_rollout_horizon=10_000)
+    assert cfg1.dream_rollout_horizon == 10_000
+
+    cfg2 = Step9DreamingConfig(planning_budget=0, dream_candidate_count=10_000)
+    assert cfg2.dream_candidate_count == 10_000


### PR DESCRIPTION
Fixes #2214.

## Summary
In `alberta_framework/steps/step7.py` and `alberta_framework/steps/step9.py`, inner planning and dreaming loop lengths were bounded only up to `_INT32_MAX` before feeding static `jnp.arange(...)` scan generators. Hostile or oversized configurations could attempt multi-gigabyte memory materializations and billion-iteration compiled loops at JAX trace time.

## Proposed Changes
1. Added auditable `ScanBudget` bounds (maximum 10,000 steps matching module precedents in `core.dreaming`) for:
   - Step 7 `planning_steps` and `planning_rollout_depth`.
   - Step 9 `planning_budget`, `dream_rollout_horizon`, and `dream_candidate_count`.
2. Updated config validators in `step7.py` and `step9.py` to enforce these scan bounds during configuration validation.
3. Added unit tests in `tests/test_step7_hostile_validation.py` and `tests/test_step9_hostile_validation.py`.

## Test Plan
- `uv run pytest tests/test_step7_hostile_validation.py tests/test_step9_hostile_validation.py` (46 passed)
- `uv run ruff check alberta_framework/steps/step7.py alberta_framework/steps/step9.py tests/test_step7_hostile_validation.py tests/test_step9_hostile_validation.py` (clean)
- `uv run mypy alberta_framework/steps/step7.py alberta_framework/steps/step9.py` (clean)
