### PR TITLE
fix(steps): make the Step 2 smoke's final_window_mse the pre-update mean squared error

### DIFF
--- a/alberta_framework/steps/step2.py
+++ b/alberta_framework/steps/step2.py
@@ -47,7 +47,7 @@ from alberta_framework.core.temporal_context import (
     TemporalContextConfig,
     TemporalContextFeaturizer,
 )
-from alberta_framework.core.upgd import UPGDLearner, run_upgd_arrays
+from alberta_framework.core.upgd import UPGDLearner, UPGDState, run_upgd_arrays
 from alberta_framework.core.upgd_memory import UPGDMemoryConfig, UPGDMemoryLearner
 from alberta_framework.steps._smoke_record_validation import require_step_shape
 from alberta_framework.streams.out_of_class import (
@@ -1186,6 +1186,24 @@ def collect_step2_arrays(
     return jnp.stack(observations), jnp.stack(targets)
 
 
+def _step2_pre_update_squared_errors(
+    learner: UPGDLearner,
+    state: UPGDState,
+    observations: Array,
+    targets: Array,
+) -> Array:
+    """Per-step mean squared error of the prediction made before each update."""
+
+    def step_fn(carry: UPGDState, inputs: tuple[Array, Array]) -> tuple[UPGDState, Array]:
+        observation, target = inputs
+        prediction = learner.predict(carry, observation)
+        squared_error = jnp.mean(jnp.square(prediction - target))
+        return learner.update(carry, observation, target).state, squared_error
+
+    _, squared_errors = jax.lax.scan(step_fn, state, (observations, targets))
+    return squared_errors
+
+
 def run_step2_smoke(
     config: Step2KernelConfig | None = None,
     *,
@@ -1210,7 +1228,13 @@ def run_step2_smoke(
     state = learner.init(cfg.feature_dim, learner_key)
     result = run_upgd_arrays(learner, state, observations, targets)
     result.metrics.block_until_ready()
-    window = result.metrics[-final_window:, 0]
+    # ``metrics[:, 0]`` is the UPGD training loss (``0.5 * SSE / denominator``,
+    # whose denominator depends on the readout's loss normalization), not the
+    # mean squared prediction error Step 1 reports under the same field name.
+    # Measure the pre-update MSE directly, exactly as Step 1 does.
+    squared_errors = _step2_pre_update_squared_errors(learner, state, observations, targets)
+    squared_errors.block_until_ready()
+    window = squared_errors[-final_window:]
     final_window_mse = float(jnp.mean(window))
     return Step2SmokeResult(
         config=cfg,

--- a/tests/test_production_steps.py
+++ b/tests/test_production_steps.py
@@ -1279,6 +1279,36 @@ def test_step2_config_from_dict_requires_exact_keys(config: Any) -> None:
             type(config).from_dict(malformed)
 
 
+def test_step2_smoke_final_window_mse_is_the_pre_update_mean_squared_error() -> None:
+    """The field shares Step 1's name and must carry Step 1's meaning, not the UPGD loss."""
+    from alberta_framework.steps.step2 import (
+        Step2KernelConfig,
+        collect_step2_arrays,
+        make_step2_learner,
+        make_step2_stream,
+        run_step2_smoke,
+    )
+
+    cfg = Step2KernelConfig(
+        feature_dim=4, n_heads=3, hidden_sizes=(8,), context_length=4, noise_std=0.0
+    )
+    steps, seed, final_window = 8, 0, 4
+    smoke = run_step2_smoke(cfg, steps=steps, seed=seed, final_window=final_window)
+
+    learner, stream = make_step2_learner(cfg), make_step2_stream(cfg)
+    data_key, learner_key = jr.split(jr.key(seed))
+    observations, targets = collect_step2_arrays(stream, steps=steps, key=data_key)
+    state = learner.init(cfg.feature_dim, learner_key)
+    squared_errors = []
+    for t in range(steps):
+        prediction = learner.predict(state, observations[t])
+        squared_errors.append(float(jnp.mean(jnp.square(prediction - targets[t]))))
+        state = learner.update(state, observations[t], targets[t]).state
+    expected = sum(squared_errors[-final_window:]) / final_window
+    assert expected > 0.0
+    assert smoke.final_window_mse == pytest.approx(expected, rel=1e-5)
+
+
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [


### PR DESCRIPTION
Outcome: **Fix** — a reported metric that is half the quantity its name and its Step 1 sibling promise. Not a Climb / Port / Close.

# What is wrong on `main`

`run_step2_smoke` (`alberta_framework/steps/step2.py`) fills `Step2SmokeResult.final_window_mse` with the mean of UPGD's metrics column 0, which is the training loss `0.5 * SSE / denominator` (`core/upgd.py`, and the denominator itself depends on the readout's loss normalization), not the mean squared prediction error. `Step1SmokeResult.final_window_mse` is the true pre-update MSE. Two smoke records with the same field name therefore report different quantities, and the Step 2 one is off by exactly a factor of two under the default `linear_mse` readout.

Reproduction on `origin/main` `c9aba7b54dedd647f8bd5f5c7bf6780b1413b676` (`feature_dim=4, n_heads=3, hidden_sizes=(8,)`, 8 steps, 4-step window, hand loop of `learner.predict` before each `learner.update` on the same data):

```text
smoke.final_window_mse = 0.024132139980793
true final-window MSE  = 0.04826427483931184
ratio                  = 0.500000053064862
```

# Change

The smoke measures the pre-update mean squared error directly with a small scan (`learner.predict`, then `learner.update`), exactly as Step 1 does, and keeps the UPGD metrics array for the shape and finiteness checks. The field name and the `Step2SmokeResult` schema are unchanged; only the value becomes what the name says.

# Evidence

Failing-test-first: `tests/test_production_steps.py::test_step2_smoke_final_window_mse_is_the_pre_update_mean_squared_error`.

At the base commit:

```text
E   assert 0.024132139980793 == 0.04826427483931184 ± 4.8e-07
E     
E     comparison failed
```

At this head (all Step 2 tests in `tests/test_production_steps.py`):

```text
224 passed, 169 deselected in 20.85s
```

Step 2 suites at this head:

```text
451 passed in 42.48s
```

Hygiene: `ruff check .` → All checks passed; `mypy` (strict) → Success: no issues found in 224 source files.

Any `Step2SmokeResult` produced before this change reports half the MSE it claims under the default readout. No benchmark lane, seeds, or `outputs/` artifacts are involved and `steps/step2.py` is not a registered evidence source.

<!-- evidence-head:35f9d3e7520f96bd0dd0f3efdb7d57b1e6ab72bd -->
<!-- evidence-row:logs -->
- [x] logs: https://github.com/hermesagent270-commits/asi/blob/ce44ffefa3aedef59ee5fa47c2a4d4fa31793dbe/evidence/pr-step2-true-mse-verification.log (immutable commit on the contributor fork)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - smoke-metric fix; the evidence is the base reproduction and the paired failing/passing test transcript above, no benchmark artifact is produced

AI provider/model: anthropic / claude-fable-5-1 · client: claude-code 2.1.260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao9Yaaw1MdRbyQMc1HeFLX

Compute receipt: 18954856 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-fix-step2-window-mse]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1P52NHY1EFQD5N3TAPRMS95","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-04T12:07:44.958Z","completed_at":"2026-09-04T12:23:32.806Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T12:07:45.484Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":1892,"output_tokens":43837,"cache_creation_tokens":94715,"cache_read_tokens":18814412,"total_tokens":18954856,"cost_micro_usd":"8808673","session_count":1},"trajectory_sha256":"d4a240f3e1870036cd607dc4c79e9321f4b1fe88dfb799170dae47498978186d","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b83ad484-2fb9-4ff7-ad11-4ad7281f04a6","object_id":"sha256:d4a240f3e1870036cd607dc4c79e9321f4b1fe88dfb799170dae47498978186d","sha256":"d4a240f3e1870036cd607dc4c79e9321f4b1fe88dfb799170dae47498978186d"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"NHMVlLkH_ma4yzDc3bxeJwV9yWTvm_GqTlgUa_Hhxh97E7YpcHTvQ1Odm0v1R8s0UK-_KOdhY-hxX5huibxeDQ"}} -->
