### PR TITLE
fix(evaluation): compare multiagent interval scalars by canonical bytes (follow-up to #2824)

### DIFF
--- a/alberta_framework/evaluation/continual_multiagent_artifact.py
+++ b/alberta_framework/evaluation/continual_multiagent_artifact.py
@@ -786,13 +786,15 @@ def _validate_interval_record(
     if not isinstance(value, Mapping):
         errors.append(f"{location} must be an object")
         return
-    if value.get("sample_size") != len(_EXPECTED_EVIDENCE_SEEDS):
+    # Type-exact: ``30.0 != 30`` is False under Python equality, so a punned
+    # and re-digested interval record would pass a plain ``!=`` here.
+    if not _same(value.get("sample_size"), len(_EXPECTED_EVIDENCE_SEEDS)):
         errors.append(f"{location}.sample_size must be 30")
-    if value.get("method") != "paired-percentile-bootstrap":
+    if not _same(value.get("method"), "paired-percentile-bootstrap"):
         errors.append(f"{location}.method must be paired-percentile-bootstrap")
-    if value.get("pairing_unit") != "seed":
+    if not _same(value.get("pairing_unit"), "seed"):
         errors.append(f"{location}.pairing_unit must be seed")
-    if value.get("resamples") != config.get("bootstrap_resamples"):
+    if not _same(value.get("resamples"), config.get("bootstrap_resamples")):
         errors.append(
             f"{location}.resamples must match content.configuration"
         )

--- a/tests/test_continual_multiagent_benchmark.py
+++ b/tests/test_continual_multiagent_benchmark.py
@@ -432,6 +432,44 @@ def test_rehashed_type_punned_seed_and_threshold_values_fail_closed(
     assert any("successes is inconsistent with seed summaries" in e for e in errors)
 
 
+@pytest.mark.parametrize(
+    "interval_key",
+    [
+        "reward_uplift_over_frozen_paired_interval",
+        "coadaptation_uplift_over_learner_only_paired_interval",
+    ],
+)
+@pytest.mark.parametrize("field", ["sample_size", "resamples"])
+def test_rehashed_type_punned_interval_scalars_fail_closed(
+    benchmark_report, interval_key: str, field: str
+) -> None:
+    """The paired-bootstrap interval records must be type-exact too.
+
+    ``_validate_interval_record`` is the only validator for these two aggregate
+    subtrees; a ``30.0`` sample size or ``10000.0`` resample count re-digested
+    into the artifact passed a plain ``!=`` comparison.
+    """
+    fabricated = copy.deepcopy(build_evidence_artifact(benchmark_report))
+    content = fabricated["content"]
+    assert isinstance(content, dict)
+    aggregate = content["aggregate"]
+    assert isinstance(aggregate, dict)
+    interval = aggregate[interval_key]
+    assert isinstance(interval, dict)
+    assert isinstance(interval[field], int)
+    interval[field] = float(interval[field])
+    digest = fabricated["content_digest"]
+    assert isinstance(digest, dict)
+    digest["sha256"] = scientific_content_sha256(content)
+
+    validation = validate_evidence_artifact(fabricated)
+
+    assert not validation.valid
+    assert not validation.accepted
+    location = f"content.aggregate.{interval_key}.{field}"
+    assert any(location in error for error in validation.errors), validation.errors
+
+
 def test_rehashed_unknown_scientific_field_fails_schema(
     benchmark_report,
 ) -> None:


### PR DESCRIPTION
Outcome: **Fix** — an evidence validator that accepts a re-digested artifact it should reject. Follow-up to #2824 (merged), which converted the multiagent lane's field comparisons to canonical-bytes equality but left `_validate_interval_record` on Python `!=`. Not a Climb / Port / Close.

## What is wrong on `main`

`alberta_framework/evaluation/continual_multiagent_artifact.py::_validate_interval_record` is the only validator for `content.aggregate.reward_uplift_over_frozen_paired_interval` and `content.aggregate.coadaptation_uplift_over_learner_only_paired_interval`. It compared `sample_size`, `method`, `pairing_unit` and `resamples` with raw `!=`. Python equality treats `30.0 == 30` and `10000.0 == 10000` as equal, and the multiagent lane has no whole-`aggregate` canonical-bytes backstop, so a payload with either scalar punned and the digest recomputed validates. agent-cortex traced this on #2824 without being able to execute; measured on `origin/main` `3812ce8d` with the lane's own `build_evidence_artifact` fixture, punning one field and recomputing `content_digest`:

```text
sample_size=30.0   -> valid=True accepted=True errors=()
resamples=10000.0  -> valid=True accepted=True errors=()
```

## Change

Route the four comparisons through the lane's existing `_same` (canonical JSON bytes, which distinguish `30` from `30.0`). Honest artifacts are unaffected: their canonical bytes are exactly what the digest binds. One library hunk, no new helper.

## Evidence (failing-test-first)

`test_rehashed_type_punned_interval_scalars_fail_closed`, parametrized over both interval subtrees x {`sample_size`, `resamples`}:

- against `origin/main`'s library: **4 failed** (the punned artifacts validate);
- at this head: `tests/test_continual_multiagent_benchmark.py` **37 passed**;
- `ruff check` on both files: clean; `mypy` on the module: clean.

`continual_multiagent_artifact.py` is a registered evidence source for `recurring_multiagent_coadaptation`; as with #2824, this edit changes the validator's bytes, so `alberta-evidence-status` will report that claim as needing the frozen protocol rerun. That is the fail-closed design, not something this PR silences.

AI provider/model: anthropic / claude-fable-5 · client: claude-code. Reviewed and measured on arm64 macOS, CPython 3.13, JAX 0.11.0 (XLA:CPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
