### PR TITLE
fix(core): decay on-policy TD(lambda) traces with the prior transition's discount

### DIFF
--- a/alberta_framework/core/learners.py
+++ b/alberta_framework/core/learners.py
@@ -2100,13 +2100,21 @@ class TDLinearLearner:
 
 @chex.dataclass(frozen=True)
 class TrueOnlineTDState:
-    """State for True Online TD(lambda) with Dutch traces."""
+    """State for True Online TD(lambda) with Dutch traces.
+
+    ``previous_gamma`` is the discount from the prior update call, carried so
+    the Dutch trace decays by ``gamma_t`` (the discount of the transition into
+    ``S_t``) while the TD error bootstraps with ``gamma_{t+1}`` (Sutton & Barto
+    2nd ed., eqs. 12.23/12.25). It is seeded to 1.0, which is inert against the
+    zero initial traces.
+    """
 
     weights: Float[Array, " feature_dim"]
     bias: Float[Array, ""]
     eligibility_traces: Float[Array, " feature_dim"]
     bias_eligibility_trace: Float[Array, ""]
     v_old: Float[Array, ""]
+    previous_gamma: Float[Array, ""]
     step_count: Array = None  # type: ignore[assignment]
     birth_timestamp: float = 0.0
     uptime_s: float = 0.0
@@ -2132,9 +2140,13 @@ class TrueOnlineTDLearner:
     """Linear True Online TD(lambda) learner with Dutch traces.
 
     Implements the true-online update for a linear value function with an
-    explicit bias feature. At terminal transitions (``gamma == 0``),
-    ``v_old`` is reset to zero so repeated one-step supervised transitions
-    reduce exactly to LMS.
+    explicit bias feature. The ``gamma`` passed to :meth:`update` is
+    ``gamma_{t+1}`` and enters only the TD-error bootstrap; the Dutch trace
+    decays by the prior call's discount carried in ``state.previous_gamma``,
+    so the update that carries a terminal reward still credits the traces
+    accumulated within the episode. At terminal transitions (``gamma == 0``),
+    the stored traces and ``v_old`` are reset to zero so repeated one-step
+    supervised transitions reduce exactly to LMS.
 
     References:
         van Seijen & Sutton (2014). "True Online TD(lambda)." ICML.
@@ -2152,13 +2164,14 @@ class TrueOnlineTDLearner:
     def init(self, feature_dim: int) -> TrueOnlineTDState:
         """Initialize learner state."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
-        _preflight_float32_resources("true-online TD state", 2 * feature_dim + 5)
+        _preflight_float32_resources("true-online TD state", 2 * feature_dim + 6)
         return TrueOnlineTDState(
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias=jnp.array(0.0, dtype=jnp.float32),
             eligibility_traces=jnp.zeros(feature_dim, dtype=jnp.float32),
             bias_eligibility_trace=jnp.array(0.0, dtype=jnp.float32),
             v_old=jnp.array(0.0, dtype=jnp.float32),
+            previous_gamma=jnp.array(1.0, dtype=jnp.float32),
             step_count=jnp.array(0, dtype=jnp.int32),
             birth_timestamp=time.time(),
             uptime_s=0.0,
@@ -2190,10 +2203,13 @@ class TrueOnlineTDLearner:
 
         trace_dot = jnp.dot(state.eligibility_traces, observation)
         trace_dot = trace_dot + state.bias_eligibility_trace
+        # The Dutch trace decays by the PRIOR call's discount
+        # (state.previous_gamma = gamma_t, the discount into S_t); only the
+        # TD-error bootstrap above uses this call's gamma_{t+1}.
         decay_scale = jnp.where(
-            (gamma_scalar == 0.0) | (lamda == 0.0),
-            jnp.zeros_like(gamma_scalar),
-            gamma_scalar * lamda,
+            (state.previous_gamma == 0.0) | (lamda == 0.0),
+            jnp.zeros_like(state.previous_gamma),
+            state.previous_gamma * lamda,
         )
         trace_scale = 1.0 - alpha * _skip_zero_scale(decay_scale, trace_dot)
         new_traces = (
@@ -2224,6 +2240,7 @@ class TrueOnlineTDLearner:
             eligibility_traces=stored_traces,
             bias_eligibility_trace=stored_bias_trace,
             v_old=new_v_old,
+            previous_gamma=gamma_scalar,
             step_count=_saturating_int32_counter_increment(state.step_count),
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,

--- a/alberta_framework/core/optimizers.py
+++ b/alberta_framework/core/optimizers.py
@@ -1933,7 +1933,7 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
             TD-IDBD state with per-weight step-sizes, traces, and h traces
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
-        _require_float32_state("TDIDBD state", 3 * feature_dim + 5)
+        _require_float32_state("TDIDBD state", 3 * feature_dim + 6)
         _require_float32_update_working_set(
             "TDIDBD update working set", 22 * feature_dim + 8
         )
@@ -1948,6 +1948,7 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
             bias_log_step_size=jnp.array(jnp.log(self._initial_step_size), dtype=jnp.float32),
             bias_eligibility_trace=jnp.array(0.0, dtype=jnp.float32),
             bias_h_trace=jnp.array(0.0, dtype=jnp.float32),
+            previous_gamma=jnp.array(1.0, dtype=jnp.float32),
         )
 
     def update(
@@ -1993,10 +1994,13 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
         )
         new_alphas = jnp.exp(new_log_step_sizes)
 
+        # The trace decays by the PRIOR call's discount (state.previous_gamma =
+        # gamma_t, the discount into S_t); only the TD-error bootstrap and the
+        # ordinary-gradient feature difference use this call's gamma_{t+1}.
         decay_scale = jnp.where(
-            (gamma_scalar == 0.0) | (lam == 0.0),
-            jnp.zeros_like(gamma_scalar),
-            gamma_scalar * lam,
+            (state.previous_gamma == 0.0) | (lam == 0.0),
+            jnp.zeros_like(state.previous_gamma),
+            state.previous_gamma * lam,
         )
         new_eligibility_traces = (
             _skip_zero_scale(decay_scale, state.eligibility_traces) + observation
@@ -2057,6 +2061,7 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
             bias_log_step_size=new_bias_log_step_size,
             bias_eligibility_trace=new_bias_eligibility_trace,
             bias_h_trace=new_bias_h_trace,
+            previous_gamma=gamma_scalar.astype(jnp.float32),
         )
         candidate_metrics = {
             "mean_step_size": jnp.mean(new_alphas),
@@ -2071,14 +2076,15 @@ class TDIDBD(TDOptimizer[TDIDBDState]):
             & (jnp.all(jnp.isfinite(next_observation)) | (gamma_scalar == 0.0))
             & jnp.isfinite(gamma_scalar)
         )
+        # Leftover traces that this update discards (decay 0) must not veto it.
         previous_checked = state.replace(  # type: ignore[attr-defined]
             eligibility_traces=jnp.where(
-                (gamma_scalar == 0.0) | (lam == 0.0),
+                decay_scale == 0.0,
                 jnp.zeros_like(state.eligibility_traces),
                 state.eligibility_traces,
             ),
             bias_eligibility_trace=jnp.where(
-                (gamma_scalar == 0.0) | (lam == 0.0),
+                decay_scale == 0.0,
                 jnp.zeros_like(state.bias_eligibility_trace),
                 state.bias_eligibility_trace,
             ),
@@ -2150,7 +2156,7 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
             AutoTDIDBD state with per-weight step-sizes, traces, h traces, and normalizers
         """
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
-        _require_float32_state("AutoTDIDBD state", 4 * feature_dim + 7)
+        _require_float32_state("AutoTDIDBD state", 4 * feature_dim + 8)
         _require_float32_update_working_set(
             "AutoTDIDBD update working set", 32 * feature_dim + 8
         )
@@ -2168,6 +2174,7 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
             bias_eligibility_trace=jnp.array(0.0, dtype=jnp.float32),
             bias_h_trace=jnp.array(0.0, dtype=jnp.float32),
             bias_normalizer=jnp.array(1.0, dtype=jnp.float32),
+            previous_gamma=jnp.array(1.0, dtype=jnp.float32),
         )
 
     def update(
@@ -2227,10 +2234,13 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
         new_log_step_sizes = jnp.clip(new_log_step_sizes, -10.0, 2.0)
         new_alphas = jnp.exp(new_log_step_sizes)
 
+        # The trace decays by the PRIOR call's discount (state.previous_gamma =
+        # gamma_t, the discount into S_t); only the TD-error bootstrap and the
+        # ordinary-gradient feature difference use this call's gamma_{t+1}.
         decay_scale = jnp.where(
-            (gamma_scalar == 0.0) | (lam == 0.0),
-            jnp.zeros_like(gamma_scalar),
-            gamma_scalar * lam,
+            (state.previous_gamma == 0.0) | (lam == 0.0),
+            jnp.zeros_like(state.previous_gamma),
+            state.previous_gamma * lam,
         )
         new_eligibility_traces = (
             _skip_zero_scale(decay_scale, state.eligibility_traces) + observation
@@ -2296,6 +2306,7 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
             bias_eligibility_trace=new_bias_eligibility_trace,
             bias_h_trace=new_bias_h_trace,
             bias_normalizer=new_bias_normalizer,
+            previous_gamma=gamma_scalar.astype(jnp.float32),
         )
         candidate_metrics = {
             "mean_step_size": jnp.mean(new_alphas),
@@ -2311,14 +2322,15 @@ class AutoTDIDBD(TDOptimizer[AutoTDIDBDState]):
             & (jnp.all(jnp.isfinite(next_observation)) | (gamma_scalar == 0.0))
             & jnp.isfinite(gamma_scalar)
         )
+        # Leftover traces that this update discards (decay 0) must not veto it.
         previous_checked = state.replace(  # type: ignore[attr-defined]
             eligibility_traces=jnp.where(
-                (gamma_scalar == 0.0) | (lam == 0.0),
+                decay_scale == 0.0,
                 jnp.zeros_like(state.eligibility_traces),
                 state.eligibility_traces,
             ),
             bias_eligibility_trace=jnp.where(
-                (gamma_scalar == 0.0) | (lam == 0.0),
+                decay_scale == 0.0,
                 jnp.zeros_like(state.bias_eligibility_trace),
                 state.bias_eligibility_trace,
             ),

--- a/alberta_framework/core/types.py
+++ b/alberta_framework/core/types.py
@@ -483,6 +483,11 @@ class TDIDBDState:
         bias_log_step_size: Log step-size for the bias term
         bias_eligibility_trace: Eligibility trace for the bias
         bias_h_trace: h trace for the bias term
+        previous_gamma: Discount from the prior update call, carried so the
+            eligibility traces decay by ``gamma_t`` (the discount of the
+            transition into ``S_t``) while the TD error bootstraps with
+            ``gamma_{t+1}`` (Sutton & Barto 2nd ed., eqs. 12.23/12.25).
+            Seeded to 1.0, which is inert against the zero initial traces.
     """
 
     log_step_sizes: Float[Array, " feature_dim"]
@@ -493,6 +498,7 @@ class TDIDBDState:
     bias_log_step_size: Float[Array, ""]
     bias_eligibility_trace: Float[Array, ""]
     bias_h_trace: Float[Array, ""]
+    previous_gamma: Float[Array, ""]
 
 
 @chex.dataclass(frozen=True)
@@ -517,6 +523,11 @@ class AutoTDIDBDState:
         bias_eligibility_trace: Eligibility trace for the bias
         bias_h_trace: h trace for the bias term
         bias_normalizer: Normalizer for the bias gradient correlation
+        previous_gamma: Discount from the prior update call, carried so the
+            eligibility traces decay by ``gamma_t`` (the discount of the
+            transition into ``S_t``) while the TD error bootstraps with
+            ``gamma_{t+1}`` (Sutton & Barto 2nd ed., eqs. 12.23/12.25).
+            Seeded to 1.0, which is inert against the zero initial traces.
     """
 
     log_step_sizes: Float[Array, " feature_dim"]
@@ -530,6 +541,7 @@ class AutoTDIDBDState:
     bias_eligibility_trace: Float[Array, ""]
     bias_h_trace: Float[Array, ""]
     bias_normalizer: Float[Array, ""]
+    previous_gamma: Float[Array, ""]
 
 
 # Union type for TD optimizer states
@@ -609,6 +621,7 @@ def create_tdidbd_state(
         bias_log_step_size=jnp.array(jnp.log(initial_step_size), dtype=jnp.float32),
         bias_eligibility_trace=jnp.array(0.0, dtype=jnp.float32),
         bias_h_trace=jnp.array(0.0, dtype=jnp.float32),
+        previous_gamma=jnp.array(1.0, dtype=jnp.float32),
     )
 
 
@@ -643,6 +656,7 @@ def create_autotdidbd_state(
         bias_eligibility_trace=jnp.array(0.0, dtype=jnp.float32),
         bias_h_trace=jnp.array(0.0, dtype=jnp.float32),
         bias_normalizer=jnp.array(1.0, dtype=jnp.float32),
+        previous_gamma=jnp.array(1.0, dtype=jnp.float32),
     )
 
 

--- a/tests/test_optimizer_nonfinite_transactions.py
+++ b/tests/test_optimizer_nonfinite_transactions.py
@@ -253,18 +253,21 @@ def test_checked_param_update_reports_internal_meta_guard(
 
 @pytest.mark.parametrize(
     ("factory", "expected_digest"),
+    # The TDIDBD/AutoTDIDBD digests cover the state tree, which now carries
+    # ``previous_gamma``; the first-step weight/bias deltas are unchanged
+    # (the seeded 1.0 is inert against zero initial traces).
     [
         (
             lambda: TDIDBD(0.02, 0.04, 0.5, True),
-            "a345406ff1f19e11a2d6d58f5829aacea6e43e27f41d487ffeeabe0affacfe6f",
+            "6b29599d10bb3cca3e2865e242c3a0dd7d48ac25962e6a83abcf96e7cf9c7e00",
         ),
         (
             lambda: TDIDBD(0.02, 0.04, 0.5, False),
-            "a345406ff1f19e11a2d6d58f5829aacea6e43e27f41d487ffeeabe0affacfe6f",
+            "6b29599d10bb3cca3e2865e242c3a0dd7d48ac25962e6a83abcf96e7cf9c7e00",
         ),
         (
             lambda: AutoTDIDBD(0.02, 0.04, 0.5, 50.0),
-            "e84c346d1530eb42df9a025c2a5744f43d09e9de266574e932b8f19c45ad257e",
+            "5169066bac6f67922563680b512a2b74baf82737078bdcc91b9ef17e262d1ed0",
         ),
         (
             lambda: SwiftTD(0.02, 0.04, 0.5, 0.1),

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1317,11 +1317,11 @@ def test_optimizer_state_allocations_are_preflighted_at_exact_byte_bounds() -> N
     with pytest.raises(ValueError, match="ObGD state byte count"):
         ObGD().init(obgd_last + 1)
 
-    td_last = (float32_scalar_limit - 5) // 3
+    td_last = (float32_scalar_limit - 6) // 3
     with pytest.raises(ValueError, match="TDIDBD state byte count"):
         TDIDBD().init(td_last + 1)
 
-    auto_td_last = (float32_scalar_limit - 7) // 4
+    auto_td_last = (float32_scalar_limit - 8) // 4
     with pytest.raises(ValueError, match="AutoTDIDBD state byte count"):
         AutoTDIDBD().init(auto_td_last + 1)
 
@@ -1340,8 +1340,8 @@ def test_optimizer_parameter_shape_products_are_preflighted_without_allocation()
         (Autostep(), 3 * 4 + 5),
         (AutostepGTDLambda(), 4 * 4 + 7),
         (ObGD(), 4 + 5),
-        (TDIDBD(), 3 * 4 + 5),
-        (AutoTDIDBD(), 4 * 4 + 7),
+        (TDIDBD(), 3 * 4 + 6),
+        (AutoTDIDBD(), 4 * 4 + 8),
     ],
 )
 def test_optimizer_vector_state_resource_formulas_are_exact(

--- a/tests/test_td_optimizers.py
+++ b/tests/test_td_optimizers.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from alberta_framework import TDIDBD, AutoTDIDBD
+from alberta_framework import TDIDBD, AutoTDIDBD, TDLinearLearner
 
 
 class TestTDIDBD:
@@ -570,3 +570,156 @@ class TestTDOptimizerComparison:
         # All should produce finite updates (even if zero)
         chex.assert_tree_all_finite(tdidbd_result.weight_delta)
         chex.assert_tree_all_finite(auto_result.weight_delta)
+
+
+# =============================================================================
+# Trace decay uses the prior transition's discount (S&B 2nd ed. eqs. 12.23/12.25)
+# =============================================================================
+
+
+def _accumulating_trace(
+    observations: list[jnp.ndarray], gammas: list[float], lam: float
+) -> tuple[np.ndarray, float]:
+    """``z_t = gamma_t * lam * z_{t-1} + phi_t`` with ``gamma_t`` the discount of
+    the transition INTO ``S_t`` (1.0 before the first update); bias trace too."""
+    z = np.zeros(len(observations[0]), dtype=np.float64)
+    z_bias = 0.0
+    previous_gamma = 1.0
+    for phi, gamma in zip(observations, gammas, strict=True):
+        z = previous_gamma * lam * z + np.asarray(phi, dtype=np.float64)
+        z_bias = previous_gamma * lam * z_bias + 1.0
+        previous_gamma = gamma
+    return z, z_bias
+
+
+class TestTraceDecaysWithPriorTransitionDiscount:
+    """The discount passed to ``update`` is ``gamma_{t+1}`` (0 at terminal) and
+    belongs to the TD-error bootstrap only. The eligibility trace decays by
+    ``gamma_t``, the discount of the transition into ``S_t``, which is the
+    discount retained from the prior update. Feeding ``gamma_{t+1}`` into the
+    decay multiplied the whole in-episode trace by zero on exactly the update
+    that carries the terminal reward, so no earlier feature was ever credited.
+    """
+
+    @pytest.fixture(params=[TDIDBD, AutoTDIDBD], ids=["tdidbd", "auto_tdidbd"])
+    def optimizer(self, request):
+        # meta_step_size=0 freezes the per-weight step-sizes at 0.1, so the
+        # weight delta is exactly alpha * delta * z.
+        return request.param(initial_step_size=0.1, meta_step_size=0.0, trace_decay=1.0)
+
+    @staticmethod
+    def _run(optimizer, observations, gammas, td_errors):
+        state = optimizer.init(feature_dim=len(observations[0]))
+        results = []
+        for phi, gamma, delta in zip(observations, gammas, td_errors, strict=True):
+            result = optimizer.update(
+                state,
+                jnp.asarray(delta, dtype=jnp.float32),
+                phi,
+                jnp.zeros_like(phi),
+                jnp.asarray(gamma, dtype=jnp.float32),
+            )
+            assert bool(result.update_applied)
+            state = result.new_state
+            results.append(result)
+        return results
+
+    def test_terminal_update_credits_pre_terminal_features(self, optimizer):
+        observations = [jnp.array([1.0, 0.0]), jnp.array([0.0, 1.0])]
+        gammas = [0.9, 0.0]
+        results = self._run(optimizer, observations, gammas, td_errors=[0.0, 1.0])
+        terminal = results[-1]
+
+        expected_z, expected_z_bias = _accumulating_trace(observations, gammas, lam=1.0)
+        np.testing.assert_allclose(terminal.new_state.eligibility_traces, expected_z, rtol=1e-6)
+        np.testing.assert_allclose(
+            float(terminal.new_state.bias_eligibility_trace), expected_z_bias, rtol=1e-6
+        )
+        np.testing.assert_allclose(terminal.weight_delta, 0.1 * 1.0 * expected_z, rtol=1e-6)
+        np.testing.assert_allclose(float(terminal.bias_delta), 0.1 * expected_z_bias, rtol=1e-6)
+        # The pre-terminal feature must receive credit for the terminal reward.
+        assert float(terminal.weight_delta[0]) > 0.0
+
+    def test_variable_discounts_decay_by_the_retained_transition_discount(self, optimizer):
+        observations = [
+            jnp.array([1.0, 0.0, 0.0]),
+            jnp.array([0.0, 1.0, 0.0]),
+            jnp.array([0.0, 0.0, 1.0]),
+        ]
+        gammas = [0.5, 0.9, 0.0]
+        results = self._run(optimizer, observations, gammas, td_errors=[0.0, 0.0, 1.0])
+        terminal = results[-1]
+
+        expected_z, expected_z_bias = _accumulating_trace(observations, gammas, lam=1.0)
+        # Neither a constant gamma nor the terminal zero: 0.5 * 0.9, 0.9, 1.0.
+        np.testing.assert_allclose(expected_z, [0.45, 0.9, 1.0])
+        np.testing.assert_allclose(terminal.new_state.eligibility_traces, expected_z, rtol=1e-6)
+        np.testing.assert_allclose(
+            float(terminal.new_state.bias_eligibility_trace), expected_z_bias, rtol=1e-6
+        )
+        np.testing.assert_allclose(terminal.weight_delta, 0.1 * expected_z, rtol=1e-6)
+
+    def test_previous_gamma_is_seeded_inert_and_advances(self, optimizer):
+        state = optimizer.init(feature_dim=2)
+        assert float(state.previous_gamma) == 1.0
+        phi = jnp.array([1.0, 0.0])
+        result = optimizer.update(
+            state, jnp.float32(0.5), phi, jnp.zeros_like(phi), jnp.float32(0.7)
+        )
+        assert bool(result.update_applied)
+        assert float(result.new_state.previous_gamma) == pytest.approx(0.7)
+
+    def test_post_terminal_update_starts_a_fresh_trace(self, optimizer):
+        observations = [jnp.array([1.0, 0.0]), jnp.array([0.0, 1.0]), jnp.array([1.0, 0.0])]
+        gammas = [0.9, 0.0, 0.9]
+        results = self._run(optimizer, observations, gammas, td_errors=[0.0, 1.0, 0.0])
+        first_of_next_episode = results[-1].new_state
+        np.testing.assert_array_equal(first_of_next_episode.eligibility_traces, observations[-1])
+        assert float(first_of_next_episode.bias_eligibility_trace) == 1.0
+
+    def test_stale_nonfinite_traces_after_terminal_do_not_block_next_episode(self):
+        # TDIDBD only: AutoTDIDBD's Algorithm 6 normalizer and effective
+        # step-size terms consume the prior trace directly, so a non-finite
+        # stale trace vetoes its update regardless of the decay.
+        optimizer = TDIDBD(initial_step_size=0.1, meta_step_size=0.0, trace_decay=1.0)
+        state = optimizer.init(feature_dim=2)
+        stale = state.replace(
+            previous_gamma=jnp.float32(0.0),
+            eligibility_traces=jnp.full(2, jnp.inf, dtype=jnp.float32),
+            bias_eligibility_trace=jnp.float32(jnp.inf),
+        )
+        phi = jnp.array([1.0, 0.0])
+        result = optimizer.update(
+            stale, jnp.float32(1.0), phi, jnp.zeros_like(phi), jnp.float32(0.9)
+        )
+        assert bool(result.update_applied)
+        np.testing.assert_array_equal(result.new_state.eligibility_traces, phi)
+        assert float(result.new_state.bias_eligibility_trace) == 1.0
+        assert float(result.new_state.previous_gamma) == pytest.approx(0.9)
+        chex.assert_tree_all_finite(result.weight_delta)
+
+    def test_single_episode_lambda_one_chain_is_monte_carlo(self):
+        """One pass over a 5-state chain with lambda=gamma=1 and reward only at
+        termination is incremental Monte Carlo: every visited state moves by
+        alpha, not only the last one."""
+        n_states, alpha = 5, 0.05
+        learner = TDLinearLearner(
+            optimizer=TDIDBD(initial_step_size=alpha, meta_step_size=0.0, trace_decay=1.0)
+        )
+        state = learner.init(n_states)
+        eye = np.eye(n_states, dtype=np.float32)
+        for t in range(n_states):
+            phi_next = (
+                jnp.asarray(eye[t + 1]) if t + 1 < n_states else jnp.zeros(n_states, jnp.float32)
+            )
+            result = learner.update(
+                state,
+                jnp.asarray(eye[t]),
+                jnp.float32(1.0 if t == n_states - 1 else 0.0),
+                phi_next,
+                jnp.float32(1.0 if t + 1 < n_states else 0.0),
+            )
+            assert bool(result.update_applied)
+            state = result.state
+        np.testing.assert_allclose(state.weights, np.full(n_states, alpha), rtol=1e-6)
+        np.testing.assert_allclose(float(state.bias), alpha * n_states, rtol=1e-6)

--- a/tests/test_true_online_td.py
+++ b/tests/test_true_online_td.py
@@ -489,3 +489,169 @@ class TestVOldPropagation:
 
         r1 = learner.update(r0.state, obs1, rewards[1], obs2, gammas[1])
         np.testing.assert_allclose(float(r1.state.v_old), expected_v_old_step2, atol=1e-6)
+
+
+# =============================================================================
+# Trace decay uses the prior transition's discount (S&B 2nd ed. eqs. 12.23/12.25)
+# =============================================================================
+
+
+def _reference_true_online_td(
+    observations: list[np.ndarray],
+    rewards: list[float],
+    next_observations: list[np.ndarray],
+    gammas: list[float],
+    *,
+    alpha: float,
+    lam: float,
+) -> tuple[np.ndarray, float]:
+    """van Seijen et al. (2016) true online TD(lambda), linear with an always-on
+    bias feature and per-transition discounts.
+
+    The Dutch trace decays by ``gamma_t * lam`` where ``gamma_t`` is the
+    discount of the transition INTO ``S_t`` (1.0 before the first update);
+    ``gamma_{t+1}`` (0 at terminal) enters only the TD-error bootstrap.
+    """
+    dim = len(observations[0]) + 1
+    w = np.zeros(dim, dtype=np.float64)
+    z = np.zeros(dim, dtype=np.float64)
+    v_old = 0.0
+    previous_gamma = 1.0
+    for x, r, x_next, gamma in zip(observations, rewards, next_observations, gammas, strict=True):
+        xa = np.append(np.asarray(x, dtype=np.float64), 1.0)
+        xna = np.append(np.asarray(x_next, dtype=np.float64), 1.0)
+        v = w @ xa
+        v_next = 0.0 if gamma == 0.0 else w @ xna
+        delta = r + gamma * v_next - v
+        decay = previous_gamma * lam
+        z = decay * z + (1.0 - alpha * decay * (z @ xa)) * xa
+        w = w + alpha * (delta + v - v_old) * z - alpha * (v - v_old) * xa
+        v_old = v_next
+        previous_gamma = gamma
+    return w[:-1], float(w[-1])
+
+
+class TestTraceDecaysWithPriorTransitionDiscount:
+    """The discount passed to ``update`` is ``gamma_{t+1}`` and belongs to the
+    TD-error bootstrap only. Decaying the Dutch trace by it multiplied the whole
+    in-episode trace by zero on the update that carries the terminal reward, so
+    lambda was silently forced to 0 exactly where credit assignment matters."""
+
+    @staticmethod
+    def _run(learner, observations, rewards, next_observations, gammas):
+        state = learner.init(len(observations[0]))
+        for x, r, x_next, gamma in zip(
+            observations, rewards, next_observations, gammas, strict=True
+        ):
+            result = learner.update(
+                state,
+                jnp.asarray(x, dtype=jnp.float32),
+                jnp.float32(r),
+                jnp.asarray(x_next, dtype=jnp.float32),
+                jnp.float32(gamma),
+            )
+            assert bool(result.update_applied)
+            state = result.state
+        return state
+
+    def test_terminal_update_credits_pre_terminal_feature(self) -> None:
+        alpha, lam = 0.1, 1.0
+        eye = np.eye(2, dtype=np.float32)
+        observations = [eye[0], eye[1]]
+        next_observations = [eye[1], np.zeros(2, dtype=np.float32)]
+        rewards = [0.0, 1.0]
+        gammas = [0.9, 0.0]
+
+        state = self._run(
+            TrueOnlineTDLearner(step_size=alpha, trace_decay=lam),
+            observations,
+            rewards,
+            next_observations,
+            gammas,
+        )
+        expected_w, expected_b = _reference_true_online_td(
+            observations, rewards, next_observations, gammas, alpha=alpha, lam=lam
+        )
+        np.testing.assert_allclose(state.weights, expected_w, rtol=1e-5, atol=1e-7)
+        np.testing.assert_allclose(float(state.bias), expected_b, rtol=1e-5, atol=1e-7)
+        # The pre-terminal state's feature must be credited for the terminal reward.
+        assert float(state.weights[0]) > 0.0
+
+    def test_variable_discounts_decay_by_the_retained_transition_discount(self) -> None:
+        alpha, lam = 0.1, 0.8
+        eye = np.eye(3, dtype=np.float32)
+        observations = [eye[0], eye[1], eye[2]]
+        next_observations = [eye[1], eye[2], np.zeros(3, dtype=np.float32)]
+        rewards = [0.25, -0.5, 1.0]
+        gammas = [0.5, 0.9, 0.0]
+
+        state = self._run(
+            TrueOnlineTDLearner(step_size=alpha, trace_decay=lam),
+            observations,
+            rewards,
+            next_observations,
+            gammas,
+        )
+        expected_w, expected_b = _reference_true_online_td(
+            observations, rewards, next_observations, gammas, alpha=alpha, lam=lam
+        )
+        np.testing.assert_allclose(state.weights, expected_w, rtol=1e-5, atol=1e-7)
+        np.testing.assert_allclose(float(state.bias), expected_b, rtol=1e-5, atol=1e-7)
+
+    def test_previous_gamma_is_seeded_inert_and_advances(self) -> None:
+        learner = TrueOnlineTDLearner(step_size=0.1, trace_decay=0.5)
+        state = learner.init(2)
+        assert float(state.previous_gamma) == 1.0
+        obs = jnp.array([1.0, 0.0])
+        result = learner.update(state, obs, jnp.float32(0.5), obs, jnp.float32(0.7))
+        assert bool(result.update_applied)
+        assert float(result.state.previous_gamma) == pytest.approx(0.7)
+        terminal = learner.update(
+            result.state, obs, jnp.float32(1.0), jnp.zeros(2), jnp.float32(0.0)
+        )
+        assert float(terminal.state.previous_gamma) == 0.0
+
+    def test_post_terminal_update_starts_a_fresh_trace(self) -> None:
+        learner = TrueOnlineTDLearner(step_size=0.1, trace_decay=1.0)
+        eye = np.eye(2, dtype=np.float32)
+        state = self._run(
+            learner,
+            [eye[0], eye[1]],
+            [0.0, 1.0],
+            [eye[1], np.zeros(2, dtype=np.float32)],
+            [0.9, 0.0],
+        )
+        result = learner.update(
+            state, jnp.asarray(eye[0]), jnp.float32(0.0), jnp.asarray(eye[1]), jnp.float32(0.9)
+        )
+        assert bool(result.update_applied)
+        np.testing.assert_array_equal(result.state.eligibility_traces, eye[0])
+        assert float(result.state.bias_eligibility_trace) == 1.0
+
+    def test_single_episode_lambda_one_chain_is_monte_carlo(self) -> None:
+        """One pass over the 5-state chain with lambda=gamma=1 and reward only
+        at termination is incremental Monte Carlo: every visited state's weight
+        moves, not only the last one's."""
+        n_states, alpha, lam = 5, 0.05, 1.0
+        eye = np.eye(n_states, dtype=np.float32)
+        observations = [eye[t] for t in range(n_states)]
+        next_observations = [
+            eye[t + 1] if t + 1 < n_states else np.zeros(n_states, dtype=np.float32)
+            for t in range(n_states)
+        ]
+        rewards = [1.0 if t == n_states - 1 else 0.0 for t in range(n_states)]
+        gammas = [1.0 if t + 1 < n_states else 0.0 for t in range(n_states)]
+
+        state = self._run(
+            TrueOnlineTDLearner(step_size=alpha, trace_decay=lam),
+            observations,
+            rewards,
+            next_observations,
+            gammas,
+        )
+        expected_w, expected_b = _reference_true_online_td(
+            observations, rewards, next_observations, gammas, alpha=alpha, lam=lam
+        )
+        np.testing.assert_allclose(state.weights, expected_w, rtol=1e-5, atol=1e-7)
+        np.testing.assert_allclose(float(state.bias), expected_b, rtol=1e-5, atol=1e-7)
+        assert bool(np.all(np.asarray(state.weights) > 0.0))


### PR DESCRIPTION
## Issue

Sutton & Barto (2nd ed.) index the two discounts in TD(λ) differently: the eligibility trace decays by the discount of the transition *into* `S_t` — `z_t = γ_t λ z_{t-1} + ∇v(S_t)` (eq. 12.25) — while the TD error bootstraps with the discount *out of* `S_t` — `δ_t = R_{t+1} + γ_{t+1} v(S_{t+1}) − v(S_t)` (eq. 12.23). Three on-policy linear learners fed the single per-transition `gamma` argument (documented as "0 at terminal", i.e. `γ_{t+1}`) into both roles:

- `TrueOnlineTDLearner.update` (`alberta_framework/core/learners.py`): `decay_scale = gamma_scalar * lamda`
- `TDIDBD.update` and `AutoTDIDBD.update` (`alberta_framework/core/optimizers.py`): `decay_scale = gamma_scalar * lam`, consumed by `TDLinearLearner`

On the one update that carries an episode's terminal reward the whole accumulated trace is multiplied by zero before the reward is credited, so no pre-terminal feature is ever credited and λ is silently forced to 0 exactly where credit assignment matters. Any episodic prediction stream with goal/terminal reward (`run_td_learning_loop`, `run_true_online_td_loop`, the gymnasium `TDStream`) gets TD(0) credit on the reward-bearing step regardless of λ.

Reproduction on origin/main `7e5a945a` (script in the attached evidence; λ=1, α=0.1, γ=0.9, one-hot features, reward only at termination):

```
### base origin/main 7e5a945a
TrueOnlineTDLearner weights  : [0.  0.1]
textbook true-online TD(1)   : [0.09 0.1 ]
TDLinearLearner(TDIDBD) weights: [0.         0.09999999]
textbook TD(lambda=1)          : [0.09 0.1 ]
5-state chain, 1 episode, lambda=1 (MC): ASI weights [0. 0. 0. 0. 0.05]
                                   textbook: every visited state credited
```

The repository already merged the correct rule for the off-policy learner in #2362 (`off_policy_td.py` carries `previous_gamma` in state). #2350 tried the actor-critic sites by substituting the *configured* gamma at boundaries and was closed by the maintainer because that silently changes the trace weight under caller-supplied varying discounts; the closure asked for "a consistent trace-state design and variable-discount regression". This PR applies the #2362 design to the on-policy learners and adds that regression.

## Change

- `TrueOnlineTDState`, `TDIDBDState`, `AutoTDIDBDState` gain `previous_gamma: Float[Array, ""]`, seeded to 1.0 (inert against the zero initial traces) and set to the current call's `gamma` after each applied update. `create_tdidbd_state` / `create_autotdidbd_state` seed it too.
- The three `update` paths decay by `state.previous_gamma * λ`; the TD-error bootstrap and the ordinary-gradient feature difference keep using this call's `gamma`.
- The TDIDBD/AutoTDIDBD rollback guard (`previous_checked`) ignores leftover traces exactly when this decay discards them (`decay_scale == 0`), mirroring the #2362 Gradient-TD acceptance-guard repair.
- Resource preflights count the extra scalar (`3n+6`, `4n+8`, `2n+6`); the byte-count and exact-formula tests follow.
- The two pinned first-step state digests in `test_optimizer_nonfinite_transactions.py` move only because the state tree gained the new leaf; the first-step weight and bias deltas are byte-identical to the base (verified by hashing deltas alone on both trees: `ce3f69bb12b41fa5…` on base and head for TDIDBD semi/ordinary and AutoTDIDBD). SwiftTD's digest is unchanged.

Explicit terminal zeroing of the stored true-online traces is kept; after the fix it is redundant with the next call's zero decay but harmless.

## Verification (head `5eac71a07525930e0e2f17105710eb3d948de0df`)

Failing-test-first. New regressions (15 fail on `7e5a945a`, all pass at head):

- `tests/test_td_optimizers.py::TestTraceDecaysWithPriorTransitionDiscount` (TDIDBD and AutoTDIDBD, `meta_step_size=0`): terminal update credits pre-terminal features with exact trace values; variable discounts `[0.5, 0.9, 0.0]` yield traces `[0.45, 0.9, 1.0]` (neither a constant gamma nor the terminal zero); `previous_gamma` seeded 1.0 and advancing; post-terminal update starts a fresh trace; stale non-finite traces after a terminal do not veto the next episode (TDIDBD); one pass over the 5-state chain with λ=γ=1 through `TDLinearLearner` moves every weight by α.
- `tests/test_true_online_td.py::TestTraceDecaysWithPriorTransitionDiscount`: the same properties for the Dutch-trace learner against a numpy reference of van Seijen et al. (2016) with per-transition discounts and an always-on bias feature.

```
.venv/bin/python -m pytest tests/test_baird.py tests/test_learner_optimizer_fallback_truthiness.py \
  tests/test_learners.py tests/test_learners_learning_loop_steps.py tests/test_learners_lifetime_clock.py \
  tests/test_off_policy_td.py tests/test_off_policy_td_scan_steps.py tests/test_off_policy_td_update_working_set.py \
  tests/test_optimizer_nonfinite_transactions.py tests/test_optimizers.py tests/test_optimizers_update_working_set.py \
  tests/test_scan_sequence_bounds_validation.py tests/test_swift_td.py tests/test_td_learners.py \
  tests/test_td_optimizers.py tests/test_true_online_td.py -q -m "not slow and not package"
693 passed in 142.23s
.venv/bin/python -m ruff check .            # All checks passed!
.venv/bin/python -m mypy                    # Success: no issues found in 224 source files
```

Full fast lane (`pytest tests -q -m "not slow and not package"`): running in the fix worktree at PR-open time (about 16,000 tests; 14% executed with no failure). The result will be posted as a comment on this PR; required CI at this head remains the merge gate.

Evidence registry: none of `core/types.py`, `core/optimizers.py`, `core/learners.py` is a registered evidence source (`evaluation/evidence_manifest.py`), so no pinned claim changes state from this diff. No `outputs/` artifact is touched.

## Remaining (not in this PR)

- The same index shift exists in `OffPolicyHordeLearner.update_with_ratios_and_discounts` head traces (`off_policy_horde.py`), `DifferentialSARSAAgent.update` (`average_reward.py`), and the six actor-critic sites of closed #2350. Each needs the same state-carried design and its own regression; one lane per PR.
- `SwiftTD` is unaffected: it applies the eligibility decay at the end of the update with this transition's gamma, which is the same indexing, so its digest is unchanged.
- `AutoTDIDBD`'s Algorithm 6 normalizer and effective-step-size terms consume the prior trace directly (as pinned in #2277); a hand-built non-finite stale trace therefore still vetoes its update. Committed updates never produce one, so this is unchanged here.
- Integration-branch blocker recorded, not repaired: the `main` `ci` run at `7e5a945a` (https://github.com/SlopDotCash/asi/actions/runs/33958019858) has had `lint`, `test-plan`, `robot-floor`, and `package` queued for over three hours while the Windows and macOS portability jobs succeeded; that is a Linux runner availability gap, not a repository-caused failure.

This is a development-only correctness fix. It is not scientific promotion, robotics readiness, or a benchmark win, and it does not populate `reference-dev`.

## Disclosure

AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code 2.1.261
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XExm6AFvAmNME5NUhWMTtH

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi
Attribution status: self-reported
— [asi-bug-hunt]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@bf7a58a914bba9eb2013d185933ce3641229b1b0:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1RRDY95WDP72JBNMS4AGXM3","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-05T12:24:26.149Z","completed_at":"2026-09-05T13:52:54.887Z","skill_sha256":"cbf063c866dc9e31a5e289788500d81964ad2a8df3c09f7d5cf08c183539d275","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-05T12:24:26.658Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ca3cb68dd85d99e66ea40e6ba604a7133b60cd26bee1e21664063381d7728e4e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"befd253c-e992-4780-98be-080949b4fcd5","object_id":"sha256:ca3cb68dd85d99e66ea40e6ba604a7133b60cd26bee1e21664063381d7728e4e","sha256":"ca3cb68dd85d99e66ea40e6ba604a7133b60cd26bee1e21664063381d7728e4e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"w0hdXy6o0C-5-flWTEkpbxzFsF2H2uTOcySLb9Demt9b34s_FjtN-qOLh-f1BMJh79amoKWeqfsvH2WIdFZgDA"}} -->
