### PR TITLE
fix(reference-life): return a committed post-execution halt from run_to_completion

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -1744,8 +1744,18 @@ class ReferenceLifeStep:
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class ReferenceLifeRun:
+    """A completed or halted life with the events it emitted.
+
+    The transcript advances on every staged receipt, not only on emitted
+    events. A post-execution halt commits a known execution with no event, so
+    the final event's transcript then equals the transcript of the state the
+    halting step started from; ``pre_halt_transcript_sha256`` records it so
+    the binding stays exact for that case and is rejected everywhere else.
+    """
+
     state: ReferenceLifeState
     events: tuple[ReferenceLifeEvent, ...]
+    pre_halt_transcript_sha256: str | None = None
 
     def __post_init__(self) -> None:
         if type(self.state) is not ReferenceLifeState:
@@ -1754,8 +1764,29 @@ class ReferenceLifeRun:
             raise ValueError("events must be an exact tuple")
         if any(type(event) is not ReferenceLifeEvent for event in self.events):
             raise ValueError("events must contain only ReferenceLifeEvent records")
-        if self.events and self.events[-1].transcript_sha256 != self.state.transcript_sha256:
-            raise ValueError("final event transcript disagrees with run state")
+        if self.pre_halt_transcript_sha256 is None:
+            if self.events and self.events[-1].transcript_sha256 != self.state.transcript_sha256:
+                raise ValueError("final event transcript disagrees with run state")
+            return
+        if (
+            type(self.pre_halt_transcript_sha256) is not str
+            or _SHA256.fullmatch(self.pre_halt_transcript_sha256) is None
+        ):
+            raise ValueError("pre_halt_transcript_sha256 must be an exact sha256 hex string")
+        if (
+            self.state.phase not in (LifePhase.HALTED, LifePhase.ABORTED)
+            or self.state.halt is None
+            or self.state.halt.stage is not HaltStage.POST_EXECUTION_DIVERGENCE
+        ):
+            raise ValueError(
+                "pre_halt_transcript_sha256 is only valid for a post-execution halt"
+            )
+        if not self.events or self.events[-1].transcript_sha256 != (
+            self.pre_halt_transcript_sha256
+        ):
+            raise ValueError("final event transcript disagrees with the pre-halt state")
+        if self.pre_halt_transcript_sha256 == self.state.transcript_sha256:
+            raise ValueError("post-execution halt must have advanced the transcript")
 
 
 @dataclasses.dataclass(slots=True)
@@ -3312,12 +3343,26 @@ class ReferenceLifeRunner:
 
         events: list[ReferenceLifeEvent] = []
         current = state
+        pre_halt_transcript: str | None = None
         while current.phase is LifePhase.QUIESCENT:
             step = self.step(current)
             if step.event is not None:
                 events.append(step.event)
+            elif (
+                events
+                and step.state.halt is not None
+                and step.state.halt.stage is HaltStage.POST_EXECUTION_DIVERGENCE
+                and step.state.transcript_sha256 != current.transcript_sha256
+            ):
+                # The halt committed a receipt-advanced transcript without an
+                # event; bind the last event to the transcript it was emitted at.
+                pre_halt_transcript = current.transcript_sha256
             current = step.state
-        return ReferenceLifeRun(state=current, events=tuple(events))
+        return ReferenceLifeRun(
+            state=current,
+            events=tuple(events),
+            pre_halt_transcript_sha256=pre_halt_transcript,
+        )
 
 
 def build_prototype_switching_life(

--- a/tests/test_reference_life.py
+++ b/tests/test_reference_life.py
@@ -45,6 +45,7 @@ from alberta_framework.reference_life import (
     RecoveryMode,
     ReferenceLifeConfig,
     ReferenceLifeMetricsAdapter,
+    ReferenceLifeRun,
     ReferenceLifeRunner,
     SwitchingEnvironmentExecution,
     SwitchingTwoStateReferenceEnvironment,
@@ -954,6 +955,66 @@ class _MismatchingEnvironment(SwitchingTwoStateReferenceEnvironment):
             autoreset=False,
             regime_id=phase,
             oracle_reward=self._environment.optimal_average_reward(phase),
+        )
+
+
+class _MismatchingOnSecondEnvironment(_MismatchingEnvironment):
+    """Executor applies the commanded action once, then the wrong action."""
+
+    def execute(
+        self,
+        state: Any,
+        command: DispatchCommand,
+        *,
+        key: Any,
+    ) -> SwitchingEnvironmentExecution:
+        if int(np.asarray(state.step_count)) == 0:
+            return SwitchingTwoStateReferenceEnvironment.execute(self, state, command, key=key)
+        return super().execute(state, command, key=key)
+
+
+def test_run_to_completion_returns_a_committed_post_execution_halt() -> None:
+    """A halt after one accepted event is the runner's own valid output, not an error.
+
+    The post-execution halt commits a receipt-advanced transcript with no
+    event, so the last emitted event carries the transcript of the state the
+    halting step started from; the run must record that binding instead of
+    rejecting its own state.
+    """
+    adapter = PrototypeReferenceAdapter.from_config(_agent_config())
+    environment = _MismatchingOnSecondEnvironment(
+        SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        observation_spec=adapter.manifest.observation_spec,
+        action_spec=adapter.manifest.action_spec,
+    )
+    runner = ReferenceLifeRunner.create(
+        agent_adapter=adapter,
+        environment_adapter=environment,
+        lifecycle_id=_LIFECYCLE_ID,
+        seed=7,
+        max_accepted_events=4,
+    )
+
+    run = runner.run_to_completion(runner.init())
+
+    assert run.state.phase is LifePhase.HALTED
+    assert run.state.halt is not None
+    assert run.state.halt.stage is HaltStage.POST_EXECUTION_DIVERGENCE
+    assert run.state.accepted_events == 1
+    assert run.state.executed_events == 2
+    assert len(run.events) == 1
+    assert run.pre_halt_transcript_sha256 == run.events[-1].transcript_sha256
+    assert run.pre_halt_transcript_sha256 != run.state.transcript_sha256
+    assert run.state == runner.current_state
+    # The binding is exact: it is rejected for a run that did not halt this way.
+    completed_runner = _runner(horizon=1)
+    completed = completed_runner.run_to_completion(completed_runner.init())
+    assert completed.state.phase is LifePhase.COMPLETED
+    with pytest.raises(ValueError, match="only valid for a post-execution halt"):
+        ReferenceLifeRun(
+            state=completed.state,
+            events=completed.events,
+            pre_halt_transcript_sha256=completed.events[-1].transcript_sha256,
         )
 
 


### PR DESCRIPTION
Outcome: **Fix** — a validator that rejects the runner's own valid output. Not a Climb / Port / Close.

# What is wrong on `main`

`ReferenceLifeRun.__post_init__` (`alberta_framework/reference_life.py`) requires `events[-1].transcript_sha256 == state.transcript_sha256`. The transcript, however, advances on every staged receipt, not only on emitted events: `_halt_after_execution_locked` ("Commit a known execution while discarding all staged learning") and the emergency halt with a staged receipt both commit a receipt-advanced transcript and return `event=None`. So any life with at least one accepted event that then halts at `POST_EXECUTION_DIVERGENCE` has a final state whose transcript no event carries, and `run_to_completion` raises on a fully committed, consistent state. The dispatch-uncertain halt, which does not advance the transcript, passes, which shows the inconsistency is in the wrapper, not the ledger.

Reproduction on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`: an executor that applies the commanded action on the first command and the wrong action on the second (the same technique as the existing `_MismatchingEnvironment` fixture), horizon 4:

```text
run_to_completion raised ValueError: final event transcript disagrees with run state
runner.current_state.phase = LifePhase.HALTED | halt.stage = post_execution_divergence | accepted = 1 | executed = 2
halt reason: executor applied action differs from the settled command
step1 accepted: True | step2 accepted: False event is None: True
last accepted event transcript == halted state transcript: False
halted state transcript == pre-halt state transcript: False
```

Meanwhile `runner.current_state` is `HALTED` at `post_execution_divergence` with one accepted and two executed events, and its halt reason is "executor applied action differs from the settled command". The halt is committed; only the run wrapper cannot represent it.

# Change

`ReferenceLifeRun` gains `pre_halt_transcript_sha256: str | None = None`. When it is `None` the existing binding applies unchanged. When set, the run must be halted or aborted at `POST_EXECUTION_DIVERGENCE`, the last event's transcript must equal it, and it must differ from the halted state's transcript (the halt advanced it). It is rejected for any other run, so the binding stays exact rather than merely relaxed. `run_to_completion` fills it from the state the halting step started from, only when a post-execution halt advanced the transcript after at least one event. Nothing serialized changes: `LifeHalt`, the ledger, the checkpoint codec, and the scorecard (which drives `runner.step` directly) are untouched.

# Evidence

Failing-test-first: `tests/test_reference_life.py::test_run_to_completion_returns_a_committed_post_execution_halt`, which also asserts the binding is rejected for a completed run.

At the base commit:

```text
E   ValueError: final event transcript disagrees with run state
/tmp/asi-main-clean3/alberta_framework/reference_life.py:1758: ValueError: final event transcript disagrees with run state
1 failed, 43 deselected in 5.81s
```

At this head (the new test with the sibling mismatch tests):

```text
5 passed, 39 deselected in 10.10s
```

Reference-life, reference-agent, and prototype-adapter suites at this head (`-m "not slow"`):

```text
252 passed, 1 skipped, 15 deselected in 120.14s (0:02:00)
```

Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

Invariants the same audit verified as holding (no change needed): double, foreign-epoch, and non-advancing receipts rejected; 16-thread CAS races yield exactly one winner; exact resume through chained checkpoints and after pending-outcome recovery reproduces identical events and transcripts; checkpoint metric tolerances hold to 200k events; RiverSwim execute/validate share the same key.

Not an evidence lane: no seeds, artifacts, or `outputs/` touched; `reference_life.py` is not a registered evidence source.

<!-- evidence-head:a4517fc8d0846c2c1243a89cdd21d45166711317 -->
<!-- evidence-row:after-screenshots -->
- [x] Screenshot of the complete original verification log: ![PR 2825 original verification log](https://github.com/user-attachments/assets/96be2ef2-2714-4d78-8c0d-41caeda6b85c)

Attachment maintenance, 2026-09-05: this screenshot reproduces the original author's published log in full, including its exact-head binding. The text log remains linked below. I inspected the source log and screenshot; this attachment update does not claim an independent rerun or scientific promotion. Evidence attachment work: OpenAI / gpt-6-astra, Codex. The original implementation attribution and signed receipt below are preserved.

<!-- evidence-row:backend-logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/289541fa45346f63986c1a0ed5112dc76162e32e/evidence/pr-reference-run-halt-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifacts -->
- [x] domain-artifact: N/A - run-wrapper validator fix; the evidence is the base reproduction and the paired failing/passing test transcript above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 13338091 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-reference-run-halt]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1P2ZJMSXKKZAW71KABJ7JZE","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T11:31:06.522Z","completed_at":"2026-09-04T11:40:15.494Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T11:31:06.978Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":1209,"output_tokens":19238,"cache_creation_tokens":32916,"cache_read_tokens":13284728,"total_tokens":13338091,"cost_micro_usd":"4953492","session_count":1},"trajectory_sha256":"91a347e37d593a93b54a7171b7661454e55f54f42a62a0135b7042f5d9f1e087","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ebe5efd8-9794-4bbf-b891-2eda5e27c740","object_id":"sha256:91a347e37d593a93b54a7171b7661454e55f54f42a62a0135b7042f5d9f1e087","sha256":"91a347e37d593a93b54a7171b7661454e55f54f42a62a0135b7042f5d9f1e087"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"0tG8VSVEXj_mH1D05V0GZLhl3rHXJhXemSJ62bgqbfpX6mUzv4Lahzs3_RooWKizA-y_Z2pfCkszLZsJS2KIBg"}} -->
