### PR TITLE
fix(checkpoint): validate switching segment metrics

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -244,6 +244,30 @@ def _switching_metric_schedule(
     )
 
 
+def _within_sequential_sum_bounds(
+    value: float,
+    *,
+    event_count: int,
+    minimum_step_value: float,
+    maximum_step_value: float,
+) -> bool:
+    """Bound one binary64 sequential sum of finite canonical step values."""
+
+    maximum_magnitude = max(abs(minimum_step_value), abs(maximum_step_value))
+    relative_error = event_count * float(np.finfo(np.float64).eps)
+    summation_slack = (
+        event_count
+        * maximum_magnitude
+        * relative_error
+        / (1.0 - relative_error)
+    )
+    return (
+        event_count * minimum_step_value - summation_slack
+        <= value
+        <= event_count * maximum_step_value + summation_slack
+    )
+
+
 class LifePhase(enum.Enum):
     QUIESCENT = "quiescent"
     HALTED = "halted"
@@ -2249,6 +2273,45 @@ class ReferenceLifeRunner:
                 expected_phase_counts[0] * oracle_rewards[0]
                 + expected_phase_counts[1] * oracle_rewards[1]
             )
+            current_payoffs = tuple(
+                float(value) for value in payoff_matrices[expected_current_phase].flat
+            )
+            current_oracle = oracle_rewards[expected_current_phase]
+            current_regrets = tuple(current_oracle - reward for reward in current_payoffs)
+            if not _within_sequential_sum_bounds(
+                metrics.current_segment_reward,
+                event_count=expected_segment_events,
+                minimum_step_value=min(current_payoffs),
+                maximum_step_value=max(current_payoffs),
+            ) or not _within_sequential_sum_bounds(
+                metrics.current_segment_regret,
+                event_count=expected_segment_events,
+                minimum_step_value=min(current_regrets),
+                maximum_step_value=max(current_regrets),
+            ):
+                raise DecisionOwnershipError(
+                    "checkpoint current segment metrics are outside configured payoff bounds"
+                )
+            if expected_phase_switches < 2:
+                first_visit_pairs = (
+                    (
+                        metrics.current_segment_reward,
+                        metrics.phase_reward_sums[expected_current_phase],
+                    ),
+                    (
+                        metrics.current_segment_regret,
+                        metrics.phase_regret_sums[expected_current_phase],
+                    ),
+                )
+                if any(
+                    type(segment) is not float
+                    or type(phase_total) is not float
+                    or struct.pack(">d", segment) != struct.pack(">d", phase_total)
+                    for segment, phase_total in first_visit_pairs
+                ):
+                    raise DecisionOwnershipError(
+                        "checkpoint current segment metrics do not match their first phase visit"
+                    )
         elif environment_kind == "riverswim":
             if metrics_mode != "stationary":
                 raise DecisionOwnershipError("checkpoint RiverSwim metrics mode is invalid")

--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -93,6 +93,34 @@ def test_checkpoint_validator_rejects_generation_and_zero_event_metric_forgery()
             runner.validate_checkpoint_state(forged)
 
 
+def test_checkpoint_validator_rejects_switching_current_segment_forgery() -> None:
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 1)
+
+    assert state.metrics.current_segment_reward in (0.0, 1.0)
+    assert state.metrics.current_segment_regret in (0.0, 1.0)
+    for field, forged_values in (
+        (
+            "current_segment_reward",
+            (1.0 - state.metrics.current_segment_reward, 123.0),
+        ),
+        (
+            "current_segment_regret",
+            (1.0 - state.metrics.current_segment_regret, -123.0),
+        ),
+    ):
+        for forged_value in forged_values:
+            forged = dataclasses.replace(
+                state,
+                metrics=dataclasses.replace(
+                    state.metrics,
+                    **{field: forged_value},
+                ),
+            )
+            with pytest.raises(ValueError, match="current segment"):
+                runner.validate_checkpoint_state(forged)
+
+
 def _agent_config() -> PrototypeAgentConfig:
     return PrototypeAgentConfig(
         oak=OaKConfig(


### PR DESCRIPTION
## Summary

- reject SwitchingTwoState checkpoint current-segment reward and regret outside the configured payoff bounds
- require the current segment to match its phase accumulator bit-for-bit on the first visit to each phase
- retain a conservative binary64 sequential-summation allowance across the supported horizon

## Reproduced defect

On unmodified `main`, a one-event SwitchingTwoState checkpoint state with phase reward `1.0` and forged current-segment reward `124.0` passed `ReferenceLifeRunner.validate_checkpoint_state`. An in-range contradictory value passed as well. Because the current segment is copied into retained completed-segment metrics on a later phase switch, restoring that state could silently corrupt downstream segment summaries.

The validator now derives current-phase reward and regret bounds from the canonical float32 payoff matrix and the deterministic segment length. During the first visit to A or B, when no earlier segment can contribute to that phase accumulator, it additionally requires bit-exact agreement between current-segment and phase totals.

## Verification

Head: `fe1ee2f36da8270ee676a833d6612d7bbdbcc8b0`

- pre-fix focused regression — failed because the malformed segment metric was accepted
- `/root/asi/.venv/bin/python -m pytest tests/test_reference_life_checkpoint.py::test_checkpoint_validator_rejects_switching_current_segment_forgery tests/test_reference_life_checkpoint.py::test_checkpoint_validator_rejects_generation_and_zero_event_metric_forgery -q -o addopts=""` — 2 passed
- representative valid checkpoint-state validation across accepted-event boundaries 0 through 6 (A→B→A) — passed
- `/root/asi/.venv/bin/python -m pytest tests/test_reference_life.py tests/test_reference_life_riverswim.py -q -o addopts=""` — 52 passed
- `/root/asi/.venv/bin/python -m pytest tests/test_reference_life_scorecard.py tests/test_reference_life_controls.py -q -o addopts=""` — 100 passed, 1 skipped
- `/root/asi/.venv/bin/python -m ruff check .` — passed
- `/root/asi/.venv/bin/python -m mypy` — passed, 224 source files
- `.venv/bin/alberta-evidence-status` — expected pre-existing `invalid` result from registered-source drift; this change touches no registered source file
- supplementary nested Orbax save/load fixture — interrupted locally after three minutes without a failure; no local pass claimed
- GitHub Actions CI on the exact head — all jobs passed, including the required `ci-ok` gate

No `outputs/` artifact was created or modified.

## Evidence scope

This is an L0 checkpoint-validator correctness fix, not a benchmark comparison, performance claim, portable checkpoint contract, authenticated execution attestation, or scientific evidence. No benchmark seeds were consumed.

Remaining limitation: these checks bind only schedule-derivable current-segment semantics. The checkpoint still retains no event log, does not reconstruct older unretained segments, and provides consistency hashes rather than authenticated execution proof.

<!-- evidence-head:fe1ee2f36da8270ee676a833d6612d7bbdbcc8b0 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - exact verification commands and results are reported above; no measured performance claim
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - validator-only fix; no output artifact was generated

## Attribution

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [reference-life-followup-next3]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1VN66DACDJQRFG0G7HYN2GB","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-06T15:25:29.900Z","completed_at":"2026-09-06T23:45:08.152Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-06T15:25:30.277Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"672f9631c40fae61b42a5fece61a134caf36a909c61addff12bad1b389ea43eb","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"0bd2adee-85f9-4da9-981c-66eaec03238f","object_id":"sha256:672f9631c40fae61b42a5fece61a134caf36a909c61addff12bad1b389ea43eb","sha256":"672f9631c40fae61b42a5fece61a134caf36a909c61addff12bad1b389ea43eb"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"YbLKABq_r6OUolN6Y0POa_U74YUzyrhpTVDa8TskQQTrcOGcu80dz2BpxKcGpB3F3DZLIcTNCg_ekjz9gwlCAw"}} -->
