### PR TITLE
fix(checkpoint): validate segment completion presence

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -2245,6 +2245,24 @@ class ReferenceLifeRunner:
                 expected_phase_switches,
                 expected_segment_events,
             ) = _switching_metric_schedule(accepted, phase_length)
+            expected_completed_presence = (
+                expected_phase_switches >= 1,
+                expected_phase_switches >= 2,
+            )
+            if any(
+                expected_phase_counts[phase] != 0
+                and (
+                    (metrics.first_completed_segment_reward[phase] is not None)
+                    != expected_present
+                    or (metrics.latest_completed_segment_reward[phase] is not None)
+                    != expected_present
+                )
+                for phase, expected_present in enumerate(expected_completed_presence)
+            ):
+                raise DecisionOwnershipError(
+                    "checkpoint completed-segment presence does not match "
+                    "the environment schedule"
+                )
             expected_oracle_reward = (
                 expected_phase_counts[0] * oracle_rewards[0]
                 + expected_phase_counts[1] * oracle_rewards[1]

--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -93,6 +93,42 @@ def test_checkpoint_validator_rejects_generation_and_zero_event_metric_forgery()
             runner.validate_checkpoint_state(forged)
 
 
+def test_checkpoint_validator_rejects_completed_segment_presence_forgery() -> None:
+    runner = _runner()
+    first_segment, _ = _advance(runner, runner.init(), 1)
+    phase_switch, _ = _advance(runner, first_segment, 2)
+
+    first_value = phase_switch.metrics.first_completed_segment_reward[0]
+    latest_value = phase_switch.metrics.latest_completed_segment_reward[0]
+    assert first_value is not None
+    assert latest_value is not None
+    forged_metrics = (
+        dataclasses.replace(
+            first_segment.metrics,
+            first_completed_segment_reward=(0.0, None),
+            latest_completed_segment_reward=(0.0, None),
+        ),
+        dataclasses.replace(
+            phase_switch.metrics,
+            first_completed_segment_reward=(None, None),
+            latest_completed_segment_reward=(None, None),
+        ),
+        dataclasses.replace(
+            phase_switch.metrics,
+            first_completed_segment_reward=(first_value, 0.0),
+            latest_completed_segment_reward=(latest_value, 0.0),
+        ),
+    )
+    for state, metrics in (
+        (first_segment, forged_metrics[0]),
+        (phase_switch, forged_metrics[1]),
+        (phase_switch, forged_metrics[2]),
+    ):
+        forged = dataclasses.replace(state, metrics=metrics)
+        with pytest.raises(ValueError, match="completed-segment presence"):
+            runner.validate_checkpoint_state(forged)
+
+
 def _agent_config() -> PrototypeAgentConfig:
     return PrototypeAgentConfig(
         oak=OaKConfig(


### PR DESCRIPTION
## Summary

- derive the required presence of SwitchingTwoState first/latest completed-segment rewards from the deterministic phase-switch schedule
- reject premature, missing, and future-phase completion summaries before checkpoint save or adoption
- retain the existing zero-event-phase diagnostic and add failure-sensitive coverage for all three forgery directions

## Reproduced defect

On upstream `main` at `f3d32c451ed1c1715e477ad56b782fc7ea89b206`, a quiescent life after one accepted event has zero phase switches, yet `validate_checkpoint_state` accepted `first_completed_segment_reward=(0.0, None)` and `latest_completed_segment_reward=(0.0, None)`. The state therefore claimed a completed phase-A segment before any phase transition had occurred.

The added test was run against the unmodified validator first and failed because no exception was raised. It now covers:

- premature phase-A summaries before switch 1;
- missing phase-A summaries after switch 1; and
- premature phase-B summaries before switch 2.

## Verification

- failure-first: `test_checkpoint_validator_rejects_completed_segment_presence_forgery` — **failed** on the base commit (`DID NOT RAISE ValueError`)
- focused regression after fix — **1 passed**
- `tests/test_reference_life_checkpoint.py` — **13 passed, 1 skipped**
- `tests/test_reference_life_riverswim_checkpoint.py` — **3 passed**
- `tests/test_reference_life.py` — **45 passed**
- Ruff on both changed files — **passed**
- strict mypy — **passed, 224 source files**
- evidence registry — expected pre-existing **invalid / exit 2** for registered-source drift; `reference_life.py` is not in the five registered source sets
- both current PR #2852 and PR #2853 patches pass `git apply --check` on this branch

This is an L0 checkpoint/measurement-integrity fix. It does not create a performance result, scientific evidence, `reference-dev` selection, or robotics-readiness claim.

Agent disclosure: provider `openai`, model `gpt-5.6-sol`, client `codex` (`0.153.4`).

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next5]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1WKFWYJH2XQVB3WR25SGVV5","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-07T00:15:05.172Z","completed_at":"2026-09-07T00:39:52.012Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-07T00:15:05.324Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ee1fa327694d9be98b2a8ab19799ada0457440b4ad5ea2da6d901c434bb572d1","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c2ef3b18-7fe7-4101-9e09-46257dfd6dd9","object_id":"sha256:ee1fa327694d9be98b2a8ab19799ada0457440b4ad5ea2da6d901c434bb572d1","sha256":"ee1fa327694d9be98b2a8ab19799ada0457440b4ad5ea2da6d901c434bb572d1"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"MpovrUmiE1MMPfwz094B-8VRqxqYdTnR1-EZXTLGLMQMSC1kPlB7tPqJ2hmEZPGM19CFmArFsX3_iMz9aKM0Ag"}} -->
