### PR TITLE
fix(checkpoint): bind initial agent seed

### DIFF
--- a/alberta_framework/reference_life.py
+++ b/alberta_framework/reference_life.py
@@ -25,6 +25,7 @@ import threading
 from collections.abc import Callable, Mapping
 from typing import Any, Protocol, TypeVar, cast
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -1873,6 +1874,37 @@ def _initial_transcript(
     )
 
 
+def _jax_trees_exact(left: Any, right: Any) -> bool:
+    """Compare the complete typed bytes of two JAX-state PyTrees."""
+
+    left_leaves, left_structure = jax.tree_util.tree_flatten(left)
+    right_leaves, right_structure = jax.tree_util.tree_flatten(right)
+    if cast(Any, left_structure) != right_structure or len(left_leaves) != len(right_leaves):
+        return False
+    for left_leaf, right_leaf in zip(left_leaves, right_leaves, strict=True):
+        if not isinstance(left_leaf, jax.Array) or not isinstance(right_leaf, jax.Array):
+            return False
+        if left_leaf.shape != right_leaf.shape or left_leaf.dtype != right_leaf.dtype:
+            return False
+        if jax.dtypes.issubdtype(  # type: ignore[attr-defined]
+            left_leaf.dtype, jax.dtypes.prng_key
+        ):
+            if str(jax.random.key_impl(left_leaf)) != str(jax.random.key_impl(right_leaf)):
+                return False
+            left_array = np.asarray(jax.random.key_data(left_leaf))
+            right_array = np.asarray(jax.random.key_data(right_leaf))
+        else:
+            left_array = np.asarray(left_leaf)
+            right_array = np.asarray(right_leaf)
+        if (
+            left_array.dtype != right_array.dtype
+            or left_array.shape != right_array.shape
+            or left_array.tobytes(order="C") != right_array.tobytes(order="C")
+        ):
+            return False
+    return True
+
+
 def _advance_transcript(
     previous_digest: str,
     *,
@@ -2203,6 +2235,28 @@ class ReferenceLifeRunner:
             raise DecisionOwnershipError("checkpoint current decision lineage is inconsistent")
         if decision.observation_id != expected_observation_id:
             raise DecisionOwnershipError("checkpoint decision observation identity is inconsistent")
+        if accepted == 0:
+            root_key = jr.key(
+                self.config.seed,
+                impl=REFERENCE_LIFE_PRNG_IMPLEMENTATION,
+            )
+            agent_key, _ = jr.split(root_key, 2)
+            canonical_agent = self._agent_adapter.init(
+                agent_key,
+                lifecycle_id=state.lifecycle_id,
+            )
+            canonical_agent, canonical_decision = self._agent_adapter.start(
+                canonical_agent,
+                observation_id=expected_observation_id,
+                observation=decision.observation,
+            )
+            if not _jax_trees_exact(
+                agent_state.agent_state,
+                canonical_agent.agent_state,
+            ) or decision != canonical_decision:
+                raise DecisionOwnershipError(
+                    "checkpoint seeded initial agent state is inconsistent"
+                )
         environment_observation = self._environment_adapter.current_observation(
             state.environment_state
         )

--- a/tests/test_reference_life_checkpoint.py
+++ b/tests/test_reference_life_checkpoint.py
@@ -587,3 +587,36 @@ def test_save_reference_life_checkpoint_refuses_off_linux(tmp_path: Path) -> Non
     with pytest.raises(OSError, match="atomic no-replace rename requires Linux renameat2"):
         save_reference_life_checkpoint(runner, state, tmp_path)
     assert not any(p.name.startswith("generation-") for p in tmp_path.iterdir())
+
+
+def test_checkpoint_validator_rejects_alternate_seed_zero_event_agent_state() -> None:
+    runner = _runner()
+    state = runner.init()
+    observation = runner.environment_adapter.current_observation(state.environment_state)
+    forged_agent = runner.agent_adapter.init(
+        jax.random.key(999, impl="threefry2x32"),
+        lifecycle_id=state.lifecycle_id,
+    )
+    forged_agent, forged_decision = runner.agent_adapter.start(
+        forged_agent,
+        observation_id=f"{state.lifecycle_id}:observation:0",
+        observation=observation,
+    )
+    assert forged_decision != state.transaction_state.decision
+    checkpoint_state = dataclasses.replace(
+        state,
+        commit_generation=1,
+        checkpoint_generation=1,
+    )
+    runner.validate_checkpoint_state(checkpoint_state)
+    forged = dataclasses.replace(
+        checkpoint_state,
+        agent_state=forged_agent,
+        transaction_state=dataclasses.replace(
+            checkpoint_state.transaction_state,
+            decision=forged_decision,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="seeded initial agent"):
+        runner.validate_checkpoint_state(forged)


### PR DESCRIPTION
## Summary

- reconstruct the canonical zero-event Prototype state from the life seed and agent-key split
- require every typed JAX state leaf and the derived initial decision to match that seeded initialization
- retain the existing environment/ledger/counter checks and later-event integrity boundary

## Reproduced defect

On upstream `main` at `f3d32c451ed1c1715e477ad56b782fc7ea89b206`, a zero-event checkpoint could replace the complete Prototype state with a separately valid state initialized from key `999`, then replace the armed ledger decision to match it. The configured life seed remained `29`; the alternate state differed and proposed action `0` instead of the canonical action `1`, yet `ReferenceLifeRunner.validate_checkpoint_state` accepted it.

Direct base reproduction printed:

```text
agent_state_differs True
original_action ... payload=b'\x01\x00\x00\x00'
forged_action ... payload=b'\x00\x00\x00\x00'
accepted alternate-seed zero-event agent state
```

The failure-first regression failed with `DID NOT RAISE ValueError`.

## Fix

For `accepted_events == 0`, the validator repeats the runner's canonical Threefry root-key split, initializes and starts the bound Prototype adapter with the retained observation, and compares the complete JAX PyTree by structure, dtype, shape, PRNG implementation, and exact bytes. It also requires the reconstructed decision to match the retained current decision.

This is distinct from #2859, which binds the seeded environment start and initial transcript. Its exact patch applies cleanly on top of this branch; all other small open code PR patches do too. Oversized PR #2849 changes unrelated files.

## Verification

- direct base reproduction — alternate-seed state and different proposed action were accepted
- failure-first focused regression on base — **1 failed** (`DID NOT RAISE ValueError`)
- focused regression after fix and at committed head — **1 passed**
- Switching/RiverSwim reference-life and checkpoint panel — **68 passed, 1 skipped**
- full Ruff — **passed**
- strict mypy — **passed, 224 source files**
- evidence registry — expected pre-existing **invalid / exit 2** for registered-source drift; `reference_life.py` is outside all five registered source sets
- all open PRs checked for overlap: #2850 through #2859 apply cleanly; #2849 changes neither modified file

This is an L0 exact-resume measurement-integrity fix. It does not make the checkpoint format portable or authenticated, reconstruct later agent history, create performance or scientific evidence, select `reference-dev`, or establish robotics readiness.

<!-- evidence-head:88df0b5afcccb39f2571483759e92c015321dab1 -->
<!-- evidence-row:logs -->
- [x] logs: N/A - exact verification commands and results are reported above; no measured performance claim
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: N/A - validator-only fix; no output artifact was generated

Agent disclosure: provider `openai`, model `gpt-5.6-sol`, client `codex` (`0.153.4`).

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next11]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1X2FW1G1DQ3J8JWN6R5D2MV","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-07T04:37:12.882Z","completed_at":"2026-09-07T05:20:19.439Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-07T04:37:13.121Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d998baa941484a08d0ed365aabf420dc3a1022243988eac76f688d5829487278","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4a3cb541-1d61-4c8c-972d-0c04ccee9804","object_id":"sha256:d998baa941484a08d0ed365aabf420dc3a1022243988eac76f688d5829487278","sha256":"d998baa941484a08d0ed365aabf420dc3a1022243988eac76f688d5829487278"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"s1oxqRxft1CmdQkhG-NttVWOg_qT7ctBgR-3k1KTSvG4hZ4UntKePUzCD5X-NGeIObrxOXaZ-ds-PSzeT6HICg"}} -->
