### PR TITLE
Fix _normalize_simplex so it always returns a probability simplex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `upgd_memory._normalize_simplex` now returns a probability simplex for
+  zero, negative, sub-`1e-12`, and float32-overflowing inputs.  The previous
+  floored-denominator helper could drop mass (including the reachable
+  zeros `previous_targets` target-trace blend) without reporting it.
 - Canonicalized discounted-SARSA lifecycle timers at the exact-dispatch
   reference-control boundary. The first compiled update can no longer grow
   persistent numeric state by promoting two host floats into JAX leaves, so

--- a/alberta_framework/core/upgd_memory.py
+++ b/alberta_framework/core/upgd_memory.py
@@ -674,8 +674,40 @@ def _active_mse(prediction: Array, target: Array) -> Array:
 
 
 def _normalize_simplex(prediction: Array) -> Array:
+    """Return a probability simplex; uniform when there is no usable mass.
+
+    The previous ``clipped / max(sum(clipped), 1e-12)`` helper did not
+    return a simplex in three float32 regimes, and every call site treats
+    the result as a distribution:
+
+    * Zero or wholly-negative mass leaves the ratio at zero.  This is
+      reachable: ``UPGDLearner`` initializes ``previous_targets`` to zeros,
+      so the target-trace blend mixes a proper simplex against a zero
+      vector until a target has been observed and the blended mass
+      collapses to ``1 - trace_gate``.
+    * A positive total below the floor is divided by the floor, so
+      ``[7.5e-13, 0, 0]`` becomes ``0.75``.
+    * A single dominant finite entry can make XLA's reciprocal flush to
+      zero, so ``[1e38, 1, 1]`` becomes the zero vector.
+
+    Rescale by an exact power of two before dividing by the true total so
+    the quotient stays in the normal range and well-formed inputs stay
+    bit-identical.  Fall back to uniform only when that normalized mass is
+    genuinely zero or non-finite.  Non-finite input, including NaN, also
+    maps to uniform: the helper's contract is a simplex, not NaN
+    propagation.
+    """
     clipped = jnp.maximum(prediction, 0.0)
-    return clipped / jnp.maximum(jnp.sum(clipped), 1e-12)
+    peak = jnp.max(clipped, axis=-1, keepdims=True)
+    finite_peak = jnp.where(jnp.isfinite(peak) & (peak > 0.0), peak, 1.0)
+    _, exponent = jnp.frexp(finite_peak)
+    rescaled = jnp.ldexp(clipped, -exponent)
+    total = jnp.sum(rescaled, axis=-1, keepdims=True)
+    safe_total = jnp.where(total > 0.0, total, jnp.ones_like(total))
+    candidate = rescaled / safe_total
+    has_mass = jnp.sum(candidate, axis=-1, keepdims=True) > 0.0
+    uniform = jnp.full_like(clipped, 1.0 / clipped.shape[-1])
+    return jnp.where(has_mass, candidate, uniform)
 
 
 class UPGDMemoryLearner:

--- a/tests/test_upgd_memory.py
+++ b/tests/test_upgd_memory.py
@@ -11,6 +11,7 @@ from alberta_framework.core.upgd_memory import (
     UPGDMemoryConfig,
     UPGDMemoryLearner,
     UPGDMemoryState,
+    _normalize_simplex,
     run_upgd_memory_arrays,
 )
 
@@ -564,3 +565,128 @@ def test_upgd_memory_preserves_legal_closed_endpoints() -> None:
     assert allocation_endpoint.target_allocation_rate == 1.0
     assert fixed_threshold.min_novelty_threshold == 0.5
     assert fixed_threshold.max_novelty_threshold == 0.5
+
+
+def _assert_simplex(normalized: jax.Array, label: str) -> None:
+    """The helper's name is its contract: non-negative, finite, sums to one."""
+    chex.assert_tree_all_finite(normalized)
+    assert float(jnp.min(normalized)) >= 0.0, label
+    chex.assert_trees_all_close(jnp.sum(normalized), 1.0, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("label", "prediction"),
+    (
+        # Reachable: UPGDLearner initializes previous_targets to zeros, so the
+        # target-trace blend mixes against this until the first target arrives.
+        ("zero mass", [0.0, 0.0, 0.0]),
+        ("wholly negative", [-1.0, -2.0, -3.0]),
+        # A single entry large enough to dominate the float32 sum makes every
+        # ratio underflow to zero when XLA flushes the reciprocal.
+        ("underflowing spread", [1e38, 1.0, 1.0]),
+        # Positive totals below the old 1e-12 denominator floor were divided by
+        # the floor rather than themselves, so this normalized to 0.75.
+        ("mass below the old floor", [7.5e-13, 0.0, 0.0]),
+        ("far below the old floor", [1e-30, 0.0, 0.0]),
+        ("overflowing equal mass", [3e38, 3e38, 3e38]),
+        ("non-finite input", [float("nan"), 0.0, 1.0]),
+    ),
+)
+def test_normalize_simplex_returns_a_simplex_for_degenerate_mass(
+    label: str,
+    prediction: list[float],
+) -> None:
+    normalized = _normalize_simplex(jnp.asarray(prediction, dtype=jnp.float32))
+    _assert_simplex(normalized, label)
+
+
+def test_normalize_simplex_zero_and_negative_mass_are_uniform() -> None:
+    """No usable mass must fall back to the uniform distribution."""
+    expected = jnp.full((3,), 1.0 / 3.0, dtype=jnp.float32)
+    chex.assert_trees_all_close(
+        _normalize_simplex(jnp.zeros(3, dtype=jnp.float32)),
+        expected,
+    )
+    chex.assert_trees_all_close(
+        _normalize_simplex(jnp.asarray([-1.0, -2.0, -3.0], dtype=jnp.float32)),
+        expected,
+    )
+
+
+def test_normalize_simplex_preserves_dominant_overflow_direction() -> None:
+    """A finite overflow-scale peak must not fall back to uniform."""
+    overflow = _normalize_simplex(jnp.asarray([1e38, 1.0, 1.0], dtype=jnp.float32))
+    mixed = _normalize_simplex(jnp.asarray([1e38, 1e-8, 0.0], dtype=jnp.float32))
+    _assert_simplex(overflow, "overflow peak")
+    _assert_simplex(mixed, "mixed overflow peak")
+    chex.assert_trees_all_close(overflow, jnp.asarray([1.0, 0.0, 0.0], dtype=jnp.float32))
+    chex.assert_trees_all_close(mixed, jnp.asarray([1.0, 0.0, 0.0], dtype=jnp.float32))
+
+
+def test_normalize_simplex_leaves_ordinary_inputs_bit_identical() -> None:
+    """Well-formed inputs must not move, including vs the old floored formula."""
+    ordinary = jnp.asarray([0.2, 0.3, 0.5], dtype=jnp.float32)
+    clipped_negative = jnp.asarray([-1.0, 2.0, 1.0], dtype=jnp.float32)
+    chex.assert_trees_all_equal(_normalize_simplex(ordinary), ordinary)
+    chex.assert_trees_all_close(
+        _normalize_simplex(clipped_negative),
+        jnp.asarray([0.0, 2.0 / 3.0, 1.0 / 3.0], dtype=jnp.float32),
+        atol=1e-6,
+    )
+    legacy = ordinary / jnp.maximum(jnp.sum(ordinary), jnp.float32(1e-12))
+    chex.assert_trees_all_equal(_normalize_simplex(ordinary), legacy)
+
+
+def test_normalize_simplex_is_jit_traceable() -> None:
+    normalized = jax.jit(_normalize_simplex)(jnp.asarray([0.25, 0.75], dtype=jnp.float32))
+    _assert_simplex(normalized, "jit ordinary")
+    chex.assert_trees_all_equal(normalized, jnp.asarray([0.25, 0.75], dtype=jnp.float32))
+
+
+def test_target_trace_blend_preserves_mass_before_the_first_target() -> None:
+    """Blending a simplex against the initial zero trace must not lose mass.
+
+    ``previous_targets`` starts as zeros, and the blend is
+    ``(1 - trace_gate) * prediction + trace_gate * trace_prediction``. When the
+    trace normalized to a zero vector the blended mass collapsed to
+    ``1 - trace_gate`` -- up to 80% of the distribution gone at the default
+    ``target_trace_blend_scale``.
+    """
+    prediction = jnp.asarray([0.2, 0.3, 0.5], dtype=jnp.float32)
+    trace_prediction = _normalize_simplex(jnp.zeros(3, dtype=jnp.float32))
+
+    for trace_gate in (0.0, 0.25, 0.5, 0.8, 1.0):
+        blended = (1.0 - trace_gate) * prediction + trace_gate * trace_prediction
+        chex.assert_trees_all_close(jnp.sum(blended), 1.0, atol=1e-6)
+
+
+def test_blend_predictions_preserves_mass_on_zero_previous_targets() -> None:
+    """The live softmax_ce blend must keep unit mass when the trace is zeros."""
+    config = UPGDMemoryConfig(
+        feature_dim=2,
+        n_heads=3,
+        hidden_sizes=(4,),
+        target_trace_blend_scale=0.8,
+        target_trace_pressure_threshold=0.0,
+        confidence_logit_scale=0.0,
+        reliability_logit_scale=0.0,
+    )
+    learner = UPGDMemoryLearner(config)
+    state = learner.init(jr.key(0))
+    assert bool(jnp.all(state.upgd_state.previous_targets == 0.0))
+    state = state.replace(  # type: ignore[attr-defined]
+        upgd_state=state.upgd_state.replace(  # type: ignore[attr-defined]
+            target_repeat_ema=jnp.asarray(1.0, dtype=jnp.float32),
+        )
+    )
+    upgd_prediction = jnp.asarray([0.2, 0.3, 0.5], dtype=jnp.float32)
+    memory_prediction = jnp.asarray([0.4, 0.4, 0.2], dtype=jnp.float32)
+
+    blended, _gate = learner._blend_predictions(
+        state,
+        upgd_prediction,
+        memory_prediction,
+        include_target_trace=True,
+    )
+
+    _assert_simplex(blended, "live blend")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes SlopDotCash/asi#2470.

This fork PR is the same change intended for **upstream** `SlopDotCash/asi:main`. Open the upstream PR from:

https://github.com/SlopDotCash/asi/compare/main...Matthewhoop:asi:cursor/fix-normalize-simplex-2470-1ca7?expand=1

## The defect

`upgd_memory._normalize_simplex` is named for the contract it is supposed to enforce, but `clipped / max(sum(clipped), 1e-12)` returns a non-simplex in several float32 cases. Every call site treats the result as a distribution; one of them **blends** it, so lost mass silently shrinks the prediction.

| input | before | after |
|---|---|---|
| `[0, 0, 0]` | 0.0 | 1.0 (uniform) |
| `[-1, -2, -3]` | 0.0 | 1.0 (uniform) |
| `[1e38, 1, 1]` | 0.0 | 1.0 (`[1, 0, 0]`) |
| `[7.5e-13, 0, 0]` | **0.75** | 1.0 |
| `[1e-30, 0, 0]` | 0.0 | 1.0 |
| `[3e38, 3e38, 3e38]` | 0.0 | 1.0 (uniform) |

Three mechanisms:

1. **Floored denominator (main bug).** A positive total below `1e-12` is divided by the floor instead of itself, so `[7.5e-13, 0, 0]` becomes `0.75`.
2. **Zero / negative mass.** The ratio stays at zero. This is reachable: `UPGDLearner` initializes `previous_targets` to zeros, and `_blend_predictions` normalizes exactly that vector. Blending a simplex against a zero vector scales the prediction to `1 - trace_gate` (up to 80% mass lost at the default `target_trace_blend_scale`).
3. **XLA reciprocal flush.** A single dominant finite entry makes `1 / total` underflow to zero, so `[1e38, 1, 1]` becomes the zero vector even when the total itself is positive.

## Fix

- Drop the `1e-12` floor and divide by the **true** (rescaled) total.
- Exact power-of-two `frexp`/`ldexp` rescale before the sum, so overflow-scale peaks stay in the normal range and well-formed inputs stay bit-identical (the scale commutes with rounding).
- Fall back to uniform only when the normalized mass is genuinely zero or non-finite.
- Preserve the dominant class on overflow inputs such as `[1e38, 1, 1]` and `[1e38, 1e-8, 0]` instead of collapsing them to uniform.
- NaN / non-finite input maps to uniform: the helper's contract is a simplex, not NaN propagation.

This is the same shape as the #2238 / #2239 review fix (true total + uniform only when mass is gone), plus the rescale that keeps overflow-scale direction.

## Tests

Regression coverage in `tests/test_upgd_memory.py`:

- issue reproduction inputs plus overflowing-equal and NaN cases
- uniform fallback for zero / negative mass
- dominant-direction overflow (not uniform)
- bit-identical well-formed inputs vs the old formula
- jit-traceability
- standalone and live `_blend_predictions` mass preservation against zero `previous_targets`

Verified: `tests/test_upgd_memory.py` + `_grad` + `_validation` — **232 passed**. `ruff check` on the touched files passed. `mypy alberta_framework/core/upgd_memory.py` — no issues.

## slop.cash payout

Solana: `7tgAqELyWqZM4bkBwSenY9UhrWMNh2ZZJAKDb2Wcze3D`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dee631b7-566b-496b-9a0c-ff18bb701ca7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dee631b7-566b-496b-9a0c-ff18bb701ca7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>