### PR TITLE
fix(checkpoint): reject impossible RiverSwim rewards

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -2260,6 +2260,27 @@ class ReferenceLifeRunner:
             expected_segment_events = accepted
             expected_oracle_reward = accepted * oracle_reward
             oracle_reward_must_match_bitwise = True
+            reward_left = float(environment_config["reward_left"])
+            reward_right = float(environment_config["reward_right"])
+            minimum_step_reward = min(0.0, reward_left, reward_right)
+            maximum_step_reward = max(0.0, reward_left, reward_right)
+            maximum_magnitude = max(abs(minimum_step_reward), abs(maximum_step_reward))
+            # Metrics add one canonical float32 reward at a time in binary64.
+            # Gamma_n is a conservative forward-error allowance for that fixed
+            # sequential accumulation, including the endpoint multiplication.
+            relative_error = accepted * np.finfo(np.float64).eps
+            summation_slack = (
+                accepted
+                * maximum_magnitude
+                * relative_error
+                / (1.0 - relative_error)
+            )
+            minimum_reward = accepted * minimum_step_reward - summation_slack
+            maximum_reward = accepted * maximum_step_reward + summation_slack
+            if not minimum_reward <= metrics.reward_sum <= maximum_reward:
+                raise DecisionOwnershipError(
+                    "checkpoint RiverSwim reward total is outside configured reward bounds"
+                )
             stationary_exact_pairs = (
                 (metrics.current_segment_reward, metrics.reward_sum),
                 (metrics.current_segment_regret, metrics.regret_sum),

--- a/tests/test_reference_life_riverswim_checkpoint.py
+++ b/tests/test_reference_life_riverswim_checkpoint.py
@@ -119,6 +119,28 @@ def test_riverswim_checkpoint_validator_rejects_sub_tolerance_metric_forgery() -
         runner.validate_checkpoint_state(forged_oracle)
 
 
+@pytest.mark.parametrize("forged_reward", [-1.0, 3.0])
+def test_riverswim_checkpoint_validator_rejects_reward_outside_configured_bounds(
+    forged_reward: float,
+) -> None:
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 2)
+    oracle_reward = state.metrics.oracle_reward_sum
+    forged_metrics = dataclasses.replace(
+        state.metrics,
+        reward_sum=forged_reward,
+        regret_sum=oracle_reward - forged_reward,
+        phase_reward_sums=(forged_reward, 0.0),
+        phase_regret_sums=(oracle_reward - forged_reward, 0.0),
+        current_segment_reward=forged_reward,
+        current_segment_regret=oracle_reward - forged_reward,
+    )
+    forged: ReferenceLifeState = dataclasses.replace(state, metrics=forged_metrics)
+
+    with pytest.raises(ValueError, match="reward bounds"):
+        runner.validate_checkpoint_state(forged)
+
+
 def _assert_typed_exact(left: object, right: object, *, path: str = "value") -> None:
     if isinstance(left, jax.Array) or isinstance(right, jax.Array):
         assert isinstance(left, jax.Array) and isinstance(right, jax.Array), path


### PR DESCRIPTION
## Summary

- reject RiverSwim checkpoint metrics whose cumulative reward lies outside the configured per-event reward bounds
- derive the bound from the canonical `0`, `reward_left`, and `reward_right` lattice
- retain a conservative binary64 sequential-summation allowance at the full accepted-event horizon

## Reproduced defect

Before the production change, a two-event RiverSwim checkpoint state with `reward_sum = -1.0` passed `ReferenceLifeRunner.validate_checkpoint_state`, even though the configured reward lattice was `{0.0, 0.01, 1.0}`. Its phase/current-segment totals and oracle/regret algebra were made internally consistent, demonstrating that the existing cross-field checks did not establish that the reward history could have come from the configured environment.

The validator now bounds the cumulative reward by the minimum and maximum configured per-event rewards, with a conservative forward-error allowance for the actual sequential binary64 accumulation. Regression cases cover impossible totals below and above the two-event range.

## Verification

Head: `395c7efc32e6f8316641951502b823484c95e9e1`

- pre-fix focused regression — failed because the malformed negative total was accepted
- `/root/asi/.venv/bin/python -m pytest tests/test_reference_life_riverswim_checkpoint.py tests/test_reference_life_checkpoint.py tests/test_reference_life_riverswim.py tests/test_reference_life.py -q -o addopts=""` — 69 passed, 1 skipped
- `/root/asi/.venv/bin/python -m pytest tests/test_reference_life_scorecard.py tests/test_reference_life_controls.py -q -o addopts=""` — 100 passed, 1 skipped
- `/root/asi/.venv/bin/python -m ruff check alberta_framework/reference_life.py tests/test_reference_life_riverswim_checkpoint.py` — passed
- `/root/asi/.venv/bin/python -m mypy` — passed, 224 source files
- unrestricted repository run — 2,154 passed, 8 skipped before interruption at 12%; no failures
- documented fast selector — 202 passed, 2 skipped, 1,260 deselected before interruption; no failures (16,438 tests are distributed across CI shards)

No `outputs/` artifact was created or modified. `alberta_framework/reference_life.py` is not in any frozen claim's registered source set.

## Evidence scope

This is an L0 checkpoint-validator correctness fix, not a benchmark comparison, performance claim, portable checkpoint contract, authenticated execution attestation, or scientific evidence. No benchmark seeds were consumed.

Remaining limitation: aggregate reward bounds are necessary but do not reconstruct the event sequence or authenticate checkpoint execution; the documented consistency-hash limitation is unchanged.

<!-- evidence-head:395c7efc32e6f8316641951502b823484c95e9e1 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - exact verification commands and results are reported above; no measured performance claim
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - validator-only fix; no output artifact was generated

## Attribution

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-next-20260906]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1VJC65XN14YR1P92YBV9N7F","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-06T14:36:20.543Z","completed_at":"2026-09-06T15:10:08.559Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-06T14:36:21.540Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"53dfea4e30a2d26ee9b8a704b2d286a90335409cb1985749b5ea1a564d2c1c3f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"835d737f-3189-4cb2-b24c-9ccb90210bc2","object_id":"sha256:53dfea4e30a2d26ee9b8a704b2d286a90335409cb1985749b5ea1a564d2c1c3f","sha256":"53dfea4e30a2d26ee9b8a704b2d286a90335409cb1985749b5ea1a564d2c1c3f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"O8Zg739YTEnkrGKJ_Y8UmFmRSKhhrTmgfvi7RDqC8IUzUDH7dKu8hleXqEhUUqKKtsX6sx-fNrQZjXreF563Dw"}} -->
