### PR TITLE
fix: keep differential control state free of host clock

### DIFF
--- a/alberta_framework/reference_life_controls.py
+++ b/alberta_framework/reference_life_controls.py
@@ -1760,7 +1760,15 @@ class DifferentialSARSAReferenceAdapter(_BaseReferenceControlAdapter):
             key,
             name="differential-SARSA initial key",
         )
-        return None, self._differential_agent.init(self.config.observation_dim, explicit_key)
+        learner = self._differential_agent.init(self.config.observation_dim, explicit_key)
+        # The exact-dispatch adapter never calls the core agent's timed loop
+        # helpers. Keep their host-clock metadata out of persistent state, as
+        # the discounted-SARSA adapter does for the same inherited fields.
+        learner = learner.replace(  # type: ignore[attr-defined]
+            birth_timestamp=jnp.asarray(0.0, dtype=jnp.float32),
+            uptime_s=jnp.asarray(0.0, dtype=jnp.float32),
+        )
+        return None, learner
 
     def _start_payload(
         self,
@@ -1799,6 +1807,8 @@ class DifferentialSARSAReferenceAdapter(_BaseReferenceControlAdapter):
             ("average_reward", learner.average_reward, ()),
             ("last_observation", learner.last_observation, (self.config.observation_dim,)),
             ("epsilon", learner.epsilon, ()),
+            ("birth_timestamp", learner.birth_timestamp, ()),
+            ("uptime_s", learner.uptime_s, ()),
         )
         for name, value, shape in expected_float_shapes:
             array = np.asarray(value)
@@ -1827,6 +1837,10 @@ class DifferentialSARSAReferenceAdapter(_BaseReferenceControlAdapter):
         )
         if not _tree_finite(learner):
             raise DecisionOwnershipError("differential-SARSA state must be finite")
+        if float(learner.birth_timestamp) != 0.0 or float(learner.uptime_s) != 0.0:
+            raise DecisionOwnershipError(
+                "differential-SARSA timing metadata must remain disabled"
+            )
         if int(learner.step_count) != state.decision_index:
             raise DecisionOwnershipError("differential-SARSA counter does not match decision")
         if not np.array_equal(step_words, _counter_words(state.decision_index)):

--- a/tests/test_reference_life_controls.py
+++ b/tests/test_reference_life_controls.py
@@ -739,6 +739,39 @@ def test_differential_sarsa_applies_hand_computed_first_update() -> None:
     assert step.event.step_result.parameters_changed
 
 
+def test_differential_sarsa_adapter_excludes_host_clock_from_persistent_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "alberta_framework.core.average_reward.time.time",
+        lambda: 1024.0,
+    )
+    adapter = _differential_switching()
+    runner = _switching_runner(
+        adapter,
+        SwitchingTwoStateConfig(phase_length=2),  # type: ignore[call-arg]
+        lifecycle_id="control.differential.no-clock-state",
+        horizon=1,
+    )
+
+    control_state = runner.init().agent_state
+
+    assert isinstance(control_state, ReferenceLifeControlState)
+    learner = control_state.agent_state
+    assert isinstance(learner, DifferentialSARSAState)
+    assert float(learner.birth_timestamp) == 0.0
+    assert float(learner.uptime_s) == 0.0
+    adapter.validate_state(control_state)
+
+    contaminated = learner.replace(  # type: ignore[attr-defined]
+        birth_timestamp=jnp.asarray(1.0, dtype=jnp.float32)
+    )
+    with pytest.raises(DecisionOwnershipError, match="timing metadata"):
+        adapter.validate_state(
+            dataclasses.replace(control_state, agent_state=contaminated)
+        )
+
+
 def test_discounted_sarsa_updates_on_continuing_unit_discount_outcome() -> None:
     rewarding = SwitchingTwoStateConfig(  # type: ignore[call-arg]
         phase_length=10,


### PR DESCRIPTION
## Summary

- remove host wall-clock input from the differential-SARSA reference control's persistent state
- canonicalize the inherited, unused lifecycle timers to float32 zero, matching the discounted-SARSA exact-control boundary
- reject nonzero or malformed timing metadata during strict control-state validation

## Why

`DifferentialSARSAAgent.init()` records `time.time()` in `birth_timestamp`. The exact-dispatch adapter never uses the core timed-loop helpers, but previously retained that value as a persistent JAX leaf. Identical control initialization could therefore differ solely because of host clock time, despite scorecard timing being telemetry-only.

The regression mocks two different clocks on the unchanged base and observes different accepted persistent states (`128.0` versus `1024.0`). At this commit both initialize to `0.0`, and a nonzero relabel is rejected.

## Verification

- `tests/test_reference_life_controls.py`: 34 passed
- `tests/test_reference_life_scorecard.py`: 67 passed, 1 skipped
- focused untouched-base reproducer: failed before the patch; passes at this commit
- repository-wide Ruff: passed
- strict mypy: passed (224 source files)
- broad fast selector reached 4,776 passed and 13 skipped before an unrelated environment-specific `RLIMIT_FSIZE` test failure; the exact failing test reproduces unchanged on `origin/main`
- evidence registry: pre-existing `invalid` status on current `main` from registered-source drift; this patch does not modify a registered evidence source or any pinned artifact

Verified head: `1947b1b6e1618a3b5cbf46bf68f13fc6b19f8df1`

This remains development-only scorecard hardening. It does not promote `reference-dev`, create performance or scientific evidence, or change any frozen artifact.

<!-- evidence-head:1947b1b6e1618a3b5cbf46bf68f13fc6b19f8df1 -->

GitHub CI at this exact head: [completed successfully](https://github.com/SlopDotCash/asi/actions/runs/34119311123), with 55 passing checks including all 48 Python 3.12/3.13 runtime shards. Draft triage was skipped.

Reproduction commands, using the project venv and the selected checkout as the import source:

```bash
.venv/bin/python -m pytest tests/test_reference_life_controls.py::test_differential_sarsa_adapter_excludes_host_clock_from_persistent_state -q
.venv/bin/python -m pytest tests/test_reference_life_controls.py -q
.venv/bin/python -m pytest tests/test_reference_life_scorecard.py -q
.venv/bin/python -m ruff check .
.venv/bin/python -m mypy
.venv/bin/python -m pytest tests -m "not slow and not package" -q
.venv/bin/python -m pytest tests/test_forager_matched_container_hardening.py::test_runpy_wrapper_enforces_file_limit_in_real_child_without_fork_hook -q
```

The final command reproduced the same local environment failure on both the patch and pristine base `f3d32c451ed1c1715e477ad56b782fc7ea89b206`. The hosted CI run passed at the submitted head.

The receipt retains the original implementation run's model attribution. Administrative completion of the trace and PR handoff was resumed by Codex based on GPT-6.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next13]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1XSTSY13XDRHY337S8CJTEE","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-07T11:25:08.418Z","completed_at":"2026-09-07T13:36:22.476Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-07T11:25:08.672Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e4477a3fc82ec6020e4a12bd56472726014869a0949b01adee2db03e85cd7f6c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"0a68f2e4-163e-4f72-8eab-0187fb7cf73e","object_id":"sha256:e4477a3fc82ec6020e4a12bd56472726014869a0949b01adee2db03e85cd7f6c","sha256":"e4477a3fc82ec6020e4a12bd56472726014869a0949b01adee2db03e85cd7f6c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"DCN-RZnPdJI4wxHzX6yFg_Z0xD4IMpsSYzRAP-QsUU1Lu4ymbrelIzBeGfriRmrNEyJcZlLlC5bQPr0TUGCeAg"}} -->
