### PR TITLE
fix(rtu): use incoming discount for eligibility credit

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -194,6 +194,9 @@ class RecurrentTraceActorCriticState(NamedTuple):
     started: Array
     actor_second_moments: RTUNetworkParameters | None = None
     critic_second_moments: RTUNetworkParameters | None = None
+    # Appended to preserve the historical positional state prefix. Legacy
+    # states without this cursor assume the configured constant discount.
+    previous_discount: Array | None = None
 
     def replace(self, **changes: Any) -> Self:
         """Return a state with selected fields replaced, like ``chex.dataclass``."""
@@ -337,7 +340,7 @@ def _preflight_state_resources(
         + 2 * sensitivity_scalars * (2 if config.rtrl_taylor_correction else 1)
         + 4 * config.hidden_size
         + 4 * width
-        + 3
+        + 4
     )
     # Two statistics counters, last action, typed key, step counter, and the
     # started flag are six logical array elements. The typed key occupies two
@@ -1923,6 +1926,7 @@ class RecurrentTraceActorCriticAgent:
             rng_key=policy_key,
             step_count=jnp.asarray(0, dtype=jnp.int32),
             started=jnp.asarray(False),
+            previous_discount=jnp.asarray(1.0, dtype=jnp.float32),
         )
 
     def _network_output(
@@ -2241,6 +2245,7 @@ class RecurrentTraceActorCriticAgent:
             last_normalized_observation=normalized,
             last_observation=jnp.asarray(observation, dtype=jnp.float32),
             started=jnp.asarray(True),
+            previous_discount=jnp.asarray(1.0, dtype=jnp.float32),
         )
         action, key, probabilities = self.select_action(advanced)
         return (
@@ -2324,6 +2329,12 @@ class RecurrentTraceActorCriticAgent:
         that supplies none of them is continuing even when configured
         ``gamma`` is zero.
 
+        Eligibility decays by the discount retained from the preceding
+        accepted transition, while this call's discount controls the TD
+        bootstrap. Boundaries clear eligibility after crediting their reward.
+        Legacy positional states with no retained discount assume configured
+        ``gamma``; their old variable-discount history cannot be reconstructed.
+
         Examples:
             A true environment termination can use ``terminated=True``.
             A time-limit truncation can use
@@ -2400,6 +2411,14 @@ class RecurrentTraceActorCriticAgent:
         check_dynamic_started: bool,
     ) -> RecurrentTraceActorCriticUpdateResult:
         """Validate one public transition and dispatch the compiled kernel."""
+        state = state.replace(
+            previous_discount=_validated_scalar(
+                "state.previous_discount",
+                self._config.gamma if state.previous_discount is None else state.previous_discount,
+                boolean=False,
+                unit_interval=True,
+            ).astype(jnp.float32)
+        )
         started = state.started
         if started.shape != ():
             raise ValueError("state.started must be scalar-shaped")
@@ -2617,14 +2636,11 @@ class RecurrentTraceActorCriticAgent:
         td_error = normalized_reward + bootstrap - value
         _, actor_gradient = self._actor_gradient(state, td_error)
 
-        # The terminating reward must still credit traces accumulated within
-        # the episode.  Stream AC(lambda) therefore applies gamma*lambda first
-        # and clears the stored trace only after the terminal update.
-        trace_discount = jnp.where(
-            boundary,
-            jnp.asarray(self._config.gamma, dtype=transition_discount.dtype),
-            transition_discount,
-        )
+        # The trace uses gamma_t, entering the current state; the bootstrap
+        # above uses gamma_{t+1}, leaving it. Terminal and truncation rewards
+        # still credit the old trace before its independent boundary reset.
+        assert state.previous_discount is not None
+        trace_discount = state.previous_discount
         actor_decay = trace_discount * self._config.actor_lamda
         critic_decay = trace_discount * self._config.critic_lamda
         actor_traces = cast(
@@ -2822,10 +2838,13 @@ class RecurrentTraceActorCriticAgent:
             last_normalized_observation=stored_observation,
             last_observation=stored_raw_observation,
             step_count=step_count,
+            previous_discount=jnp.where(boundary, 1.0, transition_discount),
         )
         candidate_applied = (
             actor_update_applied
             & critic_update_applied
+            & (trace_discount >= 0.0)
+            & (trace_discount <= 1.0)
             & _floating_tree_is_finite(
                 state.replace(
                     reward_statistics=state.reward_statistics._replace(

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -1399,15 +1399,17 @@ def test_adaptive_moments_persist_across_restart_and_checkpoint_resume() -> None
 def test_default_state_keeps_historical_positional_checkpoint_prefix() -> None:
     agent = RecurrentTraceActorCriticAgent(_small_config())
     state = agent.init(feature_dim=2, key=jr.key(351))
-    assert state._fields[-2:] == (
+    assert state._fields[-3:] == (
         "actor_second_moments",
         "critic_second_moments",
+        "previous_discount",
     )
 
-    reconstructed = type(state)(*state[:-2])
+    reconstructed = type(state)(*state[:-3])
     assert reconstructed.actor_second_moments is None
     assert reconstructed.critic_second_moments is None
-    _assert_tree_all_close(reconstructed, state)
+    assert reconstructed.previous_discount is None
+    _assert_tree_all_close(reconstructed.replace(previous_discount=state.previous_discount), state)
 
 
 def test_terminal_transition_updates_then_resets_all_temporal_traces() -> None:
@@ -2103,9 +2105,9 @@ def test_state_resource_budget_is_exact_and_init_preflights_before_rng(
     assert budget == {
         "parameter_scalars": 124,
         "sensitivity_scalars_per_network": 36,
-        "float32_state_scalars": 343,
-        "state_scalars": 349,
-        "state_nbytes": 1397,
+        "float32_state_scalars": 344,
+        "state_scalars": 350,
+        "state_nbytes": 1401,
     }
     state = RecurrentTraceActorCriticAgent(config).init(2, jr.key(2))
     leaves = jax.tree.leaves(state)

--- a/tests/test_recurrent_trace_actor_critic_discounts.py
+++ b/tests/test_recurrent_trace_actor_critic_discounts.py
@@ -1,0 +1,163 @@
+"""Delayed reward credit uses the discount entering the current RTU state."""
+
+import pickle
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.recurrent_trace_actor_critic import (
+    RecurrentTraceActorCriticAgent,
+    RecurrentTraceActorCriticConfig,
+)
+
+
+@pytest.fixture(scope="module")
+def agent() -> RecurrentTraceActorCriticAgent:
+    return RecurrentTraceActorCriticAgent(
+        RecurrentTraceActorCriticConfig(
+            n_actions=2,
+            hidden_size=2,
+            encoder_width=2,
+            output_width=2,
+            gamma=0.9,
+            actor_lamda=0.8,
+            critic_lamda=0.8,
+            actor_alpha=0.01,
+            critic_alpha=0.01,
+            actor_kappa=1.0,
+            critic_kappa=1.0,
+            layer_norm_epsilon=1.0,
+            normalize_observations=False,
+            normalize_rewards=False,
+            entropy_coefficient=0.0,
+        )
+    )
+
+
+@pytest.mark.parametrize("incoming", [0.0, 0.25, 0.9])
+@pytest.mark.parametrize("outgoing,boundary", [(0.1, False), (0.0, True), (0.7, True)])
+def test_delayed_reward_uses_incoming_discount(
+    agent: RecurrentTraceActorCriticAgent, incoming: float, outgoing: float, boundary: bool
+) -> None:
+    observation = jnp.zeros(2, dtype=jnp.float32)
+    initial, first_action, first_policy = agent.start(agent.init(2, jr.key(230)), observation)
+    np.testing.assert_array_equal(first_policy, [0.5, 0.5])
+    first = agent.update(
+        initial,
+        jnp.float32(0.0),
+        observation,
+        discount=jnp.float32(incoming),
+        episode_boundary=jnp.asarray(False),
+    )
+    assert bool(first.update_applied)
+    np.testing.assert_array_equal(first.policy, [0.5, 0.5])
+    second = agent.update(
+        first.state,
+        jnp.float32(1.0),
+        observation,
+        discount=jnp.float32(outgoing),
+        episode_boundary=jnp.asarray(boundary),
+    )
+    assert bool(second.update_applied)
+    assert float(second.td_error) == 1.0
+    assert float(second.actor_obgd_scale) == float(second.critic_obgd_scale) == 1.0
+
+    # Public initialization plus zero observations gives zero values and
+    # uniform policies. The first reward is zero, so this second reward is
+    # the only parameter update. The head-bias derivatives are analytic.
+    first_gradient = np.eye(2)[int(first_action)] - 0.5
+    second_gradient = np.eye(2)[int(first.action)] - 0.5
+    expected_actor = agent.config.actor_alpha * (
+        second_gradient + incoming * agent.config.actor_lamda * first_gradient
+    )
+    expected_critic = agent.config.critic_alpha * (1 + incoming * agent.config.critic_lamda)
+    np.testing.assert_allclose(
+        second.state.actor_params.head_bias, expected_actor, rtol=2e-6, atol=1e-8
+    )
+    np.testing.assert_allclose(
+        second.state.critic_params.head_bias, [expected_critic], rtol=2e-6, atol=1e-8
+    )
+    if boundary:
+        for leaf in jax.tree.leaves((second.state.actor_traces, second.state.critic_traces)):
+            np.testing.assert_array_equal(leaf, jnp.zeros_like(leaf))
+
+
+def test_rejected_transition_preserves_discount_for_retry(
+    agent: RecurrentTraceActorCriticAgent,
+) -> None:
+    observation = jnp.zeros(2, dtype=jnp.float32)
+    initial, _, _ = agent.start(agent.init(2, jr.key(231)), observation)
+    first = agent.update(initial, jnp.float32(0.0), observation, discount=jnp.float32(0.25))
+    assert bool(first.update_applied)
+    rejected = agent.update(first.state, jnp.float32(3e38), observation, discount=jnp.float32(0.7))
+    assert not bool(rejected.update_applied)
+    for actual, expected in zip(
+        jax.tree.leaves(rejected.state), jax.tree.leaves(first.state), strict=True
+    ):
+        if jax.dtypes.issubdtype(actual.dtype, jax.dtypes.prng_key):
+            actual, expected = jr.key_data(actual), jr.key_data(expected)
+        np.testing.assert_array_equal(actual, expected)
+
+    # A same-runtime round trip must retain the discount as well as weights.
+    restored = pickle.loads(pickle.dumps(rejected.state))
+    retried = agent.update(restored, jnp.float32(1.0), observation, terminated=jnp.asarray(True))
+    assert bool(retried.update_applied)
+    np.testing.assert_allclose(retried.state.critic_params.head_bias, [0.012], rtol=2e-6)
+
+
+def test_explicit_start_discards_previous_episode_credit(
+    agent: RecurrentTraceActorCriticAgent,
+) -> None:
+    observation = jnp.zeros(2, dtype=jnp.float32)
+    initial, _, _ = agent.start(agent.init(2, jr.key(232)), observation)
+    first = agent.update(initial, jnp.float32(0.0), observation, discount=jnp.float32(0.25))
+    restarted, _, _ = agent.start(first.state, observation)
+    result = agent.update(restarted, jnp.float32(1.0), observation, terminated=jnp.asarray(True))
+    assert bool(result.update_applied)
+    np.testing.assert_allclose(result.state.critic_params.head_bias, [0.01], rtol=2e-6)
+
+
+@pytest.mark.parametrize("enable_x64", [False, True])
+def test_legacy_positional_state_uses_configured_constant_discount(
+    agent: RecurrentTraceActorCriticAgent, enable_x64: bool
+) -> None:
+    observation = jnp.zeros(2, dtype=jnp.float32)
+    initial, _, _ = agent.start(agent.init(2, jr.key(233)), observation)
+    first = agent.update(initial, jnp.float32(0.0), observation)
+    # The original full positional prefix includes both optional moment trees.
+    legacy = type(first.state)(*first.state[:-1])
+    assert legacy.previous_discount is None
+    expected = agent.update(
+        first.state, jnp.float32(1.0), observation, terminated=jnp.asarray(True)
+    )
+    with jax.enable_x64(enable_x64):
+        actual = agent.update(legacy, jnp.float32(1.0), observation, terminated=jnp.asarray(True))
+    for actual_leaf, expected_leaf in zip(
+        jax.tree.leaves(actual), jax.tree.leaves(expected), strict=True
+    ):
+        if jax.dtypes.issubdtype(actual_leaf.dtype, jax.dtypes.prng_key):
+            actual_leaf, expected_leaf = jr.key_data(actual_leaf), jr.key_data(expected_leaf)
+        np.testing.assert_array_equal(actual_leaf, expected_leaf)
+
+
+def test_invalid_saved_discount_cannot_apply_an_update(
+    agent: RecurrentTraceActorCriticAgent,
+) -> None:
+    observation = jnp.zeros(2, dtype=jnp.float32)
+    state, _, _ = agent.start(agent.init(2, jr.key(234)), observation)
+
+    @jax.jit
+    def compiled(discount: jax.Array, next_observation: jax.Array) -> jax.Array:
+        return agent.update_from_started_state(
+            state.replace(previous_discount=discount), jnp.float32(1.0), next_observation
+        ).update_applied
+
+    for invalid in (-0.1, 1.1, float("nan"), float("inf")):
+        discount = jnp.float32(invalid)
+        with pytest.raises(ValueError, match="state.previous_discount"):
+            agent.update(state.replace(previous_discount=discount), jnp.float32(1.0), observation)
+        assert not bool(compiled(discount, observation))
+    assert bool(compiled(jnp.float32(0.25), observation))


### PR DESCRIPTION
The recurrent actor/critic currently decays eligibility with the outgoing transition discount, substituting configured gamma at episode boundaries. With variable discounts, this credits delayed rewards to the wrong history. Retain the preceding accepted discount in state and use it for actor and critic eligibility; the current discount still controls the TD bootstrap, and boundaries clear traces after applying reward credit.

A public `init/start/update` reproduction uses zero observations, rewards [0, 1], gamma 0.9, lambda 0.8, step size 0.01, and key 230. It injects no weights or eligibility. Both policies remain uniform before the second update, both TD errors are known, and ObGD scaling is 1, so the head-bias updates have an independent analytic reference:

| Incoming discount | Current transition | Main actor bias | Corrected actor bias | Main critic bias | Corrected critic bias |
| --- | --- | --- | --- | --- | --- |
| 0.25 | discount 0.1, continuing | ±0.0046 | ±0.0040 | 0.0108 | 0.0120 |
| 0.25 | terminal, discount 0 | ±0.0014 | ±0.0040 | 0.0172 | 0.0120 |
| 0 | discount 0.1, continuing | ±0.0046 | ±0.0050 | 0.0108 | 0.0100 |

Across nine combinations of incoming discount {0, 0.25, 0.9} and continuing/terminal/truncation transitions, main matches the analytic actor and critic update in 2/9 cases; this head matches 9/9. The discount indexing follows the state-value TD error and accumulating trace in [Sutton & Barto, January 2018 draft, §12.9, equations 12.22 and 12.24](https://eclass.uoa.gr/modules/document/file.php/DI437/bookdraft2018jan1.pdf): bootstrap uses gamma at the next state, while carried eligibility uses gamma entering the current state.

The saved discount advances only with an accepted update. Explicit restart and boundaries reset the cursor alongside cleared eligibility. Eager validation rejects invalid saved scalars; compiled validation uses the existing rejection guard, retaining the callback-free Forager path. The new float32 scalar adds four persistent bytes and eight bytes to the input/output working-set accounting.

The new field is appended after both existing optional moment trees, preserving the historical positional prefix. Current-state pickle continuation retains it exactly. Legacy states that lack the field assume configured gamma; their previous variable-discount history cannot be reconstructed.

Validation at `6e3ffdd19fd90087324b1bedbf20721dac315754`, against freshly fetched main `f3d32c451ed1c1715e477ad56b782fc7ea89b206`:

- Failure first: 8 new regression failures and 3 controls passing on main.
- Locked Python 3.12 / JAX 0.11.0: 155 tests pass, with one skip because the audited Foragax runtime is unavailable.
- Supplemental JAX 0.11.1: 15 focused discount and callback tests pass.
- Four 16-step constant-discount replays cover both settings of adaptive ObGD and Taylor correction, with boundaries at steps 7 and 15. All 64 updates are accepted; parameters, actions, and reported metrics match main exactly. Of 364 saved arrays, 363 are exact; three elements in the adaptive+Taylor critic Taylor trace differ by at most 2.794e-9. Full-state bit equality across changed source is not claimed.
- Ruff, formatting of the new test file, strict mypy over 224 sources, exact resource accounting, and `git diff --check` pass.
- [Required CI](https://github.com/SlopDotCash/asi/actions/runs/34242619833): all 55 jobs pass on this head.

Reproduce the retained regression panel with:

```bash
OMP_NUM_THREADS=1 .venv/bin/python -m pytest \
  tests/test_recurrent_trace_actor_critic.py \
  tests/test_recurrent_trace_actor_critic_discounts.py \
  tests/test_recurrent_trace_actor_critic_update_working_set.py \
  tests/test_forager_rtu_rtrl.py -q --tb=short -o addopts=
```

The replay uses keys 235 (initialization), 236 (17 normal observation vectors of width 2), and 237 (16 normal rewards), with n_actions=3, hidden_size=3, encoder_width=2, output_width=4, gamma=0.9, actor_alpha=critic_alpha=0.001, sparsity=0, and both normalizers disabled. Other settings use the source defaults. This is a bounded correctness comparison, not benchmark performance evidence.

The five scientific registry claims retain their pre-existing invalid statuses and identical error lists; all 25 registered source files are unchanged. The RTU file is separately bound into Forager source provenance, so this edit changes that identity. Sealed campaign artifacts were not altered or resumed.

The attached public proof bundle is `rtu-incoming-discount.evidence.zip` (236,541 bytes; SHA-256 `944c415a05e59f5e8f38e83fb04c12422103a045edf2e0a06104d3929c630e7d`). It contains the public analytic reproduction, paired main/candidate records, matched replay arrays and comparison, exact-head test logs, and per-file digests. The private trace is excluded.

Ready for review: the private trace upload, signed run receipt, and both public evidence attachments are complete. No independent acceptance or merge is claimed.

<!-- evidence-head:6e3ffdd19fd90087324b1bedbf20721dac315754 -->
<!-- evidence-row:logs -->
- [x] logs: [`rtu-incoming-discount.logs.txt`](https://github.com/user-attachments/files/32065200/rtu-incoming-discount.logs.txt), SHA-256 `e454b673941a74785f79057052ca46611cba2292b669f087a697be24c34120bd`.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [`rtu-incoming-discount.evidence.zip`](https://github.com/user-attachments/files/32065201/rtu-incoming-discount.evidence.zip), SHA-256 `944c415a05e59f5e8f38e83fb04c12422103a045edf2e0a06104d3929c630e7d`.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next24]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M20QJB1TY4PKJTHCD6QDEKM9","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-08T14:43:17.178Z","completed_at":"2026-09-08T15:22:18.169Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-08T14:43:17.758Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c26e5b889c92294630c68634d3412b948d114fdfeccf078ab2190aeece5b210f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"318e31ff-a9f9-4371-b44f-fcd76c876bb8","object_id":"sha256:c26e5b889c92294630c68634d3412b948d114fdfeccf078ab2190aeece5b210f","sha256":"c26e5b889c92294630c68634d3412b948d114fdfeccf078ab2190aeece5b210f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"uDg7fKeaN_ve4Scx3evuUQhoIr4hip1LN1dtRhuNlefDf4UC89-hkdehbvLD_w5hEm6yn2fzTLpGddJD32wICA"}} -->
