### PR TITLE
fix(checkpoint): require canonical metric schedule integers

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -568,7 +568,7 @@ class ReferenceLifeMetricsState:
             value = getattr(self, name)
             if type(value) is not int or value < 0:
                 raise ValueError(f"{name} must be a nonnegative integer")
-        if self.current_phase not in (0, 1):
+        if type(self.current_phase) is not int or self.current_phase not in (0, 1):
             raise ValueError("current_phase must be 0 or 1")
         pairs = (
             self.phase_event_counts,
@@ -579,8 +579,8 @@ class ReferenceLifeMetricsState:
         )
         if any(len(values) != 2 for values in pairs):
             raise ValueError("phase and segment metric tuples must have length two")
-        if any(value < 0 for value in self.phase_event_counts):
-            raise ValueError("phase event counts must be nonnegative")
+        if any(type(value) is not int or value < 0 for value in self.phase_event_counts):
+            raise ValueError("phase event counts must be nonnegative integers")
         if self.parameter_change_events > self.accepted_events:
             raise ValueError("parameter changes cannot exceed accepted events")
         if sum(self.phase_event_counts) != self.accepted_events:

--- a/tests/test_reference_life.py
+++ b/tests/test_reference_life.py
@@ -165,12 +165,33 @@ def test_reference_life_host_integer_identities_fail_before_comparison_hooks() -
             recovery_attempts=hostile,
         ),
         lambda: dataclasses.replace(state, accepted_events=hostile),
+        lambda: dataclasses.replace(
+            state.metrics, phase_event_counts=(hostile, 0)
+        ),
+        lambda: dataclasses.replace(state.metrics, current_phase=hostile),
     )
     for check in checks:
         _HostileInt.hook_calls = 0
-        with pytest.raises(ValueError, match="integer|count|uint32|nonnegative"):
+        with pytest.raises(ValueError, match="integer|count|uint32|nonnegative|phase"):
             check()
         assert _HostileInt.hook_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    (
+        ({"phase_event_counts": (0.0, 0)}, "phase event counts"),
+        ({"current_phase": False}, "current_phase"),
+    ),
+)
+def test_metric_schedule_fields_require_canonical_integers(
+    changes: dict[str, object],
+    message: str,
+) -> None:
+    metrics = ReferenceLifeMetricsAdapter().init(initial_phase=0)
+
+    with pytest.raises(ValueError, match=message):
+        dataclasses.replace(metrics, **changes)
 
 
 def test_switching_execution_rejects_boolean_decoded_action(


### PR DESCRIPTION
## Summary

- require canonical built-in integers for reference-life phase counters and the current phase
- reject booleans, floats, and integer subclasses before Python comparison hooks can blur their types
- align the in-memory checkpoint gate with the strict JSON checkpoint decoder

## Reproduced defect

On unmodified `main`, an initialized reference-life state could be rebuilt with either `phase_event_counts=(0.0, 0.0)` or `current_phase=False`. `ReferenceLifeRunner.validate_checkpoint_state` accepted both because Python considers `0.0 == 0` and `False == 0`, but `_decode_metrics(_encode_metrics(...))` rejected the same fields because the checkpoint schema requires integers. The save boundary could therefore accept a metric state that its own strict codec could not restore.

`ReferenceLifeMetricsState` now checks exact built-in integer types before value comparisons. The hostile-integer regression also verifies that invalid integer subclasses are rejected without invoking attacker-controlled comparison hooks.

## Verification

Head: `4a86423f3f0ef389585c0c71f613fb7be969f104`

- pre-fix focused regression — 2 failed with `DID NOT RAISE` because float phase counts and a boolean phase were accepted
- `.venv/bin/python -m pytest tests/test_reference_life.py::test_reference_life_host_integer_identities_fail_before_comparison_hooks tests/test_reference_life.py::test_metric_schedule_fields_require_canonical_integers -q -o addopts=""` — 3 passed
- `.venv/bin/python -m pytest tests/test_reference_life.py -q -o addopts=""` — 47 passed
- `.venv/bin/python -m pytest tests/test_reference_life_riverswim.py -q -o addopts=""` — 7 passed
- `.venv/bin/python -m pytest tests/test_reference_life_checkpoint.py::test_switching_metric_schedule_is_constant_time_at_counter_horizon tests/test_reference_life_checkpoint.py::test_checkpoint_validator_rejects_generation_and_zero_event_metric_forgery -q -o addopts=""` — 2 passed
- `.venv/bin/python -m ruff check .` — passed
- `.venv/bin/python -m mypy` — passed, 224 source files
- `.venv/bin/alberta-evidence-status` — expected pre-existing `invalid` result from registered-source drift; this change touches no registered claim source

No `outputs/` artifact was created or modified.

## Evidence scope

This is an L0 checkpoint-contract correctness fix, not a benchmark comparison, performance claim, portable checkpoint contract, authenticated execution attestation, or scientific evidence. No benchmark seeds were consumed.

The fix establishes canonical metric schedule field types only. It does not expand the supported checkpoint environments, recovery modes, or portability guarantees.

<!-- evidence-head:4a86423f3f0ef389585c0c71f613fb7be969f104 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - exact verification commands and results are reported above; no measured performance claim
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - validator-only fix; no output artifact was generated

## Attribution

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next4]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1WJ0VNDBVVNT84QKK6XZE9N","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-06T23:49:23.758Z","completed_at":"2026-09-07T00:00:56.029Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-06T23:49:23.907Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d380d324f02c2c073cdb60b1349f25e34868785abc3e10ee139167134937a3a7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4848932b-28b1-4aeb-a3b3-c473b935ebbd","object_id":"sha256:d380d324f02c2c073cdb60b1349f25e34868785abc3e10ee139167134937a3a7","sha256":"d380d324f02c2c073cdb60b1349f25e34868785abc3e10ee139167134937a3a7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"ABsBFAfWQbvPc3KtJSzSCTh7w6s4CnFyLmujITfbx6HPERZsEwRLJu2N98cZjwhOZwRE5cGakOyCkifyr-qtBw"}} -->
