### PR TITLE
fix(checkpoint): require metric tuple containers

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -556,6 +556,15 @@ class ReferenceLifeMetricsState:
     latest_completed_segment_reward: tuple[float | None, float | None]
 
     def __post_init__(self) -> None:
+        pair_containers = (
+            self.phase_event_counts,
+            self.phase_reward_sums,
+            self.phase_regret_sums,
+            self.first_completed_segment_reward,
+            self.latest_completed_segment_reward,
+        )
+        if any(type(values) is not tuple for values in pair_containers):
+            raise ValueError("phase and segment metrics must use tuple containers")
         if self.schema != REFERENCE_LIFE_METRICS_SCHEMA:
             raise ValueError("unsupported reference-life metrics schema")
         _require_digest(self.config_sha256, name="config_sha256")

--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -563,6 +563,8 @@ class ReferenceLifeMetricsState:
             self.first_completed_segment_reward,
             self.latest_completed_segment_reward,
         )
+        # The checkpoint decoder reconstructs builtin tuples from JSON arrays.
+        # Lists permit mutable aliases; tuple subclasses lose type identity on restore.
         if any(type(values) is not tuple for values in pair_containers):
             raise ValueError("phase and segment metrics must use tuple containers")
         if self.schema != REFERENCE_LIFE_METRICS_SCHEMA:

--- a/tests/test_reference_life.py
+++ b/tests/test_reference_life.py
@@ -225,6 +225,24 @@ def _corrupt_accepted_update(
     raise AssertionError(f"unknown test defect: {defect}")
 
 
+@pytest.mark.parametrize(
+    "field",
+    (
+        "phase_event_counts",
+        "phase_reward_sums",
+        "phase_regret_sums",
+        "first_completed_segment_reward",
+        "latest_completed_segment_reward",
+    ),
+)
+def test_metric_pair_fields_require_tuple_containers(field: str) -> None:
+    metrics = ReferenceLifeMetricsAdapter().init(initial_phase=0)
+    list_value = list(getattr(metrics, field))
+
+    with pytest.raises(ValueError, match="tuple containers"):
+        dataclasses.replace(metrics, **{field: list_value})
+
+
 def test_pure_transaction_reducer_has_no_hidden_current_state() -> None:
     adapter = PrototypeReferenceAdapter.from_config(_agent_config())
     agent_state = adapter.init(jr.key(7), lifecycle_id=_LIFECYCLE_ID)

--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -11,7 +11,7 @@ import shutil
 import struct
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import jax
 import numpy as np
@@ -227,6 +227,59 @@ def test_quiescent_checkpoint_restores_exact_continuation(
     assert restored_final.transcript_sha256 == uninterrupted_state.transcript_sha256
     assert restored_final.environment_rng_cursor == uninterrupted_state.environment_rng_cursor
     assert restored_final.checkpoint_generation == 1
+
+
+class _RewardPair(NamedTuple):
+    first: float
+    second: float
+
+
+@pytest.mark.parametrize("container", [list, _RewardPair, tuple])
+def test_adopted_metric_container_checkpoint_is_typed_exact_or_rejected(
+    saved_case: tuple[ReferenceLifeRunner, ReferenceLifeState, ReferenceLifeState, Path],
+    tmp_path: Path,
+    container: Any,
+) -> None:
+    runner, _, barrier, _ = saved_case
+    owner = ReferenceLifeRunner.create(
+        agent_adapter=runner.agent_adapter,
+        environment_adapter=runner.environment_adapter,
+        lifecycle_id=runner.config.lifecycle_id,
+        seed=runner.config.seed,
+        max_accepted_events=runner.config.max_accepted_events,
+    )
+    values = barrier.metrics.phase_reward_sums
+    pair = container(*values) if container is _RewardPair else container(values)
+    destination = tmp_path / "checkpoint"
+    try:
+        metrics = dataclasses.replace(barrier.metrics, phase_reward_sums=pair)
+        adopted = owner.adopt_checkpoint_state(dataclasses.replace(barrier, metrics=metrics))
+    except ValueError:
+        assert container is not tuple  # Canonical decoder output must remain admissible.
+        assert owner.current_state is None
+        assert not destination.exists()
+        return
+
+    saved, checkpoint = save_reference_life_checkpoint(owner, adopted, destination)
+    restored_owner, restored = load_reference_life_checkpoint(checkpoint)
+    # JSON arrays are the wire representation; the decoder already creates tuples.
+    payload = json.loads((checkpoint / "life_state.json").read_text(encoding="ascii"))
+    for field in (
+        "phase_event_counts",
+        "phase_reward_sums",
+        "phase_regret_sums",
+        "first_completed_segment_reward",
+        "latest_completed_segment_reward",
+    ):
+        assert type(payload["metrics"][field]) is list
+        assert type(getattr(restored.metrics, field)) is tuple
+    # Main publishes list/NamedTuple-backed barriers but restores builtin tuples.
+    # This assertion fails at metrics.phase_reward_sums on both accepted bad inputs.
+    _assert_semantic_state_exact(saved, restored)
+    live_step = owner.step(saved)
+    restored_step = restored_owner.step(restored)
+    assert live_step.accepted and restored_step.accepted
+    _assert_typed_exact(live_step, restored_step)
 
 
 def _write_canonical_json(path: Path, value: dict[str, Any]) -> None:


### PR DESCRIPTION
The checkpoint boundary accepts metric containers whose types it cannot restore exactly. On main, a public runner can adopt `phase_reward_sums=[2.0, 0.0]`, successfully publish a checkpoint, and restore it as the plain tuple `(2.0, 0.0)`. Keeping the original list reference also lets a caller change the adopted live phase reward from 2 to 3 without advancing its commit generation. A `NamedTuple` survives validation and publication too, but loses its subclass on restore.

Require exact builtin tuple containers for all five phase/segment metric pairs before inspecting their contents. This preserves the immutable in-memory state representation used by the development checkpoint's typed exact-resume contract. JSON arrays remain the wire format: `_decode_pair` already converts them to builtin tuples before constructing metrics, and normal checkpoints still load and continue exactly. `isinstance(values, tuple)` would leave the demonstrated `NamedTuple` type loss unresolved.

The follow-up to [the current-head review](https://github.com/SlopDotCash/asi/pull/2857#pullrequestreview-5141760869) adds a public adoption/save/load regression and documents that exact-type rationale. The existing runtime check is unchanged. The five construction regressions cover `phase_event_counts`, `phase_reward_sums`, `phase_regret_sums`, `first_completed_segment_reward`, and `latest_completed_segment_reward`.

Verified head: `da573d252e2cfa152e532543076ddc7632033fac`
<!-- evidence-head:da573d252e2cfa152e532543076ddc7632033fac -->

## Public checkpoint evidence

Baseline: `f3d32c451ed1c1715e477ad56b782fc7ea89b206` (current main). The reproduction first advances a canonical Switching life through two accepted steps and saves a real checkpoint. For each candidate container, it creates a fresh runner owner using the same public adapters and adopts a metrics-modified copy of that persisted barrier. It then calls the public save/load APIs; it does not assign private runner state, mutate a frozen dataclass with `object.__setattr__`, or invoke private codec functions.

| Input container | Main | Verified head |
| --- | --- | --- |
| `list([2.0, 0.0])` | Publishes; saved `list` becomes loaded `tuple` | Rejected before adoption; no destination created |
| `RewardPair(2.0, 0.0)` (`NamedTuple`) | Publishes; saved subclass becomes loaded `tuple` | Rejected before adoption; no destination created |
| `(2.0, 0.0)` | Publishes and preserves type | Publishes, preserves full typed state, and continues exactly |

In the main list case, changing the retained list's first element after publication changes `owner.current_state.metrics.phase_reward_sums[0]` to **3.0**, while the restored value remains **2.0** and the live commit generation is unchanged. This is an in-memory adoption/aliasing defect; ordinary runner-generated metrics and the JSON decoder already produce tuples. No claim is made that a normal rollout creates lists.

The new integration regression asserts that an admissible candidate survives public checkpointing with full typed state equality, or is rejected while the fresh owner remains empty. Against main it gives **2 failures / 1 pass**, both failures at `state.metrics.phase_reward_sums` after successful publication and reload. On the verified source it gives **3 passes**. Its canonical control checks all five on-disk JSON arrays, their decoded builtin tuple types, and an exact original-versus-restored continuation step. No type-equality assertion was weakened.

## Verification

Runtime: CPU, Python 3.12.3, locked JAX/jaxlib 0.11.0, NumPy 2.5.1 and Orbax 0.12.1. Dependencies were installed in the project venv with `uv sync --locked --no-install-project --extra dev --python <project-python>`. Executions set `OMP_NUM_THREADS=1` and select the checkout through `PYTHONPATH`.

```bash
.venv/bin/python -m pytest tests/test_reference_life_checkpoint.py -k adopted_metric_container -q --tb=short -o addopts=''
.venv/bin/python -m pytest tests/test_reference_life.py tests/test_reference_life_checkpoint.py tests/test_reference_life_riverswim.py tests/test_reference_life_riverswim_checkpoint.py tests/test_reference_life_controls.py -q --tb=short -o addopts=''
.venv/bin/python -m ruff check .
.venv/bin/python -m mypy
.venv/bin/python -m alberta_framework.evaluation.evidence_manifest_cli
git diff --check
```

- Full focused reference-life panel: **108 passed / 1 skipped**, including the three new integration cases and five existing tuple-construction cases. The skip tests Linux-only publication refusal off Linux; this host supports `renameat2`. The new checkpoint cases inherit the module's `integration` and `slow` markers and were explicitly run locally.
- Standalone public reproduction: main exits 1 on its typed-exact assertion, verified source exits 0. The output below comes from fresh processes using each checkout's source.
- Ruff, strict mypy (**224 source files**), and whitespace checks pass.
- Evidence registry exits **2** before and after; all five claim statuses and complete error lists are unchanged. `reference_life.py` is outside all 25 registered source paths. Its source bytes are part of the development checkpoint/scorecard identities, so existing generations remain subject to their source-drift refusal. Pinned outputs are untouched.

[Required CI run 34233379870](https://github.com/SlopDotCash/asi/actions/runs/34233379870) completed successfully at the verified head: **55/55 jobs passed**. The separate optional Claude triage run was skipped. No CI repair or retry was needed.

This remains an L0 development checkpoint/measurement-integrity fix. It changes no agent learning rule, configuration, persistent state size, benchmark threshold or scientific seed. Key 29 is an existing deterministic checkpoint fixture, not an evaluation seed. No timing, learning-performance, scientific-promotion, `reference-dev`, portability or robotics-readiness claim is made. Independent review and merge remain with the maintainer.

<details>
<summary>Standalone public adoption/save/load reproduction</summary>

Save as `checkpoint-repro.py` outside the checkouts. Run `.venv/bin/python checkpoint-repro.py` in separate processes with the selected checkout in `PYTHONPATH` and `OMP_NUM_THREADS=1`. It writes and removes only its own temporary checkpoint directories.

```python
import dataclasses
import json
import tempfile
from pathlib import Path
from typing import NamedTuple

from alberta_framework.core.oak import OaKConfig
from alberta_framework.core.options import STOMPConfig
from alberta_framework.core.prototype_agent import PrototypeAgentConfig
from alberta_framework.reference_life import ReferenceLifeRunner, build_prototype_switching_life
from alberta_framework.reference_life_checkpoint import (
    load_reference_life_checkpoint,
    save_reference_life_checkpoint,
)
from alberta_framework.streams.closed_loop import SwitchingTwoStateConfig


class RewardPair(NamedTuple):
    first: float
    second: float


def fresh_owner(runner):
    return ReferenceLifeRunner.create(
        agent_adapter=runner.agent_adapter,
        environment_adapter=runner.environment_adapter,
        lifecycle_id=runner.config.lifecycle_id,
        seed=runner.config.seed,
        max_accepted_events=runner.config.max_accepted_events,
    )


with tempfile.TemporaryDirectory(prefix='asi-metric-container-repro-') as root:
    runner = build_prototype_switching_life(
        agent_config=PrototypeAgentConfig(oak=OaKConfig(stomp=STOMPConfig(
            subtask_specs=(), observation_dim=2, n_primitive_actions=2,
            base_step_size=0.05, epsilon_base=0.25,
        ))),
        environment_config=SwitchingTwoStateConfig(phase_length=2),
        lifecycle_id='prototype.0000001100000012', seed=29, max_accepted_events=6,
    )
    state = runner.init()
    for _ in range(2):
        step = runner.step(state)
        assert step.accepted
        state = step.state
    barrier, path = save_reference_life_checkpoint(runner, state, Path(root) / 'canonical')
    _, restored = load_reference_life_checkpoint(path)
    assert type(restored.metrics.phase_reward_sums) is tuple
    results = []
    for kind in ('list', 'namedtuple', 'tuple'):
        values = barrier.metrics.phase_reward_sums
        candidate = list(values) if kind == 'list' else RewardPair(*values) if kind == 'namedtuple' else values
        owner = fresh_owner(runner)
        destination = Path(root) / kind
        try:
            metrics = dataclasses.replace(barrier.metrics, phase_reward_sums=candidate)
            adopted = owner.adopt_checkpoint_state(dataclasses.replace(barrier, metrics=metrics))
            saved, output = save_reference_life_checkpoint(owner, adopted, destination)
            _, loaded = load_reference_life_checkpoint(output)
        except ValueError as error:
            results.append(dict(kind=kind, rejected=str(error), owner_empty=owner.current_state is None,
                                destination_exists=destination.exists()))
            continue
        record = dict(kind=kind, published=True, saved_type=type(saved.metrics.phase_reward_sums).__name__,
                      loaded_type=type(loaded.metrics.phase_reward_sums).__name__,
                      typed_exact=type(saved.metrics.phase_reward_sums) is type(loaded.metrics.phase_reward_sums),
                      saved_values=list(saved.metrics.phase_reward_sums),
                      loaded_values=list(loaded.metrics.phase_reward_sums))
        if kind == 'list':
            generation = saved.commit_generation
            candidate[0] += 1.0
            record.update(alias_mutated_live=owner.current_state.metrics.phase_reward_sums[0],
                          restored_value=loaded.metrics.phase_reward_sums[0],
                          generation_unchanged=owner.current_state.commit_generation == generation)
        results.append(record)
    print(json.dumps(results, indent=2))
    assert all(r.get('typed_exact', r.get('owner_empty', False)) for r in results)
```

</details>

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next22]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M20KJ5067830J5YRF40MNSGX","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-08T13:33:16.678Z","completed_at":"2026-09-08T13:59:35.187Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-08T13:33:17.263Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3b22dc53b5edbbbf7f124fbc0d5b9e6fc9523cbeb28faea6404574cd11eec738","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"516ba543-cab5-4201-a3ca-7125b2ac5b9d","object_id":"sha256:3b22dc53b5edbbbf7f124fbc0d5b9e6fc9523cbeb28faea6404574cd11eec738","sha256":"3b22dc53b5edbbbf7f124fbc0d5b9e6fc9523cbeb28faea6404574cd11eec738"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"7cTGqtB_w4EiBWq-r2tjgYibtqjXevL6p7ZntlnWdCQEanVjMpUV5tLRHE9xLIFNfMOy7TtFlF0x9XEUfYJZDQ"}} -->
