### PR TITLE
fix(steps): report Step 7 planning backups as accepted only when the core applied them

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -1100,7 +1100,9 @@ def step7_update(
         def rollout_step(
             rollout_carry: tuple[DifferentialSARSAState, Array, Array, Array],
             _: Array,
-        ) -> tuple[tuple[DifferentialSARSAState, Array, Array, Array], tuple[Array, Array]]:
+        ) -> tuple[
+            tuple[DifferentialSARSAState, Array, Array, Array], tuple[Array, Array, Array]
+        ]:
             rollout_state, rollout_observation, rollout_action, rollout_key = (
                 rollout_carry
             )
@@ -1125,16 +1127,20 @@ def step7_update(
                 prediction.next_observation,
                 planned.action,
                 planned.state.rng_key,
-            ), (planned.td_error, prediction.reward)
+            ), (planned.td_error, prediction.reward, planned.update_applied)
 
         (
             (rollout_state, _rollout_observation, _rollout_action, _rollout_key),
-            (rollout_td_errors, rollout_rewards),
+            (rollout_td_errors, rollout_rewards, rollout_updates_applied),
         ) = jax.lax.scan(
             rollout_step,
             (carry_state, anchor_observation, action, key),
             jnp.arange(config.planning_rollout_depth, dtype=jnp.int32),
         )
+        # A backup counts as accepted only if the core learner actually applied
+        # every imagined update; a rolled-back update leaves the state
+        # unchanged and must not be reported as planning progress.
+        rollout_accepted = planning_ready & jnp.all(rollout_updates_applied)
         rollout_td_signal = jnp.sum(rollout_td_errors)
         root_reward = rollout_rewards[0]
         restored_state = cast(
@@ -1201,6 +1207,7 @@ def step7_update(
             jnp.where(planning_ready, behavior_prob, 0.0),
             jnp.where(planning_ready, target_prob, 0.0),
             jnp.where(planning_ready, importance_ratio, 0.0),
+            rollout_accepted,
         )
 
     (
@@ -1214,17 +1221,14 @@ def step7_update(
             planning_behavior_probs,
             planning_target_probs,
             planning_importance_ratios,
+            planning_accepted,
         ),
     ) = jax.lax.scan(
         planning_step,
         (control_after_real, memory_priorities, memory_utilities),
         jnp.arange(config.planning_steps, dtype=jnp.int32),
     )
-    planning_accepted = jnp.full(
-        (config.planning_steps,),
-        planning_ready,
-        dtype=jnp.bool_,
-    )
+    planning_accepted = planning_accepted.astype(jnp.bool_)
     new_state = Step7DynaState(
         control_state=planned_state,
         world_model_state=model_state,

--- a/tests/test_step7_production.py
+++ b/tests/test_step7_production.py
@@ -771,6 +771,62 @@ def test_step7_dyna_json_roundtrip() -> None:
     assert restored.planning_utility_step_size == config.planning_utility_step_size
 
 
+def test_step7_planning_accepted_tracks_the_core_learner_rollback() -> None:
+    """A planning backup the core learner rolled back must not be reported as accepted."""
+    from alberta_framework.steps.step6 import Step6DifferentialSARSAConfig
+    from alberta_framework.steps.step8 import Step8WorldModelConfig
+
+    # A deliberately divergent linear world model (LMS step 2.0) makes the core
+    # learner reject many imagined transitions on a natural run, without any
+    # state surgery.
+    cfg = Step7DynaConfig(
+        control=Step6DifferentialSARSAConfig(n_actions=2, q_step_size=0.05),
+        world_model=Step8WorldModelConfig(
+            observation_dim=3, n_actions=2, hidden_sizes=(), step_size=2.0, use_layer_norm=False
+        ),
+        planning_steps=1,
+        planning_rollout_depth=1,
+        planning_warmup_steps=0,
+        planning_memory_size=8,
+        planning_strategy="random",
+    )
+    agent, model = make_step7_components(cfg)
+    steps = 32
+    data_key, state_key = jr.split(jr.key(0))
+    observations = jr.normal(data_key, (steps + 1, 3), dtype=jnp.float32)
+    rewards = jnp.tanh(observations[1:, 0])
+    state = init_step7_state(
+        agent, model, key=state_key, initial_observation=observations[0], memory_size=8
+    )
+    reported: list[bool] = []
+    replayed: list[bool] = []
+    for t in range(steps):
+        result = step7_update(cfg, agent, model, state, rewards[t], observations[t + 1])
+        control = result.real_control_result.state
+        # Replay the single imagined transaction through the core agent.
+        key, action_key = jr.split(control.rng_key)
+        action = jr.randint(action_key, (), 0, 2).astype(jnp.int32)
+        key, anchor_key = jr.split(key)
+        anchor_index = int(jr.randint(anchor_key, (), 0, int(result.state.memory_count)))
+        anchor = result.state.memory_observations[anchor_index]
+        prediction = model.predict(result.real_model_result.state, anchor, action)
+        temp = control.replace(last_observation=anchor, last_action=action, rng_key=key)
+        next_action, next_key = agent.select_action(temp, prediction.next_observation)
+        core = agent.update(
+            temp.replace(rng_key=next_key),
+            prediction.reward,
+            prediction.next_observation,
+            next_action=next_action,
+        )
+        reported.append(bool(result.planning_accepted[0]))
+        replayed.append(bool(core.update_applied))
+        state = result.state
+    assert not all(replayed), "the divergent model must produce at least one rollback"
+    assert reported == replayed
+    smoke = run_step7_smoke(cfg, steps=steps, seed=0)
+    assert smoke.planning_acceptance_count == sum(replayed)
+
+
 def _legal_step7_smoke_result(**overrides: object) -> Step7SmokeResult:
     payload: dict[str, object] = {
         "config": Step7DynaConfig(),


### PR DESCRIPTION
Outcome: **Fix** — a smoke metric that counted rolled-back planning backups as accepted. Not a Climb / Port / Close.

# What is wrong on `main`

`step7_update` (`alberta_framework/steps/step7.py`) reports `planning_accepted` per planning step and `run_step7_smoke` sums it into `planning_acceptance_count`. The rollout scan discards `update_applied` from the core `DifferentialSARSAAgent.update` on each imagined transition, and `planning_accepted` is set to a constant `jnp.full((planning_steps,), planning_ready)`. A backup the core learner rolled back (its fail-closed guard rejects a non-finite or otherwise invalid imagined transition and leaves the state unchanged) is therefore reported as accepted. Step 9 already does this correctly (`rollout_updates_applied` is ANDed into `accepted`).

Reproduction on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676`, natural run, no state surgery: a linear world model with an over-large LMS step (2.0) diverges, 32 real steps, one random-strategy planning backup per step; each imagined transaction is replayed through the core agent:

```text
planning backups reported accepted but rolled back by the core learner: 15 of 32
run_step7_smoke: finite = True  planning_acceptance_count = 32
```

# Change

The rollout scan also emits `planned.update_applied`; the planning step reports `planning_ready & all(rollout_updates_applied)`, and `planning_accepted` comes from the scan outputs instead of a constant. The planned state itself is unchanged by this (a rolled-back core update already returns the input state), so only the reported acceptance moves.

# Evidence

Failing-test-first: `tests/test_step7_production.py::test_step7_planning_accepted_tracks_the_core_learner_rollback`, which replays every imagined transaction through the core agent and requires the reported flags to match exactly, with at least one rollback present, and `planning_acceptance_count` to equal the number of applied backups.

At the base commit:

```text
E   assert [True, True, ...ue, True, ...] == [True, True, ...ue, True, ...]
E     
E     At index 16 diff: True != False
E     Use -v to get more diff
1 failed, 121 deselected in 21.74s
```

At this head, focused:

```text
1 passed, 121 deselected in 24.90s
```

Step 7 and Step 9 suites at this head:

```text
335 passed in 208.77s (0:03:28)
```

Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

Steps 5–12 are library-surface kernels (root `CLAUDE.md`); no benchmark lane, seeds, or `outputs/` artifacts are involved and `steps/step7.py` is not a registered evidence source.

<!-- evidence-head:1e128b13c4c7f7df19d997a0f8ffb660fc5b57df -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/d0b0459d21d69c81e6c5c96e7264da516e3eede0/evidence/pr-step7-planning-accepted-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - smoke-metric fix; the evidence is the base reproduction and the paired failing/passing test transcript above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 18954856 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-step7-planning-accepted]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1P52P7901MGE140W6T3T1E6","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T12:07:45.641Z","completed_at":"2026-09-04T12:23:32.111Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T12:07:46.143Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":1892,"output_tokens":43837,"cache_creation_tokens":94715,"cache_read_tokens":18814412,"total_tokens":18954856,"cost_micro_usd":"8808673","session_count":1},"trajectory_sha256":"df6a429878f91e28b5e47f2c0c970c76390177fffed3450c7cfba00e3147d880","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"366b3af5-dee4-4c23-b035-69a2213ac731","object_id":"sha256:df6a429878f91e28b5e47f2c0c970c76390177fffed3450c7cfba00e3147d880","sha256":"df6a429878f91e28b5e47f2c0c970c76390177fffed3450c7cfba00e3147d880"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"kUVZA2gSMFIVQLehHScdZR2muL-gshiAi1TFbWxnyGxU9t5VKCkPJDwttgUyb-5c9I9UPpupsRO6X3_rN0AtCA"}} -->
