### PR TITLE
fix(core): ensure _normalize_simplex in upgd_memory returns a valid simplex (#2470)

### DIFF
--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -675,7 +675,20 @@ def _active_mse(prediction: Array, target: Array) -> Array:
 
 def _normalize_simplex(prediction: Array) -> Array:
     clipped = jnp.maximum(prediction, 0.0)
-    return clipped / jnp.maximum(jnp.sum(clipped), 1e-12)
+    total_mass = jnp.sum(clipped, axis=-1, keepdims=True)
+    valid_mass = jnp.isfinite(total_mass) & (total_mass > 0.0)
+    normalized = jnp.where(
+        valid_mass,
+        clipped / jnp.where(valid_mass, total_mass, 1.0),
+        jnp.ones_like(clipped) / clipped.shape[-1],
+    )
+    norm_sum = jnp.sum(normalized, axis=-1, keepdims=True)
+    valid_norm = jnp.isfinite(norm_sum) & (norm_sum > 0.0)
+    return jnp.where(
+        valid_norm,
+        normalized / jnp.where(valid_norm, norm_sum, 1.0),
+        jnp.ones_like(clipped) / clipped.shape[-1],
+    )
 
 
 class UPGDMemoryLearner:

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -564,3 +564,20 @@ def test_upgd_memory_preserves_legal_closed_endpoints() -> None:
     assert allocation_endpoint.target_allocation_rate == 1.0
     assert fixed_threshold.min_novelty_threshold == 0.5
     assert fixed_threshold.max_novelty_threshold == 0.5
+
+
+def test_normalize_simplex_returns_valid_simplex_on_degenerate_inputs() -> None:
+    import numpy as np
+
+    from alberta_framework.core.upgd_memory import _normalize_simplex
+
+    for p in (
+        [0.0, 0.0, 0.0],
+        [-1.0, -2.0, -3.0],
+        [1e38, 1.0, 1.0],
+        [7.5e-13, 0.0, 0.0],
+        [1e-30, 0.0, 0.0],
+    ):
+        out = _normalize_simplex(jnp.asarray(p, dtype=jnp.float32))
+        np.testing.assert_allclose(float(jnp.sum(out)), 1.0, atol=1e-6)
+        assert bool(jnp.all(out >= 0.0))


### PR DESCRIPTION
Fixes #2470.

## Summary
In `alberta_framework/core/upgd_memory.py`, `_normalize_simplex` computed `clipped / jnp.maximum(jnp.sum(clipped), 1e-12)`. When inputs contained zero mass, negative values only, underflowing ratios in float32, or positive totals below `1e-12`, `_normalize_simplex` returned non-simplex vectors (summing to 0 or < 1). When `UPGDLearner` initialized `previous_targets` to zeros, blending against this non-simplex vector silently lost up to 80% of prediction mass without raising.

## Proposed Changes
1. Updated `_normalize_simplex` in `upgd_memory.py` to divide by positive finite `total_mass` and renormalize, falling back to uniform `1.0 / n_actions` when total mass is zero, negative, non-finite, or when normalized ratios underflow.
2. Added unit tests in `tests/test_upgd_memory.py` verifying that degenerate, underflowing, and sub-floor inputs return valid simplices summing to 1.0.

## Test Plan
- `uv run pytest tests/test_upgd_memory.py` (134 passed)
- `uv run ruff check alberta_framework/core/upgd_memory.py tests/test_upgd_memory.py` (clean)
- `uv run mypy alberta_framework/core/upgd_memory.py` (clean)
