### PR TITLE
fix(core): fail closed when the checkpoint metadata preflight cannot stat (follow-up to #2177)

### DIFF
--- a/alberta_framework/core/checkpoints.py
+++ b/alberta_framework/core/checkpoints.py
@@ -216,8 +216,10 @@ def _preflight_on_disk_metadata(path: Path) -> None:
     try:
         if not meta_path.is_file():
             return
-    except OSError:
-        return
+    except OSError as error:
+        # A stat that fails must not skip the gates: Orbax would still open
+        # and ``json.loads`` whatever is there without any nesting preflight.
+        raise ValueError("checkpoint metadata is unreadable") from error
     with meta_path.open("rb") as stream:
         raw = stream.read(_JSON_MAX_BYTES + 1)
     if len(raw) > _JSON_MAX_BYTES:

--- a/tests/test_checkpoints_metadata_load_nest.py
+++ b/tests/test_checkpoints_metadata_load_nest.py
@@ -117,3 +117,23 @@ def test_symlinked_metadata_deep_nest_rejects_load_checkpoint(tmp_path: Path) ->
 
     with pytest.raises(ValueError, match="nesting limit"):
         load_checkpoint(state, ckpt)
+
+
+def test_unreadable_metadata_parent_fails_closed(tmp_path: Path) -> None:
+    """A stat failure must raise, not skip the preflight and hand Orbax the file."""
+    import os
+
+    if os.geteuid() == 0:
+        pytest.skip("mode bits do not restrict root")
+    ckpt = tmp_path / "unreadable"
+    (ckpt / "metadata").mkdir(parents=True)
+    _write_hostile_metadata(ckpt, 16_000)
+    parent = ckpt / "metadata"
+    parent.chmod(0)
+    try:
+        with pytest.raises(ValueError, match="checkpoint metadata is unreadable"):
+            load_checkpoint_metadata(ckpt)
+        with pytest.raises(ValueError, match="checkpoint metadata is unreadable"):
+            load_checkpoint(LinearLearner().init(3), ckpt)
+    finally:
+        parent.chmod(0o755)


### PR DESCRIPTION
Outcome: **Fix** — a fail-closed preflight that silently failed open on one error path. Follow-up to #2177 (merged), whose review by lumix5 and the standing hermesagent270-commits review both named this line. Not a Climb / Port / Close.

## What is wrong on `main`

`alberta_framework/core/checkpoints.py::_preflight_on_disk_metadata` guards Orbax's `json.loads` of `metadata/metadata` with a byte limit, a UTF-8 gate and a JSON nesting gate. If `meta_path.is_file()` raises `OSError`, the function `return`s and `load_checkpoint` / `load_checkpoint_metadata` proceed to Orbax without any of those gates. Measured on `origin/main` `3812ce8d` by driving the preflight on crafted checkpoint directories:

| `metadata/metadata` | preflight |
|---|---|
| 16,000-deep nest | `ValueError: ... exceeds the JSON nesting limit` |
| symlink to that nest | same `ValueError` |
| symlink loop (ELOOP) | **returns silently** |
| deep nest under a mode-000 parent (`is_file()` raises `PermissionError`) | **returns silently** |

On a static directory Orbax then fails on its own open, so the exposure is the race lumix5 described (stat fails, the later open succeeds); regardless, a validator whose only job is to convert `RecursionError` into a stable `ValueError` should not fail open on the one branch that reports it cannot inspect the file.

## Change

`except OSError as error: raise ValueError("checkpoint metadata is unreadable") from error`. One hunk; the honest, missing-file, symlinked and deep-nest paths are unchanged.

## Evidence (failing-test-first)

`test_unreadable_metadata_parent_fails_closed` writes a 16,000-deep nest under a mode-000 `metadata` directory (skipped as root) and asserts the stable `ValueError` from both `load_checkpoint_metadata` and `load_checkpoint`:

- against `origin/main`'s library: **fails** (the preflight returns and Orbax raises `FileNotFoundError` instead);
- at this head: `tests/test_checkpoints_metadata_load_nest.py` + `tests/test_checkpoints.py` **40 passed**; `ruff` clean; `mypy` clean on the module.

`core/checkpoints.py` is not a registered evidence source in `evidence_manifest.py`.

AI provider/model: anthropic / claude-fable-5 · client: claude-code. Measured on arm64 macOS, CPython 3.13, JAX 0.11.0 (XLA:CPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
