### PR TITLE
fix(benchmarks): refuse sentinel probes for arms whose forward is not the plain MLP

### DIFF
--- a/alberta_framework/benchmarks/ipmnist_screening.py
+++ b/alberta_framework/benchmarks/ipmnist_screening.py
@@ -6369,6 +6369,40 @@ def _hidden_rms_frozen_probe_input(
     )
 
 
+def _masked_forward_frozen_probe_input(
+    state: Any, observation: Array, hyperparameters: Mapping[str, float]
+) -> Array:
+    """Refuse sentinel probes for bounded-structure arms.
+
+    Their deployed forward is ``bounded_masked_logits``: hidden-1 activations
+    are multiplied by ``state.active1``, so half the width is masked from
+    initialization and the never-trained inactive units would be re-enabled by
+    the plain ``mlp_logits`` the probe harness computes. Failing closed is the
+    honest option until the harness can accept a per-arm forward function.
+    """
+    del state, observation, hyperparameters
+    raise NotImplementedError(
+        "sentinel probes are unsupported for bounded-structure arms: the deployed "
+        "forward pass masks hidden units and is not the plain protocol MLP"
+    )
+
+
+def _context_forward_frozen_probe_input(
+    state: Any, observation: Array, hyperparameters: Mapping[str, float]
+) -> Array:
+    """Refuse sentinel probes for replay arms whose prediction adds a context term.
+
+    With ``context_weight != 0`` the deployed prediction is
+    ``mlp_logits + label-attention context``; probing with ``mlp_logits`` alone
+    would score a model the arm never deploys.
+    """
+    del state, observation, hyperparameters
+    raise NotImplementedError(
+        "sentinel probes are unsupported for context-enabled replay arms: the "
+        "deployed prediction adds a label-attention context to the MLP logits"
+    )
+
+
 def _discovered_rule_frozen_probe_input(
     hyperparameters: Mapping[str, float],
 ) -> FrozenProbeInputFn:
@@ -8150,6 +8184,7 @@ def _build_registry() -> dict[str, ScreeningSpec]:
                 mechanism=mechanism,
                 hyperparameters=registered_bounded_elastic_hyperparameters(arm),
                 factory=_make_bounded_structure_learner,
+                frozen_probe_input=_masked_forward_frozen_probe_input,
                 description=(
                     description
                     + " Bounded arXiv:2608.01475v1 adaptation; not paper/code parity."
@@ -8269,6 +8304,11 @@ def _build_registry() -> dict[str, ScreeningSpec]:
                     replay_update=replay_update, context=context
                 ),
                 factory=make_replay_context_learner,
+                frozen_probe_input=(
+                    _context_forward_frozen_probe_input
+                    if context != 0.0
+                    else _raw_frozen_probe_input
+                ),
                 description=(
                     description
                     + " Permanently nonpromoting; not a Transformer-paper reproduction."

--- a/tests/test_ipmnist_recurring_adapter.py
+++ b/tests/test_ipmnist_recurring_adapter.py
@@ -239,6 +239,39 @@ def test_hidden_rms_active_arms_refuse_plain_mlp_sentinel_probes() -> None:
             spec.frozen_probe_input(state, sentinel_inputs, spec.hyperparameters)
 
 
+@pytest.mark.parametrize(
+    ("name", "message"),
+    [
+        ("bounded_structure_off", "bounded-structure"),
+        ("bounded_growth", "bounded-structure"),
+        ("bounded_elastic", "bounded-structure"),
+        ("replay_context_only", "context-enabled replay"),
+        ("replay_context_full", "context-enabled replay"),
+    ],
+)
+def test_arms_whose_forward_is_not_the_plain_mlp_refuse_sentinel_probes(
+    name: str, message: str
+) -> None:
+    """The probe harness scores ``mlp_logits``; arms that deploy another forward fail closed."""
+    spec = screening_spec(name)
+    init_fn, _step_fn = spec.factory(spec.hyperparameters)
+    state = init_fn(init_mlp_params(jr.key(0), CONFIG))
+    sentinel_inputs = jnp.zeros((2, CONFIG.input_dim), dtype=jnp.float32)
+    with pytest.raises(NotImplementedError, match=message):
+        spec.frozen_probe_input(state, sentinel_inputs, spec.hyperparameters)
+
+
+@pytest.mark.parametrize("name", ["replay_context_mechanism_off", "replay_gradient_only"])
+def test_context_free_replay_arms_keep_the_raw_probe(name: str) -> None:
+    spec = screening_spec(name)
+    assert spec.hyperparameters["context_weight"] == 0.0
+    init_fn, _step_fn = spec.factory(spec.hyperparameters)
+    state = init_fn(init_mlp_params(jr.key(0), CONFIG))
+    sentinel_inputs = jnp.ones((2, CONFIG.input_dim), dtype=jnp.float32)
+    probed = spec.frozen_probe_input(state, sentinel_inputs, spec.hyperparameters)
+    np.testing.assert_array_equal(np.asarray(probed), np.asarray(sentinel_inputs))
+
+
 def test_hidden_rms_inactive_sibling_keeps_its_input_side_probe() -> None:
     spec = screening_spec("disc_r1_pscale_norms")
     assert not _hidden_rms_active(spec)


### PR DESCRIPTION
Outcome: **Fix** — a measurement harness that reported numbers for a model the arm never deploys. Not a Climb / Port / Close.

# What is wrong on `main`

`run_recurring_ipmnist_retention_development` (`alberta_framework/benchmarks/ipmnist_screening.py`) applies `spec.frozen_probe_input` to each sentinel batch and then scores it with `mlp_logits(params, model_inputs)`, the plain protocol MLP. The registry's own rule, stated on `_hidden_rms_frozen_probe_input`, is that an arm whose deployed forward pass is not the plain MLP must refuse the probe: "any input-side transform would silently probe the wrong model. Failing closed here is the honest option." The RFF, naive-Bayes, RLS-head, NB-ensemble, and hidden-RMS arms all follow it. Five arms did not:

- `bounded_structure_off`, `bounded_growth`, `bounded_elastic` deploy `bounded_masked_logits`, which multiplies hidden-1 activations by `state.active1` (half the width masked from initialisation). Probing with `mlp_logits` re-enables the never-trained inactive units.
- `replay_context_only`, `replay_context_full` (`context_weight = 1.0`) deploy `contextual_logits = mlp_logits + label-attention context`. Probing with `mlp_logits` drops the term that drives the arm's online accuracy.

All five were registered with the identity probe, so their development retention reports recorded sentinel accuracies, forgetting/relearning deltas, and `learner_state_sha256`-bound snapshots of a phantom model, while the online per-step trace in the same report (which uses `step_fn`) described the real one.

Reproduction on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (synthetic data at protocol network shape, 3 phases × 50 steps, 128 sentinels; the adapter's exact key chain is replayed to recover the final params/state, then the same sentinel batch is scored with the harness forward and the arm's deployed forward):

```text
### repro_probe2 (bounded_structure_off) on clean origin/main
adapter accepted bounded_structure_off probe = _raw_frozen_probe_input
report sentinel_scores (phase, correct, n): [(0, 14, 128), (1, 16, 128), (1, 8, 128), (2, 14, 128), (2, 8, 128)]
active1 units: 150 / 300
harness (mlp_logits) correct  : 14 / 128  <- matches report phase-2 score
deployed (masked) correct     : 11 / 128
argmax disagreements          : 62 / 128
max |logit diff|              : 0.10175471752882004

### repro_replay (replay_context_only) on clean origin/main
adapter accepted replay_context_only probe = _raw_frozen_probe_input context_weight = 1.0
report sentinel_scores: [(0, 10, 128), (1, 16, 128), (1, 10, 128), (2, 13, 128), (2, 13, 128)]
harness (mlp_logits) correct : 13 /128   deployed (contextual_logits) correct: 11 /128   argmax disagreements: 108 /128
```

The harness count equals the report's phase-2 A score, which proves the report was produced from the wrong forward; the deployed forward disagrees on 62 of 128 (bounded) and 108 of 128 (context replay) sentinel argmaxes.

# Change

Two refusing probes mirroring the hidden-RMS precedent, `_masked_forward_frozen_probe_input` and `_context_forward_frozen_probe_input`, registered on the three bounded-structure specs and on the replay specs with `context_weight != 0`. The context-free replay arms (`replay_context_mechanism_off`, `replay_gradient_only`) keep the raw probe because their deployed prediction is the plain MLP. No arm's online step function, hyperparameters, or shard schema changes; existing screening shards are unaffected because the probe path is only exercised by the recurring retention adapter.

# Evidence

Failing-test-first: `tests/test_ipmnist_recurring_adapter.py::test_arms_whose_forward_is_not_the_plain_mlp_refuse_sentinel_probes` (five arms) and `test_context_free_replay_arms_keep_the_raw_probe` (two arms).

At the base commit (the five refusal cases):

```text
E   Failed: DID NOT RAISE NotImplementedError
E   Failed: DID NOT RAISE NotImplementedError
E   Failed: DID NOT RAISE NotImplementedError
E   Failed: DID NOT RAISE NotImplementedError
E   Failed: DID NOT RAISE NotImplementedError
(five parametrized cases; the two context-free replay cases pass on main and at head)
```

At this head, `tests/test_ipmnist_recurring_adapter.py`:

```text
16 passed in 6.79s
```

Screening, recurring-adapter, replay, and bounded-elastic suites at this head (`-m "not slow"`):

```text
440 passed in 161.87s (0:02:41)
```

Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

# Follow-up worth a maintainer decision

The honest long-term shape is a per-arm `probe_logits(params, state, x)` on `ScreeningSpec` so the adapter never assumes `mlp_logits`; that would let these arms be probed with their real forward instead of refusing. Left out here to keep the change to the registry's existing fail-closed contract. Any existing retention report for these five arms should be treated as describing the wrong model.

Lane: IPMNIST recurring retention development adapter (development-only, nonpromoting); no `outputs/` artifacts or seeds touched; `ipmnist_screening.py` is not a registered evidence source.

<!-- evidence-head:12caadf21ea69bf5d01fe90340646bc77f28c9a7 -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/b4f01916d83a3027e3dbda9eea0cb3d1dbeacd7a/evidence/pr-recurring-probe-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - harness fail-closed fix; the evidence is the base reproduction and the paired failing/passing test transcripts above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 25494875 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-recurring-probe-forward]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1P4SSMD8A7HWNGDN4HFX3RF","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T12:02:54.221Z","completed_at":"2026-09-04T12:23:31.461Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T12:02:54.883Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":2590,"output_tokens":60896,"cache_creation_tokens":120006,"cache_read_tokens":25311383,"total_tokens":25494875,"cost_micro_usd":"11798665","session_count":1},"trajectory_sha256":"9287a6cd081dfd9c411288ea6dee26b680412c7e7dfa2de181802bb84def65ac","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"8ad894ac-f3d8-4f48-a122-b5d311792fd0","object_id":"sha256:9287a6cd081dfd9c411288ea6dee26b680412c7e7dfa2de181802bb84def65ac","sha256":"9287a6cd081dfd9c411288ea6dee26b680412c7e7dfa2de181802bb84def65ac"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"Cg8ak-LrSdI2ewq6n9vIk5AgC2kngt5M9NCT_QotDRRmienWe8R7MeoTfp_lLjCxNa1tOKomH_2eHhFlQ154Cg"}} -->
