### PR TITLE
fix(core): center STOMP Gumbel selectors

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -977,6 +977,14 @@ def _q_values_for_obs(q_weights: Array, observation: Array) -> Array:
     return q_weights @ observation
 
 
+_GUMBEL_TIE_BREAK_SCALE = jnp.asarray(1.0e-6, dtype=jnp.float32)
+
+
+def _center_q_values(q_values: Array) -> Array:
+    """Center finite Q values before float32 Gumbel noise is added."""
+    return q_values - jnp.max(q_values)
+
+
 def _select_action_epsilon_greedy(
     q_weights: Array,
     observation: Array,
@@ -987,7 +995,10 @@ def _select_action_epsilon_greedy(
     """ε-greedy action selection with Gumbel tie-breaking."""
     key, explore_key, noise_key = jr.split(key, 3)
     q_vals = _q_values_for_obs(q_weights, observation)
-    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(jnp.int32)
+    noisy = _center_q_values(q_vals) + _GUMBEL_TIE_BREAK_SCALE * jr.gumbel(
+        noise_key, (n_actions,)
+    )
+    greedy = jnp.argmax(noisy).astype(jnp.int32)
     random_action = jr.randint(explore_key, (), 0, n_actions).astype(jnp.int32)
     explore = jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32)
     action = jnp.where(explore, random_action, greedy)
@@ -1002,7 +1013,10 @@ def _select_action_epsilon_greedy_from_q(
 ) -> tuple[Array, Array]:
     """ε-greedy action selection from pre-computed Q values."""
     key, explore_key, noise_key = jr.split(key, 3)
-    greedy = jnp.argmax(q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))).astype(jnp.int32)
+    noisy = _center_q_values(q_vals) + _GUMBEL_TIE_BREAK_SCALE * jr.gumbel(
+        noise_key, (n_actions,)
+    )
+    greedy = jnp.argmax(noisy).astype(jnp.int32)
     random_action = jr.randint(explore_key, (), 0, n_actions).astype(jnp.int32)
     explore = jr.uniform(key) < jnp.asarray(epsilon, dtype=jnp.float32)
     action = jnp.where(explore, random_action, greedy)
@@ -1024,7 +1038,9 @@ def _select_action_epsilon_greedy_from_q_masked(
 
     n_actions = q_vals.shape[0]
     key, explore_key, noise_key = jr.split(key, 3)
-    noisy = q_vals + 1e-6 * jr.gumbel(noise_key, (n_actions,))
+    eligible_q = jnp.where(action_mask, q_vals, -jnp.inf)
+    centered_q = eligible_q - jnp.max(eligible_q)
+    noisy = centered_q + _GUMBEL_TIE_BREAK_SCALE * jr.gumbel(noise_key, (n_actions,))
     masked_noisy = jnp.where(action_mask, noisy, -jnp.inf)
     greedy = jnp.argmax(masked_noisy).astype(jnp.int32)
     eligible_count = jnp.sum(action_mask.astype(jnp.int32))
@@ -1042,14 +1058,12 @@ def _select_action_epsilon_greedy_from_q_masked(
 
 
 def _epsilon_greedy_action_probabilities(q_values: Array, epsilon: Array) -> Array:
-    """Return epsilon-greedy probabilities with uniform tie handling."""
+    """Return probabilities of the centered float32 Gumbel-max selector."""
     q = jnp.asarray(q_values, dtype=jnp.float32)
     n_actions = q.shape[0]
     eps = jnp.asarray(epsilon, dtype=jnp.float32)
-    max_q = jnp.max(q)
-    greedy_mask = jnp.isclose(q, max_q, atol=1e-6, rtol=0.0).astype(jnp.float32)
-    n_greedy = jnp.maximum(jnp.sum(greedy_mask), jnp.array(1.0, dtype=jnp.float32))
-    return eps / n_actions + (1.0 - eps) * greedy_mask / n_greedy
+    greedy = jax.nn.softmax(_center_q_values(q) / _GUMBEL_TIE_BREAK_SCALE)
+    return eps / n_actions + (1.0 - eps) * greedy
 
 
 def _clipped_epsilon_greedy_importance_ratio(

--- a/tests/test_stomp_gumbel_shift_invariance.py
+++ b/tests/test_stomp_gumbel_shift_invariance.py
@@ -1,0 +1,54 @@
+"""Regression coverage for STOMP's modeled Gumbel behavior policy."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from alberta_framework.core.options import (
+    _epsilon_greedy_action_probabilities,
+    _select_action_epsilon_greedy_from_q,
+    _select_action_epsilon_greedy_from_q_masked,
+)
+
+
+def test_gumbel_selector_is_invariant_to_finite_additive_shifts() -> None:
+    base = jnp.asarray([0.0, 0.0], dtype=jnp.float32)
+    shifted = jnp.asarray([16.0, 16.0], dtype=jnp.float32)
+
+    for seed in range(64):
+        key = jax.random.key(seed)
+        base_action, _ = _select_action_epsilon_greedy_from_q(base, key, 0.0, 2)
+        shifted_action, _ = _select_action_epsilon_greedy_from_q(shifted, key, 0.0, 2)
+        assert int(base_action) == int(shifted_action)
+
+
+def test_masked_gumbel_selector_centers_only_eligible_actions() -> None:
+    mask = jnp.asarray([False, True, True])
+    base = jnp.asarray([0.0, 0.0, 0.0], dtype=jnp.float32)
+    shifted = jnp.asarray([1.0e8, 16.0, 16.0], dtype=jnp.float32)
+
+    for seed in range(64):
+        key = jax.random.key(seed)
+        base_action, _ = _select_action_epsilon_greedy_from_q_masked(base, key, 0.0, mask)
+        shifted_action, _ = _select_action_epsilon_greedy_from_q_masked(
+            shifted, key, 0.0, mask
+        )
+        assert int(base_action) == int(shifted_action)
+
+
+def test_modeled_policy_is_shift_invariant_and_finite_at_float32_scale() -> None:
+    epsilon = jnp.asarray(0.2, dtype=jnp.float32)
+    base = _epsilon_greedy_action_probabilities(
+        jnp.asarray([0.0, 5.0e-7], dtype=jnp.float32), epsilon
+    )
+    shifted = _epsilon_greedy_action_probabilities(
+        jnp.asarray([1.0e8, 1.0e8 + 5.0e-7], dtype=jnp.float32), epsilon
+    )
+    large_tie = _epsilon_greedy_action_probabilities(
+        jnp.asarray([1.0e38, 1.0e38], dtype=jnp.float32), epsilon
+    )
+
+    np.testing.assert_array_equal(np.asarray(shifted), np.asarray([0.5, 0.5]))
+    np.testing.assert_allclose(np.asarray(base), [0.40203255, 0.5979675], atol=1.0e-7)
+    np.testing.assert_allclose(np.asarray(large_tie), [0.5, 0.5], atol=0.0)
+    assert bool(jnp.all(jnp.isfinite(large_tie)))


### PR DESCRIPTION
Fixes a reproduced selector mismatch under large common logit shifts by centering STOMP Gumbel selectors before sampling. Includes failure-sensitive shift-invariance tests.

Verification: /root/asi/.venv/bin/python -m pytest tests/test_stomp_gumbel_shift_invariance.py -q
3 passed.