### PR TITLE
fix(steps): bound Step 7/9 scan loop lengths before jnp.arange (#2214)

### DIFF
--- a/alberta_framework/steps/step7.py
+++ b/alberta_framework/steps/step7.py
@@ -59,6 +59,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._scan_resources import ScanBudget, require_scan_steps
 from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.average_reward import (
     DifferentialSARSAAgent,
@@ -161,6 +162,7 @@ class Step7DynaConfig:
 
 
 _INT32_MAX = 2**31 - 1
+_STEP7_PLANNING_LOOP_BUDGET = ScanBudget("Step 7 planning", maximum_steps=10_000)
 _STEP7_CONFIG_FIELDS = frozenset(
     {
         "control",
@@ -262,6 +264,15 @@ def _require_int(
     return number
 
 
+def _require_planning_scan_steps(
+    name: str, value: object, *, minimum: int
+) -> int:
+    canonical = _require_int(name, value, minimum=minimum, maximum=_INT32_MAX)
+    if canonical == 0:
+        return 0
+    return require_scan_steps(name, canonical, _STEP7_PLANNING_LOOP_BUDGET)
+
+
 def _require_bool(name: str, value: object) -> bool:
     if type(value) is not bool:
         raise ValueError(f"{name} must be a built-in bool")
@@ -275,17 +286,15 @@ def _validate_planning_config(config: Step7DynaConfig) -> None:
         raise ValueError("control must be an actual Step6DifferentialSARSAConfig")
     if type(config.world_model) is not Step8WorldModelConfig:
         raise ValueError("world_model must be an actual Step8WorldModelConfig")
-    planning_steps = _require_int(
+    planning_steps = _require_planning_scan_steps(
         "planning_steps",
         config.planning_steps,
         minimum=0,
-        maximum=_INT32_MAX,
     )
-    planning_rollout_depth = _require_int(
+    planning_rollout_depth = _require_planning_scan_steps(
         "planning_rollout_depth",
         config.planning_rollout_depth,
         minimum=1,
-        maximum=_INT32_MAX,
     )
     planning_warmup_steps = _require_int(
         "planning_warmup_steps",

--- a/alberta_framework/steps/step9.py
+++ b/alberta_framework/steps/step9.py
@@ -36,6 +36,7 @@ import jax.random as jr
 import numpy as np
 from jax import Array
 
+from alberta_framework._scan_resources import ScanBudget, require_scan_steps
 from alberta_framework._seed_validation import require_jax_seed
 from alberta_framework.core.average_reward import (
     DifferentialSARSAAgent,
@@ -84,6 +85,7 @@ _MAX_DREAM_WORK_PER_REAL_STEP = 4_096
 # additionally includes model-based dreaming rollouts, so this module is at
 # least as exposed to the hang as its siblings.
 _STEP9_SEQUENCE_MAX_STEPS = 10_000
+_STEP9_DREAM_LOOP_BUDGET = ScanBudget("Step 9 dreaming", maximum_steps=10_000)
 _ACTUAL_INT_TYPES = frozenset(
     {
         int,
@@ -285,6 +287,13 @@ def _require_int(
     return number
 
 
+def _require_dream_scan_steps(name: str, value: object, *, minimum: int) -> int:
+    canonical = _require_int(name, value, minimum=minimum, maximum=_INT32_MAX)
+    if canonical == 0:
+        return 0
+    return require_scan_steps(name, canonical, _STEP9_DREAM_LOOP_BUDGET)
+
+
 def _require_bool(name: str, value: object) -> bool:
     if type(value) is not bool:
         raise ValueError(f"{name} must be a built-in bool")
@@ -425,21 +434,19 @@ def _validate_dreaming_config(config: Step9DreamingConfig) -> None:
         "behavior_model_step_size",
         config.behavior_model_step_size,
     )
-    planning_budget = _require_int(
-        "planning_budget", config.planning_budget, minimum=0, maximum=_INT32_MAX
+    planning_budget = _require_dream_scan_steps(
+        "planning_budget", config.planning_budget, minimum=0
     )
-    dream_rollout_horizon = _require_int(
+    dream_rollout_horizon = _require_dream_scan_steps(
         "dream_rollout_horizon",
         config.dream_rollout_horizon,
         minimum=1,
-        maximum=_INT32_MAX,
     )
     # Candidate selection publishes selected indices as signed int32 values.
-    dream_candidate_count = _require_int(
+    dream_candidate_count = _require_dream_scan_steps(
         "dream_candidate_count",
         config.dream_candidate_count,
         minimum=1,
-        maximum=_INT32_MAX,
     )
     dream_surprise_weight = _require_real(
         "dream_surprise_weight",

--- a/tests/test_step7_hostile_validation.py
+++ b/tests/test_step7_hostile_validation.py
@@ -116,6 +116,26 @@ def test_hostile_str_for_planning_steps_without_repr_leak() -> None:
     assert "!r" not in str(exc.value)
 
 
+def test_scan_loop_lengths_reject_before_arange_and_accept_budget_boundary() -> None:
+    last_fit = 10_000
+    cfg = Step7DynaConfig(**{**_valid_config_kwargs(), "planning_steps": last_fit})
+    assert cfg.planning_steps == last_fit
+    cfg = Step7DynaConfig(
+        **{
+            **_valid_config_kwargs(),
+            "planning_steps": 0,
+            "planning_rollout_depth": last_fit,
+        }
+    )
+    assert cfg.planning_rollout_depth == last_fit
+    with pytest.raises(ValueError, match="10000"):
+        Step7DynaConfig(**{**_valid_config_kwargs(), "planning_steps": 10**9})
+    with pytest.raises(ValueError, match="10000"):
+        Step7DynaConfig(
+            **{**_valid_config_kwargs(), "planning_rollout_depth": last_fit + 1}
+        )
+
+
 def test_rejects_bool_and_hostile_int() -> None:
     with pytest.raises(ValueError, match="must be an integer"):
         Step7DynaConfig(**{**_valid_config_kwargs(), "planning_steps": True})  # type: ignore[arg-type]

--- a/tests/test_step9_hostile_validation.py
+++ b/tests/test_step9_hostile_validation.py
@@ -231,6 +231,17 @@ def test_derived_allocation_and_runtime_work_fail_at_config_boundary() -> None:
         )
 
 
+def test_dream_loop_lengths_reject_before_arange() -> None:
+    with pytest.raises(ValueError, match="10000"):
+        Step9DreamingConfig(planning_budget=10**9)
+    with pytest.raises(ValueError, match="10000"):
+        Step9DreamingConfig(dream_rollout_horizon=10_001)
+    with pytest.raises(ValueError, match="10000"):
+        Step9DreamingConfig(dream_candidate_count=10_001)
+    cfg = Step9DreamingConfig(planning_budget=0)
+    assert cfg.planning_budget == 0
+
+
 def test_runtime_entry_points_require_exact_config_without_truthiness_hooks() -> None:
     calls = 0
 


### PR DESCRIPTION
## Summary
- Route Step 7 `planning_steps` / `planning_rollout_depth` and Step 9 `planning_budget` / `dream_rollout_horizon` / `dream_candidate_count` through named 10,000 `ScanBudget` guards at config validation.
- Zero remains legal for the optional planning/dream budgets. Existing Step 9 per-step dream-work product cap is unchanged.

Closes #2214

Note: open PR #2833 is a different Step 9 change (skip dream-scan tracing when planning is disabled). This PR only adds the missing loop-length fail-closed bounds.

## Test plan
- [x] `pytest tests/test_step7_hostile_validation.py tests/test_step9_hostile_validation.py`
- [x] `ruff check` on the touched files