### PR TITLE
fix: use incoming discount for Horde actor eligibility

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -161,10 +161,12 @@ def _require_horde_ac_matching_length(name: str, value: object, *, expected: int
         raise ValueError(f"{name} must share the same leading length as rewards")
 
 
-def _linear_actor_resources(n_actions: int, feature_dim: object) -> dict[str, int]:
+def _linear_actor_resources(
+    n_actions: int, feature_dim: object, *, discount_history: bool = False
+) -> dict[str, int]:
     width = _require_int32("feature_dim", feature_dim, minimum=1)
     parameters = n_actions * (width + 1)
-    float32_state = 2 * parameters + width
+    float32_state = 2 * parameters + width + int(discount_history)
     logical_state = float32_state + 4
     return _check_actor_resources(
         {
@@ -193,7 +195,7 @@ def _nonlinear_actor_resources(
     _check_actor_resources({"head_product": head_product})
     parameters += head_product + n_actions
     tensor_count = 2 * (len(hidden_sizes) + 1)
-    float32_state = 5 * parameters + 2 * tensor_count + 1 + width
+    float32_state = 5 * parameters + 2 * tensor_count + 2 + width
     logical_state = float32_state + 4
     return _check_actor_resources(
         {
@@ -331,11 +333,11 @@ class HordeActorCriticConfig:
         object.__setattr__(self, "actor_lamda", actor_lamda)
         object.__setattr__(self, "temperature", temperature)
         object.__setattr__(self, "actor_td_error_clip", actor_td_error_clip)
-        _linear_actor_resources(self.n_actions, 1)
+        _linear_actor_resources(self.n_actions, 1, discount_history=True)
 
     def actor_resource_budget(self, feature_dim: object) -> dict[str, int]:
         """Return the exact actor-only state budget for an input width."""
-        return _linear_actor_resources(self.n_actions, feature_dim)
+        return _linear_actor_resources(self.n_actions, feature_dim, discount_history=True)
 
     def to_config(self) -> dict[str, Any]:
         """Serialize this configuration to a dictionary."""
@@ -357,6 +359,7 @@ class HordeActorCriticState:
         actor_bias: Policy bias vector, shape ``(n_actions,)``.
         actor_trace_weights: Eligibility trace for actor weights.
         actor_trace_bias: Eligibility trace for actor bias.
+        previous_discount: Last accepted value transition discount for actor eligibility.
         critic_state: Underlying Horde learner state.
         last_observation: Previous observation ``s_t``.
         last_action: Previous action ``a_t``.
@@ -368,6 +371,7 @@ class HordeActorCriticState:
     actor_bias: Float[Array, " n_actions"]
     actor_trace_weights: Float[Array, "n_actions feature_dim"]
     actor_trace_bias: Float[Array, " n_actions"]
+    previous_discount: Float[Array, ""]
     critic_state: MultiHeadMLPState
     last_observation: Float[Array, " feature_dim"]
     last_action: Int[Array, ""]
@@ -906,6 +910,7 @@ class HordeActorCriticAgent:
             actor_bias=zeros_bias,
             actor_trace_weights=zeros_actor,
             actor_trace_bias=zeros_bias,
+            previous_discount=jnp.array(1.0, dtype=jnp.float32),
             critic_state=self._critic.init(feature_dim, critic_key),
             last_observation=jnp.zeros((feature_dim,), dtype=jnp.float32),
             last_action=jnp.array(-1, dtype=jnp.int32),
@@ -996,11 +1001,14 @@ class HordeActorCriticAgent:
             auxiliary_cumulants: Optional cumulants for all non-value heads,
                 ordered by Horde head index with the value head removed.
             discount: Optional scalar per-transition value-head discount. When
-                omitted, the value head's configured demon gamma is used.
+                omitted, the value head's configured demon gamma is used. This
+                outgoing discount is saved for the next accepted actor update.
 
         Returns:
             ``HordeActorCriticUpdateResult`` with actor and critic metrics.
         """
+        if state.previous_discount.shape != () or state.previous_discount.dtype != jnp.float32:
+            raise ValueError("state.previous_discount must be a scalar float32")
         cfg = self._config
         prev_obs = state.last_observation
         action_valid = (state.last_action >= 0) & (state.last_action < cfg.n_actions)
@@ -1051,7 +1059,9 @@ class HordeActorCriticAgent:
         one_hot = jax.nn.one_hot(safe_last_action, cfg.n_actions, dtype=jnp.float32)
         actor_grad_bias = (one_hot - old_policy) / cfg.temperature
         actor_grad_weights = actor_grad_bias[:, None] * prev_obs[None, :]
-        actor_decay = value_discount * cfg.actor_lamda
+        # Incoming gamma_t retains earlier credit; outgoing gamma_{t+1}
+        # controls bootstrapping and clears traces only after reward learning.
+        actor_decay = state.previous_discount * cfg.actor_lamda
         actor_trace_weights = (
             _skip_zero_scale(actor_decay, state.actor_trace_weights) + actor_grad_weights
         )
@@ -1079,6 +1089,7 @@ class HordeActorCriticAgent:
             actor_trace_bias=jnp.where(
                 carry_traces, actor_trace_bias, jnp.zeros_like(actor_trace_bias)
             ),
+            previous_discount=value_discount,
             critic_state=critic_result.state,
             step_count=_saturating_int32_counter_increment(state.step_count),
         )
@@ -1095,6 +1106,8 @@ class HordeActorCriticAgent:
             & jnp.isfinite(value_discount)
             & (value_discount >= 0.0)
             & (value_discount <= 1.0)
+            & (state.previous_discount >= 0.0)
+            & (state.previous_discount <= 1.0)
             & jnp.all(jnp.isfinite(old_policy))
             & jnp.isfinite(value)
             & ((value_discount == 0.0) | jnp.isfinite(next_value))
@@ -1513,6 +1526,8 @@ class NonlinearHordeActorCriticState:
         actor_head_opt_b: Optimizer state for ``actor_head_b``.
         actor_td_error_normalizer: EMA scale for actor-only TD-error
             normalization.
+        previous_discount: Last accepted value transition discount for actor
+            eligibility. The shared nonlinear Q actor leaves this field unused.
         critic_state: Underlying Horde learner state.
         last_observation: Previous observation for the next update call.
         last_action: Previous action index.
@@ -1530,6 +1545,7 @@ class NonlinearHordeActorCriticState:
     actor_head_opt_w: AutostepParamState
     actor_head_opt_b: AutostepParamState
     actor_td_error_normalizer: Float[Array, ""]
+    previous_discount: Float[Array, ""]
     critic_state: MultiHeadMLPState
     last_observation: Float[Array, " feature_dim"]
     last_action: Int[Array, ""]
@@ -1729,6 +1745,7 @@ class NonlinearHordeActorCriticAgent:
             actor_head_opt_w=self._actor_optimizer.init_for_shape(actor_head_w.shape),
             actor_head_opt_b=self._actor_optimizer.init_for_shape(actor_head_b.shape),
             actor_td_error_normalizer=jnp.array(0.0, dtype=jnp.float32),
+            previous_discount=jnp.array(1.0, dtype=jnp.float32),
             critic_state=self._critic.init(feature_dim, critic_key),
             last_observation=jnp.zeros((feature_dim,), dtype=jnp.float32),
             last_action=jnp.array(-1, dtype=jnp.int32),
@@ -1812,11 +1829,15 @@ class NonlinearHordeActorCriticAgent:
             reward: Scalar reward for the value head.
             observation: Next observation.
             auxiliary_cumulants: Optional cumulants for non-value heads.
-            discount: Optional per-transition value-head discount.
+            discount: Optional outgoing value-head discount, saved for the
+                next accepted actor update; prior eligibility uses the last
+                accepted transition discount.
 
         Returns:
             :class:`NonlinearHordeActorCriticUpdateResult`.
         """
+        if state.previous_discount.shape != () or state.previous_discount.dtype != jnp.float32:
+            raise ValueError("state.previous_discount must be a scalar float32")
         cfg = self._config
         prev_obs = state.last_observation
         action_valid = (state.last_action >= 0) & (state.last_action < cfg.n_actions)
@@ -1895,7 +1916,9 @@ class NonlinearHordeActorCriticAgent:
             cfg.actor_gradient_clip_norm,
         )
 
-        actor_decay = value_discount * cfg.actor_lamda
+        # Incoming gamma_t retains earlier credit; outgoing gamma_{t+1}
+        # controls bootstrapping and clears traces only after reward learning.
+        actor_decay = state.previous_discount * cfg.actor_lamda
         n_hidden = len(cfg.hidden_sizes)
 
         new_trunk_traces: list[Array] = []
@@ -2013,6 +2036,7 @@ class NonlinearHordeActorCriticAgent:
             actor_head_opt_w=new_head_opt_w,
             actor_head_opt_b=new_head_opt_b,
             actor_td_error_normalizer=actor_td_error_normalizer,
+            previous_discount=value_discount,
             critic_state=critic_result.state,
             step_count=_saturating_int32_counter_increment(state.step_count),
         )
@@ -2029,6 +2053,8 @@ class NonlinearHordeActorCriticAgent:
             & jnp.isfinite(value_discount)
             & (value_discount >= 0.0)
             & (value_discount <= 1.0)
+            & (state.previous_discount >= 0.0)
+            & (state.previous_discount <= 1.0)
             & jnp.isfinite(value)
             & ((value_discount == 0.0) | jnp.isfinite(next_value))
             & jnp.isfinite(td_error)
@@ -2438,6 +2464,7 @@ class NonlinearQHordeActorCriticAgent:
             actor_head_opt_w=self._actor_optimizer.init_for_shape(actor_head_w.shape),
             actor_head_opt_b=self._actor_optimizer.init_for_shape(actor_head_b.shape),
             actor_td_error_normalizer=jnp.array(0.0, dtype=jnp.float32),
+            previous_discount=jnp.array(1.0, dtype=jnp.float32),
             critic_state=self._critic.init(feature_dim, critic_key),
             last_observation=jnp.zeros((feature_dim,), dtype=jnp.float32),
             last_action=jnp.array(-1, dtype=jnp.int32),

--- a/tests/test_horde_actor_critic.py
+++ b/tests/test_horde_actor_critic.py
@@ -1965,16 +1965,16 @@ def test_actor_resource_budgets_preflight_before_allocation(
     linear = HordeActorCriticConfig(n_actions=2)
     assert linear.actor_resource_budget(3) == {
         "parameter_scalars": 8,
-        "float32_state_scalars": 19,
-        "state_scalars": 23,
-        "state_nbytes": 92,
+        "float32_state_scalars": 20,
+        "state_scalars": 24,
+        "state_nbytes": 96,
     }
     nonlinear = NonlinearHordeActorCriticConfig(n_actions=2, hidden_sizes=(3,))
     budget = nonlinear.actor_resource_budget(4)
     assert budget["parameter_scalars"] == 23
     assert budget["optimizer_tensor_count"] == 4
-    assert budget["float32_state_scalars"] == 128
-    assert budget["state_nbytes"] == 528
+    assert budget["float32_state_scalars"] == 129
+    assert budget["state_nbytes"] == 532
 
     with pytest.raises(ValueError, match="derived actor"):
         HordeActorCriticConfig(n_actions=2**31 - 1)

--- a/tests/test_horde_actor_trace_discount.py
+++ b/tests/test_horde_actor_trace_discount.py
@@ -1,0 +1,314 @@
+"""Actor eligibility uses the incoming discount, separately from bootstrapping."""
+
+import dataclasses
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.horde import HordeLearner
+from alberta_framework.core.horde_actor_critic import (
+    HordeActorCriticAgent,
+    HordeActorCriticConfig,
+    NonlinearHordeActorCriticAgent,
+    NonlinearHordeActorCriticConfig,
+    NonlinearQHordeActorCriticAgent,
+    NonlinearQHordeActorCriticConfig,
+    QHordeActorCriticAgent,
+    QHordeActorCriticConfig,
+    run_horde_actor_critic_from_arrays,
+    run_nonlinear_horde_actor_critic_from_arrays,
+)
+from alberta_framework.core.optimizers import LMS
+from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
+
+pytestmark = pytest.mark.unit
+
+
+def _fixture(nonlinear: bool, lamda: float = 0.8):
+    # Lambda zero isolates actor credit from the critic's separate trace rule.
+    critic = HordeLearner(
+        create_horde_spec(
+            [
+                GVFSpec(
+                    name="value",
+                    demon_type=DemonType.PREDICTION,
+                    gamma=0.9,
+                    lamda=0.0,
+                    cumulant_index=0,
+                )
+            ]
+        ),
+        hidden_sizes=(),
+        use_layer_norm=False,
+        step_size=0.1,
+    )
+    if nonlinear:
+        agent = NonlinearHordeActorCriticAgent(
+            NonlinearHordeActorCriticConfig(
+                n_actions=2, hidden_sizes=(2,), use_layer_norm=False, actor_lamda=lamda
+            ),
+            critic,
+            actor_optimizer=LMS(step_size=0.1),  # type: ignore[arg-type]
+        )
+    else:
+        agent = HordeActorCriticAgent(
+            HordeActorCriticConfig(n_actions=2, actor_step_size=0.1, actor_lamda=lamda), critic
+        )
+    state = agent.init(2, jr.key(210))
+    if nonlinear:
+        state = state.replace(
+            actor_trunk=state.actor_trunk.replace(weights=(jnp.eye(2),), biases=(jnp.ones(2),)),
+            actor_head_w=jnp.array([[0.2, 0.4], [-0.2, -0.4]], dtype=jnp.float32),
+        )
+    heads = state.critic_state.head_params
+    state = state.replace(
+        critic_state=state.critic_state.replace(
+            head_params=heads.replace(
+                weights=tuple(jnp.zeros_like(w) for w in heads.weights),
+                biases=tuple(jnp.zeros_like(b) for b in heads.biases),
+            )
+        )
+    )
+    return agent, state
+
+
+def _params(state, nonlinear: bool):
+    if nonlinear:
+        return tuple(
+            leaf
+            for pair in zip(state.actor_trunk.weights, state.actor_trunk.biases, strict=True)
+            for leaf in pair
+        ) + (state.actor_head_w, state.actor_head_b)
+    return state.actor_weights, state.actor_bias
+
+
+def _traces(state, nonlinear: bool):
+    if nonlinear:
+        return (*state.actor_trunk_traces, state.actor_head_trace_w, state.actor_head_trace_b)
+    return state.actor_trace_weights, state.actor_trace_bias
+
+
+def _clear_traces(state, nonlinear: bool):
+    if nonlinear:
+        return state.replace(
+            actor_trunk_traces=tuple(jnp.zeros_like(t) for t in state.actor_trunk_traces),
+            actor_head_trace_w=jnp.zeros_like(state.actor_head_trace_w),
+            actor_head_trace_b=jnp.zeros_like(state.actor_head_trace_b),
+        )
+    return state.replace(
+        actor_trace_weights=jnp.zeros_like(state.actor_trace_weights),
+        actor_trace_bias=jnp.zeros_like(state.actor_trace_bias),
+    )
+
+
+def _warm(agent, state, discount=0.2):
+    state = agent.start(state, jnp.array([1.0, 0.0]))[0]
+    first = agent.update(
+        state,
+        jnp.float32(0.0),
+        jnp.array([0.0, 1.0]),
+        discount=None if discount is None else jnp.float32(discount),
+    )
+    assert bool(first.update_applied)
+    return first.state
+
+
+@pytest.mark.parametrize("nonlinear", [False, True])
+@pytest.mark.parametrize("outgoing", [0.0, 0.7])
+@pytest.mark.parametrize("disable_jit", [False, True])
+def test_prior_discount_controls_delayed_credit(nonlinear, outgoing, disable_jit):
+    with jax.disable_jit(disable_jit):
+        agent, initial = _fixture(nonlinear)
+        state = _warm(agent, initial)
+        traces = _traces(state, nonlinear)
+        assert all(float(jnp.linalg.norm(trace)) > 0.0 for trace in traces)
+        result = agent.update(state, jnp.float32(1.0), jnp.ones(2), discount=jnp.float32(outgoing))
+        ablated = agent.update(
+            _clear_traces(state, nonlinear),
+            jnp.float32(1.0),
+            jnp.ones(2),
+            discount=jnp.float32(outgoing),
+        )
+        assert bool(result.update_applied) and bool(ablated.update_applied)
+        np.testing.assert_array_equal(result.td_error, ablated.td_error)
+        assert float(result.td_error) == 1.0
+        for actual, control, trace in zip(
+            _params(result.state, nonlinear), _params(ablated.state, nonlinear), traces, strict=True
+        ):
+            np.testing.assert_allclose(actual - control, 0.1 * 0.2 * 0.8 * trace, atol=1e-7)
+        if outgoing == 0.0:
+            for trace in _traces(result.state, nonlinear):
+                np.testing.assert_array_equal(trace, jnp.zeros_like(trace))
+
+
+@pytest.mark.parametrize("outgoing", [0.0, 0.7])
+def test_public_array_runner_preserves_delayed_reward(outgoing):
+    agent, state = _fixture(False)
+    result = run_horde_actor_critic_from_arrays(
+        agent,
+        state,
+        jnp.eye(2),
+        jnp.array([0.0, 1.0]),
+        jnp.array([[0.0, 1.0], [0.0, 0.0]]),
+        actions=jnp.array([0, 0]),
+        discounts=jnp.array([0.2, outgoing]),
+    )
+    np.testing.assert_array_equal(result.updates_applied, [True, True])
+    np.testing.assert_allclose(
+        result.state.actor_weights, [[0.008, 0.05], [-0.008, -0.05]], atol=1e-7
+    )
+    np.testing.assert_allclose(result.state.actor_bias, [0.058, -0.058], atol=1e-7)
+
+
+def _assert_same_tree(actual, expected):
+    for a, b in zip(jax.tree.leaves(actual), jax.tree.leaves(expected), strict=True):
+        if jax.dtypes.issubdtype(a.dtype, jax.dtypes.prng_key):
+            a, b = jr.key_data(a), jr.key_data(b)
+        np.testing.assert_array_equal(a, b)
+
+
+@pytest.mark.parametrize("nonlinear", [False, True])
+def test_rejection_retry_and_episode_boundary(nonlinear):
+    agent, initial = _fixture(nonlinear)
+    state = _warm(agent, initial)
+    rejected = agent.update(state, jnp.float32(jnp.nan), jnp.ones(2), discount=jnp.float32(0.0))
+    assert not bool(rejected.update_applied)
+    _assert_same_tree(rejected.state, state)
+    retry = agent.update(rejected.state, jnp.float32(1.0), jnp.ones(2), discount=jnp.float32(0.0))
+    direct = agent.update(state, jnp.float32(1.0), jnp.ones(2), discount=jnp.float32(0.0))
+    assert bool(retry.update_applied)
+    _assert_same_tree(retry, direct)
+    assert float(retry.state.previous_discount) == 0.0
+    for trace in _traces(retry.state, nonlinear):
+        np.testing.assert_array_equal(trace, jnp.zeros_like(trace))
+    # Even stale finite eligibility cannot cross a persisted terminal barrier.
+    restarted = agent.start(retry.state, jnp.array([1.0, 0.0]))[0]
+    if nonlinear:
+        stale = restarted.replace(
+            actor_trunk_traces=state.actor_trunk_traces,
+            actor_head_trace_w=state.actor_head_trace_w,
+            actor_head_trace_b=state.actor_head_trace_b,
+        )
+    else:
+        stale = restarted.replace(
+            actor_trace_weights=state.actor_trace_weights, actor_trace_bias=state.actor_trace_bias
+        )
+    clean_result = agent.update(restarted, jnp.float32(0.5), jnp.ones(2))
+    stale_result = agent.update(stale, jnp.float32(0.5), jnp.ones(2))
+    assert bool(clean_result.update_applied) and bool(stale_result.update_applied)
+    _assert_same_tree(stale_result, clean_result)
+
+
+@pytest.mark.parametrize("nonlinear", [False, True])
+@pytest.mark.parametrize("lamda", [0.0, 0.8])
+def test_default_discount_matches_explicit_fixed_discount(nonlinear, lamda):
+    agent, initial = _fixture(nonlinear, lamda)
+    implicit, explicit = _warm(agent, initial, None), _warm(agent, initial, 0.9)
+    _assert_same_tree(implicit, explicit)
+    implicit_result = agent.update(implicit, jnp.float32(1.0), jnp.ones(2))
+    explicit_result = agent.update(
+        explicit, jnp.float32(1.0), jnp.ones(2), discount=jnp.float32(0.9)
+    )
+    assert bool(implicit_result.update_applied) and bool(explicit_result.update_applied)
+    _assert_same_tree(implicit_result, explicit_result)
+    if lamda == 0.0:
+        ablated = agent.update(_clear_traces(implicit, nonlinear), jnp.float32(1.0), jnp.ones(2))
+        _assert_same_tree(implicit_result, ablated)
+
+
+@pytest.mark.parametrize("nonlinear", [False, True])
+@pytest.mark.parametrize("history", [-0.1, 1.1, float("nan")])
+def test_invalid_history_rejects_entire_transaction_even_with_lambda_zero(nonlinear, history):
+    agent, initial = _fixture(nonlinear, 0.0)
+    state = _warm(agent, initial).replace(previous_discount=jnp.float32(history))
+    result = agent.update(state, jnp.float32(1.0), jnp.ones(2), discount=jnp.float32(0.7))
+    assert not bool(result.update_applied)
+    _assert_same_tree(result.state, state)
+    assert not bool(result.critic_result.update_applied)
+
+
+@pytest.mark.parametrize("nonlinear", [False, True])
+@pytest.mark.parametrize("history", [jnp.array([0.2]), jnp.int32(0)])
+def test_history_requires_scalar_float32(nonlinear, history):
+    agent, initial = _fixture(nonlinear)
+    state = _warm(agent, initial).replace(previous_discount=history)
+    with pytest.raises(ValueError, match="previous_discount must be a scalar float32"):
+        agent.update(state, jnp.float32(1.0), jnp.ones(2))
+
+
+@pytest.mark.parametrize("nonlinear", [False, True])
+def test_array_runner_rejected_row_preserves_history_and_rng(nonlinear):
+    agent, initial = _fixture(nonlinear)
+    runner = (
+        run_nonlinear_horde_actor_critic_from_arrays
+        if nonlinear
+        else run_horde_actor_critic_from_arrays
+    )
+    observations = jnp.array([[1.0, 0.0], [9.0, 9.0], [0.0, 1.0]])
+    next_observations = jnp.array([[0.0, 1.0], [9.0, 9.0], [0.0, 0.0]])
+    rewards, discounts = jnp.array([0.0, jnp.nan, 1.0]), jnp.array([0.2, 0.0, 0.7])
+    result = runner(agent, initial, observations, rewards, next_observations, discounts=discounts)
+    kept = jnp.array([0, 2])
+    control = runner(
+        agent,
+        initial,
+        observations[kept],
+        rewards[kept],
+        next_observations[kept],
+        discounts=discounts[kept],
+    )
+    np.testing.assert_array_equal(result.updates_applied, [True, False, True])
+    _assert_same_tree(result.state, control.state)
+    assert float(result.state.previous_discount) == pytest.approx(0.7)
+
+
+@pytest.mark.parametrize("nonlinear", [False, True])
+@pytest.mark.parametrize("q_critic", [False, True])
+def test_actor_budget_matches_allocated_state(nonlinear, q_critic):
+    agent_class, config_class = (
+        (
+            (NonlinearQHordeActorCriticAgent, NonlinearQHordeActorCriticConfig)
+            if q_critic
+            else (NonlinearHordeActorCriticAgent, NonlinearHordeActorCriticConfig)
+        )
+        if nonlinear
+        else (
+            (QHordeActorCriticAgent, QHordeActorCriticConfig)
+            if q_critic
+            else (HordeActorCriticAgent, HordeActorCriticConfig)
+        )
+    )
+    config = config_class(n_actions=2, **({"hidden_sizes": (3,)} if nonlinear else {}))
+    critic = HordeLearner(
+        create_horde_spec(
+            [
+                GVFSpec(
+                    name=f"head{i}",
+                    demon_type=DemonType.CONTROL if q_critic else DemonType.PREDICTION,
+                    gamma=0.0 if q_critic else 0.9,
+                    lamda=0.0,
+                    cumulant_index=0,
+                )
+                for i in range(2 if q_critic else 1)
+            ]
+        ),
+        hidden_sizes=(),
+    )
+    state = agent_class(config, critic).init(4, jr.key(210))
+    leaves = jax.tree.leaves(
+        {
+            field.name: getattr(state, field.name)
+            for field in dataclasses.fields(state)
+            if field.name != "critic_state"
+        }
+    )
+    leaves = [
+        jr.key_data(x) if jax.dtypes.issubdtype(x.dtype, jax.dtypes.prng_key) else x for x in leaves
+    ]
+    budget = config.actor_resource_budget(4)
+    assert budget["state_nbytes"] == sum(x.nbytes for x in leaves)
+    assert budget["state_scalars"] == sum(x.size for x in leaves)
+    assert budget["float32_state_scalars"] == sum(x.size for x in leaves if x.dtype == jnp.float32)


### PR DESCRIPTION
A state-value Horde actor decays earlier eligibility with the outgoing bootstrap discount. This erases delayed actor credit on terminal transitions and misweights it when nonterminal discounts change. With discounts `[0.2, 0]` or `[0.2, 0.7]`, two fixed actions and rewards `[0, 1]`, main assigns the earlier feature actor weight `0` or `0.028`; the incoming-discount recurrence requires `0.008` in both cases.

Both the linear and nonlinear state-value Horde actors now retain the last **accepted** transition discount and use it for the next actor eligibility update. The outgoing discount still controls the critic bootstrap and clears actor traces after terminal reward learning. The existing whole-transaction guard commits discount history with parameters, critic state and RNG; rejected transitions preserve all of them for retry.

The discount indices follow the variable-discount recurrence in [Sutton & Barto, second edition, equations 12.23 and 12.25, printed pp. 309–310](https://www.andrew.cmu.edu/course/10-703/textbook/BartoSutton.pdf#page=331), and the actor trace pattern in [§13.5, printed p. 332](https://www.andrew.cmu.edu/course/10-703/textbook/BartoSutton.pdf#page=354). This corrects the existing semi-gradient actor's eligibility indexing; it does not implement the textbook's complete episodic policy-gradient objective.

Verified source head: `358daed6c8f3904fc3c965eeb620aa5a590a42fc`
<!-- evidence-head:358daed6c8f3904fc3c965eeb620aa5a590a42fc -->

## Verification

Baseline main: `f3d32c451ed1c1715e477ad56b782fc7ea89b206`. Runtime: Python 3.12.3, locked JAX/jaxlib 0.11.0 and NumPy 2.5.1, CPU. Install with `uv sync --locked --no-install-project --extra dev --python <project-python>`, select the checkout through `PYTHONPATH`, and set `OMP_NUM_THREADS=1`.

- Failure-first: all ten initial behavior regressions fail on main and pass after the fix. These cover both actor forms, outgoing discounts 0 and 0.7, eager and JIT execution, and the public linear array runner. The separate public-runner reproduction below fails its analytic assertion on main and passes on the candidate; all transitions commit in both executions.
- The final focused panel passes **133 tests**, including **32 new cases**. Trace ablation checks delayed credit across every nonlinear trunk/head parameter tensor, using a fixed-step LMS actor optimizer. Rejection/retry, terminal boundaries, fixed-discount default parity, lambda-zero controls, malformed history, scan rejection recovery, and actual allocated-state byte counts are covered.
- Ruff, new-file formatting, strict mypy (224 source files), and whitespace checks pass. The wider consumer panel passes **562 tests / 6 skips**, bringing local verification to **695 passed / 6 skipped**. Skips are two optional Gymnasium cases and four official Foragax cases because those optional dependencies are absent. Fake-environment Forager host/scan and chunk-parity tests pass. [Required CI run 34218404625](https://github.com/SlopDotCash/asi/actions/runs/34218404625) passed **55/55 jobs** at the verified head. The separate optional PR triage job was skipped.
- The five-claim evidence registry exits **2** before and after; every claim status and complete error list is unchanged. This module is outside all 25 registered source paths, but inside the Forager matched-analysis source closure, so the latter source identity changes. No pinned outputs, thresholds, protocols or evaluation seeds changed.

```bash
.venv/bin/python -m pytest tests/test_horde_actor_trace_discount.py tests/test_horde_actor_critic.py tests/test_horde_actor_critic_hostile.py -q --tb=short -o addopts=''
.venv/bin/python -m pytest tests/test_horde.py tests/test_mixed_horde.py tests/test_sarsa.py tests/test_pipeline.py tests/test_baseline_mlp_direct_delta.py tests/test_bounder_normalizer_config_truthiness.py tests/test_learner_optimizer_fallback_truthiness.py tests/test_forager_benchmark.py tests/test_forager_recurrent.py -q --tb=short -o addopts=''
.venv/bin/python -m ruff check .
.venv/bin/python -m ruff format --check tests/test_horde_actor_trace_discount.py
.venv/bin/python -m mypy
.venv/bin/python -m alberta_framework.evaluation.evidence_manifest_cli
git diff --check
```

## State cost and scope

One float32 scalar adds **4 persistent bytes** to `HordeActorCriticState` and `NonlinearHordeActorCriticState`; budget preflight includes that cost. The nonlinear Q actor already shares the latter state class, so it initializes and carries the additional unused scalar and its budget also increases by 4 bytes. Linear Q state and all Q actor update equations are unchanged. No new configuration is introduced. Manually constructed states now need the field; no portable checkpoint compatibility is claimed.

Critic update semantics are unchanged. This does not include the separate terminal value-critic trace reset in #2868, the linear standalone actor fix in #2866, or the fixed-gamma QHorde actor fix in #2867. The reproduction sets critic lambda to zero to isolate actor credit; arbitrary variable-discount critic traces remain open.

Key 210 is a deterministic correctness fixture, not a tuning or evaluation seed; no benchmark campaign was run. Timing and learning performance are unmeasured. This is permanently nonpromoting correctness verification, not performance or scientific evidence. Acceptance and merge require an independent maintainer.

<details>
<summary>Standalone public-runner reproduction</summary>

Save as `actor-repro.py` outside the checkouts. Run `.venv/bin/python actor-repro.py` in separate processes with each checkout selected by `PYTHONPATH`. With zero initial actor weights, the first action contributes gradient `[0.5, -0.5]`; its second-step credit is `0.1 * 1 * 0.2 * 0.8 * [0.5, -0.5] = [0.008, -0.008]`.

```python
import json
import jax.numpy as jnp
import jax.random as jr
import numpy as np
from alberta_framework import GVFSpec, DemonType, HordeLearner, create_horde_spec
from alberta_framework.core.horde_actor_critic import (
    HordeActorCriticAgent, HordeActorCriticConfig, run_horde_actor_critic_from_arrays,
)
critic = HordeLearner(create_horde_spec([
    GVFSpec(name='value', demon_type=DemonType.PREDICTION,
            gamma=0.9, lamda=0.0, cumulant_index=0),
]), hidden_sizes=(), use_layer_norm=False, step_size=0.1)
agent = HordeActorCriticAgent(
    HordeActorCriticConfig(n_actions=2, actor_step_size=0.1, actor_lamda=0.8), critic,
)
state = agent.init(2, jr.key(210))
heads = state.critic_state.head_params
state = state.replace(critic_state=state.critic_state.replace(head_params=heads.replace(
    weights=tuple(jnp.zeros_like(w) for w in heads.weights),
    biases=tuple(jnp.zeros_like(b) for b in heads.biases),
)))
records = []
for outgoing in (0.0, 0.7):
    result = run_horde_actor_critic_from_arrays(
        agent, state, jnp.eye(2), jnp.array([0.0, 1.0]),
        jnp.array([[0.0, 1.0], [0.0, 0.0]]), actions=jnp.array([0, 0]),
        discounts=jnp.array([0.2, outgoing]),
    )
    records.append(dict(outgoing_discount=outgoing,
        accepted=np.asarray(result.updates_applied).tolist(),
        actor_weights=np.asarray(result.state.actor_weights).tolist(),
        actor_bias=np.asarray(result.state.actor_bias).tolist(),
        td_errors=np.asarray(result.td_errors).tolist()))
print(json.dumps(records))
for record in records:
    np.testing.assert_array_equal(record['accepted'], [True, True])
    np.testing.assert_allclose(record['actor_weights'], [[0.008, 0.05], [-0.008, -0.05]], atol=1e-7)
    np.testing.assert_allclose(record['actor_bias'], [0.058, -0.058], atol=1e-7)
```

</details>

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next21]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M209S5606XQGYPYQMC7ADEW6","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-08T10:42:20.481Z","completed_at":"2026-09-08T13:29:33.709Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-08T10:42:20.670Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c4f795d04264d5d8595e4684dd273c9da186af4b258386d8f3588f7be1f594bf","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"26f93794-0601-44de-ba25-cabaee92453a","object_id":"sha256:c4f795d04264d5d8595e4684dd273c9da186af4b258386d8f3588f7be1f594bf","sha256":"c4f795d04264d5d8595e4684dd273c9da186af4b258386d8f3588f7be1f594bf"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"BYAwtY_d4iJlGi_Lfb4jpba4QvpuN6mcQb-z514OaSUy3M9DzGzMkEz7QAqFFTLMDcW4fnqt1T-7ZTMysUnGBw"}} -->
