### PR TITLE
fix(evaluation): fail closed when continual-IA recovery evidence is empty

### DIFF
--- a/alberta_framework/evaluation/continual_ia.py
+++ b/alberta_framework/evaluation/continual_ia.py
@@ -1479,6 +1479,16 @@ def aggregate_ia_evidence(
     mean_recovery: dict[IAConditionName, float] = {}
     for condition, group in groups.items():
         values = np.concatenate([result.recovery_lengths for result in group])
+        if values.size == 0:
+            # A schedule with no phase switch has nothing to recover from. The
+            # mean of an empty vector is NaN and the conditional mean below is
+            # inf, while ``all_values_finite`` only inspects rewards and phase
+            # means, so the aggregate would report a finite-looking record with
+            # non-finite recovery evidence. Fail closed instead.
+            raise ValueError(
+                f"recovery evidence is empty for condition {condition!r}; "
+                "the schedule must contain at least one phase switch"
+            )
         recovered = values >= 0
         recovery_fraction[condition] = float(np.mean(recovered))
         mean_recovery[condition] = (

--- a/tests/test_ia_condition_result_hostile.py
+++ b/tests/test_ia_condition_result_hostile.py
@@ -239,6 +239,35 @@ def test_ia_aggregation_binds_live_component_budget() -> None:
         )
 
 
+def test_ia_aggregation_fails_closed_on_a_schedule_with_no_phase_switch() -> None:
+    """One phase has no switch to recover from; the aggregate must raise, not report NaN."""
+    from alberta_framework.evaluation import continual_ia
+
+    config = ContinualIAConfig(num_steps=2, phase_length=2, recovery_window=1)
+    budgets = continual_ia._condition_budgets(
+        config, continual_ia._make_partner(config), continual_ia._make_ia(config)
+    )
+    results = []
+    for condition in CONDITION_NAMES:
+        overrides: dict[str, object] = {
+            "condition": condition,
+            "controller_budget": budgets[condition],
+        }
+        if condition in {"observe_only", "recommendation_p05", "accept_always"}:
+            accepted = np.array([False, condition == "accept_always"], dtype=np.bool_)
+            overrides.update(
+                recommendations=np.zeros(2, dtype=np.int64),
+                partner_proposals=np.zeros(2, dtype=np.int64),
+                accepted_recommendations=accepted,
+                nominal_recommendation_decisions=2,
+                nominal_accepted_recommendations=2 if condition == "accept_always" else 0,
+                executed_accepted_recommendations=int(np.count_nonzero(accepted)),
+            )
+        results.append(_legal(**overrides))
+    with pytest.raises(ValueError, match="recovery evidence is empty"):
+        aggregate_ia_evidence(results, config=config)
+
+
 def test_ia_result_preflights_retained_bytes_before_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Outcome: **Fix** — an aggregate that reported NaN/inf recovery evidence flagged as finite. Not a Climb / Port / Close.

# What is wrong on `main`

`ContinualIAConfig` accepts `phase_length == num_steps`. With one phase there is no switch to recover from: `_recovery_lengths` returns an empty vector for every condition, and `aggregate_ia_evidence` then computes `np.mean` over nothing. Reproduction on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (one seed, 40 steps, one phase, `n_demons=1`):

```text
single-phase config constructed: 40 40 n_phases = 1
condition_recovery_fraction: {'partner_alone': nan, 'observe_only': nan, 'recommendation_p05': nan, 'accept_always': nan, 'augmented_predictions': nan, 'augmented_noise': nan}
condition_mean_recovery_steps: {'partner_alone': inf, 'observe_only': inf, 'recommendation_p05': inf, 'accept_always': inf, 'augmented_predictions': inf, 'augmented_noise': inf}
all_values_finite: True
numpy warnings: ['Mean of empty slice', 'invalid value encountered in scalar divide']
```

The recovery fraction is NaN and the mean recovery is inf while `all_values_finite` reports True (it only inspects rewards and phase means). The strict JSON artifact encoder later refuses the NaN, so the failure surfaces as an encoder error far from its cause.

# Change

Fail closed at the defect site: `aggregate_ia_evidence` raises `recovery evidence is empty for condition ...; the schedule must contain at least one phase switch` when a condition's concatenated recovery vector is empty. The guard sits after every per-record and roster validation, so the hostile-record tests that use minimal 2-step single-phase records (`tests/test_ia_condition_result_hostile.py`) still reach the errors they target. A config-level ban was tried first and dropped: those minimal records are legitimate for revalidation tests, and the aggregate is where the non-finite value is manufactured. The frozen protocol (six phases) is unaffected.

# Evidence

Failing-test-first: `tests/test_ia_condition_result_hostile.py::test_ia_aggregation_fails_closed_on_a_schedule_with_no_phase_switch` (a full six-condition roster of single-phase records with live budgets, which on `main` aggregates to NaN with numpy's empty-slice warnings).

At the base commit:

```text
E   Failed: DID NOT RAISE ValueError
  /root/asi/.venv/lib/python3.12/site-packages/numpy/_core/fromnumeric.py:3862: RuntimeWarning: Mean of empty slice
  /root/asi/.venv/lib/python3.12/site-packages/numpy/_core/_methods.py:142: RuntimeWarning: invalid value encountered in scalar divide
1 failed, 16 deselected, 2 warnings in 2.12s
```

At this head, `tests/test_continual_ia_evidence.py tests/test_continual_ia_cli.py tests/test_continual_ia_integer_hostile.py tests/test_continual_ia_number_hostile.py tests/test_continual_ia_digest_hostile.py tests/test_ia_condition_result_hostile.py`:

```text
166 passed, 9 skipped in 93.27s (0:01:33)
```

Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

# Evidence registry impact, stated plainly

`alberta_framework/evaluation/continual_ia.py` is a registered source of the `continual_intelligence_amplification` claim. Per the fail-closed design, editing it keeps that claim `invalid` until the frozen protocol is rerun. On current `origin/main` the registry already reports every claim, including this one, as `invalid` (`alberta-evidence-status` on a clean checkout of `c9aba7b5`: overall `invalid`, 0 of 5 supported), so this change does not newly invalidate anything. The guard does not alter any measurement path the frozen protocol exercises: with six phases the recovery vector is never empty.

<!-- evidence-head:16e5c79bed139eeae79a8bdaf931e32e8cfbeba5 -->
<!-- evidence-row:after-screenshots -->
- [x] Screenshot of the complete original verification log: ![PR 2822 original verification log](https://github.com/user-attachments/assets/5ece98f0-dee1-4263-94fc-f774fe3f1f8e)

Attachment maintenance, 2026-09-05: this screenshot reproduces the original author's published log in full, including its exact-head binding. The text log remains linked below. I inspected the source log and screenshot; this attachment update does not claim an independent rerun or scientific promotion. Evidence attachment work: OpenAI / gpt-6-astra, Codex. The original implementation attribution and signed receipt below are preserved.

<!-- evidence-row:backend-logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/913a17898729a67483e1bbeabb07501fd63ab597/evidence/pr-continual-ia-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifact: N/A - configuration validator fix; the evidence is the base reproduction and the paired failing/passing test transcript above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 28035536 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-continual-ia-recovery]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1P093YA0FEHD6WJT0GP7WMA","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T10:43:53.418Z","completed_at":"2026-09-04T11:14:04.593Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T10:43:53.846Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":3414,"output_tokens":67347,"cache_creation_tokens":99755,"cache_read_tokens":27865020,"total_tokens":28035536,"cost_micro_usd":"12362845","session_count":1},"trajectory_sha256":"b385f8b4b5dca37ad96ce0081dbd154e12f36f28a93a4d80c358b4b1073339b7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"efd88d12-a7de-4479-bb1a-300b18fa2510","object_id":"sha256:b385f8b4b5dca37ad96ce0081dbd154e12f36f28a93a4d80c358b4b1073339b7","sha256":"b385f8b4b5dca37ad96ce0081dbd154e12f36f28a93a4d80c358b4b1073339b7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"-8DVzr6qPgmG5wmTyb2Rv0Xy-Jzap8SlgAAiHea_wm_uVSffTvSmoBQQpCUW_4LT2ffDY4jDkyz6oYIPKAaRDg"}} -->
