### PR TITLE
fix(evaluation): compare scale-robust and multiagent artifact subtrees by canonical bytes

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent_artifact.py
+++ b/alberta_framework/evaluation/continual_multiagent_artifact.py
@@ -692,6 +692,19 @@ def _required_mapping(
     return value
 
 
+def _same(actual: object, expected: object) -> bool:
+    """Type-exact equality for JSON values.
+
+    Python's ``==`` treats ``30 == 30.0`` and ``True == 1`` as equal, so a
+    re-digested artifact with punned scalar types would pass a plain ``!=``
+    comparison. Comparing canonical bytes rejects any byte-level drift.
+    """
+    try:
+        return canonical_content_bytes({"v": actual}) == canonical_content_bytes({"v": expected})
+    except (TypeError, ValueError):
+        return False
+
+
 def _finite_number(value: object) -> float | None:
     if type(value) is bool or (type(value) is not int and type(value) is not float):
         return None
@@ -707,7 +720,7 @@ def _validate_threshold_policy(
 
     canonical = _threshold_payload(AcceptanceThresholds())
     for key in ("minimum_seed_count", "evidence_seed_start"):
-        if thresholds.get(key) != canonical[key]:
+        if not _same(thresholds.get(key), canonical[key]):
             errors.append(
                 f"content.thresholds.{key} must equal the v1 canonical value"
             )
@@ -873,11 +886,11 @@ def _validate_seed_and_aggregate_consistency(
             "seeds 30-59 in order"
         )
     aggregate_seeds = aggregate.get("seeds")
-    if aggregate_seeds != list(_EXPECTED_EVIDENCE_SEEDS):
+    if not _same(aggregate_seeds, list(_EXPECTED_EVIDENCE_SEEDS)):
         errors.append("content.aggregate.seeds must equal held-out seeds 30-59")
-    if aggregate.get("seed_count") != len(_EXPECTED_EVIDENCE_SEEDS):
+    if not _same(aggregate.get("seed_count"), len(_EXPECTED_EVIDENCE_SEEDS)):
         errors.append("content.aggregate.seed_count must equal 30")
-    if aggregate_seeds != observed_seeds:
+    if not _same(aggregate_seeds, observed_seeds):
         errors.append(
             "content.aggregate.seeds must match content.seed_summaries"
         )
@@ -1025,14 +1038,12 @@ def _validate_seed_and_aggregate_consistency(
                         "content.aggregate.recurrence_recovery_fraction_interval."
                         f"{field_name} is inconsistent with seed summaries"
                     )
-            if recovery_interval.get("successes") != successes:
+            if not _same(recovery_interval.get("successes"), successes):
                 errors.append(
                     "content.aggregate.recurrence_recovery_fraction_interval."
                     "successes is inconsistent with seed summaries"
                 )
-            if recovery_interval.get("sample_size") != len(
-                _EXPECTED_EVIDENCE_SEEDS
-            ):
+            if not _same(recovery_interval.get("sample_size"), len(_EXPECTED_EVIDENCE_SEEDS)):
                 errors.append(
                     "content.aggregate.recurrence_recovery_fraction_interval."
                     "sample_size must equal 30"
@@ -1054,9 +1065,7 @@ def _validate_scientific_check_bindings(
     )
     resources = aggregate.get("resource_budget")
     aggregate_seeds = aggregate.get("seeds")
-    expected_schedule = float(
-        aggregate_seeds == list(_EXPECTED_EVIDENCE_SEEDS)
-    )
+    expected_schedule = float(_same(aggregate_seeds, list(_EXPECTED_EVIDENCE_SEEDS)))
     expected: dict[str, tuple[object, str, object]] = {
         "seed_count": (
             aggregate.get("seed_count"),

--- a/alberta_framework/evaluation/scale_robust_feature_artifact.py
+++ b/alberta_framework/evaluation/scale_robust_feature_artifact.py
@@ -395,6 +395,21 @@ def canonical_scientific_bytes(payload: Mapping[str, object]) -> bytes:
     ).encode("utf-8")
 
 
+def _same(actual: object, expected: object) -> bool:
+    """Type-exact equality for JSON subtrees.
+
+    Python's ``==`` treats ``True == 1.0`` and ``30 == 30.0`` as equal, so a
+    re-digested payload with punned scalar types would pass a plain ``!=``
+    comparison. Comparing canonical bytes rejects any byte-level drift.
+    """
+    try:
+        return canonical_scientific_bytes({"v": actual}) == canonical_scientific_bytes(
+            {"v": expected}
+        )
+    except (TypeError, ValueError):
+        return False
+
+
 def scientific_payload_sha256(payload: Mapping[str, object]) -> str:
     """Hash canonical deterministic scientific content."""
 
@@ -1718,7 +1733,7 @@ def _validate_metrics(
         return
     _exact_keys(metrics, _METRIC_KEYS, f"{location}.metrics", errors)
     recomputed = _metrics_from_condition(condition)
-    if metrics != recomputed:
+    if not _same(metrics, recomputed):
         errors.append(f"{location}.metrics do not match primitive phase/pair records")
     nonfinite = _strict_int(metrics.get("total_nonfinite_steps"))
     if nonfinite is None or nonfinite < 0:
@@ -2229,11 +2244,11 @@ def validate_evidence_artifact(
             "scientific_payload",
             errors,
         )
-        if scientific.get("protocol") != _protocol_payload():
+        if not _same(scientific.get("protocol"), _protocol_payload()):
             errors.append("scientific_payload.protocol is not the frozen v2 protocol")
-        if scientific.get("configuration") != frozen_configuration_payload():
+        if not _same(scientific.get("configuration"), frozen_configuration_payload()):
             errors.append("scientific_payload.configuration is not the frozen v2 configuration")
-        if scientific.get("thresholds") != _threshold_payload():
+        if not _same(scientific.get("thresholds"), _threshold_payload()):
             errors.append("scientific_payload.thresholds are not the frozen v2 thresholds")
         memory = _validate_memory(
             scientific.get("memory_by_condition"),
@@ -2244,7 +2259,7 @@ def validate_evidence_artifact(
             errors,
         )
         recomputed_aggregate = _aggregate_payload(records)
-        if scientific.get("aggregate") != recomputed_aggregate:
+        if not _same(scientific.get("aggregate"), recomputed_aggregate):
             errors.append("scientific_payload.aggregate does not match primitive records")
         comparisons = scientific.get("comparisons")
         comparisons_mapping = _mapping(
@@ -2267,7 +2282,7 @@ def validate_evidence_artifact(
                     errors=errors,
                 )
         recomputed_comparisons = _comparisons_payload(records)
-        if comparisons != recomputed_comparisons:
+        if not _same(comparisons, recomputed_comparisons):
             errors.append("scientific_payload.comparisons do not match primitive records")
         recomputed_acceptance = _acceptance_payload(
             seed_records=records,
@@ -2276,7 +2291,7 @@ def validate_evidence_artifact(
             comparisons=recomputed_comparisons,
         )
         _validate_acceptance_shape(scientific.get("acceptance"), errors)
-        if scientific.get("acceptance") != recomputed_acceptance:
+        if not _same(scientific.get("acceptance"), recomputed_acceptance):
             errors.append("scientific_payload.acceptance does not match recomputed gate")
         accepted_by_payload = bool(recomputed_acceptance["passed"])
         _validate_source_provenance(

--- a/tests/test_continual_multiagent_benchmark.py
+++ b/tests/test_continual_multiagent_benchmark.py
@@ -400,6 +400,38 @@ def test_rehashed_source_provenance_tampering_fails_current_source_binding(
     assert any("current pinned source hashes" in error for error in validation.errors)
 
 
+def test_rehashed_type_punned_seed_and_threshold_values_fail_closed(
+    benchmark_report,
+) -> None:
+    """Python equality treats 30 == 30.0; the validator must reject punned scalars."""
+    fabricated = copy.deepcopy(build_evidence_artifact(benchmark_report))
+    content = fabricated["content"]
+    assert isinstance(content, dict)
+    aggregate = content["aggregate"]
+    assert isinstance(aggregate, dict)
+    thresholds = content["thresholds"]
+    assert isinstance(thresholds, dict)
+    aggregate["seeds"] = [float(seed) for seed in aggregate["seeds"]]
+    aggregate["seed_count"] = float(aggregate["seed_count"])
+    thresholds["minimum_seed_count"] = float(thresholds["minimum_seed_count"])
+    interval = aggregate["recurrence_recovery_fraction_interval"]
+    assert isinstance(interval, dict)
+    interval["successes"] = float(interval["successes"])
+    digest = fabricated["content_digest"]
+    assert isinstance(digest, dict)
+    digest["sha256"] = scientific_content_sha256(content)
+
+    validation = validate_evidence_artifact(fabricated)
+
+    assert not validation.valid
+    assert not validation.accepted
+    errors = validation.errors
+    assert any("content.aggregate.seeds must equal held-out seeds 30-59" in e for e in errors)
+    assert any("content.aggregate.seed_count must equal 30" in e for e in errors)
+    assert any("content.thresholds.minimum_seed_count must equal" in e for e in errors)
+    assert any("successes is inconsistent with seed summaries" in e for e in errors)
+
+
 def test_rehashed_unknown_scientific_field_fails_schema(
     benchmark_report,
 ) -> None:

--- a/tests/test_scale_robust_feature_artifact.py
+++ b/tests/test_scale_robust_feature_artifact.py
@@ -992,6 +992,29 @@ def test_unknown_scientific_key_fails_even_when_rehashed(
     assert any("unknown keys" in error for error in validation.errors)
 
 
+def test_type_punned_gate_values_fail_even_when_rehashed(
+    accepted_artifact: dict[str, object],
+):
+    """Python equality treats True == 1.0 and 30 == 30.0; the validator must not."""
+    changed = copy.deepcopy(accepted_artifact)
+    check = _acceptance_checks(changed)[
+        "all_seed_primary_pre_final_d_context_noninferior_to_no_retention"
+    ]
+    assert float(check["actual"]).is_integer() and float(check["threshold"]).is_integer()
+    check["actual"] = int(check["actual"])  # JSON 4 in place of 4.0
+    check["threshold"] = bool(check["threshold"]) if check["threshold"] in (0.0, 1.0) else int(
+        check["threshold"]
+    )
+    changed["scientific_payload"]["thresholds"]["minimum_seed_count"] = 30.0
+    _rehash(changed)
+    validation = validate_evidence_artifact(changed)
+    assert not validation.valid
+    assert not validation.accepted
+    errors = validation.errors
+    assert any("acceptance does not match recomputed gate" in error for error in errors)
+    assert any("thresholds are not the frozen v2 thresholds" in error for error in errors)
+
+
 def test_primitive_tamper_fails_internal_binding_even_when_rehashed(
     accepted_artifact: dict[str, object],
 ):


### PR DESCRIPTION
Outcome: **Fix** — two evidence validators that accept re-digested artifacts they should reject. Not a Climb / Port / Close.

# What is wrong on `main`

`scale_robust_feature_artifact.py::validate_evidence_artifact` compares the recorded `protocol`, `configuration`, `thresholds`, `aggregate`, `comparisons`, and `acceptance` subtrees (and per-condition `metrics`) against recomputed values with Python `!=`. `continual_multiagent_artifact.py` does the same for the frozen threshold policy, `aggregate.seeds`, `seed_count`, and the recovery interval's `successes`/`sample_size`. Python equality treats `True == 1.0`, `4 == 4.0`, and `30 == 30.0` as equal, so a payload whose scalars were type-punned and then re-digested is accepted as valid and accepted although its canonical bytes match nothing the builders emit and its digest no longer identifies one reproducible payload. `_validate_acceptance_shape` type-checks `name`, `comparator`, and `passed`, but not `actual` or `threshold`. This is the class PR 2820 closed for the bounded-elastic lane; the FTL lane's `_compare_structure` is already type-exact.

Reproduction on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, loading the pinned artifacts read-only and isolating the validators from the known registered-source drift by patching only the source-hash provider; the acceptance check's `actual`/`threshold` become JSON booleans, `thresholds.minimum_seed_count` becomes `30.0`, and the digest is recomputed:

```text
scale-robust: baseline valid=True accepted=True → tampered (re-digested) valid=True accepted=True
multiagent:   baseline valid=True accepted=True → tampered (re-digested) valid=True accepted=True
```

Expected: rejected with the lanes' own messages ("acceptance does not match recomputed gate", "thresholds are not the frozen v2 thresholds", "content.aggregate.seeds must equal held-out seeds 30-59", ...).

# Change

Each lane gets a `_same(actual, expected)` that compares canonical JSON bytes (the lane's own digest encoding, which distinguishes `false`/`0.0` and `30`/`30.0`), mirroring `gradual_ipmnist_nonpromoting._same`. It replaces the seven scale-robust comparisons and the seven multiagent scalar/seed comparisons. Honest artifacts are unaffected: their canonical bytes are exactly what the digest already binds. `_same` returns False rather than raising if a tampered value is not JSON-encodable, so the validator reports drift instead of crashing.

# Evidence

Failing-test-first: `tests/test_scale_robust_feature_artifact.py::test_type_punned_gate_values_fail_even_when_rehashed` (against the module's synthetic accepted artifact) and `tests/test_continual_multiagent_benchmark.py::test_rehashed_type_punned_seed_and_threshold_values_fail_closed` (against the module's thirty-seed benchmark artifact).

At the base commit, tests only:

```text
E   assert not True
/tmp/asi-main-clean2/tests/test_continual_multiagent_benchmark.py:426: assert not True
FAILED tests/test_scale_robust_feature_artifact.py::test_type_punned_gate_values_fail_even_when_rehashed
FAILED tests/test_continual_multiagent_benchmark.py::test_rehashed_type_punned_seed_and_threshold_values_fail_closed
2 failed, 93 deselected in 24.46s
E   assert not True
/tmp/asi-main-clean2/tests/test_scale_robust_feature_artifact.py:1011: assert not True
FAILED tests/test_scale_robust_feature_artifact.py::test_type_punned_gate_values_fail_even_when_rehashed
1 failed, 61 deselected in 2.77s
```

At this head, focused:

```text
2 passed, 93 deselected in 21.81s
```

All `tests/test_scale_robust*.py` and `tests/test_continual_multiagent*.py` suites at this head:

```text
367 passed, 2 skipped in 28.42s
```

Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

# Evidence registry impact, stated plainly

Both files are registered sources (`scale_robust_pair_features`, `recurring_multiagent_coadaptation`). Editing them keeps those claims `invalid` until the frozen protocols rerun; on current `origin/main` the registry already reports every claim as `invalid` (`alberta-evidence-status` on a clean checkout of `c9aba7b5`: overall `invalid`, 0 of 5 supported), so nothing is newly invalidated. The pinned artifacts' canonical bytes are unchanged by this validator change.

<!-- evidence-head:ab682bc0c81a3134f320ac640872f2f0787470ca -->
<!-- evidence-row:after-screenshots -->
- [x] Screenshot of the complete original verification log: ![PR 2824 original verification log](https://github.com/user-attachments/assets/7d369e63-3532-4db6-bfba-d51e8d04752e)

Attachment maintenance, 2026-09-05: this screenshot reproduces the original author's published log in full, including its exact-head binding. The text log remains linked below. I inspected the source log and screenshot; this attachment update does not claim an independent rerun or scientific promotion. Evidence attachment work: OpenAI / gpt-6-astra, Codex. The original implementation attribution and signed receipt below are preserved.

<!-- evidence-row:backend-logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/adf93ccdcd3e3379c00f38dff1408c6fce08a07b/evidence/pr-artifact-validators-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifact: N/A - validator fix; the evidence is the paired failing/passing test transcripts above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 15338626 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-validator-canonical-compare]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1P2G1MYWED6PM9WFY2F0CTA","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T11:22:37.599Z","completed_at":"2026-09-04T11:30:42.208Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T11:22:38.104Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":2081,"output_tokens":48750,"cache_creation_tokens":88030,"cache_read_tokens":15199765,"total_tokens":15338626,"cost_micro_usd":"7664431","session_count":1},"trajectory_sha256":"a6405ee086f5bed0c319cb6c7d0c6b5b3acf94e6811f1b50de1047ac039d3d23","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9f3494a4-dc08-448b-8d9c-8be26a2e3828","object_id":"sha256:a6405ee086f5bed0c319cb6c7d0c6b5b3acf94e6811f1b50de1047ac039d3d23","sha256":"a6405ee086f5bed0c319cb6c7d0c6b5b3acf94e6811f1b50de1047ac039d3d23"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"CabYlO3ByODc27A7kdFEO6mBsI-AVdlC8ZQPbEKY2OMcZYJSsBYhpLG87snjU4Ry-i_W9yB0eS5RRabhOfI-Bg"}} -->
