### PR TITLE
fix(utils): require timeseries seed-step matrix

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -337,9 +337,15 @@ def compute_timeseries_statistics(
         Tuple of (mean, ci_lower, ci_upper) arrays of shape (n_steps,)
 
     Raises:
-        ValueError: If metric_array has no seed rows, any sample is
-            non-finite, or ``confidence_level`` is not strictly between 0 and 1.
+        ValueError: If metric_array is not a two-dimensional seed-by-step
+            matrix, has no seed rows, contains a non-finite sample, or
+            ``confidence_level`` is not strictly between 0 and 1.
     """
+    if metric_array.ndim != 2:
+        raise ValueError(
+            "metric_array must be a two-dimensional seed-by-step matrix "
+            f"(got shape {metric_array.shape})"
+        )
     n_seeds = metric_array.shape[0]
     if n_seeds == 0:
         raise ValueError("metric_array must contain at least one seed row")

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -363,6 +363,23 @@ class TestProbabilityContracts:
 
 
 class TestTimeseriesStatistics:
+    @pytest.mark.parametrize(
+        "metric_array",
+        [
+            np.asarray(1.0, dtype=np.float64),
+            np.asarray([1.0, 2.0, 3.0], dtype=np.float64),
+            np.ones((2, 3, 4), dtype=np.float64),
+        ],
+    )
+    def test_requires_seed_by_step_matrix(
+        self, metric_array: np.ndarray[Any, np.dtype[np.float64]]
+    ) -> None:
+        with pytest.raises(
+            ValueError,
+            match=r"^metric_array must be a two-dimensional seed-by-step matrix",
+        ):
+            compute_timeseries_statistics(metric_array)
+
     def test_matches_per_column_compute_statistics(self) -> None:
         """Vectorised timeseries CI agrees with per-step scalar CI."""
         rng = np.random.default_rng(2)


### PR DESCRIPTION
Makes timeseries statistics reject scalar, vector, and higher-rank inputs instead of accepting ambiguous shapes. Adds regression coverage for the exact rank contract.

Verification: /root/asi/.venv/bin/python -m pytest tests/test_statistics_validation.py -q
242 passed, 2 existing SciPy precision-loss warnings.