### PR TITLE
fix(evaluation): compare bounded-elastic matched subtrees by canonical bytes

### DIFF
--- a/alberta_framework/evaluation/bounded_elastic_matched_runner.py
+++ b/alberta_framework/evaluation/bounded_elastic_matched_runner.py
@@ -174,6 +174,16 @@ def _canonical(value: object) -> bytes:
     ).encode("ascii")
 
 
+def _same(actual: object, expected: object) -> bool:
+    """Type-exact equality for JSON subtrees.
+
+    Python's ``==`` treats ``0 == False`` and ``1.0 == 1`` as equal, so a
+    re-signed payload with punned scalar types would pass a plain ``!=``
+    comparison. Comparing canonical bytes rejects any byte-level drift.
+    """
+    return _canonical(actual) == _canonical(expected)
+
+
 def _json_preflight(value: object) -> None:
     pending: list[tuple[object, int]] = [(value, 0)]
     seen: set[int] = set()
@@ -721,14 +731,14 @@ def _validate_bounded_elastic_matched(
         or _screening_dataset_provenance(x, y) != _frozen_dataset_provenance()
     ):
         raise ValueError("campaign inputs differ from the frozen reviewed plan")
-    if root["config"] != _config_payload(checked_config):
+    if not _same(root["config"], _config_payload(checked_config)):
         raise ValueError("matched result config drifted")
-    if root["development_seeds"] != list(seeds) or root["arms"] != list(ARMS):
+    if not _same(root["development_seeds"], list(seeds)) or not _same(root["arms"], list(ARMS)):
         raise ValueError("matched result protocol roster drifted")
     expected_identity = _result_identity(x, y)
-    if root["identity"] != expected_identity:
+    if not _same(root["identity"], expected_identity):
         raise ValueError("matched result identity drifted")
-    if root["policy"] != _POLICY:
+    if not _same(root["policy"], _POLICY):
         raise ValueError("matched result must remain permanently nonpromoting")
     expected_roster = [(seed, arm) for seed in seeds for arm in ARMS]
     raw_rows = root["rows"]
@@ -752,7 +762,7 @@ def _validate_bounded_elastic_matched(
             or arm not in ARMS
         ):
             raise ValueError("matched row roster identity drifted")
-        if checked_row["execution_identity"] != identities[seed]:
+        if not _same(checked_row["execution_identity"], identities[seed]):
             raise ValueError("matched row execution identity drifted")
         payload = validate_bounded_elastic_development_result(checked_row["result"])
         if payload["outcome"] != "inconclusive":
@@ -766,7 +776,7 @@ def _validate_bounded_elastic_matched(
         validate_matched_bounded_elastic_results(
             [row["result"] for row in rows[offset : offset + len(ARMS)]]
         )
-    if root["aggregate"] != _aggregate(rows):
+    if not _same(root["aggregate"], _aggregate(rows)):
         raise ValueError("matched result aggregate drifted")
     unsigned = dict(root)
     claimed = unsigned.pop("result_sha256")
@@ -792,7 +802,7 @@ def _validate_bounded_elastic_matched(
             expected_resources = cast(dict[str, object], expected_payload["resources"])
             claimed_resources = cast(dict[str, object], claimed_payload["resources"])
             expected_resources["timing_seconds"] = claimed_resources["timing_seconds"]
-            if expected_payload != claimed_payload:
+            if not _same(expected_payload, claimed_payload):
                 raise ValueError("matched row disagrees with strict current-source reexecution")
         if _result_identity(x, y) != expected_identity:
             raise RuntimeError("source, runtime, or dataset changed during strict reexecution")

--- a/tests/test_bounded_elastic_matched_runner.py
+++ b/tests/test_bounded_elastic_matched_runner.py
@@ -258,6 +258,41 @@ def test_validator_rejects_identity_resource_and_roster_forgery(
         )
 
 
+def test_validator_rejects_type_punned_forgeries_that_compare_equal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Python equality treats 0 == False and 1.0 == 1; the validator must not."""
+    monkeypatch.setattr(runner, "run_screening_config", _fake_run)
+    result = cast(dict[str, Any], _run_for_test(*_data(), config=SMALL))
+
+    punned = copy.deepcopy(result)
+    punned["policy"]["scientific_promotion_allowed"] = 0
+    _resign(punned)
+    with pytest.raises(ValueError, match="permanently nonpromoting"):
+        runner._validate_bounded_elastic_matched_authorized(
+            punned, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+
+    punned = copy.deepcopy(result)
+    punned["development_seeds"] = [float(seed) for seed in punned["development_seeds"]]
+    _resign(punned)
+    with pytest.raises(ValueError, match="protocol roster drifted"):
+        runner._validate_bounded_elastic_matched_authorized(
+            punned, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+
+    punned = copy.deepcopy(result)
+    punned["config"]["n_tasks"] = float(punned["config"]["n_tasks"])
+    _resign(punned)
+    with pytest.raises(ValueError, match="config drifted"):
+        runner._validate_bounded_elastic_matched_authorized(
+            punned, *_data(), config=SMALL, seeds=runner.TEST_ONLY_SEEDS,
+            _capability=runner._TEST_EXECUTION_CAPABILITY,
+        )
+
+
 def test_validator_reexecutes_and_rejects_self_consistent_metric_forgery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Outcome: **Fix** — a validator that accepted what it should reject. Not a Climb / Port / Close.

# What is wrong on `main`

`_validate_bounded_elastic_matched` (`alberta_framework/evaluation/bounded_elastic_matched_runner.py`) is the gate that keeps the bounded-elastic matched development result permanently nonpromoting and byte-bound to the frozen plan. It compared the `config`, `development_seeds`/`arms`, `identity`, `policy`, per-row `execution_identity`, `aggregate`, and the strict-reexecution payload with Python `!=`. Python equality treats `0 == False` and `1.0 == 1` as equal, so a result whose scalars were type-punned and then re-signed (`result_sha256` recomputed over the punned bytes, which the validator accepts) passed every one of those checks even though its bytes differ from `_POLICY`, the frozen roster, and the config payload. The sibling gradual-IPMNIST lane already compares canonical bytes for exactly this reason (`gradual_ipmnist_nonpromoting.py::_same`).

Reproduction on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, through the module's own test harness (fake screening run, test-only seeds): a genuine result with `"scientific_promotion_allowed": 0`, or float seeds `[0.0, 1.0]`, or `"n_tasks": 1.0`, re-signed, is accepted. Expected: rejected with the existing drift messages.

# Change

Add `_same(actual, expected)` (canonical-bytes equality, mirroring the sibling lane) and use it at the seven JSON-subtree comparisons. Scalar string checks (`schema`, `status`) are unchanged. No genuine result changes outcome: the canonical bytes of an honest payload are identical to the ones the digest already binds.

# Evidence

Failing-test-first: `tests/test_bounded_elastic_matched_runner.py::test_validator_rejects_type_punned_forgeries_that_compare_equal` (policy flag `0`, float seed roster, float `n_tasks`; each re-signed, each must raise the existing message).

At the base commit:

```text
/tmp/asi-fix-belastic/tests/test_bounded_elastic_matched_runner.py:271: Failed: DID NOT RAISE ValueError
=========================== short test summary info ============================
FAILED tests/test_bounded_elastic_matched_runner.py::test_validator_rejects_type_punned_forgeries_that_compare_equal
1 failed, 34 deselected in 4.92s
```

At this head, whole module:

```text
...................................                                      [100%]
35 passed in 11.92s
```

Sibling suite `tests/test_bounded_elastic_ipmnist.py` at this head: 10 passed in 7.39s. Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

This file is not a registered evidence source; `alberta-evidence-status` is unaffected. Lane: bounded-elastic matched development validator (development-only, nonpromoting); no `outputs/` artifacts or seeds touched.

<!-- evidence-head:ff5864095482b9c785634d4b68a11b3919284785 -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/a938593b767bc0383aa203dd4ac5508937be5bc9/evidence/pr-bounded-elastic-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - validator fix; the evidence is the paired failing/passing test transcript above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 14034883 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-bounded-elastic-validator]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1NHKJ7XP2ZC50R2NM41WS3K","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T06:27:27.101Z","completed_at":"2026-09-04T10:39:16.935Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T06:27:27.556Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":2251,"output_tokens":27157,"cache_creation_tokens":630269,"cache_read_tokens":13375206,"total_tokens":14034883,"cost_micro_usd":"17329542","session_count":1},"trajectory_sha256":"3a2efcec293a8791957e7a2c034d0e1b024f5e9f2297e3144baf2f4a018f8152","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"aa584e6c-7daf-48e8-8f4f-c08d4443c5d5","object_id":"sha256:3a2efcec293a8791957e7a2c034d0e1b024f5e9f2297e3144baf2f4a018f8152","sha256":"3a2efcec293a8791957e7a2c034d0e1b024f5e9f2297e3144baf2f4a018f8152"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"a6d08pVspbiHL_0Pkpmcuhopf6xIfECCXS04CAyy6FC1DNvloyz12CJ8ljrJwZzi9v6x3Nmkg9kZfH9EttuJAg"}} -->
