### PR TITLE
fix(sarsa): carry delayed reward credit across action changes

### DIFF
--- a/alberta_framework/core/sarsa.py
+++ b/alberta_framework/core/sarsa.py
@@ -35,6 +35,10 @@ from jaxtyping import Float, Int
 
 from alberta_framework.core._float32_scalars import validated_float32_scalar_with_ratio
 from alberta_framework.core.horde import HordeLearner
+from alberta_framework.core.learners import (
+    _gradient_step_error,
+    _update_from_gradient_with_diagnostics,
+)
 from alberta_framework.core.multi_head_learner import (
     MULTI_HEAD_MLP_STATE_SCHEMA,
     AnyOptimizer,
@@ -833,6 +837,42 @@ class SARSAAgent:
             jax.lax.cond(policy_valid, lambda: key, lambda: state.rng_key),
         )
 
+    def _credit_control_trace(
+        self,
+        state: MultiHeadMLPState,
+        index: int,
+        traces: tuple[Array, Array],
+        error: Array,
+    ) -> tuple[Array, Array, tuple[Array, Array], tuple[Any, Any], Array]:
+        """Apply the shared SARSA error to an inactive head's decayed trace."""
+        learner = self._horde.learner
+        optimizer = (
+            learner.head_optimizer if learner.head_optimizer is not None else learner.optimizer
+        )
+        weights, biases = state.head_params.weights[index], state.head_params.biases[index]
+        old_w_opt, old_b_opt = state.head_optimizer_states[index]
+        w_trace, b_trace = traces
+        w_step, w_opt, w_applied = _update_from_gradient_with_diagnostics(
+            optimizer, old_w_opt, w_trace, error=error, param=weights
+        )
+        b_step, b_opt, b_applied = _update_from_gradient_with_diagnostics(
+            optimizer, old_b_opt, b_trace, error=error, param=biases
+        )
+        step_error = _gradient_step_error(optimizer, error)
+        bounder = learner._bounder
+        if bounder is not None:
+            (w_step, b_step), scale = bounder.bound(
+                (w_step, b_step), step_error, (weights, biases)
+            )
+            w_trace, b_trace = scale * w_trace, scale * b_trace
+        return (
+            weights + step_error * w_step,
+            biases + step_error * b_step,
+            (w_trace, b_trace),
+            (w_opt, b_opt),
+            w_applied & b_applied,
+        )
+
     @functools.partial(jax.jit, static_argnums=(0,))
     def update(
         self,
@@ -846,8 +886,9 @@ class SARSAAgent:
         """Perform one SARSA update step.
 
         Computes the SARSA target ``r + gamma * Q(s', a')`` and updates
-        the Horde. Only the previously-taken action's head receives the
-        target; all other Q-heads get NaN (no update).
+        the Horde. Only the previously-taken action's head receives a new
+        prediction gradient. With nonzero lambda, the same TD error also
+        updates other control heads through their decayed eligibility traces.
 
         Args:
             state: Current SARSA state
@@ -975,27 +1016,50 @@ class SARSAAgent:
             discounts,
         )
 
-        # SARSA(lambda) trace maintenance. The inner learner decays only the
-        # active head's trace (inactive heads are frozen by NaN masking), so
-        # decay the untouched control heads here and clear all control-head
-        # traces at episode boundaries so credit never crosses a reset.
+        # SARSA(lambda) uses one TD error for every eligible state/action.
+        # Horde's NaN masking freezes inactive heads, so decay AND credit
+        # those heads here without adding the current observation gradient.
+        # Apply terminal credit before clearing traces for the next episode.
+        q_old = q_previous[safe_last_action]
+        td_error = jnp.where(action_valid, sarsa_target - q_old, 0.0)
         new_learner_state = horde_result.state
+        trace_updates_applied = jnp.asarray(True, dtype=jnp.bool_)
         if self._lamda > 0.0:
             gl = jnp.asarray(gamma * self._lamda, dtype=jnp.float32)
             head_traces = list(new_learner_state.head_traces)
+            head_weights = list(new_learner_state.head_params.weights)
+            head_biases = list(new_learner_state.head_params.biases)
+            head_opt_states = list(new_learner_state.head_optimizer_states)
             for i in range(n_actions):
                 w_trace, b_trace = head_traces[i]
                 decay = jnp.where(state.last_action == i, 1.0, gl)
                 skipped_w = jnp.where(decay == 0.0, jnp.zeros_like(w_trace), decay * w_trace)
                 skipped_b = jnp.where(decay == 0.0, jnp.zeros_like(b_trace), decay * b_trace)
+                if gamma > 0.0:
+                    weights, biases, traces, opt_states, applied = jax.lax.cond(
+                        state.last_action != i,
+                        lambda: self._credit_control_trace(
+                            new_learner_state, i, (skipped_w, skipped_b), td_error
+                        ),
+                        lambda: (
+                            head_weights[i], head_biases[i], (skipped_w, skipped_b),
+                            head_opt_states[i], jnp.asarray(True, dtype=jnp.bool_),
+                        ),
+                    )
+                    head_weights[i], head_biases[i] = weights, biases
+                    skipped_w, skipped_b = traces
+                    head_opt_states[i] = opt_states
+                    trace_updates_applied = trace_updates_applied & applied
                 new_w = jnp.where(safe_terminated, jnp.zeros_like(w_trace), skipped_w)
                 new_b = jnp.where(safe_terminated, jnp.zeros_like(b_trace), skipped_b)
                 head_traces[i] = (new_w, new_b)
-            new_learner_state = new_learner_state.replace(head_traces=tuple(head_traces))
-
-        # TD error for the taken action
-        q_old = q_previous[safe_last_action]
-        td_error = jnp.where(action_valid, sarsa_target - q_old, 0.0)
+            new_learner_state = new_learner_state.replace(
+                head_params=new_learner_state.head_params.replace(
+                    weights=tuple(head_weights), biases=tuple(head_biases)
+                ),
+                head_traces=tuple(head_traces),
+                head_optimizer_states=tuple(head_opt_states),
+            )
 
         # Epsilon decay
         cfg = self._sarsa_config
@@ -1028,6 +1092,7 @@ class SARSAAgent:
             & action_valid
             & inputs_valid
             & (horde_result.update_applied | zero_decay_trace_recovery)
+            & trace_updates_applied
             & candidate_valid
         )
         diagnostic_valid = (

--- a/tests/test_sarsa.py
+++ b/tests/test_sarsa.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from alberta_framework import (
+    Adam,
     Autostep,
     DemonType,
     GVFSpec,
@@ -1176,6 +1177,114 @@ class TestSARSALambdaTraces:
     ``config.gamma * lamda`` — with the TD target still computed
     externally (no internal bootstrap).
     """
+
+    @pytest.mark.parametrize("terminated", [False, True])
+    @pytest.mark.parametrize("lamda", [0.0, 0.8])
+    def test_delayed_reward_credits_previous_action(self, terminated, lamda):
+        """A later action's TD error updates every eligible control head."""
+        agent = _make_agent(
+            hidden_sizes=(), gamma=0.9, epsilon_start=0.0, lamda=lamda, step_size=0.1
+        )
+        state = agent.init(feature_dim=2, key=jr.key(14))
+        inner = state.learner_state
+        # Q(s0, a0) = Q(s1, a1) = 0, but Q(s1, a0) = 0.4. The delayed
+        # update must use the taken action's common TD error, not head 0's.
+        params = inner.head_params.replace(
+            weights=(jnp.array([[0.0, 0.4]]), jnp.zeros((1, 2))),
+            biases=(jnp.zeros(1), jnp.zeros(1)),
+        )
+        state = state.replace(
+            learner_state=inner.replace(head_params=params),
+            last_action=jnp.array(0, dtype=jnp.int32),
+            last_observation=jnp.array([1.0, 0.0]),
+        )
+        first = agent.update(
+            state, jnp.array(0.0), jnp.array([0.0, 1.0]), jnp.array(False), jnp.array(1)
+        )
+        result = agent.update(
+            first.state, jnp.array(1.0), jnp.zeros(2), jnp.array(terminated), jnp.array(0)
+        )
+
+        assert int(result.state.step_count) == 2
+        np.testing.assert_allclose(result.td_error, 1.0)
+        expected_credit = 0.1 * 0.9 * lamda
+        np.testing.assert_allclose(
+            result.state.learner_state.head_params.weights[0],
+            [[expected_credit, 0.4]], rtol=1e-6, atol=1e-8,
+        )
+        np.testing.assert_allclose(
+            result.state.learner_state.head_params.biases[0],
+            [expected_credit], rtol=1e-6, atol=1e-8,
+        )
+        np.testing.assert_allclose(
+            result.state.learner_state.head_params.weights[1], [[0.0, 0.1]], rtol=1e-6
+        )
+        if terminated and lamda > 0.0:
+            for trace in jax.tree.leaves(result.state.learner_state.head_traces):
+                np.testing.assert_array_equal(trace, jnp.zeros_like(trace))
+
+    def test_delayed_credit_uses_head_optimizer_and_bounder(self):
+        """Inactive credit respects Adam's delta convention and the step bound."""
+        agent = _make_agent(
+            hidden_sizes=(), gamma=0.9, epsilon_start=0.0, lamda=0.8,
+            head_optimizer=Adam(step_size=0.2, beta1=0.0, beta2=0.0),
+            bounder=ObGDBounding(kappa=10.0),
+        )
+        state = agent.init(feature_dim=2, key=jr.key(15))
+        inner = state.learner_state
+        state = state.replace(
+            learner_state=inner.replace(
+                head_params=jax.tree.map(jnp.zeros_like, inner.head_params)
+            ),
+            last_action=jnp.array(0, dtype=jnp.int32),
+            last_observation=jnp.array([1.0, 0.0]),
+        )
+        first = agent.update(
+            state, jnp.array(0.0), jnp.array([0.0, 1.0]), jnp.array(False), jnp.array(1)
+        )
+        result = agent.update(
+            first.state, jnp.array(2.0), jnp.zeros(2), jnp.array(False), jnp.array(0)
+        )
+
+        assert int(result.state.step_count) == 2
+        np.testing.assert_allclose(result.td_error, 2.0)
+        # Adam with beta1=beta2=0 proposes +0.2 on each nonzero coordinate.
+        # Two coordinates (weight+bias) meet ObGD's total-step bound of 0.1.
+        np.testing.assert_allclose(
+            result.state.learner_state.head_params.weights[0], [[0.05, 0.0]],
+            rtol=1e-6, atol=1e-8,
+        )
+        np.testing.assert_allclose(
+            result.state.learner_state.head_params.biases[0], [0.05], rtol=1e-6
+        )
+
+    def test_nonfinite_delayed_credit_rolls_back_complete_update(self):
+        """A failing inactive-head update cannot commit the active head or clock."""
+        agent = _make_agent(
+            hidden_sizes=(), gamma=0.9, epsilon_start=0.0, lamda=0.8, step_size=0.1
+        )
+        state = agent.init(feature_dim=2, key=jr.key(16))
+        inner = state.learner_state
+        traces = list(inner.head_traces)
+        traces[0] = (jnp.array([[1e20, 0.0]]), jnp.zeros(1))
+        state = state.replace(
+            learner_state=inner.replace(
+                head_params=jax.tree.map(jnp.zeros_like, inner.head_params),
+                head_traces=tuple(traces),
+                birth_timestamp=jnp.array(0.0),
+                uptime_s=jnp.array(0.0),
+            ),
+            last_action=jnp.array(1, dtype=jnp.int32),
+            last_observation=jnp.array([0.0, 1.0]),
+        )
+        result = agent.update(
+            state, jnp.array(1e20), jnp.zeros(2), jnp.array(False), jnp.array(0)
+        )
+
+        # Head 1's 1e19 update is finite; the inactive head's delayed 7.2e38
+        # update overflows float32. Both updates and both counters must roll back.
+        assert int(result.action) == -1
+        chex.assert_trees_all_equal(result.state, state)
 
     def test_control_head_trace_decay_factor(self):
         """Active control head's trace decays by gamma*lamda, not 0."""


### PR DESCRIPTION
With nonzero λ, switching actions caused SARSA to lose delayed reward credit for earlier actions: inactive head traces decayed, but their weights never received the current TD error. In a two-transition example with α=0.1, γ=0.9, λ=0.8, the earlier action received 0.0 instead of the required 0.072 weight update.

This applies the common SARSA TD error to each inactive control head's decayed trace through the existing checked optimizer and bounder, before terminal trace clearing. Any failed or nonfinite head update rolls back the complete SARSA transaction. This follows the all-state/action update in [Sutton & Barto, Sarsa(λ), §7.5](https://web.stanford.edu/class/psych209/Readings/SuttonBartoIPRLBook2ndEd.pdf#page=197).

Verified head: `319cf8fb3f414012093577e55e726ca3d061b434`
<!-- evidence-head:319cf8fb3f414012093577e55e726ca3d061b434 -->

## Verification

Using the project venv with the selected checkout as its import source:

```bash
.venv/bin/python -m pytest tests/test_sarsa.py::TestSARSALambdaTraces -q
.venv/bin/python -m pytest tests/test_sarsa.py tests/test_reference_life_scorecard.py -q
.venv/bin/python -m pytest tests/test_sarsa.py tests/test_sarsa_update_working_set.py tests/test_reference_life_controls.py tests/test_step4_production.py tests/test_pipeline.py -q
.venv/bin/python -m ruff check .
.venv/bin/python -m mypy
```

- Failure-first proof on unchanged base `f3d32c451ed1c1715e477ad56b782fc7ea89b206`: both λ=0.8 cases failed with missing 0.072 credit; both λ=0 controls passed.
- Final trace lane: 11 passed, covering continuing and terminal delayed credit, λ=0, Adam with an active ObGD bound, and complete rollback on inactive-head overflow.
- Final SARSA + scorecard files: 220 passed, 3 skipped.
- Broader integration panel, before the final two regression cases were added: 439 passed, 2 skipped.
- Ruff and strict mypy passed (224 source files).
- Standalone original reproducer now observes `0.072000004` (float32) against `0.072` expected.
- Evidence registry reports the existing registered-source drift (`invalid`, exit 2). Neither changed file is in a five-claim registered source set; pinned artifacts are unchanged.

## Scope and cost

The additional optimizer work is linear in the inactive control-head parameter count and runs only with nonzero λ and γ. Persistent state layout is unchanged. The λ=0 path, zero-discount trace recovery, and prediction-demon update path retain their existing behavior. The frozen reference-life scorecard's SARSA arm uses λ=0; no scorecard configuration is retuned.

This is a learning-correctness repair, not a benchmark gain, performance result, scientific result, or evidence promotion. Independent review and merge remain maintainer-owned.

Hosted CI: [all 55 CI checks passed](https://github.com/SlopDotCash/asi/actions/runs/34131647599), including `ci-ok`, at the verified head; draft triage was skipped. The previously delayed status for Python 3.12 shard 4 now reports completed/success.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next14]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1Y2EY2YDNJ2SEVB3N1WQ48D","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-07T13:55:56.640Z","completed_at":"2026-09-07T14:32:42.413Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-07T13:55:56.855Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"93b24aa6da96240468fa68af9ffbb9356f084a71aebeec71878d2e0444586645","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"406a140c-d207-4b93-9b89-7be2109c4c4c","object_id":"sha256:93b24aa6da96240468fa68af9ffbb9356f084a71aebeec71878d2e0444586645","sha256":"93b24aa6da96240468fa68af9ffbb9356f084a71aebeec71878d2e0444586645"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"Vrhr6SXM8GOvWJjo52SaR2gqtsSi3xHlhcGFBV3D1n1zphYc3GIr6_JPPf4tqLdWgL_0T3mD3KjGE_tsjWEWCA"}} -->
