### PR TITLE
fix(actor-critic): preserve delayed credit across discount changes

### DIFF
--- a/alberta_framework/core/actor_critic.py
+++ b/alberta_framework/core/actor_critic.py
@@ -100,15 +100,15 @@ def _serialized_mapping(
 
 
 def _require_discrete_state_resources(n_actions: int, feature_dim: int) -> None:
-    state_scalars = 2 * n_actions * feature_dim + 3 * feature_dim + 2 * n_actions + 6
-    state_bytes = 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 24
+    state_scalars = 2 * n_actions * feature_dim + 3 * feature_dim + 2 * n_actions + 7
+    state_bytes = 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 28
     if state_scalars > _INT32_MAX or state_bytes > _INT32_MAX:
         raise ValueError("derived actor-critic state exceeds the signed-int32 budget")
 
 
 def _actor_critic_persistent_bytes(n_actions: int, feature_dim: int) -> int:
     """Named persist already counted inside ``_require_discrete_state_resources``."""
-    return 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 24
+    return 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 28
 
 
 def _actor_critic_update_result_extras_bytes(n_actions: int) -> int:
@@ -137,15 +137,15 @@ def _preflight_actor_critic_update_working_set(n_actions: int, feature_dim: int)
 
 
 def _require_continuous_state_resources(action_dim: int, feature_dim: int) -> None:
-    state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 5
-    state_bytes = 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 20
+    state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 6
+    state_bytes = 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 24
     if state_scalars > _INT32_MAX or state_bytes > _INT32_MAX:
         raise ValueError("derived continuous actor-critic state exceeds the signed-int32 budget")
 
 
 def _continuous_actor_critic_persistent_bytes(action_dim: int, feature_dim: int) -> int:
     """Named persist already counted inside ``_require_continuous_state_resources``."""
-    return 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 20
+    return 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 24
 
 
 def _continuous_actor_critic_update_result_extras_bytes(action_dim: int) -> int:
@@ -190,8 +190,8 @@ def _require_discrete_scan_resources(
     # the remaining terms cover every matrix/vector-width gradient, trace,
     # step, policy, selection, and scalar temporary. Charging every temporary
     # as four bytes also upper-bounds int32, uint32, and bool predicates.
-    state_scalars = 2 * n_actions * feature_dim + 3 * feature_dim + 2 * n_actions + 6
-    state_bytes = 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 24
+    state_scalars = 2 * n_actions * feature_dim + 3 * feature_dim + 2 * n_actions + 7
+    state_bytes = 8 * n_actions * feature_dim + 12 * feature_dim + 8 * n_actions + 28
     input_scalars = num_steps * (2 * feature_dim + 4)
     input_bytes = num_steps * (8 * feature_dim + 13)
     output_scalars = num_steps * (n_actions + 4)
@@ -219,8 +219,8 @@ def _require_continuous_scan_resources(
     # This is the continuous analogue of _require_discrete_scan_resources:
     # action inputs and action/mean/sigma outputs have action_dim width, while
     # the reusable workspace includes Gaussian-policy gradients and samples.
-    state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 5
-    state_bytes = 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 20
+    state_scalars = 2 * action_dim * feature_dim + 5 * action_dim + 3 * feature_dim + 6
+    state_bytes = 8 * action_dim * feature_dim + 20 * action_dim + 12 * feature_dim + 24
     input_scalars = num_steps * (2 * feature_dim + action_dim + 3)
     input_bytes = num_steps * (8 * feature_dim + 4 * action_dim + 9)
     output_scalars = num_steps * (3 * action_dim + 3)
@@ -446,6 +446,7 @@ class ActorCriticState:
         actor_trace_bias: Eligibility trace for actor bias.
         critic_trace_weights: Eligibility trace for critic weights.
         critic_trace_bias: Eligibility trace for critic bias.
+        previous_discount: Discount from the preceding accepted transition.
         last_observation: Previous observation ``s_t``.
         last_action: Previous action ``a_t``.
         rng_key: Random key used for action sampling.
@@ -460,6 +461,7 @@ class ActorCriticState:
     actor_trace_bias: Float[Array, " n_actions"]
     critic_trace_weights: Float[Array, " feature_dim"]
     critic_trace_bias: Float[Array, ""]
+    previous_discount: Float[Array, ""]
     last_observation: Float[Array, " feature_dim"]
     last_action: Int[Array, ""]
     rng_key: Array
@@ -524,12 +526,15 @@ class ActorCriticAgent:
 
     The implemented objective is the continuing or episodic AC(lambda)
     semi-gradient update. For transition ``S_t, A_t, R_{t+1}, S_{t+1}``, the
-    critic forms ``delta_t = R_{t+1} + gamma_t V(S_{t+1}) - V(S_t)`` and
+    critic forms ``delta_t = R_{t+1} + gamma_{t+1} V(S_{t+1}) - V(S_t)`` and
     updates value parameters along accumulating traces
     ``e^v_t = gamma_t lambda_v e^v_{t-1} + grad V(S_t)``. The actor updates
     linear softmax logits in the policy-gradient direction
     ``delta_t e^pi_t``, with
     ``e^pi_t = gamma_t lambda_pi e^pi_{t-1} + grad log pi(A_t | S_t)``.
+    Here ``gamma_t`` is carried from the preceding accepted transition, while
+    the update argument is the outgoing ``gamma_{t+1}``. Terminal rewards
+    credit the accumulated traces before they are cleared.
     Because logits are divided by ``temperature`` before the softmax,
     ``grad log pi`` includes the corresponding ``1 / temperature`` factor.
     """
@@ -613,6 +618,7 @@ class ActorCriticAgent:
             actor_trace_bias=zeros_policy_bias,
             critic_trace_weights=zeros_critic,
             critic_trace_bias=jnp.array(0.0, dtype=jnp.float32),
+            previous_discount=jnp.array(1.0, dtype=jnp.float32),
             last_observation=jnp.zeros((feature_dim,), dtype=jnp.float32),
             last_action=jnp.array(-1, dtype=jnp.int32),
             rng_key=key,
@@ -639,7 +645,7 @@ class ActorCriticAgent:
             leaf = getattr(state, name)
             if leaf.shape != (feature_dim,) or leaf.dtype != jnp.float32:
                 raise ValueError(f"state.{name} must have shape ({feature_dim},) and dtype float32")
-        for name in ("critic_bias", "critic_trace_bias"):
+        for name in ("critic_bias", "critic_trace_bias", "previous_discount"):
             leaf = getattr(state, name)
             if leaf.shape != () or leaf.dtype != jnp.float32:
                 raise ValueError(f"state.{name} must be a scalar float32")
@@ -724,8 +730,10 @@ class ActorCriticAgent:
 
         The transition is ``(state.last_observation, state.last_action,
         reward, observation)`` plus either a scalar transition ``discount`` or
-        the legacy ``terminated`` flag. A next action is sampled and stored in
-        the returned state for the following update.
+        the legacy ``terminated`` flag. Eligibility traces decay with the
+        preceding accepted transition's discount. The supplied discount is
+        retained only if this complete update is accepted. A next action is
+        sampled and stored in the returned state for the following update.
 
         Args:
             state: Current agent state with a valid previous observation/action.
@@ -734,7 +742,7 @@ class ActorCriticAgent:
             terminated: Backward-compatible scalar terminal flag. Non-zero
                 maps to transition discount ``0``; false maps to
                 ``config.gamma``. Ignored when ``discount`` is provided.
-            discount: Optional scalar per-transition discount ``gamma_t``.
+            discount: Optional outgoing transition discount ``gamma_{t+1}``.
                 Use this for continuing logs, variable discounts, time-limit
                 truncation semantics, and pre-collected trajectories.
 
@@ -768,8 +776,10 @@ class ActorCriticAgent:
         actor_grad_bias = (one_hot - old_policy) / cfg.temperature
         actor_grad_weights = actor_grad_bias[:, None] * prev_obs[None, :]
 
-        actor_decay = discount * cfg.actor_lamda
-        critic_decay = discount * cfg.critic_lamda
+        # Traces use the discount into the current state; the supplied
+        # discount controls the outgoing bootstrap and post-update clearing.
+        actor_decay = state.previous_discount * cfg.actor_lamda
+        critic_decay = state.previous_discount * cfg.critic_lamda
         actor_trace_weights = (
             jnp.where(
                 actor_decay == 0.0,
@@ -857,6 +867,7 @@ class ActorCriticAgent:
             actor_trace_bias=stored_actor_trace_bias,
             critic_trace_weights=stored_critic_trace_weights,
             critic_trace_bias=stored_critic_trace_bias,
+            previous_discount=discount,
             step_count=jnp.minimum(state.step_count, _INT32_MAX - 1) + 1,
         )
         # Reject the complete transition if its inputs or proposed persistent
@@ -868,6 +879,8 @@ class ActorCriticAgent:
             & jnp.isfinite(discount)
             & (discount >= 0.0)
             & (discount <= 1.0)
+            & (state.previous_discount >= 0.0)
+            & (state.previous_discount <= 1.0)
             & (action >= 0)
             & (action < cfg.n_actions)
             & jnp.all(jnp.isfinite(old_policy))
@@ -1228,6 +1241,7 @@ class ContinuousActorCriticState:
         log_sigma_trace: Trace for ``log_sigma``.
         critic_trace_weights: Trace for critic weights.
         critic_trace_bias: Trace for critic bias.
+        previous_discount: Discount from the preceding accepted transition.
         last_observation: Previous observation ``s_t``.
         last_action: Previous (continuous) action vector ``a_t``.
         rng_key: Random key used for action sampling.
@@ -1244,6 +1258,7 @@ class ContinuousActorCriticState:
     log_sigma_trace: Float[Array, " action_dim"]
     critic_trace_weights: Float[Array, " feature_dim"]
     critic_trace_bias: Float[Array, ""]
+    previous_discount: Float[Array, ""]
     last_observation: Float[Array, " feature_dim"]
     last_action: Float[Array, " action_dim"]
     rng_key: Array
@@ -1406,6 +1421,7 @@ class ContinuousActorCriticAgent:
             log_sigma_trace=jnp.zeros_like(log_sigma),
             critic_trace_weights=zeros_critic,
             critic_trace_bias=jnp.array(0.0, dtype=jnp.float32),
+            previous_discount=jnp.array(1.0, dtype=jnp.float32),
             last_observation=jnp.zeros((feature_dim,), dtype=jnp.float32),
             last_action=jnp.zeros((cfg.action_dim,), dtype=jnp.float32),
             rng_key=key,
@@ -1438,7 +1454,7 @@ class ContinuousActorCriticAgent:
             leaf = getattr(state, name)
             if leaf.shape != (feature_dim,) or leaf.dtype != jnp.float32:
                 raise ValueError(f"state.{name} must have shape ({feature_dim},) and dtype float32")
-        for name in ("critic_bias", "critic_trace_bias"):
+        for name in ("critic_bias", "critic_trace_bias", "previous_discount"):
             leaf = getattr(state, name)
             if leaf.shape != () or leaf.dtype != jnp.float32:
                 raise ValueError(f"state.{name} must be a scalar float32")
@@ -1543,8 +1559,10 @@ class ContinuousActorCriticAgent:
 
         The transition is ``(state.last_observation, state.last_action,
         reward, observation)`` plus either a scalar transition ``discount`` or
-        the legacy ``terminated`` flag. A next action is sampled and stored in
-        the returned state for the following update.
+        the legacy ``terminated`` flag. Eligibility traces decay with the
+        preceding accepted transition's discount. The supplied discount is
+        retained only if this complete update is accepted. A next action is
+        sampled and stored in the returned state for the following update.
 
         Args:
             state: Current agent state with a valid previous observation/action.
@@ -1553,7 +1571,7 @@ class ContinuousActorCriticAgent:
             terminated: Backward-compatible scalar terminal flag. Non-zero
                 maps to transition discount ``0``; false maps to
                 ``config.gamma``. Ignored when ``discount`` is provided.
-            discount: Optional scalar per-transition discount ``gamma_t``.
+            discount: Optional outgoing transition discount ``gamma_{t+1}``.
 
         Returns:
             ``ContinuousActorCriticUpdateResult`` containing the updated state.
@@ -1590,8 +1608,10 @@ class ContinuousActorCriticAgent:
         mean_grad_weights = mean_grad_bias[:, None] * prev_obs[None, :]
         log_sigma_grad = (diff * diff) / sigma_sq - 1.0
 
-        actor_decay = discount * cfg.actor_lamda
-        critic_decay = discount * cfg.critic_lamda
+        # Traces use the discount into the current state; the supplied
+        # discount controls the outgoing bootstrap and post-update clearing.
+        actor_decay = state.previous_discount * cfg.actor_lamda
+        critic_decay = state.previous_discount * cfg.critic_lamda
         mean_trace_weights = (
             jnp.where(
                 actor_decay == 0.0,
@@ -1698,6 +1718,7 @@ class ContinuousActorCriticAgent:
             log_sigma_trace=stored_log_sigma_trace,
             critic_trace_weights=stored_critic_trace_weights,
             critic_trace_bias=stored_critic_trace_bias,
+            previous_discount=discount,
             step_count=jnp.minimum(state.step_count, _INT32_MAX - 1) + 1,
         )
         inputs_valid = (
@@ -1707,6 +1728,8 @@ class ContinuousActorCriticAgent:
             & jnp.isfinite(discount)
             & (discount >= 0.0)
             & (discount <= 1.0)
+            & (state.previous_discount >= 0.0)
+            & (state.previous_discount <= 1.0)
             & jnp.all(jnp.isfinite(prev_mean))
             & jnp.all(jnp.isfinite(prev_sigma))
             & jnp.isfinite(value)

--- a/tests/test_actor_critic_merged_runtime_residuals.py
+++ b/tests/test_actor_critic_merged_runtime_residuals.py
@@ -190,8 +190,8 @@ def test_scan_terminated_contract_accepts_jit_tracers(continuous: bool) -> None:
 
 
 def test_discrete_scan_working_set_formula_has_exact_byte_boundary() -> None:
-    # Two 52-byte carry trees plus an 880-byte reusable workspace.
-    last_legal = (2**31 - 1 - 984) // 38
+    # Two 56-byte carry trees plus a 912-byte reusable workspace.
+    last_legal = (2**31 - 1 - 1_024) // 38
     actor_critic_module._require_discrete_scan_resources(
         n_actions=1, feature_dim=1, num_steps=last_legal
     )
@@ -202,8 +202,8 @@ def test_discrete_scan_working_set_formula_has_exact_byte_boundary() -> None:
 
 
 def test_continuous_scan_working_set_formula_has_exact_byte_boundary() -> None:
-    # Two 60-byte carry trees plus a 976-byte reusable workspace.
-    last_legal = (2**31 - 1 - 1_096) // 42
+    # Two 64-byte carry trees plus a 1,008-byte reusable workspace.
+    last_legal = (2**31 - 1 - 1_136) // 42
     actor_critic_module._require_continuous_scan_resources(
         action_dim=1, feature_dim=1, num_steps=last_legal
     )
@@ -216,8 +216,8 @@ def test_continuous_scan_working_set_formula_has_exact_byte_boundary() -> None:
 @pytest.mark.parametrize(
     ("continuous", "exact_bytes"),
     [
-        (False, 4_410),
-        (True, 5_022),
+        (False, 4_450),
+        (True, 5_062),
     ],
 )
 def test_scan_working_set_formula_covers_multidimensional_terms(

--- a/tests/test_actor_critic_trace_discount.py
+++ b/tests/test_actor_critic_trace_discount.py
@@ -1,0 +1,187 @@
+"""Actor and critic delayed credit uses the preceding transition's discount."""
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.actor_critic import (
+    ActorCriticAgent,
+    ActorCriticConfig,
+    ContinuousActorCriticAgent,
+    ContinuousActorCriticConfig,
+    run_actor_critic_from_arrays,
+    run_continuous_actor_critic_from_arrays,
+)
+
+
+@pytest.mark.parametrize("continuous", [False, True])
+@pytest.mark.parametrize("outgoing_discount", [0.0, 0.7])
+@pytest.mark.parametrize("disable_jit", [False, True])
+@pytest.mark.parametrize("fixed_actions", [False, True])
+def test_array_runner_credits_previous_discount(
+    continuous: bool, outgoing_discount: float, disable_jit: bool, fixed_actions: bool
+) -> None:
+    # The first transition has no reward, so both parameter vectors stay zero.
+    # At the second reward, the first feature's eligibility is 0.4 * 0.8,
+    # independently of the second transition's bootstrap discount or cfg.gamma.
+    kwargs = dict(
+        gamma=0.9,
+        actor_lamda=0.8,
+        critic_lamda=0.8,
+        actor_step_size=0.1,
+        critic_step_size=0.1,
+    )
+    observations = jnp.eye(2, dtype=jnp.float32)
+    next_observations = jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=jnp.float32)
+    rewards = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    discounts = jnp.array([0.4, outgoing_discount], dtype=jnp.float32)
+    with jax.disable_jit(disable_jit):
+        if continuous:
+            agent = ContinuousActorCriticAgent(
+                ContinuousActorCriticConfig(action_dim=1, log_sigma_init=0.0, **kwargs)
+            )
+            result = run_continuous_actor_critic_from_arrays(
+                agent,
+                agent.init(2, jr.key(170)),
+                observations,
+                rewards,
+                None,
+                next_observations,
+                actions=jnp.array([[2.0], [1.0]], dtype=jnp.float32) if fixed_actions else None,
+                discounts=discounts,
+            )
+            actor_weights = result.state.mean_weights
+            sampled = np.asarray(result.actions, dtype=np.float64)[:, 0]
+            expected_actor = [[0.032 * sampled[0], 0.1 * sampled[1]]]
+            np.testing.assert_allclose(
+                result.state.log_sigma,
+                [0.032 * (sampled[0] ** 2 - 1.0) + 0.1 * (sampled[1] ** 2 - 1.0)],
+                rtol=1e-6,
+                atol=1e-7,
+            )
+            actor_trace = result.state.mean_trace_weights
+        else:
+            agent = ActorCriticAgent(ActorCriticConfig(n_actions=2, **kwargs))
+            result = run_actor_critic_from_arrays(
+                agent,
+                agent.init(2, jr.key(170)),
+                observations,
+                rewards,
+                None,
+                next_observations,
+                actions=jnp.zeros((2,), dtype=jnp.int32) if fixed_actions else None,
+                discounts=discounts,
+            )
+            actor_weights = result.state.actor_weights
+            signs = 1.0 - 2.0 * np.asarray(result.actions)
+            expected_actor = [
+                [0.016 * signs[0], 0.05 * signs[1]],
+                [-0.016 * signs[0], -0.05 * signs[1]],
+            ]
+            actor_trace = result.state.actor_trace_weights
+    np.testing.assert_array_equal(result.updates_applied, [True, True])
+    np.testing.assert_allclose(result.state.critic_weights, [0.032, 0.1], rtol=1e-6)
+    np.testing.assert_allclose(result.state.critic_bias, 0.132, rtol=1e-6)
+    np.testing.assert_allclose(actor_weights, expected_actor, rtol=1e-6)
+    if outgoing_discount == 0.0:
+        np.testing.assert_array_equal(result.state.critic_trace_weights, [0.0, 0.0])
+        np.testing.assert_array_equal(actor_trace, jnp.zeros_like(actor_trace))
+
+
+@pytest.fixture(params=[False, True], ids=["discrete", "continuous"])
+def agent(request: pytest.FixtureRequest) -> ActorCriticAgent | ContinuousActorCriticAgent:
+    kwargs = dict(
+        gamma=0.9,
+        actor_lamda=0.8,
+        critic_lamda=0.8,
+        actor_step_size=0.1,
+        critic_step_size=0.1,
+    )
+    if request.param:
+        return ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1, **kwargs))
+    return ActorCriticAgent(ActorCriticConfig(n_actions=2, **kwargs))
+
+
+def test_rejected_transition_preserves_discount_and_delayed_credit(agent) -> None:
+    state = agent.init(3, jr.key(171))
+    observations = jnp.eye(3, dtype=jnp.float32)
+    state = agent.start(state, observations[0])[0]
+    first = agent.update(state, jnp.float32(0.0), observations[1], discount=jnp.float32(0.4))
+    assert bool(first.update_applied)
+    assert float(first.state.previous_discount) == pytest.approx(0.4)
+    rejected = agent.update(
+        first.state, jnp.float32(jnp.nan), observations[2], discount=jnp.float32(0.7)
+    )
+    assert not bool(rejected.update_applied)
+    for old, new in zip(jax.tree.leaves(first.state), jax.tree.leaves(rejected.state), strict=True):
+        if jax.dtypes.issubdtype(old.dtype, jax.dtypes.prng_key):
+            old, new = jr.key_data(old), jr.key_data(new)
+        np.testing.assert_array_equal(old, new)
+    terminal = agent.update(
+        rejected.state, jnp.float32(1.0), observations[2], discount=jnp.float32(0.0)
+    )
+    assert bool(terminal.update_applied)
+    np.testing.assert_allclose(terminal.state.critic_weights, [0.032, 0.1, 0.0], rtol=1e-6)
+    assert float(terminal.state.previous_discount) == 0.0
+    restarted = agent.start(terminal.state, observations[2])[0]
+    after_reset = agent.update(
+        restarted, jnp.float32(1.0), observations[2], discount=jnp.float32(0.9)
+    )
+    assert bool(after_reset.update_applied)
+    np.testing.assert_array_equal(
+        after_reset.state.critic_weights[:2], terminal.state.critic_weights[:2]
+    )
+    assert float(after_reset.state.previous_discount) == pytest.approx(0.9)
+
+
+def test_legacy_terminal_flag_credits_prior_trace(agent) -> None:
+    state = agent.init(2, jr.key(174))
+    observations = jnp.eye(2, dtype=jnp.float32)
+    state = agent.start(state, observations[0])[0]
+    first = agent.update(state, jnp.float32(0.0), observations[1], terminated=jnp.bool_(False))
+    terminal = agent.update(
+        first.state, jnp.float32(1.0), jnp.zeros((2,)), terminated=jnp.bool_(True)
+    )
+    assert bool(first.update_applied) and bool(terminal.update_applied)
+    np.testing.assert_allclose(terminal.state.critic_weights, [0.072, 0.1], rtol=1e-6)
+    np.testing.assert_array_equal(terminal.state.critic_trace_weights, [0.0, 0.0])
+
+
+def test_previous_discount_counts_toward_persistent_bytes(agent) -> None:
+    from alberta_framework.core.actor_critic import (
+        _actor_critic_persistent_bytes,
+        _continuous_actor_critic_persistent_bytes,
+    )
+
+    state = agent.init(3, jr.key(175))
+    physical_leaves = [
+        jr.key_data(leaf) if jax.dtypes.issubdtype(leaf.dtype, jax.dtypes.prng_key) else leaf
+        for leaf in jax.tree.leaves(state)
+    ]
+    actual_bytes = sum(leaf.size * leaf.dtype.itemsize for leaf in physical_leaves)
+    if isinstance(agent, ActorCriticAgent):
+        assert actual_bytes == _actor_critic_persistent_bytes(2, 3)
+    else:
+        assert actual_bytes == _continuous_actor_critic_persistent_bytes(1, 3)
+
+
+@pytest.mark.parametrize("previous_discount", [-0.1, 1.1, float("nan"), float("inf")])
+def test_invalid_previous_discount_rejects_update(agent, previous_discount: float) -> None:
+    observation = jnp.ones((1,), dtype=jnp.float32)
+    state = agent.start(agent.init(1, jr.key(172)), observation)[0].replace(
+        previous_discount=jnp.float32(previous_discount)
+    )
+    result = agent.update(state, jnp.float32(1.0), observation, discount=jnp.float32(0.5))
+    assert not bool(result.update_applied)
+    assert int(result.state.step_count) == 0
+    np.testing.assert_array_equal(result.state.previous_discount, state.previous_discount)
+    np.testing.assert_array_equal(result.state.critic_weights, state.critic_weights)
+
+
+@pytest.mark.parametrize("previous_discount", [jnp.ones((1,)), jnp.int32(1)])
+def test_previous_discount_requires_scalar_float32(agent, previous_discount: jax.Array) -> None:
+    state = agent.init(1, jr.key(173)).replace(previous_discount=previous_discount)
+    with pytest.raises(ValueError, match="previous_discount must be a scalar float32"):
+        agent.update(state, jnp.float32(1.0), jnp.ones((1,)), discount=jnp.float32(0.5))

--- a/tests/test_actor_critic_update_working_set.py
+++ b/tests/test_actor_critic_update_working_set.py
@@ -24,8 +24,8 @@ from alberta_framework.core.actor_critic import (
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
 _OVERFLOW_FEATURE_DIM = 40_000_000
-_LAST_FIT_FEATURE_DIM = 35_791_392
-_FIRST_OVERFLOW_FEATURE_DIM = 35_791_393
+_LAST_FIT_FEATURE_DIM = 35_791_391
+_FIRST_OVERFLOW_FEATURE_DIM = 35_791_392
 _CONTINUOUS_LAST_FIT_FEATURE_DIM = 35_791_391
 _CONTINUOUS_FIRST_OVERFLOW_FEATURE_DIM = 35_791_392
 
@@ -43,7 +43,7 @@ def test_named_persist_and_width_still_fit_at_overflow() -> None:
     persist_bytes = _actor_critic_persistent_bytes(1, _OVERFLOW_FEATURE_DIM)
     working_set_bytes = _actor_critic_update_working_set_bytes(1, _OVERFLOW_FEATURE_DIM)
     extras_bytes = working_set_bytes - 3 * persist_bytes
-    assert persist_bytes == 800_000_032
+    assert persist_bytes == 800_000_036
     assert persist_bytes <= _INT32_MAX
     assert persist_bytes + extras_bytes <= _INT32_MAX
     assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
@@ -93,7 +93,7 @@ def test_persist_bound_still_fires_before_working_set() -> None:
 
 def test_legal_small_actor_critic_still_updates() -> None:
     persist_bytes = _actor_critic_persistent_bytes(1, 4)
-    assert persist_bytes == 112
+    assert persist_bytes == 116
     agent = ActorCriticAgent(ActorCriticConfig(n_actions=1))
     state = agent.init(4, jr.key(0))
     observation = jnp.zeros((4,), dtype=jnp.float32)
@@ -112,7 +112,7 @@ def test_continuous_named_persist_and_width_still_fit_at_overflow() -> None:
         1, _OVERFLOW_FEATURE_DIM
     )
     extras_bytes = working_set_bytes - 3 * persist_bytes
-    assert persist_bytes == 800_000_040
+    assert persist_bytes == 800_000_044
     assert persist_bytes <= _INT32_MAX
     assert persist_bytes + extras_bytes <= _INT32_MAX
     assert 4 * _OVERFLOW_FEATURE_DIM <= _INT32_MAX
@@ -161,7 +161,7 @@ def test_continuous_persist_bound_still_fires_before_working_set() -> None:
 
 def test_legal_small_continuous_actor_critic_still_updates() -> None:
     persist_bytes = _continuous_actor_critic_persistent_bytes(1, 5)
-    assert persist_bytes == 140
+    assert persist_bytes == 144
     agent = ContinuousActorCriticAgent(ContinuousActorCriticConfig(action_dim=1))
     state = agent.init(5, jr.key(0))
     observation = jnp.zeros((5,), dtype=jnp.float32)


### PR DESCRIPTION
A terminal reward currently loses all credit for earlier states in the linear discrete and Gaussian actor-critic agents. With rewards `[0, 1]`, discounts `[0.4, 0]`, lambda `0.8`, and step size `0.1`, the public array runner learns critic weights `[0, 0.1]`; the correct result is `[0.032, 0.1]`. Changing the second discount to `0.7` produces `[0.056, 0.1]` on main, also incorrectly using the outgoing discount for the retained eligibility.

Carry `previous_discount` in both linear actor-critic states and use it for actor and critic trace decay. The supplied discount still controls the current bootstrap and clearing after a terminal update, and becomes the stored discount only when the complete transaction commits. Invalid discount history rejects the update. Initialization uses `1.0`, which is inert against zero initial traces; action selection preserves the history.

This addresses the linear-agent correctness concern in [closed PR #2350](https://github.com/SlopDotCash/asi/pull/2350#issuecomment-5549670633). The variable-discount rule follows Sutton & Barto, second edition, [equations 12.23 and 12.25](https://www.andrew.cmu.edu/course/10-703/textbook/BartoSutton.pdf#page=331): the bootstrap uses the outgoing discount, while the trace uses the incoming discount. This changes the discount indexing in the existing semi-gradient actor-critic update; it does not introduce a new policy-gradient objective.

Verified head: `fcedb945c541cb258c81b6c5cf1c8e49749b6b3c`
<!-- evidence-head:fcedb945c541cb258c81b6c5cf1c8e49749b6b3c -->

## Verification

Executed from this checkout with the existing project venv, `PYTHONPATH` selecting this source, and `OMP_NUM_THREADS=1`:

```bash
.venv/bin/python -m pytest tests/test_actor_critic_trace_discount.py tests/test_actor_critic.py tests/test_continuous_actor_critic.py tests/test_actor_critic_merged_runtime_residuals.py tests/test_actor_critic_update_working_set.py tests/test_horde_actor_critic.py -q --tb=short -o addopts=''
.venv/bin/python -m pytest tests/test_step_scan_bounds_validation.py::test_actor_critic_scan_validation tests/test_bounder_normalizer_config_truthiness.py::TestActorCriticBounderConfigTruthiness -q --tb=short -o addopts=''
.venv/bin/python -m ruff check .
.venv/bin/python -m mypy
```

- Failure-first at base `f3d32c451ed1c1715e477ad56b782fc7ea89b206`: all **8 initial regressions fail**, spanning both agents, terminal/nonterminal outgoing discounts, and JIT/eager execution. The untouched standalone public-runner reproduction also fails its numeric assertion.
- Final main panel: **260 passed**. Additional scan/config consumers: **3 passed**. Ruff and strict mypy pass (224 source files); `git diff --check` passes.
- New regression coverage includes sampled and supplied actions, actor and critic weights, Gaussian log-sigma credit, the legacy terminal flag, full-state rollback including the RNG key, continued credit after a rejected update, post-terminal reset, invalid history values and shape/dtype, and actual persistent byte accounting. Deterministic unit fixtures use JAX keys 170–175.
- Corrected terminal fixture: critic `[0.032, 0.1]`; discrete actor `[[0.016, 0.05], [-0.016, -0.05]]`; both updates accepted. The nonterminal discount-change fixture now uses the same correct incoming-discount weight. Legacy `gamma=0.9` termination yields critic `[0.072, 0.1]`.

## Scope and resources

`ActorCriticState` and `ContinuousActorCriticState` each gain one required float32 leaf: **4 persistent bytes**, **12 bytes** in the three-state update envelope, and **40 bytes** in the conservative scan envelope. Preflight arithmetic and exact byte-boundary expectations include the new leaf; the discrete one-action update-envelope maximum feature dimension decreases by one. Constructor configuration and top-level imports are unchanged. Manually assembled states must supply the new field; no portable checkpoint compatibility is claimed.

The scope is `ActorCriticAgent`, `ContinuousActorCriticAgent`, and their public runners. Horde and nonlinear actor-critic trace semantics remain outside this change. No pinned outputs are modified or scientific seeds consumed. The five-claim evidence registry retains its existing invalid status from registered-source drift (exit 2); the changed source is not in those registered inventories. This is a correctness repair, with no benchmark, timing, or evidence-promotion claim.

Hosted CI: [all 55 CI checks passed](https://github.com/SlopDotCash/asi/actions/runs/34198148452), including all 48 runtime shards and `ci-ok`, at the verified head. Draft triage was skipped.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next17]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1ZX1W6TN3B0AAZXXRCP7FRW","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-08T06:59:54.716Z","completed_at":"2026-09-08T07:29:39.393Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-08T06:59:54.875Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"6cf851e1850e3456bf586af45dd1c5071a2da77a5f311f80d9549306af560e0c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"db86ebe9-2ad9-417b-a580-e358347300a7","object_id":"sha256:6cf851e1850e3456bf586af45dd1c5071a2da77a5f311f80d9549306af560e0c","sha256":"6cf851e1850e3456bf586af45dd1c5071a2da77a5f311f80d9549306af560e0c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"72EswsqW3s4G4_-y7YXCa1L6pqQtFsZxqflPPGwjnpvArLshe8rR5HnjflariRZz-wcbJCmOShwxxKJ9XHrSDw"}} -->