### PR TITLE
fix(core): cap working-memory decay rate cardinality (#2220)

### DIFF
--- a/alberta_framework/core/state_builder.py
+++ b/alberta_framework/core/state_builder.py
@@ -70,6 +70,7 @@ from alberta_framework.core.working_memory import (
 )
 
 _INT32_MAX = 2**31 - 1
+_MAX_FIXED_TRACE_DECAY_RATES = 1 << 12
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -119,6 +120,10 @@ def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
     if type(value) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
     rates = cast(tuple[object, ...], value)
+    if len(rates) > _MAX_FIXED_TRACE_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_FIXED_TRACE_DECAY_RATES} rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",
@@ -129,6 +134,17 @@ def _require_decay_rates(name: str, value: object) -> tuple[float, ...]:
         )
         for index, rate in enumerate(rates)
     )
+
+
+def _decode_decay_rates_payload(name: str, value: object) -> tuple[object, ...]:
+    if type(value) is not list and type(value) is not tuple:
+        raise ValueError("decay rates must be lists or tuples")
+    rates = cast(list[object] | tuple[object, ...], value)
+    if len(rates) > _MAX_FIXED_TRACE_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_FIXED_TRACE_DECAY_RATES} rates"
+        )
+    return tuple(rates)
 
 
 def _require_derived_int32(name: str, value: int, *, minimum: int = 0) -> int:
@@ -1033,21 +1049,18 @@ class FixedTraceStateBuilderConfig:
             raise ValueError(
                 "FixedTraceStateBuilderConfig payload type must be 'FixedTraceStateBuilder'"
             )
-        obs_decays = data["observation_decay_rates"]
-        act_decays = data["action_decay_rates"]
-        out_decays = data["outcome_decay_rates"]
-        if (
-            not isinstance(obs_decays, (list, tuple))
-            or not isinstance(act_decays, (list, tuple))
-            or not isinstance(out_decays, (list, tuple))
-        ):
-            raise ValueError("decay rates must be lists or tuples")
         return cls(
             observation_dim=data["observation_dim"],
             n_actions=data["n_actions"],
-            observation_decay_rates=tuple(obs_decays),
-            action_decay_rates=tuple(act_decays),
-            outcome_decay_rates=tuple(out_decays),
+            observation_decay_rates=_decode_decay_rates_payload(
+                "observation_decay_rates", data["observation_decay_rates"]
+            ),
+            action_decay_rates=_decode_decay_rates_payload(
+                "action_decay_rates", data["action_decay_rates"]
+            ),
+            outcome_decay_rates=_decode_decay_rates_payload(
+                "outcome_decay_rates", data["outcome_decay_rates"]
+            ),
             include_raw_observation=data["include_raw_observation"],
         )
 

--- a/alberta_framework/core/working_memory.py
+++ b/alberta_framework/core/working_memory.py
@@ -123,10 +123,14 @@ class WorkingMemoryConfig:
         ):
             if key in payload:
                 value = payload[key]
+                if type(value) is not list and type(value) is not tuple:
+                    raise ValueError(f"{key} must be an actual list or tuple")
+                if len(value) > _MAX_WORKING_MEMORY_DECAY_RATES:
+                    raise ValueError(
+                        f"{key} must contain at most {_MAX_WORKING_MEMORY_DECAY_RATES} rates"
+                    )
                 if type(value) is list:
                     payload[key] = tuple(value)
-                elif type(value) is not tuple:
-                    raise ValueError(f"{key} must be an actual list or tuple")
                 if any(type(item) is not float for item in payload[key]):
                     raise ValueError(f"serialized {key} values must be JSON numbers")
         for key in ("observation_dim", "action_dim", "reward_dim"):
@@ -216,6 +220,7 @@ class WorkingMemoryArrayResult:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_WORKING_MEMORY_DECAY_RATES = 1 << 12
 _FLOAT32_MIN_NORMAL = float.fromhex("0x1.0p-126")
 _ACTUAL_INT_TYPES: tuple[type, ...] = (
     int,
@@ -287,6 +292,11 @@ def _require_array(
 def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
     if type(rates) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
+    rates_tuple = cast(tuple[object, ...], rates)
+    if len(rates_tuple) > _MAX_WORKING_MEMORY_DECAY_RATES:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_WORKING_MEMORY_DECAY_RATES} rates"
+        )
     return tuple(
         validated_float32_scalar(
             f"{name}[{index}]",
@@ -295,7 +305,7 @@ def _validate_decay_rates(name: str, rates: object) -> tuple[float, ...]:
             upper=1.0,
             upper_inclusive=False,
         )
-        for index, value in enumerate(rates)
+        for index, value in enumerate(rates_tuple)
     )
 
 

--- a/tests/test_working_memory_cardinality_bounds.py
+++ b/tests/test_working_memory_cardinality_bounds.py
@@ -1,0 +1,149 @@
+"""Cardinality preflights for working-memory and fixed-trace decay rates."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from alberta_framework.core.state_builder import (
+    _MAX_FIXED_TRACE_DECAY_RATES,
+    FixedTraceStateBuilderConfig,
+)
+from alberta_framework.core.working_memory import (
+    _MAX_WORKING_MEMORY_DECAY_RATES,
+    WorkingMemoryConfig,
+)
+
+
+class _HostileList(list[object]):
+    calls = 0
+
+    def __len__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("list length hook executed")
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        type(self).calls += 1
+        raise AssertionError("list iterator hook executed")
+
+
+def test_last_fit_working_memory_decay_count_is_accepted() -> None:
+    rates = (0.5,) * _MAX_WORKING_MEMORY_DECAY_RATES
+    cfg = WorkingMemoryConfig(
+        observation_dim=1,
+        action_dim=0,
+        reward_dim=0,
+        observation_decay_rates=rates,
+        action_decay_rates=(),
+        reward_decay_rates=(),
+        include_current_action=False,
+        include_current_reward=False,
+        include_traces=False,
+    )
+    assert len(cfg.observation_decay_rates) == _MAX_WORKING_MEMORY_DECAY_RATES
+
+
+def test_last_fit_fixed_trace_decay_count_is_accepted() -> None:
+    rates = (0.5,) * _MAX_FIXED_TRACE_DECAY_RATES
+    cfg = FixedTraceStateBuilderConfig(
+        observation_dim=1,
+        n_actions=0,
+        observation_decay_rates=rates,
+        action_decay_rates=(),
+        outcome_decay_rates=(),
+        include_raw_observation=True,
+    )
+    assert len(cfg.observation_decay_rates) == _MAX_FIXED_TRACE_DECAY_RATES
+
+
+def test_rejects_oversized_working_memory_decay_rates_before_per_rate_walk() -> None:
+    calls = 0
+
+    class HostileFloat:
+        def __float__(self) -> float:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("oversized decay tuple walked an element")
+
+    hostile: Any = HostileFloat()
+    with pytest.raises(ValueError, match="at most 4096"):
+        WorkingMemoryConfig(
+            observation_dim=1,
+            observation_decay_rates=(hostile,) * 4097,  # type: ignore[arg-type]
+        )
+    assert calls == 0
+
+
+def test_rejects_oversized_fixed_trace_decay_rates_before_per_rate_walk() -> None:
+    calls = 0
+
+    class HostileFloat:
+        def __float__(self) -> float:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("oversized decay tuple walked an element")
+
+    hostile: Any = HostileFloat()
+    with pytest.raises(ValueError, match="at most 4096"):
+        FixedTraceStateBuilderConfig(
+            observation_dim=1,
+            observation_decay_rates=(hostile,) * 4097,  # type: ignore[arg-type]
+        )
+    assert calls == 0
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["observation_decay_rates", "action_decay_rates", "reward_decay_rates"],
+)
+def test_working_memory_from_config_rejects_oversized_lists_before_tuple_copy(
+    field: str,
+) -> None:
+    config = WorkingMemoryConfig(observation_dim=1).to_config()
+    config[field] = [0.5] * 4097
+    with pytest.raises(ValueError, match="at most 4096"):
+        WorkingMemoryConfig.from_config(config)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["observation_decay_rates", "action_decay_rates", "outcome_decay_rates"],
+)
+def test_fixed_trace_from_config_rejects_oversized_lists_before_tuple_copy(
+    field: str,
+) -> None:
+    config = FixedTraceStateBuilderConfig(observation_dim=1).to_config()
+    config[field] = [0.5] * 4097
+    with pytest.raises(ValueError, match="at most 4096"):
+        FixedTraceStateBuilderConfig.from_config(config)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["observation_decay_rates", "action_decay_rates", "reward_decay_rates"],
+)
+def test_working_memory_from_config_rejects_list_subclasses_before_length_hooks(
+    field: str,
+) -> None:
+    config = WorkingMemoryConfig(observation_dim=1).to_config()
+    config[field] = _HostileList()
+    _HostileList.calls = 0
+    with pytest.raises(ValueError, match="actual list or tuple"):
+        WorkingMemoryConfig.from_config(config)
+    assert _HostileList.calls == 0
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["observation_decay_rates", "action_decay_rates", "outcome_decay_rates"],
+)
+def test_fixed_trace_from_config_rejects_list_subclasses_before_length_hooks(
+    field: str,
+) -> None:
+    config = FixedTraceStateBuilderConfig(observation_dim=1).to_config()
+    config[field] = _HostileList()
+    _HostileList.calls = 0
+    with pytest.raises(ValueError, match="lists or tuples"):
+        FixedTraceStateBuilderConfig.from_config(config)
+    assert _HostileList.calls == 0


### PR DESCRIPTION
## Summary
- Cap working-memory and `FixedTraceStateBuilder` decay-rate lists at a named 4096 budget before per-rate walks.
- Reject list subclasses and oversized JSON sequences in `from_config` before `__len__`/`__iter__` or `tuple()` copy.

Closes #2220

## Test plan
- [x] `pytest tests/test_working_memory_cardinality_bounds.py tests/test_working_memory_validation.py tests/test_state_builder_hostile_validation.py`
- [x] `ruff check` on the touched files