### PR TITLE
fix(core): bound stacked-horde demon count at 4096 (#2225)

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -132,6 +132,7 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
 
 _INT32_MAX = 2**31 - 1
+_MAX_STACKED_HORDE_DEMONS = 1 << 12
 _CONFIG_FIELDS = {
     "type",
     "n_demons",
@@ -156,13 +157,23 @@ def _require_int32(name: str, value: object, *, minimum: int, maximum: int = _IN
 def _require_sequence(name: str, value: object) -> tuple[object, ...]:
     if type(value) is not tuple:
         raise ValueError(f"{name} must be an actual tuple")
-    return cast(tuple[object, ...], value)
+    sequence = cast(tuple[object, ...], value)
+    if len(sequence) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_STACKED_HORDE_DEMONS} items"
+        )
+    return sequence
 
 
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
-    if type(value) not in (list, tuple):
+    if type(value) is not list and type(value) is not tuple:
         raise ValueError(f"{name} must be an actual list or tuple")
-    return tuple(cast(list[object] | tuple[object, ...], value))
+    sequence = cast(list[object] | tuple[object, ...], value)
+    if len(sequence) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_STACKED_HORDE_DEMONS} items"
+        )
+    return tuple(sequence)
 
 
 def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
@@ -243,7 +254,12 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        n_demons = _require_int32(
+            "n_demons",
+            self.n_demons,
+            minimum=1,
+            maximum=_MAX_STACKED_HORDE_DEMONS,
+        )
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
         raw_sequences = {
@@ -341,6 +357,12 @@ def nexting_spec(
     feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
     raw_indices = _require_sequence("cumulant_indices", cumulant_indices)
     raw_gammas = _require_sequence("gammas", gammas)
+    n_demons = len(raw_indices) * len(raw_gammas)
+    if n_demons < 1 or n_demons > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            "derived n_demons must be at most "
+            f"{_MAX_STACKED_HORDE_DEMONS} and at least 1"
+        )
     canonical_indices = tuple(
         _require_int32(f"cumulant_indices[{i}]", value, minimum=0)
         for i, value in enumerate(raw_indices)
@@ -350,9 +372,6 @@ def nexting_spec(
         for i, value in enumerate(raw_gammas)
     )
     canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
-    n_demons = len(canonical_indices) * len(canonical_gammas)
-    if n_demons < 1 or n_demons > _INT32_MAX:
-        raise ValueError("derived n_demons must be in the signed int32 domain")
     _preflight_horde_resources(n_demons, feature_dim)
     _preflight_stacked_horde_update_working_set(n_demons, feature_dim)
     idxs: list[int] = []

--- a/tests/test_stacked_horde_cardinality_bounds.py
+++ b/tests/test_stacked_horde_cardinality_bounds.py
@@ -1,0 +1,137 @@
+"""Cardinality preflights for stacked-horde demon count and sequences."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from alberta_framework.core.stacked_horde import (
+    _MAX_STACKED_HORDE_DEMONS,
+    StackedHordeConfig,
+    nexting_spec,
+)
+
+
+class _HostileList(list[object]):
+    calls = 0
+
+    def __len__(self) -> int:
+        type(self).calls += 1
+        raise AssertionError("list length hook executed")
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        type(self).calls += 1
+        raise AssertionError("list iterator hook executed")
+
+
+def _last_fit_config() -> StackedHordeConfig:
+    n = _MAX_STACKED_HORDE_DEMONS
+    return StackedHordeConfig(
+        n_demons=n,
+        feature_dim=1,
+        gammas=(0.9,) * n,
+        lamdas=(0.8,) * n,
+        cumulant_indices=(0,) * n,
+    )
+
+
+def test_last_fit_demon_count_is_accepted() -> None:
+    cfg = _last_fit_config()
+    assert cfg.n_demons == _MAX_STACKED_HORDE_DEMONS
+
+
+def test_rejects_oversized_n_demons_before_sequence_walk() -> None:
+    calls = 0
+
+    class HostileFloat:
+        def __float__(self) -> float:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("oversized n_demons walked a sequence element")
+
+    hostile: Any = HostileFloat()
+    with pytest.raises(ValueError, match="4096"):
+        StackedHordeConfig(
+            n_demons=4097,
+            feature_dim=1,
+            gammas=(hostile,),  # type: ignore[arg-type]
+            lamdas=(0.8,),
+            cumulant_indices=(0,),
+        )
+    assert calls == 0
+
+
+def test_from_config_rejects_oversized_lists_before_tuple_copy() -> None:
+    payload = StackedHordeConfig(
+        n_demons=1,
+        feature_dim=1,
+        gammas=(0.9,),
+        lamdas=(0.8,),
+        cumulant_indices=(0,),
+    ).to_config()
+    payload["gammas"] = [0.9] * 4097
+    with pytest.raises(ValueError, match="at most 4096"):
+        StackedHordeConfig.from_config(payload)
+
+
+def test_from_config_rejects_list_subclasses_before_length_hooks() -> None:
+    payload = StackedHordeConfig(
+        n_demons=1,
+        feature_dim=1,
+        gammas=(0.9,),
+        lamdas=(0.8,),
+        cumulant_indices=(0,),
+    ).to_config()
+    payload["gammas"] = _HostileList()
+    _HostileList.calls = 0
+    with pytest.raises(ValueError, match="actual list or tuple"):
+        StackedHordeConfig.from_config(payload)
+    assert _HostileList.calls == 0
+
+
+def test_last_fit_nexting_product_is_accepted() -> None:
+    cfg = nexting_spec(
+        feature_dim=1,
+        cumulant_indices=tuple(range(64)),
+        gammas=(0.0,) * 64,
+    )
+    assert cfg.n_demons == 4096
+
+
+def test_nexting_spec_rejects_product_before_expanding_or_walking() -> None:
+    calls = 0
+
+    class HostileFloat:
+        def __float__(self) -> float:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("oversized nexting product walked a gamma")
+
+    hostile: Any = HostileFloat()
+    with pytest.raises(ValueError, match="at most 4096"):
+        nexting_spec(
+            feature_dim=1,
+            cumulant_indices=tuple(range(65)),
+            gammas=(hostile,) * 64,  # type: ignore[arg-type]
+        )
+    assert calls == 0
+
+
+def test_nexting_spec_rejects_oversized_sequence_before_per_item_walk() -> None:
+    calls = 0
+
+    class HostileFloat:
+        def __float__(self) -> float:
+            nonlocal calls
+            calls += 1
+            raise AssertionError("oversized gamma tuple walked an element")
+
+    hostile: Any = HostileFloat()
+    with pytest.raises(ValueError, match="at most 4096"):
+        nexting_spec(
+            feature_dim=1,
+            cumulant_indices=(0,),
+            gammas=(hostile,) * 4097,  # type: ignore[arg-type]
+        )
+    assert calls == 0


### PR DESCRIPTION
## Summary
- Cap `StackedHordeConfig.n_demons` at a named 4096 budget before walking per-demon sequences.
- Bound deserializer sequence length and `nexting_spec` products before `tuple()` copy or product expansion.

Closes #2225

## Test plan
- [x] `pytest tests/test_stacked_horde_cardinality_bounds.py tests/test_stacked_horde.py`
- [x] `ruff check` on the touched files