### PR TITLE
fix: clear Horde value-critic eligibility after terminal credit

### DIFF
--- a/alberta_framework/core/horde.py
+++ b/alberta_framework/core/horde.py
@@ -553,8 +553,10 @@ class HordeLearner:
 
         This is the same TD update as :meth:`update`, except callers supply the
         effective discount vector for this transition. It lets control adapters
-        zero the value head at episode boundaries while keeping the Horde's
-        fixed GVF metadata and per-head trace decay intact.
+        terminate the value head at episode boundaries while keeping the
+        Horde's fixed GVF metadata and per-head trace decay intact. An accepted
+        zero-discount update applies its reward through the current eligibility,
+        then clears that head's temporal traces before the next episode.
 
         Args:
             state: Current state.
@@ -604,8 +606,29 @@ class HordeLearner:
         )
         head_updates_applied = head_inputs_valid & update_applied
 
+        # Apply terminal credit before dropping eligibility from the finished
+        # episode. Inactive/rejected heads retain their state; continuing heads
+        # retain their traces. Zero-decay heads cannot carry temporal credit and
+        # keep their ordinary-update state exactly.
+        head_traces = tuple(
+            tuple(
+                jnp.where(
+                    head_updates_applied[index] & (discounts[index] == 0.0),
+                    jnp.zeros_like(trace),
+                    trace,
+                )
+                for trace in traces
+            )
+            if float(np.float32(demon.gamma) * np.float32(demon.lamda)) != 0.0
+            else traces
+            for index, (demon, traces) in enumerate(
+                zip(self._horde_spec.demons, result.state.head_traces, strict=True)
+            )
+        )
+        proposed_state = result.state.replace(head_traces=head_traces)
+
         return HordeUpdateResult(  # type: ignore[call-arg]
-            state=jax.lax.cond(update_applied, lambda: result.state, lambda: state),
+            state=jax.lax.cond(update_applied, lambda: proposed_state, lambda: state),
             predictions=jnp.where(
                 update_applied,
                 jnp.where(

--- a/alberta_framework/core/horde.py
+++ b/alberta_framework/core/horde.py
@@ -553,10 +553,8 @@ class HordeLearner:
 
         This is the same TD update as :meth:`update`, except callers supply the
         effective discount vector for this transition. It lets control adapters
-        terminate the value head at episode boundaries while keeping the
-        Horde's fixed GVF metadata and per-head trace decay intact. An accepted
-        zero-discount update applies its reward through the current eligibility,
-        then clears that head's temporal traces before the next episode.
+        zero the value head at episode boundaries while keeping the Horde's
+        fixed GVF metadata and per-head trace decay intact.
 
         Args:
             state: Current state.
@@ -606,29 +604,8 @@ class HordeLearner:
         )
         head_updates_applied = head_inputs_valid & update_applied
 
-        # Apply terminal credit before dropping eligibility from the finished
-        # episode. Inactive/rejected heads retain their state; continuing heads
-        # retain their traces. Zero-decay heads cannot carry temporal credit and
-        # keep their ordinary-update state exactly.
-        head_traces = tuple(
-            tuple(
-                jnp.where(
-                    head_updates_applied[index] & (discounts[index] == 0.0),
-                    jnp.zeros_like(trace),
-                    trace,
-                )
-                for trace in traces
-            )
-            if float(np.float32(demon.gamma) * np.float32(demon.lamda)) != 0.0
-            else traces
-            for index, (demon, traces) in enumerate(
-                zip(self._horde_spec.demons, result.state.head_traces, strict=True)
-            )
-        )
-        proposed_state = result.state.replace(head_traces=head_traces)
-
         return HordeUpdateResult(  # type: ignore[call-arg]
-            state=jax.lax.cond(update_applied, lambda: proposed_state, lambda: state),
+            state=jax.lax.cond(update_applied, lambda: result.state, lambda: state),
             predictions=jnp.where(
                 update_applied,
                 jnp.where(

--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -19,8 +19,9 @@ the critic-form x actor-form design space:
 
 All actors implement AC(lambda), ``theta += alpha * delta * e``, with an
 eligibility trace over log-policy gradients (Sutton & Barto 2018, Ch. 13).
-The critic update is always delegated unchanged to ``HordeLearner.update()``,
-preserving per-head trace decay and auxiliary demons.
+The critic delegates learning to ``HordeLearner``, preserving per-head trace
+decay and auxiliary demons. The state-value adapters clear their value head's
+temporal eligibility after applying an accepted terminal reward.
 
 References:
     Sutton & Barto (2018). "Reinforcement Learning: An Introduction,"
@@ -228,6 +229,31 @@ def _commit_scan_safe_actor_state(
 def _skip_zero_scale(scale: Array, value: Array) -> Array:
     """Return 0 when ``scale`` is 0 so a 0*inf product cannot form."""
     return jnp.where(scale == 0.0, jnp.zeros_like(value), scale * value)
+
+
+def _clear_terminal_value_trace(
+    critic: HordeLearner,
+    result: HordeUpdateResult,
+    value_index: int,
+    discount: Array,
+) -> HordeUpdateResult:
+    """Apply terminal credit before clearing the value head's eligibility.
+
+    The adapter owns this boundary: generic Horde zero discounts can also
+    suppress bootstrap for externally computed SARSA targets. Auxiliary heads
+    continue, and zero-decay heads retain their ordinary instantaneous traces.
+    """
+    demon = critic.horde_spec.demons[value_index]
+    if float(np.float32(demon.gamma) * np.float32(demon.lamda)) == 0.0:
+        return result
+    terminal = (discount == 0.0) & result.head_updates_applied[value_index]
+    head_traces = list(result.state.head_traces)
+    head_traces[value_index] = tuple(
+        jnp.where(terminal, jnp.zeros_like(trace), trace)
+        for trace in head_traces[value_index]
+    )
+    state = result.state.replace(head_traces=tuple(head_traces))  # type: ignore[attr-defined]
+    return cast(HordeUpdateResult, result.replace(state=state))  # type: ignore[attr-defined]
 
 
 def _rollback_critic_result(
@@ -1041,6 +1067,9 @@ class HordeActorCriticAgent:
                 observation,
                 discounts,
             )
+            critic_result = _clear_terminal_value_trace(
+                self._critic, critic_result, cfg.value_head_index, value_discount
+            )
         td_error = critic_result.td_errors[cfg.value_head_index]
         actor_td_error = (
             td_error
@@ -1847,6 +1876,9 @@ class NonlinearHordeActorCriticAgent:
             discounts = self._critic.horde_spec.gammas.at[idx].set(value_discount)
             critic_result = self._critic.update_with_discounts(
                 state.critic_state, prev_obs, cumulants, observation, discounts
+            )
+            critic_result = _clear_terminal_value_trace(
+                self._critic, critic_result, idx, value_discount
             )
         td_error = critic_result.td_errors[idx]
         actor_td_error = (

--- a/tests/test_horde_terminal_critic_credit.py
+++ b/tests/test_horde_terminal_critic_credit.py
@@ -10,7 +10,10 @@ from alberta_framework import DemonType, GVFSpec, HordeLearner, create_horde_spe
 from alberta_framework.core.horde_actor_critic import (
     HordeActorCriticAgent,
     HordeActorCriticConfig,
+    NonlinearHordeActorCriticAgent,
+    NonlinearHordeActorCriticConfig,
     run_horde_actor_critic_from_arrays,
+    run_nonlinear_horde_actor_critic_from_arrays,
 )
 from alberta_framework.core.types import TraceMode
 
@@ -49,23 +52,39 @@ def _zero_params(state):
     )
 
 
-@pytest.mark.parametrize("value_index", [0, 1])
-@pytest.mark.parametrize("trace_mode", [TraceMode.ACCUMULATING, TraceMode.REPLACING])
-def test_public_runner_does_not_credit_a_finished_episode(value_index, trace_mode):
-    critic = _critic(trace_mode)
-    agent = HordeActorCriticAgent(
+def _agent(critic, value_index, nonlinear):
+    if nonlinear:
+        return NonlinearHordeActorCriticAgent(
+            NonlinearHordeActorCriticConfig(
+                n_actions=1, actor_lamda=0.0, value_head_index=value_index, hidden_sizes=(4,)
+            ),
+            critic,
+        )
+    return HordeActorCriticAgent(
         HordeActorCriticConfig(n_actions=1, actor_lamda=0.0, value_head_index=value_index),
         critic,
     )
+
+
+@pytest.mark.parametrize("nonlinear", [False, True])
+@pytest.mark.parametrize("value_index", [0, 1])
+@pytest.mark.parametrize("trace_mode", [TraceMode.ACCUMULATING, TraceMode.REPLACING])
+def test_public_runner_does_not_credit_a_finished_episode(value_index, trace_mode, nonlinear):
+    critic = _critic(trace_mode)
+    agent = _agent(critic, value_index, nonlinear)
     state = agent.init(2, jr.key(200))
     state = state.replace(critic_state=_zero_params(state.critic_state))
-    result = run_horde_actor_critic_from_arrays(
+    runner = (
+        run_nonlinear_horde_actor_critic_from_arrays
+        if nonlinear
+        else run_horde_actor_critic_from_arrays
+    )
+    result = runner(
         agent,
         state,
         observations=jnp.array([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]]),
         rewards=jnp.array([0.0, 1.0, 1.0]),
         next_observations=jnp.array([[0.0, 1.0], [0.0, 0.0], [0.0, 0.0]]),
-        actions=jnp.zeros(3, dtype=jnp.int32),
         auxiliary_cumulants=jnp.array([[0.0], [0.0], [1.0]]),
         discounts=jnp.array([0.9, 0.0, 0.0]),
     )
@@ -89,6 +108,40 @@ def test_public_runner_does_not_credit_a_finished_episode(value_index, trace_mod
         atol=1e-8,
     )
     assert bool(jnp.any(result.state.critic_state.head_params.weights[aux_index] != 0))
+
+
+@pytest.mark.parametrize("nonlinear", [False, True])
+@pytest.mark.parametrize("failure", ["reward", "discount", "observation", "action"])
+def test_rejected_boundary_keeps_credit_for_a_valid_retry(nonlinear, failure):
+    agent = _agent(_critic(), 0, nonlinear)
+    state = agent.init(2, jr.key(203))
+    state = state.replace(
+        critic_state=_zero_params(state.critic_state),
+        last_observation=jnp.array([1.0, 0.0]),
+        last_action=jnp.array(0, dtype=jnp.int32),
+    )
+    warm = agent.update(state, jnp.array(0.0), jnp.array([0.0, 1.0]), discount=0.9).state
+    reward = jnp.array(jnp.nan if failure == "reward" else 1.0)
+    discount = jnp.array(jnp.nan if failure == "discount" else 0.0)
+    observation = jnp.array([jnp.nan, 0.0]) if failure == "observation" else jnp.zeros(2)
+    if failure == "action":
+        warm = warm.replace(last_action=jnp.array(2, dtype=jnp.int32))
+    rejected = agent.update(warm, reward, observation, discount=discount)
+    assert not bool(rejected.update_applied)
+    assert not bool(jnp.any(rejected.critic_result.head_updates_applied))
+    chex.assert_trees_all_equal(
+        rejected.state.replace(rng_key=jr.key_data(rejected.state.rng_key)),
+        warm.replace(rng_key=jr.key_data(warm.rng_key)),
+    )
+    repaired = rejected.state.replace(last_action=jnp.array(0, dtype=jnp.int32))
+    retry = agent.update(repaired, jnp.array(1.0), jnp.zeros(2), discount=0.0)
+    assert bool(retry.update_applied)
+    np.testing.assert_allclose(
+        retry.state.critic_state.head_params.weights[0], [[0.072, 0.1]], rtol=1e-6, atol=1e-8
+    )
+    for trace in retry.state.critic_state.head_traces[0]:
+        np.testing.assert_array_equal(trace, jnp.zeros_like(trace))
+    chex.assert_trees_all_equal(retry.critic_result.state, retry.state.critic_state)
 
 
 @pytest.mark.parametrize("failure", ["inactive", "cumulant", "discount", "observation"])

--- a/tests/test_horde_terminal_critic_credit.py
+++ b/tests/test_horde_terminal_critic_credit.py
@@ -1,0 +1,134 @@
+"""Terminal critic credit stays inside the episode that produced its eligibility."""
+
+import chex
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework import DemonType, GVFSpec, HordeLearner, create_horde_spec
+from alberta_framework.core.horde_actor_critic import (
+    HordeActorCriticAgent,
+    HordeActorCriticConfig,
+    run_horde_actor_critic_from_arrays,
+)
+from alberta_framework.core.types import TraceMode
+
+pytestmark = pytest.mark.integration
+
+
+def _critic(trace_mode=TraceMode.ACCUMULATING, *, gamma0=False):
+    demons = [
+        GVFSpec(
+            name=f"head{index}",
+            demon_type=DemonType.PREDICTION,
+            gamma=0.0 if gamma0 and index == 0 else 0.9,
+            lamda=0.8,
+            cumulant_index=index,
+        )
+        for index in range(2)
+    ]
+    return HordeLearner(
+        create_horde_spec(demons),
+        hidden_sizes=(),
+        step_size=0.1,
+        sparsity=0.0,
+        trace_mode=trace_mode,
+    )
+
+
+def _zero_params(state):
+    params = state.head_params
+    return state.replace(
+        head_params=params.replace(
+            weights=tuple(jnp.zeros_like(x) for x in params.weights),
+            biases=tuple(jnp.zeros_like(x) for x in params.biases),
+        ),
+        birth_timestamp=0.0,
+        uptime_s=0.0,
+    )
+
+
+@pytest.mark.parametrize("value_index", [0, 1])
+@pytest.mark.parametrize("trace_mode", [TraceMode.ACCUMULATING, TraceMode.REPLACING])
+def test_public_runner_does_not_credit_a_finished_episode(value_index, trace_mode):
+    critic = _critic(trace_mode)
+    agent = HordeActorCriticAgent(
+        HordeActorCriticConfig(n_actions=1, actor_lamda=0.0, value_head_index=value_index),
+        critic,
+    )
+    state = agent.init(2, jr.key(200))
+    state = state.replace(critic_state=_zero_params(state.critic_state))
+    result = run_horde_actor_critic_from_arrays(
+        agent,
+        state,
+        observations=jnp.array([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]]),
+        rewards=jnp.array([0.0, 1.0, 1.0]),
+        next_observations=jnp.array([[0.0, 1.0], [0.0, 0.0], [0.0, 0.0]]),
+        actions=jnp.zeros(3, dtype=jnp.int32),
+        auxiliary_cumulants=jnp.array([[0.0], [0.0], [1.0]]),
+        discounts=jnp.array([0.9, 0.0, 0.0]),
+    )
+    assert bool(jnp.all(result.updates_applied))
+    # Episode one's terminal reward credits both visited features. Episode
+    # two has zero features, so its reward cannot change those weights.
+    np.testing.assert_allclose(
+        result.state.critic_state.head_params.weights[value_index],
+        [[0.072, 0.1]],
+        rtol=1e-6,
+        atol=1e-8,
+    )
+    for trace in result.state.critic_state.head_traces[value_index]:
+        np.testing.assert_array_equal(trace, jnp.zeros_like(trace))
+    # The auxiliary head keeps its continuing eligibility across this boundary.
+    aux_index = 1 - value_index
+    np.testing.assert_allclose(
+        result.state.critic_state.head_traces[aux_index][0],
+        [[0.5184, 0.72]],
+        rtol=1e-6,
+        atol=1e-8,
+    )
+    assert bool(jnp.any(result.state.critic_state.head_params.weights[aux_index] != 0))
+
+
+@pytest.mark.parametrize("failure", ["inactive", "cumulant", "discount", "observation"])
+def test_unaccepted_terminal_head_keeps_its_eligibility(failure):
+    critic = _critic()
+    state = _zero_params(critic.init(2, jr.key(201)))
+    warm = critic.update(state, jnp.array([1.0, 0.0]), jnp.zeros(2), jnp.zeros(2)).state
+    cumulants = jnp.array([1.0, 1.0])
+    discounts = jnp.array([0.0, 0.9])
+    observation = jnp.array([0.0, 1.0])
+    if failure == "inactive":
+        cumulants = cumulants.at[0].set(jnp.nan)
+    elif failure == "cumulant":
+        cumulants = cumulants.at[0].set(jnp.inf)
+    elif failure == "discount":
+        discounts = discounts.at[0].set(jnp.nan)
+    else:
+        observation = observation.at[0].set(jnp.nan)
+    result = critic.update_with_discounts(warm, observation, cumulants, jnp.zeros(2), discounts)
+    assert not bool(result.head_updates_applied[0])
+    chex.assert_trees_all_equal(result.state.head_traces[0], warm.head_traces[0])
+    chex.assert_trees_all_equal(result.state.head_params.weights[0], warm.head_params.weights[0])
+    if failure == "observation":
+        assert not bool(result.update_applied)
+        chex.assert_trees_all_equal(result.state, warm)
+    else:
+        assert bool(result.update_applied)
+        assert bool(result.head_updates_applied[1])
+
+
+@pytest.mark.parametrize("gamma0", [False, True])
+def test_default_discounts_preserve_the_existing_update_exactly(gamma0):
+    critic = _critic(gamma0=gamma0)
+    state = _zero_params(critic.init(2, jr.key(202)))
+    observation = jnp.array([1.0, 0.0])
+    next_observation = jnp.array([0.0, 1.0])
+    for cumulants in (jnp.array([0.5, 1.0]), jnp.array([1.0, -0.5])):
+        ordinary = critic.update(state, observation, cumulants, next_observation)
+        explicit = critic.update_with_discounts(
+            state, observation, cumulants, next_observation, critic.horde_spec.gammas
+        )
+        chex.assert_trees_all_equal(ordinary, explicit)
+        state = ordinary.state


### PR DESCRIPTION
A terminal Horde value-critic update leaves eligibility from the finished episode alive. A reward in the next episode can therefore change weights for observations seen only in the previous episode. Through the public runner, three accepted transitions produce old-feature weights `[0.1149235, 0.1596160]` on main instead of the correct `[0.072, 0.1]`.

The linear and nonlinear **state-value Horde actor-critic adapters** now clear their value head's temporal eligibility after applying an accepted terminal reward. Continuing auxiliary heads retain their traces, and the existing outer transaction guard rolls back the reset when an update is rejected. Zero-decay heads retain their ordinary instantaneous state.

The reset belongs in these adapters: SARSA also passes zero discounts to the generic Horde learner to suppress an already-computed bootstrap during continuing transitions. `HordeLearner.update_with_discounts` and SARSA remain byte-identical to main. This preserves their existing bootstrap-only contract.

Terminal learning must precede the reset ([Sutton & Barto, second edition, §12.2, printed pp. 292–293](https://www.andrew.cmu.edu/course/10-703/textbook/BartoSutton.pdf#page=315)). In the reproduction, the first episode's delayed credit is `0.1 * (0.9 * 0.8 * [1, 0] + [0, 1]) = [0.072, 0.1]`. The next episode's zero-feature observation must not change those weights.

Verified source head: `64867bafd52a840c5f2648145a6d376d39b1be6f`
<!-- evidence-head:64867bafd52a840c5f2648145a6d376d39b1be6f -->

## Verification

Baseline: main `f3d32c451ed1c1715e477ad56b782fc7ea89b206`. Runtime: Python 3.12.3, locked JAX/jaxlib 0.11.0 and NumPy 2.5.1 on CPU. Select the checkout with `PYTHONPATH` and set `OMP_NUM_THREADS=1`. Dependencies were installed with `uv sync --locked --no-install-project --extra dev --python <project-python>`.

```bash
.venv/bin/python -m pytest tests/test_horde_terminal_critic_credit.py tests/test_sarsa.py -q --tb=short -o addopts=''
.venv/bin/python -m pytest tests/test_horde.py tests/test_horde_actor_critic.py tests/test_horde_actor_critic_hostile.py tests/test_mixed_horde.py tests/test_pipeline.py tests/test_baseline_mlp_direct_delta.py tests/test_horde_terminal_critic_credit.py tests/test_sarsa.py -q --tb=short -o addopts=''
.venv/bin/python -m ruff check .
.venv/bin/python -m ruff format --check tests/test_horde_terminal_critic_credit.py
.venv/bin/python -m mypy
git diff --check
```

- Failure-first: the final 22-case regression file produced **16 failed / 6 passed** with production source restored to main. Eight runner cases fail the analytic weight assertion; eight rejection/retry cases correctly preserve rejected state but fail to clear the trace after the subsequent accepted terminal update. The standalone reproduction below also fails on main and passes with the fix; all three updates commit in both executions.
- **542 passed / 2 skipped** in the final broad panel, including all 22 new cases and the SARSA suite. Both skips are existing optional Gymnasium cases. [Required CI run 34214790315](https://github.com/SlopDotCash/asi/actions/runs/34214790315) completed successfully at the verified head: **55/55 jobs passed**. The separate optional triage job was skipped. Ruff, formatting, strict mypy (224 source files), and whitespace checks pass.
- Both public runners are covered, with a linear actor or a nonlinear actor with a four-unit hidden layer, both value-head positions, and accumulating/replacing eligibility. Tests preserve terminal delayed credit, clear terminal weight/bias traces, and retain the continuing auxiliary head's trace `[0.5184, 0.72]`. One action isolates critic learning; this is not a policy-performance claim.
- Rejected reward, discount, observation and action fixtures retain the complete actor/critic state and RNG, then a repaired terminal retry preserves delayed credit and clears its eligibility. Nested critic results agree with committed state. Generic Horde controls retain inactive/invalid head traces and exact default-discount complete-result equality, including zero gamma. Explicit fixture keys: 200–203.
- The initial implementation placed the reset in generic Horde and passed 383 local tests, but [CI run 34212795203](https://github.com/SlopDotCash/asi/actions/runs/34212795203) exposed three existing SARSA trace regressions. Those failures reproduced locally (**3 failed / 144 passed / 2 skipped**). Moving the reset to the adapters restores the shared learner contract; the existing SARSA assertions were not modified.
- [CI run 34214142424](https://github.com/SlopDotCash/asi/actions/runs/34214142424) also encountered an unrelated runtime-profile wall-clock assertion: its expected rejection succeeded, but elapsed time was 0.426 seconds against 0.25. All nine tests in that unchanged file pass locally. A direct job rerun was denied (admin rights required), so an empty commit restarts CI with the **identical source tree** `3c02c2e5f02443c5bc45e9c8d995abad044dfae7`; no test or threshold changed.
- The five-claim evidence registry still exits **2**, with final status and complete error lists identical to baseline. Both the final changed module and the earlier generic Horde module are outside the 25 registered source paths; all registered source bytes match main. The final module is part of the Forager matched-analysis source closure, so its source identity changes. No pinned artifacts, protocols, thresholds or evaluation seeds were modified or promoted.

## Scope and limits

The final diff changes only `core/horde_actor_critic.py` and the new regression file. The value critic still uses configured per-head gamma/lambda decay within each episode; arbitrary nonterminal variable-discount trace history remains outside this fix. Actor eligibility indexing, QHorde control, generic Horde and Prototype boundary behavior are separate concerns. This does not incorporate the actor eligibility changes in #2866/#2867.

There is no new persistent state or configuration. Terminal clearing adds elementwise selection over the existing value-head traces. Timing and learning performance are unmeasured; these deterministic correctness fixtures establish no benchmark improvement or scientific promotion. Independent acceptance and merge remain with the maintainer.

<details>
<summary>Standalone public-runner reproduction</summary>

Save as `critic-repro.py` outside the checkouts and run `.venv/bin/python critic-repro.py` in fresh processes with each checkout selected by `PYTHONPATH`. The expected feature weights come from the first episode's terminal update; the next episode has zero input features and must not change them.

```python
import json
import jax.numpy as jnp
import jax.random as jr
import numpy as np
from alberta_framework import GVFSpec, DemonType, HordeLearner, create_horde_spec
from alberta_framework.core.horde_actor_critic import (
    HordeActorCriticAgent, HordeActorCriticConfig, run_horde_actor_critic_from_arrays,
)

critic=HordeLearner(create_horde_spec([
    GVFSpec(name='value', demon_type=DemonType.PREDICTION, gamma=0.9, lamda=0.8, cumulant_index=0),
]),hidden_sizes=(),step_size=0.1,sparsity=0.0)
agent=HordeActorCriticAgent(HordeActorCriticConfig(n_actions=1,actor_lamda=0.0),critic)
state=agent.init(2,jr.key(200))
params=state.critic_state.head_params
state=state.replace(critic_state=state.critic_state.replace(head_params=params.replace(
    weights=tuple(jnp.zeros_like(x) for x in params.weights),
    biases=tuple(jnp.zeros_like(x) for x in params.biases),
)))
observations=jnp.array([[1.,0.],[0.,1.],[0.,0.]],dtype=jnp.float32)
result=run_horde_actor_critic_from_arrays(
    agent,state,observations,jnp.array([0.,1.,1.]),
    next_observations=jnp.array([[0.,1.],[0.,0.],[0.,0.]]),
    actions=jnp.zeros(3,dtype=jnp.int32),discounts=jnp.array([0.9,0.,0.]),
)
print(json.dumps({'accepted':np.asarray(result.updates_applied).tolist(),
    'td_errors':np.asarray(result.td_errors).tolist(),
    'critic_weights':np.asarray(result.state.critic_state.head_params.weights[0]).tolist(),
    'critic_trace':np.asarray(result.state.critic_state.head_traces[0][0]).tolist()}))
np.testing.assert_allclose(result.state.critic_state.head_params.weights[0],[[0.072,0.1]],rtol=1e-6,atol=1e-8)
```

</details>

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next20]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M2062C4PP14MZHKEGSA05018","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-08T09:37:28.215Z","completed_at":"2026-09-08T10:37:16.464Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-08T09:37:28.424Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"dd233390676958168546c6943de5221d4ae0b8c6ccf049be6bb4807bd2b70d75","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3b7b3082-81f5-4077-b77d-4371ba02f23b","object_id":"sha256:dd233390676958168546c6943de5221d4ae0b8c6ccf049be6bb4807bd2b70d75","sha256":"dd233390676958168546c6943de5221d4ae0b8c6ccf049be6bb4807bd2b70d75"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"JNXtwdkd35O0WMzVlKtmqsw9bCZH07IJxayomv5ob2h2S9NbFrkyAt1fpEVNwOv8nFtnDPKaWuguO72F16hyAg"}} -->
