### PR TITLE
fix(evaluation): build recurring-feature artifacts for never-recovered gates

### DIFF
--- a/alberta_framework/evaluation/recurring_feature_artifact.py
+++ b/alberta_framework/evaluation/recurring_feature_artifact.py
@@ -453,6 +453,41 @@ def wilson_score_interval(successes: int, sample_size: int) -> dict[str, object]
     }
 
 
+def _paired_interval_or_unavailable(
+    differences: Sequence[float],
+    *,
+    seed_offset: int,
+) -> dict[str, object]:
+    """Descriptive paired interval, or an explicit ``unavailable`` record.
+
+    A rejecting gate legitimately carries ``inf`` NMSE (an unrecovered task) or a
+    seed that never recovers, so its paired differences can be non-finite or
+    empty. Those are evidence, not build errors: the frozen point criteria still
+    decide, and the descriptive interval is recorded as unavailable with the
+    reason instead of crashing the artifact and losing the negative result.
+    """
+
+    values = np.asarray(tuple(differences), dtype=np.float64)
+    if values.ndim == 1 and values.size > 0 and bool(np.all(np.isfinite(values))):
+        return paired_bootstrap_mean_interval(differences, seed_offset=seed_offset)
+    finite = int(np.count_nonzero(np.isfinite(values))) if values.size else 0
+    return {
+        "estimate": None,
+        "lower": None,
+        "upper": None,
+        "confidence_level": BOOTSTRAP_CONFIDENCE_LEVEL,
+        "resamples": BOOTSTRAP_RESAMPLES,
+        "sample_size": int(values.size),
+        "finite_sample_size": finite,
+        "method": "paired-percentile-bootstrap",
+        "pairing_unit": "seed",
+        "acceptance_role": "descriptive-only; frozen gate uses point criteria",
+        "unavailable_reason": (
+            "no paired differences" if values.size == 0 else "non-finite paired differences"
+        ),
+    }
+
+
 def _per_seed_recovery_medians(
     seed: RecurringFeatureSeedEvidence,
 ) -> tuple[float, float] | None:
@@ -500,24 +535,24 @@ def _paired_effect_payload(result: RecurringFeatureGateResult) -> dict[str, obje
             acquisition, recurrence = recovery
             recovery_differences.append(acquisition - recurrence)
     return {
-        "retention_rate_gain_over_no_retention": paired_bootstrap_mean_interval(
+        "retention_rate_gain_over_no_retention": _paired_interval_or_unavailable(
             retention_differences,
             seed_offset=0,
         ),
         "per_seed_maximum_critical_nmse_reduction": (
-            paired_bootstrap_mean_interval(
+            _paired_interval_or_unavailable(
                 critical_nmse_differences,
                 seed_offset=1,
             )
         ),
         "obsolete_nmse_increase_over_no_retention": (
-            paired_bootstrap_mean_interval(
+            _paired_interval_or_unavailable(
                 obsolete_nmse_differences,
                 seed_offset=2,
             )
         ),
         "retained_acquisition_minus_recurrence_steps": (
-            paired_bootstrap_mean_interval(
+            _paired_interval_or_unavailable(
                 recovery_differences,
                 seed_offset=3,
             )
@@ -636,7 +671,10 @@ def _acceptance_payload(
         result.no_retention.maximum_critical_task_median_nmse
         - result.retained.maximum_critical_task_median_nmse
     )
-    recovery_gain = (
+    # Both medians are ``inf`` when no seed recovers; the difference is then
+    # NaN, which the strict JSON digest refuses. Record the check as failed
+    # with a null actual instead of crashing the build of a rejecting gate.
+    recovery_gain = _finite_float(
         result.retained.median_acquisition_recovery_steps
         - result.retained.median_recurrence_recovery_steps
     )
@@ -1340,25 +1378,25 @@ def _recomputed_aggregate(
         ),
         "paired_effects": {
             "retention_rate_gain_over_no_retention": (
-                paired_bootstrap_mean_interval(
+                _paired_interval_or_unavailable(
                     retention_differences,
                     seed_offset=0,
                 )
             ),
             "per_seed_maximum_critical_nmse_reduction": (
-                paired_bootstrap_mean_interval(
+                _paired_interval_or_unavailable(
                     critical_nmse_differences,
                     seed_offset=1,
                 )
             ),
             "obsolete_nmse_increase_over_no_retention": (
-                paired_bootstrap_mean_interval(
+                _paired_interval_or_unavailable(
                     obsolete_differences,
                     seed_offset=2,
                 )
             ),
             "retained_acquisition_minus_recurrence_steps": (
-                paired_bootstrap_mean_interval(
+                _paired_interval_or_unavailable(
                     recovery_differences,
                     seed_offset=3,
                 )

--- a/tests/test_recurring_feature_artifact.py
+++ b/tests/test_recurring_feature_artifact.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import math
 import os
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
@@ -31,6 +32,7 @@ from alberta_framework.recurring_feature_gate import (
     PHASE_TASKS,
     TASK_PAIRS,
     RecurringFeatureGateResult,
+    RecurringFeatureSeedEvidence,
     run_recurring_feature_gate,
 )
 
@@ -199,6 +201,99 @@ def test_exact_heldout_aggregate_and_deterministic_paired_intervals(
     assert recovery["lower"] == pytest.approx(67.63333333333334)
     assert recovery["upper"] == pytest.approx(76.40083333333332)
     assert all(_as_dict(interval)["sample_size"] == 30 for interval in effects.values())
+
+
+def _without_recovery(seed: RecurringFeatureSeedEvidence) -> RecurringFeatureSeedEvidence:
+    return replace(
+        seed,
+        phase_evidence=tuple(
+            replace(phase, recovery_steps=None) for phase in seed.phase_evidence
+        ),
+        task_recovery=tuple(
+            replace(
+                recovery,
+                acquisition_steps=None,
+                recurrence_steps=tuple(None for _ in recovery.recurrence_steps),
+            )
+            for recovery in seed.task_recovery
+        ),
+    )
+
+
+def test_never_recovered_seeds_build_instead_of_crashing(
+    frozen_result: RecurringFeatureGateResult,
+) -> None:
+    """Never-recovered seeds are permitted gate evidence, not artifact build errors.
+
+    One unrecovered seed shrinks the paired recovery interval to the seeds that
+    did recover and the artifact stays fully valid. When no seed recovers the
+    build used to raise from the paired bootstrap before anything was recorded;
+    it must now produce the artifact with an explicit ``unavailable`` interval
+    and a failed recurrence check, so the validator can name the missing
+    finite evidence instead of the CLI dying with a traceback.
+    """
+    retained = frozen_result.retained
+    first, *rest = retained.seeds
+
+    one_unrecovered = replace(
+        frozen_result, retained=replace(retained, seeds=(_without_recovery(first), *rest))
+    )
+    artifact = build_recurring_feature_artifact(
+        one_unrecovered,
+        gate_wall_seconds=6.5,
+        generated_at=datetime(2026, 7, 30, 12, 0, tzinfo=UTC),
+    )
+    validation = validate_recurring_feature_artifact(artifact)
+    assert validation.valid, validation.errors
+    effects = _as_dict(_as_dict(_scientific(artifact)["aggregate"])["paired_effects"])
+    recovery = _as_dict(effects["retained_acquisition_minus_recurrence_steps"])
+    assert recovery["estimate"] is not None
+    assert recovery["sample_size"] == len(retained.seeds) - 1
+
+    none_recovered = replace(
+        frozen_result,
+        retained=replace(retained, seeds=tuple(_without_recovery(seed) for seed in retained.seeds)),
+    )
+    artifact = build_recurring_feature_artifact(
+        none_recovered,
+        gate_wall_seconds=6.5,
+        generated_at=datetime(2026, 7, 30, 12, 0, tzinfo=UTC),
+    )
+    effects = _as_dict(_as_dict(_scientific(artifact)["aggregate"])["paired_effects"])
+    recovery = _as_dict(effects["retained_acquisition_minus_recurrence_steps"])
+    assert recovery["estimate"] is None
+    assert recovery["sample_size"] == 0
+    assert recovery["unavailable_reason"] == "no paired differences"
+    checks = {
+        _as_dict(check)["name"]: _as_dict(check)
+        for check in _as_list(_as_dict(_scientific(artifact)["acceptance"])["checks"])
+    }
+    assert checks["recurrence_faster_than_acquisition"]["actual"] is None
+    assert checks["recurrence_faster_than_acquisition"]["passed"] is False
+    validation = validate_recurring_feature_artifact(artifact)
+    assert not validation.accepted
+    # v1 requires finite recovery medians, so the validator names that gap
+    # rather than the build crashing before any artifact exists.
+    assert not validation.valid
+    assert any("recurrence_faster_than_acquisition" in error or "numeric comparison" in error
+               for error in validation.errors), validation.errors
+
+
+def test_paired_interval_reports_non_finite_differences_as_unavailable() -> None:
+    """Non-finite paired differences (``inf`` NMSE) must not crash the builder."""
+    unavailable = recurring_artifact_module._paired_interval_or_unavailable(
+        [0.5, math.inf, -0.25], seed_offset=1
+    )
+    assert unavailable["estimate"] is None
+    assert unavailable["sample_size"] == 3
+    assert unavailable["finite_sample_size"] == 2
+    assert unavailable["unavailable_reason"] == "non-finite paired differences"
+    available = recurring_artifact_module._paired_interval_or_unavailable(
+        [0.5, 0.25, -0.25], seed_offset=1
+    )
+    assert available == recurring_artifact_module.paired_bootstrap_mean_interval(
+        [0.5, 0.25, -0.25], seed_offset=1
+    )
 
 
 def test_scientific_digest_is_deterministic_and_excludes_operational_metadata(


### PR DESCRIPTION
Outcome: **Fix** — an artifact builder that crashed on a legitimate rejecting gate, so the negative result could not be recorded. Not a Climb / Port / Close.

# What is wrong on `main`

`build_recurring_feature_artifact` (`alberta_framework/evaluation/recurring_feature_artifact.py`) feeds per-seed paired differences straight into `paired_bootstrap_mean_interval`, which raises on an empty or non-finite vector. Two gate outcomes the gate module explicitly permits produce exactly that:

- a run in which **no retained seed recovers** (`recovery_steps=None` throughout, accepted by `_require_recovery_steps`) leaves the acquisition-minus-recurrence vector empty → `paired bootstrap requires a non-empty vector`;
- an `inf` held-out NMSE (accepted by `_require_nmse` as unrecovered evidence) makes the critical-NMSE difference non-finite → `paired bootstrap values must be finite`.

In the no-recovery case there is a second crash behind the first: both recovery medians are `inf`, their difference is NaN, and the strict JSON digest refuses it. Either way the build dies with a traceback and nothing is written.

Reproduction at `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, through the module's own frozen-schedule fixture with every retained seed's recovery set to `None`:

```text
/tmp/asi-fix-recurring/alberta_framework/evaluation/recurring_feature_artifact.py:404: ValueError: paired bootstrap values must be finite
=========================== short test summary info ============================
FAILED tests/test_recurring_feature_artifact.py::test_rejecting_gate_with_unrecovered_evidence_still_builds_and_validates
1 failed, 18 deselected in 11.18s
```

# Change

- `_paired_interval_or_unavailable`: returns the usual bootstrap interval when the differences are a non-empty finite vector, otherwise an explicit record (`estimate`/`lower`/`upper` null, `sample_size`, `finite_sample_size`, `unavailable_reason`). Used at all four paired effects in the builder **and** in the validator's `_recomputed_aggregate`, so the recomputed aggregate still matches byte for byte. `paired_bootstrap_mean_interval` itself is unchanged.
- The recurrence acceptance actual goes through `_finite_float`, so a NaN gain is recorded as a failed check with a null actual instead of breaking the digest.

What this does **not** do: it does not make a no-recovery artifact *valid*. The v1 contract requires finite recovery medians, and the validator now reports that (`acceptance.checks[...] has an invalid numeric comparison`) on an artifact that exists, instead of the CLI dying before one does. A gate in which one seed never recovers while the others do builds a fully valid, consistent artifact; that case is asserted too. The `inf`-NMSE case still cannot be serialized under the strict JSON contract at all; that is a schema question left out of scope and noted here.

# Evidence

Failing-test-first: `tests/test_recurring_feature_artifact.py::test_never_recovered_seeds_build_instead_of_crashing` (one-seed and no-seed cases against the frozen schedule fixture) and `test_paired_interval_reports_non_finite_differences_as_unavailable` (the non-finite branch, plus equality with the real bootstrap on finite input).

At this head, the six `tests/test_recurring_feature_*.py` suites:

```text
190 passed in 28.40s
```

Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

# Evidence registry impact, stated plainly

`alberta_framework/evaluation/recurring_feature_artifact.py` is a registered source of the `recurring_pair_features` claim. Editing it keeps that claim `invalid` until the frozen protocol is rerun; on current `origin/main` the registry already reports every claim, including this one, as `invalid` (`alberta-evidence-status` on a clean checkout of `c9aba7b5`: overall `invalid`, 0 of 5 supported), so nothing is newly invalidated. The pinned accepted artifact has finite paired differences and recovery medians, so its recomputed aggregate is byte-identical under this change.

<!-- evidence-head:1d27a8f36fdd27c42c8d99a03a57ac3e1ae8011e -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/a73a76b5f2ad616c6b26a27f62264f9668a2b2fe/evidence/pr-recurring-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - artifact builder fix; the evidence is the paired failing/passing test transcript above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 27299377 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-recurring-paired-payload]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1P0936EE0A80WAE37F5JKE0","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T10:43:52.655Z","completed_at":"2026-09-04T11:13:46.391Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T10:43:53.296Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":3412,"output_tokens":66589,"cache_creation_tokens":99128,"cache_read_tokens":27130248,"total_tokens":27299377,"cost_micro_usd":"12128692","session_count":1},"trajectory_sha256":"f4dfd4a197abb5f97bc0f32fdd91c05916eff9d4acd0999093c4367a1b8dbe38","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"51957986-e565-403c-9f2b-9d97da403855","object_id":"sha256:f4dfd4a197abb5f97bc0f32fdd91c05916eff9d4acd0999093c4367a1b8dbe38","sha256":"f4dfd4a197abb5f97bc0f32fdd91c05916eff9d4acd0999093c4367a1b8dbe38"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"ySsTagGCpj6cWYaCMdq-riaPBu6Eql9n7rQaSNvKmOxmDt2uhw4kZFpOx0p3N-ymmBx4W5hXo7h_d0C07bW_BA"}} -->
