### PR TITLE
fix: retain QHorde actor eligibility through terminal credit

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -724,7 +724,8 @@ class QHordeActorCriticAgent:
             else sampled_actor_grad_bias
         )
         actor_grad_weights = actor_grad_bias[:, None] * prev_obs[None, :]
-        actor_decay = effective_gamma * cfg.actor_lamda
+        # Credit retained within-episode eligibility before clearing terminal traces.
+        actor_decay = jnp.asarray(cfg.gamma, dtype=jnp.float32) * cfg.actor_lamda
         actor_trace_weights = (
             _skip_zero_scale(actor_decay, state.actor_trace_weights) + actor_grad_weights
         )
@@ -2590,7 +2591,8 @@ class NonlinearQHordeActorCriticAgent:
             cfg.actor_gradient_clip_norm,
         )
 
-        actor_decay = effective_gamma * cfg.actor_lamda
+        # Credit retained within-episode eligibility before clearing terminal traces.
+        actor_decay = jnp.asarray(cfg.gamma, dtype=jnp.float32) * cfg.actor_lamda
         n_hidden = len(cfg.hidden_sizes)
         new_trunk_traces: list[Array] = []
         for i in range(n_hidden):

--- a/tests/test_qhorde_terminal_credit.py
+++ b/tests/test_qhorde_terminal_credit.py
@@ -1,0 +1,159 @@
+"""Terminal Q-Horde actor updates must retain within-episode eligibility."""
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.horde import HordeLearner
+from alberta_framework.core.horde_actor_critic import (
+    NonlinearQHordeActorCriticAgent,
+    NonlinearQHordeActorCriticConfig,
+    QHordeActorCriticAgent,
+    QHordeActorCriticConfig,
+)
+from alberta_framework.core.optimizers import LMS
+from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
+
+
+def _fixture(nonlinear: bool, critic_target: str, actor_update: str, gamma: float = 0.9):
+    critic = HordeLearner(
+        create_horde_spec(
+            [
+                GVFSpec(
+                    name=f"q{i}",
+                    demon_type=DemonType.CONTROL,
+                    gamma=0.0,
+                    lamda=0.0,
+                    cumulant_index=-1,
+                )
+                for i in range(2)
+            ]
+        ),
+        hidden_sizes=(),
+        use_layer_norm=False,
+        step_size=0.1,
+    )
+    kwargs = dict(
+        n_actions=2,
+        gamma=gamma,
+        actor_lamda=0.8,
+        temperature=1.0,
+        critic_target=critic_target,
+        actor_update=actor_update,
+    )
+    if nonlinear:
+        agent = NonlinearQHordeActorCriticAgent(
+            NonlinearQHordeActorCriticConfig(hidden_sizes=(2,), use_layer_norm=False, **kwargs),
+            critic,
+            actor_optimizer=LMS(step_size=0.1),  # type: ignore[arg-type]
+        )
+    else:
+        agent = QHordeActorCriticAgent(
+            QHordeActorCriticConfig(actor_step_size=0.1, **kwargs), critic
+        )
+    state = agent.init(2, jr.key(180))
+    if nonlinear:
+        # Positive hidden activations and nonzero head weights exercise all
+        # trunk/head trace paths without a ReLU derivative at zero.
+        state = state.replace(
+            actor_trunk=state.actor_trunk.replace(weights=(jnp.eye(2),), biases=(jnp.ones((2,)),)),
+            actor_head_w=jnp.array([[0.2, 0.4], [-0.2, -0.4]], dtype=jnp.float32),
+        )
+    heads = state.critic_state.head_params
+    biases = (1.0, -1.0) if actor_update == "expected_advantage" else (0.0, 0.0)
+    state = state.replace(
+        critic_state=state.critic_state.replace(
+            head_params=heads.replace(
+                weights=tuple(jnp.zeros_like(w) for w in heads.weights),
+                biases=tuple(
+                    jnp.full_like(b, value) for b, value in zip(heads.biases, biases, strict=True)
+                ),
+            )
+        )
+    )
+    state = agent.start(state, jnp.array([1.0, 0.0], dtype=jnp.float32))[0]
+    first = agent.update(state, jnp.float32(0.0), jnp.array([0.0, 1.0]), jnp.bool_(False))
+    assert bool(first.update_applied)
+    return agent, first.state
+
+
+def _params(state, nonlinear: bool):
+    if nonlinear:
+        return tuple(
+            leaf
+            for pair in zip(state.actor_trunk.weights, state.actor_trunk.biases, strict=True)
+            for leaf in pair
+        ) + (state.actor_head_w, state.actor_head_b)
+    return state.actor_weights, state.actor_bias
+
+
+def _traces(state, nonlinear: bool):
+    if nonlinear:
+        return (*state.actor_trunk_traces, state.actor_head_trace_w, state.actor_head_trace_b)
+    return state.actor_trace_weights, state.actor_trace_bias
+
+
+def _clear_traces(state, nonlinear: bool):
+    if nonlinear:
+        return state.replace(
+            actor_trunk_traces=tuple(jnp.zeros_like(t) for t in state.actor_trunk_traces),
+            actor_head_trace_w=jnp.zeros_like(state.actor_head_trace_w),
+            actor_head_trace_b=jnp.zeros_like(state.actor_head_trace_b),
+        )
+    return state.replace(
+        actor_trace_weights=jnp.zeros_like(state.actor_trace_weights),
+        actor_trace_bias=jnp.zeros_like(state.actor_trace_bias),
+    )
+
+
+@pytest.mark.parametrize("nonlinear", [False, True])
+@pytest.mark.parametrize("critic_target", ["expected_sarsa", "sampled_sarsa"])
+@pytest.mark.parametrize("actor_update", ["td_error", "expected_advantage"])
+def test_terminal_credits_retained_actor_traces(
+    nonlinear: bool, critic_target: str, actor_update: str
+) -> None:
+    agent, state = _fixture(nonlinear, critic_target, actor_update)
+    traces = _traces(state, nonlinear)
+    assert all(float(jnp.linalg.norm(trace)) > 0.0 for trace in traces)
+    # Ablate only the earlier eligibility. Both updates have identical current
+    # parameters, critic, observation/action and RNG. Their difference must be
+    # precisely the retained credit, under the fixed-step LMS actor optimizer.
+    without_history = _clear_traces(state, nonlinear)
+    for terminated in [False, True]:
+        result = agent.update(state, jnp.float32(1.0), jnp.ones((2,)), jnp.bool_(terminated))
+        ablated = agent.update(
+            without_history, jnp.float32(1.0), jnp.ones((2,)), jnp.bool_(terminated)
+        )
+        assert bool(result.update_applied) and bool(ablated.update_applied)
+        np.testing.assert_array_equal(result.td_error, ablated.td_error)
+        signal = 1.0 if actor_update == "expected_advantage" else float(result.td_error)
+        assert abs(signal) > 0.01
+        for actual, control, trace in zip(
+            _params(result.state, nonlinear), _params(ablated.state, nonlinear), traces, strict=True
+        ):
+            expected = (
+                0.1 * signal * agent.config.gamma * agent.config.actor_lamda * np.asarray(trace)
+            )
+            np.testing.assert_allclose(actual - control, expected, rtol=1e-5, atol=1e-7)
+        if terminated:
+            assert float(result.target) == 1.0
+            for trace in _traces(result.state, nonlinear):
+                np.testing.assert_array_equal(trace, jnp.zeros_like(trace))
+
+
+@pytest.mark.parametrize("nonlinear", [False, True])
+def test_rejected_terminal_preserves_eligibility_for_retry(nonlinear: bool) -> None:
+    agent, state = _fixture(nonlinear, "expected_sarsa", "td_error")
+    rejected = agent.update(state, jnp.float32(jnp.nan), jnp.ones((2,)), jnp.bool_(True))
+    assert not bool(rejected.update_applied)
+    for old, new in zip(jax.tree.leaves(state), jax.tree.leaves(rejected.state), strict=True):
+        if hasattr(old, "dtype") and jax.dtypes.issubdtype(old.dtype, jax.dtypes.prng_key):
+            old, new = jr.key_data(old), jr.key_data(new)
+        np.testing.assert_array_equal(old, new)
+    retry = agent.update(rejected.state, jnp.float32(1.0), jnp.ones((2,)), jnp.bool_(True))
+    assert bool(retry.update_applied)
+    # A fresh episode must not carry the previous episode's terminal trace.
+    for trace in _traces(retry.state, nonlinear):
+        np.testing.assert_array_equal(trace, jnp.zeros_like(trace))


### PR DESCRIPTION
A terminal reward currently erases the Q-Horde actors' earlier eligibility before it can update their parameters. In a two-step linear fixture with rewards `[0, 1]`, gamma `0.9`, lambda `0.8`, and actor step size `0.1`, main learns `[[0, 0.05], [0, -0.05]]`; the corrected update is `[[0.036, 0.05], [-0.036, -0.05]]`. Both transitions commit, and stored terminal traces are zero in both cases.

Use the configured gamma for actor trace decay in `QHordeActorCriticAgent` and `NonlinearQHordeActorCriticAgent`, then apply the update before the existing terminal clearing. These two APIs accept a fixed configured gamma and a termination flag. The outgoing terminal discount still suppresses the critic bootstrap. Both SARSA target modes and both actor update modes take this path.

This is the fixed-discount Q-Horde slice discussed in [closed PR #2350](https://github.com/SlopDotCash/asi/pull/2350#issuecomment-5549670633). Sutton & Barto, second edition, [section 13.5, printed page 332](https://www.andrew.cmu.edu/course/10-703/textbook/BartoSutton.pdf#page=354), applies retained eligibility to the terminal update before the next episode's reset. This repair changes that ordering in the existing Q-based update; it does not implement the book's complete episodic policy-gradient objective. The variable-discount value-based Horde actors need separate discount history and are outside this change. The linear-agent history fix in #2866 is independent.

Verified head: `e9e59892ec7e6077d2d69d47f01f67d676891f6d`
<!-- evidence-head:e9e59892ec7e6077d2d69d47f01f67d676891f6d -->

## Verification

Executed from this checkout with the existing project venv, `PYTHONPATH` selecting this source, and `OMP_NUM_THREADS=1`:

```bash
.venv/bin/python -m pytest tests/test_qhorde_terminal_credit.py tests/test_horde_actor_critic.py tests/test_horde_actor_critic_hostile.py tests/test_baseline_mlp_direct_delta.py tests/test_learner_optimizer_fallback_truthiness.py -q --tb=short -o addopts=''
.venv/bin/python -m ruff check .
.venv/bin/python -m mypy
git diff --check
```

- Failure-first at base `f3d32c451ed1c1715e477ad56b782fc7ea89b206`: **8 failed, 2 passed**. Every terminal-credit combination fails its numerical assertion; the paired nonterminal comparisons pass. The standalone two-step reproduction also fails on main and passes with the fix.
- [GitHub CI](https://github.com/SlopDotCash/asi/actions/runs/34201229104): **55 jobs passed** at the verified head.
- Final regression panel: **155 passed**. Ruff and strict mypy pass (224 source files); `git diff --check` passes. The new test file passes the format check. A format check of the source file reports the same five unrelated differences on main and candidate.
- The ten new cases cover linear/nonlinear actors, expected/sampled SARSA, TD-error/expected-advantage updates, every nonlinear trunk/head parameter leaf, terminal target suppression, terminal trace clearing, and whole-state rollback including RNG followed by a successful retry. They compare identical states with only retained eligibility ablated, using fixed-step LMS to make the lost credit directly measurable. The deterministic unit fixture uses JAX key `180`; it is not a tuning or scientific evaluation seed.
- `alberta-evidence-status` exits **2**, retaining all five existing invalid claims. Their error lists are identical to the previous run. All 25 registered source files match main byte-for-byte; the changed module is outside those inventories.

## Scope

The production change is two trace-decay calculations and their comments. State schemas, parameter counts, persistent memory, critic updates, and transaction boundaries are unchanged. No pinned outputs are edited and no benchmark or scientific seeds are consumed. This is a correctness repair; learning performance and timing are unmeasured.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next18]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M1ZZ2MWAP8AMD53QGY53XCDK","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-08T07:35:17.132Z","completed_at":"2026-09-08T08:11:49.758Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-08T07:35:17.317Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a3aad25ed0e4c2b30665b792edee5d3f632e2a5448a7befe31c933d822145318","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"91d4c659-2dd3-4742-b7d5-3cc2b4bcaf3b","object_id":"sha256:a3aad25ed0e4c2b30665b792edee5d3f632e2a5448a7befe31c933d822145318","sha256":"a3aad25ed0e4c2b30665b792edee5d3f632e2a5448a7befe31c933d822145318"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"5rqPhqSIgmrJiMH4VcP7ib-CH-PKfR7NEi6a6w2ZUtss-qOIq7cNB1pmtyLYi3niIPGpVRg6XybDPiYrYr2FCA"}} -->
