### PR TITLE
fix(utils): sum running-RMSE windows directly instead of differencing a prefix sum

### DIFF
--- a/alberta_framework/utils/nexting.py
+++ b/alberta_framework/utils/nexting.py
@@ -288,14 +288,25 @@ def _finite_rmse_jvp(
 
 
 def _sliding_sum(values: Array, window_size: int) -> Array:
-    prefix = jnp.cumsum(
-        jnp.concatenate(
-            [jnp.zeros((1, values.shape[1]), dtype=values.dtype), values],
-            axis=0,
-        ),
-        axis=0,
+    """Sum each trailing window directly, without a global prefix sum.
+
+    Differencing a global cumulative sum cancels catastrophically: once the
+    prefix has grown past the magnitude of later terms, those terms fall below
+    its floating-point ulp and the window difference collapses to zero. A
+    per-window reduction only ever adds the window's own terms.
+    """
+    # A concrete zero lets JAX lower this to its windowed sum, which carries
+    # forward- and reverse-mode rules; a traced init value would fall back to
+    # the generic reducer, which has no transpose rule.
+    summed: Array = jax.lax.reduce_window(
+        values,
+        np.zeros((), dtype=values.dtype),
+        jax.lax.add,
+        window_dimensions=(window_size, 1),
+        window_strides=(1, 1),
+        padding="VALID",
     )
-    return prefix[window_size:] - prefix[:-window_size]
+    return summed
 
 
 def _pad_running_window(values: Array, window_size: int) -> Array:

--- a/tests/test_nexting.py
+++ b/tests/test_nexting.py
@@ -479,6 +479,26 @@ class TestRunningRMSE:
         # All windows should contain the same constant error
         np.testing.assert_allclose(np.asarray(running), 2.0, atol=1e-6)
 
+    def test_running_rmse_survives_a_high_error_phase_before_a_settled_phase(self) -> None:
+        """A trailing window must not inherit cancellation from an earlier large-error phase.
+
+        A global float32 prefix sum loses every squared error that is smaller than the
+        prefix's ulp, so once 2,000 unit errors have accumulated a settled phase of
+        1e-4 errors reads as exactly zero RMSE. The window's own errors are all 1e-4,
+        so every complete settled window must report 1e-4.
+        """
+        n_steps, window = 4000, 100
+        for settled in (1e-3, 1e-4, 1e-5):
+            errors = np.full((n_steps, 1), settled, dtype=np.float32)
+            errors[:2000] = 1.0
+            running = np.asarray(
+                per_horizon_running_rmse(
+                    jnp.asarray(errors), jnp.zeros((n_steps, 1), jnp.float32), window_size=window
+                )
+            )
+            settled_windows = running[2000 + window :, 0]
+            np.testing.assert_allclose(settled_windows, settled, rtol=1e-3, atol=0.0)
+
     @pytest.mark.parametrize(
         "window_size",
         [


### PR DESCRIPTION
Outcome: **Fix** — a reproduced metric defect that silently flatters a learner. Not a Climb / Port / Close.

# What is wrong on `main`

`per_horizon_running_rmse` (`alberta_framework/utils/nexting.py`) is the nexting harness's curve-over-time metric, documented for "how prediction accuracy evolves through a non-stationary stream (e.g. through Pavlovian phase transitions)". Its `_sliding_sum` computes every trailing window as `prefix[w:] - prefix[:-w]` over one global float32 cumulative sum. After an early high-error phase, later squared errors fall below the prefix's ulp and the window difference collapses to zero, so the settled phase reads as perfect prediction. That is exactly the phase-transition regime the docstring names.

Reproduction on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (`T=4000`, window 100, 2,000 unit errors then a constant settled error; every settled window contains only the settled error, so the exact answer is that error):

```text
late|err|=0.01: reported_last=np.float32(0.010004882) exact=0.01 settled_min=0.00994369 settled_max=0.0100657
late|err|=0.001: reported_last=np.float32(0.0011048543) exact=0.001 settled_min=0 settled_max=0.00110485
late|err|=0.0001: reported_last=np.float32(0.0) exact=0.0001 settled_min=0 settled_max=0
late|err|=1e-05: reported_last=np.float32(0.0) exact=1e-05 settled_min=0 settled_max=0
```

At `1e-3` the curve oscillates between 0 and 1.1e-3; at `1e-4` and below the entire settled phase reports `0.0`. `per_horizon_rmse` (a direct mean) is unaffected. `float32` is the JAX default; the same cancellation exists under x64 at a wider magnitude ratio.

# Change

`_sliding_sum` reduces each window directly with `jax.lax.reduce_window` (add, `VALID`), which only ever adds the window's own terms. The init value is a concrete NumPy zero so JAX lowers it to its windowed sum, which has both forward- and reverse-mode rules; a traced init would fall back to the generic reducer, which has no transpose rule (the existing eager/JIT/JVP gradient-convention tests caught that during development). The custom JVP shares the helper, so primal and tangent stay consistent. Two lines of behaviour, one helper.

After the change the same probe reports the exact settled error in every case:

```text
late|err|=0.01: reported_last=np.float32(0.009999999) exact=0.01 settled_min=0.01 settled_max=0.01
late|err|=0.001: reported_last=np.float32(0.001) exact=0.001 settled_min=0.001 settled_max=0.001
late|err|=0.0001: reported_last=np.float32(1e-04) exact=0.0001 settled_min=0.0001 settled_max=0.0001
late|err|=1e-05: reported_last=np.float32(1e-05) exact=1e-05 settled_min=1e-05 settled_max=1e-05
```

# Evidence

Failing-test-first: `tests/test_nexting.py::TestRunningRMSE::test_running_rmse_survives_a_high_error_phase_before_a_settled_phase` (settled errors 1e-3, 1e-4, 1e-5; every complete settled window must equal the settled error within 1e-3 relative).

At the base commit:

```text
/tmp/asi-fix-nexting/tests/test_nexting.py:500: AssertionError:
=========================== short test summary info ============================
FAILED tests/test_nexting.py::TestRunningRMSE::test_running_rmse_survives_a_high_error_phase_before_a_settled_phase
1 failed, 89 deselected in 2.06s
```

At this head, whole module (`tests/test_nexting.py`, includes the eager/JIT/JVP gradient tests):

```text
90 passed in 18.44s
```

Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

Overlap note: open PR #2711 changes the same function's causal padding and non-finite scoping but keeps the prefix-sum `_sliding_sum` body, so the two are complementary; whichever lands second needs a trivial rebase around `_pad_running_window`. #2695 fixes the same cancellation class at a different boundary (`utils/metrics.py::compute_running_mean`), not this one.

Lane: nexting metric (development diagnostics); no `outputs/` artifacts, seeds, or registered evidence sources touched.

<!-- evidence-head:8d80453ff634f9a42630234c5930ff5998c5bccc -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/496f2083cb0f353fd1d9d0709abde6f673c653d2/evidence/pr-nexting-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - metric implementation fix; the evidence is the base-vs-head probe and the paired failing/passing test transcript above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 20873574 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-nexting-running-rmse]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1NH93M13RC7502EMKT26MA0","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T06:21:44.450Z","completed_at":"2026-09-04T10:39:10.843Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T06:21:45.365Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":3340,"output_tokens":43542,"cache_creation_tokens":656595,"cache_read_tokens":20170097,"total_tokens":20873574,"cost_micro_usd":"20384924","session_count":1},"trajectory_sha256":"70552c023c97f486a0dc8e13cfe52e3aa851ca090113ca11761f074ab11df5e2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"248f5746-cb5c-4538-86bf-5f9bd8c96875","object_id":"sha256:70552c023c97f486a0dc8e13cfe52e3aa851ca090113ca11761f074ab11df5e2","sha256":"70552c023c97f486a0dc8e13cfe52e3aa851ca090113ca11761f074ab11df5e2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"FFgG4IIdUznstCOm-G5pGF7DzkYGRV-b9CiDurb6Y9-AATishJK5--aOmfJOLxAYLSxDf5tAdfMKaEzwkdxmBw"}} -->
