### PR TITLE
fix(scorecard): bind RiverSwim rewards to visits

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -2108,6 +2108,38 @@ def _validate_metric_window(
     return reward_sum
 
 
+def _validate_riverswim_reward_visit_consistency(
+    *,
+    reward_sum: float,
+    event_count: int,
+    high_end_visit_count: int,
+    protocol: Mapping[str, Any],
+    path: str,
+) -> None:
+    """Reject reward totals that require more high-end decisions than visits."""
+
+    initial_high_end = int(protocol["initial_state"] == protocol["n_states"] - 1)
+    high_end_decision_bound = min(
+        event_count,
+        high_end_visit_count + initial_high_end,
+    )
+    non_high_end_maximum = max(
+        0.0,
+        float(np.float32(protocol["reward_left"])),
+    )
+    right_end_reward = float(np.float32(protocol["reward_right"]))
+    reward_upper_bound = (
+        event_count * non_high_end_maximum
+        + high_end_decision_bound
+        * max(0.0, right_end_reward - non_high_end_maximum)
+    )
+    tolerance = 1e-9 * max(1.0, abs(reward_sum), abs(reward_upper_bound))
+    if reward_sum > reward_upper_bound + tolerance:
+        raise ValueError(
+            f"{path} right-end rewards exceed high-end visits bound"
+        )
+
+
 def _validate_completed_outcome(
     outcome: Any,
     *,
@@ -2337,6 +2369,13 @@ def _validate_completed_outcome(
         )
         if not _numerically_equal(rate, visits / horizon):
             raise ValueError(f"{path}.high_end_visit_rate is inconsistent")
+        _validate_riverswim_reward_visit_consistency(
+            reward_sum=reward_sum,
+            event_count=horizon,
+            high_end_visit_count=visits,
+            protocol=protocol,
+            path=path,
+        )
     else:
         raise ValueError(f"{path} has an unsupported environment")
 
@@ -2559,6 +2598,13 @@ def _validate_partial_outcome(
             rate_value = _require_finite_number(rate, path=f"{path}.high_end_visit_rate")
             if not _numerically_equal(rate_value, visits / accepted):
                 raise ValueError(f"{path}.high_end_visit_rate is inconsistent")
+        _validate_riverswim_reward_visit_consistency(
+            reward_sum=reward_sum,
+            event_count=accepted,
+            high_end_visit_count=visits,
+            protocol=protocol,
+            path=path,
+        )
     else:
         raise ValueError(f"{path} has an unsupported environment")
     expected_oracle = math.fsum(

--- a/tests/test_reference_life_scorecard.py
+++ b/tests/test_reference_life_scorecard.py
@@ -717,6 +717,90 @@ def test_completed_shard_rejects_impossible_reward_lattice_total() -> None:
         scorecard.validate_scorecard_run_record(record)
 
 
+def test_completed_riverswim_shard_rejects_right_rewards_without_high_end_visits() -> None:
+    plan = build_development_plan()
+    spec = next(
+        item
+        for item in scorecard.iter_run_specs(plan)
+        if item.environment_kind == "riverswim"
+        and item.arm == "random"
+        and item.seed == SEED_ROSTER[0]
+    )
+    record = _completed_record(plan, spec)
+    outcome = record["outcome"]
+    horizon = outcome["accepted_events"]
+    outcome["reward_sum"] = float(horizon)
+    outcome["mean_reward"] = 1.0
+    outcome["phase_reward_sums"] = [float(horizon), 0.0]
+    outcome["regret_sum"] = outcome["oracle_reward_sum"] - float(horizon)
+    outcome["high_end_visit_count"] = 0
+    outcome["high_end_visit_rate"] = 0.0
+    _redigest(record)
+
+    with pytest.raises(ValueError, match="right-end rewards exceed high-end visits"):
+        scorecard.validate_scorecard_run_record(record)
+
+
+def test_partial_riverswim_shard_rejects_right_reward_before_reaching_high_end() -> None:
+    plan = build_development_plan()
+    spec = next(
+        item
+        for item in scorecard.iter_run_specs(plan)
+        if item.environment_kind == "riverswim"
+        and item.arm == "random"
+        and item.seed == SEED_ROSTER[0]
+    )
+    record = _completed_record(plan, spec)
+    horizon = plan.protocol("riverswim")["horizon"]
+    oracle_reward = record["outcome"]["oracle_reward_sum"] / horizon
+    record.update(
+        {
+            "status": "failed",
+            "failure": {
+                "stage": "step",
+                "type": "RuntimeError",
+                "message": "synthetic post-step failure",
+                "accepted_events": 1,
+            },
+            "outcome": None,
+            "partial_outcome": {
+                "summary_mode": "streaming_o1_no_retained_events",
+                "configured_horizon": horizon,
+                "accepted_events": 1,
+                "reward_sum": 1.0,
+                "mean_reward": 1.0,
+                "oracle_reward_sum": oracle_reward,
+                "regret_sum": oracle_reward - 1.0,
+                "parameter_change_events": 0,
+                "phase_event_counts": [1, 0],
+                "phase_reward_sums": [1.0, 0.0],
+                "windows": {
+                    "early": {
+                        "event_count": 1,
+                        "reward_sum": 1.0,
+                        "mean_reward": 1.0,
+                        "mean_oracle_regret": oracle_reward - 1.0,
+                    },
+                    "late": None,
+                },
+                "high_end_visit_count": 0,
+                "high_end_visit_rate": 0.0,
+            },
+        }
+    )
+    record["telemetry"].update(
+        {
+            "warmed_step_seconds_total": 0.0,
+            "warmed_step_count": 0,
+            "warmed_step_seconds_mean": None,
+        }
+    )
+    _redigest(record)
+
+    with pytest.raises(ValueError, match="right-end rewards exceed high-end visits"):
+        scorecard.validate_scorecard_run_record(record)
+
+
 @pytest.mark.parametrize("environment", ENVIRONMENT_ROSTER)
 def test_failed_shard_rejects_window_reward_exceeding_partial_total(
     environment: str,


### PR DESCRIPTION
## Summary

- reject completed RiverSwim scorecard records whose reward total would require more right-end reward decisions than their recorded high-end visits permit
- apply the same necessary trajectory bound to partial failed-shard records
- retain a conservative allowance for an environment that starts at the high end, although plan v1 starts at state 0

## Reproduced defect

Before the production change, a re-digested plan-v1 RiverSwim record with `reward_sum = 20000.0`, `high_end_visit_count = 0`, and every other existing arithmetic/lattice field made internally consistent passed `validate_scorecard_run_record`. That impossible record can directly inflate development selection.

The RiverSwim reward model emits `reward_right` only for a RIGHT decision whose current state is the high end. With post-transition visit counting, the number of high-end decision states is at most `high_end_visit_count + initial_high_end`. The validator now enforces the corresponding conservative reward upper bound.

## Verification

Head: `e7c29a6dc43f64de4342b2ce55cc60d7992d6911`

- `.venv/bin/python -m pytest tests/test_reference_life_scorecard.py -q` — 69 passed, 1 skipped
- `.venv/bin/python -m pytest tests/test_reference_life_controls.py tests/test_reference_life_riverswim.py -q` — 40 passed
- `.venv/bin/python -m ruff check .` — passed
- `.venv/bin/python -m mypy` — passed, 224 source files
- repository-wide `-m "not slow and not package"` was started outside the filesystem sandbox and stopped at 4% after passing the initial several hundred tests; the repository intentionally distributes this matrix over 24 CI shards, which remain the full-lane verification

The two new regression tests failed against the pre-fix implementation and pass at this head. No `outputs/` artifact was created or modified.

## Evidence scope

This is a validator correctness fix, not a benchmark comparison or performance claim. The diagnostic scorecard smoke used consumed development seed 70000 and remains permanently nonpromoting. There is no candidate/baseline mean, spread, delta, evaluation seed, or domain artifact to claim.

Remaining limitation: this is a necessary aggregate trajectory bound, not authenticated execution attestation and not a per-window visit/reward proof. Existing consistency-hash limitations remain unchanged.

<!-- evidence-head:e7c29a6dc43f64de4342b2ce55cc60d7992d6911 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - exact verification commands and results are reported above; no measured performance claim
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - validator-only fix; no output artifact was generated

## Attribution

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-next-defect]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1VF1MEVM1EYTD8GWDHN49DT","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-06T13:38:08.988Z","completed_at":"2026-09-06T14:11:18.271Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-06T13:38:09.436Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4cb54bb065e9e8a90a88c8b1aa50966abf947be658571033a80cea277d70700f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ace59b26-b791-4133-90f5-af549062bbd1","object_id":"sha256:4cb54bb065e9e8a90a88c8b1aa50966abf947be658571033a80cea277d70700f","sha256":"4cb54bb065e9e8a90a88c8b1aa50966abf947be658571033a80cea277d70700f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"xn-ybuHqyZx9Pr3Iw5qoQH_h5_n7HnMRog3SV6CYOaK67qPM1aMm0hV5AJJQHtMo5Pk211D-amIrFeQLCU7dDA"}} -->
