### PR TITLE
fix(pipeline): stop the Step 3 Horde bootstrapping across terminal steps in sarsa mode

### DIFF
--- a/alberta_framework/core/horde.py
+++ b/alberta_framework/core/horde.py
@@ -871,6 +871,41 @@ class MixedHorde:
         next_observation: Array,
     ) -> HordeUpdateResult:
         """Update routed demons and return outputs in original demon order."""
+        return self._update_with_discounts(
+            state, observation, cumulants, next_observation, None
+        )
+
+    def update_with_discounts(
+        self,
+        state: MixedHordeState,
+        observation: Array,
+        cumulants: Array,
+        next_observation: Array,
+        discounts: Array,
+    ) -> HordeUpdateResult:
+        """Update routed demons with explicit per-demon transition discounts.
+
+        ``discounts`` has shape ``(n_demons,)`` in original demon order and is
+        split across the shared and independent paths, each applying its own
+        ``update_with_discounts``.
+        """
+        discounts = jnp.asarray(discounts, dtype=jnp.float32)
+        if discounts.shape != (self.n_demons,):
+            raise ValueError(
+                f"discounts must have shape {(self.n_demons,)}, got {discounts.shape}"
+            )
+        return self._update_with_discounts(
+            state, observation, cumulants, next_observation, discounts
+        )
+
+    def _update_with_discounts(
+        self,
+        state: MixedHordeState,
+        observation: Array,
+        cumulants: Array,
+        next_observation: Array,
+        discounts: Array | None,
+    ) -> HordeUpdateResult:
         predictions = jnp.full((self.n_demons,), jnp.nan, dtype=jnp.float32)
         td_errors = jnp.full((self.n_demons,), jnp.nan, dtype=jnp.float32)
         td_targets = jnp.full((self.n_demons,), jnp.nan, dtype=jnp.float32)
@@ -883,12 +918,15 @@ class MixedHorde:
 
         if self._shared_horde is not None:
             idx = jnp.asarray(self._shared_indices, dtype=jnp.int32)
-            shared_result = self._shared_horde.update(
-                cast(MultiHeadMLPState, state.shared_state),
-                observation,
-                cumulants[idx],
-                next_observation,
-            )
+            shared_state = cast(MultiHeadMLPState, state.shared_state)
+            if discounts is None:
+                shared_result = self._shared_horde.update(
+                    shared_state, observation, cumulants[idx], next_observation
+                )
+            else:
+                shared_result = self._shared_horde.update_with_discounts(
+                    shared_state, observation, cumulants[idx], next_observation, discounts[idx]
+                )
             new_shared_state = shared_result.state
             predictions = predictions.at[idx].set(shared_result.predictions)
             td_errors = td_errors.at[idx].set(shared_result.td_errors)
@@ -904,12 +942,19 @@ class MixedHorde:
 
         if self._independent_horde is not None:
             idx = jnp.asarray(self._independent_indices, dtype=jnp.int32)
-            independent_result = self._independent_horde.update(
-                state.independent_state,
-                observation,
-                cumulants[idx],
-                next_observation,
-            )
+            independent_state = cast(Any, state.independent_state)
+            if discounts is None:
+                independent_result = self._independent_horde.update(
+                    independent_state, observation, cumulants[idx], next_observation
+                )
+            else:
+                independent_result = self._independent_horde.update_with_discounts(
+                    independent_state,
+                    observation,
+                    cumulants[idx],
+                    next_observation,
+                    discounts[idx],
+                )
             new_independent_state = independent_result.state
             predictions = predictions.at[idx].set(independent_result.predictions)
             td_errors = td_errors.at[idx].set(independent_result.td_errors)

--- a/alberta_framework/core/independent_demon_horde.py
+++ b/alberta_framework/core/independent_demon_horde.py
@@ -934,6 +934,44 @@ class IndependentDemonHorde:
         cumulants: Array,
         next_observation: Array,
     ) -> HordeUpdateResult:
+        """Update every demon's network, bootstrapping with its fixed gamma.
+
+        See :meth:`update_with_discounts` for the transition-discount form
+        that control adapters use to zero bootstrapping at episode boundaries.
+        """
+        return self._update_with_discounts(
+            state, observation, cumulants, next_observation, None
+        )
+
+    def update_with_discounts(
+        self,
+        state: IndependentDemonHordeState,
+        observation: Array,
+        cumulants: Array,
+        next_observation: Array,
+        discounts: Array,
+    ) -> HordeUpdateResult:
+        """Update every demon with explicit per-demon transition discounts.
+
+        The same TD update as :meth:`update`, except callers supply the
+        effective bootstrap discount for this transition (for example the
+        spec gammas zeroed on a terminal step). Per-demon trace decay keeps
+        using the fixed GVF metadata, matching :class:`HordeLearner`.
+        ``discounts`` has shape ``(n_demons,)``; a non-finite entry or one
+        outside ``[0, 1]`` rejects that demon's update.
+        """
+        return self._update_with_discounts(
+            state, observation, cumulants, next_observation, discounts
+        )
+
+    def _update_with_discounts(
+        self,
+        state: IndependentDemonHordeState,
+        observation: Array,
+        cumulants: Array,
+        next_observation: Array,
+        discounts: Array | None,
+    ) -> HordeUpdateResult:
         """Update every demon's network given observation, cumulants, next obs.
 
         Computes per-demon TD targets ``r + gamma * V(s')`` using each
@@ -964,6 +1002,16 @@ class IndependentDemonHorde:
         )
         gammas = self._horde_spec.gammas
         lamdas = self._horde_spec.lamdas
+        if discounts is None:
+            effective_discounts = gammas
+            discounts_valid = jnp.ones((n_demons,), dtype=jnp.bool_)
+        else:
+            effective_discounts = self._operand("discounts", discounts, (n_demons,))
+            discounts_valid = (
+                jnp.isfinite(effective_discounts)
+                & (effective_discounts >= 0.0)
+                & (effective_discounts <= 1.0)
+            )
 
         # 1. Per-demon V(s') for bootstrapping (each demon uses its OWN net)
         next_preds = jnp.stack(
@@ -971,7 +1019,9 @@ class IndependentDemonHorde:
         )
 
         # 2. TD targets: r + gamma * V(s'). gamma=0 must not multiply inf V(s').
-        bootstrap = jnp.where(gammas == 0.0, 0.0, gammas * next_preds)
+        bootstrap = jnp.where(
+            effective_discounts == 0.0, 0.0, effective_discounts * next_preds
+        )
         targets = cumulants + bootstrap
 
         # 3. NaN means inactive; other non-finite values are rejected heads.
@@ -1003,7 +1053,11 @@ class IndependentDemonHorde:
             )
         )
         active_mask = (
-            requested_mask & jnp.isfinite(cumulants) & jnp.isfinite(targets) & global_inputs_valid
+            requested_mask
+            & jnp.isfinite(cumulants)
+            & discounts_valid
+            & jnp.isfinite(targets)
+            & global_inputs_valid
         )
         safe_targets = jnp.where(active_mask, targets, 0.0)
 

--- a/alberta_framework/pipeline.py
+++ b/alberta_framework/pipeline.py
@@ -1592,11 +1592,16 @@ class AlbertaPipeline:
             horde_td_targets = ac_result.critic_result.td_targets
             components_applied = ac_result.update_applied
         else:
-            horde_result = self._horde.update(
+            # A terminal transition must not bootstrap: zero every demon's
+            # discount on termination, as the horde_ac path and Step 4 already
+            # do, instead of letting gamma > 0 demons look across the reset.
+            horde_discounts = self._horde.horde_spec.gammas * (1.0 - terminated)
+            horde_result = self._horde.update_with_discounts(
                 state.horde_state,
                 state.last_features,
                 horde_cumulants,
                 features,
+                horde_discounts,
             )
             sarsa_state = cast(SARSAState, state.control_state)
             control_result = step4_update(

--- a/tests/test_independent_demon_horde.py
+++ b/tests/test_independent_demon_horde.py
@@ -123,6 +123,61 @@ class TestInitShape:
 # =============================================================================
 
 
+class TestUpdateWithDiscounts:
+    """Explicit transition discounts replace the fixed gammas in the bootstrap only."""
+
+    def test_spec_gammas_reproduce_update_and_zero_discounts_stop_bootstrapping(self) -> None:
+        demons = [
+            GVFSpec(
+                name=f"d{i}",
+                demon_type=DemonType.PREDICTION,
+                gamma=gamma,
+                lamda=0.5,
+                cumulant_index=i,
+            )
+            for i, gamma in enumerate((0.9, 0.5))
+        ]
+        spec = create_horde_spec(demons)
+        horde = IndependentDemonHorde(horde_spec=spec, hidden_sizes=(4,), sparsity=0.0)
+        state = horde.init(3, jr.key(0))
+        observation = jnp.asarray([0.2, -0.4, 0.1], dtype=jnp.float32)
+        cumulants = jnp.asarray([1.0, -0.5], dtype=jnp.float32)
+        next_observation = jnp.asarray([-0.3, 0.2, 0.5], dtype=jnp.float32)
+        # Warm the traces so a discount cannot be confused with trace decay.
+        state = horde.update(state, observation, cumulants, next_observation).state
+
+        plain = horde.update(state, observation, cumulants, next_observation)
+        same = horde.update_with_discounts(
+            state, observation, cumulants, next_observation, spec.gammas
+        )
+        chex.assert_trees_all_close(same.state, plain.state)
+        chex.assert_trees_all_close(same.td_targets, plain.td_targets)
+
+        terminal = horde.update_with_discounts(
+            state,
+            observation,
+            cumulants,
+            next_observation,
+            jnp.zeros((2,), dtype=jnp.float32),
+        )
+        chex.assert_trees_all_close(terminal.td_targets, cumulants, atol=1e-6)
+        assert bool(terminal.update_applied)
+
+        rejected = horde.update_with_discounts(
+            state,
+            observation,
+            cumulants,
+            next_observation,
+            jnp.asarray([1.5, 0.5], dtype=jnp.float32),
+        )
+        assert not bool(rejected.head_updates_applied[0])
+        assert bool(rejected.head_updates_applied[1])
+        with pytest.raises(ValueError, match="discounts"):
+            horde.update_with_discounts(
+                state, observation, cumulants, next_observation, jnp.zeros((3,), jnp.float32)
+            )
+
+
 class TestIndependence:
     """Updating with cumulant only on demon 0 must leave demon 1 unchanged."""
 

--- a/tests/test_mixed_horde.py
+++ b/tests/test_mixed_horde.py
@@ -17,6 +17,7 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 from alberta_framework import (
     DemonType,
@@ -605,3 +606,36 @@ class TestStep3RoutingDispatch:
         cfg = Step3HordeConfig(routing="mixed")
         restored = Step3HordeConfig.from_dict(cfg.to_dict())
         assert restored.routing == "mixed"
+
+
+def test_mixed_horde_update_with_discounts_routes_per_demon_discounts() -> None:
+    """Discounts are split across the shared and independent paths in demon order."""
+    demons = [
+        _gamma0_demon("shared0", 0),
+        _temporal_demon("independent1", 1, 0.9, 0.5),
+        _gamma0_demon("shared2", 2),
+    ]
+    spec = create_horde_spec(demons)
+    horde = MixedHorde(horde_spec=spec, hidden_sizes=(4,), sparsity=0.0)
+    state = horde.init(3, jr.key(0))
+    observation = jnp.asarray([0.2, -0.4, 0.1], dtype=jnp.float32)
+    cumulants = jnp.asarray([1.0, -0.5, 0.25], dtype=jnp.float32)
+    next_observation = jnp.asarray([-0.3, 0.2, 0.5], dtype=jnp.float32)
+    state = horde.update(state, observation, cumulants, next_observation).state
+
+    plain = horde.update(state, observation, cumulants, next_observation)
+    same = horde.update_with_discounts(
+        state, observation, cumulants, next_observation, spec.gammas
+    )
+    chex.assert_trees_all_close(same.td_targets, plain.td_targets)
+    chex.assert_trees_all_close(same.state, plain.state)
+
+    terminal = horde.update_with_discounts(
+        state, observation, cumulants, next_observation, jnp.zeros((3,), dtype=jnp.float32)
+    )
+    chex.assert_trees_all_close(terminal.td_targets, cumulants, atol=1e-6)
+    assert bool(terminal.update_applied)
+    with pytest.raises(ValueError, match="discounts must have shape"):
+        horde.update_with_discounts(
+            state, observation, cumulants, next_observation, jnp.zeros((2,), dtype=jnp.float32)
+        )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -521,6 +521,37 @@ def test_pipeline_behavioral_learns() -> None:
     )
 
 
+def test_pipeline_sarsa_terminal_step_zeroes_horde_bootstrap() -> None:
+    """In the default sarsa mode a terminal transition must not bootstrap any GVF."""
+    config = AlbertaPipelineConfig(
+        features=Step2FeatureConfig.identity(3),
+        horde=Step3HordeConfig(gammas=(0.0, 0.5, 0.9), lamdas=(0.0, 0.5, 0.8)),
+    )
+    assert config.control_mode == "sarsa"
+    pipeline = AlbertaPipeline(config)
+    state = pipeline.init(jr.key(0), jnp.asarray([0.2, -0.1, 0.4], dtype=jnp.float32))
+    state = pipeline.update(
+        state,
+        jnp.asarray([0.1, 0.3, -0.2], dtype=jnp.float32),
+        jnp.float32(0.5),
+        jnp.float32(0.0),
+    ).state
+    observation = jnp.asarray([-0.3, 0.2, 0.1], dtype=jnp.float32)
+    cumulants = jnp.asarray([0.5, -0.2, 0.3], dtype=jnp.float32)
+    next_values = pipeline.horde.predict(state.horde_state, observation)
+    gammas = jnp.asarray(config.horde.gammas, dtype=jnp.float32)
+
+    continuing = pipeline.update(state, observation, jnp.float32(0.5), jnp.float32(0.0), cumulants)
+    terminal = pipeline.update(state, observation, jnp.float32(0.5), jnp.float32(1.0), cumulants)
+
+    chex.assert_trees_all_close(
+        continuing.horde_td_targets, cumulants + gammas * next_values, atol=1e-6
+    )
+    chex.assert_trees_all_close(terminal.horde_td_targets, cumulants, atol=1e-6)
+    # Step 4 already honoured the flag; the Horde must agree with it.
+    assert float(terminal.control_td_error) != float(continuing.control_td_error)
+
+
 def test_pipeline_cumulant_fn_overrides_default() -> None:
     """Caller-provided cumulant_fn is used instead of the default channel map."""
     sentinel = jnp.array([0.123, 0.456], dtype=jnp.float32)


### PR DESCRIPTION
Outcome: **Fix** — a control path that drops a documented flag and corrupts every discounted GVF's target at episode boundaries. Not a Climb / Port / Close.

# What is wrong on `main`

`AlbertaPipeline.update` documents `terminated` as a "Scalar termination flag (0.0 or 1.0)", validates it, and forwards it to `step4_update`. In the default `control_mode="sarsa"` branch the Step 3 Horde is driven through the plain `HordeLearner.update(...)`, which always bootstraps with the fixed spec gammas (`core/horde.py`), so on a terminal transition every demon with `gamma > 0` uses target `c + γ·V(s')` instead of `c`. `HordeLearner.update_with_discounts` exists precisely so "control adapters [can] zero the value head at episode boundaries" and is unused on this path. Issue #2344 and its eight open PRs (2348, 2420, 2477, 2515, 2528, 2562, 2773, 2798) address only the `horde_ac` branch; none touches the sarsa call. `run_arrays` reaches the same code.

Reproduction on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (default sarsa mode, identity Step 2, `gammas=(0.0, 0.5, 0.9)`, one warm-up step, then the same transition with `terminated` 0 and 1):

```text
expected nonterm  [ 0.5        -0.24678278  0.20820582]
expected terminal [ 0.5 -0.2  0.3]
terminated=1.0: horde_td_targets=[ 0.5        -0.24678278  0.20820582]  control_td_error=0.3500
terminated=0.0: per-head trace norms=[0.37416574358940125, 1.0, 0.32882365584373474]
terminated=1.0: per-head trace norms=[0.37416574358940125, 1.0, 0.32882365584373474]
update_with_discounts(terminal) td_targets: [ 0.5 -0.2  0.3]
```

Step 4's TD error changes with the flag (0.655 → 0.350); the Horde's targets are byte-identical. No test in `tests/test_pipeline.py` passes `terminated=1.0` on this path.

# Change

- `IndependentDemonHorde.update_with_discounts` and `MixedHorde.update_with_discounts`, mirroring `HordeLearner`'s: the supplied per-demon discounts replace the fixed gammas in the bootstrap only; per-demon trace decay keeps the fixed GVF metadata; a non-finite or out-of-`[0, 1]` discount rejects that demon's update; the mixed form splits the vector across its shared and independent paths in original demon order. `update` now delegates with `None`, so its behaviour is unchanged (asserted bit-for-bit in the new tests by passing the spec gammas explicitly).
- The pipeline's sarsa branch calls `update_with_discounts` with `horde_spec.gammas * (1.0 - terminated)`, the same discount the `horde_ac` fixes derive for the value head.

The `gamma = 0` demons and every non-terminal step are numerically unchanged.

# Evidence

Failing-test-first:
- `tests/test_pipeline.py::test_pipeline_sarsa_terminal_step_zeroes_horde_bootstrap` (targets equal `c + γ·V(s')` when continuing and exactly `c` when terminal; Step 4's error differs between the two).
- `tests/test_independent_demon_horde.py::TestUpdateWithDiscounts` and `tests/test_mixed_horde.py::test_mixed_horde_update_with_discounts_routes_per_demon_discounts` (spec gammas reproduce `update` exactly; zero discounts stop bootstrapping; out-of-range discounts reject only that demon; wrong shape raises).

At the base commit:

```text
E   AssertionError: [Chex] Assertion assert_trees_all_close failed:  Trees (arrays) 0 and 1 differ: 
    Error in value equality check: Values not approximately equal
/root/asi/.venv/lib/python3.12/site-packages/chex/_src/asserts_internal.py:197: AssertionError: [Chex] Assertion assert_trees_all_close failed:  Trees (arrays) 0 and 1 differ:
E   AttributeError: 'IndependentDemonHorde' object has no attribute 'update_with_discounts'
/tmp/asi-main-clean4/tests/test_independent_demon_horde.py:150: AttributeError: 'IndependentDemonHorde' object has no attribute 'update_with_discounts'
E   AttributeError: 'MixedHorde' object has no attribute 'update_with_discounts'
/tmp/asi-main-clean4/tests/test_mixed_horde.py:627: AttributeError: 'MixedHorde' object has no attribute 'update_with_discounts'
FAILED tests/test_pipeline.py::test_pipeline_sarsa_terminal_step_zeroes_horde_bootstrap
FAILED tests/test_independent_demon_horde.py::TestUpdateWithDiscounts::test_spec_gammas_reproduce_update_and_zero_discounts_stop_bootstrapping
FAILED tests/test_mixed_horde.py::test_mixed_horde_update_with_discounts_routes_per_demon_discounts
```

At this head, focused:

```text
3 passed, 237 deselected in 13.25s
```

Pipeline, Horde, independent/mixed horde, Step 3, and horde actor-critic suites at this head:

```text
502 passed in 196.17s (0:03:16)
```

Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

# Scope note

`core/horde.py` is not a registered evidence source; `core/options.py` is not touched. Whether a caller should also re-`init` the pipeline after a terminal step so that `last_features` does not span the reset is a separate API question and is left alone here.

<!-- evidence-head:6571f1ec04eb42ed991596ccc545c97578763065 -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/3abb7f3af522107a471e1372e74a16bb806b895a/evidence/pr-pipeline-sarsa-terminal-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - control-path fix; the evidence is the base reproduction and the paired failing/passing test transcripts above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 36039241 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-pipeline-sarsa-terminal]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1P4FVZFVZ72BZ7RV0HDWE2Y","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T11:57:28.943Z","completed_at":"2026-09-04T12:23:30.547Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T11:57:29.592Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":4153,"output_tokens":85129,"cache_creation_tokens":170517,"cache_read_tokens":35779442,"total_tokens":36039241,"cost_micro_usd":"16597005","session_count":1},"trajectory_sha256":"a170d9349b40fa66c9f5d461adfd0e34a34a4b1bad0ff6492957ab16d4f62bb5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"0c6547f9-e266-4582-834d-6d6d2b3e36d6","object_id":"sha256:a170d9349b40fa66c9f5d461adfd0e34a34a4b1bad0ff6492957ab16d4f62bb5","sha256":"a170d9349b40fa66c9f5d461adfd0e34a34a4b1bad0ff6492957ab16d4f62bb5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"1M8MVw8x8jnL4hrfwkjVRMn_aQyXZqXwScORKW5RslsKgrESALxB-lbrvvYbD5xdm6mP8DPtQ0A7jayPqM94BQ"}} -->
