### PR TITLE
fix(core): bound stacked-horde demon count and reject oversized sequences in deserializer

### DIFF
--- a/alberta_framework/core/stacked_horde.py
+++ b/alberta_framework/core/stacked_horde.py
@@ -132,6 +132,12 @@ def _require_positive_normal_float32_step_size(value: object) -> float:
 
 
 _INT32_MAX = 2**31 - 1
+# One 12-bit cardinality budget bounds the stacked demon axis before any
+# per-demon element walk, mirroring the peer Horde/history/option-search
+# modules (``_MAX_HORDE_DEMONS``, ``_MAX_HISTORY_CONFIGURATION_ITEMS``,
+# ``_MAX_BACKUP_BUDGET``), all 4096. The int32 resource preflights still guard
+# the byte/scalar envelope; this ceiling refuses hostile cardinalities first.
+_MAX_STACKED_HORDE_DEMONS = 1 << 12
 _CONFIG_FIELDS = {
     "type",
     "n_demons",
@@ -162,7 +168,14 @@ def _require_sequence(name: str, value: object) -> tuple[object, ...]:
 def _decode_sequence(name: str, value: object) -> tuple[object, ...]:
     if type(value) not in (list, tuple):
         raise ValueError(f"{name} must be an actual list or tuple")
-    return tuple(cast(list[object] | tuple[object, ...], value))
+    sequence = cast(list[object] | tuple[object, ...], value)
+    # Length preflight on the exact builtin container refuses an
+    # attacker-sized sequence before the tuple copy walks every element.
+    if len(sequence) > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"{name} must contain at most {_MAX_STACKED_HORDE_DEMONS} entries"
+        )
+    return tuple(sequence)
 
 
 def _preflight_horde_resources(n_demons: int, feature_dim: int) -> None:
@@ -243,7 +256,9 @@ class StackedHordeConfig:
 
     def __post_init__(self) -> None:
         """Validate the configuration."""
-        n_demons = _require_int32("n_demons", self.n_demons, minimum=1)
+        n_demons = _require_int32(
+            "n_demons", self.n_demons, minimum=1, maximum=_MAX_STACKED_HORDE_DEMONS
+        )
         feature_dim = _require_int32("feature_dim", self.feature_dim, minimum=1)
 
         raw_sequences = {
@@ -351,8 +366,11 @@ def nexting_spec(
     )
     canonical_lamda = validated_float32_scalar("lamda", lamda, lower=0.0, upper=1.0)
     n_demons = len(canonical_indices) * len(canonical_gammas)
-    if n_demons < 1 or n_demons > _INT32_MAX:
-        raise ValueError("derived n_demons must be in the signed int32 domain")
+    if n_demons < 1 or n_demons > _MAX_STACKED_HORDE_DEMONS:
+        raise ValueError(
+            f"nexting_spec derives {n_demons} demons but at most "
+            f"{_MAX_STACKED_HORDE_DEMONS} are allowed"
+        )
     _preflight_horde_resources(n_demons, feature_dim)
     _preflight_stacked_horde_update_working_set(n_demons, feature_dim)
     idxs: list[int] = []

--- a/tests/test_stacked_horde_cardinality_bounds.py
+++ b/tests/test_stacked_horde_cardinality_bounds.py
@@ -1,0 +1,129 @@
+"""Cardinality bounds for :mod:`alberta_framework.core.stacked_horde`.
+
+The stacked linear Horde must refuse oversized demon axes *before* it walks
+per-demon Python sequences or copies attacker-sized lists, mirroring the
+12-bit cardinality ceiling already enforced by the peer Horde/history/
+option-search modules. These tests pin that contract: they fail against the
+unpatched module (which allowed ``n_demons`` up to signed int32) and pass once
+the ceiling and length preflights land.
+"""
+
+from typing import Any, cast
+
+import pytest
+
+from alberta_framework.core import stacked_horde
+from alberta_framework.core.stacked_horde import (
+    StackedHordeConfig,
+    _decode_sequence,
+    nexting_spec,
+)
+
+pytestmark = pytest.mark.unit
+
+_MAX = stacked_horde._MAX_STACKED_HORDE_DEMONS
+
+
+def _uniform_config(n_demons: int) -> StackedHordeConfig:
+    return StackedHordeConfig(
+        n_demons=n_demons,
+        feature_dim=4,
+        gammas=(0.9,) * n_demons,
+        lamdas=(0.7,) * n_demons,
+        cumulant_indices=(0,) * n_demons,
+        step_size=0.05,
+    )
+
+
+def test_max_stacked_horde_demons_is_4096() -> None:
+    assert _MAX == 4096
+    assert _MAX == (1 << 12)
+
+
+def test_boundary_n_demons_accepted() -> None:
+    cfg = _uniform_config(_MAX)
+    assert cfg.n_demons == _MAX
+    assert len(cfg.gammas) == _MAX
+
+
+def test_n_demons_over_ceiling_rejected_before_element_walk() -> None:
+    class _Poison:
+        """Sentinel that flags if the per-demon element walk ever touches it."""
+
+        touched = False
+
+        def __float__(self) -> float:  # pragma: no cover - must never run
+            type(self).touched = True
+            raise AssertionError("element walk ran before the n_demons ceiling")
+
+    poison = _Poison()
+    over = _MAX + 1
+    poison_seq = cast(tuple[float, ...], (poison,) * over)
+    with pytest.raises(ValueError, match="n_demons"):
+        StackedHordeConfig(
+            n_demons=over,
+            feature_dim=4,
+            gammas=poison_seq,
+            lamdas=poison_seq,
+            cumulant_indices=(0,) * over,
+            step_size=0.05,
+        )
+    assert _Poison.touched is False
+
+
+def test_decode_sequence_rejects_oversized_list_before_copy() -> None:
+    oversized = [0.0] * (_MAX + 1)
+    with pytest.raises(ValueError):
+        _decode_sequence("gammas", oversized)
+
+
+def test_decode_sequence_accepts_boundary_length() -> None:
+    boundary = [0.0] * _MAX
+    decoded = _decode_sequence("gammas", boundary)
+    assert isinstance(decoded, tuple)
+    assert len(decoded) == _MAX
+
+
+def test_decode_sequence_rejects_hostile_list_subclass_without_hooks() -> None:
+    class _HostileList(list):  # type: ignore[type-arg]
+        len_calls = 0
+        iter_calls = 0
+
+        def __len__(self) -> int:  # pragma: no cover - must never run
+            type(self).len_calls += 1
+            raise AssertionError("__len__ must not run on a list subclass")
+
+        def __iter__(self) -> Any:  # pragma: no cover - must never run
+            type(self).iter_calls += 1
+            raise AssertionError("__iter__ must not run on a list subclass")
+
+    hostile = _HostileList([0.0, 0.1, 0.2])
+    with pytest.raises(ValueError, match="actual list or tuple"):
+        _decode_sequence("gammas", hostile)
+    assert _HostileList.len_calls == 0
+    assert _HostileList.iter_calls == 0
+
+
+def test_from_config_rejects_oversized_serialized_sequence() -> None:
+    cfg = _uniform_config(2)
+    payload = cfg.to_config()
+    payload["gammas"] = [0.9] * (_MAX + 1)
+    with pytest.raises(ValueError):
+        StackedHordeConfig.from_config(payload)
+
+
+def test_nexting_spec_rejects_oversized_product() -> None:
+    # 65 * 65 = 4225 > 4096: the derived demon grid must be refused before the
+    # cumulant-major expansion allocates it.
+    cumulant_indices = tuple(range(65))
+    gammas = tuple(0.5 for _ in range(65))
+    with pytest.raises(ValueError):
+        nexting_spec(feature_dim=4, cumulant_indices=cumulant_indices, gammas=gammas)
+
+
+def test_nexting_spec_accepts_boundary_product() -> None:
+    # 64 * 64 = 4096: exactly at the ceiling.
+    cumulant_indices = tuple(range(64))
+    gammas = tuple(0.5 for _ in range(64))
+    cfg = nexting_spec(feature_dim=4, cumulant_indices=cumulant_indices, gammas=gammas)
+    assert cfg.n_demons == _MAX


### PR DESCRIPTION
## What was broken and its measurement consequence

`StackedLinearHorde` in `alberta_framework/core/stacked_horde.py` batches linear GVF demon
updates across `n_demons`. Peer modules bound demon/list cardinalities to a 12-bit budget
(`_MAX_HORDE_DEMONS = 4096` in `types.py`, `_MAX_HISTORY_CONFIGURATION_ITEMS = 4096` in
`history_features.py`, `_MAX_BACKUP_BUDGET = 4096` in `option_search_control.py`), but the
stacked Horde had **no cardinality ceiling**:

- `StackedHordeConfig.__post_init__` validated `n_demons` only against `_INT32_MAX`
  (2,147,483,647), so an oversized/hostile `n_demons` forced millions of per-element Python
  iterations (per-demon `_require_int32` / `validated_float32_scalar` walks) before any aggregate
  scalar preflight ran.
- `_decode_sequence` copied lists/tuples of any size (`tuple(value)`) with no length preflight,
  walking every element of an attacker-sized list before the constructor's length check fired.
- `nexting_spec` bounded the derived demon count `len(cumulant_indices) * len(gammas)` only by
  `_INT32_MAX`, expanding an oversized cumulant-major grid before allocation.

Measurement consequence: hostile or oversized configs could burn unbounded CPU/allocation in the
validation/deserialization path before the existing int32 resource preflights rejected them,
corrupting the latency/memory budget the stacked Horde exists to keep constant in the demon count.

## The fix (one module, one lane)

`alberta_framework/core/stacked_horde.py`:

1. Defined `_MAX_STACKED_HORDE_DEMONS = 1 << 12` (4096), mirroring the peer modules' style and the
   existing int32 preflight comment convention.
2. `StackedHordeConfig.__post_init__` now validates `n_demons` with `maximum=_MAX_STACKED_HORDE_DEMONS`
   via the existing `_require_int32` helper — enforced on the **first line**, before any per-demon
   element walk.
3. `_decode_sequence` now length-preflights the exact builtin container and rejects sequences longer
   than the ceiling **before** the `tuple(...)` copy. (The existing exact-type check
   `type(value) not in (list, tuple)` already refused list subclasses before any `__len__`/`__iter__`
   hook; the added test locks that contract.)
4. `nexting_spec` now preflights `len(cumulant_indices) * len(gammas) <= _MAX_STACKED_HORDE_DEMONS`
   before building the demon grid.

No behavior change for valid in-bounds inputs. No new abstractions or config knobs; reused the
existing `_require_int32` helper and error-message conventions. No hash-registered evidence source
or pinned `outputs/` artifact was touched (`stacked_horde.py` is core, not an evidence source).

## Failing-then-passing reproduction

New test: `tests/test_stacked_horde_cardinality_bounds.py` (9 tests, written failing-first).

**Pre-fix behavioral gap** on unpatched `main` (`.venv/bin/python`):

```
UNPATCHED accepted n_demons = 100000
UNPATCHED decoded oversized sequence len = 1000000
UNPATCHED nexting_spec n_demons = 4225
```

**Pre-fix** — the new test file cannot even collect because the ceiling constant is absent:

```
E   AttributeError: module 'alberta_framework.core.stacked_horde' has no attribute '_MAX_STACKED_HORDE_DEMONS'
ERROR tests/test_stacked_horde_cardinality_bounds.py - AttributeError: module...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
1 error in 3.44s
```

**Post-fix** — `.venv/bin/python -m pytest tests/test_stacked_horde_cardinality_bounds.py -q -o addopts=""`:

```
.........                                                                [100%]
9 passed in 2.00s
```

## Verification commands and results

Focused regression — `.venv/bin/python -m pytest tests/test_stacked_horde.py tests/test_stacked_horde_update_working_set.py tests/test_multi_head_stacked_horde_label_emnist_scan_bounds.py tests/test_stacked_horde_cardinality_bounds.py -q -o addopts=""`:

```
........................................................................ [ 55%]
.........................................................                [100%]
129 passed in 43.46s
```

Lint — `.venv/bin/python -m ruff check .`:

```
All checks passed!
```

Types — `.venv/bin/python -m mypy` (strict, py312, `files = ["alberta_framework"]`, the repo's CI invocation):

```
Success: no issues found in 224 source files
```

Test file also type-clean under scoped `.venv/bin/python -m mypy tests/test_stacked_horde_cardinality_bounds.py`:

```
Success: no issues found in 1 source file
```

## Evidence tooling note

The immutable-attachment minting tool (`attach.mjs`) is currently blocked by a GitHub login
verification interstitial in this environment, so `github.com/user-attachments/...` URLs could not be
generated. All command outputs above are reproduced verbatim and inline; every command is stated
with its exact invocation so a maintainer can re-run and confirm against the measured head.

## What remains open

Nothing for this bounded fix. The four stacked-Horde entry points now share the peer 12-bit
cardinality ceiling. Broader unification of the four peer `_MAX_*` constants into a single shared
symbol would be a separate refactor with no measured effect and is intentionally out of scope.

Closes #2225

<!-- evidence-head:fc20479fb65be220124135067536d5646e8cce35 -->
<!-- evidence-row:logs -->
- [ ] logs: attachment tool blocked (GitHub login interstitial); full logs inline above, bound to head fc20479fb65be220124135067536d5646e8cce35

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/slopdotcash@f788736eb5f61cbc138fb3ae1774fecc875d621d:skills/contribute-to-asi
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/slopdotcash@f788736eb5f61cbc138fb3ae1774fecc875d621d:skills/contribute-to-asi"} -->
