### PR TITLE
fix(core): carry the intra-option trace through the goal step

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -1367,9 +1367,13 @@ def _update_intra_option_policy(
     """Update one intra-option Q-function with a transition discount.
 
     ``terminated`` is the option's own termination decision (goal, duration,
-    or environmental termination).  It always zeros the bootstrap.  Otherwise
-    the supplied transition discount controls both bootstrapping and trace
-    carry, so fractional continuation is not silently promoted to one.
+    or environmental termination).  It zeros the bootstrap only.  The supplied
+    transition discount controls both bootstrapping and trace carry, so
+    fractional continuation is not silently promoted to one.  The incoming
+    trace is decayed by that discount even on the terminating step: the goal
+    step's TD error must still reach the earlier actions of the option
+    (``e_t = gamma_t * lambda * e_{t-1} + phi_t``); the caller clears the
+    stored trace after this update when the option's lifecycle ends.
     """
     q_i = option_policies.q_weights[option_idx]
     traces_i = option_policies.traces[option_idx]
@@ -1383,7 +1387,7 @@ def _update_intra_option_policy(
 
     alpha = jnp.asarray(step_size, dtype=jnp.float32)
     beta = jnp.asarray(avg_reward_step_size, dtype=jnp.float32)
-    lam = jnp.asarray(trace_decay, dtype=jnp.float32) * bootstrap_discount
+    lam = jnp.asarray(trace_decay, dtype=jnp.float32) * transition_discount
     rho = jnp.asarray(importance_ratio, dtype=jnp.float32)
 
     action_mask = jax.nn.one_hot(last_intra_action, n_primitive_actions, dtype=jnp.float32)

--- a/tests/test_stomp_execution_boundaries.py
+++ b/tests/test_stomp_execution_boundaries.py
@@ -118,6 +118,55 @@ def test_censored_boundary_bootstraps_intra_option_then_clears_trace() -> None:
     assert int(result.state.option_models.n_completions[0]) == 0
 
 
+def test_goal_termination_credits_earlier_option_steps_through_the_trace() -> None:
+    """The goal step's TD error must reach earlier option actions via the carried trace.
+
+    Accumulating traces decay by the discount *entering* the current state, not by
+    the termination that zeros the bootstrap: ``e_t = gamma_t * lambda * e_{t-1} +
+    phi_t``. Zeroing the incoming trace on the goal step turns intra-option
+    learning into TD(0) exactly where sparse pseudo-reward needs multi-step credit.
+    """
+    agent = STOMPAgent(_config(threshold=1.0, option_step_size=0.5, option_trace_decay=0.75))
+    state = _active_state(agent)
+    prior_trace = np.zeros((N_PRIMITIVE, OBS_DIM), dtype=np.float32)
+    prior_trace[1, 1] = 1.0  # an earlier option step took action 1 on feature 1
+    state = state.replace(
+        option_policies=state.option_policies.replace(
+            q_weights=jnp.zeros((1, N_PRIMITIVE, OBS_DIM), dtype=jnp.float32),
+            traces=jnp.asarray(prior_trace)[None, :, :],
+        )
+    )
+
+    discount = 0.5
+    result = agent.update(
+        state,
+        jnp.array(0.0, dtype=jnp.float32),
+        BOOTSTRAP_OBS,
+        jnp.array(discount, dtype=jnp.float32),
+        decision_observation=DECISION_OBS,
+    )
+
+    assert bool(result.option_terminated)
+    assert float(result.pseudo_reward) == 1.0
+    # q_prev = 0, bootstrap zeroed by termination, hence TD = pseudo_reward = 1.
+    td_error = 1.0
+    current = np.zeros((N_PRIMITIVE, OBS_DIM), dtype=np.float32)
+    current[0] = np.asarray(LAST_OBS)  # the goal step took action 0 on LAST_OBS
+    expected_trace = 0.75 * discount * prior_trace + current
+    expected_q = 0.5 * td_error * expected_trace
+    np.testing.assert_allclose(
+        np.asarray(result.state.option_policies.q_weights[0]),
+        expected_q,
+        rtol=0.0,
+        atol=1.0e-6,
+    )
+    # The lifecycle ended, so the stored trace is cleared only after the update.
+    np.testing.assert_array_equal(
+        np.asarray(result.state.option_policies.traces[0]),
+        np.zeros((N_PRIMITIVE, OBS_DIM), dtype=np.float32),
+    )
+
+
 def test_censored_boundary_keeps_positive_base_bellman_bootstrap() -> None:
     agent = STOMPAgent(_config())
     state = _with_base_weights(


### PR DESCRIPTION
Outcome: **Fix** — a reproduced learning-rule defect in the option layer. Not a Climb / Port / Close.

# What is wrong on `main`

`_update_intra_option_policy` (`alberta_framework/core/options.py`) builds the intra-option Q(λ) update. It zeros the bootstrap on the option's own termination (correct), but it also uses that termination-zeroed discount to decay the *incoming* trace:

```python
bootstrap_discount = jnp.where(terminated, 0.0, transition_discount)
lam = jnp.asarray(trace_decay) * bootstrap_discount          # <- decays e_{t-1} by zero on termination
new_traces_i = rho * (lam * traces_i + action_mask[:, None] * last_obs[None, :])
```

Accumulating traces decay by the discount entering the current state, `e_t = γ_t λ e_{t-1} + φ_t` (Sutton & Barto 2nd ed. §12.5, general γ_t); termination at S_{t+1} zeros the bootstrap and the *next* decay, not the trace that carries the current TD error back. On the goal-reaching step the earlier actions of the option therefore receive zero credit from the single most informative transition. The caller's own comment says the opposite is intended ("the boundary sample contributes to both the weight and trace update. Clear the stored trace only afterwards") and `clear_option_trace` does that after the update, but on natural goal/duration/environmental termination the trace is already gone inside the update.

Unit reproduction on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (prior trace: action 0 on φ=[1,0]; goal step: action 1 on φ=[0,1], pseudo-reward 1, α=0.5, λ=0.9, γ=1):

```text
terminated=False td=1.00 trace=[[0.8999999761581421, 0.0], [0.0, 1.0]] q[a0]=[0.44999998807907104, 0.0] q[a1]=[0.0, 0.5]
terminated=True  td=1.00 trace=[[0.0, 0.0], [0.0, 1.0]] q[a0]=[0.0, 0.0] q[a1]=[0.0, 0.5]
```

Expected on termination: the same trace and `q[a0]=[0.45, 0]` as the non-terminating row; the earlier action gets α·δ·λ·e = 0.45.

# Change

One line: decay the incoming trace by `transition_discount` instead of `bootstrap_discount`. `terminated` still zeros the bootstrap, and the caller's post-update `clear_option_trace` still prevents leakage into the next execution. Docstring updated to state the contract.

After the change the unit probe gives identical rows for both termination states:

```text
terminated=False td=1.00 trace=[[0.8999999761581421, 0.0], [0.0, 1.0]] q[a0]=[0.44999998807907104, 0.0] q[a1]=[0.0, 0.5]
terminated=True  td=1.00 trace=[[0.8999999761581421, 0.0], [0.0, 1.0]] q[a0]=[0.44999998807907104, 0.0] q[a1]=[0.0, 0.5]
```

# Evidence

Failing-test-first: `tests/test_stomp_execution_boundaries.py::test_goal_termination_credits_earlier_option_steps_through_the_trace`, through the public `STOMPAgent.update` on a goal termination (threshold 1.0) with a prior trace on action 1; it asserts the whole option Q matrix against α·δ·(λγ·e_prev + φ) and that the stored trace is cleared afterwards.

At the base commit:

```text
E   Mismatched elements: 1 / 4 (25%)
E   Mismatch at index:
E    [1, 1]: 0.0 (ACTUAL), 0.1875 (DESIRED)
E   Max absolute difference among violations: 0.1875
1 failed, 5 deselected in 2.77s
```

At this head (`tests/test_stomp_execution_boundaries.py`):

```text
6 passed in 8.91s
```

Options, STOMP, OaK, Step 10/11, and float32-validation suites at this head:

```text
757 passed in 256.88s (0:04:16)
```

Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

# Impact

Every STOMP/OaK subtask learner (`STOMPAgent.update`/`scan`, OaK via STOMP adoption, `PrototypeAgent` with options enabled) ran intra-option TD(0) on the goal step regardless of `option_trace_decay`. This changes learning dynamics for option policies with sparse pseudo-reward; no frozen evidence lane registers `core/options.py`... except `continual_intelligence_amplification`, whose registered sources include `core/options.py`. That claim already reads `invalid` on clean `origin/main` (as do all five), so nothing is newly invalidated; the IA protocol's rerun would pick up the corrected rule.

Not a benchmark claim: no seeds, artifacts, or `outputs/` touched.

<!-- evidence-head:f0d1b357265c18f477967d55b28802861f1064ec -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/9ccb244aa9f4847c26850fe4b53db4f58248dcef/evidence/pr-intra-option-trace-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - learning-rule fix; the evidence is the base-vs-head unit probe and the paired failing/passing public-path test transcript above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 19226067 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-option-trace-decay]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1P29X3SBVTCR32694MM7S43","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T11:19:16.345Z","completed_at":"2026-09-04T11:30:25.685Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T11:19:16.840Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":3219,"output_tokens":58198,"cache_creation_tokens":159813,"cache_read_tokens":19004837,"total_tokens":19226067,"cost_micro_usd":"10135907","session_count":1},"trajectory_sha256":"ba060b38d27149143951ad0cbcaa1914108330afa35316bfb104687041dd5483","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"50ae473b-158f-4dff-a8e4-797ffb097257","object_id":"sha256:ba060b38d27149143951ad0cbcaa1914108330afa35316bfb104687041dd5483","sha256":"ba060b38d27149143951ad0cbcaa1914108330afa35316bfb104687041dd5483"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"e5M3va8XWJQ0LiGx_CP8XkQMXE4cD3upDNM7Tn4rzV1tOLwuTywUMJdHDBnWj7TtDrSL7B3pvUuvrochLiIBBQ"}} -->
