### PR TITLE
fix(checkpoint): bound completed segment rewards

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -2111,6 +2111,28 @@ class ReferenceLifeRunner:
             raise DecisionOwnershipError(f"{name} must be a scalar int32")
         return int(array)
 
+    @staticmethod
+    def _sequential_sum_bounds(
+        *,
+        event_count: int,
+        minimum_step_value: float,
+        maximum_step_value: float,
+    ) -> tuple[float, float]:
+        """Bound a binary64 sequential sum of configured finite step values."""
+
+        maximum_magnitude = max(abs(minimum_step_value), abs(maximum_step_value))
+        relative_error = event_count * float(np.finfo(np.float64).eps)
+        summation_slack = (
+            event_count
+            * maximum_magnitude
+            * relative_error
+            / (1.0 - relative_error)
+        )
+        return (
+            event_count * minimum_step_value - summation_slack,
+            event_count * maximum_step_value + summation_slack,
+        )
+
     def validate_checkpoint_state(self, state: ReferenceLifeState) -> None:
         """Validate the exact cross-component quiescent checkpoint boundary."""
 
@@ -2231,6 +2253,30 @@ class ReferenceLifeRunner:
             )
             if any(payoff.shape != (2, 2) for payoff in payoff_matrices):
                 raise DecisionOwnershipError("checkpoint environment payoff schedule is invalid")
+            completed_segment_reward_bounds = tuple(
+                self._sequential_sum_bounds(
+                    event_count=phase_length,
+                    minimum_step_value=min(float(value) for value in payoff.flat),
+                    maximum_step_value=max(float(value) for value in payoff.flat),
+                )
+                for payoff in payoff_matrices
+            )
+            for phase, (minimum_reward, maximum_reward) in enumerate(
+                completed_segment_reward_bounds
+            ):
+                completed_rewards = (
+                    metrics.first_completed_segment_reward[phase],
+                    metrics.latest_completed_segment_reward[phase],
+                )
+                if any(
+                    reward is not None
+                    and not minimum_reward <= reward <= maximum_reward
+                    for reward in completed_rewards
+                ):
+                    raise DecisionOwnershipError(
+                        "checkpoint completed-segment rewards are outside configured "
+                        "payoff bounds"
+                    )
             oracle_rewards = tuple(
                 max(
                     float(payoff[0, 0]),

--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -132,6 +132,27 @@ def _advance(
     return state, tuple(steps)
 
 
+def test_checkpoint_validator_rejects_completed_segment_reward_forgery() -> None:
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 5)
+
+    for phase in (0, 1):
+        assert state.metrics.first_completed_segment_reward[phase] is not None
+        assert state.metrics.latest_completed_segment_reward[phase] is not None
+        for field, forged_value in (
+            ("first_completed_segment_reward", 123.0),
+            ("latest_completed_segment_reward", -123.0),
+        ):
+            values = list(getattr(state.metrics, field))
+            values[phase] = forged_value
+            forged = dataclasses.replace(
+                state,
+                metrics=dataclasses.replace(state.metrics, **{field: tuple(values)}),
+            )
+            with pytest.raises(ValueError, match="completed-segment rewards"):
+                runner.validate_checkpoint_state(forged)
+
+
 def _assert_semantic_state_exact(
     left: ReferenceLifeState,
     right: ReferenceLifeState,


### PR DESCRIPTION
## Summary

- bound retained first/latest completed-segment rewards by each switching phase's configured payoff range
- include a conservative binary64 sequential-summation envelope without replaying up to the int32 horizon
- reject corrupt checkpoint measurement state before adoption or exact resume

## Reproduced defect

On upstream `main` at `f3d32c451ed1c1715e477ad56b782fc7ea89b206`, a legitimate state after both phases completed one segment still passed `ReferenceLifeRunner.validate_checkpoint_state` when any retained first/latest completed reward was replaced by an impossible finite value. The direct base reproduction accepted `first_completed_segment_reward=(123.0, None)` together with `latest_completed_segment_reward=(-123.0, None)` after the first phase switch, even though the default configured rewards are only 0 or 1 and the completed segment has two events.

The failure-first regression independently forges the first and latest fields for both completed phases. It failed on the base commit with `DID NOT RAISE ValueError`; all four forgeries are now rejected as outside the phase-specific payoff bounds.

The bound uses `n * eps` binary64 accumulation slack over `n=phase_length` configured finite float32 rewards. Its work is constant-time in the checkpoint horizon.

## Verification

- failure-first focused test on base — **1 failed** (`DID NOT RAISE ValueError`)
- focused regression after fix — **1 passed**
- `tests/test_reference_life.py` — **45 passed**
- `tests/test_reference_life_checkpoint.py` — **13 passed, 1 skipped**
- `tests/test_reference_life_riverswim.py` — **7 passed**
- `tests/test_reference_life_riverswim_checkpoint.py` — **3 passed**
- full Ruff — **passed**
- strict mypy — **passed, 224 source files**
- evidence registry — expected pre-existing **invalid / exit 2** for registered-source drift; `reference_life.py` is outside the five registered source sets
- current PR #2850 through #2855 patches all pass `git apply --check` on this branch

This is an L0 checkpoint/measurement-integrity fix. It does not create a performance result, scientific evidence, `reference-dev` selection, or robotics-readiness claim.

<!-- evidence-head:c3f3125826e8eea9855e597aa6ff647f52b6328e -->

Agent disclosure: provider `openai`, model `gpt-5.6-sol`, client `codex` (`0.153.4`).

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next7]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1WQKZKMQZZ3Q4QHT0K07AG6","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-07T01:27:13.270Z","completed_at":"2026-09-07T01:56:19.508Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-07T01:27:13.425Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"529c9c3988f3b336138a99727434b3709dd5786777e19a7273cd4557b719c11f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"1090ea20-9f5f-44df-b14d-a0e2ee6e799e","object_id":"sha256:529c9c3988f3b336138a99727434b3709dd5786777e19a7273cd4557b719c11f","sha256":"529c9c3988f3b336138a99727434b3709dd5786777e19a7273cd4557b719c11f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"rSRTVf4Z-facWGkLpcFnwkiqjrEw15hu3OB1t00ykm4T73pYf86l-5aTllsc-Fa29x00HhzIb16h7XKAHyFFDQ"}} -->
