### PR TITLE
fix(core): cap PrototypeAgentConfig.n_dreams_per_step to prevent OOM/hang (#2441)

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -184,6 +184,7 @@ _PROTOTYPE_V2_REPLAY_MIGRATION_TAG = 0x50525632
 _PROTOTYPE_FEATURE_LIFECYCLE_KEY_TAG = 0x50464C43
 _UINT32_MAX = 2**32 - 1
 _INT32_MAX = 2**31 - 1
+_MAX_DREAMS_PER_STEP = 10_000
 
 # ---------------------------------------------------------------------------
 # Standalone utility
@@ -725,7 +726,7 @@ class PrototypeAgentConfig:
                 "n_dreams_per_step",
                 self.n_dreams_per_step,
                 minimum=0,
-                maximum=_INT32_MAX,
+                maximum=_MAX_DREAMS_PER_STEP,
             ),
         )
         # horde_hidden_sizes: hostile-safe per-element validation
@@ -1335,7 +1336,10 @@ class PrototypeAgentConfig:
             "buffer_capacity", data.pop("buffer_capacity", 200), minimum=1, maximum=_INT32_MAX
         )
         n_dreams_per_step = _require_int(
-            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=_INT32_MAX
+            "n_dreams_per_step",
+            data.pop("n_dreams_per_step", 0),
+            minimum=0,
+            maximum=_MAX_DREAMS_PER_STEP,
         )
         dream_next_observation_mode = data.pop(
             "dream_next_observation_mode",

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -1357,3 +1357,18 @@ class TestAutoCurate:
             state = result.state
         # Fires at step_count 0, 5, 10 → exactly 3
         assert curations == 3
+
+
+def test_prototype_agent_n_dreams_per_step_bounds() -> None:
+    from alberta_framework.core.prototype_agent import PrototypeAgentConfig
+
+    with pytest.raises(ValueError, match=r"n_dreams_per_step"):
+        PrototypeAgentConfig(oak=_oak_cfg(), world_model=_wm_cfg(), n_dreams_per_step=10_001)
+
+    cfg = PrototypeAgentConfig(oak=_oak_cfg(), world_model=_wm_cfg(), n_dreams_per_step=10_000)
+    assert cfg.n_dreams_per_step == 10_000
+
+    cfg_dict = cfg.to_config()
+    cfg_dict["n_dreams_per_step"] = 10_001
+    with pytest.raises(ValueError, match=r"n_dreams_per_step"):
+        PrototypeAgentConfig.from_config(cfg_dict)


### PR DESCRIPTION
Fixes #2441.

## Summary
In `alberta_framework/core/prototype_agent.py`, `PrototypeAgentConfig.n_dreams_per_step` was validated only against `_INT32_MAX` before driving static `jnp.arange(self._config.n_dreams_per_step)` inside `jax.lax.scan`. Values exceeding practical memory bounds caused gigabytes of allocations or hangs during compilation.

## Proposed Changes
1. Defined `_MAX_DREAMS_PER_STEP = 10_000` matching scan budgets in `core.dreaming`.
2. Bounded `n_dreams_per_step` in `PrototypeAgentConfig.__post_init__` and `PrototypeAgentConfig.from_config`.
3. Added unit tests in `tests/test_prototype_agent.py`.

## Test Plan
- `uv run pytest -k "test_prototype_agent_n_dreams_per_step_bounds" tests/test_prototype_agent.py` (1 passed)
- `uv run ruff check alberta_framework/core/prototype_agent.py tests/test_prototype_agent.py` (clean)
- `uv run mypy alberta_framework/core/prototype_agent.py` (clean)
