### PR TITLE
fix(core): align MLP baseline optimizer error contract

### DIFF
--- a/alberta_framework/core/baseline_optimizers.py
+++ b/alberta_framework/core/baseline_optimizers.py
@@ -512,8 +512,10 @@ class Adam(Optimizer[Any]):
 
     For the MLP path (:meth:`update_from_gradient`), the gradient is
     pre-computed by the caller (e.g. an eligibility trace or a VJP
-    cotangent), and the returned step does NOT include the error --
-    callers apply ``param += step`` directly.
+    cotangent).  With ``error=None`` the gradient is the loss gradient
+    and callers apply ``param -= step``; with ``error`` supplied the
+    gradient is the prediction gradient, the returned step excludes the
+    error, and callers apply ``param += error * step``.
 
     With nonzero ``weight_decay``, the MLP path implements decoupled
     weight decay (AdamW; Loshchilov & Hutter 2019): the returned step
@@ -649,22 +651,28 @@ class Adam(Optimizer[Any]):
     ) -> ParamOptimizerUpdate:
         """Compute Adam step from a pre-computed gradient (MLP path).
 
-        The returned step has the SAME sign as the descent step, i.e.
-        callers apply ``param -= step`` to minimize loss when the
-        gradient is the loss gradient. When the gradient is the
-        prediction gradient ``dy/dw`` and the caller wants to do
-        ``param += error * step``, ``error`` should be passed so it is
-        folded into the moment EMAs.
-
         When ``error`` is ``None``, the gradient is assumed to already
-        be the loss gradient and is used as-is.
+        be the loss gradient; the returned step is the descent step and
+        callers apply ``param -= step`` to minimize loss.
+
+        When ``error`` is provided, the gradient is the prediction
+        gradient ``dy/dw``: the moment EMAs accumulate the loss gradient
+        ``-error * gradient`` (for ``loss = 0.5 * error^2``) exactly as
+        the linear :meth:`update` path does, and the returned step
+        follows the framework gradient-path contract -- it excludes the
+        error, and callers apply ``param += error * step``.  That
+        application reproduces the descent delta whenever ``error`` is
+        nonzero; at exactly zero error the parameter is left unchanged
+        while the moments still decay.
 
         Args:
             state: Current per-parameter Adam state
             gradient: Pre-computed gradient (any shape matching state)
             error: Optional prediction error scalar. When provided, the
                 effective gradient becomes ``-error * gradient`` (loss
-                gradient direction for ``loss = 0.5 * error^2``).
+                gradient direction for ``loss = 0.5 * error^2``) and the
+                returned step is for ``param += error * step``
+                application.
             param: Current parameter values; required when the optimizer
                 was constructed with nonzero ``weight_decay`` so the
                 decoupled decay term ``step_size * weight_decay * param``
@@ -699,6 +707,13 @@ class Adam(Optimizer[Any]):
         step = state.step_size * m_hat / (jnp.sqrt(v_hat) + state.eps)
         if self._weight_decay != 0.0 and param is not None:
             step = step + state.step_size * self._weight_decay * param
+        if error is not None:
+            # Callers apply ``param += error * step``; dividing the descent
+            # step by the error keeps the applied delta equal to ``-step``.
+            error_scalar = jnp.squeeze(error)
+            error_is_nonzero = error_scalar != 0.0
+            safe_error = jnp.where(error_is_nonzero, error_scalar, 1.0)
+            step = jnp.where(error_is_nonzero, -step / safe_error, jnp.zeros_like(step))
 
         candidate_state = AdamParamState(
             m=new_m,
@@ -952,14 +967,23 @@ class RMSprop(Optimizer[Any]):
     ) -> ParamOptimizerUpdate:
         """Compute RMSprop step from a pre-computed gradient (MLP path).
 
-        When ``error`` is supplied, the effective gradient is treated as
-        ``-error * gradient`` (loss gradient for squared error); when it
-        is ``None`` the gradient is used as-is (already a loss gradient).
+        When ``error`` is ``None``, the gradient is used as-is (already a
+        loss gradient); the returned step is the descent step and callers
+        apply ``param -= step``.
+
+        When ``error`` is supplied, the gradient is the prediction
+        gradient ``dy/dw``: the squared-gradient EMA accumulates the loss
+        gradient ``-error * gradient`` (for ``loss = 0.5 * error^2``), and
+        the returned step follows the framework gradient-path contract --
+        it excludes the error, and callers apply ``param += error * step``.
+        That application equals the descent delta
+        ``step_size * error * gradient / (sqrt(v) + eps)`` exactly.
 
         Args:
             state: Current per-parameter RMSprop state
             gradient: Pre-computed gradient (any shape matching state)
-            error: Optional prediction error scalar
+            error: Optional prediction error scalar. When provided, the
+                returned step is for ``param += error * step`` application.
 
         Returns:
             ``(step, new_state)`` -- step has the same shape as gradient
@@ -972,7 +996,12 @@ class RMSprop(Optimizer[Any]):
         new_v = _skip_zero_scale(self._decay, state.decay, state.v) + (
             1.0 - state.decay
         ) * g**2
-        step = state.step_size * g / (jnp.sqrt(new_v) + state.eps)
+        if error is not None:
+            # Callers apply ``param += error * step``, which reproduces the
+            # descent delta ``-step_size * g / (sqrt(v) + eps)`` exactly.
+            step = state.step_size * gradient / (jnp.sqrt(new_v) + state.eps)
+        else:
+            step = state.step_size * g / (jnp.sqrt(new_v) + state.eps)
 
         candidate_state = RMSpropParamState(
             v=new_v,

--- a/tests/test_baseline_optimizers.py
+++ b/tests/test_baseline_optimizers.py
@@ -16,6 +16,8 @@ forgetting_rate=0.1``), and round-trip tests use arbitrary nondefault
 values so serialization bugs cannot hide behind defaults.
 """
 
+import math
+
 import chex
 import jax.numpy as jnp
 import pytest
@@ -577,3 +579,73 @@ class TestNADALINE:
         chex.assert_tree_all_finite(result.new_state)
         chex.assert_tree_all_finite(result.weight_delta)
         chex.assert_tree_all_finite(result.bias_delta)
+
+
+# =============================================================================
+# Gradient-path error contract (MLP path)
+# =============================================================================
+
+
+class TestGradientPathErrorContract:
+    """Callers of the gradient path apply ``param += error * step``.
+
+    The framework-wide gradient-path contract
+    (:meth:`Optimizer.update_from_gradient`) returns a step that excludes the
+    error; MLP-path learners then apply ``param += error * step``.  For Adam
+    and RMSprop that application must reproduce each method's own descent
+    update for ``loss = 0.5 * error**2``, matching the linear path's moment
+    accumulation on the loss gradient ``-error * gradient``.
+    """
+
+    def test_adam_first_step_applies_descent_delta(self):
+        optimizer = Adam(step_size=0.1)
+        state = optimizer.init_for_shape((1,))
+        gradient = jnp.array([1.0])
+        error = jnp.array(0.5)
+        result = optimizer.update_from_gradient_checked(state, gradient, error=error)
+        assert bool(result.update_applied)
+        applied = float(error * result.step[0])
+        g = float(error) * float(gradient[0])
+        expected = 0.1 * g / (abs(g) + 1e-8)
+        assert applied == pytest.approx(expected, rel=1e-5)
+
+    def test_rmsprop_first_step_applies_descent_delta(self):
+        optimizer = RMSprop(step_size=0.1, decay=0.99)
+        state = optimizer.init_for_shape((1,))
+        gradient = jnp.array([1.0])
+        error = jnp.array(0.5)
+        result = optimizer.update_from_gradient_checked(state, gradient, error=error)
+        assert bool(result.update_applied)
+        applied = float(error * result.step[0])
+        g = float(error) * float(gradient[0])
+        expected = 0.1 * g / (math.sqrt((1.0 - 0.99) * g * g) + 1e-8)
+        assert applied == pytest.approx(expected, rel=1e-4)
+
+    @pytest.mark.parametrize("make_optimizer", [Adam, RMSprop])
+    def test_scalar_regression_converges_to_target(self, make_optimizer):
+        optimizer = make_optimizer(step_size=0.1)
+        state = optimizer.init_for_shape(())
+        w = jnp.asarray(0.0, dtype=jnp.float32)
+        for _ in range(200):
+            error = jnp.asarray(1.0, dtype=jnp.float32) - w
+            result = optimizer.update_from_gradient_checked(
+                state, jnp.asarray(1.0, dtype=jnp.float32), error=error
+            )
+            assert bool(result.update_applied)
+            state = result.new_state
+            w = w + error * result.step
+        assert float(w) == pytest.approx(1.0, abs=0.05)
+
+    @pytest.mark.parametrize("make_optimizer", [Adam, RMSprop])
+    def test_zero_error_step_is_finite_and_committed(self, make_optimizer):
+        optimizer = make_optimizer(step_size=0.1)
+        state = optimizer.init_for_shape((2,))
+        gradient = jnp.array([1.0, -1.0])
+        seeded = optimizer.update_from_gradient_checked(
+            state, gradient, error=jnp.asarray(0.5, dtype=jnp.float32)
+        )
+        result = optimizer.update_from_gradient_checked(
+            seeded.new_state, gradient, error=jnp.asarray(0.0, dtype=jnp.float32)
+        )
+        assert bool(result.update_applied)
+        assert bool(jnp.all(jnp.isfinite(result.step)))

--- a/tests/test_mlp_learner.py
+++ b/tests/test_mlp_learner.py
@@ -27,6 +27,8 @@ from alberta_framework import (
     run_mlp_learning_loop,
     run_mlp_learning_loop_batched,
 )
+from alberta_framework.core.baseline_optimizers import Adam as BaselineAdam
+from alberta_framework.core.baseline_optimizers import RMSprop as BaselineRMSprop
 
 
 class TestMLPLearner:
@@ -1579,3 +1581,37 @@ def test_mlp_dimensions_are_exact_canonical_and_preflighted() -> None:
         learner.init(True, jr.key(0))
     with pytest.raises(ValueError, match="resource"):
         MLPLearner(hidden_sizes=(2**26,)).init(2, jr.key(0))
+
+
+class TestBaselineOptimizerLearning:
+    """Pluggable Adam/RMSprop must descend through the MLP path.
+
+    Regression test for the inverted error contract where
+    ``update_from_gradient_checked`` folded ``-error`` into the returned step
+    while ``MLPLearner`` applied ``param += error * step``, yielding gradient
+    ascent proportional to ``-error**2``.
+    """
+
+    @pytest.mark.parametrize("make_optimizer", [BaselineAdam, BaselineRMSprop])
+    def test_mlp_learns_stationary_linear_target(self, make_optimizer):
+        learner = MLPLearner(
+            hidden_sizes=(8,),
+            optimizer=make_optimizer(step_size=0.01),
+            use_layer_norm=False,
+            sparsity=0.0,
+        )
+        state = learner.init(feature_dim=2, key=jr.key(0))
+        key = jr.key(1)
+        squared_errors = []
+        for _ in range(300):
+            key, sample_key = jr.split(key)
+            observation = jr.uniform(sample_key, (2,), minval=-1.0, maxval=1.0)
+            target = jnp.atleast_1d(3.0 * observation[0] - 2.0 * observation[1])
+            result = learner.update(state, observation, target)
+            assert bool(result.update_applied)
+            state = result.state
+            squared_errors.append(float(result.metrics[0]))
+        first = sum(squared_errors[:50]) / 50.0
+        last = sum(squared_errors[-50:]) / 50.0
+        assert math.isfinite(last)
+        assert last < first


### PR DESCRIPTION
Summary:
- Make Adam and RMSprop gradient-path updates honor the MLPLearner parameter-plus-e times-step contract.
- Preserve loss-gradient moment accumulation while excluding the prediction error from returned steps.
- Cover scalar convergence, zero-error behavior, and end-to-end MLP learning.

Reproduced defect:
Adam and RMSprop folded negative prediction error into the returned step while MLPLearner multiplied by prediction error again, producing an ascent-direction update proportional to negative error squared.

Verification:
/root/asi/.venv/bin/python -m pytest tests/test_baseline_optimizers.py tests/test_mlp_learner.py -q
153 passed.