### PR TITLE
fix(benchmarks): bind micro ladder shard reuse to the payload's arm and seed

### DIFF
--- a/alberta_framework/benchmarks/micro_continual.py
+++ b/alberta_framework/benchmarks/micro_continual.py
@@ -1807,12 +1807,21 @@ def _run_or_skip_shard(
 ) -> Path:
     """Idempotent shard execution: existing shards are validated and kept.
 
-    A shard is only reused when it was produced by the same stream config
-    and the same network size; anything else must go to a fresh directory.
+    A shard is only reused when its payload records the requested arm and
+    seed and it was produced by the same stream config and the same network
+    size; anything else must go to a fresh directory. The filename alone is
+    not identity: a relabelled copy must never stand in for a run that never
+    happened.
     """
     path = micro_shard_path(out_dir, config.family, arm_name, seed)
     if path.exists():
         payload = load_micro_shard(path)
+        if payload["arm_name"] != arm_name or payload["seed"] != seed:
+            raise ValueError(
+                f"{path}: existing shard records arm={payload['arm_name']!r} "
+                f"seed={payload['seed']}, not the requested arm={arm_name!r} "
+                f"seed={seed}; use a fresh --out directory"
+            )
         if payload["stream_config"] != config.to_config():
             raise ValueError(
                 f"{path}: existing shard was produced by a different stream "

--- a/tests/test_micro_continual.py
+++ b/tests/test_micro_continual.py
@@ -1876,6 +1876,36 @@ class TestCLI:
             main([*base, "--hidden1", "16", "--hidden2", "6"])
         assert path.read_bytes() == first
 
+    def test_run_refuses_to_skip_a_shard_recorded_for_another_arm_or_seed(
+        self, tmp_path: Path
+    ):
+        """The idempotent skip must bind the payload's arm and seed, not just the path name."""
+        import shutil
+
+        base = [
+            "run", "--family", "input_permutation", "--out", str(tmp_path), *self.ARGS,
+        ]
+        assert main([*base, "--arm", "sgd_raw", "--seed", "0"]) == 0
+        genuine = micro_shard_path(tmp_path, "input_permutation", "sgd_raw", 0)
+        relabeled_seed = micro_shard_path(tmp_path, "input_permutation", "sgd_raw", 7)
+        relabeled_arm = micro_shard_path(tmp_path, "input_permutation", "naive_bayes", 0)
+        shutil.copyfile(genuine, relabeled_seed)
+        shutil.copyfile(genuine, relabeled_arm)
+        with pytest.raises(
+            ValueError,
+            match=r"existing shard records arm='sgd_raw' seed=0, not the requested "
+            r"arm='sgd_raw' seed=7; use a fresh --out directory",
+        ):
+            main([*base, "--arm", "sgd_raw", "--seed", "7"])
+        with pytest.raises(
+            ValueError,
+            match=r"existing shard records arm='sgd_raw' seed=0, not the requested "
+            r"arm='naive_bayes' seed=0; use a fresh --out directory",
+        ):
+            main([*base, "--arm", "naive_bayes", "--seed", "0"])
+        assert relabeled_seed.read_bytes() == genuine.read_bytes()
+        assert relabeled_arm.read_bytes() == genuine.read_bytes()
+
     def test_ladder_partial_arms_writes_summary_only(self, tmp_path: Path):
         argv = [
             "ladder", "--family", "input_permutation", "--seeds", "0",


### PR DESCRIPTION
Outcome: **Fix** — a reproduced harness defect that lets a measurement report a run that never happened. Not a Climb / Port / Close.

# What is wrong on `main`

`_run_or_skip_shard` in `alberta_framework/benchmarks/micro_continual.py` is the ladder's idempotent resume. Its docstring says an existing shard is reused only when it was produced by the same stream config and network size, and `micro_shard_path` encodes `(family, arm, seed)` in the filename. But the reuse branch compares only `stream_config` and `(hidden1, hidden2)`; it never compares the payload's own `arm_name`/`seed` with the requested slot. A shard file copied or renamed into a reused `--out` directory is therefore accepted as the requested `(arm, seed)`, the run is skipped, and the ladder hands that path to `merge_micro_shards`/`transfer_validation_from_shards`, which group by *payload* identity.

Reproduction on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (CLI, tiny config): run `sgd_raw` seed 0, copy the shard to the `sgd_raw` seed 7 and `naive_bayes` seed 0 filenames, request those slots:

```text
$ python -m alberta_framework.benchmarks.micro_continual run --family input_permutation --arm sgd_raw --seed 7 --out <dir> ...
exit 0, "shard exists, skipping", nothing executed
$ ... --arm naive_bayes --seed 0 ...
exit 0, "shard exists, skipping", nothing executed
```

Expected: `ValueError`, never a silent skip. A consistent relabelling (arm swap or seed relabel across all arms) passes the later merge checks too, so the summary's reported seed set and arm identity are not what ran. Mixed substitutions happen to fail later in `merge_micro_shards`; the fail-open window is exactly the consistent case.

# Change

Bind the payload identity before the config and network-size checks: reject with `existing shard records arm=... seed=..., not the requested arm=... seed=...; use a fresh --out directory`. One conditional, no behaviour change for genuine resumes.

# Evidence

Failing-test-first: `tests/test_micro_continual.py::TestCLI::test_run_refuses_to_skip_a_shard_recorded_for_another_arm_or_seed` (writes a genuine `sgd_raw`/seed-0 shard through the CLI, copies it to a relabelled seed and a relabelled arm, asserts both requests raise with the exact message and the files are untouched).

At the base commit:

```text
/tmp/asi-fix-micro-resume/tests/test_micro_continual.py:1894: Failed: DID NOT RAISE ValueError
=========================== short test summary info ============================
FAILED tests/test_micro_continual.py::TestCLI::test_run_refuses_to_skip_a_shard_recorded_for_another_arm_or_seed
1 failed in 9.07s
```

At this head, `TestCLI`:

```text
.......                                                                  [100%]
7 passed in 12.04s
```

Whole module at this head: `228 passed, 2 warnings in 69.34s (0:01:09)`. Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

Lane: micro-continual harness (development-only, nonpromoting); no `outputs/` artifacts, seeds, or registered evidence sources touched.

<!-- evidence-head:3ab731569e011162fea3c8a6a66db0528a10b388 -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/43303ea41dfb16bec5b661a3cd969208d9997b69/evidence/pr-micro-ladder-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - harness validation fix; the evidence is the paired failing/passing CLI test transcript above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 30664490 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-micro-ladder-resume]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1NGPFR3JB31BJZWQ7T3QN1K","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T06:11:34.276Z","completed_at":"2026-09-04T10:38:54.939Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T06:11:35.010Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":4317,"output_tokens":59008,"cache_creation_tokens":680999,"cache_read_tokens":29920166,"total_tokens":30664490,"cost_micro_usd":"24093592","session_count":1},"trajectory_sha256":"ee055e146381ec3fbec246cfead2054c34980d129a4808e6231d0ab12316dba9","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b8a1e69a-a78b-4ec2-8831-dd36f05e7a78","object_id":"sha256:ee055e146381ec3fbec246cfead2054c34980d129a4808e6231d0ab12316dba9","sha256":"ee055e146381ec3fbec246cfead2054c34980d129a4808e6231d0ab12316dba9"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"bdYKXyyMrHYqqgqK0LgF_3C2t9-nvXHiNFA_mldtSsP5ZUbVa7jSOZSVPWVbW48jLl3I5ypwQ7FNYmA9AT43Bw"}} -->
