### PR TITLE
fix(checkpoint): require canonical metric floats

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -593,8 +593,12 @@ class ReferenceLifeMetricsState:
             *self.first_completed_segment_reward,
             *self.latest_completed_segment_reward,
         )
-        if any(value is not None and not math.isfinite(value) for value in optional):
-            raise ValueError("optional segment metrics must be finite when present")
+        if any(
+            value is not None
+            and (type(value) is not float or not math.isfinite(value))
+            for value in optional
+        ):
+            raise ValueError("optional segment metrics must be finite floats when present")
         numeric = (
             self.reward_sum,
             self.oracle_reward_sum,
@@ -604,8 +608,8 @@ class ReferenceLifeMetricsState:
             self.current_segment_reward,
             self.current_segment_regret,
         )
-        if not all(math.isfinite(value) for value in numeric):
-            raise ValueError("metric accumulators must be finite")
+        if any(type(value) is not float or not math.isfinite(value) for value in numeric):
+            raise ValueError("metric accumulators must be finite floats")
 
 
 class ReferenceLifeMetricsAdapter:

--- a/tests/test_reference_life.py
+++ b/tests/test_reference_life.py
@@ -196,6 +196,27 @@ def test_switching_execution_rejects_boolean_decoded_action(
         )
 
 
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    (
+        ({"reward_sum": False}, "metric accumulators"),
+        ({"phase_reward_sums": (0, 0.0)}, "metric accumulators"),
+        (
+            {"first_completed_segment_reward": (False, None)},
+            "optional segment metrics",
+        ),
+    ),
+)
+def test_metric_values_require_canonical_floats(
+    changes: dict[str, object],
+    message: str,
+) -> None:
+    metrics = ReferenceLifeMetricsAdapter().init(initial_phase=0)
+
+    with pytest.raises(ValueError, match=message):
+        dataclasses.replace(metrics, **changes)
+
+
 def _corrupt_accepted_update(
     update: PrototypeAdapterUpdate,
     *,


### PR DESCRIPTION
## Summary

- require every reference-life reward/regret accumulator to be an exact finite Python `float`
- require present first/latest completed-segment rewards to use the same canonical float type
- reject booleans and integers before the checkpoint codec can silently normalize their types

## Reproduced defect

On upstream `main` at `f3d32c451ed1c1715e477ad56b782fc7ea89b206`, `ReferenceLifeMetricsState` accepted booleans in scalar, tuple, and optional floating metric fields. Encoding and decoding a semantically valid post-switch state then changed those fields from `bool` to `float`, because `_encode_float` coerces its input before writing binary64. That violates the development checkpoint's exact-resume state identity.

The failure-first regression exercised one field from each affected shape:

- scalar `reward_sum=False`;
- tuple `phase_reward_sums=(0, 0.0)`; and
- optional `first_completed_segment_reward=(False, None)`.

All three cases were accepted on the base commit and are now rejected at state construction.

## Verification

- failure-first focused test on base — **3 failed** (`DID NOT RAISE ValueError`)
- focused regression after fix — **3 passed**
- `tests/test_reference_life.py` — **48 passed**
- `tests/test_reference_life_checkpoint.py` — **12 passed, 1 skipped**
- `tests/test_reference_life_riverswim.py` — **7 passed**
- `tests/test_reference_life_riverswim_checkpoint.py` — **3 passed**
- full Ruff — **passed**
- strict mypy — **passed, 224 source files**
- evidence registry — expected pre-existing **invalid / exit 2** for registered-source drift; `reference_life.py` is outside the five registered source sets
- current PR #2852, #2853, and #2854 patches all pass `git apply --check` on this branch

This is an L0 checkpoint/measurement-integrity fix. It does not create a performance result, scientific evidence, `reference-dev` selection, or robotics-readiness claim.

<!-- evidence-head:cac7617e3cee154338ede2d0dda4d6f085f9abdc -->

Agent disclosure: provider `openai`, model `gpt-5.6-sol`, client `codex` (`0.153.4`).

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next6]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1WN9S7XAWY91Z21W443ESXG","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-07T00:46:41.918Z","completed_at":"2026-09-07T01:13:47.969Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-07T00:46:42.069Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4a055bcf2d001f87a3052f2cd709a07478c4bc3b8e4df12e73d939336e6c119f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9cd61774-f894-4922-9bbf-75c800cb9704","object_id":"sha256:4a055bcf2d001f87a3052f2cd709a07478c4bc3b8e4df12e73d939336e6c119f","sha256":"4a055bcf2d001f87a3052f2cd709a07478c4bc3b8e4df12e73d939336e6c119f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"kO3yR5LjV3g91RiwGv384tud6LjNcIyfzZiQAxk8KmkO5SMK-NPoThY8KjLWhNtJ3xW11fvS8yu2_GlU73OCDQ"}} -->
