### PR TITLE
fix(utils): reject empty timeseries axis

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -343,6 +343,8 @@ def compute_timeseries_statistics(
     n_seeds = metric_array.shape[0]
     if n_seeds == 0:
         raise ValueError("metric_array must contain at least one seed row")
+    if metric_array.ndim == 2 and metric_array.shape[1] == 0:
+        raise ValueError("metric_array must contain at least one time step")
     _require_finite_values(metric_array, name="metric_array")
     _validate_confidence_level(confidence_level)
     mean = np.mean(metric_array, axis=0)

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -383,6 +383,14 @@ class TestTimeseriesStatistics:
             ):
                 compute_timeseries_statistics(np.empty((0, 3)))
 
+    def test_zero_step_matrix_rejected_without_warnings(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(
+                ValueError, match=r"^metric_array must contain at least one time step$"
+            ):
+                compute_timeseries_statistics(np.empty((3, 0)))
+
     def test_nonfinite_seed_rejected_without_warnings(self) -> None:
         arr = np.array([[1.0, 2.0], [np.nan, 3.0]], dtype=np.float64)
         with warnings.catch_warnings():


### PR DESCRIPTION
Makes timeseries validation fail closed on empty seed or step axes, with a regression test for the previously accepted invalid input.

Verification: /root/asi/.venv/bin/python -m pytest tests/test_statistics_validation.py -q
240 passed, 2 existing SciPy precision-loss warnings.