### PR TITLE
fix(actor-critic): preserve Gaussian gradients across policy scales

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -1581,14 +1581,17 @@ class ContinuousActorCriticAgent:
         bootstrap = jnp.where(discount == 0.0, jnp.zeros_like(next_value), discount * next_value)
         td_error = reward + bootstrap - value
 
-        sigma_sq = prev_sigma * prev_sigma + 1e-8
         diff = action - prev_mean
         # Gaussian score function (per-dimension):
         #   grad log pi w.r.t. mean   = diff / sigma^2
         #   grad log pi w.r.t. log_sigma = diff^2 / sigma^2 - 1
-        mean_grad_bias = diff / sigma_sq
+        # Standardize first: squaring sigma can underflow/overflow even when
+        # both scores are representable. A fixed variance floor would change
+        # the policy gradient and can reverse the log-sigma update's sign.
+        standardized_diff = diff / prev_sigma
+        mean_grad_bias = standardized_diff / prev_sigma
         mean_grad_weights = mean_grad_bias[:, None] * prev_obs[None, :]
-        log_sigma_grad = (diff * diff) / sigma_sq - 1.0
+        log_sigma_grad = standardized_diff * standardized_diff - 1.0
 
         actor_decay = discount * cfg.actor_lamda
         critic_decay = discount * cfg.critic_lamda

--- a/tests/test_continuous_actor_critic.py
+++ b/tests/test_continuous_actor_critic.py
@@ -136,6 +136,140 @@ def test_continuous_actor_critic_policy_gradient_sign() -> None:
     assert float(result.td_error) > 0.0
 
 
+@pytest.mark.parametrize("log_sigma", [-10.0, -0.5, 0.0, 2.0])
+def test_continuous_actor_critic_scores_match_policy_log_probability(log_sigma: float) -> None:
+    """A rewarded two-sigma action must increase, not decrease, exploration."""
+    config = ContinuousActorCriticConfig(
+        action_dim=3,
+        actor_step_size=0.01,
+        critic_step_size=0.0,
+        actor_lamda=0.0,
+        critic_lamda=0.0,
+        log_sigma_init=log_sigma,
+        log_sigma_min=-60.0,
+        log_sigma_max=60.0,
+    )
+    agent = ContinuousActorCriticAgent(config)
+    obs = jnp.array([1.0, -0.5], dtype=jnp.float32)
+    state = agent.init(feature_dim=2, key=jr.key(150))
+    mean, sigma = agent.policy_params(state, obs)
+    action = mean + sigma * jnp.array([-2.0, 0.0, 2.0], dtype=jnp.float32)
+    state = state.replace(last_observation=obs, last_action=action)
+
+    def log_probability(mean: jax.Array, log_std: jax.Array) -> jax.Array:
+        return jax.scipy.stats.norm.logpdf(action, mean, jnp.exp(log_std)).sum()
+
+    mean_score, sigma_score = jax.grad(log_probability, argnums=(0, 1))(
+        mean, state.log_sigma
+    )
+    result = jax.jit(agent.update)(state, jnp.array(1.0), jnp.zeros_like(obs))
+
+    assert bool(result.update_applied)
+    np.testing.assert_allclose(result.state.mean_trace_bias, mean_score, rtol=1e-6)
+    np.testing.assert_allclose(result.state.log_sigma_trace, sigma_score, rtol=1e-6)
+    np.testing.assert_allclose(
+        result.state.mean_weights,
+        config.actor_step_size * mean_score[:, None] * obs[None, :],
+        rtol=1e-6,
+    )
+    np.testing.assert_allclose(
+        result.state.mean_bias, config.actor_step_size * mean_score, rtol=1e-6
+    )
+    np.testing.assert_allclose(
+        result.state.log_sigma,
+        state.log_sigma + config.actor_step_size * sigma_score,
+        rtol=1e-6,
+    )
+
+
+@pytest.mark.parametrize("log_sigma", [-50.0, 50.0])
+def test_continuous_actor_critic_scores_avoid_variance_range_loss(log_sigma: float) -> None:
+    """The score remains representable even when float32 sigma squared does not."""
+    config = ContinuousActorCriticConfig(
+        action_dim=1,
+        actor_step_size=0.01,
+        critic_step_size=0.0,
+        actor_lamda=0.0,
+        critic_lamda=0.0,
+        log_sigma_init=log_sigma,
+        log_sigma_min=-60.0,
+        log_sigma_max=60.0,
+    )
+    agent = ContinuousActorCriticAgent(config)
+    obs = jnp.ones(1, dtype=jnp.float32)
+    state = agent.init(feature_dim=1, key=jr.key(151))
+    _, sigma = agent.policy_params(state, obs)
+    action = 2.0 * sigma
+    state = state.replace(last_observation=obs, last_action=action)
+    result = jax.jit(agent.update)(state, jnp.array(1.0), jnp.zeros_like(obs))
+
+    assert bool(result.update_applied)
+    # Evaluate the analytic oracle in float64 to avoid the failing intermediates.
+    variance = np.asarray(sigma, dtype=np.float64) ** 2
+    mean_score = np.asarray(action, dtype=np.float64) / variance
+    sigma_score = np.asarray(action, dtype=np.float64) ** 2 / variance - 1.0
+    np.testing.assert_allclose(result.state.mean_trace_bias, mean_score, rtol=1e-6)
+    np.testing.assert_allclose(result.state.log_sigma_trace, sigma_score, rtol=1e-6)
+    np.testing.assert_allclose(
+        result.state.mean_bias, config.actor_step_size * mean_score, rtol=1e-6
+    )
+    np.testing.assert_allclose(
+        result.state.log_sigma, log_sigma + config.actor_step_size * sigma_score, rtol=1e-6
+    )
+
+
+def test_continuous_actor_critic_array_runner_rewards_small_sigma_action() -> None:
+    agent = ContinuousActorCriticAgent(
+        ContinuousActorCriticConfig(
+            action_dim=1,
+            actor_step_size=0.01,
+            critic_step_size=0.0,
+            actor_lamda=0.0,
+            critic_lamda=0.0,
+            log_sigma_init=-10.0,
+            log_sigma_min=-20.0,
+        )
+    )
+    state = agent.init(feature_dim=1, key=jr.key(152))
+    _, sigma = agent.policy_params(state, jnp.ones(1))
+    result = run_continuous_actor_critic_from_arrays(
+        agent,
+        state,
+        observations=jnp.ones((1, 1)),
+        rewards=jnp.ones(1),
+        terminated=jnp.ones(1, dtype=jnp.bool_),
+        next_observations=jnp.zeros((1, 1)),
+        actions=(2.0 * sigma)[None, :],
+    )
+
+    assert bool(result.updates_applied[0])
+    np.testing.assert_allclose(result.state.log_sigma, [-9.97], rtol=1e-6)
+    np.testing.assert_allclose(result.state.mean_weights, 0.02 / sigma[None, :], rtol=1e-6)
+    np.testing.assert_array_equal(result.state.log_sigma_trace, [0.0])
+
+
+@pytest.mark.parametrize("terminated", [False, True])
+def test_continuous_actor_critic_nonfinite_mean_score_rolls_back(terminated: bool) -> None:
+    """An unrepresentable true score must reject the entire transition."""
+    agent = ContinuousActorCriticAgent(
+        ContinuousActorCriticConfig(
+            action_dim=1,
+            log_sigma_init=-85.0,
+            log_sigma_min=-86.0,
+        )
+    )
+    obs = jnp.ones(1)
+    state = agent.init(feature_dim=1, key=jr.key(153))
+    _, sigma = agent.policy_params(state, obs)
+    state = state.replace(last_observation=obs, last_action=100.0 * sigma)
+    result = jax.jit(agent.update)(
+        state, jnp.array(1.0), jnp.zeros_like(obs), terminated=jnp.array(terminated)
+    )
+
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.state, state)
+
+
 def test_continuous_actor_critic_terminal_resets_traces() -> None:
     config = ContinuousActorCriticConfig(
         action_dim=2,


### PR DESCRIPTION
For a narrow Gaussian policy, the continuous actor-critic can move exploration in the wrong direction after a reward. With `log_sigma = -10`, an action two standard deviations above the mean, and TD error 1, the current code computes a log-sigma score of `-0.316432357` instead of `+3`. At actor step size 0.01, log sigma decreases by `0.003164291`; the corrected update increases it by `0.029999733` (float32).

The cause is `sigma² + 1e-8` in the score denominator, which differs from the variance of the sampled policy. Compute the standardized residual first, then the mean and log-sigma scores from it. This also avoids squaring very large or small standard deviations when the actual scores remain representable. The equations follow by differentiating the diagonal Gaussian log-likelihood in [Spinning Up, Key Concepts in RL](https://spinningup.openai.com/en/latest/spinningup/rl_intro.html#stochastic-policies).

Verified head: `42b08a1f0b11b9d93ad006432b73507b56be620e`
<!-- evidence-head:42b08a1f0b11b9d93ad006432b73507b56be620e -->

## Verification

Run from this checkout using the project venv:

```bash
.venv/bin/python -m pytest tests/test_continuous_actor_critic.py -k 'scores_match or scores_avoid' -q -o addopts=''
.venv/bin/python -m pytest tests/test_continuous_actor_critic.py tests/test_actor_critic.py tests/test_actor_critic_merged_runtime_residuals.py tests/test_actor_critic_update_working_set.py tests/test_horde_actor_critic.py -q -o addopts=''
.venv/bin/python -m ruff check .
.venv/bin/python -m mypy
```

Executed here with `PYTHONPATH` selecting this checkout and `OMP_NUM_THREADS=1`, using the existing project venv.

- Failure-first on unchanged base `f3d32c451ed1c1715e477ad56b782fc7ea89b206`: 3 failures, 3 passing controls. The narrow policy has an incorrect score; `log_sigma = -50` loses the mean score; `log_sigma = +50` rejects an otherwise representable update.
- All six original regression cases pass after the correction. Moderate scales use independent autodifferentiation of `jax.scipy.stats.norm.logpdf`; extreme scales use a float64 analytic oracle.
- Final panel: **235 passed**. It includes the public array runner, terminal trace clearing, whole-state rollback for a nonfinite true mean score, existing bounder tests, discrete actor-critic, and Horde integration. New deterministic fixtures use JAX keys 150–153; they are unit fixtures, not benchmark seeds.
- Repository-wide Ruff and strict mypy pass (224 source files); `git diff --check` passes.
- Evidence registry retains its existing five invalid claims from registered-source drift (exit 2). Neither changed file is in a five-claim registered source set. No pinned output was modified.

## Scope

This fixes the continuous Gaussian score calculation only. Persistent state, configuration, and resource accounting are unchanged. Removing the implicit variance floor increases mean updates for narrow policies; the existing configured bounder and transaction guards still apply. The unclipped Gaussian score remains the existing model; this does not introduce a likelihood correction for optional action clipping.

This is a correctness repair, with no benchmark gain or scientific promotion claim. Independent review and merge remain maintainer-owned.

Hosted CI: [all 55 CI checks passed](https://github.com/SlopDotCash/asi/actions/runs/34134897009), including all 48 runtime shards and `ci-ok`, at the verified head. Draft triage was skipped.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next15]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1Y4SR64QJKNVBGSG8MNNZ1X","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-07T14:36:48.198Z","completed_at":"2026-09-07T15:03:06.384Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-07T14:36:48.401Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f507d98098cd83bf0690823eafe993066ce74173e49c01dc76931c3cf5ac5f07","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"77106b91-a168-4e2f-b280-ead366a37ddc","object_id":"sha256:f507d98098cd83bf0690823eafe993066ce74173e49c01dc76931c3cf5ac5f07","sha256":"f507d98098cd83bf0690823eafe993066ce74173e49c01dc76931c3cf5ac5f07"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"Yu8yzqfvEQMAXTNaZeqDp9tWlTOUKk8dz-Ndn6QJhscPM5SGIvR5YT4fey_yCFKx1B4nYcYtu3yH3Y7fEsS_Cw"}} -->
