### PR TITLE
fix(utils): report within-pair d_z for paired t-test and Wilcoxon (#2154)

### DIFF
--- a/alberta_framework/utils/statistics.py
+++ b/alberta_framework/utils/statistics.py
@@ -428,6 +428,40 @@ def cohens_d(
     return float((mean_a - mean_b) / pooled_std)
 
 
+def _paired_cohens_d(
+    values_a: NDArray[np.float64] | list[float],
+    values_b: NDArray[np.float64] | list[float],
+) -> float:
+    """Compute the paired Cohen's d_z effect size.
+
+    Standardizes the mean within-pair difference by the standard deviation
+    of the differences (``ddof=1``), cancelling variance shared across the
+    paired groups. A constant nonzero shift has zero difference variance
+    and reports a signed-infinite standardized difference, mirroring the
+    zero-pooled-variance convention in :func:`cohens_d`.
+    """
+    a = _require_sample_vector(values_a, name="values_a")
+    b = _require_sample_vector(values_b, name="values_b")
+    _require_finite_values(a, name="values_a")
+    _require_finite_values(b, name="values_b")
+    if len(a) != len(b):
+        raise ValueError(
+            f"paired effect size requires equal-length samples (got {len(a)} and {len(b)})"
+        )
+    if len(a) < 2:
+        raise ValueError(
+            f"paired effect size requires at least 2 pairs (got {len(a)})"
+        )
+    differences = a - b
+    mean_difference = float(np.mean(differences))
+    std_difference = float(np.std(differences, ddof=1))
+    if std_difference == 0:
+        if mean_difference == 0:
+            return 0.0
+        return float(np.copysign(np.inf, mean_difference))
+    return float(mean_difference / std_difference)
+
+
 def ttest_comparison(
     values_a: NDArray[np.float64] | list[float],
     values_b: NDArray[np.float64] | list[float],
@@ -447,7 +481,9 @@ def ttest_comparison(
         method_b: Name of second method
 
     Returns:
-        SignificanceResult with test results
+        SignificanceResult with test results. When ``paired`` is True the
+        reported ``effect_size`` is the within-pair Cohen's d_z; otherwise
+        it is the pooled independent-groups Cohen's d.
 
     Raises:
         ValueError: If ``alpha`` is not a finite probability strictly between
@@ -503,7 +539,7 @@ def ttest_comparison(
     except ImportError:
         raise ImportError("scipy is required for t-test. Install with: pip install scipy")
 
-    effect = cohens_d(a, b)
+    effect = _paired_cohens_d(a, b) if paired else cohens_d(a, b)
 
     return SignificanceResult(
         test_name=test_name,
@@ -601,10 +637,10 @@ def wilcoxon_comparison(
 ) -> SignificanceResult:
     """Perform Wilcoxon signed-rank test (paired non-parametric).
 
-    Caveat: the reported ``effect_size`` is Cohen's d computed on the raw
-    values, not a rank-based effect size.  The standard companion to this
+    Caveat: the reported ``effect_size`` is the within-pair Cohen's d_z,
+    not a rank-based effect size.  The standard companion to this
     test is the matched-pairs rank-biserial correlation; interpret the
-    parametric d alongside a rank test with care.
+    parametric d_z alongside a rank test with care.
 
     Args:
         values_a: Values for first method
@@ -657,7 +693,7 @@ def wilcoxon_comparison(
     except ImportError:
         raise ImportError("scipy is required for Wilcoxon test. Install with: pip install scipy")
 
-    effect = cohens_d(a, b)
+    effect = _paired_cohens_d(a, b)
 
     return SignificanceResult(
         test_name="Wilcoxon signed-rank",

--- a/tests/test_statistics_validation.py
+++ b/tests/test_statistics_validation.py
@@ -668,7 +668,8 @@ class TestIdenticalWilcoxonRejection:
         assert result.test_name == "Wilcoxon signed-rank"
         assert result.statistic == pytest.approx(0.0)
         assert result.p_value < 1.0
-        assert result.effect_size == cohens_d([1.0, 2.0, 3.0], [0.5, 1.5, 2.5])
+        # Paired d_z for a constant shift: zero difference variance.
+        assert np.isposinf(result.effect_size)
 
 
 class TestOneSampleRejection:
@@ -881,6 +882,30 @@ class TestEffectSizes:
 
     def test_cohens_d_zero_variance_returns_zero(self) -> None:
         assert cohens_d([3.0, 3.0, 3.0], [3.0, 3.0, 3.0]) == 0.0
+
+    def test_paired_ttest_effect_size_is_within_pair_d_z(self) -> None:
+        # Issue #2154: shared between-seed variance must cancel. Every pair
+        # differs by exactly 1, so d_z = mean(diffs)/std(diffs, ddof=1) is
+        # huge while the pooled independent-groups d is ~0.02.
+        a = [101.0, 202.0, 303.0, 404.0]
+        b = [100.0, 200.0, 300.0, 400.0]
+        res = ttest_comparison(a, b, paired=True)
+        expected = float(np.mean(np.subtract(a, b)) / np.std(np.subtract(a, b), ddof=1))
+        assert res.effect_size == pytest.approx(expected)
+        assert res.effect_size == pytest.approx(1.9364916731037085)
+
+    def test_wilcoxon_effect_size_is_within_pair_d_z(self) -> None:
+        a = [101.0, 202.0, 303.0, 404.0]
+        b = [100.0, 200.0, 300.0, 400.0]
+        res = wilcoxon_comparison(a, b)
+        expected = float(np.mean(np.subtract(a, b)) / np.std(np.subtract(a, b), ddof=1))
+        assert res.effect_size == pytest.approx(expected)
+
+    def test_paired_d_z_constant_shift_is_signed_infinite(self) -> None:
+        res = ttest_comparison([1.0, 2.0, 3.0], [0.5, 1.5, 2.5], paired=True)
+        assert np.isposinf(res.effect_size)
+        wres = wilcoxon_comparison([1.0, 2.0, 3.0], [0.5, 1.5, 2.5])
+        assert np.isposinf(wres.effect_size)
 
     @pytest.mark.parametrize(
         "values_a, values_b, expected_sign",


### PR DESCRIPTION
<!-- evidence-head:626100d99a7c0736c8fa5f098b04ad9bb46ad382 -->
<!-- evidence-row:logs -->
- [x] logs: focused pytest output retained in PR checks; local run `tests/test_statistics_validation.py` 242 passed, `tests/test_statistics_hostile_validation.py` 12 passed, `tests/test_forager_matched_statistics.py` 52 passed

## What this fixes

Closes #2154. `ttest_comparison(..., paired=True)` and `wilcoxon_comparison(...)` reported `effect_size` via pooled independent-groups `cohens_d`, understating consistent paired shifts by ~100x (0.019 vs correct 1.94 on the issue repro). Both now report within-pair Cohen's d_z `mean(a-b)/std(a-b, ddof=1)` via a new `_paired_cohens_d` helper; unpaired paths and `cohens_d` itself are unchanged. Constant nonzero shifts report signed-inf (mirroring the pooled zero-variance convention); identical samples still reject before SciPy as before.

## Numbers (issue repro, deterministic)

- `a=[101,202,303,404]`, `b=[100,200,300,400]`
- Before: pooled/paired effect `0.0192683`
- After: paired t and Wilcoxon effect `1.9364917` (= d_z); `cohens_d(a,b)` still `0.0192683`
- No seeds/n; deterministic unit values. No benchmark shards touched.

## Checks

- Failing-test-first: added `test_paired_ttest_effect_size_is_within_pair_d_z`, `test_wilcoxon_effect_size_is_within_pair_d_z`, `test_paired_d_z_constant_shift_is_signed_infinite` (failed before fix with 0.019/0.5, pass after).
- Updated stale `test_constant_nonzero_shift_stays_defined` (Wilcoxon constant shift now expects `+inf` d_z instead of pooled d).
- `.venv/bin/python -m pytest tests/test_statistics_validation.py -q -o addopts=""` → 242 passed
- `.venv/bin/python -m pytest tests/test_statistics_hostile_validation.py -q -o addopts=""` → 12 passed
- `.venv/bin/python -m pytest tests/test_forager_matched_statistics.py -q -o addopts=""` → 52 passed
- `.venv/bin/python -m ruff check alberta_framework/utils/statistics.py tests/test_statistics_validation.py` → clean
- `.venv/bin/python -m mypy alberta_framework/utils/statistics.py` → clean
- `alberta_framework/utils/statistics.py` is not a registered evidence source; `alberta-evidence-status` claim set untouched by this path.

## Open

- Acceptance and merge left to an independent maintainer. Never self-merged.

AI provider/model: meta / muse-spark-1.3-contributor-free
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@a2fe88318864e11c72cfa96cbfe4215a166e608b:skills/contribute-to-asi
