### PR TITLE
fix(checkpoint): bound switching phase totals

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -131,6 +131,31 @@ def _require_finite_real(name: str, value: object) -> float:
     return number
 
 
+def _within_configured_sum_bounds(
+    value: float,
+    *,
+    event_count: int,
+    step_values: tuple[float, ...],
+) -> bool:
+    """Bound one binary64 sequential sum of configured finite step values."""
+
+    minimum_step_value = min(step_values)
+    maximum_step_value = max(step_values)
+    maximum_magnitude = max(abs(minimum_step_value), abs(maximum_step_value))
+    relative_error = event_count * float(np.finfo(np.float64).eps)
+    summation_slack = (
+        event_count
+        * maximum_magnitude
+        * relative_error
+        / (1.0 - relative_error)
+    )
+    return (
+        event_count * minimum_step_value - summation_slack
+        <= value
+        <= event_count * maximum_step_value + summation_slack
+    )
+
+
 def _require_prototype_lifecycle_id(value: str) -> None:
     if type(value) is not str or _PROTOTYPE_LIFECYCLE.fullmatch(value) is None:
         raise ValueError(
@@ -2299,6 +2324,26 @@ class ReferenceLifeRunner:
                     "checkpoint zero-event phase metrics must be exact positive zero "
                     "with no completed-segment values"
                 )
+        if environment_kind == "switching_two_state":
+            for phase, (count, payoff) in enumerate(
+                zip(expected_phase_counts, payoff_matrices, strict=True)
+            ):
+                phase_rewards = tuple(float(value) for value in payoff.flat)
+                phase_regrets = tuple(
+                    oracle_rewards[phase] - reward for reward in phase_rewards
+                )
+                if not _within_configured_sum_bounds(
+                    metrics.phase_reward_sums[phase],
+                    event_count=count,
+                    step_values=phase_rewards,
+                ) or not _within_configured_sum_bounds(
+                    metrics.phase_regret_sums[phase],
+                    event_count=count,
+                    step_values=phase_regrets,
+                ):
+                    raise DecisionOwnershipError(
+                        "checkpoint phase totals are outside configured payoff bounds"
+                    )
         oracle_reward_matches = (
             struct.pack(">d", metrics.oracle_reward_sum)
             == struct.pack(">d", expected_oracle_reward)

--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -587,3 +587,19 @@ def test_save_reference_life_checkpoint_refuses_off_linux(tmp_path: Path) -> Non
     with pytest.raises(OSError, match="atomic no-replace rename requires Linux renameat2"):
         save_reference_life_checkpoint(runner, state, tmp_path)
     assert not any(p.name.startswith("generation-") for p in tmp_path.iterdir())
+
+
+@pytest.mark.parametrize("field", ("phase_reward_sums", "phase_regret_sums"))
+def test_checkpoint_validator_rejects_impossible_switching_phase_totals(field: str) -> None:
+    runner = _runner()
+    state, _ = _advance(runner, runner.init(), 5)
+
+    original = getattr(state.metrics, field)
+    forged_values = (123.0, sum(original) - 123.0)
+    forged = dataclasses.replace(
+        state,
+        metrics=dataclasses.replace(state.metrics, **{field: forged_values}),
+    )
+
+    with pytest.raises(ValueError, match="phase totals.*payoff bounds"):
+        runner.validate_checkpoint_state(forged)


### PR DESCRIPTION
## Summary

- bound switching checkpoint phase reward totals by each phase's configured payoff range
- apply the same per-phase bound to oracle-minus-reward regret totals
- retain conservative binary64 sequential-accumulation slack at the full int32 event horizon

## Reproduced defect

On upstream `main` at `f3d32c451ed1c1715e477ad56b782fc7ea89b206`, a valid five-event switching checkpoint could have either `phase_reward_sums` or `phase_regret_sums` redistributed to `(123.0, original_total - 123.0)`. The global total stayed unchanged, oracle/reward/regret algebra still balanced, the schedule and segment metrics remained untouched, and `ReferenceLifeRunner.validate_checkpoint_state` accepted both impossible phase histories.

The failure-first regression reproduced both cases as **2 failures** (`DID NOT RAISE ValueError`).

## Fix

For each switching phase, the validator now derives:

- the minimum and maximum configured float32 payoff for one event
- the corresponding minimum and maximum per-event regret from that phase's oracle reward
- a conservative binary64 sequential-summation allowance based on the phase event count

Both retained phase totals must fall inside those configured bounds. The check runs after the existing zero-event canonical-value gate so its more specific diagnostic remains stable.

## Verification

- direct base reproduction — impossible phase-0 reward total `123.0` was accepted
- failure-first focused test on base — **2 failed** (`DID NOT RAISE ValueError`)
- focused regression after fix — **2 passed**
- switching/RiverSwim reference-life and checkpoint panel — **69 passed, 1 skipped**
- full Ruff — **passed**
- strict mypy — **passed, 224 source files**
- evidence registry — expected pre-existing **invalid / exit 2** for registered-source drift; `reference_life.py` is outside the five registered source sets
- current PR #2850 through #2857 patches all pass `git apply --check`; oversized IPMNIST PR #2849 changes neither modified file

This is an L0 checkpoint measurement-integrity fix. It does not create a performance result, scientific evidence, `reference-dev` selection, or robotics-readiness claim.

<!-- evidence-head:302efe6a98a64945e31c9ffbbf019d8d739ffa48 -->

Agent disclosure: provider `openai`, model `gpt-5.6-sol`, client `codex` (`0.153.4`).

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next9]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1WW484AAAXZ6TC5H20ZS6SR","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-07T02:46:00.588Z","completed_at":"2026-09-07T03:42:58.561Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-07T02:46:00.787Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"acacf2e2b7e965b7a36134214fc1bf7d48c2bf8ce6001839e9c65034b198b300","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"be49dc41-ffcf-4815-8d2c-b089f3d5a88d","object_id":"sha256:acacf2e2b7e965b7a36134214fc1bf7d48c2bf8ce6001839e9c65034b198b300","sha256":"acacf2e2b7e965b7a36134214fc1bf7d48c2bf8ce6001839e9c65034b198b300"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"gr65JXJAY4aSB9afHxAnOpRVX280jY71WWDPmf38-Nux5zklRvEjuHr0t0RUFzZvsH84KyD5n36z4uiOvxrRAQ"}} -->
