### PR TITLE
fix(core): cap n_dreams_per_step before jnp.arange scan hang (#2441)

### DIFF
--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -49,6 +49,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import Bool, Float, Int, UInt
 
+from alberta_framework._scan_resources import ScanBudget
 from alberta_framework.core._float32_scalars import validated_float32_scalar
 from alberta_framework.core.checkpoints import (
     load_checkpoint,
@@ -266,6 +267,12 @@ def feature_to_subtask_specs(
 
 
 _INT32_MAX = 2**31 - 1
+# Public last-fit in tests is 4 dreams per step. Origin handed INT32_MAX to
+# jnp.arange with no last-fit reject — hang/OOM, not an INT32 leftover.
+_PROTOTYPE_DREAM_STEP_BUDGET = ScanBudget(
+    "prototype dreams per step",
+    maximum_steps=10_000,
+)
 _UINT32_MAX = 4_294_967_295
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
         int,
@@ -731,7 +738,7 @@ class PrototypeAgentConfig:
                 "n_dreams_per_step",
                 self.n_dreams_per_step,
                 minimum=0,
-                maximum=_INT32_MAX,
+                maximum=_PROTOTYPE_DREAM_STEP_BUDGET.maximum_steps,
             ),
         )
         # horde_hidden_sizes: hostile-safe per-element validation
@@ -1341,7 +1348,10 @@ class PrototypeAgentConfig:
             "buffer_capacity", data.pop("buffer_capacity", 200), minimum=1, maximum=_INT32_MAX
         )
         n_dreams_per_step = _require_int(
-            "n_dreams_per_step", data.pop("n_dreams_per_step", 0), minimum=0, maximum=_INT32_MAX
+            "n_dreams_per_step",
+            data.pop("n_dreams_per_step", 0),
+            minimum=0,
+            maximum=_PROTOTYPE_DREAM_STEP_BUDGET.maximum_steps,
         )
         dream_next_observation_mode = data.pop(
             "dream_next_observation_mode",

--- a/tests/test_prototype_agent.py
+++ b/tests/test_prototype_agent.py
@@ -185,6 +185,44 @@ class TestPrototypeAgentConfigValidation:
         with pytest.raises(ValueError, match="n_dreams_per_step"):
             PrototypeAgentConfig(oak=_oak_cfg(), n_dreams_per_step=-1)
 
+    def test_n_dreams_per_step_rejects_scan_budget_overflow(self) -> None:
+        with pytest.raises(ValueError, match="n_dreams_per_step must be <= 10000"):
+            PrototypeAgentConfig(
+                oak=_oak_cfg(),
+                world_model=_wm_cfg(),
+                n_dreams_per_step=2**31 - 1,
+            )
+        with pytest.raises(ValueError, match="n_dreams_per_step must be <= 10000"):
+            PrototypeAgentConfig(
+                oak=_oak_cfg(),
+                world_model=_wm_cfg(),
+                n_dreams_per_step=10_001,
+            )
+
+    def test_n_dreams_per_step_accepts_budget_boundary_and_last_fit(self) -> None:
+        boundary = PrototypeAgentConfig(
+            oak=_oak_cfg(),
+            world_model=_wm_cfg(),
+            n_dreams_per_step=10_000,
+        )
+        last_fit = PrototypeAgentConfig(
+            oak=_oak_cfg(),
+            world_model=_wm_cfg(),
+            n_dreams_per_step=4,
+        )
+        assert boundary.n_dreams_per_step == 10_000
+        assert last_fit.n_dreams_per_step == 4
+
+    def test_from_config_rejects_oversized_n_dreams_per_step(self) -> None:
+        payload = PrototypeAgentConfig(
+            oak=_oak_cfg(),
+            world_model=_wm_cfg(),
+            n_dreams_per_step=4,
+        ).to_config()
+        payload["n_dreams_per_step"] = 2**31 - 1
+        with pytest.raises(ValueError, match="n_dreams_per_step must be <= 10000"):
+            PrototypeAgentConfig.from_config(payload)
+
     def test_dreams_require_world_model(self) -> None:
         with pytest.raises(ValueError, match="world_model"):
             PrototypeAgentConfig(oak=_oak_cfg(), n_dreams_per_step=2, world_model=None)


### PR DESCRIPTION
## Summary
Caps `PrototypeAgentConfig.n_dreams_per_step` at the named 10,000 `ScanBudget` used by `core.dreaming` rollouts, at both `__post_init__` and `from_config`. `2**31-1` and `10001` now raise `ValueError: n_dreams_per_step must be <= 10000` before `jnp.arange` can be traced. Last-fit 4 and boundary 10,000 still construct. Zero remains legal. This is a compute-safety fix, not learning or performance evidence.

Fixes #2441

## Test plan
- [x] `pytest tests/test_prototype_agent.py::TestPrototypeAgentConfigValidation -q -o addopts=""` — 23 passed in 20.26s (JAX CPU; host Python 3.14 venv because 3.12 is not installed)
- [x] `ruff check alberta_framework/core/prototype_agent.py tests/test_prototype_agent.py` — All checks passed
- [ ] CI on this head

<!-- evidence-head:1966b309a9f10ef3e275d30b4f6e4333c1dd3bc5 -->
<!-- evidence-row:logs -->
- [x] logs: focused pytest 23 passed / ruff clean at `1966b309a9f10ef3e275d30b4f6e4333c1dd3bc5` (local Windows CPU; orbax test fixtures omitted due to MAX_PATH)
